### PR TITLE
fix(audio): a CoreAudio index is not a device identity

### DIFF
--- a/backend/audio/adaptive_input.py
+++ b/backend/audio/adaptive_input.py
@@ -122,8 +122,15 @@ _PROBE_RATE = 16000
 
 @dataclass
 class _Incumbent:
-    """What we know about the device currently bound."""
+    """What we know about the device currently bound.
+
+    Carries the NAME as well as the index because a CoreAudio index is a
+    position in a list that changes under you. Observed live: a Continuity
+    microphone left the enumeration when the phone slept, and
+    ``MacBook Pro Microphone`` moved from index 1 to index 0. Anything
+    remembered as an integer then pointed at a different device."""
     index: Optional[int] = None
+    name: str = ""
     samples: List[QualitySample] = field(default_factory=list)
 
     def sqi(self) -> float:
@@ -166,14 +173,18 @@ class AdaptiveInputManager:
         self._clock = clock
 
         self._incumbent = _Incumbent()
-        self._builtin_index: Optional[int] = None
+        #: The fallback target, remembered by NAME. Resolved to an index only
+        #: at the moment of binding — see _resolve_index.
+        self._builtin_name: str = ""
         self._degraded_run = 0
         self._armed = False
         self._last_rebind_at = -1e9
         self._busy = False
 
-        #: Devices that starved us. Never offered again this session.
-        self._benched: Dict[int, int] = {}
+        #: Devices that starved us, keyed by NAME. Never offered again this
+        #: session. Keyed by name for the same reason as the fallback: an
+        #: index benched now can be a different device ten seconds later.
+        self._benched: Dict[str, int] = {}
         self._probation_until = 0.0
         self._last_frame_at = 0.0
         self._starve_events = 0
@@ -184,10 +195,53 @@ class AdaptiveInputManager:
     # -- telemetry in ----------------------------------------------------
 
     def note_builtin(self, index: Optional[int]) -> None:
-        """Record the device to fall back TO. Set once, at boot."""
-        self._builtin_index = index
+        """Record the device to fall back TO. Set once, at boot.
+
+        Stores the NAME. An index captured at boot is a promise about list
+        positions that CoreAudio does not keep."""
+        self._builtin_name = self._name_of(index)
         if self._incumbent.index is None:
             self._incumbent.index = index
+            self._incumbent.name = self._builtin_name
+
+    def _name_of(self, index: Optional[int]) -> str:
+        """Current name at *index*, or "" for the system default. NEVER raises."""
+        if index is None:
+            return ""
+        try:
+            sd = self._sd
+            if sd is None:
+                import sounddevice as sd  # type: ignore[no-redef]
+            devices = sd.query_devices()
+            if 0 <= int(index) < len(devices):
+                return str(devices[int(index)].get("name", ""))
+        except Exception:  # noqa: BLE001
+            pass
+        return ""
+
+    def _resolve_index(self, name: str) -> Optional[int]:
+        """Where *name* lives RIGHT NOW, or None for the system default.
+
+        None is the honest answer for a device that has left the enumeration:
+        binding the system default is what the pre-adaptive pipeline did, and
+        it is always better than binding whatever inherited the old index."""
+        if not name:
+            return None
+        try:
+            sd = self._sd
+            if sd is None:
+                import sounddevice as sd  # type: ignore[no-redef]
+            for idx, dev in enumerate(sd.query_devices()):
+                if str(dev.get("name", "")) == name:
+                    if int(dev.get("max_input_channels", 0) or 0) > 0:
+                        return idx
+        except Exception:  # noqa: BLE001
+            pass
+        logger.warning(
+            "[AdaptiveInput] %r is no longer enumerated — using the system "
+            "default rather than whatever took its index", name,
+        )
+        return None
 
     def observe(self, sample: QualitySample) -> None:
         """One rejection's measurements from the live pipeline. NEVER raises."""
@@ -251,7 +305,7 @@ class AdaptiveInputManager:
                 if incumbent_sample is None:
                     raise RuntimeError("no measurements for the incumbent yet")
                 return incumbent_sample
