### PR TITLE
fix(ui): crest fills and centres the terminal; boot leaves no debris

### DIFF
--- a/backend/core/ouroboros/battle_test/repl_completion.py
+++ b/backend/core/ouroboros/battle_test/repl_completion.py
@@ -53,6 +53,7 @@ What this module does NOT do
 """
 from __future__ import annotations
 
+import contextlib
 import enum
 import inspect
 import re
@@ -1595,6 +1596,40 @@ def _describe(fn: object) -> str:
     return ""
 
 
+@contextlib.contextmanager
+def _root_logging_preserved():
+    """Hold the root logger harmless across an arbitrary-module import walk.
+
+    Priming the verb registry imports every module in the dispatch packages
+    purely to read function names off them. Import is not inert: a module that
+    calls ``logging.basicConfig`` at import time installs a handler on the ROOT
+    logger, and from then on every unrelated log record in the cockpit carries
+    that module's format. ``isolated_agent_worker`` did exactly this, and the
+    operator's terminal filled with ``[worker]``-stamped lines emitted by
+    subsystems containing no worker.
+
+    That module is fixed at the source, but the exposure is structural: any
+    future module acquires the same power simply by being importable. Since
+    introspection has no business mutating the host's logging, the walk is
+    made non-destructive by construction — handlers and level are snapshotted
+    and restored, so a stray ``basicConfig`` affects nothing.
+
+    Deliberately narrow: only root handlers and level are restored. Named
+    loggers a module configures for ITSELF are its own business."""
+    root = logging.getLogger()
+    saved_handlers = list(root.handlers)
+    saved_level = root.level
+    try:
+        yield
+    finally:
+        try:
+            if root.handlers != saved_handlers:
+                root.handlers[:] = saved_handlers
+            root.setLevel(saved_level)
+        except Exception:  # noqa: BLE001 — never break completion over logging
+            pass
+
+
 def registry_from_dispatch() -> VerbRegistry:
     """Build a :class:`VerbRegistry` from the AUTO-DISCOVERED dispatch table.
 
@@ -1618,7 +1653,8 @@ def registry_from_dispatch() -> VerbRegistry:
             prime_registry,
         )
         try:
-            prime_registry()
+            with _root_logging_preserved():
+                prime_registry()
         except Exception:  # noqa: BLE001 — a partial table still completes
             pass
         for verb, fn in sorted(_VERB_TO_DISPATCHER.items()):

--- a/backend/core/ouroboros/governance/child_reaper.py
+++ b/backend/core/ouroboros/governance/child_reaper.py
@@ -223,8 +223,13 @@ def arm_atexit_cascade() -> None:
             if _atexit_armed:
                 return
             _atexit_armed = True
-        import atexit
-        atexit.register(lambda: cascade_terminate())
+        # Guarded: cascade_terminate() WAITS on children, which holds the
+        # shutdown window open long enough for an impatient second Ctrl+C to
+        # land inside it. KeyboardInterrupt is a BaseException, so it escapes
+        # every ordinary guard and atexit prints a traceback over the
+        # operator's prompt at the exact moment they asked to leave.
+        from .exit_guard import guarded_atexit_register
+        guarded_atexit_register(cascade_terminate)
     except Exception:  # noqa: BLE001
         pass
 

