### PR TITLE
fix(ov): non-destructive frame injection + the real cause of the suite crash

### DIFF
--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -89,10 +89,45 @@ def _render_markup_frame(text: str, console: Any = None) -> None:
         if canvas is not None:
             canvas.push_raw(safe)
             return
-        if console is not None:
-            console.print(safe, highlight=False)
-        else:
-            print(raw)
+        # NON-DESTRUCTIVE INJECTION.
+        #
+        # A Rich Console binds sys.stdout at CONSTRUCTION. `patch_stdout`
+        # swaps sys.stdout afterwards, so a console built before the prompt
+        # started writes straight past the proxy and paints over the line the
+        # operator is typing. `_print_line` already documents this — "a
+        # pre-bound Rich console would bypass the patch and corrupt the input
+        # line" — and then this branch did precisely that.
+        #
+        # It mattered little while markup carried only occasional op chrome.
+        # It matters now: every Moltbook post and all 60 REPL verb results
+        # arrive on this channel, unprompted, while the operator types.
+        #
+        # The fix is to bind LATE, not to build a redraw engine. A console
+        # constructed against the CURRENT sys.stdout is the patched proxy, so
+        # prompt_toolkit renders the line above the prompt and redraws the
+        # input buffer intact — its own machinery, reused rather than
+        # reimplemented. Width is inherited from the original console so the
+        # proxy (not a tty) does not collapse to 80 columns.
+        _emitted = False
+        try:
+            import sys as _sys
+
+            from rich.console import Console as _Console
+            _kw = {"file": _sys.stdout, "highlight": False}
+            _width = getattr(console, "width", None)
+            if isinstance(_width, int) and _width > 0:
+                _kw["width"] = _width
+            _late = _Console(**{k: v for k, v in _kw.items()
+                                if k != "highlight"})
+            _late.print(safe, highlight=False)
+            _emitted = True
+        except Exception:  # noqa: BLE001 — never lose the frame
+            _emitted = False
+        if not _emitted:
+            if console is not None:
+                console.print(safe, highlight=False)
+            else:
+                print(raw)
     except Exception:  # noqa: BLE001
         try:
             print(str(text))

--- a/scripts/check_no_stdin_guard.sh
+++ b/scripts/check_no_stdin_guard.sh
@@ -36,7 +36,29 @@ SCOPE=("docs/" "scripts/")
 EXEMPT=(
     "scripts/check_no_stdin_guard.sh"
     "docs/operations/battle_test_runbook.md"
+    # Archival memory: postmortems and topic records describe what HAPPENED,
+    # including the incidents this pattern caused. Rewriting history to
+    # satisfy a lint would destroy the evidence that motivated the ban.
+    "docs/memory_topics/"
+    # Generated HTML renders of docs already scanned in Markdown form. The
+    # source is checked; the artifact is a duplicate whose line breaks fall
+    # in different places, which is how a correctly-marked deprecation notice
+    # in the .md failed as an unmarked hit in the .html.
+    "*.html"
 )
+
+# The rule is USE vs MENTION, and a path allowlist cannot express that.
+#
+# Every document that correctly tells a reader "the old idiom is dead, use
+# --headless" contains the string it is warning about, so a path-based
+# exemption has to be edited on every such doc — which guarantees drift and
+# is exactly how this guard came to fail on OV_RESEARCH_PAPER_2026-04-16.md,
+# a file whose only offence was documenting the deprecation.
+#
+# A line that MARKS the pattern as retired is prose about the ban, not a
+# copy-pasteable command. Matching that intent keeps the guard honest without
+# a list to maintain.
+MENTION_MARKER='deprecated|replaces|replaced|instead of|no longer|banned|do not use|don'"'"'t use|superseded'
 
 # Build a `git grep` exclude list from the EXEMPT array.
 EXCLUDE_ARGS=()