-            if index in self._benched:
+            if self._name_of(index) in self._benched:
                 raise RuntimeError("benched this session")
             audio = self._capture(index, PROBE_S)
             return QualitySample.from_audio(audio, _PROBE_RATE)
@@ -260,18 +314,36 @@ class AdaptiveInputManager:
             lambda: rank_devices(probe=_probe, sd=self._sd),
         )
         for s in scores:
+            # The COMPONENTS, not just the index. sqi blends modulation,
+            # crest, level and belief, so a high score can hide a worse crest
+            # than the incumbent — and crest is the whole reason this manager
+            # exists. A composite number with no breakdown behind it is the
+            # gap this investigation kept falling into.
+            m = s.sample
+            detail = (
+                f" crest={m.crest_db:.1f}dB mod={m.modulation:.3f} "
+                f"rms={m.rms:.5f}" if m is not None else ""
+            )
             logger.info(
-                "[AdaptiveInput] candidate %d %r sqi=%.3f%s%s",
-                s.index, s.name, s.sqi,
+                "[AdaptiveInput] candidate %d %r sqi=%.3f%s%s%s",
+                s.index, s.name, s.sqi, detail,
                 " continuity" if s.is_continuity else "",
                 f" error={s.error}" if s.error else "",
             )
 
         winner = best_device(scores)
         if winner is None or winner.index == incumbent_idx:
+            top = scores[0] if scores else None
+            gap = (
+                top.sqi - scores[1].sqi
+                if top is not None and len(scores) > 1 else 0.0
+            )
             logger.info(
-                "[AdaptiveInput] staying on %s — nothing cleared the margin",
+                "[AdaptiveInput] staying on %s — best was %s at sqi %.3f, "
+                "%.3f ahead of the next (margin needed 0.150)",
                 incumbent_idx,
+                f"{top.index} {top.name!r}" if top is not None else "nothing",
+                top.sqi if top is not None else 0.0, gap,
             )
             self._armed = False
             self._degraded_run = 0
@@ -286,11 +358,11 @@ class AdaptiveInputManager:
         )
         ok = await self._call_rebind(winner.index)
         if not ok:
-            self._bench(winner.index, "rebind failed")
+            self._bench(winner.name, "rebind failed")
             self._armed = False
             return False
 
-        self._incumbent = _Incumbent(index=winner.index)
+        self._incumbent = _Incumbent(index=winner.index, name=winner.name)
         self._last_rebind_at = self._clock()
         self._probation_until = self._last_rebind_at + PROBATION_S
         self._last_frame_at = self._clock()
@@ -310,8 +382,8 @@ class AdaptiveInputManager:
         try:
             if not adaptive_input_enabled():
                 return False
-            if self._incumbent.index == self._builtin_index:
-                return False
+            if self._incumbent.name == self._builtin_name:
+                return False        # already home; nothing to retreat to
             now = self._clock()
             if now > self._probation_until:
                 return False
