### PR TITLE
feat(ov): D4 — agora as a lane, deck sizing, graceful ejection (+ layout correction)

### DIFF
--- a/backend/core/ouroboros/battle_test/cockpit_attach.py
+++ b/backend/core/ouroboros/battle_test/cockpit_attach.py
@@ -638,6 +638,37 @@ class CockpitAttachBridge:
         except Exception:  # noqa: BLE001
             logger.debug("[CockpitAttach] lane history degraded", exc_info=True)
 
+    def announce_lane_reaped(self, lane: str) -> None:
+        """Tell every cockpit a lane no longer exists. NEVER raises.
+
+        Broadcast, not addressed: any terminal could be focused on it. This
+        is the one lane message that is genuinely everyone's business."""
+        try:
+            if not self._clients:
+                return
+            loop = self._loop
+            if loop is None or loop.is_closed():
+                return
+            msg = {"type": "lane_reaped", "lane": str(lane), "ts": time.time()}
+
+            def _emit() -> None:
+                from backend.core.ouroboros.battle_test.attach_session import (
+                    session_scope,
+                )
+                with session_scope(None):     # ambient — reaches all cockpits
+                    self._broadcast(msg)
+
+            try:
+                running = asyncio.get_running_loop()
+            except RuntimeError:
+                running = None
+            if running is loop:
+                _emit()
+            else:
+                loop.call_soon_threadsafe(_emit)
+        except Exception:  # noqa: BLE001
+            logger.debug("[CockpitAttach] reap announce degraded", exc_info=True)
+
     def bind_session(self, session_id: str, w: asyncio.StreamWriter) -> None:
         """Associate a cockpit's declared identity with its socket.
 
@@ -776,6 +807,7 @@ class CockpitAttachClient:
         on_audio_state: Optional[Callable[[str], None]] = None,
         on_thermal: Optional[Callable[[str], None]] = None,
         on_lane_history: Optional[Callable[[Dict[str, Any]], None]] = None,
+        on_lane_reaped: Optional[Callable[[str], None]] = None,
         path: Optional[Path] = None,
     ) -> None:
         self._path = Path(path) if path is not None else attach_socket_path()
@@ -791,6 +823,9 @@ class CockpitAttachClient:
         #: Focused-lane hydration payloads (D3). Absent handler = the client
         #: does not use selection; the frame is simply not dispatched.
         self._on_lane_history = on_lane_history or (lambda _p: None)
+        #: A lane stopped existing. The FSM cannot infer this from an absent
+        #: heartbeat row — that is indistinguishable from a slow frame.
+        self._on_lane_reaped = on_lane_reaped or (lambda _l: None)
         #: This cockpit's identity for the life of the attachment. Declared
         #: on every outbound frame so the daemon can address answers back to
         #: the terminal that asked, instead of to all of them.
@@ -960,6 +995,10 @@ class CockpitAttachClient:
                 elif ftype == "thermal":
                     self._safe_cb_text(
                         self._on_thermal, str(frame.get("state", "")),
+                    )
+                elif ftype == "lane_reaped":
+                    self._safe_cb_text(
+                        self._on_lane_reaped, str(frame.get("lane", "")),
                     )
                 elif ftype == "lane_history":
                     try:

--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -4597,6 +4597,17 @@ class BattleTestHarness:
                 except Exception:  # noqa: BLE001
                     logger.debug("[Moltbook] live feed wiring degraded",
                                  exc_info=True)
+                # D4: a reaped lane must eject any cockpit focused on it.
+                try:
+                    from backend.core.ouroboros.battle_test.lane_rings import (
+                        get_lane_registry,
+                    )
+                    self._lane_unsub = get_lane_registry().on_reap(
+                        bridge.announce_lane_reaped,
+                    )
+                except Exception:  # noqa: BLE001
+                    logger.debug("[Moltbook] live feed wiring degraded",
+                                 exc_info=True)
                 # Attach heartbeat (2026-07-23): ~1s CC-style pulse
                 # (verb · elapsed · ↓ tokens · provider) published on
                 # the telemetry lane; publish_telemetry no-ops with

--- a/backend/core/ouroboros/battle_test/lane_rings.py
+++ b/backend/core/ouroboros/battle_test/lane_rings.py
@@ -177,6 +177,46 @@ class LaneRegistry:
         self._lanes: Dict[str, LaneState] = {}
         self._lock = threading.Lock()
         self.evicted_lanes = 0
+        #: Called with a lane id when it stops existing — TTL expiry or
+        #: eviction. The client FSM cannot infer this: a lane simply missing
+        #: from the next heartbeat is indistinguishable from a slow frame, so
+        #: an operator focused on it would sit in a pane that never updates
+        #: and never explains itself. The daemon knows the moment it happens
+        #: and says so.
+        self._reap_sinks: List[Callable[[str], None]] = []
+        #: Reaps collected under the lock, announced after it is released.
+        self._pending_reaps: List[str] = []
+
+    def on_reap(self, sink: Callable[[str], None]) -> Callable[[], None]:
+        """Subscribe to lane disappearance. Returns an unsubscribe callable."""
+        self._reap_sinks.append(sink)
+
+        def _off() -> None:
+            try:
+                self._reap_sinks.remove(sink)
+            except ValueError:
+                pass
+        return _off
+
+    def _drain_reaps(self) -> None:
+        """Announce reaps collected under the lock. Call AFTER releasing it.
+
+        The two-phase shape is deliberate: eviction and TTL expiry both run
+        inside the critical section, and a subscriber that queries the
+        registry from its callback would deadlock if notified there."""
+        with self._lock:
+            pending, self._pending_reaps = self._pending_reaps, []
+        for lane in pending:
+            self._announce_reap(lane)
+
+    def _announce_reap(self, lane: str) -> None:
+        """Fan out one reap. Called WITHOUT the lock held — a sink that
+        reaches back into the registry must not deadlock. NEVER raises."""
+        for sink in list(self._reap_sinks):
+            try:
+                sink(lane)
+            except Exception:  # noqa: BLE001
+                logger.debug("[LaneRings] reap sink degraded", exc_info=True)
 
     def record(
         self, lane: str, text: str, *, severity: str = "INFO",
@@ -205,6 +245,7 @@ class LaneRegistry:
                 st.lines.append(LaneLine(text=text, ts=now, severity=severity))
                 st.last_seen = now
                 st.total += 1
+            self._drain_reaps()
         except Exception:  # noqa: BLE001
             pass
 
@@ -230,15 +271,21 @@ class LaneRegistry:
             st = self._lanes.get(str(lane))
             return bool(st and st.tombstoned)
 
-    def _expire_tombstones(self, now: float) -> None:
+    def _expire_tombstones(self, now: float) -> List[str]:
         """Drop tombstones past their TTL. Called with the lock held.
