### PR TITLE
feat(audio): speak_immediate — the delivery half that never ran

### DIFF
--- a/backend/audio/acoustic_feedback.py
+++ b/backend/audio/acoustic_feedback.py
@@ -7,6 +7,7 @@ recogniser and the speaker, which is how a system ends up transcribing itself.
 """
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any, Optional
 
@@ -39,14 +40,71 @@ def _controller() -> Any:
         # Routed through the SAME zero-cost path the phatic acknowledgements
         # use: this is Karen reporting her own limitation, not a model turn,
         # and it must never cost a token or wait on a provider.
-        try:
-            from backend.audio.conversation_pipeline import speak_immediate
-            speak_immediate(line)
-        except (ImportError, AttributeError):
-            logger.info("[Acoustic] (unspoken) %s", line)
+        speak_immediate(line)
 
     _CONTROLLER = AcousticFeedbackController(emit=_emit, speak=_speak)
     return _CONTROLLER
+
+
+def speak_immediate(line: str) -> bool:
+    """Say *line* now, ahead of anything queued. Returns True if it was spoken.
+
+    This is Karen admitting she cannot hear — it is worth interrupting for, and
+    it must never cost a token or wait on a provider. So it takes a
+    ``SpeechRole.PRIMARY`` ticket on the EXISTING turnstile rather than opening
+    its own playback path: a second player would race the first, and two voices
+    over one speaker is the collision the scheduler was built to prevent.
+
+    THE OMISSION THIS FIXES. ``acoustic_feedback`` referenced this function
+    before it existed, so every degradation logged ``(unspoken)`` — the
+    measurement half of the loop worked perfectly and the delivery half had
+    never once executed. A dependency referenced but not defined is the
+    wired-but-inert trap, and it deserves to be named rather than quietly
+    patched.
+
+    Callable from ANY context. With a running loop the ticket is scheduled on
+    it; without one the utterance runs inline on this thread. The synthesis
+    itself is ``macos_voice``'s — reused, not reimplemented — and it already
+    takes ``playback_gate_sync`` around its own ``afplay``, so the microphone
+    is closed for exactly as long as sound is leaving the speakers.
+
+    NEVER raises: this sits on the STT rejection path."""
+    text = str(line or "").strip()
+    if not text:
+        return False
+
+    def _render() -> None:
+        # macos_voice owns synthesis AND the playback gate. Calling its
+        # existing entry point is the whole implementation; anything more
+        # would be a second audio stack.
+        from backend.voice.macos_voice import MacOSVoice
+        MacOSVoice().speak(text)
+
+    async def _ticket() -> None:
+        from backend.audio.speech_scheduler import SpeechRole, get_scheduler
+        loop = asyncio.get_running_loop()
+        await get_scheduler().speak(
+            lambda: loop.run_in_executor(None, _render),
+            agent="acoustic", role=SpeechRole.PRIMARY, text=text,
+        )
+
+    try:
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+        if loop is not None and loop.is_running():
+            # Scheduled, never awaited inline: this is called from the STT
+            # rejection path, and blocking it would stall recognition to
+            # announce that recognition is failing.
+            loop.create_task(_ticket())
+        else:
+            _render()
+        logger.info("[Acoustic] speaking: %s", text)
+        return True
+    except (ImportError, AttributeError, RuntimeError, OSError) as exc:
+        logger.warning("[Acoustic] could not speak %r: %r", text, exc)
+        return False
 
 
 def report_rejection(audio: Any, sample_rate: int, peak: float, rms: float,
@@ -82,4 +140,4 @@ def reset() -> None:
     _CONTROLLER = None
 
 
-__all__ = ["report_rejection", "reset"]
+__all__ = ["report_rejection", "reset", "speak_immediate"]

--- a/tests/audio/test_speak_immediate.py
+++ b/tests/audio/test_speak_immediate.py
@@ -1,0 +1,134 @@
+"""speak_immediate — the delivery half of the acoustic loop.
+
+The measurement half worked perfectly and this half had never executed once:
+`acoustic_feedback` referenced `speak_immediate` before it existed, so every
+degradation logged `(unspoken)`. A dependency referenced but not defined is
+the wired-but-inert trap, and these assert it is now actually wired.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any, List
+
+import pytest
+
+from backend.audio import acoustic_feedback as af
+from backend.audio.speech_scheduler import SpeechRole, reset_scheduler
+
+
+@pytest.fixture(autouse=True)
+def _fresh(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("JARVIS_TTS_ACOUSTIC_TAIL_S", "0.01")
+    reset_scheduler()
+    af.reset()
+    yield
+    reset_scheduler()
+
+
+def test_empty_lines_are_not_spoken() -> None:
+    assert af.speak_immediate("") is False
+    assert af.speak_immediate("   ") is False
+
+
+def test_it_reuses_macos_voice_and_the_turnstile() -> None:
+    """DRY, asserted structurally: no second playback stack, no subprocess
+    layer of its own — two players over one speaker is the collision the
+    scheduler exists to prevent."""
+    import inspect
+
+    src = inspect.getsource(af.speak_immediate)
+    assert "MacOSVoice" in src
+    assert "SpeechRole.PRIMARY" in src
+    assert "Popen" not in src and "subprocess" not in src
+
+
+def test_it_speaks_with_no_running_loop(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Callable from any context — the STT rejection path is not guaranteed
+    to be on a loop."""
+    spoken: List[str] = []
+
+    class _Voice:
+        def speak(self, text: str) -> None:
+            spoken.append(text)
+
+    monkeypatch.setattr("backend.voice.macos_voice.MacOSVoice", _Voice)
+    assert af.speak_immediate("the room is washing you out") is True
+    assert spoken == ["the room is washing you out"]
+
+
+@pytest.mark.asyncio
+async def test_it_takes_a_primary_ticket_on_the_turnstile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Assertion 1: it preempts. A SECONDARY utterance already waiting must
+    not beat the interrupt to the speakers."""
+    from backend.audio.speech_scheduler import get_scheduler, mark_hardware_busy, mark_hardware_idle
+
+    order: List[str] = []
+
+    class _Voice:
+        def speak(self, text: str) -> None:
+            order.append("interrupt")
+
+    monkeypatch.setattr("backend.voice.macos_voice.MacOSVoice", _Voice)
+    sched = get_scheduler()
+
+    async def _queued() -> None:
+        order.append("queued")
+
+    mark_hardware_busy()                       # hold the turnstile shut
+    try:
+        secondary = asyncio.create_task(sched.speak(
+            _queued, agent="karen", role=SpeechRole.SECONDARY,
+        ))
+        await asyncio.sleep(0.05)              # SECONDARY is waiting first
+        assert af.speak_immediate("interrupt me") is True
+        await asyncio.sleep(0.05)
+    finally:
+        mark_hardware_idle()
+
+    await asyncio.wait_for(secondary, timeout=5)
+    for _ in range(50):
+        if "interrupt" in order:
+            break
+        await asyncio.sleep(0.05)
+
+    assert "interrupt" in order, "the priority interrupt never reached the speakers"
+    assert order[0] == "interrupt", f"the queued utterance won: {order}"
+
+
+@pytest.mark.asyncio
+async def test_it_does_not_block_the_rejection_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Called from the STT rejection path — blocking it would stall
+    recognition in order to announce that recognition is failing."""
+    import time
+
+    class _SlowVoice:
+        def speak(self, text: str) -> None:
+            time.sleep(0.6)
+
+    monkeypatch.setattr("backend.voice.macos_voice.MacOSVoice", _SlowVoice)
+    t0 = time.monotonic()
+    assert af.speak_immediate("slow line") is True
+    assert time.monotonic() - t0 < 0.15, "speak_immediate blocked its caller"
+
+
+def test_a_broken_voice_engine_never_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Broken:
+        def speak(self, text: str) -> None:
+            raise OSError("no audio device")
+
+    monkeypatch.setattr("backend.voice.macos_voice.MacOSVoice", _Broken)
+    assert af.speak_immediate("anything") is False
+
+
+def test_the_controller_now_reaches_a_real_function() -> None:
+    """The omission itself: the feedback controller's speak seam must resolve
+    to something that exists."""
+    assert callable(getattr(af, "speak_immediate", None))
+    import inspect
+    src = inspect.getsource(af._controller)
+    assert "speak_immediate(line)" in src
+    assert "(unspoken)" not in src, "the fallback log is still the real path"


### PR DESCRIPTION
`acoustic_feedback` referenced `speak_immediate` before it existed. Every degradation therefore logged `(unspoken)`: the **measurement half** of the acoustic loop worked perfectly and the **delivery half had never executed once**. A dependency referenced but not defined is the wired-but-inert trap, and it's worth naming rather than quietly patching.

## Priority interrupt, on the existing turnstile

Karen admitting she cannot hear is worth interrupting for, so it takes a `SpeechRole.PRIMARY` ticket on the **merged** turnstile rather than opening its own playback path — a second player would race the first, and two voices over one speaker is precisely the collision the scheduler was built to prevent.

A test holds the turnstile shut with a SECONDARY utterance **already waiting** and asserts the interrupt still reaches the speakers first.

## DRY, asserted structurally

Synthesis is `macos_voice`'s, reused not reimplemented: it already takes `playback_gate_sync` around its own `afplay`, so the microphone closes for exactly as long as sound leaves the speakers. A test asserts no `subprocess`/`Popen` appears in the implementation — no second audio stack.

## Non-blocking by contract

Callable from any context: with a running loop the ticket is scheduled on it, without one it runs inline. It never blocks its caller, because it is invoked from the STT rejection path and stalling recognition to announce that recognition is failing would be its own joke. Verified: returns in **<150 ms against a 600 ms synthesis**.

## Not in this PR, and not claimed

The harness DI refactor (`UnmountedSynapseError`) and the DW routing audit are untouched. The empirical large-v3 probe was **inconclusive** — the newest incident held near-silence and `small`/`medium` could not download in this environment — so compute escalation remains unjustified rather than disproven.

7 new tests; **210 `tests/audio` pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implemented `speak_immediate` to deliver acoustic feedback immediately, fixing the previously inert path that logged "(unspoken)". It preempts queued audio via the existing scheduler and runs without blocking.

- **Bug Fixes**
  - `acoustic_feedback` now calls a real `speak_immediate`; fallback "(unspoken)" path removed.
  - Exported `speak_immediate` and updated the controller so feedback actually reaches speakers.

- **New Features**
  - Takes a `SpeechRole.PRIMARY` ticket on the existing turnstile to interrupt queued `SECONDARY` audio.
  - Reuses `MacOSVoice` and its `playback_gate_sync`; no new subprocess or audio stack.
  - Non-blocking by design: schedules on a running loop or runs inline if none; never raises.
  - Returns `True` when spoken; logs failures and returns `False` on errors.

<sup>Written for commit ca52ab94a01c09c06d2b75b6d558b813be73680c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

