### PR TITLE
feat(ov): resolve verb help from the code, not from a parallel table

### DIFF
--- a/backend/core/ouroboros/battle_test/repl_completion.py
+++ b/backend/core/ouroboros/battle_test/repl_completion.py
@@ -60,6 +60,12 @@ import re
 import logging
 import os
 import re
+from backend.core.ouroboros.battle_test.verb_usage import (
+    UNDOCUMENTED,
+    derive_usage,
+    extract_operator_section,
+    mine_subcommands,
+)
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, FrozenSet, List, Optional, Tuple
@@ -1565,15 +1571,28 @@ def _describe(fn: object) -> str:
         # declares palette metadata. This exists because the humanisation
         # below cannot invent what nobody wrote: these docstrings are
         # contracts for maintainers, and stripping them yields "<verb> REPL".
+        name = str(getattr(fn, "__name__", ""))
+        verb = name[len("dispatch_"):-len("_command")] if (
+            name.startswith("dispatch_") and name.endswith("_command")
+        ) else name
+
         authored = getattr(mod, "__verb_help__", None)
         if isinstance(authored, dict):
-            name = str(getattr(fn, "__name__", ""))
-            verb = name[len("dispatch_"):-len("_command")] if (
-                name.startswith("dispatch_") and name.endswith("_command")
-            ) else name
             text = authored.get(verb) or authored.get(f"/{verb}")
             if isinstance(text, str) and text.strip():
                 return text.strip()[:88]
+
+        # 1b. An ``Operator:`` section in the function's OWN docstring.
+        #
+        #     Ranked with authored help rather than with the humanised
+        #     docstring below, because it is the same KIND of thing: a
+        #     sentence someone wrote for the person typing the verb. It sits
+        #     beside the implementation instead of in a dict at the top of
+        #     the module, which is the only reason to prefer one over the
+        #     other, and 45 verbs were never going to get dict entries.
+        operator_line = extract_operator_section(getattr(fn, "__doc__", None))
+        if operator_line:
+            return operator_line[:88]
 
         # 2. The FUNCTION docstring, humanised — accepted only if it survives
         #    as prose.
@@ -1588,12 +1607,37 @@ def _describe(fn: object) -> str:
         own = _first_line(getattr(fn, "__doc__", ""))
         if own:
             return own[:88]
+
+        # 3. No prose anywhere — mine the verb's own SUBCOMMAND VOCABULARY.
+        #
+        #    Ranked above signature derivation because it is strictly more
+        #    informative here: every dispatcher takes the whole line as one
+        #    string, so the signature says "(line)" while the body knows the
+        #    verb accepts status | history | explain. That is the single most
+        #    useful thing a palette can tell someone about a verb they have
+        #    not used, and it was sitting unread in the source.
+        mined = mine_subcommands(fn)
+        if mined:
+            return " | ".join(mined)[:88]
+
+        # 4. No prose anywhere. The SIGNATURE still knows what the verb
+        #    takes, and "what arguments does this want" is most of what an
+        #    operator wants from a palette entry anyway. Translated to POSIX
+        #    brackets and stripped of injected plumbing — a raw Python
+        #    signature would be worse than the blank it replaces.
+        derived = derive_usage(fn, verb)
+        if derived:
+            return derived[:88]
     except Exception:  # noqa: BLE001
         pass
-    # 3. Nothing authored, nothing extractable. Say so plainly rather than
-    #    printing residue: an honest blank reads as "no description yet",
-    #    fabricated prose reads as a description that happens to be wrong.
-    return ""
+    # 5. Nothing authored, nothing extractable, nothing to derive. Say so
+    #    plainly rather than printing residue: fabricated prose reads as a
+    #    description that happens to be wrong, and the operator acts on it.
+    #
+    #    UNDOCUMENTED rather than "" so the gap is VISIBLE and countable —
+    #    ``/help --undocumented`` can list exactly what still needs writing,
+    #    which a blank column cannot.
+    return UNDOCUMENTED
 
 
 @contextlib.contextmanager

