### PR TITLE
feat(audio): proportional pre-quantization AGC — fast attack, slow release

### DIFF
--- a/backend/audio/audio_bus.py
+++ b/backend/audio/audio_bus.py
@@ -141,6 +141,31 @@ _RANGE_PEAK_DECAY = float(os.getenv("JARVIS_AUDIO_RANGE_DECAY", "0.9995"))
 #: Soft-knee threshold. Below this the signal is bit-identical; above it the
 #: curve begins. 0.75 leaves normal speech completely untouched (measured
 #: speech peaks here run 0.2-0.6) while catching the excursions that saturate.
+def _agc_env(name: str, default: float, lo: float, hi: float) -> float:
+    try:
+        return max(lo, min(hi, float(os.getenv(name, "").strip() or default)))
+    except (TypeError, ValueError):
+        return default
+
+
+#: Above this the frame is scaled. Below it the signal passes BIT-IDENTICAL —
+#: the common case must cost nothing and change nothing.
+_AGC_CEILING = _agc_env("JARVIS_AUDIO_AGC_CEILING", 0.90, 0.10, 0.99)
+
+#: Where a scaled frame is placed. Under the ceiling, so the scaler is not
+#: re-triggered by its own output on the next frame.
+_AGC_TARGET = _agc_env("JARVIS_AUDIO_AGC_TARGET", 0.95, 0.10, 0.99)
+
+#: Seconds for the gain to climb back toward unity once the loud passage
+#: ends. Long, deliberately: speech has pauses, and a governor that recovered
+#: inside one would raise the noise floor between every word — audible as
+#: "pumping" and, worse, a moving noise floor for the endpointer to chase.
+_AGC_RELEASE_S = _agc_env("JARVIS_AUDIO_AGC_RELEASE_S", 2.0, 0.05, 60.0)
+
+#: Floor on the gain. Without it a single freak transient could attenuate the
+#: whole session toward silence with no way back inside the release constant.
+_AGC_MIN_GAIN = _agc_env("JARVIS_AUDIO_AGC_MIN_GAIN", 0.02, 1e-4, 1.0)
+
 _AGC_THRESHOLD = max(0.05, min(0.99, float(
     os.getenv("JARVIS_AUDIO_AGC_THRESHOLD", "0.75"),
 )))
@@ -421,6 +446,11 @@ class AudioBus:
 
         # These are set during start()
         self._device: Optional[FullDuplexDevice] = None
+        #: Governor state. Declared here rather than discovered by getattr so
+        #: the object's shape is honest and a reader can see the AGC exists.
+        self._agc_gain: float = 1.0          # current linear gain, 1.0 = off
+        self._range_peak: float = 0.0        # loudest input peak ever seen
+        self._range_reports: int = 0         # log budget for over-scale input
         self._aec: Optional[AcousticEchoCanceller] = None
         self._resampler_down: Optional[Resampler] = None      # 48k -> 16k (mic)
         self._resampler_aec_ref: Optional[Resampler] = None  # 48k -> 16k (AEC ref)
@@ -757,64 +787,147 @@ class AudioBus:
     # ---- Internal: Mic frame processing ----
 
     def _fit_to_range(self, frame: np.ndarray) -> np.ndarray:
-        """Soft-knee compressor: curve hot peaks below 1.0 without clipping.
+        """Scale hot frames into range PROPORTIONALLY. Fast attack, slow release.
 
-        THE FAULT THIS REMOVES. The capture device delivers samples above full
-        scale (measured: 1.04 through 3.9998). Anything that reaches a tensor
-        saturated flat is not speech any more — faster-whisper reads formant
-        structure, and clipping is precisely the operation that destroys it.
-        The observable symptom was whisper HALLUCINATING: "I'm sorry, I'm
-        sorry, I'm sorry" in place of "Hello Karen".
+        THE FAULT THIS REMOVES. The capture device delivers float PCM above
+        full scale — measured on this machine at peak 4.19 while the operator
+        spoke. CoreAudio is right to do so: 32-bit float PCM has no ceiling,
+        and nothing is lost in memory. The loss happens at every consumer that
+        quantises, and this pipeline has several — webrtcvad takes int16, the
+        WebSocket tap takes int16, speexdsp takes int16 — each of which HARD
+        CLIPS what it is given.
 
-        Linear scaling by the peak (the previous approach) fixes the range but
-        squashes an entire utterance because one syllable was loud. A
-        compressor leaves everything below the knee UNTOUCHED and curves only
-        the excursions:
+        Why proportional and not a soft knee
+        ------------------------------------
+        The previous version curved excursions through
+        ``tanh``, which keeps the peak under 1.0 but is a NONLINEARITY: it
+        compresses the loud parts of the waveform against the quiet parts and
+        manufactures harmonics that were never spoken. Speech recognition
+        reads formant structure, so distorting the relationship between
+        harmonics is precisely the wrong tool — it was chosen to avoid hard
+        clipping, and it does, but it trades one waveform corruption for a
+        subtler one.
 
-            |x| <= T          ->  x                        (bit-identical)
-            |x| >  T          ->  sign(x)*(T + (1-T)*tanh((|x|-T)/(1-T)))
+        Multiplying the whole frame by a single scalar has no such cost. The
+        waveform is IDENTICAL in shape; only its amplitude moves. Every
+        harmonic ratio, every formant, every zero crossing survives exactly.
+        That is the operation a recogniser wants and the tanh curve is not.
 
-        The curve is continuous in VALUE at the knee (tanh(0) = 0) and in
-        SLOPE (tanh'(0) = 1), which is what makes the knee "soft" — a hard
-        knee would put a corner in the waveform and manufacture the very
-        high-frequency artifacts the compressor exists to avoid. It is
-        asymptotic to 1.0, so saturation becomes mathematically unreachable
-        rather than merely unlikely.
+        Attack and release
+        ------------------
+        Attack is immediate: the gain needed to bring THIS frame under the
+        target is applied to THIS frame, so nothing is ever handed downstream
+        above the ceiling. There is no lookahead and none is needed — the
+        frame is already in hand when its peak is known.
 
-        Sample-wise and stateless: zero latency, no lookahead, no pumping.
+        Release is slow (seconds). Restoring gain quickly would raise the
+        noise floor in every pause between words, which is audible as pumping
+        and gives the endpointer a moving floor to chase. Asymmetry is the
+        whole design: react instantly to loudness, forget it gradually.
+
+        Ramped across the frame
+        -----------------------
+        Applying a step change in gain at a frame boundary puts a
+        discontinuity in the waveform — a click, and a broadband one, which is
+        exactly the artefact this exists to avoid. The gain is therefore
+        interpolated linearly from the previous frame's value to this one's
+        across the frame, so the signal stays continuous.
+
+        Below the ceiling the frame is returned UNTOUCHED and bit-identical.
         NEVER raises."""
         try:
-            # DRY: the canonical RMS is audio_scope's, the same one the
-            # telemetry bridge and the oscilloscope use. "Hot" is decided on
-            # energy; the curve is applied per sample.
-            from backend.core.ouroboros.ui.audio_scope import rms as _rms
+            if frame is None or not frame.size:
+                return frame
+            out = np.asarray(frame, dtype=np.float32)
 
-            peak = float(np.max(np.abs(frame))) if frame.size else 0.0
-            if peak <= _AGC_THRESHOLD:
-                return frame                    # the common case, untouched
+            # Non-finite samples would poison the gain state for every frame
+            # that follows, so they are neutralised rather than propagated.
+            sanitized = False
+            if not np.all(np.isfinite(out)):
+                out = np.nan_to_num(out, nan=0.0, posinf=0.0, neginf=0.0)
+                sanitized = True
 
-            if peak > 1.0 and self._range_reports < 3:
-                self._range_reports += 1
-                logger.warning(
-                    "[AudioBus] input peak %.2f exceeds full scale "
-                    "(rms=%.4f) — compressing rather than clipping; the "
-                    "capture device is applying gain",
-                    peak, _rms(frame[:512]),
-                )
-            self._range_peak = max(self._range_peak, peak)
+            peak = float(np.max(np.abs(out)))
+            prev = getattr(self, "_agc_gain", 1.0)
+            if not np.isfinite(prev) or prev <= 0.0:
+                prev = 1.0
 
-            t = _AGC_THRESHOLD
-            span = 1.0 - t
-            mag = np.abs(frame)
-            over = mag > t
-            out = frame.astype(np.float32, copy=True)
-            out[over] = (
-                np.sign(frame[over])
-                * (t + span * np.tanh((mag[over] - t) / span))
-            ).astype(np.float32)
-            return out
+            if peak * prev > _AGC_CEILING and peak > 0.0:
+                # ATTACK — immediate, sized to this frame.
+                #
+                # The floor bounds the REMEMBERED gain, not the correction
+                # applied here. Flooring the correction let an absurd frame
+                # (1e30, a device glitch) leave at 2e28 — the ceiling
+                # defeated by the very guard meant to protect recovery. The
+                # frame is always scaled by exactly what it needs; the floor
+                # only stops one freak transient from parking the session at
+                # a gain it cannot climb back from inside the release
+                # constant.
+                frame_gain = _AGC_TARGET / peak
+                target_gain = max(_AGC_MIN_GAIN, frame_gain)
+                if peak > 1.0 and getattr(self, "_range_reports", 0) < 3:
+                    self._range_reports = getattr(self, "_range_reports", 0) + 1
+                    logger.warning(
+                        "[AudioBus] input peak %.2f exceeds full scale — "
+                        "scaling by %.3f (proportional, waveform preserved); "
+                        "the capture device is applying gain",
+                        peak, target_gain,
+                    )
+            elif prev < 1.0:
+                # RELEASE — exponential climb back toward unity, per-frame
+                # coefficient derived from the frame's own duration so the
+                # time constant is in SECONDS and independent of frame size
+                # and sample rate.
+                frame_gain = target_gain = 1.0    # release path: no attack
+                rate = float(getattr(self._config, "internal_rate", 16000) or 16000)
+                dt = out.size / max(rate, 1.0)
+                coeff = float(np.exp(-dt / _AGC_RELEASE_S))
+                target_gain = min(1.0, prev * coeff + 1.0 * (1.0 - coeff))
+            else:
+                self._agc_gain = 1.0
+                self._range_peak = max(getattr(self, "_range_peak", 0.0), peak)
+                # Return the SANITISED array when sanitising happened. The
+                # passthrough branch previously returned the caller's frame,
+                # which handed NaN/inf straight back out — the one path where
+                # "untouched" was the wrong promise.
+                return out if sanitized else frame
+
+            self._agc_gain = target_gain
+            self._range_peak = max(getattr(self, "_range_peak", 0.0), peak)
+
+            # ASYMMETRY, applied here rather than merely described above.
+            #
+            # ATTACK is a STEP, not a ramp. Ramping into an attack defeats it:
+            # the frame would start at the OLD gain, so its loudest samples —
+            # which are why the attack fired — leave the stage still above the
+            # ceiling. Caught by the smoke test: a 4.19 frame emerged at 4.14
+            # and hard-clipped downstream, i.e. the governor did nothing at
+            # exactly the moment it existed for. A step down at the onset of a
+            # loud passage is inaudible against the loud passage itself;
+            # clipping is not.
+            #
+            # RELEASE is ramped, because that is where smoothness is worth
+            # something and there is no ceiling to breach — gain is rising
+            # into headroom the signal is not using.
+            if target_gain < prev:
+                applied = min(target_gain, frame_gain)
+                return (out * np.float32(applied)).astype(np.float32)
+            ramp = np.linspace(
+                prev, target_gain, out.size, dtype=np.float32, endpoint=True,
+            )
+            return (out * ramp).astype(np.float32)
         except Exception:  # noqa: BLE001 — audio thread: never propagate
             return frame
+
+    def agc_state(self) -> dict:
+        """Observability seam — what the governor is currently doing."""
+        return {
+            "gain": round(float(getattr(self, "_agc_gain", 1.0)), 5),
+            "ceiling": _AGC_CEILING,
+            "target": _AGC_TARGET,
+            "release_s": _AGC_RELEASE_S,
+            "peak_seen": round(float(getattr(self, "_range_peak", 0.0)), 4),
+        }
 
     def _on_mic_frame(self, raw_frame: np.ndarray) -> None:
         """

--- a/backend/audio/audio_bus.py
+++ b/backend/audio/audio_bus.py
@@ -851,6 +851,20 @@ class AudioBus:
             else:
                 cleaned = internal_frame
 
+            # FORENSIC TAP (raw end of the chain). Recorded before any
+            # processing so an incident can distinguish "the microphone did
+            # not hear a voice" from "we destroyed the voice it heard" —
+            # two faults with opposite fixes, indistinguishable from the
+            # post-processing audio that diagnosis has had to rely on.
+            try:
+                from backend.audio.capture_forensics import get_forensics
+                get_forensics().note_raw(
+                    raw_frame,
+                    getattr(self._device, "sample_rate", self._config.sample_rate),
+                )
+            except (ImportError, AttributeError):
+                pass
+
             # 4. HONOUR THE RANGE CONTRACT before dispatching.
             #
             # Measured live: frames arriving at peak 1.04, 2.36, 3.26, 3.99 —
@@ -870,6 +884,14 @@ class AudioBus:
             # peak preserves relative level across an utterance and recovers
             # when the source gets quieter.
             cleaned = self._fit_to_range(cleaned)
+
+            # FORENSIC TAP (model end of the chain) — byte-for-byte what the
+            # recogniser is about to be handed.
+            try:
+                from backend.audio.capture_forensics import get_forensics
+                get_forensics().note_processed(cleaned, self._config.internal_rate)
+            except (ImportError, AttributeError):
+                pass
 
             # 5. Dispatch to all consumers
             with self._consumer_lock:

--- a/backend/audio/capture_forensics.py
+++ b/backend/audio/capture_forensics.py
@@ -1,0 +1,384 @@
+"""Evidence at the moment of failure — a flight recorder for the mic path.
+
+Why this exists
+---------------
+The microphone path has failed the same way three times across this session:
+whisper returns an EMPTY transcript from audio with speech-level amplitude.
+Every offline test exonerates the code — the device, the duplex stream, the
+resampler, the compressor and the echo canceller each pass known-good speech
+through intact — and yet the operator's voice arrives as something whisper
+scores at ``no_speech_prob = 0.81`` and, with its thresholds disabled, renders
+as "I'm sorry, I'm sorry, I'm sorry": the hallucination it produces from
+non-speech.
+
+That is the whole difficulty. The fault is not in any stage in isolation; it
+appears only in the live composition, and the live composition currently keeps
+no record of itself. Diagnosis has therefore been a sequence of plausible
+theories tested against audio captured AFTER processing, which cannot
+distinguish "the microphone heard nothing useful" from "we destroyed what it
+heard". Those two have opposite fixes.
+
+So this records BOTH ends of the chain and the metrics in between, and writes
+them only when the chain demonstrably failed.
+
+What it is not
+--------------
+Not a workaround, and not a permanent tap. It is bounded, disarmed by default
+in cost (the ring only ever holds a few seconds), self-cleaning, and it
+answers ONE question with evidence rather than inference:
+
+    Is the signal already unintelligible when it leaves the device,
+    or does it become unintelligible on the way to the model?
+
+Design
+------
+* Two rings — RAW (device rate, pre-everything) and PROCESSED (internal rate,
+  post AEC/AGC, exactly what the model was handed). Fixed sample budget, so
+  memory is constant regardless of how long the process runs.
+* Written only on a REJECTION, and rate-limited, because a recorder that fires
+  on every utterance is a disk leak wearing a diagnostic's clothes.
+* Each incident is a directory holding ``raw.wav``, ``processed.wav`` and
+  ``metrics.json`` — the two signals plus what each stage thought it saw, so
+  the comparison is arithmetic rather than opinion.
+* Every entry point is exception-proof and never blocks the audio thread: a
+  flight recorder that can crash the flight is not one.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import time
+from collections import deque
+from pathlib import Path
+from typing import Any, Deque, Dict, Optional
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+
+def forensics_enabled() -> bool:
+    """Default ON while the capture fault is open. The cost is a few seconds
+    of ring buffer; the alternative is another session of theories tested
+    against evidence that cannot settle them."""
+    return os.getenv(
+        "JARVIS_CAPTURE_FORENSICS", "1",
+    ).strip().lower() in _TRUTHY
+
+
+def _env_float(name: str, default: float, minimum: float = 0.0) -> float:
+    try:
+        return max(minimum, float(os.getenv(name, "").strip() or default))
+    except (TypeError, ValueError):
+        return default
+
+
+def _env_int(name: str, default: int, minimum: int = 1) -> int:
+    try:
+        return max(minimum, int(os.getenv(name, "").strip() or default))
+    except (TypeError, ValueError):
+        return default
+
+
+def window_s() -> float:
+    """How much history to hold. Long enough for a whole utterance plus the
+    silence that ended it — an incident cut off at its onset proves nothing."""
+    return _env_float("JARVIS_CAPTURE_FORENSICS_WINDOW_S", 12.0, 1.0)
+
+
+def max_incidents() -> int:
+    """Ceiling on stored incidents. Oldest is evicted; the fault reproduces
+    every attempt, so the newest evidence is always the relevant evidence."""
+    return _env_int("JARVIS_CAPTURE_FORENSICS_MAX", 8)
+
+
+def cooldown_s() -> float:
+    """Minimum spacing between incidents. One utterance produces a partial
+    transcription every few hundred milliseconds, and each failed partial is a
+    rejection — without this, one failed sentence writes twenty incidents."""
+    return _env_float("JARVIS_CAPTURE_FORENSICS_COOLDOWN_S", 6.0, 0.0)
+
+
+def incident_root() -> Path:
+    raw = os.getenv("JARVIS_CAPTURE_FORENSICS_DIR", "").strip()
+    if raw:
+        return Path(raw).expanduser()
+    return Path.cwd() / ".jarvis" / "capture_forensics"
+
+
+class _Ring:
+    """Fixed-sample-budget ring of frames. Never allocates while recording."""
+
+    def __init__(self, sample_rate: int, seconds: float) -> None:
+        self.sample_rate = int(sample_rate)
+        self.budget = max(1, int(self.sample_rate * seconds))
+        self._frames: Deque[np.ndarray] = deque()
+        self._held = 0
+        self._lock = threading.Lock()
+        #: Running observations — cheaper than re-deriving them from the ring,
+        #: and they survive even if the ring is later trimmed.
+        self.frames_seen = 0
+        self.peak_max = 0.0
+        self.over_full_scale = 0
+
+    def push(self, frame: np.ndarray) -> None:
+        if frame is None or not len(frame):
+            return
+        f = np.asarray(frame, dtype=np.float32).reshape(-1)
+        peak = float(np.max(np.abs(f))) if f.size else 0.0
+        with self._lock:
+            self.frames_seen += 1
+            if peak > self.peak_max:
+                self.peak_max = peak
+            if peak > 1.0:
+                self.over_full_scale += 1
+            self._frames.append(f.copy())
+            self._held += len(f)
+            while self._held > self.budget and self._frames:
+                self._held -= len(self._frames.popleft())
+
+    def snapshot(self) -> np.ndarray:
+        with self._lock:
+            if not self._frames:
+                return np.zeros(0, dtype=np.float32)
+            return np.concatenate(list(self._frames))
+
+    def stats(self) -> Dict[str, Any]:
+        a = self.snapshot()
+        if not a.size:
+            return {"samples": 0, "sample_rate": self.sample_rate,
+                    "frames_seen": self.frames_seen}
+        peak = float(np.max(np.abs(a)))
+        rms = float(np.sqrt(np.mean(a.astype(np.float64) ** 2)))
+        crest_db = 20.0 * float(np.log10(peak / rms)) if rms > 1e-9 else 0.0
+        # Syllabic rhythm: speech modulates its envelope at roughly 2-8 Hz.
+        # Noise and steady tones do not. This is the cheapest single number
+        # that distinguishes "a voice was present" from "energy was present",
+        # which is exactly the distinction the rejection cannot make.
+        env_rate = 100
+        hop = max(1, self.sample_rate // env_rate)
+        env = np.sqrt(np.convolve(a.astype(np.float64) ** 2,
+                                  np.ones(hop) / hop, mode="same")[::hop])
+        mod = 0.0
+        if env.size > 16:
+            env = env - env.mean()
+            spec = np.abs(np.fft.rfft(env * np.hanning(env.size)))
+            freqs = np.fft.rfftfreq(env.size, 1.0 / env_rate)
+            band = spec[(freqs >= 2.0) & (freqs <= 8.0)].sum()
+            total = spec[freqs >= 0.5].sum()
+            mod = float(band / total) if total > 1e-12 else 0.0
+        return {
+            "samples": int(a.size),
+            "sample_rate": self.sample_rate,
+            "duration_s": round(a.size / self.sample_rate, 3),
+            "peak": round(peak, 4),
+            "rms": round(rms, 5),
+            "crest_db": round(crest_db, 1),
+            "clipped_samples": int(np.sum(np.abs(a) >= 0.999)),
+            "over_full_scale_frames": self.over_full_scale,
+            "peak_ever": round(self.peak_max, 4),
+            "frames_seen": self.frames_seen,
+            "syllabic_modulation_2_8hz": round(mod, 3),
+        }
+
+
+class CaptureForensics:
+    """Holds the two rings and writes incidents. One per process."""
+
+    def __init__(self) -> None:
+        self._raw: Optional[_Ring] = None
+        self._processed: Optional[_Ring] = None
+        self._last_incident = 0.0
+        self._lock = threading.Lock()
+        self.incidents_written = 0
+
+    # -- taps (audio thread — must never raise, never block) -------------
+
+    def note_raw(self, frame: np.ndarray, sample_rate: int) -> None:
+        try:
+            if not forensics_enabled():
+                return
+            if self._raw is None or self._raw.sample_rate != int(sample_rate):
+                self._raw = _Ring(sample_rate, window_s())
+            self._raw.push(frame)
+        except (ValueError, TypeError, MemoryError):
+            pass
+
+    def note_processed(self, frame: np.ndarray, sample_rate: int) -> None:
+        try:
+            if not forensics_enabled():
+                return
+            if self._processed is None or self._processed.sample_rate != int(sample_rate):
+                self._processed = _Ring(sample_rate, window_s())
+            self._processed.push(frame)
+        except (ValueError, TypeError, MemoryError):
+            pass
+
+    # -- incident --------------------------------------------------------
+
+    def record_rejection(
+        self,
+        reason: str,
+        *,
+        model_audio: Optional[np.ndarray] = None,
+        model_sample_rate: int = 16000,
+        detail: Optional[Dict[str, Any]] = None,
+    ) -> Optional[Path]:
+        """Write one incident. Returns its directory, or None. NEVER raises.
+
+        *model_audio* is the exact buffer handed to the recogniser — the third
+        signal, and the only one that proves whether the buffer assembled for
+        the model resembles what the device delivered."""
+        try:
+            if not forensics_enabled():
+                return None
+            now = time.monotonic()
+            with self._lock:
+                if now - self._last_incident < cooldown_s():
+                    return None
+                self._last_incident = now
+
+            root = incident_root()
+            root.mkdir(parents=True, exist_ok=True)
+            self._evict(root)
+            stamp = time.strftime("%Y%m%d-%H%M%S")
+            out = root / f"incident-{stamp}-{int(now * 1000) % 100000}"
+            out.mkdir(parents=True, exist_ok=True)
+
+            metrics: Dict[str, Any] = {
+                "schema_version": "1.0",
+                "reason": reason,
+                "wall_time": time.strftime("%Y-%m-%dT%H:%M:%S"),
+                "detail": dict(detail or {}),
+            }
+            for name, ring in (("raw_device", self._raw),
+                               ("processed_bus", self._processed)):
+                if ring is None:
+                    metrics[name] = {"samples": 0, "note": "no frames tapped"}
+                    continue
+                metrics[name] = ring.stats()
+                self._write_wav(out / f"{name}.wav", ring.snapshot(), ring.sample_rate)
+
+            if model_audio is not None and len(model_audio):
+                a = np.asarray(model_audio, dtype=np.float32).reshape(-1)
+                self._write_wav(out / "model_input.wav", a, model_sample_rate)
+                rms = float(np.sqrt(np.mean(a.astype(np.float64) ** 2)))
+                metrics["model_input"] = {
+                    "samples": int(a.size), "sample_rate": int(model_sample_rate),
+                    "duration_s": round(a.size / max(model_sample_rate, 1), 3),
+                    "peak": round(float(np.max(np.abs(a))), 4),
+                    "rms": round(rms, 5),
+                }
+
+            metrics["verdict_hint"] = self._verdict(metrics)
+            (out / "metrics.json").write_text(
+                json.dumps(metrics, indent=2), encoding="utf-8",
+            )
+            self.incidents_written += 1
+            logger.warning(
+                "[CaptureForensics] incident written: %s (%s)",
+                out, metrics["verdict_hint"],
+            )
+            return out
+        except (OSError, ValueError, TypeError, MemoryError) as exc:
+            logger.debug("[CaptureForensics] incident degraded: %r", exc)
+            return None
+
+    @staticmethod
+    def _verdict(metrics: Dict[str, Any]) -> str:
+        """A first reading of the evidence, stated as a hypothesis.
+
+        Deliberately a HINT. It compares the syllabic modulation of the two
+        ends of the chain, which is the one measurement that separates the two
+        opposite fixes: if the raw device signal already lacks the 2-8 Hz
+        rhythm of speech, no amount of processing repair will help; if the raw
+        end has it and the processed end does not, the chain is destroying
+        it."""
+        raw = metrics.get("raw_device") or {}
+        proc = metrics.get("processed_bus") or {}
+        r_mod = raw.get("syllabic_modulation_2_8hz")
+        p_mod = proc.get("syllabic_modulation_2_8hz")
+        if not raw.get("samples"):
+            return "no raw frames tapped — cannot attribute"
+        if r_mod is None or p_mod is None:
+            return "incomplete measurements"
+        if raw.get("over_full_scale_frames", 0) > 0:
+            return (f"device delivered {raw['over_full_scale_frames']} frames "
+                    f"above full scale (peak {raw.get('peak_ever')}) — input "
+                    f"gain, not the chain")
+        if r_mod < 0.15:
+            return (f"raw device audio already lacks speech rhythm "
+                    f"(modulation {r_mod}) — the microphone did not hear a "
+                    f"voice; the chain is not at fault")
+        if p_mod < r_mod * 0.6:
+            return (f"speech rhythm present at the device ({r_mod}) and lost "
+                    f"by the bus ({p_mod}) — the chain is destroying it")
+        return (f"speech rhythm survives the chain (raw {r_mod} -> "
+                f"processed {p_mod}) — look downstream of the bus")
+
+    @staticmethod
+    def _write_wav(path: Path, audio: np.ndarray, sample_rate: int) -> None:
+        if audio is None or not len(audio):
+            return
+        try:
+            import soundfile as sf
+            sf.write(str(path), np.asarray(audio, dtype=np.float32), int(sample_rate))
+            return
+        except (ImportError, OSError, ValueError):
+            pass
+        try:                                    # stdlib fallback — no new dep
+            import wave
+            pcm = np.clip(np.asarray(audio, dtype=np.float32), -1.0, 1.0)
+            with wave.open(str(path), "wb") as w:
+                w.setnchannels(1)
+                w.setsampwidth(2)
+                w.setframerate(int(sample_rate))
+                w.writeframes((pcm * 32767.0).astype("<i2").tobytes())
+        except (OSError, ValueError):
+            pass
+
+    @staticmethod
+    def _evict(root: Path) -> None:
+        try:
+            kept = sorted(
+                (p for p in root.iterdir() if p.is_dir()),
+                key=lambda p: p.stat().st_mtime,
+            )
+            for old in kept[: max(0, len(kept) - max_incidents() + 1)]:
+                for child in old.iterdir():
+                    child.unlink(missing_ok=True)
+                old.rmdir()
+        except (OSError, ValueError):
+            pass
+
+
+_FORENSICS: Optional[CaptureForensics] = None
+_FORENSICS_LOCK = threading.Lock()
+
+
+def get_forensics() -> CaptureForensics:
+    global _FORENSICS
+    with _FORENSICS_LOCK:
+        if _FORENSICS is None:
+            _FORENSICS = CaptureForensics()
+        return _FORENSICS
+
+
+def reset_forensics() -> None:
+    """Test seam."""
+    global _FORENSICS
+    with _FORENSICS_LOCK:
+        _FORENSICS = None
+
+
+__all__ = [
+    "CaptureForensics",
+    "forensics_enabled",
+    "get_forensics",
+    "incident_root",
+    "reset_forensics",
+]

--- a/backend/audio/conversation_pipeline.py
+++ b/backend/audio/conversation_pipeline.py
@@ -476,6 +476,7 @@ class ConversationPipeline:
                 logger.info("[ConvPipeline] Session expired")
                 break
 
+            delegated = None
             try:
                 # 1. Wait for user to finish speaking (get transcript)
                 user_text = await self._listen_for_turn()
@@ -496,14 +497,10 @@ class ConversationPipeline:
                     )
                     continue
 
-                # 2b. Whoever was ADDRESSED answers.
-                #
-                # The active agent follows what the operator said, not what
-                # the process was launched with: "Hey JARVIS" in Karen's
-                # cockpit should get JARVIS's voice and JARVIS's prompt. A
-                # turn naming nobody leaves the current agent in place — it
-                # is a continuation, not a request to switch.
-                self._route_persona(user_text)
+                # 2b. Whoever was ADDRESSED answers — and if they were asked
+                # to delegate, the second agent is arbitrated into a SECONDARY
+                # role rather than racing the first.
+                summons = self._arbitrate_turn(user_text)
 
                 # 3. Add user turn to session
                 self._session.add_turn("user", user_text)
@@ -511,6 +508,12 @@ class ConversationPipeline:
                     f"[ConvPipeline] User: {user_text[:80]}"
                     f"{'...' if len(user_text) > 80 else ''}"
                 )
+
+                # 3b. A dual summon starts the delegated turn NOW, on a lane
+                # the primary is not using, so the secondary's work overlaps
+                # the primary's reply instead of following it. Nothing is
+                # awaited here: the primary speaks first, always.
+                delegated = self._begin_delegation(summons)
 
                 # 4. Classify turn intent and route deterministically
                 intent_decision = await self._classify_turn_intent(user_text)
@@ -571,9 +574,24 @@ class ConversationPipeline:
                     intent_decision=intent_decision,
                 )
 
+                # 6. The delegated agent reports — never before the primary
+                # has finished, and never over the top of it: the turnstile
+                # holds the SECONDARY ticket until the speakers are idle and
+                # the acoustic tail has cleared.
+                await self._finish_delegation(summons, delegated)
+
             except asyncio.CancelledError:
+                if delegated is not None and not delegated.done():
+                    delegated.cancel()
                 raise
             except Exception as e:
+                # A delegated turn outlives the turn that started it unless it
+                # is cancelled here: the primary failing does not stop work
+                # already running on another lane, and an orphan would report
+                # into a conversation that has moved on — or, at shutdown,
+                # keep the loop alive waiting for it.
+                if delegated is not None and not delegated.done():
+                    delegated.cancel()
                 logger.error(f"[ConvPipeline] Turn error: {e}")
                 await asyncio.sleep(0.5)
 
@@ -1382,34 +1400,158 @@ class ConversationPipeline:
                     pass
         return " ".join(spoken)
 
-    def _route_persona(self, user_text: str) -> bool:
-        """Bind the process persona to the agent named in *user_text*.
+    def _arbitrate_turn(self, user_text: str) -> Optional[Any]:
+        """Assign roles for this turn and bind the process to the PRIMARY.
 
-        Returns True when the active agent CHANGED. Writes the same env seam
-        ``active_persona`` reads, because that is what every synthesis site in
-        the process already consults — threading a persona argument through
-        each of them is how voice and identity drifted apart in the first
-        place. NEVER raises."""
+        The primary claims the audio plane by becoming the active persona
+        before anything synthesizes — every voice site in the process reads
+        that seam, so the claim is a single write rather than an argument
+        threaded through each one. NEVER raises."""
         try:
-            from backend.voice.agent_persona import active_persona
-            from backend.voice.agent_registry import route_by_wake_word
+            from backend.voice.agent_registry import arbitrate
 
-            spec = route_by_wake_word(user_text)
-            if spec is None:
-                return False
-            current = active_persona()
-            if current is not None and current.canonical is spec.persona:
-                return False
+            summons = arbitrate(user_text)
+            if summons is None:
+                return None
+            self._bind_persona(summons.primary)
+            if summons.is_dual:
+                logger.info(
+                    "[ConvPipeline] dual summon — primary=%s secondary=%s task=%r (%s)",
+                    summons.primary.display_name,
+                    summons.secondary.display_name,
+                    summons.delegated_task, summons.reason,
+                )
+            return summons
+        except (ImportError, AttributeError):
+            return None
+
+    def _begin_delegation(self, summons: Optional[Any]) -> Optional[Any]:
+        """Start the secondary's turn on a lane the primary is not using.
+
+        Returns the task, or None when this turn has no delegation. Nothing
+        is awaited: the point is that the secondary's generation overlaps the
+        primary's reply rather than queueing behind it. NEVER raises."""
+        if summons is None or not getattr(summons, "is_dual", False):
+            return None
+        if not summons.delegated_task.strip():
+            # Named but handed nothing to do. Spending a lane on an empty
+            # task would answer a sentence the operator never finished.
+            return None
+        try:
+            from backend.core.ouroboros.governance.remote_compute_dispatcher import (
+                Workload, get_dispatcher,
+            )
+
+            spec = summons.secondary
+            workload = Workload(agent=spec.persona.value, task=summons.delegated_task)
+
+            async def _fallback() -> str:
+                return await self._generate_text_as(spec, summons.delegated_task)
+
+            return get_dispatcher().spawn(workload, _fallback)
+        except (ImportError, AttributeError, RuntimeError):
+            return None
+
+    async def _finish_delegation(
+        self, summons: Optional[Any], task: Optional[Any],
+    ) -> None:
+        """Speak the secondary's answer, in the secondary's voice, after the
+        primary. NEVER raises — a delegated turn that failed must not unwind
+        the conversation loop."""
+        if summons is None or task is None:
+            return
+        from backend.audio.speech_scheduler import SpeechRole
+
+        spec = summons.secondary
+        previous = None
+        try:
+            result = await task
+            reply = str(getattr(result, "value", "") or "").strip()
+            if not reply:
+                logger.info(
+                    "[ConvPipeline] %s had nothing to report (%s)",
+                    spec.display_name, getattr(result, "error", "") or "empty",
+                )
+                return
+            logger.info(
+                "[ConvPipeline] %s reports via %s: %s",
+                spec.display_name, getattr(result, "tier", "?"), reply[:80],
+            )
+            previous = os.environ.get("JARVIS_AGENT_PERSONA", "")
+            self._bind_persona(spec)
+            self._speech_role = SpeechRole.SECONDARY
+            if self._session is not None:
+                self._session.add_turn("assistant", reply)
+            await self._speak_sentence(reply, asyncio.Event())
+        except asyncio.CancelledError:
+            raise
+        except (AttributeError, TypeError, ValueError, OSError, RuntimeError) as exc:
+            logger.warning("[ConvPipeline] delegated turn failed: %r", exc)
+        finally:
+            self._speech_role = SpeechRole.PRIMARY
+            if previous:
+                os.environ["JARVIS_AGENT_PERSONA"] = previous
+                prompt = _persona_system_prompt()
+                if prompt:
+                    self._system_prompt = prompt
+
+    async def _generate_text_as(self, spec: Any, task: str) -> str:
+        """Generate one reply AS *spec*, without speaking it.
+
+        The caller-side fallback the dispatcher uses when no remote tier is
+        wired — deliberately the same generation path the primary uses, so
+        the delegated answer is never lower quality than an undelegated one."""
+        if self._llm_client is None:
+            return ""
+        try:
+            from backend.voice.agent_registry import prompt_for
+            system = prompt_for(spec.persona) or self._system_prompt
+        except (ImportError, AttributeError):
+            system = self._system_prompt
+        messages = [
+            {"role": "system", "content": system},
+            {"role": "user", "content": task},
+        ]
+        chunks = []
+        async for chunk in self._get_llm_stream(messages, user_text=task):
+            chunks.append(chunk)
+        return "".join(chunks).strip()
+
+    def _bind_persona(self, spec: Any) -> None:
+        """Make *spec* the active agent for this process — voice and prompt
+        together, because they are one identity."""
+        try:
             os.environ["JARVIS_AGENT_PERSONA"] = spec.persona.value
-            # The prompt is part of the identity, so it moves with it —
-            # otherwise the model keeps the previous agent's self-description
-            # while speaking in the new agent's voice.
             prompt = _persona_system_prompt()
             if prompt:
                 self._system_prompt = prompt
+        except (AttributeError, OSError, TypeError):
+            pass
+
+    def _route_persona(self, user_text: str) -> bool:
+        """Bind the process persona to the agent named in *user_text*.
+
+        Returns True when the active agent CHANGED. Thin by design: role
+        assignment lives in the registry's ``arbitrate`` and binding lives in
+        ``_bind_persona``, so this is the boolean answer to "did the operator
+        hand the turn to someone else" and nothing more. Duplicating either
+        here is how the voice and the prompt drifted apart the first time.
+
+        NEVER raises."""
+        try:
+            from backend.voice.agent_persona import active_persona
+            from backend.voice.agent_registry import arbitrate
+
+            summons = arbitrate(user_text)
+            if summons is None:
+                return False               # nobody named — a continuation
+            current = active_persona()
+            if current is not None and current.canonical is summons.primary.persona:
+                return False
+            self._bind_persona(summons.primary)
             logger.info(
                 "[ConvPipeline] agent -> %s (voice %s)",
-                spec.display_name, spec.preferred_voice,
+                summons.primary.display_name, summons.primary.preferred_voice,
             )
             return True
         except (ImportError, AttributeError, OSError):
@@ -1459,11 +1601,41 @@ class ConversationPipeline:
     async def _speak_sentence(
         self, sentence: str, cancel_event: asyncio.Event
     ) -> None:
-        """Speak a single sentence through TTS, routing through AudioBus for AEC."""
+        """Speak a single sentence through TTS, routing through AudioBus for AEC.
+
+        Serialised at the speakers. Two agents in one turn ("ask Karen to…")
+        each synthesize independently and each hand a file to afplay, which is
+        a separate OS process with no idea another is playing — so without a
+        turnstile the operator hears both at once. The role comes from
+        arbitration, not from which synthesis happened to finish first."""
         if cancel_event.is_set():
             return
 
         if self._tts_engine is None:
+            return
+
+        from backend.audio.speech_scheduler import SpeechRole, get_scheduler
+
+        role = getattr(self, "_speech_role", SpeechRole.PRIMARY)
+        agent = ""
+        try:
+            from backend.voice.agent_persona import active_persona
+            persona = active_persona()
+            agent = getattr(persona, "value", "") if persona else ""
+        except (ImportError, AttributeError):
+            agent = ""
+
+        await get_scheduler().speak(
+            lambda: self._render_sentence(sentence, cancel_event),
+            agent=agent, role=role, text=sentence,
+        )
+
+    async def _render_sentence(
+        self, sentence: str, cancel_event: asyncio.Event
+    ) -> None:
+        """Actually put the sentence through TTS. Called ONLY by the scheduler,
+        which guarantees the speakers are ours for the duration."""
+        if cancel_event.is_set() or self._tts_engine is None:
             return
 
         # JIT PLAYBACK GATING — closed only while sound is LEAVING the

--- a/backend/audio/conversation_pipeline.py
+++ b/backend/audio/conversation_pipeline.py
@@ -38,6 +38,7 @@ import numpy as np
 
 from backend.audio.playback_gate import playback_gate
 from backend.audio.streaming_synthesis import streaming_enabled as _streaming_enabled
+from backend.voice.phatic_fastpath import fastpath_enabled as _phatic_intercept_enabled
 
 logger = logging.getLogger(__name__)
 
@@ -495,6 +496,15 @@ class ConversationPipeline:
                     )
                     continue
 
