### PR TITLE
feat(diag): Golden Master injector — the software pipeline is exonerated

### DIFF
--- a/backend/audio/acoustic_feedback.py
+++ b/backend/audio/acoustic_feedback.py
@@ -46,6 +46,19 @@ def _controller() -> Any:
     return _CONTROLLER
 
 
+def _note_ticket_outcome(task: Any) -> None:
+    """Retrieve a speech ticket's result so a failure is LOGGED, not lost.
+
+    An un-retrieved task exception surfaces only as an interpreter warning on
+    stderr, which in a daemon means nowhere. NEVER raises."""
+    try:
+        exc = task.exception()
+    except (asyncio.CancelledError, Exception):  # noqa: BLE001
+        return
+    if exc is not None:
+        logger.warning("[Acoustic] speech ticket failed: %r", exc)
+
+
 def speak_immediate(line: str) -> bool:
     """Say *line* now, ahead of anything queued. Returns True if it was spoken.
 
@@ -77,8 +90,21 @@ def speak_immediate(line: str) -> bool:
         # macos_voice owns synthesis AND the playback gate. Calling its
         # existing entry point is the whole implementation; anything more
         # would be a second audio stack.
+        #
+        # `say_and_wait`, not `say`: this runs inside the speech scheduler's
+        # ticket, and the scheduler holds the floor for exactly as long as
+        # this call takes. `say` only enqueues, so it would return instantly,
+        # release the floor, and let the next speaker talk over this one.
+        #
+        # It was `.speak()`, which MacOSVoice has never defined — the class
+        # exposes `say` / `say_and_wait`. So the delivery half STILL never
+        # ran: the AttributeError was raised inside an executor called from a
+        # fire-and-forget `create_task`, which lands as "Task exception was
+        # never retrieved" rather than reaching the guard below. The same
+        # wired-but-inert trap this function's docstring was written to
+        # close, one layer further down, hidden by the async boundary.
         from backend.voice.macos_voice import MacOSVoice
-        MacOSVoice().speak(text)
+        MacOSVoice().say_and_wait(text)
 
     async def _ticket() -> None:
         from backend.audio.speech_scheduler import SpeechRole, get_scheduler
@@ -97,7 +123,15 @@ def speak_immediate(line: str) -> bool:
             # Scheduled, never awaited inline: this is called from the STT
             # rejection path, and blocking it would stall recognition to
             # announce that recognition is failing.
-            loop.create_task(_ticket())
+            task = loop.create_task(_ticket())
+            # ...but fire-and-forget must not mean fail-and-never-know. The
+            # guard below cannot see inside a task, which is exactly how a
+            # call to a non-existent method survived two releases: the
+            # delivery half raised on every single invocation and the only
+            # trace was an interpreter-level "Task exception was never
+            # retrieved" on stderr. Retrieving it is the difference between a
+            # silent dead feature and a log line naming it.
+            task.add_done_callback(_note_ticket_outcome)
         else:
             _render()
         logger.info("[Acoustic] speaking: %s", text)

--- a/scripts/stt_golden_master.py
+++ b/scripts/stt_golden_master.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Golden Master injector — decide whether the STT pipeline can read speech.
+
+Why this exists
+---------------
+Every remaining theory about the empty-transcript fault is a claim about one
+of two layers, and live voice cannot separate them: a spoken test carries the
+microphone, the room, macOS Voice Isolation, proximity and the operator's
+delivery all at once, so a failure indicts everything and proves nothing.
+
+This drives the SAME ``StreamingSTTEngine`` the plane runs — same VAD, same
+endpointer, same pre-roll, same partial cadence, same faster-whisper settings
+— from audio whose content is known in advance. Nothing here reimplements the
+pipeline; that would test a copy of it. The engine is fed through its real
+entry point, ``on_audio_frame``, in real time at the exact 20 ms / 16 kHz
+cadence ``AudioBus`` delivers, so the timing-dependent logic behaves as it
+does in production.
+
+  golden PASSES, live FAILS  -> software is sound; the fault is hardware, the
+                                room, or OS-level capture processing.
+  golden FAILS               -> the fault is in the pipeline, and it is now
+                                reproducible on demand without speaking.
+
+Modes
+-----
+  --golden ["phrase"]   synthesize a phrase with macOS ``say`` and run it
+  --replay <wav>        run any wav (16 kHz mono is used as-is, else resampled)
+  --incident <dir>      run all three tracks of a capture-forensics incident:
+                        raw_device / processed_bus / model_input, which
+                        answers "is the audio we actually captured readable?"
+
+Not part of the plane. Nothing here is imported by production code, and it
+takes no lease and touches no microphone — it can run WHILE the plane is live
+without contending for CoreAudio, which is what makes a simultaneous
+dual-track possible.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import wave
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+import numpy as np
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+RATE = 16000
+FRAME_MS = 20
+FRAME = RATE * FRAME_MS // 1000
+
+DEFAULT_PHRASE = (
+    "Hello Karen, this is the golden master test of the transcription pipeline."
+)
+
+
+# ---------------------------------------------------------------------------
+# audio sources
+# ---------------------------------------------------------------------------
+
+def _read_wav(path: Path) -> Tuple[np.ndarray, int]:
+    with wave.open(str(path), "rb") as w:
+        rate = w.getframerate()
+        channels = w.getnchannels()
+        width = w.getsampwidth()
+        raw = w.readframes(w.getnframes())
+    if width != 2:
+        raise ValueError(f"{path.name}: expected 16-bit PCM, got {width * 8}-bit")
+    a = np.frombuffer(raw, dtype=np.int16).astype(np.float32) / 32768.0
+    if channels > 1:
+        a = a.reshape(-1, channels).mean(axis=1)
+    return a, rate
+
+
+def _resample(a: np.ndarray, src: int, dst: int) -> np.ndarray:
+    """Linear resample. Adequate here: the question is whether the pipeline
+    can read speech, not whether this script is a mastering-grade SRC."""
+    if src == dst or a.size == 0:
+        return a
+    n = int(round(a.size * dst / src))
+    return np.interp(
+        np.linspace(0.0, a.size - 1, n, dtype=np.float64),
+        np.arange(a.size, dtype=np.float64),
+        a.astype(np.float64),
+    ).astype(np.float32)
+
+
+def synthesize(phrase: str, voice: Optional[str] = None) -> np.ndarray:
+    """A Golden Master built from real speech.
+
+    Deliberately NOT a synthetic waveform. Whisper is an acoustic model of
+    human speech; a mathematically constructed tone or noise-modulated
+    envelope is not language and would return empty for entirely legitimate
+    reasons, proving nothing about the pipeline. ``say`` produces genuine
+    speech with a transcript known exactly in advance."""
+    with tempfile.TemporaryDirectory() as td:
+        aiff = Path(td) / "gm.aiff"
+        cmd = ["say", "-o", str(aiff)]
+        if voice:
+            cmd += ["-v", voice]
+        cmd += [phrase]
+        subprocess.run(cmd, check=True, capture_output=True)
+
+        wav = Path(td) / "gm.wav"
+        subprocess.run(
+            ["afconvert", "-f", "WAVE", "-d", f"LEI16@{RATE}", "-c", "1",
+             str(aiff), str(wav)],
+            check=True, capture_output=True,
+        )
+        a, rate = _read_wav(wav)
+    return _resample(a, rate, RATE)
+
+
+# ---------------------------------------------------------------------------
+# the harness
+# ---------------------------------------------------------------------------
+
+def _lead_out(a: np.ndarray, silence_ms: int = 1200) -> np.ndarray:
+    """Real capture never ends the instant speech does, and the endpointer
+    needs sustained silence to fire a FINAL. Without a tail the clip ends
+    mid-utterance and only partials are ever emitted."""
+    pad = np.zeros(int(RATE * silence_ms / 1000), dtype=np.float32)
+    # A touch of room tone rather than digital zero: webrtcvad treats an
+    # absolutely silent frame differently from a quiet one.
+    pad += (1e-4 * np.random.default_rng(0).standard_normal(pad.size)).astype(
+        np.float32,
+    )
+    return np.concatenate([pad[: RATE // 5], a, pad])
+
+
+async def run_track(
+    label: str, audio: np.ndarray, *, realtime: bool = True,
+    settle_s: float = 12.0,
+) -> List[Tuple[bool, str]]:
+    """Feed one track through a private engine instance and collect events.
+
+    A PRIVATE engine per track is the point. Mixing a reference signal into
+    the live bus would sum two voices into one buffer and Whisper would decode
+    the overlap — an empty result would then indict neither track. Same code,
+    same configuration, separate instances: that is what makes the tracks
+    independent rather than merely concurrent."""
+    from backend.voice.streaming_stt import StreamingSTTEngine
+
+    engine = StreamingSTTEngine(sample_rate=RATE)
+    print(f"[{label}] loading model ({os.getenv('JARVIS_STT_MODEL', 'base')})…",
+          flush=True)
+    t0 = time.monotonic()
+    await engine.start()
+    print(f"[{label}] model ready in {time.monotonic() - t0:.1f}s "
+          f"({audio.size / RATE:.2f}s of audio to feed)", flush=True)
+
+    events: List[Tuple[bool, str]] = []
+
+    async def collect() -> None:
+        async for ev in engine.get_transcripts():
+            events.append((ev.is_partial, ev.text))
+            kind = "partial" if ev.is_partial else "FINAL  "
+            print(f"[{label}] {kind} | {ev.text!r}", flush=True)
+
+    collector = asyncio.create_task(collect())
+
+    async def feed() -> None:
+        # on_audio_frame is called from AudioBus's capture thread in
+        # production. A thread here keeps that shape, and keeps the feed off
+        # the loop that has to service the transcription tasks.
+        def _pump() -> None:
+            for start in range(0, audio.size - FRAME + 1, FRAME):
+                engine.on_audio_frame(audio[start:start + FRAME].copy())
+                if realtime:
+                    time.sleep(FRAME_MS / 1000.0)
+        await asyncio.to_thread(_pump)
+
+    await feed()
+    # The endpoint FINAL is scheduled from the last frames and decoded in an
+    # executor; give it room to land rather than tearing the engine down.
+    deadline = time.monotonic() + settle_s
+    while time.monotonic() < deadline:
+        if any(not p for p, _ in events):
+            break
+        await asyncio.sleep(0.25)
+
+    await engine.stop()
+    collector.cancel()
+    try:
+        await collector
+    except (asyncio.CancelledError, Exception):  # noqa: BLE001
+        pass
+    return events
+
+
+def verdict(label: str, events: List[Tuple[bool, str]], expected: Optional[str]) -> bool:
+    finals = [t for p, t in events if not p and t.strip()]
+    partials = [t for p, t in events if p and t.strip()]
+    print(f"\n[{label}] {len(finals)} final(s), {len(partials)} non-empty partial(s)")
+    if not finals and not partials:
+        print(f"[{label}] RESULT: FAIL — the pipeline produced no text at all")
+        return False
+    heard = " ".join(finals) if finals else " ".join(partials)
+    print(f"[{label}] heard: {heard!r}")
+    if expected:
+        want = {w.strip(".,!?").lower() for w in expected.split() if len(w) > 3}
+        got = {w.strip(".,!?").lower() for w in heard.split()}
+        hit = len(want & got) / max(1, len(want))
+        print(f"[{label}] content match: {hit:.0%} of expected keywords")
+        ok = hit >= 0.5
+        print(f"[{label}] RESULT: {'PASS' if ok else 'FAIL'}")
+        return ok
+    print(f"[{label}] RESULT: PASS — transcribed")
+    return True
+
+
+# ---------------------------------------------------------------------------
+
+async def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    src = ap.add_mutually_exclusive_group(required=True)
+    src.add_argument("--golden", nargs="?", const=DEFAULT_PHRASE, metavar="PHRASE",
+                     help="synthesize a phrase with `say` and run it")
+    src.add_argument("--replay", metavar="WAV", help="run an existing wav")
+    src.add_argument("--incident", metavar="DIR",
+                     help="run all tracks of a capture-forensics incident")
+    ap.add_argument("--voice", default=None, help="`say` voice (default system)")
+    ap.add_argument("--fast", action="store_true",
+                    help="feed faster than real time (skews VAD timing)")
+    args = ap.parse_args()
+
+    # This is a diagnostic run outside the supervisor's startup sequence, so
+    # the ASR admission barrier has no startup to protect here.
+    os.environ.setdefault("JARVIS_ASR_ADMISSION_FORCE_OPEN", "1")
+    # The engine's own forensics would otherwise write incidents for these
+    # synthetic runs and evict real evidence from the 8-slot ring.
+    os.environ.setdefault("JARVIS_CAPTURE_FORENSICS", "0")
+
+    realtime = not args.fast
+    ok = True
+
+    if args.golden:
+        print(f"Golden Master phrase: {args.golden!r}")
+        audio = _lead_out(synthesize(args.golden, args.voice))
+        ev = await run_track("golden", audio, realtime=realtime)
+        ok = verdict("golden", ev, args.golden)
+
+    elif args.replay:
+        a, rate = _read_wav(Path(args.replay))
+        audio = _lead_out(_resample(a, rate, RATE))
+        ev = await run_track(Path(args.replay).stem, audio, realtime=realtime)
+        ok = verdict(Path(args.replay).stem, ev, None)
+
+    else:
+        root = Path(args.incident)
+        for name in ("model_input", "processed_bus", "raw_device"):
+            p = root / f"{name}.wav"
+            if not p.exists():
+                print(f"[{name}] absent — skipped")
+                continue
+            a, rate = _read_wav(p)
+            print(f"\n=== {name}: {a.size / rate:.2f}s @ {rate}Hz "
+                  f"peak={np.max(np.abs(a)):.4f} ===")
+            audio = _lead_out(_resample(a, rate, RATE))
+            ev = await run_track(name, audio, realtime=realtime)
+            verdict(name, ev, None)
+
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/scripts/stt_golden_master.py
+++ b/scripts/stt_golden_master.py
@@ -196,6 +196,35 @@ async def run_track(
     return events
 
 
+#: What faster-whisper emits when handed audio that is NOT speech. These are
+#: not transcripts, they are the model's prior leaking through — and treating
+#: them as success is worse than reporting nothing, because it converts "the
+#: mic heard noise" into "the pipeline works". `capture_forensics` documents
+#: the canonical one: thresholds disabled, non-speech renders as
+#: "I'm sorry, I'm sorry, I'm sorry".
+_HALLUCINATIONS = {
+    "i'm sorry", "im sorry", "sorry", "thank you", "thanks", "you",
+    "thanks for watching", "thank you for watching", "bye", "okay", "ok",
+    "please subscribe", "subscribe", "the", "yeah", "mm", "hmm", "uh",
+}
+
+
+def _is_hallucination(text: str) -> bool:
+    """True when the text is only the model's non-speech prior.
+
+    Compared on the whole utterance, not per word: a real sentence containing
+    "thank you" is speech, whereas an utterance that IS "Thank you." from a
+    0.9s buffer of room tone is the prior."""
+    t = " ".join(text.lower().replace(",", " ").split()).strip(" .!?")
+    if not t:
+        return True
+    if t in _HALLUCINATIONS:
+        return True
+    # "I'm sorry. I'm sorry. I'm sorry." — the same fragment repeated.
+    parts = [p.strip() for p in t.replace("!", ".").split(".") if p.strip()]
+    return bool(parts) and all(p in _HALLUCINATIONS for p in parts)
+
+
 def verdict(label: str, events: List[Tuple[bool, str]], expected: Optional[str]) -> bool:
     finals = [t for p, t in events if not p and t.strip()]
     partials = [t for p, t in events if p and t.strip()]
@@ -205,6 +234,10 @@ def verdict(label: str, events: List[Tuple[bool, str]], expected: Optional[str])
         return False
     heard = " ".join(finals) if finals else " ".join(partials)
     print(f"[{label}] heard: {heard!r}")
+    if _is_hallucination(heard):
+        print(f"[{label}] RESULT: FAIL — {heard!r} is whisper's non-speech "
+              f"prior, not a transcript. The audio is not intelligible speech.")
+        return False
     if expected:
         want = {w.strip(".,!?").lower() for w in expected.split() if len(w) > 3}
         got = {w.strip(".,!?").lower() for w in heard.split()}

--- a/tests/audio/test_speak_immediate.py
+++ b/tests/audio/test_speak_immediate.py
@@ -42,13 +42,66 @@ def test_it_reuses_macos_voice_and_the_turnstile() -> None:
     assert "Popen" not in src and "subprocess" not in src
 
 
+def test_the_method_it_calls_exists_on_the_real_voice() -> None:
+    """The fake mirrored the bug, so the suite stayed green while production
+    raised on EVERY invocation.
+
+    ``speak_immediate`` called ``MacOSVoice().speak(...)``. MacOSVoice has
+    never defined ``speak`` — it exposes ``say`` and ``say_and_wait``. The
+    AttributeError was raised inside an executor called from a
+    fire-and-forget task, so it never reached the guard and surfaced only as
+    "Task exception was never retrieved" on stderr. Every test below injects
+    a stand-in, and a stand-in that mirrors the caller can only ever confirm
+    the caller agrees with itself.
+
+    This asserts against the REAL class instead: whatever attribute the
+    source names, MacOSVoice must actually have it."""
+    import inspect
+    import re
+
+    from backend.voice.macos_voice import MacOSVoice
+
+    src = inspect.getsource(af.speak_immediate)
+    called = set(re.findall(r"MacOSVoice\(\)\.(\w+)", src))
+    assert called, "speak_immediate no longer calls MacOSVoice directly"
+    for name in called:
+        assert hasattr(MacOSVoice, name), (
+            f"speak_immediate calls MacOSVoice().{name}(), which does not "
+            f"exist. Available: {sorted(m for m in dir(MacOSVoice) if not m.startswith('_'))}"
+        )
+
+
+def test_a_failed_speech_ticket_is_logged_not_swallowed(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Fire-and-forget must not mean fail-and-never-know — the invisibility
+    is what let a non-existent method survive two releases."""
+    import asyncio as _aio
+
+    async def _go() -> None:
+        class _Broken:
+            def say_and_wait(self, text: str, mode: str = "normal") -> None:
+                raise AttributeError("simulated engine breakage")
+
+        monkeypatch.setattr("backend.voice.macos_voice.MacOSVoice", _Broken)
+        with caplog.at_level("WARNING"):
+            af.speak_immediate("this will fail")
+            for _ in range(40):
+                await _aio.sleep(0.01)
+                if any("speech ticket failed" in r.message for r in caplog.records):
+                    return
+        raise AssertionError("a failing speech ticket produced no log line")
+
+    _aio.run(_go())
+
+
 def test_it_speaks_with_no_running_loop(monkeypatch: pytest.MonkeyPatch) -> None:
     """Callable from any context — the STT rejection path is not guaranteed
     to be on a loop."""
     spoken: List[str] = []
 
     class _Voice:
-        def speak(self, text: str) -> None:
+        def say_and_wait(self, text: str, mode: str = "normal") -> None:
             spoken.append(text)
 
     monkeypatch.setattr("backend.voice.macos_voice.MacOSVoice", _Voice)
@@ -67,7 +120,7 @@ async def test_it_takes_a_primary_ticket_on_the_turnstile(
     order: List[str] = []
 
     class _Voice:
-        def speak(self, text: str) -> None:
+        def say_and_wait(self, text: str, mode: str = "normal") -> None:
             order.append("interrupt")
 
     monkeypatch.setattr("backend.voice.macos_voice.MacOSVoice", _Voice)
@@ -106,7 +159,7 @@ async def test_it_does_not_block_the_rejection_path(
     import time
 
     class _SlowVoice:
-        def speak(self, text: str) -> None:
+        def say_and_wait(self, text: str, mode: str = "normal") -> None:
             time.sleep(0.6)
 
     monkeypatch.setattr("backend.voice.macos_voice.MacOSVoice", _SlowVoice)
@@ -117,7 +170,7 @@ async def test_it_does_not_block_the_rejection_path(
 
 def test_a_broken_voice_engine_never_raises(monkeypatch: pytest.MonkeyPatch) -> None:
     class _Broken:
-        def speak(self, text: str) -> None:
+        def say_and_wait(self, text: str, mode: str = "normal") -> None:
             raise OSError("no audio device")
 
     monkeypatch.setattr("backend.voice.macos_voice.MacOSVoice", _Broken)


### PR DESCRIPTION
## What it is

Drives the **same** `StreamingSTTEngine` the plane runs — same VAD, endpointer, pre-roll, partial cadence, faster-whisper settings — from audio whose content is known in advance, through the real entry point `on_audio_frame` at the real 20 ms / 16 kHz cadence. Nothing is reimplemented; a copy of the pipeline would only test a copy of the bug.

```
--golden ["phrase"]   synthesize with `say` and run it
--replay <wav>        run any wav
--incident <dir>      run raw_device / processed_bus / model_input of an incident
```

## Two design decisions

**The Golden Master is real speech from `say`, not a constructed waveform.** Whisper is an acoustic model of human speech; a synthetic tone or noise-modulated envelope returns empty for entirely legitimate reasons and would prove nothing.

**A private engine per track, never a signal mixed into the live bus.** Summing a reference into `processed_bus` would have Whisper decode two overlapping voices, and an empty result would then indict neither track. Same code, same config, separate instances — independent rather than merely concurrent. It takes no lease and touches no microphone, so it can run *while* the plane is live.

## Results — the software is exonerated

| track | result |
|---|---|
| golden master | `"Hello, Karen. This is the Golden Master Test of the transcription pipeline."` — **100 % match** |
| incident 004253 — 6.68 s, peak 0.95 | **no text at all** |
| incident 004525 — 14.2 s, peak 0.95 | **no text at all** |

Loud, sustained, real captured audio produces nothing through the exact pipeline that just transcribed synthetic speech perfectly. The acoustic telemetry agrees independently on the same clip: reverb, `sqi=0.60`, modulation `0.111` (below the 0.15 speech floor), crest `24.8 dB` against the 15–21 dB of clean speech.

## Also fixes what the run exposed

`acoustic_feedback` called `MacOSVoice().speak()` — a method that has never existed; the class exposes `say` / `say_and_wait`. **The delivery half of the acoustic loop still never ran**, after the PR written to fix exactly that. The `AttributeError` was raised inside an executor called from a fire-and-forget task, so it bypassed the guard and surfaced only as `Task exception was never retrieved`.

- now calls `say_and_wait` — the scheduler holds the floor for the call's duration; `say` only enqueues and would release it instantly, letting the next speaker talk over it
- a done-callback logs ticket failures instead of losing them

The suite stayed green through all of this because **every fake defined `speak`** — mirroring the caller rather than the real contract. Fakes repointed at `say_and_wait`, plus a structural test that reflects the attribute out of the source and asserts it exists on the **real** `MacOSVoice`, and one asserting a failing ticket produces a log line.

`tests/audio` + `tests/voice`: **529 passed, 5 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Golden Master diagnostic that runs known audio through the real `StreamingSTTEngine` to isolate pipeline vs. capture issues, fixes acoustic feedback so prompts reliably play and failures are logged, and ensures the diagnostic fails on Whisper non‑speech priors instead of reporting a false pass.

- **New Features**
  - Added `scripts/stt_golden_master.py` to drive `on_audio_frame` at 20 ms / 16 kHz with `--golden`, `--replay <wav>`, and `--incident <dir>` (`raw_device`, `processed_bus`, `model_input`).
  - Uses a private engine per track; safe to run alongside the live plane.

- **Bug Fixes**
  - The diagnostic now treats Whisper non‑speech priors (e.g., "I'm sorry", repeated fragments) as FAIL by checking the whole utterance and rejecting hallucinations.
  - Switched `MacOSVoice().speak(...)` to `say_and_wait(...)` so the scheduler holds the floor and delivery actually runs; added a done-callback to log ticket exceptions.
  - Tests updated to use `say_and_wait`, assert the real `MacOSVoice` method exists, and verify a failing ticket logs a warning.

<sup>Written for commit 3584f4a93aed9889b8cf64b7f1e36cf9eefde8eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

