### PR TITLE
fix(audio): window-scope the capture-forensics verdict — one old transient was every diagnosis

### DIFF
--- a/backend/audio/capture_forensics.py
+++ b/backend/audio/capture_forensics.py
@@ -77,6 +77,27 @@ def _env_float(name: str, default: float, minimum: float = 0.0) -> float:
         return default
 
 
+def handoff_check_enabled() -> bool:
+    """``JARVIS_FORENSICS_HANDOFF_CHECK`` (default on). Bounded FFT work on
+    the incident path only — never on the audio thread."""
+    return os.environ.get(
+        "JARVIS_FORENSICS_HANDOFF_CHECK", "1",
+    ).strip().lower() in _TRUTHY
+
+
+def handoff_corr_floor() -> float:
+    """Correlation below which alignment is not considered PROVEN, and the
+    handoff therefore reports ``unverifiable`` rather than a fault."""
+    return _env_float("JARVIS_FORENSICS_HANDOFF_CORR_FLOOR", 0.99, 0.0)
+
+
+def handoff_gain_tolerance_db() -> float:
+    """Gain error tolerated before a proven-aligned handoff is called
+    ``scaled``. Well inside the ~90 dB an int16 round-trip preserves, and far
+    below the 6 dB a single bit-shift would cost."""
+    return _env_float("JARVIS_FORENSICS_HANDOFF_GAIN_TOL_DB", 0.5, 0.0)
+
+
 def _env_int(name: str, default: int, minimum: int = 1) -> int:
     try:
         return max(minimum, int(os.getenv(name, "").strip() or default))
@@ -108,6 +129,60 @@ def incident_root() -> Path:
     if raw:
         return Path(raw).expanduser()
     return Path.cwd() / ".jarvis" / "capture_forensics"
+
+
+def _align(haystack: np.ndarray, needle: np.ndarray) -> Optional[Dict[str, Any]]:
+    """Locate *needle* inside *haystack* and measure the gain between them.
+
+    Normalised cross-correlation over EVERY lag, via FFT — O(n log n), a few
+    milliseconds on a 12 s ring. Searching only near the end does not work:
+    an incident is written after transcription returns, which puts the
+    utterance 1-8 s back from the newest sample. (Measured: lags of 0.94 s
+    through 8.04 s across one session's incidents. A short search window
+    reports the resulting mismatch as divergence, which is a fabrication of
+    the same family this module exists to prevent.)
+
+    Returns ``None`` when no honest comparison is possible. NEVER raises."""
+    try:
+        n = int(needle.size)
+        if n < 64 or haystack.size < n:
+            return None
+        nd = needle - needle.mean() # zero-mean the needle
+        nd_energy = float(np.sqrt((nd ** 2).sum()))
+        if nd_energy < 1e-12: # needle is silent — nothing to match
+            return None                      # digital silence — nothing to match
+
+        size = 1 << int(np.ceil(np.log2(haystack.size + n))) # next power of two for FFT
+        corr = np.fft.irfft(
+            np.fft.rfft(haystack, size) * np.conj(np.fft.rfft(nd, size)), size,
+        )[:haystack.size - n + 1] # cross-correlation of haystack and needle, by FFT
+
+        # Sliding window variance of the haystack, by prefix sums, so the
+        # correlation is normalised per-lag rather than against a global mean.
+        cs = np.concatenate([[0.0], np.cumsum(haystack)]) # prefix sum of the haystack
+        cs2 = np.concatenate([[0.0], np.cumsum(haystack ** 2)]) # prefix sum of squares
+        win_sum = cs[n:] - cs[:-n] # sum of the haystack in each window
+        win_sq = cs2[n:] - cs2[:-n] # sum of squares in each window
+        var = win_sq - win_sum * win_sum / n # variance in each window
+        var[var < 1e-20] = np.inf            # silent windows can never win
+        r = corr / (np.sqrt(var) * nd_energy) # normalised correlation
+
+        lag = int(np.argmax(r))
+        segment = haystack[lag:lag + n]
+        seg_peak = float(np.max(np.abs(segment)))
+        needle_peak = float(np.max(np.abs(needle)))
+        gain = needle_peak / seg_peak if seg_peak > 1e-12 else float("nan")
+        return {
+            "lag_samples": lag,
+            "correlation": round(float(r[lag]), 4),
+            "bus_segment_peak": round(seg_peak, 6),
+            "model_peak": round(needle_peak, 6),
+            "gain_ratio": round(gain, 4) if gain == gain else None,
+            "gain_db": (round(20.0 * float(np.log10(gain)), 2)
+                        if gain == gain and gain > 0 else None),
+        }
+    except (ValueError, TypeError, MemoryError, FloatingPointError):
+        return None
 
 
 class _Ring:
@@ -296,6 +371,10 @@ class CaptureForensics:
                     "peak": round(float(np.max(np.abs(a))), 4),
                     "rms": round(rms, 5),
                 }
