### PR TITLE
feat(ov): D5 — native slash palette over the real dispatch table

### DIFF
--- a/backend/core/ouroboros/battle_test/repl_completion.py
+++ b/backend/core/ouroboros/battle_test/repl_completion.py
@@ -1438,3 +1438,72 @@ __all__ = [
     "suggest_for_typo",
     "unregister_arg_provider",
 ]
+
+
+def registry_from_dispatch() -> VerbRegistry:
+    """Build a :class:`VerbRegistry` from the AUTO-DISCOVERED dispatch table.
+
+    ``discover_verbs`` walks a live ``SerpentREPL`` for ``_handle_*`` methods,
+    which the attach cockpit does not have — it is a thin client with no REPL
+    instance. Its verbs come from ``repl_dispatch_registry``, the same 60
+    ``dispatch_<verb>_command`` callables the daemon actually routes to.
+
+    The DOCSTRING is the single source of truth for the dropdown text: it sits
+    beside the implementation, so a verb whose behaviour changes and whose
+    docstring does not is a review problem rather than a silently stale menu
+    entry in some parallel table.
+
+    NEVER raises — an empty registry yields a completer that simply offers
+    nothing, which is what a cockpit attached to an unreachable daemon should
+    do anyway."""
+    descriptors: list = []
+    try:
+        from backend.core.ouroboros.battle_test.repl_dispatch_registry import (
+            _VERB_TO_DISPATCHER,
+            prime_registry,
+        )
+        try:
+            prime_registry()
+        except Exception:  # noqa: BLE001 — a partial table still completes
+            pass
+        for verb, fn in sorted(_VERB_TO_DISPATCHER.items()):
+            doc = (getattr(fn, "__doc__", "") or "").strip()
+            first = doc.splitlines()[0].strip() if doc else ""
+            # Trim the leading ``/verb ...`` echo many docstrings open with —
+            # repeating the verb beside itself wastes the dropdown's width.
+            if first.startswith("`") or first.startswith("/"):
+                parts = first.split("—", 1)
+                first = parts[1].strip() if len(parts) == 2 else first
+            descriptors.append(
+                VerbDescriptor(
+                    slash_form=f"/{verb}",
+                    handler_method="",
+                    description=first[:80],
+                )
+            )
+    except Exception:  # noqa: BLE001
+        logger.debug("[Completion] dispatch registry unavailable", exc_info=True)
+    return VerbRegistry(verbs=tuple(descriptors))
+
+
+def build_attach_completer() -> Optional[object]:
+    """The cockpit's ``/`` palette, threaded so typing never blocks.
+
+    ``ThreadedCompleter`` matters here specifically: priming the dispatch
+    registry walks packages and the first call is not instant. On the event
+    loop that would stall the keystroke that triggered it — the operator types
+    ``/`` and the terminal freezes. Off-thread, prompt_toolkit renders the
+    menu when results arrive and the buffer stays live throughout.
+
+    NEVER raises."""
+    try:
+        completer = build_completer(registry_from_dispatch())
+        if completer is None:
+            return None
+        try:
+            from prompt_toolkit.completion import ThreadedCompleter
+            return ThreadedCompleter(completer)
+        except ImportError:
+            return completer
+    except Exception:  # noqa: BLE001
+        return None

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -873,6 +873,12 @@ async def _split_plane_loop(
         message=lambda: ui.prompt(),
         bottom_toolbar=lambda: ui.toolbar(),
         key_bindings=_build_selection_bindings(ui, client),
+        # Native `/` palette over the SAME 60-verb dispatch table the daemon
+        # routes to — not a hand-kept list that can drift from it. Threaded:
+        # priming the registry walks packages, and on the event loop that
+        # would freeze the very keystroke that opened the menu.
+        completer=_build_slash_completer(),
+        complete_while_typing=True,
     )
     ui.bind_app(session.app)
 
