### PR TITLE
fix: Visible idle baseline and dynamic noise-floor squelch

### DIFF
--- a/backend/core/ouroboros/ui/audio_scope.py
+++ b/backend/core/ouroboros/ui/audio_scope.py
@@ -145,13 +145,105 @@ class AdaptiveNormalizer:
     def __init__(
         self, *, decay: float = 0.995, floor: float = 1e-3,
         hold_frames: int = 40,
+        squelch: bool = True,
+        squelch_window_frames: int = 80,
+        squelch_margin: float = 3.0,   # k in floor + k*spread
+        squelch_epsilon: float = 1e-4,
+        squelch_warmup_frames: int = 20,
     ) -> None:
         self._decay = min(max(float(decay), 0.0), 0.999999)
         self._floor = max(float(floor), 1e-9)
         self._peak = self._floor
         self._hold_frames = max(0, int(hold_frames))
         self._held = 0
+        # --- dynamic noise-floor squelch -------------------------------
+        # A real microphone never reaches digital zero: fans, HVAC and room
+        # tone keep RMS hovering just above it, which renders as a permanently
+        # twitching baseline. A fixed gate cannot solve this — the right
+        # threshold in a quiet study is wrong in a coffee shop — so the floor
+        # is LEARNED from the signal itself.
+        self._squelch = bool(squelch)
+        self._noise_floor = 0.0
+        # Ambient SPREAD, not just its trough. A quiet room's tone ranges
+        # ~0.002-0.006 — a 3x spread — so a gate pinned to the minimum is
+        # sailed over by the noise's own peaks. Gating at floor + k*spread
+        # covers the distribution instead of its lower edge, and adapts to
+        # both a still study and a churning cafe without a constant.
+        self._noise_spread = 0.0
+        self._squelch_seen = 0
+        self._squelch_warmup = max(0, int(squelch_warmup_frames))
+        self._squelch_margin = max(0.0, float(squelch_margin))
+        self._squelch_eps = max(0.0, float(squelch_epsilon))
+        # EMA smoothing derived from the window rather than hardcoded, so
+        # "about four seconds at 20 FPS" stays true if the framerate changes.
+        n = max(1, int(squelch_window_frames))
+        self._squelch_alpha = 2.0 / (n + 1.0)
         self._lock = threading.Lock()