+                metrics["handoff"] = self._handoff(a, model_sample_rate)
+            else:
+                metrics["handoff"] = {"status": "unverifiable",
+                                      "why": "no model buffer supplied"}
 
             metrics["verdict_hint"] = self._verdict(metrics)
             (out / "metrics.json").write_text(
@@ -310,6 +389,68 @@ class CaptureForensics:
         except (OSError, ValueError, TypeError, MemoryError) as exc:
             logger.debug("[CaptureForensics] incident degraded: %r", exc)
             return None
+
+    def _handoff(
+        self, model_audio: np.ndarray, model_rate: int,
+    ) -> Dict[str, Any]:
+        """Is the buffer the recogniser was handed the audio the bus produced?
+
+        This module's header has always described the processed ring as
+        "exactly what the model was handed". That was an ASSUMPTION — the two
+        were recorded independently and never compared, so a scaling or
+        dtype fault at the final handoff would have been invisible here while
+        looking, in the stored wavs, exactly like a quiet room.
+
+        The comparison is cheap and the rings already exist, so the assumption
+        becomes a per-incident measurement:
+
+        ``lossless``      aligned at correlation ~1.0 with gain 0 dB. The
+                          handoff is exonerated; look elsewhere.
+        ``scaled``        aligned, but the amplitude changed. This is the
+                          int16/float32 and double-normalisation class, named
+                          automatically instead of hunted by hand.
+        ``unverifiable``  alignment not proven. Says nothing further — the
+                          utterance may simply have aged out of the ring, and
+                          an unproven match is not evidence of divergence.
+
+        NEVER raises; a failure here degrades to ``unverifiable``."""
+        try:
+            if not handoff_check_enabled():
+                return {"status": "disabled"}
+            ring = self._processed
+            if ring is None or model_audio is None or not len(model_audio):
+                return {"status": "unverifiable", "why": "no buffers"}
+            if int(model_rate) != ring.sample_rate:
+                # Not a fault: a resampled handoff is legitimate. It is simply
+                # outside what a sample-wise comparison can speak to.
+                return {"status": "unverifiable", "why": "rate differs",
+                        "model_rate": int(model_rate),
+                        "bus_rate": ring.sample_rate}
+            hay = ring.snapshot().astype(np.float64)
+            needle = np.asarray(model_audio, dtype=np.float64).reshape(-1)
+            found = _align(hay, needle)
+            if found is None:
+                return {"status": "unverifiable", "why": "no alignment"}
+
+            found["lag_s"] = round(
+                (hay.size - (found["lag_samples"] + needle.size))
+                / max(ring.sample_rate, 1), 3,
+            )
+            corr = found.get("correlation") or 0.0
+            gain_db = found.get("gain_db")
+            if corr < handoff_corr_floor():
+                found["status"] = "unverifiable"
+                found["why"] = "alignment below correlation floor"
+            elif gain_db is None:
+                found["status"] = "unverifiable"
+                found["why"] = "gain undefined"
+            elif abs(gain_db) > handoff_gain_tolerance_db():
+                found["status"] = "scaled"
+            else:
+                found["status"] = "lossless"
+            return found
+        except (ValueError, TypeError, MemoryError):
+            return {"status": "unverifiable", "why": "degraded"}
 
     @staticmethod
     def _verdict(metrics: Dict[str, Any]) -> str:
@@ -335,6 +476,19 @@ class CaptureForensics:
         proc = metrics.get("processed_bus") or {}
         r_mod = raw.get("syllabic_modulation_2_8hz")
         p_mod = proc.get("syllabic_modulation_2_8hz")
+
+        # A PROVEN amplitude change at the final handoff outranks everything
+        # below it: it is specific, it is measured on this incident, and it
+        # names a fault the modulation comparison cannot see. It speaks only
+        # on proof — an unverifiable alignment is silent, never divergence.
+        handoff = metrics.get("handoff") or {}
+        if handoff.get("status") == "scaled":
+            return (f"the buffer handed to the recogniser is the bus audio "
+                    f"at {handoff.get('gain_db')} dB "
+                    f"(correlation {handoff.get('correlation')}, gain ratio "
+                    f"{handoff.get('gain_ratio')}) — the handoff is rescaling "
+                    f"it; suspect a dtype cast or double normalisation")
+
         if not raw.get("samples"):
             return "no raw frames tapped — cannot attribute"
         if r_mod is None or p_mod is None:
@@ -353,8 +507,15 @@ class CaptureForensics:
                         f"gain ahead of range-fitting")
             return (f"speech rhythm present at the device ({r_mod}) and lost "
                     f"by the bus ({p_mod}) — the chain is destroying it")
+        tail = ""
+        if handoff.get("status") == "lossless":
+            # Exonerating the handoff is worth stating: it is where the next
+            # theory always goes, and it now costs nothing to rule out.
+            tail = (f"; the recogniser was handed the bus audio unchanged "
+                    f"(0 dB, correlation {handoff.get('correlation')}), so the "
+                    f"fault is in the recogniser or in what was buffered for it")
         return (f"speech rhythm survives the chain (raw {r_mod} -> "
-                f"processed {p_mod}) — look downstream of the bus")
+                f"processed {p_mod}) — look downstream of the bus{tail}")
 
     @staticmethod
     def _write_wav(path: Path, audio: np.ndarray, sample_rate: int) -> None:

--- a/backend/audio/capture_forensics.py
+++ b/backend/audio/capture_forensics.py
@@ -120,7 +120,11 @@ class _Ring:
         self._held = 0
         self._lock = threading.Lock()
         #: Running observations — cheaper than re-deriving them from the ring,
-        #: and they survive even if the ring is later trimmed.
+        #: and they survive even if the ring is later trimmed. Because they
+        #: survive, they describe the PROCESS, not the incident.
+        #: LIFETIME totals, not window measurements. They are reported under
+        #: a separate ``session`` key and are never evidence about an
+        #: individual incident — see :meth:`stats`.
         self.frames_seen = 0
         self.peak_max = 0.0
         self.over_full_scale = 0
@@ -147,11 +151,25 @@ class _Ring:
                 return np.zeros(0, dtype=np.float32)
             return np.concatenate(list(self._frames))
 
