### PR TITLE
feat(ov): D3 — selection, focus, and the tombstone that makes them safe

### DIFF
--- a/backend/core/ouroboros/battle_test/attach_heartbeat.py
+++ b/backend/core/ouroboros/battle_test/attach_heartbeat.py
@@ -142,9 +142,22 @@ def build_heartbeat_payload() -> Optional[Dict[str, Any]]:
             except Exception:  # noqa: BLE001
                 provider_label = provider
 
+        # Selectable lanes ride the heartbeat rather than opening a second
+        # stream: it already flows at ~1Hz, which is the cadence a deck list
+        # needs, and a dedicated lane channel would be a parallel lifecycle
+        # to keep in sync for no additional freshness.
+        try:
+            from backend.core.ouroboros.battle_test.lane_rings import (
+                get_lane_registry,
+            )
+            lanes = get_lane_registry().summary()[:12]
+        except Exception:  # noqa: BLE001 — a laneless heartbeat still beats
+            lanes = []
+
         return {
             "kind": "heartbeat",
             "schema_version": HEARTBEAT_SCHEMA_VERSION,
+            "lanes": lanes,
             "active": active,
             "verb": verb,
             "phase": phase,

--- a/backend/core/ouroboros/battle_test/cockpit_attach.py
+++ b/backend/core/ouroboros/battle_test/cockpit_attach.py
@@ -582,6 +582,62 @@ class CockpitAttachBridge:
             except Exception:  # noqa: BLE001 — ANY writer fault = drop
                 self._drop(w)
 
+    def _serve_lane_history(
+        self, lane: str, session: Optional[str], *, limit: Any = None,
+    ) -> None:
+        """Answer one lane-history request. NEVER raises.
+
+        A lane that no longer exists gets an EMPTY history with
+        ``found: false`` rather than silence. The client can then say "that
+        worker's output has aged out" instead of rendering a blank pane the
+        operator reads as "it produced nothing" — the two are very different
+        facts and the pane must not conflate them."""
+        try:
+            lane = str(lane or "").strip()
+            if not lane:
+                return
+            from backend.core.ouroboros.battle_test.lane_rings import (
+                get_lane_registry,
+            )
+            reg = get_lane_registry()
+            try:
+                n = int(limit) if limit is not None else None
+            except (TypeError, ValueError):
+                n = None
+            lines = reg.history(lane, limit=n)
+            payload = {
+                "type": "lane_history",
+                "lane": lane,
+                "found": bool(lines) or reg.is_tombstoned(lane),
+                "tombstoned": reg.is_tombstoned(lane),
+                "dropped": reg.dropped(lane),
+                "lines": [ln.text for ln in lines],
+                "ts": time.time(),
+            }
+            # Addressed to the requester alone, reusing the session scope the
+            # bridge already routes on — no second addressing mechanism.
+            from backend.core.ouroboros.battle_test.attach_session import (
+                session_scope,
+            )
+            loop = self._loop
+            if loop is None or loop.is_closed():
+                return
+
+            def _emit() -> None:
+                with session_scope(session):
+                    self._broadcast(payload)
+
+            try:
+                running = asyncio.get_running_loop()
+            except RuntimeError:
+                running = None
+            if running is loop:
+                _emit()
+            else:
+                loop.call_soon_threadsafe(_emit)
+        except Exception:  # noqa: BLE001
+            logger.debug("[CockpitAttach] lane history degraded", exc_info=True)
+
     def bind_session(self, session_id: str, w: asyncio.StreamWriter) -> None:
         """Associate a cockpit's declared identity with its socket.
 
@@ -666,6 +722,15 @@ class CockpitAttachBridge:
                                 "[CockpitAttach] input sink degraded",
                                 exc_info=True,
                             )
+                elif ftype == "lane":
+                    # Hydration request: the client focused a lane and wants
+                    # its history. Answered ONLY to the asking cockpit —
+                    # another terminal's focus is not this one's business —
+                    # by addressing the reply to the session on the frame.
+                    self._serve_lane_history(
+                        str(frame.get("lane", "")), _sid or None,
+                        limit=frame.get("limit"),
+                    )
                 elif ftype == "audio":
                     cmd = str(frame.get("cmd", "")).strip().lower()
                     if cmd in AUDIO_CMDS:
@@ -710,6 +775,7 @@ class CockpitAttachClient:
         on_telemetry: Optional[Callable[[Dict[str, Any]], None]] = None,
         on_audio_state: Optional[Callable[[str], None]] = None,
         on_thermal: Optional[Callable[[str], None]] = None,
+        on_lane_history: Optional[Callable[[Dict[str, Any]], None]] = None,
         path: Optional[Path] = None,
     ) -> None:
         self._path = Path(path) if path is not None else attach_socket_path()
@@ -722,6 +788,9 @@ class CockpitAttachClient:
         self._on_telemetry = on_telemetry or (lambda _m: None)
         self._on_audio_state = on_audio_state or (lambda _s: None)
         self._on_thermal = on_thermal or (lambda _s: None)
+        #: Focused-lane hydration payloads (D3). Absent handler = the client
+        #: does not use selection; the frame is simply not dispatched.
+        self._on_lane_history = on_lane_history or (lambda _p: None)
         #: This cockpit's identity for the life of the attachment. Declared
         #: on every outbound frame so the daemon can address answers back to
         #: the terminal that asked, instead of to all of them.
@@ -811,6 +880,23 @@ class CockpitAttachClient:
         except Exception:  # noqa: BLE001
             return False
 
+    def send_lane(self, lane: str, limit: Optional[int] = None) -> bool:
+        """Ask the daemon for one lane's history. NEVER raises."""
+        try:
+            w = self._writer
+            if not self.connected or w is None or w.is_closing():
+                return False
+            frame: Dict[str, Any] = {
+                "type": "lane", "lane": str(lane),
+                "session": self.session_id,
+            }
+            if limit is not None:
+                frame["limit"] = int(limit)
+            w.write((json.dumps(frame, separators=(",", ":")) + "\n").encode())
+            return True
+        except Exception:  # noqa: BLE001
+            return False
+
     def send_input(self, text: str) -> bool:
         """Pipe one operator line upstream. Non-blocking; False when
         detached. NEVER raises."""
@@ -875,6 +961,11 @@ class CockpitAttachClient:
                     self._safe_cb_text(
                         self._on_thermal, str(frame.get("state", "")),
                     )
+                elif ftype == "lane_history":
+                    try:
+                        self._on_lane_history(dict(frame))
+                    except Exception:  # noqa: BLE001
+                        pass
         except asyncio.CancelledError:
             raise
         except Exception:  # noqa: BLE001

--- a/backend/core/ouroboros/battle_test/cockpit_fsm.py
+++ b/backend/core/ouroboros/battle_test/cockpit_fsm.py
@@ -1,0 +1,208 @@
+"""The cockpit's view mode — FLOW / SELECT / FOCUS:<lane>.
+
+Ported from ``layout_controller`` rather than reached across to it. That FSM
+lives in the daemon and drives the LOCAL SerpentFlow console; the selection
+UX being built here is client-side, in the ``ov attach`` process. Driving a
+daemon-side FSM over the bridge would put a socket round-trip between an
+arrow key and a repaint, and would mean two attached cockpits shared one view
+mode — pressing Down in terminal A would move terminal B's cursor.
+
+So: same vocabulary, same strictness, client-side ownership. Pure logic, no
+prompt_toolkit import, so the transitions are testable without a terminal.
+
+Modes
+-----
+``flow``          ambient interleaving — the default, and what every cockpit
+                  did before selection existed.
+``select``        the deck is a cursor list; Up/Down move, Enter focuses.
+``focus:<lane>``  one lane's isolated output, hydrated from its ring.
+
+Esc pops one level from anywhere, and pops to ``flow`` rather than unwinding
+a stack: an operator hitting Escape wants out, not one step back.
+"""
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+from typing import Callable, List, Optional, Sequence
+
+COCKPIT_FSM_SCHEMA_VERSION = "cockpit_fsm.1"
+
+MODE_FLOW = "flow"
+MODE_SELECT = "select"
+MODE_FOCUS_PREFIX = "focus:"
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+#: A lane id is produced by us (``swarm/<sym>``, ``unit/<id>``), never by a
+#: model, but it crosses IPC and indexes a dict — so it is validated rather
+#: than trusted.
+_LANE_RX = re.compile(r"^[A-Za-z0-9_./:@-]{1,120}$")
+
+
+def selection_enabled() -> bool:
+    """``JARVIS_COCKPIT_SELECTION`` (default ON). OFF pins the cockpit to
+    FLOW, which is the pre-D3 behaviour."""
+    return os.environ.get(
+        "JARVIS_COCKPIT_SELECTION", "1",
+    ).strip().lower() in _TRUTHY
+
+
+def is_focus(mode: str) -> bool:
+    return isinstance(mode, str) and mode.startswith(MODE_FOCUS_PREFIX)
+
+
+def focus_lane(mode: str) -> Optional[str]:
+    """The lane id inside a focus mode, or None. Validated, not just split."""
+    if not is_focus(mode):
+        return None
+    lane = mode[len(MODE_FOCUS_PREFIX):]
+    return lane if _LANE_RX.match(lane) else None
+
+
+def is_valid_mode(mode: str) -> bool:
+    if not isinstance(mode, str):
+        return False
+    if mode in (MODE_FLOW, MODE_SELECT):
+        return True
+    return focus_lane(mode) is not None
+
+
+@dataclass(frozen=True)
+class ModeTransition:
+    old_mode: str
+    new_mode: str
+    reason: str = ""
+
+
+class CockpitFSM:
+    """View mode + deck cursor for one attached cockpit.
+
+    ``lanes_provider`` returns the current selectable rows (the daemon's
+    ``LaneRegistry.summary()``, delivered over the bridge). The FSM never
+    caches that list: a cursor held against a stale snapshot is exactly the
+    drift that makes selection unreliable, so position is resolved against
+    whatever the deck holds at the moment a key is pressed.
+    """
+
+    def __init__(
+        self,
+        *,
+        lanes_provider: Callable[[], Sequence[dict]] = lambda: (),
+        on_change: Optional[Callable[[ModeTransition], None]] = None,
+    ) -> None:
+        self._mode = MODE_FLOW
+        self._cursor = 0
+        self._lanes = lanes_provider
+        self._on_change = on_change
+
+    # -- state ------------------------------------------------------------
+
+    @property
+    def mode(self) -> str:
+        return self._mode
+
+    @property
+    def cursor(self) -> int:
+        return self._cursor
+
+    @property
+    def focused_lane(self) -> Optional[str]:
+        return focus_lane(self._mode)
+
+    def rows(self) -> List[dict]:
+        try:
+            return list(self._lanes() or [])
+        except Exception:  # noqa: BLE001 — a broken provider is an empty deck
+            return []
+
+    def _set(self, mode: str, reason: str) -> bool:
+        if not is_valid_mode(mode) or mode == self._mode:
+            return False
+        old, self._mode = self._mode, mode
+        if self._on_change is not None:
+            try:
+                self._on_change(ModeTransition(old, mode, reason))
+            except Exception:  # noqa: BLE001
+                pass
+        return True
+
+    # -- transitions ------------------------------------------------------
+
+    def enter_select(self) -> bool:
+        """FLOW -> SELECT. No-op when the deck is empty: a cursor list with
+        nothing in it is a mode the operator cannot leave by selecting."""
+        if not selection_enabled() or self._mode != MODE_FLOW:
+            return False
+        if not self.rows():
+            return False
+        self._cursor = 0
+        return self._set(MODE_SELECT, "operator_select")
+
+    def move(self, delta: int) -> bool:
+        """Move the cursor. CLAMPS rather than wraps.
+
+        Wrapping in a list whose length changes underneath you means Down at
+        the bottom can silently land on row 0 of a deck that just grew — the
+        operator's mental model breaks without any error."""
+        if self._mode != MODE_SELECT:
+            return False
+        rows = self.rows()
+        if not rows:
+            return self.escape()
+        self._cursor = max(0, min(len(rows) - 1, self._cursor + int(delta)))
+        return True
+
+    def focus_selected(self) -> bool:
+        """SELECT -> FOCUS. Resolves the cursor against the CURRENT deck."""
+        if self._mode != MODE_SELECT:
+            return False
+        rows = self.rows()
+        if not rows:
+            return self.escape()
+        idx = max(0, min(len(rows) - 1, self._cursor))
+        lane = str(rows[idx].get("lane", ""))
+        return self.focus(lane)
+
+    def focus(self, lane: str) -> bool:
+        """Focus a lane by id.
+
+        Does NOT verify the lane is live. A tombstoned lane is a legitimate
+        target — that is the entire point of retaining it — and a lane that
+        has aged out entirely simply fails validation here and leaves the
+        operator where they were."""
+        lane = str(lane or "")
+        if not selection_enabled() or not _LANE_RX.match(lane):
+            return False
+        return self._set(f"{MODE_FOCUS_PREFIX}{lane}", "operator_focus")
+
+    def escape(self) -> bool:
+        """Back to FLOW from anywhere. One press, not one level."""
+        self._cursor = 0
+        return self._set(MODE_FLOW, "operator_escape")
+
+    # -- render helpers ---------------------------------------------------
+
+    def selected_lane(self) -> Optional[str]:
+        if self._mode != MODE_SELECT:
+            return None
+        rows = self.rows()
+        if not rows:
+            return None
+        idx = max(0, min(len(rows) - 1, self._cursor))
+        return str(rows[idx].get("lane", "")) or None
+
+
+__all__ = [
+    "COCKPIT_FSM_SCHEMA_VERSION",
+    "MODE_FLOW",
+    "MODE_FOCUS_PREFIX",
+    "MODE_SELECT",
+    "CockpitFSM",
+    "ModeTransition",
+    "focus_lane",
+    "is_focus",
+    "is_valid_mode",
+    "selection_enabled",
+]

--- a/backend/core/ouroboros/battle_test/lane_rings.py
+++ b/backend/core/ouroboros/battle_test/lane_rings.py
@@ -124,6 +124,28 @@ class LaneLine:
     severity: str = "INFO"
 
 
+def tombstone_ttl_s() -> float:
+    """How long a finished lane's history outlives the worker that wrote it.
+
+    THE GHOST-PANE DEFENSE. The deck is painted from a snapshot; the operator
+    reads it, reaches for an arrow key, and presses Enter — and in that human
+    interval the worker can finish. Destroying the lane on completion makes
+    that a race the operator loses at random, and no amount of `except
+    KeyError` around the lookup fixes it: catching the miss just turns a crash
+    into an empty pane, which is the same lie told politely.
+
+    The answer is retention. A finished lane becomes read-only rather than
+    absent, so the selection that was valid when the operator saw it is still
+    valid when they act on it — and its final output, which is usually the
+    interesting part, is exactly what they get."""
+    try:
+        return max(1.0, min(3600.0, float(
+            os.environ.get("JARVIS_LANE_TOMBSTONE_TTL_S", "60") or 60,
+        )))
+    except (TypeError, ValueError):
+        return 60.0
+
+
 @dataclass
 class LaneState:
     lane: str
@@ -132,6 +154,12 @@ class LaneState:
     last_seen: float
     total: int = 0          # lifetime count, including lines the ring dropped
     label: str = ""
+    #: When the worker finished. None while it is still running.
+    died_at: Optional[float] = None
+
+    @property
+    def tombstoned(self) -> bool:
+        return self.died_at is not None
 
 
 class LaneRegistry:
@@ -180,16 +208,53 @@ class LaneRegistry:
         except Exception:  # noqa: BLE001
             pass
 
+    def mark_dead(self, lane: str) -> bool:
+        """The worker finished. Retain its history as a tombstone.
+
+        Idempotent, and deliberately NOT a delete: see :func:`tombstone_ttl_s`.
+        A lane that was never seen is not resurrected — marking the death of
+        something that never lived would put an empty pane in the deck."""
+        try:
+            with self._lock:
+                st = self._lanes.get(str(lane))
+                if st is None:
+                    return False
+                if st.died_at is None:
+                    st.died_at = self._clock()
+                return True
+        except Exception:  # noqa: BLE001
+            return False
+
+    def is_tombstoned(self, lane: str) -> bool:
+        with self._lock:
+            st = self._lanes.get(str(lane))
+            return bool(st and st.tombstoned)
+
+    def _expire_tombstones(self, now: float) -> None:
+        """Drop tombstones past their TTL. Called with the lock held.
+
+        Only tombstones expire on time. A live lane that has simply been quiet
+        for a while is still a worker the operator may want to look at, so
+        silence is not death."""
+        for k, st in list(self._lanes.items()):
+            if st.died_at is not None and now - st.died_at > tombstone_ttl_s():
+                del self._lanes[k]
+
     def _reap_if_needed(self, now: float) -> None:
         """Evict the least-recently-active lane when at the ceiling.
 
         Called with the lock held. Recency rather than size: a finished
         worker's history stops being interesting long before a busy one's,
         and the operator focuses what is happening now."""
+        self._expire_tombstones(now)
         limit = max_lanes()
         if len(self._lanes) < limit:
             return
-        victim = min(self._lanes.values(), key=lambda s: s.last_seen)
+        # Prefer a tombstone as the victim: a finished lane's history is worth
+        # less than a running worker's, whatever the timestamps say.
+        pool = [s for s in self._lanes.values() if s.tombstoned] or \
+               list(self._lanes.values())
+        victim = min(pool, key=lambda s: s.last_seen)
         self._lanes.pop(victim.lane, None)
         self.evicted_lanes += 1
 
@@ -210,14 +275,29 @@ class LaneRegistry:
             lines = list(st.lines)
         return lines[-limit:] if limit else lines
 
-    def summary(self) -> List[Tuple[str, int, float, str]]:
-        """``(lane, retained, last_seen, label)`` — what the deck lists."""
+    def summary(self) -> List[Dict[str, Any]]:
+        """What the selectable deck lists — live lanes first, then tombstones.
+
+        A dict rather than a tuple because this crosses the IPC bridge into
+        the client's selection list, and a positional payload would have to be
+        re-agreed at both ends every time a field is added."""
         with self._lock:
+            now = self._clock()
+            self._expire_tombstones(now)
+            rows = sorted(
+                self._lanes.values(),
+                key=lambda s: (s.tombstoned, -s.last_seen),
+            )
             return [
-                (s.lane, len(s.lines), s.last_seen, s.label)
-                for s in sorted(
-                    self._lanes.values(), key=lambda s: -s.last_seen,
-                )
+                {
+                    "lane": s.lane,
+                    "lines": len(s.lines),
+                    "last_seen": s.last_seen,
+                    "label": s.label,
+                    "tombstoned": s.tombstoned,
+                    "age_s": round(now - s.last_seen, 1),
+                }
+                for s in rows
             ]
 
     def dropped(self, lane: str) -> int:

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -393,6 +393,47 @@ class AttachUI:
             self.deck: Any = DeckManager()
         except Exception:  # noqa: BLE001 — a deckless cockpit still works
             self.deck = None
+        # D3: selectable lanes. The list is whatever the last heartbeat
+        # carried — never a client-side cache, so the cursor always resolves
+        # against what the daemon currently holds.
+        self._lanes: List[dict] = []
+        self._focus_lines: List[str] = []
+        self._focus_note: str = ""
+        try:
+            from backend.core.ouroboros.battle_test.cockpit_fsm import (
+                CockpitFSM,
+            )
+            self.fsm: Any = CockpitFSM(lanes_provider=lambda: self._lanes)
+        except Exception:  # noqa: BLE001
+            self.fsm = None
+
+    def refresh(self) -> None:
+        """Repaint after a mode change. Alias of the invalidate seam so key
+        handlers read as intent rather than mechanism."""
+        self._invalidate()
+
+    def on_lane_history(self, payload: dict) -> None:
+        """Hydrate the focused pane from the daemon's ring. NEVER raises.
+
+        ``found: false`` is rendered as an explicit notice rather than as an
+        empty pane: "this worker's output has aged out" and "this worker
+        produced nothing" are different facts and must not look alike."""
+        try:
+            lane = str(payload.get("lane", ""))
+            if self.fsm is not None and self.fsm.focused_lane != lane:
+                return                      # a stale answer for a lane we left
+            self._focus_lines = [str(x) for x in (payload.get("lines") or [])]
+            if not payload.get("found"):
+                self._focus_note = "no retained output — this lane has aged out"
+            elif payload.get("tombstoned"):
+                dropped = int(payload.get("dropped") or 0)
+                more = f", {dropped} earlier line(s) dropped" if dropped else ""
+                self._focus_note = f"finished — final output{more}"
+            else:
+                self._focus_note = "live"
+            self._invalidate()
+        except Exception:  # noqa: BLE001
+            pass
 
     def bind_app(self, app: Any) -> None:
         self._app_ref = app
@@ -457,6 +498,44 @@ class AttachUI:
             f" ov attach — organism live{audio} · 'detach' to leave"
         )
 
