### PR TITLE
fix(stt): the first partial of every utterance was pre-roll, not speech

### DIFF
--- a/backend/audio/capture_forensics.py
+++ b/backend/audio/capture_forensics.py
@@ -144,11 +144,11 @@ def _align(haystack: np.ndarray, needle: np.ndarray) -> Optional[Dict[str, Any]]
 
     Returns ``None`` when no honest comparison is possible. NEVER raises."""
     try:
-        n = int(needle.size)
-        if n < 64 or haystack.size < n:
+        n = int(needle.size) # length of the needle, in samples
+        if n < 64 or haystack.size < n: # needle is too short or haystack is too short to match
             return None
         nd = needle - needle.mean() # zero-mean the needle
-        nd_energy = float(np.sqrt((nd ** 2).sum()))
+        nd_energy = float(np.sqrt((nd ** 2).sum())) # energy of the needle
         if nd_energy < 1e-12: # needle is silent — nothing to match
             return None                      # digital silence — nothing to match
 
@@ -167,19 +167,21 @@ def _align(haystack: np.ndarray, needle: np.ndarray) -> Optional[Dict[str, Any]]
         var[var < 1e-20] = np.inf            # silent windows can never win
         r = corr / (np.sqrt(var) * nd_energy) # normalised correlation
 
-        lag = int(np.argmax(r))
-        segment = haystack[lag:lag + n]
-        seg_peak = float(np.max(np.abs(segment)))
-        needle_peak = float(np.max(np.abs(needle)))
-        gain = needle_peak / seg_peak if seg_peak > 1e-12 else float("nan")
+        lag = int(np.argmax(r)) # lag of the best match
+        segment = haystack[lag:lag + n] # segment of haystack that best matches the needle
+        seg_peak = float(np.max(np.abs(segment))) # peak of the best-matching segment
+        needle_peak = float(np.max(np.abs(needle))) # peak of the needle
+        gain = needle_peak / seg_peak if seg_peak > 1e-12 else float("nan") # gain ratio between needle and segment
+        # The gain is the ratio of the peak amplitudes of the needle and the best-matching 
+        # segment of the haystack. If the segment is silent, the gain is undefined (NaN).
         return {
-            "lag_samples": lag,
-            "correlation": round(float(r[lag]), 4),
-            "bus_segment_peak": round(seg_peak, 6),
-            "model_peak": round(needle_peak, 6),
-            "gain_ratio": round(gain, 4) if gain == gain else None,
-            "gain_db": (round(20.0 * float(np.log10(gain)), 2)
-                        if gain == gain and gain > 0 else None),
+            "lag_samples": lag, # lag of the best match in samples
+            "correlation": round(float(r[lag]), 4), # correlation coefficient at the best match
+            "bus_segment_peak": round(seg_peak, 6), # peak of the best-matching segment of the haystack
+            "model_peak": round(needle_peak, 6), # peak of the needle
+            "gain_ratio": round(gain, 4) if gain == gain else None, # gain ratio (None if undefined)
+            "gain_db": (round(20.0 * float(np.log10(gain)), 2) # gain in decibels,
+                        if gain == gain and gain > 0 else None), # gain in dB (None if undefined or negative)
         }
     except (ValueError, TypeError, MemoryError, FloatingPointError):
         return None

--- a/backend/voice/streaming_stt.py
+++ b/backend/voice/streaming_stt.py
@@ -172,6 +172,11 @@ class StreamingSTTEngine:
         self._buffer_lock = threading.Lock()
         self._total_frames = 0
         self._max_buffer_frames = int(_MAX_BUFFER_SECONDS * sample_rate)
+        #: Samples of PRE-ROLL currently sitting at the head of the buffer.
+        #: Pre-roll is context carried FOR the recogniser; it is not evidence
+        #: that an utterance is long enough to be worth transcribing, so the
+        #: minimum-duration gate measures the buffer MINUS this.
+        self._preroll_samples = 0
 
         # VAD state
         self._speech_active = False
@@ -282,6 +287,7 @@ class StreamingSTTEngine:
         with self._buffer_lock:
             self._audio_buffer.clear()
             self._total_frames = 0
+            self._preroll_samples = 0
 
         if self._transcript_queue is not None:
             # Signal end
@@ -328,10 +334,33 @@ class StreamingSTTEngine:
             # says "speech" the onset is already past. Without this, every
             # utterance loses its first consonant — "hello" arrives as "ello".
             with self._buffer_lock:
+                self._preroll_samples = 0
                 for held in self._preroll:
                     self._audio_buffer.append(held)
                     self._total_frames += len(held)
+                    self._preroll_samples += len(held)
                 self._preroll.clear()
+
+            # ANCHOR THE PARTIAL CADENCE TO THE ONSET.
+            #
+            # The interval test below is `now - _last_partial_time > 500ms`,
+            # and _last_partial_time was left wherever the PREVIOUS utterance
+            # abandoned it — seconds or minutes in the past. So the test was
+            # always already true when speech began, and the first partial of
+            # every utterance fired on its FIRST FRAME: 320ms of pre-roll room
+            # tone plus 20ms of speech.
+            #
+            # Whisper returned nothing, correctly — it was handed 94% silence.
+            # The pipeline then logged "signal has SPEECH-level amplitude: the
+            # model rejected it", wrote a forensic incident, and held the
+            # transcription lock long enough that the FIRST USEFUL partial,
+            # 500ms later, was skipped as busy. Measured in one live session:
+            # 334 transcriptions of exactly 00:00.340 — the single most common
+            # duration in the log, more than double the next.
+            #
+            # Restarting the clock here costs nothing and makes the first
+            # partial land one full interval after speech actually started.
+            self._last_partial_time = now_ms
 
         if self._speech_active:
             # Accumulate EVERYTHING until the endpoint — including the silence
@@ -342,6 +371,13 @@ class StreamingSTTEngine:
                 while self._total_frames > self._max_buffer_frames:
                     oldest = self._audio_buffer.popleft()
                     self._total_frames -= len(oldest)
+                    # The cap evicts from the HEAD, which is where pre-roll
+                    # sits — so the pre-roll accounting has to shrink with it,
+                    # or a long utterance would keep discounting samples that
+                    # were dropped minutes ago.
+                    self._preroll_samples = max(
+                        0, self._preroll_samples - len(oldest),
+                    )
 
             if is_speech:
                 self._silence_start_ms = None
@@ -402,12 +438,24 @@ class StreamingSTTEngine:
             # WebRTC VAD mode 3 misclassifies ambient noise as speech for
             # single 20ms frames — without this gate, Whisper wastes CPU
             # processing 20-120ms noise fragments.
+            #
+            # Measured against the SPEECH, not the buffer. Pre-roll is 320ms
+            # by default and the gate is 300ms, so the buffer cleared this
+            # test on pre-roll alone: the one guard whose entire purpose is to
+            # keep sub-speech fragments away from the recogniser was being
+            # satisfied by audio that is, by construction, not speech. A
+            # single 20ms frame of real voice was enough to pass it.
             duration_ms = (len(audio) / self._sample_rate) * 1000
-            if duration_ms < _MIN_SPEECH_DURATION_MS:
+            speech_ms = (
+                max(0, len(audio) - self._preroll_samples)
+                / self._sample_rate
+            ) * 1000
+            if speech_ms < _MIN_SPEECH_DURATION_MS:
                 if not is_partial:
                     # Still clear buffer on final to prevent stale accumulation
                     self._audio_buffer.clear()
                     self._total_frames = 0
+                    self._preroll_samples = 0
                 return
 
             if not is_partial:
@@ -432,6 +480,7 @@ class StreamingSTTEngine:
                 self._audio_buffer.clear()
                 self._total_frames = 0
                 self._voiced_frames = 0
+                self._preroll_samples = 0
                 if voiced == 0:
                     logger.debug(
                         "[StreamingSTT] final suppressed: %.2fs buffered with "

--- a/tests/audio/test_stt_partial_cadence.py
+++ b/tests/audio/test_stt_partial_cadence.py
@@ -1,0 +1,200 @@
+"""Partial cadence — the first partial of an utterance was pre-roll.
+
+`_last_partial_time` was never reset when speech began, so the interval test
+``now - _last_partial_time > _PARTIAL_INTERVAL_MS`` was already true on the
+FIRST speech frame (the previous partial having fired seconds or minutes
+earlier, in some other utterance). Every utterance therefore opened by handing
+faster-whisper 320 ms of pre-roll room tone plus 20 ms of speech.
+
+Whisper returned nothing, which was correct — it was given 94% silence. The
+pipeline then logged "signal has SPEECH-level amplitude: the model rejected
+it", wrote a capture-forensics incident, and held the transcription lock long
+enough that the first genuinely useful partial 500 ms later was skipped as
+busy. In one live session the fingerprint was unmistakable: 334 transcriptions
+of exactly ``00:00.340`` — 320 + 20 — the most common duration in the log by
+more than 2x, and 4 of the 8 retained incidents.
+
+Coupled to it, the minimum-speech gate measured the whole BUFFER. At a 320 ms
+pre-roll against a 300 ms floor, the one guard whose purpose is to keep
+sub-speech fragments away from the recogniser was satisfied by pre-roll alone.
+
+Tests 3 and 4 pin behaviour that already worked before this change (post-roll
+retention and micro-pause coalescence) so that a future "adaptive buffering"
+rewrite cannot quietly remove it.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from backend.voice import streaming_stt as sst
+
+RATE = 16000
+FRAME = RATE * 20 // 1000          # 20 ms, the cadence AudioBus delivers
+
+
+class _Clock:
+    """Deterministic wall clock; the engine reads ``time.time()``."""
+
+    def __init__(self) -> None:
+        self.t = 1000.0
+
+    def time(self) -> float:
+        return self.t
+
+
+class _Probe(sst.StreamingSTTEngine):
+    """Real segmentation AND the real ``_schedule_transcription``.
+
+    The sibling suite (``test_stt_endpointing``) stubs the scheduler because
+    the buffer is its subject. Here the scheduler IS the subject, so only the
+    event loop and the model are replaced — the gate, the pre-roll accounting
+    and the clearing all run for real."""
+
+    def __init__(self, mask) -> None:
+        super().__init__()
+        self._running = True
+        self._mask = list(mask)
+        self._i = 0
+        self.dispatched: list[tuple[bool, int]] = []
+        self._transcript_queue = object()      # only checked for None
+        self._loop = self                      # stands in for the loop
+
+    # -- event loop stand-in -------------------------------------------
+    def call_soon_threadsafe(self, fn):
+        fn()
+
+    def create_task(self, x):
+        return x
+
+    # -- deterministic VAD ---------------------------------------------
+    def _detect_speech(self, frame) -> bool:
+        v = self._mask[self._i] if self._i < len(self._mask) else False
+        self._i += 1
+        return bool(v)
+
+    # -- capture instead of transcribing --------------------------------
+    def _run_transcription(self, audio, is_partial):   # type: ignore[override]
+        self.dispatched.append((is_partial, len(audio)))
+        return None
+
+
+def _drive(mask, monkeypatch) -> _Probe:
+    clock = _Clock()
+    monkeypatch.setattr(sst, "time", clock)
+    eng = _Probe(mask)
+    rng = np.random.default_rng(0)
+    for speaking in mask:
+        amp = 0.2 if speaking else 0.001
+        eng.on_audio_frame((amp * rng.standard_normal(FRAME)).astype(np.float32))
+        clock.t += 0.020
+    return eng
+
+
+def _ms(samples: int) -> float:
+    return samples / RATE * 1000.0
+
+
+# --------------------------------------------------------------------------
+# 1. the defect
+# --------------------------------------------------------------------------
+
+def test_first_partial_is_not_a_preroll_fragment(monkeypatch) -> None:
+    eng = _drive([False] * 40 + [True] * 60, monkeypatch)
+    partials = [n for p, n in eng.dispatched if p]
+    assert partials, "expected at least one partial"
+
+    first = _ms(partials[0])
+    preroll_only = sst._PREROLL_MS + 20      # the 00:00.340 fingerprint
+    assert first > preroll_only + 1, (
+        f"first partial was {first:.0f}ms — pre-roll plus a single frame"
+    )
+    # It should land one full interval after ONSET, pre-roll included.
+    assert first == pytest.approx(
+        sst._PREROLL_MS + sst._PARTIAL_INTERVAL_MS, abs=60,
+    )
+
+
+def test_partial_cadence_is_anchored_to_onset_not_the_previous_utterance(
+    monkeypatch,
+) -> None:
+    """Two utterances separated by a long silence. The second must not fire a
+    partial on its first frame just because the clock ran on during the gap."""
+    mask = ([False] * 40 + [True] * 40 + [False] * 60
+            + [True] * 40 + [False] * 60)
+    eng = _drive(mask, monkeypatch)
+    for is_partial, n in eng.dispatched:
+        if is_partial:
+            assert _ms(n) > sst._PREROLL_MS + 20 + 1
+
+
+def test_preroll_alone_cannot_satisfy_the_min_speech_gate(monkeypatch) -> None:
+    """One frame of speech behind a 320ms pre-roll is 340ms of buffer and
+    20ms of voice. The gate exists to stop exactly this reaching the model."""
+    eng = _drive([False] * 40 + [True] * 1 + [False] * 60, monkeypatch)
+    for _is_partial, n in eng.dispatched:
+        speech = _ms(n) - sst._PREROLL_MS
+        assert speech >= sst._MIN_SPEECH_DURATION_MS - 1, (
+            f"dispatched {_ms(n):.0f}ms holding only {speech:.0f}ms of speech"
+        )
+
+
+# --------------------------------------------------------------------------
+# 2. behaviour that already worked — pinned so a rewrite cannot drop it
+# --------------------------------------------------------------------------
+
+def test_post_roll_is_retained_through_the_hangover(monkeypatch) -> None:
+    """Frames keep accumulating while ``_speech_active`` holds, so the silence
+    that ENDS an utterance is already in the buffer. 400ms of speech yields a
+    final of pre-roll + speech + the full endpoint hangover."""
+    eng = _drive([False] * 20 + [True] * 20 + [False] * 50, monkeypatch)
+    finals = [n for p, n in eng.dispatched if not p]
+    assert len(finals) == 1
+    total = _ms(finals[0])
+    post_roll = total - sst._PREROLL_MS - 400
+    assert post_roll >= sst._VAD_SILENCE_THRESHOLD_MS - 40, (
+        f"only {post_roll:.0f}ms of post-roll survived"
+    )
+
+
+def test_micro_pause_does_not_split_the_utterance(monkeypatch) -> None:
+    """A 200ms gap is shorter than the endpoint hangover, so it must coalesce
+    into ONE utterance rather than two fragments."""
+    eng = _drive(
+        [False] * 20 + [True] * 15 + [False] * 10 + [True] * 15 + [False] * 50,
+        monkeypatch,
+    )
+    finals = [n for p, n in eng.dispatched if not p]
+    assert len(finals) == 1, f"micro-pause split into {len(finals)} finals"
+    # The gap itself must survive inside the utterance — consonants live there.
+    assert _ms(finals[0]) > 15 * 20 + 10 * 20 + 15 * 20
+
+
+# --------------------------------------------------------------------------
+# 3. pre-roll accounting
+# --------------------------------------------------------------------------
+
+def test_preroll_accounting_resets_after_a_final(monkeypatch) -> None:
+    eng = _drive([False] * 40 + [True] * 40 + [False] * 60, monkeypatch)
+    assert eng._preroll_samples == 0
+
+
+def test_preroll_accounting_shrinks_when_the_cap_evicts_the_head() -> None:
+    """The 30s cap evicts from the head, which is where pre-roll sits."""
+    eng = sst.StreamingSTTEngine()
+    eng._preroll_samples = 3 * FRAME
+    eng._max_buffer_frames = 2 * FRAME
+    eng._running = True
+    eng._speech_active = True
+    for _ in range(4):
+        with eng._buffer_lock:
+            eng._audio_buffer.append(np.zeros(FRAME, np.float32))
+            eng._total_frames += FRAME
+            while eng._total_frames > eng._max_buffer_frames:
+                oldest = eng._audio_buffer.popleft()
+                eng._total_frames -= len(oldest)
+                eng._preroll_samples = max(
+                    0, eng._preroll_samples - len(oldest),
+                )
+    assert eng._preroll_samples < 3 * FRAME
+    assert eng._preroll_samples >= 0