@@ -45,25 +67,28 @@ for f in "${EXEMPT[@]}"; do
 done
 
 if command -v git > /dev/null 2>&1 && git rev-parse --git-dir > /dev/null 2>&1; then
-    if git grep -E "${PATTERN}" -- "${SCOPE[@]}" "${EXCLUDE_ARGS[@]}" 2>/dev/null; then
-        echo "" >&2
-        echo "ERROR: banned 'tail -f /dev/null | python' stdin-guard pattern" \
-             "found in docs/ or scripts/." >&2
-        echo "       Use --headless instead. See docs/operations/battle_test_runbook.md." >&2
-        exit 1
-    fi
+    HITS=$(git grep -nE "${PATTERN}" -- "${SCOPE[@]}" "${EXCLUDE_ARGS[@]}" 2>/dev/null || true)
 else
     # grep -r fallback: build --exclude= args from EXEMPT basenames
     EXCLUDE_GREP=()
     for f in "${EXEMPT[@]}"; do
         EXCLUDE_GREP+=("--exclude=$(basename "${f}")")
     done
-    if grep -rE "${PATTERN}" "${EXCLUDE_GREP[@]}" "${SCOPE[@]}" 2>/dev/null; then
-        echo "" >&2
-        echo "ERROR: banned 'tail -f /dev/null | python' stdin-guard pattern" \
-             "found in docs/ or scripts/." >&2
-        exit 1
-    fi
+    HITS=$(grep -rnE "${PATTERN}" "${EXCLUDE_GREP[@]}" "${SCOPE[@]}" 2>/dev/null || true)
+fi
+
+# Drop lines that document the ban rather than commit it.
+VIOLATIONS=$(printf '%s\n' "${HITS}" | grep -vEi "${MENTION_MARKER}" | sed '/^$/d' || true)
+
+if [ -n "${VIOLATIONS}" ]; then
+    printf '%s\n' "${VIOLATIONS}" >&2
+    echo "" >&2
+    echo "ERROR: banned 'tail -f /dev/null | python' stdin-guard pattern" \
+         "found in docs/ or scripts/." >&2
+    echo "       Use --headless instead. See docs/operations/battle_test_runbook.md." >&2
+    echo "       (Prose documenting the deprecation is allowed — mark it with" \
+         "'deprecated', 'replaces', 'instead of', etc.)" >&2
+    exit 1
 fi
 
 echo "OK: no banned stdin-guard patterns in docs/ or scripts/."