--- a/backend/core/ouroboros/governance/exit_guard.py
+++ b/backend/core/ouroboros/governance/exit_guard.py
@@ -1,0 +1,86 @@
+"""Interpreter-exit handlers that cannot spray a traceback on Ctrl+C.
+
+The defect this closes is visible the moment an operator quits ``ov``::
+
+    Error in atexit._run_exitfuncs:
+    Traceback (most recent call last):
+      ...
+    KeyboardInterrupt
+
+``atexit`` handlers run on the main thread during interpreter shutdown, so a
+Ctrl+C arriving in that window is delivered *into* whichever handler happens
+to be running. Handlers that block — draining a pool, waiting on child
+processes — hold that window open long enough to be a real target, and a
+second impatient Ctrl+C lands squarely inside one.
+
+The usual ``except Exception`` guard does not help, and its presence is what
+makes this surprising: ``KeyboardInterrupt`` and ``SystemExit`` derive from
+``BaseException``, not ``Exception``. Handlers written to be defensive are
+therefore *exactly* as exposed as handlers that were not, which is why the
+traceback appears despite the try/except sitting right there in the source.
+
+Nothing useful can be reported at this point anyway — stderr may already be
+torn down, and the process is leaving regardless. The operator asked to quit;
+the correct response is to quit, not to explain.
+
+Deliberately NOT a blanket ``sys.excepthook`` or an ``atexit`` monkeypatch:
+those would swallow tracebacks from handlers registered by third-party
+libraries, where a traceback may be the only evidence of a real fault. This is
+opt-in per registration site.
+"""
+from __future__ import annotations
+
+import atexit
+import logging
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["guarded_atexit_register", "run_guarded"]
+
+
+def run_guarded(fn: Callable[..., Any], *args: Any, **kwargs: Any) -> None:
+    """Run ``fn`` so that nothing whatsoever escapes.
+
+    ``BaseException`` is caught on purpose. At interpreter-exit time the
+    alternative to swallowing is a traceback printed over the operator's
+    prompt, and there is no caller left to handle anything.
+    """
+    try:
+        fn(*args, **kwargs)
+    except BaseException:  # noqa: BLE001 — see module docstring
+        # Best-effort breadcrumb. Logging itself may be half torn down during
+        # shutdown, so even this is guarded; losing the breadcrumb is strictly
+        # better than the traceback it replaces.
+        try:
+            logger.debug(
+                "[exit_guard] suppressed exception from exit handler %r",
+                getattr(fn, "__qualname__", fn),
+                exc_info=True,
+            )
+        except BaseException:  # noqa: BLE001
+            pass
+
+
+def guarded_atexit_register(
+    fn: Callable[..., Any], *args: Any, **kwargs: Any,
+) -> Callable[..., Any]:
+    """``atexit.register`` for a handler that must never print on the way out.
+
+    Returns the registered wrapper (not ``fn``), which is what
+    ``atexit.unregister`` needs if a caller ever wants to withdraw it.
+    """
+    def _wrapper() -> None:
+        run_guarded(fn, *args, **kwargs)
+
+    # Keep the wrapper identifiable in tracebacks and in atexit's own
+    # bookkeeping — an anonymous frame is hard to attribute during shutdown.
+    try:
+        _wrapper.__qualname__ = (
+            f"guarded[{getattr(fn, '__qualname__', repr(fn))}]"
+        )
+    except Exception:  # noqa: BLE001
+        pass
+
+    atexit.register(_wrapper)
+    return _wrapper

--- a/backend/core/ouroboros/governance/isolated_agent_worker.py
+++ b/backend/core/ouroboros/governance/isolated_agent_worker.py
@@ -79,12 +79,30 @@ import traceback
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-logging.basicConfig(
-    level=logging.DEBUG if os.environ.get("JARVIS_WORKER_DEBUG") else logging.WARNING,
-    format="%(asctime)s [worker] %(message)s",
-    stream=sys.stderr,  # logs to stderr, protocol on stdout
-)
 logger = logging.getLogger(__name__)
+
+
+def _configure_worker_logging() -> None:
+    """Install the worker's root log format — ONLY when run as a subprocess.
+
+    This used to execute at import. That is fine for the ``python3 -m`` entry
+    point and wrong everywhere else: ``basicConfig`` configures the ROOT
+    logger, so any process that merely IMPORTS this module inherits a root
+    handler stamping every unrelated record with ``[worker]``. The cockpit's
+    slash-palette primes its verb registry by walking the governance package
+    and importing each module to read its dispatch functions — so opening
+    ``ov`` pulled this module in, and the operator's terminal filled with
+    ``[worker]`` lines emitted by subsystems that have no worker in them.
+
+    A library import must not configure logging for its host. Configuration
+    is an application decision, so it moves to the application entry point.
+    """
+    logging.basicConfig(
+        level=(logging.DEBUG if os.environ.get("JARVIS_WORKER_DEBUG")
+               else logging.WARNING),
+        format="%(asctime)s [worker] %(message)s",
+        stream=sys.stderr,  # logs to stderr, protocol on stdout
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -815,4 +833,5 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    _configure_worker_logging()
     sys.exit(main())

--- a/backend/core/ouroboros/governance/operation_advisor.py
+++ b/backend/core/ouroboros/governance/operation_advisor.py
@@ -500,7 +500,8 @@ def _get_advisor_blast_executor() -> "_futures.ThreadPoolExecutor":
                     max_workers=_ADVISOR_BLAST_EXECUTOR_MAX_WORKERS,
                     thread_name_prefix="advisor-blast",
                 )
