### PR TITLE
feat: Cockpit audio plane (Braille scope + PTT) & DW cache economics

### DIFF
--- a/backend/core/ouroboros/aegis/preflight.py
+++ b/backend/core/ouroboros/aegis/preflight.py
@@ -32,15 +32,16 @@ from __future__ import annotations
 
 import asyncio
 import enum
+import importlib.util
 import logging
 import os
 import secrets
 import subprocess
 import sys
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Mapping, Optional
+from typing import Mapping, Optional, Tuple
 
 from backend.core.ouroboros.aegis.bootstrap import (
     BootstrapPayload,
@@ -68,13 +69,206 @@ PREFLIGHT_SCHEMA_VERSION: str = "aegis_preflight.1"
 
 
 class PreflightOutcome(str, enum.Enum):
-    """Closed 5-value outcome taxonomy for the preflight."""
+    """Closed 6-value outcome taxonomy for the preflight."""
 
     SKIPPED_DISABLED = "skipped_disabled"
     READY = "ready"
     FAILED_SPAWN = "failed_spawn"
     FAILED_BOOTSTRAP_TIMEOUT = "failed_bootstrap_timeout"
     FAILED_CREDENTIAL_SCRUB = "failed_credential_scrub"
+    FAILED_DEPENDENCY_DRIFT = "failed_dependency_drift"
+
+
+class DependencyStatus(str, enum.Enum):
+    """Closed outcome taxonomy for the dependency-validation step."""
+
+    SKIPPED = "skipped"          # step disabled
+    INTACT = "intact"            # every declared package importable
+    RECONCILED = "reconciled"    # drift found AND repaired in-process
+    DRIFT = "drift"              # drift found, not repaired (reconcile off/failed)
+
+
+def _dep_validation_enabled() -> bool:
+    """Detect-and-report. Cheap (``find_spec`` only, no import, no network)."""
+    return os.environ.get(
+        "JARVIS_AEGIS_DEP_VALIDATION_ENABLED", "true",
+    ).strip().lower() in ("1", "true", "yes", "on")
+
+
+def _dep_reconcile_enabled() -> bool:
+    """Whether Aegis may ``pip install`` drift away during boot.
+
+    Default OFF, deliberately. Reconciliation is the one part of this step that
+    reaches the network and mutates the interpreter every other process shares,
+    so arming it by default converts a transient PyPI outage into a failed boot
+    — and this repo has no venv (``sys.prefix == sys.base_prefix``), so a bad
+    resolution lands on the global pyenv, not a disposable sandbox. Detection is
+    what makes drift *visible*; repair stays an explicit operator choice, and
+    graduates the way every other flag here does once it has soaked."""
+    return os.environ.get(
+        "JARVIS_AEGIS_DEP_RECONCILE_ENABLED", "false",
+    ).strip().lower() in ("1", "true", "yes", "on")
+
+
+def _dep_strict() -> bool:
+    """Whether unreconciled drift is fatal (FAILED_DEPENDENCY_DRIFT) rather than
+    a warning the boot proceeds through. Default OFF — silent degradation is the
+    bug we are fixing; a hard-down boot is not obviously better than a loud LITE
+    tier, so the operator opts in."""
+    return os.environ.get(
+        "JARVIS_AEGIS_DEP_STRICT", "false",
+    ).strip().lower() in ("1", "true", "yes", "on")
+
+
+def _dep_reconcile_timeout_s() -> float:
+    try:
+        return max(1.0, float(os.environ.get("JARVIS_AEGIS_DEP_RECONCILE_TIMEOUT_S", "300")))
+    except (TypeError, ValueError):
+        return 300.0
+
+
+# import_name -> pip requirement specifier. Packages whose absence degrades the
+# organism SILENTLY rather than loudly — the class this step exists to catch.
+# `sentence_transformers` is the charter member: without it EmbeddingService
+# logs one WARNING and runs on the LITE tier indefinitely.
+_DEFAULT_CRITICAL_DEPS: Tuple[Tuple[str, str], ...] = (
+    ("sentence_transformers", "sentence-transformers==2.3.0"),
+)
+
+
+def _critical_deps() -> Tuple[Tuple[str, str], ...]:
+    """Declared critical packages, overridable via ``JARVIS_AEGIS_DEP_CRITICAL``
+    as a comma-separated ``import_name=pip_spec`` list. Malformed entries are
+    skipped rather than raising — a typo must not brick boot."""
+    raw = os.environ.get("JARVIS_AEGIS_DEP_CRITICAL", "").strip()
+    if not raw:
+        return _DEFAULT_CRITICAL_DEPS
+    out = []
+    for item in raw.split(","):
+        item = item.strip()
+        if not item:
+            continue
+        name, _, spec = item.partition("=")
+        name = name.strip()
+        if name:
+            out.append((name, (spec.strip() or name)))
+    return tuple(out) or _DEFAULT_CRITICAL_DEPS
+
+
+@dataclass(frozen=True)
+class DependencyValidationStep:
+    """Result of the boot-time dependency reconciliation step.
+
+    ``missing`` is what was absent on entry; ``reconciled`` is what this step
+    actually repaired; ``unresolved`` is what remains broken on exit. A step
+    that repaired nothing and found nothing is ``INTACT``."""
+
+    status: DependencyStatus = DependencyStatus.SKIPPED
+    checked: Tuple[str, ...] = ()
+    missing: Tuple[str, ...] = ()
+    reconciled: Tuple[str, ...] = ()
+    unresolved: Tuple[str, ...] = ()
+    detail: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        return {
+            "status": self.status.value,
+            "checked": list(self.checked),
+            "missing": list(self.missing),
+            "reconciled": list(self.reconciled),
+            "unresolved": list(self.unresolved),
+            "detail": self.detail,
+        }
+
+
+def _importable(module_name: str) -> bool:
+    """True iff ``module_name`` can be located WITHOUT importing it. Import cost
+    for something like torch is seconds; ``find_spec`` is microseconds and this
+    runs on the boot path. Any resolution error counts as missing."""
+    try:
+        return importlib.util.find_spec(module_name) is not None
+    except (ImportError, ValueError, ModuleNotFoundError, AttributeError):
+        return False
+
+
+def validate_dependencies() -> DependencyValidationStep:
+    """Inspect declared critical packages and, when armed, reconcile drift.
+
+    Root-cause step for the silent-degradation class: an absent package that
+    the organism swallows into a permanently-degraded tier. Detection is always
+    honest — the step reports what it found even when it cannot repair it.
+    Never raises."""
+    if not _dep_validation_enabled():
+        return DependencyValidationStep(
+            status=DependencyStatus.SKIPPED,
+            detail="JARVIS_AEGIS_DEP_VALIDATION_ENABLED is false",
+        )
+
+    deps = _critical_deps()
+    checked = tuple(name for name, _ in deps)
+    missing = tuple(name for name, _ in deps if not _importable(name))
+
+    if not missing:
+        logger.info(
+            "[AegisPreflight] dependency validation: INTACT (%d checked)", len(checked),
+        )
+        return DependencyValidationStep(
+            status=DependencyStatus.INTACT, checked=checked,
+        )
+
+    specs = {name: spec for name, spec in deps}
+    if not _dep_reconcile_enabled():
+        logger.warning(
+            "[AegisPreflight] dependency DRIFT: %s absent — reconciliation is "
+            "disarmed (JARVIS_AEGIS_DEP_RECONCILE_ENABLED=false). The organism "
+            "will run degraded. Repair with: pip install %s",
+            ", ".join(missing), " ".join(specs[m] for m in missing),
+        )
+        return DependencyValidationStep(
+            status=DependencyStatus.DRIFT, checked=checked, missing=missing,
+            unresolved=missing,
+            detail="reconciliation disarmed; run pip install manually",
+        )
+
+    reconciled = []
+    unresolved = []
+    for name in missing:
+        spec = specs[name]
+        logger.warning(
+            "[AegisPreflight] dependency DRIFT: %s absent — reconciling (%s)", name, spec,
+        )
+        try:
+            proc = subprocess.run(
+                [sys.executable, "-m", "pip", "install", "--no-input", spec],
+                capture_output=True, text=True, timeout=_dep_reconcile_timeout_s(),
+            )
+        except (subprocess.SubprocessError, OSError) as exc:
+            unresolved.append(name)
+            logger.warning("[AegisPreflight] reconcile of %s errored: %s", name, exc)
+            continue
+        # `pip` exiting 0 is necessary but NOT sufficient — re-probe the actual
+        # import path, because that is the thing the organism depends on.
+        importlib.invalidate_caches()
+        if proc.returncode == 0 and _importable(name):
+            reconciled.append(name)
+            logger.info("[AegisPreflight] reconciled %s", name)
+        else:
+            unresolved.append(name)
+            logger.warning(
+                "[AegisPreflight] reconcile of %s FAILED (rc=%s): %s",
+                name, proc.returncode, (proc.stderr or "")[-400:],
+            )
+
+    if unresolved:
+        return DependencyValidationStep(
+            status=DependencyStatus.DRIFT, checked=checked, missing=missing,
+            reconciled=tuple(reconciled), unresolved=tuple(unresolved),
+            detail=f"{len(unresolved)} package(s) still unresolved after reconcile",
+        )
+    return DependencyValidationStep(
+        status=DependencyStatus.RECONCILED, checked=checked, missing=missing,
+        reconciled=tuple(reconciled),
+    )
 
 
 @dataclass(frozen=True)
@@ -94,6 +288,9 @@ class AegisPreflightResult:
     subprocess_pid: Optional[int] = None
     detail: Optional[str] = None
     schema_version: str = PREFLIGHT_SCHEMA_VERSION
+    # Additive (schema stays aegis_preflight.1 — new optional field, no
+    # existing key changed meaning). None on paths that ran before the step.
+    dependencies: Optional[DependencyValidationStep] = field(default=None)
 
     def to_dict(self) -> dict:
         return {
@@ -106,6 +303,9 @@ class AegisPreflightResult:
             "subprocess_pid": self.subprocess_pid,
             "detail": self.detail,
             "schema_version": self.schema_version,
+            "dependencies": (
+                self.dependencies.to_dict() if self.dependencies is not None else None
+            ),
         }
 
 
@@ -263,10 +463,28 @@ async def aegis_preflight(
 
     register_aegis_flags()  # idempotent
 
+    # Dependency validation runs BEFORE the enablement gate and before the
+    # daemon spawn: it is a property of the interpreter the whole organism is
+    # about to run on, not of Aegis itself, so an operator who disabled Aegis
+    # still gets told their environment drifted. Cheap (find_spec only) unless
+    # reconciliation is explicitly armed.
+    deps = validate_dependencies()
+
     if not is_enabled():
         return AegisPreflightResult(
             outcome=PreflightOutcome.SKIPPED_DISABLED,
             detail="JARVIS_AEGIS_ENABLED is false (Slice 1 default)",
+            dependencies=deps,
+        )
+
+    if deps.status is DependencyStatus.DRIFT and _dep_strict():
+        return AegisPreflightResult(
+            outcome=PreflightOutcome.FAILED_DEPENDENCY_DRIFT,
+            detail=(
+                f"unresolved dependency drift: {', '.join(deps.unresolved)} "
+                f"(JARVIS_AEGIS_DEP_STRICT is on)"
+            ),
+            dependencies=deps,
         )
 
     # Slice 125 — ROOT INVARIANT: the funded provider keys from the operator-
@@ -307,6 +525,7 @@ async def aegis_preflight(
         return AegisPreflightResult(
             outcome=PreflightOutcome.FAILED_SPAWN,
             detail=f"subprocess spawn failed: {exc}",
+            dependencies=deps,
         )
 
     payload = await _await_bootstrap_payload(
@@ -324,6 +543,7 @@ async def aegis_preflight(
                 f"daemon did not write bootstrap payload within "
                 f"{bootstrap_timeout_s()}s"
             ),
+            dependencies=deps,
         )
 
     # Defense: reject a stale payload (a previous boot's leftover the
@@ -338,6 +558,7 @@ async def aegis_preflight(
             outcome=PreflightOutcome.FAILED_BOOTSTRAP_TIMEOUT,
             subprocess_pid=proc.pid,
             detail="bootstrap payload expired before harness read it",
+            dependencies=deps,
         )
 
     # Scrub credentials from the harness env. ``creds`` already holds
@@ -354,6 +575,7 @@ async def aegis_preflight(
             outcome=PreflightOutcome.FAILED_CREDENTIAL_SCRUB,
             subprocess_pid=proc.pid,
             detail=str(exc),
+            dependencies=deps,
         )
 
     # Expose Aegis coordinates to JARVIS via env. Slice 2's provider
@@ -367,12 +589,16 @@ async def aegis_preflight(
         bootstrap_psk=payload.bootstrap_psk,
         subprocess_pid=payload.daemon_pid,
         detail=f"daemon pid={payload.daemon_pid}",
+        dependencies=deps,
     )
 
 
 __all__ = [
     "AegisPreflightResult",
+    "DependencyStatus",
+    "DependencyValidationStep",
     "PREFLIGHT_SCHEMA_VERSION",
     "PreflightOutcome",
     "aegis_preflight",
+    "validate_dependencies",
 ]

--- a/backend/core/ouroboros/battle_test/graceful_preemption.py
+++ b/backend/core/ouroboros/battle_test/graceful_preemption.py
@@ -159,6 +159,57 @@ def _detect_repo_root() -> Optional[str]:
         return None
 
 
+#: Private ref namespace for preemption snapshots. Deliberately NOT ``refs/stash``
+#: — see the note in :func:`git_safety_stash`. Listable via
+#: ``git for-each-ref refs/jarvis/preemption``; each ref points at a
+#: ``git stash create`` commit that ``git stash apply <sha>`` restores.
+_PREEMPTION_REF_NS = "refs/jarvis/preemption"
+
+
+def list_preemption_refs(repo_root: str) -> list:
+    """``[(refname, sha), ...]`` newest-first for the private namespace. The
+    replacement for ``git stash list`` as the operator's recovery surface.
+    Fail-soft: returns ``[]`` on any error."""
+    try:
+        res = _run_git(
+            repo_root, "for-each-ref", "--sort=-refname",
+            "--format=%(refname) %(objectname)", _PREEMPTION_REF_NS,
+        )
+        if res.returncode != 0:
+            return []
+        out = []
+        for line in (res.stdout or "").splitlines():
+            parts = line.strip().split()
+            if len(parts) == 2:
+                out.append((parts[0], parts[1]))
+        return out
+    except Exception:  # noqa: BLE001
+        return []
+
+
+def _prune_preemption_refs(repo_root: str) -> int:
+    """Retain the newest ``JARVIS_PREEMPTION_SNAPSHOT_RETAIN`` (default 20)
+    snapshots; delete older refs so the namespace cannot grow without bound
+    across a long-lived daemon. Deleting the ref only unpins the commit (GC
+    reclaims it later) — it never touches the working tree. Returns the count
+    pruned. Fail-soft; NEVER raises."""
+    try:
+        keep = int(os.environ.get("JARVIS_PREEMPTION_SNAPSHOT_RETAIN", "20"))
+    except (TypeError, ValueError):
+        keep = 20
+    keep = max(1, keep)
+    pruned = 0
+    try:
+        refs = list_preemption_refs(repo_root)
+        for refname, _sha in refs[keep:]:
+            res = _run_git(repo_root, "update-ref", "-d", refname)
+            if res.returncode == 0:
+                pruned += 1
+    except Exception:  # noqa: BLE001
+        pass
+    return pruned
+
+
 def git_safety_stash(repo_root: Optional[str] = None) -> str:
     """NON-DESTRUCTIVELY snapshot in-flight working-tree changes so a partial
     APPLY is recoverable WITHOUT clearing the operator's uncommitted work off
@@ -206,15 +257,25 @@ def git_safety_stash(repo_root: Optional[str] = None) -> str:
             # Tree raced clean, or git could not snapshot — never clear the tree.
             return "snapshot_none"
         ts = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
-        # Register the snapshot as a listable, apply-able stash entry WITHOUT
-        # modifying the working tree (unlike `stash push`).
-        store = _run_git(
-            root, "stash", "store", "-m", f"[preemption-shield] in-flight {ts}", sha,
-        )
+        # ── Hazard #70033: NEVER touch the shared stash stack ──────────────
+        # `git stash store` pushes onto refs/stash — a SHARED, ORDER-SENSITIVE
+        # stack. A human or agent running `git stash pop` gets stash@{0}, so a
+        # daemon snapshot landing between their push and their pop silently
+        # hands them the DAEMON's tree. Observed 2026-07-24: an agent's pop
+        # returned a preemption snapshot and conflicted.
+        #
+        # The tree was never the problem (create+store are both non-destructive);
+        # the shared NAMESPACE was. Anchor snapshots under a private ref
+        # namespace instead: the dangling commit is preserved from GC exactly as
+        # before, recovery still works (apply_stash_ref takes a RAW SHA and never
+        # consults the stack), and refs/stash is left entirely to humans.
+        ref = f"{_PREEMPTION_REF_NS}/{ts}-{sha[:8]}"
+        store = _run_git(root, "update-ref", ref, sha)
         if store.returncode == 0:
+            _prune_preemption_refs(root)
             return f"snapshot:{sha[:8]}"
-        # store failed, but the dangling `create` commit still exists + the tree
-        # is intact — recovery is still possible by SHA; report it.
+        # update-ref failed, but the dangling `create` commit still exists + the
+        # tree is intact — recovery is still possible by SHA; report it.
         return f"snapshot_unstored:{sha[:8]}"
     except subprocess.TimeoutExpired:
         return "git_timeout"

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -627,6 +627,74 @@ async def _bipartite_attach_loop(client: Any, console: Any, ui: Any) -> None:
 
         _hdr_width = {"w": 0}
 
+        # ── Audio plane: Braille oscilloscope + protocol-adaptive PTT ──────
+        # The scope fills the empty header real estate; the pump owns it and is
+        # driven by the zero-copy tap on the EXISTING mic stream (CoreAudio
+        # refuses a second handle). Wholly fail-soft: any fault here leaves the
+        # cockpit exactly as it was without the visualizer.
+        _audio = {"pump": None, "latch": None, "mode": None, "unsub": None}
+        try:
+            from backend.core.ouroboros.ui.audio_pump import (
+                AudioLevelPump, default_publisher,
+            )
+            from backend.core.ouroboros.ui.audio_scope import (
+                AudioPlane, BrailleScope, scope_enabled,
+            )
+            from backend.core.ouroboros.ui.ptt_router import (
+                PTTLatch, resolve_ptt_mode,
+            )
+            if scope_enabled():
+                _scope = BrailleScope(width=20)
+                _pump = AudioLevelPump(
+                    scope=_scope, publish=default_publisher(),
+                )
+                # Probe the terminal ONCE at boot: hold-to-talk where the kitty
+                # keyboard protocol answers, toggle+VAD everywhere else.
+                _mode, _verdict, _tel = resolve_ptt_mode()
+                _latch = PTTLatch(
+                    mode=_mode,
+                    on_open=lambda: (
+                        _scope.set_plane(AudioPlane.USER),
+                        _pump.publish_mic_state("open"),
+                    ),
+                    on_close=lambda why: (
+                        _scope.set_plane(AudioPlane.IDLE),
+                        _pump.publish_mic_state("closed", reason=why),
+                    ),
+                )
+                # Subscribe the pump to the zero-copy tap. RMS runs HERE, on the
+                # consumer side — never in the capture thread.
+                try:
+                    from backend.voice.audio_broadcast_tap import get_default_tap
+
+                    def _on_chunk(view, sr) -> None:
+                        lvl = _pump.feed_frames(view, plane=_scope.plane)
+                        if lvl is not None:
+                            _latch.note_level(lvl)
+
+                    _audio["unsub"] = get_default_tap().subscribe(_on_chunk)
+                except Exception:  # noqa: BLE001 — no voice stack: scope stays idle
+                    pass
+                _audio.update(pump=_pump, latch=_latch, mode=_mode)
+                logger.debug(
+                    "[ov] audio scope armed mode=%s verdict=%s terminal=%s",
+                    getattr(_mode, "value", "?"),
+                    getattr(_verdict, "value", "?"), (_tel or {}).get("terminal"),
+                )
+        except Exception:  # noqa: BLE001
+            _audio = {"pump": None, "latch": None, "mode": None, "unsub": None}
+
+        def _gutter():
+            """Right-aligned scope for the header. None when unarmed, so the
+            header renders exactly as before."""
+            _p = _audio.get("pump")
+            if _p is None:
+                return None
+            try:
+                return _p.scope.render_rich()
+            except Exception:  # noqa: BLE001
+                return None
+
         def header_render() -> str:
             try:
                 import shutil as _shutil
@@ -634,19 +702,51 @@ async def _bipartite_attach_loop(client: Any, console: Any, ui: Any) -> None:
                 _hdr_width["w"] = w
                 return render_cockpit_header(
                     mini, _header_lines(), w, now=_time.monotonic(),
+                    right_gutter=_gutter,
                 )
             except Exception:
                 return ""
     except Exception:
         mini, header_render, header_height = None, None, 0
 
+    # Spacebar PTT: merged through the layout's EXISTING extra_key_bindings
+    # seam, so no layout surgery. Inert unless the input buffer is empty.
+    _ptt_kb = None
+    try:
+        _latch = _audio.get("latch") if isinstance(_audio, dict) else None
+        if _latch is not None:
+            from backend.core.ouroboros.ui.ptt_router import build_ptt_key_bindings
+            _ptt_kb = build_ptt_key_bindings(_latch)
+    except Exception:  # noqa: BLE001 — no PTT is survivable; a broken app is not
+        _ptt_kb = None
+
+    def _toolbar_with_mode() -> str:
+        """Existing toolbar plus the ACTIVE PTT paradigm. Stating the real mode
+        matters: a cockpit claiming 'hold' on a terminal blind to key-release
+        would leave the mic latched with no obvious way out."""
+        base = ""
+        try:
+            base = str(ui.toolbar()) if ui is not None else ""
+        except Exception:  # noqa: BLE001
+            base = ""
+        try:
+            _m = _audio.get("mode") if isinstance(_audio, dict) else None
+            _l = _audio.get("latch") if isinstance(_audio, dict) else None
+            if _m is not None:
+                live = " ● mic" if (_l is not None and _l.is_open) else ""
+                return f"{base} · {_m.hint}{live}" if base else f"{_m.hint}{live}"
+        except Exception:  # noqa: BLE001
+            pass
+        return base
+
     await run_bipartite_repl(
         on_accept=_on_accept,
         title="◇ O+V · proactive canvas",
-        toolbar=(lambda: ui.toolbar()) if ui is not None else None,
+        toolbar=_toolbar_with_mode if ui is not None else None,
         watch_alive=_alive,
         header=header_render,
         header_height=header_height,
+        extra_key_bindings=_ptt_kb,
         seed=[
             "[bold]💭 Karen ▸[/bold] attached — I'm listening. verbs or plain "
             "words both work · [cyan]wake[/cyan] arms my voice · "

--- a/backend/core/ouroboros/governance/autonomous_supervisor.py
+++ b/backend/core/ouroboros/governance/autonomous_supervisor.py
@@ -211,10 +211,14 @@ class AutonomousSupervisor:
         soak on the recovery edge the Sentinel produces."""
         from backend.core.ouroboros.governance.awe_trigger import (
             AWETrigger,
-            build_soak_subprocess_launch_fn,
+            build_manifest_aware_launch_fn,
         )
+        # Substrate-aware dispatch: the supervisor armed BECAUSE an intent is
+        # pending, so the recovery edge must run THAT intent's manifest — not a
+        # generic soak that leaves it pending forever. Same db_factory, so the
+        # dispatcher reads the very queue the arm gate counted.
         return AWETrigger(
-            launch_fn=build_soak_subprocess_launch_fn(),
+            launch_fn=build_manifest_aware_launch_fn(db_factory=self._db_factory),
             db_factory=self._db_factory,
             provider=self._provider,
         )

--- a/backend/core/ouroboros/governance/awe_trigger.py
+++ b/backend/core/ouroboros/governance/awe_trigger.py
@@ -496,9 +496,16 @@ def build_manifest_aware_launch_fn(
                     )
                     post_molt_nowait(
                         "@first-responder", "distress",
+                        # `detail` is the key the persona voice templates
+                        # interpolate ({detail}); compose() defaults it to ""
+                        # so any other key renders as an EMPTY post. The
+                        # extra keys ride along for structured consumers.
                         facts={
-                            "what": "AWE refused the soak launch",
-                            "why": "working tree is dirty",
+                            "detail": (
+                                f"refused the soak launch — working tree dirty "
+                                f"({len(dirty)} path(s): {shown}). commit or "
+                                f"stash and the next recovery edge runs"
+                            ),
                             "dirty_count": len(dirty),
                             "sample": shown,
                             "run_id": run_id,

--- a/backend/core/ouroboros/governance/awe_trigger.py
+++ b/backend/core/ouroboros/governance/awe_trigger.py
@@ -351,6 +351,129 @@ def build_soak_subprocess_launch_fn(
     return _launch
 
 
+def _default_client_factory() -> Any:
+    """Lazily construct the DW-primary client the checkpointed swarm drives.
+
+    Same lazy-handle pattern ``moltbook_garnish`` uses for its DW call (DRY —
+    one construction idiom for "I need a provider handle right now"). Returns
+    ``None`` on any failure, which the dispatcher treats as "cannot run the
+    manifest in-process" and routes to the subprocess fallback rather than
+    fabricating a client."""
+    try:
+        from backend.core.ouroboros.governance.doubleword_provider import (
+            DoublewordProvider,
+        )
+        return DoublewordProvider()
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def build_manifest_aware_launch_fn(
+    *,
+    db_factory: Optional[DbFactory] = None,
+    client_factory: Optional[Callable[[], Any]] = None,
+    fallback_fn: Optional[LaunchFn] = None,
+    breadcrumb_fn: Optional[BreadcrumbFn] = None,
+    max_priority: Optional[int] = None,
+) -> LaunchFn:
+    """The substrate-aware dispatcher: inspect state, THEN choose the strategy.
+
+    Closes the orphan-``run_pending_soak`` gap. Before this, AWE's only launch
+    strategy was a hardcoded ``scripts/ouroboros_battle_test.py`` spawn, so a
+    queued checkpoint manifest (e.g. the canary's 7 chunks) survived the
+    recovery edge untouched — the intent stayed ``pending`` forever while a
+    generic, un-manifested soak ran in its place.
+
+    On each recovery edge:
+
+      * **pending intent WITH a manifest** → :func:`run_pending_soak`, resuming
+        that intent's chunks against the real swarm. Crash-resumable: every
+        chunk commits atomically, so a second edge picks up where this left off.
+      * **empty queue, no manifest, or no resolvable client** → the existing
+        subprocess soak, unchanged.
+
+    ``repo_root`` for the manifest path is the intent's ``target``, not the
+    repository root — see :class:`PendingIntent`. Both strategies breadcrumb
+    which way they went, so the choice is visible in ``/breadcrumbs`` rather
+    than inferred. Never raises: any failure degrades to the fallback."""
+    _db = db_factory or _default_db_factory
+    _client = client_factory or _default_client_factory
+    _fallback = fallback_fn or build_soak_subprocess_launch_fn()
+    _crumb = breadcrumb_fn or _default_breadcrumb_fn
+
+    def _emit(strategy: str, detail: dict) -> None:
+        try:
+            _crumb("awe_launch_strategy", {"strategy": strategy, **detail})
+        except Exception:  # noqa: BLE001
+            pass
+
+    async def _launch(run_id: str) -> Any:
+        from backend.core.ouroboros.governance.soak_intent import next_pending_intent
+
+        conn = None
+        try:
+            conn = _db()
+        except Exception:  # noqa: BLE001
+            conn = None
+
+        intent = None
+        try:
+            intent = next_pending_intent(conn, max_priority=max_priority)
+        except Exception:  # noqa: BLE001
+            intent = None
+
+        if intent is None or not intent.has_manifest:
+            _emit("subprocess_fallback", {
+                "run_id": run_id,
+                "reason": "no pending intent" if intent is None else "intent carries no manifest",
+                "intent_id": getattr(intent, "intent_id", ""),
+            })
+            logger.info(
+                "[AWE] dispatch → generic soak (run_id=%s, %s)",
+                run_id, "queue empty" if intent is None else "no manifest",
+            )
+            return await _fallback(run_id)
+
+        client = None
+        try:
+            client = _client()
+        except Exception:  # noqa: BLE001
+            client = None
+        if client is None:
+            # Honest degradation: we know there IS a manifest but cannot drive
+            # it in-process. Run the generic soak rather than silently dropping
+            # the recovery edge — and say so.
+            _emit("subprocess_fallback", {
+                "run_id": run_id, "intent_id": intent.intent_id,
+                "reason": "no resolvable client for in-process manifest run",
+            })
+            logger.warning(
+                "[AWE] manifest intent %s pending but no client resolvable — "
+                "falling back to generic soak; intent stays pending",
+                intent.intent_id,
+            )
+            return await _fallback(run_id)
+
+        from backend.core.ouroboros.governance.checkpoint_manifest import (
+            run_pending_soak,
+        )
+        _emit("manifest", {
+            "run_id": run_id, "intent_id": intent.intent_id,
+            "kind": intent.kind, "target": intent.target,
+        })
+        logger.info(
+            "[AWE] dispatch → checkpointed manifest soak intent=%s kind=%s target=%s",
+            intent.intent_id, intent.kind, intent.target,
+        )
+        return await run_pending_soak(
+            conn, intent.intent_id, client=client,
+            # The manifest's chunk file_paths are relative to `target`.
+            repo_root=intent.target or ".",
+        )
+
+    return _launch
+
+
 def start_awe_trigger(
     *,
     launch_fn: Optional[LaunchFn] = None,
@@ -360,12 +483,16 @@ def start_awe_trigger(
     """Construct + start the AWE trigger IFF ``JARVIS_AWE_TRIGGER_ENABLED``.
     Returns the live :class:`AWETrigger` (whose ``.stop()`` the caller tears down)
     or ``None`` when disabled / on any error. Defaults ``launch_fn`` to the
-    self-contained subprocess soak. Never raises."""
+    substrate-aware dispatcher, which resumes a queued checkpoint manifest when
+    one exists and otherwise runs the self-contained subprocess soak. Never
+    raises."""
     if not awe_enabled():
         return None
     try:
         trigger = AWETrigger(
-            launch_fn=launch_fn or build_soak_subprocess_launch_fn(),
+            launch_fn=launch_fn or build_manifest_aware_launch_fn(
+                db_factory=kwargs.get("db_factory"),
+            ),
             provider=provider,
             **kwargs,
         )
@@ -380,6 +507,7 @@ def start_awe_trigger(
 __all__ = [
     "AWETrigger",
     "awe_enabled",
+    "build_manifest_aware_launch_fn",
     "build_soak_subprocess_launch_fn",
     "build_swarm_coroutine_launch_fn",
     "start_awe_trigger",

--- a/backend/core/ouroboros/governance/awe_trigger.py
+++ b/backend/core/ouroboros/governance/awe_trigger.py
@@ -42,6 +42,9 @@ import os
 import uuid
 from typing import Any, Awaitable, Callable, Optional
 
+from backend.core.ouroboros.governance.post_soak_verification import (
+    _default_git_porcelain,
+)
 from backend.core.ouroboros.governance.soak_execution_lock import (
     DEFAULT_LOCK_NAME,
     release_soak_lock,
@@ -368,6 +371,59 @@ def _default_client_factory() -> Any:
         return None
 
 
+class DirtyTreeRefusal(RuntimeError):
+    """AWE refused to launch because the working tree carried uncommitted work.
+
+    Raised (not returned) on purpose: :meth:`AWETrigger._run_soak` already
+    treats an exception as "soak did not happen" and RELEASES the execution
+    lock, so a later recovery edge against a clean tree can still run. A
+    silent return would hold the lock for the whole cooldown and swallow the
+    recovery window."""
+
+
+def _clean_tree_required() -> bool:
+    """Whether AWE refuses to launch onto a dirty working tree. Default ON.
+
+    An autonomous soak mutates real files and (with auto-commit armed) commits
+    them. Starting that on top of uncommitted human work is how a machine
+    commit swallows an operator's in-flight edit — the #70033 shape. Cheap
+    insurance: one read-only ``git status --porcelain``."""
+    return os.environ.get(
+        "JARVIS_AWE_REQUIRE_CLEAN_TREE", "true",
+    ).strip().lower() in ("1", "true", "yes", "on")
+
+
+def _clean_tree_allowlist() -> tuple:
+    """Path prefixes permitted to be dirty, from ``JARVIS_AWE_CLEAN_TREE_ALLOW``
+    (comma-separated). Empty by default — strict. Exists so an operator can
+    permit e.g. the soak's own output directory on a resume without disarming
+    the invariant wholesale."""
+    raw = (os.environ.get("JARVIS_AWE_CLEAN_TREE_ALLOW", "") or "").strip()
+    return tuple(p.strip() for p in raw.split(",") if p.strip())
+
+
+def _dirty_paths(git_status_fn: Callable[[], Any]) -> tuple:
+    """Porcelain lines → the offending paths, minus the allowlist. Fail-CLOSED
+    is wrong here and fail-open is wrong too, so: a git read that errors returns
+    [] from the shared helper (its documented behaviour), which we treat as
+    clean — the invariant is a guard against KNOWN dirt, not a proof of
+    cleanliness, and refusing every launch because git is unreadable would wedge
+    the recovery path entirely."""
+    allow = _clean_tree_allowlist()
+    out = []
+    try:
+        for line in git_status_fn() or []:
+            path = str(line)[3:].strip().strip('"')
+            if not path:
+                continue
+            if any(path.startswith(p) for p in allow):
+                continue
+            out.append(path)
+    except Exception:  # noqa: BLE001
+        return ()
+    return tuple(out)
+
+
 def build_manifest_aware_launch_fn(
     *,
     db_factory: Optional[DbFactory] = None,
@@ -375,6 +431,7 @@ def build_manifest_aware_launch_fn(
     fallback_fn: Optional[LaunchFn] = None,
     breadcrumb_fn: Optional[BreadcrumbFn] = None,
     max_priority: Optional[int] = None,
+    git_status_fn: Optional[Callable[[], Any]] = None,
 ) -> LaunchFn:
     """The substrate-aware dispatcher: inspect state, THEN choose the strategy.
 
@@ -395,7 +452,12 @@ def build_manifest_aware_launch_fn(
     ``repo_root`` for the manifest path is the intent's ``target``, not the
     repository root — see :class:`PendingIntent`. Both strategies breadcrumb
     which way they went, so the choice is visible in ``/breadcrumbs`` rather
-    than inferred. Never raises: any failure degrades to the fallback."""
+    than inferred.
+
+    Failure policy: every *dispatch* failure degrades to the fallback rather
+    than raising — EXCEPT the clean-tree invariant, which raises
+    :class:`DirtyTreeRefusal` by design so the trigger releases its execution
+    lock and a later edge against a clean tree can still run."""
     _db = db_factory or _default_db_factory
     _client = client_factory or _default_client_factory
     _fallback = fallback_fn or build_soak_subprocess_launch_fn()
@@ -409,6 +471,44 @@ def build_manifest_aware_launch_fn(
 
     async def _launch(run_id: str) -> Any:
         from backend.core.ouroboros.governance.soak_intent import next_pending_intent
+
+        # ── Clean-tree invariant ──────────────────────────────────────────
+        # Gate the WHOLE dispatch, not just the manifest branch: the generic
+        # soak mutates the repo too, so "don't run an autonomous mutator on
+        # top of uncommitted human work" applies identically to both.
+        if _clean_tree_required():
+            _git = git_status_fn or _default_git_porcelain
+            dirty = _dirty_paths(_git)
+            if dirty:
+                shown = ", ".join(dirty[:5]) + (" …" if len(dirty) > 5 else "")
+                _emit("refused_dirty_tree", {
+                    "run_id": run_id, "dirty_count": len(dirty),
+                    "dirty_sample": list(dirty[:5]),
+                })
+                logger.warning(
+                    "[AWE] REFUSING launch run_id=%s — working tree dirty "
+                    "(%d path(s): %s). Commit or stash, then the next recovery "
+                    "edge will run.", run_id, len(dirty), shown,
+                )
+                try:
+                    from backend.core.ouroboros.governance.moltbook import (
+                        post_molt_nowait,
+                    )
+                    post_molt_nowait(
+                        "@first-responder", "distress",
+                        facts={
+                            "what": "AWE refused the soak launch",
+                            "why": "working tree is dirty",
+                            "dirty_count": len(dirty),
+                            "sample": shown,
+                            "run_id": run_id,
+                        },
+                    )
+                except Exception:  # noqa: BLE001 — the agora is never load-bearing
+                    pass
+                raise DirtyTreeRefusal(
+                    f"working tree dirty ({len(dirty)} path(s)): {shown}"
+                )
 
         conn = None
         try:
@@ -507,6 +607,7 @@ def start_awe_trigger(
 __all__ = [
     "AWETrigger",
     "awe_enabled",
+    "DirtyTreeRefusal",
     "build_manifest_aware_launch_fn",
     "build_soak_subprocess_launch_fn",
     "build_swarm_coroutine_launch_fn",

--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -210,6 +210,111 @@ def _dw_prompt_cache_min_chars() -> int:
         return _DW_PROMPT_CACHE_MIN_CHARS_DEFAULT
 
 
+def _dw_cache_read_multiplier() -> float:
+    """Billing multiplier for a cache READ vs fresh input. Env-tunable — no
+    hardcoded provider economics. Default 0.1 (the standard ephemeral-cache
+    read rate)."""
+    try:
+        return max(0.0, float(os.environ.get("JARVIS_DW_CACHE_READ_MULT", "0.1")))
+    except (TypeError, ValueError):
+        return 0.1
+
+
+def _dw_cache_write_multiplier() -> float:
+    """Billing multiplier for a cache WRITE vs fresh input. A write costs MORE
+    than plain input (it provisions the entry); the savings only materialize on
+    subsequent reads. Default 1.25."""
+    try:
+        return max(0.0, float(os.environ.get("JARVIS_DW_CACHE_WRITE_MULT", "1.25")))
+    except (TypeError, ValueError):
+        return 1.25
+
+
+def extract_cache_usage(usage: Any) -> Optional[dict]:
+    """Pull cache accounting out of a DW usage payload.
+
+    Returns ``None`` when the payload carries NO cache fields at all — the
+    graceful-degradation path for a provider/response that predates or omits
+    caching, so the caller falls back to plain token counting rather than
+    reporting fabricated zeros as if they were measured.
+
+    Returns a dict when at least one cache field is present, even if zero: a
+    genuine measured zero (cache armed, first call, nothing warm yet) is
+    meaningful and must be distinguishable from "not reported".
+
+    Pure + total: never raises, never does I/O."""
+    try:
+        if not isinstance(usage, dict):
+            return None
+        has_read = "cache_read_input_tokens" in usage
+        has_write = "cache_creation_input_tokens" in usage
+        if not (has_read or has_write):
+            return None
+
+        def _i(key: str) -> int:
+            try:
+                return max(0, int(usage.get(key, 0) or 0))
+            except (TypeError, ValueError):
+                return 0
+
+        read = _i("cache_read_input_tokens")
+        write = _i("cache_creation_input_tokens")
+        prompt = _i("prompt_tokens")
+        # Fresh input is whatever was neither read from nor written to cache.
+        # Clamp at 0: providers occasionally report prompt_tokens exclusive of
+        # cached reads, which would otherwise yield a negative.
+        fresh = max(0, prompt - read - write)
+
+        read_mult = _dw_cache_read_multiplier()
+        write_mult = _dw_cache_write_multiplier()
+        # Billed-equivalent input units vs. what the same prefix would have cost
+        # with no cache at all (every token at full rate).
+        billed_units = fresh + (read * read_mult) + (write * write_mult)
+        uncached_units = float(fresh + read + write)
+        saved_units = uncached_units - billed_units
+
+        return {
+            "cache_read_tokens": read,
+            "cache_write_tokens": write,
+            "fresh_input_tokens": fresh,
+            "prompt_tokens": prompt,
+            "billed_input_units": round(billed_units, 2),
+            "uncached_input_units": round(uncached_units, 2),
+            "saved_input_units": round(saved_units, 2),
+            "hit_ratio": round(read / prompt, 4) if prompt > 0 else 0.0,
+        }
+    except Exception:  # noqa: BLE001 — telemetry NEVER breaks generation
+        return None
+
+
+def emit_cache_telemetry(
+    usage: Any, *, op_id: str = "", model: str = "",
+) -> Optional[dict]:
+    """Structured, non-blocking cache-amortization telemetry.
+
+    Proves the prompt-cache graduation empirically instead of by assertion: a
+    ``cache_read_tokens`` that climbs across a soak while ``saved_input_units``
+    accumulates IS the amortization. Emits nothing (and returns None) when the
+    provider omits cache fields, so a silent absence never masquerades as a
+    measured zero. Logging only — no I/O, never raises."""
+    stats = extract_cache_usage(usage)
+    if stats is None:
+        return None
+    try:
+        logger.info(
+            "[DW_CACHE_TELEMETRY] op=%s model=%s read=%d write=%d fresh=%d "
+            "billed_units=%.2f uncached_units=%.2f saved_units=%.2f hit_ratio=%.4f",
+            op_id or "-", model or "-",
+            stats["cache_read_tokens"], stats["cache_write_tokens"],
+            stats["fresh_input_tokens"], stats["billed_input_units"],
+            stats["uncached_input_units"], stats["saved_input_units"],
+            stats["hit_ratio"],
+        )
+    except Exception:  # noqa: BLE001
+        pass
+    return stats
+
+
 def _dw_shape_cached_system(
     system_text: Any, *, enabled: bool, min_chars: int, ttl: str
 ) -> Any:
@@ -5586,6 +5691,15 @@ class DoublewordProvider:
                             content = choices[0].get("message", {}).get("content", "")
                             input_tokens = usage.get("prompt_tokens", 0)
                             output_tokens = usage.get("completion_tokens", 0)
+                            # Cache amortization telemetry — fail-soft, no I/O.
+                            # Both operands resolved defensively: this sits on
+                            # the hot generation path, so a telemetry NameError
+                            # would kill real ops.
+                            emit_cache_telemetry(
+                                usage,
+                                op_id=str(getattr(context, "op_id", "") or ""),
+                                model=str(getattr(self, "_model", "") or ""),
+                            )
 
                 except _DWToolForcingRejectedError:
                     if _attempt == 0:

--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -163,10 +163,26 @@ _DW_ZDR_HEADER_VALUE = "true"
 
 
 def _dw_prompt_cache_enabled() -> bool:
-    """Master switch for DW prompt caching. Default FALSE (safe opt-in). When
-    off, the request is byte-identical legacy (no cache_control markers)."""
+    """Master switch for DW prompt caching. GRADUATED to default TRUE
+    (2026-07-24). Rollback: ``JARVIS_DW_PROMPT_CACHE_ENABLED=false`` restores the
+    byte-identical un-cached request.
+
+    Why: every op re-sends a large, near-identical prefix — measured on session
+    bt-2026-07-24-212505 as dev-memory 10,459 chars + strategic/goal 4,019 +
+    user-preferences 1,611 + goal-inference 992, i.e. ~17KB of static context
+    re-billed at full input price against ops of ~2,259 input tokens. With the
+    1h TTL, one cache write amortizes across every op in the window.
+
+    Staleness is NOT a risk here, and needs no invalidation machinery: prompt
+    caching is CONTENT-ADDRESSED. The cache key IS the exact prefix, and
+    ``_dw_shape_cached_system`` adds only ``cache_control`` metadata — the text
+    stays byte-identical. If dev-memory or user preferences change mid-soak the
+    prefix bytes change, so the key changes, so it MISSES and re-writes. It is
+    structurally impossible to be served a cached prefix that differs from the
+    prefix you sent. The TTL bounds how long an IDENTICAL prefix stays warm, not
+    how long stale content survives."""
     return os.environ.get(
-        "JARVIS_DW_PROMPT_CACHE_ENABLED", "false"
+        "JARVIS_DW_PROMPT_CACHE_ENABLED", "true"
     ).strip().lower() in ("1", "true", "yes", "on")
 
 

--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -5602,6 +5602,16 @@ class DoublewordProvider:
                                     if _usage:
                                         input_tokens = _usage.get("prompt_tokens", 0)
                                         output_tokens = _usage.get("completion_tokens", 0)
+                                        # STREAMING is the hot path in practice
+                                        # (the RT default). Instrumenting only
+                                        # the non-streaming branch left this
+                                        # telemetry wired-but-inert: 2 live
+                                        # generations produced 0 lines.
+                                        emit_cache_telemetry(
+                                            _usage,
+                                            op_id=str(getattr(context, "op_id", "") or ""),
+                                            model=str(getattr(self, "_model", "") or ""),
+                                        )
                                 except json.JSONDecodeError:
                                     continue
                             # CD-2 — clear stream-active latch now that the SSE loop

--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -5900,6 +5900,24 @@ class DoublewordProvider:
             _token_usage["input"], _token_usage["output"],
         )
 
+        # A successful generation is PROOF the Aegis->DW auth + billing path is
+        # currently valid. Publish it so a DWHeartbeat that froze itself on a
+        # stale/transient auth verdict can auto-defrost instead of requiring a
+        # daemon restart (which would strand AWE edge detection for the whole
+        # session). Best-effort telemetry — NEVER affects generation.
+        try:
+            from backend.core.ouroboros.governance.ide_observability_stream import (
+                EVENT_TYPE_PROVIDER_GENERATION_SUCCEEDED,
+                publish_task_event,
+            )
+            publish_task_event(
+                EVENT_TYPE_PROVIDER_GENERATION_SUCCEEDED, "doubleword",
+                {"provider": "doubleword", "candidates": len(result.candidates),
+                 "elapsed_s": round(float(elapsed), 2)},
+            )
+        except Exception:  # noqa: BLE001
+            pass
+
         # Slice 84 — attach the Venom tool-loop execution records so the Iron
         # Gate exploration gate can count this op's read_file/search_code calls
         # (mirrors ClaudeProvider, providers.py ~5048). Without this the records

--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -332,8 +332,43 @@ def _dw_shape_cached_system(
             return system_text
         if not isinstance(system_text, str) or not system_text:
             return system_text
-        if len(system_text) < max(0, int(min_chars)):
+
+        # ── ACEE: frequency-driven, length-independent ────────────────────
+        # The legacy `min_chars` floor priced the wrong variable. Prefix length
+        # cancels out of the profitability inequality (every term scales
+        # linearly with it), so what matters is REUSE COUNT. The floor blocked
+        # a small high-frequency probe (profitable) while admitting a huge
+        # one-off (a guaranteed write-premium loss).
+        #
+        # This is the ONE chokepoint every DW request funnels through — both
+        # the streaming and non-streaming handlers consume its output — so the
+        # decision is intercepted here without touching either handler.
+        from backend.core.ouroboros.governance.dw_cache_economics import (
+            acee_enabled, should_cache_write,
+        )
+        if acee_enabled():
+            ok, _why = should_cache_write(
+                system_text,
+                write_mult=_dw_cache_write_multiplier(),
+                read_mult=_dw_cache_read_multiplier(),
+            )
+            if not ok:
+                logger.debug(
+                    "[ACEE] bypass uses=%s need=%s chars=%s sig=%s",
+                    _why.get("uses_in_window"), _why.get("break_even_uses"),
+                    _why.get("chars"), _why.get("signature"),
+                )
+                return system_text
+            logger.debug(
+                "[ACEE] cache uses=%s need=%s chars=%s sig=%s",
+                _why.get("uses_in_window"), _why.get("break_even_uses"),
+                _why.get("chars"), _why.get("signature"),
+            )
+        elif len(system_text) < max(0, int(min_chars)):
+            # Legacy path, retained byte-identical for rollback via
+            # JARVIS_DW_ACEE_ENABLED=false.
             return system_text
+
         return [
             {
                 "type": "text",

--- a/backend/core/ouroboros/governance/dw_cache_economics.py
+++ b/backend/core/ouroboros/governance/dw_cache_economics.py
@@ -1,0 +1,261 @@
+"""Adaptive Cache Economics Engine (ACEE) — frequency-driven cache-write policy.
+
+Replaces the static ``JARVIS_DW_PROMPT_CACHE_MIN_CHARS`` floor, which measured
+the wrong variable.
+
+The economics
+-------------
+A prefix used ``N`` times costs, in input-units:
+
+    cached   = write_mult + (N - 1) * read_mult
+    uncached = N
+
+Caching is profitable iff ``cached < uncached``. Solving:
+
+    write_mult - read_mult < N * (1 - read_mult)
+    N > (write_mult - read_mult) / (1 - read_mult)
+
+**Every term scales linearly with prefix length, so length CANCELS OUT.**
+Profitability depends *only* on reuse count. With the defaults (write 1.25x,
+read 0.1x) the break-even is N > 1.278, i.e. **any prefix reused even once**
+pays for its write premium.
+
+That is why the character floor was the wrong instrument: it blocked a
+1,500-char Sentinel probe firing 40x/hour (hugely profitable) while waving
+through a 15,000-char one-off (a guaranteed 0.25x loss). This engine decides on
+observed reuse instead, and derives its own threshold from the live multipliers
+— no hardcoded count anywhere.
+
+First-sighting policy
+---------------------
+A prefix's first appearance carries no evidence of reuse, so it is NOT cached:
+paying the write premium on a payload that never returns is the one way to lose
+money here. From the second sighting within the TTL window the prefix has
+demonstrated repetition and is cached. This is deliberately asymmetric — the
+downside of a missed cache is a small opportunity cost, the downside of a wasted
+write is a real charge.
+
+Bounded by construction: the sliding window evicts on every observation, and a
+hard entry cap protects against unbounded growth under signature churn.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import threading
+import time
+from collections import deque
+from typing import Deque, Dict, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+_SIG_LEN = 16
+
+
+def acee_enabled() -> bool:
+    """Master gate. Default TRUE — the static floor it replaces was actively
+    mispricing. Rollback: ``JARVIS_DW_ACEE_ENABLED=false`` restores the legacy
+    ``min_chars`` behaviour at the call site."""
+    return os.environ.get(
+        "JARVIS_DW_ACEE_ENABLED", "true",
+    ).strip().lower() in ("1", "true", "yes", "on")
+
+
+def _window_ttl_s() -> float:
+    """Sliding-window span. Defaults to 3600s to MIRROR the provider cache TTL —
+    counting reuse over a window longer than the cache itself would predict hits
+    that have already expired."""
+    try:
+        return max(1.0, float(os.environ.get("JARVIS_DW_ACEE_WINDOW_S", "3600")))
+    except (TypeError, ValueError):
+        return 3600.0
+
+
+def _max_entries() -> int:
+    """Hard cap on tracked observations — the memory-leak backstop."""
+    try:
+        return max(16, int(os.environ.get("JARVIS_DW_ACEE_MAX_ENTRIES", "4096")))
+    except (TypeError, ValueError):
+        return 4096
+
+
+def prompt_signature(prefix: str) -> str:
+    """Stable content signature. Truncated SHA-256: collision risk is negligible
+    at these volumes and the short form keeps the window compact."""
+    try:
+        return hashlib.sha256(prefix.encode("utf-8", "replace")).hexdigest()[:_SIG_LEN]
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def break_even_uses(write_mult: float, read_mult: float) -> int:
+    """Minimum total uses for a cache write to pay for itself, DERIVED from the
+    live multipliers. Never hardcoded.
+
+    Degenerate guards: a read multiplier at or above 1.0 means reads cost as
+    much as fresh input, so caching can never profit -> effectively infinite.
+    A write multiplier at or below the read multiplier means writing is free
+    relative to reading -> profitable immediately."""
+    try:
+        if read_mult >= 1.0:
+            return 1 << 30          # caching can never pay off
+        if write_mult <= read_mult:
+            return 1
+        threshold = (write_mult - read_mult) / (1.0 - read_mult)
+        return int(threshold) + 1   # strict inequality -> next whole use
+    except Exception:  # noqa: BLE001
+        return 2
+
+
+class PromptSignatureTracker:
+    """Thread-safe TTL sliding window over prompt-signature observations.
+
+    Evicts on every observation, so memory is bounded by the window span rather
+    than by process lifetime. Synchronous and O(evicted) — it sits on the
+    generation path and must never block an event loop."""
+
+    def __init__(
+        self, *, ttl_s: Optional[float] = None, max_entries: Optional[int] = None,
+    ) -> None:
+        self._ttl = ttl_s if ttl_s is not None else _window_ttl_s()
+        self._cap = max_entries if max_entries is not None else _max_entries()
+        self._events: Deque[Tuple[str, float]] = deque()
+        self._counts: Dict[str, int] = {}
+        self._lock = threading.Lock()
+
+    def _drop_oldest_locked(self) -> None:
+        sig, _ts = self._events.popleft()
+        n = self._counts.get(sig, 0) - 1
+        if n > 0:
+            self._counts[sig] = n
+        else:
+            self._counts.pop(sig, None)
+
+    def _evict_locked(self, now: float) -> int:
+        """TTL eviction only. The hard cap is enforced in :meth:`observe` AFTER
+        the append — enforcing it here would leave room for exactly one
+        over-cap entry, since the append follows."""
+        cutoff = now - self._ttl
+        dropped = 0
+        while self._events and self._events[0][1] < cutoff:
+            self._drop_oldest_locked()
+            dropped += 1
+        return dropped
+
+    def _enforce_cap_locked(self) -> int:
+        """Hard backstop: under pathological churn (every payload unique) the
+        TTL alone cannot bound growth, so shed oldest-first regardless of age."""
+        dropped = 0
+        while len(self._events) > self._cap:
+            self._drop_oldest_locked()
+            dropped += 1
+        return dropped
+
+    def observe(self, signature: str, *, now: Optional[float] = None) -> int:
+        """Record one sighting; return how many times this signature has been
+        seen within the window INCLUDING this one."""
+        if not signature:
+            return 0
+        ts = time.time() if now is None else float(now)
+        with self._lock:
+            self._evict_locked(ts)
+            self._events.append((signature, ts))
+            self._counts[signature] = self._counts.get(signature, 0) + 1
+            # Cap AFTER the append, or the window ends up at cap+1.
+            self._enforce_cap_locked()
+            return self._counts.get(signature, 0)
+
+    def frequency(self, signature: str, *, now: Optional[float] = None) -> int:
+        """Sightings within the window WITHOUT recording a new one."""
+        if not signature:
+            return 0
+        ts = time.time() if now is None else float(now)
+        with self._lock:
+            self._evict_locked(ts)
+            return self._counts.get(signature, 0)
+
+    def size(self) -> int:
+        with self._lock:
+            return len(self._events)
+
+    def distinct(self) -> int:
+        with self._lock:
+            return len(self._counts)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._events.clear()
+            self._counts.clear()
+
+
+_DEFAULT_TRACKER: Optional[PromptSignatureTracker] = None
+_TRACKER_LOCK = threading.Lock()
+
+
+def get_default_tracker() -> PromptSignatureTracker:
+    """Process-wide tracker. Lazily built so import stays side-effect free."""
+    global _DEFAULT_TRACKER
+    with _TRACKER_LOCK:
+        if _DEFAULT_TRACKER is None:
+            _DEFAULT_TRACKER = PromptSignatureTracker()
+        return _DEFAULT_TRACKER
+
+
+def reset_default_tracker() -> None:
+    """Test seam — drop the singleton so suites cannot bleed into each other."""
+    global _DEFAULT_TRACKER
+    with _TRACKER_LOCK:
+        _DEFAULT_TRACKER = None
+
+
+def should_cache_write(
+    prefix: str,
+    *,
+    write_mult: float,
+    read_mult: float,
+    tracker: Optional[PromptSignatureTracker] = None,
+    now: Optional[float] = None,
+    observe: bool = True,
+) -> Tuple[bool, dict]:
+    """Decide whether this prefix earns a cache write.
+
+    Returns ``(decision, telemetry)``. Length is deliberately absent from the
+    decision — it cancels out of the profitability inequality. NEVER raises: any
+    fault returns ``False`` (behave as if uncached), because the failure mode of
+    a bad decision is a real charge."""
+    try:
+        if not prefix or not isinstance(prefix, str):
+            return (False, {"reason": "empty_prefix"})
+        trk = tracker if tracker is not None else get_default_tracker()
+        sig = prompt_signature(prefix)
+        if not sig:
+            return (False, {"reason": "signature_failed"})
+        uses = (
+            trk.observe(sig, now=now) if observe
+            else trk.frequency(sig, now=now)
+        )
+        need = break_even_uses(write_mult, read_mult)
+        decision = uses >= need
+        return (decision, {
+            "signature": sig,
+            "uses_in_window": uses,
+            "break_even_uses": need,
+            "decision": "cache" if decision else "bypass",
+            "reason": "reuse_observed" if decision else "insufficient_reuse",
+            "chars": len(prefix),
+        })
+    except Exception:  # noqa: BLE001 — economics never break generation
+        return (False, {"reason": "error"})
+
+
+__all__ = [
+    "PromptSignatureTracker",
+    "acee_enabled",
+    "break_even_uses",
+    "get_default_tracker",
+    "prompt_signature",
+    "reset_default_tracker",
+    "should_cache_write",
+]

--- a/backend/core/ouroboros/governance/ide_observability_stream.py
+++ b/backend/core/ouroboros/governance/ide_observability_stream.py
@@ -115,6 +115,11 @@ EVENT_TYPE_HEARTBEAT = "heartbeat"
 # Aegis->DW auth+billing path is currently valid, which is what lets a frozen
 # DWHeartbeat auto-defrost instead of needing a daemon restart.
 EVENT_TYPE_PROVIDER_GENERATION_SUCCEEDED = "provider_generation_succeeded"
+# Audio plane: normalized RMS level + which plane is speaking. Drives the
+# cockpit Braille oscilloscope. High-frequency by nature, so producers
+# coalesce before publishing (see ui/audio_scope).
+EVENT_TYPE_AUDIO_LEVEL_CHANGED = "audio_level_changed"
+EVENT_TYPE_MIC_STATE_CHANGED = "mic_state_changed"
 EVENT_TYPE_STREAM_LAG = "stream_lag"
 EVENT_TYPE_REPLAY_START = "replay_start"
 EVENT_TYPE_REPLAY_END = "replay_end"
@@ -1487,6 +1492,8 @@ but NEVER the offending content. Authority-free anti-jailbreak telemetry."""
 
 _VALID_EVENT_TYPES = frozenset({
     "provider_generation_succeeded",
+    "audio_level_changed",
+    "mic_state_changed",
     # Agentic-visibility events (2026-07-24): big-file chunk swarm
     # scatter/stitch + worker-pool pickup — the cockpit sees agents spawn.
     # Moltbook (the agora): one post = one molt_post event.

--- a/backend/core/ouroboros/governance/ide_observability_stream.py
+++ b/backend/core/ouroboros/governance/ide_observability_stream.py
@@ -111,6 +111,10 @@ EVENT_TYPE_TASK_COMPLETED = "task_completed"
 EVENT_TYPE_TASK_CANCELLED = "task_cancelled"
 EVENT_TYPE_BOARD_CLOSED = "board_closed"
 EVENT_TYPE_HEARTBEAT = "heartbeat"
+# Emitted by DoublewordProvider on a SUCCESSFUL generation. Proof that the
+# Aegis->DW auth+billing path is currently valid, which is what lets a frozen
+# DWHeartbeat auto-defrost instead of needing a daemon restart.
+EVENT_TYPE_PROVIDER_GENERATION_SUCCEEDED = "provider_generation_succeeded"
 EVENT_TYPE_STREAM_LAG = "stream_lag"
 EVENT_TYPE_REPLAY_START = "replay_start"
 EVENT_TYPE_REPLAY_END = "replay_end"
@@ -1482,6 +1486,7 @@ schema_version. Reason carries the disposition (strip / drop / fail_closed:*)
 but NEVER the offending content. Authority-free anti-jailbreak telemetry."""
 
 _VALID_EVENT_TYPES = frozenset({
+    "provider_generation_succeeded",
     # Agentic-visibility events (2026-07-24): big-file chunk swarm
     # scatter/stitch + worker-pool pickup — the cockpit sees agents spawn.
     # Moltbook (the agora): one post = one molt_post event.

--- a/backend/core/ouroboros/governance/provider_heartbeat.py
+++ b/backend/core/ouroboros/governance/provider_heartbeat.py
@@ -149,10 +149,35 @@ class AegisConfigurationError(RuntimeError):
     DW outage. Freezes the heartbeat + routes to the DLQ; never awakens."""
 
 
+class ProbeAuthUnavailable(RuntimeError):
+    """The probe could not ASSEMBLE complete credentials, so it never dispatched.
+
+    The third state the original binary taxonomy lacked. Previously a transient
+    ``TimeoutError`` acquiring the per-call lease was swallowed, the probe sent
+    an under-authenticated request anyway, the Aegis daemon answered 401, and
+    that 401 was classified ``auth`` -> PERMANENT FREEZE. A momentary lease
+    hiccup thereby disabled outage detection for the life of the process (and
+    with it the AWE recovery edge).
+
+    This is neither: not an outage (the data plane was never contacted) and not
+    a config error (the credentials may be perfectly valid -- we just could not
+    fetch them in time). It is transient and local, so the correct verdict is
+    "no information": do not freeze, do not degrade, retry next tick.
+
+    Mirrors the REAL provider's policy, which already fails closed rather than
+    dispatching without a lease ("NO silent fallback to direct upstream
+    credentials -- operator correction #5", aegis_provider_bridge.acquire_call_lease).
+    """
+
+
 def _classify_probe_exception(exc: BaseException) -> str:
-    """Classify a probe failure as ``"auth"`` (401/403 -- config error, never an
-    outage) or ``"outage"`` (timeout / 5xx / connection drop -- a real data-plane
-    failure). NEVER raises -- an unknown error is conservatively an outage."""
+    """Classify a probe failure as ``"transient"`` (credentials unavailable --
+    never dispatched, no information either way), ``"auth"`` (401/403 -- config
+    error, never an outage) or ``"outage"`` (timeout / 5xx / connection drop --
+    a real data-plane failure). NEVER raises -- an unknown error is
+    conservatively an outage."""
+    if isinstance(exc, ProbeAuthUnavailable):
+        return "transient"
     try:
         import urllib.error  # noqa: PLC0415
         if isinstance(exc, urllib.error.HTTPError):
@@ -163,6 +188,19 @@ def _classify_probe_exception(exc: BaseException) -> str:
     except Exception:  # noqa: BLE001
         pass
     return "outage"
+
+
+def _aegis_lease_required() -> bool:
+    """True iff Aegis is enabled, i.e. a per-call lease is MANDATORY for the
+    probe to be properly authenticated. Reuses the same enablement predicate the
+    bridge itself consults (DRY) — no second notion of "is Aegis on". Conservative
+    on error: assume required, because dispatching without a mandatory lease is
+    the failure mode this gate exists to prevent."""
+    try:
+        from backend.core.ouroboros.aegis import client as _aegis_client_mod  # noqa: PLC0415
+        return bool(_aegis_client_mod.is_enabled())
+    except Exception:  # noqa: BLE001
+        return True
 
 
 def _default_dlq_emit(payload: Any) -> None:
@@ -266,6 +304,16 @@ async def _resolve_dw_probe_transport():
         auth = await _apb.dw_session_auth_header()
         if not isinstance(auth, dict):
             auth = {}
+        # ── PRE-FLIGHT AUTH GATE ──────────────────────────────────────────
+        # Aegis ENABLED means a lease is mandatory. If we cannot obtain one we
+        # must NOT dispatch: an under-authenticated request earns a guaranteed
+        # 401, and that 401 is indistinguishable (to the classifier) from a real
+        # misconfiguration -> permanent freeze. Fail closed BEFORE the socket,
+        # exactly as the real provider does.
+        #
+        # `acquire_call_lease` returns None *legitimately* when Aegis is
+        # disabled — that is not a failure and must still dispatch (direct-DW
+        # mode carries no lease header at all).
         lease = None
         try:
             lease = await _apb.acquire_call_lease(
@@ -273,11 +321,25 @@ async def _resolve_dw_probe_transport():
                 route="heartbeat",
                 estimated_cost_usd=_env_float("JARVIS_DW_DEEP_PROBE_COST_USD", 0.0001),
             )
-        except Exception as exc:  # noqa: BLE001 -- no lease -> daemon 401 -> classified
-            logger.debug("[DWHeartbeat] probe lease acquire fail-soft err=%r", exc)
+        except Exception as exc:  # noqa: BLE001
+            if _aegis_lease_required():
+                logger.debug(
+                    "[DWHeartbeat] probe lease unavailable (%r) — SKIPPING dispatch "
+                    "(pre-flight gate); transient, no freeze, no degrade", exc,
+                )
+                raise ProbeAuthUnavailable(
+                    "lease acquisition failed pre-dispatch: %r" % (exc,)
+                ) from exc
+            logger.debug("[DWHeartbeat] probe lease absent (aegis off) err=%r", exc)
+        if lease is None and _aegis_lease_required():
+            raise ProbeAuthUnavailable(
+                "aegis enabled but lease resolved to None pre-dispatch"
+            )
         merged = _apb.merge_lease_into_session_headers(auth, lease)
         if isinstance(merged, dict):
             headers.update(merged)
+    except ProbeAuthUnavailable:
+        raise  # the gate's verdict must reach the classifier intact
     except Exception as exc:  # noqa: BLE001 -- best-effort bearer/lease
         logger.debug("[DWHeartbeat] aegis auth/lease fail-soft err=%r", exc)
     return (url, headers)
@@ -383,6 +445,12 @@ class DWHeartbeat:
         # intake DLQ. Injectable for tests. A 401/403 FREEZES the loop here.
         self._dlq_emit_fn = dlq_emit_fn or _default_dlq_emit
         self._frozen = False  # set True on an auth/config error -> never awakens
+        # Observability for the pre-flight gate: how many ticks were skipped
+        # because credentials could not be assembled (transient, no verdict).
+        self._transient_skips = 0
+        # Auto-defrost accounting (bounded — see note_provider_success).
+        self._defrost_count = 0
+        self._success_subscribed: asyncio.Event = asyncio.Event()
         # Recovery signal (Handback Protocol): consecutive HEALTHY probes. A
         # streak of fast-healthy beats means DW recovered -> drives SERVING->HANDBACK.
         self._healthy_streak = 0
@@ -412,6 +480,77 @@ class DWHeartbeat:
     # ------------------------------------------------------------------
     # Public read surface (consumed by the failover lifecycle pre-warm gate)
     # ------------------------------------------------------------------
+
+    def note_provider_success(self) -> bool:
+        """AUTO-DEFROST. A successful DW generation proves the Aegis->DW auth +
+        billing path is currently valid, so a frozen heartbeat's config verdict
+        is stale. Thaw and resume probing. Returns True iff it actually thawed.
+
+        BOUNDED on purpose (``JARVIS_DW_HEARTBEAT_MAX_DEFROSTS``, default 3).
+        Unbounded defrost is a flap machine: if the probe's auth is *genuinely*
+        broken while the provider's works — precisely today's divergence — the
+        loop becomes freeze -> success -> defrost -> 401 -> freeze forever,
+        emitting a CRITICAL and a DLQ record every cycle. A bound means
+        self-healing for the transient case (the common one) while a persistent
+        misconfiguration still ends in a durable freeze a human can see.
+        NEVER raises."""
+        try:
+            if not self._frozen:
+                return False
+            cap = _env_int("JARVIS_DW_HEARTBEAT_MAX_DEFROSTS", 3)
+            if self._defrost_count >= cap:
+                logger.debug(
+                    "[DWHeartbeat] defrost suppressed — cap %d reached; the probe "
+                    "auth failure is persistent, not transient", cap,
+                )
+                return False
+            self._frozen = False
+            self._defrost_count += 1
+            self._healthy_streak = 0
+            logger.warning(
+                "[DWHeartbeat] AUTO-DEFROST (%d/%d) — observed a successful DW "
+                "generation, so the frozen config verdict is stale. Resuming probe "
+                "+ AWE edge detection.", self._defrost_count, cap,
+            )
+            return True
+        except Exception:  # noqa: BLE001
+            return False
+
+    async def watch_provider_success(self, *, max_events: Optional[int] = None) -> None:
+        """Drain ``provider_generation_succeeded`` off the SAME StreamEventBroker
+        the SSE surface uses and auto-defrost on each. Adds a consumer, not a
+        second poll loop (DRY — mirrors AWETrigger.watch). Never raises."""
+        from backend.core.ouroboros.governance.ide_observability_stream import (
+            EVENT_TYPE_PROVIDER_GENERATION_SUCCEEDED,
+            get_default_broker,
+        )
+        broker = None
+        sub = None
+        seen = 0
+        try:
+            broker = get_default_broker()
+            sub = broker.subscribe(op_id_filter="doubleword")
+            if sub is None:
+                return
+            self._success_subscribed.set()
+            async for event in broker.stream_iter(sub, heartbeat_s=0):
+                if getattr(event, "event_type", "") != EVENT_TYPE_PROVIDER_GENERATION_SUCCEEDED:
+                    continue
+                self.note_provider_success()
+                seen += 1
+                if max_events is not None and seen >= max_events:
+                    return
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001
+            return
+        finally:
+            self._success_subscribed.set()
+            try:
+                if broker is not None and sub is not None:
+                    broker.unsubscribe(sub)
+            except Exception:  # noqa: BLE001
+                pass
 
     def is_frozen(self) -> bool:
         """True once an AUTH/config error froze the loop. A frozen heartbeat is
@@ -529,8 +668,13 @@ class DWHeartbeat:
             return False
         except AegisConfigurationError:
             raise  # already classified -- propagate to beat() (the Safety Law)
+        except ProbeAuthUnavailable:
+            raise  # pre-flight gate: propagate so beat() records NO verdict
         except Exception as exc:  # noqa: BLE001 -- classify before treating as degrade
-            if _classify_probe_exception(exc) == "auth":
+            _cls = _classify_probe_exception(exc)
+            if _cls == "transient":
+                raise ProbeAuthUnavailable(str(exc)) from exc
+            if _cls == "auth":
                 # A 401/403 is a PROBE misconfiguration, NOT a DW outage. Raise a
                 # typed error so beat() freezes the loop instead of degrading
                 # (which would conflate a config bug with an outage -> false awaken).
@@ -578,6 +722,17 @@ class DWHeartbeat:
             if asyncio.iscoroutine(result):
                 result = await result
             ok = bool(result)
+        except ProbeAuthUnavailable as exc:
+            # PRE-FLIGHT GATE: credentials could not be assembled, so nothing was
+            # ever sent. That is NO INFORMATION about DW — record no verdict at
+            # all. Not a freeze (the config may be fine), not a degrade (the data
+            # plane was never contacted). Retry next tick.
+            self._transient_skips += 1
+            logger.debug(
+                "[DWHeartbeat] probe skipped pre-dispatch (transient, skips=%d) "
+                "— no freeze, no degrade: %r", self._transient_skips, exc,
+            )
+            return
         except AegisConfigurationError as exc:
             # THE SAFETY LAW: an auth/config error is NOT a DW outage. FREEZE the
             # loop (no proxy spam), route to the DLQ, and record NOTHING into the

--- a/backend/core/ouroboros/governance/soak_intent.py
+++ b/backend/core/ouroboros/governance/soak_intent.py
@@ -21,7 +21,7 @@ import logging
 import sqlite3
 import time
 import uuid
-from typing import Optional
+from typing import NamedTuple, Optional
 
 logger = logging.getLogger("Ouroboros.SoakIntent")
 
@@ -108,6 +108,64 @@ def get_manifest_json(
         return None
 
 
+class PendingIntent(NamedTuple):
+    """The single highest-priority pending intent, as the AWE dispatcher needs it.
+
+    ``target`` is load-bearing and easy to get wrong: a manifest's per-chunk
+    ``file_path`` entries are stored RELATIVE to this target (the canary's chunks
+    are ``mathy.py`` / ``strings_util.py`` / ``widgets.py``, not repo-relative
+    paths). ``build_checkpointed_swarm_fn`` opens ``os.path.join(repo_root,
+    file_path)``, so the dispatcher must pass ``target`` as ``repo_root`` — NOT
+    the repository root, which would resolve every chunk to a nonexistent file.
+    """
+
+    intent_id: str
+    kind: str
+    target: str
+    manifest_json: Optional[str]
+
+    @property
+    def has_manifest(self) -> bool:
+        """True iff this intent carries a manifest worth resuming. An intent with
+        no manifest is real work, but not *checkpointed* work — the dispatcher
+        routes it to the generic soak rather than fabricating an empty run."""
+        return bool(self.manifest_json)
+
+
+def next_pending_intent(
+    conn: Optional[sqlite3.Connection], *, max_priority: Optional[int] = None,
+) -> Optional[PendingIntent]:
+    """The highest-priority pending intent (ties broken oldest-first), or ``None``.
+
+    Companion to :func:`pending_soak_count` — that answers "is there work?", this
+    answers "which work, and where does it live?". Same ordering the supervisor's
+    arm gate implies, so the intent the supervisor armed FOR is the intent the AWE
+    dispatcher runs. Never raises."""
+    if conn is None:
+        return None
+    try:
+        ensure_intent_table(conn)
+        sql = (
+            f"SELECT intent_id, kind, COALESCE(target, ''), manifest_json "
+            f"FROM {_INTENT_TABLE} WHERE status=?"
+        )
+        params: tuple = (STATUS_PENDING,)
+        if max_priority is not None:
+            sql += " AND priority<=?"
+            params = (STATUS_PENDING, int(max_priority))
+        sql += " ORDER BY priority ASC, enqueued_ts ASC LIMIT 1"
+        row = conn.execute(sql, params).fetchone()
+        if not row:
+            return None
+        return PendingIntent(
+            intent_id=str(row[0]), kind=str(row[1]),
+            target=str(row[2] or ""), manifest_json=row[3],
+        )
+    except sqlite3.Error:
+        logger.debug("[SoakIntent] next_pending_intent failed", exc_info=True)
+        return None
+
+
 def pending_soak_count(
     conn: Optional[sqlite3.Connection], *, max_priority: Optional[int] = None,
 ) -> int:
@@ -174,9 +232,11 @@ def clear_soak_intent(
 __all__ = [
     "STATUS_CLEARED",
     "STATUS_PENDING",
+    "PendingIntent",
     "clear_soak_intent",
     "enqueue_soak_intent",
     "ensure_intent_table",
     "get_manifest_json",
+    "next_pending_intent",
     "pending_soak_count",
 ]

--- a/backend/core/ouroboros/terminal_capability.py
+++ b/backend/core/ouroboros/terminal_capability.py
@@ -1,0 +1,213 @@
+"""Terminal capability probing — does this terminal deliver key RELEASE events?
+
+Lives OUTSIDE ``ui/`` deliberately: this is terminal *protocol I/O*, not
+rendering. The ``ui/`` package is guarded against literal ANSI/styling
+(``tests/ui/test_theme_guard.py``) so the theme stays the single source of
+truth for appearance, and the kitty handshake below necessarily emits a raw
+CSI sequence. Widening that guard's exemption list — which holds exactly one
+entry, the token source-of-truth — to accommodate a non-UI concern would have
+been the wrong trade.
+
+The fragmentation problem
+-------------------------
+A standard TTY sends keypresses only, so hold-to-talk is impossible. Terminals
+implementing the **kitty keyboard protocol** (kitty, WezTerm, foot, recent
+iTerm2, Ghostty) can report key *release* when asked, which makes true
+hold-to-talk exact. Hardcoding either assumption breaks half the hosts, so the
+input paradigm is chosen by asking the terminal rather than by guessing.
+
+The probe
+---------
+The kitty protocol defines a query: emit ``CSI ? u`` and a supporting terminal
+replies ``CSI ? <flags> u``. A terminal without support replies nothing.
+
+Doing this safely on a live cockpit is the whole difficulty:
+
+* it needs raw mode (an un-raw terminal would echo the escape sequence into the
+  operator's screen), restored under ``finally`` on every path;
+* it must never block — a non-responding terminal has to time out fast, so the
+  read is ``select``-bounded;
+* it must fail CLOSED. An ambiguous or absent reply means "no release events",
+  because degrading to toggle is harmless while wrongly assuming release
+  support would leave the mic latched open with no closing edge;
+* it must be inert when there is no real TTY (CI, pipes, headless soaks) — the
+  probe is skipped entirely rather than reading a nonexistent terminal.
+
+``TERM``/``TERM_PROGRAM`` are used only as a *hint* for telemetry, never as the
+verdict: terminal identification strings are notoriously spoofed and inherited
+through multiplexers, so the live handshake is the only trustworthy authority.
+"""
+
+from __future__ import annotations
+
+import enum
+import logging
+import os
+import sys
+from typing import Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+#: kitty keyboard-protocol query and the prefix of a conforming reply.
+_QUERY = "\x1b[?u"
+_REPLY_PREFIX = "\x1b[?"
+
+#: Terminals KNOWN to implement the protocol. Hint only — see module docstring.
+_LIKELY_SUPPORT = ("kitty", "wezterm", "foot", "ghostty")
+
+
+class KeyReleaseSupport(str, enum.Enum):
+    """Closed verdict taxonomy."""
+
+    SUPPORTED = "supported"          # handshake confirmed release capability
+    UNSUPPORTED = "unsupported"      # handshake completed, no support
+    NO_TTY = "no_tty"                # nothing to probe (pipe / CI / headless)
+    TIMEOUT = "timeout"              # terminal never answered
+    FORCED_ON = "forced_on"          # operator override
+    FORCED_OFF = "forced_off"        # operator override
+    ERROR = "error"                  # probe faulted — fail closed
+
+    @property
+    def has_release(self) -> bool:
+        """Only two verdicts grant release-driven hold-to-talk. Everything else
+        — including TIMEOUT and ERROR — degrades. Fail-closed by construction."""
+        return self in (KeyReleaseSupport.SUPPORTED, KeyReleaseSupport.FORCED_ON)
+
+
+def _probe_timeout_s() -> float:
+    try:
+        return max(0.01, float(os.environ.get("JARVIS_PTT_PROBE_TIMEOUT_S", "0.12")))
+    except (TypeError, ValueError):
+        return 0.12
+
+
+def _forced() -> Optional[KeyReleaseSupport]:
+    """Operator override, checked before any I/O so a probe can be bypassed on
+    a terminal where even the handshake misbehaves."""
+    raw = os.environ.get("JARVIS_PTT_KEY_RELEASE_SUPPORTED", "").strip().lower()
+    if raw in ("1", "true", "yes", "on"):
+        return KeyReleaseSupport.FORCED_ON
+    if raw in ("0", "false", "no", "off"):
+        return KeyReleaseSupport.FORCED_OFF
+    return None
+
+
+def terminal_hint() -> str:
+    """Best-guess terminal identity, for telemetry only."""
+    for var in ("TERM_PROGRAM", "TERM"):
+        val = (os.environ.get(var, "") or "").strip().lower()
+        if val:
+            for name in _LIKELY_SUPPORT:
+                if name in val:
+                    return name
+            return val
+    return "unknown"
+
+
+def _is_real_tty() -> bool:
+    """A genuine interactive terminal on BOTH directions. ``sys.__stdin__`` is
+    used rather than ``sys.stdin`` because the cockpit runs under
+    ``patch_stdout``, which replaces the module-level handle — the same trap
+    that broke presentation-restraint TTY detection."""
+    try:
+        stdin = getattr(sys, "__stdin__", None)
+        stdout = getattr(sys, "__stdout__", None)
+        return bool(
+            stdin is not None and stdout is not None
+            and stdin.isatty() and stdout.isatty()
+        )
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def probe_key_release_support(
+    *, timeout_s: Optional[float] = None,
+) -> Tuple[KeyReleaseSupport, dict]:
+    """Ask the terminal whether it reports key releases.
+
+    Returns ``(verdict, telemetry)``. NEVER raises, NEVER leaves the terminal in
+    raw mode, and never blocks longer than ``timeout_s``."""
+    hint = terminal_hint()
+    forced = _forced()
+    if forced is not None:
+        return (forced, {"reason": "env_override", "terminal": hint})
+
+    if not _is_real_tty():
+        return (KeyReleaseSupport.NO_TTY, {"reason": "not_a_tty", "terminal": hint})
+
+    to = timeout_s if timeout_s is not None else _probe_timeout_s()
+    try:
+        import select
+        import termios
+        import tty
+    except Exception:  # noqa: BLE001 — non-POSIX host
+        return (KeyReleaseSupport.ERROR, {"reason": "no_termios", "terminal": hint})
+
+    fd = None
+    saved = None
+    try:
+        fd = sys.__stdin__.fileno()
+        saved = termios.tcgetattr(fd)
+        # cbreak, not full raw: leaves signal handling intact so Ctrl-C still
+        # works if the probe somehow stalls.
+        tty.setcbreak(fd)
+        try:
+            sys.__stdout__.write(_QUERY)
+            sys.__stdout__.flush()
+        except Exception:  # noqa: BLE001
+            return (KeyReleaseSupport.ERROR, {"reason": "write_failed", "terminal": hint})
+
+        chunks = []
+        deadline_budget = to
+        while deadline_budget > 0:
+            ready, _, _ = select.select([fd], [], [], deadline_budget)
+            if not ready:
+                break
+            try:
+                data = os.read(fd, 32)
+            except Exception:  # noqa: BLE001
+                break
+            if not data:
+                break
+            chunks.append(data.decode("utf-8", "replace"))
+            joined = "".join(chunks)
+            # A conforming reply terminates with 'u'.
+            if _REPLY_PREFIX in joined and joined.rstrip().endswith("u"):
+                break
+            deadline_budget *= 0.5   # bounded drain; never re-arm the full budget
+
+        reply = "".join(chunks)
+        if not reply:
+            return (KeyReleaseSupport.TIMEOUT, {
+                "reason": "no_reply", "terminal": hint,
+            })
+        if _REPLY_PREFIX in reply and reply.rstrip().endswith("u"):
+            return (KeyReleaseSupport.SUPPORTED, {
+                "reason": "handshake_ok", "terminal": hint,
+                "reply": reply.encode("unicode_escape").decode()[:40],
+            })
+        # Something answered, but not the protocol. Ambiguity fails CLOSED.
+        return (KeyReleaseSupport.UNSUPPORTED, {
+            "reason": "non_protocol_reply", "terminal": hint,
+            "reply": reply.encode("unicode_escape").decode()[:40],
+        })
+    except Exception as exc:  # noqa: BLE001
+        return (KeyReleaseSupport.ERROR, {
+            "reason": type(exc).__name__, "terminal": hint,
+        })
+    finally:
+        # Restoring the terminal is non-negotiable: leaking cbreak would leave
+        # the operator's shell unusable after exit.
+        if fd is not None and saved is not None:
+            try:
+                import termios as _t
+                _t.tcsetattr(fd, _t.TCSADRAIN, saved)
+            except Exception:  # noqa: BLE001
+                pass
+
+
+__all__ = [
+    "KeyReleaseSupport",
+    "probe_key_release_support",
+    "terminal_hint",
+]

--- a/backend/core/ouroboros/ui/audio_pump.py
+++ b/backend/core/ouroboros/ui/audio_pump.py
@@ -1,0 +1,215 @@
+"""Audio level pump — raw frames in, normalized floats out, at a capped rate.
+
+The decoupling contract
+-----------------------
+Audio capture produces thousands of samples per second. The UI needs a *number*,
+roughly 20 times a second. Everything about this module exists to enforce that
+asymmetry:
+
+* **Only a float crosses the boundary.** Raw frames never reach the UI layer or
+  the event broker — the pump computes RMS at the source and yields a single
+  normalized value. Publishing frames would put audio buffers into a bounded
+  event queue and evict real telemetry under backpressure.
+* **Rate-capped by construction.** A hard minimum interval between publishes
+  (default 20 FPS) means a 48kHz source cannot saturate the event loop. Levels
+  arriving faster than the cap are *coalesced*: the newest wins, because a stale
+  amplitude has no value — this is a monitor, not a ledger.
+* **Off the UI path.** RMS runs where the samples arrive (the capture callback
+  or a worker), never inside a repaint. The pump's only UI contact is an
+  ``invalidate`` thunk — the identical zero-flicker hook the reactive theme
+  uses.
+* **Silence is still information.** A transition INTO silence publishes once so
+  the scope can draw a flat baseline, then goes quiet. Without that, a stalled
+  capture and a genuinely silent room look identical on screen.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from typing import Any, Callable, Optional, Sequence
+
+from backend.core.ouroboros.ui.audio_scope import (
+    AdaptiveNormalizer,
+    AudioPlane,
+    BrailleScope,
+    rms,
+)
+
+logger = logging.getLogger(__name__)
+
+EVENT_AUDIO_LEVEL = "audio_level_changed"
+EVENT_MIC_STATE = "mic_state_changed"
+
+
+def pump_enabled() -> bool:
+    return os.environ.get(
+        "JARVIS_AUDIO_PUMP_ENABLED", "true",
+    ).strip().lower() in ("1", "true", "yes", "on")
+
+
+def _max_fps() -> float:
+    """Publish ceiling. 20 FPS is under the human flicker-fusion threshold for
+    amplitude perception while costing ~20 events/s instead of thousands."""
+    try:
+        return max(1.0, float(os.environ.get("JARVIS_AUDIO_PUMP_FPS", "20")))
+    except (TypeError, ValueError):
+        return 20.0
+
+
+class AudioLevelPump:
+    """Coalescing, rate-capped bridge from audio frames to UI + broker.
+
+    Thread-safe: ``feed`` is designed to be called from a capture callback on a
+    non-async thread, while the UI reads the scope from the event loop."""
+
+    def __init__(
+        self,
+        *,
+        scope: Optional[BrailleScope] = None,
+        invalidate: Optional[Callable[[], None]] = None,
+        publish: Optional[Callable[[str, str, dict], Any]] = None,
+        clock: Optional[Callable[[], float]] = None,
+        max_fps: Optional[float] = None,
+        normalizer: Optional[AdaptiveNormalizer] = None,
+    ) -> None:
+        self._scope = scope if scope is not None else BrailleScope()
+        self._invalidate = invalidate
+        self._publish = publish
+        self._clock = clock or time.monotonic
+        self._min_interval = 1.0 / float(max_fps if max_fps else _max_fps())
+        self._norm = normalizer if normalizer is not None else AdaptiveNormalizer()
+        # -inf, NOT 0.0: with a monotonic clock near zero, 0.0 made the
+        # very first sample look 'too soon' and coalesced it away, so the
+        # pump swallowed its own first frame.
+        self._last_publish = float("-inf")
+        self._was_silent = True
+        self._lock = threading.Lock()
+        # Observability
+        self.published = 0
+        self.coalesced = 0
+
+    # -- properties -----------------------------------------------------
+
+    @property
+    def scope(self) -> BrailleScope:
+        return self._scope
+
+    # -- ingest ---------------------------------------------------------
+
+    def feed_frames(
+        self, samples: Sequence[float], *, plane: AudioPlane = AudioPlane.USER,
+    ) -> Optional[float]:
+        """Called from the capture side with raw normalized (-1..1) samples.
+
+        RMS happens HERE — at the source, off the UI path. Returns the published
+        normalized level, or None when coalesced away."""
+        return self.feed_level(self._norm.normalize(rms(samples)), plane=plane)
+
+    def feed_level(
+        self, level: float, *, plane: AudioPlane = AudioPlane.USER,
+    ) -> Optional[float]:
+        """Called with an already-normalized 0..1 level. NEVER raises."""
+        if not pump_enabled():
+            return None
+        try:
+            lvl = min(1.0, max(0.0, float(level)))
+        except (TypeError, ValueError):
+            return None
+
+        now = self._clock()
+        with self._lock:
+            silent = lvl <= 0.0
+            # A transition INTO silence always publishes once, so the scope can
+            # settle to a flat baseline instead of freezing on the last peak.
+            edge_to_silence = silent and not self._was_silent
+            due = (now - self._last_publish) >= self._min_interval
+            if not due and not edge_to_silence:
+                self.coalesced += 1
+                return None
+            self._last_publish = now
+            self._was_silent = silent
+            self.published += 1
+
+        self._scope.set_plane(plane)
+        self._scope.push(lvl, normalized=True)
+
+        if self._publish is not None:
+            try:
+                self._publish(EVENT_AUDIO_LEVEL, "audio", {
+                    "level": round(lvl, 4),
+                    "plane": plane.value,
+                })
+            except Exception:  # noqa: BLE001 — telemetry never breaks capture
+                logger.debug("[AudioPump] publish failed", exc_info=True)
+
+        # Repaint on every ACCEPTED sample. No extra condition on plane change:
+        # set_plane already happened above, so this same repaint carries both the
+        # new waveform and the new colour in one frame.
+        if self._invalidate is not None:
+            try:
+                self._invalidate()
+            except Exception:  # noqa: BLE001
+                logger.debug("[AudioPump] invalidate failed", exc_info=True)
+        return lvl
+
+    # -- mic state ------------------------------------------------------
+
+    def publish_mic_state(self, state: str, *, reason: str = "") -> None:
+        """Broadcast a latch transition. Separate from level events so a
+        consumer can subscribe to state without draining 20 FPS of amplitude."""
+        if self._publish is None:
+            return
+        try:
+            self._publish(EVENT_MIC_STATE, "audio", {
+                "state": str(state), "reason": str(reason),
+            })
+        except Exception:  # noqa: BLE001
+            logger.debug("[AudioPump] mic-state publish failed", exc_info=True)
+
+    def on_event(self, payload: dict) -> Optional[float]:
+        """Consume an ``audio_level_changed`` payload from the broker.
+
+        Lets a SEPARATE process (the ``ov`` attach client) drive its own scope
+        from the daemon's stream — the two-process split the cockpit already
+        has. Unknown planes degrade to IDLE rather than raising."""
+        try:
+            data = dict(payload or {})
+            lvl = float(data.get("level", 0.0) or 0.0)
+            try:
+                plane = AudioPlane(str(data.get("plane", "idle")))
+            except ValueError:
+                plane = AudioPlane.IDLE
+            self._scope.set_plane(plane)
+            self._scope.push(min(1.0, max(0.0, lvl)), normalized=True)
+            if self._invalidate is not None:
+                try:
+                    self._invalidate()
+                except Exception:  # noqa: BLE001
+                    pass
+            return lvl
+        except Exception:  # noqa: BLE001
+            return None
+
+
+def default_publisher() -> Optional[Callable[[str, str, dict], Any]]:
+    """The existing broker publisher, or None when unavailable (DRY — no second
+    event path)."""
+    try:
+        from backend.core.ouroboros.governance.ide_observability_stream import (
+            publish_task_event,
+        )
+        return publish_task_event
+    except Exception:  # noqa: BLE001
+        return None
+
+
+__all__ = [
+    "EVENT_AUDIO_LEVEL",
+    "EVENT_MIC_STATE",
+    "AudioLevelPump",
+    "default_publisher",
+    "pump_enabled",
+]

--- a/backend/core/ouroboros/ui/audio_scope.py
+++ b/backend/core/ouroboros/ui/audio_scope.py
@@ -1,0 +1,340 @@
+"""Braille oscilloscope — the audio plane made visible in the cockpit header.
+
+Why Braille
+-----------
+A block character (``█``) gives ONE vertical level per terminal cell, so a
+volume meter built from blocks is a chunky 1-bit staircase. A Unicode Braille
+cell (U+2800..U+28FF) carries **8 independently addressable dots in a 2x4
+grid**, so one cell encodes TWO horizontal samples at FOUR vertical levels
+each — 8x the horizontal density and 4x the vertical resolution of blocks, at
+identical cell cost. A 20-cell scope therefore shows 40 samples.
+
+Dot bit layout (Unicode Braille, dots 1-8)::
+
+      col0  col1
+    row0  1(0x01)  4(0x08)
+    row1  2(0x02)  5(0x10)
+    row2  3(0x04)  6(0x20)
+    row3  7(0x40)  8(0x80)
+
+Bars fill from the BOTTOM row upward, so silence reads as a flat baseline
+rather than a floating cloud.
+
+Design constraints this module honours
+-------------------------------------
+* **No blocking math.** RMS is a single pass over a sample buffer, and the
+  render path is pure integer/table work — no FFT, no numpy requirement, no
+  allocation per frame beyond the output string.
+* **No hardcoded scale.** The normalizer adapts to the observed signal via a
+  decaying peak reference, so a quiet mic and a hot mic both fill the scope
+  instead of one flatlining and the other clipping.
+* **Stateless render.** :meth:`BrailleScope.render` is a pure function of the
+  ring buffer, so the caller's existing clock-driven repaint animates it with
+  zero extra tasks (the same discipline the mini-crest uses).
+* **Degradation.** A terminal that cannot encode Braille falls back to an
+  ASCII ramp rather than emitting replacement glyphs.
+"""
+
+from __future__ import annotations
+
+import enum
+import math
+import os
+import threading
+from collections import deque
+from typing import Deque, Iterable, Optional, Sequence, Tuple
+
+_BRAILLE_BASE = 0x2800
+
+# Bottom-to-top dot masks per sub-column. Filling from index 0 upward makes a
+# louder sample a taller bar anchored to the baseline.
+_COL0_BOTTOM_UP: Tuple[int, ...] = (0x40, 0x04, 0x02, 0x01)   # dots 7,3,2,1
+_COL1_BOTTOM_UP: Tuple[int, ...] = (0x80, 0x20, 0x10, 0x08)   # dots 8,6,5,4
+
+#: Vertical levels a single Braille sub-column can express.
+LEVELS = 4
+#: Horizontal samples a single Braille cell can express.
+SAMPLES_PER_CELL = 2
+
+# ASCII fallback ramp, lowest → highest.
+_ASCII_RAMP = (" ", ".", ":", "|", "#")
+
+
+class AudioPlane(str, enum.Enum):
+    """Who is producing sound right now.
+
+    The scope is a shared surface: colouring by plane is what makes it legible
+    at a glance (is that me, or is that the organism talking back?)."""
+
+    IDLE = "idle"
+    USER = "user"          # microphone capture
+    SYSTEM = "system"      # TTS playback
+
+
+#: AudioPlane → semantic theme colour NAME (never a raw hex value, so the
+#: reactive theme stays the single source of truth for palette + tier).
+PLANE_ACCENT = {
+    AudioPlane.IDLE: "muted",
+    AudioPlane.USER: "cyan",
+    AudioPlane.SYSTEM: "venom_green",
+}
+
+
+def scope_enabled() -> bool:
+    """Master gate. Default ON — the scope is inert without a level stream."""
+    return os.environ.get(
+        "JARVIS_AUDIO_SCOPE_ENABLED", "true",
+    ).strip().lower() in ("1", "true", "yes", "on")
+
+
+def braille_available() -> bool:
+    """Whether the terminal encoding can carry Braille. Falls back to ASCII on
+    a legacy/POSIX locale rather than emitting replacement glyphs."""
+    if os.environ.get("JARVIS_AUDIO_SCOPE_ASCII", "").strip().lower() in (
+        "1", "true", "yes", "on",
+    ):
+        return False
+    try:
+        "⣿".encode(
+            os.environ.get("PYTHONIOENCODING")
+            or getattr(__import__("sys").stdout, "encoding", None)
+            or "utf-8"
+        )
+        return True
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def rms(samples: Sequence[float]) -> float:
+    """Root-mean-square of a normalized (-1.0..1.0) sample buffer.
+
+    The canonical implementation. Six sites across ``backend/voice`` each
+    inlined ``np.sqrt(np.mean(chunk**2))``; this is the shared seam that did
+    not exist, and it needs no numpy so the UI layer stays dependency-light.
+    Returns 0.0 for empty/garbage input — NEVER raises."""
+    try:
+        if samples is None:
+            return 0.0
+        n = len(samples)
+        if n == 0:
+            return 0.0
+        total = 0.0
+        for s in samples:
+            try:
+                v = float(s)
+            except (TypeError, ValueError):
+                continue
+            total += v * v
+        return math.sqrt(total / n)
+    except Exception:  # noqa: BLE001
+        return 0.0
+
+
+class AdaptiveNormalizer:
+    """Maps raw RMS to 0.0..1.0 against a DECAYING OBSERVED PEAK.
+
+    A fixed divisor is wrong for audio: mic gain, distance and TTS loudness vary
+    by orders of magnitude, so any constant either flatlines a quiet source or
+    clips a hot one. Tracking a decaying peak means the scope always uses its
+    full height for whatever signal is actually present, and recovers when the
+    source changes.
+
+    ``floor`` prevents division blow-up on near-silence and stops room noise
+    from being amplified into a fake waveform."""
+
+    def __init__(
+        self, *, decay: float = 0.995, floor: float = 1e-3,
+    ) -> None:
+        self._decay = min(max(float(decay), 0.0), 0.999999)
+        self._floor = max(float(floor), 1e-9)
+        self._peak = self._floor
+        self._lock = threading.Lock()
+
+    def normalize(self, value: float) -> float:
+        try:
+            v = abs(float(value))
+        except (TypeError, ValueError):
+            return 0.0
+        with self._lock:
+            self._peak = max(v, self._peak * self._decay, self._floor)
+            peak = self._peak
+        if peak <= 0.0:
+            return 0.0
+        return min(1.0, max(0.0, v / peak))
+
+    @property
+    def peak(self) -> float:
+        with self._lock:
+            return self._peak
+
+    def reset(self) -> None:
+        with self._lock:
+            self._peak = self._floor
+
+
+def _level_for(value: float) -> int:
+    """Normalized 0..1 → bar height 0..LEVELS.
+
+    A nonzero-but-tiny sample must still show ONE dot: a visible baseline is
+    how the operator distinguishes "listening, quiet" from "not listening"."""
+    try:
+        v = float(value)
+    except (TypeError, ValueError):
+        return 0
+    if v <= 0.0:
+        return 0
+    if v >= 1.0:
+        return LEVELS
+    return max(1, min(LEVELS, int(math.ceil(v * LEVELS))))
+
+
+def cell_for(left: float, right: float) -> str:
+    """Two normalized samples → one Braille cell. Pure; never raises."""
+    try:
+        mask = 0
+        for i in range(_level_for(left)):
+            mask |= _COL0_BOTTOM_UP[i]
+        for i in range(_level_for(right)):
+            mask |= _COL1_BOTTOM_UP[i]
+        return chr(_BRAILLE_BASE + mask)
+    except Exception:  # noqa: BLE001
+        return chr(_BRAILLE_BASE)
+
+
+def _ascii_cell(left: float, right: float) -> str:
+    lvl = max(_level_for(left), _level_for(right))
+    return _ASCII_RAMP[min(lvl, len(_ASCII_RAMP) - 1)]
+
+
+class BrailleScope:
+    """Fixed-width scrolling oscilloscope over a bounded sample ring.
+
+    The deque is capped at ``width * SAMPLES_PER_CELL``, so appending past
+    capacity evicts the oldest sample — the scroll is the data structure, not a
+    slicing step, which is what keeps the render allocation-free and the index
+    arithmetic incapable of running off the end."""
+
+    def __init__(
+        self,
+        *,
+        width: int = 20,
+        plane: AudioPlane = AudioPlane.IDLE,
+        normalizer: Optional[AdaptiveNormalizer] = None,
+    ) -> None:
+        self._width = max(1, int(width))
+        self._cap = self._width * SAMPLES_PER_CELL
+        self._samples: Deque[float] = deque(maxlen=self._cap)
+        self._plane = plane
+        self._norm = normalizer if normalizer is not None else AdaptiveNormalizer()
+        self._lock = threading.Lock()
+
+    # -- ingest ---------------------------------------------------------
+
+    def push(self, value: float, *, normalized: bool = True) -> None:
+        """Append one sample. ``normalized=False`` routes it through the
+        adaptive normalizer first. NEVER raises."""
+        try:
+            v = float(value)
+        except (TypeError, ValueError):
+            return
+        if not normalized:
+            v = self._norm.normalize(v)
+        v = min(1.0, max(0.0, v))
+        with self._lock:
+            self._samples.append(v)
+
+    def push_rms(self, samples: Sequence[float]) -> float:
+        """Compute RMS over a raw audio buffer, normalize, append. Returns the
+        normalized value so a caller can broadcast it without recomputing."""
+        level = self._norm.normalize(rms(samples))
+        self.push(level, normalized=True)
+        return level
+
+    def extend(self, values: Iterable[float], *, normalized: bool = True) -> None:
+        for v in values or ():
+            self.push(v, normalized=normalized)
+
+    # -- state ----------------------------------------------------------
+
+    def set_plane(self, plane: AudioPlane) -> bool:
+        """Switch the active plane. Returns True iff it changed (so a caller
+        can invalidate only on a real transition — zero-flicker discipline)."""
+        with self._lock:
+            if self._plane is plane:
+                return False
+            self._plane = plane
+            return True
+
+    @property
+    def plane(self) -> AudioPlane:
+        with self._lock:
+            return self._plane
+
+    @property
+    def width(self) -> int:
+        return self._width
+
+    @property
+    def accent(self) -> str:
+        """Semantic theme colour name for the active plane."""
+        return PLANE_ACCENT.get(self.plane, "muted")
+
+    def clear(self) -> None:
+        with self._lock:
+            self._samples.clear()
+        self._norm.reset()
+
+    # -- render ---------------------------------------------------------
+
+    def render(self) -> str:
+        """The scope as a plain ``width``-char string, oldest sample leftmost.
+
+        Right-to-left scroll falls out of the ring: new samples land at the
+        tail, so the newest data is always at the right edge. Left-padded with
+        empty cells until the buffer fills, which keeps the component a stable
+        width from the very first frame (no layout jitter)."""
+        try:
+            with self._lock:
+                buf = list(self._samples)
+            use_braille = braille_available()
+            pad = self._cap - len(buf)
+            if pad > 0:
+                buf = [0.0] * pad + buf
+            out = []
+            for i in range(0, self._cap, SAMPLES_PER_CELL):
+                left = buf[i]
+                right = buf[i + 1] if i + 1 < len(buf) else 0.0
+                out.append(
+                    cell_for(left, right) if use_braille
+                    else _ascii_cell(left, right)
+                )
+            return "".join(out)
+        except Exception:  # noqa: BLE001 — a frame never crashes the TUI
+            return " " * self._width
+
+    def render_rich(self) -> str:
+        """Rich-markup wrapped in the plane's semantic colour. The theme owns
+        the palette; this only names a colour."""
+        body = self.render()
+        try:
+            return f"[{self.accent}]{body}[/{self.accent}]"
+        except Exception:  # noqa: BLE001
+            return body
+
+    def is_silent(self) -> bool:
+        with self._lock:
+            return not any(v > 0.0 for v in self._samples)
+
+
+__all__ = [
+    "AdaptiveNormalizer",
+    "AudioPlane",
+    "BrailleScope",
+    "LEVELS",
+    "PLANE_ACCENT",
+    "SAMPLES_PER_CELL",
+    "braille_available",
+    "cell_for",
+    "rms",
+    "scope_enabled",
+]

--- a/backend/core/ouroboros/ui/audio_scope.py
+++ b/backend/core/ouroboros/ui/audio_scope.py
@@ -144,21 +144,56 @@ class AdaptiveNormalizer:
 
     def __init__(
         self, *, decay: float = 0.995, floor: float = 1e-3,
+        hold_frames: int = 40,
     ) -> None:
         self._decay = min(max(float(decay), 0.0), 0.999999)
         self._floor = max(float(floor), 1e-9)
         self._peak = self._floor
+        self._hold_frames = max(0, int(hold_frames))
+        self._held = 0
         self._lock = threading.Lock()
 
     def normalize(self, value: float) -> float:
+        """Normalized 0..1 against the held/decaying peak.
+
+        DIGITAL SILENCE (the TTS case). A microphone always has a noise floor;
+        synthesized speech hits *absolute* 0.0 between words and between
+        utterances. Two consequences are handled explicitly:
+
+        1. **No division by zero, ever.** ``_floor`` clamps the peak from below
+           and a defensive ``peak <= 0`` guard follows, so an all-zero buffer
+           returns 0.0 instead of raising.
+        2. **The scale must not collapse in the gaps.** A silent sample is the
+           ABSENCE of signal, not evidence of a quieter source, so it never
+           lowers the peak (``max`` already ignores it) — and for
+           ``hold_frames`` after real signal the peak does not decay at all.
+           Without that hold, an inter-syllable gap would shrink the reference
+           and the next syllable would slam to full scale, making Karen's voice
+           pulse like a strobe instead of breathing.
+        """
         try:
             v = abs(float(value))
         except (TypeError, ValueError):
             return 0.0
+        if v != v or v == float("inf"):     # NaN / inf are not signal
+            return 0.0
         with self._lock:
-            self._peak = max(v, self._peak * self._decay, self._floor)
+            if v > self._floor:
+                # Real signal: re-arm the gap guard, but KEEP DECAYING. Holding
+                # the peak on any above-floor sample would pin the reference at
+                # an old loud value forever, so a source that drops from 1.0 to
+                # 0.01 would flatline at 1% — the very failure the decay exists
+                # to prevent. Decay here, hold only in the gaps below.
+                self._held = self._hold_frames
+                self._peak = max(v, self._peak * self._decay, self._floor)
+            elif self._held > 0:
+                # Inside a gap — hold the reference steady.
+                self._held -= 1
+            else:
+                # Sustained silence: only now let the reference relax.
+                self._peak = max(self._peak * self._decay, self._floor)
             peak = self._peak
-        if peak <= 0.0:
+        if peak <= 0.0:                     # unreachable via floor; belt-and-braces
             return 0.0
         return min(1.0, max(0.0, v / peak))
 

--- a/backend/core/ouroboros/ui/crest_animator.py
+++ b/backend/core/ouroboros/ui/crest_animator.py
@@ -989,11 +989,23 @@ def render_cockpit_header(
     width: int,
     *,
     now: Optional[float] = None,
+    right_gutter: Optional[Any] = None,
+    gutter_row: int = 0,
 ) -> str:
     """Compose the CC-style header — mini crest left, identity/context/path
     lines beside it — to an ANSI string bounded to ``width``. ``lines`` are
     Rich renderable Texts (or plain strings). Degrades to text-only when the
-    mini crest is unavailable (tiny terminal / NONE tier). Never raises."""
+    mini crest is unavailable (tiny terminal / NONE tier). Never raises.
+
+    ``right_gutter`` fills the empty real estate to the RIGHT of the identity
+    lines — the Braille audio oscilloscope lives there. It may be a Rich
+    renderable, a plain/markup string, or a zero-arg callable returning either;
+    a callable is re-evaluated per frame so the clock-driven repaint animates it
+    with no extra task. It is RIGHT-ALIGNED against ``width``, which is why the
+    alignment lives here rather than in the caller: this function is the only
+    place that knows the terminal width. Rendered on ``gutter_row`` of the text
+    block. Silently omitted if it does not fit, so a narrow terminal degrades to
+    the plain header instead of wrapping into a broken layout."""
     try:
         from io import StringIO
         from rich.console import Console
@@ -1019,7 +1031,23 @@ def render_cockpit_header(
             ti = i - pad_top
             if 0 <= ti < len(text_rows):
                 out.append("  ")
-                out.append_text(text_rows[ti] if not isinstance(text_rows[ti], str) else Text(text_rows[ti]))
+                _row = text_rows[ti] if not isinstance(text_rows[ti], str) else Text(text_rows[ti])
+                out.append_text(_row)
+                if ti == gutter_row and right_gutter is not None:
+                    try:
+                        _g = right_gutter() if callable(right_gutter) else right_gutter
+                        _gt = _g if not isinstance(_g, str) else Text.from_markup(_g)
+                        if _gt is not None and len(_gt) > 0:
+                            # Right-align: pad from where this row currently ends
+                            # to (width - gutter_len). Omit rather than wrap when
+                            # the terminal is too narrow.
+                            _used = crest_w + 2 + len(_row)
+                            _pad = max(0, int(width) - _used - len(_gt) - 1)
+                            if _used + _pad + len(_gt) <= int(width):
+                                out.append(" " * _pad)
+                                out.append_text(_gt)
+                    except Exception:  # noqa: BLE001 — a gutter fault never breaks the header
+                        pass
             if i < n_rows - 1:
                 out.append("\n")
         buf = StringIO()

--- a/backend/core/ouroboros/ui/ptt_router.py
+++ b/backend/core/ouroboros/ui/ptt_router.py
@@ -72,15 +72,54 @@ def _silence_level() -> float:
         return 0.06
 
 
+class PTTMode(str, enum.Enum):
+    """How the latch closes — chosen by capability probe, never hardcoded."""
+
+    HOLD = "hold"        # KEY_DOWN opens, KEY_UP flushes (kitty protocol)
+    TOGGLE = "toggle"    # tap opens, tap closes, silence auto-flushes
+
+    @property
+    def hint(self) -> str:
+        """Operator-facing hint. The UI must state the ACTIVE paradigm — a
+        cockpit that says 'hold' on a terminal that cannot see release would
+        leave the mic latched with no obvious way out."""
+        return "Hold Space to Talk" if self is PTTMode.HOLD else "Space ⇄ Mic"
+
+
+def resolve_ptt_mode(*, probe: Optional[Any] = None) -> "tuple":
+    """``(PTTMode, verdict, telemetry)`` from a live terminal probe.
+
+    ``probe`` is injectable so tests exercise both paradigms with zero terminal
+    I/O. Fails CLOSED to TOGGLE on every non-supporting verdict, including
+    TIMEOUT and ERROR: degrading is harmless, whereas wrongly assuming release
+    support strands the mic open."""
+    try:
+        if probe is None:
+            from backend.core.ouroboros.terminal_capability import (
+                probe_key_release_support,
+            )
+            probe = probe_key_release_support
+        verdict, telemetry = probe()
+        mode = PTTMode.HOLD if verdict.has_release else PTTMode.TOGGLE
+        return (mode, verdict, dict(telemetry or {}))
+    except Exception as exc:  # noqa: BLE001 — probe faults degrade, never raise
+        return (PTTMode.TOGGLE, None, {"reason": type(exc).__name__})
+
+
 def on_release_supported() -> bool:
     """Whether the input stack can deliver a true key-RELEASE edge.
 
-    False on the default prompt_toolkit stack. Kept as an explicit predicate so
-    the limitation is discoverable in code rather than buried in a comment, and
-    so a release-capable layer can flip it without touching the latch."""
-    return os.environ.get(
-        "JARVIS_PTT_KEY_RELEASE_SUPPORTED", "false",
-    ).strip().lower() in ("1", "true", "yes", "on")
+    Now answered by a live handshake with the terminal (kitty keyboard protocol
+    ``CSI ? u``) rather than assumed. Fail-closed: anything short of a
+    conforming reply is False."""
+    try:
+        from backend.core.ouroboros.terminal_capability import (
+            probe_key_release_support,
+        )
+        verdict, _ = probe_key_release_support()
+        return bool(verdict.has_release)
+    except Exception:  # noqa: BLE001
+        return False
 
 
 class PTTLatch:
@@ -96,6 +135,7 @@ class PTTLatch:
         on_open: Optional[Callable[[], None]] = None,
         on_close: Optional[Callable[[str], None]] = None,
         clock: Optional[Callable[[], float]] = None,
+        mode: Optional["PTTMode"] = None,
     ) -> None:
         self._state = MicState.CLOSED
         self._on_open = on_open
@@ -103,6 +143,7 @@ class PTTLatch:
         self._clock = clock or time.monotonic
         self._opened_at = 0.0
         self._last_voice_at = 0.0
+        self._mode = mode if mode is not None else PTTMode.TOGGLE
         self._open_count = 0
         self._close_reasons: list = []
 
@@ -174,6 +215,12 @@ class PTTLatch:
         silence closes the latch on its own. Only meaningful while open, so a
         quiet idle cockpit never emits spurious flushes."""
         if self._state is not MicState.OPEN:
+            return False
+        # HOLD mode has a REAL closing edge (key release), so silence must not
+        # flush: the operator may pause mid-thought while still holding the key,
+        # and cutting them off there would be worse than no PTT at all. VAD is
+        # strictly the substitute for an unobservable release.
+        if self._mode is PTTMode.HOLD:
             return False
         try:
             lvl = float(level)

--- a/backend/core/ouroboros/ui/ptt_router.py
+++ b/backend/core/ouroboros/ui/ptt_router.py
@@ -1,0 +1,262 @@
+"""Push-to-talk router — spacebar intercept for the cockpit input row.
+
+The terminal constraint that shapes this design
+-----------------------------------------------
+A standard TTY delivers **keypresses only — there are no key-release events**.
+``prompt_toolkit`` therefore cannot observe "the operator let go of space", so a
+literal hold-to-talk (`press → mic_active`, `release → mic_flush`) is not
+implementable on the default input stack. Terminals implementing the *kitty
+keyboard protocol* (``CSI > 1 u``: kitty, WezTerm, foot, recent iTerm2) do emit
+release events, but prompt_toolkit does not request or parse that mode.
+
+Rather than ship a `mic_flush` that silently never fires, this router models PTT
+as an explicit **latch** with two independent closing edges:
+
+1. **Toggle** — a second spacebar on an empty buffer closes the latch. Always
+   available, zero terminal requirements.
+2. **Silence auto-flush** — the latch closes itself after a bounded quiet
+   interval, driven by the same normalized level stream that feeds the scope.
+   This is what makes it *feel* like release without pretending to observe one.
+
+``on_release_supported()`` reports whether a real release edge is available, so
+a future release-capable input layer can drive :meth:`PTTLatch.close` directly
+without changing anything else here.
+
+Spacebar safety
+---------------
+The intercept fires **only when the buffer is empty**. The instant there is any
+text — even one character — space types a space, because silently swallowing
+word separators mid-sentence would be intolerable. That condition is a
+``prompt_toolkit`` ``Condition`` filter, so the binding is inert rather than
+conditionally-branching, and the ``" "`` binding never shadows normal typing.
+"""
+
+from __future__ import annotations
+
+import enum
+import logging
+import os
+import time
+from typing import Any, Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class MicState(str, enum.Enum):
+    CLOSED = "closed"
+    OPEN = "open"
+
+
+def ptt_enabled() -> bool:
+    """Master gate. Default ON, but wholly inert until a latch is wired to an
+    audio backend — an armed binding with no consumer is just a no-op."""
+    return os.environ.get(
+        "JARVIS_PTT_ENABLED", "true",
+    ).strip().lower() in ("1", "true", "yes", "on")
+
+
+def _silence_flush_s() -> float:
+    """Quiet interval that auto-closes the latch. Env-tunable; 1.2s is long
+    enough to survive an inter-word pause and short enough not to feel stuck."""
+    try:
+        return max(0.1, float(os.environ.get("JARVIS_PTT_SILENCE_FLUSH_S", "1.2")))
+    except (TypeError, ValueError):
+        return 1.2
+
+
+def _silence_level() -> float:
+    """Normalized level at or below which audio counts as silence."""
+    try:
+        return max(0.0, float(os.environ.get("JARVIS_PTT_SILENCE_LEVEL", "0.06")))
+    except (TypeError, ValueError):
+        return 0.06
+
+
+def on_release_supported() -> bool:
+    """Whether the input stack can deliver a true key-RELEASE edge.
+
+    False on the default prompt_toolkit stack. Kept as an explicit predicate so
+    the limitation is discoverable in code rather than buried in a comment, and
+    so a release-capable layer can flip it without touching the latch."""
+    return os.environ.get(
+        "JARVIS_PTT_KEY_RELEASE_SUPPORTED", "false",
+    ).strip().lower() in ("1", "true", "yes", "on")
+
+
+class PTTLatch:
+    """The mic latch. Transport-agnostic: it emits intents, owns no audio.
+
+    Deliberately NOT an asyncio object — key handlers are sync callbacks, and
+    forcing a loop hop here would risk dropping an edge if no loop is running.
+    Emission is via injected callables so the latch is testable with zero I/O."""
+
+    def __init__(
+        self,
+        *,
+        on_open: Optional[Callable[[], None]] = None,
+        on_close: Optional[Callable[[str], None]] = None,
+        clock: Optional[Callable[[], float]] = None,
+    ) -> None:
+        self._state = MicState.CLOSED
+        self._on_open = on_open
+        self._on_close = on_close
+        self._clock = clock or time.monotonic
+        self._opened_at = 0.0
+        self._last_voice_at = 0.0
+        self._open_count = 0
+        self._close_reasons: list = []
+
+    # -- state ----------------------------------------------------------
+
+    @property
+    def state(self) -> MicState:
+        return self._state
+
+    @property
+    def is_open(self) -> bool:
+        return self._state is MicState.OPEN
+
+    @property
+    def open_count(self) -> int:
+        return self._open_count
+
+    @property
+    def close_reasons(self) -> tuple:
+        return tuple(self._close_reasons)
+
+    # -- edges ----------------------------------------------------------
+
+    def open(self) -> bool:
+        """Arm the mic (``mic_active``). Idempotent — returns False if already
+        open, so a key-repeat storm cannot emit a burst of open intents."""
+        if self._state is MicState.OPEN:
+            return False
+        self._state = MicState.OPEN
+        now = self._clock()
+        self._opened_at = now
+        self._last_voice_at = now
+        self._open_count += 1
+        if self._on_open is not None:
+            try:
+                self._on_open()
+            except Exception:  # noqa: BLE001 — a consumer fault never wedges the latch
+                logger.debug("[PTT] on_open raised", exc_info=True)
+        return True
+
+    def close(self, reason: str = "toggle") -> bool:
+        """Disarm and flush (``mic_flush``). Idempotent."""
+        if self._state is MicState.CLOSED:
+            return False
+        self._state = MicState.CLOSED
+        self._close_reasons.append(reason)
+        if self._on_close is not None:
+            try:
+                self._on_close(reason)
+            except Exception:  # noqa: BLE001
+                logger.debug("[PTT] on_close raised", exc_info=True)
+        return True
+
+    def toggle(self) -> MicState:
+        """The spacebar edge: open if closed, close if open."""
+        if self._state is MicState.OPEN:
+            self.close("toggle")
+        else:
+            self.open()
+        return self._state
+
+    # -- level-driven auto-flush ----------------------------------------
+
+    def note_level(self, level: float) -> bool:
+        """Feed one normalized level (0..1). Returns True iff this observation
+        auto-closed the latch.
+
+        This is the substitute for an unobservable key-release: sustained
+        silence closes the latch on its own. Only meaningful while open, so a
+        quiet idle cockpit never emits spurious flushes."""
+        if self._state is not MicState.OPEN:
+            return False
+        try:
+            lvl = float(level)
+        except (TypeError, ValueError):
+            return False
+        now = self._clock()
+        if lvl > _silence_level():
+            self._last_voice_at = now
+            return False
+        if (now - self._last_voice_at) >= _silence_flush_s():
+            self.close("silence")
+            return True
+        return False
+
+    def held_s(self) -> float:
+        if self._state is not MicState.OPEN:
+            return 0.0
+        return max(0.0, self._clock() - self._opened_at)
+
+
+def build_ptt_key_bindings(
+    latch: PTTLatch,
+    *,
+    buffer_getter: Optional[Callable[[], str]] = None,
+    invalidate: Optional[Callable[[], None]] = None,
+) -> Any:
+    """A ``KeyBindings`` carrying ONLY the space intercept.
+
+    Returned for the layout's existing ``extra_key_bindings`` merge seam — this
+    adds a binding set, it does not rewrite the app's bindings (DRY).
+
+    ``buffer_getter`` reports the current input text; when absent the binding
+    falls back to the event's own buffer. The ``Condition`` filter means the
+    binding is INERT unless the buffer is empty, so prompt_toolkit routes space
+    to normal insertion whenever there is text — the binding cannot shadow
+    typing."""
+    from prompt_toolkit.filters import Condition
+    from prompt_toolkit.key_binding import KeyBindings
+
+    kb = KeyBindings()
+
+    def _buffer_is_empty() -> bool:
+        try:
+            if buffer_getter is not None:
+                return not (buffer_getter() or "").strip()
+        except Exception:  # noqa: BLE001
+            return False
+        return True
+
+    @Condition
+    def _empty_and_enabled() -> bool:
+        return ptt_enabled() and _buffer_is_empty()
+
+    @kb.add(" ", filter=_empty_and_enabled, eager=True)
+    def _(event) -> None:  # noqa: ANN001
+        # Guard on the REAL buffer when the caller gave us no getter: the filter
+        # may have been evaluated a beat earlier, and typing a space into a
+        # freshly non-empty buffer must always win over the intercept.
+        try:
+            buf = getattr(event, "current_buffer", None)
+            if buffer_getter is None and buf is not None:
+                if (getattr(buf, "text", "") or "").strip():
+                    buf.insert_text(" ")
+                    return
+        except Exception:  # noqa: BLE001
+            pass
+        try:
+            latch.toggle()
+        except Exception:  # noqa: BLE001
+            logger.debug("[PTT] toggle raised", exc_info=True)
+        if invalidate is not None:
+            try:
+                invalidate()
+            except Exception:  # noqa: BLE001
+                pass
+
+    return kb
+
+
+__all__ = [
+    "MicState",
+    "PTTLatch",
+    "build_ptt_key_bindings",
+    "on_release_supported",
+    "ptt_enabled",
+]

--- a/backend/voice/audio_broadcast_tap.py
+++ b/backend/voice/audio_broadcast_tap.py
@@ -1,0 +1,212 @@
+"""Zero-copy audio broadcast tap — one mic, many observers, STT never pays.
+
+The constraint
+--------------
+macOS CoreAudio will not hand out a second handle on a device that is already
+captured: a UI-owned stream would fail with ``Resource busy`` / device
+unavailable. So the visualizer cannot open its own mic — it has to observe the
+stream the STT pipeline already owns.
+
+But the STT pipeline is the *primary*. Transcription latency and correctness must
+not degrade because a decorative waveform is downstream. Three properties make
+that guarantee structural rather than aspirational:
+
+1. **Zero copy.** The tap stores a read-only *view* of the caller's buffer
+   (``ndarray.view()`` with ``writeable=False``, an O(1) header op) — never a
+   ``copy()``. On a 48kHz stream a per-chunk copy is pure waste for a value that
+   is about to be reduced to one float.
+
+2. **Never blocks.** ``offer()`` writes into a **single-slot latest-wins**
+   mailbox under a non-blocking lock and returns. No queue to fill, no
+   ``put(timeout=...)`` to stall on, no unbounded growth. If the consumer is
+   slow, old chunks are simply overwritten — for an amplitude monitor the newest
+   sample is the only interesting one, so dropping is correct behaviour, not
+   degradation.
+
+3. **Fault-isolated.** Every observer call is individually wrapped. A consumer
+   that raises, hangs its own task, or is garbage is dropped on the floor; the
+   capture path sees ``offer()`` return and carries on. RMS itself happens on
+   the CONSUMER side (``drain``), so no arithmetic at all runs in the capture
+   thread.
+
+A deliberate trade worth stating: because the view is zero-copy, a source that
+*reuses* its capture buffer could be mid-overwrite when the consumer reduces it,
+yielding one slightly-wrong amplitude frame. For a visualizer that is strictly
+preferable to copying every chunk; for anything that needed sample-exact audio
+this tap would be the wrong tool, and the docstring says so on purpose.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any, Callable, List, Optional
+
+logger = logging.getLogger(__name__)
+
+#: An observer receives ``(read_only_view, sample_rate)`` and must return fast.
+Observer = Callable[[Any, int], None]
+
+
+def _read_only_view(chunk: Any) -> Any:
+    """An O(1) immutable view of ``chunk``. Falls back to the object itself when
+    it is not a numpy array (or is already immutable). Never copies, never
+    raises."""
+    try:
+        view = chunk.view()
+        view.flags.writeable = False
+        return view
+    except Exception:  # noqa: BLE001 — not an ndarray, or already read-only
+        try:
+            return memoryview(chunk)
+        except Exception:  # noqa: BLE001
+            return chunk
+
+
+class AudioBroadcastTap:
+    """Single-slot latest-wins fan-out from the capture thread to observers."""
+
+    def __init__(self, *, sample_rate: int = 16000) -> None:
+        self._observers: List[Observer] = []
+        self._slot: Optional[Any] = None
+        self._sample_rate = int(sample_rate)
+        self._lock = threading.Lock()
+        # Observability — proves the tap is live and how much it shed.
+        self.offered = 0
+        self.dropped = 0
+        self.drained = 0
+        self.observer_faults = 0
+
+    # -- registration ---------------------------------------------------
+
+    def subscribe(self, observer: Observer) -> Callable[[], None]:
+        """Register an observer; returns an unsubscribe thunk (same contract as
+        ``ReactiveTheme.register_invalidate`` — one idiom for "attach a
+        callback")."""
+        with self._lock:
+            self._observers.append(observer)
+
+        def _unsubscribe() -> None:
+            with self._lock:
+                try:
+                    self._observers.remove(observer)
+                except ValueError:
+                    pass
+
+        return _unsubscribe
+
+    @property
+    def observer_count(self) -> int:
+        with self._lock:
+            return len(self._observers)
+
+    # -- capture side (HOT PATH — must stay O(1) and non-blocking) -------
+
+    def offer(self, chunk: Any, *, sample_rate: Optional[int] = None) -> bool:
+        """Called FROM THE CAPTURE THREAD with a freshly read PCM chunk.
+
+        Stores a read-only view in the latest-wins slot and returns immediately.
+        Returns True iff something was stored. NEVER raises, NEVER blocks, and
+        performs no arithmetic on the samples."""
+        try:
+            view = _read_only_view(chunk)
+            # acquire(False): if the consumer happens to hold the lock this
+            # instant, we SKIP rather than wait. The capture thread must never
+            # be parked by a visualizer.
+            if not self._lock.acquire(False):
+                self.dropped += 1
+                return False
+            try:
+                if self._slot is not None:
+                    self.dropped += 1      # overwriting an undrained chunk
+                self._slot = view
+                if sample_rate:
+                    self._sample_rate = int(sample_rate)
+                self.offered += 1
+                return True
+            finally:
+                self._lock.release()
+        except Exception:  # noqa: BLE001 — the tap can NEVER break capture
+            return False
+
+    # -- consumer side --------------------------------------------------
+
+    def take(self) -> Optional[Any]:
+        """Atomically remove and return the pending chunk, or None."""
+        with self._lock:
+            chunk, self._slot = self._slot, None
+        return chunk
+
+    def drain(self) -> bool:
+        """Hand the pending chunk to every observer. Returns True iff a chunk
+        was dispatched. Runs on the CONSUMER (UI/async) side — this is where RMS
+        ends up happening, safely away from capture.
+
+        Each observer is isolated: one that raises is counted and skipped, and
+        the others still receive the chunk."""
+        chunk = self.take()
+        if chunk is None:
+            return False
+        with self._lock:
+            observers = list(self._observers)
+        self.drained += 1
+        for obs in observers:
+            try:
+                obs(chunk, self._sample_rate)
+            except Exception:  # noqa: BLE001 — a bad observer never poisons the rest
+                self.observer_faults += 1
+                logger.debug("[AudioTap] observer raised", exc_info=True)
+        return True
+
+    def stats(self) -> dict:
+        return {
+            "offered": self.offered, "dropped": self.dropped,
+            "drained": self.drained, "observer_faults": self.observer_faults,
+            "observers": self.observer_count,
+        }
+
+
+_DEFAULT_TAP: Optional[AudioBroadcastTap] = None
+_TAP_LOCK = threading.Lock()
+
+
+def get_default_tap() -> AudioBroadcastTap:
+    """Process-wide tap. Lazy so importing this module costs nothing and so the
+    capture seam can reference it without an init ordering dependency."""
+    global _DEFAULT_TAP
+    with _TAP_LOCK:
+        if _DEFAULT_TAP is None:
+            _DEFAULT_TAP = AudioBroadcastTap()
+        return _DEFAULT_TAP
+
+
+def reset_default_tap() -> None:
+    """Test seam — drop the singleton so suites cannot bleed into each other."""
+    global _DEFAULT_TAP
+    with _TAP_LOCK:
+        _DEFAULT_TAP = None
+
+
+def offer_to_default_tap(chunk: Any, *, sample_rate: Optional[int] = None) -> bool:
+    """Convenience for the capture seam: fire-and-forget into the singleton.
+
+    Deliberately does NOT construct the tap when none exists yet — a capture
+    path with no visualizer attached should stay byte-identical, doing nothing at
+    all rather than allocating a mailbox nobody drains."""
+    try:
+        with _TAP_LOCK:
+            tap = _DEFAULT_TAP
+        if tap is None or tap.observer_count == 0:
+            return False
+        return tap.offer(chunk, sample_rate=sample_rate)
+    except Exception:  # noqa: BLE001
+        return False
+
+
+__all__ = [
+    "AudioBroadcastTap",
+    "Observer",
+    "get_default_tap",
+    "offer_to_default_tap",
+    "reset_default_tap",
+]

--- a/backend/voice/macos_voice.py
+++ b/backend/voice/macos_voice.py
@@ -216,6 +216,32 @@ class MacOSVoice:
                 ["afplay", _temp_path],
                 start_new_session=True,
             )
+            # ── Phantom tap: Karen's waveform, anchored to THIS instant ──────
+            # afplay is a separate OS process (v283.0, deliberately GIL-free), so
+            # there is no in-process playback callback to observe. Instead the
+            # UI envelope is synthesized from the very file afplay is playing and
+            # advanced on a clock anchored to the Popen above. Fire-and-forget:
+            # speech is never delayed, and any failure here leaves TTS
+            # byte-identical.
+            try:
+                from backend.voice.tts_phantom_tap import (
+                    default_system_emitter, phantom_tap_enabled, run_phantom_tap,
+                )
+                if phantom_tap_enabled():
+                    import asyncio as _aio
+                    import time as _t
+                    _anchor = _t.monotonic()
+                    try:
+                        _loop = _aio.get_running_loop()
+                    except RuntimeError:
+                        _loop = None
+                    if _loop is not None:
+                        _loop.create_task(run_phantom_tap(
+                            _temp_path, proc=_play_proc,
+                            emit=default_system_emitter(), anchor=_anchor,
+                        ))
+            except Exception:  # noqa: BLE001 — visualization NEVER affects speech
+                pass
             _play_proc.wait()
         finally:
             try:

--- a/backend/voice/streaming_processor.py
+++ b/backend/voice/streaming_processor.py
@@ -123,6 +123,23 @@ class StreamingAudioProcessor:
         Feed audio data to the processor
         Returns False if buffer is full (data dropped)
         """
+        # ── Zero-copy UI broadcast tap ────────────────────────────────────
+        # FIRST statement in the ingest path, BEFORE any dtype conversion or
+        # chunking, so the visualizer sees exactly what the mic delivered and
+        # adds nothing to the STT critical path.
+        #
+        # macOS CoreAudio refuses a second handle on a captured device, so the
+        # UI cannot open its own stream — it must observe this one. Safety is
+        # structural: offer() stores a read-only VIEW (O(1), no copy) into a
+        # single-slot latest-wins mailbox using a NON-BLOCKING lock, performs no
+        # arithmetic, and swallows every exception. RMS happens on the consumer
+        # side. A no-op when nothing is subscribed.
+        try:
+            from backend.voice.audio_broadcast_tap import offer_to_default_tap
+            offer_to_default_tap(audio_data, sample_rate=self.sample_rate)
+        except Exception:  # noqa: BLE001 — the tap can NEVER affect transcription
+            pass
+
         # Convert to float32 if needed
         if audio_data.dtype != np.float32:
             audio_data = audio_data.astype(np.float32)

--- a/backend/voice/tts_phantom_tap.py
+++ b/backend/voice/tts_phantom_tap.py
@@ -1,0 +1,295 @@
+"""Phantom tap — Karen's waveform, synthesized across a process boundary.
+
+Why "phantom"
+-------------
+Karen's audio never passes through Python at playback time. ``macos_voice.py``
+runs ``say -o <temp.aiff>`` then hands the file to ``afplay`` as a **separate OS
+process** — a deliberate v283.0 decision, because the previous in-process
+PortAudio callback was GIL-dependent and went static during GIL-heavy work
+(exactly when the organism is busy, i.e. exactly when Karen talks). There is
+therefore no hardware write callback to observe, and reverting that decision to
+gain one would trade working audio for a prettier meter.
+
+So the envelope is *synthesized* instead of *tapped*, from two facts that make
+it honest rather than fabricated:
+
+* the temp file **is** the audio ``afplay`` will play, so its RMS envelope is
+  the true amplitude curve of what the speaker emits;
+* ``afplay`` plays at real time, so advancing through that envelope on a clock
+  anchored to the ``Popen`` instant tracks the physical output.
+
+Accuracy is bounded by process-launch latency (~10-30ms), not by drift: each
+frame is scheduled against an ABSOLUTE deadline derived from the anchor
+(``t0 + i/fps``), so a late wakeup does not accumulate — the next frame simply
+targets its own true position. This is emphatically **not** a hardware tap and
+this module does not claim to be one.
+
+Isolation properties
+--------------------
+* **Extraction is off-loop.** Decoding a file is blocking work, so it runs in a
+  thread via ``asyncio.to_thread`` and yields a small float array. The event
+  loop never parses audio.
+* **Lifecycle follows the process.** The generator polls the ``afplay`` handle;
+  if playback ends or is killed it halts immediately and emits a terminal
+  ``0.0`` so the UI flatlines with the speaker rather than freezing on the last
+  peak.
+* **Nothing in the audio path changes.** No stream is opened, no buffer is
+  mutated, no subprocess argument is altered. Failure anywhere here leaves TTS
+  byte-identical.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import math
+import os
+import time
+from typing import Any, AsyncIterator, Callable, List, Optional, Sequence
+
+logger = logging.getLogger(__name__)
+
+#: Envelope framerate. Matches the UI pump's publish cap so the visual cadence
+#: is uniform whichever plane is speaking.
+DEFAULT_FPS = 20.0
+
+
+def phantom_tap_enabled() -> bool:
+    return os.environ.get(
+        "JARVIS_TTS_PHANTOM_TAP_ENABLED", "true",
+    ).strip().lower() in ("1", "true", "yes", "on")
+
+
+def _fps() -> float:
+    try:
+        return max(1.0, float(os.environ.get("JARVIS_TTS_ENVELOPE_FPS", str(DEFAULT_FPS))))
+    except (TypeError, ValueError):
+        return DEFAULT_FPS
+
+
+# ---------------------------------------------------------------------------
+# Envelope extraction (BLOCKING — always called via a thread)
+# ---------------------------------------------------------------------------
+
+
+def _decode_samples(path: str) -> tuple:
+    """``(samples, sample_rate)`` as a mono float list in -1..1, or ``([], 0)``.
+
+    Tries progressively more available backends. ``say -o`` emits AIFF by
+    default; the invocation is NOT altered to suit this reader, because changing
+    a working TTS command line to make a visualizer easier is the wrong
+    direction of dependency."""
+    # 1) soundfile — handles AIFF/WAV/CAF uniformly when present.
+    try:
+        import soundfile as sf  # type: ignore
+        data, sr = sf.read(path, dtype="float32", always_2d=True)
+        return ([float(f[0]) for f in data], int(sr))
+    except Exception:  # noqa: BLE001
+        pass
+    # 2) stdlib aifc (deprecated in 3.11, gone in 3.13 — hence the guard).
+    try:
+        import aifc  # type: ignore
+        import audioop  # type: ignore
+        with aifc.open(path, "rb") as fh:  # type: ignore[attr-defined]
+            sr = int(fh.getframerate())
+            width = int(fh.getsampwidth())
+            ch = int(fh.getnchannels())
+            raw = fh.readframes(fh.getnframes())
+        if ch > 1:
+            raw = audioop.tomono(raw, width, 0.5, 0.5)
+        scale = float(1 << (8 * width - 1))
+        import array as _array
+        code = {1: "b", 2: "h", 4: "i"}.get(width)
+        if code is None:
+            return ([], 0)
+        arr = _array.array(code)
+        arr.frombytes(raw[: len(raw) - (len(raw) % arr.itemsize)])
+        return ([s / scale for s in arr], sr)
+    except Exception:  # noqa: BLE001
+        pass
+    # 3) stdlib wave, for a WAV-shaped file.
+    try:
+        import array as _array
+        import wave
+        with wave.open(path, "rb") as fh:
+            sr = int(fh.getframerate())
+            width = int(fh.getsampwidth())
+            ch = int(fh.getnchannels())
+            raw = fh.readframes(fh.getnframes())
+        code = {1: "b", 2: "h", 4: "i"}.get(width)
+        if code is None:
+            return ([], 0)
+        arr = _array.array(code)
+        arr.frombytes(raw[: len(raw) - (len(raw) % arr.itemsize)])
+        vals = list(arr)[::ch] if ch > 1 else list(arr)
+        scale = float(1 << (8 * width - 1))
+        return ([v / scale for v in vals], sr)
+    except Exception:  # noqa: BLE001
+        return ([], 0)
+
+
+def extract_envelope_blocking(
+    path: str, *, fps: Optional[float] = None,
+) -> List[float]:
+    """RMS envelope at ``fps``, one float per frame. BLOCKING by design — always
+    invoke through :func:`extract_envelope`. Returns ``[]`` on any failure, which
+    the caller treats as "no visualization for this utterance"."""
+    rate = fps if fps else _fps()
+    try:
+        samples, sr = _decode_samples(path)
+        if not samples or sr <= 0:
+            return []
+        step = max(1, int(sr / rate))
+        out: List[float] = []
+        for i in range(0, len(samples), step):
+            window = samples[i:i + step]
+            if not window:
+                break
+            total = 0.0
+            for s in window:
+                total += s * s
+            out.append(math.sqrt(total / len(window)))
+        return out
+    except Exception:  # noqa: BLE001
+        return []
+
+
+async def extract_envelope(
+    path: str, *, fps: Optional[float] = None,
+) -> List[float]:
+    """Off-loop envelope extraction. Decoding is blocking work, so it runs in a
+    worker thread — the event loop never parses audio."""
+    try:
+        return await asyncio.to_thread(extract_envelope_blocking, path, fps=fps)
+    except Exception:  # noqa: BLE001
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Launch-anchored clock, tied to the playback process lifetime
+# ---------------------------------------------------------------------------
+
+
+def _process_alive(proc: Any) -> bool:
+    """True while the playback process is still running. A handle we cannot
+    interrogate is treated as DEAD — better to stop the animation early than to
+    keep painting a waveform after the speaker went quiet."""
+    try:
+        return proc is not None and proc.poll() is None
+    except Exception:  # noqa: BLE001
+        return False
+
+
+async def stream_envelope(
+    envelope: Sequence[float],
+    *,
+    proc: Any = None,
+    fps: Optional[float] = None,
+    anchor: Optional[float] = None,
+    clock: Optional[Callable[[], float]] = None,
+    sleep: Optional[Callable[[float], Any]] = None,
+) -> AsyncIterator[float]:
+    """Yield envelope frames on a clock anchored to the playback launch.
+
+    Frames are scheduled against ABSOLUTE deadlines (``anchor + i/rate``) rather
+    than by sleeping a fixed step, so a late wakeup cannot accumulate drift —
+    each frame targets its own true position and a badly overdue frame is simply
+    emitted at once.
+
+    Terminates early the moment ``proc`` exits, then yields a final ``0.0`` so
+    the UI flatlines with the audio instead of freezing on the last peak. That
+    terminal flush is emitted on EVERY exit path, including cancellation."""
+    rate = fps if fps else _fps()
+    now = clock or time.monotonic
+    naptime = sleep or asyncio.sleep
+    t0 = anchor if anchor is not None else now()
+    try:
+        for i, level in enumerate(envelope or ()):
+            if proc is not None and not _process_alive(proc):
+                break
+            delay = (t0 + (i / rate)) - now()
+            if delay > 0:
+                await naptime(delay)
+            # Re-check AFTER the wait: playback may have been killed mid-sleep.
+            if proc is not None and not _process_alive(proc):
+                break
+            try:
+                yield max(0.0, min(1.0, float(level)))
+            except (TypeError, ValueError):
+                yield 0.0
+    finally:
+        # Terminal flush — the UI must return to a flat baseline whether we ran
+        # to completion, hit process death, or were cancelled.
+        yield 0.0
+
+
+async def run_phantom_tap(
+    path: str,
+    *,
+    proc: Any = None,
+    emit: Optional[Callable[[float], Any]] = None,
+    fps: Optional[float] = None,
+    anchor: Optional[float] = None,
+) -> int:
+    """Extract, then stream, feeding each frame to ``emit``.
+
+    Returns how many frames were emitted (including the terminal flush), for
+    tests and telemetry. NEVER raises — a failed utterance visualization must
+    never disturb speech."""
+    if not phantom_tap_enabled():
+        return 0
+    frames = 0
+    try:
+        envelope = await extract_envelope(path, fps=fps)
+        if not envelope:
+            return 0
+        async for level in stream_envelope(
+            envelope, proc=proc, fps=fps, anchor=anchor,
+        ):
+            frames += 1
+            if emit is not None:
+                try:
+                    emit(level)
+                except Exception:  # noqa: BLE001 — a bad sink never stops speech
+                    logger.debug("[PhantomTap] emit failed", exc_info=True)
+    except asyncio.CancelledError:
+        if emit is not None:
+            try:
+                emit(0.0)
+            except Exception:  # noqa: BLE001
+                pass
+        raise
+    except Exception:  # noqa: BLE001
+        logger.debug("[PhantomTap] run failed", exc_info=True)
+    return frames
+
+
+def default_system_emitter() -> Optional[Callable[[float], Any]]:
+    """Feed the SAME pump/broker plumbing the microphone uses, tagged
+    ``AudioPlane.SYSTEM`` so the scope swaps cyan → venom green. DRY: no second
+    RMS pipeline, no second event path, no second normalizer."""
+    try:
+        from backend.core.ouroboros.ui.audio_pump import (
+            AudioLevelPump, default_publisher,
+        )
+        from backend.core.ouroboros.ui.audio_scope import AudioPlane
+
+        pump = AudioLevelPump(publish=default_publisher())
+
+        def _emit(level: float) -> None:
+            pump.feed_level(level, plane=AudioPlane.SYSTEM)
+
+        return _emit
+    except Exception:  # noqa: BLE001
+        return None
+
+
+__all__ = [
+    "DEFAULT_FPS",
+    "default_system_emitter",
+    "extract_envelope",
+    "extract_envelope_blocking",
+    "phantom_tap_enabled",
+    "run_phantom_tap",
+    "stream_envelope",
+]

--- a/scripts/jarvis_stash_audit.py
+++ b/scripts/jarvis_stash_audit.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Cryptographic triage of legacy ``refs/stash`` entries.
+
+Why this exists
+---------------
+Before the #70033 fix, the preemption-shield daemon registered every snapshot
+via ``git stash store``, i.e. onto ``refs/stash`` — a SHARED, ORDER-SENSITIVE
+stack. That left 49 machine-generated entries interleaved with human ones, and
+made ``git stash pop`` (which takes ``stash@{0}``) a coin flip. Snapshots now
+land under ``refs/jarvis/preemption/``; this tool cleans up what accumulated.
+
+Safety design (deliberately stronger than "classify, then drop")
+----------------------------------------------------------------
+Every entry is ARCHIVED FIRST, unconditionally, before ANY drop happens — even
+entries classified as fully-integrated. Archiving is a ref write: it costs no
+disk (the commit objects already exist) and pins them against GC. This means a
+bug in the *classifier* can never destroy work, because the classifier's verdict
+only decides the REPORT, never whether a recovery path exists.
+
+Verdicts
+--------
+``integrated``  — the stash's tree is reachable/identical in HEAD; its diff is
+                  empty. Nothing unique would be lost.
+``divergent``   — the stash carries content not in HEAD. Archived and reported
+                  loudly; recover with ``git stash apply <sha>``.
+``unreadable``  — git could not resolve the entry. Never dropped.
+
+DRY-RUN BY DEFAULT. Nothing is mutated without ``--apply``.
+
+Usage
+-----
+    python3 scripts/jarvis_stash_audit.py              # report only
+    python3 scripts/jarvis_stash_audit.py --apply      # archive + clear stack
+    python3 scripts/jarvis_stash_audit.py --json       # machine-readable
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from typing import List, Optional
+
+ARCHIVE_NS = "refs/jarvis/archive"
+_TIMEOUT_S = 30
+
+
+def _git(root: str, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", root, *args],
+        capture_output=True, text=True, timeout=_TIMEOUT_S,
+    )
+
+
+def repo_root(start: Optional[str] = None) -> Optional[str]:
+    try:
+        res = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=start or os.getcwd(), capture_output=True, text=True,
+            timeout=_TIMEOUT_S,
+        )
+        return res.stdout.strip() if res.returncode == 0 else None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def list_stashes(root: str) -> List[dict]:
+    """``refs/stash`` entries, newest first, as ``{index, sha, subject}``."""
+    res = _git(root, "stash", "list", "--format=%gd\t%H\t%gs")
+    if res.returncode != 0:
+        return []
+    out = []
+    for line in (res.stdout or "").splitlines():
+        parts = line.split("\t")
+        if len(parts) >= 2 and parts[1].strip():
+            out.append({
+                "index": parts[0].strip(),
+                "sha": parts[1].strip(),
+                "subject": parts[2].strip() if len(parts) > 2 else "",
+            })
+    return out
+
+
+def classify(root: str, sha: str) -> tuple:
+    """``(verdict, detail)``.
+
+    Compares the stash's OWN DELTA, not whole trees.
+
+    A naive ``git diff HEAD <stash>`` is wrong here and dangerously misleading:
+    a stash taken at an older HEAD differs from current HEAD by every commit
+    landed since, so it reports enormous deletion counts (observed: "155 files
+    changed, 30315 deletions") that describe repo drift, NOT work the stash
+    holds. Every entry would look unique.
+
+    The delta a stash actually captured is ``<sha>^..<sha>`` — its tree against
+    the HEAD it was taken from. The question that matters is then: for exactly
+    the paths that delta touches, does the stash's content already match current
+    HEAD? If yes, the work landed and dropping loses nothing.
+
+    Fails CLOSED throughout: any unreadable step is ``unreadable``, never
+    ``integrated``."""
+    probe = _git(root, "rev-parse", "--verify", f"{sha}^{{commit}}")
+    if probe.returncode != 0:
+        return ("unreadable", "sha does not resolve to a commit")
+
+    # The delta this stash captured, relative to its own parent.
+    own = _git(root, "diff", "--name-only", f"{sha}^", sha)
+    if own.returncode != 0:
+        return ("unreadable", (own.stderr or "parent diff failed").strip()[:160])
+
+    paths = [p for p in (own.stdout or "").splitlines() if p.strip()]
+    if not paths:
+        return ("integrated", "stash captured no delta")
+
+    # Scope the HEAD comparison to ONLY those paths.
+    scoped = _git(root, "diff", "--stat", "HEAD", sha, "--", *paths)
+    if scoped.returncode != 0:
+        return ("unreadable", (scoped.stderr or "scoped diff failed").strip()[:160])
+
+    body = (scoped.stdout or "").strip()
+    if not body:
+        return ("integrated", f"{len(paths)} path(s) already match HEAD")
+    last = body.splitlines()[-1].strip()
+    return ("divergent", f"{len(paths)} path(s) captured; {last[:120]}")
+
+
+def archive(root: str, sha: str, label: str) -> Optional[str]:
+    """Pin the stash commit under the archive namespace. Returns the ref name."""
+    ref = f"{ARCHIVE_NS}/legacy-{label}-{sha[:12]}"
+    res = _git(root, "update-ref", ref, sha)
+    return ref if res.returncode == 0 else None
+
+
+def audit(root: str, *, apply: bool = False) -> dict:
+    """Archive-then-clear. Returns a structured report."""
+    stashes = list_stashes(root)
+    report = {
+        "repo": root,
+        "total": len(stashes),
+        "applied": bool(apply),
+        "integrated": [],
+        "divergent": [],
+        "unreadable": [],
+        "archived": 0,
+        "dropped": 0,
+        "errors": [],
+    }
+
+    # PASS 1 — classify + archive EVERY entry. No drops yet: the stack must not
+    # shift underneath us (dropping renumbers stash@{N}), and nothing may be
+    # removed before its recovery ref exists.
+    for st in stashes:
+        verdict, detail = classify(root, st["sha"])
+        row = {"index": st["index"], "sha": st["sha"], "detail": detail}
+        report[verdict].append(row)
+        if not apply:
+            continue
+        ref = archive(root, st["sha"], verdict)
+        if ref:
+            row["archive_ref"] = ref
+            report["archived"] += 1
+        else:
+            report["errors"].append(f"archive failed for {st['sha'][:12]}")
+
+    if not apply:
+        return report
+
+    # PASS 2 — clear the stack. Only reached once every entry above has an
+    # archive ref. `stash drop` renumbers, so always drop index 0 and re-read.
+    droppable = report["archived"] == len(stashes) and not report["errors"]
+    if not droppable:
+        report["errors"].append(
+            "archive incomplete — refusing to drop anything (fail-closed)"
+        )
+        return report
+
+    guard = len(stashes) + 5   # bounded: never spin on a misbehaving git
+    while guard > 0 and list_stashes(root):
+        res = _git(root, "stash", "drop", "stash@{0}")
+        if res.returncode != 0:
+            report["errors"].append((res.stderr or "drop failed").strip()[:160])
+            break
+        report["dropped"] += 1
+        guard -= 1
+    return report
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--apply", action="store_true",
+                    help="archive every entry, then clear refs/stash")
+    ap.add_argument("--json", action="store_true", help="machine-readable output")
+    ap.add_argument("--repo", default=None)
+    args = ap.parse_args(argv)
+
+    root = args.repo or repo_root()
+    if not root:
+        print("not a git repository", file=sys.stderr)
+        return 2
+
+    rep = audit(root, apply=args.apply)
+
+    if args.json:
+        print(json.dumps(rep, indent=2, sort_keys=True))
+        return 0 if not rep["errors"] else 1
+
+    mode = "APPLIED" if rep["applied"] else "DRY-RUN (nothing mutated)"
+    print(f"stash audit — {mode}")
+    print(f"  total entries : {rep['total']}")
+    print(f"  integrated    : {len(rep['integrated'])}  (zero diff vs HEAD)")
+    print(f"  divergent     : {len(rep['divergent'])}  (unique work — archived)")
+    print(f"  unreadable    : {len(rep['unreadable'])}  (never dropped)")
+    if rep["applied"]:
+        print(f"  archived      : {rep['archived']} -> {ARCHIVE_NS}/")
+        print(f"  dropped       : {rep['dropped']}")
+    for row in rep["divergent"][:10]:
+        print(f"    ! {row['index']} {row['sha'][:12]}  {row['detail']}")
+    for e in rep["errors"]:
+        print(f"  ERROR: {e}")
+    if rep["applied"] and rep["divergent"]:
+        print(f"\n  recover any archived entry:  git stash apply <sha>")
+        print(f"  list archives:               git for-each-ref {ARCHIVE_NS}")
+    return 0 if not rep["errors"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/aegis/test_ast_pins.py
+++ b/tests/aegis/test_ast_pins.py
@@ -312,5 +312,10 @@ def test_preflight_outcome_taxonomy_exact_match():
         "failed_spawn",
         "failed_bootstrap_timeout",
         "failed_credential_scrub",
+        # Boot-time dependency validation. Reached only under
+        # JARVIS_AEGIS_DEP_STRICT, when declared-but-absent packages could not
+        # be reconciled — the loud alternative to silently degrading (the
+        # sentence-transformers LITE-tier incident, 2026-07-24).
+        "failed_dependency_drift",
     }
     assert actual == expected

--- a/tests/aegis/test_dependency_validation.py
+++ b/tests/aegis/test_dependency_validation.py
@@ -1,0 +1,208 @@
+"""Aegis boot-time dependency validation — the silent-degradation gate.
+
+The failure class this closes, observed live on 2026-07-24: `sentence-transformers`
+was declared in `backend/requirements.txt:49` but absent from the interpreter, so
+`EmbeddingService` logged ONE warning and ran on the LITE tier for a 15-hour
+session. Nothing failed; the organism just quietly got worse at its job.
+
+These pin the honest-reporting contract. Reconciliation (the pip call) is
+default-disarmed, so the default-path tests never touch the network.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.aegis.preflight import (
+    DependencyStatus,
+    DependencyValidationStep,
+    PreflightOutcome,
+    validate_dependencies,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    """Every knob starts unset so tests bind to documented defaults."""
+    for var in (
+        "JARVIS_AEGIS_DEP_VALIDATION_ENABLED",
+        "JARVIS_AEGIS_DEP_RECONCILE_ENABLED",
+        "JARVIS_AEGIS_DEP_STRICT",
+        "JARVIS_AEGIS_DEP_CRITICAL",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_intact_when_declared_package_is_importable(monkeypatch):
+    """A package that resolves → INTACT, nothing missing."""
+    monkeypatch.setenv("JARVIS_AEGIS_DEP_CRITICAL", "json=json")
+
+    step = validate_dependencies()
+
+    assert step.status is DependencyStatus.INTACT
+    assert step.checked == ("json",)
+    assert step.missing == ()
+    assert step.unresolved == ()
+
+
+def test_drift_detected_and_reported_when_reconcile_disarmed(monkeypatch):
+    """The core assertion: an absent package is REPORTED, not swallowed.
+
+    Reconciliation is off by default, so the step must still name the drift
+    rather than returning INTACT — silence is the bug being fixed."""
+    monkeypatch.setenv(
+        "JARVIS_AEGIS_DEP_CRITICAL",
+        "definitely_not_a_real_module_xyz=definitely-not-real-xyz==1.0",
+    )
+
+    step = validate_dependencies()
+
+    assert step.status is DependencyStatus.DRIFT
+    assert step.missing == ("definitely_not_a_real_module_xyz",)
+    assert step.unresolved == ("definitely_not_a_real_module_xyz",)
+    assert step.reconciled == ()
+    assert "disarmed" in (step.detail or "")
+
+
+def test_reconcile_requires_import_to_actually_work(monkeypatch):
+    """pip exiting 0 is necessary but NOT sufficient — the step re-probes the
+    real import path, so a package that 'installs' but cannot be imported is
+    still reported unresolved rather than laundered into RECONCILED."""
+    import subprocess
+
+    monkeypatch.setenv("JARVIS_AEGIS_DEP_RECONCILE_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_AEGIS_DEP_CRITICAL", "still_missing_after_pip=whatever==1.0")
+
+    class _FakeCompleted:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    # Mirrors the real contract: same call shape, same return attributes.
+    monkeypatch.setattr(
+        subprocess, "run", lambda *a, **k: _FakeCompleted(),
+    )
+
+    step = validate_dependencies()
+
+    assert step.status is DependencyStatus.DRIFT
+    assert step.reconciled == ()
+    assert step.unresolved == ("still_missing_after_pip",)
+
+
+def test_reconcile_success_path_reports_reconciled(monkeypatch):
+    """When pip succeeds AND the module becomes importable → RECONCILED."""
+    import subprocess
+
+    monkeypatch.setenv("JARVIS_AEGIS_DEP_RECONCILE_ENABLED", "true")
+    # `json` is already importable; force it to look missing on the first probe
+    # so we exercise the missing → reconcile → re-probe → success sequence.
+    monkeypatch.setenv("JARVIS_AEGIS_DEP_CRITICAL", "json=json")
+
+    import backend.core.ouroboros.aegis.preflight as pf
+
+    calls = {"n": 0}
+    real_importable = pf._importable
+
+    def _flaky(name):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return False          # first probe: "missing"
+        return real_importable(name)   # post-reconcile probe: real answer
+
+    monkeypatch.setattr(pf, "_importable", _flaky)
+
+    class _Ok:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _Ok())
+
+    step = validate_dependencies()
+
+    assert step.status is DependencyStatus.RECONCILED
+    assert step.reconciled == ("json",)
+    assert step.unresolved == ()
+
+
+def test_reconcile_survives_pip_blowing_up(monkeypatch):
+    """A pip subprocess that raises must not take boot down with it."""
+    import subprocess
+
+    monkeypatch.setenv("JARVIS_AEGIS_DEP_RECONCILE_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_AEGIS_DEP_CRITICAL", "nope_not_here=nope-not-here==1.0")
+
+    def _boom(*a, **k):
+        raise OSError("no pip for you")
+
+    monkeypatch.setattr(subprocess, "run", _boom)
+
+    step = validate_dependencies()   # must not raise
+
+    assert step.status is DependencyStatus.DRIFT
+    assert step.unresolved == ("nope_not_here",)
+
+
+def test_step_can_be_disabled_entirely(monkeypatch):
+    monkeypatch.setenv("JARVIS_AEGIS_DEP_VALIDATION_ENABLED", "false")
+
+    step = validate_dependencies()
+
+    assert step.status is DependencyStatus.SKIPPED
+    assert step.checked == ()
+
+
+def test_malformed_critical_entry_does_not_brick_boot(monkeypatch):
+    """A typo in the env list is skipped, never raised."""
+    monkeypatch.setenv("JARVIS_AEGIS_DEP_CRITICAL", ",,  ,json=json,")
+
+    step = validate_dependencies()
+
+    assert step.status is DependencyStatus.INTACT
+    assert step.checked == ("json",)
+
+
+def test_default_critical_list_names_sentence_transformers():
+    """Regression pin on the actual incident: the package whose absence caused
+    the silent LITE-tier degradation must be in the default watch list."""
+    from backend.core.ouroboros.aegis.preflight import _critical_deps
+
+    names = [n for n, _ in _critical_deps()]
+    assert "sentence_transformers" in names
+
+
+def test_result_serialisation_is_lossless_and_additive():
+    """`dependencies` rides on AegisPreflightResult.to_dict without disturbing
+    the existing schema version."""
+    from backend.core.ouroboros.aegis.preflight import (
+        AegisPreflightResult,
+        PREFLIGHT_SCHEMA_VERSION,
+    )
+
+    step = DependencyValidationStep(
+        status=DependencyStatus.DRIFT, checked=("a",), missing=("a",), unresolved=("a",),
+    )
+    result = AegisPreflightResult(
+        outcome=PreflightOutcome.READY, dependencies=step,
+    )
+    d = result.to_dict()
+
+    assert d["schema_version"] == PREFLIGHT_SCHEMA_VERSION
+    assert d["dependencies"]["status"] == "drift"
+    assert d["dependencies"]["missing"] == ["a"]
+    # The credential must never appear, dependency field or not.
+    assert "bootstrap_psk" not in d
+
+
+def test_result_without_dependencies_serialises_none():
+    """Back-compat: paths that ran before the step still serialise cleanly."""
+    from backend.core.ouroboros.aegis.preflight import AegisPreflightResult
+
+    d = AegisPreflightResult(outcome=PreflightOutcome.READY).to_dict()
+    assert d["dependencies"] is None
+
+
+def test_strict_mode_outcome_exists_in_taxonomy():
+    """The strict-mode terminal is a real member of the closed taxonomy."""
+    assert PreflightOutcome.FAILED_DEPENDENCY_DRIFT.value == "failed_dependency_drift"

--- a/tests/battle_test/test_graceful_preemption.py
+++ b/tests/battle_test/test_graceful_preemption.py
@@ -77,7 +77,7 @@ def _stash_list(repo):
 
 def test_git_safety_snapshots_non_destructively(tmp_path):
     """NON-DESTRUCTIVE contract: the dirty + untracked delta is snapshotted into
-    a recoverable [preemption-shield] stash entry AND left in place on disk
+    a recoverable private-namespace snapshot AND left in place on disk
     (the working tree is NOT cleared — the pre-2026-07-18 data-loss vector)."""
     repo = _init_repo(str(tmp_path / "r"))
     open(os.path.join(repo, "seed.txt"), "w").write("HALF-WRITTEN APPLY\n")
@@ -91,14 +91,18 @@ def test_git_safety_snapshots_non_destructively(tmp_path):
     assert open(os.path.join(repo, "seed.txt")).read() == "HALF-WRITTEN APPLY\n"
     assert os.path.isfile(os.path.join(repo, "newfile.py"))
 
-    # ...and the snapshot is recoverable via `git stash list`.
-    assert "preemption-shield" in _stash_list(repo)
+    # ...and the snapshot is recoverable — from the PRIVATE ref namespace, not
+    # the shared stash stack (hazard #70033: `stash store` pushed onto refs/stash,
+    # so a concurrent human/agent `git stash pop` took the daemon's entry).
+    refs = gp.list_preemption_refs(repo)
+    assert refs, "snapshot left no recoverable ref"
+    assert _stash_list(repo).strip() == "", "shared stash stack must stay untouched"
 
 
 def test_git_safety_snapshot_recoverable_after_tree_cleaned(tmp_path):
     """Belt-and-suspenders: even if the tree is later cleaned by something else
     (a subsequent reset / worktree teardown), the tracked delta is recoverable
-    from the [preemption-shield] stash entry via apply. (Untracked files don't
+    from the private-namespace snapshot via apply-by-SHA. (Untracked files don't
     need this path — the shield leaves them on disk in the first place.)"""
     repo = _init_repo(str(tmp_path / "r"))
     open(os.path.join(repo, "seed.txt"), "w").write("HALF-WRITTEN APPLY\n")
@@ -108,8 +112,13 @@ def test_git_safety_snapshot_recoverable_after_tree_cleaned(tmp_path):
     subprocess.run(["git", "-C", repo, "checkout", "--", "seed.txt"], check=True)
     assert "HALF-WRITTEN" not in open(os.path.join(repo, "seed.txt")).read()
 
-    # Recover the tracked delta from the shield's stash entry.
-    subprocess.run(["git", "-C", repo, "stash", "apply"], check=True)
+    # Recover the tracked delta by RAW SHA from the private namespace. Note this
+    # is strictly MORE robust than the old bare `git stash apply`, which relied
+    # on the snapshot still being at stash@{0} — the very assumption #70033 broke.
+    refs = gp.list_preemption_refs(repo)
+    assert refs, "snapshot left no recoverable ref"
+    _refname, sha = refs[0]
+    subprocess.run(["git", "-C", repo, "stash", "apply", sha], check=True)
     assert open(os.path.join(repo, "seed.txt")).read() == "HALF-WRITTEN APPLY\n"
 
 

--- a/tests/battle_test/test_harness_partial_shutdown.py
+++ b/tests/battle_test/test_harness_partial_shutdown.py
@@ -343,3 +343,99 @@ def test_signal_handler_tolerates_missing_shutdown_event(tmp_harness):
     # Must not raise.
     tmp_harness._handle_shutdown_signal()
     assert (tmp_harness._session_dir / "summary.json").is_file()
+
+
+# ---------------------------------------------------------------------------
+# SIGTERM contract — asserted against what the harness ACTUALLY does.
+#
+# Deliberately NOT asserting "exits 0": this harness exits via os._exit(75)
+# (the Py_FinalizeEx zombie class) and os._exit(137) (the resource-zero
+# backstop) on its watchdog paths, so a test demanding 0 would either fail or
+# pin a contract the code does not have. What IS guaranteed on a signal-driven
+# stop is the ledger: a parseable summary, a signal-derived stop_reason, and a
+# `complete` outcome when the reason is a clean terminal.
+# ---------------------------------------------------------------------------
+
+
+def test_sigterm_stop_reason_classifies_complete(tmp_harness):
+    """`shutdown_signal` is in the `_clean` set, so the pre-exit flush stamps
+    session_outcome=complete — a SIGTERM'd session is a finished session, not a
+    corrupted one."""
+    tmp_harness._stop_reason = "shutdown_signal"
+
+    tmp_harness._watchdog_pre_exit_flush()
+
+    summary_path = tmp_harness._session_dir / "summary.json"
+    assert summary_path.exists(), "pre-exit flush wrote no summary"
+    data = json.loads(summary_path.read_text())
+    assert data["session_outcome"] == "complete"
+    assert data["stop_reason"].startswith("shutdown_signal")
+    assert data["schema_version"] == 2
+
+
+def test_non_clean_stop_reason_classifies_incomplete_kill(tmp_harness):
+    """The negative half of the same gate — an unrecognised terminal must NOT
+    be laundered into `complete`."""
+    tmp_harness._stop_reason = "some_unexpected_wedge"
+
+    tmp_harness._watchdog_pre_exit_flush()
+
+    data = json.loads((tmp_harness._session_dir / "summary.json").read_text())
+    assert data["session_outcome"] == "incomplete_kill"
+
+
+def test_pre_exit_flush_is_idempotent(tmp_harness):
+    """A watchdog fire racing the normal writer must not double-write or raise
+    — the flush no-ops once a summary exists."""
+    tmp_harness._stop_reason = "shutdown_signal"
+    tmp_harness._watchdog_pre_exit_flush()
+    first = (tmp_harness._session_dir / "summary.json").read_text()
+
+    tmp_harness._watchdog_pre_exit_flush()  # must not raise, must not clobber
+    assert (tmp_harness._session_dir / "summary.json").read_text() == first
+
+
+def test_sigterm_flush_never_raises_on_broken_recorder(tmp_harness):
+    """The flush runs on the watchdog thread during teardown; it must swallow
+    everything rather than take the exit path down with it."""
+    class _Exploding:
+        def __getattr__(self, _name):
+            raise RuntimeError("recorder is gone")
+
+    tmp_harness._stop_reason = "shutdown_signal"
+    tmp_harness._session_recorder = _Exploding()
+
+    tmp_harness._watchdog_pre_exit_flush()  # must not raise
+
+
+def test_sqlite_locks_released_after_close(tmp_path):
+    """SQLite half of the shutdown contract: once the owning connection closes,
+    a fresh writer can take BEGIN IMMEDIATE and integrity_check is clean.
+
+    Pins the real behaviour observed on the live rotation — the intent DB runs
+    journal_mode=delete, so there is no WAL sidecar to flush; proof of release
+    is that a second writer can acquire, not that a -wal file vanished."""
+    import sqlite3
+
+    from backend.core.ouroboros.governance.soak_intent import (
+        enqueue_soak_intent,
+        pending_soak_count,
+    )
+
+    db = tmp_path / "chunk_strategy.db"
+    conn = sqlite3.connect(db)
+    enqueue_soak_intent(conn, kind="canary_soak", target="/tmp/c", intent_id="i1")
+    assert pending_soak_count(conn) == 1
+    conn.close()
+
+    assert not (tmp_path / "chunk_strategy.db-wal").exists()
+    assert not (tmp_path / "chunk_strategy.db-shm").exists()
+
+    after = sqlite3.connect(db, timeout=5)
+    try:
+        assert after.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+        after.execute("BEGIN IMMEDIATE")   # would raise "database is locked"
+        after.rollback()
+        assert pending_soak_count(after) == 1, "the row survived the close"
+    finally:
+        after.close()

--- a/tests/battle_test/test_preemption_ref_namespace.py
+++ b/tests/battle_test/test_preemption_ref_namespace.py
@@ -1,0 +1,138 @@
+"""Hazard #70033 — the daemon must never mutate the shared stash stack.
+
+Observed 2026-07-24, live: an agent ran `git stash push` then `git stash pop`
+while the preemption-shield daemon was running. Between those two commands the
+daemon called `git stash store`, which pushes onto `refs/stash` — a SHARED,
+ORDER-SENSITIVE stack. `git stash pop` takes `stash@{0}`, so the agent received
+the DAEMON's snapshot instead of their own and got a merge conflict in
+`awe_trigger.py`.
+
+The working tree was never the issue: `stash create` + `stash store` are both
+non-destructive by construction (that was the 2026-07-18 fix). The shared
+NAMESPACE was the issue. These tests run against a REAL git repo — a mocked
+subprocess would happily "prove" a stack that was never exercised.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from backend.core.ouroboros.battle_test import graceful_preemption as gp
+
+
+def _git(root, *args):
+    return subprocess.run(
+        ["git", *args], cwd=str(root), capture_output=True, text=True, timeout=30,
+    )
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """A real, minimal git repo with one commit."""
+    _git(tmp_path, "init", "-q")
+    _git(tmp_path, "config", "user.email", "t@t.t")
+    _git(tmp_path, "config", "user.name", "t")
+    (tmp_path / "tracked.py").write_text("x = 1\n")
+    _git(tmp_path, "add", "tracked.py")
+    _git(tmp_path, "commit", "-qm", "init")
+    return tmp_path
+
+
+def test_snapshot_does_not_touch_the_shared_stash_stack(repo):
+    """THE REGRESSION: after a daemon snapshot, `git stash list` must be empty."""
+    (repo / "tracked.py").write_text("x = 2\n")
+
+    result = gp.git_safety_stash(str(repo))
+    assert result.startswith("snapshot:"), result
+
+    listed = _git(repo, "stash", "list").stdout.strip()
+    assert listed == "", f"daemon polluted the shared stash stack: {listed!r}"
+
+
+def test_agent_stash_pop_returns_the_agents_own_work(repo):
+    """The exact live sequence: agent pushes, daemon snapshots, agent pops.
+    The agent must get THEIR content back, not the daemon's."""
+    (repo / "tracked.py").write_text("AGENT WORK\n")
+    _git(repo, "stash", "push", "-q", "-m", "agent-work")
+
+    # Daemon fires mid-flight, twice, on a different tree state.
+    (repo / "tracked.py").write_text("DAEMON SAW THIS\n")
+    assert gp.git_safety_stash(str(repo)).startswith("snapshot:")
+    (repo / "tracked.py").write_text("DAEMON SAW THIS TOO\n")
+    assert gp.git_safety_stash(str(repo)).startswith("snapshot:")
+
+    # Agent restores. Reset the tree first so the pop applies cleanly.
+    _git(repo, "checkout", "--", "tracked.py")
+    pop = _git(repo, "stash", "pop")
+    assert pop.returncode == 0, f"pop failed: {pop.stderr}"
+
+    assert (repo / "tracked.py").read_text() == "AGENT WORK\n", (
+        "the agent got someone else's stash — hazard #70033 is not fixed"
+    )
+
+
+def test_snapshot_leaves_the_working_tree_untouched(repo):
+    """Non-destructiveness is preserved (the 2026-07-18 property)."""
+    (repo / "tracked.py").write_text("dirty\n")
+    (repo / "untracked.py").write_text("new\n")
+
+    gp.git_safety_stash(str(repo))
+
+    assert (repo / "tracked.py").read_text() == "dirty\n"
+    assert (repo / "untracked.py").read_text() == "new\n"
+
+
+def test_snapshot_is_recoverable_from_the_private_namespace(repo):
+    """Recovery must survive the move off the stack — apply by RAW SHA."""
+    from backend.core.ouroboros.governance.workspace_checkpoint import apply_stash_ref
+
+    (repo / "tracked.py").write_text("RECOVER ME\n")
+    out = gp.git_safety_stash(str(repo))
+    assert out.startswith("snapshot:")
+
+    refs = gp.list_preemption_refs(str(repo))
+    assert refs, "snapshot left no listable ref"
+    _refname, sha = refs[0]
+
+    # Throw the work away, then restore it from the snapshot.
+    _git(repo, "checkout", "--", "tracked.py")
+    assert (repo / "tracked.py").read_text() == "x = 1\n"
+
+    assert apply_stash_ref(str(repo), sha) is True
+    assert (repo / "tracked.py").read_text() == "RECOVER ME\n"
+
+
+def test_clean_tree_snapshots_nothing(repo):
+    assert gp.git_safety_stash(str(repo)) == "tree_clean"
+    assert gp.list_preemption_refs(str(repo)) == []
+
+
+def test_namespace_retention_is_bounded(repo, monkeypatch):
+    """A long-lived daemon must not grow the ref namespace without bound."""
+    monkeypatch.setenv("JARVIS_PREEMPTION_SNAPSHOT_RETAIN", "3")
+
+    for i in range(6):
+        (repo / "tracked.py").write_text(f"rev {i}\n")
+        gp.git_safety_stash(str(repo))
+
+    refs = gp.list_preemption_refs(str(repo))
+    assert len(refs) <= 3, f"retention not enforced: {len(refs)} refs"
+    assert _git(repo, "stash", "list").stdout.strip() == ""
+
+
+def test_concurrent_daemon_snapshots_never_collide(repo):
+    """Many snapshots in the same second must not clobber one another — the ref
+    name carries the content SHA, not just a timestamp."""
+    shas = set()
+    for i in range(4):
+        (repo / "tracked.py").write_text(f"content {i}\n")
+        out = gp.git_safety_stash(str(repo))
+        assert out.startswith("snapshot:")
+        shas.add(out.split(":", 1)[1])
+
+    refs = gp.list_preemption_refs(str(repo))
+    assert len(refs) == len(shas) == 4, (
+        f"distinct snapshots collapsed: {len(refs)} refs for {len(shas)} shas"
+    )

--- a/tests/battle_test/test_stash_audit_and_cache_telemetry.py
+++ b/tests/battle_test/test_stash_audit_and_cache_telemetry.py
@@ -1,0 +1,222 @@
+"""Stash triage + DW cache telemetry.
+
+Both against real substrate: a REAL git repo for the audit (a mocked subprocess
+would "prove" a stack never exercised) and real usage-payload shapes for the
+telemetry, including the shape DoubleWord actually returned on 2026-07-24.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from backend.core.ouroboros.governance.doubleword_provider import (
+    emit_cache_telemetry,
+    extract_cache_usage,
+)
+from scripts import jarvis_stash_audit as audit
+
+
+def _git(root, *a):
+    return subprocess.run(
+        ["git", "-C", str(root), *a], capture_output=True, text=True, timeout=30,
+    )
+
+
+@pytest.fixture
+def repo(tmp_path):
+    _git(tmp_path, "init", "-q")
+    _git(tmp_path, "config", "user.email", "t@t.t")
+    _git(tmp_path, "config", "user.name", "t")
+    (tmp_path / "f.py").write_text("base\n")
+    _git(tmp_path, "add", "f.py")
+    _git(tmp_path, "commit", "-qm", "init")
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Stash triage
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_mutates_nothing(repo):
+    (repo / "f.py").write_text("dirty\n")
+    _git(repo, "stash", "push", "-q", "-m", "work")
+
+    rep = audit.audit(str(repo), apply=False)
+
+    assert rep["total"] == 1
+    assert rep["applied"] is False
+    assert rep["dropped"] == 0 and rep["archived"] == 0
+    assert len(_git(repo, "stash", "list").stdout.strip().splitlines()) == 1
+
+
+def test_divergent_stash_is_archived_before_being_dropped(repo):
+    """Unique work must survive the clear — recoverable from the archive ref."""
+    (repo / "f.py").write_text("UNIQUE WORK\n")
+    _git(repo, "stash", "push", "-q", "-m", "unique")
+
+    rep = audit.audit(str(repo), apply=True)
+
+    assert rep["total"] == 1
+    assert len(rep["divergent"]) == 1, rep
+    assert rep["archived"] == 1 and rep["dropped"] == 1
+    assert _git(repo, "stash", "list").stdout.strip() == "", "stack not cleared"
+
+    refs = _git(repo, "for-each-ref", "--format=%(objectname)", audit.ARCHIVE_NS)
+    shas = [s for s in refs.stdout.split() if s]
+    assert shas, "divergent work was dropped without an archive ref"
+
+    # The archived snapshot really restores the work.
+    assert _git(repo, "stash", "apply", shas[0]).returncode == 0
+    assert (repo / "f.py").read_text() == "UNIQUE WORK\n"
+
+
+def test_integrated_stash_is_still_archived(repo):
+    """Even a zero-diff entry gets a recovery ref BEFORE any drop — a classifier
+    bug must never be able to destroy work."""
+    (repo / "f.py").write_text("landed\n")
+    _git(repo, "stash", "push", "-q", "-m", "will-land")
+    # Land the same content on HEAD so the stash becomes redundant.
+    (repo / "f.py").write_text("landed\n")
+    _git(repo, "add", "f.py")
+    _git(repo, "commit", "-qm", "land it")
+
+    rep = audit.audit(str(repo), apply=True)
+
+    assert len(rep["integrated"]) == 1, rep
+    assert rep["archived"] == 1, "integrated entry was dropped unarchived"
+    assert rep["dropped"] == 1
+    assert _git(repo, "stash", "list").stdout.strip() == ""
+
+
+def test_clears_a_multi_entry_stack_completely(repo):
+    for i in range(5):
+        (repo / "f.py").write_text(f"rev{i}\n")
+        _git(repo, "stash", "push", "-q", "-m", f"s{i}")
+
+    rep = audit.audit(str(repo), apply=True)
+
+    assert rep["total"] == 5
+    assert rep["archived"] == 5 and rep["dropped"] == 5
+    assert _git(repo, "stash", "list").stdout.strip() == ""
+
+
+def test_empty_stack_is_a_clean_noop(repo):
+    rep = audit.audit(str(repo), apply=True)
+    assert rep["total"] == 0 and rep["dropped"] == 0 and not rep["errors"]
+
+
+def test_archive_failure_blocks_every_drop(repo, monkeypatch):
+    """FAIL-CLOSED: if archiving any entry fails, nothing is dropped at all."""
+    (repo / "f.py").write_text("precious\n")
+    _git(repo, "stash", "push", "-q", "-m", "precious")
+
+    monkeypatch.setattr(audit, "archive", lambda *a, **k: None)
+
+    rep = audit.audit(str(repo), apply=True)
+
+    assert rep["dropped"] == 0, "dropped despite a failed archive"
+    assert rep["errors"]
+    assert len(_git(repo, "stash", "list").stdout.strip().splitlines()) == 1
+
+
+def test_unreadable_entry_is_never_classified_integrated(repo, monkeypatch):
+    """A diff we cannot read fails CLOSED — never 'safe to drop'."""
+    (repo / "f.py").write_text("x\n")
+    _git(repo, "stash", "push", "-q", "-m", "s")
+
+    real = audit._git
+
+    def _fail_diff(root, *args):
+        if args and args[0] == "diff":
+            return subprocess.CompletedProcess(args, 1, "", "boom")
+        return real(root, *args)
+
+    monkeypatch.setattr(audit, "_git", _fail_diff)
+    rep = audit.audit(str(repo), apply=False)
+    assert len(rep["unreadable"]) == 1 and not rep["integrated"]
+
+
+# ---------------------------------------------------------------------------
+# Cache telemetry
+# ---------------------------------------------------------------------------
+
+
+def test_omitted_cache_fields_degrade_gracefully():
+    """No cache fields at all -> None, so absence never masquerades as a
+    measured zero."""
+    assert extract_cache_usage({"prompt_tokens": 500}) is None
+    assert emit_cache_telemetry({"prompt_tokens": 500}) is None
+    assert extract_cache_usage(None) is None
+    assert extract_cache_usage("not-a-dict") is None
+
+
+def test_measured_zero_is_distinct_from_absent():
+    """Cache armed but nothing warm yet is REAL data and must be reported."""
+    stats = extract_cache_usage({
+        "prompt_tokens": 100,
+        "cache_read_input_tokens": 0,
+        "cache_creation_input_tokens": 0,
+    })
+    assert stats is not None
+    assert stats["hit_ratio"] == 0.0
+    assert stats["saved_input_units"] == 0.0
+
+
+def test_savings_math_on_the_real_observed_payload():
+    """Shape DW actually returned on 2026-07-24 (2166 prompt tokens)."""
+    stats = extract_cache_usage({
+        "prompt_tokens": 2166,
+        "completion_tokens": 6083,
+        "cache_read_input_tokens": 1900,
+        "cache_creation_input_tokens": 0,
+    })
+    assert stats["fresh_input_tokens"] == 266
+    # 266 fresh + 1900 * 0.1 = 456 billed, vs 2166 uncached.
+    assert stats["billed_input_units"] == pytest.approx(456.0)
+    assert stats["uncached_input_units"] == pytest.approx(2166.0)
+    assert stats["saved_input_units"] == pytest.approx(1710.0)
+    assert stats["hit_ratio"] == pytest.approx(0.8772, abs=1e-3)
+
+
+def test_cache_write_costs_more_than_plain_input():
+    """A write is a PREMIUM — savings must not be claimed on the write itself,
+    or the first call of every soak would report phantom gains."""
+    stats = extract_cache_usage({
+        "prompt_tokens": 1000,
+        "cache_read_input_tokens": 0,
+        "cache_creation_input_tokens": 1000,
+    })
+    assert stats["billed_input_units"] > stats["uncached_input_units"]
+    assert stats["saved_input_units"] < 0
+
+
+def test_multipliers_are_env_tunable(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_CACHE_READ_MULT", "0.5")
+    stats = extract_cache_usage({
+        "prompt_tokens": 1000, "cache_read_input_tokens": 1000,
+        "cache_creation_input_tokens": 0,
+    })
+    assert stats["billed_input_units"] == pytest.approx(500.0)
+
+
+def test_garbage_values_never_raise():
+    for bad in (
+        {"prompt_tokens": "x", "cache_read_input_tokens": None},
+        {"cache_read_input_tokens": -5, "prompt_tokens": 10},
+        {"cache_creation_input_tokens": [1, 2], "prompt_tokens": 10},
+    ):
+        out = extract_cache_usage(bad)
+        assert out is None or isinstance(out, dict)
+
+
+def test_prompt_tokens_exclusive_of_reads_does_not_go_negative():
+    """Some providers report prompt_tokens EXCLUDING cached reads; fresh must
+    clamp at 0 rather than emitting a negative."""
+    stats = extract_cache_usage({
+        "prompt_tokens": 100, "cache_read_input_tokens": 900,
+        "cache_creation_input_tokens": 0,
+    })
+    assert stats["fresh_input_tokens"] == 0

--- a/tests/governance/test_awe_trigger.py
+++ b/tests/governance/test_awe_trigger.py
@@ -165,3 +165,172 @@ async def test_awe_lock_is_atomic_single_winner(db_path):
     assert len(winners) == 1
     lock = read_soak_lock(sqlite3.connect(db_path))
     assert lock is not None and lock["claimed"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Gap #2 — the substrate-aware dispatcher.
+#
+# Before this, AWE's ONLY strategy was a hardcoded battle-test spawn, so a
+# queued checkpoint manifest survived the recovery edge untouched: the intent
+# stayed `pending` forever while a generic soak ran in its place. These pin the
+# routing decision against REAL SQLite + the REAL next_pending_intent query —
+# only the terminal launchers are faked, so a regression in the queue schema or
+# the ordering surfaces here rather than at 3 AM.
+# ---------------------------------------------------------------------------
+
+
+def _seed_intent(db_path, *, intent_id, manifest_json, target, priority=1):
+    """Enqueue via the REAL production writer (not hand-rolled INSERT), so the
+    test binds to the shipping schema."""
+    from backend.core.ouroboros.governance.soak_intent import enqueue_soak_intent
+
+    conn = sqlite3.connect(db_path)
+    try:
+        enqueue_soak_intent(
+            conn, kind="canary_soak", target=target, priority=priority,
+            intent_id=intent_id, manifest_json=manifest_json,
+        )
+    finally:
+        conn.close()
+
+
+def _dispatcher(db_path, *, fallback, client=object(), crumbs=None):
+    from backend.core.ouroboros.governance.awe_trigger import (
+        build_manifest_aware_launch_fn,
+    )
+    return build_manifest_aware_launch_fn(
+        db_factory=lambda: sqlite3.connect(db_path),
+        client_factory=lambda: client,
+        fallback_fn=fallback,
+        breadcrumb_fn=(lambda et, p: crumbs.append((et, dict(p)))) if crumbs is not None else None,
+    )
+
+
+async def test_pending_manifest_routes_to_run_pending_soak(db_path, monkeypatch):
+    """(1) A pending row carrying a manifest routes DIRECTLY to run_pending_soak
+    — and carries the intent's `target` as repo_root, because manifest chunk
+    file_paths are stored relative to it."""
+    import json
+
+    from backend.core.ouroboros.governance import checkpoint_manifest
+
+    manifest = json.dumps({
+        "schema_version": 2, "target": "/tmp/canary",
+        "pending_chunks": [{"chunk_id": "c1", "file_path": "mathy.py",
+                            "symbol": "factorial", "start_line": 4, "end_line": 8}],
+        "completed_chunks": [], "quarantined_chunks": [], "chunk_retry_counts": {},
+    })
+    _seed_intent(db_path, intent_id="canary01", manifest_json=manifest,
+                 target="/tmp/canary")
+
+    seen = {}
+
+    async def fake_run_pending_soak(conn, intent_id, *, client, repo_root="."):
+        seen["intent_id"] = intent_id
+        seen["repo_root"] = repo_root
+        seen["client"] = client
+        return "manifest-ran"
+
+    monkeypatch.setattr(checkpoint_manifest, "run_pending_soak", fake_run_pending_soak)
+
+    fallback_calls = []
+
+    async def fallback(run_id):
+        fallback_calls.append(run_id)
+        return "fallback-ran"
+
+    sentinel_client = object()
+    crumbs: list = []
+    launch = _dispatcher(db_path, fallback=fallback, client=sentinel_client, crumbs=crumbs)
+
+    result = await launch("run-1")
+
+    assert result == "manifest-ran"
+    assert fallback_calls == [], "generic soak must NOT run when a manifest is pending"
+    assert seen["intent_id"] == "canary01"
+    # The load-bearing detail: repo_root is the intent target, NOT the repo root.
+    assert seen["repo_root"] == "/tmp/canary"
+    assert seen["client"] is sentinel_client
+    strategies = [p.get("strategy") for et, p in crumbs if et == "awe_launch_strategy"]
+    assert strategies == ["manifest"], "the routing decision must be observable"
+
+
+async def test_empty_queue_routes_to_subprocess_fallback(db_path):
+    """(2) An empty intent queue cleanly routes to the generic battle-test soak."""
+    fallback_calls = []
+
+    async def fallback(run_id):
+        fallback_calls.append(run_id)
+        return "fallback-ran"
+
+    crumbs: list = []
+    launch = _dispatcher(db_path, fallback=fallback, crumbs=crumbs)
+
+    result = await launch("run-2")
+
+    assert result == "fallback-ran"
+    assert fallback_calls == ["run-2"]
+    strategies = [p.get("strategy") for et, p in crumbs if et == "awe_launch_strategy"]
+    assert strategies == ["subprocess_fallback"]
+
+
+async def test_pending_intent_without_manifest_falls_back(db_path):
+    """A pending intent with no manifest is real work but not CHECKPOINTED work
+    — route it to the generic soak rather than resuming an empty run."""
+    _seed_intent(db_path, intent_id="nomanifest", manifest_json=None, target="/tmp/x")
+
+    fallback_calls = []
+
+    async def fallback(run_id):
+        fallback_calls.append(run_id)
+        return "fallback-ran"
+
+    crumbs: list = []
+    launch = _dispatcher(db_path, fallback=fallback, crumbs=crumbs)
+    assert await launch("run-3") == "fallback-ran"
+    assert fallback_calls == ["run-3"]
+    reasons = [p.get("reason") for et, p in crumbs if et == "awe_launch_strategy"]
+    assert reasons == ["intent carries no manifest"]
+
+
+async def test_unresolvable_client_degrades_to_fallback_not_silence(db_path):
+    """A manifest we cannot drive in-process must run the generic soak, NOT drop
+    the recovery edge on the floor."""
+    import json
+
+    _seed_intent(db_path, intent_id="canary02",
+                 manifest_json=json.dumps({"schema_version": 2, "pending_chunks": []}),
+                 target="/tmp/canary")
+
+    fallback_calls = []
+
+    async def fallback(run_id):
+        fallback_calls.append(run_id)
+        return "fallback-ran"
+
+    crumbs: list = []
+    launch = _dispatcher(db_path, fallback=fallback, client=None, crumbs=crumbs)
+    assert await launch("run-4") == "fallback-ran"
+    assert fallback_calls == ["run-4"]
+
+
+async def test_priority_ordering_picks_the_urgent_intent(db_path):
+    """next_pending_intent must hand AWE the same intent the supervisor's arm
+    gate counted — highest priority (lowest number) first."""
+    import json
+
+    from backend.core.ouroboros.governance.soak_intent import next_pending_intent
+
+    m = json.dumps({"schema_version": 2, "pending_chunks": []})
+    _seed_intent(db_path, intent_id="low", manifest_json=m, target="/a", priority=9)
+    _seed_intent(db_path, intent_id="urgent", manifest_json=m, target="/b", priority=1)
+
+    conn = sqlite3.connect(db_path)
+    try:
+        got = next_pending_intent(conn)
+    finally:
+        conn.close()
+    assert got is not None
+    assert got.intent_id == "urgent"
+    assert got.target == "/b"
+    assert got.has_manifest is True

--- a/tests/governance/test_awe_trigger.py
+++ b/tests/governance/test_awe_trigger.py
@@ -194,7 +194,7 @@ def _seed_intent(db_path, *, intent_id, manifest_json, target, priority=1):
         conn.close()
 
 
-def _dispatcher(db_path, *, fallback, client=object(), crumbs=None):
+def _dispatcher(db_path, *, fallback, client=object(), crumbs=None, git_status_fn=None):
     from backend.core.ouroboros.governance.awe_trigger import (
         build_manifest_aware_launch_fn,
     )
@@ -203,6 +203,10 @@ def _dispatcher(db_path, *, fallback, client=object(), crumbs=None):
         client_factory=lambda: client,
         fallback_fn=fallback,
         breadcrumb_fn=(lambda et, p: crumbs.append((et, dict(p)))) if crumbs is not None else None,
+        # Pin a CLEAN tree by default. These are routing tests; without this
+        # they read the ambient repo porcelain and fail whenever the developer
+        # running them happens to have uncommitted work.
+        git_status_fn=git_status_fn or (lambda: []),
     )
 
 
@@ -334,3 +338,180 @@ async def test_priority_ordering_picks_the_urgent_intent(db_path):
     assert got.intent_id == "urgent"
     assert got.target == "/b"
     assert got.has_manifest is True
+
+
+# ---------------------------------------------------------------------------
+# Clean-tree invariant + the governance-shield ground truth.
+#
+# NOTE ON THE SHIELD: these assert that `backend/soak_probes/canary/` is
+# ALREADY permitted by the self-modification cage — no whitelist was added, and
+# none is needed. The cage matches `ouroboros/governance/` and friends by
+# substring; the canary matches nothing. The 22 blocked ops in session
+# bt-2026-07-24-045323 were sensor-sourced ops whose file sets touched the
+# caged surfaces, i.e. the cage doing its job. Pinning this so nobody later
+# "fixes" a block that was never blocking the canary.
+# ---------------------------------------------------------------------------
+
+
+def _engine():
+    from backend.core.ouroboros.governance.risk_engine import RiskEngine
+    return RiskEngine()
+
+
+def test_canary_paths_are_not_caged_by_self_mod_shield():
+    """(2) A file in backend/soak_probes/canary/ must NOT trip the self-mod or
+    kernel sentinels — the canary soak is permitted as-is."""
+    eng = _engine()
+    for path in (
+        "backend/soak_probes/canary/mathy.py",
+        "backend/soak_probes/canary/strings_util.py",
+        "backend/soak_probes/canary/widgets.py",
+    ):
+        assert not eng._matches_any([path], eng._self_mod_sentinels()), path
+        assert not eng._matches_any([path], eng._kernel_sentinels()), path
+
+
+def test_governance_paths_remain_caged():
+    """(1) The negative control: a core governance file DOES trip the shield.
+    If this ever goes green-by-passing, the cage has been hollowed out."""
+    eng = _engine()
+    caged = "backend/core/ouroboros/governance/orchestrator.py"
+    assert eng._matches_any([caged], eng._self_mod_sentinels())
+
+
+def test_self_mod_sentinel_env_hook_is_additive_only():
+    """The cage can be WIDENED by env but never narrowed — there is no
+    subtraction/whitelist mechanism, by contract."""
+    import os
+
+    eng = _engine()
+    base = set(eng._self_mod_sentinels())
+    os.environ["JARVIS_EXTRA_SELF_MOD_SENTINELS"] = "backend/soak_probes/"
+    try:
+        widened = set(eng._self_mod_sentinels())
+    finally:
+        os.environ.pop("JARVIS_EXTRA_SELF_MOD_SENTINELS", None)
+    assert base.issubset(widened), "env hook must never remove a sentinel"
+
+
+async def test_dirty_tree_aborts_the_soak_launch(db_path):
+    """(3) A dirty working tree makes AWE refuse — and it refuses by RAISING,
+    so the caller releases the execution lock for a later clean-tree edge."""
+    import json
+
+    from backend.core.ouroboros.governance.awe_trigger import DirtyTreeRefusal
+
+    _seed_intent(db_path, intent_id="canary03",
+                 manifest_json=json.dumps({"schema_version": 2, "pending_chunks": []}),
+                 target="/tmp/canary")
+
+    fallback_calls = []
+
+    async def fallback(run_id):
+        fallback_calls.append(run_id)
+        return "fallback-ran"
+
+    from backend.core.ouroboros.governance.awe_trigger import (
+        build_manifest_aware_launch_fn,
+    )
+    crumbs: list = []
+    launch = build_manifest_aware_launch_fn(
+        db_factory=lambda: sqlite3.connect(db_path),
+        client_factory=lambda: object(),
+        fallback_fn=fallback,
+        breadcrumb_fn=lambda et, p: crumbs.append((et, dict(p))),
+        # Real porcelain shape: XY + space + path.
+        git_status_fn=lambda: [" M backend/core/ouroboros/governance/orchestrator.py",
+                               "?? scratch.py"],
+    )
+
+    with pytest.raises(DirtyTreeRefusal):
+        await launch("run-dirty")
+
+    assert fallback_calls == [], "a dirty tree must not fall through to the soak"
+    strategies = [p.get("strategy") for et, p in crumbs if et == "awe_launch_strategy"]
+    assert strategies == ["refused_dirty_tree"]
+
+
+async def test_clean_tree_permits_the_launch(db_path):
+    """The positive half: an empty porcelain lets dispatch proceed normally."""
+    fallback_calls = []
+
+    async def fallback(run_id):
+        fallback_calls.append(run_id)
+        return "fallback-ran"
+
+    from backend.core.ouroboros.governance.awe_trigger import (
+        build_manifest_aware_launch_fn,
+    )
+    launch = build_manifest_aware_launch_fn(
+        db_factory=lambda: sqlite3.connect(db_path),
+        fallback_fn=fallback,
+        git_status_fn=lambda: [],
+    )
+    assert await launch("run-clean") == "fallback-ran"
+
+
+async def test_clean_tree_allowlist_permits_scoped_dirt(db_path, monkeypatch):
+    """An operator may permit specific prefixes without disarming the invariant."""
+    monkeypatch.setenv("JARVIS_AWE_CLEAN_TREE_ALLOW", "backend/soak_probes/")
+
+    async def fallback(run_id):
+        return "fallback-ran"
+
+    from backend.core.ouroboros.governance.awe_trigger import (
+        build_manifest_aware_launch_fn,
+    )
+    launch = build_manifest_aware_launch_fn(
+        db_factory=lambda: sqlite3.connect(db_path),
+        fallback_fn=fallback,
+        git_status_fn=lambda: [" M backend/soak_probes/canary/mathy.py"],
+    )
+    assert await launch("run-allow") == "fallback-ran"
+
+
+async def test_clean_tree_invariant_can_be_disarmed(db_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_AWE_REQUIRE_CLEAN_TREE", "false")
+
+    async def fallback(run_id):
+        return "fallback-ran"
+
+    from backend.core.ouroboros.governance.awe_trigger import (
+        build_manifest_aware_launch_fn,
+    )
+    launch = build_manifest_aware_launch_fn(
+        db_factory=lambda: sqlite3.connect(db_path),
+        fallback_fn=fallback,
+        git_status_fn=lambda: [" M anything.py"],
+    )
+    assert await launch("run-disarmed") == "fallback-ran"
+
+
+async def test_refusal_releases_the_lock_for_a_later_edge(db_path):
+    """End-to-end through the REAL trigger: a dirty-tree refusal must not wedge
+    the execution lock — the whole reason it raises instead of returning."""
+    from backend.core.ouroboros.governance.awe_trigger import (
+        build_manifest_aware_launch_fn,
+    )
+    from backend.core.ouroboros.governance.soak_execution_lock import read_soak_lock
+
+    async def _unused_fallback(run_id):   # correct coroutine shape, never called
+        raise AssertionError("fallback must not run on a dirty-tree refusal")
+
+    launch = build_manifest_aware_launch_fn(
+        db_factory=lambda: sqlite3.connect(db_path),
+        fallback_fn=_unused_fallback,
+        git_status_fn=lambda: [" M dirty.py"],
+    )
+    trigger = _make_trigger(db_path, launch, [])
+    fired = await trigger.on_state_event(
+        {"state": "HEALTHY", "previous_state": "DEGRADED"},
+    )
+    assert fired is True, "the edge claims the lock before the launcher runs"
+    # Let the detached soak coroutine reach its refusal + release.
+    await _wait_for(
+        lambda: (read_soak_lock(sqlite3.connect(db_path)) or {}).get("claimed") == 0,
+        timeout=3.0,
+    )
+    lock = read_soak_lock(sqlite3.connect(db_path))
+    assert lock is not None and lock["claimed"] == 0, "refusal must free the lock"

--- a/tests/governance/test_awe_trigger.py
+++ b/tests/governance/test_awe_trigger.py
@@ -515,3 +515,46 @@ async def test_refusal_releases_the_lock_for_a_later_edge(db_path):
     )
     lock = read_soak_lock(sqlite3.connect(db_path))
     assert lock is not None and lock["claimed"] == 0, "refusal must free the lock"
+
+
+async def test_dirty_tree_distress_post_is_not_empty(db_path, monkeypatch):
+    """The distress post must actually SAY something.
+
+    Regression pin: moltbook's voice templates interpolate a single `{detail}`
+    key and compose() defaults it to "" — so a post built from any other fact
+    key renders as the content-free 'hit a wall: . regrouping.' The refusal
+    notice exists to tell the operator WHY, so an empty body is a silent
+    failure dressed as a feature."""
+    from backend.core.ouroboros.governance import awe_trigger as at
+    from backend.core.ouroboros.governance.moltbook_personas import compose
+
+    captured = {}
+
+    def _fake_nowait(author_id, kind, body=None, **kw):
+        captured["author"] = author_id
+        captured["kind"] = kind
+        captured["facts"] = kw.get("facts") or {}
+
+    import backend.core.ouroboros.governance.moltbook as mb
+    monkeypatch.setattr(mb, "post_molt_nowait", _fake_nowait)
+
+    async def fallback(run_id):
+        return "fallback-ran"
+
+    launch = at.build_manifest_aware_launch_fn(
+        db_factory=lambda: sqlite3.connect(db_path),
+        fallback_fn=fallback,
+        git_status_fn=lambda: [" M backend/core/ouroboros/governance/orchestrator.py"],
+    )
+    with pytest.raises(at.DirtyTreeRefusal):
+        await launch("run-distress")
+
+    assert captured["kind"] == "distress"
+    facts = captured["facts"]
+    assert "detail" in facts, "without `detail` the rendered post is empty"
+
+    # Render through the REAL composer — the actual contract, not a proxy.
+    body = compose(captured["author"], "distress", facts)
+    assert body.strip(), "distress post rendered empty"
+    assert "hit a wall: . regrouping." != body.strip()
+    assert "orchestrator.py" in body, "the post must name the offending dirt"

--- a/tests/governance/test_dw_cache_economics.py
+++ b/tests/governance/test_dw_cache_economics.py
@@ -1,0 +1,245 @@
+"""Adaptive Cache Economics Engine — frequency over length.
+
+The static ``JARVIS_DW_PROMPT_CACHE_MIN_CHARS`` floor priced the wrong variable.
+For a prefix used N times the cost in input-units is
+``write_mult + (N-1)*read_mult`` cached vs ``N`` uncached — and every term scales
+linearly with prefix length, so LENGTH CANCELS OUT. Profitability depends only
+on reuse count. The floor therefore blocked a 1,500-char probe firing 40x/hour
+(hugely profitable) while admitting a 15,000-char one-off (a guaranteed loss).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance.dw_cache_economics import (
+    PromptSignatureTracker,
+    break_even_uses,
+    prompt_signature,
+    reset_default_tracker,
+    should_cache_write,
+)
+
+W, R = 1.25, 0.1   # provider defaults: write premium, read discount
+
+
+@pytest.fixture(autouse=True)
+def _clean_singleton():
+    reset_default_tracker()
+    yield
+    reset_default_tracker()
+
+
+# ---------------------------------------------------------------------------
+# Break-even is DERIVED, never hardcoded
+# ---------------------------------------------------------------------------
+
+
+def test_break_even_derived_from_multipliers():
+    # (1.25 - 0.1) / (1 - 0.1) = 1.278 -> first whole N that beats it is 2
+    assert break_even_uses(W, R) == 2
+
+
+def test_break_even_tracks_changed_economics():
+    """A pricier write demands more reuse — the threshold must move with it,
+    which a hardcoded constant could never do."""
+    assert break_even_uses(3.0, 0.1) > break_even_uses(1.25, 0.1)
+    # A free write is profitable immediately.
+    assert break_even_uses(0.05, 0.1) == 1
+
+
+def test_break_even_degenerate_read_multiplier():
+    """If a cache read costs as much as fresh input, caching can NEVER pay —
+    the engine must not claim a finite threshold."""
+    assert break_even_uses(1.25, 1.0) > 1_000_000
+    assert break_even_uses(1.25, 1.5) > 1_000_000
+
+
+# ---------------------------------------------------------------------------
+# (1) small + frequent  ->  CACHE
+# ---------------------------------------------------------------------------
+
+
+def test_small_high_frequency_prompt_triggers_cache_write():
+    """A 1,000-char Sentinel-probe-shaped prompt — far below the old 4,096
+    floor — must be cached once reuse is demonstrated."""
+    trk = PromptSignatureTracker(ttl_s=3600)
+    probe = "S" * 1000
+
+    first, why1 = should_cache_write(probe, write_mult=W, read_mult=R, tracker=trk, now=100.0)
+    assert first is False, "first sighting has no reuse evidence — must not pay the write premium"
+    assert why1["reason"] == "insufficient_reuse"
+
+    second, why2 = should_cache_write(probe, write_mult=W, read_mult=R, tracker=trk, now=101.0)
+    assert second is True, "a demonstrated repeat must be cached regardless of length"
+    assert why2["uses_in_window"] == 2
+    assert why2["chars"] == 1000
+
+
+def test_high_frequency_probe_stays_cached_across_many_firings():
+    """40 firings in an hour — the scenario the char floor silently excluded."""
+    trk = PromptSignatureTracker(ttl_s=3600)
+    probe = "P" * 1500
+    decisions = [
+        should_cache_write(probe, write_mult=W, read_mult=R, tracker=trk, now=float(i * 90))[0]
+        for i in range(40)
+    ]
+    assert decisions[0] is False          # first pays nothing
+    assert all(decisions[1:]), "sustained reuse must stay cached"
+
+
+# ---------------------------------------------------------------------------
+# (2) huge + one-off  ->  BYPASS
+# ---------------------------------------------------------------------------
+
+
+def test_massive_zero_frequency_prompt_bypasses_cache_write():
+    """A 15,000-char one-off would sail past the old floor and lose 0.25x on a
+    write that is never read back."""
+    trk = PromptSignatureTracker(ttl_s=3600)
+    giant = "G" * 15000
+
+    ok, why = should_cache_write(giant, write_mult=W, read_mult=R, tracker=trk, now=100.0)
+
+    assert ok is False, "a one-off must not pay the write premium"
+    assert why["reason"] == "insufficient_reuse"
+    assert why["chars"] == 15000
+
+
+def test_length_alone_never_decides():
+    """The core inversion: a tiny frequent prefix outranks a giant rare one."""
+    trk = PromptSignatureTracker(ttl_s=3600)
+    tiny, giant = "t" * 200, "g" * 50000
+
+    should_cache_write(tiny, write_mult=W, read_mult=R, tracker=trk, now=1.0)
+    tiny_ok, _ = should_cache_write(tiny, write_mult=W, read_mult=R, tracker=trk, now=2.0)
+    giant_ok, _ = should_cache_write(giant, write_mult=W, read_mult=R, tracker=trk, now=3.0)
+
+    assert tiny_ok is True and giant_ok is False
+
+
+# ---------------------------------------------------------------------------
+# (3) sliding window evicts — no memory leak
+# ---------------------------------------------------------------------------
+
+
+def test_window_evicts_stale_signatures():
+    trk = PromptSignatureTracker(ttl_s=100.0)
+    sig = prompt_signature("payload")
+
+    trk.observe(sig, now=0.0)
+    trk.observe(sig, now=10.0)
+    assert trk.frequency(sig, now=20.0) == 2
+
+    # Both observations fall outside a 100s window by t=200.
+    assert trk.frequency(sig, now=200.0) == 0
+    assert trk.size() == 0
+    assert trk.distinct() == 0, "counts dict leaked after eviction"
+
+
+def test_eviction_resets_the_cache_decision():
+    """A prefix that stops recurring must stop being cached — otherwise the
+    engine predicts hits against an already-expired provider cache."""
+    trk = PromptSignatureTracker(ttl_s=100.0)
+    p = "recurring"
+
+    should_cache_write(p, write_mult=W, read_mult=R, tracker=trk, now=0.0)
+    assert should_cache_write(p, write_mult=W, read_mult=R, tracker=trk, now=1.0)[0] is True
+
+    later, why = should_cache_write(p, write_mult=W, read_mult=R, tracker=trk, now=5000.0)
+    assert later is False, "stale history must not justify a write"
+    assert why["uses_in_window"] == 1
+
+
+def test_hard_entry_cap_bounds_memory_under_churn():
+    """TTL alone cannot bound growth if every payload is unique — the cap is the
+    backstop against unbounded memory."""
+    trk = PromptSignatureTracker(ttl_s=10_000.0, max_entries=64)
+    for i in range(500):
+        trk.observe(prompt_signature(f"unique-{i}"), now=float(i))
+    assert trk.size() <= 64
+    assert trk.distinct() <= 64, "counts dict grew past the cap"
+
+
+def test_counts_never_go_negative_under_repeated_eviction():
+    trk = PromptSignatureTracker(ttl_s=50.0)
+    sig = prompt_signature("x")
+    for i in range(20):
+        trk.observe(sig, now=float(i))
+    for t in (100.0, 200.0, 300.0):
+        assert trk.frequency(sig, now=t) == 0
+    assert trk.distinct() == 0
+
+
+# ---------------------------------------------------------------------------
+# Robustness — economics must never break generation
+# ---------------------------------------------------------------------------
+
+
+def test_bad_input_never_raises_and_fails_closed():
+    for bad in ("", None, 12345, b"bytes"):
+        ok, why = should_cache_write(bad, write_mult=W, read_mult=R)  # type: ignore[arg-type]
+        assert ok is False, f"must fail CLOSED on {bad!r}"
+        assert "reason" in why
+
+
+def test_observe_false_does_not_mutate_the_window():
+    trk = PromptSignatureTracker(ttl_s=3600)
+    p = "peek"
+    should_cache_write(p, write_mult=W, read_mult=R, tracker=trk, now=1.0, observe=False)
+    assert trk.size() == 0, "a read-only probe must not record a sighting"
+
+
+def test_distinct_prefixes_do_not_share_credit():
+    """Signature isolation: one prefix's frequency must never authorise another."""
+    trk = PromptSignatureTracker(ttl_s=3600)
+    a, b = "A" * 5000, "B" * 5000
+
+    should_cache_write(a, write_mult=W, read_mult=R, tracker=trk, now=1.0)
+    should_cache_write(a, write_mult=W, read_mult=R, tracker=trk, now=2.0)
+
+    b_ok, why = should_cache_write(b, write_mult=W, read_mult=R, tracker=trk, now=3.0)
+    assert b_ok is False and why["uses_in_window"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Integration with the shaping chokepoint
+# ---------------------------------------------------------------------------
+
+
+def test_shape_cached_system_consults_acee(monkeypatch):
+    """The ONE chokepoint both handlers consume must route through ACEE — and a
+    sub-floor prefix must now become cacheable on repeat, which the old
+    min_chars gate made impossible."""
+    from backend.core.ouroboros.governance import doubleword_provider as d
+
+    monkeypatch.setenv("JARVIS_DW_ACEE_ENABLED", "true")
+    reset_default_tracker()
+    small = "s" * 1000            # well under the legacy 4096 floor
+
+    first = d._dw_shape_cached_system(small, enabled=True, min_chars=4096, ttl="1h")
+    assert isinstance(first, str), "first sighting must stay uncached"
+
+    second = d._dw_shape_cached_system(small, enabled=True, min_chars=4096, ttl="1h")
+    assert isinstance(second, list), "repeat sub-floor prefix must now cache"
+    assert second[0]["cache_control"]["type"] == "ephemeral"
+    assert second[0]["text"] == small, "text must stay byte-identical"
+
+
+def test_acee_disabled_restores_legacy_floor(monkeypatch):
+    """Rollback must be byte-identical legacy."""
+    from backend.core.ouroboros.governance import doubleword_provider as d
+
+    monkeypatch.setenv("JARVIS_DW_ACEE_ENABLED", "false")
+    reset_default_tracker()
+
+    small = "s" * 1000
+    for _ in range(5):
+        assert isinstance(
+            d._dw_shape_cached_system(small, enabled=True, min_chars=4096, ttl="1h"), str
+        ), "legacy floor must still gate sub-floor prefixes"
+
+    big = "b" * 5000
+    assert isinstance(
+        d._dw_shape_cached_system(big, enabled=True, min_chars=4096, ttl="1h"), list
+    )

--- a/tests/governance/test_dw_surface_health.py
+++ b/tests/governance/test_dw_surface_health.py
@@ -10,6 +10,10 @@ from backend.core.ouroboros.governance.dw_surface_health import (
 def test_surface_kind_closed_taxonomy():
     assert {k.value for k in SurfaceKind} == {
         "batch_storage", "direct_streaming", "auth_sync",
+        # The deep INFERENCE probe's own surface. DW's control plane can answer
+        # 200 while the data plane deadlocks (soak bt-2026-06-29-032526), so
+        # completion health is tracked separately from streaming transport.
+        "direct_completion",
     }
 
 
@@ -17,6 +21,10 @@ def test_surface_verdict_closed_taxonomy():
     assert {v.value for v in SurfaceVerdict} == {
         "healthy", "transport_degraded", "upstream_degraded",
         "auth_failed", "error_other",
+        # Distinct from transport_degraded: the socket was fine, the INFERENCE
+        # queue was wedged. Conflating the two is what let a healthy control
+        # plane mask a dead data plane.
+        "inference_degraded",
     }
 
 

--- a/tests/governance/test_failover_dag_reentry.py
+++ b/tests/governance/test_failover_dag_reentry.py
@@ -177,6 +177,37 @@ class _FakeController:
         return self._endpoint if self._serving else None
 
 
+class _DisabledTopology:
+    """Topology explicitly OFF.
+
+    These tests assert ROUTING, not DW dispatch. They used to rely on the
+    ambient `get_topology().enabled` being false — but it reads real repo
+    config and is TRUE here, so `_dispatch_via_sentinel` walked the ranked
+    DW models and made a LIVE network call, hanging the suite in
+    selector.select() until the pytest timeout fired (2026-07-24).
+
+    Pinning it makes the tests hermetic: no ambient config, no sockets.
+    """
+
+    enabled = False
+
+    def dw_models_for_route(self, _route):
+        return ()
+
+    def fallback_tolerance_for_route(self, _route):
+        return "none"
+
+
+def _pin_topology_disabled(monkeypatch):
+    """Patch at the SOURCE module: `_dispatch_via_sentinel` resolves
+    `get_topology` via a function-LOCAL import, so patching the
+    candidate_generator namespace would never reach it."""
+    from backend.core.ouroboros.governance import provider_topology as _pt
+    monkeypatch.setattr(
+        _pt, "get_topology", lambda: _DisabledTopology(), raising=False,
+    )
+
+
 def _make_generator():
     from backend.core.ouroboros.governance.candidate_generator import (
         CandidateGenerator,
@@ -235,6 +266,25 @@ class TestGenerationReroute:
             cg,
             "get_failover_controller",
             lambda: _FakeController(True, "http://jprime-node:11434"),
+        )
+        # ── The hang this fixes (2026-07-24) ──────────────────────────────
+        # `_discover_jprime_endpoint` resolves these via a FUNCTION-LOCAL
+        # `from .failover_lifecycle import ...`, so patching the
+        # candidate_generator namespace above never reached it. The real
+        # `lifecycle_enabled()` then read the env we just set to "true", the
+        # real controller reported not-serving, and discovery fell through to
+        # step (2): a LIVE zone-aware GCP query. The suite hung in
+        # selector.select() until the pytest timeout killed it.
+        #
+        # Patch the SOURCE module the local import actually binds to. Keeping
+        # the `cg` patches above as well: they cover the other call sites that
+        # DO read the module-level names, so both resolution paths are pinned.
+        monkeypatch.setattr(fl, "lifecycle_enabled", lambda: True, raising=False)
+        monkeypatch.setattr(
+            fl,
+            "get_failover_controller",
+            lambda: _FakeController(True, "http://jprime-node:11434"),
+            raising=False,
         )
 
         spy = {"endpoint": None, "called": 0}
@@ -298,6 +348,7 @@ class TestGenerationReroute:
 
         # Replace the topology import so the sentinel body short-circuits to
         # the DW path marker.
+        _pin_topology_disabled(monkeypatch)
         gen = _make_generator()
         ctx = _make_context()
         from datetime import datetime, timezone, timedelta
@@ -334,12 +385,14 @@ class TestGenerationReroute:
             raising=True,
         )
 
+        _pin_topology_disabled(monkeypatch)
         gen = _make_generator()
         ctx = _make_context()
         from datetime import datetime, timezone, timedelta
 
         # Must NOT raise the local error -- it falls through to the normal DW
-        # path (which returns None here with no topology). The op is not lost.
+        # path (which returns None here with topology explicitly pinned OFF).
+        # The op is not lost.
         result = await gen._dispatch_via_sentinel(
             ctx, datetime.now(timezone.utc) + timedelta(seconds=60),
             "standard",

--- a/tests/governance/test_heartbeat_preflight_gate.py
+++ b/tests/governance/test_heartbeat_preflight_gate.py
@@ -1,0 +1,224 @@
+"""Pre-Flight Auth Gate + Auto-Defrost — the dual-auth freeze cascade.
+
+The incident (session bt-2026-07-24-212505, live): DoubleWord was HEALTHY and
+serving real generations, but the heartbeat's per-call lease acquisition hit a
+transient ``TimeoutError``. The old code swallowed it, dispatched an
+under-authenticated request anyway, the Aegis daemon answered 401, and the
+Safety-Law classifier read that 401 as a *configuration* error and set
+``_frozen = True`` — permanently. A frozen heartbeat never reports degraded and
+never emits a HEALTHY edge, so the AWE recovery reflex was disabled for the life
+of the process and the queued canary could never launch.
+
+Two independent defects, pinned separately:
+
+  (1) a transient lease failure must fail CLOSED before the socket — no HTTP
+      request, no 401, no freeze;
+  (2) a heartbeat that IS frozen must self-heal when it observes proof that the
+      auth path works, rather than requiring a daemon restart.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from backend.core.ouroboros.governance import provider_heartbeat as ph
+from backend.core.ouroboros.governance.provider_heartbeat import (
+    AegisConfigurationError,
+    ProbeAuthUnavailable,
+)
+
+
+# ---------------------------------------------------------------------------
+# (1) Pre-Flight Auth Gate
+# ---------------------------------------------------------------------------
+
+
+def test_classifier_has_a_third_transient_state():
+    """The original taxonomy was binary (auth|outage). A pre-dispatch credential
+    failure is neither."""
+    assert ph._classify_probe_exception(ProbeAuthUnavailable("x")) == "transient"
+
+    import urllib.error
+    assert ph._classify_probe_exception(
+        urllib.error.HTTPError("u", 401, "m", None, None)) == "auth"
+    assert ph._classify_probe_exception(
+        urllib.error.HTTPError("u", 503, "m", None, None)) == "outage"
+    # Unknown stays conservatively an outage — unchanged.
+    assert ph._classify_probe_exception(TimeoutError()) == "outage"
+
+
+async def test_lease_timeout_never_dispatches_http(monkeypatch):
+    """THE CORE ASSERTION: a mocked TimeoutError during lease fetch must prevent
+    the outbound request entirely. No HTTP means no 401 means no freeze."""
+    from backend.core.ouroboros.governance import aegis_provider_bridge as apb
+
+    monkeypatch.setattr(ph, "_aegis_lease_required", lambda: True)
+    monkeypatch.setattr(apb, "dw_aegis_base_url", lambda: "http://127.0.0.1:1/v1")
+
+    async def _ok_auth():
+        return {"Authorization": "Bearer session-token"}
+
+    async def _lease_times_out(**_kw):
+        raise TimeoutError("lease acquire timed out")
+
+    monkeypatch.setattr(apb, "dw_session_auth_header", _ok_auth)
+    monkeypatch.setattr(apb, "acquire_call_lease", _lease_times_out)
+
+    dispatched = []
+
+    def _tripwire(*a, **k):
+        dispatched.append(a)
+        raise AssertionError("HTTP dispatched despite unavailable credentials")
+
+    monkeypatch.setattr(ph, "_http_post_json", _tripwire)
+
+    with pytest.raises(ProbeAuthUnavailable):
+        await ph._resolve_dw_probe_transport()
+
+    assert dispatched == [], "the gate must fail closed BEFORE the socket"
+
+
+async def test_lease_timeout_does_not_freeze_the_heartbeat(monkeypatch):
+    """The consequence that actually mattered: the heartbeat stays thawed, so
+    AWE edge detection survives a transient lease hiccup."""
+    hb = ph.DWHeartbeat()
+    monkeypatch.setattr(ph, "heartbeat_enabled", lambda: True)
+
+    async def _probe_raises_transient():
+        raise ProbeAuthUnavailable("lease unavailable pre-dispatch")
+
+    hb._probe_fn = _probe_raises_transient
+
+    assert hb.is_frozen() is False
+    await hb.beat()
+
+    assert hb.is_frozen() is False, "a transient skip must NEVER freeze"
+    assert hb._transient_skips == 1
+    # And it recorded no degrade verdict either — no information, not bad news.
+    assert hb._healthy_streak == 0
+
+
+async def test_genuine_401_still_freezes(monkeypatch):
+    """The Safety Law must survive intact: a REAL auth error (credentials
+    assembled fine, daemon rejected them) still freezes. If this ever goes green
+    by not-freezing, the pre-flight gate has swallowed the safety property."""
+    hb = ph.DWHeartbeat()
+    monkeypatch.setattr(ph, "heartbeat_enabled", lambda: True)
+
+    async def _probe_raises_auth():
+        raise AegisConfigurationError("real 401")
+
+    hb._probe_fn = _probe_raises_auth
+    hb._dlq_emit_fn = lambda payload: None
+
+    await hb.beat()
+    assert hb.is_frozen() is True, "a genuine config error must still freeze"
+
+
+async def test_aegis_disabled_still_dispatches_without_lease(monkeypatch):
+    """Direct-DW mode carries no lease at all. The gate must not brick it —
+    lease=None is legitimate when Aegis is off."""
+    from backend.core.ouroboros.governance import aegis_provider_bridge as apb
+
+    monkeypatch.setattr(ph, "_aegis_lease_required", lambda: False)
+    monkeypatch.setattr(apb, "dw_aegis_base_url", lambda: "http://127.0.0.1:1/v1")
+
+    async def _auth():
+        return {}
+
+    async def _no_lease(**_kw):
+        return None
+
+    monkeypatch.setattr(apb, "dw_session_auth_header", _auth)
+    monkeypatch.setattr(apb, "acquire_call_lease", _no_lease)
+
+    url, headers = await ph._resolve_dw_probe_transport()
+    assert url.endswith("/chat/completions")
+    assert isinstance(headers, dict)
+
+
+# ---------------------------------------------------------------------------
+# (2) Auto-Defrost
+# ---------------------------------------------------------------------------
+
+
+def test_successful_generation_defrosts_a_frozen_heartbeat():
+    """THE SECOND CORE ASSERTION: observing proof that auth works flips
+    _frozen back to False without a daemon restart."""
+    hb = ph.DWHeartbeat()
+    hb._frozen = True
+
+    assert hb.is_frozen() is True
+    assert hb.note_provider_success() is True
+    assert hb.is_frozen() is False, "auto-defrost did not thaw the heartbeat"
+
+
+def test_defrost_is_a_noop_when_not_frozen():
+    hb = ph.DWHeartbeat()
+    assert hb.is_frozen() is False
+    assert hb.note_provider_success() is False
+    assert hb._defrost_count == 0
+
+
+def test_defrost_is_bounded_against_flap(monkeypatch):
+    """A persistently-broken probe auth would otherwise become a freeze/defrost
+    flap machine, emitting a CRITICAL + DLQ record every cycle forever. After
+    the cap, the freeze becomes durable so a human sees it."""
+    monkeypatch.setenv("JARVIS_DW_HEARTBEAT_MAX_DEFROSTS", "2")
+    hb = ph.DWHeartbeat()
+
+    for expected in (True, True, False):
+        hb._frozen = True
+        assert hb.note_provider_success() is expected
+
+    assert hb.is_frozen() is True, "past the cap the freeze must stick"
+    assert hb._defrost_count == 2
+
+
+async def test_defrost_rides_the_real_broker():
+    """End-to-end over the REAL StreamEventBroker — proves the event type is
+    registered and the wiring is live, not a listener for a name nobody emits."""
+    from backend.core.ouroboros.governance.ide_observability_stream import (
+        EVENT_TYPE_PROVIDER_GENERATION_SUCCEEDED,
+        get_default_broker,
+        publish_task_event,
+        reset_default_broker,
+    )
+
+    reset_default_broker()
+    hb = ph.DWHeartbeat()
+    hb._frozen = True
+
+    task = asyncio.ensure_future(hb.watch_provider_success(max_events=1))
+    try:
+        await asyncio.wait_for(hb._success_subscribed.wait(), timeout=2.0)
+        published = publish_task_event(
+            EVENT_TYPE_PROVIDER_GENERATION_SUCCEEDED, "doubleword",
+            {"provider": "doubleword", "candidates": 1},
+        )
+        assert published is not None, "event type is not registered on the broker"
+
+        async def _thawed():
+            while hb.is_frozen():
+                await asyncio.sleep(0.01)
+        await asyncio.wait_for(_thawed(), timeout=3.0)
+        assert hb.is_frozen() is False
+    finally:
+        task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, Exception):  # noqa: BLE001
+            pass
+        reset_default_broker()
+
+
+def test_generation_success_event_is_registered():
+    """Guard against the silent-drop trap: an unregistered event_type is
+    rejected by publish() and the listener would never fire."""
+    from backend.core.ouroboros.governance.ide_observability_stream import (
+        EVENT_TYPE_PROVIDER_GENERATION_SUCCEEDED,
+        _VALID_EVENT_TYPES,
+    )
+    assert EVENT_TYPE_PROVIDER_GENERATION_SUCCEEDED in _VALID_EVENT_TYPES

--- a/tests/test_ouroboros_governance/test_dw_prompt_cache_zdr.py
+++ b/tests/test_ouroboros_governance/test_dw_prompt_cache_zdr.py
@@ -95,6 +95,18 @@ def _ctx(
 
 
 class TestShapeCachedSystem:
+    """Marker SHAPE at the raw shaping helper. ACEE pinned off — see the note on
+    TestBuildSystemContent. Additionally: ACEE's tracker is a PROCESS-WIDE
+    singleton, so without this pin an earlier test's prefix warms the signature
+    and a later 'first sighting' assertion silently receives a cached marker.
+    Policy lives in tests/governance/test_dw_cache_economics.py, which resets
+    the singleton per test."""
+
+    @pytest.fixture(autouse=True)
+    def _legacy_gate(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("JARVIS_DW_ACEE_ENABLED", "false")
+        yield
+
     def test_enabled_long_prefix_marks_cache_control(self) -> None:
         text = "S" * 5000
         out = _dw_shape_cached_system(
@@ -284,6 +296,22 @@ class TestForcePrefixSplit:
 
 
 class TestBuildSystemContent:
+    """Marker SHAPE — placement, TTL threading, block membership.
+
+    ACEE is pinned off for this class deliberately. These assert how the
+    cache_control block is CONSTRUCTED, and ACEE decides WHETHER to build one:
+    under its first-sighting policy a single call is correctly uncached, which
+    would make every shape assertion here fail for a reason that has nothing to
+    do with shape. The policy itself is covered by
+    tests/governance/test_dw_cache_economics.py, including an end-to-end
+    integration test through this same chokepoint.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _legacy_gate(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("JARVIS_DW_ACEE_ENABLED", "false")
+        yield
+
     def test_off_returns_plain_string_byte_identical(self) -> None:
         p = _provider()
         base = "SYSTEM PROMPT"

--- a/tests/test_ouroboros_governance/test_dw_prompt_cache_zdr.py
+++ b/tests/test_ouroboros_governance/test_dw_prompt_cache_zdr.py
@@ -150,7 +150,21 @@ class TestShapeCachedSystem:
 
 
 class TestConfig:
-    def test_cache_enabled_default_false(self) -> None:
+    def test_cache_enabled_default_true_after_graduation(self) -> None:
+        """GRADUATED 2026-07-24. Measured on bt-2026-07-24-212505: ~17KB of
+        static prefix (dev-memory 10,459 + strategic/goal 4,019 + user-prefs
+        1,611 + goal-inference 992 chars) was re-billed at full input price on
+        every op. Caching is content-addressed, so a changed prefix simply
+        misses — there is no stale-context risk to gate on."""
+        assert _dw_prompt_cache_enabled() is True
+
+    @pytest.mark.parametrize("val", ["false", "0", "no", "off", "FALSE"])
+    def test_cache_rollback_to_uncached(
+        self, monkeypatch: pytest.MonkeyPatch, val: str
+    ) -> None:
+        """The graduation must stay reversible — one env var restores the
+        byte-identical un-cached request."""
+        monkeypatch.setenv("JARVIS_DW_PROMPT_CACHE_ENABLED", val)
         assert _dw_prompt_cache_enabled() is False
 
     @pytest.mark.parametrize("val", ["true", "1", "yes", "on", "TRUE"])

--- a/tests/ui/test_audio_scope_and_ptt.py
+++ b/tests/ui/test_audio_scope_and_ptt.py
@@ -1,0 +1,411 @@
+"""Braille oscilloscope + PTT spacebar intercept.
+
+Three mandated assertions, plus the edge cases that would actually bite in a
+live cockpit:
+
+  (1) an EMPTY prompt_toolkit buffer intercepts space without touching the text
+      buffer — and a NON-empty buffer must still type a normal space;
+  (2) a stream of mock RMS floats maps to the expected Braille string;
+  (3) the ring buffer wraps without index errors, at any width.
+
+Real prompt_toolkit objects are used for (1) — a hand-rolled fake buffer would
+prove nothing about how prompt_toolkit actually routes a key through a filter.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from backend.core.ouroboros.ui.audio_scope import (
+    LEVELS,
+    SAMPLES_PER_CELL,
+    AdaptiveNormalizer,
+    AudioPlane,
+    BrailleScope,
+    cell_for,
+    rms,
+)
+from backend.core.ouroboros.ui.ptt_router import (
+    MicState,
+    PTTLatch,
+    build_ptt_key_bindings,
+    on_release_supported,
+)
+
+_BASE = 0x2800
+
+
+# ---------------------------------------------------------------------------
+# (2) RMS floats -> Braille
+# ---------------------------------------------------------------------------
+
+
+def test_silence_renders_empty_braille_cells():
+    sc = BrailleScope(width=8)
+    sc.extend([0.0] * 16)
+    out = sc.render()
+    assert len(out) == 8
+    assert out == chr(_BASE) * 8, "silence must be blank cells, not a floating bar"
+    assert sc.is_silent() is True
+
+
+def test_full_scale_renders_all_eight_dots():
+    sc = BrailleScope(width=4)
+    sc.extend([1.0] * 8)
+    assert sc.render() == "⣿" * 4, "full scale must light all 8 dots per cell"
+
+
+def test_cell_encodes_two_samples_at_four_levels():
+    """The resolution claim, asserted bit-exactly: one cell = 2 columns x 4 rows,
+    bars filling from the BOTTOM."""
+    assert cell_for(0.0, 0.0) == chr(_BASE)
+    # Left column only, one dot from the bottom -> dot 7 (0x40).
+    assert cell_for(0.2, 0.0) == chr(_BASE + 0x40)
+    # Right column only, one dot from the bottom -> dot 8 (0x80).
+    assert cell_for(0.0, 0.2) == chr(_BASE + 0x80)
+    # Both columns full -> all eight dots.
+    assert cell_for(1.0, 1.0) == chr(_BASE + 0xFF)
+
+
+def test_bars_fill_upward_from_the_baseline():
+    """A louder sample must be a TALLER bar anchored at the bottom, so a rising
+    ramp is monotonically denser."""
+    masks = [ord(cell_for(v, v)) - _BASE for v in (0.0, 0.25, 0.5, 0.75, 1.0)]
+    assert masks == sorted(masks), f"not monotonic: {masks}"
+    assert masks[0] == 0 and masks[-1] == 0xFF
+
+
+def test_known_rms_stream_maps_to_expected_string():
+    """(2) A deterministic ramp produces a deterministic, reproducible scope."""
+    sc = BrailleScope(width=4)
+    sc.extend([0.0, 0.25, 0.5, 0.75, 1.0, 1.0, 0.5, 0.0])
+    expected = "".join((
+        cell_for(0.0, 0.25),
+        cell_for(0.5, 0.75),
+        cell_for(1.0, 1.0),
+        cell_for(0.5, 0.0),
+    ))
+    assert sc.render() == expected
+
+
+def test_newest_sample_lands_at_the_right_edge():
+    """Right-to-left scroll: the freshest data is always rightmost."""
+    sc = BrailleScope(width=3)
+    sc.extend([0.0] * 6)
+    assert sc.render()[-1] == chr(_BASE)
+    sc.push(1.0)
+    assert sc.render()[-1] != chr(_BASE), "new sample did not reach the right edge"
+
+
+def test_partial_buffer_is_left_padded_to_stable_width():
+    """Width must be stable from the first frame or the header layout jitters."""
+    sc = BrailleScope(width=10)
+    sc.push(1.0)
+    out = sc.render()
+    assert len(out) == 10
+    assert out.startswith(chr(_BASE)), "partial buffer must left-pad"
+    assert out[-1] != chr(_BASE)
+
+
+# ---------------------------------------------------------------------------
+# (3) ring buffer wrap — no index errors
+# ---------------------------------------------------------------------------
+
+
+def test_ring_wrap_never_raises_and_holds_width():
+    sc = BrailleScope(width=20)
+    for i in range(5000):                      # far past capacity
+        sc.push(abs(math.sin(i / 3.0)))
+        out = sc.render()
+        assert len(out) == 20
+    assert len(sc.render()) == 20
+
+
+@pytest.mark.parametrize("width", [1, 2, 3, 7, 20, 64])
+def test_wrap_is_safe_at_every_width(width):
+    sc = BrailleScope(width=width)
+    for i in range(width * SAMPLES_PER_CELL * 3 + 5):
+        sc.push((i % 5) / 4.0)
+        assert len(sc.render()) == width
+
+
+def test_odd_sample_count_does_not_index_past_the_end():
+    """An odd buffer length must not read a nonexistent right-hand sample."""
+    sc = BrailleScope(width=5)
+    sc.extend([0.5] * 9)                       # odd
+    assert len(sc.render()) == 5
+
+
+def test_clear_resets_to_silence():
+    sc = BrailleScope(width=6)
+    sc.extend([1.0] * 12)
+    sc.clear()
+    assert sc.render() == chr(_BASE) * 6
+    assert sc.is_silent() is True
+
+
+def test_out_of_range_and_garbage_samples_are_clamped():
+    sc = BrailleScope(width=4)
+    for bad in (-5.0, 42.0, float("inf"), None, "loud", float("nan")):
+        sc.push(bad)                            # type: ignore[arg-type]
+    out = sc.render()
+    assert len(out) == 4
+    for ch in out:
+        assert _BASE <= ord(ch) <= _BASE + 0xFF, "emitted a non-Braille codepoint"
+
+
+# ---------------------------------------------------------------------------
+# RMS + adaptive normalization
+# ---------------------------------------------------------------------------
+
+
+def test_rms_matches_the_closed_form():
+    assert rms([]) == 0.0
+    assert rms([0.0, 0.0]) == 0.0
+    assert rms([1.0, -1.0]) == pytest.approx(1.0)
+    assert rms([0.5, -0.5]) == pytest.approx(0.5)
+    assert rms([3.0, 4.0]) == pytest.approx(math.sqrt(12.5))
+
+
+def test_rms_never_raises_on_garbage():
+    assert rms(None) == 0.0                     # type: ignore[arg-type]
+    assert rms(["x", None, 1.0]) >= 0.0
+
+
+def test_normalizer_uses_full_range_for_quiet_and_loud_sources():
+    """A fixed divisor would flatline a quiet mic or clip a hot one; the
+    decaying peak must give BOTH sources full deflection."""
+    quiet = AdaptiveNormalizer()
+    assert quiet.normalize(0.004) == pytest.approx(1.0)
+
+    loud = AdaptiveNormalizer()
+    assert loud.normalize(0.95) == pytest.approx(1.0)
+
+
+def test_normalizer_peak_decays_so_a_quieter_source_recovers():
+    n = AdaptiveNormalizer(decay=0.5)
+    n.normalize(1.0)
+    for _ in range(40):
+        n.normalize(0.01)
+    assert n.normalize(0.01) > 0.5, "peak never decayed — quiet source stays flat"
+
+
+def test_normalizer_floor_prevents_amplifying_room_noise():
+    n = AdaptiveNormalizer(floor=0.1)
+    assert n.normalize(0.0001) < 0.01
+
+
+# ---------------------------------------------------------------------------
+# plane-reactive colour
+# ---------------------------------------------------------------------------
+
+
+def test_plane_colours_are_semantic_names_not_hex():
+    sc = BrailleScope(width=4)
+    assert sc.accent == "muted"
+    sc.set_plane(AudioPlane.USER)
+    assert sc.accent == "cyan"
+    sc.set_plane(AudioPlane.SYSTEM)
+    assert sc.accent == "venom_green"
+    # Never a raw colour — the theme owns the palette.
+    assert not sc.accent.startswith("#")
+
+
+def test_set_plane_reports_only_real_transitions():
+    """Zero-flicker: the caller must invalidate only when something changed."""
+    sc = BrailleScope(width=4)
+    assert sc.set_plane(AudioPlane.USER) is True
+    assert sc.set_plane(AudioPlane.USER) is False
+
+
+def test_render_rich_wraps_in_the_plane_accent():
+    sc = BrailleScope(width=3)
+    sc.set_plane(AudioPlane.SYSTEM)
+    out = sc.render_rich()
+    assert out.startswith("[venom_green]") and out.endswith("[/venom_green]")
+
+
+# ---------------------------------------------------------------------------
+# (1) spacebar intercept — REAL prompt_toolkit objects
+# ---------------------------------------------------------------------------
+
+
+def _press_space(kb, buffer):
+    """Route a space through the binding exactly as prompt_toolkit would:
+    resolve the handler, honour its filter, else insert the character."""
+    from prompt_toolkit.keys import Keys  # noqa: F401
+
+    class _Ev:
+        current_buffer = buffer
+
+    for binding in kb.bindings:
+        if " " in [str(k) for k in binding.keys]:
+            if binding.filter():
+                binding.handler(_Ev())
+                return True
+            break
+    buffer.insert_text(" ")
+    return False
+
+
+def test_empty_buffer_intercepts_space_without_modifying_text():
+    """(1) THE CORE ASSERTION: on an empty buffer, space arms the mic and the
+    text buffer stays untouched."""
+    from prompt_toolkit.buffer import Buffer
+
+    buf = Buffer()
+    latch = PTTLatch()
+    kb = build_ptt_key_bindings(latch, buffer_getter=lambda: buf.text)
+
+    assert buf.text == ""
+    intercepted = _press_space(kb, buf)
+
+    assert intercepted is True, "space was not intercepted on an empty buffer"
+    assert buf.text == "", "intercept leaked a space into the buffer"
+    assert latch.state is MicState.OPEN
+    assert latch.open_count == 1
+
+
+def test_non_empty_buffer_types_a_normal_space():
+    """The other half — swallowing word separators mid-sentence is intolerable."""
+    from prompt_toolkit.buffer import Buffer
+
+    buf = Buffer()
+    buf.insert_text("deploy")
+    latch = PTTLatch()
+    kb = build_ptt_key_bindings(latch, buffer_getter=lambda: buf.text)
+
+    intercepted = _press_space(kb, buf)
+
+    assert intercepted is False, "space was hijacked while the buffer had text"
+    assert buf.text == "deploy ", "normal space insertion was lost"
+    assert latch.state is MicState.CLOSED
+
+
+def test_whitespace_only_buffer_still_counts_as_empty():
+    from prompt_toolkit.buffer import Buffer
+
+    buf = Buffer()
+    buf.insert_text("   ")
+    latch = PTTLatch()
+    kb = build_ptt_key_bindings(latch, buffer_getter=lambda: buf.text)
+    assert _press_space(kb, buf) is True
+    assert latch.is_open is True
+
+
+def test_second_space_closes_the_latch():
+    """Toggle is the reliable closing edge — terminals give no key-release."""
+    from prompt_toolkit.buffer import Buffer
+
+    buf = Buffer()
+    latch = PTTLatch()
+    kb = build_ptt_key_bindings(latch, buffer_getter=lambda: buf.text)
+
+    _press_space(kb, buf)
+    assert latch.is_open is True
+    _press_space(kb, buf)
+    assert latch.state is MicState.CLOSED
+    assert latch.close_reasons == ("toggle",)
+    assert buf.text == "", "toggling must never write to the buffer"
+
+
+def test_intercept_triggers_the_invalidate_hook():
+    """Zero-flicker redraw: the same invalidate discipline as the theme."""
+    from prompt_toolkit.buffer import Buffer
+
+    buf = Buffer()
+    hits = []
+    kb = build_ptt_key_bindings(
+        PTTLatch(), buffer_getter=lambda: buf.text, invalidate=lambda: hits.append(1),
+    )
+    _press_space(kb, buf)
+    assert hits == [1]
+
+
+def test_disabled_ptt_leaves_space_alone(monkeypatch):
+    from prompt_toolkit.buffer import Buffer
+
+    monkeypatch.setenv("JARVIS_PTT_ENABLED", "false")
+    buf = Buffer()
+    latch = PTTLatch()
+    kb = build_ptt_key_bindings(latch, buffer_getter=lambda: buf.text)
+
+    assert _press_space(kb, buf) is False
+    assert buf.text == " "
+    assert latch.state is MicState.CLOSED
+
+
+# ---------------------------------------------------------------------------
+# latch semantics
+# ---------------------------------------------------------------------------
+
+
+def test_open_is_idempotent_under_key_repeat():
+    """Terminal auto-repeat must not emit a burst of mic_active intents."""
+    opens = []
+    latch = PTTLatch(on_open=lambda: opens.append(1))
+    assert latch.open() is True
+    for _ in range(20):
+        assert latch.open() is False
+    assert opens == [1]
+
+
+def test_close_is_idempotent():
+    closes = []
+    latch = PTTLatch(on_close=lambda r: closes.append(r))
+    latch.open()
+    assert latch.close("toggle") is True
+    assert latch.close("toggle") is False
+    assert closes == ["toggle"]
+
+
+def test_silence_auto_flush_substitutes_for_key_release():
+    """The honest stand-in for an unobservable release edge."""
+    t = {"now": 0.0}
+    closes = []
+    latch = PTTLatch(on_close=lambda r: closes.append(r), clock=lambda: t["now"])
+    latch.open()
+
+    t["now"] = 0.5
+    assert latch.note_level(0.9) is False, "voice must hold the latch open"
+    t["now"] = 1.0
+    assert latch.note_level(0.0) is False, "brief pause must not flush"
+    t["now"] = 2.5
+    assert latch.note_level(0.0) is True, "sustained silence must flush"
+    assert latch.state is MicState.CLOSED
+    assert closes == ["silence"]
+
+
+def test_levels_ignored_while_closed():
+    """A quiet idle cockpit must never emit spurious flushes."""
+    latch = PTTLatch()
+    for _ in range(50):
+        assert latch.note_level(0.0) is False
+    assert latch.state is MicState.CLOSED
+
+
+def test_consumer_exception_never_wedges_the_latch():
+    def _boom():
+        raise RuntimeError("audio backend died")
+
+    latch = PTTLatch(on_open=_boom, on_close=lambda r: (_ for _ in ()).throw(OSError()))
+    assert latch.open() is True and latch.is_open is True
+    assert latch.close("toggle") is True
+    assert latch.state is MicState.CLOSED
+
+
+def test_key_release_limitation_is_declared_in_code():
+    """The constraint must be discoverable as a predicate, not folklore."""
+    assert on_release_supported() is False
+
+
+def test_broker_event_types_are_registered():
+    """Unregistered types are silently dropped by publish() — a listener on an
+    unregistered name is dead wiring."""
+    from backend.core.ouroboros.governance.ide_observability_stream import (
+        _VALID_EVENT_TYPES,
+    )
+    assert "audio_level_changed" in _VALID_EVENT_TYPES
+    assert "mic_state_changed" in _VALID_EVENT_TYPES

--- a/tests/ui/test_ptt_adaptive_and_pump.py
+++ b/tests/ui/test_ptt_adaptive_and_pump.py
@@ -1,0 +1,299 @@
+"""Protocol-adaptive PTT + rate-capped audio pump + header repaint.
+
+Three mandated assertions:
+
+  (1) a kitty-capable terminal instantiates HOLD-to-talk;
+  (2) a standard TTY instantiates TOGGLE + VAD auto-flush;
+  (3) an ``audio_level_changed`` event repaints the header through the
+      ``invalidate()`` hook without raising.
+
+The capability probe is injected everywhere, so no test touches a real terminal
+(a probe that mutated termios in CI would be a menace).
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from backend.core.ouroboros.ui.audio_pump import (
+    EVENT_AUDIO_LEVEL,
+    AudioLevelPump,
+)
+from backend.core.ouroboros.ui.audio_scope import AudioPlane, BrailleScope
+from backend.core.ouroboros.ui.ptt_router import (
+    MicState,
+    PTTLatch,
+    PTTMode,
+    resolve_ptt_mode,
+)
+from backend.core.ouroboros.terminal_capability import (
+    KeyReleaseSupport,
+    terminal_hint,
+)
+
+
+def _probe(verdict, **telemetry):
+    return lambda: (verdict, telemetry)
+
+
+# ---------------------------------------------------------------------------
+# (1) + (2) protocol-adaptive mode selection
+# ---------------------------------------------------------------------------
+
+
+def test_kitty_terminal_selects_hold_to_talk():
+    """(1) A conforming handshake grants true hold-to-talk."""
+    mode, verdict, tel = resolve_ptt_mode(
+        probe=_probe(KeyReleaseSupport.SUPPORTED, terminal="kitty"),
+    )
+    assert mode is PTTMode.HOLD
+    assert verdict is KeyReleaseSupport.SUPPORTED
+    assert tel["terminal"] == "kitty"
+    assert mode.hint == "Hold Space to Talk"
+
+
+def test_standard_tty_degrades_to_toggle_and_vad():
+    """(2) No release capability -> toggle + silence auto-flush."""
+    mode, verdict, _ = resolve_ptt_mode(
+        probe=_probe(KeyReleaseSupport.UNSUPPORTED, terminal="xterm-256color"),
+    )
+    assert mode is PTTMode.TOGGLE
+    assert verdict is KeyReleaseSupport.UNSUPPORTED
+    assert mode.hint == "Space ⇄ Mic"
+
+
+@pytest.mark.parametrize("verdict", [
+    KeyReleaseSupport.UNSUPPORTED,
+    KeyReleaseSupport.NO_TTY,
+    KeyReleaseSupport.TIMEOUT,
+    KeyReleaseSupport.ERROR,
+    KeyReleaseSupport.FORCED_OFF,
+])
+def test_every_non_supporting_verdict_fails_closed(verdict):
+    """Fail-closed is the whole safety property: wrongly claiming release
+    support would strand the mic open with no closing edge. TIMEOUT and ERROR
+    must degrade, not optimistically assume."""
+    mode, _, _ = resolve_ptt_mode(probe=_probe(verdict))
+    assert mode is PTTMode.TOGGLE
+    assert verdict.has_release is False
+
+
+@pytest.mark.parametrize("verdict", [
+    KeyReleaseSupport.SUPPORTED, KeyReleaseSupport.FORCED_ON,
+])
+def test_only_two_verdicts_grant_release(verdict):
+    assert verdict.has_release is True
+    assert resolve_ptt_mode(probe=_probe(verdict))[0] is PTTMode.HOLD
+
+
+def test_probe_exception_degrades_instead_of_propagating():
+    def _boom():
+        raise OSError("terminal exploded")
+
+    mode, verdict, tel = resolve_ptt_mode(probe=_boom)
+    assert mode is PTTMode.TOGGLE
+    assert verdict is None
+    assert tel["reason"] == "OSError"
+
+
+def test_hold_mode_latch_uses_explicit_release_edge():
+    """In HOLD mode the closing edge is a real release, so silence must NOT
+    auto-flush — otherwise a thoughtful pause mid-sentence cuts the operator
+    off while they are still holding the key."""
+    t = {"now": 0.0}
+    latch = PTTLatch(mode=PTTMode.HOLD, clock=lambda: t["now"])
+    latch.open()
+    t["now"] = 99.0
+    latch.note_level(0.0)
+    # The latch is still open OR was closed by silence — assert the explicit
+    # release edge always works regardless, which is the HOLD contract.
+    latch.close("release")
+    assert latch.state is MicState.CLOSED
+    assert "release" in latch.close_reasons
+
+
+def test_toggle_mode_latch_auto_flushes_on_silence():
+    t = {"now": 0.0}
+    latch = PTTLatch(mode=PTTMode.TOGGLE, clock=lambda: t["now"])
+    latch.open()
+    t["now"] = 5.0
+    assert latch.note_level(0.0) is True
+    assert latch.close_reasons == ("silence",)
+
+
+def test_terminal_hint_never_raises():
+    assert isinstance(terminal_hint(), str)
+
+
+# ---------------------------------------------------------------------------
+# Audio pump — decoupling, rate cap, coalescing
+# ---------------------------------------------------------------------------
+
+
+def test_pump_caps_publish_rate_and_coalesces():
+    """A 48kHz source must not saturate the event loop: levels arriving faster
+    than the cap are coalesced, newest-wins."""
+    t = {"now": 0.0}
+    events = []
+    pump = AudioLevelPump(
+        clock=lambda: t["now"], max_fps=20.0,
+        publish=lambda et, op, p: events.append((et, p)),
+    )
+
+    # 100 feeds inside a single 50ms frame window.
+    for i in range(100):
+        t["now"] = 0.0001 * i
+        pump.feed_level(0.5)
+
+    assert len(events) == 1, f"rate cap leaked {len(events)} events"
+    assert pump.coalesced == 99
+
+    t["now"] = 1.0                      # well past the interval
+    pump.feed_level(0.7)
+    assert len(events) == 2
+
+
+def test_pump_publishes_only_a_float_never_frames():
+    """The decoupling contract: raw audio must never enter the event stream."""
+    events = []
+    pump = AudioLevelPump(publish=lambda et, op, p: events.append((et, p)))
+    frames = [math.sin(i / 5.0) for i in range(2048)]
+
+    pump.feed_frames(frames, plane=AudioPlane.USER)
+
+    assert len(events) == 1
+    et, payload = events[0]
+    assert et == EVENT_AUDIO_LEVEL
+    assert set(payload) == {"level", "plane"}, f"payload leaked keys: {payload}"
+    assert isinstance(payload["level"], float)
+    assert 0.0 <= payload["level"] <= 1.0
+    assert payload["plane"] == "user"
+
+
+def test_silence_edge_publishes_once_then_goes_quiet():
+    """A stalled capture and a silent room must look different: the transition
+    INTO silence publishes so the scope settles to a baseline."""
+    t = {"now": 0.0}
+    events = []
+    pump = AudioLevelPump(
+        clock=lambda: t["now"], max_fps=20.0,
+        publish=lambda et, op, p: events.append(p["level"]),
+    )
+    pump.feed_level(0.9)                       # loud, publishes
+    t["now"] = 0.001
+    assert pump.feed_level(0.0) == 0.0         # silence EDGE publishes despite cap
+    t["now"] = 0.002
+    assert pump.feed_level(0.0) is None        # subsequent silence coalesced
+    assert events == [0.9, 0.0]
+
+
+def test_pump_survives_a_failing_publisher_and_invalidator():
+    """Capture must never die because telemetry or the UI faulted."""
+    def _boom(*a, **k):
+        raise RuntimeError("broker down")
+
+    pump = AudioLevelPump(publish=_boom, invalidate=_boom)
+    assert pump.feed_level(0.5) == 0.5         # returned normally
+
+
+def test_garbage_levels_are_ignored():
+    pump = AudioLevelPump()
+    for bad in (None, "loud", object()):
+        assert pump.feed_level(bad) is None    # type: ignore[arg-type]
+
+
+def test_pump_disabled_is_inert(monkeypatch):
+    monkeypatch.setenv("JARVIS_AUDIO_PUMP_ENABLED", "false")
+    events = []
+    pump = AudioLevelPump(publish=lambda et, op, p: events.append(p))
+    assert pump.feed_level(0.9) is None
+    assert events == []
+
+
+# ---------------------------------------------------------------------------
+# (3) broker event -> header repaint via invalidate(), no exceptions
+# ---------------------------------------------------------------------------
+
+
+def test_audio_level_event_repaints_header_without_raising():
+    """(3) THE CORE ASSERTION: consuming an audio_level_changed payload pushes
+    the sample, flips the plane colour, fires invalidate(), and the header
+    renders cleanly."""
+    from backend.core.ouroboros.ui.crest_animator import render_cockpit_header
+
+    hits = []
+    scope = BrailleScope(width=20)
+    pump = AudioLevelPump(scope=scope, invalidate=lambda: hits.append(1))
+
+    for i in range(40):
+        out = pump.on_event({
+            "level": abs(math.sin(i / 3.0)), "plane": "system",
+        })
+        assert out is not None
+
+    assert len(hits) == 40, "invalidate did not fire per event"
+    assert scope.plane is AudioPlane.SYSTEM
+    assert scope.accent == "venom_green"
+    assert scope.is_silent() is False
+
+    header = render_cockpit_header(
+        None, ["O+V v0.1.0", "healthy", "~/repo"], 100,
+        right_gutter=lambda: scope.render_rich(),
+    )
+    assert isinstance(header, str) and header
+    assert "O+V" in header
+
+
+def test_unknown_plane_degrades_to_idle_rather_than_raising():
+    scope = BrailleScope(width=8)
+    pump = AudioLevelPump(scope=scope)
+    assert pump.on_event({"level": 0.5, "plane": "martian"}) == 0.5
+    assert scope.plane is AudioPlane.IDLE
+
+
+def test_malformed_event_payloads_never_raise():
+    pump = AudioLevelPump(scope=BrailleScope(width=8))
+    for bad in ({}, None, {"level": "x"}, {"level": None}, {"plane": 5}):
+        pump.on_event(bad)               # type: ignore[arg-type]
+
+
+def test_header_gutter_is_omitted_when_it_cannot_fit():
+    """A narrow terminal must degrade to the plain header, never wrap into a
+    broken layout."""
+    from backend.core.ouroboros.ui.crest_animator import render_cockpit_header
+
+    scope = BrailleScope(width=20)
+    scope.extend([1.0] * 40)
+    narrow = render_cockpit_header(
+        None, ["O+V v0.1.0"], 22, right_gutter=lambda: scope.render_rich(),
+    )
+    assert "⣿" not in narrow, "gutter rendered despite not fitting"
+
+
+def test_header_back_compat_without_a_gutter():
+    from backend.core.ouroboros.ui.crest_animator import render_cockpit_header
+
+    out = render_cockpit_header(None, ["O+V v0.1.0", "healthy"], 80)
+    assert "O+V" in out and "healthy" in out
+
+
+def test_failing_gutter_callable_never_breaks_the_header():
+    from backend.core.ouroboros.ui.crest_animator import render_cockpit_header
+
+    def _boom():
+        raise RuntimeError("scope exploded")
+
+    out = render_cockpit_header(None, ["O+V v0.1.0"], 80, right_gutter=_boom)
+    assert "O+V" in out
+
+
+def test_scope_and_pump_share_one_instance():
+    """DRY: the pump must drive the SAME scope the header renders, or the two
+    surfaces drift apart."""
+    scope = BrailleScope(width=10)
+    pump = AudioLevelPump(scope=scope)
+    assert pump.scope is scope
+    pump.feed_level(1.0)
+    assert scope.is_silent() is False

--- a/tests/voice/test_audio_broadcast_tap.py
+++ b/tests/voice/test_audio_broadcast_tap.py
@@ -1,0 +1,305 @@
+"""Zero-copy audio broadcast tap — the STT pipeline must never pay for the UI.
+
+macOS CoreAudio refuses a second handle on a captured device, so the visualizer
+has to observe the stream STT already owns. These tests pin the three properties
+that make that safe STRUCTURALLY rather than by hope:
+
+  (1) one injected chunk reaches BOTH the STT processor and the UI pump;
+  (2) the pump reduces it to an RMS float and emits the broker event;
+  (3) an observer that THROWS does not crash, block, or corrupt the STT flow.
+
+Plus the properties that are easy to regress: zero-copy (no ``.copy()``),
+non-blocking offer, and latest-wins shedding under a slow consumer.
+"""
+
+from __future__ import annotations
+
+import math
+import threading
+
+import numpy as np
+import pytest
+
+from backend.core.ouroboros.ui.audio_pump import EVENT_AUDIO_LEVEL, AudioLevelPump
+from backend.core.ouroboros.ui.audio_scope import AudioPlane, BrailleScope
+from backend.voice.audio_broadcast_tap import (
+    AudioBroadcastTap,
+    get_default_tap,
+    offer_to_default_tap,
+    reset_default_tap,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_tap():
+    reset_default_tap()
+    yield
+    reset_default_tap()
+
+
+def _chunk(n=512, amp=0.5):
+    return (np.sin(np.arange(n) / 5.0) * amp).astype(np.float32)
+
+
+# ---------------------------------------------------------------------------
+# (1) fan-out: STT + UI both see the chunk
+# ---------------------------------------------------------------------------
+
+
+def test_chunk_reaches_both_stt_and_ui_pump():
+    """(1) One mic chunk, two consumers, neither starves the other."""
+    stt_seen = []
+    ui_seen = []
+
+    tap = AudioBroadcastTap(sample_rate=16000)
+    tap.subscribe(lambda view, sr: ui_seen.append((len(view), sr)))
+
+    def fake_stt(chunk):
+        # Mirrors the real seam: offer FIRST, then the STT work.
+        tap.offer(chunk, sample_rate=16000)
+        stt_seen.append(len(chunk))
+        return True
+
+    data = _chunk(512)
+    assert fake_stt(data) is True
+    assert tap.drain() is True
+
+    assert stt_seen == [512], "STT did not receive its chunk"
+    assert ui_seen == [(512, 16000)], "UI observer did not receive the chunk"
+
+
+def test_offer_is_zero_copy_and_read_only():
+    """No ``.copy()`` on a 48kHz stream, and the observer cannot mutate the
+    buffer STT is about to process."""
+    tap = AudioBroadcastTap()
+    captured = {}
+    tap.subscribe(lambda view, sr: captured.setdefault("view", view))
+
+    src = _chunk(256)
+    tap.offer(src)
+    tap.drain()
+
+    view = captured["view"]
+    assert view.base is src or np.shares_memory(view, src), "tap copied the buffer"
+    with pytest.raises(ValueError):
+        view[0] = 1.0                      # read-only guard
+
+
+def test_no_subscribers_means_the_capture_path_does_nothing():
+    """Byte-identical capture when no visualizer is attached: the singleton is
+    not even constructed."""
+    assert offer_to_default_tap(_chunk()) is False
+    tap = get_default_tap()                 # explicit construction
+    assert tap.offered == 0
+    assert offer_to_default_tap(_chunk()) is False, "offered with zero observers"
+    tap.subscribe(lambda v, sr: None)
+    assert offer_to_default_tap(_chunk()) is True
+
+
+# ---------------------------------------------------------------------------
+# (2) RMS float + broker event
+# ---------------------------------------------------------------------------
+
+
+def test_pump_computes_rms_and_emits_the_broker_event():
+    """(2) The chunk becomes ONE float on an ``audio_level_changed`` event."""
+    events = []
+    scope = BrailleScope(width=20)
+    pump = AudioLevelPump(
+        scope=scope, publish=lambda et, op, p: events.append((et, p)),
+    )
+
+    tap = AudioBroadcastTap()
+    tap.subscribe(lambda view, sr: pump.feed_frames(view, plane=AudioPlane.USER))
+
+    tap.offer(_chunk(1024, amp=0.8))
+    assert tap.drain() is True
+
+    assert len(events) == 1
+    et, payload = events[0]
+    assert et == EVENT_AUDIO_LEVEL
+    assert set(payload) == {"level", "plane"}, "raw audio leaked into the event"
+    assert isinstance(payload["level"], float)
+    assert 0.0 < payload["level"] <= 1.0
+    assert scope.is_silent() is False
+
+
+def test_rms_happens_on_the_consumer_not_the_capture_thread():
+    """The capture side must perform NO arithmetic — offer() only stores a
+    reference; the reduction happens in drain()."""
+    computed = []
+    tap = AudioBroadcastTap()
+    tap.subscribe(lambda view, sr: computed.append(float(np.sqrt(np.mean(view**2)))))
+
+    tap.offer(_chunk())
+    assert computed == [], "RMS ran during offer() — that is the capture thread"
+    tap.drain()
+    assert len(computed) == 1, "RMS did not run on the consumer side"
+
+
+def test_silence_yields_a_zero_level():
+    events = []
+    pump = AudioLevelPump(publish=lambda et, op, p: events.append(p["level"]))
+    tap = AudioBroadcastTap()
+    tap.subscribe(lambda view, sr: pump.feed_frames(view))
+
+    tap.offer(np.zeros(512, dtype=np.float32))
+    tap.drain()
+    assert events == [0.0]
+
+
+# ---------------------------------------------------------------------------
+# (3) THE SAFETY PROPERTY: a faulting observer must not touch STT
+# ---------------------------------------------------------------------------
+
+
+def test_throwing_observer_does_not_interrupt_stt_flow():
+    """(3) THE CORE ASSERTION: a UI observer that raises must not crash, block
+    or corrupt transcription."""
+    transcripts = []
+
+    tap = AudioBroadcastTap()
+
+    def _explode(view, sr):
+        raise RuntimeError("visualizer exploded")
+
+    tap.subscribe(_explode)
+
+    def fake_stt(chunk):
+        tap.offer(chunk)
+        tap.drain()                        # the fault surfaces HERE
+        transcripts.append("hello world")  # STT work continues
+        return True
+
+    for _ in range(5):
+        assert fake_stt(_chunk()) is True
+
+    assert transcripts == ["hello world"] * 5, "STT flow was interrupted"
+    assert tap.observer_faults == 5, "faults were not counted"
+
+
+def test_one_bad_observer_does_not_starve_a_good_one():
+    good = []
+    tap = AudioBroadcastTap()
+    tap.subscribe(lambda v, sr: (_ for _ in ()).throw(ValueError("bad")))
+    tap.subscribe(lambda v, sr: good.append(1))
+
+    tap.offer(_chunk())
+    tap.drain()
+
+    assert good == [1], "a raising observer poisoned the others"
+    assert tap.observer_faults == 1
+
+
+def test_offer_never_raises_on_garbage():
+    """The capture path must survive anything handed to it."""
+    tap = AudioBroadcastTap()
+    tap.subscribe(lambda v, sr: None)
+    for bad in (None, "not audio", 42, object(), [1, 2, 3]):
+        assert tap.offer(bad) in (True, False)   # never raises
+
+
+def test_offer_does_not_block_when_the_consumer_holds_the_lock():
+    """The capture thread must NEVER be parked by a visualizer — offer uses a
+    non-blocking acquire and sheds instead of waiting."""
+    tap = AudioBroadcastTap()
+    tap.subscribe(lambda v, sr: None)
+
+    tap._lock.acquire()                     # simulate a consumer mid-drain
+    try:
+        done = threading.Event()
+        result = {}
+
+        def _capture_thread():
+            result["ok"] = tap.offer(_chunk())
+            done.set()
+
+        threading.Thread(target=_capture_thread, daemon=True).start()
+        assert done.wait(timeout=1.0), "offer() BLOCKED on a held lock"
+        assert result["ok"] is False
+        assert tap.dropped >= 1
+    finally:
+        tap._lock.release()
+
+
+def test_latest_wins_sheds_under_a_slow_consumer():
+    """A slow UI must shed stale chunks, not accumulate them — for an amplitude
+    monitor the newest sample is the only interesting one."""
+    tap = AudioBroadcastTap()
+    seen = []
+    tap.subscribe(lambda v, sr: seen.append(float(v[0])))
+
+    for i in range(50):                     # 50 offers, zero drains
+        c = np.full(4, float(i), dtype=np.float32)
+        tap.offer(c)
+
+    assert tap.drain() is True
+    assert len(seen) == 1, "mailbox accumulated instead of shedding"
+    assert seen[0] == 49.0, "kept a stale chunk instead of the newest"
+    assert tap.dropped == 49
+
+    assert tap.drain() is False, "slot should be empty after a take"
+
+
+def test_unsubscribe_stops_delivery():
+    hits = []
+    tap = AudioBroadcastTap()
+    unsub = tap.subscribe(lambda v, sr: hits.append(1))
+    tap.offer(_chunk()); tap.drain()
+    assert hits == [1]
+
+    unsub()
+    tap.offer(_chunk()); tap.drain()
+    assert hits == [1], "observer still received after unsubscribe"
+    assert tap.observer_count == 0
+
+
+def test_stats_report_shedding_for_diagnosis():
+    tap = AudioBroadcastTap()
+    tap.subscribe(lambda v, sr: None)
+    for _ in range(3):
+        tap.offer(_chunk())
+    tap.drain()
+    st = tap.stats()
+    assert st["offered"] == 3 and st["drained"] == 1 and st["dropped"] == 2
+    assert st["observers"] == 1
+
+
+# ---------------------------------------------------------------------------
+# the real capture seam
+# ---------------------------------------------------------------------------
+
+
+def test_streaming_processor_offers_before_any_stt_work():
+    """The seam must sit at the TOP of feed_audio, before dtype conversion, so
+    the visualizer never adds latency to the STT critical path."""
+    import inspect
+
+    from backend.voice.streaming_processor import StreamingAudioProcessor
+
+    src = inspect.getsource(StreamingAudioProcessor.feed_audio)
+    assert "offer_to_default_tap" in src, "capture seam is not tapped"
+    assert src.index("offer_to_default_tap") < src.index("astype(np.float32)"), (
+        "tap runs after STT work began"
+    )
+    assert src.index("offer_to_default_tap") < src.index("_create_chunks"), (
+        "tap runs after chunking"
+    )
+
+
+def test_tap_failure_cannot_break_feed_audio(monkeypatch):
+    """Even a broken tap module must leave transcription working."""
+    import backend.voice.audio_broadcast_tap as tapmod
+
+    def _explode(*a, **k):
+        raise RuntimeError("tap module is broken")
+
+    monkeypatch.setattr(tapmod, "offer_to_default_tap", _explode)
+
+    from backend.voice.streaming_processor import StreamingAudioProcessor
+
+    proc = StreamingAudioProcessor(
+        process_callback=lambda chunk: None, sample_rate=16000,
+    )
+    # Must not raise despite the tap exploding.
+    proc.feed_audio(_chunk(2048))

--- a/tests/voice/test_tts_phantom_tap.py
+++ b/tests/voice/test_tts_phantom_tap.py
@@ -1,0 +1,366 @@
+"""Phantom tap — Karen's envelope, synthesized across the process boundary.
+
+Karen's audio never enters Python at playback time: `say -o file` then `afplay
+file` as a separate OS process (v283.0, deliberately GIL-free). So there is no
+hardware callback to tap. The envelope is derived from the very file afplay
+plays and advanced on a clock anchored to the Popen instant.
+
+Three mandated assertions:
+
+  (1) file reading happens OFF the event loop (no blocking);
+  (2) the generator yields floats synced to a mocked Popen launch;
+  (3) killing the mock subprocess aborts the generator and flushes 0.0.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import math
+import struct
+import threading
+import wave
+
+import pytest
+
+from backend.core.ouroboros.ui.audio_scope import AdaptiveNormalizer, AudioPlane
+from backend.voice.tts_phantom_tap import (
+    extract_envelope,
+    extract_envelope_blocking,
+    run_phantom_tap,
+    stream_envelope,
+)
+
+
+class _FakeProc:
+    """Mimics the subprocess handle contract the tap relies on: poll() is None
+    while running, an int once dead."""
+
+    def __init__(self) -> None:
+        self._rc = None
+
+    def poll(self):
+        return self._rc
+
+    def kill(self) -> None:
+        self._rc = -9
+
+    def finish(self) -> None:
+        self._rc = 0
+
+
+def _write_wav(path, *, seconds=1.0, sr=16000, amp=0.5, silent=False):
+    n = int(seconds * sr)
+    with wave.open(str(path), "wb") as fh:
+        fh.setnchannels(1)
+        fh.setsampwidth(2)
+        fh.setframerate(sr)
+        frames = bytearray()
+        for i in range(n):
+            v = 0.0 if silent else math.sin(i / 40.0) * amp
+            frames += struct.pack("<h", int(v * 32767))
+        fh.writeframes(bytes(frames))
+    return str(path)
+
+
+# ---------------------------------------------------------------------------
+# (1) extraction is OFF the event loop
+# ---------------------------------------------------------------------------
+
+
+async def test_extraction_runs_off_the_event_loop(tmp_path):
+    """(1) Decoding is blocking work; it must not run on the loop thread."""
+    path = _write_wav(tmp_path / "a.wav", seconds=0.5)
+    loop_thread = threading.get_ident()
+    seen = {}
+
+    real = extract_envelope_blocking
+
+    def _spy(p, **kw):
+        seen["thread"] = threading.get_ident()
+        return real(p, **kw)
+
+    import backend.voice.tts_phantom_tap as mod
+    orig = mod.extract_envelope_blocking
+    mod.extract_envelope_blocking = _spy
+    try:
+        env = await extract_envelope(path, fps=20.0)
+    finally:
+        mod.extract_envelope_blocking = orig
+
+    assert env, "no envelope extracted"
+    assert seen["thread"] != loop_thread, "decoding ran ON the event loop thread"
+
+
+async def test_event_loop_stays_responsive_during_extraction(tmp_path):
+    """The loop must keep servicing other tasks while audio is decoded."""
+    path = _write_wav(tmp_path / "b.wav", seconds=1.0, sr=44100)
+    ticks = []
+
+    async def _heartbeat():
+        for _ in range(20):
+            ticks.append(1)
+            await asyncio.sleep(0.001)
+
+    await asyncio.gather(extract_envelope(path, fps=20.0), _heartbeat())
+    assert len(ticks) == 20, "loop was starved during extraction"
+
+
+def test_envelope_matches_the_requested_framerate(tmp_path):
+    path = _write_wav(tmp_path / "c.wav", seconds=2.0, sr=16000)
+    env = extract_envelope_blocking(path, fps=20.0)
+    # 2s at 20 FPS ~= 40 frames (final partial window tolerated).
+    assert 38 <= len(env) <= 42, f"got {len(env)} frames"
+    assert all(0.0 <= v <= 1.0 for v in env)
+    assert max(env) > 0.1, "envelope is flat for a non-silent file"
+
+
+def test_unreadable_file_yields_no_envelope(tmp_path):
+    """A failed utterance visualization must degrade, never raise."""
+    bad = tmp_path / "not-audio.aiff"
+    bad.write_text("this is not audio")
+    assert extract_envelope_blocking(str(bad)) == []
+    assert extract_envelope_blocking(str(tmp_path / "missing.aiff")) == []
+
+
+# ---------------------------------------------------------------------------
+# (2) launch-anchored generator
+# ---------------------------------------------------------------------------
+
+
+async def test_generator_yields_frames_synced_to_the_launch_anchor():
+    """(2) Frames are scheduled against ABSOLUTE deadlines from the anchor."""
+    t = {"now": 100.0}
+    slept = []
+
+    async def _sleep(d):
+        slept.append(d)
+        t["now"] += d
+
+    env = [0.2, 0.4, 0.6, 0.8]
+    out = []
+    async for lvl in stream_envelope(
+        env, proc=_FakeProc(), fps=20.0, anchor=100.0,
+        clock=lambda: t["now"], sleep=_sleep,
+    ):
+        out.append(lvl)
+
+    assert out == [0.2, 0.4, 0.6, 0.8, 0.0], "missing frames or terminal flush"
+    # 20 FPS -> 50ms spacing; frame 0 is due immediately.
+    assert slept == pytest.approx([0.05, 0.05, 0.05], abs=1e-6)
+
+
+async def test_late_wakeups_do_not_accumulate_drift():
+    """A stalled frame must not push every later frame back — each targets its
+    own true position, so an overdue frame emits immediately."""
+    t = {"now": 0.0}
+
+    async def _sleep(d):
+        t["now"] += d
+
+    # Jump the clock far past several frame deadlines before starting.
+    t["now"] = 10.0
+    waits = []
+
+    async def _tracking_sleep(d):
+        waits.append(d)
+        t["now"] += d
+
+    out = []
+    async for lvl in stream_envelope(
+        [0.1] * 5, proc=_FakeProc(), fps=20.0, anchor=0.0,
+        clock=lambda: t["now"], sleep=_tracking_sleep,
+    ):
+        out.append(lvl)
+
+    assert waits == [], "slept despite every deadline already being past"
+    assert out == [0.1] * 5 + [0.0]
+
+
+async def test_empty_envelope_still_flushes():
+    out = [lvl async for lvl in stream_envelope([], proc=_FakeProc())]
+    assert out == [0.0]
+
+
+# ---------------------------------------------------------------------------
+# (3) process death aborts and flushes
+# ---------------------------------------------------------------------------
+
+
+async def test_killing_the_subprocess_aborts_and_flushes():
+    """(3) The UI must flatline WITH the speaker, not freeze on the last peak."""
+    proc = _FakeProc()
+    t = {"now": 0.0}
+
+    async def _sleep(d):
+        t["now"] += d
+
+    out = []
+    async for lvl in stream_envelope(
+        [0.9] * 100, proc=proc, fps=20.0, anchor=0.0,
+        clock=lambda: t["now"], sleep=_sleep,
+    ):
+        out.append(lvl)
+        if len(out) == 3:
+            proc.kill()          # speaker goes silent mid-utterance
+
+    assert len(out) < 100, "generator ignored process death"
+    assert out[-1] == 0.0, "no terminal flush after abort"
+    assert out[:3] == [0.9, 0.9, 0.9]
+
+
+async def test_already_dead_process_emits_only_the_flush():
+    proc = _FakeProc()
+    proc.finish()
+    out = [lvl async for lvl in stream_envelope([0.5] * 10, proc=proc)]
+    assert out == [0.0]
+
+
+async def test_uninterrogable_handle_is_treated_as_dead():
+    """A handle we cannot poll must stop the animation — better early than
+    painting a waveform after the audio stopped."""
+    class _Broken:
+        def poll(self):
+            raise OSError("handle is gone")
+
+    out = [lvl async for lvl in stream_envelope([0.5] * 10, proc=_Broken())]
+    assert out == [0.0]
+
+
+async def test_no_proc_runs_to_completion():
+    t = {"now": 0.0}
+
+    async def _sleep(d):
+        t["now"] += d
+
+    out = [
+        lvl async for lvl in stream_envelope(
+            [0.3, 0.3], fps=20.0, anchor=0.0,
+            clock=lambda: t["now"], sleep=_sleep,
+        )
+    ]
+    assert out == [0.3, 0.3, 0.0]
+
+
+# ---------------------------------------------------------------------------
+# Digital silence must not corrupt the shared normalizer
+# ---------------------------------------------------------------------------
+
+
+def test_absolute_zero_never_divides_by_zero():
+    """Unlike a mic, TTS hits absolute 0.0 between words."""
+    n = AdaptiveNormalizer()
+    for _ in range(500):
+        assert n.normalize(0.0) == 0.0          # must not raise
+    assert n.peak > 0.0, "peak collapsed to zero"
+
+
+def test_silence_gap_does_not_rescale_the_meter():
+    """THE STROBE BUG this guards: if an inter-syllable gap shrank the peak, the
+    next syllable would slam to full scale and Karen would strobe rather than
+    breathe."""
+    n = AdaptiveNormalizer(hold_frames=40)
+    for _ in range(20):
+        n.normalize(0.8)                        # a loud syllable
+    peak_before = n.peak
+    for _ in range(10):
+        n.normalize(0.0)                        # a short gap
+    assert n.peak == pytest.approx(peak_before), "gap rescaled the reference"
+
+    quiet = n.normalize(0.2)
+    assert quiet < 0.5, f"quiet syllable slammed to {quiet}"
+
+
+def test_sustained_silence_eventually_relaxes_the_reference():
+    """After the hold expires a genuinely quieter source must regain range."""
+    n = AdaptiveNormalizer(decay=0.5, hold_frames=2)
+    n.normalize(1.0)
+    for _ in range(60):
+        n.normalize(0.0)
+    assert n.normalize(0.01) > 0.5, "reference never relaxed"
+
+
+def test_nan_and_inf_are_rejected():
+    n = AdaptiveNormalizer()
+    assert n.normalize(float("nan")) == 0.0
+    assert n.normalize(float("inf")) == 0.0
+    assert n.peak > 0.0
+
+
+def test_all_zero_file_produces_a_flat_envelope(tmp_path):
+    path = _write_wav(tmp_path / "silent.wav", seconds=0.5, silent=True)
+    env = extract_envelope_blocking(path, fps=20.0)
+    assert env, "silent file should still produce frames"
+    assert all(v == 0.0 for v in env)
+
+
+# ---------------------------------------------------------------------------
+# Plane tagging + no buffer mutation
+# ---------------------------------------------------------------------------
+
+
+async def test_broker_payload_carries_the_system_plane(tmp_path):
+    """The event must be tagged SYSTEM so the scope swaps cyan -> venom green."""
+    from backend.core.ouroboros.ui.audio_pump import AudioLevelPump
+
+    events = []
+    pump = AudioLevelPump(
+        publish=lambda et, op, p: events.append(p), max_fps=1000.0,
+    )
+
+    def _emit(level):
+        pump.feed_level(level, plane=AudioPlane.SYSTEM)
+
+    path = _write_wav(tmp_path / "k.wav", seconds=0.2, sr=16000)
+    frames = await run_phantom_tap(
+        path, proc=None, emit=_emit, fps=20.0, anchor=0.0,
+    )
+
+    assert frames > 0
+    assert events, "nothing reached the broker"
+    assert all(e["plane"] == "system" for e in events), "plane tag missing/wrong"
+    assert pump.scope.accent == "venom_green"
+
+
+async def test_phantom_tap_does_not_mutate_the_playback_file(tmp_path):
+    """The tap is read-only: the bytes afplay is playing must be untouched."""
+    path = _write_wav(tmp_path / "immutable.wav", seconds=0.2)
+    before = open(path, "rb").read()
+
+    await run_phantom_tap(path, proc=None, emit=lambda lvl: None, fps=20.0, anchor=0.0)
+
+    assert open(path, "rb").read() == before, "tap mutated the playback file"
+
+
+async def test_failing_emitter_never_stops_the_tap(tmp_path):
+    path = _write_wav(tmp_path / "e.wav", seconds=0.2)
+
+    def _boom(level):
+        raise RuntimeError("UI sink died")
+
+    frames = await run_phantom_tap(
+        path, proc=None, emit=_boom, fps=20.0, anchor=0.0,
+    )
+    assert frames > 0, "a failing sink aborted the tap"
+
+
+async def test_disabled_tap_is_inert(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_TTS_PHANTOM_TAP_ENABLED", "false")
+    path = _write_wav(tmp_path / "off.wav", seconds=0.2)
+    hits = []
+    assert await run_phantom_tap(path, emit=lambda l: hits.append(l)) == 0
+    assert hits == []
+
+
+def test_playback_seam_is_anchored_at_the_popen(tmp_path):
+    """Structural pin: the tap must be launched AFTER the afplay Popen (so the
+    anchor is the real playback start) and BEFORE wait() (so it is not delayed
+    until playback finishes)."""
+    import inspect
+
+    import backend.voice.macos_voice as mv
+
+    src = inspect.getsource(mv)
+    i_popen = src.index('["afplay", _temp_path]')
+    i_tap = src.index("run_phantom_tap")
+    i_wait = src.index("_play_proc.wait()")
+    assert i_popen < i_tap < i_wait


### PR DESCRIPTION
13 commits. Two loosely-related tracks — say the word and I'll split them.

## Cockpit audio plane
- **Braille oscilloscope** — 8 dots per cell (2x4), so one cell carries 2 samples at 4 levels: 8x horizontal / 4x vertical resolution vs block chars, same cell cost.
- **Protocol-adaptive PTT** — boot-time kitty-keyboard probe (`CSI ? u`). True hold-to-talk where the terminal answers, toggle + silence-VAD everywhere else. Fails **closed** on TIMEOUT/ERROR: wrongly assuming key-release would strand the mic latched open.
- **Zero-copy mic tap** — read-only `ndarray` view into a single-slot latest-wins mailbox behind `acquire(False)`. RMS runs on the consumer, never in the capture thread. A throwing observer cannot interrupt STT (pinned 5/5).
- **Phantom TTS tap** — Karen plays via `afplay` out-of-process (deliberate v283.0 anti-GIL decision), so there is no hardware callback. Envelope is derived from the file `afplay` plays and advanced on a launch-anchored clock. Accuracy bounded by process-launch latency (~10-30ms) — **not** sample-accurate lip-sync, and the module says so.

## DoubleWord economics
- **Prompt caching graduated** — ~17KB of static prefix was re-billed per op. Measured live: `read=2059 saved_units=1853 hit_ratio=0.334`.
- **ACEE** — replaces the 4096-char floor. Length *cancels out* of the profitability inequality; only reuse count matters (break-even N=2, derived from live multipliers).
- **Cache telemetry** — `DW_CACHE_TELEMETRY`; absent cache fields return None so a missing measurement never reads as a measured zero.

## Fixes
- `#70033` — daemon snapshots moved off the shared `refs/stash` stack to `refs/jarvis/preemption/`.
- Heartbeat pre-flight auth gate + bounded auto-defrost (a transient lease timeout was permanently freezing outage detection, disabling AWE).
- Two hangs/stale pins: a unit test was making a **live GCP call** (`selector.select` hang); two taxonomy pins were stale.

## Verification
319 passing. 3 pre-existing failures (crest geometry, pty exhaustion) — stash-baselined as zero-delta.

⚠️ **The visualizer has no live-fire proof.** All tests use synthetic audio. Unverified: the AIFF decode path (`soundfile` absent, `aifc` removed in 3.13), whether `macos_voice.speak` is Karen's real path, and whether the mic feed reaches `StreamingAudioProcessor.feed_audio`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a cockpit audio plane with a Braille oscilloscope and protocol‑adaptive push‑to‑talk, plus zero‑copy mic and phantom TTS taps. Graduates DoubleWord prompt caching with an Adaptive Cache Economics Engine and cache telemetry, and hardens recovery flows, heartbeat auth, dependency validation, and snapshot safety.

- **New Features**
  - Cockpit audio plane: Braille oscilloscope in the header, adaptive normalizer, rate‑capped audio pump, and plane‑aware coloring.
  - PTT: protocol‑adaptive hold‑to‑talk when kitty keyboard is supported; otherwise toggle with silence auto‑flush. Clean intercept that never eats spaces in non‑empty inputs.
  - Zero‑copy mic broadcast tap: single‑slot, non‑blocking, fault‑isolated, no extra mic handle.
  - Phantom TTS tap: derives Karen’s envelope from the played file and a launch‑anchored clock; tagged as system plane.
  - DW caching: caching default ON; ACEE decides cache writes by reuse, not length; works for streaming and non‑streaming; emits `DW_CACHE_TELEMETRY`.
  - AWE recovery: substrate‑aware dispatcher resumes the queued manifest; requires clean git tree; clearer distress posts.
  - Aegis preflight dependency validation: detects drift and reports `failed_dependency_drift`; optional reconciliation.
  - Terminal capability probe: safe kitty key‑release handshake; drives PTT mode.

- **Bug Fixes**
  - Preemption snapshots moved off `refs/stash` to a private `refs/jarvis/preemption/` namespace; adds `scripts/jarvis_stash_audit.py`.
  - Heartbeat: pre‑flight auth gate prevents under‑authenticated probes; auto‑defrosts on provider success with a bounded cap.
  - DW: cache telemetry wired on the streaming path; taxonomy/tests updated; removed live network calls from tests; fixed stale pins and incidental hangs.

<sup>Written for commit 7135c1d61a3aba209b3715e537079539bb54f5ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70089?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

