### PR TITLE
feat(ov): lay the palette out as a page, not a widget

### DIFF
--- a/backend/core/ouroboros/battle_test/bipartite_layout.py
+++ b/backend/core/ouroboros/battle_test/bipartite_layout.py
@@ -502,7 +502,25 @@ def build_bipartite_application(
         # Bright venom-purple hairlines (Style Guide brand) — visible framing.
         return Window(height=1, char="─", style="fg:#a371f7")
 
-    rows += [canvas, _rule(), prompt, _rule()]
+    # The palette sits ABOVE the input, full width, and pushes the prompt down
+    # as it opens — the same relationship Claude Code has. A Float would
+    # overlay the canvas at the widget's own width; a row participates in the
+    # layout, so it wraps to the terminal and the prompt stays anchored under
+    # it. `dont_extend_height` keeps it at zero rows when nothing is matching.
+    _palette = None
+    if completer is not None:
+        try:
+            from backend.core.ouroboros.battle_test.palette_render import (
+                build_palette_window,
+            )
+            _palette = build_palette_window()
+        except Exception:  # noqa: BLE001
+            logger.debug("[Bipartite] palette row unavailable", exc_info=True)
+
+    rows += [canvas]
+    if _palette is not None:
+        rows.append(_palette)
+    rows += [_rule(), prompt, _rule()]
     if toolbar is not None:
         # A one-row morphing footer (e.g. the attach client's AttachUI.toolbar —
         # audio state, detach hint). Re-evaluated each repaint; a failing
@@ -518,7 +536,7 @@ def build_bipartite_application(
             height=1, wrap_lines=False,
         ))
     root: Any = HSplit(rows)
-    if completer is not None:
+    if completer is not None and _palette is None:
         # THE missing half. A CompletionsMenu is a Float; without a
         # FloatContainer it is never rendered no matter how many completions
         # the buffer holds.

