### PR TITLE
test(ov): align the exit-75 vigil test with the widened ignition contract

### DIFF
--- a/tests/cli/test_thin_client.py
+++ b/tests/cli/test_thin_client.py
@@ -605,9 +605,18 @@ class TestStarvedOrganismHonesty:
     async def test_child_exit_75_stops_wait_and_names_incumbent(
         self, sock_dir, monkeypatch,
     ):
-        """A single-flight-rejected ignition (exit 75) must stop the wait
-        within seconds and attribute the lock holder — never a blind
-        full-deadline vigil over a corpse."""
+        """A single-flight-rejected ignition (exit 75) must stop BOUNDED and
+        attribute the lock holder — never a blind full-deadline vigil over a
+        corpse.
+
+        The contract widened (2026-07-25): a refusal is usually TRANSIENT (an
+        organism draining after SIGTERM still holds its flock), so the cockpit
+        now waits it out rather than telling the operator to retry. The
+        anti-vigil guarantee is unchanged — the wait is its own bounded budget,
+        strictly shorter than the boot deadline, and the incumbent is still
+        named when it expires. The retry budget is pinned small here so the
+        test measures the CONTRACT, not the clock."""
+        monkeypatch.setenv("JARVIS_OV_IGNITION_RETRY_S", "1")
         path = sock_dir / "attach.sock"        # absent → cold boot branch
         import backend.core.ouroboros.battle_test.cockpit_attach as ca
         monkeypatch.setattr(ca, "attach_socket_path", lambda: path)


### PR DESCRIPTION
`JARVIS_OV_IGNITION_RETRY_S` shipped in `thin_client.py:506`, but this test still asserted the pre-retry behaviour: that a single-flight refusal (exit 75) ends the wait immediately.

A refusal is usually **transient** — an organism draining after SIGTERM still holds its flock — so the cockpit now waits it out instead of telling the operator to retry.

The anti-vigil guarantee the test exists to protect is unchanged: the wait has its own bounded budget, strictly shorter than the boot deadline, and the lock holder is still named when it expires. The retry budget is pinned to 1s so the test measures the **contract** rather than the clock.

35/35 pass in `tests/cli/test_thin_client.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the exit-75 ignition vigil test with the widened ignition contract: on a single-flight refusal, the cockpit now waits within a bounded retry window instead of stopping immediately. The test sets `JARVIS_OV_IGNITION_RETRY_S=1` to enforce a small, bounded wait that stays under the boot deadline and still names the incumbent when it expires.

<sup>Written for commit 077a949d7c8077e5d76dfea21ed111c2969c9afa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70097?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