--- a/backend/core/ouroboros/battle_test/verb_usage.py
+++ b/backend/core/ouroboros/battle_test/verb_usage.py
@@ -1,0 +1,335 @@
+"""Operator-facing help derived from the code, not from a parallel table.
+
+45 of the cockpit's verbs showed a blank description. The reflex fix is to
+author 45 ``__verb_help__`` strings across 45 modules, which is 45 new places
+to drift out of step with behaviour nobody will update. The actual root cause
+is the absence of a runtime introspection layer: the information is already
+in the source — in docstrings, and in the signatures themselves — and nothing
+was reading it.
+
+Two resolvers live here, both pure and both safe on anything:
+
+``extract_operator_section``
+    Pulls an ``Operator:`` block out of a docstring. This is the one place a
+    maintainer can write a sentence aimed at the person typing the verb rather
+    than at the next maintainer, and it wins over everything else.
+
+``derive_usage``
+    Builds ``Usage: /verb <required> [optional]`` from the signature when no
+    prose exists anywhere. A verb with no description at least tells the
+    operator what it takes.
+
+The signature is TRANSLATED, not dumped. A raw Python signature in a palette
+is worse than a blank: ``dispatch_search_command(line, ctx=None, *, limit=5)``
+answers nothing an operator asked. Two rules do the translation:
+
+  * **Injected parameters are invisible.** ``self``, ``ctx``, ``session`` and
+    friends are wiring the dispatcher receives, never something typed. So is
+    ``line`` and its synonyms — the raw command text every dispatcher in this
+    codebase accepts as its transport. Rendering ``/molt <line>`` would be
+    technically accurate and completely useless.
+  * **POSIX brackets.** Required positionals become ``<arg>``; anything with a
+    default becomes ``[arg]``; ``*args`` becomes ``[arg...]``. That is the
+    convention every CLI user already knows, so it needs no legend.
+
+Nothing here raises. A palette that throws while the operator is typing is a
+worse failure than a palette with a gap in it.
+"""
+from __future__ import annotations
+
+import ast
+import inspect
+import logging
+import os
+import re
+from typing import Any, FrozenSet, List
+
+logger = logging.getLogger("Ouroboros.VerbUsage")
+
+__all__ = [
+    "UNDOCUMENTED",
+    "derive_usage",
+    "extract_operator_section",
+    "injected_parameters",
+    "mine_subcommands",
+]
+
+#: Shown when every resolver comes up empty. Deliberately not a blank and
+#: deliberately not a guess: it reads as "nobody has written this yet", which
+#: is true and actionable, where invented prose reads as a description that
+#: happens to be wrong — and the operator acts on it.
+UNDOCUMENTED = "[undocumented]"
+
+#: Parameters a dispatcher RECEIVES rather than ones an operator TYPES.
+#:
+#: Split into two groups because they are wrong for different reasons, and
+#: conflating them hides that from whoever edits this next:
+#:
+#:   * plumbing — the execution context injected by the router;
+#:   * transport — the raw command text itself. Every ``dispatch_<verb>_command``
+#:     in this codebase takes the whole line and parses it internally, so the
+#:     parameter is an implementation detail of the calling convention. The
+#:     operator's actual arguments live INSIDE that string, where no signature
+#:     can see them, which is exactly why an authored ``Operator:`` line beats
+#:     a derived one and is tried first.
+_PLUMBING = (
+    "self", "cls", "ctx", "context", "session", "app", "ui", "client",
+    "repl", "flow", "console", "loop", "bridge", "state", "registry",
+    "logger", "bus", "harness", "orchestrator", "service", "deps",
+)
+_TRANSPORT = ("line", "raw", "text", "argv", "args", "arg", "command", "cmd",
+              "rest", "tail", "input")
+
+
+def injected_parameters() -> FrozenSet[str]:
+    """Names hidden from derived usage.
+
+    Env-extendable via ``JARVIS_VERB_USAGE_HIDE`` (comma-separated) so a new
+    injection convention does not require a code change here — the list is a
+    property of the calling convention, which is allowed to evolve.
+    """
+    names = set(_PLUMBING) | set(_TRANSPORT)
+    try:
+        extra = os.environ.get("JARVIS_VERB_USAGE_HIDE", "") or ""
+        names |= {n.strip() for n in extra.split(",") if n.strip()}
+    except Exception:  # noqa: BLE001
+        pass
+    return frozenset(names)
+
+
+# ---------------------------------------------------------------------------
+# 1. authored operator prose
+# ---------------------------------------------------------------------------
+
+#: ``Operator:`` at the start of a line, any indentation, any case. The value
+#: may continue onto following lines until a blank line or the next section.
+_OPERATOR_RE = re.compile(r"^[ \t]*operator[ \t]*:[ \t]*(.*)$", re.IGNORECASE)
+#: A following line that starts a NEW docstring section ends the block.
+_SECTION_RE = re.compile(r"^[ \t]*[A-Za-z][A-Za-z ]{0,20}:[ \t]*$")
+
+
+def extract_operator_section(doc: Any) -> str:
+    """Return the ``Operator:`` block of a docstring, or ``""``.
+
+    Accepts anything at all. ``__doc__`` is ``None`` on a great many callables
+    — C builtins, ``functools.partial``, anything run under ``python -OO`` —
+    and the whole point of this layer is that it runs over callables nobody
+    curated, so a type check is not enough: the argument is coerced.
+
+    Continuation lines are joined so a maintainer can wrap naturally without
+    the palette showing a truncated half-sentence.
+    """
+    try:
+        text = doc if isinstance(doc, str) else ""
+        if not text.strip():
+            return ""
+        collected: List[str] = []
+        capturing = False
+        for raw_line in text.splitlines():
+            if not capturing:
+                match = _OPERATOR_RE.match(raw_line)
+                if match:
+                    capturing = True
+                    head = match.group(1).strip()
+                    if head:
+                        collected.append(head)
+                continue
+            stripped = raw_line.strip()
+            if not stripped or _SECTION_RE.match(raw_line):
+                break
+            collected.append(stripped)
+        return " ".join(collected).strip()
+    except Exception:  # noqa: BLE001 — never break a palette over a docstring
+        logger.debug("[VerbUsage] operator-section parse degraded",
+                     exc_info=True)
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# 2. usage derived from the signature
+# ---------------------------------------------------------------------------
+
+def _unwrap(fn: Any) -> Any:
+    """See through decorators and partials to the function actually called.
+
+    Without this a decorated dispatcher reports ``(*args, **kwargs)`` — the
+    wrapper's signature — which is both useless and confidently wrong.
+    """
+    try:
+        import functools
+        seen = 0
+        while isinstance(fn, functools.partial) and seen < 8:
+            fn = fn.func
+            seen += 1
+        return inspect.unwrap(fn)
+    except Exception:  # noqa: BLE001
+        return fn
+
+
+def derive_usage(fn: Any, verb: str) -> str:
+    """``Usage: /verb <required> [optional]``, or ``""`` if nothing to say.
+
+    Empty rather than ``Usage: /verb`` when every parameter is injected: a
+    usage line listing no arguments tells the operator nothing they did not
+    already know from typing the verb, and it would crowd out the honest
+    ``[undocumented]`` marker that says help is genuinely missing.
+    """
+    try:
+        target = _unwrap(fn)
+        try:
+            sig = inspect.signature(target)
+        except (TypeError, ValueError):
+            # Builtins and C extensions have no introspectable signature.
+            return ""
+        hidden = injected_parameters()
+        parts: List[str] = []
+        for name, param in sig.parameters.items():
+            if name in hidden or name.startswith("_"):
+                continue
+            kind = param.kind
+            if kind is inspect.Parameter.VAR_KEYWORD:
+                continue                      # **kwargs is never typed
+            if kind is inspect.Parameter.VAR_POSITIONAL:
+                parts.append(f"[{name}...]")
+                continue
+            if param.default is inspect.Parameter.empty:
+                # Keyword-only with no default IS required, and POSIX renders
+                # required the same way regardless of how Python passes it.
+                parts.append(f"<{name}>")
+            else:
+                parts.append(f"[{name}]")
+        if not parts:
+            return ""
+        slug = str(verb or "").lstrip("/")
+        return f"Usage: /{slug} " + " ".join(parts)
+    except Exception:  # noqa: BLE001
+        logger.debug("[VerbUsage] usage derivation degraded", exc_info=True)
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# 3. the subcommand vocabulary, mined from the dispatcher's own body
+# ---------------------------------------------------------------------------
+
+#: Variables that plausibly hold a parsed token. A comparison against one of
+#: these is a dispatch decision; a comparison against ``self.mode`` or
+#: ``response.status`` is internal logic that happens to use a string.
+_TOKEN_NAMES = frozenset({
+    "sub", "subcmd", "subcommand", "cmd", "command", "verb", "action",
+    "mode", "op", "kind", "what", "which", "head", "first", "token",
+    "arg", "argument", "choice", "target", "part", "word", "tail", "rest",
+})
+
+#: Strings that are never a subcommand even when compared against a token.
+_NOT_SUBCOMMANDS = frozenset({
+    "true", "false", "none", "null", "nan", "y", "n", "0", "1",
+    "utf-8", "utf8", "ascii", "r", "w", "a", "rb", "wb",
+})
+
+#: Never show more than this many; a palette line is one line.
+_MAX_SUBCOMMANDS = 8
+
+
+def _is_token_target(node: Any) -> bool:
+    """True when *node* looks like a parsed command token.
+
+    ``sub``, ``parts[1]``, ``tokens[0].lower()`` — all yes. ``self.mode`` and
+    ``resp.status`` — no: an attribute is object state, and mining it produces
+    confident nonsense like ``/breadcrumbs completed | failed``.
+    """
+    try:
+        while isinstance(node, ast.Call):        # unwrap .lower()/.strip()
+            node = node.func
+        if isinstance(node, ast.Attribute):
+            if node.attr in ("lower", "upper", "strip", "casefold"):
+                return _is_token_target(node.value)
+            return False
+        if isinstance(node, ast.Subscript):
+            return _is_token_target(node.value)
+        if isinstance(node, ast.Name):
+            return node.id.lower().lstrip("_").rstrip("0123456789") in _TOKEN_NAMES
+        return False
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _literal_strings(node: Any) -> List[str]:
+    out: List[str] = []
+    for item in getattr(node, "elts", []) if isinstance(
+        node, (ast.Tuple, ast.List, ast.Set)
+    ) else []:
+        if isinstance(item, ast.Constant) and isinstance(item.value, str):
+            out.append(item.value)
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        out.append(node.value)
+    return out
+
+
+def mine_subcommands(fn: Any) -> List[str]:
+    """The subcommands a dispatcher actually accepts, read from its body.
+
+    This exists because signature introspection is nearly blind here. Every
+    ``dispatch_<verb>_command`` takes the whole line as one string and parses
+    it internally, so the signature says ``(line)`` and the real vocabulary —
+    ``status``, ``history``, ``explain`` — lives in the comparisons the body
+    makes against the parsed token. That vocabulary is what an operator wants
+    from a palette, and it was sitting unread in the source.
+
+    Deliberately conservative, in the direction of saying nothing:
+
+      * only comparisons against a token-shaped variable count, so object
+        state (``self.mode == "fast"``) is ignored;
+      * a single literal is not a vocabulary — one hit is far more likely to
+        be an internal flag check than a subcommand, so two are required;
+      * order of first appearance is preserved, because dispatchers are
+        written with the common case first and that is a better ordering than
+        alphabetical.
+
+    Returns ``[]`` for anything it cannot read — a C builtin, a lambda, a
+    function whose source is unavailable (``exec``, a REPL definition, a
+    stripped ``.pyc``). NEVER raises.
+    """
+    try:
+        import textwrap
+        target = _unwrap(fn)
+        try:
+            src = textwrap.dedent(inspect.getsource(target))
+        except (OSError, TypeError):
+            return []
+        try:
+            tree = ast.parse(src)
+        except SyntaxError:
+            # A decorated nested def can dedent to something unparseable.
+            return []
+
+        found: List[str] = []
+
+        def _add(values: List[str]) -> None:
+            for value in values:
+                low = value.strip().lower()
+                if not low or low in _NOT_SUBCOMMANDS:
+                    continue
+                if " " in low or len(low) > 16 or low.startswith(("-", "/")):
+                    continue
+                if not low[0].isalpha():
+                    continue
+                if low not in found:
+                    found.append(low)
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Compare) and _is_token_target(node.left):
+                for op, comparator in zip(node.ops, node.comparators):
+                    if isinstance(op, (ast.Eq, ast.In)):
+                        _add(_literal_strings(comparator))
+            # ``if sub in DISPATCH`` where DISPATCH is a literal dict.
+            elif isinstance(node, ast.Dict) and node.keys:
+                keys = [k for k in node.keys
+                        if isinstance(k, ast.Constant)
+                        and isinstance(k.value, str)]
+                if len(keys) >= 2 and len(keys) == len(node.keys):
+                    _add([k.value for k in keys])
+
+        return found[:_MAX_SUBCOMMANDS] if len(found) >= 2 else []
+    except Exception:  # noqa: BLE001
+        logger.debug("[VerbUsage] subcommand mining degraded", exc_info=True)
+        return []

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -915,6 +915,12 @@ async def _split_plane_loop(
         # would freeze the very keystroke that opened the menu.
         completer=_build_slash_completer(),
         complete_while_typing=True,
+        # The SAME Style the bipartite cockpit uses. Without it
+        # prompt_toolkit paints its default filled light-grey listbox — the
+        # loudest thing on a dark screen, and the exact look #70121 removed
+        # from the other surface. Two surfaces, one palette (DRY): the brand
+        # owns its colours in ui.theme, not per widget.
+        style=_cockpit_style(),
     )
     ui.bind_app(session.app)
 