+
+    # -- noise-floor profiler -------------------------------------------
+
+    def _update_noise_floor(self, v: float) -> None:
+        """Track the TROUGH of the stream, asymmetrically. Caller holds lock.
+
+        Down-fast / up-slow is the whole trick. A sample below the current
+        floor is new evidence about how quiet the room can be, so it is adopted
+        quickly. A sample above it might be speech, so the floor creeps upward
+        at a fraction of that rate — otherwise a few seconds of talking would
+        drag the floor up and squelch the speaker's own voice.
+
+        Pure float math on two scalars: no allocation, no deque scan, nothing
+        that could stall the caller."""
+        if self._squelch_seen < self._squelch_warmup:
+            # Warmup: adopt the running minimum outright. One sample cannot
+            # characterise a room, and clamping before the profile exists would
+            # squelch the first words spoken.
+            if self._squelch_seen == 0:
+                self._noise_floor = v
+                self._noise_spread = 0.0
+            else:
+                self._noise_floor = min(self._noise_floor, v)
+                self._noise_spread += (
+                    abs(v - self._noise_floor) - self._noise_spread
+                ) * 0.5          # converge fast during the short warmup
+            return
+        if v < self._noise_floor:
+            a = self._squelch_alpha            # fall toward a quieter trough
+        else:
+            a = self._squelch_alpha * 0.05     # rise 20x slower — speech-proof
+        self._noise_floor += (v - self._noise_floor) * a
+        # Spread learns ONLY from samples the gate currently calls ambient.
+        # Letting speech widen it would inflate the gate until the speaker
+        # squelched themselves.
+        if v <= self._gate_locked():
+            self._noise_spread += (
+                abs(v - self._noise_floor) - self._noise_spread
+            ) * self._squelch_alpha
+
+    def _gate_locked(self) -> float:
+        """The ambient ceiling: trough + k*spread + epsilon. Caller holds lock.
+        Single definition so the profiler and the clamp can never disagree
+        about what counts as noise."""
+        return (
+            self._noise_floor
+            + self._squelch_margin * self._noise_spread
+            + self._squelch_eps
+        )
+
+    @property
+    def noise_gate(self) -> float:
+        with self._lock:
+            return self._gate_locked()
+
+    @property
+    def noise_floor(self) -> float:
+        with self._lock:
+            return self._noise_floor
+
+    @property
+    def squelch_ready(self) -> bool:
+        """True once enough frames have been seen to trust the profile."""
+        with self._lock:
+            return self._squelch_seen >= self._squelch_warmup
 
     def normalize(self, value: float) -> float:
         """Normalized 0..1 against the held/decaying peak.
@@ -178,6 +270,21 @@ class AdaptiveNormalizer:
         if v != v or v == float("inf"):     # NaN / inf are not signal
             return 0.0
         with self._lock:
+            # ── Dynamic squelch, BEFORE scaling ────────────────────────────
+            # The profiler learns from every sample (including squelched ones —
+            # that is precisely where the room tone lives). Anything at or
+            # below floor*margin + eps is declared ambient and clamped to a
+            # hard 0.0, so the meter renders a dead-stable baseline instead of
+            # amplifying HVAC into a waveform. Everything downstream then
+            # operates on the squelched value, so a clamped sample is
+            # indistinguishable from true digital silence — including to the
+            # peak tracker, which must not treat room tone as signal.
+            if self._squelch:
+                self._update_noise_floor(v)
+                self._squelch_seen += 1
+                if self._squelch_seen >= self._squelch_warmup:
+                    if v <= self._gate_locked():
+                        v = 0.0
             if v > self._floor:
                 # Real signal: re-arm the gap guard, but KEEP DECAYING. Holding
                 # the peak on any above-floor sample would pin the reference at

--- a/backend/core/ouroboros/ui/audio_scope.py
+++ b/backend/core/ouroboros/ui/audio_scope.py
@@ -223,21 +223,42 @@ def _level_for(value: float) -> int:
     return max(1, min(LEVELS, int(math.ceil(v * LEVELS))))
 
 
-def cell_for(left: float, right: float) -> str:
-    """Two normalized samples → one Braille cell. Pure; never raises."""
+def cell_for(left: float, right: float, *, baseline: bool = True) -> str:
+    """Two normalized samples → one Braille cell. Pure; never raises.
+
+    ``baseline`` draws the bottom dot row for a silent sample. This is not
+    decoration — it is the difference between a working meter and an invisible
+    one. U+2800 is the BLANK braille pattern, so a silent scope without a
+    baseline renders as pure whitespace, which an operator cannot distinguish
+    from "the feature isn't installed". A real oscilloscope shows a flat line
+    at rest; so does this one now.
+
+    (This module's docstring claimed a flat baseline from the start; the code
+    never did it. Caught by looking at a live cockpit and seeing nothing.)"""
     try:
         mask = 0
-        for i in range(_level_for(left)):
+        left_n, right_n = _level_for(left), _level_for(right)
+        for i in range(left_n):
             mask |= _COL0_BOTTOM_UP[i]
-        for i in range(_level_for(right)):
+        for i in range(right_n):
             mask |= _COL1_BOTTOM_UP[i]
+        if baseline:
+            # Silent sub-columns still get their bottom dot, so the trace is
+            # continuous across quiet passages instead of breaking into
+            # floating islands.
+            if left_n == 0:
+                mask |= _COL0_BOTTOM_UP[0]
+            if right_n == 0:
+                mask |= _COL1_BOTTOM_UP[0]
         return chr(_BRAILLE_BASE + mask)
     except Exception:  # noqa: BLE001
         return chr(_BRAILLE_BASE)
 
 
-def _ascii_cell(left: float, right: float) -> str:
+def _ascii_cell(left: float, right: float, *, baseline: bool = True) -> str:
     lvl = max(_level_for(left), _level_for(right))
+    if lvl == 0 and baseline:
+        return "_"          # visible flat line, same reason as the Braille path
     return _ASCII_RAMP[min(lvl, len(_ASCII_RAMP) - 1)]
 
 

--- a/tests/ui/test_audio_scope_and_ptt.py
+++ b/tests/ui/test_audio_scope_and_ptt.py
@@ -35,6 +35,10 @@ from backend.core.ouroboros.ui.ptt_router import (
 )
 
 _BASE = 0x2800
+#: A silent sub-column still draws its bottom dot, so quiet renders as a
+#: visible flat line. U+2800 is BLANK — a scope made of it is invisible,
+#: which is indistinguishable from the feature not being installed.
+_BASELINE = chr(_BASE + 0x40 + 0x80)   # dots 7+8, both bottom dots
 
 
 # ---------------------------------------------------------------------------
@@ -47,7 +51,7 @@ def test_silence_renders_empty_braille_cells():
     sc.extend([0.0] * 16)
     out = sc.render()
     assert len(out) == 8
-    assert out == chr(_BASE) * 8, "silence must be blank cells, not a floating bar"
+    assert out == _BASELINE * 8, "silence must be a visible flat line"
     assert sc.is_silent() is True
 
 
@@ -60,19 +64,21 @@ def test_full_scale_renders_all_eight_dots():
 def test_cell_encodes_two_samples_at_four_levels():
     """The resolution claim, asserted bit-exactly: one cell = 2 columns x 4 rows,
     bars filling from the BOTTOM."""
-    assert cell_for(0.0, 0.0) == chr(_BASE)
+    assert cell_for(0.0, 0.0, baseline=False) == chr(_BASE)
+    assert cell_for(0.0, 0.0) == _BASELINE          # baseline on by default
     # Left column only, one dot from the bottom -> dot 7 (0x40).
-    assert cell_for(0.2, 0.0) == chr(_BASE + 0x40)
+    assert cell_for(0.2, 0.0, baseline=False) == chr(_BASE + 0x40)
     # Right column only, one dot from the bottom -> dot 8 (0x80).
-    assert cell_for(0.0, 0.2) == chr(_BASE + 0x80)
+    assert cell_for(0.0, 0.2, baseline=False) == chr(_BASE + 0x80)
     # Both columns full -> all eight dots.
-    assert cell_for(1.0, 1.0) == chr(_BASE + 0xFF)
+    assert cell_for(1.0, 1.0) == chr(_BASE + 0xFF)   # unchanged: full scale
 
 
 def test_bars_fill_upward_from_the_baseline():
     """A louder sample must be a TALLER bar anchored at the bottom, so a rising
     ramp is monotonically denser."""
-    masks = [ord(cell_for(v, v)) - _BASE for v in (0.0, 0.25, 0.5, 0.75, 1.0)]
+    masks = [ord(cell_for(v, v, baseline=False)) - _BASE
+             for v in (0.0, 0.25, 0.5, 0.75, 1.0)]
     assert masks == sorted(masks), f"not monotonic: {masks}"
     assert masks[0] == 0 and masks[-1] == 0xFF
 
@@ -94,9 +100,9 @@ def test_newest_sample_lands_at_the_right_edge():
     """Right-to-left scroll: the freshest data is always rightmost."""
     sc = BrailleScope(width=3)
     sc.extend([0.0] * 6)
-    assert sc.render()[-1] == chr(_BASE)
+    assert sc.render()[-1] == _BASELINE
     sc.push(1.0)
-    assert sc.render()[-1] != chr(_BASE), "new sample did not reach the right edge"
+    assert sc.render()[-1] != _BASELINE, "new sample did not reach the right edge"
 
 
 def test_partial_buffer_is_left_padded_to_stable_width():
@@ -105,7 +111,7 @@ def test_partial_buffer_is_left_padded_to_stable_width():
     sc.push(1.0)
     out = sc.render()
     assert len(out) == 10
-    assert out.startswith(chr(_BASE)), "partial buffer must left-pad"
+    assert out.startswith(_BASELINE), "partial buffer must left-pad with baseline"
     assert out[-1] != chr(_BASE)
 
 
@@ -142,7 +148,7 @@ def test_clear_resets_to_silence():
     sc = BrailleScope(width=6)
     sc.extend([1.0] * 12)
     sc.clear()
-    assert sc.render() == chr(_BASE) * 6
+    assert sc.render() == _BASELINE * 6
     assert sc.is_silent() is True
 
 
@@ -438,3 +444,31 @@ def test_broker_event_types_are_registered():
     )
     assert "audio_level_changed" in _VALID_EVENT_TYPES
     assert "mic_state_changed" in _VALID_EVENT_TYPES
+
+
+def test_idle_scope_is_visible_not_blank():
+    """THE BUG A LIVE COCKPIT EXPOSED: U+2800 is the BLANK braille pattern, so
+    a silent scope rendered as pure whitespace — the operator saw nothing and
+    could not tell it from an uninstalled feature. A real oscilloscope shows a
+    flat line at rest."""
+    sc = BrailleScope(width=20)
+    out = sc.render()
+    assert all(ord(c) != _BASE for c in out), "idle scope is invisible"
+    assert out == _BASELINE * 20
+    assert sc.is_silent() is True, "baseline must not be mistaken for signal"
+
+
+def test_baseline_is_below_every_signal_level():
+    """The flat line must sit UNDER the trace, never overlap it — otherwise a
+    quiet passage would look louder than it is."""
+    quiet = ord(cell_for(0.0, 0.0)) - _BASE
+    loud = ord(cell_for(1.0, 1.0)) - _BASE
+    assert quiet & loud == quiet, "baseline dots are not a subset of full scale"
+
+
+def test_ascii_fallback_also_shows_a_baseline(monkeypatch):
+    monkeypatch.setenv("JARVIS_AUDIO_SCOPE_ASCII", "true")
+    sc = BrailleScope(width=6)
+    out = sc.render()
+    assert out.strip(), "ASCII fallback rendered invisible whitespace"
+    assert out == "_" * 6

--- a/tests/ui/test_audio_scope_and_ptt.py
+++ b/tests/ui/test_audio_scope_and_ptt.py
@@ -191,7 +191,11 @@ def test_normalizer_uses_full_range_for_quiet_and_loud_sources():
 
 
 def test_normalizer_peak_decays_so_a_quieter_source_recovers():
-    n = AdaptiveNormalizer(decay=0.5)
+    """Squelch OFF on purpose: this isolates the PEAK-DECAY mechanism. With the
+    squelch armed a sustained 0.01 is correctly identified as room tone and
+    clamped to zero, so the peak would never see it — a true behaviour, but a
+    different one, covered by the squelch tests below."""
+    n = AdaptiveNormalizer(decay=0.5, squelch=False)
     n.normalize(1.0)
     for _ in range(40):
         n.normalize(0.01)
@@ -472,3 +476,129 @@ def test_ascii_fallback_also_shows_a_baseline(monkeypatch):
     out = sc.render()
     assert out.strip(), "ASCII fallback rendered invisible whitespace"
     assert out == "_" * 6
+
+
+# ---------------------------------------------------------------------------
+# dynamic noise-floor squelch
+# ---------------------------------------------------------------------------
+
+
+def _noise(n, lo, hi, seed=11):
+    import random
+    r = random.Random(seed)
+    return [r.uniform(lo, hi) for _ in range(n)]
+
+
+def test_ambient_noise_clamps_to_absolute_zero_after_the_window_adapts():
+    """(1) A live mic never reaches digital zero — fans and HVAC keep RMS
+    hovering, which renders as a permanently twitching baseline. Once the
+    profile is learned, ambient must clamp to a HARD 0.0."""
+    n = AdaptiveNormalizer()
+    out = [n.normalize(v) for v in _noise(200, 0.002, 0.006)]
+
+    assert all(v == 0.0 for v in out[-100:]), (
+        f"ambient leaked through: max={max(out[-100:]):.4f}"
+    )
+    assert n.squelch_ready is True
+
+
+def test_speech_bypasses_the_clamp_and_registers_high():
+    """(2) The gate must open instantly for real signal — a meter that swallows
+    the first word is worse than no meter."""
+    n = AdaptiveNormalizer()
+    for v in _noise(120, 0.002, 0.006):
+        n.normalize(v)
+
+    loud = n.normalize(0.7)
+    assert loud > 0.5, f"speech was squelched (got {loud})"
+
+
+def test_squelch_adapts_across_wildly_different_rooms():
+    """The reason a constant cannot work: the correct gate in a quiet study is
+    20x too low for a cafe. Both must end up silent."""
+    for lo, hi in ((0.002, 0.006), (0.02, 0.05), (0.06, 0.10)):
+        n = AdaptiveNormalizer()
+        out = [n.normalize(v) for v in _noise(200, lo, hi)]
+        assert all(v == 0.0 for v in out[-80:]), (
+            f"room {lo}-{hi} still jittering: max={max(out[-80:]):.4f}"
+        )
+        assert n.normalize(0.7) > 0.5, f"speech blocked in room {lo}-{hi}"
+
+
+def test_gate_spans_the_ambient_distribution_not_just_its_trough():
+    """A gate pinned to the MINIMUM is sailed over by the noise's own peaks —
+    the first implementation failed exactly here in a quiet room."""
+    n = AdaptiveNormalizer()
+    for v in _noise(200, 0.002, 0.006):
+        n.normalize(v)
+    assert n.noise_gate > 0.006, (
+        f"gate {n.noise_gate:.4f} sits below the ambient ceiling 0.006"
+    )
+    assert n.noise_floor < 0.006, "floor should track the trough, not the peak"
+
+
+def test_speech_does_not_drag_the_gate_up():
+    """Speech must not widen the profile, or a talker would progressively
+    squelch themselves."""
+    n = AdaptiveNormalizer()
+    for v in _noise(150, 0.02, 0.05):
+        n.normalize(v)
+    before = n.noise_gate
+    for _ in range(30):
+        n.normalize(0.8)
+    after = n.noise_gate
+    assert after < before * 1.5, f"gate inflated under speech: {before:.4f}->{after:.4f}"
+    assert n.normalize(0.8) > 0.5, "speaker squelched themselves"
+
+
+def test_no_clamping_before_the_profile_exists():
+    """One sample cannot characterise a room. Clamping during warmup would
+    swallow the first words after launch."""
+    n = AdaptiveNormalizer(squelch_warmup_frames=20)
+    assert n.squelch_ready is False
+    assert n.normalize(0.5) > 0.0, "clamped before learning the room"
+
+
+def test_squelch_can_be_disabled():
+    n = AdaptiveNormalizer(squelch=False)
+    out = [n.normalize(v) for v in _noise(200, 0.002, 0.006)]
+    assert any(v > 0.0 for v in out[-50:]), "squelch ran while disabled"
+
+
+def test_a_quieter_room_is_adopted_quickly():
+    """Down-fast: moving somewhere quieter must not leave a stale high gate
+    that swallows speech."""
+    n = AdaptiveNormalizer()
+    for v in _noise(150, 0.06, 0.10):
+        n.normalize(v)
+    loud_gate = n.noise_gate
+    for v in _noise(300, 0.001, 0.003, seed=5):
+        n.normalize(v)
+    assert n.noise_gate < loud_gate, "gate never fell after the room quietened"
+
+
+def test_squelch_is_allocation_free_scalar_math():
+    """Structural: the profiler must stay two float updates. A deque scan per
+    frame would put real work on the path that feeds the STT thread."""
+    import inspect
+
+    src = inspect.getsource(AdaptiveNormalizer._update_noise_floor)
+    # Strip the docstring first: it *describes* the costs being avoided, and a
+    # naive substring scan matched its own prose rather than the code.
+    body = src.split('"""')[-1]
+    for banned in ("deque", "sorted", "np.", "numpy", "for ", "while "):
+        assert banned not in body, f"profiler is doing {banned!r} work per frame"
+
+
+def test_squelched_output_renders_a_stable_baseline():
+    """End-to-end into the visual: a noisy room must draw the flat line, not a
+    twitching trace."""
+    sc = BrailleScope(width=20)
+    n = AdaptiveNormalizer()
+    for v in _noise(40, 0.002, 0.006):
+        n.normalize(v)
+    for v in _noise(40, 0.002, 0.006, seed=3):
+        sc.push(n.normalize(v))
+    out = sc.render()
+    assert len(set(out)) == 1, f"baseline is jittering: {out}"
+    assert sc.is_silent() is True

