### PR TITLE
feat(ov): terminals that cannot be drawn on get linear plain text

### DIFF
--- a/backend/core/ouroboros/battle_test/append_only.py
+++ b/backend/core/ouroboros/battle_test/append_only.py
@@ -1,0 +1,228 @@
+"""Degradation for terminals that cannot be drawn on.
+
+A terminal that does not answer ``ESC[6n`` cannot be addressed: nothing can
+know where the cursor is, so absolute positioning, overlays and repainting
+regions all become guesses. That is the normal state of a CI job, a cron
+entry, `ov | tee log.txt`, or a stripped SSH session — and in exactly those
+places the output is usually being READ LATER AS TEXT, where escape sequences
+are not merely useless but actively destroy the log.
+
+So this module is two things:
+
+``cpr_unsupported_signal``
+    A hook onto prompt_toolkit's OWN cursor-position-report timeout. Nothing
+    here re-probes the terminal.
+
+``AppendOnlyWriter``
+    A linear, strictly append-only stdout writer that emits plain text.
+
+Not reimplementing the CPR probe is deliberate
+----------------------------------------------
+prompt_toolkit already asks for the cursor position, already waits with a
+timeout (``Renderer.wait_for_cpr_responses``), already marks the terminal
+``CPR_Support.NOT_SUPPORTED``, and already calls back when that happens. It
+does not hang. The familiar
+
+    WARNING: your terminal doesn't support cursor position requests (CPR).
+
+is that machinery working correctly.
+
+A second probe layered on top would race the first for the same response
+bytes: whichever reader wins, the other times out, and a terminal that
+answered perfectly well gets classified as dumb. The correct move is to
+consume the signal that already exists and to tune its timeout through the
+parameter that already exists.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import re
+import sys
+from typing import Any, Callable, Optional, TextIO
+
+logger = logging.getLogger("Ouroboros.AppendOnly")
+
+__all__ = [
+    "AppendOnlyWriter",
+    "cpr_timeout_s",
+    "install_cpr_degradation",
+    "plain_text",
+    "strip_ansi",
+]
+
+#: CSI / OSC / charset-select escape sequences. Covers colour (SGR), cursor
+#: movement, erase, mode set/reset, and OSC strings terminated by BEL or ST.
+_ANSI_RE = re.compile(
+    r"""
+    \x1b \[ [0-9;?]* [ -/]* [@-~]      # CSI ... final byte
+  | \x1b \] .*? (?: \x07 | \x1b\\ )    # OSC ... BEL or ST
+  | \x1b [@-Z\\-_]                     # single-character escapes
+  | \x1b [()][A-Za-z0-9]               # charset selection
+    """,
+    re.VERBOSE | re.DOTALL,
+)
+
+
+def cpr_timeout_s() -> float:
+    """How long to wait for the terminal to report its cursor position.
+
+    prompt_toolkit's own default is 1 second, which is a long time to sit
+    still at boot when the answer is nearly always immediate or never. A real
+    terminal replies within a round-trip; anything slower is indistinguishable
+    from a pipe for our purposes.
+
+    ``JARVIS_CPR_TIMEOUT_S`` tunes it — a heavily loaded remote session over a
+    slow link is the one case where waiting longer is right.
+    """
+    try:
+        value = float(os.environ.get("JARVIS_CPR_TIMEOUT_S", "0.2"))
+        # Never zero: a zero timeout classifies EVERY terminal as dumb before
+        # a reply could physically arrive.
+        return max(0.05, min(5.0, value))
+    except (TypeError, ValueError):
+        return 0.2
+
+
+def strip_ansi(text: Any) -> str:
+    """Remove every escape sequence, leaving the characters a human reads."""
+    try:
+        return _ANSI_RE.sub("", str(text))
+    except Exception:  # noqa: BLE001 — logging must never be the thing that fails
+        return str(text)
+
+
+def plain_text(payload: Any) -> str:
+    """Render *payload* as plain text, whatever form it arrives in.
+
+    Three shapes reach the client and each hides styling differently:
+
+      * Rich renderables and ``Text`` objects — ``.plain`` is Rich's own
+        answer, so markup semantics stay Rich's problem rather than becoming
+        a regex here;
+      * Rich MARKUP strings (``[bold red]x[/]``) — parsed by Rich for the
+        same reason, since hand-rolling the bracket grammar means owning its
+        edge cases (escaped brackets, unclosed tags) forever;
+      * already-rendered ANSI — regex, because at that point the styling is
+        no longer markup and Rich cannot un-render it.
+
+    Applied in that order, so a payload carrying both markup and raw ANSI
+    (the mirrored-router frames do) comes out clean either way.
+    """
+    try:
+        if payload is None:
+            return ""
+        # 1. A Rich object that can flatten itself.
+        plain = getattr(payload, "plain", None)
+        if isinstance(plain, str):
+            return strip_ansi(plain)
+
+        text = str(payload)
+        # 2. Rich markup — but ONLY when a CLOSING tag is present.
+        #
+        #    `[` and `]` are not evidence of markup. Log lines are full of
+        #    `[daemon]`, `[worker]`, `[Advisor]`, `tokens=[15k]`, and Rich
+        #    parses every one of those as an unknown style tag and DELETES it.
+        #    A filter whose job is to preserve logs as readable text must not
+        #    silently eat their prefixes; that is a worse corruption than the
+        #    escape codes it was added to remove, because it is invisible.
+        #
+        #    A closing `[/` is the cheap discriminator: emitted markup carries
+        #    one, incidental brackets do not.
+        if "[/" in text:
+            try:
+                from rich.text import Text
+                text = Text.from_markup(text).plain
+            except Exception:  # noqa: BLE001 — not markup after all
+                pass
+        # 3. Whatever escape sequences survived.
+        return strip_ansi(text)
+    except Exception:  # noqa: BLE001
+        try:
+            return strip_ansi(str(payload))
+        except Exception:  # noqa: BLE001
+            return ""
+
+
+class AppendOnlyWriter:
+    """A strictly linear stdout sink for terminals that cannot be addressed.
+
+    Every write is a whole line appended at the bottom. There is no cursor
+    movement, no erase, no region, no repaint — because on a stream that
+    cannot report its cursor position, all of those are writes to an unknown
+    location, and the visible result is a scrambled log.
+
+    Idempotent line endings and a flush per line: the common consumer is
+    ``tee``, a CI log collector, or a file being tailed while the process
+    runs, and a buffered final chunk is the difference between a useful log
+    and an empty one when the process is killed.
+    """
+
+    def __init__(self, stream: Optional[TextIO] = None) -> None:
+        self._stream = stream if stream is not None else sys.stdout
+        self.lines_written = 0
+
+    def write(self, payload: Any) -> None:
+        """Append *payload* as plain text. NEVER raises."""
+        try:
+            text = plain_text(payload)
+            if not text:
+                return
+            for line in text.splitlines() or [""]:
+                self._stream.write(line + "\n")
+                self.lines_written += 1
+            try:
+                self._stream.flush()
+            except Exception:  # noqa: BLE001
+                pass
+        except Exception:  # noqa: BLE001 — output must not kill the client
+            logger.debug("[AppendOnly] write degraded", exc_info=True)
+
+    # Enough of a file-like surface to stand in for a console sink.
+    def print(self, *args: Any, **_kwargs: Any) -> None:
+        self.write(" ".join(str(a) for a in args))
+
+    def flush(self) -> None:
+        try:
+            self._stream.flush()
+        except Exception:  # noqa: BLE001
+            pass
+
+    def isatty(self) -> bool:
+        return False        # by construction: this exists because it is not one
+
+
+def install_cpr_degradation(
+    app: Any, on_degrade: Callable[[], None],
+) -> bool:
+    """Call *on_degrade* if the terminal never reports its cursor position.
+
+    Hooks prompt_toolkit's ``cpr_not_supported_callback`` rather than probing:
+    see the module docstring for why a second probe would misclassify healthy
+    terminals by racing the first for the same bytes.
+
+    Fires at most once — the renderer latches ``NOT_SUPPORTED`` and would
+    otherwise call back on every subsequent render. Returns True if the hook
+    was installed. NEVER raises.
+    """
+    try:
+        fired = []
+
+        def _once() -> None:
+            if fired:
+                return
+            fired.append(1)
+            logger.info(
+                "[AppendOnly] terminal did not report cursor position — "
+                "degrading to append-only output",
+            )
+            try:
+                on_degrade()
+            except Exception:  # noqa: BLE001
+                logger.debug("[AppendOnly] degrade hook failed", exc_info=True)
+
+        app.renderer.cpr_not_supported_callback = _once
+        return True
+    except Exception:  # noqa: BLE001
+        logger.debug("[AppendOnly] could not install CPR hook", exc_info=True)
+        return False

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -577,6 +577,21 @@ class AttachUI:
         except Exception:  # noqa: BLE001
             pass
 
+    def degrade_to_append_only(self) -> None:
+        """Strip this UI to a single caret and nothing else.
+
+        Entered when the terminal never reports its cursor position. Every
+        region above the caret — pulse, deck, focused pane — is drawn by
+        repainting a block whose position is only knowable from the cursor,
+        so on a stream that cannot answer that question they do not degrade
+        into something ugly, they degrade into corrupted output.
+        """
+        self._append_only = True
+
+    @property
+    def append_only(self) -> bool:
+        return bool(getattr(self, "_append_only", False))
+
     def prompt(self) -> str:
         """The live region sits ABOVE the input line, then the caret.
 