--- a/tests/battle_test/conftest.py
+++ b/tests/battle_test/conftest.py
@@ -1,0 +1,73 @@
+"""Keep a test-owned watchdog from killing the test runner.
+
+``BoundedShutdownWatchdog`` exists to hard-``os._exit(75)`` a harness whose
+shutdown has wedged. ``BattleTestHarness.__init__`` constructs one with the
+default ``exit_fn`` — i.e. the real ``os._exit`` — and it runs on a daemon
+thread. Ten test files build a harness; none of them stop it.
+
+So any test that arms a harness's watchdog leaves a live thread holding a
+deadline. Nothing fails at the time. Minutes later, mid-way through an
+unrelated file, the deadline elapses and ``os._exit(75)`` takes the entire
+pytest process down with it — no summary, no failure list, no traceback
+pointing anywhere near the test that armed it.
+
+That is what made ``pytest tests/battle_test/`` unrunnable as a directory
+while every file passed on its own, and why the crash appeared to move
+around: it lands wherever the clock happens to be.
+
+The fix is scoped to the DEFAULT. A test that explicitly passes ``exit_fn``
+is exercising the exit contract deliberately and is left exactly as it was;
+only the implicit ``os._exit`` — which no test ever asked for — is replaced
+with a recorder. Production is untouched: this lives in conftest.
+"""
+from __future__ import annotations
+
+from typing import Any, List, Tuple
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _never_hard_exit_the_test_runner(monkeypatch: pytest.MonkeyPatch):
+    """Neutralise implicit ``os._exit`` in shutdown watchdogs; stop threads."""
+    try:
+        from backend.core.ouroboros.battle_test import shutdown_watchdog as sw
+    except Exception:  # noqa: BLE001 — module absent, nothing to guard
+        yield
+        return
+
+    cls = getattr(sw, "BoundedShutdownWatchdog", None)
+    if cls is None:
+        yield
+        return
+
+    recorded: List[Tuple[Any, int]] = []
+    created: List[Any] = []
+    original_init = cls.__init__
+
+    def _patched_init(self: Any, *args: Any, **kwargs: Any) -> None:
+        if "exit_fn" not in kwargs:
+            # Not a silent no-op: record it, so a test that wants to assert
+            # "the watchdog fired" can still read it off the instance rather
+            # than discovering it as a dead test session.
+            kwargs["exit_fn"] = lambda code: recorded.append((self, code))
+        original_init(self, *args, **kwargs)
+        created.append(self)
+        try:
+            self._test_recorded_exits = recorded  # type: ignore[attr-defined]
+        except Exception:  # noqa: BLE001
+            pass
+
+    monkeypatch.setattr(cls, "__init__", _patched_init)
+    try:
+        yield
+    finally:
+        # Release the daemon threads. stop() is documented for exactly this:
+        # "only needed when a test constructs a watchdog and wants to release
+        # the thread before the test ends."
+        for wdg in created:
+            for method in ("disarm", "stop"):
+                try:
+                    getattr(wdg, method)()
+                except Exception:  # noqa: BLE001
+                    pass

--- a/tests/battle_test/test_ephemeral_streaming_spinner.py
+++ b/tests/battle_test/test_ephemeral_streaming_spinner.py
@@ -37,6 +37,33 @@ def _serpent_flow_src() -> str:
     ).read_text()
 
 
+def _code_only(block: str) -> str:
+    """Strip docstrings and comments — leave executable source.
+
+    A source-inspection pin must distinguish a USE from a MENTION. The
+    docstring of ``show_streaming_start`` explains that Slice 7 "retired the
+    Rich ``Live(Syntax)`` persistent region", so a naive substring check for
+    ``Live(`` fails on the very sentence documenting its removal."""
+    out, in_doc, delim = [], False, ""
+    for line in block.splitlines():
+        stripped = line.strip()
+        if in_doc:
+            if delim in stripped:
+                in_doc = False
+            continue
+        for d in ('"""', "'''"):
+            if stripped.startswith(d):
+                # A one-line docstring opens and closes on the same line.
+                if stripped.count(d) == 1:
+                    in_doc, delim = True, d
+                stripped = ""
+                break
+        if not stripped or stripped.startswith("#"):
+            continue
+        out.append(stripped.split("  #")[0])
+    return "\n".join(out)
+
+
 def _streaming_block() -> str:
     """Return source of show_streaming_start/token/end as one block."""
     src = _serpent_flow_src()
@@ -70,13 +97,30 @@ def test_streaming_block_no_live_syntax_construction():
     )
 
 
-def test_streaming_block_uses_console_status():
-    """The new ephemeral path uses ``self.console.status(...)`` (Rich
-    ephemeral spinner primitive) and stores the handle on
-    ``self._active_status``."""
-    block = _streaming_block()
-    assert "self.console.status(" in block
-    assert "self._active_status" in block
+def test_streaming_block_leaves_no_persistent_region():
+    """Streaming progress is EPHEMERAL — no fixed Rich region.
+
+    This pin used to assert ``self.console.status(`` and
+    ``self._active_status`` appeared in the block. Both were retired on
+    purpose: the D3 emit-tier work moved the streaming indicator to the
+    ``bottom_toolbar`` spinner, and ``_active_status`` is now declared once
+    with the comment "no longer driven by spinner code". The pin was
+    freezing a MECHANISM the codebase had deliberately superseded, and it
+    documented its own obsolescence in the source it was reading.
+
+    What Slice 7 actually guaranteed, and what still matters, is the
+    absence of the persistent ``Live(Syntax)`` region it replaced —
+    operators see WHAT was generated as a clean diff block, not as a
+    fixed-region token stream.
+    """
+    code = _code_only(_streaming_block())
+    assert "Live(" not in code, (
+        "a persistent Live region is back in the streaming path — Slice 7 "
+        "retired it in favour of ephemeral progress plus a diff block"
+    )
+    assert "Syntax(" not in code, (
+        "fixed-region syntax rendering is back in the streaming path"
+    )
 
 
 def test_streaming_block_emits_receipt_on_end():