+    def _mode_lines(self) -> Optional[List[str]]:
+        """SELECT / FOCUS rendering, or None to fall through to the deck.
+
+        Both modes draw into the SAME bottom toolbar the ambient deck uses —
+        one region, three states — so nothing competes for the terminal and
+        the operator's input line is never disturbed."""
+        try:
+            from backend.core.ouroboros.battle_test.cockpit_fsm import (
+                MODE_SELECT,
+            )
+            fsm = self.fsm
+            if fsm is None:
+                return None
+            if fsm.mode == MODE_SELECT:
+                rows = fsm.rows()
+                if not rows:
+                    return ["  (no lanes) · esc"]
+                out = ["  [bold]lanes[/bold] [dim]↑↓ move · ⏎ focus · esc[/dim]"]
+                for i, r in enumerate(rows[:8]):
+                    cur = "▸" if i == fsm.cursor else " "
+                    dead = " [dim](finished)[/dim]" if r.get("tombstoned") else ""
+                    out.append(
+                        f"  {cur} {r.get('lane','?')}{dead} "
+                        f"[dim]{r.get('lines',0)} lines · {r.get('age_s',0)}s[/dim]"
+                    )
+                return out
+            lane = fsm.focused_lane
+            if lane:
+                head = (
+                    f"  [bold]{lane}[/bold] "
+                    f"[dim]{self._focus_note} · esc to return[/dim]"
+                )
+                body = [f"  [dim]│[/dim] {ln}" for ln in self._focus_lines[-6:]]
+                return [head] + (body or ["  [dim]│ (hydrating…)[/dim]"])
+            return None
+        except Exception:  # noqa: BLE001
+            return None
+
     def _with_deck(self, pulse_line: str) -> str:
         """Pulse on top, ambient rows beneath.
 
@@ -468,6 +547,10 @@ class AttachUI:
                 GLYPHS,
                 deck_enabled,
             )
+            # SELECT / FOCUS take the region when active; FLOW shows ambient.
+            mode_lines = self._mode_lines()
+            if mode_lines is not None:
+                return "\n".join([pulse_line] + mode_lines)
             if self.deck is None or not deck_enabled():
                 return pulse_line
             rows = self.deck.rows()
@@ -489,6 +572,13 @@ class AttachUI:
                 import time as _time
                 self._heartbeat = frame
                 self._heartbeat_arrived = _time.monotonic()
+                # Selectable lanes ride the heartbeat. Replaced wholesale
+                # rather than merged: the daemon's summary IS the truth, and
+                # a client-side merge would resurrect lanes the daemon has
+                # already reaped.
+                lanes = frame.get("lanes")
+                if isinstance(lanes, list):
+                    self._lanes = [x for x in lanes if isinstance(x, dict)]
         except Exception:
             pass
 
@@ -648,6 +738,7 @@ async def _split_plane_loop(
     session: Any = PromptSession(
         message=lambda: ui.prompt(),
         bottom_toolbar=lambda: ui.toolbar(),
+        key_bindings=_build_selection_bindings(ui, client),
     )
     ui.bind_app(session.app)
 
@@ -689,6 +780,88 @@ async def _split_plane_loop(
             if outcome == "detach":
                 break
 
+
+
+def _build_selection_bindings(ui: Any, client: Any) -> Any:
+    """Arrow/Enter/Esc for the selectable deck. NEVER raises.
+
+    Every binding is gated by a ``@Condition`` on the FSM mode rather than by
+    an ``if`` inside the handler. The difference matters: a filtered binding
+    is not registered for that keypress at all, so ``Up`` still edits history
+    and ``Enter`` still submits the line while the cockpit is in FLOW. A
+    handler that swallowed the key and then decided not to act would have
+    stolen normal editing from the operator.
+
+    Returns None when selection is disabled, which leaves the session exactly
+    as it was before D3."""
+    try:
+        from prompt_toolkit.filters import Condition
+        from prompt_toolkit.key_binding import KeyBindings
+
+        from backend.core.ouroboros.battle_test.cockpit_fsm import (
+            MODE_FLOW,
+            MODE_SELECT,
+            selection_enabled,
+        )
+        if not selection_enabled():
+            return None
+
+        kb = KeyBindings()
+        fsm = ui.fsm
+
+        in_select = Condition(lambda: fsm.mode == MODE_SELECT)
+        not_flow = Condition(lambda: fsm.mode != MODE_FLOW)
+        # Entering SELECT is only offered when the buffer is EMPTY. Ctrl-O on
+        # a half-typed command would otherwise discard the operator's context
+        # to open a picker they can only leave by escaping.
+        can_open = Condition(
+            lambda: fsm.mode == MODE_FLOW and not _buffer_text(),
+        )
+
+        @kb.add("c-o", filter=can_open)
+        def _open(event: Any) -> None:
+            fsm.enter_select()
+            ui.refresh()
+
+        @kb.add("up", filter=in_select)
+        def _up(event: Any) -> None:
+            fsm.move(-1)
+            ui.refresh()
+
+        @kb.add("down", filter=in_select)
+        def _down(event: Any) -> None:
+            fsm.move(1)
+            ui.refresh()
+
+        @kb.add("enter", filter=in_select)
+        def _enter(event: Any) -> None:
+            lane = fsm.selected_lane()
+            if fsm.focus_selected() and lane:
+                # Hydration is REQUESTED, never assumed present. The daemon
+                # answers from the lane's ring — including a tombstoned one.
+                try:
+                    client.send_lane(lane)
+                except Exception:  # noqa: BLE001
+                    pass
+            ui.refresh()
+
+        @kb.add("escape", filter=not_flow, eager=True)
+        def _esc(event: Any) -> None:
+            fsm.escape()
+            ui.refresh()
+
+        return kb
+    except Exception:  # noqa: BLE001 — a cockpit without selection still works
+        return None
+
+
+def _buffer_text() -> str:
+    """Current input buffer, or "" when there is no live application."""
+    try:
+        from prompt_toolkit.application.current import get_app
+        return get_app().current_buffer.text or ""
+    except Exception:  # noqa: BLE001
+        return ""
 
 
 async def _attach_rms_stream(scope: Any) -> Any:
@@ -1266,6 +1439,7 @@ def run_attach(console: Any) -> int:
             on_markup=_markup_sink,
             on_telemetry=ui.on_telemetry,
             on_audio_state=ui.on_audio_state,
+            on_lane_history=ui.on_lane_history,
         )
         if not await client.connect():
             console.print(_NO_ORGANISM_MESSAGE, markup=False, highlight=False)

--- a/backend/core/ouroboros/governance/autonomy/subagent_scheduler.py
+++ b/backend/core/ouroboros/governance/autonomy/subagent_scheduler.py
@@ -177,12 +177,25 @@ class GenerationSubagentExecutor:
         except Exception:  # noqa: BLE001 — untagged beats not running
             import contextlib as _ctxlib
             _lane_ctx = _ctxlib.nullcontext()
-        with _lane_ctx:
-            return await self._execute_tagged(
-                graph, unit, started_at_ns, causal_parent_id,
-                _worktree_path, _sandbox, _worktree_create_mono,
-                _worktree_lifespan_s, _dw_cost_usd, _branch_label, _result,
-            )
+        try:
+            with _lane_ctx:
+                return await self._execute_tagged(
+                    graph, unit, started_at_ns, causal_parent_id,
+                    _worktree_path, _sandbox, _worktree_create_mono,
+                    _worktree_lifespan_s, _dw_cost_usd, _branch_label, _result,
+                )
+        finally:
+            # TOMBSTONE, not delete — the deck may be showing this unit and
+            # the operator's selection takes a human moment. Retained
+            # read-only so focusing a just-finished worker hydrates its final
+            # output instead of racing its destruction.
+            try:
+                from backend.core.ouroboros.battle_test.lane_rings import (
+                    get_lane_registry,
+                )
+                get_lane_registry().mark_dead(f"unit/{unit.unit_id}")
+            except Exception:  # noqa: BLE001
+                pass
 
     async def _execute_tagged(
         self, graph: ExecutionGraph, unit: WorkUnitSpec,

--- a/backend/core/ouroboros/governance/chunk_swarm.py
+++ b/backend/core/ouroboros/governance/chunk_swarm.py
@@ -135,6 +135,18 @@ async def swarm_repair(
                 return (target, None, exc)
             finally:
                 in_flight["cur"] -= 1
+                # TOMBSTONE, not delete. The deck may already be showing this
+                # lane, and the operator's arrow-and-Enter takes a human
+                # moment — destroying the ring here would make that selection
+                # race the worker's completion. Its final output is usually
+                # the interesting part, so it is retained read-only.
+                try:
+                    from backend.core.ouroboros.battle_test.lane_rings import (
+                        get_lane_registry,
+                    )
+                    get_lane_registry().mark_dead(_lane)
+                except Exception:  # noqa: BLE001
+                    pass
 
     # asyncio.gather = structured concurrent fan-out (Python 3.9-safe; the
     # TaskGroup equivalent without the 3.11 floor the codebase forbids). Each

--- a/tests/battle_test/test_cockpit_selection.py
+++ b/tests/battle_test/test_cockpit_selection.py
@@ -1,0 +1,349 @@
+"""D3 — selection, focus, and the tombstone that makes them safe.
+
+The ghost pane
+--------------
+The deck is painted from a snapshot. The operator reads it, reaches for an
+arrow key, and presses Enter — and in that human interval the worker can
+finish. Destroying the lane on completion makes that a race the operator
+loses at random.
+
+Wrapping the lookup in ``except KeyError`` does not fix it. Catching the miss
+turns a crash into an empty pane, which is the same lie told politely: the
+operator asked to see a worker's output and was shown nothing, with no way to
+tell "it produced nothing" from "it was deleted between your eye and your
+finger". The fix is retention, so the selection that was valid when it was
+displayed is still valid when it is acted on.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, Dict, List
+
+import pytest
+
+from backend.core.ouroboros.battle_test.cockpit_fsm import (
+    MODE_FLOW,
+    MODE_SELECT,
+    CockpitFSM,
+    focus_lane,
+    is_valid_mode,
+)
+from backend.core.ouroboros.battle_test.lane_rings import (
+    LaneRegistry,
+    get_lane_registry,
+    reset_lane_registry,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean():
+    reset_lane_registry()
+    yield
+    reset_lane_registry()
+
+
+def _rows(*lanes: str) -> List[Dict[str, Any]]:
+    return [
+        {"lane": ln, "lines": 3, "last_seen": 0.0, "label": "",
+         "tombstoned": False, "age_s": 0.1}
+        for ln in lanes
+    ]
+
+
+# --------------------------------------------------------------------------
+# 1. the tombstone — requirement 1
+# --------------------------------------------------------------------------
+
+def test_focusing_a_just_finished_lane_hydrates_its_history() -> None:
+    """The race the operator would otherwise lose."""
+    reg = LaneRegistry(ring=10)
+    reg.record("unit/7", "read saga.py")
+    reg.record("unit/7", "patched _topological_sort")
+    reg.mark_dead("unit/7")          # worker finishes mid-selection
+
+    assert reg.is_tombstoned("unit/7")
+    hist = [ln.text for ln in reg.history("unit/7")]
+    assert hist == ["read saga.py", "patched _topological_sort"], (
+        "a finished lane lost its history — the pane would render empty"
+    )
+
+
+def test_a_tombstoned_lane_is_still_listed_and_selectable() -> None:
+    reg = LaneRegistry(ring=10)
+    reg.record("unit/7", "x")
+    reg.mark_dead("unit/7")
+    rows = reg.summary()
+    assert rows and rows[0]["lane"] == "unit/7"
+    assert rows[0]["tombstoned"] is True
+
+    fsm = CockpitFSM(lanes_provider=lambda: rows)
+    assert fsm.enter_select() is True
+    assert fsm.focus_selected() is True
+    assert fsm.focused_lane == "unit/7"
+
+
+def test_live_lanes_sort_above_tombstones() -> None:
+    """A running worker is more interesting than a finished one."""
+    clock = {"t": 0.0}
+    reg = LaneRegistry(ring=10, clock=lambda: clock["t"])
+    reg.record("unit/dead", "x")
+    reg.mark_dead("unit/dead")
+    clock["t"] = 1.0
+    reg.record("unit/live", "y")
+    assert [r["lane"] for r in reg.summary()] == ["unit/live", "unit/dead"]
+
+
+def test_tombstones_expire_but_quiet_live_lanes_do_not(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Silence is not death — a quiet worker is still a worker."""
+    monkeypatch.setenv("JARVIS_LANE_TOMBSTONE_TTL_S", "10")
+    clock = {"t": 0.0}
+    reg = LaneRegistry(ring=10, clock=lambda: clock["t"])
+    reg.record("unit/dead", "x")
+    reg.record("unit/quiet", "y")
+    reg.mark_dead("unit/dead")
+    clock["t"] = 30.0
+    lanes = [r["lane"] for r in reg.summary()]
+    assert "unit/dead" not in lanes
+    assert "unit/quiet" in lanes
+
+
+def test_marking_an_unknown_lane_does_not_invent_one() -> None:
+    reg = LaneRegistry(ring=10)
+    assert reg.mark_dead("never/existed") is False
+    assert reg.summary() == []
+
+
+def test_eviction_prefers_tombstones_over_live_lanes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_LANE_MAX", "2")
+    clock = {"t": 0.0}
+    reg = LaneRegistry(ring=5, clock=lambda: clock["t"])
+    reg.record("live/old", "a")          # oldest, but ALIVE
+    clock["t"] = 5.0
+    reg.record("dead/new", "b")
+    reg.mark_dead("dead/new")
+    clock["t"] = 10.0
+    reg.record("live/new", "c")          # forces an eviction
+    lanes = [r["lane"] for r in reg.summary()]
+    assert "live/old" in lanes, "a running worker was evicted for a corpse"
+    assert "dead/new" not in lanes
+
+
+# --------------------------------------------------------------------------
+# 2. the FSM — requirement 2
+# --------------------------------------------------------------------------
+
+def test_escape_returns_to_flow_from_focus() -> None:
+    fsm = CockpitFSM(lanes_provider=lambda: _rows("unit/1"))
+    fsm.enter_select()
+    fsm.focus_selected()
+    assert fsm.mode.startswith("focus:")
+    assert fsm.escape() is True
+    assert fsm.mode == MODE_FLOW, "esc did not restore the ambient view"
+
+
+def test_escape_from_select_also_returns_to_flow() -> None:
+    fsm = CockpitFSM(lanes_provider=lambda: _rows("unit/1"))
+    fsm.enter_select()
+    fsm.escape()
+    assert fsm.mode == MODE_FLOW
+
+
+def test_escape_is_one_press_not_one_level() -> None:
+    """An operator hitting Escape wants out, not one step back."""
+    fsm = CockpitFSM(lanes_provider=lambda: _rows("a", "b"))
+    fsm.enter_select()
+    fsm.move(1)
+    fsm.focus_selected()
+    fsm.escape()
+    assert fsm.mode == MODE_FLOW
+    assert fsm.cursor == 0
+
+
+def test_select_is_refused_on_an_empty_deck() -> None:
+    """A cursor list with nothing in it is a mode you cannot leave by
+    selecting."""
+    fsm = CockpitFSM(lanes_provider=lambda: [])
+    assert fsm.enter_select() is False
+    assert fsm.mode == MODE_FLOW
+
+
+def test_cursor_clamps_and_does_not_wrap() -> None:
+    """Wrapping in a list whose length changes underneath means Down at the
+    bottom can silently land on row 0 of a deck that just grew."""
+    fsm = CockpitFSM(lanes_provider=lambda: _rows("a", "b"))
+    fsm.enter_select()
+    fsm.move(-5)
+    assert fsm.cursor == 0
+    fsm.move(99)
+    assert fsm.cursor == 1
+
+
+def test_cursor_resolves_against_the_current_deck_not_a_snapshot() -> None:
+    """The structural answer to drift: nothing is cached, so a deck that
+    shrank between keypresses cannot produce an out-of-range selection."""
+    rows = _rows("a", "b", "c")
+    fsm = CockpitFSM(lanes_provider=lambda: rows)
+    fsm.enter_select()
+    fsm.move(2)
+    assert fsm.cursor == 2
+    del rows[1:]                       # the deck shrinks under the cursor
+    assert fsm.focus_selected() is True
+    assert fsm.focused_lane == "a", "selection resolved against a stale list"
+
+
+def test_deck_emptying_during_select_drops_back_to_flow() -> None:
+    rows = _rows("a")
+    fsm = CockpitFSM(lanes_provider=lambda: rows)
+    fsm.enter_select()
+    rows.clear()
+    fsm.move(1)
+    assert fsm.mode == MODE_FLOW
+
+
+def test_a_broken_lanes_provider_is_an_empty_deck() -> None:
+    def _boom() -> Any:
+        raise RuntimeError("provider on fire")
+
+    fsm = CockpitFSM(lanes_provider=_boom)
+    assert fsm.rows() == []
+    assert fsm.enter_select() is False
+
+
+@pytest.mark.parametrize("bad", ["", "focus:", "focus:has space",
+                                 "focus:" + "x" * 200, "nonsense"])
+def test_invalid_modes_are_rejected(bad: str) -> None:
+    assert is_valid_mode(bad) is False
+    assert focus_lane(bad) is None
+
+
+def test_selection_can_be_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JARVIS_COCKPIT_SELECTION", "0")
+    fsm = CockpitFSM(lanes_provider=lambda: _rows("a"))
+    assert fsm.enter_select() is False
+    assert fsm.focus("a") is False
+
+
+# --------------------------------------------------------------------------
+# 3. hydration over the bridge
+# --------------------------------------------------------------------------
+
+class _Writer:
+    def __init__(self) -> None:
+        self.frames: List[Dict[str, Any]] = []
+
+    def is_closing(self) -> bool:
+        return False
+
+    def write(self, data: bytes) -> None:
+        for line in data.decode().splitlines():
+            if line.strip():
+                self.frames.append(json.loads(line))
+
+    def close(self) -> None:
+        pass
+
+
+async def test_history_request_is_answered_only_to_the_asker() -> None:
+    from backend.core.ouroboros.battle_test.cockpit_attach import (
+        CockpitAttachBridge,
+    )
+    reg = get_lane_registry()
+    reg.record("unit/9", "did the thing")
+    reg.mark_dead("unit/9")
+
+    a, b = _Writer(), _Writer()
+    bridge = CockpitAttachBridge()
+    bridge._loop = asyncio.get_running_loop()   # type: ignore[attr-defined]
+    for w, sid in ((a, "sess-A"), (b, "sess-B")):
+        bridge._clients.add(w)                  # type: ignore[arg-type]
+        bridge.bind_session(sid, w)             # type: ignore[arg-type]
+
+    bridge._serve_lane_history("unit/9", "sess-A")
+    await asyncio.sleep(0)
+
+    assert a.frames and a.frames[0]["type"] == "lane_history"
+    assert a.frames[0]["lines"] == ["did the thing"]
+    assert a.frames[0]["tombstoned"] is True
+    assert b.frames == [], "another cockpit saw terminal A's focused lane"
+
+
+async def test_a_vanished_lane_answers_found_false_not_silence() -> None:
+    """An empty pane and an aged-out lane are different facts."""
+    from backend.core.ouroboros.battle_test.cockpit_attach import (
+        CockpitAttachBridge,
+    )
+    w = _Writer()
+    bridge = CockpitAttachBridge()
+    bridge._loop = asyncio.get_running_loop()   # type: ignore[attr-defined]
+    bridge._clients.add(w)                      # type: ignore[arg-type]
+    bridge.bind_session("sess-A", w)            # type: ignore[arg-type]
+
+    bridge._serve_lane_history("unit/gone", "sess-A")
+    await asyncio.sleep(0)
+    assert w.frames[0]["found"] is False
+    assert w.frames[0]["lines"] == []
+
+
+# --------------------------------------------------------------------------
+# 4. the client renders each mode into the one toolbar region
+# --------------------------------------------------------------------------
+
+def test_toolbar_shows_the_lane_list_in_select() -> None:
+    from backend.core.ouroboros.cli import ov
+
+    ui = ov.AttachUI()
+    ui._lanes = _rows("swarm/a", "unit/b")
+    assert ui.fsm.enter_select() is True
+    out = ui.toolbar()
+    assert "swarm/a" in out and "unit/b" in out
+    assert "↑↓" in out, "no affordance shown for the new mode"
+
+
+def test_toolbar_shows_hydrated_output_in_focus() -> None:
+    from backend.core.ouroboros.cli import ov
+
+    ui = ov.AttachUI()
+    ui._lanes = _rows("unit/b")
+    ui.fsm.enter_select()
+    ui.fsm.focus_selected()
+    ui.on_lane_history({
+        "lane": "unit/b", "found": True, "tombstoned": True,
+        "dropped": 0, "lines": ["patched saga.py"],
+    })
+    out = ui.toolbar()
+    assert "patched saga.py" in out
+    assert "finished" in out
+
+
+def test_stale_hydration_for_an_abandoned_lane_is_ignored() -> None:
+    """The operator escaped before the answer arrived; it must not repaint
+    a pane they already left."""
+    from backend.core.ouroboros.cli import ov
+
+    ui = ov.AttachUI()
+    ui._lanes = _rows("unit/b")
+    ui.fsm.enter_select()
+    ui.fsm.focus_selected()
+    ui.fsm.escape()
+    ui.on_lane_history({
+        "lane": "unit/b", "found": True, "lines": ["late answer"],
+    })
+    assert "late answer" not in ui.toolbar()
+
+
+def test_escape_restores_the_ambient_deck_view() -> None:
+    """Requirement 2, at the render layer."""
+    from backend.core.ouroboros.cli import ov
+
+    ui = ov.AttachUI()
+    ui.on_ambient("DW provider failover")
+    ui._lanes = _rows("unit/b")
+    ui.fsm.enter_select()
+    assert "failover" not in ui.toolbar(), "ambient deck leaked into SELECT"
+    ui.fsm.escape()
+    assert "failover" in ui.toolbar(), "ambient view was not restored"


### PR DESCRIPTION
## The ghost pane

The deck is painted from a snapshot. The operator reads it, reaches for an arrow key, presses Enter — and in that human interval the worker can finish. Destroying the lane on completion makes that a race the operator loses at random.

**`except KeyError` does not fix it.** Catching the miss turns a crash into an empty pane — the same lie told politely. They asked to see a worker's output and were shown nothing, with no way to distinguish *"it produced nothing"* from *"it was deleted between your eye and your finger"*.

So a finished worker is **tombstoned, not deleted**: read-only, retained 60 s, still listed and still selectable. The selection that was valid when displayed is still valid when acted on, and the final output — usually the interesting part — is exactly what hydrates.

Two supporting properties:

- Live lanes sort above tombstones, and eviction **prefers a tombstone as its victim** — a running worker is never evicted for a corpse.
- **Only tombstones expire on a clock.** A quiet live lane is still a worker worth looking at; silence is not death.

## Client-side FSM

`cockpit_fsm.py` ports `layout_controller`'s mode machine *into the client* rather than reaching across to it. That FSM lives in the daemon and drives the local console; driving it over the bridge would put a socket round-trip between an arrow key and a repaint — and would mean two attached cockpits **shared one view mode**, so Down in terminal A moves terminal B's cursor.

`FLOW` / `SELECT` / `FOCUS:<lane>`. The cursor is **never cached**: it resolves against whatever the deck holds at the moment a key is pressed, which is the structural answer to drift — a deck that shrank cannot yield an out-of-range selection. It **clamps rather than wraps**, because wrapping in a list whose length changes means Down at the bottom silently lands on row 0 of a deck that just grew. `Esc` pops to `FLOW` from anywhere: one press, not one level.

## Atomic keybindings

Every binding is gated by a `@Condition` on the mode, **not** an `if` inside the handler. A filtered binding isn't registered for that keypress at all, so `Up` still edits history and `Enter` still submits while in FLOW. A handler that swallowed the key then declined to act would have stolen normal editing.

`Ctrl-O` opens SELECT only when the input buffer is **empty** — otherwise it would discard a half-typed command to open a picker.

## DRY

- Lane list rides the **existing ~1 Hz heartbeat** — a dedicated channel would be a parallel lifecycle for no extra freshness.
- Focus hydrates from `LaneRegistry.history()` via one `lane` request, answered **only to the asking session**, reusing D2's session scope — no second addressing mechanism.
- All three modes render into the **same bottom toolbar** as the D1 deck. One region, three states.

A vanished lane answers `found: false` rather than silence, so the pane can say *"aged out"* instead of rendering blank.

```
❯ █
  ✽ Synthesizing… (4m 9s · ↓ 15.9k · DW-397B)
  lanes  ↑↓ move · ⏎ focus · esc
  ▸ swarm/chunk-3          12 lines · 0.4s
    unit/7 (finished)       8 lines · 3.1s
```

## Tests

26 — both requirement cases (focusing a just-tombstoned lane hydrates; `Esc` restores the ambient view at both FSM and render layers), plus cursor drift against a shrinking deck, eviction preferring corpses, stale hydration for an abandoned lane ignored, and per-session history isolation.

selection 26 · lane 16 · deck 19 · omni 16 · attach 28 · heartbeat 13 · autonomy **700** · cli 265 (2 pre-existing, baseline-verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds safe lane selection and focus with tombstones, plus a client-side FSM that keeps the UI responsive and avoids the “ghost pane” race. The deck now lists live lanes first, and focusing hydrates per-session history reliably.

- New Features
  - Tombstones: finished lanes are retained read-only for 60s (configurable), still listed/selectable; only tombstones expire; eviction prefers tombstones over live lanes.
  - Client-side FSM: FLOW / SELECT / FOCUS:<lane>; cursor clamps (no wrap); selection resolves against the current deck; Esc returns to FLOW from anywhere.
  - Bridge + heartbeat: heartbeat carries a lane summary for selection; lane history requests are answered only to the requesting session; vanished lanes reply with found=false.
  - UI/keybindings: Ctrl+O opens SELECT only on an empty buffer; ↑/↓ to move, Enter to focus and hydrate; SELECT/FOCUS render in the existing toolbar; selection can be disabled with JARVIS_COCKPIT_SELECTION.
  - Tests: added coverage for tombstones, deck drift, per-session history isolation, Esc behavior, and eviction rules.

- Migration
  - No changes required. Optional: set JARVIS_LANE_TOMBSTONE_TTL_S to tune retention; set JARVIS_COCKPIT_SELECTION=0 to disable selection.

<sup>Written for commit e0a1776174d10a85dae48a911f0ed0dc79913d5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