+
+        Returns the reaped ids rather than announcing them, because the
+        caller holds the lock and a sink that reaches back in would deadlock.
 
         Only tombstones expire on time. A live lane that has simply been quiet
         for a while is still a worker the operator may want to look at, so
         silence is not death."""
+        reaped: List[str] = []
         for k, st in list(self._lanes.items()):
             if st.died_at is not None and now - st.died_at > tombstone_ttl_s():
                 del self._lanes[k]
+                reaped.append(k)
+        return reaped
 
     def _reap_if_needed(self, now: float) -> None:
         """Evict the least-recently-active lane when at the ceiling.
@@ -246,17 +293,18 @@ class LaneRegistry:
         Called with the lock held. Recency rather than size: a finished
         worker's history stops being interesting long before a busy one's,
         and the operator focuses what is happening now."""
-        self._expire_tombstones(now)
+        reaped = self._expire_tombstones(now)
         limit = max_lanes()
-        if len(self._lanes) < limit:
-            return
-        # Prefer a tombstone as the victim: a finished lane's history is worth
-        # less than a running worker's, whatever the timestamps say.
-        pool = [s for s in self._lanes.values() if s.tombstoned] or \
-               list(self._lanes.values())
-        victim = min(pool, key=lambda s: s.last_seen)
-        self._lanes.pop(victim.lane, None)
-        self.evicted_lanes += 1
+        if len(self._lanes) >= limit:
+            # Prefer a tombstone as the victim: a finished lane's history is
+            # worth less than a running worker's, whatever the timestamps say.
+            pool = [s for s in self._lanes.values() if s.tombstoned] or \
+                   list(self._lanes.values())
+            victim = min(pool, key=lambda s: s.last_seen)
+            self._lanes.pop(victim.lane, None)
+            self.evicted_lanes += 1
+            reaped.append(victim.lane)
+        self._pending_reaps.extend(reaped)
 
     # -- read side --------------------------------------------------------
 
@@ -283,12 +331,12 @@ class LaneRegistry:
         re-agreed at both ends every time a field is added."""
         with self._lock:
             now = self._clock()
-            self._expire_tombstones(now)
+            self._pending_reaps.extend(self._expire_tombstones(now))
             rows = sorted(
                 self._lanes.values(),
                 key=lambda s: (s.tombstoned, -s.last_seen),
             )
