### PR TITLE
feat(ov): D1 — the ambient deck, with severity deciding who gets a slot

### DIFF
--- a/backend/core/ouroboros/battle_test/ambient_deck.py
+++ b/backend/core/ouroboros/battle_test/ambient_deck.py
@@ -1,0 +1,363 @@
+"""The ambient deck — what the organism is doing, below the prompt.
+
+Addressed output (you typed ``/moltbook``) belongs in the scrollback: you
+asked for it, you keep it. Ambient output — a worker spawning, a provider
+failing over, a persona arguing with you — belongs in a live region that
+redraws in place and ages out. That distinction already exists on the wire
+as of the Omni-Channel bus; this is the surface that consumes it.
+
+Why not a deque
+---------------
+A FIFO ring treats every event as equally worth a slot, so the loudest
+producer wins. The agora posts on its own initiative and never stops, which
+means a five-row FIFO is a five-row feed of personas — and the row that said
+"DoubleWord failed over" is gone in under a second. That is not a cosmetic
+problem: it is a monitoring surface silently losing the only line that
+mattered, to a joke.
+
+So slots are allocated by SEVERITY, not arrival:
+
+  * ``FATAL`` / ``WARN`` are OPERATIONAL. They pin. Nothing of lower severity
+    can evict them, and they leave only by explicit resolution or their own
+    TTL — an alert that scrolls itself away has not been seen, it has been
+    lost.
+  * ``INFO`` fills what remains, newest first.
+  * ``SOCIAL`` gets whatever is left, and when there is nothing left it
+    COMPACTS: the whole agora collapses to one rolling line carrying a count.
+    It never takes a slot from an operational row, and it is never silently
+    discarded either — the count is the evidence that something happened.
+
+Keys, not rows
+--------------
+Entries are keyed. A provider flapping publishes the same key repeatedly and
+updates one row rather than filling the deck with itself, which is the other
+way a chatty producer takes the screen.
+"""
+from __future__ import annotations
+
+import enum
+import os
+import time
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List, Optional, Tuple
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+
+class Severity(enum.IntEnum):
+    """Ordered so comparison is meaningful — higher wins a slot."""
+
+    SOCIAL = 0
+    INFO = 1
+    WARN = 2
+    FATAL = 3
+
+
+#: Severities that pin. These describe the ORGANISM's health, and the
+#: operator's decision to keep working depends on seeing them.
+OPERATIONAL: Tuple[Severity, ...] = (Severity.FATAL, Severity.WARN)
+
+
+def deck_enabled() -> bool:
+    """``JARVIS_AMBIENT_DECK`` (default ON). OFF returns the single-line
+    toolbar, which is the pre-deck behaviour and the only honest A/B."""
+    return os.environ.get(
+        "JARVIS_AMBIENT_DECK", "1",
+    ).strip().lower() in _TRUTHY
+
+
+def _env_int(name: str, default: int, lo: int, hi: int) -> int:
+    try:
+        return max(lo, min(hi, int(os.environ.get(name, "").strip() or default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _env_float(name: str, default: float, lo: float, hi: float) -> float:
+    try:
+        return max(lo, min(hi, float(os.environ.get(name, "").strip() or default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def max_rows() -> int:
+    """Deck height, excluding the pulse line the toolbar always shows."""
+    return _env_int("JARVIS_AMBIENT_DECK_ROWS", 4, 1, 20)
+
+
+def social_ttl_s() -> float:
+    return _env_float("JARVIS_AMBIENT_DECK_SOCIAL_TTL_S", 25.0, 1.0, 3600.0)
+
+
+def info_ttl_s() -> float:
+    return _env_float("JARVIS_AMBIENT_DECK_INFO_TTL_S", 60.0, 1.0, 3600.0)
+
+
+def operational_ttl_s() -> float:
+    """Deliberately long. An operational alert is not noise that should fade
+    while the operator is reading their screen; it is state that stopped being
+    true or was acknowledged."""
+    return _env_float("JARVIS_AMBIENT_DECK_OP_TTL_S", 900.0, 1.0, 86400.0)
+
+
+@dataclass
+class DeckEntry:
+    key: str
+    text: str
+    severity: Severity
+    ts: float
+    hits: int = 1
+
+    @property
+    def pinned(self) -> bool:
+        return self.severity in OPERATIONAL
+
+
+@dataclass
+class _Social:
+    """The compaction bucket. Social events that could not get a slot are
+    counted here rather than dropped, so the deck can always say how much it
+    is not showing."""
+
+    hidden: int = 0
+    last_text: str = ""
+    last_ts: float = 0.0
+    authors: List[str] = field(default_factory=list)
+
+    def note(self, text: str, author: str, now: float) -> None:
+        self.hidden += 1
+        self.last_text = text
+        self.last_ts = now
+        if author and author not in self.authors:
+            self.authors.append(author)
+            del self.authors[:-3]
+
+    def clear(self) -> None:
+        self.hidden = 0
+        self.authors.clear()
+
+
+class DeckManager:
+    """Severity-ordered ambient rows for the bottom toolbar.
+
+    Pure logic: no prompt_toolkit, no Rich, no I/O. The toolbar asks it for
+    lines; tests ask it the same question. NEVER raises from ``push`` or
+    ``render`` — this sits on a background receive path and on the render
+    hook, and an exception in either detaches the cockpit or blanks it.
+    """
+
+    def __init__(
+        self,
+        *,
+        clock: Callable[[], float] = time.monotonic,
+        rows: Optional[int] = None,
+    ) -> None:
+        self._clock = clock
+        self._rows = rows
+        self._entries: Dict[str, DeckEntry] = {}
+        self._social = _Social()
+        self.dropped_social = 0
+
+    # -- ingest ----------------------------------------------------------
+
+    def push(
+        self,
+        text: str,
+        *,
+        severity: Severity = Severity.INFO,
+        key: Optional[str] = None,
+        author: str = "",
+    ) -> None:
+        """Offer one ambient event to the deck. NEVER raises."""
+        try:
+            text = str(text or "").strip()
+            if not text:
+                return
+            now = self._clock()
+            self._expire(now)
+
+            if severity is Severity.SOCIAL:
+                self._push_social(text, author, now)
+                return
+
+            k = key or f"{severity.name}:{text[:60]}"
+            existing = self._entries.get(k)
+            if existing is not None:
+                existing.text = text
+                existing.ts = now
+                existing.hits += 1
+                existing.severity = max(existing.severity, severity)
+                return
+            self._entries[k] = DeckEntry(
+                key=k, text=text, severity=severity, ts=now,
+            )
+            self._evict_if_needed()
+        except Exception:  # noqa: BLE001 — the deck must never break the UI
+            pass
+
+    def _push_social(self, text: str, author: str, now: float) -> None:
+        """Social gets a real row only if one is free AFTER operational and
+        info rows have taken theirs. Otherwise it compacts."""
+        limit = self._rows if self._rows is not None else max_rows()
+        non_social = [e for e in self._entries.values()
+                      if e.severity is not Severity.SOCIAL]
+        # One slot is reserved for the compaction line whenever anything is
+        # hidden, so the operator always learns that chatter exists.
+        if len(non_social) >= limit:
+            self._social.note(text, author, now)
+            self.dropped_social += 1
+            return
+        # A single social row, replaced in place: the agora is ONE voice on
+        # this surface no matter how many residents are talking. Without this
+        # a lively conversation still evicts info rows one by one.
+        self._entries["__social__"] = DeckEntry(
+            key="__social__", text=text, severity=Severity.SOCIAL, ts=now,
+            hits=self._entries.get("__social__", DeckEntry(
+                "", "", Severity.SOCIAL, now, 0)).hits + 1,
+        )
+        if author:
+            self._social.authors.append(author)
+            del self._social.authors[:-3]
+        self._evict_if_needed()
+
+    def resolve(self, key: str) -> bool:
+        """Clear a pinned row because the condition ended. Returns True if
+        something was removed. This is the intended exit for an operational
+        alert — TTL is the backstop, not the mechanism."""
+        try:
+            return self._entries.pop(key, None) is not None
+        except Exception:  # noqa: BLE001
+            return False
+
+    # -- eviction --------------------------------------------------------
+
+    def _expire(self, now: float) -> None:
+        for k, e in list(self._entries.items()):
+            ttl = (
+                operational_ttl_s() if e.pinned
+                else social_ttl_s() if e.severity is Severity.SOCIAL
+                else info_ttl_s()
+            )
+            if now - e.ts > ttl:
+                del self._entries[k]
+        if self._social.hidden and now - self._social.last_ts > social_ttl_s():
+            self._social.clear()
+
+    def _evict_if_needed(self) -> None:
+        """Drop the least important row when over capacity.
+
+        Ordering is (severity, recency) ASCENDING, so the victim is the least
+        severe and, among equals, the oldest. A pinned row is never the victim
+        while any unpinned row exists — that is the whole point."""
+        limit = self._rows if self._rows is not None else max_rows()
+        if len(self._entries) <= limit:
+            return
+        ordered = sorted(
+            self._entries.values(), key=lambda e: (int(e.severity), e.ts),
+        )
+        for victim in ordered:
+            if len(self._entries) <= limit:
+                break
+            if victim.severity is Severity.SOCIAL:
+                self._social.note(victim.text, "", victim.ts)
+                self.dropped_social += 1
+            self._entries.pop(victim.key, None)
+
+    # -- render ----------------------------------------------------------
+
+    def rows(self) -> List[Tuple[Severity, str]]:
+        """Deck contents, most important first. NEVER raises."""
+        try:
+            now = self._clock()
+            self._expire(now)
+            limit = self._rows if self._rows is not None else max_rows()
+            ordered = sorted(
+                self._entries.values(),
+                key=lambda e: (-int(e.severity), -e.ts),
+            )
+            out: List[Tuple[Severity, str]] = [
+                (e.severity, e.text) for e in ordered[:limit]
+            ]
+            if self._social.hidden:
+                line = self._compaction_line()
+                if len(out) < limit:
+                    out.append((Severity.SOCIAL, line))
+                else:
+                    # Every slot is operational. Rather than evict one, the
+                    # count rides on the least-important visible row so the
+                    # operator still learns chatter is being withheld.
+                    sev, last = out[-1]
+                    if sev is not Severity.SOCIAL:
+                        out[-1] = (sev, f"{last}   [dim]· {line}[/dim]")
+            return out
+        except Exception:  # noqa: BLE001
+            return []
+
+    def _compaction_line(self) -> str:
+        who = ", ".join(self._social.authors[-2:])
+        who = f" {who}" if who else ""
+        return f"🐍 agora{who} ({self._social.hidden} hidden)"
+
+    # -- introspection (for /deck and tests) ------------------------------
+
+    @property
+    def hidden_social(self) -> int:
+        return self._social.hidden
+
+    def pinned_keys(self) -> List[str]:
+        return [e.key for e in self._entries.values() if e.pinned]
+
+
+#: Glyph per severity — the deck's whole visual vocabulary.
+GLYPHS: Dict[Severity, str] = {
+    Severity.FATAL: "✖",
+    Severity.WARN: "▲",
+    Severity.INFO: "▸",
+    Severity.SOCIAL: "·",
+}
+
+#: Rich style per severity. Named rather than literal so the theme owns them.
+STYLES: Dict[Severity, str] = {
+    Severity.FATAL: "bold red",
+    Severity.WARN: "yellow",
+    Severity.INFO: "cyan",
+    Severity.SOCIAL: "dim",
+}
+
+
+def classify(text: str, *, kind: str = "") -> Tuple[Severity, str]:
+    """Best-effort severity + key for an untyped ambient line.
+
+    The daemon does not yet tag frames with severity, so the client infers it.
+    That is a stopgap and it is marked as one: when the typed event spine
+    carries severity, this function should be deleted rather than tuned.
+    NEVER raises."""
+    try:
+        low = str(text or "").lower()
+        k = str(kind or "").lower()
+        if k == "molt_post" or "🐍" in str(text):
+            return Severity.SOCIAL, "__social__"
+        for token in ("fatal", "exhausted", "cannot continue", "aborted",
+                      "circuit tripped", "wedged"):
+            if token in low:
+                return Severity.FATAL, f"fatal:{token}"
+        for token in ("failover", "degraded", "warning", "retry", "throttl",
+                      "quarantin", "budget", "stale", "timeout"):
+            if token in low:
+                return Severity.WARN, f"warn:{token}"
+        return Severity.INFO, ""
+    except Exception:  # noqa: BLE001
+        return Severity.INFO, ""
+
+
+__all__ = [
+    "GLYPHS",
+    "OPERATIONAL",
+    "STYLES",
+    "DeckEntry",
+    "DeckManager",
+    "Severity",
+    "classify",
+    "deck_enabled",
+    "max_rows",
+]

--- a/backend/core/ouroboros/battle_test/cockpit_attach.py
+++ b/backend/core/ouroboros/battle_test/cockpit_attach.py
@@ -531,6 +531,17 @@ class CockpitAttachBridge:
         else:
             writers = list(self._clients)
 
+        # Tell the client WHICH kind of output this is. It already knows here
+        # — the ContextVar decided it one line up — and the client cannot
+        # re-derive it, because "was this answering my command?" is not a
+        # property of the text. Addressed output belongs in the scrollback the
+        # operator asked for; ambient output belongs in the live deck that
+        # ages out. Without the marker the client would have to guess, and
+        # guessing puts provider failovers in the transcript and command
+        # answers in a region that erases them.
+        msg = dict(msg)
+        msg["addressed"] = target is not None
+
         data = (json.dumps(msg, separators=(",", ":")) + "\n").encode()
         for w in writers:
             try:
@@ -811,7 +822,18 @@ class CockpitAttachClient:
                     # Daemon-composed styled line. No on_markup handler →
                     # degrade to on_line (conservative clients escape it).
                     cb = self._on_markup or self._on_line
-                    self._safe_cb_text(cb, str(frame.get("text", "")))
+                    # Forward the addressed/ambient marker to sinks that want
+                    # it, using the same arity inspection the input path uses
+                    # rather than a second convention. A one-argument sink —
+                    # every pre-deck client — is called exactly as before.
+                    if _accepts_two_positional(cb):
+                        try:
+                            cb(str(frame.get("text", "")),
+                               bool(frame.get("addressed", False)))
+                        except Exception:  # noqa: BLE001
+                            pass
+                    else:
+                        self._safe_cb_text(cb, str(frame.get("text", "")))
                 elif ftype == "telemetry":
                     try:
                         self._on_telemetry(dict(frame))

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -383,9 +383,51 @@ class AttachUI:
         # time-driven glyph (the pt refresh_interval animates it free).
         self._heartbeat: Any = None
         self._heartbeat_arrived: float = 0.0
+        # The ambient deck: severity-ordered rows below the pulse. Ambient
+        # frames land here instead of the scrollback, so a chatty agora
+        # cannot bury the session it is commenting on.
+        try:
+            from backend.core.ouroboros.battle_test.ambient_deck import (
+                DeckManager,
+            )
+            self.deck: Any = DeckManager()
+        except Exception:  # noqa: BLE001 — a deckless cockpit still works
+            self.deck = None
 
     def bind_app(self, app: Any) -> None:
         self._app_ref = app
+
+    def on_ambient(self, text: str, *, kind: str = "") -> None:
+        """One ambient frame → the deck, then repaint. NEVER raises."""
+        try:
+            if self.deck is None:
+                return
+            from backend.core.ouroboros.battle_test.ambient_deck import (
+                classify,
+            )
+            severity, key = classify(text, kind=kind)
+            author = ""
+            if "@" in text:
+                for tok in text.split():
+                    if tok.startswith("@"):
+                        author = tok.strip("[]")
+                        break
+            self.deck.push(
+                text, severity=severity, key=key or None, author=author,
+            )
+            self._invalidate()
+        except Exception:  # noqa: BLE001
+            pass
+
+    def _invalidate(self) -> None:
+        """Ask prompt_toolkit to repaint. Its own scheduler decides when, so
+        this never touches the operator's keystroke buffer."""
+        try:
+            app = self._app_ref
+            if app is not None:
+                app.invalidate()
+        except Exception:  # noqa: BLE001
+            pass
 
     def prompt(self) -> str:
         return self._PROMPTS.get(self.audio_state, "ov › ")
@@ -408,10 +450,35 @@ class AttachUI:
                 self._heartbeat, arrival_mono=self._heartbeat_arrived,
             )
             if pulse:
-                return f"{pulse}{audio} · 'detach' to leave"
+                return self._with_deck(f"{pulse}{audio} · 'detach' to leave")
         except Exception:
             pass
-        return f" ov attach — organism live{audio} · 'detach' to leave"
+        return self._with_deck(
+            f" ov attach — organism live{audio} · 'detach' to leave"
+        )
+
+    def _with_deck(self, pulse_line: str) -> str:
+        """Pulse on top, ambient rows beneath.
+
+        Rendered into the SAME bottom_toolbar prompt_toolkit already repaints
+        — no second render loop, no Live region competing for the terminal.
+        The toolbar simply grows to the number of lines returned."""
+        try:
+            from backend.core.ouroboros.battle_test.ambient_deck import (
+                GLYPHS,
+                deck_enabled,
+            )
+            if self.deck is None or not deck_enabled():
+                return pulse_line
+            rows = self.deck.rows()
+            if not rows:
+                return pulse_line
+            lines = [pulse_line]
+            for severity, text in rows:
+                lines.append(f"  {GLYPHS.get(severity, '·')} {text}")
+            return "\n".join(lines)
+        except Exception:  # noqa: BLE001
+            return pulse_line
 
     def on_telemetry(self, frame: Any) -> None:
         """Telemetry lane landing point — retain heartbeat frames for
@@ -1176,9 +1243,27 @@ def run_attach(console: Any) -> int:
                 pass
             hydrated.set()
 
+        def _markup_sink(text: str, addressed: bool = False) -> None:
+            """THE ambient/addressed split, at the one place both arrive.
+
+            Addressed — the daemon answering a command this cockpit sent —
+            goes to the scrollback: the operator asked for it and expects to
+            scroll back to it. Ambient — a worker spawning, a provider
+            failing over, the agora talking — goes to the deck, which is
+            severity-ordered and ages out.
+
+            Routed on the daemon's marker rather than inferred from the text,
+            because "was this answering my command?" is not a property of the
+            characters. The daemon knows; it decided when it addressed the
+            frame."""
+            if addressed:
+                _render_markup_frame(text, console)
+                return
+            ui.on_ambient(text)
+
         client = CockpitAttachClient(
             on_hydration=_on_hydration, on_line=_print_line,
-            on_markup=lambda t: _render_markup_frame(t, console),
+            on_markup=_markup_sink,
             on_telemetry=ui.on_telemetry,
             on_audio_state=ui.on_audio_state,
         )

--- a/tests/battle_test/test_ambient_deck.py
+++ b/tests/battle_test/test_ambient_deck.py
@@ -1,0 +1,242 @@
+"""The ambient deck — severity wins slots, not arrival order.
+
+A FIFO ring treats every event as equally worth a slot, so the loudest
+producer takes the screen. The agora posts on its own initiative and never
+stops; a five-row FIFO becomes five rows of personas, and the line that said
+"DoubleWord failed over" is gone in under a second. That is a monitoring
+surface losing the only row that mattered, to a joke.
+
+These tests pin the three properties that prevent it: operational rows pin,
+social compacts rather than evicting, and the addressed/ambient split sends
+command answers to the scrollback while ambient chatter goes to the deck.
+"""
+from __future__ import annotations
+
+from typing import List
+
+import pytest
+
+from backend.core.ouroboros.battle_test.ambient_deck import (
+    DeckManager,
+    Severity,
+    classify,
+)
+
+
+class _Clock:
+    def __init__(self) -> None:
+        self.t = 1000.0
+
+    def __call__(self) -> float:
+        return self.t
+
+
+def _texts(deck: DeckManager) -> List[str]:
+    return [t for _s, t in deck.rows()]
+
+
+# --------------------------------------------------------------------------
+# 1. the DOS case — the requirement
+# --------------------------------------------------------------------------
+
+def test_social_flood_cannot_evict_a_fatal_row() -> None:
+    """The whole reason the deck is not a deque."""
+    clock = _Clock()
+    deck = DeckManager(clock=clock, rows=3)
+    deck.push("DW provider failover", severity=Severity.FATAL, key="dw")
+
+    for i in range(50):
+        clock.t += 0.1
+        deck.push(f"@the-pit joke #{i}", severity=Severity.SOCIAL,
+                  author="@the-pit")
+
+    rows = _texts(deck)
+    assert any("failover" in r for r in rows), (
+        "50 social events buried the FATAL row — the deck is a FIFO again"
+    )
+    assert "dw" in deck.pinned_keys()
+
+
+def test_a_full_operational_deck_compacts_social_instead_of_evicting() -> None:
+    clock = _Clock()
+    deck = DeckManager(clock=clock, rows=2)
+    deck.push("budget exhausted", severity=Severity.FATAL, key="budget")
+    deck.push("DW degraded", severity=Severity.WARN, key="dw")
+
+    for i in range(3):
+        clock.t += 0.1
+        deck.push(f"@cassandra post {i}", severity=Severity.SOCIAL,
+                  author="@cassandra")
+
+    rows = _texts(deck)
+    assert len(rows) == 2, "the deck grew past its row budget"
+    assert any("budget exhausted" in r for r in rows)
+    assert any("DW degraded" in r for r in rows)
+    assert deck.hidden_social == 3
+    # The count still surfaces — hidden is not the same as discarded.
+    assert any("hidden" in r for r in rows), (
+        "chatter was withheld with no indication any existed"
+    )
+
+
+def test_social_takes_a_free_slot_when_one_exists() -> None:
+    deck = DeckManager(clock=_Clock(), rows=4)
+    deck.push("DW degraded", severity=Severity.WARN, key="dw")
+    deck.push("@cassandra says hello", severity=Severity.SOCIAL,
+              author="@cassandra")
+    rows = _texts(deck)
+    assert any("cassandra" in r for r in rows)
+
+
+def test_the_agora_is_one_voice_on_the_deck() -> None:
+    """Many residents talking must not consume many rows — otherwise a lively
+    conversation evicts info rows one at a time."""
+    clock = _Clock()
+    deck = DeckManager(clock=clock, rows=4)
+    for who in ("@cassandra", "@the-pit", "@the-skeptic", "@ouroboros"):
+        clock.t += 0.1
+        deck.push(f"{who} weighs in", severity=Severity.SOCIAL, author=who)
+    social_rows = [t for s, t in deck.rows() if s is Severity.SOCIAL]
+    assert len(social_rows) == 1, f"agora took {len(social_rows)} rows"
+
+
+# --------------------------------------------------------------------------
+# 2. pinning + resolution
+# --------------------------------------------------------------------------
+
+def test_operational_rows_outrank_info_regardless_of_recency() -> None:
+    clock = _Clock()
+    deck = DeckManager(clock=clock, rows=2)
+    deck.push("DW failover", severity=Severity.WARN, key="dw")
+    for i in range(5):
+        clock.t += 0.1
+        deck.push(f"info {i}", severity=Severity.INFO, key=f"i{i}")
+    assert any("failover" in r for r in _texts(deck))
+
+
+def test_severity_orders_the_rows() -> None:
+    deck = DeckManager(clock=_Clock(), rows=4)
+    deck.push("chatter", severity=Severity.SOCIAL, author="@x")
+    deck.push("info line", severity=Severity.INFO, key="i")
+    deck.push("fatal line", severity=Severity.FATAL, key="f")
+    deck.push("warn line", severity=Severity.WARN, key="w")
+    order = [s for s, _t in deck.rows()]
+    assert order == sorted(order, reverse=True), "rows are not severity-ordered"
+    assert deck.rows()[0][1] == "fatal line"
+
+
+def test_resolution_is_the_intended_exit_for_a_pinned_row() -> None:
+    deck = DeckManager(clock=_Clock(), rows=3)
+    deck.push("DW degraded", severity=Severity.WARN, key="dw")
+    assert deck.resolve("dw") is True
+    assert not any("degraded" in r for r in _texts(deck))
+    assert deck.resolve("dw") is False
+
+
+def test_a_pinned_row_expires_on_its_own_ttl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """TTL is the backstop, not the mechanism — but it must exist, or a
+    resolved-but-unreported condition pins forever."""
+    monkeypatch.setenv("JARVIS_AMBIENT_DECK_OP_TTL_S", "10")
+    clock = _Clock()
+    deck = DeckManager(clock=clock, rows=3)
+    deck.push("DW degraded", severity=Severity.WARN, key="dw")
+    clock.t += 11
+    assert _texts(deck) == []
+
+
+def test_a_repeating_producer_updates_one_row(
+) -> None:
+    """A flapping provider must not fill the deck with itself."""
+    clock = _Clock()
+    deck = DeckManager(clock=clock, rows=4)
+    for i in range(10):
+        clock.t += 0.1
+        deck.push(f"DW failover (attempt {i})", severity=Severity.WARN,
+                  key="dw")
+    assert len(deck.rows()) == 1
+    assert "attempt 9" in deck.rows()[0][1]
+
+
+# --------------------------------------------------------------------------
+# 3. bulletproof
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("junk", [None, "", "   ", 12345, object()])
+def test_push_never_raises_on_junk(junk: object) -> None:
+    deck = DeckManager(clock=_Clock(), rows=3)
+    deck.push(junk)  # type: ignore[arg-type]
+
+
+def test_rows_never_raises_even_with_a_broken_clock() -> None:
+    def _boom() -> float:
+        raise RuntimeError("clock on fire")
+
+    deck = DeckManager(clock=_boom, rows=3)
+    assert deck.rows() == []
+
+
+def test_classify_recognises_operational_language() -> None:
+    assert classify("DW provider failover")[0] is Severity.WARN
+    assert classify("budget exhausted, cannot continue")[0] is Severity.FATAL
+    assert classify("🐍 @cassandra said something")[0] is Severity.SOCIAL
+    assert classify("post", kind="molt_post")[0] is Severity.SOCIAL
+    assert classify("read 4 files")[0] is Severity.INFO
+
+
+# --------------------------------------------------------------------------
+# 4. the addressed/ambient split at the client
+# --------------------------------------------------------------------------
+
+def test_addressed_goes_to_scrollback_ambient_goes_to_the_deck(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The routing rule, asserted at the seam where both frames arrive."""
+    from backend.core.ouroboros.cli import ov
+
+    scrollback: List[str] = []
+    monkeypatch.setattr(
+        ov, "_render_markup_frame",
+        lambda text, console=None: scrollback.append(text),
+    )
+    ui = ov.AttachUI()
+
+    def _markup_sink(text: str, addressed: bool = False) -> None:
+        if addressed:
+            ov._render_markup_frame(text, None)
+            return
+        ui.on_ambient(text)
+
+    _markup_sink("[bold]🐍 Moltbook[/bold] — 12 posts", addressed=True)
+    _markup_sink("🐍 @cassandra: the soak refused", addressed=False)
+
+    assert scrollback == ["[bold]🐍 Moltbook[/bold] — 12 posts"], (
+        "the command answer did not reach the permanent scrollback"
+    )
+    assert any("cassandra" in t for t in _texts(ui.deck)), (
+        "the ambient post did not reach the deck"
+    )
+    assert not any("Moltbook" in t for t in _texts(ui.deck)), (
+        "an addressed answer leaked into the ephemeral deck and will vanish"
+    )
+
+
+def test_toolbar_grows_to_show_deck_rows() -> None:
+    from backend.core.ouroboros.cli import ov
+
+    ui = ov.AttachUI()
+    assert "\n" not in ui.toolbar(), "empty deck should stay one line"
+    ui.on_ambient("DW provider failover")
+    out = ui.toolbar()
+    assert "\n" in out and "failover" in out
+    assert out.splitlines()[0].strip() != "", "the pulse line was lost"
+
+
+def test_deck_can_be_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    from backend.core.ouroboros.cli import ov
+
+    monkeypatch.setenv("JARVIS_AMBIENT_DECK", "0")
+    ui = ov.AttachUI()
+    ui.on_ambient("DW provider failover")
+    assert "\n" not in ui.toolbar(), "OFF must restore the single-line toolbar"


### PR DESCRIPTION
Addressed output (you typed `/moltbook`) belongs in the **scrollback** — you asked for it, you keep it. Ambient output — a worker spawning, a provider failing over, a persona arguing with you — belongs in a **live region** that redraws in place and ages out. #70113 put both on one channel; this is the surface that tells them apart.

## Why not a deque

A FIFO ring treats every event as equally worth a slot, so the loudest producer wins. The agora posts on its own initiative and never stops, so a five-row FIFO becomes five rows of personas — and the line that said *"DoubleWord failed over"* is gone in under a second. That's a monitoring surface losing the only row that mattered, to a joke.

Slots go by **severity**:

| | behaviour |
|---|---|
| `FATAL` / `WARN` | **pin.** Nothing lower evicts them. They leave via explicit `resolve()` or a long TTL — an alert that scrolls itself away hasn't been seen, it's been lost |
| `INFO` | fills what remains |
| `SOCIAL` | takes what's left, and **compacts** when there's none — the agora collapses to one rolling line with a count |

Two properties that matter as much as the ordering:

- Entries are **keyed**, so a flapping provider updates one row instead of filling the deck with itself — the other way a chatty producer takes the screen.
- The agora is **one voice** on the deck no matter how many residents talk, so a lively conversation can't evict info rows one at a time.

And when every slot is pinned, the hidden-count **rides on the least-important visible row** rather than being dropped. "Hidden" and "discarded" must not look the same.

## The addressed/ambient split

The bridge stamps `addressed` on every frame. It already knows — the ContextVar decided one line earlier — and the client *cannot* re-derive it, because "was this answering my command?" is not a property of the text. Guessing would put provider failovers in the transcript and command answers in a region that erases them.

Client-side the marker is forwarded with the **same** arity inspection the input path uses (`_accepts_two_positional`), not a second convention. A one-argument sink — every pre-deck client — is called exactly as before.

## DRY

Rendered into the `bottom_toolbar` prompt_toolkit already repaints, on top of the existing heartbeat formatter. No second render loop, no `Live` region competing for the terminal — the toolbar simply grows to the lines returned.

```
❯ fix the failing test█

  ✽ Synthesizing… (4m 9s · ↓ 15.9k · DW-397B)
  ✖ DW provider failover
  ▸ chunk_swarm  7 workers · 3 stitched
  · 🐍 agora @cassandra, @the-pit (3 hidden)
```

## Tests

19, including: 50 social events cannot evict a `FATAL`; a full operational deck compacts instead of evicting; agora-is-one-voice; keyed coalescing; TTL expiry; broken-clock safety; and the addressed/ambient routing asserted at the seam where both frames arrive.

Master `JARVIS_AMBIENT_DECK` (default ON; OFF restores the single-line toolbar). Rows and TTLs env-tunable.

`tests/cli` + attach suites: **341 passed**. The 2 failures there (`test_ov_ignition_retry`, `test_split_plane_mux`) are pre-existing and baseline-verified with these changes stashed.

> Correction carried forward: the `tests/battle_test/` directory is **not** at 100%. #70114 made it *complete* (2310 passed / 23 failed) where it previously died at 40%. Those 23 are pre-existing and were invisible before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an ambient “deck” under the prompt that shows live system events by severity, and route addressed responses to scrollback while ambient events go to the deck. This prevents chatty social messages from burying important alerts and improves observability.

- **New Features**
  - Severity-ordered deck: FATAL/WARN pin; INFO fills remaining; SOCIAL compacts into a single rolling line with a count.
  - Keyed entries coalesce updates; the social feed is a single “voice” so conversations don’t consume multiple rows.
  - Explicit resolve() for pinned rows; TTL-based expiry for social/info/operational entries.
  - Addressed/ambient split: daemon marks frames as addressed; client forwards the marker and routes addressed to scrollback, ambient to the deck; legacy one-arg sinks still work.
  - Toolbar integration: deck rows render beneath the pulse in the same bottom toolbar; no second render loop.
  - Config: toggle with JARVIS_AMBIENT_DECK (default ON); rows via JARVIS_AMBIENT_DECK_ROWS; TTLs via JARVIS_AMBIENT_DECK_SOCIAL_TTL_S, JARVIS_AMBIENT_DECK_INFO_TTL_S, JARVIS_AMBIENT_DECK_OP_TTL_S.
  - Tests cover pinning, compaction, coalescing, routing, TTL expiry, and safety guards.

<sup>Written for commit 3159b8c63ec2743bb6bb20bcd664a5c7e6e622c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