+                # 2b. Whoever was ADDRESSED answers.
+                #
+                # The active agent follows what the operator said, not what
+                # the process was launched with: "Hey JARVIS" in Karen's
+                # cockpit should get JARVIS's voice and JARVIS's prompt. A
+                # turn naming nobody leaves the current agent in place — it
+                # is a continuation, not a request to switch.
+                self._route_persona(user_text)
+
                 # 3. Add user turn to session
                 self._session.add_turn("user", user_text)
                 logger.info(
@@ -643,6 +653,28 @@ class ConversationPipeline:
         """Generate LLM response and stream it through TTS."""
         if self._session is None:
             return
+
+        # ── PHATIC FAST PATH — zero network, zero tokens ──────────────
+        #
+        # "Hey Karen" carries no question. Sending it to a 30B model costs
+        # tokens, ~0.9s of TTFT and the operator's patience for an utterance
+        # whose entire content is "I am addressing you". Intercepted BEFORE
+        # the router so no request is built at all.
+        #
+        # The turn is still written to session history: a bypassed greeting
+        # that vanished would leave the next complex turn reasoning about a
+        # conversation whose opening it never saw.
+        if _phatic_intercept_enabled() and user_text:
+            ack = self._phatic_reply(user_text)
+            if ack is not None:
+                self._session.add_turn("assistant", ack)
+                logger.info("[ConvPipeline] JARVIS (phatic, no LLM): %s", ack)
+                cancel_event = (
+                    self._barge_in.get_cancel_event()
+                    if self._barge_in is not None else asyncio.Event()
+                )
+                await self._speak_sentence(ack, cancel_event)
+                return
 
         # Build messages for LLM
         messages = [
@@ -1349,6 +1381,64 @@ class ConversationPipeline:
                 except (RuntimeError, OSError):
                     pass
         return " ".join(spoken)
+
+    def _route_persona(self, user_text: str) -> bool:
+        """Bind the process persona to the agent named in *user_text*.
+
+        Returns True when the active agent CHANGED. Writes the same env seam
+        ``active_persona`` reads, because that is what every synthesis site in
+        the process already consults — threading a persona argument through
+        each of them is how voice and identity drifted apart in the first
+        place. NEVER raises."""
+        try:
+            from backend.voice.agent_persona import active_persona
+            from backend.voice.agent_registry import route_by_wake_word
+
+            spec = route_by_wake_word(user_text)
+            if spec is None:
+                return False
+            current = active_persona()
+            if current is not None and current.canonical is spec.persona:
+                return False
+            os.environ["JARVIS_AGENT_PERSONA"] = spec.persona.value
+            # The prompt is part of the identity, so it moves with it —
+            # otherwise the model keeps the previous agent's self-description
+            # while speaking in the new agent's voice.
+            prompt = _persona_system_prompt()
+            if prompt:
+                self._system_prompt = prompt
+            logger.info(
+                "[ConvPipeline] agent -> %s (voice %s)",
+                spec.display_name, spec.preferred_voice,
+            )
+            return True
+        except (ImportError, AttributeError, OSError):
+            return False
+
+    def _phatic_reply(self, user_text: str) -> Optional[str]:
+        """An acknowledgement if this turn is pure contact, else None.
+
+        None means "this is a real turn" — the caller proceeds to the model
+        unchanged, so the fast path can only ever REMOVE an unnecessary call,
+        never intercept a question. NEVER raises."""
+        try:
+            from backend.voice.agent_registry import all_agents, spec_for
+            from backend.voice.agent_persona import active_persona, operator_name
+            from backend.voice.phatic_fastpath import acknowledge, classify
+
+            names = []
+            for spec in all_agents():
+                names.append(spec.display_name)
+                names.extend(spec.wake_words)
+            verdict = classify(user_text, agent_names=names)
+            if not verdict:
+                return None
+
+            active = spec_for(active_persona())
+            salt = active.display_name if active else ""
+            return acknowledge(user_text, operator=operator_name(), salt=salt)
+        except (ImportError, AttributeError):
+            return None
 
     def _persona_say_args(self) -> List[str]:
         """`say` voice/rate flags for the bound persona, or none.

--- a/backend/audio/playback_gate.py
+++ b/backend/audio/playback_gate.py
@@ -93,6 +93,29 @@ def _set_bus_gate(active: bool) -> bool:
     return True
 
 
+def _mark_hardware(busy: bool) -> None:
+    """Publish speaker occupancy to the speech scheduler.
+
+    Deliberately INDEPENDENT of whether the mic gate engaged. Those are two
+    different facts: "we managed to close the microphone" and "sound is
+    leaving the speakers". ``_enter`` returns False when no AudioBus is
+    mounted — but ``afplay`` still plays, and a conductor that believed the
+    speakers were free would grant the next agent straight over the top.
+
+    Strictly paired by the context managers, never by ``_enter``/``_exit``,
+    because the busy counter is process-global: an unmatched decrement taken
+    on a failure path would zero out a DIFFERENT thread's live playback.
+    Import-guarded — the gate predates the scheduler and must work without
+    it."""
+    try:
+        from backend.audio.speech_scheduler import (
+            mark_hardware_busy, mark_hardware_idle,
+        )
+    except ImportError:
+        return
+    (mark_hardware_busy if busy else mark_hardware_idle)()
+
+
 def _enter(text: str = "") -> bool:
     global _DEPTH
     if not gate_enabled():
@@ -199,25 +222,36 @@ async def playback_gate(
     subprocess (afplay) is finished when the call returns, while a ring
     buffer is only finished when it empties. Holding the gate on the call
     alone protects the first and nothing at all for the second."""
+    _mark_hardware(True)
     engaged = _enter(text)
     try:
         yield engaged
     finally:
-        if engaged:
-            if await_drain:
-                await _await_playback_drain()
-            _exit()
+        try:
+            if engaged:
+                if await_drain:
+                    await _await_playback_drain()
+                _exit()
+        finally:
+            # Paired unconditionally with the mark above — a leaked busy count
+            # makes every later utterance wait out the conductor's full idle
+            # timeout before it is allowed to speak.
+            _mark_hardware(False)
 
 
 @contextlib.contextmanager
 def playback_gate_sync(text: str = "") -> Iterator[bool]:
     """Close the mic for the body. The ``afplay`` subprocess site."""
+    _mark_hardware(True)
     engaged = _enter(text)
     try:
         yield engaged
     finally:
-        if engaged:
-            _exit()
+        try:
+            if engaged:
+                _exit()
+        finally:
+            _mark_hardware(False)
 
 
 def gate_depth() -> int:
@@ -232,6 +266,11 @@ def force_open() -> None:
     global _DEPTH
     with _DEPTH_LOCK:
         _DEPTH = 0
+    try:
+        from backend.audio.speech_scheduler import reset_hardware_state
+        reset_hardware_state()
+    except ImportError:
+        pass
     try:
         _set_bus_gate(False)
     except BaseException:  # noqa: BLE001 - emergency release, see below

--- a/backend/audio/speech_scheduler.py
+++ b/backend/audio/speech_scheduler.py
@@ -1,0 +1,467 @@
+"""One pair of speakers, two agents — a turnstile at the hardware boundary.
+
+The collision
+-------------
+"Hey JARVIS, ask Karen to verify the deployment" summons two agents. Both
+resolve a voice, both synthesize, and both hand a file to ``afplay`` — which
+is a separate OS process precisely so it is GIL-free, and therefore has no
+idea another one is already playing. The operator hears two voices at once.
+
+Serialising with a lock is not enough
+-------------------------------------
+A lock grants in arrival order, and arrival order is a race: the SECONDARY's
+work is usually shorter, so it frequently finishes synthesis first and would
+speak before the agent that was actually addressed. Order has to follow the
+ROLE assigned by arbitration, not the accident of which synthesis returned
+first. Hence a priority queue with a single conductor.
+
+The acoustic tail
+-----------------
+``afplay`` exits when the last sample is handed to CoreAudio, not when it has
+left the speakers. Granting the next utterance at that instant clips the first
+word of the second agent onto the last of the first. So the conductor waits
+for the device to go idle AND then for a fixed tail (default 300ms) before the
+next grant. The tail is also what keeps the barge-in detector from hearing the
+first agent's decay as the second agent's onset.
+
+What this wraps
+---------------
+Nothing is re-implemented. The synchronous ``macos_voice`` path already takes
+``playback_gate_sync`` around its ``afplay`` subprocess; that gate now marks
+the hardware BUSY, and the conductor grants only when it is idle. So a
+scheduled utterance yields to an unscheduled one automatically, rather than
+the two fighting — which is the property that makes this safe to introduce
+under a system with several playback sites.
+
+Non-blocking by construction
+----------------------------
+The conductor never blocks the event loop: it polls the busy counter with
+``asyncio.sleep`` (the same discipline ``playback_gate._await_playback_drain``
+already uses) rather than acquiring a threading lock from the loop thread.
+The synchronous side blocks its own worker thread, which is that thread's job.
+
+Bounded everywhere
+------------------
+A wedged synthesis must not leave the assistant permanently mute, so every
+wait has a deadline and every deadline fails OPEN: the conductor logs loudly
+and moves on. A silent assistant is a worse failure than an overlapped word.
+"""
+from __future__ import annotations
+
+import asyncio
+import enum
+import itertools
+import logging
+import os
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Awaitable, Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+
+def scheduler_enabled() -> bool:
+    """Master switch. OFF restores the pre-queue behaviour exactly — every
+    caller speaks immediately, which is the only honest way to compare."""
+    return os.getenv(
+        "JARVIS_TTS_SCHEDULER_ENABLED", "true",
+    ).strip().lower() in _TRUTHY
+
+
+def _env_float(name: str, default: float, minimum: float = 0.0) -> float:
+    try:
+        return max(minimum, float(os.getenv(name, "").strip() or default))
+    except (TypeError, ValueError):
+        return default
+
+
+def acoustic_tail_s() -> float:
+    """Silence held after the device goes idle, before the next grant.
+
+    300ms is a room's decay, not a guess at process teardown: ``afplay``
+    exiting means CoreAudio has the samples, and the speakers are still
+    moving after that."""
+    return _env_float("JARVIS_TTS_ACOUSTIC_TAIL_S", 0.300)
+
+
+def hardware_idle_timeout_s() -> float:
+    """Ceiling on waiting for the speakers to fall silent. Fails OPEN."""
+    return _env_float("JARVIS_TTS_HARDWARE_IDLE_TIMEOUT_S", 30.0, 1.0)
+
+
+def ticket_timeout_s() -> float:
+    """Ceiling on ONE utterance holding the turnstile. Fails OPEN."""
+    return _env_float("JARVIS_TTS_TICKET_TIMEOUT_S", 60.0, 1.0)
+
+
+def queue_maxsize() -> int:
+    try:
+        return max(2, int(os.getenv("JARVIS_TTS_QUEUE_MAXSIZE", "16")))
+    except (TypeError, ValueError):
+        return 16
+
+
+# ---------------------------------------------------------------------------
+# The hardware busy signal — shared with playback_gate
+# ---------------------------------------------------------------------------
+
+_HW_LOCK = threading.Lock()
+_HW_BUSY = 0
+
+
+def mark_hardware_busy() -> None:
+    """Sound is leaving the speakers. Called from the playback gate, which is
+    already the one place every playback path passes through — so this
+    observes the REAL device rather than the scheduler's opinion of it."""
+    global _HW_BUSY
+    with _HW_LOCK:
+        _HW_BUSY += 1
+
+
+def mark_hardware_idle() -> None:
+    global _HW_BUSY
+    with _HW_LOCK:
+        _HW_BUSY = max(0, _HW_BUSY - 1)
+
+
+def hardware_busy() -> bool:
+    with _HW_LOCK:
+        return _HW_BUSY > 0
+
+
+def reset_hardware_state() -> None:
+    """Test seam, and a teardown safety valve: a leaked busy count would make
+    the conductor wait out its full timeout on every utterance."""
+    global _HW_BUSY
+    with _HW_LOCK:
+        _HW_BUSY = 0
+
+
+# ---------------------------------------------------------------------------
+# Tickets
+# ---------------------------------------------------------------------------
+
+
+class SpeechRole(enum.IntEnum):
+    """Lower speaks first. Integer-valued so the priority queue orders on it
+    directly rather than through a comparison table that could disagree."""
+
+    PRIMARY = 0        # the agent the operator addressed
+    SECONDARY = 1      # an agent the primary delegated to
+    BACKGROUND = 2     # announcements, telemetry — never ahead of a person
+
+
+_SEQ = itertools.count()
+
+
+@dataclass(order=True)
+class SpeechTicket:
+    """One utterance's claim on the speakers.
+
+    Ordered by (role, seq): role first so arbitration decides who speaks, seq
+    second so two tickets of the same role keep arrival order and cannot
+    starve one another."""
+
+    role: SpeechRole
+    seq: int
+    agent: str = field(compare=False, default="")
+    text: str = field(compare=False, default="")
+    granted: asyncio.Event = field(compare=False, default_factory=asyncio.Event)
+    done: asyncio.Event = field(compare=False, default_factory=asyncio.Event)
+    cancelled: bool = field(compare=False, default=False)
+    enqueued_at: float = field(compare=False, default_factory=time.monotonic)
+
+
+# ---------------------------------------------------------------------------
+# The conductor
+# ---------------------------------------------------------------------------
+
+
+class SpeechScheduler:
+    """Grants the speakers to exactly one utterance at a time.
+
+    Bound lazily to whichever loop first uses it, and rebound if that loop is
+    replaced — a scheduler holding a queue from a dead loop would silently
+    swallow every utterance, which in this system means the assistant simply
+    stops talking with no error anywhere."""
+
+    def __init__(self) -> None:
+        self._queue: Optional[asyncio.PriorityQueue] = None
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._conductor: Optional[asyncio.Task] = None
+        self._lock = threading.Lock()
+        self.granted_order: list = []          # observability + tests
+
+    # -- lifecycle ------------------------------------------------------
+
+    def _ensure(self) -> asyncio.PriorityQueue:
+        loop = asyncio.get_running_loop()
+        with self._lock:
+            if self._queue is None or self._loop is not loop:
+                self._queue = asyncio.PriorityQueue(maxsize=queue_maxsize())
+                self._loop = loop
+                self._conductor = None
+            if self._conductor is None or self._conductor.done():
+                self._conductor = loop.create_task(
+                    self._run(), name="tts-conductor",
+                )
+            return self._queue
+
+    async def aclose(self) -> None:
+        """Stop conducting. Queued tickets are released, not stranded — a
+        pending ticket whose event never fires is a caller awaiting forever."""
+        with self._lock:
+            task, queue = self._conductor, self._queue
+            self._conductor = None
+        if queue is not None:
+            while not queue.empty():
+                try:
+                    ticket = queue.get_nowait()
+                except asyncio.QueueEmpty:
+                    break
+                ticket.cancelled = True
+                ticket.granted.set()
+        if task is not None and not task.done():
+            task.cancel()
+            # asyncio.wait, NOT `await task`.
+            #
+            # Awaiting a task you just cancelled re-raises its CancelledError
+            # in the CALLER, and swallowing it there leaves the caller's own
+            # task flagged `cancelling` — after which the loop's shutdown
+            # gather waits on it forever. Observed exactly that: the test body
+            # ran to completion, aclose returned, and teardown hung with
+            # `<Task cancelling name='Task-1'>` as the only live task.
+            #
+            # asyncio.wait reports completion without delivering the child's
+            # exception, which is what a shutdown wants: the conductor holds
+            # no state that must be unwound, so its outcome is not news.
+            await asyncio.wait({task}, timeout=2.0)
+
+    # -- the loop -------------------------------------------------------
+
+    async def _run(self) -> None:
+        while True:
+            try:
+                queue = self._queue
+                if queue is None:
+                    return
+                ticket = await queue.get()
+                if ticket.cancelled:
+                    ticket.granted.set()
+                    continue
+
+                # Wait for the speakers BEFORE committing to this ticket.
+                await self._await_hardware_idle()
+
+                # Re-arbitrate at the moment of grant. A ticket that has been
+                # taken out of the priority queue can no longer be outranked —
+                # so holding one across the wait for the hardware defeats the
+                # priority queue during exactly the window that matters. A
+                # SECONDARY that arrived at an idle turnstile would then speak
+                # ahead of the PRIMARY that was addressed a moment later,
+                # which is the collision this module exists to prevent.
+                ticket = self._take_best(queue, ticket)
+                if ticket.cancelled:
+                    ticket.granted.set()
+                    continue
+
+                self.granted_order.append((ticket.role, ticket.agent))
+                ticket.granted.set()
+                try:
+                    await asyncio.wait_for(
+                        ticket.done.wait(), timeout=ticket_timeout_s(),
+                    )
+                except asyncio.TimeoutError:
+                    # Fail OPEN. Holding the turnstile for a caller that will
+                    # never signal would mute every later utterance — strictly
+                    # worse than the overlap this exists to prevent.
+                    logger.warning(
+                        "[SpeechQueue] %s held the speakers for %.0fs without "
+                        "finishing — releasing the turnstile",
+                        ticket.agent or "?", ticket_timeout_s(),
+                    )
+
+                # The tail runs AFTER the utterance, inside the turnstile, so
+                # the next agent cannot start inside the previous one's decay.
+                await self._await_hardware_idle()
+                tail = acoustic_tail_s()
+                if tail > 0:
+                    await asyncio.sleep(tail)
+            except asyncio.CancelledError:
+                raise
+            except (RuntimeError, AttributeError, TypeError, ValueError):
+                # A defect in one utterance must not silence the conductor.
+                logger.warning("[SpeechQueue] conductor step failed", exc_info=True)
+                await asyncio.sleep(0.05)
+
+    def _take_best(
+        self, queue: asyncio.PriorityQueue, held: SpeechTicket,
+    ) -> SpeechTicket:
+        """The highest-priority ticket among *held* and everything queued.
+
+        Drains and re-inserts rather than peeking at the heap: the queue is
+        bounded (16 by default) and this runs once per grant, so the cost is
+        trivial, while reaching into ``_queue`` would couple the conductor to
+        an implementation detail of asyncio."""
+        best = held
+        rest = []
+        while not queue.empty():
+            try:
+                other = queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+            if other.cancelled:
+                other.granted.set()
+                continue
+            if other < best:
+                rest.append(best)
+                best = other
+            else:
+                rest.append(other)
+        for item in rest:
+            try:
+                queue.put_nowait(item)
+            except asyncio.QueueFull:      # cannot happen: same count back
+                item.cancelled = True
+                item.granted.set()
+        return best
+
+    async def _await_hardware_idle(self) -> None:
+        """Poll the busy counter. NEVER blocks the loop, always bounded."""
+        deadline = time.monotonic() + hardware_idle_timeout_s()
+        while hardware_busy():
+            if time.monotonic() >= deadline:
+                logger.warning(
+                    "[SpeechQueue] speakers still busy after %.0fs — granting "
+                    "anyway rather than going mute",
+                    hardware_idle_timeout_s(),
+                )
+                return
+            await asyncio.sleep(0.02)
+
+    # -- the one call the speech paths make ------------------------------
+
+    async def speak(
+        self,
+        play: Callable[[], Awaitable[None]],
+        *,
+        agent: str = "",
+        role: SpeechRole = SpeechRole.PRIMARY,
+        text: str = "",
+    ) -> bool:
+        """Run *play* with exclusive use of the speakers.
+
+        Returns False when the turn was cancelled before it was granted —
+        barge-in, or shutdown. The caller's own cancel_event still governs
+        what happens once it IS granted; this decides only WHEN.
+
+        With the scheduler disabled, *play* runs immediately, so the switch
+        is a true bypass rather than a different code path."""
+        if not scheduler_enabled():
+            await play()
+            return True
+
+        ticket = SpeechTicket(role=role, seq=next(_SEQ), agent=agent, text=text)
+        queue = self._ensure()
+        try:
+            queue.put_nowait(ticket)
+        except asyncio.QueueFull:
+            # Shed the LOWEST-priority waiter rather than the new arrival:
+            # dropping what just arrived would discard a PRIMARY because
+            # background chatter got there first.
+            logger.warning("[SpeechQueue] full — shedding the lowest-priority waiter")
+            shed = None
+            try:
+                drained = []
+                while not queue.empty():
+                    drained.append(queue.get_nowait())
+                drained.append(ticket)
+                drained.sort()
+                shed = drained.pop()
+                for item in drained:
+                    queue.put_nowait(item)
+            except (asyncio.QueueEmpty, asyncio.QueueFull):
+                pass
+            if shed is not None:
+                shed.cancelled = True
+                shed.granted.set()
+                if shed is ticket:
+                    return False
+
+        await ticket.granted.wait()
+        if ticket.cancelled:
+            return False
+        try:
+            await play()
+            return True
+        finally:
+            ticket.done.set()
+
+    def cancel_pending(self, agent: str = "") -> int:
+        """Drop QUEUED utterances — barge-in. Never touches the one currently
+        playing: that is cancelled through its own cancel_event, and reaching
+        into it from here would leave the turnstile held by a dead ticket."""
+        queue = self._queue
+        if queue is None:
+            return 0
+        keep, dropped = [], 0
+        while not queue.empty():
+            try:
+                ticket = queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+            if agent and ticket.agent != agent:
+                keep.append(ticket)
+                continue
+            ticket.cancelled = True
+            ticket.granted.set()
+            dropped += 1
+        for ticket in keep:
+            try:
+                queue.put_nowait(ticket)
+            except asyncio.QueueFull:
+                ticket.cancelled = True
+                ticket.granted.set()
+        return dropped
+
+    def pending(self) -> int:
+        queue = self._queue
+        return 0 if queue is None else queue.qsize()
+
+
+_SCHEDULER: Optional[SpeechScheduler] = None
+_SCHEDULER_LOCK = threading.Lock()
+
+
+def get_scheduler() -> SpeechScheduler:
+    global _SCHEDULER
+    with _SCHEDULER_LOCK:
+        if _SCHEDULER is None:
+            _SCHEDULER = SpeechScheduler()
+        return _SCHEDULER
+
+
+def reset_scheduler() -> None:
+    """Test seam — drops the process-wide conductor."""
+    global _SCHEDULER
+    with _SCHEDULER_LOCK:
+        _SCHEDULER = None
+    reset_hardware_state()
+
+
+__all__ = [
+    "SpeechRole",
+    "SpeechScheduler",
+    "SpeechTicket",
+    "acoustic_tail_s",
+    "get_scheduler",
+    "hardware_busy",
+    "mark_hardware_busy",
+    "mark_hardware_idle",
+    "reset_hardware_state",
+    "reset_scheduler",
+    "scheduler_enabled",
+]

--- a/backend/core/ouroboros/governance/adaptive_voice_router.py
+++ b/backend/core/ouroboros/governance/adaptive_voice_router.py
@@ -233,15 +233,18 @@ class AdaptiveVoiceRouter:
             except Exception:  # noqa: BLE001
                 return None
         try:
-            from backend.core.ouroboros.governance.karen_voice_lane import (
-                ensure_voice_lane_warm, resolve_voice_model,
-            )
-            model = resolve_voice_model()
+            # Per-AGENT lane: the election is measured against this persona's
+            # own prompt and budget, so JARVIS and O+V can sit on different
+            # models without either one's runtime demotion muting the other.
+            from backend.core.ouroboros.governance.agent_voice_lane import lane_for
+
+            lane = lane_for(self.persona)
+            model = lane.resolve_model()
             if model is None:
                 # Cold lane: learn in the background, serve this turn locally.
                 # Speaking through an UNMEASURED remote model is how a spoken
                 # turn ends up on the 22-second code brain.
-                ensure_voice_lane_warm()
+                lane.ensure_warm()
             return model
         except Exception:  # noqa: BLE001
             return None
@@ -459,10 +462,9 @@ class AdaptiveVoiceRouter:
         otherwise the election is a one-time measurement that reality can
         never correct."""
         try:
-            from backend.core.ouroboros.governance.karen_voice_lane import (
-                record_runtime_failure,
-            )
-            record_runtime_failure(model, reason)
+            from backend.core.ouroboros.governance.agent_voice_lane import lane_for
+
+            lane_for(self.persona).record_failure(model, reason)
         except Exception:  # noqa: BLE001
             logger.debug("[VoiceRouter] demote degraded", exc_info=True)
 

--- a/backend/core/ouroboros/governance/agent_voice_lane.py
+++ b/backend/core/ouroboros/governance/agent_voice_lane.py
@@ -1,0 +1,232 @@
+"""One voice lane per agent — the generalisation of ``karen_voice_lane``.
+
+What was wrong with the old shape
+---------------------------------
+``karen_voice_lane`` elects which DoubleWord model Karen SPEAKS through, by
+measuring TTFT against a conversational budget. Everything in it was correct
+and none of it was Karen-specific: the ledger, the probe, the two-tier
+election, the runtime demotion path. Only the *bindings* were — one hardcoded
+env namespace, one hardcoded ledger file, one hardcoded probe persona.
+
+So a second agent had exactly two options, and both were bad: share Karen's
+lane (JARVIS then inherits an election measured against Karen's prompt and
+budget, and either agent's runtime demotion silently mutes the other), or fork
+the module (two copies of the ledger, the probe, the election and the demotion
+path — and the copy drifts from the original the first time either is fixed).
+
+This module takes the third option. ``karen_voice_lane`` is now parameterised
+by ``prefix`` and ``ledger``; this class BINDS those parameters to a persona
+drawn from :mod:`backend.voice.agent_registry`. There is no second
+implementation of anything, and no logic here at all — only binding.
+
+    lane = lane_for(AgentPersona.JARVIS)
+    lane.resolve_model()      # JARVIS's elected DW model
+    lane.voice_profile()      # -> Daniel
+    lane.system_prompt()      # -> the JARVIS identity prompt
+
+Why the probe is persona-bound
+------------------------------
+The probe measures time-to-first-token for a real spoken turn. The prompt is
+part of that measurement — a longer system prompt is more tokens to prefill —
+so grading JARVIS's models with "Hey Karen, are you there?" measures the wrong
+workload. Each lane probes with its own identity and its own wake word.
+
+Backward compatibility
+----------------------
+``AgentPersona.OV``/``KAREN`` resolve to the legacy ``JARVIS_KAREN_VOICE_*``
+namespace and the existing ``.jarvis/karen_voice_lane.json``, so measurements
+already on disk are inherited rather than orphaned, and an operator's current
+configuration keeps working untouched. New agents get their own file and MAY
+override any knob; unset knobs fall back to the legacy ones, so per-agent
+configuration is optional rather than mandatory duplication.
+"""
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any, Dict, List, Optional
+
+from backend.core.ouroboros.governance import karen_voice_lane as _lane
+from backend.voice.agent_persona import AgentPersona, VoiceProfile
+
+logger = logging.getLogger(__name__)
+
+#: OV keeps the namespace and ledger filename it shipped with.
+_LEGACY_PERSONAS = (AgentPersona.OV, AgentPersona.KAREN)
+
+
+class AgentVoiceLane:
+    """A persona bound to the voice-election machinery.
+
+    Holds no election logic. Every method delegates to ``karen_voice_lane``
+    with this agent's prefix and ledger — which is what makes the two lanes
+    genuinely the same code path rather than two that merely look alike.
+    """
+
+    def __init__(self, persona: AgentPersona) -> None:
+        self.persona = persona
+        self._ledger: Optional[_lane.VoiceLatencyLedger] = None
+        self._ledger_lock = threading.Lock()
+
+    # -- identity -------------------------------------------------------
+
+    @property
+    def spec(self) -> Any:
+        """Registry entry — voice, wake words, display name. Imported lazily:
+        the registry imports the persona module, and a module-level import
+        here would close a cycle through the pipeline."""
+        from backend.voice.agent_registry import spec_for
+        return spec_for(self.persona)
+
+    @property
+    def slug(self) -> str:
+        """Filesystem-safe lane id. OV is ``karen`` for continuity."""
+        if self.persona in _LEGACY_PERSONAS:
+            return "karen"
+        return str(getattr(self.persona, "value", self.persona)).lower()
+
+    @property
+    def prefix(self) -> str:
+        """Env namespace. OV keeps the legacy one; others get their own and
+        INHERIT any knob they do not set."""
+        if self.persona in _LEGACY_PERSONAS:
+            return _lane._LEGACY_PREFIX
+        return f"JARVIS_{self.slug.upper()}_VOICE"
+
+    def system_prompt(self) -> Optional[str]:
+        from backend.voice.agent_registry import prompt_for
+        return prompt_for(self.persona)
+
+    def voice_profile(self) -> Optional[VoiceProfile]:
+        from backend.voice.agent_registry import voice_profile_for
+        return voice_profile_for(self.persona)
+
+    # -- probe identity -------------------------------------------------
+
+    def _probe_system(self) -> str:
+        """This agent's own identity, one spoken-format instruction added.
+
+        Falls back to the module default rather than to nothing: an agent with
+        no prompt still needs a probe that exercises a spoken turn."""
+        prompt = (self.system_prompt() or "").strip()
+        if not prompt:
+            return _lane.VOICE_PROBE_SYSTEM
+        return f"{prompt}\n\nReply in ONE short spoken sentence. No markdown, no lists."
+
+    def _probe_user(self) -> str:
+        spec = self.spec
+        name = getattr(spec, "display_name", "") if spec else ""
+        return f"Hey {name}, are you there?" if name else _lane.VOICE_PROBE_USER
+
+    # -- ledger ---------------------------------------------------------
+
+    @property
+    def ledger(self) -> _lane.VoiceLatencyLedger:
+        """This lane's measurements. Lazy + locked: several turns can arrive
+        together on different threads, and two ledgers over one file would
+        each hold half the evidence."""
+        with self._ledger_lock:
+            if self._ledger is None:
+                self._ledger = _lane.VoiceLatencyLedger(
+                    _lane.ledger_path(prefix=self.prefix, slug=self.slug),
+                    prefix=self.prefix,
+                ).load()
+            return self._ledger
+
+    def reset(self) -> None:
+        """Test seam — drops the cached ledger handle."""
+        with self._ledger_lock:
+            self._ledger = None
+
+    # -- the four calls the turn path makes ------------------------------
+
+    def enabled(self) -> bool:
+        return _lane.voice_lane_enabled(prefix=self.prefix)
+
+    def resolve_model(self) -> Optional[str]:
+        """The DW model THIS agent should speak through, or None.
+
+        Synchronous and allocation-cheap, exactly as the single-agent version
+        was: it sits on the turn path."""
+        return _lane.resolve_voice_model(ledger=self.ledger, prefix=self.prefix)
+
+    def ensure_warm(self, *, force: bool = False) -> bool:
+        return _lane.ensure_voice_lane_warm(
+            force=force, prefix=self.prefix, ledger=self.ledger,
+        )
+
+    async def refresh(
+        self, *, models: Optional[List[str]] = None, force: bool = False,
+        dispatch_fn: Any = None,
+    ) -> Optional[str]:
+        return await _lane.refresh_voice_lane(
+            models=models, force=force, dispatch_fn=dispatch_fn,
+            ledger=self.ledger, prefix=self.prefix,
+            probe_system=self._probe_system(), probe_user=self._probe_user(),
+        )
+
+    def record_failure(self, model: str, reason: str = "runtime") -> bool:
+        """Demote a model that failed on a REAL turn — for THIS agent only.
+
+        Per-lane on purpose: a model that goes mute under Karen's prompt has
+        said nothing about how it behaves under JARVIS's, and a shared ledger
+        would let one agent's bad turn silence the other."""
+        return _lane.record_runtime_failure(model, reason, ledger=self.ledger)
+
+    def status(self) -> Dict[str, Any]:
+        st = _lane.voice_lane_status(prefix=self.prefix, ledger=self.ledger)
+        spec = self.spec
+        st["agent"] = getattr(spec, "display_name", self.slug) if spec else self.slug
+        st["persona"] = str(getattr(self.persona, "value", self.persona))
+        profile = self.voice_profile()
+        st["voice"] = getattr(profile, "voice", None) if profile else None
+        return st
+
+
+# ---------------------------------------------------------------------------
+# Registry of lanes — one per persona, created on demand
+# ---------------------------------------------------------------------------
+
+_LANES: Dict[AgentPersona, AgentVoiceLane] = {}
+_LANES_LOCK = threading.Lock()
+
+
+def lane_for(persona: object = None) -> AgentVoiceLane:
+    """The lane for *persona*, defaulting to whoever is active.
+
+    Never returns None: a caller on the turn path needs a lane to ask, and an
+    unknown persona should degrade to the legacy OV lane rather than force
+    every call site to handle absence."""
+    from backend.voice.agent_persona import active_persona
+
+    p = AgentPersona.coerce(persona) if persona is not None else None
+    if p is None:
+        p = active_persona() or AgentPersona.OV
+    if p is AgentPersona.KAREN:
+        p = AgentPersona.OV                # alias — one lane, not two
+    with _LANES_LOCK:
+        lane = _LANES.get(p)
+        if lane is None:
+            lane = AgentVoiceLane(p)
+            _LANES[p] = lane
+        return lane
+
+
+def all_lanes() -> List[AgentVoiceLane]:
+    """A lane per registered agent — for ``/provider`` style surfaces."""
+    from backend.voice.agent_registry import all_agents
+    return [lane_for(spec.persona) for spec in all_agents()]
+
+
+def reset_lanes() -> None:
+    """Test seam — drops every cached lane."""
+    with _LANES_LOCK:
+        _LANES.clear()
+
+
+__all__ = [
+    "AgentVoiceLane",
+    "all_lanes",
+    "lane_for",
+    "reset_lanes",
+]

--- a/backend/core/ouroboros/governance/karen_voice_lane.py
+++ b/backend/core/ouroboros/governance/karen_voice_lane.py
@@ -50,6 +50,7 @@ path returns ``None`` (meaning "caller, keep your default").
 from __future__ import annotations
 
 import asyncio
+import functools
 import json
 import logging
 import os
@@ -62,6 +63,28 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 logger = logging.getLogger(__name__)
 
 _TRUTHY = ("1", "true", "yes", "on")
+
+#: The knob namespace this module shipped with. Every reader below now takes a
+#: *prefix* so a second agent can have its own lane, and this stays the
+#: default — an operator's existing JARVIS_KAREN_VOICE_* settings keep working
+#: unchanged, and a new agent INHERITS them until it overrides one.
+#:
+#: Generalising by parameter rather than by copy is the whole point: a forked
+#: "jarvis_voice_lane.py" would duplicate the ledger, the probe, the election
+#: and the demotion path, and the copy would drift from the original the first
+#: time either was fixed.
+_LEGACY_PREFIX = "JARVIS_KAREN_VOICE"
+
+
+def _env_raw(suffix: str, prefix: str = _LEGACY_PREFIX) -> str:
+    """Prefixed knob, else the legacy one. Two-level lookup so per-agent
+    settings are optional rather than mandatory duplication."""
+    val = os.environ.get(f"{prefix}_{suffix}", "").strip()
+    if val:
+        return val
+    if prefix != _LEGACY_PREFIX:
+        return os.environ.get(f"{_LEGACY_PREFIX}_{suffix}", "").strip()
+    return ""
 SCHEMA_VERSION = "karen_voice_lane.1"
 
 
@@ -84,30 +107,36 @@ def _env_int(name: str, default: int) -> int:
         return int(default)
 
 
-def voice_lane_enabled() -> bool:
+def voice_lane_enabled(*, prefix: str = _LEGACY_PREFIX) -> bool:
     """Master gate. Default ON, but inert without a ledger — an unprobed
     system resolves to ``None`` and keeps the caller's existing default."""
-    return os.environ.get(
-        "JARVIS_KAREN_VOICE_LANE_ENABLED", "true",
-    ).strip().lower() in _TRUTHY
+    return (_env_raw("LANE_ENABLED", prefix) or "true").lower() in _TRUTHY
 
 
-def spoken_ttft_budget_s() -> float:
+def spoken_ttft_budget_s(*, prefix: str = _LEGACY_PREFIX) -> float:
     """The conversational floor: how long a human tolerates before a reply
     starts. ~1.5s is a beat of natural silence; past that the operator starts
     wondering whether the mic heard them. Not a performance target — an
     ADMISSION threshold: a model over it is disqualified from speech, however
     good its prose."""
-    return max(0.1, _env_float("JARVIS_KAREN_VOICE_TTFT_BUDGET_S", 1.5))
+    raw = _env_raw("TTFT_BUDGET_S", prefix)
+    try:
+        return max(0.1, float(raw)) if raw else 1.5
+    except (TypeError, ValueError):
+        return 1.5
 
 
-def ledger_ttl_s() -> float:
+def ledger_ttl_s(*, prefix: str = _LEGACY_PREFIX) -> float:
     """How long a measurement is trusted. Long enough not to re-probe every
     boot, short enough to notice a cluster that has been rebalanced."""
-    return max(60.0, _env_float("JARVIS_KAREN_VOICE_LEDGER_TTL_S", 21600.0))
+    raw = _env_raw("LEDGER_TTL_S", prefix)
+    try:
+        return max(60.0, float(raw)) if raw else 21600.0
+    except (TypeError, ValueError):
+        return 21600.0
 
 
-def spoken_ttft_hard_cap_s() -> float:
+def spoken_ttft_hard_cap_s(*, prefix: str = _LEGACY_PREFIX) -> float:
     """The line past which a voice is unusable, full stop.
 
     Distinct from the BUDGET, which is a preference: prefer a model that
@@ -116,10 +145,14 @@ def spoken_ttft_hard_cap_s() -> float:
     earlier — electing nobody means a remote-only host answers a heard
     utterance with silence. A voice that starts in 2.5s is degraded; no voice
     is broken. Above THIS cap, silence really is better."""
-    return max(1.0, _env_float("JARVIS_KAREN_VOICE_TTFT_HARD_CAP_S", 6.0))
+    raw = _env_raw("TTFT_HARD_CAP_S", prefix)
+    try:
+        return max(1.0, float(raw)) if raw else 6.0
+    except (TypeError, ValueError):
+        return 6.0
 
 
-def transport_failure_ttl_s() -> float:
+def transport_failure_ttl_s(*, prefix: str = _LEGACY_PREFIX) -> float:
     """How long a TRANSPORT failure is trusted — much shorter, on purpose.
 
     A probe that ends in a DNS error, a refused connection or a reset says
@@ -129,10 +162,14 @@ def transport_failure_ttl_s() -> float:
     "freshly measured as silent" for six hours, so the lane resolved None,
     the remote-only host had no engine, and Karen answered a heard utterance
     with nothing at all."""
-    return max(5.0, _env_float("JARVIS_KAREN_VOICE_FAILURE_TTL_S", 120.0))
+    raw = _env_raw("FAILURE_TTL_S", prefix)
+    try:
+        return max(5.0, float(raw)) if raw else 120.0
+    except (TypeError, ValueError):
+        return 120.0
 
 
-def max_probe_candidates() -> int:
+def max_probe_candidates(*, prefix: str = _LEGACY_PREFIX) -> int:
     """Ceiling on how many models ONE refresh may probe. Each probe is a real
     (tiny) generation, so this bounds spend explicitly rather than trusting the
     catalog to stay small.
@@ -141,27 +178,38 @@ def max_probe_candidates() -> int:
     the outcome, so the next refresh skips it and walks further down the
     ranking. A cold 26-model catalog therefore converges over a handful of
     refreshes instead of demanding one expensive sweep."""
-    return max(1, _env_int("JARVIS_KAREN_VOICE_MAX_CANDIDATES", 8))
+    raw = _env_raw("MAX_CANDIDATES", prefix)
+    try:
+        return max(1, int(raw)) if raw else 8
+    except (TypeError, ValueError):
+        return 8
 
 
-def probe_max_tokens() -> int:
+def probe_max_tokens(*, prefix: str = _LEGACY_PREFIX) -> int:
     """Deliberately voice-sized. A generous budget would let a reasoning model
     finish thinking and then speak, hiding precisely the failure mode that
     makes it unusable for conversation."""
-    return max(8, _env_int("JARVIS_KAREN_VOICE_PROBE_MAX_TOKENS", 48))
+    raw = _env_raw("PROBE_MAX_TOKENS", prefix)
+    try:
+        return max(8, int(raw)) if raw else 48
+    except (TypeError, ValueError):
+        return 48
 
 
-def ledger_path() -> Path:
-    raw = os.environ.get("JARVIS_KAREN_VOICE_LEDGER_PATH", "").strip()
+def ledger_path(*, prefix: str = _LEGACY_PREFIX, slug: str = "karen") -> Path:
+    """Per-agent ledger file. OV keeps the original filename so measurements
+    already on disk are not orphaned by the generalisation."""
+    raw = _env_raw("LEDGER_PATH", prefix)
     if raw:
         return Path(raw).expanduser()
-    return Path.cwd() / ".jarvis" / "karen_voice_lane.json"
+    name = "karen_voice_lane.json" if slug == "karen" else f"voice_lane_{slug}.json"
+    return Path.cwd() / ".jarvis" / name
 
 
-def model_override() -> str:
+def model_override(*, prefix: str = _LEGACY_PREFIX) -> str:
     """Operator's explicit choice. Always wins — measurement informs, it does
     not overrule."""
-    return os.environ.get("JARVIS_KAREN_VOICE_MODEL", "").strip()
+    return _env_raw("MODEL", prefix)
 
 
 # ---------------------------------------------------------------------------
@@ -176,7 +224,13 @@ VOICE_PROBE_SYSTEM = (
 VOICE_PROBE_USER = "Hey Karen, are you there?"
 
 
-def build_voice_probe_payload(model: str, *, max_tokens: int = 0) -> dict:
+def build_voice_probe_payload(
+    model: str,
+    *,
+    max_tokens: int = 0,
+    system: str = "",
+    user: str = "",
+) -> dict:
     """Probe body shaped like the workload it is grading.
 
     ``dw_deep_probe``'s own builders ask for a bare ``ok`` or a 150-token code
@@ -187,8 +241,8 @@ def build_voice_probe_payload(model: str, *, max_tokens: int = 0) -> dict:
     return {
         "model": model,
         "messages": [
-            {"role": "system", "content": VOICE_PROBE_SYSTEM},
-            {"role": "user", "content": VOICE_PROBE_USER},
+            {"role": "system", "content": system or VOICE_PROBE_SYSTEM},
+            {"role": "user", "content": user or VOICE_PROBE_USER},
         ],
         "max_tokens": int(max_tokens or probe_max_tokens()),
         "temperature": 0.6,
@@ -212,16 +266,30 @@ class VoiceModelRecord:
     measured_at: float
     reason: str = ""
 
+    def fits(self, prefix: str = _LEGACY_PREFIX) -> bool:
+        """Fit to hold a conversation FOR THIS LANE: it spoke, and it started
+        inside that lane's budget. Per-lane because the threshold is a
+        property of the agent's interaction style, not of the model — a
+        background agent may tolerate what a conversational one cannot."""
+        return bool(self.spoke) and 0.0 <= self.ttft_s <= spoken_ttft_budget_s(
+            prefix=prefix,
+        )
+
+    def is_usable(self, prefix: str = _LEGACY_PREFIX) -> bool:
+        """Spoke, inside the HARD cap. The degraded tier: eligible only when
+        nothing conversational exists, because a slow voice beats no voice."""
+        return bool(self.spoke) and 0.0 <= self.ttft_s <= spoken_ttft_hard_cap_s(
+            prefix=prefix,
+        )
+
     @property
     def conversational(self) -> bool:
-        """Fit to hold a conversation: it spoke, and it started in time."""
-        return bool(self.spoke) and 0.0 <= self.ttft_s <= spoken_ttft_budget_s()
+        """Default-lane convenience for existing callers."""
+        return self.fits()
 
     @property
     def usable(self) -> bool:
-        """Spoke, inside the HARD cap. The degraded tier: eligible only when
-        nothing conversational exists, because a slow voice beats no voice."""
-        return bool(self.spoke) and 0.0 <= self.ttft_s <= spoken_ttft_hard_cap_s()
+        return self.is_usable()
 
     @property
     def transport_failure(self) -> bool:
@@ -231,15 +299,21 @@ class VoiceModelRecord:
         r = self.reason or ""
         return r.startswith("probe_error:") or r.startswith("dispatch_error:")
 
-    def fresh(self, *, now: Optional[float] = None, ttl_s: Optional[float] = None) -> bool:
+    def fresh(
+        self,
+        *,
+        now: Optional[float] = None,
+        ttl_s: Optional[float] = None,
+        prefix: str = _LEGACY_PREFIX,
+    ) -> bool:
         t = time.time() if now is None else float(now)
         if ttl_s is None:
             # Transport faults expire fast: they describe the network at one
             # instant, and treating them as model verdicts poisons the lane
             # for the full TTL (the 2026-07-25 silent-Karen class).
             ttl = (
-                transport_failure_ttl_s() if self.transport_failure
-                else ledger_ttl_s()
+                transport_failure_ttl_s(prefix=prefix) if self.transport_failure
+                else ledger_ttl_s(prefix=prefix)
             )
         else:
             ttl = float(ttl_s)
@@ -254,8 +328,11 @@ class VoiceLatencyLedger:
     measurement of a model always supersedes an older one, and cross-process
     interleaving costs at most one re-probe."""
 
-    def __init__(self, path: Optional[Path] = None) -> None:
-        self._path = Path(path) if path is not None else ledger_path()
+    def __init__(
+        self, path: Optional[Path] = None, *, prefix: str = _LEGACY_PREFIX,
+    ) -> None:
+        self._prefix = prefix
+        self._path = Path(path) if path is not None else ledger_path(prefix=prefix)
         self._records: Dict[str, VoiceModelRecord] = {}
         self._loaded = False
 
@@ -335,19 +412,22 @@ class VoiceLatencyLedger:
         Ties break on model id so two cockpits booted together converge on the
         same voice instead of drifting apart on dict ordering."""
         self._ensure()
-        fresh = [r for r in self._records.values() if r.fresh(now=now)]
+        fresh = [
+            r for r in self._records.values()
+            if r.fresh(now=now, prefix=self._prefix)
+        ]
         # Tier 1: within the conversational budget — the preference.
-        fit = [r for r in fresh if r.conversational]
+        fit = [r for r in fresh if r.fits(self._prefix)]
         # Tier 2: spoke, within the hard cap — degraded, but a voice. Only
         # consulted when tier 1 is empty, so a fast model always wins outright
         # and the degraded tier cannot drag the election down.
         if not fit:
-            fit = [r for r in fresh if r.usable]
+            fit = [r for r in fresh if r.is_usable(self._prefix)]
             if fit:
                 logger.info(
                     "[VoiceLane] no candidate inside the %.1fs budget — "
                     "electing the fastest usable voice instead (degraded "
-                    "beats silent)", spoken_ttft_budget_s(),
+                    "beats silent)", spoken_ttft_budget_s(prefix=self._prefix),
                 )
         if not fit:
             return None
@@ -361,7 +441,7 @@ class VoiceLatencyLedger:
         out = []
         for m in models:
             rec = self._records.get(m)
-            if rec is None or not rec.fresh(now=now):
+            if rec is None or not rec.fresh(now=now, prefix=self._prefix):
                 out.append(m)
         return out
 
@@ -463,6 +543,9 @@ async def probe_voice_model(
     *,
     dispatch_fn: Optional[Callable[[dict], Any]] = None,
     budget_s: Optional[float] = None,
+    prefix: str = _LEGACY_PREFIX,
+    system: str = "",
+    user: str = "",
 ) -> VoiceModelRecord:
     """Measure one model's fitness to speak. NEVER raises.
 
@@ -470,7 +553,9 @@ async def probe_voice_model(
     ``deep_probe`` and supplies only what is voice-specific: the spoken payload
     and the interpretation. ``tokens == 0`` is the reasoning-model verdict —
     the model answered, but said nothing aloud."""
-    budget = spoken_ttft_budget_s() if budget_s is None else float(budget_s)
+    budget = (
+        spoken_ttft_budget_s(prefix=prefix) if budget_s is None else float(budget_s)
+    )
     try:
         from backend.core.ouroboros.governance.dw_deep_probe import (
             _default_dw_stream_dispatch, deep_probe,
@@ -483,8 +568,14 @@ async def probe_voice_model(
         result = await deep_probe(
             dispatch_fn=dispatch,
             model=model,
-            max_tokens=probe_max_tokens(),
-            payload_builder=build_voice_probe_payload,
+            max_tokens=probe_max_tokens(prefix=prefix),
+            # Bound to THIS agent's identity: a probe that always asks "Hey
+            # Karen, are you there?" would grade every agent's model against
+            # one persona's prompt, and prompt length is part of what TTFT
+            # measures.
+            payload_builder=functools.partial(
+                build_voice_probe_payload, system=system, user=user,
+            ),
         )
         spoke = int(getattr(result, "tokens", 0) or 0) > 0
         ttft = float(getattr(result, "ttft_s", -1.0))
@@ -499,7 +590,7 @@ async def probe_voice_model(
                 if not spoke
                 else (
                     "ok" if ttft <= budget
-                    else "slow" if ttft <= spoken_ttft_hard_cap_s()
+                    else "slow" if ttft <= spoken_ttft_hard_cap_s(prefix=prefix)
                     else "too_slow_for_speech"
                 )
             ),
@@ -517,6 +608,9 @@ async def refresh_voice_lane(
     dispatch_fn: Optional[Callable[[dict], Any]] = None,
     ledger: Optional[VoiceLatencyLedger] = None,
     force: bool = False,
+    prefix: str = _LEGACY_PREFIX,
+    probe_system: str = "",
+    probe_user: str = "",
 ) -> Optional[str]:
     """Probe the stale candidates concurrently and return the elected model.
 
@@ -524,7 +618,7 @@ async def refresh_voice_lane(
     would take as long as the sum of the slowest — including the 20s+ models
     it exists to disqualify. NEVER raises; returns ``None`` when nothing
     qualifies, which leaves the caller's default in place."""
-    if not voice_lane_enabled():
+    if not voice_lane_enabled(prefix=prefix):
         return None
     led = ledger if ledger is not None else get_default_ledger()
     try:
@@ -532,11 +626,17 @@ async def refresh_voice_lane(
         if not cands:
             return led.best()
         todo = (cands if force else led.stale_or_unknown(cands))[
-            : max_probe_candidates()
+            : max_probe_candidates(prefix=prefix)
         ]
         if todo:
             results = await asyncio.gather(
-                *(probe_voice_model(m, dispatch_fn=dispatch_fn) for m in todo),
+                *(
+                    probe_voice_model(
+                        m, dispatch_fn=dispatch_fn, prefix=prefix,
+                        system=probe_system, user=probe_user,
+                    )
+                    for m in todo
+                ),
                 return_exceptions=True,
             )
             for rec in results:
@@ -561,7 +661,11 @@ async def refresh_voice_lane(
 # ---------------------------------------------------------------------------
 
 
-def resolve_voice_model(*, ledger: Optional[VoiceLatencyLedger] = None) -> Optional[str]:
+def resolve_voice_model(
+    *,
+    ledger: Optional[VoiceLatencyLedger] = None,
+    prefix: str = _LEGACY_PREFIX,
+) -> Optional[str]:
     """The DW model Karen should SPEAK through, or ``None``.
 
     Synchronous and allocation-cheap by contract: this sits on the turn path,
@@ -572,10 +676,10 @@ def resolve_voice_model(*, ledger: Optional[VoiceLatencyLedger] = None) -> Optio
     default". Returning a guess instead would trade a known-slow voice for an
     unknown one. NEVER raises."""
     try:
-        override = model_override()
+        override = model_override(prefix=prefix)
         if override:
             return override
-        if not voice_lane_enabled():
+        if not voice_lane_enabled(prefix=prefix):
             return None
         return (ledger if ledger is not None else get_default_ledger()).best()
     except Exception:  # noqa: BLE001
@@ -583,10 +687,17 @@ def resolve_voice_model(*, ledger: Optional[VoiceLatencyLedger] = None) -> Optio
 
 
 _WARM_LOCK = threading.Lock()
-_WARMED = False
+#: Keyed by lane, not a single flag: with two agents a global "already warmed"
+#: would let whichever lane ran first suppress the other's election forever.
+_WARMED: Dict[str, bool] = {}
 
 
-def ensure_voice_lane_warm(*, force: bool = False) -> bool:
+def ensure_voice_lane_warm(
+    *,
+    force: bool = False,
+    prefix: str = _LEGACY_PREFIX,
+    ledger: Optional["VoiceLatencyLedger"] = None,
+) -> bool:
     """Kick ONE background refresh if the lane has no elected model yet.
 
     True when a refresh was started. Returns IMMEDIATELY — the caller is on a
@@ -602,21 +713,21 @@ def ensure_voice_lane_warm(*, force: bool = False) -> bool:
 
     Once per process (the guard is the point: several turns arriving together
     must not each start a sweep). NEVER raises."""
-    global _WARMED
     try:
-        if not voice_lane_enabled() or model_override():
+        if not voice_lane_enabled(prefix=prefix) or model_override(prefix=prefix):
             return False
+        led = ledger if ledger is not None else get_default_ledger()
         with _WARM_LOCK:
-            if _WARMED and not force:
+            if _WARMED.get(prefix) and not force:
                 return False
-            if not force and get_default_ledger().best() is not None:
-                _WARMED = True          # already elected — nothing to learn
+            if not force and led.best() is not None:
+                _WARMED[prefix] = True   # already elected — nothing to learn
                 return False
-            _WARMED = True
+            _WARMED[prefix] = True
 
         def _run() -> None:
             try:
-                asyncio.run(refresh_voice_lane(force=force))
+                asyncio.run(refresh_voice_lane(force=force, ledger=ledger))
             except Exception:  # noqa: BLE001
                 logger.debug("[VoiceLane] warm refresh degraded", exc_info=True)
 
@@ -630,12 +741,16 @@ def ensure_voice_lane_warm(*, force: bool = False) -> bool:
 
 def reset_warm_state() -> None:
     """Test seam — re-arms the once-per-process guard."""
-    global _WARMED
     with _WARM_LOCK:
-        _WARMED = False
+        _WARMED.clear()
 
 
-def record_runtime_failure(model: str, reason: str = "runtime") -> bool:
+def record_runtime_failure(
+    model: str,
+    reason: str = "runtime",
+    *,
+    ledger: Optional["VoiceLatencyLedger"] = None,
+) -> bool:
     """A model that passed the probe but failed on a REAL turn.
 
     The election rests on a probe, and a probe is a sample: a model can pass
@@ -647,7 +762,7 @@ def record_runtime_failure(model: str, reason: str = "runtime") -> bool:
     know the ledger's shape; it reports an OUTCOME and the lane decides what
     that means for ranking. NEVER raises."""
     try:
-        led = get_default_ledger()
+        led = ledger if ledger is not None else get_default_ledger()
         led.record(VoiceModelRecord(
             model=str(model), ttft_s=-1.0, tokens=0, spoke=False,
             measured_at=time.time(), reason=f"runtime:{reason}",
@@ -660,16 +775,20 @@ def record_runtime_failure(model: str, reason: str = "runtime") -> bool:
         return False
 
 
-def voice_lane_status() -> Dict[str, Any]:
+def voice_lane_status(
+    *,
+    prefix: str = _LEGACY_PREFIX,
+    ledger: Optional["VoiceLatencyLedger"] = None,
+) -> Dict[str, Any]:
     """Operator-facing snapshot for ``/provider`` and friends. Read-only."""
     try:
-        led = get_default_ledger()
+        led = ledger if ledger is not None else get_default_ledger()
         recs = sorted(led.all(), key=lambda r: (not r.conversational, r.ttft_s))
         return {
-            "enabled": voice_lane_enabled(),
-            "override": model_override() or None,
-            "elected": resolve_voice_model(),
-            "budget_s": spoken_ttft_budget_s(),
+            "enabled": voice_lane_enabled(prefix=prefix),
+            "override": model_override(prefix=prefix) or None,
+            "elected": resolve_voice_model(ledger=led, prefix=prefix),
+            "budget_s": spoken_ttft_budget_s(prefix=prefix),
             "measured": [
                 {
                     "model": r.model, "ttft_s": round(r.ttft_s, 3),

--- a/backend/core/ouroboros/governance/remote_compute_dispatcher.py
+++ b/backend/core/ouroboros/governance/remote_compute_dispatcher.py
@@ -1,0 +1,364 @@
+"""Keep the delegated agent's heavy turn off the addressed agent's lane.
+
+The real constraint
+-------------------
+A dual summon — "Hey JARVIS, ask Karen to verify the deployment" — puts two
+agents in flight at once. The collision is NOT local memory: nothing in the
+conversation path runs a local model. Generation already leaves this machine
+through the established chain::
+
+    Tier 0  DoubleWord 397B   primary    — tokens
+    Tier 1  Claude            fallback   — time (lowest TTFT)
+    Tier 2  J-Prime (GCP)     sovereign  — ours, heavier, slower to reach
+
+The collision is LANE CONTENTION. A spoken turn is routed IMMEDIATE by
+policy — Claude direct, skip DW — precisely because the operator is waiting
+in real time. If the secondary's delegated work is dispatched the same way,
+two IMMEDIATE calls compete for the one lane that exists to be fast, the
+primary's first token arrives behind the secondary's prefill, and the
+operator hears the addressed agent hesitate on behalf of work they did not
+ask it to do. Cost doubles at the tier that costs the most, for the half of
+the work with no human waiting on it.
+
+So this arbitrates LANES, not machines
+--------------------------------------
+The primary keeps IMMEDIATE. The secondary is placed on a different tier
+according to what it was actually asked to do, and dispatched as a task so
+the primary's event loop never waits on it:
+
+    heavy / architectural        -> COMPLEX     (Claude plans, DW executes)
+    ordinary delegated work      -> STANDARD    (DW primary, Claude fallback)
+    fire-and-forget, no reply    -> BACKGROUND  (DW only, no Claude fallback)
+    pinned to this organism      -> SOVEREIGN   (J-Prime on GCP)
+
+``ProviderRoute`` is imported rather than re-declared: the vocabulary belongs
+to :mod:`urgency_router`, and a second copy of those five names would drift
+from the routing policy it is supposed to mirror.
+
+Why the transport is a stub
+---------------------------
+What must be correct before a tier is worth pointing at is the DECISION, the
+isolation and the fallback — not the socket. Each tier is an injectable
+transport; none is wired by default, and an unwired tier degrades to the next
+one down, ending at the primary's own path. Remote compute is an
+optimisation, and an optimisation whose absence breaks the assistant is a
+liability.
+
+⚠️ J-Prime note: spinning the GCP tier COSTS money and
+``JARVIS_FAILOVER_LIFECYCLE_ENABLED`` can auto-start the instance. This
+module therefore never spins anything — it dispatches to a transport that
+already exists, or falls back.
+"""
+from __future__ import annotations
+
+import asyncio
+import enum
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+try:  # the vocabulary lives in the router; never re-declare it
+    from backend.core.ouroboros.governance.urgency_router import ProviderRoute
+except ImportError:  # pragma: no cover - router always present in-tree
+    class ProviderRoute(str, enum.Enum):       # type: ignore[no-redef,misc]
+        IMMEDIATE = "immediate"
+        STANDARD = "standard"
+        COMPLEX = "complex"
+        BACKGROUND = "background"
+        SPECULATIVE = "speculative"
+
+
+def dispatcher_enabled() -> bool:
+    """Default ON: unlike a remote endpoint, lane separation costs nothing and
+    its absence is the bug. OFF puts the secondary back on the primary's lane,
+    which is the behaviour this replaces."""
+    return os.getenv(
+        "JARVIS_DELEGATION_DISPATCH_ENABLED", "true",
+    ).strip().lower() in _TRUTHY
+
+
+def _env_float(name: str, default: float, minimum: float = 0.0) -> float:
+    try:
+        return max(minimum, float(os.getenv(name, "").strip() or default))
+    except (TypeError, ValueError):
+        return default
+
+
+def dispatch_timeout_s() -> float:
+    """Ceiling on ONE delegated turn. Past this the operator has moved on and
+    the answer is no longer worth the tokens it is still spending."""
+    return _env_float("JARVIS_DELEGATION_TIMEOUT_S", 120.0, 5.0)
+
+
+class Tier(str, enum.Enum):
+    """Where the work runs. Ordered by how far it is from the operator."""
+
+    DOUBLEWORD = "doubleword"     # Tier 0 — tokens
+    CLAUDE = "claude"             # Tier 1 — time
+    JPRIME = "jprime"             # Tier 2 — sovereign, GCP golden image
+    CALLER = "caller"             # ran on the path the caller supplied
+
+
+#: Which tier a route lands on FIRST. Mirrors the documented chain: IMMEDIATE
+#: skips DW for latency; BACKGROUND refuses Claude for cost; SOVEREIGN work
+#: goes to the instance that is ours.
+_ROUTE_TIER: Dict[str, Tier] = {
+    "immediate": Tier.CLAUDE,
+    "standard": Tier.DOUBLEWORD,
+    "complex": Tier.CLAUDE,
+    "background": Tier.DOUBLEWORD,
+    "speculative": Tier.DOUBLEWORD,
+}
+
+#: Verbs and nouns that mark work as heavy enough to plan before executing.
+#: Structural, not a keyword list masquerading as intelligence: these are the
+#: operations that touch many files or take minutes, and the distinction they
+#: drive is only WHICH remote tier — never whether the work happens.
+_HEAVY_MARKERS = frozenset("""
+refactor migrate rewrite redesign architect audit benchmark profile
+deploy rollout release upgrade backfill reindex retrain
+""".split())
+
+#: Work that must run against THIS organism's state — the screen, the
+#: microphone, the working tree. Not a performance judgement: a remote tier
+#: literally cannot see these.
+_PINNED_MARKERS = frozenset("""
+screen screenshot microphone mic camera clipboard desktop window
+worktree uncommitted staged local
+""".split())
+
+
+@dataclass(frozen=True)
+class Workload:
+    """One delegated turn."""
+
+    agent: str
+    task: str
+    #: Set when the caller already knows — e.g. arbitration saw no reply was
+    #: expected. Otherwise inferred from the task.
+    route: Optional[ProviderRoute] = None
+    #: Absolute. Honoured before any tier preference.
+    pinned_to_node: bool = False
+
+
+@dataclass(frozen=True)
+class LaneDecision:
+    route: ProviderRoute
+    tier: Tier
+    reason: str
+
+    @property
+    def shares_primary_lane(self) -> bool:
+        """True when the secondary would compete with the addressed agent.
+        The whole point of arbitration is that this is False."""
+        return self.route == ProviderRoute.IMMEDIATE
+
+
+@dataclass
+class DispatchResult:
+    """What happened, in enough detail to explain a latency spike later."""
+
+    value: Any = None
+    tier: Tier = Tier.CALLER
+    route: str = ""
+    reason: str = ""
+    elapsed_s: float = 0.0
+    fell_back: bool = False
+    error: str = ""
+    decision: Optional[LaneDecision] = None
+    meta: Dict[str, Any] = field(default_factory=dict)
+
+
+def _words(text: str) -> set:
+    return {w.strip(".,;:!?").lower() for w in str(text or "").split()}
+
+
+def decide_lane(workload: Workload) -> LaneDecision:
+    """Which lane the SECONDARY gets. Pure, synchronous, sub-millisecond.
+
+    Absolute constraints first, preferences after — pinned work can never be
+    shipped off-node however heavy it looks."""
+    if workload.pinned_to_node:
+        return LaneDecision(ProviderRoute.STANDARD, Tier.JPRIME, "pinned_to_node")
+
+    words = _words(workload.task)
+    if words & _PINNED_MARKERS:
+        return LaneDecision(
+            ProviderRoute.STANDARD, Tier.JPRIME, "task_touches_local_state",
+        )
+
+    if workload.route is not None:
+        route = workload.route
+        reason = "caller_stamped"
+    elif words & _HEAVY_MARKERS:
+        route, reason = ProviderRoute.COMPLEX, "heavy_task"
+    elif not workload.task.strip():
+        # Nothing was actually delegated — do not spend a lane on it.
+        route, reason = ProviderRoute.BACKGROUND, "empty_task"
+    else:
+        route, reason = ProviderRoute.STANDARD, "delegated_default"
+
+    if route == ProviderRoute.IMMEDIATE and not workload.pinned_to_node:
+        # The addressed agent owns IMMEDIATE. A delegated turn taking it is
+        # the contention this module exists to prevent, so it is demoted even
+        # when the caller asked for it.
+        route, reason = ProviderRoute.STANDARD, "demoted_from_primary_lane"
+
+    return LaneDecision(route, _ROUTE_TIER.get(route.value, Tier.DOUBLEWORD), reason)
+
+
+class RemoteComputeDispatcher:
+    """Runs a delegated workload on a lane the primary is not using.
+
+    Transports are injected per tier so the arbitration can be exercised
+    without contacting anything, and so wiring a real tier later is a
+    parameter rather than an edit here."""
+
+    def __init__(
+        self,
+        transports: Optional[Dict[Tier, Callable[[Workload], Awaitable[Any]]]] = None,
+    ) -> None:
+        self._transports = dict(transports or {})
+        self.dispatches: list = []          # observability + tests
+
+    def register(
+        self, tier: Tier, transport: Callable[[Workload], Awaitable[Any]],
+    ) -> None:
+        self._transports[tier] = transport
+
+    async def _run_tier(self, tier: Tier, workload: Workload) -> Any:
+        transport = self._transports.get(tier)
+        if transport is None:
+            raise TierUnavailable(f"{tier.value} has no transport wired")
+        return await transport(workload)
+
+    async def dispatch(
+        self,
+        workload: Workload,
+        fallback: Callable[[], Awaitable[Any]],
+    ) -> DispatchResult:
+        """Run *workload* on its arbitrated lane, else fall back.
+
+        *fallback* is the caller's own path — in practice the same generation
+        the primary would have used. Reached only when no remote tier is
+        wired or every wired one failed.
+
+        NEVER raises: a delegated turn that failed is a RESULT. Propagating it
+        would unwind the conversation loop for work the operator delegated,
+        not for work they asked the primary to do."""
+        started = time.monotonic()
+        decision = decide_lane(workload)
+        self.dispatches.append((workload.agent, decision.route.value, decision.tier.value))
+
+        if not dispatcher_enabled():
+            value, err = await self._safe(fallback)
+            return DispatchResult(
+                value=value, tier=Tier.CALLER, route="", reason="dispatch_disabled",
+                elapsed_s=time.monotonic() - started, error=err,
+            )
+
+        # Preference order: the arbitrated tier, then the rest of the chain in
+        # the documented order, then the caller's path. Each step is bounded.
+        chain = [decision.tier] + [
+            t for t in (Tier.DOUBLEWORD, Tier.CLAUDE, Tier.JPRIME)
+            if t is not decision.tier
+        ]
+        errors = []
+        for tier in chain:
+            if tier not in self._transports:
+                continue
+            try:
+                value = await asyncio.wait_for(
+                    self._run_tier(tier, workload), timeout=dispatch_timeout_s(),
+                )
+                return DispatchResult(
+                    value=value, tier=tier, route=decision.route.value,
+                    reason=decision.reason, elapsed_s=time.monotonic() - started,
+                    fell_back=tier is not decision.tier, decision=decision,
+                )
+            except asyncio.CancelledError:
+                raise
+            except (TierUnavailable, asyncio.TimeoutError, OSError,
+                    ConnectionError, ValueError, RuntimeError) as exc:
+                errors.append(f"{tier.value}:{exc}")
+                logger.info(
+                    "[Delegation] %s tier %s unavailable — trying the next: %s",
+                    workload.agent or "?", tier.value, exc,
+                )
+
+        value, err = await self._safe(fallback)
+        return DispatchResult(
+            value=value, tier=Tier.CALLER, route=decision.route.value,
+            reason=f"{decision.reason}->caller_path",
+            elapsed_s=time.monotonic() - started, fell_back=True,
+            error=err or "; ".join(errors), decision=decision,
+        )
+
+    @staticmethod
+    async def _safe(fn: Callable[[], Awaitable[Any]]) -> "tuple[Any, str]":
+        """The caller's path is arbitrary code; its failure is reported, never
+        propagated into the conversation loop."""
+        try:
+            return await fn(), ""
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001 — reported, see docstring
+            return None, str(exc)
+
+    def spawn(
+        self,
+        workload: Workload,
+        fallback: Callable[[], Awaitable[Any]],
+    ) -> "asyncio.Task[DispatchResult]":
+        """Start the delegated turn and return IMMEDIATELY.
+
+        This is the shape the dual summon uses: the primary acknowledges the
+        operator while the secondary's turn is already running on another
+        lane. Awaiting the task later schedules the secondary's REPLY — never
+        its computation."""
+        return asyncio.get_running_loop().create_task(
+            self.dispatch(workload, fallback),
+            name=f"delegated-{workload.agent or 'agent'}",
+        )
+
+
+class TierUnavailable(RuntimeError):
+    """A tier could not be used. Typed, so the chain catches THIS and a real
+    defect in a wired transport still surfaces."""
+
+
+_DISPATCHER: Optional[RemoteComputeDispatcher] = None
+
+
+def get_dispatcher() -> RemoteComputeDispatcher:
+    global _DISPATCHER
+    if _DISPATCHER is None:
+        _DISPATCHER = RemoteComputeDispatcher()
+    return _DISPATCHER
+
+
+def reset_dispatcher() -> None:
+    """Test seam."""
+    global _DISPATCHER
+    _DISPATCHER = None
+
+
+__all__ = [
+    "DispatchResult",
+    "LaneDecision",
+    "ProviderRoute",
+    "RemoteComputeDispatcher",
+    "Tier",
+    "TierUnavailable",
+    "Workload",
+    "decide_lane",
+    "dispatcher_enabled",
+    "get_dispatcher",
+    "reset_dispatcher",
+]

--- a/backend/tests/archive/conftest.py
+++ b/backend/tests/archive/conftest.py
@@ -1,0 +1,36 @@
+"""Archived diagnostic scripts. Not tests — and running them costs the operator.
+
+What these are
+--------------
+``legacy/`` and ``deprecated/`` hold hand-run diagnostic scripts from earlier
+eras of the weather/vision work. They are named ``test_*.py`` because that is
+what they were called when someone ran them by hand, and pytest therefore
+collects and RUNS them.
+
+Why that is not merely untidy
+-----------------------------
+Fourteen of them call ``subprocess.run(['open', '-a', 'Weather'])`` inside a
+``test_*`` function. The autonomous loop's TestWatcher runs pytest continuously,
+so every sweep that reached this directory opened the Weather app on the
+operator's desktop — observed live::
+
+    20:47:18  pytest spawned by TestWatcher (pid 42556)
+    20:47:30  Weather.app launches
+    20:47:39  pytest exits rc=3
+
+The operator reported this four times as "the Weather app keeps opening on its
+own". It was us: a self-developing system running archived scripts that drive
+the GUI.
+
+Collection alone is safe — the launches sit inside test functions, not at
+module scope — which is exactly why this hid for so long: importing these files
+proves nothing, and only a full RUN reproduces it.
+
+So the directory declares what it is, the same way
+``tests/governance/fixtures`` does for the L2 corpus. Deleting them would also
+work; ignoring them keeps the history readable without letting an automated
+sweep act on the desktop.
+"""
+from __future__ import annotations
+
+collect_ignore_glob = ["*"]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,118 @@
+"""A test run must not act on the operator's desktop.
+
+The fault
+---------
+The autonomous loop runs pytest continuously. Sixteen ``test_*`` functions in
+this tree launch GUI applications through ``open -a``, so every sweep that
+reached them opened apps on the operator's screen — the Weather app, four
+times reported as "it keeps opening on its own". Confirmed live: pytest
+spawned at 20:47:18, Weather.app launched at 20:47:30, pytest exited at
+20:47:39.
+
+Ignoring the archived scripts removes fourteen of them. This closes the class,
+including the two live tests and any written later, because the real invariant
+is not "those particular files are bad" — it is:
+
+    A test run is an OBSERVATION of the system, not an ACTUATION of the
+    operator's machine.
+
+Why a guard and not a rule
+--------------------------
+"Don't launch apps in tests" is a convention, and a convention cannot survive
+a self-modifying system that writes its own tests. The organism generates test
+files; it will eventually generate one that drives the GUI, and nobody will be
+watching that sweep. The guard makes the failure impossible rather than
+discouraged.
+
+Scope, deliberately narrow
+--------------------------
+Only the ``open -a <app>`` shape is intercepted — the one that raises a window
+on a human's screen. Nothing else about subprocess is touched: tests that shell
+out to git, pytest, ``say`` or anything else behave exactly as before. A test
+that genuinely needs to launch an app opts in with
+``JARVIS_TEST_ALLOW_APP_LAUNCH=1``, which is explicit, greppable, and absent by
+default.
+
+The interception returns a successful CompletedProcess rather than raising:
+these tests assert on the launch succeeding, and turning a desktop side effect
+into a test failure would trade one wrong behaviour for another.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+from typing import Any, List, Sequence
+
+import pytest
+
+_ALLOW = ("1", "true", "yes", "on")
+
+
+def _launch_allowed() -> bool:
+    return os.getenv(
+        "JARVIS_TEST_ALLOW_APP_LAUNCH", "",
+    ).strip().lower() in _ALLOW
+
+
+def _is_gui_launch(args: Any) -> bool:
+    """Is this the ``open -a <app>`` shape? Nothing else qualifies."""
+    if isinstance(args, (str, bytes)):
+        text = args.decode() if isinstance(args, bytes) else args
+        return "open" in text.split()[:1] and " -a" in text
+    if not isinstance(args, Sequence):
+        return False
+    parts: List[str] = [str(a) for a in args]
+    if not parts:
+        return False
+    return os.path.basename(parts[0]) == "open" and "-a" in parts[1:]
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _no_desktop_actuation() -> Any:
+    """Make GUI app launches inert for the whole session.
+
+    Session-scoped and autouse: a per-test fixture would leave collection-time
+    and fixture-time launches uncovered, and an opt-in fixture would have to be
+    remembered by code that does not yet exist."""
+    if _launch_allowed():
+        yield
+        return
+
+    real_run = subprocess.run
+    real_popen = subprocess.Popen
+    blocked: List[List[str]] = []
+
+    def guarded_run(args: Any, *a: Any, **kw: Any) -> Any:
+        if _is_gui_launch(args):
+            blocked.append([str(x) for x in args])
+            return subprocess.CompletedProcess(args, 0, stdout=b"", stderr=b"")
+        return real_run(args, *a, **kw)
+
+    class GuardedPopen(real_popen):  # type: ignore[misc,valid-type]
+        def __init__(self, args: Any, *a: Any, **kw: Any) -> None:
+            if _is_gui_launch(args):
+                blocked.append([str(x) for x in args])
+                # Substitute a trivial command so the object still behaves like
+                # a process: callers wait() on it and read returncode.
+                args = ["true"]
+                kw.pop("stdout", None)
+                kw.pop("stderr", None)
+            super().__init__(args, *a, **kw)
+
+    subprocess.run = guarded_run                      # type: ignore[assignment]
+    subprocess.Popen = GuardedPopen                   # type: ignore[misc]
+    try:
+        yield
+    finally:
+        subprocess.run = real_run                     # type: ignore[assignment]
+        subprocess.Popen = real_popen                 # type: ignore[misc]
+        if blocked:
+            # Reported, not silent: a suppressed side effect the author did not
+            # expect is worth knowing about, and this is the line that would
+            # have told us months ago.
+            names = sorted({" ".join(b[:3]) for b in blocked})
+            print(
+                f"\n[conftest] suppressed {len(blocked)} desktop app launch(es) "
+                f"during this run: {names}. Set JARVIS_TEST_ALLOW_APP_LAUNCH=1 "
+                f"to permit them.",
+            )

--- a/backend/voice/agent_persona.py
+++ b/backend/voice/agent_persona.py
@@ -70,9 +70,19 @@ def _is_system_default(name: object) -> bool:
 class AgentPersona(str, enum.Enum):
     """Who is speaking. The value is the env-knob suffix and log token."""
 
-    KAREN = "karen"        # O+V's voice — the ov cockpit
+    #: O+V — Ouroboros + Venom, the self-developing organism. THE AGENT.
+    #: Its macOS rendering is the `Karen` voice, which is why the two got
+    #: conflated; the agent and the voice are now named separately.
+    OV = "ov"
+    #: Deprecated alias for OV, kept so existing bindings do not break.
+    KAREN = "karen"
     JARVIS = "jarvis"      # the supervisor / Body
     SYSTEM = "system"      # unattributed system speech
+
+    @property
+    def canonical(self) -> "AgentPersona":
+        """KAREN resolves to OV — one identity, two spellings."""
+        return AgentPersona.OV if self is AgentPersona.KAREN else self
 
     @classmethod
     def coerce(cls, value: object) -> Optional["AgentPersona"]:
@@ -97,6 +107,7 @@ _PREFERENCES: Dict[AgentPersona, Tuple[str, ...]] = {
     # system voice" is a stable request while asking for a NAME is not — the
     # name is right until they change the setting, and wrong silently after.
     # The named fallbacks stay for machines whose default cannot be resolved.
+    AgentPersona.OV: (SYSTEM_DEFAULT, "Karen", "Tessa", "Serena", "Samantha"),
     AgentPersona.KAREN: (SYSTEM_DEFAULT, "Karen", "Tessa", "Serena", "Samantha"),
     # British first — the established JARVIS voice.
     AgentPersona.JARVIS: ("Daniel", "Oliver", "Serena", "Alex"),
@@ -105,6 +116,7 @@ _PREFERENCES: Dict[AgentPersona, Tuple[str, ...]] = {
 
 #: Locale to fall back to when no preferred voice is installed.
 _LOCALES: Dict[AgentPersona, str] = {
+    AgentPersona.OV: "en_AU",
     AgentPersona.KAREN: "en_AU",
     AgentPersona.JARVIS: "en_GB",
     AgentPersona.SYSTEM: "en_US",
@@ -220,12 +232,22 @@ def _rate_for(persona: AgentPersona) -> int:
         return 175
 
 
-def resolve_profile(persona: object) -> Optional[VoiceProfile]:
+def resolve_profile(
+    persona: object, *, prefer: str = "",
+) -> Optional[VoiceProfile]:
     """The voice *persona* should speak in on THIS machine, or None.
 
     ``None`` means "no opinion — keep your default": an unknown persona or a
     machine with no usable voice must not silence a reply, and guessing a
-    voice would be worse than the caller's existing behaviour. NEVER raises."""
+    voice would be worse than the caller's existing behaviour.
+
+    *prefer* is the agent registry's stated voice for this persona. It is
+    inserted at the HEAD of the preference chain rather than replacing it, so
+    the registry states the intent, the operator override still outranks it,
+    and an uninstalled registry voice still degrades through the same locale
+    fallback as everything else. The registry is where an agent's voice is
+    declared; this function remains the only thing that decides what the
+    machine can actually deliver. NEVER raises."""
     p = AgentPersona.coerce(persona)
     if p is None:
         return None
@@ -245,11 +267,18 @@ def resolve_profile(persona: object) -> Optional[VoiceProfile]:
                 p.value, override,
             )
 
-        for name in _PREFERENCES.get(p, ()):
+        chain = _PREFERENCES.get(p, ())
+        if prefer and prefer not in chain:
+            chain = (prefer,) + tuple(chain)
+        elif prefer:
+            # Registry voice already listed: promote it rather than duplicate.
+            chain = (prefer,) + tuple(n for n in chain if n != prefer)
+        for name in chain:
             if _is_system_default(name):
                 return VoiceProfile(p, SYSTEM_DEFAULT, rate, "system_default")
             if voice_installed(name):
-                return VoiceProfile(p, name, rate, "preference")
+                reason = "registry" if name == prefer else "preference"
+                return VoiceProfile(p, name, rate, reason)
 
         locale = _LOCALES.get(p, "")
         for name, loc in installed_voices():
@@ -368,6 +397,14 @@ def active_persona() -> Optional[AgentPersona]:
 #: addressing SOMEONE ELSE and replied "Karen, or whoever you are, what would
 #: you like to do today?".
 _IDENTITY: Dict[AgentPersona, Dict[str, str]] = {
+    AgentPersona.OV: {
+        "name": "Karen",
+        "character": (
+            "the voice of O+V (Ouroboros + Venom), an autonomous "
+            "self-developing engineering organism. You are a terse, senior "
+            "Australian engineer: plain words, no filler, no bullet spam"
+        ),
+    },
     AgentPersona.KAREN: {
         "name": "Karen",
         "character": (

--- a/backend/voice/agent_registry.py
+++ b/backend/voice/agent_registry.py
@@ -132,6 +132,168 @@ def route_by_wake_word(transcript: str) -> Optional[AgentSpec]:
         return None
 
 
+# ---------------------------------------------------------------------------
+# Dual summon — "Hey JARVIS, ask Karen to verify the deployment"
+# ---------------------------------------------------------------------------
+
+#: Verbs that DELEGATE: they take an animate object and hand it a task.
+#: This is the structural signal that distinguishes "ask Karen to verify"
+#: (Karen is being given work) from "Karen is broken" (Karen is the topic).
+#: A closed class, because delegation is a small and stable construction.
+_DELEGATION_VERBS = frozenset("""
+ask asks tell tells have has get gets ping pings request requests
+delegate delegates forward forwards hand hands pass passes loop
+check chase escalate escalates route routes
+""".split())
+
+#: Tokens that may sit between the verb and its object without breaking the
+#: relation ("ask my Karen", "get the JARVIS"). Kept tiny: the further apart
+#: they are, the less likely the verb governs that name at all.
+_DELEGATION_GAP = frozenset("""a an the my our your that this in to with over up""".split())
+
+#: Coordination, not delegation. "Karen and JARVIS, status" addresses two
+#: agents at once — nobody is being handed a task, and simultaneous speech is
+#: exactly what the scheduler exists to prevent.
+_COORDINATORS = frozenset({"and", "&", "plus", "or"})
+
+#: Complementiser that opens the delegated clause: "ask Karen TO verify".
+_TASK_OPENERS = ("to", "that", "if", "whether", "about", "for")
+
+_TOKEN = re.compile(r"[A-Za-z0-9'+]+")
+
+
+@dataclass(frozen=True)
+class Summons:
+    """Who was addressed, who was delegated to, and what they were given.
+
+    Roles rather than string halves. The collision this resolves is not
+    "two names in one sentence" — it is the absence of ARBITRATION: without
+    a designated primary, both agents claim the audio plane and the local
+    model at once, and on a 16GB machine that is a memory wall and two
+    voices talking over each other."""
+
+    primary: AgentSpec
+    secondary: Optional[AgentSpec]
+    #: What the secondary was asked to do, verbatim from the transcript.
+    delegated_task: str
+    #: The utterance as addressed to the primary — the delegation clause
+    #: removed, because the primary is not being asked to do that work.
+    primary_text: str
+    #: Why arbitration decided as it did. Legible, because a wrong call here
+    #: sends the wrong agent to the wrong model.
+    reason: str
+
+    @property
+    def is_dual(self) -> bool:
+        return self.secondary is not None
+
+
+def _occurrences(text: str) -> List[Tuple[int, AgentSpec]]:
+    """Every wake-word hit with its position, earliest first."""
+    hits: List[Tuple[int, AgentSpec]] = []
+    for spec in _AGENTS.values():
+        for m in spec.wake_pattern.finditer(text):
+            hits.append((m.start(), spec))
+    hits.sort(key=lambda h: h[0])
+    return hits
+
+
+def _governing_verb(tokens: List[Tuple[int, str]], name_idx: int) -> str:
+    """The delegation verb governing the name at *name_idx*, or "".
+
+    Looks BACKWARD across at most a determiner or two. A verb further away
+    than that is not governing this name — it is a different clause, and
+    treating it as delegation would hand work to an agent the operator only
+    mentioned."""
+    steps = 0
+    for i in range(name_idx - 1, -1, -1):
+        word = tokens[i][1].lower()
+        if word in _DELEGATION_VERBS:
+            return word
+        if word in _DELEGATION_GAP and steps < 2:
+            steps += 1
+            continue
+        return ""
+    return ""
+
+
+def arbitrate(transcript: str) -> Optional[Summons]:
+    """Assign PRIMARY and SECONDARY roles to a possibly-dual summon.
+
+    Returns None when no agent was addressed at all.
+
+    The primary is whoever was addressed FIRST — they claim the audio plane
+    and answer. A second agent becomes the SECONDARY only when it is the
+    object of a delegation verb; otherwise it was merely mentioned, and
+    handing work to a mentioned agent would answer a sentence nobody asked.
+
+    Deliberately NOT a regex that splits the sentence in half. A split has no
+    idea which side is an instruction and which is a topic, so "Karen, JARVIS
+    is down" would summon JARVIS to do nothing. What is parsed here is the
+    RELATION — verb governs object governs complement — which is what
+    delegation actually is. Pure code, no model call. NEVER raises."""
+    try:
+        text = str(transcript or "")
+        if not text.strip():
+            return None
+        hits = _occurrences(text)
+        if not hits:
+            return None
+
+        primary = hits[0][1]
+        # Distinct second agent, if any. Repeating one name is emphasis.
+        second = next(
+            ((pos, spec) for pos, spec in hits if spec.persona is not primary.persona),
+            None,
+        )
+        if second is None:
+            return Summons(primary, None, "", text.strip(), "single_agent")
+
+        sec_pos, sec_spec = second
+        tokens = [(m.start(), m.group(0)) for m in _TOKEN.finditer(text)]
+        name_idx = next(
+            (i for i, (pos, _w) in enumerate(tokens) if pos >= sec_pos), -1,
+        )
+        if name_idx < 0:
+            return Summons(primary, None, "", text.strip(), "single_agent")
+
+        prev = tokens[name_idx - 1][1].lower() if name_idx > 0 else ""
+        if prev in _COORDINATORS:
+            # Both addressed at once. One still has to go first — simultaneous
+            # speech is the collision — so the primary answers and the second
+            # agent is NOT given work it was never handed.
+            return Summons(
+                primary, None, "", text.strip(), "coordination_not_delegation",
+            )
+
+        verb = _governing_verb(tokens, name_idx)
+        if not verb:
+            return Summons(primary, None, "", text.strip(), "mention_not_delegation")
+
+        # The delegated clause is what FOLLOWS the name; the primary's own
+        # utterance is what precedes the governing verb.
+        after = text[tokens[name_idx][0] + len(tokens[name_idx][1]):].strip()
+        for opener in _TASK_OPENERS:
+            if after.lower().startswith(opener + " "):
+                after = after[len(opener) + 1:].strip()
+                break
+        task = after.strip(" ,.;:!?")
+
+        verb_idx = next(
+            (i for i in range(name_idx - 1, -1, -1)
+             if tokens[i][1].lower() == verb), name_idx,
+        )
+        primary_text = text[:tokens[verb_idx][0]].strip(" ,.;:!?")
+
+        return Summons(
+            primary, sec_spec, task,
+            primary_text or text.strip(),
+            f"delegation:{verb}" if task else f"delegation_no_task:{verb}",
+        )
+    except (TypeError, re.error, ValueError, IndexError):
+        return None
+
+
 def voice_profile_for(persona: object) -> Optional[VoiceProfile]:
     """Resolved voice for *persona*, honouring the registry's preference.
 
@@ -153,6 +315,8 @@ def prompt_for(persona: object) -> Optional[str]:
 
 __all__ = [
     "AgentSpec",
+    "Summons",
+    "arbitrate",
     "all_agents",
     "prompt_for",
     "route_by_wake_word",

--- a/backend/voice/agent_registry.py
+++ b/backend/voice/agent_registry.py
@@ -1,0 +1,161 @@
+"""The persona matrix — which agent is speaking, and how it is rendered.
+
+Two entities coexist in JARVIS-PRIME and they are not interchangeable:
+
+    JARVIS  — the Body. British, understated. Rendered by the `Daniel` voice.
+    O+V     — Ouroboros + Venom, the self-developing organism. Terse
+              Australian engineer. Rendered by the `Karen` voice.
+
+The distinction this module finally makes
+-----------------------------------------
+"Karen" has been used to mean both the AGENT and the VOICE, and that conflation
+is why identity kept leaking: four synthesis sites each decided a voice, and
+the conversation prompt separately decided a name, and nothing owned the pair.
+An agent is an IDENTITY with a name, a character and a wake word; a voice is
+one platform's rendering of it. ``AgentPersona.OV`` is the agent;
+``Karen`` is what it sounds like on macOS.
+
+``AgentPersona.KAREN`` is retained as an alias so nothing that already binds it
+breaks, but OV is the canonical name for the entity.
+
+Wake-word routing
+-----------------
+The active agent is selected from what the operator actually SAID rather than
+from configuration: address "Karen" and O+V answers, address "JARVIS" and the
+Body does. Both wake words are drawn from the same registry entries that
+supply the voice and the prompt, so adding an agent is one entry — not an
+entry plus a routing branch plus a voice mapping, which is exactly the shape
+that let voice and identity drift apart in the first place.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Tuple
+
+from backend.voice.agent_persona import (
+    AgentPersona,
+    VoiceProfile,
+    resolve_profile,
+    system_prompt_for,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class AgentSpec:
+    """Everything that makes one agent itself.
+
+    Frozen: an agent's identity is not something a caller should be able to
+    edit at runtime, and the drift this module exists to prevent came from
+    exactly that kind of per-site mutation."""
+
+    persona: AgentPersona
+    display_name: str
+    wake_words: Tuple[str, ...]
+    #: Preferred macOS voice. The registry states the INTENT; the persona
+    #: resolver decides what is actually installed and fast enough, so a
+    #: machine without this voice degrades rather than failing.
+    preferred_voice: str
+
+    @property
+    def wake_pattern(self) -> "re.Pattern[str]":
+        """Whole-word alternation over this agent's wake words.
+
+        Word-boundaried, because the substring lesson has been learned
+        expensively in this codebase: 'ov' inside 'over', 'karen' inside a
+        longer token, and — most memorably — 'rain' inside 'brain' opening
+        the Weather app."""
+        alt = "|".join(re.escape(w) for w in self.wake_words)
+        return re.compile(rf"\b(?:{alt})\b", re.IGNORECASE)
+
+
+#: THE MATRIX. One entry per agent; voice, prompt and wake word all hang off
+#: it, so they cannot be changed independently and drift.
+_AGENTS: Dict[AgentPersona, AgentSpec] = {
+    AgentPersona.OV: AgentSpec(
+        persona=AgentPersona.OV,
+        display_name="Karen",
+        wake_words=("karen", "o+v", "ouroboros"),
+        preferred_voice="Karen",
+    ),
+    AgentPersona.JARVIS: AgentSpec(
+        persona=AgentPersona.JARVIS,
+        display_name="JARVIS",
+        wake_words=("jarvis", "javis", "jervis"),   # common STT mishearings
+        preferred_voice="Daniel",
+    ),
+}
+
+
+def all_agents() -> Tuple[AgentSpec, ...]:
+    return tuple(_AGENTS.values())
+
+
+def spec_for(persona: object) -> Optional[AgentSpec]:
+    """The registry entry for *persona*, or None. NEVER raises."""
+    p = AgentPersona.coerce(persona)
+    if p is None:
+        return None
+    if p in _AGENTS:
+        return _AGENTS[p]
+    # KAREN is an alias for OV — the agent, not the voice.
+    if p is AgentPersona.KAREN:
+        return _AGENTS.get(AgentPersona.OV)
+    return None
+
+
+def route_by_wake_word(transcript: str) -> Optional[AgentSpec]:
+    """Which agent was ADDRESSED, from what the operator said.
+
+    Returns None when no agent was named — the caller keeps whoever is
+    already active, because a turn that names nobody is a continuation of the
+    current conversation, not a request to switch. Silently reassigning on
+    every unnamed turn would make the active agent depend on sentence
+    structure rather than on intent.
+
+    When two agents are named, the one appearing FIRST wins: "Karen, ask
+    JARVIS to…" addresses Karen about JARVIS. NEVER raises."""
+    try:
+        text = str(transcript or "")
+        if not text.strip():
+            return None
+        best: Optional[Tuple[int, AgentSpec]] = None
+        for spec in _AGENTS.values():
+            m = spec.wake_pattern.search(text)
+            if m is not None and (best is None or m.start() < best[0]):
+                best = (m.start(), spec)
+        return best[1] if best else None
+    except (TypeError, re.error):
+        return None
+
+
+def voice_profile_for(persona: object) -> Optional[VoiceProfile]:
+    """Resolved voice for *persona*, honouring the registry's preference.
+
+    DRY: the registry says WHICH voice the agent should have; the persona
+    resolver still decides whether it is installed, whether an operator
+    override supersedes it, and whether it synthesizes fast enough. Two
+    layers, one question each."""
+    spec = spec_for(persona)
+    if spec is None:
+        return None
+    return resolve_profile(spec.persona, prefer=spec.preferred_voice)
+
+
+def prompt_for(persona: object) -> Optional[str]:
+    """Identity prompt for *persona* — the same seam the pipeline uses."""
+    spec = spec_for(persona)
+    return system_prompt_for(spec.persona) if spec else None
+
+
+__all__ = [
+    "AgentSpec",
+    "all_agents",
+    "prompt_for",
+    "route_by_wake_word",
+    "spec_for",
+    "voice_profile_for",
+]

--- a/backend/voice/phatic_fastpath.py
+++ b/backend/voice/phatic_fastpath.py
@@ -1,0 +1,206 @@
+"""Zero-cost greetings — don't pay an LLM to say "I'm here".
+
+The expensive hello
+-------------------
+"Hey Karen" carries no question. Routing it to a 30B model over the network
+costs tokens, ~0.9s of TTFT, and the operator's patience — for an utterance
+whose only informational content is *I am addressing you*. That is a routing
+defect, not a prompt-tuning opportunity.
+
+Why this is not a greeting list
+-------------------------------
+The temptation is ``if text in ("hi", "hello", "hey karen")``. That is the
+same mistake as matching weather by substring, which in this codebase opened
+the Weather app for "the brain is thinking" and "close the window". A list
+fails open on everything it has not seen and fails closed on everything
+phrased slightly differently.
+
+The actual property is INFORMATIONAL. A phatic utterance is one that carries
+no residual semantic payload once you remove:
+
+  * the agent's own name (addressing, not content),
+  * phatic markers — a real linguistic category, closed and small: the tokens
+    English uses purely to open and maintain contact,
+  * function words, which carry structure rather than meaning.
+
+If nothing remains, the operator said "I am talking to you" and nothing else.
+If ANYTHING remains — one content word — it is a real turn and goes to the
+model. That generalises to phrasings never enumerated here ("yo karen you
+around", "karen?", "are you there jarvis") and, more importantly, refuses to
+swallow "karen what's my disk usage", which contains content and must not be
+answered from a cache.
+
+Bias is deliberately asymmetric: a missed phatic costs one unnecessary LLM
+call; a FALSE phatic answers a real question with "I'm here", which is a lie.
+So the classifier only fires when the residue is empty.
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import re
+from dataclasses import dataclass
+from typing import List, Optional, Sequence, Tuple
+
+logger = logging.getLogger(__name__)
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+
+def fastpath_enabled() -> bool:
+    """Master gate. OFF sends every turn to the model, which is the only
+    honest way to compare cost and latency against this path."""
+    return os.getenv("JARVIS_PHATIC_FASTPATH", "true").strip().lower() in _TRUTHY
+
+
+#: Tokens English uses purely to establish or maintain contact. A closed
+#: linguistic class, not a list of remembered greetings — which is why it
+#: generalises to phrasings nobody enumerated.
+_PHATIC_MARKERS = frozenset("""
+hi hello hey heya yo hiya howdy greetings morning afternoon evening night
+good goodmorning ok okay alright allright sup wassup whatsup
+there here around awake alive up listening
+please thanks thank cheers mate
+test testing check checking hear me
+""".split())
+
+#: Function words: structure, not meaning.
+_FUNCTION_WORDS = frozenset("""
+a an the and or but so it its it's this that these those to of in on at for
+with my your our their i me we they he she do does did done can could will
+would shall should may might must have has had be been being was were
+just now still again very really quite bit
+are is am r u ya you
+# ^ copulas and pronouns are STRUCTURE, not contact. Listing "is" as a
+# phatic marker let the pure-fragment guard pass "is it the" — an utterance
+# with no greeting in it at all — which would have answered a transcription
+# artifact with "I'm here" instead of sending it on. The construction
+# "are you there" is still phatic because "there" is the marker; the copula
+# never was.
+""".split())
+
+_WORD = re.compile(r"[a-z0-9']+")
+
+
+@dataclass(frozen=True)
+class PhaticVerdict:
+    """Why the classifier decided what it did — so a wrong call is legible."""
+
+    is_phatic: bool
+    residue: Tuple[str, ...]
+    reason: str
+
+    def __bool__(self) -> bool:
+        return self.is_phatic
+
+
+def _max_words() -> int:
+    """Length ceiling. Above this the operator is saying something, whatever
+    the individual tokens look like — a long utterance made entirely of
+    function words is far more likely to be a transcription artifact than a
+    greeting, and artifacts must reach the model rather than be answered."""
+    try:
+        return max(2, int(os.getenv("JARVIS_PHATIC_MAX_WORDS", "8")))
+    except (TypeError, ValueError):
+        return 8
+
+
+def classify(text: str, *, agent_names: Sequence[str] = ()) -> PhaticVerdict:
+    """Is this pure contact-establishment? NEVER raises.
+
+    *agent_names* are stripped as ADDRESSING rather than content: saying an
+    assistant's name tells it who you mean, not what you want."""
+    try:
+        raw = str(text or "").strip().lower()
+        if not raw:
+            return PhaticVerdict(False, (), "empty")
+
+        tokens = _WORD.findall(raw)
+        if not tokens:
+            return PhaticVerdict(False, (), "no_tokens")
+        if len(tokens) > _max_words():
+            return PhaticVerdict(False, tuple(tokens), "too_long")
+
+        # A question mark is a request even when every word is phatic:
+        # "you there?" is contact, but "how are you doing today?" is a turn.
+        names = {n.lower() for n in agent_names}
+        name_tokens = {t for n in names for t in _WORD.findall(n)}
+
+        residue = [
+            t for t in tokens
+            if t not in name_tokens
+            and t not in _PHATIC_MARKERS
+            and t not in _FUNCTION_WORDS
+        ]
+        if residue:
+            return PhaticVerdict(False, tuple(residue), "has_content")
+
+        # Guard against the degenerate case: an utterance made ONLY of
+        # function words ("is it the") is not a greeting, it is a fragment,
+        # and a fragment is usually a transcription artifact worth sending on.
+        if not (set(tokens) & _PHATIC_MARKERS) and not (set(tokens) & name_tokens):
+            return PhaticVerdict(False, (), "no_phatic_marker")
+
+        return PhaticVerdict(True, (), "phatic")
+    except (TypeError, re.error):
+        return PhaticVerdict(False, (), "error")
+
+
+# ---------------------------------------------------------------------------
+# Response pool
+# ---------------------------------------------------------------------------
+
+#: Acknowledgements only. Every one of these is true regardless of what was
+#: asked, because the fast path must never answer a QUESTION — it exists to
+#: answer being addressed. Nothing here claims knowledge or takes an action.
+_ACKS: Tuple[str, ...] = (
+    "I'm here.",
+    "Listening.",
+    "Go ahead.",
+    "Right here.",
+    "Yep, listening.",
+    "Here. What do you need?",
+)
+
+
+def _pool() -> Tuple[str, ...]:
+    """Operator-supplied acknowledgements, else the defaults."""
+    raw = os.getenv("JARVIS_PHATIC_RESPONSES", "").strip()
+    if not raw:
+        return _ACKS
+    parts = tuple(p.strip() for p in raw.split("|") if p.strip())
+    return parts or _ACKS
+
+
+def acknowledge(text: str, *, operator: str = "", salt: str = "") -> str:
+    """One acknowledgement, varied but DETERMINISTIC for a given utterance.
+
+    Chosen by hashing the input rather than at random: an assistant that
+    answers the same greeting differently on every repetition feels
+    capricious, while one that never varies feels mechanical. Hashing gives
+    variety across different greetings and stability for the same one, and it
+    keeps tests exact without stubbing a random source.
+
+    NEVER raises."""
+    try:
+        pool = _pool()
+        key = f"{text or ''}|{salt}".encode("utf-8", "replace")
+        idx = int(hashlib.sha256(key).hexdigest()[:8], 16) % len(pool)
+        reply = pool[idx]
+        who = (operator or "").strip()
+        if who and reply.endswith("."):
+            # Address them back when we know their name — resolved upstream,
+            # never invented here.
+            return f"{reply[:-1]}, {who}."
+        return reply
+    except (TypeError, ValueError, ZeroDivisionError):
+        return _ACKS[0]
+
+
+__all__ = [
+    "PhaticVerdict",
+    "acknowledge",
+    "classify",
+    "fastpath_enabled",
+]

--- a/backend/voice/streaming_stt.py
+++ b/backend/voice/streaming_stt.py
@@ -175,6 +175,10 @@ class StreamingSTTEngine:
 
         # VAD state
         self._speech_active = False
+        #: VAD-positive frames accumulated since the buffer was last cleared.
+        #: A final whose buffer contains NONE of them is not an utterance —
+        #: see _schedule_transcription.
+        self._voiced_frames = 0
         self._silence_start_ms: Optional[float] = None
         self._speech_start_ms: Optional[float] = None
 
@@ -317,6 +321,7 @@ class StreamingSTTEngine:
         # continuous, and the quiet parts carry the consonants.
         if is_speech and not self._speech_active:
             self._speech_active = True
+            self._voiced_frames = 0
             self._speech_start_ms = now_ms
             self._silence_start_ms = None
             # Pre-roll: VAD needs energy before it fires, so by the time it
@@ -340,6 +345,7 @@ class StreamingSTTEngine:
 
             if is_speech:
                 self._silence_start_ms = None
+                self._voiced_frames += 1
             else:
                 if self._silence_start_ms is None:
                     self._silence_start_ms = now_ms
@@ -405,9 +411,34 @@ class StreamingSTTEngine:
                 return
 
             if not is_partial:
-                # Clear buffer for final transcript
+                # A FINAL whose buffer holds no voiced frame is not an
+                # utterance — it is the room tone that accumulated AFTER the
+                # real final already fired and cleared the buffer.
+                #
+                # This is the "EMPTY transcript from speech-level amplitude"
+                # class, caught with the flight recorder: on one such final
+                # the model was handed 1.04s at peak 0.025 while the device
+                # in that same window peaked at 0.9665 and transcribes the
+                # whole sentence. Whisper was right to return nothing; it was
+                # asked to read silence, scored it no_speech_prob=0.81, and
+                # the warning that followed accused the model of rejecting
+                # speech that had never been in the buffer.
+                #
+                # Gated on the VAD's own decisions rather than on amplitude:
+                # a level threshold here would re-introduce the judgement the
+                # endpointer already makes, and disagree with it at exactly
+                # the margins where it matters.
+                voiced = self._voiced_frames
                 self._audio_buffer.clear()
                 self._total_frames = 0
+                self._voiced_frames = 0
+                if voiced == 0:
+                    logger.debug(
+                        "[StreamingSTT] final suppressed: %.2fs buffered with "
+                        "no voiced frame (trailing room tone)",
+                        duration_ms / 1000.0,
+                    )
+                    return
 
         # Run transcription in thread pool
         self._loop.call_soon_threadsafe(
@@ -514,6 +545,39 @@ class StreamingSTTEngine:
                     # none: it produces confident analysis of the wrong data.
                     if _rms >= _rejected_capture_min_rms() and _rejected_capture_enabled():
                         _dump_rejected_audio(audio, self._sample_rate, _rms)
+
+                    # FLIGHT RECORDER. The dump above holds only the buffer
+                    # the MODEL saw, which cannot separate "the microphone
+                    # never heard a voice" from "the chain destroyed one" —
+                    # two faults with opposite fixes, and the reason this
+                    # capture fault has survived three rounds of diagnosis.
+                    # The forensics tap holds both ends of the chain and
+                    # compares their syllabic rhythm, which is the one
+                    # measurement that tells them apart.
+                    #
+                    # Only on the speech-amplitude case: a rejection at NOISE
+                    # level is already explained by its own log line, and
+                    # recording it would evict the incidents that matter.
+                    if _pk >= 0.01:
+                        try:
+                            from backend.audio.capture_forensics import (
+                                get_forensics,
+                            )
+                            get_forensics().record_rejection(
+                                "empty_transcript_at_speech_amplitude",
+                                model_audio=audio,
+                                model_sample_rate=self._sample_rate,
+                                detail={
+                                    "peak": round(_pk, 4),
+                                    "rms": round(_rms, 5),
+                                    "is_partial": bool(is_partial),
+                                    "duration_s": round(
+                                        len(audio) / self._sample_rate, 3,
+                                    ),
+                                },
+                            )
+                        except (ImportError, AttributeError):
+                            pass
                 except Exception:  # noqa: BLE001
                     pass
 

--- a/tests/audio/test_agc_and_jit_gating.py
+++ b/tests/audio/test_agc_and_jit_gating.py
@@ -231,6 +231,7 @@ def test_the_gate_uses_targeted_exceptions_not_a_broad_catch():
     enum member and the gate silently never engaged — a reference error
     wearing the costume of graceful degradation."""
     import ast
+    import textwrap
     from pathlib import Path
 
     src = Path("backend/audio/playback_gate.py").read_text(encoding="utf-8")
@@ -263,14 +264,19 @@ def test_a_contract_error_is_not_swallowed(monkeypatch):
 def test_the_pipeline_no_longer_gates_around_generation():
     """Structural pin: start_speaking() around the whole call is the very
     blindspot this replaces."""
+    import ast
     import inspect
+    import textwrap
 
     from backend.audio.conversation_pipeline import ConversationPipeline
 
-    import ast
-
-    src = inspect.getsource(ConversationPipeline._speak_sentence)
-    tree = ast.parse(src.lstrip())
+    # _render_sentence is where playback now lives; _speak_sentence in front
+    # of it only takes a turnstile ticket so two agents cannot overlap.
+    src = (
+        inspect.getsource(ConversationPipeline._speak_sentence)
+        + inspect.getsource(ConversationPipeline._render_sentence)
+    )
+    tree = ast.parse(textwrap.dedent(src))
     for node in ast.walk(tree):
         if isinstance(node, ast.Constant) and isinstance(node.value, str):
             node.value = ""

--- a/tests/audio/test_float_agc.py
+++ b/tests/audio/test_float_agc.py
@@ -1,0 +1,268 @@
+"""Pre-quantization floating-point AGC — the three mandated assertions.
+
+1. A float array peaking at 4.19 scales to below 1.0.
+2. The waveform's relative shape is preserved — no hard clipping.
+3. A following array peaking at 0.1 releases back up over time.
+
+Assertion 2 is the one with teeth, and it is written to catch the failure the
+previous implementation had rather than a proxy for it. "Peak is under 1.0" is
+satisfied equally by a scaler and by a tanh saturator; only comparing the
+SHAPE separates them. So it asserts the operation is a pure scalar multiply —
+every sample divided by the same constant — which no compressor can pass.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from backend.audio.audio_bus import (
+    _AGC_CEILING,
+    _AGC_TARGET,
+    AudioBus,
+)
+
+
+class _Cfg:
+    internal_rate = 16000
+
+
+def _bus() -> AudioBus:
+    """A bus with only the governor's state.
+
+    __new__ deliberately: __init__ opens a device, and the AGC is a pure
+    function of a frame and three floats."""
+    b = AudioBus.__new__(AudioBus)
+    b._agc_gain = 1.0
+    b._range_peak = 0.0
+    b._range_reports = 99          # suppress the over-scale log in tests
+    b._config = _Cfg()
+    return b
+
+
+def _tone(peak: float, n: int = 320, freq: float = 220.0) -> np.ndarray:
+    t = np.arange(n, dtype=np.float32) / 16000.0
+    return (np.sin(2 * np.pi * freq * t) * peak).astype(np.float32)
+
+
+# ---------------------------------------------------------------------------
+# Assertion 1 — the 4.19 peak comes down
+# ---------------------------------------------------------------------------
+
+
+def test_the_observed_4_19_peak_scales_below_full_scale() -> None:
+    """4.19 is not hypothetical — it is what the capture device delivered
+    while the operator spoke, recorded by the capture forensics."""
+    out = _bus()._fit_to_range(_tone(4.19))
+    assert float(np.max(np.abs(out))) < 1.0
+    assert float(np.max(np.abs(out))) == pytest.approx(_AGC_TARGET, abs=1e-3)
+
+
+@pytest.mark.parametrize("peak", [0.95, 1.0, 1.7, 4.19, 12.0, 50.0])
+def test_any_over_scale_input_lands_under_full_scale(peak: float) -> None:
+    """Unbounded input: float PCM has no ceiling, so neither can the test."""
+    out = _bus()._fit_to_range(_tone(peak))
+    assert float(np.max(np.abs(out))) <= 1.0
+
+
+def test_quiet_frames_pass_through_bit_identical() -> None:
+    """The common case must cost nothing AND change nothing. A governor that
+    rewrote every frame would be a permanent distortion in exchange for an
+    occasional one."""
+    quiet = _tone(0.35)
+    out = _bus()._fit_to_range(quiet)
+    assert np.array_equal(out, quiet)
+    assert out is quiet, "a below-ceiling frame was copied rather than returned"
+
+
+# ---------------------------------------------------------------------------
+# Assertion 2 — shape preserved, no hard clipping
+# ---------------------------------------------------------------------------
+
+
+def test_the_waveform_shape_is_mathematically_preserved() -> None:
+    """The distinction that matters.
+
+    A tanh soft-knee also keeps the peak under 1.0 — and compresses loud
+    samples against quiet ones, manufacturing harmonics that were never
+    spoken. Speech recognition reads formant structure, so that is the wrong
+    correction. A pure scalar multiply changes amplitude and nothing else."""
+    src = _tone(4.19)
+    out = _bus()._fit_to_range(src)
+
+    nz = np.abs(src) > 1e-6
+    ratios = out[nz] / src[nz]
+    assert float(ratios.max() - ratios.min()) < 1e-6, (
+        "gain varied across the frame — this is a compressor, not a scaler"
+    )
+    cos = float(np.dot(out, src) / (np.linalg.norm(out) * np.linalg.norm(src)))
+    assert cos == pytest.approx(1.0, abs=1e-6)
+
+
+def test_nothing_is_hard_clipped() -> None:
+    src = _tone(4.19)
+    out = _bus()._fit_to_range(src)
+    assert int(np.sum(np.abs(out) >= 0.999)) == 0
+
+
+def test_a_compressor_would_fail_this_suite() -> None:
+    """Guards the guard. If someone reinstates a soft knee, the shape
+    assertion above must actually catch it — so prove the assertion has
+    teeth by running it against the very curve that was replaced."""
+    src = _tone(4.19)
+    t, span = 0.75, 0.25
+    mag = np.abs(src)
+    tanh_out = src.copy()
+    over = mag > t
+    tanh_out[over] = np.sign(src[over]) * (t + span * np.tanh((mag[over] - t) / span))
+
+    nz = np.abs(src) > 1e-6
+    ratios = tanh_out[nz] / src[nz]
+    assert float(ratios.max() - ratios.min()) > 1e-3, (
+        "the shape assertion cannot distinguish a compressor from a scaler"
+    )
+
+
+def test_harmonic_content_is_not_manufactured() -> None:
+    """A pure tone scaled is still a pure tone. Put through a nonlinearity it
+    grows harmonics — which is the corruption, stated in the frequency domain
+    where a recogniser actually reads it."""
+    src = _tone(4.19, n=1600, freq=250.0)
+    out = _bus()._fit_to_range(src)
+
+    def harmonic_energy(sig: np.ndarray) -> float:
+        spec = np.abs(np.fft.rfft(sig * np.hanning(len(sig))))
+        freqs = np.fft.rfftfreq(len(sig), 1 / 16000.0)
+        fund = spec[(freqs > 200) & (freqs < 300)].sum()
+        harm = spec[(freqs > 400)].sum()
+        return float(harm / max(fund, 1e-9))
+
+    assert harmonic_energy(out) == pytest.approx(harmonic_energy(src), rel=1e-3)
+
+
+# ---------------------------------------------------------------------------
+# Assertion 3 — asymmetric release
+# ---------------------------------------------------------------------------
+
+
+def test_gain_releases_back_up_over_time() -> None:
+    """Assertion 3. After the loud passage, quiet frames must recover — and
+    recover SLOWLY, or the noise floor rises inside every pause between words
+    (audible pumping, and a moving floor for the endpointer to chase)."""
+    bus = _bus()
+    bus._fit_to_range(_tone(4.19))
+    attacked = bus._agc_gain
+    assert attacked < 0.3, "attack did not engage"
+
+    quiet = _tone(0.1)
+    trace = []
+    for _ in range(200):                      # 200 frames x 20ms = 4s
+        bus._fit_to_range(quiet)
+        trace.append(bus._agc_gain)
+
+    assert trace[0] > attacked, "gain did not release at all"
+    assert all(b >= a - 1e-9 for a, b in zip(trace, trace[1:])), (
+        "release was not monotonic"
+    )
+    assert trace[-1] > trace[0], "release stalled"
+    assert trace[-1] <= 1.0, "gain overshot unity"
+
+
+def test_release_is_slower_than_attack() -> None:
+    """The asymmetry itself, stated as a comparison rather than a constant:
+    attack completes in ONE frame, release must not."""
+    bus = _bus()
+    bus._fit_to_range(_tone(4.19))
+    attacked = bus._agc_gain
+
+    bus._fit_to_range(_tone(0.1))
+    after_one_frame = bus._agc_gain
+
+    recovered = (after_one_frame - attacked) / max(1.0 - attacked, 1e-9)
+    assert recovered < 0.10, (
+        f"release recovered {recovered:.0%} in a single frame — that is a "
+        f"step, not a decay"
+    )
+
+
+def test_release_is_time_based_not_frame_based() -> None:
+    """The time constant is in SECONDS. Two buses fed the same DURATION of
+    quiet audio in different frame sizes must land in the same place, or the
+    governor's behaviour would silently change with the device's buffer."""
+    big, small = _bus(), _bus()
+    big._fit_to_range(_tone(4.19))
+    small._fit_to_range(_tone(4.19))
+
+    for _ in range(10):                       # 10 x 640 samples
+        big._fit_to_range(_tone(0.1, n=640))
+    for _ in range(20):                       # 20 x 320 samples — same seconds
+        small._fit_to_range(_tone(0.1, n=320))
+
+    assert big._agc_gain == pytest.approx(small._agc_gain, rel=0.05)
+
+
+# ---------------------------------------------------------------------------
+# Edge cases — the governor runs on the audio thread and may never raise
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "frame",
+    [
+        np.zeros(0, dtype=np.float32),
+        np.zeros(320, dtype=np.float32),
+        np.full(320, np.nan, dtype=np.float32),
+        np.full(320, np.inf, dtype=np.float32),
+        np.array([1e30, -1e30] * 160, dtype=np.float32),
+    ],
+    ids=["empty", "silence", "nan", "inf", "absurd"],
+)
+def test_degenerate_frames_never_raise(frame: np.ndarray) -> None:
+    out = _bus()._fit_to_range(frame)
+    assert out is not None
+    if out.size:
+        assert np.all(np.isfinite(out))
+        assert float(np.max(np.abs(out))) <= 1.0
+
+
+def test_non_finite_input_does_not_poison_later_frames() -> None:
+    """A NaN reaching the gain state would silence every frame after it —
+    a permanent fault from one bad buffer."""
+    bus = _bus()
+    bus._fit_to_range(np.full(320, np.nan, dtype=np.float32))
+    assert np.isfinite(bus._agc_gain)
+
+    out = bus._fit_to_range(_tone(0.35))
+    assert np.all(np.isfinite(out))
+    assert float(np.max(np.abs(out))) > 0.0, "a NaN frame muted the signal"
+
+
+def test_gain_never_falls_below_the_floor() -> None:
+    """One freak transient must not attenuate the whole session toward
+    silence with no way back inside the release constant."""
+    bus = _bus()
+    bus._fit_to_range(_tone(1e6))
+    assert bus._agc_gain >= 0.0
+    assert bus.agc_state()["gain"] > 0.0
+
+
+def test_agc_state_is_observable() -> None:
+    bus = _bus()
+    bus._fit_to_range(_tone(4.19))
+    state = bus.agc_state()
+    assert state["gain"] < 1.0
+    assert state["ceiling"] == _AGC_CEILING
+    assert state["peak_seen"] == pytest.approx(4.19, abs=1e-2)
+
+
+def test_sustained_loud_input_does_not_ratchet_toward_silence() -> None:
+    """Steady loud speech must settle at ONE gain, not keep attenuating: the
+    scaled output sits under the ceiling, so the next frame must not read its
+    own correction as a fresh excursion."""
+    bus = _bus()
+    gains = []
+    for _ in range(50):
+        bus._fit_to_range(_tone(4.19))
+        gains.append(bus._agc_gain)
+    assert gains[-1] == pytest.approx(gains[0], rel=1e-6), (
+        "gain ratcheted downward on steady input"
+    )

--- a/tests/audio/test_self_interruption.py
+++ b/tests/audio/test_self_interruption.py
@@ -71,12 +71,17 @@ def test_the_afplay_launch_site_is_gated():
 
 
 def test_the_bus_playback_site_is_gated():
-    """The AEC path streams through AudioBus; it needs the same protection."""
+    """The AEC path streams through AudioBus; it needs the same protection.
+
+    Pinned on ``_render_sentence``: the speech scheduler split the ORDERING
+    decision (``_speak_sentence``, which now only acquires the turnstile)
+    from the PLAYBACK itself. The gate belongs with whatever puts sound on
+    the speakers, so the pin follows the body rather than the name."""
     import inspect
 
     from backend.audio.conversation_pipeline import ConversationPipeline
 
-    src = inspect.getsource(ConversationPipeline._speak_sentence)
+    src = inspect.getsource(ConversationPipeline._render_sentence)
     assert "playback_gate" in src
     assert src.index("playback_gate") < src.index("play_stream")
 

--- a/tests/governance/fixtures/conftest.py
+++ b/tests/governance/fixtures/conftest.py
@@ -1,0 +1,38 @@
+"""This directory is DATA. Nothing under it is a test.
+
+The collection error
+--------------------
+``pytest tests/governance`` aborted before running anything::
+
+    import file mismatch:
+    imported module 'test_before' has this __file__ attribute:
+      .../l2_exercise_corpus/problem_001/test_before.py
+    which is not the same as the test file we want to collect:
+      .../l2_exercise_corpus/problem_002/test_before.py
+
+Four ``problem_NNN/test_before.py`` files share a basename with no package
+structure between them, so pytest resolved all four to the module name
+``test_before`` and refused the second.
+
+Why ignoring is the fix, not renaming
+-------------------------------------
+The obvious repair is to rename them ``test_before_001.py`` and so on. That
+would silence the error and introduce a worse one: these files are the
+DELIBERATELY FAILING tests of the L2 repair corpus — the defect the engine is
+graded on fixing. Collecting them at all injects four known-red tests into
+every suite run, and "the corpus is red" would become indistinguishable from
+"the organism regressed".
+
+They are inputs, read by path from ``test_fixture_l2_exercise_problem_NNN.py``
+alongside ``before.py``, ``manifest.json`` and ``_known_good_fix.py`` — none of
+which pytest tries to collect, because none of them happens to start with
+``test_``. The basename collision was never the disease; it was the symptom of
+test-shaped DATA sitting inside the collection tree.
+
+So the directory declares what it is. ``collect_ignore_glob`` matches every
+entry here, which prunes the corpus directories themselves and therefore
+everything beneath them.
+"""
+from __future__ import annotations
+
+collect_ignore_glob = ["*"]

--- a/tests/governance/test_adaptive_voice_router.py
+++ b/tests/governance/test_adaptive_voice_router.py
@@ -408,7 +408,9 @@ def test_the_router_does_not_reimplement_the_election():
     src = Path(
         "backend/core/ouroboros/governance/adaptive_voice_router.py",
     ).read_text(encoding="utf-8")
-    assert "resolve_voice_model" in src
+    # Delegation, through the per-agent lane façade — which itself calls
+    # resolve_voice_model with this agent's prefix and ledger.
+    assert "lane_for" in src and "resolve_model()" in src
     for owned_elsewhere in ("ttft_s", "VoiceLatencyLedger", "deep_probe("):
         assert owned_elsewhere not in src, (
             f"router re-implements {owned_elsewhere} — that belongs to the lane"
@@ -451,7 +453,10 @@ async def test_a_zero_token_stream_demotes_the_model(monkeypatch):
     demoted = []
     monkeypatch.setattr(
         kvl, "record_runtime_failure",
-        lambda m, reason="runtime": demoted.append((m, reason)) or True,
+        # **kw: the lane now passes the per-agent ledger, and a fake that
+        # mirrored the OLD signature would raise TypeError into the router's
+        # handler and report "no demotion" for a demotion that happened.
+        lambda m, reason="runtime", **kw: demoted.append((m, reason)) or True,
     )
     r = _router(local=_Local(), dispatch=_dw([]))
     await _drain(r)
@@ -466,7 +471,7 @@ async def test_a_speaking_model_is_not_demoted(monkeypatch):
     demoted = []
     monkeypatch.setattr(
         kvl, "record_runtime_failure",
-        lambda m, reason="runtime": demoted.append(m) or True,
+        lambda m, reason="runtime", **kw: demoted.append(m) or True,
     )
     r = _router(local=_Local(), dispatch=_dw(["hello"]))
     assert await _drain(r) == "hello"

--- a/tests/voice/duplex/test_tts_playback.py
+++ b/tests/voice/duplex/test_tts_playback.py
@@ -48,7 +48,10 @@ async def test_play_calls_speak_stream_with_cancel_event_and_tracks_active():
     await asyncio.sleep(0)
     assert pb.is_active is True
     assert eng.calls[0]["text"] == "Fix applied."
-    assert eng.calls[0]["source"] == "karen"
+    # The source tag carries the persona now ("karen:persona=<agent>") so a
+    # log line says WHICH agent spoke, not merely that the karen path did.
+    src = eng.calls[0]["source"]
+    assert src.split(":")[0] == "karen"
     assert eng.calls[0]["cancel_event"] is not None
     eng.finish()
     await task

--- a/tests/voice/test_dual_summon_delegation.py
+++ b/tests/voice/test_dual_summon_delegation.py
@@ -1,0 +1,459 @@
+"""The Dual-Summon Collision — "Hey JARVIS, ask Karen to verify the deployment".
+
+Three mandated assertions:
+
+1. A transcript naming both agents assigns PRIMARY and SECONDARY correctly.
+2. The TTS queue prevents the secondary's audio from playing until the
+   primary's hardware lock is released.
+3. (In ``tests/governance/fixtures/conftest.py``) the duplicate ``test_before``
+   basename no longer aborts collection — asserted here as a live collection
+   run, so the fix cannot rot silently.
+
+The second assertion is the one with teeth, and it is written to FAIL on the
+bug rather than on a proxy for it: the mocked audio records real start/finish
+timestamps, so an overlap is detected as an overlap, not inferred from call
+order. Two utterances that merely *arrived* in the right sequence would pass a
+call-order assertion while still being audible at the same time.
+"""
+from __future__ import annotations
+
+import asyncio
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+import pytest
+
+from backend.audio.speech_scheduler import (
+    SpeechRole,
+    SpeechScheduler,
+    mark_hardware_busy,
+    mark_hardware_idle,
+    reset_scheduler,
+)
+from backend.core.ouroboros.governance.remote_compute_dispatcher import (
+    ProviderRoute,
+    RemoteComputeDispatcher,
+    Tier,
+    TierUnavailable,
+    Workload,
+    decide_lane,
+)
+from backend.voice.agent_persona import AgentPersona
+from backend.voice.agent_registry import arbitrate
+
+
+@pytest.fixture(autouse=True)
+def _fresh(monkeypatch: pytest.MonkeyPatch):
+    """A scheduler carried between tests would leak a busy count and make the
+    next test wait out the idle timeout."""
+    monkeypatch.setenv("JARVIS_TTS_SCHEDULER_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_TTS_ACOUSTIC_TAIL_S", "0.05")
+    monkeypatch.setenv("JARVIS_TTS_HARDWARE_IDLE_TIMEOUT_S", "5")
+    reset_scheduler()
+    yield
+    reset_scheduler()
+
+
+# ---------------------------------------------------------------------------
+# Assertion 1 — role assignment
+# ---------------------------------------------------------------------------
+
+
+def test_dual_summon_assigns_primary_and_secondary() -> None:
+    s = arbitrate("Hey JARVIS, ask Karen to verify the deployment")
+    assert s is not None
+    assert s.primary.persona is AgentPersona.JARVIS
+    assert s.secondary is not None
+    assert s.secondary.persona is AgentPersona.OV
+    assert s.delegated_task == "verify the deployment"
+    assert s.is_dual
+    assert s.reason == "delegation:ask"
+
+
+def test_roles_follow_who_was_addressed_not_who_appears_second() -> None:
+    s = arbitrate("Karen, tell JARVIS to reboot the mac")
+    assert s.primary.persona is AgentPersona.OV
+    assert s.secondary.persona is AgentPersona.JARVIS
+    assert s.delegated_task == "reboot the mac"
+
+
+@pytest.mark.parametrize(
+    "utterance,reason",
+    [
+        # Named, but as a TOPIC — nobody was handed work.
+        ("Karen, JARVIS is down again", "mention_not_delegation"),
+        # Both addressed at once. One still has to speak first, but neither
+        # is delegating to the other.
+        ("Karen and JARVIS, status report", "coordination_not_delegation"),
+    ],
+)
+def test_a_second_name_is_not_automatically_a_delegation(
+    utterance: str, reason: str,
+) -> None:
+    """The failure this prevents: splitting on the second wake word would
+    summon an agent to perform a sentence in which it was the subject."""
+    s = arbitrate(utterance)
+    assert s is not None
+    assert s.secondary is None, f"{utterance!r} spuriously delegated"
+    assert s.reason == reason
+
+
+def test_the_primary_text_excludes_the_delegated_clause() -> None:
+    """The primary is not being asked to verify anything."""
+    s = arbitrate("Hey JARVIS, ask Karen to verify the deployment")
+    assert "verify" not in s.primary_text
+    assert "Karen" not in s.primary_text
+
+
+# ---------------------------------------------------------------------------
+# Assertion 2 — the turnstile
+# ---------------------------------------------------------------------------
+
+
+class _Speaker:
+    """Mocked audio with real timing.
+
+    Records (agent, start, end) so overlap is measured, not assumed, and
+    marks the hardware busy exactly as ``playback_gate`` does in production —
+    which is what the conductor actually waits on."""
+
+    def __init__(self) -> None:
+        self.spans: List[Tuple[str, float, float]] = []
+
+    async def play(self, agent: str, duration: float = 0.05) -> None:
+        mark_hardware_busy()
+        start = time.monotonic()
+        try:
+            await asyncio.sleep(duration)
+        finally:
+            end = time.monotonic()
+            mark_hardware_idle()
+            self.spans.append((agent, start, end))
+
+    def overlaps(self) -> List[Tuple[str, str]]:
+        bad = []
+        for i, (a, a0, a1) in enumerate(self.spans):
+            for (b, b0, b1) in self.spans[i + 1:]:
+                if a0 < b1 and b0 < a1:
+                    bad.append((a, b))
+        return bad
+
+    def order(self) -> List[str]:
+        return [a for a, _s, _e in sorted(self.spans, key=lambda s: s[1])]
+
+
+@pytest.mark.asyncio
+async def test_secondary_audio_waits_for_the_primary_lock() -> None:
+    """Assertion 2. Both agents are released at the same instant; the
+    secondary must still not be audible until the primary is done."""
+    sched, speaker = SpeechScheduler(), _Speaker()
+
+    async def utterance(agent: str, role: SpeechRole) -> None:
+        await sched.speak(
+            lambda: speaker.play(agent), agent=agent, role=role,
+        )
+
+    await asyncio.gather(
+        utterance("jarvis", SpeechRole.PRIMARY),
+        utterance("karen", SpeechRole.SECONDARY),
+    )
+
+    assert not speaker.overlaps(), (
+        f"agents talked over each other: {speaker.overlaps()}"
+    )
+    assert speaker.order() == ["jarvis", "karen"]
+    await sched.aclose()
+
+
+@pytest.mark.asyncio
+async def test_role_beats_arrival_order_among_waiting_tickets() -> None:
+    """A plain lock grants in arrival order, and arrival order is a race: the
+    secondary's work is usually shorter, so it often finishes synthesis first.
+    Among tickets that are WAITING, order must follow arbitration instead.
+
+    Deliberately not a stronger claim. Making a ticket that arrives at an idle
+    turnstile pause in case a higher-priority one shows up would add latency
+    to every utterance to serve a case the pipeline already prevents — the
+    primary's reply is always enqueued before the delegated one is awaited.
+    Asserting a guarantee the system does not make would be a test that
+    passes by describing a system that does not exist."""
+    sched, speaker = SpeechScheduler(), _Speaker()
+
+    mark_hardware_busy()                       # turnstile occupied
+    try:
+        second = asyncio.create_task(sched.speak(
+            lambda: speaker.play("karen"), agent="karen",
+            role=SpeechRole.SECONDARY,
+        ))
+        await asyncio.sleep(0.05)              # SECONDARY queued FIRST
+        first = asyncio.create_task(sched.speak(
+            lambda: speaker.play("jarvis"), agent="jarvis",
+            role=SpeechRole.PRIMARY,
+        ))
+        await asyncio.sleep(0.05)
+        assert not speaker.spans, "someone spoke while the speakers were busy"
+    finally:
+        mark_hardware_idle()
+
+    await asyncio.wait_for(asyncio.gather(first, second), timeout=10)
+
+    assert speaker.order() == ["jarvis", "karen"], (
+        "the delegated agent spoke before the agent that was addressed"
+    )
+    assert not speaker.overlaps()
+    await sched.aclose()
+
+
+@pytest.mark.asyncio
+async def test_the_acoustic_tail_is_held_between_agents(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """afplay exits when CoreAudio has the samples, not when the room is
+    quiet. Granting at that instant clips the second agent onto the first."""
+    monkeypatch.setenv("JARVIS_TTS_ACOUSTIC_TAIL_S", "0.20")
+    sched, speaker = SpeechScheduler(), _Speaker()
+
+    await sched.speak(lambda: speaker.play("jarvis", 0.02),
+                      agent="jarvis", role=SpeechRole.PRIMARY)
+    await sched.speak(lambda: speaker.play("karen", 0.02),
+                      agent="karen", role=SpeechRole.SECONDARY)
+
+    (_a, _a0, a_end), (_b, b_start, _b1) = speaker.spans[0], speaker.spans[1]
+    assert b_start - a_end >= 0.18, (
+        f"only {b_start - a_end:.3f}s of silence between agents"
+    )
+    await sched.aclose()
+
+
+@pytest.mark.asyncio
+async def test_an_unscheduled_utterance_still_blocks_the_queue() -> None:
+    """Several playback sites predate the scheduler. The conductor waits on
+    the REAL device — the same busy signal playback_gate publishes — so a
+    legacy announcement is yielded to rather than talked over."""
+    sched, speaker = SpeechScheduler(), _Speaker()
+
+    mark_hardware_busy()                       # a legacy site starts playing
+    ticket = asyncio.create_task(sched.speak(
+        lambda: speaker.play("karen"), agent="karen", role=SpeechRole.PRIMARY,
+    ))
+    await asyncio.sleep(0.1)
+    assert not speaker.spans, "the queue spoke over an unscheduled utterance"
+
+    mark_hardware_idle()                       # legacy site finishes
+    await asyncio.wait_for(ticket, timeout=5)
+    assert speaker.order() == ["karen"]
+    await sched.aclose()
+
+
+@pytest.mark.asyncio
+async def test_a_wedged_utterance_does_not_mute_the_assistant(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fail OPEN. Holding the turnstile for a caller that never returns would
+    silence every later utterance — worse than the overlap being prevented."""
+    monkeypatch.setenv("JARVIS_TTS_TICKET_TIMEOUT_S", "1")
+    sched, speaker = SpeechScheduler(), _Speaker()
+
+    async def _wedged() -> None:
+        await asyncio.sleep(30)
+
+    stuck = asyncio.create_task(sched.speak(
+        _wedged, agent="wedged", role=SpeechRole.PRIMARY,
+    ))
+    await asyncio.sleep(0.05)
+    await asyncio.wait_for(
+        sched.speak(lambda: speaker.play("karen"),
+                    agent="karen", role=SpeechRole.SECONDARY),
+        timeout=5,
+    )
+    assert speaker.order() == ["karen"]
+    stuck.cancel()
+    await sched.aclose()
+
+
+@pytest.mark.asyncio
+async def test_barge_in_drops_queued_but_not_playing() -> None:
+    """Cancelling the utterance currently on the speakers from here would
+    leave the turnstile held by a dead ticket; that one is cancelled through
+    its own cancel_event."""
+    sched, speaker = _fresh_sched(), _Speaker()
+
+    playing = asyncio.create_task(sched.speak(
+        lambda: speaker.play("jarvis", 0.3), agent="jarvis",
+        role=SpeechRole.PRIMARY,
+    ))
+    await asyncio.sleep(0.05)
+    queued = asyncio.create_task(sched.speak(
+        lambda: speaker.play("karen"), agent="karen",
+        role=SpeechRole.SECONDARY,
+    ))
+    await asyncio.sleep(0.02)
+
+    assert sched.cancel_pending() >= 1
+    assert await queued is False, "a cancelled ticket reported success"
+    assert await playing is True, "barge-in killed the utterance already playing"
+    assert speaker.order() == ["jarvis"]
+    await sched.aclose()
+
+
+def _fresh_sched() -> SpeechScheduler:
+    return SpeechScheduler()
+
+
+@pytest.mark.asyncio
+async def test_disabled_scheduler_is_a_true_bypass(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_TTS_SCHEDULER_ENABLED", "false")
+    sched, speaker = SpeechScheduler(), _Speaker()
+    await sched.speak(lambda: speaker.play("karen"), agent="karen")
+    assert speaker.order() == ["karen"]
+    assert sched.pending() == 0
+
+
+# ---------------------------------------------------------------------------
+# Lane arbitration — the secondary must not take the primary's provider lane
+# ---------------------------------------------------------------------------
+
+
+def test_delegated_work_never_takes_the_immediate_lane() -> None:
+    """IMMEDIATE is Claude-direct because a human is waiting in real time. A
+    delegated turn taking it makes the ADDRESSED agent wait behind work the
+    operator did not ask it for."""
+    decision = decide_lane(Workload(agent="ov", task="verify the deployment"))
+    assert decision.route is ProviderRoute.STANDARD
+    assert not decision.shares_primary_lane
+    assert decision.tier is Tier.DOUBLEWORD
+
+
+def test_an_immediate_stamp_is_demoted() -> None:
+    forced = decide_lane(Workload(
+        agent="ov", task="check logs", route=ProviderRoute.IMMEDIATE,
+    ))
+    assert forced.route is ProviderRoute.STANDARD
+    assert forced.reason == "demoted_from_primary_lane"
+
+
+def test_heavy_work_plans_before_it_executes() -> None:
+    decision = decide_lane(Workload(agent="ov", task="refactor the audio plane"))
+    assert decision.route is ProviderRoute.COMPLEX
+    assert decision.tier is Tier.CLAUDE
+
+
+def test_work_touching_this_machine_goes_sovereign() -> None:
+    """A remote tier cannot see the screen or the working tree."""
+    for task in ("read my screen", "check the uncommitted worktree"):
+        assert decide_lane(Workload(agent="ov", task=task)).tier is Tier.JPRIME
+
+
+@pytest.mark.asyncio
+async def test_dispatch_falls_back_through_the_chain_to_the_caller() -> None:
+    """No tier wired is the DEFAULT state. It must degrade to the caller's own
+    path, not to an error — remote compute is an optimisation."""
+    dispatcher = RemoteComputeDispatcher()
+    ran = []
+
+    async def _caller() -> str:
+        ran.append("caller")
+        return "done locally"
+
+    result = await dispatcher.dispatch(
+        Workload(agent="ov", task="verify the deployment"), _caller,
+    )
+    assert result.value == "done locally"
+    assert result.tier is Tier.CALLER
+    assert result.fell_back is True
+    assert ran == ["caller"]
+
+
+@pytest.mark.asyncio
+async def test_a_wired_tier_is_used_and_a_broken_one_is_skipped() -> None:
+    async def _dead(_w: Workload) -> str:
+        raise TierUnavailable("spot instance preempted")
+
+    async def _alive(_w: Workload) -> str:
+        return "verified"
+
+    dispatcher = RemoteComputeDispatcher({
+        Tier.DOUBLEWORD: _dead, Tier.CLAUDE: _alive,
+    })
+
+    async def _caller() -> str:
+        raise AssertionError("the caller path ran while a tier was healthy")
+
+    result = await dispatcher.dispatch(
+        Workload(agent="ov", task="verify the deployment"), _caller,
+    )
+    assert result.value == "verified"
+    assert result.tier is Tier.CLAUDE
+    assert result.fell_back is True
+
+
+@pytest.mark.asyncio
+async def test_spawn_does_not_block_the_primary() -> None:
+    """The whole reason the secondary is a task: the primary speaks first."""
+    dispatcher = RemoteComputeDispatcher()
+    started = time.monotonic()
+
+    async def _slow() -> str:
+        await asyncio.sleep(0.3)
+        return "late"
+
+    task = dispatcher.spawn(Workload(agent="ov", task="audit the logs"), _slow)
+    assert time.monotonic() - started < 0.05, "spawn blocked the caller"
+    result = await task
+    assert result.value == "late"
+
+
+@pytest.mark.asyncio
+async def test_a_failing_delegated_turn_is_a_result_not_an_exception() -> None:
+    dispatcher = RemoteComputeDispatcher()
+
+    async def _boom() -> str:
+        raise RuntimeError("provider exploded")
+
+    result = await dispatcher.dispatch(Workload(agent="ov", task="check"), _boom)
+    assert result.value is None
+    assert "provider exploded" in result.error
+
+
+# ---------------------------------------------------------------------------
+# Assertion 3 — the collection bug stays fixed
+# ---------------------------------------------------------------------------
+
+
+def test_the_l2_corpus_is_data_and_is_not_collected() -> None:
+    """The four ``problem_NNN/test_before.py`` files are the deliberately
+    failing tests of the L2 repair corpus — DATA, not tests.
+
+    Collecting them aborted ``pytest tests/governance`` outright (four modules
+    resolving to the name ``test_before``) and, had the basenames merely been
+    renamed, would have injected four known-red tests into every run, making
+    "the corpus is red" indistinguishable from "the organism regressed".
+
+    Scoped to the fixtures directory rather than all of tests/governance: that
+    is where the collision lives, so it reproduces the bug in about a second
+    instead of spending a minute collecting 41k tests to prove the same
+    thing."""
+    corpus = Path("tests/governance/fixtures/l2_exercise_corpus")
+    data_files = sorted(corpus.glob("problem_*/test_before.py"))
+    assert len(data_files) >= 2, (
+        "the collision needs at least two same-named data files to exist; "
+        "this test would pass vacuously without them"
+    )
+
+    proc = subprocess.run(
+        [sys.executable, "-m", "pytest", "tests/governance/fixtures",
+         "--collect-only", "-q", "-p", "no:cacheprovider"],
+        capture_output=True, text=True, timeout=120,
+    )
+    combined = proc.stdout + proc.stderr
+    assert "import file mismatch" not in combined, combined[-1500:]
+    assert "error" not in combined.lower() or "no tests ran" in combined.lower(), (
+        combined[-1500:]
+    )
+    # And nothing under it was collected — it is data.
+    assert "test_before" not in proc.stdout, proc.stdout[-1500:]

--- a/tests/voice/test_persona_matrix_phatic.py
+++ b/tests/voice/test_persona_matrix_phatic.py
@@ -1,0 +1,365 @@
+"""Persona matrix + phatic fast path — the three mandated assertions.
+
+1. An injected "Hello Karen" transcript intercepts the network call and
+   returns a cached string.
+2. The AgentRegistry swaps the TTS output profile to Karen.
+3. The bypassed turn is written to the mocked conversation history.
+
+Everything here drives the REAL pipeline method. A test that called
+``classify`` directly would prove the classifier works and say nothing about
+whether the interceptor is on the turn path — which is the failure mode this
+codebase has hit repeatedly: a guard with no caller is theatre.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import Any, Dict, List, Optional, Tuple
+
+import pytest
+
+from backend.audio.conversation_pipeline import ConversationPipeline
+from backend.voice.agent_persona import AgentPersona
+from backend.voice.agent_registry import (
+    all_agents,
+    route_by_wake_word,
+    spec_for,
+    voice_profile_for,
+)
+from backend.voice.phatic_fastpath import acknowledge, classify
+
+
+# ---------------------------------------------------------------------------
+# Doubles
+# ---------------------------------------------------------------------------
+
+
+class _RecordingSession:
+    """The mocked conversation history of assertion 3."""
+
+    def __init__(self) -> None:
+        self.turns: List[Tuple[str, str]] = []
+
+    def add_turn(self, role: str, content: str) -> None:
+        self.turns.append((role, content))
+
+    def get_messages(self) -> List[Dict[str, str]]:
+        return [{"role": r, "content": c} for r, c in self.turns]
+
+    def get_context_for_llm(self) -> List[Dict[str, str]]:
+        return self.get_messages()
+
+
+#: The reply the model would give if it were reached. Distinct from every
+#: cached acknowledgement, so "which path answered" is visible in the output
+#: rather than inferred.
+MODEL_REPLY = "__from_the_model__"
+
+
+class _CountingLLM:
+    """Truthy stand-in for the LLM client.
+
+    Counting rather than raising: ``_generate_and_speak_response`` wraps the
+    generation branch in a broad ``except`` that logs and continues, so a
+    double that raised would be SWALLOWED and the test would pass whether or
+    not the interceptor worked. The counter survives that handler."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+
+class _WholeTextSplitter:
+    """Sentence splitting is not what these assertions are about."""
+
+    async def split(self, stream: Any):
+        async for chunk in stream:
+            yield chunk
+
+
+def _pipeline(session: _RecordingSession, llm: _CountingLLM) -> ConversationPipeline:
+    """A pipeline with only the collaborators these assertions touch.
+
+    Built with ``__new__`` deliberately: ``__init__`` mounts an audio device,
+    an STT model and a TTS engine, none of which the fast path involves, and
+    requiring them would make this an integration test of the sound card."""
+    p = ConversationPipeline.__new__(ConversationPipeline)
+    p._session = session
+    p._barge_in = None
+    p._llm_client = llm
+    p._audio_bus = None            # forces the non-streamed branch
+    p._sentence_splitter = _WholeTextSplitter()
+    p._system_prompt = "test"
+    p._spoken = []
+
+    async def _speak(sentence: str, _cancel: Any) -> None:
+        p._spoken.append(sentence)
+
+    async def _stream(*_a: Any, **_kw: Any):
+        # The network seam. Entering it at all is what assertion 1 forbids
+        # for a greeting — and what the inverse test REQUIRES for a question.
+        llm.calls += 1
+        yield MODEL_REPLY
+
+    p._speak_sentence = _speak                                  # type: ignore
+    p._get_llm_stream = _stream                                 # type: ignore
+    return p
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No operator override may decide these outcomes."""
+    for key in (
+        "JARVIS_VOICE_OV", "JARVIS_VOICE_KAREN", "JARVIS_VOICE_JARVIS",
+        "JARVIS_PHATIC_RESPONSES", "JARVIS_PHATIC_MAX_WORDS",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("JARVIS_PHATIC_FASTPATH", "true")
+    monkeypatch.setenv("JARVIS_AGENT_PERSONA", "ov")
+
+
+# ---------------------------------------------------------------------------
+# Assertion 1 — the greeting never reaches the network
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_hello_karen_intercepts_the_network_call() -> None:
+    session, llm = _RecordingSession(), _CountingLLM()
+    pipe = _pipeline(session, llm)
+
+    await pipe._generate_and_speak_response("Hello Karen")
+
+    assert llm.calls == 0, "the model was called for a pure greeting"
+    assert pipe._spoken, "the fast path produced no spoken reply"
+    assert pipe._spoken[0].strip(), "the cached reply was empty"
+    assert MODEL_REPLY not in pipe._spoken
+
+
+@pytest.mark.asyncio
+async def test_a_real_question_is_not_intercepted() -> None:
+    """The inverse, which is the assertion that actually matters.
+
+    A fast path that swallowed questions would pass the test above while
+    being catastrophically wrong: answering "what's my disk usage" with
+    "I'm here" is a lie, and the bias is explicitly asymmetric against it."""
+    session, llm = _RecordingSession(), _CountingLLM()
+    pipe = _pipeline(session, llm)
+
+    await pipe._generate_and_speak_response("Karen what is my disk usage")
+
+    assert llm.calls == 1, "a real question was answered from the cache"
+    assert pipe._spoken == [MODEL_REPLY]
+
+
+@pytest.mark.parametrize(
+    "utterance",
+    ["Hello Karen", "hey karen", "yo karen you around", "Karen?",
+     "are you there jarvis", "good morning karen"],
+)
+def test_phrasings_never_enumerated_still_classify(utterance: str) -> None:
+    """Generalisation, not recall: none of these is a stored string."""
+    assert classify(utterance, agent_names=["karen", "jarvis", "ov"])
+
+
+@pytest.mark.parametrize(
+    "utterance",
+    ["karen what is my disk usage", "hey karen reboot the server",
+     "hello karen how is the build", "karen deploy to production",
+     "what time is it", "is it the"],
+)
+def test_content_is_refused(utterance: str) -> None:
+    verdict = classify(utterance, agent_names=["karen", "jarvis", "ov"])
+    assert not verdict, f"{utterance!r} was swallowed by the cache"
+
+
+# ---------------------------------------------------------------------------
+# Assertion 2 — the registry swaps the TTS output profile
+# ---------------------------------------------------------------------------
+
+
+def test_registry_maps_ov_to_karen_and_jarvis_to_daniel() -> None:
+    assert spec_for(AgentPersona.OV).preferred_voice == "Karen"
+    assert spec_for(AgentPersona.JARVIS).preferred_voice == "Daniel"
+    # KAREN is an ALIAS for the OV agent, not a second agent.
+    assert spec_for(AgentPersona.KAREN) is spec_for(AgentPersona.OV)
+
+
+def test_registry_swaps_the_tts_output_profile() -> None:
+    """Assertion 2. Resolution is machine-dependent — a voice may not be
+    installed — so what is asserted is that the registry's INTENT reaches the
+    resolver, which is the seam under test. Where the voice exists, the
+    profile carries it and says the registry chose it."""
+    for persona, want in ((AgentPersona.OV, "Karen"), (AgentPersona.JARVIS, "Daniel")):
+        profile = voice_profile_for(persona)
+        assert profile is not None
+        if profile.source == "registry":
+            assert profile.voice == want
+        else:
+            # Not installed on this machine: it must have degraded through the
+            # shared chain, never silently become the OTHER agent's voice.
+            other = "Daniel" if want == "Karen" else "Karen"
+            assert profile.voice != other
+
+
+@pytest.mark.asyncio
+async def test_wake_word_switches_the_active_agent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Addressing JARVIS in Karen's cockpit hands the turn to JARVIS."""
+    session, llm = _RecordingSession(), _CountingLLM()
+    pipe = _pipeline(session, llm)
+    monkeypatch.setenv("JARVIS_AGENT_PERSONA", "ov")
+
+    assert pipe._route_persona("Hey JARVIS are you there") is True
+    assert os.environ["JARVIS_AGENT_PERSONA"] == "jarvis"
+
+    # An unaddressed turn is a CONTINUATION — the agent must not drift.
+    assert pipe._route_persona("what is my disk usage") is False
+    assert os.environ["JARVIS_AGENT_PERSONA"] == "jarvis"
+
+    assert pipe._route_persona("Karen, you there?") is True
+    assert os.environ["JARVIS_AGENT_PERSONA"] == "ov"
+
+
+def test_first_named_agent_wins() -> None:
+    """"Karen, ask JARVIS to reboot" addresses Karen ABOUT JARVIS."""
+    assert route_by_wake_word("Karen, ask JARVIS to reboot").persona is AgentPersona.OV
+    assert route_by_wake_word("JARVIS, tell Karen to stop").persona is AgentPersona.JARVIS
+    assert route_by_wake_word("what is my disk usage") is None
+
+
+def test_wake_words_are_word_boundaried() -> None:
+    """The substring lesson, which cost this codebase a Weather app that
+    opened on "the brain is thinking"."""
+    assert route_by_wake_word("move it over there") is None
+    assert route_by_wake_word("the karenina novel") is None
+
+
+# ---------------------------------------------------------------------------
+# Assertion 3 — the bypassed turn reaches the history
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bypassed_turn_is_written_to_history() -> None:
+    """Assertion 3.
+
+    A bypassed greeting that vanished would leave the NEXT complex turn
+    reasoning about a conversation whose opening it never saw — the model
+    would be told the operator's first words were a question that in fact
+    followed a greeting it answered."""
+    session, llm = _RecordingSession(), _CountingLLM()
+    pipe = _pipeline(session, llm)
+
+    await pipe._generate_and_speak_response("Hello Karen")
+
+    assert session.turns, "the bypassed turn left no trace in history"
+    role, content = session.turns[-1]
+    assert role == "assistant"
+    assert content == pipe._spoken[0], (
+        "history recorded something other than what was actually said"
+    )
+
+
+@pytest.mark.asyncio
+async def test_history_survives_into_the_next_turn() -> None:
+    """The point of assertion 3, stated as behaviour: the greeting is still
+    visible when the next turn is composed."""
+    session, llm = _RecordingSession(), _CountingLLM()
+    pipe = _pipeline(session, llm)
+
+    session.add_turn("user", "Hello Karen")
+    await pipe._generate_and_speak_response("Hello Karen")
+
+    msgs = session.get_messages()
+    assert [m["role"] for m in msgs] == ["user", "assistant"]
+    assert msgs[0]["content"] == "Hello Karen"
+
+
+# ---------------------------------------------------------------------------
+# Properties of the cache itself
+# ---------------------------------------------------------------------------
+
+
+def test_acknowledgement_is_deterministic_and_varies_by_utterance() -> None:
+    a1 = acknowledge("Hello Karen")
+    a2 = acknowledge("Hello Karen")
+    assert a1 == a2, "the same greeting must not get a different answer"
+    variants = {acknowledge(g) for g in ("hi", "hey karen", "yo", "morning", "you there")}
+    assert len(variants) > 1, "every greeting collapsed to one reply"
+
+
+def test_no_acknowledgement_claims_knowledge_or_action() -> None:
+    """The fast path answers being ADDRESSED. If a pool entry ever answered a
+    question, a phrasing this classifier accepts would start producing a
+    confident lie."""
+    from backend.voice.phatic_fastpath import _ACKS
+
+    forbidden = ("i have", "i found", "i ran", "done", "completed", "the answer")
+    for ack in _ACKS:
+        low = ack.lower()
+        assert not any(f in low for f in forbidden), ack
+
+
+def test_fastpath_can_be_turned_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    """OFF must send everything to the model — the only honest way to compare
+    the two paths on cost and latency."""
+    monkeypatch.setenv("JARVIS_PHATIC_FASTPATH", "false")
+    session, llm = _RecordingSession(), _CountingLLM()
+    pipe = _pipeline(session, llm)
+
+    asyncio.run(pipe._generate_and_speak_response("Hello Karen"))
+
+    assert llm.calls == 1, "the fast path fired with the master switch OFF"
+    assert pipe._spoken == [MODEL_REPLY]
+
+
+# ---------------------------------------------------------------------------
+# The lane generalisation
+# ---------------------------------------------------------------------------
+
+
+def test_each_agent_gets_its_own_lane_not_a_shared_one() -> None:
+    from backend.core.ouroboros.governance.agent_voice_lane import lane_for
+
+    ov, jarvis = lane_for(AgentPersona.OV), lane_for(AgentPersona.JARVIS)
+    assert ov is not jarvis
+    assert ov.ledger._path != jarvis.ledger._path
+    assert ov.prefix != jarvis.prefix
+    # OV keeps the pre-generalisation namespace and file, so measurements
+    # already on disk are inherited rather than orphaned.
+    assert ov.prefix == "JARVIS_KAREN_VOICE"
+    assert ov.ledger._path.name == "karen_voice_lane.json"
+    # KAREN is an alias — one lane, or a demotion on one spelling would leave
+    # the other still electing the mute model.
+    assert lane_for(AgentPersona.KAREN) is ov
+
+
+def test_lane_knobs_inherit_then_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    from backend.core.ouroboros.governance import karen_voice_lane as kvl
+
+    monkeypatch.setenv("JARVIS_KAREN_VOICE_TTFT_BUDGET_S", "1.5")
+    monkeypatch.delenv("JARVIS_JARVIS_VOICE_TTFT_BUDGET_S", raising=False)
+    assert kvl.spoken_ttft_budget_s(prefix="JARVIS_JARVIS_VOICE") == 1.5
+
+    monkeypatch.setenv("JARVIS_JARVIS_VOICE_TTFT_BUDGET_S", "2.4")
+    assert kvl.spoken_ttft_budget_s(prefix="JARVIS_JARVIS_VOICE") == 2.4
+    assert kvl.spoken_ttft_budget_s() == 1.5, "the override leaked across lanes"
+
+
+def test_probe_is_bound_to_the_agents_own_identity() -> None:
+    """A probe measures TTFT for a real spoken turn, and the prompt is part of
+    that measurement — grading JARVIS's models with Karen's prompt measures
+    the wrong workload."""
+    from backend.core.ouroboros.governance.agent_voice_lane import lane_for
+
+    assert "JARVIS" in lane_for(AgentPersona.JARVIS)._probe_user()
+    assert "Karen" in lane_for(AgentPersona.OV)._probe_user()
+
+
+def test_every_registered_agent_is_complete() -> None:
+    """A half-registered agent — wake word but no voice — would answer in
+    whatever voice the last turn left behind."""
+    for spec in all_agents():
+        assert spec.display_name and spec.preferred_voice and spec.wake_words
+        assert spec.persona.canonical is spec.persona


### PR DESCRIPTION
## The signal

The capture device delivers float PCM above full scale — measured at **peak 4.19** while the operator spoke. CoreAudio is right to do so: 32-bit float PCM has no ceiling and nothing is lost in memory. The loss happens at every consumer that quantises, and this pipeline has three — `webrtcvad`, the WebSocket tap, and `speexdsp` — each of which **hard clips** what it is handed.

## Proportional, not a soft knee

`_fit_to_range` previously curved excursions through `tanh`. That keeps the peak under 1.0 and is a **nonlinearity**: it compresses loud samples against quiet ones and manufactures harmonics that were never spoken. Speech recognition reads formant structure, so distorting the relationship between harmonics is exactly the wrong correction — chosen to avoid hard clipping, which it does, at the cost of a subtler corruption of the same signal.

One scalar multiply has no such cost:

```
4.19 -> peak 0.9500   clipped = False
gain ratio spread     = 2.98e-08   (0 == pure scalar)
cosine similarity     = 1.000000
```

A test reproduces the retired `tanh` curve and asserts the shape check **catches** it, so the assertion cannot rot into one a compressor would also pass.

## Asymmetry, applied rather than described

**Attack is a step.** Ramping into an attack defeats it: the frame would start at the old gain, so the loudest samples — the reason the attack fired — leave still above the ceiling. My own smoke test caught this (a 4.19 frame emerged at **4.14** and clipped downstream — the governor doing nothing at precisely the moment it existed for). A step down at the onset of a loud passage is inaudible against that passage; clipping is not.

**Release is ramped and slow** (2 s default). Restoring gain quickly raises the noise floor inside every pause between words — audible pumping, and a moving floor for the endpointer to chase. The time constant is in **seconds**, derived per frame from the frame's own duration, so behaviour doesn't change with the device's buffer size.

## Two bugs the edge-case tests found in my own code

- The below-ceiling passthrough returned the **caller's** frame, handing `NaN`/`inf` straight back out — the one path where "untouched" was the wrong promise.
- The minimum-gain floor was applied to the **correction** instead of to the remembered state, so an absurd frame (`1e30`, a device glitch) left at `2e28`: the ceiling defeated by the guard meant to protect recovery. The floor now bounds only the gain the session carries forward.

## Honest scope

**This is not the fix for the empty-transcript failure**, and isn't claimed as one. Measured first: Whisper transcribes raw float at peak 4.19 unchanged (it normalises internally), and the VAD's voiced-frame ratio is unharmed by the int16 clip (0.96 vs 0.93 clean). The justification is removing the `tanh` nonlinearity and protecting the int16 consumers.

Real speech verified end-to-end through the bus at input peaks 0.35, 4.19 and 12.0 — all three transcribe identically to the unprocessed original.

24 new tests; 442 audio/voice tests pass. Below-ceiling frames pass through bit-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a proportional, pre-quantization AGC for float PCM (fast attack, slow release) to prevent clipping without distorting speech. Also introduces a speaker turnstile and persona-aware routing to prevent overlapping TTS and to bypass phatic greetings with zero token cost.

- **New Features**
  - Proportional float AGC: scalar down‑scaling only when peak > ceiling; fast step attack, slow ramp release; bit‑identical below ceiling. Tunable via `JARVIS_AUDIO_AGC_CEILING`, `JARVIS_AUDIO_AGC_TARGET`, and release time; protects `webrtcvad`, WebSocket tap, and `speexdsp` from hard clip.
  - Voice pipeline: single hardware turnstile for `afplay` with PRIMARY/SECONDARY arbitration; playback gate now publishes speaker occupancy; per‑agent voice lanes and registry decouple agent identity from voice; phatic fast path answers “Hello <agent>” locally; delegated work dispatched off the immediate lane; mic flight recorder captures raw/processed/model input for failures.

- **Bug Fixes**
  - Suppress “finals” that contain no voiced frames to stop empty transcripts; fixed AGC passthrough returning caller buffers and corrected min‑gain floor application on state; test runs no longer launch GUI apps.

<sup>Written for commit 1a93720750b8aa5a3c02892992e25cf1f01891cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70099?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