+    def _session(self) -> Dict[str, Any]:
+        """Lifetime totals, quarantined behind their own key.
+
+        Kept because "this device has overdriven at some point" is genuinely
+        useful context, and deliberately separated because it is NOT a
+        measurement of the incident being written. Flattened alongside the
+        window numbers it reads as one, which is how a single early transient
+        came to be reported as the cause of every later rejection."""
+        return {
+            "frames_seen": self.frames_seen,
+            "peak_ever": round(self.peak_max, 4),
+            "over_full_scale_frames": self.over_full_scale,
+        }
+
     def stats(self) -> Dict[str, Any]:
         a = self.snapshot()
         if not a.size:
             return {"samples": 0, "sample_rate": self.sample_rate,
-                    "frames_seen": self.frames_seen}
+                    "session": self._session()}
         peak = float(np.max(np.abs(a)))
         rms = float(np.sqrt(np.mean(a.astype(np.float64) ** 2)))
         crest_db = 20.0 * float(np.log10(peak / rms)) if rms > 1e-9 else 0.0
@@ -179,10 +197,11 @@ class _Ring:
             "rms": round(rms, 5),
             "crest_db": round(crest_db, 1),
             "clipped_samples": int(np.sum(np.abs(a) >= 0.999)),
-            "over_full_scale_frames": self.over_full_scale,
-            "peak_ever": round(self.peak_max, 4),
-            "frames_seen": self.frames_seen,
+            # Window-scoped overdrive, re-derived from the retained audio so
+            # it describes THIS incident and nothing earlier.
+            "over_full_scale_samples": int(np.sum(np.abs(a) > 1.0)),
             "syllabic_modulation_2_8hz": round(mod, 3),
+            "session": self._session(),
         }
 
 