-            return [
+            out = [
                 {
                     "lane": s.lane,
                     "lines": len(s.lines),
@@ -299,6 +347,11 @@ class LaneRegistry:
                 }
                 for s in rows
             ]
+        # Announced here, outside the lock: summary() is polled ~1Hz by the
+        # heartbeat, which makes it the reliable place a TTL expiry becomes
+        # observable even if nothing else touches the registry.
+        self._drain_reaps()
+        return out
 
     def dropped(self, lane: str) -> int:
         """Lines this lane emitted that the ring no longer holds. Reported

--- a/backend/core/ouroboros/battle_test/termination_hook_default_adapters.py
+++ b/backend/core/ouroboros/battle_test/termination_hook_default_adapters.py
@@ -185,6 +185,18 @@ _CAUSE_TO_SESSION_OUTCOME: dict = {
     TerminationCause.WALL_CLOCK_CAP: "complete",
     TerminationCause.IDLE_TIMEOUT: "complete",
     TerminationCause.BUDGET_EXCEEDED: "complete",
+    # A memory-cap kill is a RESOURCE GUARD firing, not a finished session.
+    # Grouped with the signal causes rather than the intended ones: the
+    # harness was stopped mid-work by a watchdog, so the run is interrupted
+    # and its summary is partial. Stamping "complete" would let the soak
+    # classifier score an OOM abort as a clean bar — the precise mistake the
+    # Layer 8 mapping exists to prevent, in the opposite direction.
+    #
+    # This mapping was MISSING: PROCESS_MEMORY_CAP was added to the enum
+    # without being classified here, which is exactly the omission
+    # test_cause_map_covers_all_causes was written to catch. The pin worked;
+    # nobody read it, because the suite it lives in could not complete.
+    TerminationCause.PROCESS_MEMORY_CAP: "incomplete_kill",
     TerminationCause.NORMAL_EXIT: None,  # clean path writes
                                           # "complete" itself
     TerminationCause.UNKNOWN: "incomplete_kill",  # safe default

--- a/backend/core/ouroboros/battle_test/termination_hook_registry.py
+++ b/backend/core/ouroboros/battle_test/termination_hook_registry.py
@@ -966,6 +966,11 @@ def register_shipped_invariants() -> list:
                 "WALL_CLOCK_CAP", "SIGTERM", "SIGINT", "SIGHUP",
                 "IDLE_TIMEOUT", "BUDGET_EXCEEDED",
                 "NORMAL_EXIT", "UNKNOWN",
+                # Widened deliberately. The pin demands "update the AST pin
+                # AND the test suite when widening the vocabulary" — both
+                # done, along with the _CAUSE_TO_SESSION_OUTCOME mapping the
+                # addition had silently skipped.
+                "PROCESS_MEMORY_CAP",
             },
         )
 

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -399,6 +399,9 @@ class AttachUI:
         self._lanes: List[dict] = []
         self._focus_lines: List[str] = []
         self._focus_note: str = ""
+        self._flash_text: str = ""
+        self._flash_until: float = 0.0
+        self._deck_size: str = "full"
         try:
             from backend.core.ouroboros.battle_test.cockpit_fsm import (
                 CockpitFSM,
@@ -406,6 +409,65 @@ class AttachUI:
             self.fsm: Any = CockpitFSM(lanes_provider=lambda: self._lanes)
         except Exception:  # noqa: BLE001
             self.fsm = None
+
+    def on_lane_reaped(self, lane: str) -> None:
+        """The daemon garbage-collected a lane. Eject if we are in it.
+
+        DRY: an auto-eject is the daemon pressing Esc for the operator, so it
+        calls the SAME ``fsm.escape()`` the key binding calls — one transition
+        path, one set of invariants. A parallel "force_flow" would be a second
+        way to reach FLOW that could drift from the first.
+
+        The flash matters as much as the transition. Silently yanking someone
+        out of a pane looks like the UI glitched; naming it turns a mystery
+        into an explanation. NEVER raises."""
+        try:
+            fsm = self.fsm
+            if fsm is None or not lane:
+                return
+            if fsm.focused_lane != lane:
+                return          # not our pane — nothing to eject from
+            fsm.escape()
+            self.flash(f"lane {lane} expired — returned to ambient view")
+            self._focus_lines = []
+            self._focus_note = ""
+            self._invalidate()
+        except Exception:  # noqa: BLE001
+            pass
+
+    def flash(self, message: str, seconds: float = 4.0) -> None:
+        """Show a transient notice above the caret. NEVER raises."""
+        try:
+            import time as _t
+            self._flash_text = str(message)
+            self._flash_until = _t.monotonic() + max(0.5, float(seconds))
+            self._invalidate()
+        except Exception:  # noqa: BLE001
+            pass
+
+    def _flash_line(self) -> Optional[str]:
+        try:
+            import time as _t
+            if self._flash_text and _t.monotonic() < self._flash_until:
+                return f"  [yellow]![/yellow] {self._flash_text}"
+            self._flash_text = ""
+        except Exception:  # noqa: BLE001
+            pass
+        return None
+
+    def set_deck_size(self, mode: str) -> str:
+        """``/deck off|compact|full`` — the operator's screen budget.
+
+        Height is a CLIENT concern: two cockpits on different terminals want
+        different amounts of screen, and the daemon has no business knowing
+        how tall anyone's window is."""
+        mode = str(mode or "").strip().lower()
+        sizes = {"off": 0, "compact": 2, "full": 8}
+        if mode not in sizes:
+            return f"deck: {self._deck_size} (off | compact | full)"
+        self._deck_size = mode
+        self._invalidate()
+        return f"deck: {mode}"
 
     def refresh(self) -> None:
         """Repaint after a mode change. Alias of the invalidate seam so key
@@ -471,18 +533,59 @@ class AttachUI:
             pass
 
     def prompt(self) -> str:
-        return self._PROMPTS.get(self.audio_state, "ov › ")
+        """The live region sits ABOVE the input line, then the caret.
 
-    def toolbar(self) -> str:
-        note = self._TOOLBAR_NOTES.get(self.audio_state)
-        if note is not None:
-            audio = f" · {note}"
-        elif self.audio_state == "OFFLINE":
-            audio = " · voice: off ('wake')"
-        else:
-            audio = f" · voice: {self.audio_state.lower()}"
-        # CC-style live pulse while the organism works — falls back to
-        # the idle line when inactive/stale. NEVER raises.
+        Operator correction, and it is the right shape: the pulse, the deck
+        and a focused pane are all things the organism is DOING, and reading
+        order runs downward — status, then the line you are typing. A live
+        region below the caret makes the eye travel back up to read what just
+        happened, and the caret drifts down the screen as the region grows.
+
+        prompt_toolkit renders a multi-line ``message`` above the cursor and
+        repaints the whole block on invalidate, so this is the same seam and
+        the same redraw machinery — no second region, no manual cursor math.
+        The bottom toolbar keeps only the static key hints, which genuinely
+        do belong under the input."""
+        caret = self._PROMPTS.get(self.audio_state, "ov › ")
+        try:
+            block = self._live_region()
+            return f"{block}\n{caret}" if block else caret
+        except Exception:  # noqa: BLE001 — a caret always renders
+            return caret
+
+    def _live_region(self) -> str:
+        """Pulse + (deck | lanes | focused pane) — the block above the caret.
+
+        One region, three states, exactly as before; only its position moved.
+        Composed from the same pieces the toolbar used, so nothing about the
+        deck, the FSM or the heartbeat formatter had to change."""
+        try:
+            pulse = self._pulse_line()
+            flash = self._flash_line()
+            mode_lines = self._mode_lines()
+            if mode_lines is not None:
+                return "\n".join([pulse] + ([flash] if flash else []) + mode_lines)
+            from backend.core.ouroboros.battle_test.ambient_deck import (
+                GLYPHS,
+                deck_enabled,
+            )
+            head = [pulse] + ([flash] if flash else [])
+            cap = {"off": 0, "compact": 2, "full": 99}.get(self._deck_size, 99)
+            if self.deck is None or not deck_enabled() or cap == 0:
+                return "\n".join(head)
+            rows = self.deck.rows()[:cap]
+            if not rows:
+                return "\n".join(head)
+            return "\n".join(
+                head + [
+                    f"  {GLYPHS.get(sev, '·')} {text}" for sev, text in rows
+                ]
+            )
+        except Exception:  # noqa: BLE001
+            return ""
+
+    def _pulse_line(self) -> str:
+        """The CC-style working pulse, or the idle breadcrumb."""
         try:
             from backend.core.ouroboros.battle_test.attach_heartbeat import (
                 format_heartbeat_line,
@@ -491,12 +594,33 @@ class AttachUI:
                 self._heartbeat, arrival_mono=self._heartbeat_arrived,
             )
             if pulse:
-                return self._with_deck(f"{pulse}{audio} · 'detach' to leave")
-        except Exception:
+                return pulse
+        except Exception:  # noqa: BLE001
             pass
-        return self._with_deck(
-            f" ov attach — organism live{audio} · 'detach' to leave"
-        )
+        return "  ov attach — organism live"
+
+    def toolbar(self) -> str:
+        """Static key hints only. The live region moved above the caret; what
+        remains under the input is the affordance list, which genuinely
+        belongs there because it describes the line you are typing on."""
+        note = self._TOOLBAR_NOTES.get(self.audio_state)
+        if note is not None:
+            audio = f" · {note}"
+        elif self.audio_state == "OFFLINE":
+            audio = " · voice: off ('wake')"
+        else:
+            audio = f" · voice: {self.audio_state.lower()}"
+        try:
+            from backend.core.ouroboros.battle_test.cockpit_fsm import (
+                MODE_FLOW, selection_enabled,
+            )
+            keys = ""
+            if selection_enabled() and self.fsm is not None:
+                keys = (" · ^O lanes" if self.fsm.mode == MODE_FLOW
+                        else " · esc back")
+        except Exception:  # noqa: BLE001
+            keys = ""
+        return f"{audio.lstrip(' ·')}{keys} · 'detach' to leave"
 
     def _mode_lines(self) -> Optional[List[str]]:
         """SELECT / FOCUS rendering, or None to fall through to the deck.
@@ -672,6 +796,16 @@ def _route_operator_line(client: Any, ui: Any, line: Any) -> str:
             "mute": "sleep", "sleep": "sleep",
             "barge": "barge",
         }
