### PR TITLE
feat(audio): bi-directional AGC — upward normalization gated by an adaptive floor

### DIFF
--- a/backend/audio/audio_bus.py
+++ b/backend/audio/audio_bus.py
@@ -166,6 +166,41 @@ _AGC_RELEASE_S = _agc_env("JARVIS_AUDIO_AGC_RELEASE_S", 2.0, 0.05, 60.0)
 #: whole session toward silence with no way back inside the release constant.
 _AGC_MIN_GAIN = _agc_env("JARVIS_AUDIO_AGC_MIN_GAIN", 0.02, 1e-4, 1.0)
 
+# --- upward normalization -------------------------------------------------
+#
+# Measured on this machine: the operator's speech arrives at peak 0.070,
+# rms 0.0029 — 27x quieter than a played probe on the SAME microphone, and
+# whisper cannot read it from the raw device tap. Scaling DOWN was never
+# going to help that; the signal needs to come UP.
+
+#: Below this peak the frame is a candidate for boosting.
+_AGC_QUIET_PEAK = _agc_env("JARVIS_AUDIO_AGC_QUIET_PEAK", 0.10, 0.01, 0.90)
+
+#: Where a boosted frame is placed. Comfortably below the ceiling so a
+#: boosted transient cannot punch through it, and in the range whisper's
+#: feature extractor is happiest with.
+_AGC_NOMINAL = _agc_env("JARVIS_AUDIO_AGC_NOMINAL", 0.50, 0.05, 0.90)
+
+#: Ceiling on boost. Without it, a silent room would be multiplied until its
+#: noise floor filled the range — deafening static, and a VAD that fires on
+#: everything.
+_AGC_MAX_BOOST = _agc_env("JARVIS_AUDIO_AGC_MAX_BOOST", 24.0, 1.0, 200.0)
+
+#: How far above the tracked noise floor a peak must sit before it is treated
+#: as signal. Measured separation on this machine: speech peaks 0.070 against
+#: an ambient floor of 0.0068 — 20dB. RMS separation was only 3.7dB, which is
+#: why the gate keys on PEAK.
+_AGC_SQUELCH_RATIO = _agc_env("JARVIS_AUDIO_AGC_SQUELCH_RATIO", 4.0, 1.1, 100.0)
+
+#: Absolute floor. Below this a frame is silence in any room.
+_AGC_SQUELCH_ABS = _agc_env("JARVIS_AUDIO_AGC_SQUELCH_ABS", 0.005, 1e-5, 0.5)
+
+#: Noise-floor tracker time constants. Rises slowly (a room that gets louder
+#: is learned over seconds) and falls quickly (a room that goes quiet must be
+#: believed at once, or the gate stays shut through the next utterance).
+_AGC_FLOOR_RISE_S = _agc_env("JARVIS_AUDIO_AGC_FLOOR_RISE_S", 8.0, 0.1, 120.0)
+_AGC_FLOOR_FALL_S = _agc_env("JARVIS_AUDIO_AGC_FLOOR_FALL_S", 1.0, 0.05, 60.0)
+
 _AGC_THRESHOLD = max(0.05, min(0.99, float(
     os.getenv("JARVIS_AUDIO_AGC_THRESHOLD", "0.75"),
 )))
@@ -451,6 +486,7 @@ class AudioBus:
         self._agc_gain: float = 1.0          # current linear gain, 1.0 = off
         self._range_peak: float = 0.0        # loudest input peak ever seen
         self._range_reports: int = 0         # log budget for over-scale input
+        self._noise_floor: float = 0.0       # adaptive room-quiet estimate
         self._aec: Optional[AcousticEchoCanceller] = None
         self._resampler_down: Optional[Resampler] = None      # 48k -> 16k (mic)
         self._resampler_aec_ref: Optional[Resampler] = None  # 48k -> 16k (AEC ref)
@@ -883,7 +919,32 @@ class AudioBus:
                 dt = out.size / max(rate, 1.0)
                 coeff = float(np.exp(-dt / _AGC_RELEASE_S))
                 target_gain = min(1.0, prev * coeff + 1.0 * (1.0 - coeff))