--- a/backend/core/ouroboros/battle_test/palette_render.py
+++ b/backend/core/ouroboros/battle_test/palette_render.py
@@ -1,0 +1,221 @@
+"""The `/` palette, laid out like a page rather than a widget.
+
+Why not ``CompletionsMenu``
+---------------------------
+prompt_toolkit's menu is a bounded float: one line per entry, width set by the
+longest entry, descriptions truncated at its edge, a scrollbar down the side.
+It reads as a control dropped on top of the terminal.
+
+Claude Code's palette reads as part of the page — full terminal width, a fixed
+gutter between name and description, and long descriptions WRAPPED with a
+hanging indent instead of cut off. That is a different layout, not a different
+colour scheme, so no amount of styling the widget produces it.
+
+This renders the same state (``buffer.complete_state``) as a full-width block
+placed above the prompt. Everything is computed from the live terminal size
+and the actual entries — no fixed columns, no assumed widths — so it adapts to
+a resized window and to a verb table that grows.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, List, Optional, Tuple
+
+logger = logging.getLogger("Ouroboros.PaletteRender")
+
+#: Fraction of the width the name column may take before descriptions get
+#: squeezed. A single very long verb must not push every description off the
+#: screen — past this the name is ellipsised instead.
+_NAME_COL_MAX_FRACTION = 0.34
+
+#: Gutter between the name column and the description column.
+_GUTTER = 3
+
+
+def palette_rows() -> int:
+    """Maximum entries drawn at once (``JARVIS_PALETTE_HEIGHT``)."""
+    try:
+        return max(3, min(30, int(
+            os.environ.get("JARVIS_PALETTE_HEIGHT", "12") or 12,
+        )))
+    except (TypeError, ValueError):
+        return 12
+
+
+def _ellipsis(text: str, width: int) -> str:
+    if width <= 1 or len(text) <= width:
+        return text
+    return text[: max(1, width - 1)] + "…"
+
+
+def _wrap(text: str, width: int) -> List[str]:
+    """Greedy wrap. Deliberately not ``textwrap``: descriptions may contain
+    long unbroken tokens (paths, flags, module names) that ``textwrap`` will
+    either explode or refuse to break, and a palette row that overflows its
+    column corrupts every row below it."""
+    if width <= 0:
+        return [""]
+    out: List[str] = []
+    line = ""
+    for word in str(text).split():
+        while len(word) > width:            # unbreakable token
+            if line:
+                out.append(line)
+                line = ""
+            out.append(word[: width - 1] + "…")
+            word = ""
+        if not word:
+            continue
+        candidate = f"{line} {word}".strip()
+        if len(candidate) <= width:
+            line = candidate
+        else:
+            if line:
+                out.append(line)
+            line = word
+    if line:
+        out.append(line)
+    return out or [""]
+
+
+def layout_palette(
+    entries: List[Tuple[str, str]],
+    *,
+    width: int,
+    selected: int = -1,
+    max_rows: Optional[int] = None,
+    wrap_descriptions: bool = True,
+) -> List[List[Tuple[str, str]]]:
+    """Lay entries out as styled fragment lines. Pure — no prompt_toolkit.
+
+    Returns one fragment list per RENDERED line, which is not one per entry:
+    a wrapped description occupies several, and the continuation lines are
+    indented to the description column so the block reads as a table.
+
+    Scrolls to keep *selected* visible rather than clamping the window at the
+    top — with 76 verbs and 12 rows, a cursor that walks off the bottom into
+    nothing is the single most obvious way a palette feels broken."""
+    if width <= 0 or not entries:
+        return []
+    limit = max_rows if max_rows is not None else palette_rows()
+
+    names = [n for n, _d in entries]
+    name_col = min(
+        max((len(n) for n in names), default=0),
+        max(8, int(width * _NAME_COL_MAX_FRACTION)),
+    )
+    desc_col = max(8, width - name_col - _GUTTER - 2)
+
+    # Window the ENTRY list around the selection before rendering, so wrapping
+    # cost is paid only for what is shown.
+    total = len(entries)
+    start = 0
+    if selected >= 0 and total > limit:
+        start = max(0, min(selected - limit // 2, total - limit))
+    visible = entries[start: start + limit]
+
+    lines: List[List[Tuple[str, str]]] = []
+    for offset, (name, desc) in enumerate(visible):
+        idx = start + offset
+        current = idx == selected
+        base = ("class:completion-menu.completion.current" if current
+                else "class:completion-menu.completion")
+        meta = ("class:completion-menu.meta.completion.current" if current
+                else "class:completion-menu.meta.completion")
+        shown = _ellipsis(str(name), name_col)
+        pad = " " * max(0, name_col - len(shown))
+        body = _wrap(str(desc), desc_col) if wrap_descriptions else [
+            _ellipsis(str(desc), desc_col)
+        ]
+        lines.append([
+            (base, f"  {shown}{pad}"),
+            (meta, " " * _GUTTER + body[0]),
+        ])
+        # Continuation lines: blank name column, description aligned under
+        # itself. This is what makes a wrapped entry read as one row.
+        for extra in body[1:]:
+            lines.append([
+                (base, "  " + " " * name_col),
+                (meta, " " * _GUTTER + extra),
+            ])
+    return lines
+
+
+def build_palette_window(condition_style: str = "") -> Any:
+    """A full-width container that draws the palette above the prompt.
+
+    Visible only while a completion is in progress, and it takes its height
+    from the content — so the prompt sits directly beneath the last entry
+    exactly as it does with no palette open. NEVER raises."""
+    try:
+        from prompt_toolkit.application.current import get_app
+        from prompt_toolkit.filters import Condition
+        from prompt_toolkit.layout import ConditionalContainer, Window
+        from prompt_toolkit.layout.controls import FormattedTextControl
+        from prompt_toolkit.layout.dimension import Dimension
+    except ImportError:
+        return None
+
+    def _state() -> Any:
+        try:
+            return get_app().current_buffer.complete_state
+        except Exception:  # noqa: BLE001
+            return None
+
+    def _entries_and_index():
+        st = _state()
+        if st is None or not st.completions:
+            return [], -1
+        rows = [
+            (c.display_text or c.text, c.display_meta_text or "")
+            for c in st.completions
+        ]
+        idx = st.complete_index if st.complete_index is not None else -1
+        return rows, idx
+
+    def _fragments():
+        try:
+            rows, idx = _entries_and_index()
+            if not rows:
+                return []
+            width = get_app().output.get_size().columns
+            lines = layout_palette(rows, width=width, selected=idx)
+            out: List[Tuple[str, str]] = []
+            for i, line in enumerate(lines):
+                out.extend(line)
+                if i < len(lines) - 1:
+                    out.append(("", "\n"))
+            return out
+        except Exception:  # noqa: BLE001 — a palette fault must not blank the UI
+            logger.debug("[Palette] render degraded", exc_info=True)
+            return []
+
+    def _height() -> int:
+        try:
+            rows, idx = _entries_and_index()
+            if not rows:
+                return 0
+            width = get_app().output.get_size().columns
+            return len(layout_palette(rows, width=width, selected=idx))
+        except Exception:  # noqa: BLE001
+            return 0
+
+    return ConditionalContainer(
+        content=Window(
+            content=FormattedTextControl(_fragments, focusable=False),
+            height=Dimension(min=0, max=palette_rows() * 3,
+                             preferred=1, weight=0),
+            dont_extend_height=True,
+            wrap_lines=False,
+            style=condition_style or "class:completion-menu",
+        ),
+        filter=Condition(lambda: _height() > 0),
+    )
+
+
+__all__ = [
+    "build_palette_window",
+    "layout_palette",
+    "palette_rows",
+]

--- a/tests/cli/test_palette_layout.py
+++ b/tests/cli/test_palette_layout.py
@@ -1,0 +1,165 @@
+"""The palette's LAYOUT — a page, not a widget.
+
+prompt_toolkit's CompletionsMenu is a bounded float: one line per entry, width
+set by the longest entry, descriptions truncated at its edge, scrollbar down
+the side. Claude Code's palette is full terminal width, has a fixed gutter,
+and WRAPS long descriptions with a hanging indent.
+
+That is a layout difference, not a colour one — no amount of styling the
+widget produces it. These tests pin the layout maths, which is pure and
+therefore testable without a terminal.
+"""
+from __future__ import annotations
+
+from typing import List, Tuple
+
+import pytest
+
+from backend.core.ouroboros.battle_test.palette_render import (
+    layout_palette,
+    palette_rows,
+)
+
+
+def _text(lines) -> List[str]:
+    return ["".join(t for _s, t in line) for line in lines]
+
+
+LONG = ("Review the current diff for correctness bugs and reuse or "
+        "simplification cleanups at the given effort level")
+
+
+# --------------------------------------------------------------------------
+# 1. the CC structure
+# --------------------------------------------------------------------------
+
+def test_long_descriptions_wrap_instead_of_truncating() -> None:
+    out = _text(layout_palette([("/code-review", LONG)], width=90))
+    assert len(out) > 1, "description was truncated instead of wrapped"
+    assert "effort level" in " ".join(out), "the tail of the text was lost"
+
+
+def test_continuation_lines_hang_under_the_description_column() -> None:
+    """What makes a wrapped entry read as ONE row rather than two."""
+    out = _text(layout_palette([("/code-review", LONG)], width=90))
+    first_desc_col = out[0].index("Review")
+    second = out[1]
+    assert second[:first_desc_col].strip() == "", (
+        "continuation line intrudes into the name column"
+    )
+    assert len(second) - len(second.lstrip()) == first_desc_col, (
+        "continuation is not aligned under the description column"
+    )
+
+
+def test_every_line_fits_the_terminal_width() -> None:
+    """A row that overflows its column corrupts every row below it."""
+    rows = [("/x" * 30, LONG), ("/deck", "deck height"), ("/a", "")]
+    for width in (40, 80, 120, 200):
+        for line in _text(layout_palette(rows, width=width)):
+            assert len(line) <= width, (
+                f"line of {len(line)} exceeds width {width}: {line[:60]!r}"
+            )
+
+
+def test_the_name_column_cannot_swallow_the_screen() -> None:
+    """One pathological verb must not push every description off-screen."""
+    rows = [("/" + "z" * 200, "a real description here"), ("/ok", "short")]
+    out = _text(layout_palette(rows, width=100))
+    assert "a real description here" in " ".join(out)
+    assert "…" in out[0], "the oversized name was not ellipsised"
+
+
+def test_the_gutter_is_consistent_across_entries() -> None:
+    rows = [("/a", "alpha"), ("/longer-verb", "beta"), ("/mid", "gamma")]
+    out = _text(layout_palette(rows, width=100))
+    cols = [line.index(word) for line, word in
+            zip(out, ("alpha", "beta", "gamma"))]
+    assert len(set(cols)) == 1, f"descriptions start at ragged columns: {cols}"
+
+
+# --------------------------------------------------------------------------
+# 2. selection + scrolling
+# --------------------------------------------------------------------------
+
+def test_the_window_scrolls_to_keep_the_selection_visible() -> None:
+    """With 76 verbs and 12 rows, a cursor that walks off the bottom into
+    nothing is the most obvious way a palette feels broken."""
+    rows = [(f"/verb{i}", f"desc {i}") for i in range(80)]
+    out = _text(layout_palette(rows, width=100, selected=70, max_rows=10))
+    assert any("/verb70" in line for line in out), "selection scrolled off"
+
+
+def test_the_selected_row_is_styled_differently() -> None:
+    rows = [("/a", "alpha"), ("/b", "beta")]
+    lines = layout_palette(rows, width=100, selected=1)
+    styles = [line[0][0] for line in lines]
+    assert "current" in styles[1], "selected row carries no distinct style"
+    assert "current" not in styles[0]
+
+
+def test_no_selection_renders_cleanly() -> None:
+    """complete_index is None until the operator arrows — every row unselected."""
+    lines = layout_palette([("/a", "alpha")], width=100, selected=-1)
+    assert lines and "current" not in lines[0][0][0]
+
+
+# --------------------------------------------------------------------------
+# 3. bulletproof
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("width", [0, -5, 1, 3])
+def test_degenerate_widths_never_raise(width: int) -> None:
+    layout_palette([("/a", "alpha")], width=width)
+
+
+def test_an_undescribed_verb_renders_its_name_alone() -> None:
+    out = _text(layout_palette([("/anticipate", "")], width=100))
+    assert out == ["  /anticipate   "] or out[0].strip() == "/anticipate"
+
+
+def test_an_unbreakable_token_is_broken_rather_than_overflowing() -> None:
+    """Paths and module names have no spaces; textwrap either explodes or
+    refuses, and either way the column overflows."""
+    rows = [("/x", "a" * 300)]
+    for line in _text(layout_palette(rows, width=60)):
+        assert len(line) <= 60
+
+
+def test_empty_input_is_an_empty_layout() -> None:
+    assert layout_palette([], width=100) == []
+
+
+def test_height_knob_is_bounded() -> None:
+    assert 3 <= palette_rows() <= 30
+
+
+# --------------------------------------------------------------------------
+# 4. wired into the cockpit as a ROW, not a float
+# --------------------------------------------------------------------------
+
+def test_the_palette_is_a_layout_row_above_the_prompt() -> None:
+    """A Float overlays the canvas at the widget's own width. A row
+    participates in the layout, so it wraps to the terminal and the prompt
+    stays anchored beneath it."""
+    import contextlib
+    import io
+
+    from prompt_toolkit.layout import ConditionalContainer
+
+    from backend.core.ouroboros.battle_test.bipartite_layout import (
+        BipartiteLayout,
+        build_bipartite_application,
+    )
+    from backend.core.ouroboros.cli.ov import _build_slash_completer
+
+    with contextlib.redirect_stderr(io.StringIO()):
+        app = build_bipartite_application(
+            BipartiteLayout(width=100, height=20, title="t"),
+            on_accept=lambda _t: None, completer=_build_slash_completer(),
+        )
+    root = app.layout.container
+    kids = list(root.get_children())
+    assert any(isinstance(k, ConditionalContainer) for k in kids), (
+        "no conditional palette row in the layout"
+    )

--- a/tests/cli/test_slash_palette.py
+++ b/tests/cli/test_slash_palette.py
@@ -176,24 +176,34 @@ def _cockpit_app():
 
 
 def test_the_cockpit_layout_can_actually_draw_a_menu() -> None:
-    """THE bug the operator reported.
+    """THE bug the operator reported: completions computed, nothing drawn.
 
-    D5 built a correct completer yielding 76 verbs and wired it to
-    `_split_plane_loop`'s PromptSession — a surface the bipartite cockpit
-    never runs. Even once reached, the layout was a bare HSplit: prompt_toolkit
-    draws the completions menu as a Float, so with no FloatContainer it had
-    nowhere to exist. Completions were computed and silently discarded."""
-    from prompt_toolkit.layout import FloatContainer
+    Asserted as an INVARIANT — the layout contains somewhere for the palette
+    to render — rather than as a mechanism. This test originally required the
+    root to be a FloatContainer, which was true while the menu was
+    prompt_toolkit's Float widget and became false the moment the palette
+    moved to a full-width row above the prompt. The mechanism changed; the
+    thing worth protecting did not.
+
+    Either shape satisfies it:
+      * a FloatContainer carrying a CompletionsMenu float, or
+      * a ConditionalContainer palette row participating in the layout."""
+    from prompt_toolkit.layout import ConditionalContainer, FloatContainer
 
     app = _cockpit_app()
     root = app.layout.container
-    assert isinstance(root, FloatContainer), (
-        "the cockpit root is not a FloatContainer — a completions menu has "
-        "nowhere to render, however many completions the buffer holds"
-    )
-    kinds = [type(f.content).__name__ for f in root.floats]
-    assert any("CompletionsMenu" in k for k in kinds), (
-        f"no completions menu float is mounted; floats={kinds}"
+
+    if isinstance(root, FloatContainer):
+        kinds = [type(f.content).__name__ for f in root.floats]
+        assert any("CompletionsMenu" in k for k in kinds), (
+            f"FloatContainer root with no completions float; floats={kinds}"
+        )
+        return
+
+    kids = list(getattr(root, "get_children", lambda: [])())
+    assert any(isinstance(k, ConditionalContainer) for k in kids), (
+        "the cockpit layout has neither a completions float nor a palette "
+        "row — completions are computed and silently discarded"
     )
 
 


### PR DESCRIPTION
The styling landed, but the **structure** was still prompt_toolkit's widget.

| `CompletionsMenu` | Claude Code |
|---|---|
| bounded box + scrollbar | **full terminal width** |
| truncated at the box edge | **wrapped, hanging indent** |
| column set by longest entry | fixed gutter |
| float over the canvas | a row above the input |

That's a layout difference, not a colour one — no amount of styling the widget produces it. `CompletionsMenu` is one line per entry at its own width *by construction*.

## The fix

`palette_render.py` renders the same state (`buffer.complete_state`) as a full-width block placed **above** the prompt as a participating layout row.

A `Float` overlays the canvas at the widget's width. A **row** wraps to the terminal and lets the prompt stay anchored beneath it — that's the relationship CC has, and the reason its palette reads as part of the page rather than a control dropped on top.

```
  /code-review   Review the current diff for correctness bugs and reuse or
                 simplification cleanups at the given effort level
  /deck          deck height — off | compact | full
  /anticipate
```

Everything computed from the live terminal size and the actual entries — no fixed columns:

- **name column** = longest name, capped at 34 % of width, so one pathological verb can't push every description off-screen (it ellipsises instead)
- **descriptions wrap** to the remaining space, continuation lines aligned under the description column — that's what makes a wrapped entry read as *one* row
- **the window scrolls** to keep the selection visible; with 76 verbs and 12 rows, a cursor walking off the bottom into nothing is the most obvious way a palette feels broken

Wrapping is greedy rather than `textwrap`: descriptions carry long unbroken tokens (paths, flags, module names) that `textwrap` either explodes or refuses to break, and one row overflowing its column corrupts every row below it. Pinned by a test that every emitted line fits at 40/80/120/200 columns.

## Testability

The layout maths is **pure** — no prompt_toolkit import — so it's testable without a terminal. That's precisely the part of this arc that kept being untestable and kept shipping broken.

## One test re-expressed, not deleted

An earlier test of mine required the root to be a `FloatContainer` — true while the menu *was* a float, false the moment the palette became a row. It now asserts the **invariant** (the layout contains somewhere for the palette to render) and accepts either shape. The mechanism changed; the thing worth protecting didn't.

17 layout tests. `cli` 311 passed (2 pre-existing) · `bipartite` 20 · `repl_completion` 50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lay the slash-command palette out as a full-width row above the prompt instead of a `prompt_toolkit` `CompletionsMenu` float. Matches Claude Code’s page-style palette with wrapped descriptions, a fixed gutter, and scrolling that keeps the selection visible.

- New Features
  - Added `palette_render.py` to render `buffer.complete_state` as a full-width block with hanging-indent wrapping, a fixed gutter, and a name column capped at 34% (ellipsized when needed).
  - Palette height is content-driven, responsive to terminal width, and configurable via `JARVIS_PALETTE_HEIGHT` (bounded 3–30; default 12).
  - Integrated as a conditional layout row in the cockpit so the prompt stays anchored beneath the palette.

- Bug Fixes
  - The cockpit now always has somewhere to render completions: uses the new row when available, falls back to the float path otherwise.
  - Tests rewritten to assert the invariant (palette render target exists) and add 17 layout tests for wrapping, width bounds (40/80/120/200), scrolling, and degenerate widths.

<sup>Written for commit f06e073fa5b9f0656126df3f092aa70941de76c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

