### PR TITLE
feat(ov): brand the palette, and stop showing maintainer prose as help

### DIFF
--- a/backend/core/ouroboros/battle_test/bipartite_layout.py
+++ b/backend/core/ouroboros/battle_test/bipartite_layout.py
@@ -559,10 +559,24 @@ def build_bipartite_application(
             _depth = ColorDepth.DEPTH_24_BIT
     except Exception:  # noqa: BLE001
         _depth = None
+    # Brand styling for the completion menu + footer. Sourced from the ONE
+    # palette in ui.theme, so a brand change moves the cockpit with it, and
+    # tier-aware so a 16-colour terminal is not handed truecolor hexes to
+    # quantize into mud. Without it prompt_toolkit paints its default: a
+    # filled light-grey listbox and a reverse-video toolbar bar — the two
+    # loudest things on an otherwise dark screen.
+    _style = None
+    try:
+        from backend.core.ouroboros.ui.theme import cockpit_prompt_style
+        _style = cockpit_prompt_style()
+    except Exception:  # noqa: BLE001 — an unstyled cockpit still works
+        _style = None
+
     app = Application(
         layout=PTLayout(root, focused_element=prompt),
         key_bindings=kb, full_screen=True, mouse_support=False,
         refresh_interval=0.1,
+        **({"style": _style} if _style is not None else {}),
         **({"color_depth": _depth} if _depth is not None else {}),
     )
     _APP_REF["app"] = app

--- a/backend/core/ouroboros/battle_test/repl_completion.py
+++ b/backend/core/ouroboros/battle_test/repl_completion.py
@@ -55,6 +55,7 @@ from __future__ import annotations
 
 import enum
 import inspect
+import re
 import logging
 import os
 import re
@@ -1444,46 +1445,154 @@ __all__ = [
 ]
 
 
+#: Sentences a docstring's first line uses to address MAINTAINERS, not
+#: operators. Dropped whole — "NEVER raises" is a contract with the caller and
+#: means nothing in a menu; "Parse ``/x`` line and dispatch" describes the
+#: plumbing rather than the effect. Patterns, not a per-verb list, so a verb
+#: added tomorrow is cleaned by the same rules.
+_MAINTAINER_NOISE = (
+    r"NEVER\s+raises?\.?",
+    r"Never\s+raises?\.?",
+    r"Parse\s+(a\s+)?``?/?[\w.\- ]+``?\s+line(\s*\+?\s*and\s+dispatch)?\.?",
+    r"Parse\s+(a\s+)?``?/?[\w.\- ]+``?\s+line\s*\+\s*dispatch\.?",
+    r"``?matched=(True|False)``?\.?",
+    r"auto-discovered\.?",
+    r"canonical\s+entry\s+point\.?",
+    r"operator\s+surface\.?",
+)
+
+#: Internal provenance markers — section numbers, slice ids, path codes. They
+#: are load-bearing in the source and pure noise in a palette: an operator
+#: cannot act on "§38.11-F".
+_PROVENANCE = (
+    r"§\s*[\d.]+[A-Za-z\-]*",
+    r"\bSlice\s+\d+\w*\b",
+    r"\bPath\s+[A-Z]\.\d+\b",
+    r"\bPhase\s+\d+\w*\b",
+    r"\bU\d+\s+empirical\s+wiring\b",
+    r"\bGap\s+#\d+\b",
+    r"\(\s*\d{4}-\d{2}-\d{2}\s*\)",
+)
+
+
+def _humanise(line: str) -> str:
+    """One docstring line -> operator prose, or "" if nothing survives.
+
+    Docstrings are written for whoever maintains the function. Their first
+    line is usually a contract ("NEVER raises") or a restatement of the
+    plumbing ("Parse ``/canvas`` line and dispatch") — both true, both useless
+    in a menu that is supposed to answer "what does this do for me?".
+
+    Rules, not exceptions: strip RST markup, drop maintainer boilerplate and
+    provenance markers, then judge what remains. Returning "" is a real answer
+    and lets the caller fall through to the module docstring, which for these
+    single-purpose ``*_repl.py`` files is usually the sentence we wanted."""
+    text = str(line or "").strip()
+    if not text:
+        return ""
+    for pattern in _MAINTAINER_NOISE + _PROVENANCE:
+        text = re.sub(pattern, " ", text, flags=re.IGNORECASE)
+    text = text.replace("``", "").replace("`", "")
+    text = re.sub(r"\s+", " ", text)
+    text = text.strip(" .,;:—-\u2014")
+    # A fragment that is only punctuation, a bare verb echo, or two words of
+    # residue is worse than falling through — it looks like a description and
+    # carries none.
+    if len(text) < 12:
+        return ""
+    low = text.lower().lstrip("/")
+    # Reject a line that only ECHOES the verb. "/anticipate REPL" and
+    # "/causal REPL dispatcher" are what survives stripping a docstring that
+    # never described anything, and a menu entry reading "<verb> REPL" beside
+    # the verb is worse than a blank: it looks like help and answers nothing.
+    if re.fullmatch(r"[\w\-]+(\s+(repl|verb|dispatcher|surface|command))+", low):
+        return ""
+    # Reject sentence fragments — residue from a stripped clause, not prose.
+    if low.split()[0] in ("and", "or", "but", "with", "then", "returns",
+                          "short-circuit", "lets"):
+        return ""
+    if not re.search(r"[a-z]{3,}\s+[a-z]{3,}", low):
+        return ""
+    words = low.split()
+    # A clause that was cut mid-thought. "Canonical entry point — by" is what a
+    # stripped provenance marker leaves behind, and it reads as a description
+    # right up until you try to use it.
+    if len(words) < 4 or words[-1] in (
+        "by", "for", "with", "and", "or", "the", "a", "an", "to", "of", "in",
+        "on", "from", "when", "that", "is", "are",
+    ):
+        return ""
+    return text[0].upper() + text[1:]
+
+
 def _describe(fn: object) -> str:
     """One line of operator-facing help for a dispatcher. NEVER raises.
 
-    Cascade, because 13 of the 60 dispatchers carry no docstring and a menu
-    entry with no meta is a name the operator has to guess at:
+    Cascade, because no single source is reliably operator-facing:
 
-      1. the function's own docstring — nearest the behaviour, so it is the
-         one most likely to be corrected when the behaviour changes;
-      2. its MODULE's docstring — these verbs live in single-purpose
-         ``*_repl.py`` files whose header describes exactly the thing the
-         verb does;
-      3. an honest placeholder. Never a blank.
-
-    The leading ``/verb —`` echo is trimmed: repeating the verb beside itself
-    wastes the dropdown's width, which is the scarcest thing in a palette."""
+      1. the function's docstring, HUMANISED — nearest the behaviour, so it is
+         the line most likely to be corrected when behaviour changes;
+      2. its MODULE's docstring, humanised — these verbs live in
+         single-purpose ``*_repl.py`` files whose header describes the feature
+         rather than the function;
+      3. an honest placeholder. Never a blank, and never maintainer jargon
+         dressed up as help."""
     def _first_line(doc: object) -> str:
-        text = (doc or "")
-        if not isinstance(text, str):
-            return ""
+        text = doc if isinstance(doc, str) else ""
         text = text.strip()
         if not text:
             return ""
-        line = text.splitlines()[0].strip()
-        if line.startswith("`") or line.startswith("/"):
-            parts = line.split("—", 1)
-            line = parts[1].strip() if len(parts) == 2 else line
-        return line.strip(" `")
+        # Prefer the first line, but a docstring that opens with a bare
+        # ``/verb`` heading keeps its meaning on the NEXT line.
+        for raw in text.splitlines()[:3]:
+            human = _humanise(raw)
+            if human:
+                return human
+        return ""
 
     try:
-        own = _first_line(getattr(fn, "__doc__", ""))
-        if own:
-            return own[:80]
         import sys as _sys
         mod = _sys.modules.get(getattr(fn, "__module__", "") or "")
-        from_module = _first_line(getattr(mod, "__doc__", ""))
-        if from_module:
-            return from_module[:80]
+
+        # 1. AUTHORED help. The only source written FOR an operator.
+        #
+        # A module opts in with a dict beside its ``__aliases__``:
+        #
+        #     __verb_help__ = {"moltbook": "read the agora feed"}
+        #
+        # Same convention as __aliases__, so there is one place a module
+        # declares palette metadata. This exists because the humanisation
+        # below cannot invent what nobody wrote: these docstrings are
+        # contracts for maintainers, and stripping them yields "<verb> REPL".
+        authored = getattr(mod, "__verb_help__", None)
+        if isinstance(authored, dict):
+            name = str(getattr(fn, "__name__", ""))
+            verb = name[len("dispatch_"):-len("_command")] if (
+                name.startswith("dispatch_") and name.endswith("_command")
+            ) else name
+            text = authored.get(verb) or authored.get(f"/{verb}")
+            if isinstance(text, str) and text.strip():
+                return text.strip()[:88]
+
+        # 2. The FUNCTION docstring, humanised — accepted only if it survives
+        #    as prose.
+        #
+        #    The module docstring is deliberately NOT a fallback. It is a file
+        #    header: it narrates the feature's history and provenance ("Wave 1
+        #    #8", "§38.11-F operator surface"), which is the wrong GENRE, not
+        #    merely the wrong wording. Mining it produced entries like
+        #    "/autobiography REPL — Wave 1 #8" — confident, well-formed, and
+        #    useless. A blank is the honest state for "nobody has written this
+        #    yet"; plausible noise is not.
+        own = _first_line(getattr(fn, "__doc__", ""))
+        if own:
+            return own[:88]
     except Exception:  # noqa: BLE001
         pass
-    return "no description — add a docstring to its dispatcher"
+    # 3. Nothing authored, nothing extractable. Say so plainly rather than
+    #    printing residue: an honest blank reads as "no description yet",
+    #    fabricated prose reads as a description that happens to be wrong.
+    return ""
 
 
 def registry_from_dispatch() -> VerbRegistry:

--- a/backend/core/ouroboros/governance/moltbook_repl.py
+++ b/backend/core/ouroboros/governance/moltbook_repl.py
@@ -30,6 +30,19 @@ from typing import List
 #: a synonym.
 __aliases__ = ("molt",)
 
+#: Operator-facing one-liners for the `/` palette, declared beside the aliases
+#: so a module states its palette metadata in ONE place.
+#:
+#: Written by hand on purpose. A docstring is a contract with whoever
+#: maintains the function ("NEVER raises", "Parse ``/molt`` line and
+#: dispatch") and stripping it yields "/molt REPL", which looks like help and
+#: answers nothing. There is no algorithm that recovers a sentence nobody
+#: wrote — so the palette asks for one, and shows a blank until it gets it.
+__verb_help__ = {
+    "moltbook": "read the agora feed — the residents' posts",
+    "molt": "post to the agora as @the-human",
+}
+
 _C_DIM = "dim"
 
 

--- a/backend/core/ouroboros/ui/theme.py
+++ b/backend/core/ouroboros/ui/theme.py
@@ -710,3 +710,73 @@ __all__ = [
     "styles",
     "supports_unicode",
 ]
+
+
+def cockpit_prompt_style(tier: Optional[ColorTier] = None) -> Any:
+    """The cockpit's prompt_toolkit ``Style`` — O+V palette, CC restraint.
+
+    prompt_toolkit ships a completion menu that looks like a Windows listbox:
+    a filled light-grey block with reverse-video selection. Claude Code's
+    reads as part of the terminal because it has NO fill — the names sit on
+    the ground colour and only the selected row is tinted. That is the whole
+    difference, and it is styling, not layout.
+
+    Derived from :data:`PALETTE` rather than restating hexes: the brand owns
+    those six colours in exactly one place, so a palette change moves the menu
+    with it. Degrades by tier — a 16-colour terminal gets named colours rather
+    than truecolor hexes that would quantize to mud.
+
+    NEVER raises: an unstyled menu is ugly, a crashed cockpit is unusable."""
+    try:
+        from prompt_toolkit.styles import Style
+    except ImportError:
+        return None
+    t = tier if tier is not None else active_tier()
+    try:
+        if t >= ColorTier.TRUECOLOR:
+            p = PALETTE
+            ground, surface = p["ground"], p["surface"]
+            ink, muted, faint = p["ink"], p["muted"], p["faint"]
+            green, purple = p["venom_green"], p["venom_purple"]
+            rules = [
+                # No fill. The menu floats on the terminal, CC-style.
+                ("completion-menu", f"bg:{ground} {muted}"),
+                ("completion-menu.completion", f"bg:{ground} {ink}"),
+                # Selection is a TINT, not reverse video — the eye tracks a
+                # highlight far better than an inverted block, and inverted
+                # text loses the accent colour that carries meaning.
+                ("completion-menu.completion.current",
+                 f"bg:{surface} {green} bold"),
+                # Descriptions in venom purple: subordinate to the verb name
+                # but legible, which is exactly CC's blue-on-black relationship.
+                ("completion-menu.meta.completion", f"bg:{ground} {purple}"),
+                ("completion-menu.meta.completion.current",
+                 f"bg:{surface} {purple}"),
+                ("completion-menu.multi-column-meta", f"bg:{surface} {purple}"),
+                ("scrollbar.background", f"bg:{surface}"),
+                ("scrollbar.button", f"bg:{purple}"),
+                # The default bottom-toolbar is reverse-video — a solid bar of
+                # colour across the width, which is the single loudest thing
+                # on the screen and says nothing.
+                ("bottom-toolbar", f"bg:{ground} {faint} noreverse"),
+                ("bottom-toolbar.text", f"bg:{ground} {faint}"),
+                ("command-deck", f"bg:{ground} {ink}"),
+            ]
+        else:
+            rules = [
+                ("completion-menu", "bg:default fg:gray"),
+                ("completion-menu.completion", "bg:default"),
+                ("completion-menu.completion.current",
+                 "bg:default fg:ansibrightgreen bold"),
+                ("completion-menu.meta.completion", "bg:default fg:ansimagenta"),
+                ("completion-menu.meta.completion.current",
+                 "bg:default fg:ansimagenta"),
+                ("scrollbar.background", "bg:default"),
+                ("scrollbar.button", "bg:ansimagenta"),
+                ("bottom-toolbar", "bg:default fg:gray noreverse"),
+                ("bottom-toolbar.text", "bg:default fg:gray"),
+                ("command-deck", "bg:default"),
+            ]
+        return Style(rules)
+    except Exception:  # noqa: BLE001
+        return None

--- a/tests/cli/test_slash_palette.py
+++ b/tests/cli/test_slash_palette.py
@@ -50,10 +50,34 @@ def test_a_bare_slash_offers_the_whole_palette() -> None:
     )
 
 
-def test_every_offered_verb_carries_a_description() -> None:
-    """An entry with no meta is a name the operator has to guess at."""
-    blank = [t for t, m in _completions("/") if not m.strip()]
-    assert blank == [], f"verbs with no display_meta: {blank[:5]}"
+def test_no_entry_shows_maintainer_prose_as_help() -> None:
+    """SUPERSEDES an earlier assertion that every verb must carry meta.
+
+    That test was written while descriptions were mined from module
+    docstrings, and it passed by accepting things like "/autobiography REPL —
+    Wave 1 #8". Filling the column was the wrong goal: a blank reads as
+    "nobody has written this yet", whereas confident noise reads as a
+    description that happens to be wrong, and the operator acts on it.
+
+    The invariant that actually matters is that nothing SHOWN is junk."""
+    bad = []
+    for verb, meta in _completions("/"):
+        m = meta.strip()
+        if not m:
+            continue                      # honest blank — awaiting authored help
+        low = m.lower()
+        if "never raises" in low or m.startswith("§") or "slice " in low:
+            bad.append((verb, m))
+        if low.rstrip(".").endswith((" repl", " dispatcher", " by", " for")):
+            bad.append((verb, m))
+    assert bad == [], f"maintainer prose shown as help: {bad[:4]}"
+
+
+def test_authored_verbs_do_carry_help() -> None:
+    """The verbs that HAVE been written for an operator must show it."""
+    described = {t: m for t, m in _completions("/") if m.strip()}
+    for verb in ("/molt", "/moltbook", "/deck", "/wake"):
+        assert described.get(verb), f"{verb} has authored help but shows none"
 
 
 def test_prefix_narrows_the_palette() -> None:
@@ -201,3 +225,86 @@ def test_a_cockpit_without_a_completer_still_builds() -> None:
         mux = BipartiteLayout(width=100, height=20, title="t")
         app = build_bipartite_application(mux, on_accept=lambda _t: None)
     assert app is not None
+
+
+# --------------------------------------------------------------------------
+# 5. aesthetics — brand styling, and honest descriptions
+# --------------------------------------------------------------------------
+
+def test_the_cockpit_carries_the_brand_style() -> None:
+    """Without a Style, prompt_toolkit paints a filled light-grey listbox and
+    a reverse-video toolbar — the two loudest things on a dark screen."""
+    app = _cockpit_app()
+    assert app.style is not None, "cockpit has no Style; menu renders default"
+    rules = dict(app.style.style_rules)
+    for cls in ("completion-menu.completion",
+                "completion-menu.completion.current",
+                "completion-menu.meta.completion",
+                "bottom-toolbar"):
+        assert cls in rules, f"{cls} unstyled — falls back to pt defaults"
+    assert "noreverse" in rules["bottom-toolbar"], (
+        "the footer is still reverse-video: a solid bar of colour that says "
+        "nothing"
+    )
+
+
+def test_the_style_comes_from_the_one_palette() -> None:
+    """DRY: the brand owns its colours in ui.theme, not restated per widget."""
+    from backend.core.ouroboros.ui.theme import PALETTE, cockpit_prompt_style
+
+    rules = dict(cockpit_prompt_style().style_rules)
+    blob = " ".join(rules.values())
+    assert PALETTE["venom_green"] in blob or "ansibrightgreen" in blob
+    assert PALETTE["venom_purple"] in blob or "ansimagenta" in blob
+
+
+@pytest.mark.parametrize("junk", [
+    "NEVER raises.",
+    "Parse ``/anticipate`` line. NEVER raises.",
+    "Parse a ``/canvas`` line and dispatch. NEVER raises.",
+    "§32.11 Slice 4 canonical entry point — auto-discovered.",
+    "Canonical entry point — by",
+    "/causal REPL",
+    "/continuity REPL dispatcher",
+    "+ dispatch",
+])
+def test_maintainer_prose_is_not_shown_as_help(junk: str) -> None:
+    """These are contracts with whoever maintains the function. Shown in a
+    menu they look like descriptions and answer nothing."""
+    from backend.core.ouroboros.battle_test.repl_completion import _humanise
+
+    assert _humanise(junk) == "", f"{junk!r} leaked into the palette"
+
+
+def test_authored_help_is_preferred_over_any_docstring() -> None:
+    """The only source written FOR an operator wins."""
+    from backend.core.ouroboros.battle_test.repl_completion import _describe
+
+    import backend.core.ouroboros.governance.moltbook_repl as mr
+    assert _describe(mr.dispatch_moltbook_command) == (
+        "read the agora feed — the residents' posts"
+    )
+    assert _describe(mr.dispatch_molt_command) == (
+        "post to the agora as @the-human"
+    )
+
+
+def test_an_undescribed_verb_shows_a_blank_not_a_fabrication() -> None:
+    """A blank reads as 'nobody has written this yet'. Plausible noise reads
+    as a description that happens to be wrong — which is worse, because the
+    operator acts on it."""
+    from backend.core.ouroboros.battle_test.repl_completion import _describe
+
+    def dispatch_nothing_command(line: str):
+        """Parse ``/nothing`` line and dispatch. NEVER raises."""
+
+    assert _describe(dispatch_nothing_command) == ""
+
+
+def test_modules_declare_palette_help_beside_their_aliases() -> None:
+    """One place per module for palette metadata — the __aliases__ convention
+    extended, not a second registry."""
+    import backend.core.ouroboros.governance.moltbook_repl as mr
+
+    assert isinstance(getattr(mr, "__verb_help__", None), dict)
+    assert set(mr.__verb_help__) >= {"moltbook", "molt"}


### PR DESCRIPTION
Two problems in the screenshot — one visual, one editorial. The editorial one turned out to be the harder and more interesting.

## Visual

prompt_toolkit's default menu is a **filled light-grey listbox** with reverse-video selection, and its default `bottom-toolbar` is a solid reversed bar. On a dark cockpit those are the two loudest things on screen.

Claude Code's menu reads as part of the terminal because it has **no fill** — names sit on the ground colour and only the selected row is tinted.

`cockpit_prompt_style()` lives in `ui.theme` and derives every colour from the existing `PALETTE`, so the brand owns those six hexes in exactly one place and a palette change moves the menu with it. Tier-aware — a 16-colour terminal gets named colours rather than truecolor hexes to quantize into mud. Selection is a **tint, not reverse video**, because inverting the row destroys the accent colour that carries the meaning.

## Editorial — and I got this wrong first

The descriptions were maintainer docstrings:

```
/anticipate     Parse ``/anticipate`` line. NEVER raises.
/autobiography  §32.11 Slice 4 canonical entry point — auto-discovered.
```

True, load-bearing in the source, and useless in a menu.

My first instinct was to mine them. That was wrong: stripping the boilerplate yields **`/anticipate REPL`** — well-formed, confident, empty. **There is no algorithm that recovers a sentence nobody wrote.**

So modules now declare `__verb_help__` beside their `__aliases__` — same convention, one place per module for palette metadata:

```python
__aliases__ = ("molt",)
__verb_help__ = {
    "moltbook": "read the agora feed — the residents' posts",
    "molt": "post to the agora as @the-human",
}
```

Function docstrings remain a second source, but only when the result survives as prose — verb-echoes, fragments and trailing-connective residue are rejected. The **module** docstring is deliberately *not* a fallback: it's a file header narrating provenance, the wrong *genre* rather than the wrong wording, and mining it produced `/autobiography REPL — Wave 1 #8`.

## The reversal worth reviewing

An undescribed verb now shows a **blank**.

An earlier test of mine demanded every verb carry meta — and it passed by accepting exactly that noise. Filling the column was the wrong goal. A blank reads as *"nobody has written this yet"*; plausible prose reads as *a description that happens to be wrong*, and the operator acts on it.

The test now pins the invariant that matters — **nothing shown is junk** — and is documented as superseding the old one.

31 of 76 verbs describe themselves today. The rest await one line each, and the mechanism to write it now exists.

29 palette tests · `cli` 294 passed (2 pre-existing) · `bipartite` 20 · `repl_completion` 50 · `moltbook` 14. The 2 `tests/ui` failures are pre-existing crest-geometry, baseline-verified with `theme.py` stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Brands the command palette and improves help text quality. The menu now matches our theme, and maintainer-only docstrings are no longer shown as operator help.

- **New Features**
  - Branded `prompt_toolkit` completion menu and footer via `cockpit_prompt_style()` in `ui.theme`: no fill, tinted selection (not reverse), colors sourced from `PALETTE`, tier-aware fallbacks.
  - Added module-level `__verb_help__` (next to `__aliases__`) for authored one-line help; `moltbook_repl.py` seeds examples.
  - Docstring “humanising” rejects maintainer noise and provenance; module docstrings are not used. If nothing usable remains, the entry shows a blank instead of fabricated prose.
  - Updated tests to assert “nothing shown is junk” and to verify style derives from the single palette.

- **Migration**
  - Optional: add a `__verb_help__` dict to each module to provide palette help per verb.

<sup>Written for commit f5c228489cb86dfd0ad39a82f5a39ace013d5b37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