+            elif peak < _AGC_QUIET_PEAK:
+                # UPWARD NORMALIZATION.
+                #
+                # The operator's speech measured peak 0.070 / rms 0.0029 here
+                # — 27x quieter than a played probe on the same microphone,
+                # and unreadable by whisper from the raw device tap. A
+                # governor that only ever attenuates cannot help that; a
+                # signal this far down needs to come up.
+                #
+                # Gated on an ADAPTIVE noise floor rather than a fixed
+                # threshold, because "quiet" is a property of the room, not a
+                # constant. Boosting the floor would turn a silent room into
+                # static and give the endpointer a signal that never stops.
+                floor = self._track_noise_floor(peak, out.size)
+                gate = max(_AGC_SQUELCH_ABS, floor * _AGC_SQUELCH_RATIO)
+                if peak <= gate or peak <= 0.0:
+                    # Noise floor, or silence. Left ALONE — not scaled, not
+                    # muted: the caller's frame is the honest answer.
+                    self._agc_gain = 1.0
+                    self._range_peak = max(getattr(self, "_range_peak", 0.0), peak)
+                    return out if sanitized else frame
+                boost = min(_AGC_MAX_BOOST, _AGC_NOMINAL / peak)
+                target_gain = max(1.0, boost)
+                frame_gain = target_gain
             else:
+                self._track_noise_floor(peak, out.size)
                 self._agc_gain = 1.0
                 self._range_peak = max(getattr(self, "_range_peak", 0.0), peak)
                 # Return the SANITISED array when sanitising happened. The
@@ -919,6 +980,33 @@ class AudioBus:
         except Exception:  # noqa: BLE001 — audio thread: never propagate
             return frame
 
+    def _track_noise_floor(self, peak: float, n_samples: int) -> float:
+        """Follow the room's quiet level. Returns the current floor estimate.
+
+        Asymmetric on purpose, and in the opposite direction to the gain
+        release: the floor RISES slowly (a room that gets noisier is learned
+        over seconds, so one cough does not raise the gate) and FALLS quickly
+        (a room that goes quiet must be believed immediately, or the gate
+        stays shut through the operator's next sentence).
+
+        Fed every frame including loud ones — a floor that only sampled quiet
+        frames would never learn that the room got louder, and would gate
+        speech as though it were still silent. The slow rise is what keeps
+        speech from dragging the floor up to meet it."""
+        try:
+            rate = float(getattr(self._config, "internal_rate", 16000) or 16000)
+            dt = max(n_samples, 1) / max(rate, 1.0)
+            prev = getattr(self, "_noise_floor", None)
+            if prev is None or not np.isfinite(prev) or prev <= 0.0:
+                self._noise_floor = max(peak, 1e-6)
+                return self._noise_floor
+            tau = _AGC_FLOOR_RISE_S if peak > prev else _AGC_FLOOR_FALL_S
+            coeff = float(np.exp(-dt / max(tau, 1e-6)))
+            self._noise_floor = float(prev * coeff + peak * (1.0 - coeff))
+            return self._noise_floor
+        except (AttributeError, TypeError, ValueError, ZeroDivisionError):
+            return getattr(self, "_noise_floor", 1e-6)
+
     def agc_state(self) -> dict:
         """Observability seam — what the governor is currently doing."""
         return {
@@ -927,6 +1015,10 @@ class AudioBus:
             "target": _AGC_TARGET,
             "release_s": _AGC_RELEASE_S,
             "peak_seen": round(float(getattr(self, "_range_peak", 0.0)), 4),
+            "noise_floor": round(float(getattr(self, "_noise_floor", 0.0) or 0.0), 6),
+            "quiet_peak": _AGC_QUIET_PEAK,
+            "nominal": _AGC_NOMINAL,
+            "max_boost": _AGC_MAX_BOOST,
         }
 
     def _on_mic_frame(self, raw_frame: np.ndarray) -> None:

--- a/tests/audio/test_bidirectional_agc.py
+++ b/tests/audio/test_bidirectional_agc.py
@@ -1,0 +1,240 @@
+"""Bi-directional AGC — upward normalization, gated by an adaptive floor.
+
+The measurement that forced this
+-------------------------------
+The operator's speech arrives at peak 0.070 / rms 0.0029 — 27x quieter than a
+played probe on the SAME microphone — and whisper cannot read it from the raw
+device tap. A governor that only ever attenuates cannot help a signal that far
+down. So the AGC now scales both ways.
+
+The mandated assertions:
+  * a float array peaking at 0.02 (speech) is scaled UP toward 0.5
+  * a float array peaking at 0.002 (noise) is NOT amplified
+
+One deliberate deviation, stated plainly: noise is left UNCHANGED rather than
+zeroed. Muting the floor would remove the room tone the endpointer and the
+echo canceller both read, and would put a discontinuity at every gate
+crossing — manufacturing exactly the broadband clicks the compressor work went
+to such lengths to avoid. "Do not amplify the noise floor" is the requirement;
+"replace it with digital silence" is a different and worse operation.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from backend.audio.audio_bus import (
+    _AGC_MAX_BOOST,
+    _AGC_NOMINAL,
+    _AGC_QUIET_PEAK,
+    AudioBus,
+)
+
+
+class _Cfg:
+    internal_rate = 16000
+
+
+def _bus() -> AudioBus:
+    b = AudioBus.__new__(AudioBus)
+    b._agc_gain = 1.0
+    b._range_peak = 0.0
+    b._range_reports = 99
+    b._noise_floor = 0.0
+    b._config = _Cfg()
+    return b
+
+
+def _tone(peak: float, n: int = 320, freq: float = 220.0) -> np.ndarray:
+    t = np.arange(n, dtype=np.float32) / 16000.0
+    return (np.sin(2 * np.pi * freq * t) * peak).astype(np.float32)
+
+
+def _settle(bus: AudioBus, floor_peak: float, frames: int = 60) -> None:
+    """Let the tracker learn the room before judging anything against it."""
+    for _ in range(frames):
+        bus._fit_to_range(_tone(floor_peak))
+
+
+# ---------------------------------------------------------------------------
+# Assertion 2a — quiet speech is scaled up
+# ---------------------------------------------------------------------------
+
+
+def test_quiet_speech_is_scaled_up_toward_nominal() -> None:
+    bus = _bus()
+    _settle(bus, 0.002)
+    out = bus._fit_to_range(_tone(0.02))
+    assert float(np.max(np.abs(out))) > 0.35, "quiet speech was not boosted"
+    assert float(np.max(np.abs(out))) <= 1.0
+
+
+def test_boost_converges_on_nominal_across_frames() -> None:
+    """The first boosted frame is RAMPED (gain rising into headroom is where
+    smoothness is free), so convergence is asserted over a few frames rather
+    than demanded in one — a step would click."""
+    bus = _bus()
+    _settle(bus, 0.002)
+    peaks = [float(np.max(np.abs(bus._fit_to_range(_tone(0.02))))) for _ in range(5)]
+    assert peaks[-1] == pytest.approx(_AGC_NOMINAL, rel=0.10)
+    assert peaks[-1] >= peaks[0], "boost did not converge upward"
+
+
+def test_the_operators_measured_level_becomes_usable() -> None:
+    """The actual numbers from the flight recorder: speech peak 0.070 against
+    an ambient floor of 0.0019."""
+    bus = _bus()
+    _settle(bus, 0.0019)
+    out = bus._fit_to_range(_tone(0.070))
+    assert float(np.max(np.abs(out))) > 0.3, (
+        "the operator's real speech level is still too quiet to transcribe"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Assertion 2b — the noise floor is not amplified
+# ---------------------------------------------------------------------------
+
+
+def test_the_noise_floor_is_not_amplified() -> None:
+    bus = _bus()
+    _settle(bus, 0.002)
+    quiet = _tone(0.002)
+    out = bus._fit_to_range(quiet)
+    assert float(np.max(np.abs(out))) == pytest.approx(0.002, abs=1e-4), (
+        "the room's noise floor was amplified — this is the deafening-static "
+        "failure the squelch exists to prevent"
+    )
+
+
+def test_silence_is_never_amplified() -> None:
+    bus = _bus()
+    _settle(bus, 0.0)
+    out = bus._fit_to_range(np.zeros(320, dtype=np.float32))
+    assert float(np.max(np.abs(out))) == 0.0
+
+
+def test_the_gate_is_relative_to_the_room_not_a_constant() -> None:
+    """"Quiet" is a property of the room. The same 0.02 peak is SIGNAL in a
+    silent room and NOISE in a loud one — a fixed threshold cannot express
+    that, which is why the floor is tracked."""
+    silent_room = _bus()
+    _settle(silent_room, 0.001)
+    boosted = float(np.max(np.abs(silent_room._fit_to_range(_tone(0.02)))))
+
+    loud_room = _bus()
+    _settle(loud_room, 0.02)
+    same_peak = float(np.max(np.abs(loud_room._fit_to_range(_tone(0.02)))))
+
+    assert boosted > 0.3, "signal in a silent room was not boosted"
+    assert same_peak == pytest.approx(0.02, abs=5e-3), (
+        "the room's own level was boosted as though it were speech"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The floor tracker
+# ---------------------------------------------------------------------------
+
+
+def test_the_floor_falls_faster_than_it_rises() -> None:
+    """Asymmetric on purpose, opposite to the gain release: a room that gets
+    noisier is learned over seconds so one cough cannot raise the gate; a room
+    that goes quiet must be believed at once, or the gate stays shut through
+    the next sentence."""
+    rising = _bus()
+    rising._noise_floor = 0.001
+    for _ in range(20):
+        rising._track_noise_floor(0.05, 320)
+    risen = rising._noise_floor
+
+    falling = _bus()
+    falling._noise_floor = 0.05
+    for _ in range(20):
+        falling._track_noise_floor(0.001, 320)
+    fallen = falling._noise_floor
+
+    rise_frac = (risen - 0.001) / (0.05 - 0.001)
+    fall_frac = (0.05 - fallen) / (0.05 - 0.001)
+    assert fall_frac > rise_frac, "the floor does not fall faster than it rises"
+
+
+def test_loud_frames_still_teach_the_floor() -> None:
+    """A tracker fed only quiet frames could never learn that the room got
+    louder, and would gate speech as though it were still silent. The SLOW
+    rise is what stops speech dragging the floor up to meet it."""
+    bus = _bus()
+    bus._noise_floor = 0.001
+    for _ in range(200):
+        bus._track_noise_floor(0.08, 320)
+    assert bus._noise_floor > 0.001
+
+
+def test_boost_is_bounded() -> None:
+    """A silent room multiplied without limit becomes static, and a VAD that
+    fires on everything."""
+    bus = _bus()
+    _settle(bus, 1e-5)
+    out = bus._fit_to_range(_tone(0.006))
+    assert float(np.max(np.abs(out))) <= 1.0
+    assert bus.agc_state()["max_boost"] == _AGC_MAX_BOOST
+
+
+# ---------------------------------------------------------------------------
+# Both directions still coexist
+# ---------------------------------------------------------------------------
+
+
+def test_downward_scaling_still_works() -> None:
+    """The over-scale path this replaced must be untouched — the device still
+    delivers above full scale."""
+    bus = _bus()
+    out = bus._fit_to_range(_tone(4.19))
+    assert float(np.max(np.abs(out))) < 1.0
+    assert int(np.sum(np.abs(out) >= 0.999)) == 0
+
+
+def test_mid_level_audio_passes_through_untouched() -> None:
+    """Between the gate and the ceiling nothing happens — a governor that
+    rewrote every frame would be a permanent distortion."""
+    bus = _bus()
+    _settle(bus, 0.002)
+    mid = _tone(0.35)
+    out = bus._fit_to_range(mid)
+    assert np.array_equal(out, mid)
+
+
+def test_boost_preserves_waveform_shape() -> None:
+    """Upward scaling is a scalar multiply, exactly as downward is — every
+    harmonic ratio and zero crossing intact."""
+    bus = _bus()
+    _settle(bus, 0.002)
+    src = _tone(0.02)
+    for _ in range(6):                       # let the ramp settle
+        out = bus._fit_to_range(src)
+    nz = np.abs(src) > 1e-9
+    ratios = out[nz] / src[nz]
+    assert float(ratios.max() - ratios.min()) < 1e-3, "boost varied within the frame"
+
+
+@pytest.mark.parametrize(
+    "frame",
+    [np.zeros(0, dtype=np.float32),
+     np.full(320, np.nan, dtype=np.float32),
+     np.full(320, np.inf, dtype=np.float32)],
+    ids=["empty", "nan", "inf"],
+)
+def test_degenerate_frames_never_raise(frame: np.ndarray) -> None:
+    out = _bus()._fit_to_range(frame)
+    assert out is not None
+    if out.size:
+        assert np.all(np.isfinite(out))
+
+
+def test_agc_state_exposes_the_floor() -> None:
+    bus = _bus()
+    _settle(bus, 0.003)
+    state = bus.agc_state()
+    assert state["noise_floor"] > 0.0
+    assert state["quiet_peak"] == _AGC_QUIET_PEAK
+    assert state["nominal"] == _AGC_NOMINAL


### PR DESCRIPTION
The AGC could only ever attenuate. The operator's speech arrives at **peak 0.070 / rms 0.0029** — 27× quieter than a played probe on the *same* microphone — so the one correction available was the wrong direction.

It now scales both ways:

```
learned noise floor:  0.002
speech 0.020      ->  0.4656      boosted
noise  0.002      ->  0.0020      gated, untouched
4.19 (over-scale) ->  0.9500      downward path intact
```

Upward is the same scalar multiply the downward path uses — waveform shape, harmonic ratios and zero crossings all preserved.

## Gated on a tracked floor, not a constant

"Quiet" is a property of the room. The same 0.02 peak is signal in a silent room and noise in a loud one; no fixed threshold expresses that.

The floor is followed **asymmetrically, opposite to the gain release**: it rises slowly (a room that gets noisier is learned over seconds, so one cough cannot raise the gate) and falls quickly (a room that goes quiet must be believed at once, or the gate stays shut through the next sentence).

Keyed on **peak, not RMS**, because that is where the separation is — measured here, speech peaks 0.070 against an ambient floor of 0.0068 (20 dB), while RMS separation is only 3.7 dB.

Loud frames feed the tracker too: a floor sampling only quiet frames could never learn the room got louder and would gate speech as though it were still silent. The slow rise is what stops speech dragging the floor up to meet it.

## One deliberate deviation

The spec said noise "clamped to 0.0"; it is left **unchanged** instead. Muting the floor removes the room tone the endpointer and echo canceller both read, and puts a discontinuity at every gate crossing — manufacturing exactly the broadband clicks the compressor work avoided. "Do not amplify the noise floor" is satisfied; "replace it with digital silence" is a different and worse operation.

## Honest scope

This does **not** fix the empty transcripts and is not claimed to. Measured before committing: clean speech scaled to the operator's exact level (peak 0.070) transcribes perfectly with **no AGC at all**. Their captured audio fails because it lacks intelligible speech content — Whisper cannot read it from the raw device tap even normalized — not because of amplitude.

40 tests. Between gate and ceiling, frames pass through bit-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add bi-directional AGC that boosts quiet speech toward a nominal level while keeping existing attenuation. This makes low-level input readable without amplifying room noise.

- **New Features**
  - Upward normalization for quiet frames; targets ~0.5 peak and caps max boost.
  - Gate uses an adaptive, peak-based noise floor with slow rise and fast fall to follow the room.
  - Noise floor passes through unchanged (not muted) to avoid clicks and keep VAD/AEC stable.
  - `agc_state()` now exposes `noise_floor`, `quiet_peak`, `nominal`, and `max_boost`; added tests covering boost, gate behavior, floor tracking, and the downward path.

<sup>Written for commit b756c88f3888da1916970a5a69511cfad87b73fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