+        # /deck sizing is a CLIENT concern — two cockpits on different
+        # terminals want different amounts of screen, and the daemon has no
+        # business knowing how tall anyone's window is. Handled here rather
+        # than relayed.
+        if low.startswith("/deck") or low == "deck" or low.startswith("deck "):
+            arg = text.split(None, 1)[1].strip() if " " in text else ""
+            if ui is not None and hasattr(ui, "set_deck_size"):
+                ui.flash(ui.set_deck_size(arg))
+            return "handled"
+
         cmd = audio_verbs.get(low)
         if cmd is not None:
             # AUTO-SPAWN REFLEX. `ov` boots ouroboros_battle_test.py, which has
@@ -1440,6 +1574,7 @@ def run_attach(console: Any) -> int:
             on_telemetry=ui.on_telemetry,
             on_audio_state=ui.on_audio_state,
             on_lane_history=ui.on_lane_history,
+            on_lane_reaped=ui.on_lane_reaped,
         )
         if not await client.connect():
             console.print(_NO_ORGANISM_MESSAGE, markup=False, highlight=False)

--- a/backend/core/ouroboros/governance/moltbook.py
+++ b/backend/core/ouroboros/governance/moltbook.py
@@ -602,6 +602,19 @@ async def post_molt(
             )
         except Exception:  # noqa: BLE001
             pass
+        # D4: the agora is a LANE, not a bespoke widget. Recording the post
+        # under a lane id means it lists, selects and focuses exactly like a
+        # swarm worker — @cassandra is a participant whose output happens to
+        # be posts. No special case in the deck, the FSM or the hydration.
+        try:
+            from backend.core.ouroboros.battle_test.lane_rings import (
+                get_lane_registry,
+            )
+            get_lane_registry().record(
+                "agora", f"{stored.handle}: {stored.body}", label="the agora",
+            )
+        except Exception:  # noqa: BLE001
+            pass
         _notify_subscribers(stored)
         # Proactive community: schedule the residents' reactions off
         # this call's critical path (replies never breed replies).

