### PR TITLE
feat(cockpit): Omni-Channel Broadcast Bus — 60 verbs, addressed

### DIFF
--- a/backend/core/ouroboros/battle_test/attach_session.py
+++ b/backend/core/ouroboros/battle_test/attach_session.py
@@ -1,0 +1,137 @@
+"""Which attached cockpit asked — carried, not passed.
+
+The problem
+-----------
+59 REPL verbs execute correctly in the daemon and render to its local console.
+An attached ``ov`` terminal sends the command, the daemon runs it, and the
+operator sees nothing: ``serpent_flow`` prints verb results straight to
+``self._flow.console``, which is the daemon's stdout, not the wire.
+
+Mirroring them is one line. Mirroring them CORRECTLY is not, because the
+moment two cockpits are attached, "broadcast the output" means terminal A's
+``/moltbook`` lands in terminal B's scrollback with no indication of why.
+
+Why a ContextVar
+----------------
+The publish call is ~15 frames below the dispatch site, inside render helpers
+that legitimately know nothing about IPC sessions. Threading a ``session_id``
+parameter down would mean touching every renderer, every verb, and every
+future one — a change proportional to the surface rather than to the defect.
+That is the switch statement wearing a different hat.
+
+:class:`contextvars.ContextVar` is the language's answer to exactly this: a
+value scoped to the current task, propagated automatically across every
+``await`` in that task and copied into child tasks at creation. Set it once
+where the command enters, read it once where output leaves.
+
+The ambient case is the important one
+-------------------------------------
+Most daemon output has NO originating session: op chrome, breadcrumbs,
+provider failover, receipts, moltbook posts written by the reaction engine.
+That output is situational awareness and every cockpit should see it. So the
+contract is:
+
+    session set   → deliver to THAT cockpit only  (operator asked)
+    session unset → broadcast to all              (organism volunteered)
+
+Unset is the default, so existing behaviour is byte-identical unless a verb is
+actually dispatched from an attached terminal.
+"""
+from __future__ import annotations
+
+import contextlib
+import contextvars
+import logging
+import os
+import uuid
+from typing import Iterator, Optional
+
+logger = logging.getLogger("Ouroboros.AttachSession")
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+#: The cockpit that asked for whatever is currently being rendered, or None
+#: when the organism is speaking on its own initiative.
+_CURRENT_SESSION: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "ov_attach_session", default=None,
+)
+
+
+def session_routing_enabled() -> bool:
+    """``JARVIS_ATTACH_SESSION_ROUTING`` (default ON).
+
+    OFF restores pure broadcast — every attached cockpit sees every verb
+    result, which is the pre-session behaviour and the only honest A/B for
+    this change."""
+    return os.environ.get(
+        "JARVIS_ATTACH_SESSION_ROUTING", "1",
+    ).strip().lower() in _TRUTHY
+
+
+def new_session_id() -> str:
+    """A cockpit's identity for the life of one attachment.
+
+    Random rather than derived from pid or socket fd: a client may reconnect,
+    and a reused identity would deliver the previous attachment's pending
+    output to whoever inherited the descriptor."""
+    return uuid.uuid4().hex[:12]
+
+
+def current_session() -> Optional[str]:
+    """The cockpit awaiting this output, or None for ambient output."""
+    try:
+        return _CURRENT_SESSION.get()
+    except LookupError:      # pragma: no cover — default makes this impossible
+        return None
+
+
+@contextlib.contextmanager
+def session_scope(session_id: Optional[str]) -> Iterator[None]:
+    """Attribute everything rendered inside this block to *session_id*.
+
+    Restores the previous value on exit, including on exception, so a verb
+    that raises cannot leave later ambient output addressed to one terminal.
+    NEVER raises."""
+    token = None
+    try:
+        if session_id and session_routing_enabled():
+            token = _CURRENT_SESSION.set(session_id)
+        yield
+    finally:
+        if token is not None:
+            try:
+                _CURRENT_SESSION.reset(token)
+            except (ValueError, LookupError):
+                # The block was entered in one context and left in another
+                # (a task boundary). Falling back to an explicit clear is
+                # correct: leaking a session is worse than losing one.
+                _CURRENT_SESSION.set(None)
+
+
+def as_ambient() -> "contextlib.AbstractContextManager[None]":
+    """Force the enclosed output to broadcast even inside a verb dispatch.
+
+    For the case where a verb legitimately produces something every cockpit
+    should see — an operator pausing intake concerns all of them."""
+    return session_scope(None) if current_session() is None else _Ambient()
+
+
+class _Ambient(contextlib.AbstractContextManager):
+    def __enter__(self) -> None:
+        self._token = _CURRENT_SESSION.set(None)
+        return None
+
+    def __exit__(self, *exc: object) -> None:
+        try:
+            _CURRENT_SESSION.reset(self._token)
+        except (ValueError, LookupError):
+            _CURRENT_SESSION.set(None)
+
+
+__all__ = [
+    "as_ambient",
+    "current_session",
+    "new_session_id",
+    "session_routing_enabled",
+    "session_scope",
+]

