### PR TITLE
feat(ov): the `/` palette becomes a Z-index overlay on the cockpit

### DIFF
--- a/backend/core/ouroboros/battle_test/bipartite_layout.py
+++ b/backend/core/ouroboros/battle_test/bipartite_layout.py
@@ -518,8 +518,10 @@ def build_bipartite_application(
             logger.debug("[Bipartite] palette row unavailable", exc_info=True)
 
     rows += [canvas]
-    if _palette is not None:
-        rows.append(_palette)
+    # The palette is NOT a row. See the FloatContainer below: as an HSplit row
+    # it shares the ambient grid with the canvas, so every asynchronous Deck or
+    # Lane frame arriving underneath forces the palette's geometry to be
+    # recomputed along with everything else.
     rows += [_rule(), prompt, _rule()]
     if toolbar is not None:
         # A one-row morphing footer (e.g. the attach client's AttachUI.toolbar —
@@ -536,17 +538,51 @@ def build_bipartite_application(
             height=1, wrap_lines=False,
         ))
     root: Any = HSplit(rows)
-    if completer is not None and _palette is None:
-        # THE missing half. A CompletionsMenu is a Float; without a
-        # FloatContainer it is never rendered no matter how many completions
-        # the buffer holds.
+    if _palette is not None:
+        # Z-INDEX OVERLAY, not a row.
         #
-        # Anchored to the cursor, so it opens ABOVE the ❯ row when the prompt
-        # sits at the bottom of the frame — which it always does here. That is
-        # the placement the operator is used to, and it falls out of
-        # prompt_toolkit's own float positioning rather than being computed.
+        # This cockpit takes asynchronous IPC continuously — Deck entries, Lane
+        # frames, the heartbeat. A palette that participates in the HSplit
+        # shares the ambient grid with all of it, so each of those frames
+        # recomputes the palette's geometry too, and the reflow lands on the
+        # keystroke that opened the menu.
+        #
+        # A Float is measured independently of the grid: the canvas beneath can
+        # repaint at whatever rate the daemon pushes without the overlay taking
+        # part. Background updates stop being able to disturb the menu.
+        #
+        # The float carries OUR page-style palette, not prompt_toolkit's
+        # CompletionsMenu widget. That widget is a bounded dropdown sized to
+        # its longest entry — the narrow grey control #70123 replaced and
+        # #70140 stripped — and reintroducing it as a float would trade the
+        # layout back for the tearing fix. There is no need to choose:
+        #
+        #   left=0, right=0  -> spans the terminal, so descriptions wrap into
+        #                       a real column instead of the widget's width;
+        #   ycursor=True     -> tracks the caret. The prompt here is a
+        #                       multi-line block (pulse + deck + caret) whose
+        #                       height changes as those regions fill, so any
+        #                       fixed `bottom=` offset would drift the moment
+        #                       the live region grew a line.
         try:
-            from prompt_toolkit.layout import FloatContainer, Float
+            from prompt_toolkit.layout import Float, FloatContainer
+            root = FloatContainer(
+                content=root,
+                floats=[Float(
+                    content=_palette,
+                    left=0, right=0,          # full terminal width
+                    ycursor=True,             # follow the caret, not a constant
+                )],
+            )
+        except Exception:  # noqa: BLE001 — a cockpit without a menu still types
+            logger.debug("[Bipartite] palette overlay unavailable",
+                         exc_info=True)
+    elif completer is not None:
+        # No page palette available (import failure). Fall back to
+        # prompt_toolkit's own widget rather than leaving completions
+        # invisible: a bounded dropdown beats no menu at all.
+        try:
+            from prompt_toolkit.layout import Float, FloatContainer
             from prompt_toolkit.layout.menus import (
                 CompletionsMenu, MultiColumnCompletionsMenu,
             )
@@ -559,7 +595,7 @@ def build_bipartite_application(
                 content=root,
                 floats=[Float(xcursor=True, ycursor=True, content=_menu)],
             )
-        except Exception:  # noqa: BLE001 — a cockpit without a menu still types
+        except Exception:  # noqa: BLE001
             logger.debug("[Bipartite] completion menu unavailable", exc_info=True)
     # Adaptive color depth (root cause of the quantized/muddy logo): pt 3.0.x's
     # default depth reads TERM only — COLORTERM is ignored, so a truecolor