--- a/tests/ui/test_headless_tui_integration.py
+++ b/tests/ui/test_headless_tui_integration.py
@@ -343,3 +343,56 @@ def test_repeated_sessions_do_not_exhaust_the_pty_pool():
             [sys.executable, "-c", "print('ok',flush=True)"], env=_env(),
         ) as s:
             assert s.wait_for("ok", timeout=30)
+
+
+# ---------------------------------------------------------------------------
+# the invisible-idle regression
+# ---------------------------------------------------------------------------
+
+
+def test_idle_scope_is_visible_in_a_real_terminal():
+    """A live cockpit showed NOTHING in the gutter. The wiring was correct all
+    along — the scope was rendering 20 x U+2800, the BLANK braille pattern, so
+    a silent meter was literally whitespace and looked identical to an
+    uninstalled feature.
+
+    Asserted through the production header renderer into a real terminal,
+    because that is the only place the bug was observable: every unit test
+    compared strings and a string of blanks compares fine."""
+    probe = (
+        "from backend.core.ouroboros.ui.audio_scope import BrailleScope;"
+        "from backend.core.ouroboros.ui.crest_animator import render_cockpit_header;"
+        "sc=BrailleScope(width=20);"          # never fed — the idle case
+        "out=render_cockpit_header(None,['O+V v0.1.0','healthy','~/repo'],100,"
+        "right_gutter=lambda: sc.render_rich());"
+        "print('HDR',flush=True); print(out,flush=True); print('END',flush=True)"
+    )
+    with PtySession([sys.executable, "-c", probe], env=_env()) as s:
+        assert s.wait_for("END", timeout=60), s.output()
+        out = s.output()
+        blanks = [c for c in out if ord(c) == 0x2800]
+        marks = [c for c in out if 0x2801 <= ord(c) <= 0x28FF]
+        assert not blanks, "idle scope emitted BLANK braille — invisible again"
+        assert len(marks) >= 10, (
+            f"idle scope drew no visible baseline (got {len(marks)} glyphs)"
+        )
+
+
+def test_idle_and_active_scopes_are_visually_distinct():
+    """The baseline must not be so prominent that a silent meter reads as a
+    live one — quiet and loud have to look different at a glance."""
+    probe = (
+        "from backend.core.ouroboros.ui.audio_scope import BrailleScope;"
+        "a=BrailleScope(width=10);"
+        "b=BrailleScope(width=10); b.extend([1.0]*20);"
+        "print('IDLE:'+a.render(),flush=True);"
+        "print('LOUD:'+b.render(),flush=True);"
+        "print('END',flush=True)"
+    )
+    with PtySession([sys.executable, "-c", probe], env=_env()) as s:
+        assert s.wait_for("END", timeout=60), s.output()
+        out = s.output()
+        idle = [l for l in out.splitlines() if l.startswith("IDLE:")][0][5:]
+        loud = [l for l in out.splitlines() if l.startswith("LOUD:")][0][5:]
+        assert idle != loud, "idle and full-scale render identically"
+        assert "⣿" in loud, "full scale missing"