--- a/tests/battle_test/test_ambient_deck.py
+++ b/tests/battle_test/test_ambient_deck.py
@@ -222,15 +222,20 @@ def test_addressed_goes_to_scrollback_ambient_goes_to_the_deck(
     )
 
 
-def test_toolbar_grows_to_show_deck_rows() -> None:
+def test_live_region_grows_above_the_caret() -> None:
+    """The pulse and deck render ABOVE the input line (operator layout), so
+    the block is part of the prompt, not the bottom toolbar."""
     from backend.core.ouroboros.cli import ov
 
     ui = ov.AttachUI()
-    assert "\n" not in ui.toolbar(), "empty deck should stay one line"
+    base_lines = len(ui.prompt().splitlines())
     ui.on_ambient("DW provider failover")
-    out = ui.toolbar()
-    assert "\n" in out and "failover" in out
-    assert out.splitlines()[0].strip() != "", "the pulse line was lost"
+    out = ui.prompt()
+    assert "failover" in out
+    assert len(out.splitlines()) > base_lines, "the deck row did not appear"
+    assert out.splitlines()[-1].strip().endswith("›"), (
+        "the caret must be the LAST line — the live region sits above it"
+    )
 
 
 def test_deck_can_be_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -239,4 +244,4 @@ def test_deck_can_be_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("JARVIS_AMBIENT_DECK", "0")
     ui = ov.AttachUI()
     ui.on_ambient("DW provider failover")
-    assert "\n" not in ui.toolbar(), "OFF must restore the single-line toolbar"
+    assert "failover" not in ui.prompt(), "OFF must hide the deck rows"

--- a/tests/battle_test/test_cockpit_selection.py
+++ b/tests/battle_test/test_cockpit_selection.py
@@ -293,18 +293,18 @@ async def test_a_vanished_lane_answers_found_false_not_silence() -> None:
 # 4. the client renders each mode into the one toolbar region
 # --------------------------------------------------------------------------
 
-def test_toolbar_shows_the_lane_list_in_select() -> None:
+def test_lane_list_renders_above_the_caret_in_select() -> None:
     from backend.core.ouroboros.cli import ov
 
     ui = ov.AttachUI()
     ui._lanes = _rows("swarm/a", "unit/b")
     assert ui.fsm.enter_select() is True
-    out = ui.toolbar()
+    out = ui.prompt()   # the live region sits ABOVE the caret
     assert "swarm/a" in out and "unit/b" in out
     assert "↑↓" in out, "no affordance shown for the new mode"
 
 
-def test_toolbar_shows_hydrated_output_in_focus() -> None:
+def test_hydrated_output_renders_above_the_caret_in_focus() -> None:
     from backend.core.ouroboros.cli import ov
 
     ui = ov.AttachUI()
@@ -315,7 +315,7 @@ def test_toolbar_shows_hydrated_output_in_focus() -> None:
         "lane": "unit/b", "found": True, "tombstoned": True,
         "dropped": 0, "lines": ["patched saga.py"],
     })
-    out = ui.toolbar()
+    out = ui.prompt()
     assert "patched saga.py" in out
     assert "finished" in out
 
@@ -333,7 +333,7 @@ def test_stale_hydration_for_an_abandoned_lane_is_ignored() -> None:
     ui.on_lane_history({
         "lane": "unit/b", "found": True, "lines": ["late answer"],
     })
-    assert "late answer" not in ui.toolbar()
+    assert "late answer" not in ui.prompt()
 
 
 def test_escape_restores_the_ambient_deck_view() -> None:
@@ -344,6 +344,6 @@ def test_escape_restores_the_ambient_deck_view() -> None:
     ui.on_ambient("DW provider failover")
     ui._lanes = _rows("unit/b")
     ui.fsm.enter_select()
-    assert "failover" not in ui.toolbar(), "ambient deck leaked into SELECT"
+    assert "failover" not in ui.prompt(), "ambient deck leaked into SELECT"
     ui.fsm.escape()
-    assert "failover" in ui.toolbar(), "ambient view was not restored"
+    assert "failover" in ui.prompt(), "ambient view was not restored"

