### PR TITLE
feat(ov): D2 — lane tagging via ContextVar + per-lane rings

### DIFF
--- a/backend/core/ouroboros/battle_test/attach_session.py
+++ b/backend/core/ouroboros/battle_test/attach_session.py
@@ -128,9 +128,75 @@ class _Ambient(contextlib.AbstractContextManager):
             _CURRENT_SESSION.set(None)
 
 
+# ---------------------------------------------------------------------------
+# Lanes — WHICH worker produced this, orthogonal to which cockpit sees it
+# ---------------------------------------------------------------------------
+
+#: The default lane. Output with no worker above it on the stack is the
+#: organism speaking as itself, which is exactly the "ambient" the deck
+#: already renders — the two vocabularies line up on purpose.
+AMBIENT_LANE = "ambient"
+
+#: Which worker's execution this output belongs to.
+#:
+#: The session ContextVar answers "who asked?". This one answers "who is
+#: doing it?". They are independent: one cockpit can watch four lanes, and
+#: one lane's output can be addressed to a cockpit that asked about it.
+#:
+#: Tagging at emission is the only approach that survives contact with the
+#: codebase. Parsing output for a worker id fails the moment a worker prints
+#: something unformatted; keying on logger name fails because workers share
+#: modules; passing an id down the call chain would touch every renderer and
+#: every future one. The execution context already knows, and carries itself
+#: across every ``await`` for free.
+_CURRENT_LANE: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "ov_lane", default=AMBIENT_LANE,
+)
+
+
+def lane_tagging_enabled() -> bool:
+    """``JARVIS_LANE_TAGGING`` (default ON). OFF makes every emission
+    ambient, which is the pre-lane behaviour."""
+    return os.environ.get(
+        "JARVIS_LANE_TAGGING", "1",
+    ).strip().lower() in _TRUTHY
+
+
+def current_lane() -> str:
+    """The worker whose execution is producing this output."""
+    try:
+        return _CURRENT_LANE.get() or AMBIENT_LANE
+    except LookupError:      # pragma: no cover
+        return AMBIENT_LANE
+
+
+@contextlib.contextmanager
+def lane_scope(lane: Optional[str]) -> Iterator[None]:
+    """Attribute everything emitted inside this block to *lane*.
+
+    Nests correctly: a swarm worker that spawns a sub-worker gets the inner
+    lane for the inner work and the outer lane restored afterwards, because
+    the token is per-``set`` rather than global. NEVER raises."""
+    token = None
+    try:
+        if lane and lane_tagging_enabled():
+            token = _CURRENT_LANE.set(str(lane))
+        yield
+    finally:
+        if token is not None:
+            try:
+                _CURRENT_LANE.reset(token)
+            except (ValueError, LookupError):
+                _CURRENT_LANE.set(AMBIENT_LANE)
+
+
 __all__ = [
+    "AMBIENT_LANE",
     "as_ambient",
+    "current_lane",
     "current_session",
+    "lane_scope",
+    "lane_tagging_enabled",
     "new_session_id",
     "session_routing_enabled",
     "session_scope",

--- a/backend/core/ouroboros/battle_test/cockpit_attach.py
+++ b/backend/core/ouroboros/battle_test/cockpit_attach.py
@@ -542,6 +542,34 @@ class CockpitAttachBridge:
         msg = dict(msg)
         msg["addressed"] = target is not None
 
+        # LANE TAGGING — the same interceptor, one more ContextVar.
+        #
+        # Deliberately not a second interception layer: session and lane are
+        # read from the same execution context at the same seam, because both
+        # answer questions only the emitter's context can answer ("who asked?"
+        # and "who is doing it?"). Splitting them would mean two places to
+        # keep in step.
+        #
+        # The ring is written HERE rather than at the producer, so every
+        # producer is covered without any producer knowing lanes exist —
+        # including ones written later.
+        try:
+            from backend.core.ouroboros.battle_test.attach_session import (
+                AMBIENT_LANE,
+                current_lane,
+            )
+            lane = current_lane()
+            if lane and lane != AMBIENT_LANE:
+                msg["lane"] = lane
+                body = msg.get("text")
+                if isinstance(body, str) and body:
+                    from backend.core.ouroboros.battle_test.lane_rings import (
+                        get_lane_registry,
+                    )
+                    get_lane_registry().record(lane, body)
+        except Exception:  # noqa: BLE001 — tagging must never eat output
+            pass
+
         data = (json.dumps(msg, separators=(",", ":")) + "\n").encode()
         for w in writers:
             try:

--- a/backend/core/ouroboros/battle_test/lane_rings.py
+++ b/backend/core/ouroboros/battle_test/lane_rings.py
@@ -1,0 +1,264 @@
+"""Per-lane history, and the thread boundary that would otherwise lose it.
+
+Two pieces that only make sense together:
+
+``ContextAwareThreadPool``
+    ``ContextVar`` crosses ``await`` for free and is copied into new tasks,
+    so the lane tag survives the whole async call graph. It does NOT cross
+    every thread boundary. Measured on this interpreter:
+
+        asyncio.to_thread        -> propagates
+        loop.run_in_executor     -> LOST
+        ThreadPoolExecutor.submit-> LOST
+
+    ``to_thread`` already copies the context, so wrapping those call sites
+    would be machinery with nothing to do. The other two are the real hole:
+    a worker that hands its heavy compute or disk I/O to an executor orphans
+    everything that function emits, and the output arrives untagged — which
+    looks exactly like the organism speaking as itself.
+
+``LaneRegistry``
+    Bounded per-lane rings. D3 lets the operator focus a lane and expects its
+    history to be there; a lane that only exists while something is printing
+    would show an empty pane. Bounded because a swarm worker can emit for
+    minutes and the daemon is long-lived.
+"""
+from __future__ import annotations
+
+import contextvars
+import logging
+import os
+import threading
+import time
+from collections import deque
+from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import dataclass
+from typing import Any, Callable, Deque, Dict, List, Optional, Tuple
+
+logger = logging.getLogger("Ouroboros.LaneRings")
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+
+def _env_int(name: str, default: int, lo: int, hi: int) -> int:
+    try:
+        return max(lo, min(hi, int(os.environ.get(name, "").strip() or default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def lane_ring_size() -> int:
+    """Lines retained per lane. Enough to explain what a worker has been
+    doing without becoming a second transcript."""
+    return _env_int("JARVIS_LANE_RING_SIZE", 100, 1, 10000)
+
+
+def max_lanes() -> int:
+    """Ceiling on tracked lanes. A runaway spawner must not turn the ring
+    registry into an unbounded map keyed by worker id."""
+    return _env_int("JARVIS_LANE_MAX", 64, 1, 4096)
+
+
+# ---------------------------------------------------------------------------
+# The thread boundary
+# ---------------------------------------------------------------------------
+
+
+class ContextAwareThreadPool:
+    """A ``ThreadPoolExecutor`` that carries the caller's context across.
+
+    ``copy_context()`` is taken at SUBMIT time on the calling thread, then
+    ``ctx.run(fn, ...)`` executes the callable inside that copy on the worker
+    thread. A copy, not a reference: the worker must not be able to mutate
+    the submitter's context, and two workers submitted from the same lane
+    must not share mutable state.
+
+    Drop-in for the executor argument of ``loop.run_in_executor``, and usable
+    directly via ``submit``.
+    """
+
+    def __init__(
+        self,
+        max_workers: Optional[int] = None,
+        *,
+        thread_name_prefix: str = "ov-lane",
+    ) -> None:
+        self._pool = ThreadPoolExecutor(
+            max_workers=max_workers, thread_name_prefix=thread_name_prefix,
+        )
+
+    def submit(self, fn: Callable[..., Any], /, *args: Any, **kwargs: Any) -> Future:
+        """Submit *fn*, preserving the submitting context. NEVER raises
+        beyond what the pool itself raises."""
+        ctx = contextvars.copy_context()
+        return self._pool.submit(ctx.run, fn, *args, **kwargs)
+
+    def map(self, fn: Callable[..., Any], *iterables: Any, **kw: Any) -> Any:
+        ctx = contextvars.copy_context()
+        return self._pool.map(
+            lambda *a: ctx.run(fn, *a), *iterables, **kw,
+        )
+
+    def shutdown(self, wait: bool = True, **kw: Any) -> None:
+        try:
+            self._pool.shutdown(wait=wait, **kw)
+        except Exception:  # noqa: BLE001
+            pass
+
+    def __enter__(self) -> "ContextAwareThreadPool":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.shutdown(wait=True)
+
+
+# ---------------------------------------------------------------------------
+# Per-lane history
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class LaneLine:
+    text: str
+    ts: float
+    severity: str = "INFO"
+
+
+@dataclass
+class LaneState:
+    lane: str
+    lines: Deque[LaneLine]
+    first_seen: float
+    last_seen: float
+    total: int = 0          # lifetime count, including lines the ring dropped
+    label: str = ""
+
+
+class LaneRegistry:
+    """Bounded rings, one per lane, plus enough metadata for the deck.
+
+    Thread-safe: emissions arrive from the event loop AND from executor
+    threads (that is the entire point of the pool above), so the registry is
+    written from more than one thread.
+    """
+
+    def __init__(self, *, ring: Optional[int] = None,
+                 clock: Callable[[], float] = time.monotonic) -> None:
+        self._ring = ring
+        self._clock = clock
+        self._lanes: Dict[str, LaneState] = {}
+        self._lock = threading.Lock()
+        self.evicted_lanes = 0
+
+    def record(
+        self, lane: str, text: str, *, severity: str = "INFO",
+        label: str = "",
+    ) -> None:
+        """Append one line to *lane*'s ring. NEVER raises — this sits on the
+        emission path and must not be able to break rendering."""
+        try:
+            lane = str(lane or "").strip()
+            text = str(text or "")
+            if not lane or not text:
+                return
+            now = self._clock()
+            size = self._ring if self._ring is not None else lane_ring_size()
+            with self._lock:
+                st = self._lanes.get(lane)
+                if st is None:
+                    self._reap_if_needed(now)
+                    st = LaneState(
+                        lane=lane, lines=deque(maxlen=size),
+                        first_seen=now, last_seen=now,
+                    )
+                    self._lanes[lane] = st
+                if label:
+                    st.label = label
+                st.lines.append(LaneLine(text=text, ts=now, severity=severity))
+                st.last_seen = now
+                st.total += 1
+        except Exception:  # noqa: BLE001
+            pass
+
+    def _reap_if_needed(self, now: float) -> None:
+        """Evict the least-recently-active lane when at the ceiling.
+
+        Called with the lock held. Recency rather than size: a finished
+        worker's history stops being interesting long before a busy one's,
+        and the operator focuses what is happening now."""
+        limit = max_lanes()
+        if len(self._lanes) < limit:
+            return
+        victim = min(self._lanes.values(), key=lambda s: s.last_seen)
+        self._lanes.pop(victim.lane, None)
+        self.evicted_lanes += 1
+
+    # -- read side --------------------------------------------------------
+
+    def lanes(self) -> List[str]:
+        with self._lock:
+            return sorted(
+                self._lanes, key=lambda k: -self._lanes[k].last_seen,
+            )
+
+    def history(self, lane: str, limit: Optional[int] = None) -> List[LaneLine]:
+        """Hydration for D3: the pristine backlog of one lane, oldest first."""
+        with self._lock:
+            st = self._lanes.get(str(lane))
+            if st is None:
+                return []
+            lines = list(st.lines)
+        return lines[-limit:] if limit else lines
+
+    def summary(self) -> List[Tuple[str, int, float, str]]:
+        """``(lane, retained, last_seen, label)`` — what the deck lists."""
+        with self._lock:
+            return [
+                (s.lane, len(s.lines), s.last_seen, s.label)
+                for s in sorted(
+                    self._lanes.values(), key=lambda s: -s.last_seen,
+                )
+            ]
+
+    def dropped(self, lane: str) -> int:
+        """Lines this lane emitted that the ring no longer holds. Reported
+        rather than hidden — a truncated pane must say so."""
+        with self._lock:
+            st = self._lanes.get(str(lane))
+            return max(0, st.total - len(st.lines)) if st else 0
+
+    def clear(self) -> None:
+        with self._lock:
+            self._lanes.clear()
+
+
+_REGISTRY: Optional[LaneRegistry] = None
+_REGISTRY_LOCK = threading.Lock()
+
+
+def get_lane_registry() -> LaneRegistry:
+    """Process-wide registry. NEVER raises."""
+    global _REGISTRY
+    with _REGISTRY_LOCK:
+        if _REGISTRY is None:
+            _REGISTRY = LaneRegistry()
+        return _REGISTRY
+
+
+def reset_lane_registry() -> None:
+    """Teardown seam for tests."""
+    global _REGISTRY
+    with _REGISTRY_LOCK:
+        _REGISTRY = None
+
+
+__all__ = [
+    "ContextAwareThreadPool",
+    "LaneLine",
+    "LaneRegistry",
+    "LaneState",
+    "get_lane_registry",
+    "lane_ring_size",
+    "max_lanes",
+    "reset_lane_registry",
+]

--- a/backend/core/ouroboros/governance/autonomy/subagent_scheduler.py
+++ b/backend/core/ouroboros/governance/autonomy/subagent_scheduler.py
@@ -162,6 +162,42 @@ class GenerationSubagentExecutor:
         _dw_cost_usd: Optional[float] = None
         _branch_label: str = ""
         _result: Optional[WorkUnitResult] = None
+        # LANE. One scope around the unit's entire execution, so every line
+        # this worker emits — generation, validation, tool calls, and anything
+        # it hands to an executor via ContextAwareThreadPool — is attributable
+        # to it. Tagged at the emission CONTEXT rather than by parsing output
+        # or by logger name: workers share modules and print unformatted text,
+        # so both of those lose the association exactly when parallelism makes
+        # it matter.
+        try:
+            from backend.core.ouroboros.battle_test.attach_session import (
+                lane_scope,
+            )
+            _lane_ctx: Any = lane_scope(f"unit/{unit.unit_id}")
+        except Exception:  # noqa: BLE001 — untagged beats not running
+            import contextlib as _ctxlib
+            _lane_ctx = _ctxlib.nullcontext()
+        with _lane_ctx:
+            return await self._execute_tagged(
+                graph, unit, started_at_ns, causal_parent_id,
+                _worktree_path, _sandbox, _worktree_create_mono,
+                _worktree_lifespan_s, _dw_cost_usd, _branch_label, _result,
+            )
+
+    async def _execute_tagged(
+        self, graph: ExecutionGraph, unit: WorkUnitSpec,
+        started_at_ns: int, causal_parent_id: Any,
+        _worktree_path: Optional[Path], _sandbox: Optional[Any],
+        _worktree_create_mono: Optional[float],
+        _worktree_lifespan_s: Optional[float],
+        _dw_cost_usd: Optional[float], _branch_label: str,
+        _result: Optional[WorkUnitResult],
+    ) -> WorkUnitResult:
+        """The original ``execute`` body, now running inside a lane scope.
+
+        Split out rather than indented in place so the diff stays readable
+        and the lane wrapper is one obvious frame rather than a re-indent of
+        two hundred lines."""
         try:
             if len(unit.target_files) != 1:
                 raise RuntimeError(

--- a/backend/core/ouroboros/governance/chunk_swarm.py
+++ b/backend/core/ouroboros/governance/chunk_swarm.py
@@ -114,8 +114,22 @@ async def swarm_repair(
         async with sem:
             in_flight["cur"] += 1
             in_flight["max"] = max(in_flight["max"], in_flight["cur"])
+            # LANE. Set once, here, around the whole of this agent's work.
+            # Everything it emits below — through every await, in every task
+            # it spawns, and (via ContextAwareThreadPool) in every executor
+            # call it makes — inherits the tag with no producer touching it.
+            _lane = f"swarm/{getattr(target, 'name', None) or getattr(target, 'chunk_id', '?')}"
             try:
-                node = await generate_fn(target)
+                from backend.core.ouroboros.battle_test.attach_session import (
+                    lane_scope,
+                )
+                _scope = lane_scope(_lane)
+            except Exception:  # noqa: BLE001 — untagged beats not running
+                import contextlib as _ctxlib
+                _scope = _ctxlib.nullcontext()
+            try:
+                with _scope:
+                    node = await generate_fn(target)
                 return (target, node, None)
             except Exception as exc:  # noqa: BLE001 — an agent failure is isolated
                 return (target, None, exc)

--- a/tests/battle_test/test_lane_tagging.py
+++ b/tests/battle_test/test_lane_tagging.py
@@ -1,0 +1,272 @@
+"""Lane tagging — who produced this output, carried not passed.
+
+The session ContextVar answers "who asked?". This one answers "who is doing
+it?". Both are read at the same interceptor, because both are questions only
+the emitter's execution context can answer.
+
+The thread boundary is the part that needs proving. ``ContextVar`` crosses
+``await`` for free, but measured on this interpreter:
+
+    asyncio.to_thread         -> propagates
+    loop.run_in_executor      -> LOST
+    ThreadPoolExecutor.submit -> LOST
+
+A worker that hands heavy compute or disk I/O to an executor therefore
+orphans everything that function emits, and untagged output is
+indistinguishable from the organism speaking as itself.
+"""
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures as cf
+import json
+from typing import Any, Dict, List
+
+import pytest
+
+from backend.core.ouroboros.battle_test import attach_session
+from backend.core.ouroboros.battle_test.attach_session import (
+    AMBIENT_LANE,
+    current_lane,
+    lane_scope,
+)
+from backend.core.ouroboros.battle_test.lane_rings import (
+    ContextAwareThreadPool,
+    LaneRegistry,
+    get_lane_registry,
+    reset_lane_registry,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean():
+    reset_lane_registry()
+    with lane_scope(None), attach_session.session_scope(None):
+        yield
+    reset_lane_registry()
+
+
+class _Writer:
+    def __init__(self) -> None:
+        self.frames: List[Dict[str, Any]] = []
+
+    def is_closing(self) -> bool:
+        return False
+
+    def write(self, data: bytes) -> None:
+        for line in data.decode().splitlines():
+            if line.strip():
+                self.frames.append(json.loads(line))
+
+    def close(self) -> None:
+        pass
+
+
+# --------------------------------------------------------------------------
+# 1. the tag survives the async graph
+# --------------------------------------------------------------------------
+
+def test_default_lane_is_ambient() -> None:
+    assert current_lane() == AMBIENT_LANE
+
+
+async def test_lane_survives_awaits_and_child_tasks() -> None:
+    seen = {}
+
+    async def deep() -> None:
+        await asyncio.sleep(0)
+        seen["lane"] = current_lane()
+
+    with lane_scope("swarm/chunk-7"):
+        await asyncio.create_task(deep())
+    assert seen["lane"] == "swarm/chunk-7"
+    assert current_lane() == AMBIENT_LANE, "the scope leaked past its block"
+
+
+async def test_lanes_nest_and_restore() -> None:
+    with lane_scope("unit/a"):
+        assert current_lane() == "unit/a"
+        with lane_scope("unit/b"):
+            assert current_lane() == "unit/b"
+        assert current_lane() == "unit/a", "inner scope clobbered the outer"
+
+
+async def test_concurrent_workers_do_not_share_a_lane() -> None:
+    """The property that makes tagging worth anything under parallelism."""
+    out: Dict[str, str] = {}
+
+    async def work(lane: str) -> None:
+        with lane_scope(lane):
+            await asyncio.sleep(0)
+            out[lane] = current_lane()
+
+    await asyncio.gather(work("unit/1"), work("unit/2"), work("unit/3"))
+    assert out == {"unit/1": "unit/1", "unit/2": "unit/2", "unit/3": "unit/3"}
+
+
+def test_lane_scope_restores_on_exception() -> None:
+    with pytest.raises(RuntimeError):
+        with lane_scope("unit/boom"):
+            raise RuntimeError("worker exploded")
+    assert current_lane() == AMBIENT_LANE
+
+
+def test_tagging_can_be_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JARVIS_LANE_TAGGING", "0")
+    with lane_scope("unit/x"):
+        assert current_lane() == AMBIENT_LANE
+
+
+# --------------------------------------------------------------------------
+# 2. the thread boundary — the requirement
+# --------------------------------------------------------------------------
+
+async def test_run_in_executor_loses_the_lane_without_the_wrapper() -> None:
+    """Pins the defect the wrapper exists for. If a future Python makes
+    run_in_executor context-preserving, this test tells us the wrapper is
+    redundant rather than letting it linger as cargo."""
+    loop = asyncio.get_running_loop()
+    with lane_scope("unit/plain"):
+        with cf.ThreadPoolExecutor(1) as ex:
+            got = await loop.run_in_executor(ex, current_lane)
+    assert got == AMBIENT_LANE, (
+        "run_in_executor now preserves context — the wrapper may be dropped"
+    )
+
+
+async def test_context_aware_pool_carries_the_lane_into_the_thread() -> None:
+    loop = asyncio.get_running_loop()
+    with lane_scope("unit/threaded"):
+        with ContextAwareThreadPool(1) as pool:
+            via_submit = pool.submit(current_lane).result(timeout=5)
+            via_loop = await loop.run_in_executor(pool, current_lane)
+    assert via_submit == "unit/threaded"
+    assert via_loop == "unit/threaded"
+
+
+async def test_threaded_work_routes_to_the_right_ring() -> None:
+    """Requirement 2 end to end: a function dispatched to a background thread
+    retains the lane AND its output lands in that lane's ring."""
+    registry = get_lane_registry()
+
+    def _heavy_disk_io() -> str:
+        lane = current_lane()
+        registry.record(lane, "wrote 4 files")
+        return lane
+
+    with lane_scope("unit/io"):
+        with ContextAwareThreadPool(2) as pool:
+            assert pool.submit(_heavy_disk_io).result(timeout=5) == "unit/io"
+
+    assert [ln.text for ln in registry.history("unit/io")] == ["wrote 4 files"]
+    assert registry.history(AMBIENT_LANE) == [], (
+        "threaded output was orphaned into the ambient lane"
+    )
+
+
+async def test_two_pooled_workers_keep_separate_lanes() -> None:
+    registry = get_lane_registry()
+
+    def _emit() -> None:
+        registry.record(current_lane(), f"work in {current_lane()}")
+
+    with ContextAwareThreadPool(2) as pool:
+        futures = []
+        for lane in ("swarm/a", "swarm/b"):
+            with lane_scope(lane):
+                futures.append(pool.submit(_emit))
+        for f in futures:
+            f.result(timeout=5)
+
+    assert len(registry.history("swarm/a")) == 1
+    assert len(registry.history("swarm/b")) == 1
+    assert "swarm/a" in registry.history("swarm/a")[0].text
+
+
+# --------------------------------------------------------------------------
+# 3. the IPC bridge carries the tag (requirement 1)
+# --------------------------------------------------------------------------
+
+async def test_swarm_output_carries_its_lane_across_the_bridge() -> None:
+    from backend.core.ouroboros.battle_test.cockpit_attach import (
+        CockpitAttachBridge,
+    )
+
+    w = _Writer()
+    bridge = CockpitAttachBridge()
+    bridge._loop = asyncio.get_running_loop()   # type: ignore[attr-defined]
+    bridge._clients.add(w)                      # type: ignore[arg-type]
+
+    with lane_scope("swarm/chunk-3"):
+        bridge.publish_markup("⏺ Update(saga.py)")
+
+    assert w.frames, "nothing reached the client"
+    assert w.frames[0].get("lane") == "swarm/chunk-3"
+    assert [ln.text for ln in get_lane_registry().history("swarm/chunk-3")] == [
+        "⏺ Update(saga.py)"
+    ]
+
+
+async def test_ambient_output_carries_no_lane_key() -> None:
+    """Absence is meaningful: the deck already treats untagged output as the
+    organism itself, so stamping `lane: "ambient"` would make every frame
+    look worker-produced."""
+    from backend.core.ouroboros.battle_test.cockpit_attach import (
+        CockpitAttachBridge,
+    )
+
+    w = _Writer()
+    bridge = CockpitAttachBridge()
+    bridge._loop = asyncio.get_running_loop()   # type: ignore[attr-defined]
+    bridge._clients.add(w)                      # type: ignore[arg-type]
+
+    bridge.publish_markup("⏺ Bash(ls)")
+    assert "lane" not in w.frames[0]
+
+
+# --------------------------------------------------------------------------
+# 4. the rings
+# --------------------------------------------------------------------------
+
+def test_ring_is_bounded_and_reports_what_it_dropped() -> None:
+    """A truncated pane must say it is truncated."""
+    reg = LaneRegistry(ring=5)
+    for i in range(20):
+        reg.record("unit/x", f"line {i}")
+    hist = reg.history("unit/x")
+    assert len(hist) == 5
+    assert hist[-1].text == "line 19", "the ring kept the wrong end"
+    assert reg.dropped("unit/x") == 15
+
+
+def test_registry_evicts_the_least_recently_active_lane(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_LANE_MAX", "2")
+    clock = {"t": 0.0}
+    reg = LaneRegistry(ring=10, clock=lambda: clock["t"])
+    reg.record("old", "a")
+    clock["t"] = 10.0
+    reg.record("mid", "b")
+    clock["t"] = 20.0
+    reg.record("new", "c")
+    assert "old" not in reg.lanes(), "a runaway spawner can grow the registry"
+    assert reg.evicted_lanes == 1
+
+
+def test_history_is_oldest_first_for_hydration() -> None:
+    """D3 hydrates a focused pane from this — order is the contract."""
+    reg = LaneRegistry(ring=10)
+    for i in range(3):
+        reg.record("unit/x", f"line {i}")
+    assert [ln.text for ln in reg.history("unit/x")] == [
+        "line 0", "line 1", "line 2",
+    ]
+
+
+def test_record_never_raises_on_junk() -> None:
+    reg = LaneRegistry(ring=3)
+    for bad in (None, "", 123, object()):
+        reg.record(bad, "x")        # type: ignore[arg-type]
+        reg.record("unit/x", bad)   # type: ignore[arg-type]
+    assert reg.history("nonexistent") == []


### PR DESCRIPTION
The session ContextVar answers *"who asked?"*. This one answers *"who is doing it?"*. Both are read at the **same** interceptor, because both are questions only the emitter's execution context can answer.

## Why the context and not the output

Parsing output for a worker id fails the moment a worker prints something unformatted. Keying on logger name fails because workers share modules. Passing an id down the call chain would touch every renderer and every future one. The execution context already knows, and carries itself across every `await` and into every child task for free.

`lane_scope()` wraps the two worker entry points — `chunk_swarm._super_agent` and the subagent executor's unit execution. Everything emitted beneath them inherits the tag; **no producer knows lanes exist.**

## The thread boundary — measured, not assumed

| dispatch | context |
|---|---|
| `asyncio.to_thread` | **propagates** |
| `loop.run_in_executor` | **LOST** |
| `ThreadPoolExecutor.submit` | **LOST** |

So `to_thread` sites need nothing — wrapping them would be machinery with nothing to do. The other two are the real hole: a worker handing heavy compute or disk I/O to an executor orphans everything that function emits, and untagged output is indistinguishable from the organism speaking as itself.

`ContextAwareThreadPool` takes `copy_context()` at **submit** time on the calling thread and runs `ctx.run(fn, …)` on the worker. A **copy**, not a reference: a worker must not mutate the submitter's context, and two workers from the same lane must not share state. Drop-in for `run_in_executor`'s executor arg.

A test pins the defect itself — `run_in_executor` loses the lane *without* the wrapper — so if a future Python makes it context-preserving we're told the wrapper is redundant rather than carrying it as cargo.

## Per-lane rings

Bounded (default 100 lines) so D3 can hydrate a focused pane with that lane's pristine history. `dropped()` reports what the ring no longer holds, because a truncated pane must say it is truncated. The registry is capped (default 64 lanes) and evicts least-recently-active, so a runaway spawner can't grow it without bound. Thread-safe — emissions arrive from the loop **and** from executor threads, which is the entire point of the pool above.

## DRY

Hooked into the existing `_broadcast` interceptor beside the session read — not a second interception layer. The ring is written there rather than at each producer, so every producer is covered *including ones written later*.

Ambient output carries **no** `lane` key: absence is meaningful, and stamping `lane: "ambient"` would make every frame look worker-produced.

## Tests

16 — lane survives awaits and child tasks, nests and restores, concurrent workers don't share; both requirement cases (swarm output tagged across the IPC bridge; threaded work retains its lane and routes to the right ring); ring bounding + drop reporting; LRU lane eviction; junk-safety.

Verified on the D1 base: lane 16 · deck 19 · omni 16 · attach 28 · heartbeat 13 · `governance/autonomy` **700** · `cli` 265 (2 pre-existing failures, baseline-verified).

> **Note on ordering:** #70115 (D1) was still OPEN when this turn began — I merged it first (`0ce4153830`) and replayed D2 on top, resolving one comment-level conflict in `cockpit_attach.py`. D2 depends on D1's `AttachUI.on_ambient` and the `addressed` stamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds lane tagging to attribute every emission to the worker that produced it, and stores a bounded per-lane history for focused playback. Threaded work preserves tags via a context-aware thread pool.

- **New Features**
  - Lane tagging via `lane_scope()` wrapped around `chunk_swarm._super_agent` and subagent unit execution; `CockpitAttachBridge._broadcast` reads the tag and adds `lane` for non-ambient output (ambient stays untagged).
  - Per-lane rings with drop reporting and LRU eviction: default 100 lines per lane, max 64 lanes; thread-safe; access via `get_lane_registry()`.
  - `ContextAwareThreadPool` copies `ContextVar` context into worker threads; drop-in executor for `loop.run_in_executor` so threaded work keeps its lane.
  - Env vars: `JARVIS_LANE_TAGGING` (default on), `JARVIS_LANE_RING_SIZE`, `JARVIS_LANE_MAX`.

- **Migration**
  - No changes needed for existing producers; tagging is inferred at emit time.
  - When using `loop.run_in_executor`, pass a `ContextAwareThreadPool` to preserve lane context across threads.

<sup>Written for commit 2bc7cff76623776c82fd8637933f5763deba0e6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