### PR DESCRIPTION
Two defects a live cockpit exposed, plus real-world acoustic hardening.

## 1. The idle scope was invisible

A live cockpit showed **nothing** in the header gutter. The wiring was correct all along — verified by executing `ov.py`'s audio block end to end: imports OK, pump OK, mode resolves to `Space ⇄ Mic`, tap subscribes, gutter returns a string.

The string was 20 × `U+2800` — the **BLANK** braille pattern. Silence rendered as pure whitespace, indistinguishable from an uninstalled feature.

Worse: the module docstring claimed *"silence reads as a flat baseline"* **from the first commit**. The code never did it.

**Why the unit tests missed it:** they asserted `render() == chr(0x2800) * 8` — the defect encoded as the expectation. Same shape as the invisible-colour bug in the previous PR. Both were only observable in a real terminal, so both are now pinned in the PTY harness.

## 2. Dynamic noise-floor squelch

A live mic never reaches digital zero — fans and HVAC keep RMS hovering, so the baseline would twitch permanently. A constant gate can't fix it: the right threshold in a quiet study is 20× too low for a cafe.

The floor is **learned**, inside `AdaptiveNormalizer`, with the existing peak-scaling operating on the squelched output.

**Asymmetric trough tracking** — a sample below the floor is adopted fast; one above creeps up 20× slower, or a few seconds of talking would drag the floor up until the speaker squelched themselves.