--- a/tests/battle_test/test_d4_agora_and_ejection.py
+++ b/tests/battle_test/test_d4_agora_and_ejection.py
@@ -1,0 +1,298 @@
+"""D4 — the agora as a lane, deck sizing, and graceful ejection.
+
+The state trap: the daemon garbage-collects a lane (TTL or pressure) while a
+cockpit is FOCUSED on it. Nothing in the heartbeat can tell the client this —
+a lane simply absent from the next frame is indistinguishable from a slow
+frame — so without an explicit event the operator sits in a pane that never
+updates and never explains itself.
+
+The ejection reuses ``fsm.escape()`` rather than introducing a force-flow
+path: an auto-eject IS the daemon pressing Esc for the operator, and a second
+route to FLOW is a second set of invariants to keep in step.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, Dict, List
+
+import pytest
+
+from backend.core.ouroboros.battle_test.cockpit_fsm import MODE_FLOW
+from backend.core.ouroboros.battle_test.lane_rings import (
+    LaneRegistry,
+    reset_lane_registry,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean():
+    reset_lane_registry()
+    yield
+    reset_lane_registry()
+
+
+def _rows(*lanes: str) -> List[Dict[str, Any]]:
+    return [
+        {"lane": ln, "lines": 2, "last_seen": 0.0, "label": "",
+         "tombstoned": False, "age_s": 0.1}
+        for ln in lanes
+    ]
+
+
+# --------------------------------------------------------------------------
+# 1. graceful ejection — requirement 1
+# --------------------------------------------------------------------------
+
+def test_reap_of_the_focused_lane_ejects_to_flow() -> None:
+    from backend.core.ouroboros.cli import ov
+
+    ui = ov.AttachUI()
+    ui._lanes = _rows("unit/7")
+    ui.fsm.enter_select()
+    ui.fsm.focus_selected()
+    assert ui.fsm.focused_lane == "unit/7"
+
+    ui.on_lane_reaped("unit/7")
+
+    assert ui.fsm.mode == MODE_FLOW, "operator left trapped in a dead pane"
+    assert "expired" in ui.prompt(), "no explanation for the context shift"
+
+
+def test_reap_of_another_lane_does_not_disturb_the_focus() -> None:
+    """Ejecting on someone else's reap would yank the operator out of a pane
+    that is perfectly alive."""
+    from backend.core.ouroboros.cli import ov
+
+    ui = ov.AttachUI()
+    ui._lanes = _rows("unit/7", "unit/8")
+    ui.fsm.enter_select()
+    ui.fsm.focus_selected()
+    ui.on_lane_reaped("unit/8")
+    assert ui.fsm.focused_lane == "unit/7"
+
+
+def test_reap_while_in_flow_is_a_no_op() -> None:
+    from backend.core.ouroboros.cli import ov
+
+    ui = ov.AttachUI()
+    ui.on_lane_reaped("unit/7")
+    assert ui.fsm.mode == MODE_FLOW
+    assert "expired" not in ui.prompt(), "flashed about a lane we never saw"
+
+
+def test_ejection_reuses_the_escape_transition(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """DRY, asserted structurally: an auto-eject is the daemon pressing Esc."""
+    from backend.core.ouroboros.cli import ov
+
+    ui = ov.AttachUI()
+    ui._lanes = _rows("unit/7")
+    ui.fsm.enter_select()
+    ui.fsm.focus_selected()
+
+    calls: List[str] = []
+    real_escape = ui.fsm.escape
+    monkeypatch.setattr(
+        ui.fsm, "escape",
+        lambda: (calls.append("escape"), real_escape())[1],
+    )
+    ui.on_lane_reaped("unit/7")
+    assert calls == ["escape"], "ejection took a second path to FLOW"
+
+
+def test_the_flash_expires(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A transient notice that never leaves is chrome, not a notice."""
+    from backend.core.ouroboros.cli import ov
+
+    clock = {"t": 100.0}
+    import time as _t
+    monkeypatch.setattr(_t, "monotonic", lambda: clock["t"])
+
+    ui = ov.AttachUI()
+    ui.flash("lane expired", seconds=2.0)
+    assert "lane expired" in ui.prompt()
+    clock["t"] += 5.0
+    assert "lane expired" not in ui.prompt()
+
+
+# --------------------------------------------------------------------------
+# 2. the reap event reaches the client
+# --------------------------------------------------------------------------
+
+class _Writer:
+    def __init__(self) -> None:
+        self.frames: List[Dict[str, Any]] = []
+
+    def is_closing(self) -> bool:
+        return False
+
+    def write(self, data: bytes) -> None:
+        for line in data.decode().splitlines():
+            if line.strip():
+                self.frames.append(json.loads(line))
+
+    def close(self) -> None:
+        pass
+
+
+async def test_reap_is_broadcast_to_every_cockpit() -> None:
+    """Any terminal could be focused on it — this is the one lane message
+    that is genuinely everyone's business."""
+    from backend.core.ouroboros.battle_test.cockpit_attach import (
+        CockpitAttachBridge,
+    )
+    a, b = _Writer(), _Writer()
+    bridge = CockpitAttachBridge()
+    bridge._loop = asyncio.get_running_loop()   # type: ignore[attr-defined]
+    for w, sid in ((a, "sess-A"), (b, "sess-B")):
+        bridge._clients.add(w)                  # type: ignore[arg-type]
+        bridge.bind_session(sid, w)             # type: ignore[arg-type]
+
+    bridge.announce_lane_reaped("unit/7")
+    await asyncio.sleep(0)
+
+    for w in (a, b):
+        assert w.frames and w.frames[0]["type"] == "lane_reaped"
+        assert w.frames[0]["lane"] == "unit/7"
+
+
+def test_registry_announces_ttl_expiry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_LANE_TOMBSTONE_TTL_S", "10")
+    clock = {"t": 0.0}
+    seen: List[str] = []
+    reg = LaneRegistry(ring=5, clock=lambda: clock["t"])
+    reg.on_reap(seen.append)
+
+    reg.record("unit/7", "x")
+    reg.mark_dead("unit/7")
+    clock["t"] = 30.0
+    reg.summary()                       # the ~1Hz poll observes the expiry
+    assert seen == ["unit/7"]
+
+
+def test_registry_announces_pressure_eviction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_LANE_MAX", "1")
+    seen: List[str] = []
+    reg = LaneRegistry(ring=5)
+    reg.on_reap(seen.append)
+    reg.record("unit/a", "x")
+    reg.record("unit/b", "y")           # forces an eviction
+    assert seen == ["unit/a"]
+
+
+def test_a_reap_sink_that_queries_the_registry_does_not_deadlock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Announced outside the lock, so a sink may reach back in."""
+    monkeypatch.setenv("JARVIS_LANE_MAX", "1")
+    reg = LaneRegistry(ring=5)
+    out: List[int] = []
+    reg.on_reap(lambda _l: out.append(len(reg.summary())))
+    reg.record("unit/a", "x")
+    reg.record("unit/b", "y")
+    assert out, "the sink never ran — likely deadlocked under the lock"
+
+
+# --------------------------------------------------------------------------
+# 3. the agora is a lane, not a special case
+# --------------------------------------------------------------------------
+
+def test_a_post_records_into_the_agora_lane() -> None:
+    from backend.core.ouroboros.battle_test.lane_rings import get_lane_registry
+    from backend.core.ouroboros.governance import moltbook
+
+    class _Post:
+        handle = "@cassandra"
+        body = "the soak refused to launch"
+        op_id = ""
+        author_id = "cassandra"
+        glyph = "🐍"
+        kind = "distress"
+
+        def to_payload(self) -> dict:
+            return {}
+
+    reg = get_lane_registry()
+    reg.record("agora", f"{_Post.handle}: {_Post.body}", label="the agora")
+    hist = [ln.text for ln in reg.history("agora")]
+    assert hist and "cassandra" in hist[0]
+    assert "agora" in [r["lane"] for r in reg.summary()]
+    assert moltbook is not None
+
+
+def test_the_agora_selects_like_any_other_lane() -> None:
+    from backend.core.ouroboros.cli import ov
+
+    ui = ov.AttachUI()
+    ui._lanes = _rows("swarm/a", "agora")
+    ui.fsm.enter_select()
+    ui.fsm.move(1)
+    assert ui.fsm.focus_selected() is True
+    assert ui.fsm.focused_lane == "agora", (
+        "the agora needed a bespoke path — it should just be a lane"
+    )
+
+
+# --------------------------------------------------------------------------
+# 4. deck sizing
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("mode,expect_rows", [("off", 0), ("compact", 2)])
+def test_deck_sizing_caps_the_rendered_rows(mode: str, expect_rows: int) -> None:
+    from backend.core.ouroboros.cli import ov
+
+    ui = ov.AttachUI()
+    for i in range(5):
+        ui.on_ambient(f"info line {i}")
+    ui.set_deck_size(mode)
+    body = [ln for ln in ui.prompt().splitlines() if "info line" in ln]
+    assert len(body) <= expect_rows
+
+
+def test_deck_full_restores_rows() -> None:
+    from backend.core.ouroboros.cli import ov
+
+    ui = ov.AttachUI()
+    ui.on_ambient("DW provider failover")
+    ui.set_deck_size("off")
+    assert "failover" not in ui.prompt()
+    ui.set_deck_size("full")
+    assert "failover" in ui.prompt()
+
+
+def test_unknown_deck_arg_reports_usage_without_changing_state() -> None:
+    from backend.core.ouroboros.cli import ov
+
+    ui = ov.AttachUI()
+    before = ui._deck_size
+    msg = ui.set_deck_size("sideways")
+    assert "off | compact | full" in msg
+    assert ui._deck_size == before
+
+
+def test_deck_verb_is_handled_client_side() -> None:
+    """Screen height is not the daemon's business — the verb must not be
+    relayed upstream."""
+    from backend.core.ouroboros.cli import ov
+
+    class _Client:
+        def __init__(self) -> None:
+            self.sent: List[str] = []
+
+        def send_input(self, text: str) -> bool:
+            self.sent.append(text)
+            return True
+
+        def send_audio(self, cmd: str) -> bool:
+            return True
+
+    c, ui = _Client(), ov.AttachUI()
+    assert ov._route_operator_line(c, ui, "/deck compact") == "handled"
+    assert c.sent == [], "the deck verb was relayed to the daemon"
+    assert ui._deck_size == "compact"

--- a/tests/battle_test/test_termination_hook_slice1.py
+++ b/tests/battle_test/test_termination_hook_slice1.py
@@ -95,15 +95,22 @@ def _ctx(
 
 
 class TestTaxonomy:
-    def test_termination_cause_eight_values(self):
-        assert len(list(TerminationCause)) == 8
+    def test_termination_cause_nine_values(self):
+        assert len(list(TerminationCause)) == 9
 
     def test_termination_cause_vocabulary_frozen(self):
         # Pin the literal vocabulary against silent additions.
+        #
+        # UPDATED, not loosened. This pin's whole job is to make an addition
+        # impossible to land silently, so the correct response to it failing
+        # is to acknowledge the new member here — which is also the moment
+        # the contributor is forced to classify it in
+        # _CAUSE_TO_SESSION_OUTCOME. `process_memory_cap` reached the enum
+        # without either step; both are done now.
         expected = {
             "wall_clock_cap", "sigterm", "sigint", "sighup",
             "idle_timeout", "budget_exceeded", "normal_exit",
-            "unknown",
+            "process_memory_cap", "unknown",
         }
         assert {c.value for c in TerminationCause} == expected
 

--- a/tests/battle_test/test_termination_hook_slice3_wiring.py
+++ b/tests/battle_test/test_termination_hook_slice3_wiring.py
@@ -148,7 +148,7 @@ class TestAdapterSchema:
             == "partial_summary_writer"
         )
 
-    def test_cause_map_covers_all_8_causes(self):
+    def test_cause_map_covers_all_causes(self):
         # Every TerminationCause must have an explicit mapping —
         # silent additions to TerminationCause MUST be classified
         # against this map by the next contributor.

--- a/tests/cli/test_dual_client_multiplex.py
+++ b/tests/cli/test_dual_client_multiplex.py
@@ -64,7 +64,10 @@ class TestDualClientMultiplex:
             # BOTH clients update from the ONE broadcast:
             assert await _wait(lambda: ov_ui.audio_state == "SPEAKING")
             assert await _wait(lambda: topo.state["audio"] == "SPEAKING")
-            assert ov_ui.prompt() == "🗣 Karen (speaking) › "   # ov morph
+            # The caret is the LAST line: the live region (pulse + deck)
+            # renders above it, so prompt() is a block rather than one string.
+            # What this pins is unchanged — the audio state morphs the caret.
+            assert ov_ui.prompt().splitlines()[-1] == "🗣 Karen (speaking) › "
             assert "🗣 speaking" in topo.render()               # jarvis map
             assert "lease: HELD" in topo.render()
         finally:


### PR DESCRIPTION
## Layout correction (operator)

The pulse renders **above** the caret now, not below. Reading order runs downward — status, then the line you're typing — and a live region under the caret makes the eye travel back up while the caret drifts down the screen as the region grows.

prompt_toolkit renders a multi-line `message` above the cursor and repaints it on invalidate, so this is the **same seam and the same redraw machinery**: no second region, no cursor math. The bottom toolbar keeps only static key hints, which genuinely belong under the input because they describe the line you're on.

## Graceful ejection

The daemon can garbage-collect a lane while a cockpit is FOCUSED on it. The client **cannot infer this** — a lane absent from the next heartbeat is indistinguishable from a slow frame — so the operator would sit in a pane that never updates and never explains itself.

`LaneRegistry` announces reaps → bridge broadcasts `lane_reaped` (to **all** cockpits; any could be focused) → the client ejects if it's their lane and flashes *"lane X expired"*, so a context shift is an explanation rather than a glitch.

**DRY, asserted by test:** the eject calls the same `fsm.escape()` the key binding calls. An auto-eject *is* the daemon pressing Esc, and a parallel force-flow path would be a second set of invariants to keep in step.

**Two-phase announce:** reaps are collected under the registry lock and fanned out after releasing it, so a subscriber that queries the registry from its callback can't deadlock. Pinned by a test that does exactly that.

## Agora as a lane

`post_molt` records into lane `agora`. No bespoke widget — @cassandra is a participant whose output happens to be posts, so it lists, selects and focuses like any swarm worker. A test asserts it needs no special path.

## Deck sizing

`/deck off|compact|full`, handled **client-side and never relayed** — two cockpits on different terminals want different amounts of screen, and the daemon has no business knowing how tall anyone's window is.

## Test suite — 6 of 22 closed, and one was a real bug

`PROCESS_MEMORY_CAP` was added to `TerminationCause` **without being classified** in `_CAUSE_TO_SESSION_OUTCOME`. Three pins fired exactly as designed and nobody read them, because the suite they live in couldn't complete — the `os._exit(75)` crash aborted the run before reaching them. *That* is the cost of an unfinishable suite: not the noise, the silence.

Mapped to `incomplete_kill` (a memory-cap kill is a resource guard firing, not a finished session; `complete` would let the soak classifier score an OOM abort as a clean bar). Both vocabulary pins **updated, not loosened** — their job is to make additions impossible to land silently.

### Remaining 16, triaged

| file | n | assessment |
|---|---|---|
| `test_process_memory_watchdog` | 3 | **not rot** — genuinely unwired watchdog, needs its own change |
| `test_oracle_deferred_boot` | 4 | source-literal pins vs a refactored `boot_oracle` |
| `test_oracle_cache_symmetry` / `_atomic` | 4 | untriaged |
| `test_serpent_flow_inline_boot` | 2 | banner drift (Panel retired) |
| `test_bounded_shutdown_watchdog` | 2 | order-dependent exit recording |
| `test_slice234_runtime_repo_root` / `test_process_hygiene_slice3` / `test_ouroboros_spinner` | 3 | untriaged |

**The suite is not green.** I'd rather say so than claim it.

d4 16 · selection 26 · deck 19 · lane 16 · omni 16 · attach 28 · moltbook 14 · slice1 30 · slice3 38 · slice4 43 · cli 265 (2 pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds graceful ejection when a focused lane is garbage-collected, moves the live status region above the caret, makes the agora a lane, and adds client‑side deck sizing. Also fixes a missing termination-cause mapping and updates tests accordingly.

- **New Features**
  - `LaneRegistry` now emits reaps; bridge broadcasts `lane_reaped` to all cockpits. The client ejects if focused and flashes a short notice, reusing `fsm.escape()`. Two‑phase announce avoids lock reentrancy.
  - Live region (pulse, deck, select/focus) renders above the input; the toolbar keeps only static key hints.
  - Posts record to the `agora` lane, so they list/select/focus like any worker.
  - Deck sizing via `/deck off|compact|full`, handled client‑side and never relayed.

- **Bug Fixes**
  - Maps `PROCESS_MEMORY_CAP` to `incomplete_kill` in `_CAUSE_TO_SESSION_OUTCOME`; widens the vocabulary pins and tests to cover the new cause.

<sup>Written for commit ad8eab98c59ac4c1838fabdfd1c3a74b42786823. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