@@ -956,6 +962,15 @@ async def _split_plane_loop(
             if outcome == "detach":
                 break
 
+
+
+def _cockpit_style() -> Any:
+    """The brand Style, or None if unavailable. NEVER raises."""
+    try:
+        from backend.core.ouroboros.ui.theme import cockpit_prompt_style
+        return cockpit_prompt_style()
+    except Exception:  # noqa: BLE001 — default styling still types fine
+        return None
 
 
 def _build_slash_completer() -> Any:

--- a/tests/cli/test_slash_palette.py
+++ b/tests/cli/test_slash_palette.py
@@ -299,16 +299,24 @@ def test_authored_help_is_preferred_over_any_docstring() -> None:
     )
 
 
-def test_an_undescribed_verb_shows_a_blank_not_a_fabrication() -> None:
-    """A blank reads as 'nobody has written this yet'. Plausible noise reads
-    as a description that happens to be wrong — which is worse, because the
-    operator acts on it."""
+def test_an_undescribed_verb_is_marked_not_fabricated() -> None:
+    """SUPERSEDED 2026-07-26: was ``== ""``.
+
+    The honesty requirement is unchanged and still the point — nothing may
+    invent a description. What changed is how the absence is SPOKEN. A blank
+    column is indistinguishable from a rendering fault and cannot be counted;
+    ``[undocumented]`` is visible and greppable, so the remaining gaps can be
+    listed instead of silently tolerated.
+
+    Full coverage of the cascade that now sits in front of this lives in
+    tests/cli/test_verb_usage_resolver.py."""
     from backend.core.ouroboros.battle_test.repl_completion import _describe
