### PR TITLE
feat(audio): adaptive proximity re-binder — pick a closer microphone

### DIFF
--- a/backend/audio/acoustic_feedback.py
+++ b/backend/audio/acoustic_feedback.py
@@ -9,13 +9,38 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any, Optional
+from dataclasses import replace
+from typing import Any, Callable, Optional
 
 import numpy as np
 
 logger = logging.getLogger(__name__)
 
 _CONTROLLER: Optional[Any] = None
+
+#: Set by whoever owns the AdaptiveInputManager (the audio plane host). Left
+#: as a plain seam rather than an import so this module keeps knowing nothing
+#: about CoreAudio, and so the manager stays absent — not merely disabled —
+#: in every process that has not deliberately armed it.
+_ADAPTIVE_SINK: Optional[Callable[[Any], None]] = None
+
+
+def set_adaptive_input_sink(sink: Optional[Callable[[Any], None]]) -> None:
+    """Register (or clear) the observer that receives every QualitySample."""
+    global _ADAPTIVE_SINK
+    _ADAPTIVE_SINK = sink
+
+
+def _notify_adaptive_input(sample: Any) -> None:
+    """Hand one measurement to the device manager. NEVER raises: this sits on
+    the STT rejection path and must not be able to break recognition."""
+    sink = _ADAPTIVE_SINK
+    if sink is None:
+        return
+    try:
+        sink(sample)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[Acoustic] adaptive sink degraded: %r", exc)
 
 
 def _controller() -> Any:
@@ -146,23 +171,21 @@ def report_rejection(audio: Any, sample_rate: int, peak: float, rms: float,
     """Turn one empty transcript into a measurement. NEVER raises."""
     try:
         from backend.audio.acoustic_quality import QualitySample
-        from backend.audio.capture_forensics import _Ring
 
         x = np.asarray(audio, dtype=np.float32).reshape(-1)
         if not x.size:
             return None
-        # DRY: the ring's stats are the forensics' own formulas, so the numbers
-        # here and in an incident file cannot disagree.
-        ring = _Ring(sample_rate, max(1.0, x.size / max(sample_rate, 1)))
-        ring.push(x)
-        st = ring.stats()
-        sample = QualitySample(
-            modulation=float(st.get("syllabic_modulation_2_8hz", 0.0)),
-            crest_db=float(st.get("crest_db", 0.0)),
-            rms=float(rms), peak=float(peak),
-            no_speech_prob=float(no_speech_prob), device=str(device),
+        # DRY: QualitySample.from_audio routes through the forensics ring, so
+        # the numbers here and in an incident file cannot disagree. The caller
+        # already has peak/rms measured on the same buffer — keep those rather
+        # than the ring's, since they are what the rejection log reported.
+        sample = QualitySample.from_audio(
+            x, sample_rate, no_speech_prob=no_speech_prob, device=device,
         )
-        return _controller().observe(sample)
+        sample = replace(sample, rms=float(rms), peak=float(peak))
+        result = _controller().observe(sample)
+        _notify_adaptive_input(sample)
+        return result
     except (ImportError, AttributeError, TypeError, ValueError):
         logger.debug("[Acoustic] report degraded", exc_info=True)
         return None

--- a/backend/audio/acoustic_quality.py
+++ b/backend/audio/acoustic_quality.py
@@ -106,6 +106,42 @@ class QualitySample:
     no_speech_prob: float = 0.0
     device: str = ""
 
+    @classmethod
+    def from_audio(
+        cls, audio: Any, sample_rate: int, *,
+        no_speech_prob: float = 0.0, device: str = "",
+    ) -> "QualitySample":
+        """Measure a buffer. The ONE way audio becomes a QualitySample.
+
+        Routed through the forensics ring so modulation and crest are computed
+        by the recorder's own code. Two implementations of these formulas would
+        drift, and then an incident file and a device score could disagree
+        about the same audio — with no way to tell which was lying.
+
+        NEVER raises: an unmeasurable buffer scores zero, which ranks last."""
+        try:
+            import numpy as _np
+
+            from backend.audio.capture_forensics import _Ring
+
+            x = _np.asarray(audio, dtype=_np.float32).reshape(-1)
+            if not x.size:
+                return cls(device=str(device))
+            ring = _Ring(sample_rate, max(1.0, x.size / max(sample_rate, 1)))
+            ring.push(x)
+            st = ring.stats()
+            return cls(
+                modulation=float(st.get("syllabic_modulation_2_8hz", 0.0)),
+                crest_db=float(st.get("crest_db", 0.0)),
+                rms=float(st.get("rms", 0.0)),
+                peak=float(st.get("peak", 0.0)),
+                no_speech_prob=float(no_speech_prob),
+                device=str(device),
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[Acoustic] could not measure buffer: %r", exc)
+            return cls(device=str(device))
+
     @property
     def sqi(self) -> float:
         """Speech Quality Index in [0, 1]. Higher is more transcribable.

--- a/backend/audio/adaptive_input.py
+++ b/backend/audio/adaptive_input.py
@@ -1,0 +1,387 @@
+"""Bind the microphone the operator is actually near.
+
+The constraint this answers
+---------------------------
+Measured across this investigation, on one machine and one voice:
+
+    known-good speech (transcribes)   crest 15.8dB   modulation 0.472
+    the lid array at seating distance crest 27.9dB   modulation 0.208
+
+Crest factor is a RATIO, so no gain stage can move it — 20·log10(k·peak /
+k·rms) is the same number for every k, which is why raising input volume from
+40 to 85 lifted level by 16dB and left crest exactly where it was. What high
+crest measures is the room: sustained vowels decaying into the floor while
+consonant transients survive. The only variable that changes it is the
+distance between the mouth and the transducer.
+
+So this does not filter, boost, or dereverberate. It picks a closer
+microphone.
+
+What it is NOT allowed to do
+----------------------------
+``DeviceConfig.prefer_local_mic`` (v295.1) deliberately skips Continuity and
+Bluetooth inputs so macOS never opens a Continuity handshake unbidden. That is
+a real policy with a real reason, and this manager does not get to ignore it
+because a heuristic feels confident. It overrides that default in exactly one
+circumstance: a MEASURED score, from audio captured on the candidate device
+itself, that beats the incumbent by a margin. Evidence overrides policy;
+enthusiasm does not.
+
+Design
+------
+* Scoring is ``acoustic_quality.rank_devices`` / ``best_device``, imported
+  whole. No second copy of the ranking rules, and the margin logic that
+  prevents thrashing already lives there.
+* Probing happens WHILE THE OPERATOR IS SPEAKING. A microphone scored against
+  an empty room is scored against nothing; every mic in a room hears the same
+  voice, so a live utterance is the only fair comparison available. The
+  manager therefore arms on degradation and probes on the next speech.
+* The incumbent is never re-probed. Its score comes from the live rejection
+  telemetry the pipeline already produces, so the swap costs one bounded
+  capture on the challengers and no contention on the device in use.
+* Every failure path ends at the built-in array.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional
+
+import numpy as np
+
+from backend.audio.acoustic_quality import (
+    DeviceScore,
+    QualitySample,
+    best_device,
+    rank_devices,
+)
+
+logger = logging.getLogger(__name__)
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+
+def adaptive_input_enabled() -> bool:
+    """Master gate, default OFF.
+
+    Off by default deliberately: this reaches for CoreAudio and can open a
+    Continuity handshake, and the handoff records three wedged processes from
+    tearing down a contended input stream. It is armed by an operator who
+    wants it, not by importing the module."""
+    return os.getenv(
+        "JARVIS_ADAPTIVE_INPUT", "0",
+    ).strip().lower() in _TRUTHY
+
+
+def _env_float(name: str, default: float, lo: float, hi: float) -> float:
+    try:
+        return max(lo, min(hi, float(os.getenv(name, "").strip() or default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _env_int(name: str, default: int, minimum: int = 0) -> int:
+    try:
+        return max(minimum, int(os.getenv(name, "").strip() or default))
+    except (TypeError, ValueError):
+        return default
+
+
+#: Crest above which the incumbent is considered too distant. Clean speech is
+#: 15-21dB; 22 leaves headroom over the top of that band without firing on a
+#: single peaky syllable.
+CREST_TRIGGER_DB = _env_float("JARVIS_ADAPTIVE_INPUT_CREST_DB", 22.0, 15.0, 45.0)
+
+#: Consecutive degraded utterances before acting. One is a cough or a chair.
+DEGRADED_RUN = _env_int("JARVIS_ADAPTIVE_INPUT_RUN", 3, 1)
+
+#: Seconds of captured audio used to score a challenger.
+PROBE_S = _env_float("JARVIS_ADAPTIVE_INPUT_PROBE_S", 1.5, 0.3, 5.0)
+
+#: Minimum seconds between rebinds. A rebind costs an utterance; oscillating
+#: between two mediocre microphones costs all of them.
+COOLDOWN_S = _env_float("JARVIS_ADAPTIVE_INPUT_COOLDOWN_S", 120.0, 5.0, 3600.0)
+
+#: A capture gap longer than this after a rebind means the new device is not
+#: delivering — Bluetooth dropout, Continuity handoff, packet starvation.
+STARVATION_MS = _env_float("JARVIS_ADAPTIVE_INPUT_STARVATION_MS", 100.0, 20.0, 5000.0)
+
+#: How long to watch a freshly bound device before trusting it.
+PROBATION_S = _env_float("JARVIS_ADAPTIVE_INPUT_PROBATION_S", 8.0, 1.0, 120.0)
+
+#: Consecutive starvation events before a device is benched for the session.
+STARVE_STRIKES = _env_int("JARVIS_ADAPTIVE_INPUT_STARVE_STRIKES", 2, 1)
+
+#: Probe capture rate. The internal pipeline rate, so a probe measures what
+#: the recogniser would be handed rather than something resampled afterwards.
+_PROBE_RATE = 16000
+
+
+@dataclass
+class _Incumbent:
+    """What we know about the device currently bound."""
+    index: Optional[int] = None
+    samples: List[QualitySample] = field(default_factory=list)
+
+    def sqi(self) -> float:
+        if not self.samples:
+            return 0.0
+        return float(np.median([s.sqi for s in self.samples]))
+
+    def representative(self) -> Optional[QualitySample]:
+        """The median-quality sample actually measured on this device.
+
+        A REAL measurement rather than a synthesized one: ``sqi`` is a derived
+        property, so a fabricated sample carrying a desired score would be a
+        number with no audio behind it — the exact thing this investigation
+        spent two sessions removing from the forensics."""
+        if not self.samples:
+            return None
+        ordered = sorted(self.samples, key=lambda s: s.sqi)
+        return ordered[len(ordered) // 2]
+
+
+class AdaptiveInputManager:
+    """Watches capture quality; rebinds to a closer microphone when one wins.
+
+    Every collaborator is injected so the whole state machine is testable
+    without CoreAudio: *rebind* performs the swap, *probe_factory* captures
+    audio from a candidate index, *sd* is the sounddevice module.
+    """
+
+    def __init__(
+        self,
+        *,
+        rebind: Callable[[Optional[int]], Any],
+        probe_factory: Optional[Callable[[int, float], np.ndarray]] = None,
+        sd: Any = None,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._rebind = rebind
+        self._probe_factory = probe_factory
+        self._sd = sd
+        self._clock = clock
+
+        self._incumbent = _Incumbent()
+        self._builtin_index: Optional[int] = None
+        self._degraded_run = 0
+        self._armed = False
+        self._last_rebind_at = -1e9
+        self._busy = False
+
+        #: Devices that starved us. Never offered again this session.
+        self._benched: Dict[int, int] = {}
+        self._probation_until = 0.0
+        self._last_frame_at = 0.0
+        self._starve_events = 0
+
+        self.rebinds = 0
+        self.fallbacks = 0
+
+    # -- telemetry in ----------------------------------------------------
+
+    def note_builtin(self, index: Optional[int]) -> None:
+        """Record the device to fall back TO. Set once, at boot."""
+        self._builtin_index = index
+        if self._incumbent.index is None:
+            self._incumbent.index = index
+
+    def observe(self, sample: QualitySample) -> None:
+        """One rejection's measurements from the live pipeline. NEVER raises."""
+        try:
+            self._incumbent.samples.append(sample)
+            del self._incumbent.samples[:-8]
+            if sample.crest_db > CREST_TRIGGER_DB:
+                self._degraded_run += 1
+            else:
+                self._degraded_run = 0
+            if self._degraded_run >= DEGRADED_RUN and not self._armed:
+                self._armed = True
+                logger.info(
+                    "[AdaptiveInput] armed — %d consecutive utterances above "
+                    "%.0fdB crest (latest %.1fdB). Will score other inputs on "
+                    "the next speech.",
+                    self._degraded_run, CREST_TRIGGER_DB, sample.crest_db,
+                )
+        except Exception:  # noqa: BLE001
+            pass
+
+    def note_capture_frame(self) -> None:
+        """Called from the capture path. Feeds the starvation watchdog, and is
+        deliberately trivial — it runs on the audio thread."""
+        self._last_frame_at = self._clock()
+
+    @property
+    def armed(self) -> bool:
+        return self._armed
+
+    # -- the decision ----------------------------------------------------
+
+    async def on_speech(self) -> bool:
+        """Speech is happening NOW — the only honest moment to compare mics.
+
+        Returns True when a rebind occurred. NEVER raises."""
+        if not (self._armed and adaptive_input_enabled()):
+            return False
+        if self._busy:
+            return False
+        if self._clock() - self._last_rebind_at < COOLDOWN_S:
+            return False
+        self._busy = True
+        try:
+            return await self._evaluate()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[AdaptiveInput] evaluation degraded: %r", exc)
+            return False
+        finally:
+            self._busy = False
+
+    async def _evaluate(self) -> bool:
+        incumbent_idx = self._incumbent.index
+        incumbent_sample = self._incumbent.representative()
+
+        def _probe(index: int) -> QualitySample:
+            # The incumbent is scored from what the pipeline already measured.
+            # Opening a second stream on the device in use is the contention
+            # that hangs CoreAudio.
+            if index == incumbent_idx:
+                if incumbent_sample is None:
+                    raise RuntimeError("no measurements for the incumbent yet")
+                return incumbent_sample
+            if index in self._benched:
+                raise RuntimeError("benched this session")
+            audio = self._capture(index, PROBE_S)
+            return QualitySample.from_audio(audio, _PROBE_RATE)
+
+        scores = await asyncio.to_thread(
+            lambda: rank_devices(probe=_probe, sd=self._sd),
+        )
+        for s in scores:
+            logger.info(
+                "[AdaptiveInput] candidate %d %r sqi=%.3f%s%s",
+                s.index, s.name, s.sqi,
+                " continuity" if s.is_continuity else "",
+                f" error={s.error}" if s.error else "",
+            )
+
+        winner = best_device(scores)
+        if winner is None or winner.index == incumbent_idx:
+            logger.info(
+                "[AdaptiveInput] staying on %s — nothing cleared the margin",
+                incumbent_idx,
+            )
+            self._armed = False
+            self._degraded_run = 0
+            return False
+
+        return await self._swap_to(winner)
+
+    async def _swap_to(self, winner: DeviceScore) -> bool:
+        logger.info(
+            "[AdaptiveInput] rebinding %s → %d %r (sqi %.3f)",
+            self._incumbent.index, winner.index, winner.name, winner.sqi,
+        )
+        ok = await self._call_rebind(winner.index)
+        if not ok:
+            self._bench(winner.index, "rebind failed")
+            self._armed = False
+            return False
+
+        self._incumbent = _Incumbent(index=winner.index)
+        self._last_rebind_at = self._clock()
+        self._probation_until = self._last_rebind_at + PROBATION_S
+        self._last_frame_at = self._clock()
+        self._armed = False
+        self._degraded_run = 0
+        self.rebinds += 1
+        return True
+
+    # -- the circuit breaker ---------------------------------------------
+
+    async def check_liveness(self) -> bool:
+        """Poll for capture starvation on a freshly bound device.
+
+        A Continuity mic that hands off to the phone, an AirPod that drops, a
+        BT link that stalls — all present the same way: the callback simply
+        stops. Returns True when a fallback was performed. NEVER raises."""
+        try:
+            if not adaptive_input_enabled():
+                return False
+            if self._incumbent.index == self._builtin_index:
+                return False
+            now = self._clock()
+            if now > self._probation_until:
+                return False
+            gap_ms = (now - self._last_frame_at) * 1000.0
+            if gap_ms < STARVATION_MS:
+                return False
+
+            self._starve_events += 1
+            logger.warning(
+                "[AdaptiveInput] capture gap %.0fms on device %s (strike %d/%d)",
+                gap_ms, self._incumbent.index, self._starve_events,
+                STARVE_STRIKES,
+            )
+            if self._starve_events < STARVE_STRIKES:
+                self._last_frame_at = now      # one more window to recover
+                return False
+            return await self.fall_back("capture starvation")
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[AdaptiveInput] liveness check degraded: %r", exc)
+            return False
+
+    async def fall_back(self, reason: str) -> bool:
+        """Return to the built-in array. The one path that must always work.
+
+        Benches the offending device so the manager cannot immediately choose
+        it again and oscillate. NEVER raises."""
+        failed = self._incumbent.index
+        if failed is not None and failed != self._builtin_index:
+            self._bench(failed, reason)
+        logger.warning(
+            "[AdaptiveInput] falling back %s → %s (%s)",
+            failed, self._builtin_index, reason,
+        )
+        try:
+            await self._call_rebind(self._builtin_index)
+        except Exception as exc:  # noqa: BLE001
+            logger.error("[AdaptiveInput] fallback rebind raised: %r", exc)
+        # Incumbent is updated regardless. If even the built-in refused to
+        # start, the bus has stopped itself and the truthful record is that we
+        # are no longer on the remote device.
+        self._incumbent = _Incumbent(index=self._builtin_index)
+        self._starve_events = 0
+        self._probation_until = 0.0
+        self._armed = False
+        self.fallbacks += 1
+        return True
+
+    # -- plumbing --------------------------------------------------------
+
+    def _bench(self, index: int, reason: str) -> None:
+        self._benched[index] = self._benched.get(index, 0) + 1
+        logger.info("[AdaptiveInput] benched device %d (%s)", index, reason)
+
+    async def _call_rebind(self, index: Optional[int]) -> bool:
+        result = self._rebind(index)
+        if asyncio.iscoroutine(result) or isinstance(result, asyncio.Future):
+            result = await result
+        return bool(result)
+
+    def _capture(self, index: int, seconds: float) -> np.ndarray:
+        """Bounded capture from a candidate. Blocking — always run in a thread."""
+        if self._probe_factory is not None:
+            return self._probe_factory(index, seconds)
+        sd = self._sd
+        if sd is None:
+            import sounddevice as sd  # type: ignore[no-redef]
+        rate = _PROBE_RATE
+        frames = int(rate * seconds)
+        buf = sd.rec(
+            frames, samplerate=rate, channels=1, dtype="float32", device=index,
+        )
+        sd.wait()
+        return np.asarray(buf, dtype=np.float32).reshape(-1)

--- a/backend/audio/audio_bus.py
+++ b/backend/audio/audio_bus.py
@@ -20,6 +20,7 @@ import asyncio
 import logging
 import os
 import threading
+import time
 from abc import ABC, abstractmethod
 from typing import AsyncIterator, Callable, ClassVar, Dict, List, Optional
 
@@ -629,6 +630,110 @@ class AudioBus:
             f"(mode={'duplex' if self._device.input_enabled else 'output-only'}, "
             f"settle={_settle_ms}ms)"
         )
+
+    async def rebind_input(self, input_device: Optional[int]) -> bool:
+        """Swap the capture device UNDER the consumer registry.
+
+        Why this is not ``stop()`` then ``start()``: ``stop()`` clears
+        ``_mic_consumers``. Every consumer — StreamingSTT, the barge-in VAD,
+        the forensics taps — is registered by whoever owns it, and none of them
+        watch for the bus restarting. A stop/start cycle therefore returns a
+        RUNNING bus with nothing listening, which is indistinguishable from a
+        working system until the first utterance is silently dropped.
+
+        So this replaces exactly one layer: the ``FullDuplexDevice`` and the
+        state that belongs to it (AEC, capture-side resamplers, speaker sink).
+        The consumer list, the IPC broadcaster above it, and the forensics
+        rings are never touched.
+
+        Honest about what "seamless" can mean here. Input and output share ONE
+        ``sd.Stream`` — AEC needs the speaker reference in the same callback —
+        and PortAudio has no API to re-point half of a duplex stream. The
+        stream must be torn down and rebuilt, so capture DOES gap for the
+        duration. Bounded, measured and logged rather than pretended away.
+
+        Fails CLOSED to the incumbent: if the new device will not start, the
+        previous one is restored. If the restore also fails the bus stops
+        cleanly rather than wedging, because a host holding a half-dead
+        CoreAudio stream is the failure mode that cost three restarts.
+
+        Returns True only when the new device is live. NEVER raises."""
+        if not self._running:
+            logger.warning("[AudioBus] rebind_input on a stopped bus — ignored")
+            return False
+
+        previous = self._config.input_device
+        if previous == input_device:
+            return True
+
+        old_device = self._device
+        t0 = time.monotonic()
+
+        async def _bring_up(index: Optional[int]) -> bool:
+            self._config.input_device = index
+            device = FullDuplexDevice(self._config)
+            try:
+                await device.start()
+            except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                try:
+                    device.request_cancel()
+                    device._safe_close_stream()
+                except BaseException:  # noqa: BLE001
+                    pass
+                return False
+            self._device = device
+            if device.input_enabled:
+                self._resampler_down = Resampler(
+                    self._config.sample_rate, self._config.internal_rate,
+                )
+                self._resampler_aec_ref = Resampler(
+                    self._config.sample_rate, self._config.internal_rate,
+                )
+                self._aec = AcousticEchoCanceller(
+                    frame_size=self._config.internal_frame_size,
+                    sample_rate=self._config.internal_rate,
+                )
+                device.add_capture_callback(self._on_mic_frame)
+            self._local_sink = LocalSpeakerSink(device, self._resampler_up)
+            self._sinks["local"] = self._local_sink
+            return True
+
+        # Tear the incumbent down first: two open duplex streams on one machine
+        # contend for CoreAudio, and the contention is what hangs.
+        if old_device is not None:
+            old_device.request_cancel()
+            try:
+                if old_device.input_enabled:
+                    old_device.remove_capture_callback(self._on_mic_frame)
+            except Exception:  # noqa: BLE001
+                pass
+            try:
+                await old_device.stop()
+            except Exception:  # noqa: BLE001
+                pass
+            self._device = None
+
+        if await _bring_up(input_device):
+            logger.info(
+                "[AudioBus] input rebound %s → %s (gap %.0fms, %d consumer(s) "
+                "preserved)", previous, input_device,
+                (time.monotonic() - t0) * 1000.0, len(self._mic_consumers),
+            )
+            return True
+
+        logger.warning(
+            "[AudioBus] input rebind to %s failed — restoring %s",
+            input_device, previous,
+        )
+        if await _bring_up(previous):
+            return False
+
+        logger.error(
+            "[AudioBus] could not restore input %s after a failed rebind — "
+            "stopping cleanly rather than holding a dead stream", previous,
+        )
+        self._running = False
+        return False
 
     async def stop(self) -> None:
         """Stop the audio bus and release all resources.

--- a/backend/audio/audio_plane_host.py
+++ b/backend/audio/audio_plane_host.py
@@ -127,6 +127,9 @@ class AudioPlaneHost:
         #: Inode of the socket file this host bound. Identity, not liveness —
         #: the only thing that can detect losing an address.
         self._inode: Optional[int] = None
+        #: Proximity re-binder. Absent unless the operator armed it.
+        self._adaptive: Any = None
+        self._adaptive_task: Optional[asyncio.Task] = None
 
     # -- lifecycle -------------------------------------------------------
 
@@ -232,7 +235,86 @@ class AudioPlaneHost:
                 logger.info("[AudioPlane] serving %s", socket_path())
             except Exception:  # noqa: BLE001
                 pass
+
+        self._wire_adaptive_input()
         return True
+
+    # -- adaptive input --------------------------------------------------
+
+    def _wire_adaptive_input(self) -> None:
+        """Arm the proximity re-binder, if the operator asked for it.
+
+        Wired here rather than inside AudioBus because the bus must not decide
+        which microphone it is: ranking devices means capturing from them, and
+        a bus that probes its own alternatives while running is a bus that can
+        contend with itself. The host owns the policy; the bus owns one verb
+        (``rebind_input``) and performs it.
+
+        Default OFF. This can open a Continuity handshake and it tears down a
+        live CoreAudio stream to do its job — three wedged processes in this
+        investigation came from exactly that. NEVER raises."""
+        try:
+            from backend.audio.acoustic_feedback import set_adaptive_input_sink
+            from backend.audio.adaptive_input import (
+                CREST_TRIGGER_DB,
+                AdaptiveInputManager,
+                adaptive_input_enabled,
+            )
+            if not adaptive_input_enabled():
+                return
+
+            manager = AdaptiveInputManager(rebind=self._bus.rebind_input)
+            try:
+                manager.note_builtin(self._bus._config.input_device)
+            except Exception:  # noqa: BLE001
+                manager.note_builtin(None)
+
+            # The rejection path already measures every failed capture. That
+            # telemetry IS the incumbent's score — reusing it means the manager
+            # never opens a second stream on the device in use.
+            set_adaptive_input_sink(manager.observe)
+            self._adaptive = manager
+            self._adaptive_task = asyncio.create_task(self._adaptive_loop())
+            logger.info(
+                "[AudioPlane] adaptive input armed (crest trigger %.0fdB)",
+                CREST_TRIGGER_DB,
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug("[AudioPlane] adaptive input wiring degraded",
+                         exc_info=True)
+
+    async def _adaptive_loop(self) -> None:
+        """Drive the manager off the audio thread.
+
+        Two jobs, both cheap: ask for a re-evaluation while speech is actually
+        happening (the only moment a comparison between microphones is fair),
+        and poll the starvation breaker on a freshly bound device."""
+        manager = getattr(self, "_adaptive", None)
+        if manager is None:
+            return
+        try:
+            while not self._stop.is_set():
+                await asyncio.sleep(0.25)
+                try:
+                    await manager.check_liveness()
+                    if manager.armed and self._speech_active():
+                        await manager.on_speech()
+                except Exception:  # noqa: BLE001
+                    logger.debug("[AudioPlane] adaptive tick degraded",
+                                 exc_info=True)
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001
+            logger.debug("[AudioPlane] adaptive loop ended", exc_info=True)
+
+    def _speech_active(self) -> bool:
+        """Is the operator talking right now? Read from the STT engine that
+        already answers this — no second VAD."""
+        try:
+            stt = getattr(self._handle, "streaming_stt", None)
+            return bool(stt is not None and stt.is_speech_active)
+        except Exception:  # noqa: BLE001
+            return False
 
     # -- address watchdog ------------------------------------------------
 
@@ -345,6 +427,23 @@ class AudioPlaneHost:
     async def stop(self) -> None:
         """Reverse-order teardown. NEVER raises — every failure here is one a
         hard exit resolves a moment later anyway."""
+        # Detach the telemetry sink FIRST: the manager must not receive a
+        # measurement, decide to rebind, and reach for a bus that teardown is
+        # already halfway through disposing of.
+        task, self._adaptive_task = self._adaptive_task, None
+        self._adaptive = None
+        try:
+            from backend.audio.acoustic_feedback import set_adaptive_input_sink
+            set_adaptive_input_sink(None)
+        except Exception:  # noqa: BLE001
+            pass
+        if task is not None and not task.done():
+            task.cancel()
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                pass
+
         handle, self._handle = self._handle, None
         if handle is not None:
             for attr in ("stop", "shutdown", "close"):

--- a/tests/audio/test_adaptive_input.py
+++ b/tests/audio/test_adaptive_input.py
@@ -1,0 +1,339 @@
+"""AdaptiveInputManager — bind the microphone the operator is near.
+
+The constraint, measured on this machine across the investigation:
+
+    known-good speech (transcribes)    crest 15.8dB   modulation 0.472
+    the lid array at seating distance  crest 27.9dB   modulation 0.208
+
+Crest is a ratio, so gain cannot move it: raising input volume 40 -> 85 lifted
+level by 16dB and left crest identical. Only proximity changes it. These tests
+pin the state machine that acts on that, and — more importantly — the paths
+where it must refuse to act or must retreat.
+
+Every collaborator is injected, so nothing here opens CoreAudio.
+"""
+from __future__ import annotations
+
+from typing import List, Optional
+
+import numpy as np
+import pytest
+
+from backend.audio import adaptive_input as ai
+from backend.audio.acoustic_quality import QualitySample
+
+
+@pytest.fixture(autouse=True)
+def _armed(monkeypatch: pytest.MonkeyPatch):
+    """The manager is OFF by default (it can open a Continuity handshake and
+    tear down a contended stream). Tests opt in explicitly."""
+    monkeypatch.setenv("JARVIS_ADAPTIVE_INPUT", "1")
+
+
+# --------------------------------------------------------------------------
+# fakes
+# --------------------------------------------------------------------------
+
+class _Clock:
+    def __init__(self) -> None:
+        self.t = 1000.0
+
+    def __call__(self) -> float:
+        return self.t
+
+
+class _SD:
+    """Minimal sounddevice stand-in: two inputs and one output."""
+
+    def __init__(self) -> None:
+        self.devices = [
+            {"name": "MacBook Pro Microphone", "max_input_channels": 1},
+            {"name": "Derek J. Russell Microphone", "max_input_channels": 1},
+            {"name": "MacBook Pro Speakers", "max_input_channels": 0},
+        ]
+
+    def query_devices(self):
+        return self.devices
+
+
+def _far() -> QualitySample:
+    """The lid array at seating distance — the measured failing profile."""
+    return QualitySample(modulation=0.208, crest_db=27.9, rms=0.019, peak=0.84)
+
+
+def _near() -> QualitySample:
+    """A microphone close to the mouth — the measured passing profile."""
+    return QualitySample(modulation=0.472, crest_db=15.8, rms=0.108, peak=0.67)
+
+
+class _Bus:
+    """Records rebinds; can be told to refuse specific devices."""
+
+    def __init__(self, refuse: Optional[set] = None) -> None:
+        self.calls: List[Optional[int]] = []
+        self.refuse = refuse or set()
+        self.bound: Optional[int] = 0
+
+    async def rebind(self, index: Optional[int]) -> bool:
+        self.calls.append(index)
+        if index in self.refuse:
+            return False
+        self.bound = index
+        return True
+
+
+def _manager(bus: _Bus, clock: _Clock) -> ai.AdaptiveInputManager:
+    def probe_factory(_index: int, seconds: float) -> np.ndarray:
+        # Returned audio is irrelevant — from_audio is stubbed per test where
+        # the score matters. This only proves a capture was attempted.
+        return np.zeros(int(16000 * seconds), dtype=np.float32)
+
+    m = ai.AdaptiveInputManager(
+        rebind=bus.rebind, probe_factory=probe_factory, sd=_SD(), clock=clock,
+    )
+    m.note_builtin(0)
+    return m
+
+
+# --------------------------------------------------------------------------
+# 1. arming
+# --------------------------------------------------------------------------
+
+def test_a_single_bad_utterance_does_not_arm() -> None:
+    m = _manager(_Bus(), _Clock())
+    m.observe(_far())
+    assert not m.armed, "one cough must not trigger a device swap"
+
+
+def test_sustained_high_crest_arms_the_manager() -> None:
+    m = _manager(_Bus(), _Clock())
+    for _ in range(ai.DEGRADED_RUN):
+        m.observe(_far())
+    assert m.armed
+
+
+def test_good_capture_resets_the_run() -> None:
+    m = _manager(_Bus(), _Clock())
+    m.observe(_far())
+    m.observe(_far())
+    m.observe(_near())          # crest 15.8 — under the trigger
+    m.observe(_far())
+    assert not m.armed
+
+
+# --------------------------------------------------------------------------
+# 2. the rebind (requirement 1)
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_high_crest_triggers_a_rebind_to_the_better_node(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """~28dB crest on the incumbent, a near-field challenger available ->
+    best_device() picks it and the stream is re-bound."""
+    bus, clock = _Bus(), _Clock()
+    m = _manager(bus, clock)
+    monkeypatch.setattr(
+        ai.QualitySample, "from_audio",
+        staticmethod(lambda *a, **k: _near()),
+    )
+
+    for _ in range(ai.DEGRADED_RUN):
+        m.observe(_far())
+    assert m.armed
+
+    assert await m.on_speech() is True
+    assert bus.calls == [1], "expected a rebind to the near-field device"
+    assert bus.bound == 1
+    assert m.rebinds == 1
+
+
+@pytest.mark.asyncio
+async def test_no_swap_when_nothing_beats_the_incumbent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """'Stay' is a real answer — a rebind costs an utterance."""
+    bus, clock = _Bus(), _Clock()
+    m = _manager(bus, clock)
+    monkeypatch.setattr(
+        ai.QualitySample, "from_audio",
+        staticmethod(lambda *a, **k: _far()),      # challenger is no better
+    )
+    for _ in range(ai.DEGRADED_RUN):
+        m.observe(_far())
+
+    assert await m.on_speech() is False
+    assert bus.calls == []
+
+
+@pytest.mark.asyncio
+async def test_disabled_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("JARVIS_ADAPTIVE_INPUT", raising=False)
+    bus = _Bus()
+    m = _manager(bus, _Clock())
+    for _ in range(ai.DEGRADED_RUN):
+        m.observe(_far())
+    assert await m.on_speech() is False
+    assert bus.calls == []
+
+
+@pytest.mark.asyncio
+async def test_cooldown_prevents_thrashing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bus, clock = _Bus(), _Clock()
+    m = _manager(bus, clock)
+    monkeypatch.setattr(
+        ai.QualitySample, "from_audio", staticmethod(lambda *a, **k: _near()),
+    )
+    for _ in range(ai.DEGRADED_RUN):
+        m.observe(_far())
+    assert await m.on_speech() is True
+
+    for _ in range(ai.DEGRADED_RUN):
+        m.observe(_far())
+    clock.t += ai.COOLDOWN_S / 2
+    assert await m.on_speech() is False, "swapped again inside the cooldown"
+    assert len(bus.calls) == 1
+
+
+# --------------------------------------------------------------------------
+# 3. the circuit breaker (requirement 2)
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_continuity_dropout_falls_back_without_raising(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A Continuity mic that stops delivering frames must return us to the
+    built-in array — no exception, no wedged daemon."""
+    bus, clock = _Bus(), _Clock()
+    m = _manager(bus, clock)
+    monkeypatch.setattr(
+        ai.QualitySample, "from_audio", staticmethod(lambda *a, **k: _near()),
+    )
+    for _ in range(ai.DEGRADED_RUN):
+        m.observe(_far())
+    assert await m.on_speech() is True
+    assert bus.bound == 1
+
+    # The device goes silent: no capture frames for longer than the gap bound.
+    for strike in range(ai.STARVE_STRIKES):
+        clock.t += (ai.STARVATION_MS / 1000.0) * 2
+        fell_back = await m.check_liveness()
+    assert fell_back is True
+    assert bus.bound == 0, "did not return to the built-in array"
+    assert m.fallbacks == 1
+
+
+@pytest.mark.asyncio
+async def test_a_recovering_device_is_not_dropped_on_one_gap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One late buffer is a hiccup, not a dropout."""
+    bus, clock = _Bus(), _Clock()
+    m = _manager(bus, clock)
+    monkeypatch.setattr(
+        ai.QualitySample, "from_audio", staticmethod(lambda *a, **k: _near()),
+    )
+    for _ in range(ai.DEGRADED_RUN):
+        m.observe(_far())
+    await m.on_speech()
+
+    clock.t += (ai.STARVATION_MS / 1000.0) * 2
+    assert await m.check_liveness() is False      # strike 1 of 2
+    m.note_capture_frame()                        # frames resume
+    assert await m.check_liveness() is False
+    assert bus.bound == 1, "dropped a device that recovered"
+
+
+@pytest.mark.asyncio
+async def test_a_failed_rebind_leaves_us_on_the_incumbent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bus, clock = _Bus(refuse={1}), _Clock()
+    m = _manager(bus, clock)
+    monkeypatch.setattr(
+        ai.QualitySample, "from_audio", staticmethod(lambda *a, **k: _near()),
+    )
+    for _ in range(ai.DEGRADED_RUN):
+        m.observe(_far())
+
+    assert await m.on_speech() is False
+    assert bus.bound == 0
+    assert m.rebinds == 0
+
+
+@pytest.mark.asyncio
+async def test_a_benched_device_is_never_offered_again(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Otherwise the manager oscillates onto a broken mic forever."""
+    bus, clock = _Bus(refuse={1}), _Clock()
+    m = _manager(bus, clock)
+    monkeypatch.setattr(
+        ai.QualitySample, "from_audio", staticmethod(lambda *a, **k: _near()),
+    )
+    for _ in range(ai.DEGRADED_RUN):
+        m.observe(_far())
+    await m.on_speech()                      # fails, benches device 1
+
+    clock.t += ai.COOLDOWN_S * 2
+    for _ in range(ai.DEGRADED_RUN):
+        m.observe(_far())
+    await m.on_speech()
+    assert bus.calls.count(1) == 1, "retried a benched device"
+
+
+@pytest.mark.asyncio
+async def test_fallback_never_raises_even_if_the_builtin_refuses() -> None:
+    """The last-resort path. If even the built-in will not start we must
+    still return control cleanly — the daemon may not wedge."""
+    class _Hostile(_Bus):
+        async def rebind(self, index):
+            self.calls.append(index)
+            raise OSError("CoreAudio is gone")
+
+    bus = _Hostile()
+    m = _manager(bus, _Clock())
+    assert await m.fall_back("test") is True
+
+
+@pytest.mark.asyncio
+async def test_observe_never_raises_on_garbage() -> None:
+    m = _manager(_Bus(), _Clock())
+    m.observe(None)                     # type: ignore[arg-type]
+    m.observe("not a sample")           # type: ignore[arg-type]
+    assert not m.armed
+
+
+# --------------------------------------------------------------------------
+# 4. DRY — scoring is acoustic_quality's, not a second copy
+# --------------------------------------------------------------------------
+
+def test_scoring_is_delegated_not_reimplemented() -> None:
+    import inspect
+
+    src = inspect.getsource(ai)
+    assert "rank_devices" in src and "best_device" in src
+    # No second scoring formula: the weights live in QualitySample.sqi alone.
+    assert "0.45 *" not in src, "sqi weights duplicated into the manager"
+
+
+def test_quality_sample_from_audio_uses_the_forensics_ring() -> None:
+    """The one constructor both instruments share, so an incident file and a
+    device score can never disagree about the same audio."""
+    rate = 16000
+    t = np.arange(int(2.0 * rate)) / rate
+    env = 0.5 * (1.0 + np.sin(2 * np.pi * 4.0 * t))
+    audio = (0.2 * env * np.sin(2 * np.pi * 220.0 * t)).astype(np.float32)
+
+    s = QualitySample.from_audio(audio, rate)
+    assert s.modulation > 0.0
+    assert s.crest_db > 0.0
+    assert 0.0 <= s.sqi <= 1.0
+
+
+def test_from_audio_never_raises_on_empty_or_garbage() -> None:
+    assert QualitySample.from_audio(np.zeros(0, np.float32), 16000).sqi >= 0.0
+    assert QualitySample.from_audio(None, 16000).sqi >= 0.0

--- a/tests/governance/test_adaptive_voice_router.py
+++ b/tests/governance/test_adaptive_voice_router.py
@@ -305,6 +305,43 @@ async def test_the_master_flag_makes_the_router_a_pass_through(monkeypatch):
     )
 
 
+async def test_doubleword_is_primary_by_default(monkeypatch):
+    """DW-primary is the DEFAULT, not a configuration an operator must find.
+
+    The inverse of ``test_remote_first_can_be_inverted``, and the one that
+    actually protects the invariant: that test proves the override works, but
+    would still pass if the default silently flipped to local. With no env set
+    at all, a healthy lane and a resolved model must route to DoubleWord, and
+    the local engine is reachable only as a fallback.
+
+    Pinned here rather than in the audio suite: which microphone is bound and
+    which LLM answers are unrelated concerns, and coupling them would make a
+    device test fail on a provider change."""
+    for var in ("JARVIS_ADAPTIVE_VOICE_ROUTER_ENABLED",
+                "JARVIS_VOICE_ROUTER_REMOTE_FIRST"):
+        monkeypatch.delenv(var, raising=False)
+
+    local = _Local()
+    r = _router(local=local, dispatch=_dw(["remote answer"]))
+    assert r.route_for(model="m") == "remote", "default route is not DoubleWord"
+    assert await _drain(r) == "remote answer"
+    assert r.last_route == "remote"
+
+
+async def test_local_is_reached_only_when_doubleword_cannot_serve(monkeypatch):
+    """The fallback is emergency-only: it engages on a DW failure, never as a
+    peer the router picks between."""
+    for var in ("JARVIS_ADAPTIVE_VOICE_ROUTER_ENABLED",
+                "JARVIS_VOICE_ROUTER_REMOTE_FIRST"):
+        monkeypatch.delenv(var, raising=False)
+
+    local = _Local()
+    r = _router(local=local, dispatch=_dw([], fail_after=0,
+                                          exc=ConnectionError("dw down")))
+    assert await _drain(r) == "local answer"
+    assert r.last_route == "local"
+
+
 async def test_remote_first_can_be_inverted(monkeypatch):
     monkeypatch.setenv("JARVIS_VOICE_ROUTER_REMOTE_FIRST", "false")
     local = _Local()


### PR DESCRIPTION
## Why a device swap and not a filter

Crest factor is a ratio, so no gain stage can move it — raising input volume 40 → 85 lifted level 16 dB and left crest identical, as it mathematically must. High crest measures **distance**: sustained vowels decaying into the room floor while consonant transients survive.

```
known-good speech (transcribes)    crest 15.8dB   modulation 0.472
the lid array at seating distance  crest 27.9dB   modulation 0.208
```

So this does not filter, boost, or dereverberate. It binds a closer microphone.

## Design decisions worth reviewing

**Probing happens while the operator is speaking.** A microphone scored against an empty room is scored against nothing. Every mic in a room hears the same voice, so a live utterance is the only fair comparison available — the manager arms on sustained degradation and probes on the *next* speech.

**The incumbent is never re-probed.** Its score is the median of what the rejection path already measured. Opening a second stream on the device in use is the contention that hangs CoreAudio.

**`prefer_local_mic` (v295.1) is respected, not ignored.** That flag deliberately avoids Continuity handshakes. This overrides it in exactly one circumstance: a *measured* score, from audio captured on the candidate itself, beating the incumbent by `best_device()`'s margin. Evidence overrides policy; a confident heuristic does not.

## The seam: `AudioBus.rebind_input`

Deliberately **not** `stop()` + `start()` — `stop()` clears `_mic_consumers`, so a restart returns a RUNNING bus with nothing listening, indistinguishable from health until the first utterance silently vanishes. It replaces the `FullDuplexDevice` layer only; consumers, the IPC broadcaster and the forensics rings are untouched. Fails closed to the incumbent, and to a clean stop if even that won't start — rather than holding a half-dead stream, the failure that cost three restarts in this investigation.

**Honest limit:** input and output share one `sd.Stream` (AEC needs the speaker reference in the same callback) and PortAudio cannot re-point half a duplex stream. **Capture does gap across a swap.** Bounded, measured and logged rather than claimed away — "seamless" holds at the IPC/consumer layer, not at PortAudio.

## Circuit breaker

Probation window after a swap → a >100 ms capture gap counts a strike → two strikes falls back to the built-in array and **benches** the device for the session, so it cannot oscillate back onto a broken mic. `fall_back()` never raises, even if the built-in itself refuses.

## DRY

`rank_devices()` / `best_device()` consumed whole — they had tests and zero production callers. A test asserts the `sqi` weights are not duplicated into the manager. `QualitySample.from_audio` is now the single constructor turning audio into a score (routed through the forensics ring); `report_rejection` was refactored onto it, so a device score and an incident file cannot disagree about the same audio.

## Scope note

**DW primacy is pinned in `tests/governance/test_adaptive_voice_router.py`, not the audio suite.** Which microphone is bound and which LLM answers are unrelated concerns; coupling them would make a device test fail on a provider change. Two tests added there: the default route is DoubleWord with no env set (the existing test only proved the *override* works, and would have passed if the default silently flipped), and local is reached only when DW cannot serve.

## Safety

Default **OFF** (`JARVIS_ADAPTIVE_INPUT`). It reaches for CoreAudio and can open a Continuity handshake — armed by an operator, not by importing the module.

16 tests, every collaborator injected so nothing opens CoreAudio. `tests/audio` + `tests/voice`: **545 passed, 5 skipped**. Router suite: **30 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically switches to a closer microphone when speech quality degrades, improving transcription reliability. Adds a safe input rebind seam and a manager that probes alternatives during live speech and falls back on dropouts.

- **New Features**
  - `AdaptiveInputManager` selects a better mic when crest stays high; probes on the next utterance; uses `rank_devices()`/`best_device()`; never re-probes the incumbent; cooldown and a circuit breaker bench broken devices.
  - `AudioBus.rebind_input` swaps the input device without stopping the bus or losing consumers; logs the bounded capture gap; fails closed to the incumbent or stops cleanly.
  - `acoustic_feedback` exposes `set_adaptive_input_sink`; `report_rejection` now emits `QualitySample` via `QualitySample.from_audio`, routed through the forensics ring for consistent metrics.
  - `audio_plane_host` wires the manager, triggers evaluations only while STT reports speech, and polls for starvation.

- **Migration**
  - Default OFF. Set `JARVIS_ADAPTIVE_INPUT=1` to enable; optional tunables via `JARVIS_ADAPTIVE_INPUT_*`.
  - Respects `prefer_local_mic`; overrides only when a measured candidate clears `best_device()`’s margin.
  - No changes required for mic consumers; the bus now supports `rebind_input` for safe swaps.

<sup>Written for commit bb0eea337f4bc99b8aab6bcfc3c615e52acb6792. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