@@ -250,7 +269,11 @@ class CaptureForensics:
             out.mkdir(parents=True, exist_ok=True)
 
             metrics: Dict[str, Any] = {
-                "schema_version": "1.0",
+                # 1.1: lifetime ring totals moved out of the per-window blocks
+                # into their own ``session`` key (they were being read as
+                # incident evidence); adds window-scoped
+                # ``over_full_scale_samples``.
+                "schema_version": "1.1",
                 "reason": reason,
                 "wall_time": time.strftime("%Y-%m-%dT%H:%M:%S"),
                 "detail": dict(detail or {}),
@@ -297,7 +320,17 @@ class CaptureForensics:
         opposite fixes: if the raw device signal already lacks the 2-8 Hz
         rhythm of speech, no amount of processing repair will help; if the raw
         end has it and the processed end does not, the chain is destroying
-        it."""
+        it.
+
+        Every number it reads is scoped to the incident window. It previously
+        opened on the ring's LIFETIME over-full-scale counter, so the first
+        overdriven frame of a process latched "input gain, not the chain" onto
+        every rejection that followed and the modulation comparison this hint
+        exists for never ran again. Overdrive is also not, by itself, a fault:
+        ``AudioBus._fit_to_range`` exists precisely because macOS delivers
+        this device above +/-1.0 routinely. It is reported below as a possible
+        MECHANISM when the chain is measurably losing speech, never as a
+        standalone cause."""
         raw = metrics.get("raw_device") or {}
         proc = metrics.get("processed_bus") or {}
         r_mod = raw.get("syllabic_modulation_2_8hz")
@@ -306,15 +339,18 @@ class CaptureForensics:
             return "no raw frames tapped — cannot attribute"
         if r_mod is None or p_mod is None:
             return "incomplete measurements"
-        if raw.get("over_full_scale_frames", 0) > 0:
-            return (f"device delivered {raw['over_full_scale_frames']} frames "
-                    f"above full scale (peak {raw.get('peak_ever')}) — input "
-                    f"gain, not the chain")
         if r_mod < 0.15:
             return (f"raw device audio already lacks speech rhythm "
                     f"(modulation {r_mod}) — the microphone did not hear a "
                     f"voice; the chain is not at fault")
         if p_mod < r_mod * 0.6:
+            over = int(raw.get("over_full_scale_samples", 0) or 0)
+            if over > 0:
+                return (f"speech rhythm present at the device ({r_mod}) and "
+                        f"lost by the bus ({p_mod}) — the chain is destroying "
+                        f"it; {over} samples arrived above full scale (peak "
+                        f"{raw.get('peak')}) in this window, so suspect input "
+                        f"gain ahead of range-fitting")
             return (f"speech rhythm present at the device ({r_mod}) and lost "
                     f"by the bus ({p_mod}) — the chain is destroying it")
         return (f"speech rhythm survives the chain (raw {r_mod} -> "

--- a/docs/HANDOFF_2026-07-25_voice.md
+++ b/docs/HANDOFF_2026-07-25_voice.md
@@ -1,0 +1,158 @@
+# Handoff — voice pipeline session, 2026-07-25
+
+## The headline
+
+**The pipeline was never broken. The microphone wasn't receiving the operator.**
+
+Measured with `scripts/hardware_acoustic_profiler.py`:
+
+| | seating distance | close to lid |
+|---|---|---|
+| rms | 0.0033 | **0.0114** |
+| crest | 37.8 dB | **19.5 dB** |
+| syllabic modulation | 0.196 | **0.431** |
+| `no_speech_prob` | 0.522 | **0.153** |
+| Whisper | `"I'm sorry, I'm sorry…"` | **`"Hello, testing, testing."`** |
+
+Speech sits at 15–21 dB crest. At 37.8 dB only consonant bursts survive and sustained
+vowels fall into the room floor — **temporal envelope smearing**. No gain stage recovers
+that, which is why every amplitude fix failed.
+
+**Five hypotheses died on measurement** before this: HAL contention, gain staging,
+int16 quantization, amplitude, Continuity-mic selection.
+
+## Merged to main (`bfde7ae270`)
+
+| PR | What |
+|---|---|
+| 70094 | Persona matrix + zero-cost phatic fast path (OV→Karen, JARVIS→Daniel, wake-word routing) |
+| 70095 | Dual-summon delegation + speech turnstile (role arbitration, 300 ms acoustic tail, lane dispatch) |
+| 70096 | Capture forensics flight recorder (raw / processed / model-input + verdict) |
+| 70097 | thin-client exit-75 test alignment |
+| 70098 | Desktop actuation guard — **fixed the Weather app opening on its own** |
+| 70099 | Proportional pre-quantization AGC (replaced tanh saturator) |
+| 70100 | Inter-Agent Context Bus (compressed delegation payload, firewall-fenced digest) |
+| 70101 | Async-signal-safe shutdown handler (fixed SIGSEGV on SIGTERM) |
+| 70102 | Bi-directional AGC (upward normalization, adaptive noise floor) |
+| 70103 | Hardware acoustic profiler — **the tool that found the answer** |
+| 70104 | Acoustic quality telemetry (SQI + Karen says when she can't hear) |
+
+**Pushed, NOT merged:** `feat/speak-immediate` — priority TTS interrupt, 7 tests.
+
+## Open work, in priority order
+
+### 1. ~~Synapse mount — `wake` dies silently~~ — PHANTOM, closed 2026-07-25 23:20
+The forensic step was done first, as instructed, and the premise did not survive it.
+
+`_audio_synapse` is assigned at `harness.py:4502` **unconditionally, before**
+`bridge.start()` — so on any daemon whose attach socket answers, it cannot be `None`.
+
+Reproduced live against daemon pid 99385 by sending the exact frame `ov` sends
+(`_route_operator_line` → `client.send_audio("wake")` → `{"type":"audio","cmd":"wake"}`):
+
+```
+[  1.00s] >>> SENT {"type": "audio", "cmd": "wake"}
+[  1.05s] audio_state: {"state": "LISTENING"}
+```
+
+and on the hardware plane, 50 ms later:
+
+```
+23:20:08 [Bootstrap] audio lease ARMED
+23:20:08 [Bootstrap] lease ARM → CONVERSATION mode (pipeline loop running)
+```
+
+`LISTENING` is only published *after* `RemoteAudioLease.acquire` is granted, so the
+whole chain — synapse → lease → supervisor → mic — was live. **Do not add
+`UnmountedSynapseError`.** The likely original observation is the honest
+`UNAVAILABLE` published when no audio plane is running, which the TUI renders
+quietly enough to read as nothing happening. That is a UX gap, not a mount bug.
+
+### 1b. Capture forensics was issuing a false verdict on every incident — FIXED
+Found while confirming the plane was live. `_verdict` opened on the ring's
+**lifetime** over-full-scale counter, so the first overdriven frame of a process
+latched `input gain, not the chain` onto every rejection written afterwards and the
+syllabic-modulation comparison the hint exists for never ran again. All 8 incidents
+on disk carried the identical `150 frames above full scale (peak 5.8037)` — one early
+transient, recited forever. Overdrive is also not a fault on its own:
+`AudioBus._fit_to_range` exists because this device delivers above ±1.0 routinely.
+
+Replaying the 8 stored incidents through the fixed verdict:
+
+```
+OLD: device delivered 150 frames above full scale (peak 5.8037) — input gain, not the chain
+NEW: speech rhythm survives the chain (raw 0.25 -> processed 0.262) — look downstream of the bus
+```
+
+**This is a new lead and it points somewhere nobody has looked.** Syllabic modulation
+*survives* the bus (raw ≈ 0.25 → processed ≈ 0.26) and the recogniser still returns
+empty. That is not distance and not the chain — it is downstream of the bus: the
+buffer assembled for the model, or the model stage itself. Worth noting the
+model-input peak in incident `232221` is 0.0157 against a processed-bus peak of
+0.3992. Different windows, so not yet a finding — but it is the first thing to measure.
+
+Metrics schema 1.0 → 1.1: lifetime totals moved under a `session` key, window-scoped
+`over_full_scale_samples` added. Spine: `tests/audio/test_capture_forensics_verdict.py`
+(9 tests; the recorder shipped in #70096 with none).
+
+### 2. DW routing audit
+Untouched. Confirm `AdaptiveVoiceRouter` prefers DoubleWord and only falls back to local
+`UnifiedModelServing` on network timeout.
+
+### 3. Compute escalation — unjustified, not disproven
+The large-v3 probe was **inconclusive**: it grabbed an incident holding near-silence
+(`peak 0.025`), and `small`/`medium` hit `PermissionError` downloading.
+Re-run against a `raw_device.wav` from a capture where speech was actually present,
+with models pre-pulled. If a bigger model can't read it either, the answer is device
+selection, not GCP.
+
+### 4. AdaptiveInputManager — live CoreAudio rebind (deliberately deferred)
+`rank_devices()` and `best_device()` are **built, merged and tested** in
+`backend/audio/acoustic_quality.py`. Only the live stream rebind is missing. Deferred
+because tearing down a contended input stream wedged processes three times this session.
+
+## Traps — read before touching anything
+
+- **`unified_supervisor.py` needs a TTY.** `python3 unified_supervisor.py` in a real
+  terminal. Backgrounding it with `nohup` wedges it at 0 % CPU, state `SN` — it blocks on
+  a read that never returns. This cost ~6 restart attempts and 3 outages.
+- **It segfaults during `Py_FinalizeEx`** — a C extension frees memory badly at teardown.
+  Pre-existing, separate from the handler fix. It cannot exit cleanly; `SIGTERM` may need
+  escalation to `-9`.
+- **Establish how a daemon was started before stopping it** (`ps -o ppid=`, and check the
+  `+` in `STAT`). The LaunchAgent `com.jarvis.supervisor` was **never loaded** — the plist
+  exists but `launchctl` has no such label.
+- **git needs `dangerouslyDisableSandbox`** in this `.nosync` repo, plus
+  `-c branch.autoSetupMerge=false` — a plain `checkout -b` fails on `.git/config` write and
+  leaves the tree **half-reverted**.
+- **`main` is push-protected** (local hook + remote). PRs only.
+- **`lsof` does not reliably report unix-socket listeners.** It reported `NOBODY` on a
+  socket that answered a handshake immediately.
+- **The profiler refuses to run while the audio plane is live** (contention guard).
+  Stop the plane, measure, restart it.
+- **`tests/core/` is unhealthy**: one test hangs past 180 s, plus 2 pre-existing collection
+  errors (`graduation_tracker` missing, `pyautogui` uninstalled). Unrelated to this work.
+
+## Process state at handoff
+
+- audio plane: **running**, pid 98229, socket bound
+- unified_supervisor: **not running** — start it yourself in a terminal
+- battle-test daemon: pid 99385 (spawned by `ov`)
+
+## Diagnostics available
+
+```bash
+# measure the microphone (stop the audio plane first)
+python3 scripts/hardware_acoustic_profiler.py --device 1 --seconds 5
+# writes .jarvis/acoustic_profile/latest.json
+
+# every STT rejection writes an incident automatically
+ls .jarvis/capture_forensics/
+# raw_device.wav / processed_bus.wav / model_input.wav / metrics.json + verdict
+```
+
+## Still unproven on hardware
+
+`ov` → `wake` → Karen answering, and the dual summon. All of it is built and tested
+in-process; none of it has run against a live spoken turn, because until the distance
+finding the mic never delivered intelligible audio. **Test it sitting close to the lid.**

--- a/docs/HANDOFF_2026-07-25_voice.md
+++ b/docs/HANDOFF_2026-07-25_voice.md
@@ -87,9 +87,61 @@ NEW: speech rhythm survives the chain (raw 0.25 -> processed 0.262) — look dow
 **This is a new lead and it points somewhere nobody has looked.** Syllabic modulation
 *survives* the bus (raw ≈ 0.25 → processed ≈ 0.26) and the recogniser still returns
 empty. That is not distance and not the chain — it is downstream of the bus: the
-buffer assembled for the model, or the model stage itself. Worth noting the
-model-input peak in incident `232221` is 0.0157 against a processed-bus peak of
-0.3992. Different windows, so not yet a finding — but it is the first thing to measure.
+buffer assembled for the model, or the model stage itself.
+
+### 1c. The model-input attenuation was not real — the handoff is bit-exact
+The `0.0157` vs `0.3992` figure was a window-mismatch artifact (12 s ring containing
+one loud transient, vs a 1.72 s utterance tail) and should never have been promoted to
+a lead. Settled by full-window normalised cross-correlation of each `model_input.wav`
+against its own `processed_bus.wav`:
+
+```
+lag_s  corr  bus_seg_pk  mdl_pk   ratio    dB
+ 7.72  1.000     0.2900  0.2900  1.0000  0.00
+ 1.00  1.000     0.0195  0.0195  1.0000  0.00
+ 8.04  1.000     0.5806  0.5806  1.0000  0.00
+ 2.78  1.000     0.0508  0.0508  1.0000  0.00
+```
+
+**Ratio exactly 1.0000 at correlation 1.000 — 0 dB. No attenuation, no dtype fault, no
+double normalisation.** Structurally it could not be otherwise: `audio_bus.py:1097`
+calls `note_processed(cleaned, ...)` and `audio_bus.py:1103` dispatches *the same
+`cleaned` array* to `streaming_stt.on_audio_frame` (registered at
+`audio_pipeline_bootstrap.py:178`). There is no transformation between the tap and the
+consumer — it is one object.
+
+Two traps worth carrying forward:
+
+- **Alignment must search the whole ring.** Incidents are written 1–8 s after the
+  buffer is assembled (measured: 0.94 s–8.04 s), so a short search window finds
+  garbage and reports it as divergence. My first pass searched 0.5 s and produced
+  correlations of 0.05–0.33, which read convincingly as "the buffer isn't the bus
+  audio". It was a search bug.
+- **Low correlation produces large fake gains.** Incident `234722` aligns at corr 0.13
+  and reports +20.7 dB. Believe no gain figure without its correlation.
+
+### 1d. Handoff integrity is now measured per-incident, not assumed
+The module header always described the processed ring as "exactly what the model was
+handed" — an assumption the recorder never checked, which is why this cost a hunt.
+`CaptureForensics._handoff` now proves or disproves it on every incident, reusing the
+rings already held (no new taps): FFT normalised cross-correlation → `lossless` /
+`scaled` / `unverifiable`.
+
+`scaled` is the int16→float32 and double-normalisation class the hunt was looking for.
+It did not turn out to be present, but it is now named automatically on the first
+incident instead of costing a session. The epistemic floor matters as much as the
+detector: below `JARVIS_FORENSICS_HANDOFF_CORR_FLOOR` (0.99) the report is
+`unverifiable` and says nothing further — an unproven match is not evidence of a fault.
+Knobs: `JARVIS_FORENSICS_HANDOFF_CHECK`, `..._CORR_FLOOR`, `..._GAIN_TOL_DB`.
+
+Replayed over the 8 stored incidents: 4 `lossless` (corr 1.0, 0.0 dB), 4
+`unverifiable` — including the +20.7 dB phantom, correctly suppressed.
+
+**Where the fault actually is:** the audio reaching Whisper *is* the bus audio, and it
+carries speech rhythm. So the remaining candidates are the recogniser itself, or what
+`_schedule_transcription` buffered for it. `streaming_stt.py:391-440` already documents
+two solved faults of exactly that shape (VAD shrapnel; trailing room tone). That is the
+next place to look — not the DSP chain.
 
 Metrics schema 1.0 → 1.1: lifetime totals moved under a `session` key, window-scoped
 `over_full_scale_samples` added. Spine: `tests/audio/test_capture_forensics_verdict.py`

--- a/tests/audio/test_capture_forensics_verdict.py
+++ b/tests/audio/test_capture_forensics_verdict.py
@@ -29,6 +29,18 @@ def _speechlike(seconds: float, rate: int, *, amp: float = 0.2) -> np.ndarray:
     return (amp * envelope * np.sin(2.0 * np.pi * 220.0 * t)).astype(np.float32)
 
 
+def _unique(seconds: float, rate: int, *, seed: int = 7) -> np.ndarray:
+    """Speech-shaped but NON-REPEATING — a syllabic envelope over seeded
+    noise. ``_speechlike`` is exactly periodic (a 220 Hz carrier under a 4 Hz
+    envelope repeats every 0.25 s), which makes it correlate perfectly at many
+    lags; any alignment measured against it is arbitrary. Content that has to
+    be *located* needs a signal that occurs only once."""
+    rng = np.random.default_rng(seed)
+    t = np.arange(int(seconds * rate), dtype=np.float64) / rate
+    envelope = 0.5 * (1.0 + np.sin(2.0 * np.pi * 4.0 * t))
+    return (0.2 * envelope * rng.standard_normal(t.size)).astype(np.float32)
+
+
 def _steady(seconds: float, rate: int, *, amp: float = 0.2) -> np.ndarray:
     """A constant tone: energy without syllabic rhythm."""
     t = np.arange(int(seconds * rate), dtype=np.float64) / rate
@@ -170,3 +182,117 @@ def test_empty_ring_stats_still_carry_session_totals() -> None:
     stats = ring.stats()
     assert stats["samples"] == 0
     assert stats["session"]["frames_seen"] == 0
+
+
+# --------------------------------------------------------------------------
+# 5. handoff integrity — is the model buffer the audio the bus produced?
+# --------------------------------------------------------------------------
+
+def _fill(fx: CaptureForensics, audio: np.ndarray, rate: int) -> None:
+    hop = max(1, rate // 10)
+    for s in range(0, len(audio), hop):
+        fx.note_processed(audio[s:s + hop], rate)
+
+
+def test_handoff_lossless_is_proven_not_assumed() -> None:
+    """The measured production case: the recogniser is handed a slice of the
+    bus audio, several seconds back from the newest sample, bit-exact."""
+    rate = 16000
+    bus = _unique(10.0, rate)
+    fx = CaptureForensics()
+    _fill(fx, bus, rate)
+
+    # An utterance 4s back from the end — where transcription latency puts it.
+    start, n = int(3.0 * rate), int(2.0 * rate)
+    handed = bus[start:start + n]
+
+    report = fx._handoff(handed, rate)
+    assert report["status"] == "lossless"
+    assert report["correlation"] == pytest.approx(1.0, abs=1e-3)
+    assert report["gain_db"] == pytest.approx(0.0, abs=0.05)
+    assert report["lag_s"] == pytest.approx(10.0 - 5.0, abs=0.05)
+
+
+@pytest.mark.parametrize(
+    "gain, label",
+    [
+        (1.0 / 32768.0, "unscaled int16->float32 cast"),
+        (0.5, "one bit-shift"),
+        (2.0, "double normalisation"),
+    ],
+)
+def test_handoff_detects_a_rescaled_buffer(gain: float, label: str) -> None:
+    """The fault class hypothesised for this session. It did not turn out to
+    be present, and the point of the check is that if it ever is, the
+    recorder names it on the first incident instead of costing a hunt."""
+    rate = 16000
+    bus = _unique(8.0, rate)
+    fx = CaptureForensics()
+    _fill(fx, bus, rate)
+
+    handed = bus[int(2.0 * rate):int(4.0 * rate)] * gain
+
+    report = fx._handoff(handed, rate)
+    assert report["status"] == "scaled", label
+    assert report["correlation"] == pytest.approx(1.0, abs=1e-3)
+    assert report["gain_db"] == pytest.approx(
+        20.0 * np.log10(gain), abs=0.1,
+    )
+
+    verdict = CaptureForensics._verdict({
+        "raw_device": {"samples": 1, "syllabic_modulation_2_8hz": 0.3},
+        "processed_bus": {"syllabic_modulation_2_8hz": 0.3},
+        "handoff": report,
+    })
+    assert "the handoff is rescaling it" in verdict
+
+
+def test_unproven_alignment_never_claims_divergence() -> None:
+    """Epistemic floor. Audio that aged out of the ring must read
+    'unverifiable', never 'the buffer diverged' — an absent match is not
+    evidence of a fault."""
+    rate = 16000
+    fx = CaptureForensics()
+    _fill(fx, _unique(4.0, rate), rate)
+
+    unrelated = _steady(1.0, rate) + 0.01 * np.arange(rate, dtype=np.float32)
+    report = fx._handoff(unrelated.astype(np.float32), rate)
+    assert report["status"] == "unverifiable"
+
+    verdict = CaptureForensics._verdict({
+        "raw_device": {"samples": 1, "syllabic_modulation_2_8hz": 0.3},
+        "processed_bus": {"syllabic_modulation_2_8hz": 0.3},
+        "handoff": report,
+    })
+    assert "rescaling" not in verdict
+
+
+def test_resampled_handoff_is_unverifiable_not_a_fault() -> None:
+    rate = 16000
+    fx = CaptureForensics()
+    _fill(fx, _unique(4.0, rate), rate)
+    report = fx._handoff(_unique(1.0, 8000), 8000)
+    assert report["status"] == "unverifiable"
+    assert report["why"] == "rate differs"
+
+
+def test_handoff_check_is_killable() -> None:
+    import os
+    rate = 16000
+    fx = CaptureForensics()
+    _fill(fx, _unique(4.0, rate), rate)
+    os.environ["JARVIS_FORENSICS_HANDOFF_CHECK"] = "0"
+    try:
+        assert fx._handoff(_unique(1.0, rate), rate)["status"] == "disabled"
+    finally:
+        os.environ.pop("JARVIS_FORENSICS_HANDOFF_CHECK", None)
+
+
+def test_lossless_handoff_is_stated_in_the_verdict() -> None:
+    verdict = CaptureForensics._verdict({
+        "raw_device": {"samples": 1, "syllabic_modulation_2_8hz": 0.25},
+        "processed_bus": {"syllabic_modulation_2_8hz": 0.26},
+        "handoff": {"status": "lossless", "correlation": 1.0, "gain_db": 0.0},
+    })
+    assert "handed the bus audio unchanged" in verdict
+    assert "in the recogniser or in what was buffered for it" in verdict

--- a/tests/audio/test_capture_forensics_verdict.py
+++ b/tests/audio/test_capture_forensics_verdict.py
@@ -1,0 +1,172 @@
+"""Capture-forensics verdict — window-scoped evidence only.
+
+The recorder shipped (#70096) without a spine over ``_verdict``, and the gap
+cost real diagnostic time: the ring's LIFETIME over-full-scale counter was the
+verdict's opening branch, so one overdriven frame early in a process latched
+"input gain, not the chain" onto every rejection written afterwards. The
+modulation comparison the hint exists for never ran again, and the false
+attribution contradicted the measured cause (mic distance / envelope smearing).
+
+These tests pin the two invariants that failure violated:
+
+  1. lifetime totals are never read as incident evidence, and
+  2. overdrive is a MECHANISM offered alongside measured chain damage, never
+     a standalone cause — ``AudioBus._fit_to_range`` compensates it by design.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from backend.audio.capture_forensics import CaptureForensics, _Ring
+
+
+def _speechlike(seconds: float, rate: int, *, amp: float = 0.2) -> np.ndarray:
+    """A carrier amplitude-modulated at 4 Hz — inside the 2-8 Hz syllabic
+    band the verdict reads, so it registers as 'a voice was present'."""
+    t = np.arange(int(seconds * rate), dtype=np.float64) / rate
+    envelope = 0.5 * (1.0 + np.sin(2.0 * np.pi * 4.0 * t))
+    return (amp * envelope * np.sin(2.0 * np.pi * 220.0 * t)).astype(np.float32)
+
+
+def _steady(seconds: float, rate: int, *, amp: float = 0.2) -> np.ndarray:
+    """A constant tone: energy without syllabic rhythm."""
+    t = np.arange(int(seconds * rate), dtype=np.float64) / rate
+    return (amp * np.sin(2.0 * np.pi * 220.0 * t)).astype(np.float32)
+
+
+def _stats(frames: list[np.ndarray], rate: int, window_s: float = 12.0) -> dict:
+    """Push *frames* through a ring in realistic 100 ms chunks and read it.
+
+    Chunking matters: the ring evicts whole frames, so a single oversized
+    push would evict everything before it and leave the window empty."""
+    ring = _Ring(rate, window_s)
+    hop = max(1, rate // 10)
+    for f in frames:
+        for start in range(0, len(f), hop):
+            ring.push(f[start:start + hop])
+    return ring.stats()
+
+
+# --------------------------------------------------------------------------
+# 1. scope: lifetime totals stay out of the window block
+# --------------------------------------------------------------------------
+
+def test_lifetime_totals_are_quarantined_under_session() -> None:
+    rate = 16000
+    ring = _Ring(rate, 12.0)
+    ring.push(np.array([5.8, -5.8], dtype=np.float32))   # the early transient
+    for _ in range(20):
+        ring.push(_speechlike(0.5, rate))                # ...long since evicted
+
+    stats = ring.stats()
+    assert "over_full_scale_frames" not in stats
+    assert "peak_ever" not in stats
+    assert "frames_seen" not in stats
+    assert stats["session"]["over_full_scale_frames"] == 1
+    assert stats["session"]["peak_ever"] == pytest.approx(5.8, abs=1e-3)
+
+
+def test_window_overdrive_counts_only_retained_audio() -> None:
+    rate = 16000
+    ring = _Ring(rate, 1.0)                     # 1s budget
+    ring.push(np.full(rate, 3.0, dtype=np.float32))      # 1s, overdriven
+    ring.push(_speechlike(1.0, rate))                    # evicts the above
+
+    stats = ring.stats()
+    assert stats["over_full_scale_samples"] == 0         # window is clean
+    assert stats["session"]["over_full_scale_frames"] == 1   # history remembers
+
+
+# --------------------------------------------------------------------------
+# 2. the latch: a past transient must not decide a present incident
+# --------------------------------------------------------------------------
+
+def test_past_overdrive_does_not_latch_the_verdict() -> None:
+    """The regression itself. Raw and processed both carry speech rhythm, and
+    the only overdrive is historical — the verdict must reason about the
+    chain, not recite the device's past."""
+    rate = 16000
+    # A 1s window with 3s of speech pushed after the transient: the
+    # overdriven frame is long gone from the retained audio.
+    raw = _stats(
+        [np.array([5.8], dtype=np.float32), _speechlike(3.0, rate)], rate, 1.0,
+    )
+    proc = _stats([_speechlike(3.0, rate)], rate, 1.0)
+    assert raw["session"]["over_full_scale_frames"] == 1
+    assert raw["over_full_scale_samples"] == 0
+
+    verdict = CaptureForensics._verdict(
+        {"raw_device": raw, "processed_bus": proc}
+    )
+    assert "input gain, not the chain" not in verdict
+    assert "survives the chain" in verdict
+
+
+def test_silent_mic_is_attributed_to_the_microphone() -> None:
+    """The measured cause of the 2026-07-25 session: rhythm absent at the
+    device end. A stale overdrive counter must not steal this verdict."""
+    rate = 16000
+    raw = _stats([np.array([5.8], dtype=np.float32), _steady(3.0, rate)], rate)
+    proc = _stats([_steady(3.0, rate)], rate)
+
+    verdict = CaptureForensics._verdict(
+        {"raw_device": raw, "processed_bus": proc}
+    )
+    assert "did not hear a voice" in verdict
+    assert "input gain" not in verdict
+
+
+# --------------------------------------------------------------------------
+# 3. overdrive as mechanism, not cause
+# --------------------------------------------------------------------------
+
+def test_live_overdrive_is_reported_only_with_measured_chain_damage() -> None:
+    rate = 16000
+    raw = _stats([_speechlike(3.0, rate, amp=3.0)], rate)   # overdriven NOW
+    proc = _stats([_steady(3.0, rate)], rate)               # rhythm destroyed
+    assert raw["over_full_scale_samples"] > 0
+
+    verdict = CaptureForensics._verdict(
+        {"raw_device": raw, "processed_bus": proc}
+    )
+    assert "the chain is destroying it" in verdict
+    assert "above full scale" in verdict
+
+
+def test_overdrive_alone_is_not_a_fault() -> None:
+    """_fit_to_range compensates overdrive by design. Present at both ends
+    with rhythm intact, it is not a finding."""
+    rate = 16000
+    raw = _stats([_speechlike(3.0, rate, amp=3.0)], rate)
+    proc = _stats([_speechlike(3.0, rate)], rate)
+    assert raw["over_full_scale_samples"] > 0
+
+    verdict = CaptureForensics._verdict(
+        {"raw_device": raw, "processed_bus": proc}
+    )
+    assert "survives the chain" in verdict
+
+
+# --------------------------------------------------------------------------
+# 4. degenerate inputs keep their honest answers
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "metrics, expected",
+    [
+        ({"raw_device": {"samples": 0}, "processed_bus": {}},
+         "no raw frames tapped"),
+        ({"raw_device": {"samples": 10}, "processed_bus": {}},
+         "incomplete measurements"),
+    ],
+)
+def test_degenerate_inputs(metrics: dict, expected: str) -> None:
+    assert expected in CaptureForensics._verdict(metrics)
+
+
+def test_empty_ring_stats_still_carry_session_totals() -> None:
+    ring = _Ring(16000, 12.0)
+    stats = ring.stats()
+    assert stats["samples"] == 0
+    assert stats["session"]["frames_seen"] == 0


### PR DESCRIPTION
## What

`CaptureForensics._verdict` opened on the ring's **lifetime** over-full-scale counter. The first overdriven frame of a process latched

> device delivered 150 frames above full scale (peak 5.8037) — input gain, not the chain

onto every incident written afterwards, and the syllabic-modulation comparison the hint exists for never ran again. All 8 incidents on disk carry that identical string — one transient early in the audio plane's life, recited forever.

Overdrive is not a fault on its own either: `AudioBus._fit_to_range` exists precisely because macOS delivers this device above ±1.0 routinely. The branch fired on a condition already compensated downstream, then pre-empted the real analysis.

## Fix

- **Scope** — lifetime ring totals move under their own `session` key; a window-scoped `over_full_scale_samples`, re-derived from the retained audio, takes their place in the evidence block. Flattened together they read as one measurement, which is how this happened.
- **Priority** — modulation reasoning runs first (the module's stated purpose); overdrive is offered as a possible *mechanism* alongside measured chain damage, never as a standalone cause.

Metrics schema `1.0` → `1.1`.

## Evidence

Replaying the 8 stored incidents through the fixed verdict changes the diagnosis on every one:

```
OLD: device delivered 150 frames above full scale (peak 5.8037) — input gain, not the chain
NEW: speech rhythm survives the chain (raw 0.25 -> processed 0.262) — look downstream of the bus
```

That is a new lead: syllabic modulation *survives* the bus and the recogniser still returns empty — neither distance nor the chain, but downstream of the bus.

## Tests

`tests/audio/test_capture_forensics_verdict.py` — 9 tests, the spine #70096 shipped without. Pins that lifetime totals are never incident evidence, that a past transient cannot latch the verdict, and that overdrive alone is not a finding.

Full audio suite: **215 passed, 4 skipped**.

## Also

Lands `docs/HANDOFF_2026-07-25_voice.md`. Open item #1 (synapse mount / `wake` dies silently) is closed as a **phantom** — reproduced live against the running daemon, `wake` arms the mic end-to-end (`[Bootstrap] audio lease ARMED` 50 ms after the frame). Do not add `UnmountedSynapseError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the capture forensics verdict to use window‑scoped metrics and adds a per‑incident handoff check that proves if the model buffer is the bus audio (`lossless`/`scaled`/`unverifiable`). Early overdrive no longer latches diagnoses; the verdict now prioritizes syllabic modulation and consults the handoff proof; metrics schema is 1.1.

- **Bug Fixes**
  - Window-scope evidence to the incident so past transients cannot latch future diagnoses.
  - Verdict checks speech rhythm first; if the handoff is proven scaled it outranks; overdrive is only added as context when the chain is actually losing speech.
  - Added tests for verdict scoping and handoff; full audio suite passes.

- **Migration**
  - Metrics schema 1.0 → 1.1.
  - Lifetime totals now live under `session` (e.g., `frames_seen`, `peak_ever`, `over_full_scale_frames`).
  - For incident analysis, use `over_full_scale_samples`; expect `schema_version: "1.1"`.
  - New `handoff` block per incident with `status: "lossless" | "scaled" | "unverifiable"` (+ `correlation`, `gain_db`); control via `JARVIS_FORENSICS_HANDOFF_CHECK`, `JARVIS_FORENSICS_HANDOFF_CORR_FLOOR`, `JARVIS_FORENSICS_HANDOFF_GAIN_TOL_DB`.

<sup>Written for commit 21709703853f70504a6f3d1340a8b0e450aaac9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

