### PR TITLE
fix(ov): the slash palette was truncated, incomplete, and inventive

### DIFF
--- a/backend/core/ouroboros/battle_test/repl_completion.py
+++ b/backend/core/ouroboros/battle_test/repl_completion.py
@@ -1164,7 +1164,9 @@ def discover_verbs(repl_instance: object) -> VerbRegistry:
 # ===========================================================================
 
 
-def build_completer(registry: VerbRegistry) -> Optional[object]:
+def build_completer(
+    registry: VerbRegistry, *, max_results: int = 8,
+) -> Optional[object]:
     """Build a ``prompt_toolkit.completion.Completer`` that fires only
     when the input starts with ``/``. Returns ``None`` when
     prompt_toolkit isn't available (headless / sandbox).
@@ -1251,7 +1253,9 @@ def build_completer(registry: VerbRegistry) -> Optional[object]:
             # fuzzy meaningful. Byte-identical to legacy prefix-match
             # for the common case (operator typing a known verb).
             try:
-                matches = fuzzy_match(text, registry)
+                matches = fuzzy_match(
+                    text, registry, max_results=max_results,
+                )
             except Exception:  # noqa: BLE001 — defensive
                 matches = ()
             for verb in matches:
@@ -1440,6 +1444,48 @@ __all__ = [
 ]
 
 
+def _describe(fn: object) -> str:
+    """One line of operator-facing help for a dispatcher. NEVER raises.
+
+    Cascade, because 13 of the 60 dispatchers carry no docstring and a menu
+    entry with no meta is a name the operator has to guess at:
+
+      1. the function's own docstring — nearest the behaviour, so it is the
+         one most likely to be corrected when the behaviour changes;
+      2. its MODULE's docstring — these verbs live in single-purpose
+         ``*_repl.py`` files whose header describes exactly the thing the
+         verb does;
+      3. an honest placeholder. Never a blank.
+
+    The leading ``/verb —`` echo is trimmed: repeating the verb beside itself
+    wastes the dropdown's width, which is the scarcest thing in a palette."""
+    def _first_line(doc: object) -> str:
+        text = (doc or "")
+        if not isinstance(text, str):
+            return ""
+        text = text.strip()
+        if not text:
+            return ""
+        line = text.splitlines()[0].strip()
+        if line.startswith("`") or line.startswith("/"):
+            parts = line.split("—", 1)
+            line = parts[1].strip() if len(parts) == 2 else line
+        return line.strip(" `")
+
+    try:
+        own = _first_line(getattr(fn, "__doc__", ""))
+        if own:
+            return own[:80]
+        import sys as _sys
+        mod = _sys.modules.get(getattr(fn, "__module__", "") or "")
+        from_module = _first_line(getattr(mod, "__doc__", ""))
+        if from_module:
+            return from_module[:80]
+    except Exception:  # noqa: BLE001
+        pass
+    return "no description — add a docstring to its dispatcher"
+
+
 def registry_from_dispatch() -> VerbRegistry:
     """Build a :class:`VerbRegistry` from the AUTO-DISCOVERED dispatch table.
 
@@ -1467,22 +1513,37 @@ def registry_from_dispatch() -> VerbRegistry:
         except Exception:  # noqa: BLE001 — a partial table still completes
             pass
         for verb, fn in sorted(_VERB_TO_DISPATCHER.items()):
-            doc = (getattr(fn, "__doc__", "") or "").strip()
-            first = doc.splitlines()[0].strip() if doc else ""
-            # Trim the leading ``/verb ...`` echo many docstrings open with —
-            # repeating the verb beside itself wastes the dropdown's width.
-            if first.startswith("`") or first.startswith("/"):
-                parts = first.split("—", 1)
-                first = parts[1].strip() if len(parts) == 2 else first
             descriptors.append(
                 VerbDescriptor(
                     slash_form=f"/{verb}",
                     handler_method="",
-                    description=first[:80],
+                    description=_describe(fn),
                 )
             )
     except Exception:  # noqa: BLE001
         logger.debug("[Completion] dispatch registry unavailable", exc_info=True)
+
+    # Client-handled verbs belong in the SAME palette. `/deck`, `wake` and
+    # `detach` never reach the daemon, so a dispatch-only registry both omits
+    # them AND — because no verb starts with "/deck" — sends the operator into
+    # the fuzzy fallback, which answered "/deck" with "/bus, /cost". A palette
+    # that invents plausible wrong answers is worse than one that says nothing.
+    try:
+        from backend.core.ouroboros.cli.ov import client_verbs
+        known = {d.slash_form for d in descriptors}
+        for verb, help_text in sorted(client_verbs().items()):
+            slash = f"/{verb}"
+            if slash in known:
+                continue
+            descriptors.append(
+                VerbDescriptor(
+                    slash_form=slash, handler_method="",
+                    description=help_text or "handled by this cockpit",
+                )
+            )
+    except Exception:  # noqa: BLE001 — daemon verbs alone still complete
+        logger.debug("[Completion] client verbs unavailable", exc_info=True)
+
     return VerbRegistry(verbs=tuple(descriptors))
 
 
@@ -1497,7 +1558,15 @@ def build_attach_completer() -> Optional[object]:
 
     NEVER raises."""
     try:
-        completer = build_completer(registry_from_dispatch())
+        # A browsable palette, not a "did you mean" hint. The default cap of
+        # 8 exists for typo suggestion, and it silently truncated a 60-verb
+        # menu to its first eight alphabetically — the operator saw
+        # /anticipate..../bus and reasonably concluded the palette was broken.
+        # prompt_toolkit's CompletionsMenu scrolls, so the ceiling only needs
+        # to exceed the table.
+        completer = build_completer(
+            registry_from_dispatch(), max_results=512,
+        )
         if completer is None:
             return None
         try:

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -66,6 +66,51 @@ def version_line() -> str:
     except Exception:
         return "ov — ouroboros + venom"
 
+#: Operator words the CLIENT handles itself, mapped to the audio command they
+#: fire. Module scope on purpose: ``_route_operator_line`` dispatches from this
+#: table and the slash palette ENUMERATES it, so a verb cannot exist in one and
+#: be missing from the other. A second list for the menu is exactly how a
+#: palette starts lying about what the CLI accepts.
+AUDIO_VERBS = {
+    "wake": "wake", "voice": "wake", "listen": "wake",
+    "wake!": "force_wake", "force-wake": "force_wake",
+    "force wake": "force_wake",
+    "ptt": "ptt",
+    "ptt stop": "ptt_stop", "ptt-stop": "ptt_stop", "ptt off": "ptt_stop",
+    "flush": "flush", "shh": "flush", "hush": "flush",
+    "mute": "sleep", "sleep": "sleep",
+    "barge": "barge",
+}
+
+#: One line per client verb for the palette's ``display_meta``. Keys that are
+#: absent fall back to a generated description, so adding to AUDIO_VERBS can
+#: never break the menu — it just reads less well until documented here.
+CLIENT_VERB_HELP = {
+    "wake": "arm Karen's microphone",
+    "sleep": "disarm the microphone",
+    "barge": "interrupt Karen mid-sentence",
+    "flush": "halt outbound audio now (ducking)",
+    "ptt": "hold push-to-talk open",
+    "ptt stop": "close the push-to-talk hold",
+    "force-wake": "seize the mic from another terminal",
+    "deck": "deck height — off | compact | full",
+    "detach": "leave; the organism keeps running",
+}
+
+
+def client_verbs() -> "dict":
+    """Verbs this cockpit answers WITHOUT the daemon. NEVER raises.
+
+    Derived from the live dispatch tables rather than transcribed beside
+    them: the audio words come from AUDIO_VERBS (the same object the router
+    switches on) and the local-only verbs are listed once here."""
+    out = {v: CLIENT_VERB_HELP.get(v, f"audio: {AUDIO_VERBS[v]}")
+           for v in AUDIO_VERBS}
+    for v in ("deck", "detach"):
+        out[v] = CLIENT_VERB_HELP.get(v, "")
+    return out
+
+
 def _render_markup_frame(text: str, console: Any = None) -> None:
     """Render ONE daemon-composed styled line (the typed ``markup`` frame:
     CC-style ⏺/⎿ tool blocks + numbered diffs). Unlike the untyped ``line``
@@ -786,16 +831,7 @@ def _route_operator_line(client: Any, ui: Any, line: Any) -> str:
         low = text.lower()
         if low in ("detach", "exit", "quit"):
             return "detach"
-        audio_verbs = {
-            "wake": "wake", "voice": "wake", "listen": "wake",
-            "wake!": "force_wake", "force-wake": "force_wake",
-            "force wake": "force_wake",
-            "ptt": "ptt",
-            "ptt stop": "ptt_stop", "ptt-stop": "ptt_stop", "ptt off": "ptt_stop",
-            "flush": "flush", "shh": "flush", "hush": "flush",
-            "mute": "sleep", "sleep": "sleep",
-            "barge": "barge",
-        }
+        audio_verbs = AUDIO_VERBS
         # /deck sizing is a CLIENT concern — two cockpits on different
         # terminals want different amounts of screen, and the daemon has no
         # business knowing how tall anyone's window is. Handled here rather

--- a/tests/cli/test_slash_palette.py
+++ b/tests/cli/test_slash_palette.py
@@ -1,0 +1,132 @@
+"""The `/` palette — browsable, complete, and never inventive.
+
+Three defects this pins, all found by probing the shipped completer rather
+than by reading it:
+
+1. ``/`` yielded 8 of 60 verbs. ``fuzzy_match``'s ``max_results`` default is 8
+   because it was written for "did you mean", and reusing it for a palette
+   silently truncated the menu to the first eight alphabetically. The operator
+   saw /anticipate../bus and concluded the palette was broken.
+
+2. ``/deck`` yielded ``/bus, /cost, /m10``. No verb starts with "/deck" — it
+   is client-handled and absent from the dispatch registry — so the fuzzy
+   fallback answered a valid verb with edit-distance noise. A palette that
+   invents plausible wrong answers is worse than one that says nothing.
+
+3. Client verbs were missing entirely, which is what caused (2).
+"""
+from __future__ import annotations
+
+import contextlib
+import io
+from typing import List, Tuple
+
+import pytest
+
+
+def _completions(text: str) -> List[Tuple[str, str]]:
+    from prompt_toolkit.document import Document
+
+    from backend.core.ouroboros.cli.ov import _build_slash_completer
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+        c = _build_slash_completer()
+        assert c is not None, "no completer was built"
+        return [
+            (o.text, o.display_meta_text)
+            for o in c.get_completions(Document(text), None)
+        ]
+
+
+# --------------------------------------------------------------------------
+# 1. browsable
+# --------------------------------------------------------------------------
+
+def test_a_bare_slash_offers_the_whole_palette() -> None:
+    out = _completions("/")
+    assert len(out) > 50, (
+        f"only {len(out)} verbs offered — the 'did you mean' cap of 8 is "
+        f"truncating a browsable menu"
+    )
+
+
+def test_every_offered_verb_carries_a_description() -> None:
+    """An entry with no meta is a name the operator has to guess at."""
+    blank = [t for t, m in _completions("/") if not m.strip()]
+    assert blank == [], f"verbs with no display_meta: {blank[:5]}"
+
+
+def test_prefix_narrows_the_palette() -> None:
+    out = [t for t, _m in _completions("/mol")]
+    assert set(out) == {"/molt", "/moltbook"}
+
+
+# --------------------------------------------------------------------------
+# 2. client verbs are in the same palette
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("verb", ["/deck", "/wake", "/detach"])
+def test_client_handled_verbs_are_offered(verb: str) -> None:
+    """They never reach the daemon, so a dispatch-only registry omits them —
+    and their absence is what sent /deck into the fuzzy fallback."""
+    assert any(t == verb for t, _m in _completions(verb)), (
+        f"{verb} is handled by the cockpit but missing from its own palette"
+    )
+
+
+def test_deck_resolves_to_itself_not_to_noise() -> None:
+    out = [t for t, _m in _completions("/deck")]
+    assert out == ["/deck"], (
+        f"/deck offered {out} — the fuzzy fallback is answering a valid verb "
+        f"with edit-distance guesses"
+    )
+
+
+def test_the_palette_and_the_router_share_one_table() -> None:
+    """DRY, asserted: a verb the router dispatches must be offerable, so the
+    menu cannot drift from what the CLI actually accepts."""
+    from backend.core.ouroboros.cli.ov import AUDIO_VERBS, client_verbs
+
+    offered = {t.lstrip("/") for t, _m in _completions("/")}
+    for verb in AUDIO_VERBS:
+        if " " in verb:          # multi-word forms are typed, not completed
+            continue
+        assert verb in offered, f"router accepts {verb!r}; palette omits it"
+    assert "deck" in client_verbs()
+
+
+# --------------------------------------------------------------------------
+# 3. it never invents
+# --------------------------------------------------------------------------
+
+def test_a_genuine_typo_still_gets_suggestions() -> None:
+    """Fuzzy is right for a typo of a REAL verb — that behaviour is kept."""
+    out = [t for t, _m in _completions("/moltbok")]
+    assert any("molt" in t for t in out), "typo recovery was lost"
+
+
+def test_prose_never_triggers_the_palette() -> None:
+    """Operators type goals and sentences; a menu must not interleave."""
+    assert _completions("fix the failing test") == []
+
+
+def test_the_local_repl_default_is_unchanged() -> None:
+    """build_completer's default cap must stay 8 — SerpentFlow's palette is a
+    suggestion list and was not part of this change."""
+    import inspect
+
+    from backend.core.ouroboros.battle_test.repl_completion import (
+        build_completer,
+    )
+    sig = inspect.signature(build_completer)
+    assert sig.parameters["max_results"].default == 8
+
+
+def test_completer_is_threaded() -> None:
+    """Priming the registry walks packages; on the event loop that would
+    freeze the very keystroke that opened the menu."""
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+        from backend.core.ouroboros.cli.ov import _build_slash_completer
+        c = _build_slash_completer()
+    assert type(c).__name__ == "ThreadedCompleter"


### PR DESCRIPTION
Three defects, all found by **probing the shipped completer** rather than reading it. D5 wired a palette; it never verified what the palette said.

| # | defect | cause |
|---|---|---|
| 1 | `/` offered **8 of 60** | `fuzzy_match`'s `max_results` defaults to 8 — written for "did you mean", reused for a browsable menu |
| 2 | `/deck` offered `/bus, /cost, /m10` | no verb starts with `/deck`, so the **fuzzy fallback** answered a valid verb with edit-distance noise |
| 3 | client verbs absent entirely | the registry held only *daemon* dispatch verbs — and this is what caused (2) |

## 1 — truncated

The operator typed `/`, saw `/anticipate … /bus`, and reasonably concluded the palette was broken. The palette now passes `max_results=512`; `CompletionsMenu` scrolls, so the ceiling only has to exceed the table.

`build_completer`'s **default stays 8** — SerpentFlow's local palette genuinely *is* a suggestion list, and its behaviour is byte-identical. Pinned by a test.

## 2 — inventive

Fixed at the cause, **not** by disabling fuzzy. Typo recovery for a real verb (`/moltbok` → `/molt`) still works and is pinned. What's gone is answering a *valid* verb with guesses.

## 3 — incomplete, and the DRY fix

`audio_verbs` was a dict local to `_route_operator_line`. It's now module-level `AUDIO_VERBS`, and `client_verbs()` derives the palette from the **same object the router switches on** — so a verb cannot be dispatchable but unlistable.

A second table for the menu is exactly how a palette starts lying about what the CLI accepts. A test asserts the two agree.

## Bonus defect the tests caught

13 of the 60 dispatchers carry **no docstring**, so their menu entry was a bare name. `_describe()` now cascades:

1. the function's own docstring — nearest the behaviour
2. its **module** docstring — these verbs live in single-purpose `*_repl.py` files whose header describes exactly what the verb does
3. an honest placeholder naming the omission

**Never a blank.** `/bus` now reads *"Path D.4 — `/bus` REPL operator surface for L1 Command…"*.

```
/                    76 verbs, each described
/deck                deck height — off | compact | full
/wake                arm Karen's microphone
/detach              leave; the organism keeps running
```

12 tests. Local palette 50 passed; cli 277 passed (2 pre-existing failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the slash palette so it shows the full verb list, includes client-only verbs, and never offers invented fuzzy suggestions; every entry now has a description. Local REPL behavior is unchanged.

- **Bug Fixes**
  - Browsable list: pass max_results=512 when attaching; `build_completer` default stays 8.
  - Complete palette: merge daemon verbs with `client_verbs()` derived from module-level `AUDIO_VERBS`; `/deck`, `/wake`, `/detach` are offered and resolve to themselves.
  - No invention: keep fuzzy only for genuine typos (e.g., `/moltbok` → `/molt`), not when a valid verb exists.
  - Descriptions: `_describe()` cascades function docstring → module docstring → placeholder to avoid blank `display_meta`.

<sup>Written for commit fedd685c4a4826a800586e9bd6ae86845d994169. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