@@ -338,21 +410,28 @@ class AdaptiveInputManager:
 
         Benches the offending device so the manager cannot immediately choose
         it again and oscillate. NEVER raises."""
-        failed = self._incumbent.index
-        if failed is not None and failed != self._builtin_index:
-            self._bench(failed, reason)
+        failed_name = self._incumbent.name
+        if failed_name and failed_name != self._builtin_name:
+            self._bench(failed_name, reason)
+        # Resolve the fallback NOW, not from an index captured at boot: the
+        # enumeration may have shifted since, and binding a stale index is
+        # how a fallback lands on the very device it is retreating from.
+        builtin_index = self._resolve_index(self._builtin_name)
         logger.warning(
-            "[AdaptiveInput] falling back %s → %s (%s)",
-            failed, self._builtin_index, reason,
+            "[AdaptiveInput] falling back %r → %r (index %s) (%s)",
+            failed_name or self._incumbent.index,
+            self._builtin_name or "system default", builtin_index, reason,
         )
         try:
-            await self._call_rebind(self._builtin_index)
+            await self._call_rebind(builtin_index)
         except Exception as exc:  # noqa: BLE001
             logger.error("[AdaptiveInput] fallback rebind raised: %r", exc)
         # Incumbent is updated regardless. If even the built-in refused to
         # start, the bus has stopped itself and the truthful record is that we
         # are no longer on the remote device.
-        self._incumbent = _Incumbent(index=self._builtin_index)
+        self._incumbent = _Incumbent(
+            index=builtin_index, name=self._builtin_name,
+        )
         self._starve_events = 0
         self._probation_until = 0.0
         self._armed = False
@@ -361,9 +440,11 @@ class AdaptiveInputManager:
 
     # -- plumbing --------------------------------------------------------
 
-    def _bench(self, index: int, reason: str) -> None:
-        self._benched[index] = self._benched.get(index, 0) + 1
-        logger.info("[AdaptiveInput] benched device %d (%s)", index, reason)
+    def _bench(self, name: str, reason: str) -> None:
+        if not name:
+            return
+        self._benched[name] = self._benched.get(name, 0) + 1
+        logger.info("[AdaptiveInput] benched %r (%s)", name, reason)
 
     async def _call_rebind(self, index: Optional[int]) -> bool:
         result = self._rebind(index)

--- a/tests/audio/test_adaptive_input.py
+++ b/tests/audio/test_adaptive_input.py
@@ -308,6 +308,102 @@ async def test_observe_never_raises_on_garbage() -> None:
 
 
 # --------------------------------------------------------------------------
+# 3b. device identity — indices move under you (found in live testing)
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_fallback_follows_the_device_not_the_index(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The bug the first live run exposed.
+
+    Observed: a Continuity microphone left the enumeration when the phone
+    slept, and 'MacBook Pro Microphone' moved from index 1 to index 0. A
+    fallback target remembered as the integer 0 would, once the phone
+    reconnects and retakes index 0, bind the PHONE while believing it was
+    retreating to the built-in array — the one path that must always be
+    correct, pointed at the device it is fleeing."""
+    sd = _SD()
+    # Boot order: built-in is at index 1, behind the Continuity device.
+    bus, clock = _Bus(), _Clock()
+    m = ai.AdaptiveInputManager(
+        rebind=bus.rebind,
+        probe_factory=lambda _i, s: np.zeros(int(16000 * s), np.float32),
+        sd=sd, clock=clock,
+    )
+    m.note_builtin(1)                       # 'MacBook Pro Microphone'
+
+    monkeypatch.setattr(
+        ai.QualitySample, "from_audio", staticmethod(lambda *a, **k: _near()),
+    )
+    for _ in range(ai.DEGRADED_RUN):
+        m.observe(_far())
+    assert await m.on_speech() is True
+    assert bus.bound == 0, "expected a swap to the Continuity device"
+
+    # The enumeration now REORDERS: something is inserted ahead of both, so
+    # the built-in is at 2 and index 1 belongs to a different device.
+    sd.devices.insert(0, {"name": "USB Interface", "max_input_channels": 2})
+
+    await m.fall_back("phone slept")
+    assert bus.bound == 2, (
+        f"fell back to index {bus.bound} — followed the stale index instead "
+        f"of the device named 'MacBook Pro Microphone'"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_vanished_fallback_device_binds_the_system_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the built-in is not enumerated at all, None (system default) is the
+    honest answer — never whatever inherited its old index."""
+    sd = _SD()
+    bus, clock = _Bus(), _Clock()
+    m = ai.AdaptiveInputManager(
+        rebind=bus.rebind,
+        probe_factory=lambda _i, s: np.zeros(int(16000 * s), np.float32),
+        sd=sd, clock=clock,
+    )
+    m.note_builtin(0)                       # 'MacBook Pro Microphone'
+    sd.devices = [{"name": "Some Other Mic", "max_input_channels": 1}]
+
+    await m.fall_back("device gone")
+    assert bus.bound is None, "bound a stranger that inherited the index"
+
+
+@pytest.mark.asyncio
+async def test_bench_survives_reindexing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A device benched for starving us must stay benched under its own name,
+    not release a different device from the bench when indices shift."""
+    sd = _SD()
+    bus, clock = _Bus(refuse={1}), _Clock()
+    m = ai.AdaptiveInputManager(
+        rebind=bus.rebind,
+        probe_factory=lambda _i, s: np.zeros(int(16000 * s), np.float32),
+        sd=sd, clock=clock,
+    )
+    m.note_builtin(0)
+    monkeypatch.setattr(
+        ai.QualitySample, "from_audio", staticmethod(lambda *a, **k: _near()),
+    )
+    for _ in range(ai.DEGRADED_RUN):
+        m.observe(_far())
+    await m.on_speech()                     # fails -> benches by NAME
+
+    sd.devices.insert(0, {"name": "USB Interface", "max_input_channels": 2})
+    clock.t += ai.COOLDOWN_S * 2
+    for _ in range(ai.DEGRADED_RUN):
+        m.observe(_far())
+    await m.on_speech()
+    assert 2 not in bus.calls, (
+        "the benched device came back under its new index"
+    )
+
+
+# --------------------------------------------------------------------------
 # 4. DRY — scoring is acoustic_quality's, not a second copy
 # --------------------------------------------------------------------------
 


### PR DESCRIPTION
## Found in the first live run

The Continuity microphone left the enumeration when the phone slept, and `MacBook Pro Microphone` **moved index**:

```
01:28  index 0 'Derek J. Russell Microphone'   index 1 'MacBook Pro Microphone'
01:35  index 0 'MacBook Pro Microphone'        (continuity gone)
```

#70109 remembered the fallback target, the incumbent, and the bench list as **integers**. So once the phone reconnects and retakes index 0, a fallback recorded at boot binds the *phone* while logging that it is retreating to the built-in array — the one path that must always be correct, aimed at the device it is fleeing. The bench had the same flaw in reverse: a device that starved us released itself simply by moving.

Benign right now (one device enumerated), latent the moment the phone wakes.

## Fix — identity is the name, resolved at point of use

- `_builtin_name` replaces `_builtin_index`; `fall_back()` resolves it fresh against the current enumeration
- `_benched` keyed by name
- `_Incumbent` carries `name` alongside `index`
- a fallback device that is **no longer enumerated** binds `None` (system default) rather than whatever inherited its old index — that is what the pre-adaptive pipeline did, and it beats binding a stranger

## Also: log the components, not just the composite

Candidates now log `crest / mod / rms` individually, and the "staying" line names the winner and the actual margin shortfall.

`sqi` blends modulation, crest, level and belief — a high score can conceal a *worse* crest than the incumbent, and crest is the entire reason this manager exists. Logging only the composite reproduced, inside the new tool, the exact observability gap this investigation has been closing everywhere else. From the live run:

```
[AdaptiveInput] candidate 0 'MacBook Pro Microphone' sqi=0.649 crest=18.5dB mod=0.196 rms=0.00707
[AdaptiveInput] staying on 0 — best was 0 'MacBook Pro Microphone' at sqi 0.649,
                0.000 ahead of the next (margin needed 0.150)
```

## Tests

3 new, each failing against the pre-fix manager with its specific symptom:

- `fell back to index 1 — followed the stale index instead of the device named 'MacBook Pro Microphone'`
- `bound a stranger that inherited the index`
- `the benched device came back under its new index`

19 in the file. `tests/audio` + `tests/voice`: **548 passed, 5 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes AdaptiveInput on CoreAudio by identifying devices by name instead of index, preventing wrong-device fallbacks or benches when the device list reorders. Also improves logs with clearer candidate metrics and margin details.

- **Bug Fixes**
  - Use device name as identity: `_builtin_name` replaces `_builtin_index`, `_Incumbent` stores `name`, and `_benched` is keyed by `name`.
  - Fallback resolves the name to a current index at bind time; if the device is gone, bind `None` (system default) rather than whatever took its old index.
  - Bench and liveness checks compare names, avoiding oscillation and misbinding when Continuity devices disconnect and indices shift.

- **New Features**
  - Candidate logs include crest, modulation, and RMS; the "staying" message shows the top candidate and margin to the next.

<sup>Written for commit 39aa8f164d4d8c45cb3e43b38c139d998960bd5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