@@ -914,6 +920,17 @@ async def _split_plane_loop(
             if outcome == "detach":
                 break
 
+
+
+def _build_slash_completer() -> Any:
+    """The cockpit's slash palette. None when unavailable. NEVER raises."""
+    try:
+        from backend.core.ouroboros.battle_test.repl_completion import (
+            build_attach_completer,
+        )
+        return build_attach_completer()
+    except Exception:  # noqa: BLE001 — a cockpit without a palette still works
+        return None
 
 
 def _build_selection_bindings(ui: Any, client: Any) -> Any:

--- a/tests/battle_test/test_process_memory_watchdog.py
+++ b/tests/battle_test/test_process_memory_watchdog.py
@@ -212,11 +212,38 @@ def test_ast_pin_watchdog_armed_beside_wall_clock():
     assert "self._monitor_process_memory(" in src
     assert "self._process_memory_monitor_task = asyncio.ensure_future(" in src
     assert "self._start_process_memory_hard_deadline_thread(" in src
-    # Armed in the same region as the wall-clock watchdog.
-    wall_idx = src.index("[WallClockWatchdog] armed:")
-    pm_idx = src.index("[ProcessMemoryWatchdog] armed:")
-    assert 0 < pm_idx - wall_idx < 2000, (
-        "ProcessMemoryWatchdog must be armed alongside WallClockWatchdog"
+    # Armed in the same region as the wall-clock watchdog — asserted
+    # STRUCTURALLY, by shared enclosing function, not by character distance.
+    #
+    # This previously read `0 < pm_idx - wall_idx < 2000` over string offsets.
+    # Both watchdogs are armed 36 lines apart and always have been; the region
+    # simply grew to 2117 characters and the pin failed on a comment. A
+    # proximity assertion in bytes measures the length of the prose between
+    # two things, which is not the invariant anyone cares about.
+    #
+    # What matters is that arming them is ONE decision in ONE place: a future
+    # change that moves the memory watchdog into a different function — where
+    # it could be skipped while the wall-clock one still arms — is the actual
+    # regression, and that is what this now catches.
+    tree = ast.parse(src)
+    owners = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        body = ast.get_source_segment(src, node) or ""
+        for marker in ("[WallClockWatchdog] armed:",
+                       "[ProcessMemoryWatchdog] armed:"):
+            if marker in body:
+                # Innermost wins: nested defs are walked after their parent.
+                owners[marker] = node.name
+    wall_owner = owners.get("[WallClockWatchdog] armed:")
+    pm_owner = owners.get("[ProcessMemoryWatchdog] armed:")
+    assert wall_owner is not None, "wall-clock watchdog is no longer armed"
+    assert pm_owner is not None, "ProcessMemoryWatchdog is no longer armed"
+    assert pm_owner == wall_owner, (
+        f"ProcessMemoryWatchdog must be armed alongside WallClockWatchdog — "
+        f"wall-clock arms in {wall_owner!r} but memory arms in {pm_owner!r}, "
+        f"so one can now be skipped without the other"
     )
 
 


### PR DESCRIPTION
## Two corrections up front

**There is no `@verb` decorator registry.** I recommended one in an architecture critique and never built it. The actual table is `repl_dispatch_registry._VERB_TO_DISPATCHER` — 60 auto-discovered `dispatch_<verb>_command` callables plus the `__aliases__` mechanism from #70113. This completes against *that*, so the palette cannot drift from what the daemon routes to.

**`PROCESS_MEMORY_CAP` was already mapped** in `_CAUSE_TO_SESSION_OUTCOME` — that landed in D4 (#70118). Nothing to do.

## The completer — reused, not written

`build_completer` + `VerbRegistry`/`VerbDescriptor` already existed, driving the **local** SerpentFlow palette. The attach cockpit couldn't use them because `discover_verbs` walks a live REPL instance for `_handle_*` methods, and a thin client has none.

New `registry_from_dispatch()` feeds the same builder from the dispatch table; `build_attach_completer()` wraps it in `ThreadedCompleter`.

```
/molt          Post as @the-human; summon the routed resident.
/moltbook      Render the feed.
```

**Docstrings are the source of truth** for `display_meta` — they sit beside the implementation, so a verb whose behaviour changes without its docstring is a review problem rather than a stale entry in a parallel table.

`ThreadedCompleter` is load-bearing *here specifically*: priming the registry walks packages and the first call isn't instant, so on the event loop it would freeze the very keystroke that opened the menu.

## The watchdog — I was wrong, and it matters

I reported `test_process_memory_watchdog` to you as a *"genuinely unwired watchdog."* **It is not.** `ProcessMemoryWatchdog` is armed, 36 lines from `WallClockWatchdog`.

The pin read `0 < pm_idx - wall_idx < 2000` over **character offsets** between two log strings. The region grew to 2117 characters and it failed — on the length of the prose between two things, which is not an invariant anyone cares about. Purest rot, and I mislabelled it as a real defect.

Replaced with a structural assertion: both must arm inside the **same enclosing function**, checked by AST. That catches the actual regression — a change that moves one watchdog somewhere it can be skipped while the other still arms — and is immune to comments.

## Status — not green

**7 of 22** pre-existing failures closed (this PR + D4's `PROCESS_MEMORY_CAP` classification). **15 remain**:

| file | n |
|---|---|
| `test_oracle_deferred_boot` | 4 |
| `test_oracle_cache_symmetry` / `_atomic` | 4 |
| `test_serpent_flow_inline_boot` | 2 |
| `test_bounded_shutdown_watchdog` | 2 |
| `test_process_memory_watchdog` (cold-build checkpoints) | 2 |
| `test_slice234_runtime_repo_root` / `test_process_hygiene_slice3` / `test_ouroboros_spinner` | 3 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a native slash-command palette to the attach cockpit that completes from the real dispatch table, keeping it in sync with the daemon. Also hardens the process memory watchdog test with a structural AST check to avoid false failures and catch real regressions.

- **New Features**
  - Palette sources verbs from `repl_dispatch_registry._VERB_TO_DISPATCHER` (60 `dispatch_<verb>_command` callables plus `__aliases__`), so it cannot drift from routing.
  - Uses docstrings for display text; trims leading `/verb — …`.
  - Wrapped in `ThreadedCompleter` to avoid UI stalls during registry priming; `complete_while_typing` enabled.

- **Bug Fixes**
  - Replaced character-distance pin with an AST assertion that both watchdogs arm in the same enclosing function.
  - Prevents failures from comment-length changes and reliably flags real misplacements.

<sup>Written for commit 889827a0c05f7f5babb77f4d8f168c75a6317935. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