-                _atexit.register(_shutdown_advisor_blast_executor)
+                from .exit_guard import guarded_atexit_register
+                guarded_atexit_register(_shutdown_advisor_blast_executor)
                 logger.info(
                     "[Advisor] dedicated executor initialized "
                     "(max_workers=%d, thread_prefix=advisor-blast)",

--- a/backend/core/ouroboros/ui/awakening.py
+++ b/backend/core/ouroboros/ui/awakening.py
@@ -337,7 +337,8 @@ class AwakeningConductor:
         # never a raw-ANSI overwrite hack.
         try:
             if self._last_size is not None:
-                _rows_needed = frame.rows + 6      # crest + header lines
+                from .crest import CREST_HEADER_ROWS
+                _rows_needed = frame.rows + CREST_HEADER_ROWS
                 if self._last_size[1] < _rows_needed:
                     from .crest import render_crest_auto as _rca
                     self._console.print(_rca(frame, tier))

--- a/backend/core/ouroboros/ui/crest.py
+++ b/backend/core/ouroboros/ui/crest.py
@@ -122,6 +122,57 @@ class CrestFrame:
     unavailable_reason: Optional[str] = None
 
 
+#: Rows the awakening ceremony prints beneath the crest (header + spacing).
+#: Both the fit and the ceremony's own "will the animated path fit" check read
+#: this, so the crest is never sized into space the header is about to claim.
+CREST_HEADER_ROWS = 6
+
+
+def _fit_cols(measured_cols: int, measured_rows: int) -> Tuple[int, int, int]:
+    """Largest crest that fits BOTH dimensions: (lo, hi, fitted).
+
+    Sizing used to be width-only — ``min(measured - 1, 88)`` — with height as
+    a veto: if the resulting crest was taller than the terminal, the whole
+    thing was suppressed. Two consequences, both visible:
+
+      * on a wide terminal the crest capped at 88 columns and sat in under
+        half the available width, because 88 was chosen when the reference
+        geometry was drawn rather than measured against anything;
+      * simply raising that cap makes the crest VANISH on a short-but-wide
+        window, since a wider crest needs proportionally more rows.
+
+    So width and height are solved together: take the widest crest whose
+    ``rows_needed`` still fits the rows we actually have. The ceiling becomes
+    a true bound on the terminal rather than an arbitrary number, and the
+    crest degrades by shrinking instead of disappearing.
+
+    Search is a descending scan, not a formula: ``rows_needed`` involves a
+    ceil, so inverting it algebraically lands off-by-one at the boundaries —
+    exactly where a crest either overflows or vanishes. The range is at most
+    a few hundred integers and this runs once per resize."""
+    # The cap is now a SAFETY rail, not the working limit: a crest wider than
+    # it stops reading as an emblem and starts reading as wallpaper. The
+    # bounds and the one-column margin come from _clamp_cols so there is a
+    # single definition of each (DRY).
+    lo, hi, width_budget = _clamp_cols(measured_cols)
+    # Reserve rows for the header the ceremony prints beneath the crest.
+    # CREST_HEADER_ROWS is the single definition of that number — awakening
+    # independently reserved 6 rows before deciding whether the animated path
+    # would fit, so a reserve chosen separately here would be a second copy
+    # free to drift out of step with it.
+    try:
+        reserve = max(0, int(os.environ.get(
+            "JARVIS_OV_CREST_ROW_RESERVE", str(CREST_HEADER_ROWS))))
+    except (TypeError, ValueError):
+        reserve = CREST_HEADER_ROWS
+    row_budget = max(0, int(measured_rows) - reserve)
+
+    fitted = width_budget
+    while fitted > lo and _Geometry.rows_needed(fitted) > row_budget:
+        fitted -= 1
+    return lo, hi, fitted
+
+
 def _clamp_cols(measured: int) -> Tuple[int, int, int]:
     """Return (lo, hi, clamped) column bounds for a measured width.
 
@@ -129,15 +180,20 @@ def _clamp_cols(measured: int) -> Tuple[int, int, int]:
     check the low bound against ``measured`` directly (not ``clamped``,
     which is floored at ``lo`` by construction and so can never itself
     read as "below minimum").
+
+    Width-only. Since 2026-07-25 this is the WIDTH HALF of
+    :func:`_fit_cols`, which additionally solves for height — callers that
+    know their row count must use that instead, or a wide-but-short window
+    gets a crest too tall to draw and the emblem vanishes entirely.
+
+    Strict bounding-box margin (operator finding 2026-07-18): a crest exactly
+    as wide as the terminal auto-wraps its last cell onto the next line, and
+    every row sheds one detached artifact block. One column of right margin
+    kills the whole off-by-one wrap class.
     """
     lo = int(os.environ.get("JARVIS_OV_CREST_MIN_COLS", "46"))
-    hi = int(os.environ.get("JARVIS_OV_CREST_MAX_COLS", "88"))
-    # Strict bounding-box margin (operator finding 2026-07-18): a crest
-    # exactly as wide as the terminal auto-wraps its last cell onto the
-    # next line — every row sheds one detached artifact block. One
-    # column of right margin kills the whole off-by-one wrap class.
-    clamped = max(lo, min(measured - 1, hi))
-    return lo, hi, clamped
+    hi = int(os.environ.get("JARVIS_OV_CREST_MAX_COLS", "140"))
+    return lo, hi, max(lo, min(measured - 1, hi))
 
 
 # ===========================================================================
@@ -456,11 +512,13 @@ def generate_crest(
             return CrestFrame(0, 0, (), 0.0, "unicode required")
         if tier is ColorTier.NONE:
             return CrestFrame(0, 0, (), 0.0, "color tier NONE")
-        lo, _hi, clamped = _clamp_cols(measured_cols)
+        lo, _hi, clamped = _fit_cols(measured_cols, measured_rows)
         if measured_cols < lo:
             return CrestFrame(0, 0, (), 0.0, f"width {measured_cols} < min {lo}")
         needed_rows = _Geometry.rows_needed(clamped)
         if measured_rows < needed_rows:
+            # Only reachable when even the MINIMUM crest is too tall — the
+            # fit already shrank as far as it is allowed to go.
             return CrestFrame(0, 0, (), 0.0,
                                f"rows {measured_rows} < needed {needed_rows}")
         return _generate_cached(clamped, needed_rows, int(tier))
@@ -702,7 +760,7 @@ def generate_crest_pixels(
     """Half-block raster sized like :func:`generate_crest` (same clamps
     + row fit). None when the terminal can't fit it. NEVER raises."""
     try:
-        lo, _hi, clamped = _clamp_cols(measured_cols)
+        lo, _hi, clamped = _fit_cols(measured_cols, measured_rows)
         if measured_cols < lo:
             return None
         rows = _Geometry.rows_needed(clamped)
@@ -765,19 +823,64 @@ def pixels_to_text(
             return ""
 
 
+def center_pad(crest_cols: int, term_cols: Optional[int] = None) -> int:
+    """Left padding that centres a ``crest_cols``-wide emblem. Never negative,
+    never wide enough to push the crest off the right edge.
+
+    Measured here rather than passed down because the crest is centred on the
+    TERMINAL, not on whatever container a caller happens to be inside — every
+    consumer that has tried to own this ended up left-aligned."""
+    try:
+        if os.environ.get("JARVIS_OV_CREST_CENTER", "1").strip().lower() in (
+                "0", "false", "no", "off"):
+            return 0
+        if term_cols is None:
+            import shutil
+            term_cols = shutil.get_terminal_size(fallback=(80, 24)).columns
+        return max(0, (int(term_cols) - int(crest_cols)) // 2)
+    except Exception:  # noqa: BLE001
+        return 0
+
+
+def _indent(text: "Any", pad: int) -> "Any":
+    """Prefix every rendered row with ``pad`` spaces, styles intact.
+
+    Done on the composed Text instead of inside the two pixel/quadrant loops:
+    padding is a placement concern, and threading an offset through both
+    renderers would put the same arithmetic in two places that must agree."""
+    if pad <= 0:
+        return text
+    try:
+        from rich.text import Text
+        out = Text()
+        for i, line in enumerate(text.split("\n")):
+            if i:
+                out.append("\n")
+            out.append(" " * pad)
+            out.append_text(line)
+        return out
+    except Exception:  # noqa: BLE001
+        return text
+
+
 def render_crest_auto(
     frame: "CrestFrame", tier: ColorTier, *, elapsed: Optional[float] = None,
+    term_cols: Optional[int] = None,
 ) -> "Any":
     """THE renderer dispatch: half-block pixels on capable terminals
     (C256+ and renderer=halfblock), quadrant glyphs otherwise. Both
-    paths honor the reveal clock. NEVER raises."""
+    paths honor the reveal clock, and both come out centred on the
+    terminal. NEVER raises."""
+    body = None
     try:
         if crest_renderer() == "halfblock" and tier >= ColorTier.C256:
             pf = _generate_pixels_cached(frame.cols, frame.rows)
-            return pixels_to_text(pf, elapsed=elapsed)
+            body = pixels_to_text(pf, elapsed=elapsed)
     except Exception:  # noqa: BLE001
-        pass
-    return frame_to_text(frame, tier, elapsed=elapsed)
+        body = None
+    if body is None:
+        body = frame_to_text(frame, tier, elapsed=elapsed)
+    return _indent(body, center_pad(frame.cols, term_cols))
 
 
 def frame_to_text(

--- a/tests/battle_test/test_audio_visual_synapse.py
+++ b/tests/battle_test/test_audio_visual_synapse.py
@@ -337,8 +337,16 @@ class TestCrestBoundingAndBlit:
         # the off-by-one detached-artifact class. One column of margin.
         _lo, _hi, clamped = crest._clamp_cols(80)
         assert clamped == 79
-        _lo, _hi, clamped = crest._clamp_cols(200)
-        assert clamped == 88                    # cap still wins when roomy
+        # SUPERSEDED 2026-07-25: the cap was 88 — a number chosen when the
+        # reference geometry was drawn, not measured against anything — so on
+        # a 200-column terminal the crest sat in under half the width. The
+        # safety rail is now 140 and sizing is solved in BOTH dimensions by
+        # _fit_cols. What this test protects is the one-column wrap margin,
+        # which is unchanged; the specific ceiling is a tunable, not an
+        # invariant, so it is read rather than restated.
+        _lo, hi, clamped = crest._clamp_cols(200)
+        assert clamped == hi                    # cap still wins when roomy
+        assert hi > 88, "the crest is still capped at the old hardcoded width"
 
     def test_blit_writes_one_atomic_frame(self):
         from backend.core.ouroboros.ui import crest

--- a/tests/ui/test_crest.py
+++ b/tests/ui/test_crest.py
@@ -13,6 +13,9 @@ from backend.core.ouroboros.ui.theme import ColorTier
 T = ColorTier.TRUECOLOR
 
 
+from backend.core.ouroboros.ui import crest as crest_mod
+
+
 def gen(cols=60, rows=24, tier=T, unicode_ok=True) -> CrestFrame:
     return generate_crest(cols, rows, tier=tier, unicode_ok=unicode_ok)
 
@@ -87,11 +90,30 @@ def test_geometry_scales_with_width():
 
 
 def test_hard_clamp_at_default_max():
-    # 2026-07-18 sharpening pass: default max raised 72 -> 88 (still
-    # terminal-clamped; env-overridable via JARVIS_OV_CREST_MAX_COLS).
+    # 2026-07-18 sharpening pass: default max raised 72 -> 88.
+    # 2026-07-25 SUPERSEDED: sizing is no longer width-only. ``gen`` supplies
+    # rows=24, and on a 24-row terminal the binding constraint is HEIGHT, not
+    # the column cap — an 88-column crest plus the ceremony's 6-line header
+    # does not fit. Asserting 88 here was asserting that the crest ignores the
+    # rows it was handed, which is the bug that made a wide-but-short window
+    # either overflow or vanish.
+    #
+    # The invariants that survive: the cap still bounds the crest, the crest
+    # still fits with its header, and no cell escapes the frame.
+    from backend.core.ouroboros.ui.crest import CREST_HEADER_ROWS, _Geometry
     f = gen(cols=200)
-    assert f.cols == 88
-    assert max(c.x for c in f.cells) < 88
+    _lo, hi, _c = crest_mod._clamp_cols(200)
+    assert f.cols <= hi
+    assert _Geometry.rows_needed(f.cols) + CREST_HEADER_ROWS <= 24
+    assert max(c.x for c in f.cells) < f.cols
+
+
+def test_a_tall_terminal_lifts_the_height_constraint():
+    """The same 200 columns, with rows to spend, reaches the cap — proof the
+    shrink above is height doing its job and not a smaller ceiling."""
+    _lo, hi, _c = crest_mod._clamp_cols(200)
+    assert gen(cols=200, rows=60).cols == hi
+    assert gen(cols=200, rows=60).cols > gen(cols=200, rows=24).cols
 
 
 def test_env_min_clamp(monkeypatch):

--- a/tests/ui/test_crest_fit_and_boot_hygiene.py
+++ b/tests/ui/test_crest_fit_and_boot_hygiene.py
@@ -1,0 +1,294 @@
+"""The boot crest fills the terminal and sits in the middle of it — and the
+act of booting leaves no debris on the way in or out.
+
+Four defects, all visible in one paste of ``ov`` starting up:
+
+1. The crest capped at 88 columns on a 200-column terminal. 88 was chosen
+   when the reference geometry was drawn and never measured against a real
+   window, so the emblem occupied under half the available width.
+
+2. Raising that cap alone would make the crest DISAPPEAR on a wide-but-short
+   window: sizing was width-only with height as a veto, and a wider crest
+   needs proportionally more rows. The two dimensions have to be solved
+   together or the fix trades one bad output for a worse one.
+
+3. Every log line came out stamped ``[worker]``. The slash palette primes its
+   verb registry by importing each module in the dispatch packages, and one
+   of them called ``logging.basicConfig`` at import — configuring the ROOT
+   logger for the whole cockpit.
+
+4. Ctrl+C printed ``Error in atexit._run_exitfuncs`` and a traceback.
+
+Written against observable output rather than internals wherever possible:
+the recurring failure in this arc has been tests that pass on the inputs
+while the rendered screen stays wrong.
+"""
+from __future__ import annotations
+
+import atexit
+import io
+import logging
+import re
+from typing import Tuple
+
+import pytest
+
+from backend.core.ouroboros.ui import crest as C
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch):
+    for name in ("JARVIS_OV_CREST_MIN_COLS", "JARVIS_OV_CREST_MAX_COLS",
+                 "JARVIS_OV_CREST_ROW_RESERVE", "JARVIS_OV_CREST_CENTER"):
+        monkeypatch.delenv(name, raising=False)
+    yield
+
+
+def _rendered(width: int, height: int) -> Tuple[int, list]:
+    """Size a crest for a terminal and return (cols, rendered lines)."""
+    frame = C.generate_crest(
+        width, height, tier=C.ColorTier.TRUECOLOR, unicode_ok=True,
+    )
+    text = C.render_crest_auto(frame, C.ColorTier.TRUECOLOR, term_cols=width)
+    return frame.cols, str(text).split("\n")
+
+
+# --------------------------------------------------------------------------
+# 1. it grows with the terminal
+# --------------------------------------------------------------------------
+
+def test_a_wide_terminal_gets_a_wide_crest() -> None:
+    """THE operator report: 200 columns, and the emblem used 88 of them."""
+    cols, _ = _rendered(200, 50)
+    assert cols > 88, (
+        f"crest is {cols} columns on a 200-column terminal — still pinned to "
+        f"the old hardcoded ceiling"
+    )
+
+
+def test_the_crest_grows_monotonically_with_width() -> None:
+    """A bigger window must never produce a smaller emblem."""
+    seen = [_rendered(w, 60)[0] for w in (60, 90, 120, 160, 200)]
+    assert seen == sorted(seen), f"non-monotonic sizing: {seen}"
+
+
+def test_it_never_touches_the_right_edge() -> None:
+    """One column of margin — a crest exactly as wide as the terminal wraps
+    its last cell and every row sheds a detached artifact."""
+    for w in (60, 100, 137, 200):
+        cols, _ = _rendered(w, 60)
+        assert cols <= w - 1, f"crest {cols} leaves no margin in {w} columns"
+
+
+# --------------------------------------------------------------------------
+# 2. height is solved, not merely vetoed
+# --------------------------------------------------------------------------
+
+def test_a_short_wide_terminal_shrinks_instead_of_vanishing() -> None:
+    """The regression a width-only cap raise would have introduced."""
+    frame = C.generate_crest(
+        200, 20, tier=C.ColorTier.TRUECOLOR, unicode_ok=True,
+    )
+    assert frame.unavailable_reason is None, (
+        f"crest vanished on a 200x20 terminal: {frame.unavailable_reason}"
+    )
+    assert frame.cols < _rendered(200, 60)[0], (
+        "a short terminal got the same crest as a tall one — height is not "
+        "participating in the fit"
+    )
+
+
+@pytest.mark.parametrize("width,height", [
+    (200, 50), (200, 24), (160, 30), (120, 40), (90, 25), (60, 20),
+])
+def test_the_crest_always_fits_the_rows_it_is_given(
+    width: int, height: int,
+) -> None:
+    """Measured on the RENDERED output, not on the geometry that claims to
+    describe it — the two have disagreed before."""
+    _cols, lines = _rendered(width, height)
+    assert len(lines) <= height, (
+        f"crest drew {len(lines)} rows into a {height}-row terminal"
+    )
+
+
+def test_both_renderers_agree_on_size(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The halfblock raster and the quadrant path are sized by separate
+    functions; a 256-colour terminal takes the raster, so a cap left behind
+    in one of them survives every test aimed at the other. That is precisely
+    how the 88 outlived the first attempt to remove it."""
+    for w, h in ((200, 50), (120, 40), (60, 20)):
+        frame = C.generate_crest(
+            w, h, tier=C.ColorTier.TRUECOLOR, unicode_ok=True,
+        )
+        pf = C.generate_crest_pixels(w, h)
+        assert pf is not None, f"raster unavailable at {w}x{h}"
+        assert pf.cols == frame.cols, (
+            f"{w}x{h}: raster {pf.cols} vs quadrant {frame.cols}"
+        )
+
+
+def test_an_impossible_terminal_degrades_rather_than_raising() -> None:
+    for w, h in ((10, 4), (200, 2), (0, 0), (-5, -5)):
+        frame = C.generate_crest(
+            w, h, tier=C.ColorTier.TRUECOLOR, unicode_ok=True,
+        )
+        assert isinstance(frame, C.CrestFrame)
+
+
+# --------------------------------------------------------------------------
+# 3. it is centred
+# --------------------------------------------------------------------------
+
+def test_the_crest_is_centred_in_the_terminal() -> None:
+    """Asserted on the drawn glyphs: the blank margin left of the emblem and
+    the blank margin right of it must be within a column of each other."""
+    width = 200
+    cols, lines = _rendered(width, 60)
+    inked = [ln for ln in lines if ln.strip()]
+    assert inked, "nothing was drawn"
+    left = min(len(ln) - len(ln.lstrip(" ")) for ln in inked)
+    right = width - max(len(ln.rstrip(" ")) for ln in inked)
+    assert abs(left - right) <= 1, (
+        f"crest is off-centre: {left} columns of margin on the left, "
+        f"{right} on the right"
+    )
+
+
+def test_centering_never_pushes_the_crest_off_the_right_edge() -> None:
+    for w in (60, 100, 200):
+        _cols, lines = _rendered(w, 60)
+        longest = max((len(ln.rstrip(" ")) for ln in lines), default=0)
+        assert longest <= w, f"line of {longest} in a {w}-column terminal"
+
+
+def test_a_crest_wider_than_its_terminal_is_not_negatively_padded() -> None:
+    assert C.center_pad(120, 80) == 0
+
+
+def test_centering_is_defeatable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Left-aligned output is what every prior consumer expected; an operator
+    or a downstream composer must be able to get it back."""
+    monkeypatch.setenv("JARVIS_OV_CREST_CENTER", "0")
+    assert C.center_pad(60, 200) == 0
+
+
+# --------------------------------------------------------------------------
+# 4. booting leaves no debris
+# --------------------------------------------------------------------------
+
+def test_priming_the_palette_does_not_configure_the_root_logger() -> None:
+    """THE ``[worker]`` line noise. Importing modules to read their names off
+    them must not reconfigure logging for the host process."""
+    from backend.core.ouroboros.battle_test.repl_completion import (
+        registry_from_dispatch,
+    )
+    root = logging.getLogger()
+    before, level = list(root.handlers), root.level
+    buf = io.StringIO()
+    try:
+        import contextlib
+        with contextlib.redirect_stderr(buf):
+            registry_from_dispatch()
+        assert root.handlers == before, (
+            f"palette priming installed root handlers: "
+            f"{[getattr(h.formatter, '_fmt', None) for h in root.handlers]}"
+        )
+        assert root.level == level
+    finally:
+        root.handlers[:] = before
+        root.setLevel(level)
+
+
+def test_the_guard_survives_a_hostile_import() -> None:
+    """Fixing the one offending module is not the fix — any module acquires
+    the same power by being importable."""
+    from backend.core.ouroboros.battle_test.repl_completion import (
+        _root_logging_preserved,
+    )
+    root = logging.getLogger()
+    before, level = list(root.handlers), root.level
+    try:
+        with _root_logging_preserved():
+            logging.basicConfig(format="%(asctime)s [hostile] %(message)s")
+            logging.getLogger().setLevel(logging.DEBUG)
+        assert root.handlers == before
+        assert root.level == level
+    finally:
+        root.handlers[:] = before
+        root.setLevel(level)
+
+
+def test_the_worker_still_configures_itself_when_run_as_a_subprocess() -> None:
+    """The format was moved, not deleted — the ``python3 -m`` entry point
+    still needs it, and stderr must stay the stream because the protocol
+    owns stdout."""
+    import inspect
+
+    from backend.core.ouroboros.governance import isolated_agent_worker as w
+
+    src = inspect.getsource(w._configure_worker_logging)
+    assert "[worker]" in src and "sys.stderr" in src
+    whole = inspect.getsource(w)
+    body = whole.split('if __name__ == "__main__":')[-1]
+    assert "_configure_worker_logging()" in body, (
+        "logging moved off import but was never called from the entry point"
+    )
+    assert not re.search(r"^logging\.basicConfig", whole, re.M), (
+        "a module-level basicConfig is back — importing this module will "
+        "reconfigure the root logger of whatever process does it"
+    )
+
+
+def test_an_exit_handler_cannot_print_a_traceback_on_ctrl_c() -> None:
+    """``KeyboardInterrupt`` is a BaseException, so the ``except Exception``
+    already sitting in these handlers never caught it."""
+    from backend.core.ouroboros.governance.exit_guard import run_guarded
+
+    ran = []
+
+    def blocking_handler() -> None:
+        ran.append("started")
+        raise KeyboardInterrupt()
+
+    run_guarded(blocking_handler)          # must not raise
+    assert ran == ["started"]
+
+
+@pytest.mark.parametrize("exc", [
+    KeyboardInterrupt, SystemExit, RuntimeError, MemoryError,
+])
+def test_nothing_escapes_a_guarded_handler(exc) -> None:
+    from backend.core.ouroboros.governance.exit_guard import run_guarded
+
+    def handler() -> None:
+        raise exc()
+
+    run_guarded(handler)
+
+
+def test_a_guarded_handler_can_be_withdrawn() -> None:
+    """The wrapper is returned precisely so ``atexit.unregister`` works — a
+    handler that cannot be removed leaks into every test after it."""
+    from backend.core.ouroboros.governance.exit_guard import (
+        guarded_atexit_register,
+    )
+    calls = []
+    wrapper = guarded_atexit_register(calls.append, "x")
+    try:
+        wrapper()
+        assert calls == ["x"]
+    finally:
+        atexit.unregister(wrapper)
+
+
+def test_the_blocking_reaper_is_registered_through_the_guard() -> None:
+    """Structural: cascade_terminate WAITS on children, which is what holds
+    the shutdown window open long enough to be interrupted."""
+    import inspect
+
+    from backend.core.ouroboros.governance import child_reaper
+
+    src = inspect.getsource(child_reaper)
+    assert "guarded_atexit_register(cascade_terminate)" in src
+    assert "atexit.register(lambda: cascade_terminate())" not in src


### PR DESCRIPTION
Four defects, all visible in one paste of `ov` starting up.

### 1 · The crest used under half the terminal
Capped at 88 columns — a number chosen when the reference geometry was drawn, never measured against a real window.

### 2 · Raising that cap alone would have made it *vanish*
Sizing was width-only with height as a veto: `min(measured-1, 88)`, then suppress the whole emblem if `rows_needed(cols) > rows`. A wider crest needs proportionally more rows, so a bigger cap silently deletes the crest on a wide-but-short window.

`_fit_cols` solves both dimensions together — the widest crest whose rows still fit — so it degrades by **shrinking** instead of disappearing. Descending scan rather than an inverted formula: `rows_needed` ceils, and inverting it lands off-by-one exactly at the boundaries where a crest either overflows or vanishes.

The halfblock raster sized itself through a **second** clamp, and a 256-colour terminal takes that path — the cap would have survived a fix aimed only at the quadrant path. Both now share one fit, pinned by a test that renders through each and compares.

| terminal | before | after |
|---|---|---|
| 200×50 | 88 | **140** |
| 200×24 | 88 *(crest+header overflowed)* | **75** *(fits exactly)* |
| 200×20 | 88 | **56** |
| 120×40 | 88 | **119** |

`CREST_HEADER_ROWS` replaces the `6` that `awakening` reserved independently from the reserve the fit needed — one definition, so the crest is never sized into space the header is about to claim.

### 3 · Every log line stamped `[worker]`
`isolated_agent_worker` called `logging.basicConfig` at **import**. Fine for its `python3 -m` entry point, wrong everywhere else: basicConfig configures the **root** logger, and the slash palette primes its verb registry by importing every module in the dispatch packages to read their dispatch functions off them. Opening `ov` pulled the worker in, and the terminal filled with `[worker]` lines emitted by subsystems containing no worker.

```
root handlers after palette priming:
  before fix: [<StreamHandler>]  fmt='%(asctime)s [worker] %(message)s'
  after fix:  []
```

Configuration moves to the entry point. The exposure is structural though — any module acquires the same power by being importable — so the introspection walk is made non-destructive by construction: root handlers and level snapshotted and restored around it.

### 4 · Ctrl+C printed a traceback
`KeyboardInterrupt` is a `BaseException`, so the `except Exception` already sitting in those handlers never caught it — which is why the traceback appeared despite a guard being right there in the source. `exit_guard` registers handlers that cannot print on the way out, applied to the two that block long enough to be interrupted (`cascade_terminate` waits on children).

Opt-in per site, not a global excepthook: swallowing tracebacks from third-party handlers would hide real faults.

---

Centring lives at `render_crest_auto` — the single renderer dispatch both paths already go through — and is measured against the **terminal**, since every consumer that tried to own this ended up left-aligned. Defeatable via `JARVIS_OV_CREST_CENTER=0`.

### Tests
26 new in `tests/ui/test_crest_fit_and_boot_hygiene.py`, asserting on **rendered output**: margins measured off the drawn glyphs, row counts off the emitted lines. Tests that pass on the inputs while the screen stays wrong have been the recurring failure in this arc.

Two superseded pins updated rather than deleted, with the reasoning recorded. `test_hard_clamp_at_default_max` asserted 88 on a 24-row terminal — that was asserting the crest ignores the rows it is handed.

### Not caused by this change
- 2 crest tests expecting `cols == measured`, stale since the 2026-07-18 one-column wrap margin (71≠72, 49≠50)
- 1 pty exhaustion in this environment
- 8 governance failures — identical at baseline (719 passed with and without)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the startup crest fill and center the terminal, and keep boot quiet. Fix sizing so the crest shrinks to fit short terminals, and stop root logger and atexit traceback noise.

- New Features
  - Crest auto-centers in the terminal via `render_crest_auto` (disable with `JARVIS_OV_CREST_CENTER=0`).
  - Smarter sizing across both renderers: `_fit_cols` picks the widest crest that also fits the rows; `CREST_HEADER_ROWS` reserves header space; default `JARVIS_OV_CREST_MAX_COLS` raised to 140 while keeping a 1-column right margin.

- Bug Fixes
  - Removed import-time `logging.basicConfig` from `governance/isolated_agent_worker`; added `_root_logging_preserved` around palette priming so root handlers/level are unchanged.
  - Added `governance/exit_guard` with `guarded_atexit_register` and `run_guarded`; applied to `child_reaper.cascade_terminate` and advisor executor shutdown to prevent Ctrl+C atexit tracebacks.
  - Tests: added rendered-output assertions for fit/centering (26 new), ensured halfblock and quadrant paths agree, and updated two stale pins.

<sup>Written for commit a642818b65584d8b5c857ec2e953e592d8c1f670. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