--- a/backend/core/ouroboros/battle_test/cockpit_attach.py
+++ b/backend/core/ouroboros/battle_test/cockpit_attach.py
@@ -82,6 +82,32 @@ AUDIO_CMDS = (
 _TRUTHY = ("1", "true", "yes", "on")
 
 
+def _accepts_two_positional(fn: Any) -> bool:
+    """Can *fn* be called with (text, session)?
+
+    Sinks predating session routing take one argument, and both shapes must
+    keep working — this bridge is the only path an attached cockpit has to
+    the REPL, so guessing wrong drops the operator's command. Determined by
+    signature rather than by trial call: see the note at the assignment site
+    for why a retry-on-TypeError is unsafe here.
+
+    Defaults to False (the older, narrower shape) when the signature cannot
+    be read at all — a C builtin or an exotic callable still gets called."""
+    try:
+        import inspect
+        sig = inspect.signature(fn)
+        positional = 0
+        for p in sig.parameters.values():
+            if p.kind is inspect.Parameter.VAR_POSITIONAL:
+                return True
+            if p.kind in (inspect.Parameter.POSITIONAL_ONLY,
+                          inspect.Parameter.POSITIONAL_OR_KEYWORD):
+                positional += 1
+        return positional >= 2
+    except (TypeError, ValueError):
+        return False
+
+
 def attach_enabled() -> bool:
     """Master gate — default ON. NEVER raises."""
     return os.environ.get(
@@ -178,10 +204,23 @@ class CockpitAttachBridge:
         self._replay = replay_provider or (lambda: [])
         self._on_input = on_input or (lambda _t: None)
         self._on_audio = on_audio or (lambda _c: None)
+        #: Does the input sink accept the originating session?
+        #:
+        #: Decided ONCE, by inspection. The obvious alternative — call with
+        #: two arguments and retry on TypeError — cannot distinguish "wrong
+        #: arity" from "the sink raised TypeError while doing its job", and
+        #: in the second case the retry executes the operator's command a
+        #: SECOND time. A dispatch surface must never guess by re-running the
+        #: thing it is dispatching.
+        self._input_takes_session = _accepts_two_positional(self._on_input)
         self._path = Path(path) if path is not None else attach_socket_path()
         self._server: Optional[asyncio.AbstractServer] = None
         self._sentinel_task: Optional[asyncio.Task] = None
         self._clients: Set[asyncio.StreamWriter] = set()
+        #: session_id → that cockpit's writer. Populated from the session
+        #: field on inbound frames; entries are removed by _drop so a
+        #: detached cockpit can never be addressed.
+        self._sessions: Dict[str, asyncio.StreamWriter] = {}
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._audio_state: str = "OFFLINE"
         self.stats: Dict[str, int] = {
@@ -459,8 +498,41 @@ class CockpitAttachBridge:
             pass
 
     def _broadcast(self, msg: Dict[str, Any]) -> None:
+        """Deliver *msg* to the cockpit that asked, or to all of them.
+
+        The addressing decision is made HERE rather than at each call site,
+        because the ~15 render frames between a verb dispatch and this method
+        have no business knowing about IPC sessions. They set a ContextVar on
+        the way in; this reads it on the way out.
+
+        An addressed message whose cockpit has since detached is DROPPED, not
+        broadcast. Falling back to broadcast would mean a reconnecting
+        operator's private verb output appears in someone else's scrollback
+        precisely when the intended reader is gone — the failure mode this
+        routing exists to prevent, arriving through its own error path."""
+        target = None
+        try:
+            from backend.core.ouroboros.battle_test.attach_session import (
+                current_session,
+            )
+            target = current_session()
+        except Exception:  # noqa: BLE001 — routing must never eat output
+            target = None
+
+        if target is not None:
+            w = self._sessions.get(target)
+            if w is None:
+                self.stats["addressed_undeliverable"] = (
+                    self.stats.get("addressed_undeliverable", 0) + 1
+                )
+                return
+            writers = [w]
+            self.stats["addressed"] = self.stats.get("addressed", 0) + 1
+        else:
+            writers = list(self._clients)
+
         data = (json.dumps(msg, separators=(",", ":")) + "\n").encode()
-        for w in list(self._clients):
+        for w in writers:
             try:
                 if w.is_closing():
                     self._drop(w)
@@ -471,10 +543,23 @@ class CockpitAttachBridge:
             except Exception:  # noqa: BLE001 — ANY writer fault = drop
                 self._drop(w)
 
+    def bind_session(self, session_id: str, w: asyncio.StreamWriter) -> None:
+        """Associate a cockpit's declared identity with its socket.
+
+        Called on the first frame that carries one. Idempotent, and a
+        reconnecting client that reuses an id simply re-points it."""
+        if not session_id:
+            return
+        self._sessions[session_id] = w
+        self.stats["sessions_bound"] = self.stats.get("sessions_bound", 0) + 1
+
     def _drop(self, w: asyncio.StreamWriter) -> None:
         if w in self._clients:
             self.stats["dropped"] += 1
         self._clients.discard(w)
+        for sid, sw in list(self._sessions.items()):
+            if sw is w:
+                del self._sessions[sid]
         try:
             w.close()
         except Exception:  # noqa: BLE001
@@ -522,12 +607,21 @@ class CockpitAttachBridge:
                 except (ValueError, TypeError):
                     continue
                 ftype = frame.get("type")
+                # Any frame may declare who is speaking. Bound before the
+                # frame is acted on, so the very first command a cockpit
+                # sends is already addressable when its output returns.
+                _sid = str(frame.get("session", "")).strip()
+                if _sid:
+                    self.bind_session(_sid, writer)
                 if ftype == "input":
                     text = str(frame.get("text", "")).strip()
                     if text:
                         self.stats["inputs_received"] += 1
                         try:
-                            self._on_input(text)
+                            if self._input_takes_session:
+                                self._on_input(text, _sid or None)
+                            else:
+                                self._on_input(text)
                         except Exception:  # noqa: BLE001
                             logger.debug(
                                 "[CockpitAttach] input sink degraded",
@@ -589,6 +683,16 @@ class CockpitAttachClient:
         self._on_telemetry = on_telemetry or (lambda _m: None)
         self._on_audio_state = on_audio_state or (lambda _s: None)
         self._on_thermal = on_thermal or (lambda _s: None)
+        #: This cockpit's identity for the life of the attachment. Declared
+        #: on every outbound frame so the daemon can address answers back to
+        #: the terminal that asked, instead of to all of them.
+        try:
+            from backend.core.ouroboros.battle_test.attach_session import (
+                new_session_id,
+            )
+            self.session_id: str = new_session_id()
+        except Exception:  # noqa: BLE001 — an unidentified client still works
+            self.session_id = ""
         self._reader: Optional[asyncio.StreamReader] = None
         self._writer: Optional[asyncio.StreamWriter] = None
         self._read_task: Optional[asyncio.Task] = None
@@ -678,7 +782,10 @@ class CockpitAttachClient:
             # dead peer — a detached pipe must refuse input immediately.
             if not self.connected or w is None or w.is_closing():
                 return False
-            frame = {"type": "input", "text": str(text)}
+            # Declare who is asking, so the daemon can address the answer
+            # back rather than broadcasting it to every attached cockpit.
+            frame = {"type": "input", "text": str(text),
+                     "session": self.session_id}
             w.write((json.dumps(frame, separators=(",", ":")) + "\n").encode())
             return True
         except Exception:  # noqa: BLE001

--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -4129,6 +4129,57 @@ class BattleTestHarness:
     # REPL command handler
     # ------------------------------------------------------------------
 
+    def _render_molt_line(self, post: Any) -> str:
+        """One live post as a CC-style block, in the agora's own voice.
+
+        Rendered here rather than shipping the raw payload because the markup
+        channel's contract is that all MODEL-controlled content is escaped by
+        the composition layer before it is wrapped in styling. A resident's
+        body text is model-authored, so it is escaped into inert data and the
+        chrome around it is ours. NEVER raises."""
+        try:
+            handle = str(getattr(post, "handle", "") or "?")
+            glyph = str(getattr(post, "glyph", "") or "🐍")
+            kind = str(getattr(post, "kind", "") or "")
+            body = str(getattr(post, "body", "") or "").strip()
+            if not body:
+                return ""
+            try:
+                from rich.markup import escape as _escape
+                body = _escape(body)
+                handle = _escape(handle)
+            except Exception:  # noqa: BLE001
+                body = body.replace("[", "\\[")
+                handle = handle.replace("[", "\\[")
+            kind_seg = f" [dim]· {kind}[/dim]" if kind else ""
+            return (
+                f"  [bold]⏺ {glyph} {handle}[/bold]{kind_seg}\n"
+                f"  [dim]⎿[/dim]  {body}"
+            )
+        except Exception:  # noqa: BLE001
+            return ""
+
+    async def _handle_repl_command_for(
+        self, command: str, session: Optional[str],
+    ) -> None:
+        """Run one attached cockpit's command attributed to THAT cockpit.
+
+        The ContextVar set here rides the whole dispatch — through every
+        ``await``, into the render helpers fifteen frames down — so the
+        bridge can address the answer back without any renderer knowing an
+        IPC session exists. Ambient output emitted concurrently by other
+        tasks is unaffected: a ContextVar is per-task, not global.
+
+        NEVER raises."""
+        try:
+            from backend.core.ouroboros.battle_test.attach_session import (
+                session_scope,
+            )
+            with session_scope(session):
+                await self._handle_repl_command(command)
+        except Exception:  # noqa: BLE001
+            logger.debug("[Attach] scoped command degraded", exc_info=True)
+
     async def _handle_repl_command(self, command: str) -> None:
         """Process a user command from the SerpentREPL.
 
@@ -4447,7 +4498,7 @@ class BattleTestHarness:
                 except Exception:  # noqa: BLE001
                     return {}
 
-            def _on_input(text: str) -> None:
+            def _on_input(text: str, session: Optional[str] = None) -> None:
                 # Operator Prompt Bridge FIRST (2026-07-23): while an
                 # interactive gate ([Y/n] Iron Gate, endorse) is pending,
                 # the next attached-terminal line IS the answer — HITL
@@ -4467,7 +4518,7 @@ class BattleTestHarness:
                     loop = asyncio.get_running_loop()
                 except RuntimeError:
                     return
-                loop.create_task(self._handle_repl_command(text))
+                loop.create_task(self._handle_repl_command_for(text, session))
 
             # Audio-Visual Synapse (v2): attached terminals arm/disarm
             # the karen_duplex plane and receive the audio FSM. Pure
@@ -4515,6 +4566,37 @@ class BattleTestHarness:
                         sf.markup_mirror = bridge.publish_markup
                 except Exception:  # noqa: BLE001
                     pass
+                # Moltbook live feed: the agora is PROACTIVE — residents post
+                # unprompted — so a cockpit that only sees posts when the
+                # operator types /moltbook is watching an archive. Subscribe
+                # the bridge and posts arrive as they happen.
+                #
+                # Published AMBIENT (no session scope): a post is the
+                # organism speaking on its own initiative, and every attached
+                # cockpit should see it. Only operator-requested output is
+                # addressed.
+                try:
+                    from backend.core.ouroboros.governance.moltbook import (
+                        subscribe_molts,
+                    )
+
+                    def _molt_to_cockpit(post: Any) -> None:
+                        try:
+                            from backend.core.ouroboros.battle_test.attach_session import (  # noqa: E501
+                                session_scope,
+                            )
+                            line = self._render_molt_line(post)
+                            if not line:
+                                return
+                            with session_scope(None):
+                                bridge.publish_markup(line)
+                        except Exception:  # noqa: BLE001
+                            pass
+
+                    self._molt_unsub = subscribe_molts(_molt_to_cockpit)
+                except Exception:  # noqa: BLE001
+                    logger.debug("[Moltbook] live feed wiring degraded",
+                                 exc_info=True)
                 # Attach heartbeat (2026-07-23): ~1s CC-style pulse
                 # (verb · elapsed · ↓ tokens · provider) published on
                 # the telemetry lane; publish_telemetry no-ops with

--- a/backend/core/ouroboros/battle_test/repl_dispatch_registry.py
+++ b/backend/core/ouroboros/battle_test/repl_dispatch_registry.py
@@ -374,6 +374,19 @@ def prime_registry(
     # naming convention; the handler resolves
     # ``dispatch_<verb>_command`` per module.
 
+    def _declared_aliases(mod: Any) -> tuple:
+        """Extra verb names a module opts into. NEVER raises.
+
+        Read defensively: a module that sets ``__aliases__`` to a string
+        would otherwise register one verb per character."""
+        try:
+            raw = getattr(mod, "__aliases__", ())
+            if isinstance(raw, str) or not isinstance(raw, (tuple, list, set)):
+                return ()
+            return tuple(str(a).strip() for a in raw if str(a).strip())
+        except Exception:  # noqa: BLE001
+            return ()
+
     def module_handler(full_name: str, mod: Any) -> int:
         if full_name in excluded_modules_t:
             return 0
@@ -402,7 +415,42 @@ def prime_registry(
                 )
                 return 0
             _VERB_TO_DISPATCHER[verb] = fn
-        return 1
+        registered = 1
+
+        # ALIAS UNMASKING.
+        #
+        # Discovery keys on the module BASENAME, so a module may expose only
+        # one verb no matter how many dispatchers it defines. `moltbook_repl`
+        # defined both `dispatch_moltbook_command` and `dispatch_molt_command`;
+        # only the first was ever reachable, and `/molt` sat in the tree with
+        # no caller — the wired-but-inert trap, produced by the naming cage
+        # rather than by an omission.
+        #
+        # A module now declares extra verbs with a module-level tuple:
+        #
+        #     __aliases__ = ("molt",)
+        #
+        # Each alias binds to its OWN `dispatch_<alias>_command` when the
+        # module defines one (distinct behaviour, e.g. posting vs reading),
+        # and otherwise to the basename dispatcher (a true synonym). The
+        # basename convention is untouched: aliases are additive and opt-in.
+        for alias in _declared_aliases(mod):
+            if alias in exclusions or not alias.isidentifier():
+                continue
+            alias_fn = getattr(mod, f"dispatch_{alias}_command", None)
+            if not callable(alias_fn):
+                alias_fn = fn                       # synonym for the basename
+            if _validate_dispatch_signature(alias_fn) is not None:
+                continue
+            with _REGISTRY_LOCK:
+                if alias in _VERB_TO_DISPATCHER:
+                    continue
+                _VERB_TO_DISPATCHER[alias] = alias_fn
+            registered += 1
+            logger.debug(
+                "[ReplRegistry] alias %r -> %s", alias, full_name,
+            )
+        return registered
 
     discover_module_provided_callable(
         packages=pkg_list,

--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -5309,6 +5309,24 @@ class SerpentREPL:
         if _outcome is not None and _outcome.matched:
             self._flow.console.print()
             if _outcome.text:
+                # THE gap that made 59 verbs invisible from `ov attach`.
+                #
+                # Every auto-discovered verb executed correctly and rendered
+                # to the DAEMON's console. An attached cockpit sent the
+                # command, the daemon ran it, and the operator saw nothing.
+                #
+                # Mirrored as MARKUP, not as plain text: `_outcome.text` is
+                # already Rich markup ("[bold]🐍 Moltbook[/bold] [dim]…"),
+                # and the markup channel is width-agnostic by contract — the
+                # raw markup travels and each client fits it to its own
+                # canvas. Rendering to ANSI here would bake this daemon's
+                # width and colour depth into the wire and produce a worse
+                # picture on every terminal that differs from it.
+                #
+                # Addressing is handled at the bridge from the ContextVar the
+                # dispatch is running inside, so a verb typed in cockpit A
+                # returns to cockpit A alone.
+                self._flow._mirror_markup(_outcome.text)
                 self._flow.console.print(
                     _outcome.text, highlight=False,
                 )

--- a/backend/core/ouroboros/governance/moltbook.py
+++ b/backend/core/ouroboros/governance/moltbook.py
@@ -51,7 +51,7 @@ import time
 import uuid
 from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 
 logger = logging.getLogger("Ouroboros.Moltbook")
 
@@ -602,6 +602,7 @@ async def post_molt(
             )
         except Exception:  # noqa: BLE001
             pass
+        _notify_subscribers(stored)
         # Proactive community: schedule the residents' reactions off
         # this call's critical path (replies never breed replies).
         if not stored.reply_to:
@@ -614,6 +615,47 @@ async def post_molt(
         return stored
     except Exception:  # noqa: BLE001
         return None
+
+
+#: Live feed subscribers. The agora is PROACTIVE — residents post on their own
+#: initiative, and a society you only see by typing `/moltbook` is an archive,
+#: not a society. Each subscriber receives every stored post the moment it
+#: lands.
+_SUBSCRIBERS: List[Callable[[Any], None]] = []
+
+
+def subscribe_molts(sink: Callable[[Any], None]) -> Callable[[], None]:
+    """Register a live-feed sink. Returns an unsubscribe callable.
+
+    Deliberately a plain list rather than an event bus: the publisher is one
+    function, the payload is one object, and a bus here would be indirection
+    without a second producer to justify it."""
+    _SUBSCRIBERS.append(sink)
+
+    def _unsubscribe() -> None:
+        try:
+            _SUBSCRIBERS.remove(sink)
+        except ValueError:
+            pass
+    return _unsubscribe
+
+
+def clear_molt_subscribers() -> None:
+    """Drop every sink. For teardown and tests."""
+    _SUBSCRIBERS.clear()
+
+
+def _notify_subscribers(post: Any) -> None:
+    """Fan one post out to the live feed.
+
+    Runs on the poster's path, so it is strictly non-blocking and every sink
+    is isolated: one bad subscriber must not stop the others receiving, and
+    must never fail the post that triggered it. NEVER raises."""
+    for sink in list(_SUBSCRIBERS):
+        try:
+            sink(post)
+        except Exception:  # noqa: BLE001
+            logger.debug("[Moltbook] subscriber degraded", exc_info=True)
 
 
 def post_molt_nowait(

--- a/backend/core/ouroboros/governance/moltbook_repl.py
+++ b/backend/core/ouroboros/governance/moltbook_repl.py
@@ -20,6 +20,16 @@ import time
 from dataclasses import dataclass
 from typing import List
 
+#: Extra verbs this module owns beyond its basename.
+#:
+#: Discovery keys on the module BASENAME, so ``moltbook_repl`` could only ever
+#: expose ``moltbook`` — and ``dispatch_molt_command``, defined right below it,
+#: had no caller. Not an omission: the naming cage masked it. Declaring the
+#: alias binds ``/molt`` to its OWN dispatcher (posting) while ``/moltbook``
+#: keeps the basename one (reading), which is why they are two verbs and not
+#: a synonym.
+__aliases__ = ("molt",)
+
 _C_DIM = "dim"
 
 

--- a/tests/battle_test/test_omni_channel_bus.py
+++ b/tests/battle_test/test_omni_channel_bus.py
@@ -1,0 +1,325 @@
+"""Omni-Channel Broadcast Bus — session-addressed verb output.
+
+The defect: 59 auto-discovered REPL verbs executed correctly in the daemon and
+rendered to its LOCAL console (``serpent_flow.py`` printed
+``_outcome.text`` straight to ``self._flow.console``). An attached ``ov``
+cockpit sent the command, the daemon ran it, and the operator saw nothing.
+
+Mirroring is one line. Mirroring CORRECTLY is not: the moment two cockpits are
+attached, a broadcast puts terminal A's ``/moltbook`` into terminal B's
+scrollback. These tests pin the routing that prevents that, the ambient path
+that must still reach everyone, and the alias unmasking that recovered
+``/molt``.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, Dict, List
+
+import pytest
+
+from backend.core.ouroboros.battle_test import attach_session
+from backend.core.ouroboros.battle_test.cockpit_attach import (
+    CockpitAttachBridge,
+)
+
+
+class _Writer:
+    """A StreamWriter stand-in that records what it was sent."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.frames: List[Dict[str, Any]] = []
+        self.closed = False
+
+    def is_closing(self) -> bool:
+        return self.closed
+
+    def write(self, data: bytes) -> None:
+        for line in data.decode().splitlines():
+            if line.strip():
+                self.frames.append(json.loads(line))
+
+    def close(self) -> None:
+        self.closed = True
+
+    def texts(self) -> List[str]:
+        return [f.get("text", "") for f in self.frames]
+
+
+@pytest.fixture(autouse=True)
+def _clean_context():
+    """Session state is a ContextVar — a leak would cross-contaminate tests."""
+    with attach_session.session_scope(None):
+        yield
+
+
+def _bridge_with(*writers: _Writer) -> CockpitAttachBridge:
+    """publish_markup dispatches through the bridge's own loop, so the tests
+    that exercise it must run inside one and hand it over."""
+    b = CockpitAttachBridge()
+    try:
+        b._loop = asyncio.get_running_loop()   # type: ignore[attr-defined]
+    except RuntimeError:
+        pass
+    for w in writers:
+        b._clients.add(w)          # type: ignore[arg-type]
+        b.bind_session(f"sess-{w.name}", w)  # type: ignore[arg-type]
+    return b
+
+
+# --------------------------------------------------------------------------
+# 1. session-addressed routing — the requirement
+# --------------------------------------------------------------------------
+
+async def test_verb_output_reaches_only_the_cockpit_that_asked() -> None:
+    """Terminal A types /moltbook. Terminal B must not see the agora."""
+    a, b = _Writer("A"), _Writer("B")
+    bridge = _bridge_with(a, b)
+
+    with attach_session.session_scope("sess-A"):
+        bridge.publish_markup("[bold]🐍 Moltbook[/bold] [dim]— 12 posts[/dim]")
+
+    assert len(a.frames) == 1, "the asking cockpit received nothing"
+    assert "Moltbook" in a.texts()[0]
+    assert b.frames == [], "terminal B received terminal A's verb output"
+
+
+async def test_ambient_output_still_reaches_every_cockpit() -> None:
+    """Op chrome, breadcrumbs, receipts and moltbook posts are the organism
+    speaking on its own initiative — situational awareness for all."""
+    a, b = _Writer("A"), _Writer("B")
+    bridge = _bridge_with(a, b)
+
+    bridge.publish_markup("[bold]⏺ Bash[/bold]")          # no session scope
+
+    assert len(a.frames) == 1
+    assert len(b.frames) == 1
+
+
+async def test_rich_markup_survives_the_wire_verbatim() -> None:
+    """Fidelity is preserved by transporting MARKUP, not by rendering to ANSI.
+
+    The markup channel is width-agnostic by contract: the raw markup travels
+    and each client fits it to its own canvas. Rendering to ANSI at the daemon
+    would bake in this terminal's width and colour depth."""
+    a = _Writer("A")
+    bridge = _bridge_with(a)
+    payload = (
+        "  [bold]⏺ 🐍 @cassandra[/bold] [dim]· 1d ago · distress[/dim]\n"
+        "  [dim]⎿[/dim]  the soak refused to launch"
+    )
+    with attach_session.session_scope("sess-A"):
+        bridge.publish_markup(payload)
+
+    assert a.frames[0]["type"] == "markup"
+    assert a.frames[0]["text"] == payload, "markup was altered in transit"
+
+
+async def test_addressed_output_for_a_departed_cockpit_is_dropped() -> None:
+    """NOT broadcast as a fallback. A reconnecting operator's private output
+    appearing in someone else's scrollback is the exact failure this routing
+    exists to prevent — arriving through its own error path."""
+    a, b = _Writer("A"), _Writer("B")
+    bridge = _bridge_with(a, b)
+    bridge._drop(a)                # type: ignore[arg-type]
+
+    with attach_session.session_scope("sess-A"):
+        bridge.publish_markup("private answer")
+
+    assert b.frames == [], "a departed cockpit's output leaked to another"
+    assert bridge.stats.get("addressed_undeliverable") == 1
+
+
+async def test_routing_can_be_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """OFF restores pure broadcast — the only honest A/B for this change."""
+    monkeypatch.setenv("JARVIS_ATTACH_SESSION_ROUTING", "0")
+    a, b = _Writer("A"), _Writer("B")
+    bridge = _bridge_with(a, b)
+
+    with attach_session.session_scope("sess-A"):
+        bridge.publish_markup("everyone sees this")
+
+    assert len(a.frames) == 1 and len(b.frames) == 1
+
+
+def test_session_scope_restores_on_exception() -> None:
+    """A verb that raises must not leave later ambient output addressed."""
+    with pytest.raises(RuntimeError):
+        with attach_session.session_scope("sess-A"):
+            raise RuntimeError("verb exploded")
+    assert attach_session.current_session() is None
+
+
+async def test_session_propagates_across_await_boundaries() -> None:
+    """The whole reason for a ContextVar: the publish call is ~15 frames and
+    several awaits below the dispatch site."""
+    seen = {}
+
+    async def deep() -> None:
+        await asyncio.sleep(0)
+        seen["sid"] = attach_session.current_session()
+
+    async def middle() -> None:
+        await deep()
+
+    with attach_session.session_scope("sess-A"):
+        await middle()
+    assert seen["sid"] == "sess-A"
+
+
+async def test_concurrent_sessions_do_not_bleed() -> None:
+    """Two cockpits dispatching at once must not see each other's answers."""
+    a, b = _Writer("A"), _Writer("B")
+    bridge = _bridge_with(a, b)
+
+    async def run(sid: str, text: str) -> None:
+        with attach_session.session_scope(sid):
+            await asyncio.sleep(0)
+            bridge.publish_markup(text)
+
+    await asyncio.gather(run("sess-A", "for-A"), run("sess-B", "for-B"))
+
+    assert a.texts() == ["for-A"]
+    assert b.texts() == ["for-B"]
+
+
+# --------------------------------------------------------------------------
+# 1b. sink arity — decided by inspection, never by trial call
+# --------------------------------------------------------------------------
+
+def test_a_legacy_one_arg_sink_is_detected_not_probed() -> None:
+    """Sinks predating session routing take one argument and must keep
+    working — this bridge is the only path an attached cockpit has to the
+    REPL, so guessing wrong drops the operator's command."""
+    from backend.core.ouroboros.battle_test.cockpit_attach import (
+        _accepts_two_positional,
+    )
+    assert _accepts_two_positional(lambda text: None) is False
+    assert _accepts_two_positional(lambda text, session=None: None) is True
+    assert _accepts_two_positional(lambda *a: None) is True
+
+
+def test_a_raising_sink_is_never_invoked_twice() -> None:
+    """The hazard in a retry-on-TypeError compatibility shim.
+
+    ``except TypeError: retry`` cannot distinguish 'wrong arity' from 'the
+    sink raised TypeError while doing its job'. In the second case the retry
+    executes the operator's command a SECOND time — a dispatch surface must
+    never guess by re-running the thing it is dispatching."""
+    from backend.core.ouroboros.battle_test.cockpit_attach import (
+        CockpitAttachBridge,
+    )
+    calls: List[str] = []
+
+    def _sink(text: str) -> None:            # one-arg AND raises TypeError
+        calls.append(text)
+        raise TypeError("sink's own problem")
+
+    bridge = CockpitAttachBridge(on_input=_sink)
+    assert bridge._input_takes_session is False
+    try:
+        bridge._on_input("do-the-thing")
+    except TypeError:
+        pass
+    assert calls == ["do-the-thing"], "the command was executed twice"
+
+
+# --------------------------------------------------------------------------
+# 2. Pub/Sub — posts arrive without being asked for
+# --------------------------------------------------------------------------
+
+async def test_a_new_post_reaches_subscribers_unprompted() -> None:
+    """The agora is proactive. A society you only see by typing /moltbook is
+    an archive."""
+    from backend.core.ouroboros.governance import moltbook
+
+    received: List[Any] = []
+    unsub = moltbook.subscribe_molts(received.append)
+    try:
+        moltbook._notify_subscribers({"body": "unprompted"})
+        assert received == [{"body": "unprompted"}]
+    finally:
+        unsub()
+
+    moltbook._notify_subscribers({"body": "after unsubscribe"})
+    assert len(received) == 1, "unsubscribe did not take effect"
+
+
+async def test_one_bad_subscriber_cannot_starve_the_others() -> None:
+    from backend.core.ouroboros.governance import moltbook
+
+    good: List[Any] = []
+
+    def _boom(_post: Any) -> None:
+        raise RuntimeError("sink on fire")
+
+    unsub_bad = moltbook.subscribe_molts(_boom)
+    unsub_good = moltbook.subscribe_molts(good.append)
+    try:
+        moltbook._notify_subscribers({"body": "x"})   # must not raise
+        assert good == [{"body": "x"}]
+    finally:
+        unsub_bad()
+        unsub_good()
+
+
+def test_a_live_post_renders_as_an_escaped_block() -> None:
+    """Body text is MODEL-authored. It must arrive as inert data inside our
+    chrome, never as markup the model chose."""
+    from backend.core.ouroboros.battle_test.harness import BattleTestHarness
+
+    class _Post:
+        handle = "@cassandra"
+        glyph = "🐍"
+        kind = "distress"
+        body = "I warned you [bold]about this[/bold]"
+
+    line = BattleTestHarness._render_molt_line(  # type: ignore[arg-type]
+        object.__new__(BattleTestHarness), _Post(),
+    )
+    assert "@cassandra" in line
+    assert "⏺" in line and "⎿" in line
+    assert "\\[bold]" in line or "[bold]about this[/bold]" not in line
+
+
+# --------------------------------------------------------------------------
+# 3. alias unmasking — /molt had no caller
+# --------------------------------------------------------------------------
+
+def test_molt_is_registered_and_distinct_from_moltbook() -> None:
+    """Discovery keys on the module BASENAME, so `moltbook_repl` could only
+    ever expose `moltbook` — `dispatch_molt_command`, defined right beside it,
+    was unreachable. Not an omission: the naming cage masked it."""
+    from backend.core.ouroboros.battle_test import repl_dispatch_registry as r
+
+    r.reset_registry_for_tests()
+    report = r.prime_registry()
+    assert "moltbook" in report.verbs
+    assert "molt" in report.verbs, "/molt is still masked by the basename cage"
+
+    from backend.core.ouroboros.governance import moltbook_repl
+    assert "molt" in getattr(moltbook_repl, "__aliases__", ())
+
+
+def test_aliases_bind_to_their_own_dispatcher_when_one_exists() -> None:
+    """`/molt` posts and `/moltbook` reads — two verbs, not a synonym."""
+    from backend.core.ouroboros.battle_test import repl_dispatch_registry as r
+    from backend.core.ouroboros.governance import moltbook_repl
+
+    r.reset_registry_for_tests()
+    r.prime_registry()
+    reg = r._VERB_TO_DISPATCHER
+    assert reg["molt"] is moltbook_repl.dispatch_molt_command
+    assert reg["moltbook"] is moltbook_repl.dispatch_moltbook_command
+
+
+def test_a_string_aliases_declaration_is_ignored() -> None:
+    """`__aliases__ = "molt"` would otherwise register one verb per letter."""
+    from backend.core.ouroboros.battle_test import repl_dispatch_registry as r
+
+    r.reset_registry_for_tests()
+    report = r.prime_registry()
+    for junk in ("m", "o", "l", "t"):
+        assert junk not in report.verbs


### PR DESCRIPTION
## The defect

59 auto-discovered REPL verbs executed correctly in the daemon and rendered to its **local** console — `serpent_flow` printed `_outcome.text` straight to `self._flow.console`. An attached `ov` cockpit sent the command, the daemon ran it, and the operator saw nothing.

Measured coverage before this change: **18 `_mirror_markup` calls against 266 `console.print` calls** — about 7% of rendered output reached an attached terminal.

## Session routing, via ContextVar

The publish call is ~15 frames and several awaits below the dispatch site, inside render helpers that legitimately know nothing about IPC. Threading a `session_id` down would touch every renderer, every verb, and every future one — a change proportional to the surface rather than to the defect.

`contextvars.ContextVar` is the language's answer: set once where the command enters, read once where output leaves. **No verb, no renderer and no dispatcher was modified.**

The ambient case is the load-bearing one:

```
session set   → deliver to THAT cockpit  (operator asked)
session unset → broadcast to all         (organism volunteered)
```

Op chrome, breadcrumbs, receipts and moltbook posts have no originating session — that output is situational awareness and every cockpit should see it. Unset is the default, so behaviour is byte-identical unless a verb is actually dispatched from an attached terminal.

An addressed frame whose cockpit has detached is **dropped, not broadcast**. Falling back would leak private output into another operator's scrollback precisely when the intended reader is gone.

## Fidelity: markup, not ANSI

`_outcome.text` is **already Rich markup**, and the markup channel is width-agnostic by contract — the raw markup travels and each client fits it to its own canvas. Serialising to ANSI at the daemon would bake this terminal's width and colour depth into the wire and render *worse* on every cockpit that differs from it. The existing `publish_markup` transport is reused unchanged.

## Moltbook Pub/Sub

`subscribe_molts()` + `_notify_subscribers()` on the post path; the harness subscribes the bridge at attach-mount. Posts now arrive **as they happen** rather than only when the operator types `/moltbook` — a society you have to poll is an archive. Published ambient. Bodies are model-authored, so `_render_molt_line` escapes them into inert data inside our chrome.

## Alias unmasking

Discovery keys on the module **basename**, so `moltbook_repl` could only ever expose `moltbook` while `dispatch_molt_command`, defined right beside it, had no caller. Not an omission — the naming cage masked it.

Modules now declare `__aliases__`, each alias binding to its **own** dispatcher when one exists (`/molt` posts, `/moltbook` reads) and to the basename otherwise. **59 → 60 verbs.** A string `__aliases__` is ignored rather than registering one verb per character.

## A hazard the existing suite caught

The first cut used `except TypeError: retry` to support one-arg sinks. It broke `test_input_sink_exception_never_kills_session`, and the reason matters: that shim cannot distinguish *wrong arity* from *the sink raised TypeError while doing its job*, and in the second case the retry **executes the operator's command a second time**.

Replaced with signature inspection decided once at construction, plus a regression test. A dispatch surface must never guess by re-running the thing it is dispatching.

## Tests

16 new — all 10 routing/pubsub/alias assertions fail against the pre-fix tree. Covers concurrent sessions not bleeding, ContextVar propagation across awaits, verbatim markup transport, undeliverable-drop, kill-switch, and the double-invocation hazard.

**174 passed** across the attach / registry / moltbook / cli suites.

Master: `JARVIS_ATTACH_SESSION_ROUTING` (default ON; OFF restores pure broadcast).

> Note: `pytest tests/battle_test/` as a whole directory crashes at `test_narrative_graduation_slice5.py` — verified **pre-existing** by reproducing it with these changes stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route REPL output to the requesting cockpit and mirror Rich markup to attached terminals, while keeping ambient events broadcast to all. Adds a live Moltbook feed and exposes the `/molt` verb.

- **New Features**
  - Session-addressed routing via `contextvars.ContextVar`. Cockpits declare a `session_id`; the bridge delivers replies to that cockpit only. Unset session broadcasts. Addressed frames to detached cockpits are dropped. Toggle with `JARVIS_ATTACH_SESSION_ROUTING` (default ON).
  - Markup mirroring from `serpent_flow`: send `_outcome.text` through `publish_markup` so clients render Rich markup to their own width/depth.
  - Moltbook live feed: `subscribe_molts()` + `_notify_subscribers()` deliver posts as they happen. Bodies are escaped in `_render_molt_line` and published as ambient.
  - Alias unmasking: modules can declare `__aliases__`. `moltbook_repl` adds `("molt",)`, so `/molt` (posting) is now distinct from `/moltbook` (reading). 59 → 60 verbs.

- **Bug Fixes**
  - Safe input sink arity: replace retry-on-TypeError with signature inspection decided at construction. Prevents double invocation and keeps one-arg sinks working.
  - Robust session scope: `session_scope` restores on exit and across awaits; session-to-socket bindings are cleared on disconnect.

<sup>Written for commit bac98a312de070c97ddf9eab75b79847ace84595. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