--- a/backend/core/ouroboros/battle_test/palette_render.py
+++ b/backend/core/ouroboros/battle_test/palette_render.py
@@ -288,8 +288,16 @@ def build_palette_window(condition_style: str = "") -> Any:
     return ConditionalContainer(
         content=Window(
             content=FormattedTextControl(_fragments, focusable=False),
-            height=Dimension(min=0, max=palette_rows() * 3,
-                             preferred=1, weight=0),
+            # Height must be the CONTENT's height, computed per render.
+            #
+            # This was `preferred=1`, which was invisible while the palette was
+            # an HSplit row: `dont_extend_height` let the row take what its
+            # content needed. Inside a Float there is no such negotiation — the
+            # preferred height IS the height, so the overlay painted exactly
+            # one entry and looked like a broken menu.
+            height=lambda: Dimension(
+                min=0, preferred=_height(), max=palette_rows() * 3, weight=0,
+            ),
             dont_extend_height=True,
             wrap_lines=False,
             style=condition_style or "class:completion-menu",

--- a/tests/cli/test_bipartite_palette_overlay.py
+++ b/tests/cli/test_bipartite_palette_overlay.py
@@ -1,0 +1,288 @@
+"""The palette is a Z-index overlay on the cockpit, not a row in its grid.
+
+The bipartite cockpit is the surface `ov` actually mounts on a real TTY — the
+`PromptSession` is its fallback. Confirmed at runtime, not by grep:
+`should_run_bipartite()` is True whenever stdout is a real terminal and the
+kill-switch is unset.
+
+As an `HSplit` row the palette shared the ambient grid with the canvas, so
+every asynchronous Deck / Lane frame recomputed the palette's geometry along
+with everything else — and that reflow lands on the keystroke that opened the
+menu. As a `Float` it is measured independently: the canvas beneath repaints
+at whatever rate the daemon pushes without the overlay taking part.
+
+The float carries the page-style palette, NOT prompt_toolkit's
+`CompletionsMenu` widget. That widget is a bounded dropdown sized to its
+longest entry; reintroducing it as a float would have traded the layout back
+for the tearing fix.
+"""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import io
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[2]
+
+
+def _app(with_completer: bool = True) -> Any:
+    from backend.core.ouroboros.battle_test.bipartite_layout import (
+        BipartiteLayout, build_bipartite_application,
+    )
+    from backend.core.ouroboros.battle_test.repl_completion import (
+        build_attach_completer,
+    )
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+        mux = BipartiteLayout(width=150, height=40, title="t")
+        app = build_bipartite_application(
+            mux, on_accept=lambda _t: None,
+            completer=build_attach_completer() if with_completer else None,
+        )
+    return mux, app
+
+
+# --------------------------------------------------------------------------
+# 1. it is an overlay
+# --------------------------------------------------------------------------
+
+def test_the_layout_root_is_a_float_container() -> None:
+    from prompt_toolkit.layout import FloatContainer
+
+    _mux, app = _app()
+    assert isinstance(app.layout.container, FloatContainer), (
+        "the cockpit root is not a FloatContainer — the palette is back in "
+        "the ambient grid"
+    )
+
+
+def test_the_palette_float_spans_the_terminal_and_tracks_the_caret() -> None:
+    """Both halves matter and they solve different problems.
+
+    ``left=0, right=0`` is what keeps the page layout: a float sized to its
+    content would be the narrow dropdown again, with descriptions truncated
+    at the widget edge instead of wrapped into a column.
+
+    ``ycursor=True`` is what survives a growing prompt. This surface's prompt
+    is a multi-line block — pulse, deck, then the caret — so any fixed
+    ``bottom=`` offset drifts the moment the live region gains a line.
+    """
+    _mux, app = _app()
+    floats = app.layout.container.floats
+    assert floats, "no floats at all"
+    palette = floats[0]
+    assert palette.left == 0 and palette.right == 0, (
+        f"palette float does not span the width: left={palette.left} "
+        f"right={palette.right}"
+    )
+    assert palette.ycursor, "palette float is not anchored to the caret"
+
+
+def test_the_float_carries_our_palette_not_the_native_widget() -> None:
+    from backend.core.ouroboros.battle_test.palette_render import (
+        _is_native_completion_menu,
+    )
+    _mux, app = _app()
+    for float_ in app.layout.container.floats:
+        assert not _is_native_completion_menu(float_.content), (
+            "prompt_toolkit's dropdown is back — the page layout was traded "
+            "away for the overlay"
+        )
+
+
+def test_the_palette_is_no_longer_a_row_in_the_split() -> None:
+    """Structural: a row participates in the grid, which is the whole defect."""
+    import inspect
+
+    from backend.core.ouroboros.battle_test import bipartite_layout
+
+    src = inspect.getsource(bipartite_layout.build_bipartite_application)
+    assert "rows.append(_palette)" not in src, (
+        "the palette was re-added as an HSplit row"
+    )
+    assert "floats=[Float(" in src
+
+
+def test_a_cockpit_without_a_completer_grows_no_float() -> None:
+    from prompt_toolkit.layout import FloatContainer
+
+    _mux, app = _app(with_completer=False)
+    root = app.layout.container
+    if isinstance(root, FloatContainer):
+        assert not root.floats
+
+
+# --------------------------------------------------------------------------
+# 2. background IPC does not disturb the overlay
+# --------------------------------------------------------------------------
+
+async def test_canvas_writes_do_not_change_the_palette() -> None:
+    """MANDATE 4(2). Deck/Lane traffic underneath must leave the menu alone.
+
+    Asserted on the palette's rendered fragments across a burst of canvas
+    writes: the overlay's content is a pure function of the completion state,
+    which the canvas does not touch."""
+    from backend.core.ouroboros.battle_test.palette_render import (
+        palette_fragments,
+    )
+    mux, _app_ = _app()
+    before = palette_fragments()
+    for i in range(50):
+        mux.push_raw(f"[daemon] op-{i} GENERATE tokens={i}k")
+        if i % 10 == 0:
+            await asyncio.sleep(0)
+    assert palette_fragments() == before, (
+        "background canvas traffic altered the palette's rendered content"
+    )
+
+
+async def test_the_overlay_is_measured_apart_from_the_canvas() -> None:
+    """The structural reason the above holds: the palette is not among the
+    HSplit's children, so the canvas cannot pull it into a reflow."""
+    from prompt_toolkit.layout import FloatContainer
+
+    _mux, app = _app()
+    root = app.layout.container
+    assert isinstance(root, FloatContainer)
+    float_contents = {id(f.content) for f in root.floats}
+    body = root.content
+    grid_children = {id(c) for c in getattr(body, "children", [])}
+    assert not (float_contents & grid_children), (
+        "the palette is in BOTH the float list and the grid"
+    )
+
+
+# --------------------------------------------------------------------------
+# 3. the router mounts this surface, and it actually paints
+# --------------------------------------------------------------------------
+
+_PTY_DRIVER = r'''
+import os, pty, sys, time, select, re
+def child():
+    os.environ.setdefault("TERM", "xterm-256color")
+    import asyncio
+    from backend.core.ouroboros.battle_test.bipartite_layout import (
+        BipartiteLayout, build_bipartite_application, should_run_bipartite,
+    )
+    from backend.core.ouroboros.battle_test.repl_completion import build_attach_completer
+    from backend.core.ouroboros.cli.ov import AttachUI
+    sys.stderr.write("ROUTER=%s\n" % should_run_bipartite()); sys.stderr.flush()
+    if not should_run_bipartite():
+        return
+    ui = AttachUI()
+    mux = BipartiteLayout(width=150, height=40, title="ov attach")
+    app = build_bipartite_application(
+        mux, on_accept=lambda t: None, completer=build_attach_completer(),
+        toolbar=lambda: ui.toolbar(),
+    )
+    async def drive():
+        async def feed():
+            i = 0
+            while True:
+                mux.push_raw("[daemon] op-%d GENERATE" % i)
+                app.invalidate(); i += 1
+                await asyncio.sleep(0.2)
+        t = asyncio.ensure_future(feed())
+        try: await app.run_async()
+        finally: t.cancel()
+    def _painted(_a=None):
+        sys.stderr.write("PAINTED\n"); sys.stderr.flush()
+    try: app.after_render += _painted
+    except Exception: pass
+    sys.stderr.write("READY\n"); sys.stderr.flush()
+    try: asyncio.run(drive())
+    except (EOFError, KeyboardInterrupt): pass
+if os.environ.get("PTY_CHILD"):
+    child(); sys.exit(0)
+pid, fd = pty.fork()
+if pid == 0:
+    os.environ["PTY_CHILD"] = "1"; os.execv(sys.executable, [sys.executable, __file__])
+import fcntl, struct, termios
+fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", 40, 150, 0, 0))
+out = bytearray(); t0 = time.time(); sent = False; mark = 0
+while time.time() - t0 < 100:
+    r, _, _ = select.select([fd], [], [], 0.3)
+    if r:
+        try: c = os.read(fd, 65536)
+        except OSError: break
+        if not c: break
+        out += c
+        # Answer the cursor-position query like a real terminal. Without it
+        # prompt_toolkit never learns the renderer height and geometry-
+        # dependent regions are never drawn at all.
+        if b"\x1b[6n" in c: os.write(fd, b"\x1b[30;1R")
+    if not sent and b"PAINTED" in out:
+        time.sleep(0.4); mark = len(out); os.write(fd, b"/"); sent = True; ts = time.time()
+    if sent and time.time() - ts > 7: break
+raw = out.decode("utf8", "replace")
+print("RESULT_ROUTER=" + ("True" if "ROUTER=True" in raw else "False"))
+print("RESULT_PAINTED=" + ("1" if b"PAINTED" in out else "0"))
+print("RESULT_BODY_START")
+print(re.sub(r"\x1b\[[0-9;?]*[a-zA-Z]", "", raw[mark:]))
+# Reap properly. kill(9) alone leaves a zombie holding the pty slave open,
+# so the master fd never releases its device — and the NEXT pty test in the
+# same run gets a degraded or unavailable terminal. Two tests that each pass
+# alone and fail together is the signature of a leaked device, not of a
+# product bug.
+try: os.kill(pid, 9)
+except Exception: pass
+try: os.waitpid(pid, 0)
+except Exception: pass
+try: os.close(fd)
+except Exception: pass
+'''
+
+
+@pytest.mark.timeout(200)
+def test_the_router_mounts_bipartite_and_the_overlay_paints(
+    tmp_path: Path,
+) -> None:
+    """MANDATE 4(1)+(2). The router's own decision, then what was painted.
+
+    Every `/` fix before this one asserted on the completer or the layout and
+    shipped green while the screen was unchanged — twice on a surface the
+    operator never reaches. So this takes the mounting decision the way
+    `ov.py` takes it, and then reads pixels.
+    """
+    driver = tmp_path / "driver.py"
+    driver.write_text(_PTY_DRIVER)
+    try:
+        proc = subprocess.run(
+            [sys.executable, str(driver)], capture_output=True, text=True,
+            timeout=150, cwd=str(_REPO),
+            env={**os.environ, "PYTHONPATH": str(_REPO)},
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        pytest.skip(f"pty driver unavailable: {exc}")
+    if "RESULT_BODY_START" not in proc.stdout:
+        pytest.skip(f"pty allocation failed: {proc.stderr[-300:]}")
+
+    if "RESULT_PAINTED=1" not in proc.stdout:
+        pytest.skip(
+            "pty child never rendered a frame (device/scheduler "
+            "contention under a full-suite run) — no screen to assert on")
+    assert "RESULT_ROUTER=True" in proc.stdout, (
+        "should_run_bipartite() refused a real TTY — the cockpit is not the "
+        "surface being mounted"
+    )
+    if "RESULT_PAINTED=1" not in proc.stdout:
+        pytest.skip(
+            "pty child never rendered a frame (device/scheduler "
+            "contention under a full-suite run) — no screen to assert on")
+    body = proc.stdout.split("RESULT_BODY_START", 1)[1]
+    rows = [ln for ln in body.splitlines() if ln.strip().startswith("/")]
+    assert len(rows) >= 8, (
+        f"'/' painted {len(rows)} palette rows on the cockpit — the overlay "
+        f"is collapsed (a float honours its PREFERRED height, so a stale "
+        f"preferred=1 renders exactly one entry)"
+    )
+    described = [r for r in rows if re.match(r"\s*/\S+\s{2,}\S", r)]
+    assert described, f"no aligned description column: {rows[:3]}"

--- a/tests/cli/test_palette_on_attach_surface.py
+++ b/tests/cli/test_palette_on_attach_surface.py
@@ -228,6 +228,15 @@ def child():
         style=_cockpit_style(), reserve_space_for_menu=0,
     )
     n = _strip_native_menu(session.app)
+    # Signal on the FIRST ACTUAL FRAME rather than letting the parent sleep
+    # and hope. Under full-suite load the fixed wait elapsed before anything
+    # was painted, so "/" went into a prompt that did not exist yet and the
+    # test failed while passing in isolation — a UI test lying in the most
+    # expensive direction.
+    def _painted(_app=None):
+        sys.stderr.write("PAINTED\n"); sys.stderr.flush()
+    try: session.app.after_render += _painted
+    except Exception: pass
     sys.stderr.write("STRIPPED=%d\nREADY\n" % n); sys.stderr.flush()
     try: session.prompt()
     except (EOFError, KeyboardInterrupt): pass
@@ -239,7 +248,7 @@ if pid == 0:
 import fcntl, struct, termios
 fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", 44, 150, 0, 0))
 out = bytearray(); t0 = time.time(); sent = False; mark = 0
-while time.time() - t0 < 60:
+while time.time() - t0 < 90:
     r, _, _ = select.select([fd], [], [], 0.3)
     if r:
         try: c = os.read(fd, 65536)
@@ -250,20 +259,31 @@ while time.time() - t0 < 60:
         # prompt_toolkit never learns the renderer height and HIDES the
         # bottom toolbar, so the palette cannot be observed at all.
         if b"\x1b[6n" in c: os.write(fd, b"\x1b[22;1R")
-    if not sent and (b"READY" in out or time.time() - t0 > 30):
-        time.sleep(1.5); mark = len(out); os.write(fd, b"/"); sent = True; ts = time.time()
-    if sent and time.time() - ts > 6: break
+    if not sent and b"PAINTED" in out:
+        time.sleep(0.4); mark = len(out); os.write(fd, b"/"); sent = True; ts = time.time()
+    if sent and (b"|" in out[mark:] or b"Usage:" in out[mark:]
+                 or time.time() - ts > 20): break
 raw = out.decode("utf8", "replace")
 plain = re.sub(r"\x1b\[[0-9;?]*[a-zA-Z]", "", raw[mark:])
 print("RESULT_STRIPPED=" + (raw.split("STRIPPED=")[1][:1] if "STRIPPED=" in raw else "0"))
+print("RESULT_PAINTED=" + ("1" if b"PAINTED" in out else "0"))
 print("RESULT_BODY_START")
 print(plain)
+# Reap properly. kill(9) alone leaves a zombie holding the pty slave open,
+# so the master fd never releases its device — and the NEXT pty test in the
+# same run gets a degraded or unavailable terminal. Two tests that each pass
+# alone and fail together is the signature of a leaked device, not of a
+# product bug.
 try: os.kill(pid, 9)
+except Exception: pass
+try: os.waitpid(pid, 0)
+except Exception: pass
+try: os.close(fd)
 except Exception: pass
 '''
 
 
-@pytest.mark.timeout(120)
+@pytest.mark.timeout(180)
 def test_pressing_slash_actually_draws_the_palette(tmp_path: Path) -> None:
     """THE test this arc kept not having.
 
@@ -277,7 +297,7 @@ def test_pressing_slash_actually_draws_the_palette(tmp_path: Path) -> None:
     try:
         proc = subprocess.run(
             [sys.executable, str(driver)],
-            capture_output=True, text=True, timeout=100,
+            capture_output=True, text=True, timeout=130,
             cwd=str(_REPO), env={**os.environ, "PYTHONPATH": str(_REPO)},
         )
     except (subprocess.TimeoutExpired, OSError) as exc:
@@ -286,6 +306,10 @@ def test_pressing_slash_actually_draws_the_palette(tmp_path: Path) -> None:
         pytest.skip(f"pty allocation failed: {proc.stderr[-300:]}")
 
     stripped = proc.stdout.split("RESULT_STRIPPED=")[1][:1]
+    if "RESULT_PAINTED=1" not in proc.stdout:
+        pytest.skip(
+            "pty child never rendered a frame (device/scheduler "
+            "contention under a full-suite run) — no screen to assert on")
     body = proc.stdout.split("RESULT_BODY_START", 1)[1]
 
     assert stripped != "0", "the native completions float was never removed"

--- a/tests/cli/test_slash_palette.py
+++ b/tests/cli/test_slash_palette.py
@@ -194,10 +194,13 @@ def test_the_cockpit_layout_can_actually_draw_a_menu() -> None:
     root = app.layout.container
 
     if isinstance(root, FloatContainer):
-        kinds = [type(f.content).__name__ for f in root.floats]
-        assert any("CompletionsMenu" in k for k in kinds), (
-            f"FloatContainer root with no completions float; floats={kinds}"
-        )
+        # THIRD mechanism for the same invariant (2026-07-27). The float used
+        # to be prompt_toolkit's CompletionsMenu; it is now our page-style
+        # palette, moved into a float so asynchronous canvas traffic cannot
+        # pull it into a grid reflow. Either satisfies "there is somewhere for
+        # completions to render", which is the thing worth protecting — the
+        # widget class never was.
+        assert root.floats, "FloatContainer root with no floats at all"
         return
 
     kids = list(getattr(root, "get_children", lambda: [])())


### PR DESCRIPTION
Step 1 of Single-Surface Ascendancy — on the surface that actually mounts.

The bipartite cockpit, **not** the `PromptSession`, is what `ov` runs at a real terminal. Verified at runtime under `pty.fork()`, not by grep:

```
enabled=True  should_run=True  real_tty=True  split_plane=True
```

### The palette moves out of the ambient grid
As an `HSplit` row it shared geometry with the canvas, so every asynchronous Deck / Lane frame recomputed the palette along with everything else — and that reflow lands on the very keystroke that opened the menu.

As a `Float` it is measured independently: the canvas beneath repaints at whatever rate the daemon pushes without the overlay taking part.

### The float carries our palette, not prompt_toolkit's widget
A literal `CompletionsMenu` float would have reinstated the bounded grey dropdown that #70123 replaced and #70140 stripped — trading the page layout back for the tearing fix. There's no need to choose:

| | why |
|---|---|
| `left=0, right=0` | spans the terminal, so descriptions wrap into a real column instead of truncating at a widget edge |
| `ycursor=True` | tracks the caret — this prompt is a multi-line block (pulse + deck + caret), so any fixed `bottom=` offset drifts the moment the live region gains a line |

### A float honours its PREFERRED height
`build_palette_window` declared `preferred=1`. Invisible while `dont_extend_height` let an HSplit row take what it needed; inside a Float it **is** the height, and the overlay painted exactly one entry. Height now follows content per render.

Found by looking at the screen, not the tree.

### DRY
Completion engine untouched — same registry, same `_describe` cascade, same mined vocabularies from #70125. Presentation only.

### Proven
CPR-answering pty, through the router's own decision, with background canvas traffic feeding underneath:

```
ROUTER should_run_bipartite=True
palette rows painted: 12
    /backlog_auto_proposed   help | list | show | approve | reject | history
    /canvas                  help | tree | op | json | dot | fanout | multi_prior
    /coherence               help | status | stats | config | audits | advisories
```

8 new tests. 393 passing across `tests/cli` + bipartite.

### ⚠️ Known red, and mine
`test_pressing_slash_actually_draws_the_palette` (#70140, the **fallback** surface) passes in isolation and fails under a full-suite run, reporting 0 painted rows.

Not root-caused after four attempts. Readiness now keys off prompt_toolkit's `after_render` instead of a sleep; pty children are reaped and their masters closed; the child confirms it rendered a frame before anything is asserted — and it still fails when run alongside the new pty test.

It guards the fallback surface so it does not gate this change, but it must be resolved before Step 2 promotes anything.

Two other failures (`test_ov_ignition_retry`, `test_split_plane_mux`) are pre-existing — verified failing with these changes stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the `/` palette a full‑width Z-index overlay on the bipartite cockpit to stop grid reflows and flicker. Keeps the page-style layout stable while the canvas updates asynchronously.

- New Features
  - Moved the palette from an HSplit row into a `Float` overlay that spans the terminal (`left=0, right=0`) and follows the caret (`ycursor=True`).
  - Uses our page-style palette, not `prompt_toolkit`’s `CompletionsMenu`; falls back to the native menu only if the page palette can’t load.
  - Added a pty-backed test that verifies the router mounts the bipartite surface and that `/` renders multiple palette rows.

- Bug Fixes
  - Fixed overlay height: compute per render so all entries show (Floats honor preferred height).
  - Stabilized UI tests by signaling on `after_render` and fully reaping pty children; reduced flakiness from fixed sleeps and leaked devices.

<sup>Written for commit 51d78bc01c1a15535eec9693c5453f2970d47fb7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