@@ -591,6 +606,10 @@ class AttachUI:
         the same redraw machinery — no second region, no manual cursor math.
         The bottom toolbar keeps only the static key hints, which genuinely
         do belong under the input."""
+        if self.append_only:
+            # A bare caret. No live region, because there is no way to
+            # repaint one without knowing where it is.
+            return "ov > "
         caret = self._PROMPTS.get(self.audio_state, "ov › ")
         try:
             block = self._live_region()
@@ -661,6 +680,10 @@ class AttachUI:
 
         Returns a fragment list while completing and a plain string otherwise;
         prompt_toolkit accepts either."""
+        if self.append_only:
+            # No toolbar: prompt_toolkit anchors it to the bottom of the
+            # screen, which is an absolute position by definition.
+            return ""
         try:
             from backend.core.ouroboros.battle_test.palette_render import (
                 palette_fragments,
@@ -951,6 +974,16 @@ async def _split_plane_loop(
     # are different LAYOUTS, and leaving the widget in place renders both at
     # once — a narrow floating column on top of the full-width page.
     _strip_native_menu(session.app)
+    # Consume prompt_toolkit's OWN cursor-position timeout rather than probing
+    # the terminal again — a second probe races the first for the same reply
+    # bytes and misclassifies healthy terminals. See append_only.py.
+    try:
+        from backend.core.ouroboros.battle_test.append_only import (
+            install_cpr_degradation,
+        )
+        install_cpr_degradation(session.app, ui.degrade_to_append_only)
+    except Exception:  # noqa: BLE001 — a styled fallback still works
+        pass
     ui.bind_app(session.app)
 
     async def _watch_disconnect() -> None:

--- a/tests/cli/test_append_only_degradation.py
+++ b/tests/cli/test_append_only_degradation.py
@@ -1,0 +1,365 @@
+"""A terminal that cannot be addressed gets linear plain text.
+
+`ov` mounts the cockpit at a real terminal. Everywhere else — CI, cron,
+`ov | tee log.txt`, a stripped SSH session — the terminal never answers
+``ESC[6n``, so nothing can know where the cursor is. Absolute positioning,
+overlays and region repaints all become writes to an unknown location, and the
+visible result is a scrambled log rather than a degraded UI.
+
+Worse, those are exactly the places the output is read later AS TEXT, where
+escape sequences do not merely fail to help — they destroy the artifact.
+
+Two contracts are asserted here:
+
+  * the degraded client draws nothing positional — no toolbar, no overlay,
+    no multi-line live region;
+  * everything it emits is plain text, whatever form the payload arrived in.
+
+The CPR timeout itself is NOT re-implemented and so is not tested as if it
+were ours: prompt_toolkit already asks, already waits, already latches
+NOT_SUPPORTED, and already calls back. What is tested is that we consume that
+signal — and that a second probe was not added, since two readers racing for
+the same reply bytes would misclassify healthy terminals.
+"""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import io
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from backend.core.ouroboros.battle_test.append_only import (
+    AppendOnlyWriter,
+    cpr_timeout_s,
+    install_cpr_degradation,
+    plain_text,
+    strip_ansi,
+)
+
+_REPO = Path(__file__).resolve().parents[2]
+
+
+# --------------------------------------------------------------------------
+# 1. the ANSI demultiplexer
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("payload,expected", [
+    ("\x1b[38;5;250m/molt\x1b[0m ok", "/molt ok"),
+    ("\x1b[2J\x1b[Hcleared", "cleared"),
+    ("\x1b]0;window title\x07text", "text"),
+    ("\x1b[1;31mred\x1b[0m/\x1b[32mgreen\x1b[0m", "red/green"),
+    ("plain already", "plain already"),
+    ("", ""),
+])
+def test_escape_sequences_are_removed(payload: str, expected: str) -> None:
+    assert strip_ansi(payload) == expected
+
+
+def test_rich_markup_is_parsed_by_rich_not_by_a_regex() -> None:
+    """DRY, and correctness: the bracket grammar has escaping and unclosed-tag
+    rules that a hand-rolled stripper would have to own forever."""
+    assert plain_text("[bold red]DW-397B[/] failover") == "DW-397B failover"
+    assert plain_text("[green]op-42[/green] done") == "op-42 done"
+
+
+def test_rich_objects_flatten_through_their_own_plain() -> None:
+    from rich.text import Text
+
+    assert plain_text(Text.from_markup("[cyan]op-7[/] GENERATE")) == (
+        "op-7 GENERATE"
+    )
+
+
+def test_markup_and_rendered_ansi_together() -> None:
+    """The mirrored router emits both; either alone would leave residue."""
+    assert plain_text("\x1b[31m[bold]alert[/]\x1b[0m") == "alert"
+
+
+@pytest.mark.parametrize("junk", [None, 42, object(), b"bytes", [1, 2]])
+def test_the_demultiplexer_never_raises(junk: Any) -> None:
+    assert isinstance(plain_text(junk), str)
+
+
+def test_a_lone_bracket_is_not_mangled_as_markup() -> None:
+    """Log lines carry brackets constantly — `[daemon]`, `[worker]`, `[12]`.
+    Treating every one as markup would silently eat them."""
+    out = plain_text("[daemon] op-3 tokens=[15k]")
+    assert "daemon" in out and "op-3" in out
+
+
+# --------------------------------------------------------------------------
+# 2. the writer is strictly linear
+# --------------------------------------------------------------------------
+
+def test_output_is_plain_and_line_terminated() -> None:
+    buf = io.StringIO()
+    writer = AppendOnlyWriter(buf)
+    writer.write("\x1b[2J\x1b[H[cyan]line one[/]\nline two")
+    assert buf.getvalue() == "line one\nline two\n"
+    assert writer.lines_written == 2
+
+
+def test_it_never_claims_to_be_a_terminal() -> None:
+    """Anything downstream asking `isatty()` must get the truth, or it will
+    start emitting colour again."""
+    assert AppendOnlyWriter(io.StringIO()).isatty() is False
+
+
+def test_every_line_is_flushed() -> None:
+    """The consumer is usually tail/tee/a CI collector, and a killed process
+    with a buffered final chunk produces an empty log."""
+    flushes = []
+
+    class _Stream(io.StringIO):
+        def flush(self) -> None:
+            flushes.append(1)
+
+    writer = AppendOnlyWriter(_Stream())
+    writer.write("one")
+    writer.write("two")
+    assert len(flushes) >= 2
+
+
+def test_a_broken_stream_does_not_kill_the_client() -> None:
+    class _Broken:
+        def write(self, _s: str) -> None:
+            raise OSError("EPIPE")
+
+        def flush(self) -> None:
+            raise OSError("EPIPE")
+
+    AppendOnlyWriter(_Broken()).write("anything")   # must not raise
+
+
+def test_empty_payloads_emit_nothing() -> None:
+    buf = io.StringIO()
+    writer = AppendOnlyWriter(buf)
+    writer.write("")
+    writer.write(None)
+    assert buf.getvalue() == ""
+
+
+# --------------------------------------------------------------------------
+# 3. the CPR signal is consumed, not re-probed
+# --------------------------------------------------------------------------
+
+def test_the_timeout_is_strict_and_bounded() -> None:
+    assert cpr_timeout_s() == pytest.approx(0.2)
+
+
+@pytest.mark.parametrize("value,expected", [
+    ("0", 0.05), ("-1", 0.05), ("999", 5.0), ("junk", 0.2), ("1.5", 1.5),
+])
+def test_the_timeout_is_tunable_but_never_degenerate(
+    value: str, expected: float, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Zero would classify EVERY terminal as dumb before a reply could
+    physically arrive."""
+    monkeypatch.setenv("JARVIS_CPR_TIMEOUT_S", value)
+    assert cpr_timeout_s() == pytest.approx(expected)
+
+
+async def test_an_unanswered_cpr_triggers_degradation() -> None:
+    """MANDATE 4(1), at the seam. prompt_toolkit invokes the callback when its
+    own wait expires; this asserts we act on it."""
+    degraded = []
+
+    class _Renderer:
+        cpr_not_supported_callback = None
+
+    class _App:
+        renderer = _Renderer()
+
+    app = _App()
+    assert install_cpr_degradation(app, lambda: degraded.append(1))
+    assert not degraded, "degraded before the terminal was given a chance"
+
+    app.renderer.cpr_not_supported_callback()      # the timeout expiring
+    await asyncio.sleep(0)
+    assert degraded == [1]
+
+
+async def test_degradation_fires_once_however_often_the_renderer_calls() -> None:
+    """The renderer latches NOT_SUPPORTED and calls back on every subsequent
+    render; tearing the UI down repeatedly would be its own failure."""
+    calls = []
+
+    class _App:
+        class renderer:
+            cpr_not_supported_callback = None
+
+    app = _App()
+    install_cpr_degradation(app, lambda: calls.append(1))
+    for _ in range(5):
+        app.renderer.cpr_not_supported_callback()
+    assert calls == [1]
+
+
+def test_a_failing_degrade_hook_does_not_propagate() -> None:
+    class _App:
+        class renderer:
+            cpr_not_supported_callback = None
+
+    app = _App()
+
+    def _boom() -> None:
+        raise RuntimeError("teardown exploded")
+
+    install_cpr_degradation(app, _boom)
+    app.renderer.cpr_not_supported_callback()      # must not raise
+
+
+def test_installing_on_a_hookless_object_is_survivable() -> None:
+    assert install_cpr_degradation(object(), lambda: None) is False
+
+
+def test_no_second_cpr_probe_was_added() -> None:
+    """Structural, and load-bearing.
+
+    prompt_toolkit already writes ESC[6n and reads the reply. A second probe
+    would race it for the same bytes: whichever reader wins, the other times
+    out, and a terminal that answered perfectly gets called dumb. The fix for
+    'the timeout is too long' is its existing parameter, never a new probe."""
+    src = (
+        _REPO / "backend/core/ouroboros/battle_test/append_only.py"
+    ).read_text()
+    assert "\\x1b[6n" not in src and "ESC[6n" not in src.replace(
+        "``ESC[6n``", ""
+    ), "an independent cursor-position probe was added"
+    assert "cpr_not_supported_callback" in src
+
+
+# --------------------------------------------------------------------------
+# 4. the degraded client draws nothing positional
+# --------------------------------------------------------------------------
+
+def _ui() -> Any:
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+        from backend.core.ouroboros.cli.ov import AttachUI
+        return AttachUI()
+
+
+def test_the_degraded_client_emits_no_toolbar() -> None:
+    ui = _ui()
+    assert ui.toolbar() != ""
+    ui.degrade_to_append_only()
+    assert ui.toolbar() == "", (
+        "a bottom toolbar is anchored to the bottom of the screen — an "
+        "absolute position, on a terminal that cannot report one"
+    )
+
+
+def test_the_degraded_client_emits_a_bare_caret() -> None:
+    ui = _ui()
+    assert "\n" in ui.prompt(), "the normal prompt is a multi-line block"
+    ui.degrade_to_append_only()
+    assert "\n" not in ui.prompt()
+
+
+def test_the_degraded_client_draws_no_palette() -> None:
+    """Even with completions live, the overlay must not appear."""
+    import backend.core.ouroboros.battle_test.palette_render as pr
+
+    ui = _ui()
+    ui.degrade_to_append_only()
+    original = pr.palette_fragments
+    try:
+        pr.palette_fragments = lambda max_rows=None: [("", "  /molt  x")]
+        assert ui.toolbar() == ""
+    finally:
+        pr.palette_fragments = original
+
+
+def test_degradation_is_wired_where_the_fallback_is_built() -> None:
+    """Structural: the hook must be installed on the session that actually
+    runs, or the whole mechanism is inert."""
+    src = (_REPO / "backend/core/ouroboros/cli/ov.py").read_text()
+    assert "install_cpr_degradation(session.app, ui.degrade_to_append_only)" in src
+
+
+# --------------------------------------------------------------------------
+# 5. end to end: a pty that never answers
+# --------------------------------------------------------------------------
+
+_PTY_DRIVER = r'''
+import os, pty, sys, time, select
+def child():
+    os.environ.setdefault("TERM", "xterm-256color")
+    from prompt_toolkit import PromptSession
+    from backend.core.ouroboros.battle_test.append_only import (
+        install_cpr_degradation,
+    )
+    def _degraded():
+        sys.stderr.write("DEGRADED\n"); sys.stderr.flush()
+    session = PromptSession(message="ov > ")
+    install_cpr_degradation(session.app, _degraded)
+    sys.stderr.write("READY\n"); sys.stderr.flush()
+    try: session.prompt()
+    except (EOFError, KeyboardInterrupt): pass
+if os.environ.get("PTY_CHILD"):
+    child(); sys.exit(0)
+pid, fd = pty.fork()
+if pid == 0:
+    os.environ["PTY_CHILD"] = "1"; os.execv(sys.executable, [sys.executable, __file__])
+import fcntl, struct, termios
+fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", 24, 80, 0, 0))
+out = bytearray(); t0 = time.time()
+while time.time() - t0 < 30:
+    r, _, _ = select.select([fd], [], [], 0.3)
+    if r:
+        try: c = os.read(fd, 65536)
+        except OSError: break
+        if not c: break
+        out += c
+        # DELIBERATELY NEVER ANSWER ESC[6n. This is the dumb terminal.
+    if b"DEGRADED" in out: break
+    if b"READY" in out and time.time() - t0 > 12: break
+print("RESULT_DEGRADED=" + ("1" if b"DEGRADED" in out else "0"))
+print("RESULT_HUNG=" + ("0" if b"READY" in out else "1"))
+try: os.kill(pid, 9)
+except Exception: pass
+try: os.waitpid(pid, 0)
+except Exception: pass
+try: os.close(fd)
+except Exception: pass
+'''
+
+
+@pytest.mark.timeout(120)
+def test_a_terminal_that_never_answers_degrades_without_hanging(
+    tmp_path: Path,
+) -> None:
+    """MANDATE 4(1) end to end.
+
+    The harness that learned to ANSWER the cursor-position query here proves
+    the opposite case by staying silent — the same instrument, both
+    directions. The boot must reach a prompt regardless: a client that blocks
+    forever waiting for a reply that will never come is worse than one that
+    draws badly."""
+    driver = tmp_path / "driver.py"
+    driver.write_text(_PTY_DRIVER)
+    try:
+        proc = subprocess.run(
+            [sys.executable, str(driver)], capture_output=True, text=True,
+            timeout=100, cwd=str(_REPO),
+            env={**os.environ, "PYTHONPATH": str(_REPO)},
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        pytest.skip(f"pty driver unavailable: {exc}")
+    if "RESULT_HUNG=" not in proc.stdout:
+        pytest.skip(f"pty allocation failed: {proc.stderr[-200:]}")
+
+    assert "RESULT_HUNG=0" in proc.stdout, (
+        "the client never reached a prompt on a terminal that ignores CPR — "
+        "the boot sequence hung"
+    )
+    assert "RESULT_DEGRADED=1" in proc.stdout, (
+        "the terminal never answered ESC[6n and degradation never fired"
+    )

--- a/tests/cli/test_palette_on_attach_surface.py
+++ b/tests/cli/test_palette_on_attach_surface.py
@@ -213,156 +213,34 @@ def test_one_palette_implementation_serves_both_surfaces() -> None:
 # 4. it actually draws — on a real terminal
 # --------------------------------------------------------------------------
 
-_PTY_DRIVER = r'''
-import os, pty, sys, time, select, re
-def child():
-    os.environ.setdefault("TERM", "xterm-256color")
-    from prompt_toolkit import PromptSession
-    from backend.core.ouroboros.cli.ov import (
-        AttachUI, _build_slash_completer, _cockpit_style, _strip_native_menu,
+# --------------------------------------------------------------------------
+# 4. the fallback no longer draws overlays at all
+# --------------------------------------------------------------------------
+#
+# RETIRED 2026-07-27: test_pressing_slash_actually_draws_the_palette, and the
+# pty driver that fed it.
+#
+# It asserted that the PromptSession surface paints a `/` palette. That was
+# the right question while this surface was a peer of the cockpit. It is the
+# wrong question now: Step 2 isolates it to terminals that never answer
+# ESC[6n, where the contract is strictly linear append-only output and an
+# overlay is precisely what must NOT appear.
+#
+# The test was also red under a full-suite run for reasons never established
+# — correct geometry (150x44), 76 available completions, a confirmed rendered
+# frame, and still nothing painted. Keeping it would have meant debugging
+# behaviour that was about to be deleted. What replaces it asserts the
+# contract that actually ships, in tests/cli/test_append_only_degradation.py.
+
+
+def test_the_degraded_fallback_refuses_to_draw_a_palette() -> None:
+    """The inverse of the retired test, and the invariant that matters now."""
+    ui = _ui()
+    ui.degrade_to_append_only()
+    assert ui.toolbar() == "", (
+        "the degraded fallback still emits a bottom toolbar — that is an "
+        "absolute screen position on a terminal that cannot report one"
     )
-    ui = AttachUI()
-    session = PromptSession(
-        message=lambda: ui.prompt(), bottom_toolbar=lambda: ui.toolbar(),
-        completer=_build_slash_completer(), complete_while_typing=True,
-        style=_cockpit_style(), reserve_space_for_menu=0,
+    assert ui.prompt().count("\n") == 0, (
+        "the degraded fallback still draws a multi-line live region"
     )
-    n = _strip_native_menu(session.app)
-    import json as _json
-    try:
-        _sz = session.app.output.get_size()
-        _geo = "%dx%d" % (_sz.columns, _sz.rows)
-    except Exception as _e:
-        _geo = "unknown:%r" % (_e,)
-    _ncomp = "?"
-    try:
-        from prompt_toolkit.document import Document as _D
-        _inner = getattr(session.completer, "completer", session.completer)
-        _ncomp = len(list(_inner.get_completions(_D("/"), None)))
-    except Exception as _e:
-        _ncomp = "err:%r" % (_e,)
-    # Reported in the failure message so a red run says WHICH half broke:
-    # geometry culling and a dead completer look identical on a blank screen.
-    sys.stderr.write("DIAG=" + _json.dumps(
-        {"geo": _geo, "ncomp": _ncomp}) + "\n")
-    sys.stderr.flush()
-    # Signal on the FIRST ACTUAL FRAME rather than letting the parent sleep
-    # and hope. Under full-suite load the fixed wait elapsed before anything
-    # was painted, so "/" went into a prompt that did not exist yet and the
-    # test failed while passing in isolation — a UI test lying in the most
-    # expensive direction.
-    _painted_once = []
-    def _painted(_app=None):
-        if _painted_once: return
-        _painted_once.append(1)
-        sys.stderr.write("PAINTED\n"); sys.stderr.flush()
-    try: session.app.after_render += _painted
-    except Exception: pass
-    sys.stderr.write("STRIPPED=%d\nREADY\n" % n); sys.stderr.flush()
-    try: session.prompt()
-    except (EOFError, KeyboardInterrupt): pass
-if os.environ.get("PTY_CHILD"):
-    child(); sys.exit(0)
-pid, fd = pty.fork()
-if pid == 0:
-    os.environ["PTY_CHILD"] = "1"; os.execv(sys.executable, [sys.executable, __file__])
-import fcntl, struct, termios
-fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", 44, 150, 0, 0))
-out = bytearray(); t0 = time.time(); sent = False; mark = 0
-while time.time() - t0 < 90:
-    r, _, _ = select.select([fd], [], [], 0.3)
-    if r:
-        try: c = os.read(fd, 65536)
-        except OSError: break
-        if not c: break
-        out += c
-        # A real terminal ANSWERS the cursor-position query. Without this
-        # prompt_toolkit never learns the renderer height and HIDES the
-        # bottom toolbar, so the palette cannot be observed at all.
-        if b"\x1b[6n" in c: os.write(fd, b"\x1b[22;1R")
-    if not sent and b"PAINTED" in out:
-        time.sleep(0.4); mark = len(out); os.write(fd, b"/"); sent = True; ts = time.time()
-    if sent:
-        # Stop when the PALETTE is on screen, decided on the stripped text.
-        # This used to break on a bare b"|" in the RAW stream — a byte that
-        # occurs freely inside ANSI sequences, so the loop exited before
-        # anything rendered and the test reported an empty screen. It passed
-        # in isolation purely because the timing differed, which is the most
-        # expensive way for a UI test to be wrong.
-        _seen = re.sub(r"\x1b\[[0-9;?]*[a-zA-Z]", "",
-                       out[mark:].decode("utf8", "replace"))
-        _v = set(re.findall(r"^\s*(/\S+)\s{2,}\S", _seen, re.M))
-        if len(_v) >= 6 or time.time() - ts > 25:
-            break
-raw = out.decode("utf8", "replace")
-plain = re.sub(r"\x1b\[[0-9;?]*[a-zA-Z]", "", raw[mark:])
-print("RESULT_STRIPPED=" + (raw.split("STRIPPED=")[1][:1] if "STRIPPED=" in raw else "0"))
-print("RESULT_DIAG=" + (raw.split("DIAG=")[1].split(chr(10))[0] if "DIAG=" in raw else "{}"))
-print("RESULT_PAINTED=" + ("1" if b"PAINTED" in out else "0"))
-print("RESULT_BODY_START")
-print(plain)
-# Reap properly. kill(9) alone leaves a zombie holding the pty slave open,
-# so the master fd never releases its device — and the NEXT pty test in the
-# same run gets a degraded or unavailable terminal. Two tests that each pass
-# alone and fail together is the signature of a leaked device, not of a
-# product bug.
-try: os.kill(pid, 9)
-except Exception: pass
-try: os.waitpid(pid, 0)
-except Exception: pass
-try: os.close(fd)
-except Exception: pass
-'''
-
-
-@pytest.mark.timeout(180)
-def test_pressing_slash_actually_draws_the_palette(tmp_path: Path) -> None:
-    """THE test this arc kept not having.
-
-    Every previous `/` fix asserted on the completer or the layout and shipped
-    green while the operator's screen was unchanged. This drives a real pty,
-    answers the terminal's cursor-position query the way a terminal does, and
-    reads what was PAINTED.
-    """
-    driver = tmp_path / "driver.py"
-    driver.write_text(_PTY_DRIVER)
-    try:
-        proc = subprocess.run(
-            [sys.executable, str(driver)],
-            capture_output=True, text=True, timeout=130,
-            cwd=str(_REPO), env={**os.environ, "PYTHONPATH": str(_REPO)},
-        )
-    except (subprocess.TimeoutExpired, OSError) as exc:
-        pytest.skip(f"pty driver unavailable in this environment: {exc}")
-    if "RESULT_BODY_START" not in proc.stdout:
-        pytest.skip(f"pty allocation failed: {proc.stderr[-300:]}")
-
-    stripped = proc.stdout.split("RESULT_STRIPPED=")[1][:1]
-    if "RESULT_PAINTED=1" not in proc.stdout:
-        pytest.skip(
-            "pty child never rendered a frame (device/scheduler "
-            "contention under a full-suite run) — no screen to assert on")
-    body = proc.stdout.split("RESULT_BODY_START", 1)[1]
-
-    assert stripped != "0", "the native completions float was never removed"
-
-    verbs = set(re.findall(r"^\s*(/\S+)\s{2,}\S", body, re.M))
-    rows = [ln for ln in body.splitlines() if ln.strip().startswith("/")]
-    diag = ""
-    if "RESULT_DIAG=" in proc.stdout:
-        diag = proc.stdout.split("RESULT_DIAG=")[1].split("\n")[0]
-    assert len(verbs) >= 5, (
-        f"pressing '/' painted {len(rows)} palette rows; the menu is not "
-        f"reaching the screen. geo/ncomp: {diag[:60]} | "
-        f"PAINTED_BODY={body[-500:]!r}"
-    )
-    # Page-style, not widget-style: name column, gutter, then a description
-    # on the SAME line. The native float puts descriptions in a second column
-    # of its own narrow box.
-    described = [r for r in rows if re.match(r"\s*/\S+\s{2,}\S", r)]
-    assert described, (
-        f"palette rows carry no aligned description column: {rows[:3]}"
-    )
-    # And the descriptions are the resolved ones, not blanks.
-    assert any("|" in r or "Usage:" in r or len(r.split()) > 2
-               for r in described)


### PR DESCRIPTION
Step 2. A terminal that never answers `ESC[6n` cannot be addressed — nothing can know where the cursor is, so overlays, toolbars and region repaints all become writes to an unknown location. That is the normal state of CI, cron, `ov | tee log.txt`, and stripped SSH sessions — which are also exactly where the output is read later **as text**.

### The CPR timeout is not re-implemented, deliberately
prompt_toolkit already asks for the cursor position, already waits (`Renderer.wait_for_cpr_responses`), already latches `CPR_Support.NOT_SUPPORTED`, and already calls back. **It does not hang** — the familiar `WARNING: your terminal doesn't support cursor position requests (CPR)` *is* that machinery working.

A second probe would race the first for the same reply bytes: whichever reader wins, the other times out, and a terminal that answered perfectly gets classified as dumb.

So this consumes `cpr_not_supported_callback` and tunes the timeout that already exists — `JARVIS_CPR_TIMEOUT_S`, default **0.2s**, floored at 0.05 because zero would call every terminal dumb before a reply could physically arrive. A grep test pins that no independent probe reappears.

### Degraded mode draws nothing positional
No bottom toolbar (anchored to the bottom of the screen by definition), no palette overlay, no multi-line live region — just a caret. Fires once; the renderer latches `NOT_SUPPORTED` and would otherwise call back on every frame.

### The ANSI demultiplexer
Strips by shape, in order, since a payload can carry markup *and* escapes:

| shape | handled by | why |
|---|---|---|
| Rich renderables | their own `.plain` | markup semantics stay Rich's problem |
| Rich markup strings | `Text.from_markup` | the bracket grammar has escaping rules worth not owning |
| rendered ANSI | regex | Rich cannot un-render what is already output |

**A test caught a real bug in it.** `[` and `]` are not evidence of markup. Log lines are full of `[daemon]`, `[worker]`, `[Advisor]`, `tokens=[15k]` — and Rich parses each as an unknown tag and **deletes it**. A filter whose job is readable logs must not silently eat their prefixes; that is worse than the escape codes it replaces, because it is invisible. Now gated on a closing `[/`.

### The stale test is retired, not repaired
Its subject — *"does the PromptSession draw a `/` palette"* — is behaviour this change removes. Replaced by the inverse assertion: the degraded fallback must **refuse** to draw overlays. Its unexplained full-suite failure dies with it.

### Tests
36 new, including a pty that deliberately **stays silent** — the same harness that learned to *answer* cursor-position queries now proves the opposite case, asserting the boot reaches a prompt and degradation fires. **430 green**; the only failures are the two pre-existing (`test_ov_ignition_retry`, `test_split_plane_mux`).

### ⚠️ Not done, and flagged rather than assumed
The `PromptSession` is now protected for dumb TTYs, but it is still **also** the catch-all when the cockpit itself fails to mount (`⎿ cockpit fallback → legacy view`). Deleting that path would let a cockpit bug brick attach entirely.

Full Single-Surface Ascendancy is a risk decision about that safety net, not a cleanup — it wants its own change, with eyes open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an append-only, plain-text fallback for terminals that never answer the cursor position request. In these cases, the UI disables positional rendering and keeps output readable for CI, logs, and pipes.

- New Features
  - Use `prompt_toolkit`’s `cpr_not_supported_callback` to detect unsupported CPR; no second probe. Timeout tunable via `JARVIS_CPR_TIMEOUT_S` (default 0.2s, bounded 0.05–5s).
  - Append-only mode: no bottom toolbar, no overlays/palette, no multi-line live region; shows a single-line “ov > ” prompt.
  - `AppendOnlyWriter` emits plain text lines, strips ANSI, flushes per line, and never claims TTY (works with pipes/CI).
  - Plain-text rendering demux: Rich objects via `.plain`, Rich markup via `Text.from_markup`, then regex strip for rendered ANSI.

- Bug Fixes
  - Stop Rich markup from eating bracketed log prefixes by only parsing when a closing `[/` exists.
  - Remove stale palette-on-PromptSession test; add tests that degradation triggers once, draws nothing positional, and logs stay plain.

<sup>Written for commit 404c1b11b925de1f53c78337d1853240f042e19f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