### PR DESCRIPTION
## The defect

`_last_partial_time` was never reset when speech began, so the interval test

```python
now_ms - self._last_partial_time > _PARTIAL_INTERVAL_MS
```

was **already true on the first speech frame** — the previous partial having fired seconds or minutes earlier, in some other utterance. Every utterance therefore opened by handing faster-whisper 320 ms of pre-roll room tone plus 20 ms of speech.

Whisper returned nothing, correctly: it was given 94 % silence. The pipeline then logged *"signal has SPEECH-level amplitude: the model rejected it"*, wrote a capture-forensics incident, and held the transcription lock long enough that the first genuinely useful partial 500 ms later was **skipped as busy**. The defect cost the real partial as well as producing a fake one.

The fingerprint in one live session:

```
334 x 00:00.340   <- 320ms pre-roll + one 20ms frame
119 x 00:00.860
 47 x 00:01.380
```

`00:00.340` is the most common duration in the entire log by more than 2×, and 4 of the 8 retained forensic incidents are exactly it with `is_partial=true`. Those false incidents were also crowding real evidence out of the 8-slot ring.

## Coupled second defect

The minimum-speech gate measured the whole **buffer**. At a 320 ms pre-roll against a 300 ms floor, the one guard whose purpose is keeping sub-speech fragments away from the recogniser was satisfied by pre-roll alone — a single 20 ms frame of voice passed it. It now measures the buffer *minus* the pre-roll it carries, with the accounting following head eviction under the 30 s cap.

