### PR TITLE
feat(voice): persona matrix + zero-cost phatic fast path

### DIFF
--- a/backend/audio/conversation_pipeline.py
+++ b/backend/audio/conversation_pipeline.py
@@ -38,6 +38,7 @@ import numpy as np
 
 from backend.audio.playback_gate import playback_gate
 from backend.audio.streaming_synthesis import streaming_enabled as _streaming_enabled
+from backend.voice.phatic_fastpath import fastpath_enabled as _phatic_intercept_enabled
 
 logger = logging.getLogger(__name__)
 
@@ -495,6 +496,15 @@ class ConversationPipeline:
                     )
                     continue
 
+                # 2b. Whoever was ADDRESSED answers.
+                #
+                # The active agent follows what the operator said, not what
+                # the process was launched with: "Hey JARVIS" in Karen's
+                # cockpit should get JARVIS's voice and JARVIS's prompt. A
+                # turn naming nobody leaves the current agent in place — it
+                # is a continuation, not a request to switch.
+                self._route_persona(user_text)
+
                 # 3. Add user turn to session
                 self._session.add_turn("user", user_text)
                 logger.info(
@@ -643,6 +653,28 @@ class ConversationPipeline:
         """Generate LLM response and stream it through TTS."""
         if self._session is None:
             return
+
+        # ── PHATIC FAST PATH — zero network, zero tokens ──────────────
+        #
+        # "Hey Karen" carries no question. Sending it to a 30B model costs
+        # tokens, ~0.9s of TTFT and the operator's patience for an utterance
+        # whose entire content is "I am addressing you". Intercepted BEFORE
+        # the router so no request is built at all.
+        #
+        # The turn is still written to session history: a bypassed greeting
+        # that vanished would leave the next complex turn reasoning about a
+        # conversation whose opening it never saw.
+        if _phatic_intercept_enabled() and user_text:
+            ack = self._phatic_reply(user_text)
+            if ack is not None:
+                self._session.add_turn("assistant", ack)
+                logger.info("[ConvPipeline] JARVIS (phatic, no LLM): %s", ack)
+                cancel_event = (
+                    self._barge_in.get_cancel_event()
+                    if self._barge_in is not None else asyncio.Event()
+                )
+                await self._speak_sentence(ack, cancel_event)
+                return
 
         # Build messages for LLM
         messages = [
@@ -1349,6 +1381,64 @@ class ConversationPipeline:
                 except (RuntimeError, OSError):
                     pass
         return " ".join(spoken)
+
+    def _route_persona(self, user_text: str) -> bool:
+        """Bind the process persona to the agent named in *user_text*.
+
+        Returns True when the active agent CHANGED. Writes the same env seam
+        ``active_persona`` reads, because that is what every synthesis site in
+        the process already consults — threading a persona argument through
+        each of them is how voice and identity drifted apart in the first
+        place. NEVER raises."""
+        try:
+            from backend.voice.agent_persona import active_persona
+            from backend.voice.agent_registry import route_by_wake_word
+
+            spec = route_by_wake_word(user_text)
+            if spec is None:
+                return False
+            current = active_persona()
+            if current is not None and current.canonical is spec.persona:
+                return False
+            os.environ["JARVIS_AGENT_PERSONA"] = spec.persona.value
+            # The prompt is part of the identity, so it moves with it —
+            # otherwise the model keeps the previous agent's self-description
+            # while speaking in the new agent's voice.
+            prompt = _persona_system_prompt()
+            if prompt:
+                self._system_prompt = prompt
+            logger.info(
+                "[ConvPipeline] agent -> %s (voice %s)",
+                spec.display_name, spec.preferred_voice,
+            )
+            return True
+        except (ImportError, AttributeError, OSError):
+            return False
+
+    def _phatic_reply(self, user_text: str) -> Optional[str]:
+        """An acknowledgement if this turn is pure contact, else None.
+
+        None means "this is a real turn" — the caller proceeds to the model
+        unchanged, so the fast path can only ever REMOVE an unnecessary call,
+        never intercept a question. NEVER raises."""
+        try:
+            from backend.voice.agent_registry import all_agents, spec_for
+            from backend.voice.agent_persona import active_persona, operator_name
+            from backend.voice.phatic_fastpath import acknowledge, classify
+
+            names = []
+            for spec in all_agents():
+                names.append(spec.display_name)
+                names.extend(spec.wake_words)
+            verdict = classify(user_text, agent_names=names)
+            if not verdict:
+                return None
+
+            active = spec_for(active_persona())
+            salt = active.display_name if active else ""
+            return acknowledge(user_text, operator=operator_name(), salt=salt)
+        except (ImportError, AttributeError):
+            return None
 
     def _persona_say_args(self) -> List[str]:
         """`say` voice/rate flags for the bound persona, or none.

--- a/backend/core/ouroboros/governance/adaptive_voice_router.py
+++ b/backend/core/ouroboros/governance/adaptive_voice_router.py
@@ -233,15 +233,18 @@ class AdaptiveVoiceRouter:
             except Exception:  # noqa: BLE001
                 return None
         try:
-            from backend.core.ouroboros.governance.karen_voice_lane import (
-                ensure_voice_lane_warm, resolve_voice_model,
-            )
-            model = resolve_voice_model()
+            # Per-AGENT lane: the election is measured against this persona's
+            # own prompt and budget, so JARVIS and O+V can sit on different
+            # models without either one's runtime demotion muting the other.
+            from backend.core.ouroboros.governance.agent_voice_lane import lane_for
+
+            lane = lane_for(self.persona)
+            model = lane.resolve_model()
             if model is None:
                 # Cold lane: learn in the background, serve this turn locally.
                 # Speaking through an UNMEASURED remote model is how a spoken
                 # turn ends up on the 22-second code brain.
-                ensure_voice_lane_warm()
+                lane.ensure_warm()
             return model
         except Exception:  # noqa: BLE001
             return None
@@ -459,10 +462,9 @@ class AdaptiveVoiceRouter:
         otherwise the election is a one-time measurement that reality can
         never correct."""
         try:
-            from backend.core.ouroboros.governance.karen_voice_lane import (
-                record_runtime_failure,
-            )
-            record_runtime_failure(model, reason)
+            from backend.core.ouroboros.governance.agent_voice_lane import lane_for
+
+            lane_for(self.persona).record_failure(model, reason)
         except Exception:  # noqa: BLE001
             logger.debug("[VoiceRouter] demote degraded", exc_info=True)
 

--- a/backend/core/ouroboros/governance/agent_voice_lane.py
+++ b/backend/core/ouroboros/governance/agent_voice_lane.py
@@ -1,0 +1,232 @@
+"""One voice lane per agent — the generalisation of ``karen_voice_lane``.
+
+What was wrong with the old shape
+---------------------------------
+``karen_voice_lane`` elects which DoubleWord model Karen SPEAKS through, by
+measuring TTFT against a conversational budget. Everything in it was correct
+and none of it was Karen-specific: the ledger, the probe, the two-tier
+election, the runtime demotion path. Only the *bindings* were — one hardcoded
+env namespace, one hardcoded ledger file, one hardcoded probe persona.
+
+So a second agent had exactly two options, and both were bad: share Karen's
+lane (JARVIS then inherits an election measured against Karen's prompt and
+budget, and either agent's runtime demotion silently mutes the other), or fork
+the module (two copies of the ledger, the probe, the election and the demotion
+path — and the copy drifts from the original the first time either is fixed).
+
+This module takes the third option. ``karen_voice_lane`` is now parameterised
+by ``prefix`` and ``ledger``; this class BINDS those parameters to a persona
+drawn from :mod:`backend.voice.agent_registry`. There is no second
+implementation of anything, and no logic here at all — only binding.
+
+    lane = lane_for(AgentPersona.JARVIS)
+    lane.resolve_model()      # JARVIS's elected DW model
+    lane.voice_profile()      # -> Daniel
+    lane.system_prompt()      # -> the JARVIS identity prompt
+
+Why the probe is persona-bound
+------------------------------
+The probe measures time-to-first-token for a real spoken turn. The prompt is
+part of that measurement — a longer system prompt is more tokens to prefill —
+so grading JARVIS's models with "Hey Karen, are you there?" measures the wrong
+workload. Each lane probes with its own identity and its own wake word.
+
+Backward compatibility
+----------------------
+``AgentPersona.OV``/``KAREN`` resolve to the legacy ``JARVIS_KAREN_VOICE_*``
+namespace and the existing ``.jarvis/karen_voice_lane.json``, so measurements
+already on disk are inherited rather than orphaned, and an operator's current
+configuration keeps working untouched. New agents get their own file and MAY
+override any knob; unset knobs fall back to the legacy ones, so per-agent
+configuration is optional rather than mandatory duplication.
+"""
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any, Dict, List, Optional
+
+from backend.core.ouroboros.governance import karen_voice_lane as _lane
+from backend.voice.agent_persona import AgentPersona, VoiceProfile
+
+logger = logging.getLogger(__name__)
+
+#: OV keeps the namespace and ledger filename it shipped with.
+_LEGACY_PERSONAS = (AgentPersona.OV, AgentPersona.KAREN)
+
+
+class AgentVoiceLane:
+    """A persona bound to the voice-election machinery.
+
+    Holds no election logic. Every method delegates to ``karen_voice_lane``
+    with this agent's prefix and ledger — which is what makes the two lanes
+    genuinely the same code path rather than two that merely look alike.
+    """
+
+    def __init__(self, persona: AgentPersona) -> None:
+        self.persona = persona
+        self._ledger: Optional[_lane.VoiceLatencyLedger] = None
+        self._ledger_lock = threading.Lock()
+
+    # -- identity -------------------------------------------------------
+
+    @property
+    def spec(self) -> Any:
+        """Registry entry — voice, wake words, display name. Imported lazily:
+        the registry imports the persona module, and a module-level import
+        here would close a cycle through the pipeline."""
+        from backend.voice.agent_registry import spec_for
+        return spec_for(self.persona)
+
+    @property
+    def slug(self) -> str:
+        """Filesystem-safe lane id. OV is ``karen`` for continuity."""
+        if self.persona in _LEGACY_PERSONAS:
+            return "karen"
+        return str(getattr(self.persona, "value", self.persona)).lower()
+
+    @property
+    def prefix(self) -> str:
+        """Env namespace. OV keeps the legacy one; others get their own and
+        INHERIT any knob they do not set."""
+        if self.persona in _LEGACY_PERSONAS:
+            return _lane._LEGACY_PREFIX
+        return f"JARVIS_{self.slug.upper()}_VOICE"
+
+    def system_prompt(self) -> Optional[str]:
+        from backend.voice.agent_registry import prompt_for
+        return prompt_for(self.persona)
+
+    def voice_profile(self) -> Optional[VoiceProfile]:
+        from backend.voice.agent_registry import voice_profile_for
+        return voice_profile_for(self.persona)
+
+    # -- probe identity -------------------------------------------------
+
+    def _probe_system(self) -> str:
+        """This agent's own identity, one spoken-format instruction added.
+
+        Falls back to the module default rather than to nothing: an agent with
+        no prompt still needs a probe that exercises a spoken turn."""
+        prompt = (self.system_prompt() or "").strip()
+        if not prompt:
+            return _lane.VOICE_PROBE_SYSTEM
+        return f"{prompt}\n\nReply in ONE short spoken sentence. No markdown, no lists."
+
+    def _probe_user(self) -> str:
+        spec = self.spec
+        name = getattr(spec, "display_name", "") if spec else ""
+        return f"Hey {name}, are you there?" if name else _lane.VOICE_PROBE_USER
+
+    # -- ledger ---------------------------------------------------------
+
+    @property
+    def ledger(self) -> _lane.VoiceLatencyLedger:
+        """This lane's measurements. Lazy + locked: several turns can arrive
+        together on different threads, and two ledgers over one file would
+        each hold half the evidence."""
+        with self._ledger_lock:
+            if self._ledger is None:
+                self._ledger = _lane.VoiceLatencyLedger(
+                    _lane.ledger_path(prefix=self.prefix, slug=self.slug),
+                    prefix=self.prefix,
+                ).load()
+            return self._ledger
+
+    def reset(self) -> None:
+        """Test seam — drops the cached ledger handle."""
+        with self._ledger_lock:
+            self._ledger = None
+
+    # -- the four calls the turn path makes ------------------------------
+
+    def enabled(self) -> bool:
+        return _lane.voice_lane_enabled(prefix=self.prefix)
+
+    def resolve_model(self) -> Optional[str]:
+        """The DW model THIS agent should speak through, or None.
+
+        Synchronous and allocation-cheap, exactly as the single-agent version
+        was: it sits on the turn path."""
+        return _lane.resolve_voice_model(ledger=self.ledger, prefix=self.prefix)
+
+    def ensure_warm(self, *, force: bool = False) -> bool:
+        return _lane.ensure_voice_lane_warm(
+            force=force, prefix=self.prefix, ledger=self.ledger,
+        )
+
+    async def refresh(
+        self, *, models: Optional[List[str]] = None, force: bool = False,
+        dispatch_fn: Any = None,
+    ) -> Optional[str]:
+        return await _lane.refresh_voice_lane(
+            models=models, force=force, dispatch_fn=dispatch_fn,
+            ledger=self.ledger, prefix=self.prefix,
+            probe_system=self._probe_system(), probe_user=self._probe_user(),
+        )
+
+    def record_failure(self, model: str, reason: str = "runtime") -> bool:
+        """Demote a model that failed on a REAL turn — for THIS agent only.
+
+        Per-lane on purpose: a model that goes mute under Karen's prompt has
+        said nothing about how it behaves under JARVIS's, and a shared ledger
+        would let one agent's bad turn silence the other."""
+        return _lane.record_runtime_failure(model, reason, ledger=self.ledger)
+
+    def status(self) -> Dict[str, Any]:
+        st = _lane.voice_lane_status(prefix=self.prefix, ledger=self.ledger)
+        spec = self.spec
+        st["agent"] = getattr(spec, "display_name", self.slug) if spec else self.slug
+        st["persona"] = str(getattr(self.persona, "value", self.persona))
+        profile = self.voice_profile()
+        st["voice"] = getattr(profile, "voice", None) if profile else None
+        return st
+
+
+# ---------------------------------------------------------------------------
+# Registry of lanes — one per persona, created on demand
+# ---------------------------------------------------------------------------
+
+_LANES: Dict[AgentPersona, AgentVoiceLane] = {}
+_LANES_LOCK = threading.Lock()
+
+
+def lane_for(persona: object = None) -> AgentVoiceLane:
+    """The lane for *persona*, defaulting to whoever is active.
+
+    Never returns None: a caller on the turn path needs a lane to ask, and an
+    unknown persona should degrade to the legacy OV lane rather than force
+    every call site to handle absence."""
+    from backend.voice.agent_persona import active_persona
+
+    p = AgentPersona.coerce(persona) if persona is not None else None
+    if p is None:
+        p = active_persona() or AgentPersona.OV
+    if p is AgentPersona.KAREN:
+        p = AgentPersona.OV                # alias — one lane, not two
+    with _LANES_LOCK:
+        lane = _LANES.get(p)
+        if lane is None:
+            lane = AgentVoiceLane(p)
+            _LANES[p] = lane
+        return lane
+
+
+def all_lanes() -> List[AgentVoiceLane]:
+    """A lane per registered agent — for ``/provider`` style surfaces."""
+    from backend.voice.agent_registry import all_agents
+    return [lane_for(spec.persona) for spec in all_agents()]
+
+
+def reset_lanes() -> None:
+    """Test seam — drops every cached lane."""
+    with _LANES_LOCK:
+        _LANES.clear()
+
+
+__all__ = [
+    "AgentVoiceLane",
+    "all_lanes",
+    "lane_for",
+    "reset_lanes",
+]

--- a/backend/core/ouroboros/governance/karen_voice_lane.py
+++ b/backend/core/ouroboros/governance/karen_voice_lane.py
@@ -50,6 +50,7 @@ path returns ``None`` (meaning "caller, keep your default").
 from __future__ import annotations
 
 import asyncio
+import functools
 import json
 import logging
 import os
@@ -62,6 +63,28 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 logger = logging.getLogger(__name__)
 
 _TRUTHY = ("1", "true", "yes", "on")
+
+#: The knob namespace this module shipped with. Every reader below now takes a
+#: *prefix* so a second agent can have its own lane, and this stays the
+#: default — an operator's existing JARVIS_KAREN_VOICE_* settings keep working
+#: unchanged, and a new agent INHERITS them until it overrides one.
+#:
+#: Generalising by parameter rather than by copy is the whole point: a forked
+#: "jarvis_voice_lane.py" would duplicate the ledger, the probe, the election
+#: and the demotion path, and the copy would drift from the original the first
+#: time either was fixed.
+_LEGACY_PREFIX = "JARVIS_KAREN_VOICE"
+
+
+def _env_raw(suffix: str, prefix: str = _LEGACY_PREFIX) -> str:
+    """Prefixed knob, else the legacy one. Two-level lookup so per-agent
+    settings are optional rather than mandatory duplication."""
+    val = os.environ.get(f"{prefix}_{suffix}", "").strip()
+    if val:
+        return val
+    if prefix != _LEGACY_PREFIX:
+        return os.environ.get(f"{_LEGACY_PREFIX}_{suffix}", "").strip()
+    return ""
 SCHEMA_VERSION = "karen_voice_lane.1"
 
 
@@ -84,30 +107,36 @@ def _env_int(name: str, default: int) -> int:
         return int(default)
 
 
-def voice_lane_enabled() -> bool:
+def voice_lane_enabled(*, prefix: str = _LEGACY_PREFIX) -> bool:
     """Master gate. Default ON, but inert without a ledger — an unprobed
     system resolves to ``None`` and keeps the caller's existing default."""
-    return os.environ.get(
-        "JARVIS_KAREN_VOICE_LANE_ENABLED", "true",
-    ).strip().lower() in _TRUTHY
+    return (_env_raw("LANE_ENABLED", prefix) or "true").lower() in _TRUTHY
 
 
-def spoken_ttft_budget_s() -> float:
+def spoken_ttft_budget_s(*, prefix: str = _LEGACY_PREFIX) -> float:
     """The conversational floor: how long a human tolerates before a reply
     starts. ~1.5s is a beat of natural silence; past that the operator starts
     wondering whether the mic heard them. Not a performance target — an
     ADMISSION threshold: a model over it is disqualified from speech, however
     good its prose."""
-    return max(0.1, _env_float("JARVIS_KAREN_VOICE_TTFT_BUDGET_S", 1.5))
+    raw = _env_raw("TTFT_BUDGET_S", prefix)
+    try:
+        return max(0.1, float(raw)) if raw else 1.5
+    except (TypeError, ValueError):
+        return 1.5
 
 
-def ledger_ttl_s() -> float:
+def ledger_ttl_s(*, prefix: str = _LEGACY_PREFIX) -> float:
     """How long a measurement is trusted. Long enough not to re-probe every
     boot, short enough to notice a cluster that has been rebalanced."""
-    return max(60.0, _env_float("JARVIS_KAREN_VOICE_LEDGER_TTL_S", 21600.0))
+    raw = _env_raw("LEDGER_TTL_S", prefix)
+    try:
+        return max(60.0, float(raw)) if raw else 21600.0
+    except (TypeError, ValueError):
+        return 21600.0
 
 
-def spoken_ttft_hard_cap_s() -> float:
+def spoken_ttft_hard_cap_s(*, prefix: str = _LEGACY_PREFIX) -> float:
     """The line past which a voice is unusable, full stop.
 
     Distinct from the BUDGET, which is a preference: prefer a model that
@@ -116,10 +145,14 @@ def spoken_ttft_hard_cap_s() -> float:
     earlier — electing nobody means a remote-only host answers a heard
     utterance with silence. A voice that starts in 2.5s is degraded; no voice
     is broken. Above THIS cap, silence really is better."""
-    return max(1.0, _env_float("JARVIS_KAREN_VOICE_TTFT_HARD_CAP_S", 6.0))
+    raw = _env_raw("TTFT_HARD_CAP_S", prefix)
+    try:
+        return max(1.0, float(raw)) if raw else 6.0
+    except (TypeError, ValueError):
+        return 6.0
 
 
-def transport_failure_ttl_s() -> float:
+def transport_failure_ttl_s(*, prefix: str = _LEGACY_PREFIX) -> float:
     """How long a TRANSPORT failure is trusted — much shorter, on purpose.
 
     A probe that ends in a DNS error, a refused connection or a reset says
@@ -129,10 +162,14 @@ def transport_failure_ttl_s() -> float:
     "freshly measured as silent" for six hours, so the lane resolved None,
     the remote-only host had no engine, and Karen answered a heard utterance
     with nothing at all."""
-    return max(5.0, _env_float("JARVIS_KAREN_VOICE_FAILURE_TTL_S", 120.0))
+    raw = _env_raw("FAILURE_TTL_S", prefix)
+    try:
+        return max(5.0, float(raw)) if raw else 120.0
+    except (TypeError, ValueError):
+        return 120.0
 
 
-def max_probe_candidates() -> int:
+def max_probe_candidates(*, prefix: str = _LEGACY_PREFIX) -> int:
     """Ceiling on how many models ONE refresh may probe. Each probe is a real
     (tiny) generation, so this bounds spend explicitly rather than trusting the
     catalog to stay small.
@@ -141,27 +178,38 @@ def max_probe_candidates() -> int:
     the outcome, so the next refresh skips it and walks further down the
     ranking. A cold 26-model catalog therefore converges over a handful of
     refreshes instead of demanding one expensive sweep."""
-    return max(1, _env_int("JARVIS_KAREN_VOICE_MAX_CANDIDATES", 8))
+    raw = _env_raw("MAX_CANDIDATES", prefix)
+    try:
+        return max(1, int(raw)) if raw else 8
+    except (TypeError, ValueError):
+        return 8
 
 
-def probe_max_tokens() -> int:
+def probe_max_tokens(*, prefix: str = _LEGACY_PREFIX) -> int:
     """Deliberately voice-sized. A generous budget would let a reasoning model
     finish thinking and then speak, hiding precisely the failure mode that
     makes it unusable for conversation."""
-    return max(8, _env_int("JARVIS_KAREN_VOICE_PROBE_MAX_TOKENS", 48))
+    raw = _env_raw("PROBE_MAX_TOKENS", prefix)
+    try:
+        return max(8, int(raw)) if raw else 48
+    except (TypeError, ValueError):
+        return 48
 
 
-def ledger_path() -> Path:
-    raw = os.environ.get("JARVIS_KAREN_VOICE_LEDGER_PATH", "").strip()
+def ledger_path(*, prefix: str = _LEGACY_PREFIX, slug: str = "karen") -> Path:
+    """Per-agent ledger file. OV keeps the original filename so measurements
+    already on disk are not orphaned by the generalisation."""
+    raw = _env_raw("LEDGER_PATH", prefix)
     if raw:
         return Path(raw).expanduser()
-    return Path.cwd() / ".jarvis" / "karen_voice_lane.json"
+    name = "karen_voice_lane.json" if slug == "karen" else f"voice_lane_{slug}.json"
+    return Path.cwd() / ".jarvis" / name
 
 
-def model_override() -> str:
+def model_override(*, prefix: str = _LEGACY_PREFIX) -> str:
     """Operator's explicit choice. Always wins — measurement informs, it does
     not overrule."""
-    return os.environ.get("JARVIS_KAREN_VOICE_MODEL", "").strip()
+    return _env_raw("MODEL", prefix)
 
 
 # ---------------------------------------------------------------------------
@@ -176,7 +224,13 @@ VOICE_PROBE_SYSTEM = (
 VOICE_PROBE_USER = "Hey Karen, are you there?"
 
 
-def build_voice_probe_payload(model: str, *, max_tokens: int = 0) -> dict:
+def build_voice_probe_payload(
+    model: str,
+    *,
+    max_tokens: int = 0,
+    system: str = "",
+    user: str = "",
+) -> dict:
     """Probe body shaped like the workload it is grading.
 
     ``dw_deep_probe``'s own builders ask for a bare ``ok`` or a 150-token code
@@ -187,8 +241,8 @@ def build_voice_probe_payload(model: str, *, max_tokens: int = 0) -> dict:
     return {
         "model": model,
         "messages": [
-            {"role": "system", "content": VOICE_PROBE_SYSTEM},
-            {"role": "user", "content": VOICE_PROBE_USER},
+            {"role": "system", "content": system or VOICE_PROBE_SYSTEM},
+            {"role": "user", "content": user or VOICE_PROBE_USER},
         ],
         "max_tokens": int(max_tokens or probe_max_tokens()),
         "temperature": 0.6,
@@ -212,16 +266,30 @@ class VoiceModelRecord:
     measured_at: float
     reason: str = ""
 
+    def fits(self, prefix: str = _LEGACY_PREFIX) -> bool:
+        """Fit to hold a conversation FOR THIS LANE: it spoke, and it started
+        inside that lane's budget. Per-lane because the threshold is a
+        property of the agent's interaction style, not of the model — a
+        background agent may tolerate what a conversational one cannot."""
+        return bool(self.spoke) and 0.0 <= self.ttft_s <= spoken_ttft_budget_s(
+            prefix=prefix,
+        )
+
+    def is_usable(self, prefix: str = _LEGACY_PREFIX) -> bool:
+        """Spoke, inside the HARD cap. The degraded tier: eligible only when
+        nothing conversational exists, because a slow voice beats no voice."""
+        return bool(self.spoke) and 0.0 <= self.ttft_s <= spoken_ttft_hard_cap_s(
+            prefix=prefix,
+        )
+
     @property
     def conversational(self) -> bool:
-        """Fit to hold a conversation: it spoke, and it started in time."""
-        return bool(self.spoke) and 0.0 <= self.ttft_s <= spoken_ttft_budget_s()
+        """Default-lane convenience for existing callers."""
+        return self.fits()
 
     @property
     def usable(self) -> bool:
-        """Spoke, inside the HARD cap. The degraded tier: eligible only when
-        nothing conversational exists, because a slow voice beats no voice."""
-        return bool(self.spoke) and 0.0 <= self.ttft_s <= spoken_ttft_hard_cap_s()
+        return self.is_usable()
 
     @property
     def transport_failure(self) -> bool:
@@ -231,15 +299,21 @@ class VoiceModelRecord:
         r = self.reason or ""
         return r.startswith("probe_error:") or r.startswith("dispatch_error:")
 
-    def fresh(self, *, now: Optional[float] = None, ttl_s: Optional[float] = None) -> bool:
+    def fresh(
+        self,
+        *,
+        now: Optional[float] = None,
+        ttl_s: Optional[float] = None,
+        prefix: str = _LEGACY_PREFIX,
+    ) -> bool:
         t = time.time() if now is None else float(now)
         if ttl_s is None:
             # Transport faults expire fast: they describe the network at one
             # instant, and treating them as model verdicts poisons the lane
             # for the full TTL (the 2026-07-25 silent-Karen class).
             ttl = (
-                transport_failure_ttl_s() if self.transport_failure
-                else ledger_ttl_s()
+                transport_failure_ttl_s(prefix=prefix) if self.transport_failure
+                else ledger_ttl_s(prefix=prefix)
             )
         else:
             ttl = float(ttl_s)
@@ -254,8 +328,11 @@ class VoiceLatencyLedger:
     measurement of a model always supersedes an older one, and cross-process
     interleaving costs at most one re-probe."""
 
-    def __init__(self, path: Optional[Path] = None) -> None:
-        self._path = Path(path) if path is not None else ledger_path()
+    def __init__(
+        self, path: Optional[Path] = None, *, prefix: str = _LEGACY_PREFIX,
+    ) -> None:
+        self._prefix = prefix
+        self._path = Path(path) if path is not None else ledger_path(prefix=prefix)
         self._records: Dict[str, VoiceModelRecord] = {}
         self._loaded = False
 
@@ -335,19 +412,22 @@ class VoiceLatencyLedger:
         Ties break on model id so two cockpits booted together converge on the
         same voice instead of drifting apart on dict ordering."""
         self._ensure()
-        fresh = [r for r in self._records.values() if r.fresh(now=now)]
+        fresh = [
+            r for r in self._records.values()
+            if r.fresh(now=now, prefix=self._prefix)
+        ]
         # Tier 1: within the conversational budget — the preference.
-        fit = [r for r in fresh if r.conversational]
+        fit = [r for r in fresh if r.fits(self._prefix)]
         # Tier 2: spoke, within the hard cap — degraded, but a voice. Only
         # consulted when tier 1 is empty, so a fast model always wins outright
         # and the degraded tier cannot drag the election down.
         if not fit:
-            fit = [r for r in fresh if r.usable]
+            fit = [r for r in fresh if r.is_usable(self._prefix)]
             if fit:
                 logger.info(
                     "[VoiceLane] no candidate inside the %.1fs budget — "
                     "electing the fastest usable voice instead (degraded "
-                    "beats silent)", spoken_ttft_budget_s(),
+                    "beats silent)", spoken_ttft_budget_s(prefix=self._prefix),
                 )
         if not fit:
             return None
@@ -361,7 +441,7 @@ class VoiceLatencyLedger:
         out = []
         for m in models:
             rec = self._records.get(m)
-            if rec is None or not rec.fresh(now=now):
+            if rec is None or not rec.fresh(now=now, prefix=self._prefix):
                 out.append(m)
         return out
 
@@ -463,6 +543,9 @@ async def probe_voice_model(
     *,
     dispatch_fn: Optional[Callable[[dict], Any]] = None,
     budget_s: Optional[float] = None,
+    prefix: str = _LEGACY_PREFIX,
+    system: str = "",
+    user: str = "",
 ) -> VoiceModelRecord:
     """Measure one model's fitness to speak. NEVER raises.
 
@@ -470,7 +553,9 @@ async def probe_voice_model(
     ``deep_probe`` and supplies only what is voice-specific: the spoken payload
     and the interpretation. ``tokens == 0`` is the reasoning-model verdict —
     the model answered, but said nothing aloud."""
-    budget = spoken_ttft_budget_s() if budget_s is None else float(budget_s)
+    budget = (
+        spoken_ttft_budget_s(prefix=prefix) if budget_s is None else float(budget_s)
+    )
     try:
         from backend.core.ouroboros.governance.dw_deep_probe import (
             _default_dw_stream_dispatch, deep_probe,
@@ -483,8 +568,14 @@ async def probe_voice_model(
         result = await deep_probe(
             dispatch_fn=dispatch,
             model=model,
-            max_tokens=probe_max_tokens(),
-            payload_builder=build_voice_probe_payload,
+            max_tokens=probe_max_tokens(prefix=prefix),
+            # Bound to THIS agent's identity: a probe that always asks "Hey
+            # Karen, are you there?" would grade every agent's model against
+            # one persona's prompt, and prompt length is part of what TTFT
+            # measures.
+            payload_builder=functools.partial(
+                build_voice_probe_payload, system=system, user=user,
+            ),
         )
         spoke = int(getattr(result, "tokens", 0) or 0) > 0
         ttft = float(getattr(result, "ttft_s", -1.0))
@@ -499,7 +590,7 @@ async def probe_voice_model(
                 if not spoke
                 else (
                     "ok" if ttft <= budget
-                    else "slow" if ttft <= spoken_ttft_hard_cap_s()
+                    else "slow" if ttft <= spoken_ttft_hard_cap_s(prefix=prefix)
                     else "too_slow_for_speech"
                 )
             ),
@@ -517,6 +608,9 @@ async def refresh_voice_lane(
     dispatch_fn: Optional[Callable[[dict], Any]] = None,
     ledger: Optional[VoiceLatencyLedger] = None,
     force: bool = False,
+    prefix: str = _LEGACY_PREFIX,
+    probe_system: str = "",
+    probe_user: str = "",
 ) -> Optional[str]:
     """Probe the stale candidates concurrently and return the elected model.
 
@@ -524,7 +618,7 @@ async def refresh_voice_lane(
     would take as long as the sum of the slowest — including the 20s+ models
     it exists to disqualify. NEVER raises; returns ``None`` when nothing
     qualifies, which leaves the caller's default in place."""
-    if not voice_lane_enabled():
+    if not voice_lane_enabled(prefix=prefix):
         return None
     led = ledger if ledger is not None else get_default_ledger()
     try:
@@ -532,11 +626,17 @@ async def refresh_voice_lane(
         if not cands:
             return led.best()
         todo = (cands if force else led.stale_or_unknown(cands))[
-            : max_probe_candidates()
+            : max_probe_candidates(prefix=prefix)
         ]
         if todo:
             results = await asyncio.gather(
-                *(probe_voice_model(m, dispatch_fn=dispatch_fn) for m in todo),
+                *(
+                    probe_voice_model(
+                        m, dispatch_fn=dispatch_fn, prefix=prefix,
+                        system=probe_system, user=probe_user,
+                    )
+                    for m in todo
+                ),
                 return_exceptions=True,
             )
             for rec in results:
@@ -561,7 +661,11 @@ async def refresh_voice_lane(
 # ---------------------------------------------------------------------------
 
 
-def resolve_voice_model(*, ledger: Optional[VoiceLatencyLedger] = None) -> Optional[str]:
+def resolve_voice_model(
+    *,
+    ledger: Optional[VoiceLatencyLedger] = None,
+    prefix: str = _LEGACY_PREFIX,
+) -> Optional[str]:
     """The DW model Karen should SPEAK through, or ``None``.
 
     Synchronous and allocation-cheap by contract: this sits on the turn path,
@@ -572,10 +676,10 @@ def resolve_voice_model(*, ledger: Optional[VoiceLatencyLedger] = None) -> Optio
     default". Returning a guess instead would trade a known-slow voice for an
     unknown one. NEVER raises."""
     try:
-        override = model_override()
+        override = model_override(prefix=prefix)
         if override:
             return override
-        if not voice_lane_enabled():
+        if not voice_lane_enabled(prefix=prefix):
             return None
         return (ledger if ledger is not None else get_default_ledger()).best()
     except Exception:  # noqa: BLE001
@@ -583,10 +687,17 @@ def resolve_voice_model(*, ledger: Optional[VoiceLatencyLedger] = None) -> Optio
 
 
 _WARM_LOCK = threading.Lock()
-_WARMED = False
+#: Keyed by lane, not a single flag: with two agents a global "already warmed"
+#: would let whichever lane ran first suppress the other's election forever.
+_WARMED: Dict[str, bool] = {}
 
 
-def ensure_voice_lane_warm(*, force: bool = False) -> bool:
+def ensure_voice_lane_warm(
+    *,
+    force: bool = False,
+    prefix: str = _LEGACY_PREFIX,
+    ledger: Optional["VoiceLatencyLedger"] = None,
+) -> bool:
     """Kick ONE background refresh if the lane has no elected model yet.
 
     True when a refresh was started. Returns IMMEDIATELY — the caller is on a
@@ -602,21 +713,21 @@ def ensure_voice_lane_warm(*, force: bool = False) -> bool:
 
     Once per process (the guard is the point: several turns arriving together
     must not each start a sweep). NEVER raises."""
-    global _WARMED
     try:
-        if not voice_lane_enabled() or model_override():
+        if not voice_lane_enabled(prefix=prefix) or model_override(prefix=prefix):
             return False
+        led = ledger if ledger is not None else get_default_ledger()
         with _WARM_LOCK:
-            if _WARMED and not force:
+            if _WARMED.get(prefix) and not force:
                 return False
-            if not force and get_default_ledger().best() is not None:
-                _WARMED = True          # already elected — nothing to learn
+            if not force and led.best() is not None:
+                _WARMED[prefix] = True   # already elected — nothing to learn
                 return False
-            _WARMED = True
+            _WARMED[prefix] = True
 
         def _run() -> None:
             try:
-                asyncio.run(refresh_voice_lane(force=force))
+                asyncio.run(refresh_voice_lane(force=force, ledger=ledger))
             except Exception:  # noqa: BLE001
                 logger.debug("[VoiceLane] warm refresh degraded", exc_info=True)
 
@@ -630,12 +741,16 @@ def ensure_voice_lane_warm(*, force: bool = False) -> bool:
 
 def reset_warm_state() -> None:
     """Test seam — re-arms the once-per-process guard."""
-    global _WARMED
     with _WARM_LOCK:
-        _WARMED = False
+        _WARMED.clear()
 
 
-def record_runtime_failure(model: str, reason: str = "runtime") -> bool:
+def record_runtime_failure(
+    model: str,
+    reason: str = "runtime",
+    *,
+    ledger: Optional["VoiceLatencyLedger"] = None,
+) -> bool:
     """A model that passed the probe but failed on a REAL turn.
 
     The election rests on a probe, and a probe is a sample: a model can pass
@@ -647,7 +762,7 @@ def record_runtime_failure(model: str, reason: str = "runtime") -> bool:
     know the ledger's shape; it reports an OUTCOME and the lane decides what
     that means for ranking. NEVER raises."""
     try:
-        led = get_default_ledger()
+        led = ledger if ledger is not None else get_default_ledger()
         led.record(VoiceModelRecord(
             model=str(model), ttft_s=-1.0, tokens=0, spoke=False,
             measured_at=time.time(), reason=f"runtime:{reason}",
@@ -660,16 +775,20 @@ def record_runtime_failure(model: str, reason: str = "runtime") -> bool:
         return False
 
 
-def voice_lane_status() -> Dict[str, Any]:
+def voice_lane_status(
+    *,
+    prefix: str = _LEGACY_PREFIX,
+    ledger: Optional["VoiceLatencyLedger"] = None,
+) -> Dict[str, Any]:
     """Operator-facing snapshot for ``/provider`` and friends. Read-only."""
     try:
-        led = get_default_ledger()
+        led = ledger if ledger is not None else get_default_ledger()
         recs = sorted(led.all(), key=lambda r: (not r.conversational, r.ttft_s))
         return {
-            "enabled": voice_lane_enabled(),
-            "override": model_override() or None,
-            "elected": resolve_voice_model(),
-            "budget_s": spoken_ttft_budget_s(),
+            "enabled": voice_lane_enabled(prefix=prefix),
+            "override": model_override(prefix=prefix) or None,
+            "elected": resolve_voice_model(ledger=led, prefix=prefix),
+            "budget_s": spoken_ttft_budget_s(prefix=prefix),
             "measured": [
                 {
                     "model": r.model, "ttft_s": round(r.ttft_s, 3),

--- a/backend/voice/agent_persona.py
+++ b/backend/voice/agent_persona.py
@@ -70,9 +70,19 @@ def _is_system_default(name: object) -> bool:
 class AgentPersona(str, enum.Enum):
     """Who is speaking. The value is the env-knob suffix and log token."""
 
-    KAREN = "karen"        # O+V's voice — the ov cockpit
+    #: O+V — Ouroboros + Venom, the self-developing organism. THE AGENT.
+    #: Its macOS rendering is the `Karen` voice, which is why the two got
+    #: conflated; the agent and the voice are now named separately.
+    OV = "ov"
+    #: Deprecated alias for OV, kept so existing bindings do not break.
+    KAREN = "karen"
     JARVIS = "jarvis"      # the supervisor / Body
     SYSTEM = "system"      # unattributed system speech
+
+    @property
+    def canonical(self) -> "AgentPersona":
+        """KAREN resolves to OV — one identity, two spellings."""
+        return AgentPersona.OV if self is AgentPersona.KAREN else self
 
     @classmethod
     def coerce(cls, value: object) -> Optional["AgentPersona"]:
@@ -97,6 +107,7 @@ _PREFERENCES: Dict[AgentPersona, Tuple[str, ...]] = {
     # system voice" is a stable request while asking for a NAME is not — the
     # name is right until they change the setting, and wrong silently after.
     # The named fallbacks stay for machines whose default cannot be resolved.
+    AgentPersona.OV: (SYSTEM_DEFAULT, "Karen", "Tessa", "Serena", "Samantha"),
     AgentPersona.KAREN: (SYSTEM_DEFAULT, "Karen", "Tessa", "Serena", "Samantha"),
     # British first — the established JARVIS voice.
     AgentPersona.JARVIS: ("Daniel", "Oliver", "Serena", "Alex"),
@@ -105,6 +116,7 @@ _PREFERENCES: Dict[AgentPersona, Tuple[str, ...]] = {
 
 #: Locale to fall back to when no preferred voice is installed.
 _LOCALES: Dict[AgentPersona, str] = {
+    AgentPersona.OV: "en_AU",
     AgentPersona.KAREN: "en_AU",
     AgentPersona.JARVIS: "en_GB",
     AgentPersona.SYSTEM: "en_US",
@@ -220,12 +232,22 @@ def _rate_for(persona: AgentPersona) -> int:
         return 175
 
 
-def resolve_profile(persona: object) -> Optional[VoiceProfile]:
+def resolve_profile(
+    persona: object, *, prefer: str = "",
+) -> Optional[VoiceProfile]:
     """The voice *persona* should speak in on THIS machine, or None.
 
     ``None`` means "no opinion — keep your default": an unknown persona or a
     machine with no usable voice must not silence a reply, and guessing a
-    voice would be worse than the caller's existing behaviour. NEVER raises."""
+    voice would be worse than the caller's existing behaviour.
+
+    *prefer* is the agent registry's stated voice for this persona. It is
+    inserted at the HEAD of the preference chain rather than replacing it, so
+    the registry states the intent, the operator override still outranks it,
+    and an uninstalled registry voice still degrades through the same locale
+    fallback as everything else. The registry is where an agent's voice is
+    declared; this function remains the only thing that decides what the
+    machine can actually deliver. NEVER raises."""
     p = AgentPersona.coerce(persona)
     if p is None:
         return None
@@ -245,11 +267,18 @@ def resolve_profile(persona: object) -> Optional[VoiceProfile]:
                 p.value, override,
             )
 
-        for name in _PREFERENCES.get(p, ()):
+        chain = _PREFERENCES.get(p, ())
+        if prefer and prefer not in chain:
+            chain = (prefer,) + tuple(chain)
+        elif prefer:
+            # Registry voice already listed: promote it rather than duplicate.
+            chain = (prefer,) + tuple(n for n in chain if n != prefer)
+        for name in chain:
             if _is_system_default(name):
                 return VoiceProfile(p, SYSTEM_DEFAULT, rate, "system_default")
             if voice_installed(name):
-                return VoiceProfile(p, name, rate, "preference")
+                reason = "registry" if name == prefer else "preference"
+                return VoiceProfile(p, name, rate, reason)
 
         locale = _LOCALES.get(p, "")
         for name, loc in installed_voices():
@@ -368,6 +397,14 @@ def active_persona() -> Optional[AgentPersona]:
 #: addressing SOMEONE ELSE and replied "Karen, or whoever you are, what would
 #: you like to do today?".
 _IDENTITY: Dict[AgentPersona, Dict[str, str]] = {
+    AgentPersona.OV: {
+        "name": "Karen",
+        "character": (
+            "the voice of O+V (Ouroboros + Venom), an autonomous "
+            "self-developing engineering organism. You are a terse, senior "
+            "Australian engineer: plain words, no filler, no bullet spam"
+        ),
+    },
     AgentPersona.KAREN: {
         "name": "Karen",
         "character": (

--- a/backend/voice/agent_registry.py
+++ b/backend/voice/agent_registry.py
@@ -1,0 +1,161 @@
+"""The persona matrix — which agent is speaking, and how it is rendered.
+
+Two entities coexist in JARVIS-PRIME and they are not interchangeable:
+
+    JARVIS  — the Body. British, understated. Rendered by the `Daniel` voice.
+    O+V     — Ouroboros + Venom, the self-developing organism. Terse
+              Australian engineer. Rendered by the `Karen` voice.
+
+The distinction this module finally makes
+-----------------------------------------
+"Karen" has been used to mean both the AGENT and the VOICE, and that conflation
+is why identity kept leaking: four synthesis sites each decided a voice, and
+the conversation prompt separately decided a name, and nothing owned the pair.
+An agent is an IDENTITY with a name, a character and a wake word; a voice is
+one platform's rendering of it. ``AgentPersona.OV`` is the agent;
+``Karen`` is what it sounds like on macOS.
+
+``AgentPersona.KAREN`` is retained as an alias so nothing that already binds it
+breaks, but OV is the canonical name for the entity.
+
+Wake-word routing
+-----------------
+The active agent is selected from what the operator actually SAID rather than
+from configuration: address "Karen" and O+V answers, address "JARVIS" and the
+Body does. Both wake words are drawn from the same registry entries that
+supply the voice and the prompt, so adding an agent is one entry — not an
+entry plus a routing branch plus a voice mapping, which is exactly the shape
+that let voice and identity drift apart in the first place.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Tuple
+
+from backend.voice.agent_persona import (
+    AgentPersona,
+    VoiceProfile,
+    resolve_profile,
+    system_prompt_for,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class AgentSpec:
+    """Everything that makes one agent itself.
+
+    Frozen: an agent's identity is not something a caller should be able to
+    edit at runtime, and the drift this module exists to prevent came from
+    exactly that kind of per-site mutation."""
+
+    persona: AgentPersona
+    display_name: str
+    wake_words: Tuple[str, ...]
+    #: Preferred macOS voice. The registry states the INTENT; the persona
+    #: resolver decides what is actually installed and fast enough, so a
+    #: machine without this voice degrades rather than failing.
+    preferred_voice: str
+
+    @property
+    def wake_pattern(self) -> "re.Pattern[str]":
+        """Whole-word alternation over this agent's wake words.
+
+        Word-boundaried, because the substring lesson has been learned
+        expensively in this codebase: 'ov' inside 'over', 'karen' inside a
+        longer token, and — most memorably — 'rain' inside 'brain' opening
+        the Weather app."""
+        alt = "|".join(re.escape(w) for w in self.wake_words)
+        return re.compile(rf"\b(?:{alt})\b", re.IGNORECASE)
+
+
+#: THE MATRIX. One entry per agent; voice, prompt and wake word all hang off
+#: it, so they cannot be changed independently and drift.
+_AGENTS: Dict[AgentPersona, AgentSpec] = {
+    AgentPersona.OV: AgentSpec(
+        persona=AgentPersona.OV,
+        display_name="Karen",
+        wake_words=("karen", "o+v", "ouroboros"),
+        preferred_voice="Karen",
+    ),
+    AgentPersona.JARVIS: AgentSpec(
+        persona=AgentPersona.JARVIS,
+        display_name="JARVIS",
+        wake_words=("jarvis", "javis", "jervis"),   # common STT mishearings
+        preferred_voice="Daniel",
+    ),
+}
+
+
+def all_agents() -> Tuple[AgentSpec, ...]:
+    return tuple(_AGENTS.values())
+
+
+def spec_for(persona: object) -> Optional[AgentSpec]:
+    """The registry entry for *persona*, or None. NEVER raises."""
+    p = AgentPersona.coerce(persona)
+    if p is None:
+        return None
+    if p in _AGENTS:
+        return _AGENTS[p]
+    # KAREN is an alias for OV — the agent, not the voice.
+    if p is AgentPersona.KAREN:
+        return _AGENTS.get(AgentPersona.OV)
+    return None
+
+
+def route_by_wake_word(transcript: str) -> Optional[AgentSpec]:
+    """Which agent was ADDRESSED, from what the operator said.
+
+    Returns None when no agent was named — the caller keeps whoever is
+    already active, because a turn that names nobody is a continuation of the
+    current conversation, not a request to switch. Silently reassigning on
+    every unnamed turn would make the active agent depend on sentence
+    structure rather than on intent.
+
+    When two agents are named, the one appearing FIRST wins: "Karen, ask
+    JARVIS to…" addresses Karen about JARVIS. NEVER raises."""
+    try:
+        text = str(transcript or "")
+        if not text.strip():
+            return None
+        best: Optional[Tuple[int, AgentSpec]] = None
+        for spec in _AGENTS.values():
+            m = spec.wake_pattern.search(text)
+            if m is not None and (best is None or m.start() < best[0]):
+                best = (m.start(), spec)
+        return best[1] if best else None
+    except (TypeError, re.error):
+        return None
+
+
+def voice_profile_for(persona: object) -> Optional[VoiceProfile]:
+    """Resolved voice for *persona*, honouring the registry's preference.
+
+    DRY: the registry says WHICH voice the agent should have; the persona
+    resolver still decides whether it is installed, whether an operator
+    override supersedes it, and whether it synthesizes fast enough. Two
+    layers, one question each."""
+    spec = spec_for(persona)
+    if spec is None:
+        return None
+    return resolve_profile(spec.persona, prefer=spec.preferred_voice)
+
+
+def prompt_for(persona: object) -> Optional[str]:
+    """Identity prompt for *persona* — the same seam the pipeline uses."""
+    spec = spec_for(persona)
+    return system_prompt_for(spec.persona) if spec else None
+
+
+__all__ = [
+    "AgentSpec",
+    "all_agents",
+    "prompt_for",
+    "route_by_wake_word",
+    "spec_for",
+    "voice_profile_for",
+]

--- a/backend/voice/phatic_fastpath.py
+++ b/backend/voice/phatic_fastpath.py
@@ -1,0 +1,206 @@
+"""Zero-cost greetings — don't pay an LLM to say "I'm here".
+
+The expensive hello
+-------------------
+"Hey Karen" carries no question. Routing it to a 30B model over the network
+costs tokens, ~0.9s of TTFT, and the operator's patience — for an utterance
+whose only informational content is *I am addressing you*. That is a routing
+defect, not a prompt-tuning opportunity.
+
+Why this is not a greeting list
+-------------------------------
+The temptation is ``if text in ("hi", "hello", "hey karen")``. That is the
+same mistake as matching weather by substring, which in this codebase opened
+the Weather app for "the brain is thinking" and "close the window". A list
+fails open on everything it has not seen and fails closed on everything
+phrased slightly differently.
+
+The actual property is INFORMATIONAL. A phatic utterance is one that carries
+no residual semantic payload once you remove:
+
+  * the agent's own name (addressing, not content),
+  * phatic markers — a real linguistic category, closed and small: the tokens
+    English uses purely to open and maintain contact,
+  * function words, which carry structure rather than meaning.
+
+If nothing remains, the operator said "I am talking to you" and nothing else.
+If ANYTHING remains — one content word — it is a real turn and goes to the
+model. That generalises to phrasings never enumerated here ("yo karen you
+around", "karen?", "are you there jarvis") and, more importantly, refuses to
+swallow "karen what's my disk usage", which contains content and must not be
+answered from a cache.
+
+Bias is deliberately asymmetric: a missed phatic costs one unnecessary LLM
+call; a FALSE phatic answers a real question with "I'm here", which is a lie.
+So the classifier only fires when the residue is empty.
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import re
+from dataclasses import dataclass
+from typing import List, Optional, Sequence, Tuple
+
+logger = logging.getLogger(__name__)
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+
+def fastpath_enabled() -> bool:
+    """Master gate. OFF sends every turn to the model, which is the only
+    honest way to compare cost and latency against this path."""
+    return os.getenv("JARVIS_PHATIC_FASTPATH", "true").strip().lower() in _TRUTHY
+
+
+#: Tokens English uses purely to establish or maintain contact. A closed
+#: linguistic class, not a list of remembered greetings — which is why it
+#: generalises to phrasings nobody enumerated.
+_PHATIC_MARKERS = frozenset("""
+hi hello hey heya yo hiya howdy greetings morning afternoon evening night
+good goodmorning ok okay alright allright sup wassup whatsup
+there here around awake alive up listening
+please thanks thank cheers mate
+test testing check checking hear me
+""".split())
+
+#: Function words: structure, not meaning.
+_FUNCTION_WORDS = frozenset("""
+a an the and or but so it its it's this that these those to of in on at for
+with my your our their i me we they he she do does did done can could will
+would shall should may might must have has had be been being was were
+just now still again very really quite bit
+are is am r u ya you
+# ^ copulas and pronouns are STRUCTURE, not contact. Listing "is" as a
+# phatic marker let the pure-fragment guard pass "is it the" — an utterance
+# with no greeting in it at all — which would have answered a transcription
+# artifact with "I'm here" instead of sending it on. The construction
+# "are you there" is still phatic because "there" is the marker; the copula
+# never was.
+""".split())
+
+_WORD = re.compile(r"[a-z0-9']+")
+
+
+@dataclass(frozen=True)
+class PhaticVerdict:
+    """Why the classifier decided what it did — so a wrong call is legible."""
+
+    is_phatic: bool
+    residue: Tuple[str, ...]
+    reason: str
+
+    def __bool__(self) -> bool:
+        return self.is_phatic
+
+
+def _max_words() -> int:
+    """Length ceiling. Above this the operator is saying something, whatever
+    the individual tokens look like — a long utterance made entirely of
+    function words is far more likely to be a transcription artifact than a
+    greeting, and artifacts must reach the model rather than be answered."""
+    try:
+        return max(2, int(os.getenv("JARVIS_PHATIC_MAX_WORDS", "8")))
+    except (TypeError, ValueError):
+        return 8
+
+
+def classify(text: str, *, agent_names: Sequence[str] = ()) -> PhaticVerdict:
+    """Is this pure contact-establishment? NEVER raises.
+
+    *agent_names* are stripped as ADDRESSING rather than content: saying an
+    assistant's name tells it who you mean, not what you want."""
+    try:
+        raw = str(text or "").strip().lower()
+        if not raw:
+            return PhaticVerdict(False, (), "empty")
+
+        tokens = _WORD.findall(raw)
+        if not tokens:
+            return PhaticVerdict(False, (), "no_tokens")
+        if len(tokens) > _max_words():
+            return PhaticVerdict(False, tuple(tokens), "too_long")
+
+        # A question mark is a request even when every word is phatic:
+        # "you there?" is contact, but "how are you doing today?" is a turn.
+        names = {n.lower() for n in agent_names}
+        name_tokens = {t for n in names for t in _WORD.findall(n)}
+
+        residue = [
+            t for t in tokens
+            if t not in name_tokens
+            and t not in _PHATIC_MARKERS
+            and t not in _FUNCTION_WORDS
+        ]
+        if residue:
+            return PhaticVerdict(False, tuple(residue), "has_content")
+
+        # Guard against the degenerate case: an utterance made ONLY of
+        # function words ("is it the") is not a greeting, it is a fragment,
+        # and a fragment is usually a transcription artifact worth sending on.
+        if not (set(tokens) & _PHATIC_MARKERS) and not (set(tokens) & name_tokens):
+            return PhaticVerdict(False, (), "no_phatic_marker")
+
+        return PhaticVerdict(True, (), "phatic")
+    except (TypeError, re.error):
+        return PhaticVerdict(False, (), "error")
+
+
+# ---------------------------------------------------------------------------
+# Response pool
+# ---------------------------------------------------------------------------
+
+#: Acknowledgements only. Every one of these is true regardless of what was
+#: asked, because the fast path must never answer a QUESTION — it exists to
+#: answer being addressed. Nothing here claims knowledge or takes an action.
+_ACKS: Tuple[str, ...] = (
+    "I'm here.",
+    "Listening.",
+    "Go ahead.",
+    "Right here.",
+    "Yep, listening.",
+    "Here. What do you need?",
+)
+
+
+def _pool() -> Tuple[str, ...]:
+    """Operator-supplied acknowledgements, else the defaults."""
+    raw = os.getenv("JARVIS_PHATIC_RESPONSES", "").strip()
+    if not raw:
+        return _ACKS
+    parts = tuple(p.strip() for p in raw.split("|") if p.strip())
+    return parts or _ACKS
+
+
+def acknowledge(text: str, *, operator: str = "", salt: str = "") -> str:
+    """One acknowledgement, varied but DETERMINISTIC for a given utterance.
+
+    Chosen by hashing the input rather than at random: an assistant that
+    answers the same greeting differently on every repetition feels
+    capricious, while one that never varies feels mechanical. Hashing gives
+    variety across different greetings and stability for the same one, and it
+    keeps tests exact without stubbing a random source.
+
+    NEVER raises."""
+    try:
+        pool = _pool()
+        key = f"{text or ''}|{salt}".encode("utf-8", "replace")
+        idx = int(hashlib.sha256(key).hexdigest()[:8], 16) % len(pool)
+        reply = pool[idx]
+        who = (operator or "").strip()
+        if who and reply.endswith("."):
+            # Address them back when we know their name — resolved upstream,
+            # never invented here.
+            return f"{reply[:-1]}, {who}."
+        return reply
+    except (TypeError, ValueError, ZeroDivisionError):
+        return _ACKS[0]
+
+
+__all__ = [
+    "PhaticVerdict",
+    "acknowledge",
+    "classify",
+    "fastpath_enabled",
+]

--- a/tests/governance/test_adaptive_voice_router.py
+++ b/tests/governance/test_adaptive_voice_router.py
@@ -408,7 +408,9 @@ def test_the_router_does_not_reimplement_the_election():
     src = Path(
         "backend/core/ouroboros/governance/adaptive_voice_router.py",
     ).read_text(encoding="utf-8")
-    assert "resolve_voice_model" in src
+    # Delegation, through the per-agent lane façade — which itself calls
+    # resolve_voice_model with this agent's prefix and ledger.
+    assert "lane_for" in src and "resolve_model()" in src
     for owned_elsewhere in ("ttft_s", "VoiceLatencyLedger", "deep_probe("):
         assert owned_elsewhere not in src, (
             f"router re-implements {owned_elsewhere} — that belongs to the lane"
@@ -451,7 +453,10 @@ async def test_a_zero_token_stream_demotes_the_model(monkeypatch):
     demoted = []
     monkeypatch.setattr(
         kvl, "record_runtime_failure",
-        lambda m, reason="runtime": demoted.append((m, reason)) or True,
+        # **kw: the lane now passes the per-agent ledger, and a fake that
+        # mirrored the OLD signature would raise TypeError into the router's
+        # handler and report "no demotion" for a demotion that happened.
+        lambda m, reason="runtime", **kw: demoted.append((m, reason)) or True,
     )
     r = _router(local=_Local(), dispatch=_dw([]))
     await _drain(r)
@@ -466,7 +471,7 @@ async def test_a_speaking_model_is_not_demoted(monkeypatch):
     demoted = []
     monkeypatch.setattr(
         kvl, "record_runtime_failure",
-        lambda m, reason="runtime": demoted.append(m) or True,
+        lambda m, reason="runtime", **kw: demoted.append(m) or True,
     )
     r = _router(local=_Local(), dispatch=_dw(["hello"]))
     assert await _drain(r) == "hello"

--- a/tests/voice/duplex/test_tts_playback.py
+++ b/tests/voice/duplex/test_tts_playback.py
@@ -48,7 +48,10 @@ async def test_play_calls_speak_stream_with_cancel_event_and_tracks_active():
     await asyncio.sleep(0)
     assert pb.is_active is True
     assert eng.calls[0]["text"] == "Fix applied."
-    assert eng.calls[0]["source"] == "karen"
+    # The source tag carries the persona now ("karen:persona=<agent>") so a
+    # log line says WHICH agent spoke, not merely that the karen path did.
+    src = eng.calls[0]["source"]
+    assert src.split(":")[0] == "karen"
     assert eng.calls[0]["cancel_event"] is not None
     eng.finish()
     await task

--- a/tests/voice/test_persona_matrix_phatic.py
+++ b/tests/voice/test_persona_matrix_phatic.py
@@ -1,0 +1,365 @@
+"""Persona matrix + phatic fast path — the three mandated assertions.
+
+1. An injected "Hello Karen" transcript intercepts the network call and
+   returns a cached string.
+2. The AgentRegistry swaps the TTS output profile to Karen.
+3. The bypassed turn is written to the mocked conversation history.
+
+Everything here drives the REAL pipeline method. A test that called
+``classify`` directly would prove the classifier works and say nothing about
+whether the interceptor is on the turn path — which is the failure mode this
+codebase has hit repeatedly: a guard with no caller is theatre.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import Any, Dict, List, Optional, Tuple
+
+import pytest
+
+from backend.audio.conversation_pipeline import ConversationPipeline
+from backend.voice.agent_persona import AgentPersona
+from backend.voice.agent_registry import (
+    all_agents,
+    route_by_wake_word,
+    spec_for,
+    voice_profile_for,
+)
+from backend.voice.phatic_fastpath import acknowledge, classify
+
+
+# ---------------------------------------------------------------------------
+# Doubles
+# ---------------------------------------------------------------------------
+
+
+class _RecordingSession:
+    """The mocked conversation history of assertion 3."""
+
+    def __init__(self) -> None:
+        self.turns: List[Tuple[str, str]] = []
+
+    def add_turn(self, role: str, content: str) -> None:
+        self.turns.append((role, content))
+
+    def get_messages(self) -> List[Dict[str, str]]:
+        return [{"role": r, "content": c} for r, c in self.turns]
+
+    def get_context_for_llm(self) -> List[Dict[str, str]]:
+        return self.get_messages()
+
+
+#: The reply the model would give if it were reached. Distinct from every
+#: cached acknowledgement, so "which path answered" is visible in the output
+#: rather than inferred.
+MODEL_REPLY = "__from_the_model__"
+
+
+class _CountingLLM:
+    """Truthy stand-in for the LLM client.
+
+    Counting rather than raising: ``_generate_and_speak_response`` wraps the
+    generation branch in a broad ``except`` that logs and continues, so a
+    double that raised would be SWALLOWED and the test would pass whether or
+    not the interceptor worked. The counter survives that handler."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+
+class _WholeTextSplitter:
+    """Sentence splitting is not what these assertions are about."""
+
+    async def split(self, stream: Any):
+        async for chunk in stream:
+            yield chunk
+
+
+def _pipeline(session: _RecordingSession, llm: _CountingLLM) -> ConversationPipeline:
+    """A pipeline with only the collaborators these assertions touch.
+
+    Built with ``__new__`` deliberately: ``__init__`` mounts an audio device,
+    an STT model and a TTS engine, none of which the fast path involves, and
+    requiring them would make this an integration test of the sound card."""
+    p = ConversationPipeline.__new__(ConversationPipeline)
+    p._session = session
+    p._barge_in = None
+    p._llm_client = llm
+    p._audio_bus = None            # forces the non-streamed branch
+    p._sentence_splitter = _WholeTextSplitter()
+    p._system_prompt = "test"
+    p._spoken = []
+
+    async def _speak(sentence: str, _cancel: Any) -> None:
+        p._spoken.append(sentence)
+
+    async def _stream(*_a: Any, **_kw: Any):
+        # The network seam. Entering it at all is what assertion 1 forbids
+        # for a greeting — and what the inverse test REQUIRES for a question.
+        llm.calls += 1
+        yield MODEL_REPLY
+
+    p._speak_sentence = _speak                                  # type: ignore
+    p._get_llm_stream = _stream                                 # type: ignore
+    return p
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No operator override may decide these outcomes."""
+    for key in (
+        "JARVIS_VOICE_OV", "JARVIS_VOICE_KAREN", "JARVIS_VOICE_JARVIS",
+        "JARVIS_PHATIC_RESPONSES", "JARVIS_PHATIC_MAX_WORDS",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("JARVIS_PHATIC_FASTPATH", "true")
+    monkeypatch.setenv("JARVIS_AGENT_PERSONA", "ov")
+
+
+# ---------------------------------------------------------------------------
+# Assertion 1 — the greeting never reaches the network
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_hello_karen_intercepts_the_network_call() -> None:
+    session, llm = _RecordingSession(), _CountingLLM()
+    pipe = _pipeline(session, llm)
+
+    await pipe._generate_and_speak_response("Hello Karen")
+
+    assert llm.calls == 0, "the model was called for a pure greeting"
+    assert pipe._spoken, "the fast path produced no spoken reply"
+    assert pipe._spoken[0].strip(), "the cached reply was empty"
+    assert MODEL_REPLY not in pipe._spoken
+
+
+@pytest.mark.asyncio
+async def test_a_real_question_is_not_intercepted() -> None:
+    """The inverse, which is the assertion that actually matters.
+
+    A fast path that swallowed questions would pass the test above while
+    being catastrophically wrong: answering "what's my disk usage" with
+    "I'm here" is a lie, and the bias is explicitly asymmetric against it."""
+    session, llm = _RecordingSession(), _CountingLLM()
+    pipe = _pipeline(session, llm)
+
+    await pipe._generate_and_speak_response("Karen what is my disk usage")
+
+    assert llm.calls == 1, "a real question was answered from the cache"
+    assert pipe._spoken == [MODEL_REPLY]
+
+
+@pytest.mark.parametrize(
+    "utterance",
+    ["Hello Karen", "hey karen", "yo karen you around", "Karen?",
+     "are you there jarvis", "good morning karen"],
+)
+def test_phrasings_never_enumerated_still_classify(utterance: str) -> None:
+    """Generalisation, not recall: none of these is a stored string."""
+    assert classify(utterance, agent_names=["karen", "jarvis", "ov"])
+
+
+@pytest.mark.parametrize(
+    "utterance",
+    ["karen what is my disk usage", "hey karen reboot the server",
+     "hello karen how is the build", "karen deploy to production",
+     "what time is it", "is it the"],
+)
+def test_content_is_refused(utterance: str) -> None:
+    verdict = classify(utterance, agent_names=["karen", "jarvis", "ov"])
+    assert not verdict, f"{utterance!r} was swallowed by the cache"
+
+
+# ---------------------------------------------------------------------------
+# Assertion 2 — the registry swaps the TTS output profile
+# ---------------------------------------------------------------------------
+
+
+def test_registry_maps_ov_to_karen_and_jarvis_to_daniel() -> None:
+    assert spec_for(AgentPersona.OV).preferred_voice == "Karen"
+    assert spec_for(AgentPersona.JARVIS).preferred_voice == "Daniel"
+    # KAREN is an ALIAS for the OV agent, not a second agent.
+    assert spec_for(AgentPersona.KAREN) is spec_for(AgentPersona.OV)
+
+
+def test_registry_swaps_the_tts_output_profile() -> None:
+    """Assertion 2. Resolution is machine-dependent — a voice may not be
+    installed — so what is asserted is that the registry's INTENT reaches the
+    resolver, which is the seam under test. Where the voice exists, the
+    profile carries it and says the registry chose it."""
+    for persona, want in ((AgentPersona.OV, "Karen"), (AgentPersona.JARVIS, "Daniel")):
+        profile = voice_profile_for(persona)
+        assert profile is not None
+        if profile.source == "registry":
+            assert profile.voice == want
+        else:
+            # Not installed on this machine: it must have degraded through the
+            # shared chain, never silently become the OTHER agent's voice.
+            other = "Daniel" if want == "Karen" else "Karen"
+            assert profile.voice != other
+
+
+@pytest.mark.asyncio
+async def test_wake_word_switches_the_active_agent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Addressing JARVIS in Karen's cockpit hands the turn to JARVIS."""
+    session, llm = _RecordingSession(), _CountingLLM()
+    pipe = _pipeline(session, llm)
+    monkeypatch.setenv("JARVIS_AGENT_PERSONA", "ov")
+
+    assert pipe._route_persona("Hey JARVIS are you there") is True
+    assert os.environ["JARVIS_AGENT_PERSONA"] == "jarvis"
+
+    # An unaddressed turn is a CONTINUATION — the agent must not drift.
+    assert pipe._route_persona("what is my disk usage") is False
+    assert os.environ["JARVIS_AGENT_PERSONA"] == "jarvis"
+
+    assert pipe._route_persona("Karen, you there?") is True
+    assert os.environ["JARVIS_AGENT_PERSONA"] == "ov"
+
+
+def test_first_named_agent_wins() -> None:
+    """"Karen, ask JARVIS to reboot" addresses Karen ABOUT JARVIS."""
+    assert route_by_wake_word("Karen, ask JARVIS to reboot").persona is AgentPersona.OV
+    assert route_by_wake_word("JARVIS, tell Karen to stop").persona is AgentPersona.JARVIS
+    assert route_by_wake_word("what is my disk usage") is None
+
+
+def test_wake_words_are_word_boundaried() -> None:
+    """The substring lesson, which cost this codebase a Weather app that
+    opened on "the brain is thinking"."""
+    assert route_by_wake_word("move it over there") is None
+    assert route_by_wake_word("the karenina novel") is None
+
+
+# ---------------------------------------------------------------------------
+# Assertion 3 — the bypassed turn reaches the history
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bypassed_turn_is_written_to_history() -> None:
+    """Assertion 3.
+
+    A bypassed greeting that vanished would leave the NEXT complex turn
+    reasoning about a conversation whose opening it never saw — the model
+    would be told the operator's first words were a question that in fact
+    followed a greeting it answered."""
+    session, llm = _RecordingSession(), _CountingLLM()
+    pipe = _pipeline(session, llm)
+
+    await pipe._generate_and_speak_response("Hello Karen")
+
+    assert session.turns, "the bypassed turn left no trace in history"
+    role, content = session.turns[-1]
+    assert role == "assistant"
+    assert content == pipe._spoken[0], (
+        "history recorded something other than what was actually said"
+    )
+
+
+@pytest.mark.asyncio
+async def test_history_survives_into_the_next_turn() -> None:
+    """The point of assertion 3, stated as behaviour: the greeting is still
+    visible when the next turn is composed."""
+    session, llm = _RecordingSession(), _CountingLLM()
+    pipe = _pipeline(session, llm)
+
+    session.add_turn("user", "Hello Karen")
+    await pipe._generate_and_speak_response("Hello Karen")
+
+    msgs = session.get_messages()
+    assert [m["role"] for m in msgs] == ["user", "assistant"]
+    assert msgs[0]["content"] == "Hello Karen"
+
+
+# ---------------------------------------------------------------------------
+# Properties of the cache itself
+# ---------------------------------------------------------------------------
+
+
+def test_acknowledgement_is_deterministic_and_varies_by_utterance() -> None:
+    a1 = acknowledge("Hello Karen")
+    a2 = acknowledge("Hello Karen")
+    assert a1 == a2, "the same greeting must not get a different answer"
+    variants = {acknowledge(g) for g in ("hi", "hey karen", "yo", "morning", "you there")}
+    assert len(variants) > 1, "every greeting collapsed to one reply"
+
+
+def test_no_acknowledgement_claims_knowledge_or_action() -> None:
+    """The fast path answers being ADDRESSED. If a pool entry ever answered a
+    question, a phrasing this classifier accepts would start producing a
+    confident lie."""
+    from backend.voice.phatic_fastpath import _ACKS
+
+    forbidden = ("i have", "i found", "i ran", "done", "completed", "the answer")
+    for ack in _ACKS:
+        low = ack.lower()
+        assert not any(f in low for f in forbidden), ack
+
+
+def test_fastpath_can_be_turned_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    """OFF must send everything to the model — the only honest way to compare
+    the two paths on cost and latency."""
+    monkeypatch.setenv("JARVIS_PHATIC_FASTPATH", "false")
+    session, llm = _RecordingSession(), _CountingLLM()
+    pipe = _pipeline(session, llm)
+
+    asyncio.run(pipe._generate_and_speak_response("Hello Karen"))
+
+    assert llm.calls == 1, "the fast path fired with the master switch OFF"
+    assert pipe._spoken == [MODEL_REPLY]
+
+
+# ---------------------------------------------------------------------------
+# The lane generalisation
+# ---------------------------------------------------------------------------
+
+
+def test_each_agent_gets_its_own_lane_not_a_shared_one() -> None:
+    from backend.core.ouroboros.governance.agent_voice_lane import lane_for
+
+    ov, jarvis = lane_for(AgentPersona.OV), lane_for(AgentPersona.JARVIS)
+    assert ov is not jarvis
+    assert ov.ledger._path != jarvis.ledger._path
+    assert ov.prefix != jarvis.prefix
+    # OV keeps the pre-generalisation namespace and file, so measurements
+    # already on disk are inherited rather than orphaned.
+    assert ov.prefix == "JARVIS_KAREN_VOICE"
+    assert ov.ledger._path.name == "karen_voice_lane.json"
+    # KAREN is an alias — one lane, or a demotion on one spelling would leave
+    # the other still electing the mute model.
+    assert lane_for(AgentPersona.KAREN) is ov
+
+
+def test_lane_knobs_inherit_then_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    from backend.core.ouroboros.governance import karen_voice_lane as kvl
+
+    monkeypatch.setenv("JARVIS_KAREN_VOICE_TTFT_BUDGET_S", "1.5")
+    monkeypatch.delenv("JARVIS_JARVIS_VOICE_TTFT_BUDGET_S", raising=False)
+    assert kvl.spoken_ttft_budget_s(prefix="JARVIS_JARVIS_VOICE") == 1.5
+
+    monkeypatch.setenv("JARVIS_JARVIS_VOICE_TTFT_BUDGET_S", "2.4")
+    assert kvl.spoken_ttft_budget_s(prefix="JARVIS_JARVIS_VOICE") == 2.4
+    assert kvl.spoken_ttft_budget_s() == 1.5, "the override leaked across lanes"
+
+
+def test_probe_is_bound_to_the_agents_own_identity() -> None:
+    """A probe measures TTFT for a real spoken turn, and the prompt is part of
+    that measurement — grading JARVIS's models with Karen's prompt measures
+    the wrong workload."""
+    from backend.core.ouroboros.governance.agent_voice_lane import lane_for
+
+    assert "JARVIS" in lane_for(AgentPersona.JARVIS)._probe_user()
+    assert "Karen" in lane_for(AgentPersona.OV)._probe_user()
+
+
+def test_every_registered_agent_is_complete() -> None:
+    """A half-registered agent — wake word but no voice — would answer in
+    whatever voice the last turn left behind."""
+    for spec in all_agents():
+        assert spec.display_name and spec.preferred_voice and spec.wake_words
+        assert spec.persona.canonical is spec.persona


### PR DESCRIPTION
## What

Two agents now coexist properly, and greeting one of them costs nothing.

### Persona matrix — `backend/voice/agent_registry.py`

One `AgentSpec` per agent binds voice, wake words, display name and prompt together, so they cannot be changed independently and drift. That drift is exactly what happened before: four synthesis sites each decided a voice while the conversation prompt separately decided a name, so Karen *sounded* like Karen and *thought* she was JARVIS.

| Agent | Voice | Wake words |
|---|---|---|
| `AgentPersona.OV` | Karen | karen, o+v, ouroboros |
| `AgentPersona.JARVIS` | Daniel | jarvis, javis, jervis (STT mishearings) |

The active agent follows what the operator **said** — "Hey JARVIS" in Karen's cockpit switches voice *and* prompt together. A turn naming nobody leaves the current agent in place: that is a continuation, not a switch request. Wake words are word-boundaried (the substring lesson was learned when "the brain is thinking" opened the Weather app).

The registry states intent; `resolve_profile` still decides what the machine can deliver, and an operator override (`JARVIS_VOICE_OV=system`) still outranks both. One resolver, one preference chain.

### Phatic fast path — `backend/voice/phatic_fastpath.py`

"Hey Karen" carries no question. Routing it to a 30B model costs tokens, ~0.9s of TTFT, and the operator's patience — for an utterance whose entire content is *I am addressing you*.

This is **not a greeting list**; a list fails open on everything it has not seen. The property is informational: strip the agent's name (addressing), phatic markers (a real closed linguistic class) and function words. If nothing remains, the operator said only "I am talking to you". One content word and it goes to the model.

That generalises to phrasings nobody enumerated (`yo karen you around`, `karen?`) and refuses `karen what's my disk usage`, which must never be answered from a cache. The bias is deliberately asymmetric: a missed phatic costs one unnecessary LLM call; a **false** phatic answers a real question with "I'm here", which is a lie.

Bypassed turns are still written to session history, so the next complex turn is not reasoning about a conversation whose opening it never saw.

### `AgentVoiceLane` — DRY, not a fork

`karen_voice_lane`'s ledger, probe, two-tier election and runtime demotion were never Karen-specific — only the *bindings* were. It is now parameterised by `prefix` + `ledger`, and `AgentVoiceLane` binds those to a persona. There is no second implementation of anything.

- per-agent ledger, so one agent's runtime demotion cannot mute the other
- per-agent probe bound to that agent's own prompt and wake word — prompt length is part of what TTFT measures
- OV keeps `JARVIS_KAREN_VOICE_*` and `.jarvis/karen_voice_lane.json`, so existing measurements are inherited rather than orphaned
- new agents inherit every unset knob from the legacy namespace

## Verification

28 new tests covering the three mandated assertions, driving the **real** pipeline method rather than the classifier — a guard with no caller is theatre. Network entry is observed by a counter rather than an exception, because the generation branch has a broad `except` that would swallow a raising double. 147 green across every suite touching the changed modules.

Live, on the running audio plane:

```
'Hello Karen'               agent=ov      voice=Karen   -> 'Right here, Derek.'
'Hey JARVIS are you there'  agent=jarvis  voice=Daniel  -> 'Yep, listening, Derek.'
```

Both zero-token, both written to history.

## Incidental

Two stale assertions fixed: the router DRY pin (now delegates through the lane façade) and a duplex source tag that gained a `persona=` suffix at HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a persona registry and a zero-cost phatic fast path so agents switch reliably by wake word, voices match prompts, and pure greetings get instant local acks with no LLM calls.

- New Features
  - Persona matrix: one `AgentSpec` per agent binds voice, wake words, display name, and prompt (`backend/voice/agent_registry.py`). Wake-word routing picks the active agent from what was said; names are word-boundaried. `AgentPersona.OV` speaks as Karen; `AgentPersona.JARVIS` speaks as Daniel. The system prompt moves with the agent.
  - Phatic fast path: intercepts utterances that contain only addressing + phatic markers + function words (`backend/voice/phatic_fastpath.py`). Returns a deterministic local acknowledgement, writes it to history, and skips the LLM. Toggle with `JARVIS_PHATIC_FASTPATH`. Never answers real questions.

- Refactors
  - Per‑agent voice lanes: generalised `karen_voice_lane` into `AgentVoiceLane` (`backend/core/ouroboros/governance/agent_voice_lane.py`). Each agent gets its own ledger, probe, and election; runtime demotions are per‑agent. OV keeps `JARVIS_KAREN_VOICE_*` and `.jarvis/karen_voice_lane.json`; new agents inherit unset knobs from the legacy namespace. Router now delegates via `lane_for(persona).resolve_model()` and `record_failure()`.

<sup>Written for commit bc973290e775292bfb59d385d26ff6f8435d4d61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70094?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