--- a/tests/battle_test/test_gap_7_graduation_slice5.py
+++ b/tests/battle_test/test_gap_7_graduation_slice5.py
@@ -81,12 +81,21 @@ class _StubRegistry:
 
 
 def test_register_flags_seeds_six_specs():
-    """Three master flags + three sub-knobs = six FlagSpecs."""
+    """The Gap #7 flags are all registered.
+
+    Asserted as a SUBSET, not an exact set/count. The original pinned
+    ``count == 6`` and an exact name set, so every legitimately-added flag
+    broke it — the borderless op-block and TUI-pulse knobs from the later
+    cockpit arcs took it to 8 while nothing this test cares about changed.
+
+    A removal is still caught: the required names below must all be present.
+    An addition is the normal case and should not fail a graduation pin.
+    """
     reg = _StubRegistry()
     count = register_flags(reg)
-    assert count == 6
     names = {s.name for s in reg.registered}
-    assert names == {
+    assert count == len(reg.registered), "count disagrees with what was registered"
+    assert names >= {
         "JARVIS_PRESENTATION_RESTRAINT_ENABLED",
         "JARVIS_REPL_COMPLETION_ENABLED",
         "JARVIS_REPL_HISTORY_ENABLED",

--- a/tests/battle_test/test_harness_epic_graduation_pins_slice4.py
+++ b/tests/battle_test/test_harness_epic_graduation_pins_slice4.py
@@ -73,14 +73,26 @@ def test_shutdown_deadline_default_30s(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_intake_lock_stale_ttl_default_7200s_in_source():
-    """Source-grep: stale-TTL default is 7200 (2h) in the lock cleanup."""
+    """Stale-TTL default is 7200 (2h) in the lock cleanup.
+
+    Matched with whitespace tolerance rather than as a contiguous literal.
+    The previous form asserted ``'JARVIS_INTAKE_LOCK_STALE_TTL_S", "7200"'``
+    appeared verbatim, so reflowing the ``os.environ.get(...)`` call across
+    three lines broke the pin while the flag, the default and the behaviour
+    were all completely unchanged. A pin that fails on line breaks is
+    measuring the formatter, not the invariant.
+    """
+    import re
+
     src = Path(
         "backend/core/ouroboros/governance/intake/unified_intake_router.py"
     ).read_text()
-    # Used in the staleness check default fallback
-    assert 'JARVIS_INTAKE_LOCK_STALE_TTL_S", "7200"' in src
-    # Default 7200s
-    assert "_stale_ttl = 7200.0" in src
+    assert re.search(
+        r'"JARVIS_INTAKE_LOCK_STALE_TTL_S"\s*,\s*"7200"', src,
+    ), "the stale-TTL env default is no longer 7200"
+    assert re.search(r"_stale_ttl\s*=\s*7200\.0", src), (
+        "the stale-TTL parse fallback is no longer 7200.0"
+    )
 
 
 def test_exit_code_harness_wedged_constant():
@@ -292,26 +304,45 @@ def test_slice_3_pin_canonical_pgrep_consistent_runbook_vs_launcher():
 
 
 def test_slice_3_pin_codebase_clean_of_banned_pattern():
-    """Slice 3 — no banned 'tail -f /dev/null | python' pattern outside
-    the documented exemptions (guard script + runbook)."""
-    EXEMPT_PATHS = {
-        "scripts/check_no_stdin_guard.sh",
-        "docs/operations/battle_test_runbook.md",
-    }
-    for scope in (Path("docs"), Path("scripts")):
-        for f in scope.rglob("*"):
-            if not f.is_file():
-                continue
-            relpath = str(f.as_posix())
-            if relpath in EXEMPT_PATHS:
-                continue
-            try:
-                content = f.read_text(errors="ignore")
-            except (OSError, UnicodeDecodeError):
-                continue
-            assert "tail -f /dev/null | python" not in content, (
-                f"banned pattern found in {f} — use --headless instead"
-            )
+    """Slice 3 — no banned 'tail -f /dev/null | python' pattern in the
+    prescriptive surfaces an operator copy-pastes from.
+
+    DELEGATES to the guard script rather than re-implementing the scan.
+    This test used to carry its own copy of the rule with its own hardcoded
+    exemption list, and the two drifted: the script and the test disagreed
+    about whether a research paper documenting the deprecation was a
+    violation. One invariant, one implementation — the script is the
+    authority because CI runs it.
+    """
+    result = subprocess.run(
+        ["bash", "scripts/check_no_stdin_guard.sh"],
+        capture_output=True, text=True, timeout=60,
+    )
+    assert result.returncode == 0, (
+        f"banned stdin-guard pattern present — use --headless instead.\n"
+        f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+    )
+
+
+def test_slice_3_guard_still_detects_a_real_use(tmp_path):
+    """The guard must not have been softened into uselessness.
+
+    A rule that exempts its way to green is worse than no rule, so this
+    proves the mention-marker still lets an actual runnable command through
+    to a failure."""
+    marked = "The deprecated `tail -f /dev/null | python3 ...` idiom is gone."
+    unmarked = "    tail -f /dev/null | python3 scripts/ouroboros_battle_test.py"
+
+    import re
+    src = Path("scripts/check_no_stdin_guard.sh").read_text()
+    m = re.search(r"MENTION_MARKER='([^']*(?:'\"'\"'[^']*)*)'", src)
+    assert m, "guard no longer declares a MENTION_MARKER"
+    marker = m.group(1).replace("'\"'\"'", "'")
+
+    assert re.search(marker, marked, re.I), "a documented mention would fail"
+    assert not re.search(marker, unmarked, re.I), (
+        "a bare runnable command is being treated as documentation"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/battle_test/test_harness_partial_shutdown.py
+++ b/tests/battle_test/test_harness_partial_shutdown.py
@@ -31,12 +31,32 @@ def tmp_harness(tmp_path: Path) -> Iterator[BattleTestHarness]:
     """Build a harness rooted in tmp_path. Clean up its atexit handler
     after the test so pytest's own shutdown doesn't fire 100 fallbacks
     across a suite run."""
+    # Make tmp_path a PLAUSIBLE repo root before building the config.
+    #
+    # HarnessConfig.__post_init__ re-anchors repo_path to the real .git root
+    # unless the path "carries the canonical source tree"
+    # (_repo_root_plausible). A bare tmp_path does not, so the config silently
+    # redirected to the developer's actual repo: this fixture wrote its
+    # summary into tmp_path and LastSessionSummary then read the REAL
+    # .ouroboros/sessions/, returning whichever live session sorted highest
+    # (observed: bt-iso-1783997989). The isolation was theatre, and the test
+    # only started failing once that directory accumulated real sessions.
+    #
+    # The re-anchor already documents the escape hatch — "an explicit,
+    # already-plausible repo root (e.g. a worktree or a hermetic fixture) is
+    # honored verbatim". This makes the fixture hermetic enough to qualify.
+    (tmp_path / "backend" / "core" / "ouroboros").mkdir(parents=True, exist_ok=True)
+
     session_dir = tmp_path / ".ouroboros" / "sessions" / "bt-unit-test"
     config = HarnessConfig(
         repo_path=tmp_path,
         cost_cap_usd=0.05,
         idle_timeout_s=30.0,
         session_dir=session_dir,
+    )
+    assert config.repo_path == tmp_path.resolve(), (
+        "the harness re-anchored away from the fixture root — this test is "
+        "not isolated and will read the developer's live sessions"
     )
     harness = BattleTestHarness(config)
     yield harness

--- a/tests/cli/test_ov_ui_multiplexing.py
+++ b/tests/cli/test_ov_ui_multiplexing.py
@@ -1,0 +1,160 @@
+"""Incoming frames must not paint over the operator's input line.
+
+A Rich ``Console`` binds ``sys.stdout`` at CONSTRUCTION. ``patch_stdout``
+swaps ``sys.stdout`` afterwards, so a console built before the prompt started
+writes straight past the proxy and over whatever the operator is typing.
+
+``_print_line`` already knew this — its comment reads "a pre-bound Rich
+console would bypass the patch and corrupt the input line" — and used builtin
+``print()``, which resolves ``sys.stdout`` dynamically. ``_render_markup_frame``
+did the opposite.
+
+That was survivable while markup carried occasional op chrome. It is not now:
+the Omni-Channel bus put all 60 REPL verb results on that channel, and the
+Moltbook Pub/Sub puts unprompted posts on it too — arriving precisely while
+the operator is mid-command.
+"""
+from __future__ import annotations
+
+import contextlib
+import io
+from typing import Any
+
+import pytest
+
+from backend.core.ouroboros.cli import ov
+
+
+class _PatchedStdout(io.StringIO):
+    """Stands in for prompt_toolkit's patch_stdout proxy.
+
+    The real proxy queues writes and repaints the prompt around them. What
+    matters for this test is identity: writes must land HERE, because that is
+    what gives prompt_toolkit the chance to redraw. Anything reaching the
+    original stdout has bypassed the multiplexer."""
+
+
+class _PreBoundConsole:
+    """A Rich-console stand-in captured BEFORE the prompt started."""
+
+    width = 100
+
+    def __init__(self) -> None:
+        self.printed: list = []
+
+    def print(self, *args: Any, **kwargs: Any) -> None:
+        self.printed.append(args[0] if args else "")
+
+
+@contextlib.contextmanager
+def swapped_stdout():
+    """Swap sys.stdout for the duration of the call.
+
+    `contextlib.redirect_stdout`, not `monkeypatch.setattr(sys, "stdout")` —
+    pytest's own capture also owns sys.stdout, and a monkeypatch of it is
+    undone underneath the test, which made these assertions read the real
+    stdout and fail against a fix that was already correct."""
+    proxy = _PatchedStdout()
+    with contextlib.redirect_stdout(proxy):
+        yield proxy
+
+
+# --------------------------------------------------------------------------
+# 1. the requirement — background frames go through the active proxy
+# --------------------------------------------------------------------------
+
+def test_markup_frame_writes_through_the_patched_stdout() -> None:
+    """A Moltbook post arriving mid-typing must reach the proxy, which is what
+    lets prompt_toolkit print it ABOVE the prompt and redraw the buffer."""
+    pre_bound = _PreBoundConsole()
+
+    with swapped_stdout() as proxy:
+        ov._render_markup_frame(
+            "  [bold]⏺ 🐍 @cassandra[/bold] [dim]· distress[/dim]", pre_bound,
+        )
+    out = proxy.getvalue()
+    assert "cassandra" in out, (
+        "the frame never reached the patched stdout — it bypassed the "
+        "multiplexer and would have painted over the input line"
+    )
+    assert pre_bound.printed == [], (
+        "the frame went to the console captured before patch_stdout, which "
+        "writes past the proxy and corrupts the operator's prompt"
+    )
+
+
+def test_plain_line_frame_also_respects_the_proxy() -> None:
+    """The untyped `line` channel already did this correctly — pin it so a
+    future refactor cannot regress it to a bound console."""
+    import inspect
+
+    src = inspect.getsource(ov)
+    assert "print(text)" in src, (
+        "the line-frame path no longer uses builtin print(), which is what "
+        "resolves sys.stdout dynamically under patch_stdout"
+    )
+
+
+def test_styling_survives_the_late_binding() -> None:
+    """Late binding must not cost fidelity — markup still renders as markup,
+    not as literal tag text."""
+    with swapped_stdout() as proxy:
+        ov._render_markup_frame("[bold]Moltbook[/bold]", _PreBoundConsole())
+    out = proxy.getvalue()
+    assert "Moltbook" in out
+    assert "[bold]" not in out, "markup tags leaked through as literal text"
+
+
+def test_malformed_markup_is_escaped_not_dropped() -> None:
+    """Fail-soft is part of the contract: a frame that will not parse renders
+    inert rather than vanishing or crashing the canvas."""
+    with swapped_stdout() as proxy:
+        ov._render_markup_frame("[not-a-tag unclosed", _PreBoundConsole())
+    assert "not-a-tag" in proxy.getvalue()
+
+
+def test_width_is_inherited_not_collapsed() -> None:
+    """The proxy is not a tty, so a freshly-built console would fall back to
+    80 columns and wrap differently from every other line on screen."""
+    pre_bound = _PreBoundConsole()
+    pre_bound.width = 120
+    with swapped_stdout() as proxy:
+        ov._render_markup_frame("x" * 110, pre_bound)
+    out = proxy.getvalue()
+    assert "x" * 110 in out.replace("\n", ""), (
+        "output wrapped early — the inherited width was ignored"
+    )
+
+
+def test_render_never_raises_even_with_a_hostile_console() -> None:
+    """This sits on a background receive path; an exception here would kill
+    the reader task and silently detach the cockpit."""
+    class _Hostile:
+        width = "not-an-int"
+
+        def print(self, *a: Any, **k: Any) -> None:
+            raise RuntimeError("console on fire")
+
+    ov._render_markup_frame("[bold]hello[/bold]", _Hostile())
+
+
+def test_canvas_path_still_wins_when_bipartite_is_active(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The Bipartite cockpit owns its own region; when a canvas is mounted the
+    frame belongs to it, not to stdout."""
+    pushed: list = []
+
+    class _Canvas:
+        def push_raw(self, s: str) -> None:
+            pushed.append(s)
+
+    import backend.core.ouroboros.battle_test.bipartite_layout as bl
+    monkeypatch.setattr(bl, "get_active_canvas", lambda: _Canvas())
+
+    with swapped_stdout() as proxy:
+        ov._render_markup_frame("[bold]via canvas[/bold]", _PreBoundConsole())
+    assert pushed and "via canvas" in pushed[0]
+    assert proxy.getvalue() == "", (
+        "frame was written to stdout as well as the canvas — duplicated"
+    )


### PR DESCRIPTION
## UI multiplexing

A Rich `Console` binds `sys.stdout` at **construction**. `patch_stdout` swaps `sys.stdout` afterwards, so a console built before the prompt started writes past the proxy and paints over the line the operator is typing.

`_print_line` already knew this — its comment reads *"a pre-bound Rich console would bypass the patch and corrupt the input line"* — and uses builtin `print()`, which resolves `sys.stdout` dynamically. **`_render_markup_frame` did the exact thing that comment warns against.**

Survivable while markup carried occasional op chrome. Not survivable now: #70113 put all 60 REPL verb results on that channel, and the Moltbook Pub/Sub puts unprompted posts on it — arriving while the operator is mid-command.

Fixed by **binding late, not by building a redraw engine**: a Console constructed against the *current* `sys.stdout` **is** the patched proxy, so prompt_toolkit prints above the prompt and redraws the buffer with its own machinery. Width is inherited so the proxy (not a tty) doesn't collapse to 80 columns. Canvas path still wins when Bipartite is mounted; fail-soft fallback retained.

## The suite crash was never a timeout

`pytest tests/battle_test/` died at ~40% while every file passed alone. **Exit code 75 = `EXIT_CODE_HARNESS_WEDGED`.**

`BattleTestHarness.__init__` (`harness.py:748`) constructs a `BoundedShutdownWatchdog` with the **default `exit_fn` — the real `os._exit`** — on a daemon thread. Ten test files build a harness; none stop it. Any test that arms one leaves a live thread holding a deadline. Minutes later, mid-way through an unrelated file, `os._exit(75)` takes the whole pytest process down: no summary, no failure list, and the apparent crash site moves with the clock.

`tests/battle_test/conftest.py` substitutes a recorder for the **implicit** `exit_fn` only — tests that pass one explicitly are exercising the exit contract deliberately and are untouched — and stops every watchdog at teardown.

**Result: the directory completes.** 2310 passed / 23 failed in 144 s, where it previously never reached 40 %.

## Test rot — 5 fixed, each at root cause

| Pin | Root cause |
|---|---|
| banned-pattern guard | rule is **use vs mention**, mechanism was a path allowlist → every doc documenting the deprecation broke it. Now marker-based; the duplicate pytest scan **deleted** and delegated to the script (the two copies had already drifted into disagreeing) |
| intake-lock TTL | asserted a contiguous source literal → reflowing the call across 3 lines broke a pin whose flag, default and behaviour were unchanged |
| partial-summary isolation | `HarnessConfig` re-anchors `repo_path` to the real `.git` root unless the path carries a source tree — so the fixture wrote to tmp and read the **developer's live sessions**. The isolation was theatre |
| gap-7 flag pin | hardcoded `count == 6` → two later cockpit flags broke it. Now a subset assertion: removals still caught, additions are normal |
| streaming spinner | froze a mechanism the codebase documented as superseded (`_active_status` literally says "no longer driven by spinner code"). Re-pointed at the durable invariant — and needed a docstring stripper, because the naive check tripped on the sentence explaining the removal. Same use-vs-mention trap, one file over |

## Honest status

**Not 100 % green.** 23 failures remain across 12 files — all pre-existing, all previously **invisible** because the run never reached them. Verified against `a9dd810c02` in a clean worktree. The crash is fixed and they are now diagnosable; clearing them is separate work.

7 new UI tests (4 fail against the pre-fix renderer). `tests/cli`: 281 passed, 2 pre-existing failures, likewise baseline-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes non-destructive UI frame injection by late-binding a `rich.Console` so background frames render above the prompt without corrupting input. Also stops intermittent suite exits by neutralizing the harness watchdog in tests and cleans up brittle test pins.

- **Bug Fixes**
  - Route markup frames through the active `patch_stdout` proxy by constructing a fresh `rich.Console` with inherited width; canvas path still wins; fail-soft retained.
  - Prevent suite-wide hard exits by replacing the implicit `os._exit` in `BoundedShutdownWatchdog` during tests and stopping watchdog threads at teardown.
  - Update `scripts/check_no_stdin_guard.sh` to a mention-marker rule and exclude archives/`*.html`; test now delegates to the script.

- **Tests**
  - Add UI multiplexing tests verifying proxy routing, markup fidelity, width inheritance, fail-soft, and canvas precedence.
  - Fix brittle pins: whitespace-tolerant intake-lock TTL; hermetic harness repo path in fixture; Gap #7 flags asserted as a subset; streaming path asserts no persistent `Live(Syntax)` using code-only parsing.
  - Suite now runs end-to-end; remaining failures are pre-existing and now visible.

<sup>Written for commit 565fa9312c74b398756d5e6f04e8cc91bfa5cd34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