## Verification

Driving the real segmentation with synthetic frames: first partial **340 ms → 860 ms**.

7 tests. 4 fail against the unfixed engine with the literal signature (`first partial was 340ms — pre-roll plus a single frame`, `340ms holding only 20ms of speech`). `tests/audio` + `tests/voice`: **527 passed, 5 skipped**.

## What I did NOT change, and why

Measurement showed three of the requested capabilities already exist. Rebuilding them would have duplicated working code:

| capability | status | evidence |
|---|---|---|
| pre-roll | present | `_preroll` deque, `JARVIS_STT_PREROLL_MS`, drained at onset |
| post-roll | present | frames accumulate while `_speech_active` holds — 400 ms of speech yields a **1360 ms** final: 320 pre + 400 speech + **640 post** |
| shrapnel coalescence | present | a 200 ms micro-pause produces **one** final of 1760 ms, not two fragments |

Tests 3 and 4 now pin post-roll and coalescence so a later rewrite cannot quietly drop them. `streaming_stt.py:302-327` documents the VAD-as-gate bug that coalescence already fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes STT partial cadence by anchoring the partial timer to speech onset and gating on speech-only duration, preventing pre-roll-only partials and restoring the first real partial. Reduces empty Whisper calls and false forensic incidents.

- **Bug Fixes**
  - Reset `_last_partial_time` on VAD speech onset so the first partial fires after `_PARTIAL_INTERVAL_MS` instead of immediately (≈860 ms with defaults).
  - Track `_preroll_samples` and measure the min-speech gate against buffer minus pre-roll; shrink on head eviction and reset on stop/final.
  - Drain and account pre-roll at onset; clear state consistently on finalization.
  - Added `tests/audio/test_stt_partial_cadence.py` pinning: first partial timing, gate ignores pre-roll, post-roll retention, and micro-pause coalescence. Comments-only clarifications in `capture_forensics._align`.

<sup>Written for commit 5361458f4729cde37eb61d548f927148a18a115e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