**The first implementation was wrong, and the fix is the interesting part.** Gating at `trough × margin` worked in a cafe and *failed* in a quiet room: ambient there spans ~0.002–0.006, a 3× spread, so the noise's own peaks sailed over a gate pinned to its minimum. The gate must span the ambient **distribution** — `floor + k·spread + ε`, with spread learning only from samples already inside the gate.

```
quiet study  floor=0.0024  gate=0.0076   silent   speech 0.7 → 1.0
office hum   floor=0.0240  gate=0.0558   silent   speech 0.7 → 1.0
coffee shop  floor=0.0652  gate=0.1141   silent   speech 0.7 → 1.0
```

**Cost:** two scalar EMA updates per frame. No deque, no sort, no numpy, no loop — a structural test greps the profiler body to keep it that way, since this feeds the STT thread.

## Verification

**606 passing.** The 4 remaining failures (awakening resize, crest geometry, tts persona, split-plane mux) are verified identical on a pristine tree.

⚠️ The audio chain still has never run end to end — no supervisor boot with a real mic. This fixes what the operator could see; it does not prove the waveform moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the idle audio scope visibly show a flat baseline instead of blank output, and add adaptive noise-floor squelch so ambient noise clamps to zero while speech passes cleanly.

- **Bug Fixes**
  - Idle scope now draws a visible baseline (bottom dots) instead of U+2800 blanks; ASCII fallback uses "_" so silence isn’t invisible.
  - Updated `BrailleScope` rendering and PTY-based integration tests to assert “no blank braille” in the cockpit header.

- **New Features**
  - Adaptive noise-floor squelch in the normalizer: learns floor + spread; gate = floor + k·spread + ε; clamps ambient to 0 after warmup; asymmetric trough tracking; constant-time per frame; can be disabled.
  - Exposes `noise_gate`, `noise_floor`, and `squelch_ready`; peak scaling now operates on squelched values; tests cover quiet/office/cafe rooms and guard against gate inflation.

<sup>Written for commit 07e15e13447ef6028f81bc1b50ed0d5433be141d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