+    from backend.core.ouroboros.battle_test.verb_usage import UNDOCUMENTED
 
     def dispatch_nothing_command(line: str):
         """Parse ``/nothing`` line and dispatch. NEVER raises."""
 
-    assert _describe(dispatch_nothing_command) == ""
+    assert _describe(dispatch_nothing_command) == UNDOCUMENTED
 
 
 def test_modules_declare_palette_help_beside_their_aliases() -> None:

--- a/tests/cli/test_verb_usage_resolver.py
+++ b/tests/cli/test_verb_usage_resolver.py
@@ -1,0 +1,367 @@
+"""Operator help resolved from the code, with nothing authored by hand.
+
+45 verbs showed a blank description. Authoring 45 ``__verb_help__`` strings
+would have satisfied the UI while leaving the actual defect in place: there
+was no runtime introspection layer, so the help already present in the source
+— docstrings, signatures, and the dispatch vocabulary in the function bodies —
+was never read.
+
+The cascade, most-authored first:
+
+    __verb_help__  ->  Operator:  ->  docstring prose  ->  mined subcommands
+                   ->  derived signature  ->  [undocumented]
+
+Every stage below the first two is DERIVED, so it cannot go stale: change what
+a verb accepts and its palette entry changes with it.
+"""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import io
+import time
+from typing import List
+
+import pytest
+
+from backend.core.ouroboros.battle_test.verb_usage import (
+    UNDOCUMENTED,
+    derive_usage,
+    extract_operator_section,
+    injected_parameters,
+    mine_subcommands,
+)
+
+
+# --------------------------------------------------------------------------
+# 1. semantic signature introspection — the two mandated assertions
+# --------------------------------------------------------------------------
+
+def test_an_injected_ctx_is_stripped_from_derived_usage() -> None:
+    """MANDATE 4(1). ``ctx`` is wiring the router injects; the operator never
+    types it, so a usage line that mentions it is actively misleading."""
+    def my_verb(ctx, query: str, limit: int = 5):
+        ...
+
+    usage = derive_usage(my_verb, "my_verb")
+    assert usage == "Usage: /my_verb <query> [limit]"
+    assert "ctx" not in usage
+
+
+def test_required_and_optional_get_the_right_brackets() -> None:
+    """MANDATE 4(2). POSIX: ``<required>``, ``[optional]``."""
+    def verb(ctx, source, dest, force: bool = False, depth: int = 1):
+        ...
+
+    assert derive_usage(verb, "verb") == (
+        "Usage: /verb <source> <dest> [force] [depth]"
+    )
+
+
+@pytest.mark.parametrize("name", sorted(injected_parameters())[:12])
+def test_every_injected_name_is_hidden(name: str) -> None:
+    ns: dict = {}
+    exec(f"def verb({name}, real):\n    ...", ns)      # noqa: S102
+    usage = derive_usage(ns["verb"], "verb")
+    assert usage == "Usage: /verb <real>", f"{name} leaked into {usage!r}"
+
+
+def test_the_hidden_set_is_extendable_without_a_code_change(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The calling convention is allowed to evolve; this file should not need
+    editing when it does."""
+    def verb(tenant_id, query):
+        ...
+
+    assert "tenant_id" in derive_usage(verb, "verb")
+    monkeypatch.setenv("JARVIS_VERB_USAGE_HIDE", "tenant_id")
+    assert derive_usage(verb, "verb") == "Usage: /verb <query>"
+
+
+def test_var_positional_renders_as_a_repeatable_optional() -> None:
+    def verb(ctx, *paths):
+        ...
+
+    assert derive_usage(verb, "verb") == "Usage: /verb [paths...]"
+
+
+def test_var_keyword_is_never_shown() -> None:
+    def verb(ctx, name, **kwargs):
+        ...
+
+    assert derive_usage(verb, "verb") == "Usage: /verb <name>"
+
+
+def test_keyword_only_without_a_default_is_required() -> None:
+    """Python's calling convention is not the operator's concern — a
+    parameter with no default must be supplied, so it renders as required."""
+    def verb(ctx, *, target, limit=5):
+        ...
+
+    assert derive_usage(verb, "verb") == "Usage: /verb <target> [limit]"
+
+
+def test_a_fully_injected_signature_yields_nothing_rather_than_a_bare_usage():
+    """``Usage: /verb`` with no arguments tells the operator nothing they did
+    not know from typing the verb, and would crowd out ``[undocumented]``."""
+    def verb(line):
+        ...
+
+    assert derive_usage(verb, "verb") == ""
+
+
+def test_decorators_do_not_mask_the_real_signature() -> None:
+    """A wrapper reports ``(*args, **kwargs)`` — useless AND confident."""
+    import functools
+
+    def deco(fn):
+        @functools.wraps(fn)
+        def inner(*args, **kwargs):
+            return fn(*args, **kwargs)
+        return inner
+
+    @deco
+    def verb(ctx, query, limit=3):
+        ...
+
+    assert derive_usage(verb, "verb") == "Usage: /verb <query> [limit]"
+
+
+@pytest.mark.parametrize("bad", [None, 42, object(), len, print, lambda: None])
+def test_derivation_never_raises_on_anything(bad) -> None:
+    assert isinstance(derive_usage(bad, "x"), str)
+
+
+# --------------------------------------------------------------------------
+# 2. Operator: extraction — MANDATE 4, safe evaluation
+# --------------------------------------------------------------------------
+
+def test_the_operator_section_wins_and_is_joined() -> None:
+    def verb(line):
+        """Parse the /thing line. NEVER raises.
+
+        Operator: inspect a running operation and
+          print its phase timings.
+
+        Args:
+            line: raw text.
+        """
+
+    assert extract_operator_section(verb.__doc__) == (
+        "inspect a running operation and print its phase timings."
+    )
+
+
+@pytest.mark.parametrize("doc", [
+    None, "", "   ", 42, object(), b"bytes", ["a"], {"k": "v"},
+])
+def test_extraction_is_safe_on_malformed_docstrings(doc) -> None:
+    """MANDATE 4(3): ``__doc__`` is ``None`` on a great many callables, and
+    this layer runs over callables nobody curated."""
+    assert extract_operator_section(doc) == ""
+
+
+def test_a_docstring_with_no_operator_section_yields_nothing() -> None:
+    assert extract_operator_section("Parse it.\n\nArgs:\n    x: y\n") == ""
+
+
+def test_the_section_stops_at_the_next_heading() -> None:
+    doc = "H.\n\nOperator: do the thing.\nReturns:\n    None\n"
+    assert extract_operator_section(doc) == "do the thing."
+
+
+def test_the_section_stops_at_a_blank_line() -> None:
+    doc = "H.\n\nOperator: do the thing.\n\nUnrelated prose follows.\n"
+    assert extract_operator_section(doc) == "do the thing."
+
+
+def test_the_marker_is_case_and_indent_insensitive() -> None:
+    assert extract_operator_section("\t  OPERATOR:  go\n") == "go"
+
+
+# --------------------------------------------------------------------------
+# 3. mined subcommand vocabulary
+# --------------------------------------------------------------------------
+
+def test_the_vocabulary_is_mined_from_the_body() -> None:
+    """The signature is blind here — the dispatcher takes one string — so the
+    real vocabulary lives in the comparisons the body makes."""
+    def dispatch_thing_command(line):
+        sub = line.split()[1] if " " in line else ""
+        if sub == "status":
+            return 1
+        if sub == "history":
+            return 2
+        if sub in ("explain", "why"):
+            return 3
+        return 0
+
+    assert mine_subcommands(dispatch_thing_command) == [
+        "status", "history", "explain", "why",
+    ]
+
+
+def test_source_order_is_preserved() -> None:
+    """Dispatchers put the common case first; that beats alphabetical."""
+    def verb(line):
+        cmd = line
+        if cmd == "zebra":
+            return 1
+        if cmd == "apple":
+            return 2
+
+    assert mine_subcommands(verb) == ["zebra", "apple"]
+
+
+def test_object_state_is_not_mistaken_for_a_vocabulary() -> None:
+    """``self.mode == "fast"`` is internal logic that happens to use a
+    string. Mining it produces confident nonsense."""
+    class Thing:
+        def verb(self, line):
+            if self.mode == "fast":
+                return 1
+            if self.mode == "slow":
+                return 2
+
+    assert mine_subcommands(Thing.verb) == []
+
+
+def test_a_single_literal_is_not_a_vocabulary() -> None:
+    """One hit is far more likely an internal flag check."""
+    def verb(line):
+        sub = line
+        if sub == "status":
+            return 1
+
+    assert mine_subcommands(verb) == []
+
+
+def test_mining_is_bounded() -> None:
+    body = "\n".join(f'    if sub == "s{i}":\n        return {i}'
+                     for i in range(40))
+    ns: dict = {}
+    exec(f"def verb(line):\n    sub = line\n{body}", ns)   # noqa: S102
+    assert len(mine_subcommands(ns["verb"])) <= 8
+
+
+@pytest.mark.parametrize("bad", [None, 42, len, print, lambda x: x])
+def test_mining_never_raises(bad) -> None:
+    assert isinstance(mine_subcommands(bad), list)
+
+
+def test_mining_survives_an_unreadable_source() -> None:
+    """Functions defined via exec have no retrievable source file."""
+    ns: dict = {}
+    exec("def verb(line):\n    return 1", ns)              # noqa: S102
+    assert mine_subcommands(ns["verb"]) == []
+
+
+# --------------------------------------------------------------------------
+# 4. the cascade, end to end
+# --------------------------------------------------------------------------
+
+def _describe(fn):
+    from backend.core.ouroboros.battle_test.repl_completion import _describe as d
+    return d(fn)
+
+
+def test_authored_help_still_outranks_everything_derived() -> None:
+    import backend.core.ouroboros.governance.moltbook_repl as mr
+
+    assert _describe(mr.dispatch_moltbook_command) == (
+        "read the agora feed — the residents' posts"
+    )
+
+
+def test_the_cascade_reaches_undocumented_only_when_truly_empty() -> None:
+    """SUPERSEDES the earlier assertion that this returns ``""``.
+
+    A blank column could not be distinguished from a rendering fault, and
+    could not be counted. ``[undocumented]`` is the same honesty — it does
+    NOT invent a description — while being visible and greppable."""
+    def dispatch_nothing_command(line: str):
+        """Parse ``/nothing`` line and dispatch. NEVER raises."""
+
+    assert _describe(dispatch_nothing_command) == UNDOCUMENTED
+
+
+def test_the_real_palette_is_substantially_hydrated() -> None:
+    """The point of the exercise, measured on the shipped table."""
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+        from backend.core.ouroboros.battle_test.repl_completion import (
+            registry_from_dispatch,
+        )
+        reg = registry_from_dispatch()
+    metas = [d.description for d in reg.verbs]
+    assert len(metas) > 50
+    blank = [m for m in metas if not str(m).strip()]
+    assert blank == [], f"{len(blank)} verbs render an empty column"
+    undocumented = [m for m in metas if m == UNDOCUMENTED]
+    assert len(undocumented) <= 5, (
+        f"{len(undocumented)}/{len(metas)} still undocumented — the "
+        f"introspection layer is not reaching the real dispatch table"
+    )
+
+
+# --------------------------------------------------------------------------
+# 5. MANDATE 3 — resolved once, never on a keystroke
+# --------------------------------------------------------------------------
+
+async def test_resolution_does_not_happen_on_the_keystroke_path() -> None:
+    """The cascade reads source and parses ASTs. Paying that per keystroke
+    would make typing stutter — the exact failure the palette is meant to
+    avoid — so it must be resolved when the registry is built."""
+    from prompt_toolkit.document import Document
+
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+        from backend.core.ouroboros.cli.ov import _build_slash_completer
+        completer = await asyncio.to_thread(_build_slash_completer)
+    assert completer is not None
+    inner = getattr(completer, "completer", completer)
+
+    # Warm nothing deliberately: the FIRST keystroke must already be cheap.
+    started = time.perf_counter()
+    out = list(inner.get_completions(Document("/"), None))
+    elapsed = time.perf_counter() - started
+
+    assert len(out) > 50
+    assert elapsed < 0.05, (
+        f"first '/' took {elapsed*1000:.0f}ms — the cascade is being "
+        f"evaluated per keystroke instead of cached at build"
+    )
+
+
+async def test_repeated_completions_stay_flat() -> None:
+    """No lazy per-entry work that only shows up under a real typist."""
+    from prompt_toolkit.document import Document
+
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+        from backend.core.ouroboros.cli.ov import _build_slash_completer
+        completer = await asyncio.to_thread(_build_slash_completer)
+    inner = getattr(completer, "completer", completer)
+
+    timings: List[float] = []
+    for probe in ("/", "/m", "/mo", "/mol", "/molt", "/"):
+        t0 = time.perf_counter()
+        list(inner.get_completions(Document(probe), None))
+        timings.append(time.perf_counter() - t0)
+    assert max(timings) < 0.05, f"keystroke cost spiked: {timings}"
+
+
+async def test_the_completer_builds_off_the_event_loop() -> None:
+    """Building primes the registry, imports packages and parses ASTs — it
+    must never run on the loop that is trying to draw the prompt."""
+    from backend.core.ouroboros.battle_test.repl_completion import (
+        build_attach_completer,
+    )
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+        completer = await asyncio.to_thread(build_attach_completer)
+    assert type(completer).__name__ == "ThreadedCompleter", (
+        "completion must be threaded; on the loop the keystroke that opens "
+        "the menu is the one that freezes"
+    )


### PR DESCRIPTION
45 of 76 verbs showed a blank description. Authoring 45 `__verb_help__` strings would have satisfied the UI and left the defect in place: there was no runtime introspection layer, so help already present in the source was never read. **Three files change, not 45.**

```
__verb_help__ → Operator: → docstring prose → mined subcommands
              → derived signature → [undocumented]
```

### Semantic signature introspection
Translated, not dumped. `dispatch_search_command(line, ctx=None, *, limit=5)` answers nothing anyone asked.

Injected parameters are invisible — **plumbing** (`self`, `ctx`, `session`) and **transport** (`line` and synonyms: every dispatcher here takes the raw command text, so `/molt <line>` would be accurate and useless). What remains is POSIX: `<required>`, `[optional]`, `[args...]`.

```python
def my_verb(ctx, query: str, limit: int = 5)   →   Usage: /my_verb <query> [limit]
```

Decorators are unwrapped, so a wrapper cannot report `(*args, **kwargs)` — useless *and* confident.

### Mined subcommand vocabulary
Signature derivation alone reached only **2** verbs, precisely because the argument lives inside that one string. The real vocabulary is in the comparisons the body makes, so it is read by AST:

```
/posture    status | explain | history | signals | override | clear-override | health
/voice      status | on | unmute | off | mute | tier | cooldown
/proposals  panel | all | show | accept | reject | expire | status
```

Derived, so it cannot go stale — change what a verb accepts and its palette entry changes with it.

Conservative by construction: only token-shaped targets count (`self.mode == "fast"` is object state, and mining it yields confident nonsense); two literals minimum, since one hit is more likely an internal flag check; source order preserved, because dispatchers put the common case first.

| | before | after |
|---|---|---|
| prose | 31 | 30 |
| mined vocabulary | — | **45** |
| derived usage | — | 1 |
| **blank / undocumented** | **43** | **1** |

### `[undocumented]` rather than a blank
The honesty requirement is unchanged — nothing invents a description. What changed is that the absence is now visible and countable rather than indistinguishable from a rendering fault.

### Resolved once, never on a keystroke
The cascade reads source and parses ASTs. Measured: build **5.15s once**, first `/` **0.41ms**, flat across repeated probes. Pinned by a test that fails if the first keystroke exceeds 50ms.

### Also fixed
The `PromptSession` attach surface never received `cockpit_prompt_style()`, so its menu rendered in prompt_toolkit's default filled light-grey — the look #70121 removed from the *bipartite* surface. Same Style object, both surfaces.

### Tests
56 new, including the two mandated assertions (`ctx` stripped; required vs optional bracketing), plus malformed-docstring safety across `None`, ints, bytes, dicts, C builtins, lambdas and exec-defined functions. One superseded assertion updated with its reasoning rather than deleted.

Unrelated failures in `tests/cli` are sandbox socket denials (`PermissionError`), all 28 of them — zero non-sandbox failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Builds operator help from the code at runtime to hydrate the slash palette and remove stale, hand-authored tables. Most verbs now show accurate, derived help, and truly missing entries are marked clearly without slowing typing.

- New Features
  - Added a resolver that derives help in order: __verb_help__ → Operator: docstring → first docstring line → mined subcommands → derived signature → "[undocumented]".
  - Semantic usage derivation: hides injected params (e.g., ctx, self, line), uses POSIX brackets, and unwraps decorators.
  - AST-mines subcommand vocabulary from dispatcher bodies; conservative and source-order preserving.
  - Resolved once at registry build (not per keystroke); test pins first "/" under 50ms.
  - Outcome: reduces blank entries from 43 to 1.

- Bug Fixes
  - Applied cockpit brand Style to the `prompt_toolkit` PromptSession palette for visual consistency.

<sup>Written for commit 4e63819a9d0bb94eba329d9486b346e3893c80f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

