### PR TITLE
fix(ov): the `/` palette reaches the surface ov actually attaches with

### DIFF
--- a/backend/core/ouroboros/battle_test/palette_render.py
+++ b/backend/core/ouroboros/battle_test/palette_render.py
@@ -142,6 +142,113 @@ def layout_palette(
     return lines
 
 
+def live_completion_entries() -> Tuple[List[Tuple[str, str]], int]:
+    """The live completion state as ``(entries, selected_index)``.
+
+    Reads ``buffer.complete_state`` — the ONE place prompt_toolkit keeps this
+    — so every surface renders the same state rather than each keeping its own
+    idea of what is being completed. ``([], -1)`` whenever nothing is active
+    or no application is running. NEVER raises."""
+    try:
+        from prompt_toolkit.application.current import get_app
+        state = get_app().current_buffer.complete_state
+        if state is None or not state.completions:
+            return [], -1
+        rows = [
+            (c.display_text or c.text, c.display_meta_text or "")
+            for c in state.completions
+        ]
+        index = state.complete_index if state.complete_index is not None else -1
+        return rows, index
+    except Exception:  # noqa: BLE001
+        return [], -1
+
+
+def palette_fragments(max_rows: Optional[int] = None) -> List[Tuple[str, str]]:
+    """The palette as ONE formatted-text fragment list, newlines included.
+
+    This is the form prompt_toolkit accepts anywhere formatted text is taken —
+    ``bottom_toolbar``, ``message``, a ``FormattedTextControl``. Having it
+    means a surface does not need a container to show the palette, which is
+    what kept the page layout confined to the full ``Application`` while the
+    ``PromptSession`` cockpit fell back to the native widget.
+
+    Empty list when nothing is being completed. NEVER raises."""
+    try:
+        rows, index = live_completion_entries()
+        if not rows:
+            return []
+        try:
+            from prompt_toolkit.application.current import get_app
+            width = get_app().output.get_size().columns
+        except Exception:  # noqa: BLE001
+            width = 80
+        lines = layout_palette(rows, width=width, selected=index,
+                               max_rows=max_rows)
+        out: List[Tuple[str, str]] = []
+        for i, line in enumerate(lines):
+            out.extend(line)
+            if i < len(lines) - 1:
+                out.append(("", "\n"))
+        return out
+    except Exception:  # noqa: BLE001 — a palette fault must not blank the UI
+        logger.debug("[Palette] fragment render degraded", exc_info=True)
+        return []
+
+
+def _is_native_completion_menu(container: Any) -> bool:
+    """True if *container* is (or wraps) prompt_toolkit's own menu widget.
+
+    Checked at EVERY level rather than after unwrapping to the innermost
+    child: ``CompletionsMenu`` is itself a ``ConditionalContainer`` subclass,
+    so unwrapping first walks straight past the thing being looked for. That
+    exact mistake left both menus on screen at once during development.
+    """
+    names = ("CompletionsMenu", "MultiColumnCompletionsMenu")
+    seen = 0
+    while container is not None and seen < 8:
+        if type(container).__name__ in names:
+            return True
+        for base in type(container).__mro__:
+            if base.__name__ in names:
+                return True
+        inner = getattr(container, "content", None)
+        if inner is None or inner is container:
+            break
+        container = inner
+        seen += 1
+    return False
+
+
+def strip_native_completion_menu(app: Any) -> int:
+    """Remove prompt_toolkit's completions float from *app*. Returns the count.
+
+    The palette REPLACES the native presentation rather than restyling it —
+    they are different layouts, not different colour schemes — so leaving the
+    widget in place renders both at once: a narrow floating column on top of
+    the full-width page.
+
+    ``FloatContainer.floats`` is a plain list and mutating it is how floats are
+    managed, so this is not reaching past an API. It is done after
+    construction because ``PromptSession`` builds its layout internally and
+    exposes no seam to opt out of the menu.
+
+    NEVER raises; returns 0 when there is nothing to remove."""
+    removed = 0
+    try:
+        from prompt_toolkit.layout import FloatContainer
+        for node in app.layout.walk():
+            if not isinstance(node, FloatContainer):
+                continue
+            keep = [f for f in node.floats
+                    if not _is_native_completion_menu(f.content)]
+            removed += len(node.floats) - len(keep)
+            node.floats[:] = keep
+    except Exception:  # noqa: BLE001
+        logger.debug("[Palette] native menu strip degraded", exc_info=True)
+    return removed
+
+
 def build_palette_window(condition_style: str = "") -> Any:
     """A full-width container that draws the palette above the prompt.
 
@@ -164,32 +271,9 @@ def build_palette_window(condition_style: str = "") -> Any:
             return None
 
     def _entries_and_index():
-        st = _state()
-        if st is None or not st.completions:
-            return [], -1
-        rows = [
-            (c.display_text or c.text, c.display_meta_text or "")
-            for c in st.completions
-        ]
-        idx = st.complete_index if st.complete_index is not None else -1
-        return rows, idx
+        return live_completion_entries()
 
-    def _fragments():
-        try:
-            rows, idx = _entries_and_index()
-            if not rows:
-                return []
-            width = get_app().output.get_size().columns
-            lines = layout_palette(rows, width=width, selected=idx)
-            out: List[Tuple[str, str]] = []
-            for i, line in enumerate(lines):
-                out.extend(line)
-                if i < len(lines) - 1:
-                    out.append(("", "\n"))
-            return out
-        except Exception:  # noqa: BLE001 — a palette fault must not blank the UI
-            logger.debug("[Palette] render degraded", exc_info=True)
-            return []
+    _fragments = palette_fragments
 
     def _height() -> int:
         try:
@@ -217,5 +301,8 @@ def build_palette_window(condition_style: str = "") -> Any:
 __all__ = [
     "build_palette_window",
     "layout_palette",
+    "live_completion_entries",
+    "palette_fragments",
     "palette_rows",
+    "strip_native_completion_menu",
 ]

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -644,10 +644,32 @@ class AttachUI:
             pass
         return "  ov attach — organism live"
 
-    def toolbar(self) -> str:
-        """Static key hints only. The live region moved above the caret; what
-        remains under the input is the affordance list, which genuinely
-        belongs there because it describes the line you are typing on."""
+    def toolbar(self) -> Any:
+        """The slash palette while completing; static key hints otherwise.
+
+        The region directly beneath the caret is where a command palette
+        belongs — it describes the line being typed — and on this surface it
+        is the only full-width region available. ``PromptSession`` builds its
+        own layout and takes no extra containers, which is why the page-style
+        palette shipped in #70123 reached the bipartite cockpit and never
+        reached the surface ``ov`` actually attaches with: it was written as a
+        container, and this surface has nowhere to put one.
+
+        Rendering it as formatted text instead removes that constraint. Same
+        ``layout_palette`` maths, same live ``complete_state`` — one palette,
+        both surfaces, no second implementation to drift.
+
+        Returns a fragment list while completing and a plain string otherwise;
+        prompt_toolkit accepts either."""
+        try:
+            from backend.core.ouroboros.battle_test.palette_render import (
+                palette_fragments,
+            )
+            fragments = palette_fragments()
+            if fragments:
+                return fragments
+        except Exception:  # noqa: BLE001 — hints are the safe fallback
+            pass
         note = self._TOOLBAR_NOTES.get(self.audio_state)
         if note is not None:
             audio = f" · {note}"
@@ -921,7 +943,14 @@ async def _split_plane_loop(
         # from the other surface. Two surfaces, one palette (DRY): the brand
         # owns its colours in ui.theme, not per widget.
         style=_cockpit_style(),
+        # The palette draws in the toolbar, so the native menu's reserved
+        # strip would only open a gap between the caret and the entries.
+        reserve_space_for_menu=0,
     )
+    # Replace prompt_toolkit's floating menu rather than restyling it: they
+    # are different LAYOUTS, and leaving the widget in place renders both at
+    # once — a narrow floating column on top of the full-width page.
+    _strip_native_menu(session.app)
     ui.bind_app(session.app)
 
     async def _watch_disconnect() -> None:
@@ -962,6 +991,17 @@ async def _split_plane_loop(
             if outcome == "detach":
                 break
 
+
+
+def _strip_native_menu(app: Any) -> int:
+    """Drop prompt_toolkit's completions float. NEVER raises."""
+    try:
+        from backend.core.ouroboros.battle_test.palette_render import (
+            strip_native_completion_menu,
+        )
+        return strip_native_completion_menu(app)
+    except Exception:  # noqa: BLE001 — the native menu is a survivable fallback
+        return 0
 
 
 def _cockpit_style() -> Any:

--- a/tests/cli/test_palette_on_attach_surface.py
+++ b/tests/cli/test_palette_on_attach_surface.py
@@ -1,0 +1,307 @@
+"""The `/` palette reaches the surface `ov` actually attaches with.
+
+The page-style palette shipped in #70123 and the operator's screen did not
+change, because it was written as a CONTAINER and wired into
+``build_bipartite_application`` — while ``ov`` attach builds a
+``PromptSession``, which constructs its own layout and accepts no extra
+containers. The palette had no caller on the path anyone uses. Four PRs on
+`/` shipped green over that gap.
+
+Two changes close it, and both are asserted here:
+
+  * ``palette_fragments`` renders the same layout as FORMATTED TEXT, which
+    every prompt_toolkit surface accepts. A surface no longer needs somewhere
+    to put a container in order to show the palette.
+  * ``strip_native_completion_menu`` removes prompt_toolkit's own floating
+    widget. The palette REPLACES that presentation rather than restyling it —
+    leaving it in place renders both at once.
+
+The load-bearing lesson from the arc is in the last test: assertions about the
+completer passed throughout while the screen stayed wrong. Structure alone is
+not evidence, so the final check drives a real terminal.
+"""
+from __future__ import annotations
+
+import contextlib
+import io
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, List, Tuple
+
+import pytest
+
+from backend.core.ouroboros.battle_test.palette_render import (
+    _is_native_completion_menu,
+    layout_palette,
+    live_completion_entries,
+    palette_fragments,
+    strip_native_completion_menu,
+)
+
+_REPO = Path(__file__).resolve().parents[2]
+
+
+# --------------------------------------------------------------------------
+# 1. the palette renders without a container
+# --------------------------------------------------------------------------
+
+def test_fragments_are_empty_with_no_application_running() -> None:
+    """Called from a plain thread, a toolbar callback, or a test — never a
+    crash and never a stale menu."""
+    assert palette_fragments() == []
+    assert live_completion_entries() == ([], -1)
+
+
+def test_fragments_carry_newlines_so_one_call_draws_a_block() -> None:
+    """The whole reason this form works on a surface with no container: a
+    single formatted-text value spanning several lines."""
+    lines = layout_palette(
+        [(f"/verb{i}", f"description {i}") for i in range(4)],
+        width=100, selected=1,
+    )
+    assert len(lines) >= 4
+    flat = "".join(text for line in lines for _style, text in line)
+    assert "/verb0" in flat and "description 3" in flat
+
+
+def test_the_selected_row_is_styled_differently() -> None:
+    lines = layout_palette([("/a", "x"), ("/b", "y")], width=80, selected=1)
+    styles = {style for line in lines for style, _t in line}
+    assert any("current" in s for s in styles), (
+        "no current-completion style — the cursor would be invisible"
+    )
+
+
+# --------------------------------------------------------------------------
+# 2. the native widget is removed, not restyled
+# --------------------------------------------------------------------------
+
+def test_the_menu_is_detected_through_its_wrappers() -> None:
+    """``CompletionsMenu`` IS a ``ConditionalContainer`` subclass, so code
+    that unwraps to the innermost child before testing walks straight past
+    it. That mistake left both menus on screen during development."""
+    from prompt_toolkit.layout.menus import CompletionsMenu
+
+    assert _is_native_completion_menu(CompletionsMenu())
+
+
+def test_unrelated_containers_are_left_alone() -> None:
+    from prompt_toolkit.layout import Window
+
+    assert not _is_native_completion_menu(Window())
+    assert not _is_native_completion_menu(None)
+    assert not _is_native_completion_menu(object())
+
+
+def test_stripping_removes_the_float_from_a_real_prompt_session() -> None:
+    from prompt_toolkit import PromptSession
+    from prompt_toolkit.completion import WordCompleter
+    from prompt_toolkit.layout import FloatContainer
+
+    session = PromptSession(completer=WordCompleter(["/a", "/b"]))
+    removed = strip_native_completion_menu(session.app)
+    assert removed >= 1, "prompt_toolkit's completions float was not found"
+
+    for node in session.app.layout.walk():
+        if isinstance(node, FloatContainer):
+            for float_ in node.floats:
+                assert not _is_native_completion_menu(float_.content), (
+                    "a native menu survived — both palettes would draw"
+                )
+
+
+def test_stripping_is_idempotent_and_safe_on_anything() -> None:
+    from prompt_toolkit import PromptSession
+
+    session = PromptSession()
+    strip_native_completion_menu(session.app)
+    assert strip_native_completion_menu(session.app) == 0
+    assert strip_native_completion_menu(object()) == 0
+    assert strip_native_completion_menu(None) == 0
+
+
+async def test_the_prompt_still_works_without_its_native_menu() -> None:
+    """Removing a float must not break the buffer underneath it.
+
+    Async because ``insert_text`` schedules prompt_toolkit's validator as a
+    background task, which needs a running loop — the same reason this must
+    be exercised the way the cockpit runs it rather than synchronously."""
+    from prompt_toolkit import PromptSession
+    from prompt_toolkit.completion import WordCompleter
+
+    session = PromptSession(completer=WordCompleter(["/alpha"]))
+    strip_native_completion_menu(session.app)
+    session.app.current_buffer.insert_text("/al")
+    assert session.app.current_buffer.text == "/al"
+
+
+# --------------------------------------------------------------------------
+# 3. the attach surface is wired to it
+# --------------------------------------------------------------------------
+
+def _ui() -> Any:
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+        from backend.core.ouroboros.cli.ov import AttachUI
+        return AttachUI()
+
+
+def test_the_toolbar_falls_back_to_hints_when_not_completing() -> None:
+    toolbar = _ui().toolbar()
+    assert isinstance(toolbar, str)
+    assert "detach" in toolbar
+
+
+def test_the_toolbar_renders_the_palette_while_completing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The wiring itself, isolated from a running terminal."""
+    import backend.core.ouroboros.battle_test.palette_render as pr
+
+    monkeypatch.setattr(
+        pr, "live_completion_entries",
+        lambda: ([("/molt", "post to the agora"), ("/moltbook", "read it")], 0),
+    )
+    monkeypatch.setattr(
+        pr, "palette_fragments",
+        lambda max_rows=None: [("class:completion-menu.completion", "  /molt")],
+    )
+    toolbar = _ui().toolbar()
+    assert not isinstance(toolbar, str), (
+        "the toolbar ignored an active completion and drew hints"
+    )
+    assert any("/molt" in text for _style, text in toolbar)
+
+
+def test_a_palette_fault_degrades_to_hints_rather_than_blanking(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import backend.core.ouroboros.battle_test.palette_render as pr
+
+    def _boom(max_rows=None):
+        raise RuntimeError("palette exploded")
+
+    monkeypatch.setattr(pr, "palette_fragments", _boom)
+    toolbar = _ui().toolbar()
+    assert isinstance(toolbar, str) and "detach" in toolbar
+
+
+def test_the_attach_surface_strips_its_native_menu_and_reserves_no_gap():
+    """Structural: both are set where the session is built, so a future edit
+    that drops one leaves a visible defect this catches."""
+    src = (_REPO / "backend/core/ouroboros/cli/ov.py").read_text()
+    assert "_strip_native_menu(session.app)" in src
+    assert "reserve_space_for_menu=0" in src
+
+
+def test_one_palette_implementation_serves_both_surfaces() -> None:
+    """DRY, asserted: the container form composes the fragment form rather
+    than restating the layout, so the two cannot diverge."""
+    import inspect
+
+    from backend.core.ouroboros.battle_test import palette_render
+
+    body = inspect.getsource(palette_render.build_palette_window)
+    assert "palette_fragments" in body
+    assert "live_completion_entries" in body
+
+
+# --------------------------------------------------------------------------
+# 4. it actually draws — on a real terminal
+# --------------------------------------------------------------------------
+
+_PTY_DRIVER = r'''
+import os, pty, sys, time, select, re
+def child():
+    os.environ.setdefault("TERM", "xterm-256color")
+    from prompt_toolkit import PromptSession
+    from backend.core.ouroboros.cli.ov import (
+        AttachUI, _build_slash_completer, _cockpit_style, _strip_native_menu,
+    )
+    ui = AttachUI()
+    session = PromptSession(
+        message=lambda: ui.prompt(), bottom_toolbar=lambda: ui.toolbar(),
+        completer=_build_slash_completer(), complete_while_typing=True,
+        style=_cockpit_style(), reserve_space_for_menu=0,
+    )
+    n = _strip_native_menu(session.app)
+    sys.stderr.write("STRIPPED=%d\nREADY\n" % n); sys.stderr.flush()
+    try: session.prompt()
+    except (EOFError, KeyboardInterrupt): pass
+if os.environ.get("PTY_CHILD"):
+    child(); sys.exit(0)
+pid, fd = pty.fork()
+if pid == 0:
+    os.environ["PTY_CHILD"] = "1"; os.execv(sys.executable, [sys.executable, __file__])
+import fcntl, struct, termios
+fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", 44, 150, 0, 0))
+out = bytearray(); t0 = time.time(); sent = False; mark = 0
+while time.time() - t0 < 60:
+    r, _, _ = select.select([fd], [], [], 0.3)
+    if r:
+        try: c = os.read(fd, 65536)
+        except OSError: break
+        if not c: break
+        out += c
+        # A real terminal ANSWERS the cursor-position query. Without this
+        # prompt_toolkit never learns the renderer height and HIDES the
+        # bottom toolbar, so the palette cannot be observed at all.
+        if b"\x1b[6n" in c: os.write(fd, b"\x1b[22;1R")
+    if not sent and (b"READY" in out or time.time() - t0 > 30):
+        time.sleep(1.5); mark = len(out); os.write(fd, b"/"); sent = True; ts = time.time()
+    if sent and time.time() - ts > 6: break
+raw = out.decode("utf8", "replace")
+plain = re.sub(r"\x1b\[[0-9;?]*[a-zA-Z]", "", raw[mark:])
+print("RESULT_STRIPPED=" + (raw.split("STRIPPED=")[1][:1] if "STRIPPED=" in raw else "0"))
+print("RESULT_BODY_START")
+print(plain)
+try: os.kill(pid, 9)
+except Exception: pass
+'''
+
+
+@pytest.mark.timeout(120)
+def test_pressing_slash_actually_draws_the_palette(tmp_path: Path) -> None:
+    """THE test this arc kept not having.
+
+    Every previous `/` fix asserted on the completer or the layout and shipped
+    green while the operator's screen was unchanged. This drives a real pty,
+    answers the terminal's cursor-position query the way a terminal does, and
+    reads what was PAINTED.
+    """
+    driver = tmp_path / "driver.py"
+    driver.write_text(_PTY_DRIVER)
+    try:
+        proc = subprocess.run(
+            [sys.executable, str(driver)],
+            capture_output=True, text=True, timeout=100,
+            cwd=str(_REPO), env={**os.environ, "PYTHONPATH": str(_REPO)},
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        pytest.skip(f"pty driver unavailable in this environment: {exc}")
+    if "RESULT_BODY_START" not in proc.stdout:
+        pytest.skip(f"pty allocation failed: {proc.stderr[-300:]}")
+
+    stripped = proc.stdout.split("RESULT_STRIPPED=")[1][:1]
+    body = proc.stdout.split("RESULT_BODY_START", 1)[1]
+
+    assert stripped != "0", "the native completions float was never removed"
+
+    rows = [ln for ln in body.splitlines() if ln.strip().startswith("/")]
+    assert len(rows) >= 5, (
+        f"pressing '/' painted {len(rows)} palette rows; the menu is not "
+        f"reaching the screen"
+    )
+    # Page-style, not widget-style: name column, gutter, then a description
+    # on the SAME line. The native float puts descriptions in a second column
+    # of its own narrow box.
+    described = [r for r in rows if re.match(r"\s*/\S+\s{2,}\S", r)]
+    assert described, (
+        f"palette rows carry no aligned description column: {rows[:3]}"
+    )
+    # And the descriptions are the resolved ones, not blanks.
+    assert any("|" in r or "Usage:" in r or len(r.split()) > 2
+               for r in described)


### PR DESCRIPTION
The page-style palette shipped in #70123 and **the operator's screen did not change.**

Root cause: it was written as a **container** and wired into `build_bipartite_application` — but `ov` attach builds a `PromptSession`, which constructs its own layout internally and accepts no extra containers. `ov.py` never referenced the bipartite application at all. The palette had no caller on the path anyone uses: wired, and inert.

That split is also why four consecutive `/` fixes shipped green while the screen stayed wrong. Every one of them asserted on the completer — which was correct the whole time.

### Rendered as formatted text, not as a container
`palette_fragments()` returns the same `layout_palette` output as one fragment list with embedded newlines — the form *every* prompt_toolkit surface accepts. A surface no longer needs somewhere to put a container in order to show the palette.

`build_palette_window` now composes it rather than restating the layout, so the two surfaces cannot diverge again.

### Drawn under the caret
The attach surface renders it through `bottom_toolbar` — directly beneath the input line, where a command palette belongs, and the only full-width region this surface has. Falls back to key hints when nothing is completing, and on any palette fault.

### The native widget is removed, not restyled
Different **layouts**, so leaving prompt_toolkit's float in place renders both at once — a narrow floating column on top of the full-width page.

Detection tests at **every** wrapper level, because `CompletionsMenu` is itself a `ConditionalContainer` subclass: unwrapping to the innermost child first walks straight past it. That is exactly what left both menus on screen during development.

### Rejected on evidence
`complete_style=READLINE_LIKE` looked like a clean way to suppress the float. prompt_toolkit **explicitly disables `complete_while_typing` under it**, so `complete_state` is never populated and the palette has nothing to read. Measured (`state=False n=0`), not assumed.

### Proven on a real terminal
The last test drives a pty, answers the cursor-position query the way a terminal does, and asserts on what was **painted**.

That CPR answer is load-bearing: without it prompt_toolkit never learns the renderer height and **hides the bottom toolbar entirely**. The first version of this harness reported a blank screen for that reason and nearly sent me after the wrong defect.

Live result — 2 floats stripped, and `/` paints:

```
  /anticipate              help | panel | banners | prefetch | status
  /autobiography           help | status | refresh | commit | escapes | corpus
  /backlog_auto_proposed   help | list | show | approve | reject | history
  /bus                     help | stats
  /canvas                  help | tree | op | json | dot | fanout | multi_prior
```

Full-width, aligned description column, resolved descriptions from #70125.

### Tests
14 new. 109 green across the palette, resolver, multiplex and D4 suites. The pty test skips cleanly where pty devices are unavailable (CI sandboxes) rather than failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the `/` command palette render on the attach surface. It now draws as formatted text in the `PromptSession` toolbar and replaces the native menu, so operators see a full-width palette beneath the caret.

- **Bug Fixes**
  - Render palette as formatted text via `palette_fragments()`; used by `AttachUI.toolbar()` in `bottom_toolbar`.
  - Remove the native `prompt_toolkit` completion float with `strip_native_completion_menu()`; set `reserve_space_for_menu=0`.
  - DRY: `build_palette_window()` composes `palette_fragments()` and reads live `complete_state` for both surfaces.
  - Fall back to key hints when not completing or on palette errors.
  - Tests add a pty-backed paint assertion plus menu detection/stripping and fragment behavior.

<sup>Written for commit bd2dba7fb248a2c94f47980c42e76b89b9c120cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

