### PR TITLE
feat(ov): a software crash can no longer masquerade as a hardware downgrade

### DIFF
--- a/backend/core/ouroboros/battle_test/mount_breaker.py
+++ b/backend/core/ouroboros/battle_test/mount_breaker.py
@@ -1,0 +1,157 @@
+"""Tell a hardware downgrade apart from a software crash.
+
+The attach path has one fallback and two entirely different reasons to take
+it, and until now they printed the same line:
+
+    ⎿ cockpit fallback → legacy view (ValueError: ...)
+
+*Hardware* — no TTY, a kill-switch, a terminal that will not report its cursor
+position. Expected, correct, and nothing is wrong. It should be quiet.
+
+*Software* — the cockpit raised. A layout error, a bad IPC payload, an import
+that broke. Something IS wrong, and the evidence was being truncated to 80
+characters and thrown away with the traceback.
+
+Collapsing those into one message is how a crash hides: the operator reads a
+routine downgrade notice, the parachute opens, the session continues, and the
+bug is never reported. This module keeps the parachute and makes the two
+causes distinguishable — silence for hardware, a loud banner plus a full
+traceback on disk for software.
+
+Deliberately NOT re-raising. The fallback exists so a cockpit bug cannot brick
+attach, and that judgement is unchanged. Being loud is not the same as being
+fatal.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import traceback
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional, Tuple
+
+logger = logging.getLogger("Ouroboros.MountBreaker")
+
+__all__ = [
+    "HARDWARE",
+    "SOFTWARE",
+    "classify_mount_failure",
+    "crash_banner",
+    "crash_log_path",
+    "record_mount_crash",
+]
+
+#: The terminal cannot host the cockpit. Expected; stay quiet.
+HARDWARE = "hardware"
+#: The cockpit raised. Unexpected; be loud and keep the evidence.
+SOFTWARE = "software"
+
+
+def classify_mount_failure(
+    exc: Optional[BaseException], reason: str = "",
+) -> str:
+    """``HARDWARE`` or ``SOFTWARE``.
+
+    An exception is the only reliable evidence of a software fault, so the
+    classification is driven by whether one was raised rather than by pattern
+    matching the reason string. A reason is prose written for an operator; it
+    changes freely and is the wrong thing to branch on.
+    """
+    return SOFTWARE if exc is not None else HARDWARE
+
+
+def crash_log_path() -> Path:
+    """Where the traceback goes. ``JARVIS_OV_CRASH_LOG`` overrides."""
+    override = os.environ.get("JARVIS_OV_CRASH_LOG", "").strip()
+    if override:
+        return Path(override)
+    return Path(os.environ.get("JARVIS_REPO_PATH", ".")) / ".jarvis" / "logs" / "ov-crash.log"
+
+
+def record_mount_crash(
+    exc: BaseException, *, path: Optional[Path] = None,
+) -> Optional[Path]:
+    """Append the full traceback to the crash log. Returns the path, or None.
+
+    APPENDS rather than truncates: a cockpit that fails intermittently is a
+    much harder bug than one that fails always, and the previous occurrences
+    are the evidence that distinguishes them.
+
+    Returns None on any I/O failure — an unwritable log must not turn a
+    survivable crash into a fatal one, which would defeat the parachute this
+    exists to instrument.
+    """
+    target = path if path is not None else crash_log_path()
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        stamp = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        body = "".join(
+            traceback.format_exception(type(exc), exc, exc.__traceback__)
+        )
+        with target.open("a", encoding="utf-8") as handle:
+            handle.write(
+                f"\n{'=' * 72}\n"
+                f"[{stamp}] cockpit mount failed — degraded to safe mode\n"
+                f"{'=' * 72}\n{body}"
+            )
+        return target
+    except Exception:  # noqa: BLE001 — never escalate a survivable crash
+        logger.debug("[MountBreaker] could not write crash log", exc_info=True)
+        return None
+
+
+def crash_banner(exc: BaseException, path: Optional[Path]) -> str:
+    """The line an operator must not be able to scroll past without noticing.
+
+    Plain ASCII and no markup: this is printed at the moment the rich surface
+    has just proven it does not work, so it must not depend on anything the
+    failure might have taken with it.
+    """
+    name = type(exc).__name__
+    detail = str(exc).strip().splitlines()[0] if str(exc).strip() else ""
+    if len(detail) > 120:
+        detail = detail[:117] + "..."
+    where = str(path) if path else "(crash log unwritable)"
+    return (
+        "\n"
+        "!! FATAL MOUNT EXCEPTION - DEGRADING TO SAFE MODE\n"
+        f"!! {name}: {detail}\n"
+        f"!! full traceback: {where}\n"
+    )
+
+
+def announce(
+    exc: Optional[BaseException],
+    reason: str,
+    *,
+    emit: Any = print,
+    path: Optional[Path] = None,
+) -> Tuple[str, Optional[Path]]:
+    """Classify, record, and say the right thing. Returns (kind, log path).
+
+    The single seam both fallback causes pass through, so they cannot drift
+    into two policies. Hardware downgrades get one quiet line; software
+    crashes get the banner and a file. NEVER raises.
+    """
+    try:
+        kind = classify_mount_failure(exc, reason)
+        if kind == HARDWARE:
+            try:
+                emit(f"⎿ cockpit fallback → legacy view ({reason or 'unknown'})")
+            except Exception:  # noqa: BLE001
+                pass
+            return kind, None
+        assert exc is not None
+        log_path = record_mount_crash(exc, path=path)
+        try:
+            emit(crash_banner(exc, log_path))
+        except Exception:  # noqa: BLE001
+            pass
+        logger.error(
+            "[MountBreaker] cockpit mount raised %s — degraded to safe mode",
+            type(exc).__name__, exc_info=exc,
+        )
+        return kind, log_path
+    except Exception:  # noqa: BLE001
+        return HARDWARE, None

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -1733,6 +1733,7 @@ def run_attach(console: Any) -> int:
                 # cockpit can never brick the attach). Kill-switch:
                 # JARVIS_BIPARTITE_LAYOUT_DISABLED=1.
                 _why = ""
+                _crash: Optional[BaseException] = None
                 try:
                     from backend.core.ouroboros.battle_test.bipartite_layout import (
                         bipartite_enabled,
@@ -1746,16 +1747,39 @@ def run_attach(console: Any) -> int:
                     else:
                         _why = "stdout is not a real TTY"
                 except Exception as _exc:
+                    # A software crash, NOT a hardware downgrade. Keep the
+                    # exception itself: the old code truncated it to 80
+                    # characters, discarded the traceback, and printed the
+                    # same routine line a missing TTY produces — which is how
+                    # a cockpit bug reaches an operator disguised as normal
+                    # behaviour and never gets reported.
                     _ran_cockpit = False
+                    _crash = _exc
                     _why = f"{type(_exc).__name__}: {str(_exc)[:80]}"
                 if not _ran_cockpit:
-                    # Observability over silent reroute (operator law): say WHY
-                    # the cockpit did not mount before falling back.
+                    # ONE seam for both causes (DRY): quiet for hardware, a
+                    # banner plus a full traceback on disk for software. Both
+                    # then land in the same degraded session below.
                     try:
-                        console.print(
-                            f"⎿ cockpit fallback → legacy view ({_why or 'unknown'})",
-                            markup=False, highlight=False,
+                        from backend.core.ouroboros.battle_test.mount_breaker import (
+                            announce,
                         )
+                        _kind, _ = announce(
+                            _crash, _why,
+                            emit=lambda text: console.print(
+                                text, markup=False, highlight=False,
+                            ),
+                        )
+                        if _kind == "software":
+                            # A crash mid-render leaves the terminal in an
+                            # UNKNOWN state — possibly alt-screen, possibly
+                            # raw mode, cursor anywhere. The parachute must
+                            # therefore assume nothing about the screen and
+                            # emit strictly linear plain text, exactly as it
+                            # does for a terminal that cannot be addressed.
+                            # Hardware downgrades that still have a good TTY
+                            # keep their colour; nothing is broken there.
+                            ui.degrade_to_append_only()
                     except Exception:
                         pass
                     await _split_plane_loop(client, console, ui)

--- a/tests/cli/test_mount_circuit_breaker.py
+++ b/tests/cli/test_mount_circuit_breaker.py
@@ -1,0 +1,256 @@
+"""A software crash must not be able to look like a hardware downgrade.
+
+One fallback, two causes. Until now both printed the same line:
+
+    ⎿ cockpit fallback → legacy view (ValueError: ...)
+
+*Hardware* — no TTY, kill-switch, a terminal that will not report its cursor
+position. Expected; nothing is wrong; stay quiet.
+
+*Software* — the cockpit raised. Something IS wrong, and the evidence was
+being truncated to 80 characters with the traceback discarded.
+
+That collapse is how a crash hides: the operator reads a routine downgrade
+notice, the parachute opens, the session continues, and the bug is never
+reported. These tests pin that the two are distinguishable — and that being
+loud did NOT become being fatal, because the parachute is the whole point.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, List
+
+import pytest
+
+from backend.core.ouroboros.battle_test.mount_breaker import (
+    HARDWARE,
+    SOFTWARE,
+    announce,
+    classify_mount_failure,
+    crash_banner,
+    crash_log_path,
+    record_mount_crash,
+)
+
+_REPO = Path(__file__).resolve().parents[2]
+
+
+# --------------------------------------------------------------------------
+# 1. classification
+# --------------------------------------------------------------------------
+
+def test_no_exception_is_a_hardware_downgrade() -> None:
+    assert classify_mount_failure(None, "stdout is not a real TTY") == HARDWARE
+    assert classify_mount_failure(None, "kill-switch") == HARDWARE
+
+
+@pytest.mark.parametrize("exc", [
+    ValueError("layout"), ImportError("missing"), RuntimeError("ipc"),
+    KeyError("payload"), AttributeError("None has no .render"),
+])
+def test_any_exception_is_a_software_crash(exc: Exception) -> None:
+    assert classify_mount_failure(exc, "whatever") == SOFTWARE
+
+
+def test_classification_ignores_the_reason_prose() -> None:
+    """The reason is a sentence written for an operator — it changes freely.
+    Branching on it would make the classifier drift with the copy."""
+    assert classify_mount_failure(None, "ValueError: looks scary") == HARDWARE
+    assert classify_mount_failure(ValueError("x"), "just a TTY thing") == SOFTWARE
+
+
+# --------------------------------------------------------------------------
+# 2. the black box
+# --------------------------------------------------------------------------
+
+def _raised(exc_type: Any = ValueError, msg: str = "layout blew up"):
+    try:
+        raise exc_type(msg)
+    except Exception as exc:      # noqa: BLE001 — a real traceback is the point
+        return exc
+
+
+def test_the_full_traceback_reaches_disk(tmp_path: Path) -> None:
+    log = tmp_path / "ov-crash.log"
+    assert record_mount_crash(_raised(), path=log) == log
+    body = log.read_text()
+    assert "ValueError: layout blew up" in body
+    assert "Traceback" in body
+    assert "test_mount_circuit_breaker" in body, (
+        "the frames were lost — a one-line message is what this replaces"
+    )
+
+
+def test_crashes_append_rather_than_overwrite(tmp_path: Path) -> None:
+    """An intermittent cockpit failure is a far harder bug than a constant
+    one, and the earlier occurrences are what tell them apart."""
+    log = tmp_path / "ov-crash.log"
+    record_mount_crash(_raised(msg="first"), path=log)
+    record_mount_crash(_raised(msg="second"), path=log)
+    body = log.read_text()
+    assert "first" in body and "second" in body
+
+
+def test_a_missing_directory_is_created(tmp_path: Path) -> None:
+    log = tmp_path / "deep" / "nested" / "ov-crash.log"
+    assert record_mount_crash(_raised(), path=log) is not None
+    assert log.exists()
+
+
+def test_an_unwritable_log_does_not_escalate_the_crash(tmp_path: Path) -> None:
+    """The log instruments the parachute; it must never be the thing that
+    turns a survivable crash into a fatal one."""
+    blocker = tmp_path / "blocker"
+    blocker.write_text("i am a file, not a directory")
+    assert record_mount_crash(_raised(), path=blocker / "ov-crash.log") is None
+
+
+def test_the_log_path_is_overridable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JARVIS_OV_CRASH_LOG", "/tmp/somewhere/else.log")
+    assert crash_log_path() == Path("/tmp/somewhere/else.log")
+
+
+def test_the_default_path_is_under_dot_jarvis(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("JARVIS_OV_CRASH_LOG", raising=False)
+    assert crash_log_path().name == "ov-crash.log"
+    assert ".jarvis" in str(crash_log_path())
+
+
+# --------------------------------------------------------------------------
+# 3. the banner
+# --------------------------------------------------------------------------
+
+def test_the_banner_names_the_fault_and_where_to_look(tmp_path: Path) -> None:
+    banner = crash_banner(_raised(), tmp_path / "ov-crash.log")
+    assert "FATAL MOUNT EXCEPTION" in banner
+    assert "SAFE MODE" in banner
+    assert "ValueError" in banner
+    assert "ov-crash.log" in banner
+
+
+def test_the_banner_survives_an_unwritable_log() -> None:
+    assert "unwritable" in crash_banner(_raised(), None)
+
+
+def test_the_banner_carries_no_markup() -> None:
+    """It prints at the moment the rich surface just proved it does not work,
+    so it must not depend on anything the failure may have taken with it."""
+    banner = crash_banner(_raised(), Path("/tmp/x.log"))
+    assert "[" not in banner.replace("[6n", "")
+    assert "\x1b" not in banner
+
+
+def test_an_enormous_exception_message_is_bounded() -> None:
+    banner = crash_banner(_raised(msg="x" * 5000), Path("/tmp/x.log"))
+    assert len(banner) < 500, "a runaway message would push the banner offscreen"
+
+
+def test_a_multiline_exception_message_stays_on_one_line() -> None:
+    banner = crash_banner(_raised(msg="line one\nline two"), Path("/tmp/x.log"))
+    assert "line two" not in banner
+
+
+# --------------------------------------------------------------------------
+# 4. the seam — one path in, two behaviours out
+# --------------------------------------------------------------------------
+
+def test_a_hardware_downgrade_stays_quiet() -> None:
+    out: List[str] = []
+    kind, log = announce(None, "stdout is not a real TTY", emit=out.append)
+    assert kind == HARDWARE
+    assert log is None
+    assert len(out) == 1
+    assert "FATAL" not in out[0]
+    assert "not a real TTY" in out[0]
+
+
+def test_a_software_crash_is_loud_and_recorded(tmp_path: Path) -> None:
+    """MANDATE 4(1): trips Path B, writes the log, does not kill anything."""
+    out: List[str] = []
+    log = tmp_path / "ov-crash.log"
+    kind, written = announce(
+        _raised(), "ValueError: layout blew up", emit=out.append, path=log,
+    )
+    assert kind == SOFTWARE
+    assert written == log and log.exists()
+    assert "FATAL MOUNT EXCEPTION" in "".join(out)
+    assert "Traceback" in log.read_text()
+
+
+def test_the_seam_never_raises_however_badly_it_is_used() -> None:
+    """It runs at the exact moment something else already failed."""
+    def _boom(_text: str) -> None:
+        raise OSError("stdout is gone too")
+
+    announce(_raised(), "x", emit=_boom)                 # must not raise
+    announce(None, "x", emit=_boom)
+    announce(_raised(), "x", emit=None)                  # type: ignore[arg-type]
+
+
+# --------------------------------------------------------------------------
+# 5. wiring
+# --------------------------------------------------------------------------
+
+def test_the_attach_path_routes_both_causes_through_one_seam() -> None:
+    """DRY, asserted structurally: two branches printing their own message is
+    exactly the arrangement that let a crash impersonate a downgrade."""
+    src = (_REPO / "backend/core/ouroboros/cli/ov.py").read_text()
+    assert "from backend.core.ouroboros.battle_test.mount_breaker import" in src
+    assert "announce(" in src
+    assert '_crash = _exc' in src, (
+        "the exception is being discarded again — a truncated str() cannot be "
+        "classified or logged"
+    )
+
+
+def test_a_software_crash_forces_append_only_output() -> None:
+    """A crash mid-render leaves the terminal in an unknown state — possibly
+    alt-screen, possibly raw mode, cursor anywhere. The parachute must assume
+    nothing about the screen."""
+    src = (_REPO / "backend/core/ouroboros/cli/ov.py").read_text()
+    assert 'if _kind == "software":' in src
+    assert "ui.degrade_to_append_only()" in src
+
+
+def test_a_hardware_downgrade_keeps_its_colour() -> None:
+    """The inverse, and it matters: a missing TTY on an otherwise healthy
+    terminal is not a reason to strip every operator's output to plain text."""
+    import ast
+
+    src = (_REPO / "backend/core/ouroboros/cli/ov.py").read_text()
+    tree = ast.parse(src)
+
+    # Asserted on the AST, not on a character window. The first version of
+    # this sliced 400 characters after the branch and broke the moment a
+    # comment was added above the call — measuring prose length, not
+    # structure, which is the same mistake a proximity pin makes.
+    guarded = False
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.If):
+            continue
+        if "_kind" not in ast.unparse(node.test) or "software" not in ast.unparse(node.test):
+            continue
+        body = "\n".join(ast.unparse(stmt) for stmt in node.body)
+        assert "degrade_to_append_only" in body, (
+            "the software branch no longer forces append-only output"
+        )
+        guarded = True
+    assert guarded, "the `_kind == software` branch is gone"
+
+    # And it appears NOWHERE else in the attach flow, so a hardware downgrade
+    # on a healthy terminal keeps its colour.
+    assert src.count("ui.degrade_to_append_only()") == 1, (
+        "append-only is being forced outside the software-crash branch — a "
+        "missing TTY is not a reason to strip every operator's output"
+    )
+
+
+async def test_the_breaker_does_not_re_raise() -> None:
+    """Being loud is not the same as being fatal. The fallback exists so a
+    cockpit bug cannot brick attach, and that judgement is unchanged."""
+    out: List[str] = []
+    kind, _ = announce(_raised(), "boom", emit=out.append,
+                       path=Path("/dev/null/nope/ov-crash.log"))
+    assert kind == SOFTWARE          # reached the end, nothing propagated

--- a/tests/cli/test_split_plane_mux.py
+++ b/tests/cli/test_split_plane_mux.py
@@ -138,9 +138,24 @@ def test_non_tty_degrades_to_legacy_pump():
 def test_line_renderer_resolves_stdout_dynamically():
     """The pre-bound Rich console would bypass patch_stdout and corrupt
     the prompt — daemon lines must go through builtin print()."""
+    import ast
+
+    # Asserted on the FUNCTION, not on a 700-character window after its name.
+    # The window measured how much prose sat between the def and the call, so
+    # it failed the moment a comment was added — the same defect as a
+    # proximity pin. The invariant never changed.
     src = _src()
-    body = src[src.index("def _print_line"):][:700]
-    assert "print(text)" in body
+    body = None
+    for node in ast.walk(ast.parse(src)):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and \
+                node.name == "_print_line":
+            body = "\n".join(ast.unparse(stmt) for stmt in node.body)
+            break
+    assert body is not None, "_print_line is gone"
+    assert "print(" in body, (
+        "daemon lines no longer go through builtin print() — a pre-bound Rich "
+        "console bypasses patch_stdout and corrupts the prompt"
+    )
     assert "console.print" not in body
 
 


### PR DESCRIPTION
One fallback, two causes, one message. Until now both printed:

```
⎿ cockpit fallback → legacy view (ValueError: ...)
```

| | cause | correct behaviour |
|---|---|---|
| **Hardware** | no TTY, kill-switch, terminal won't report cursor position | expected — stay quiet |
| **Software** | the cockpit raised | something IS wrong — be loud, keep evidence |

Collapsing them is how a crash hides: the operator reads a routine downgrade notice, the parachute opens, the session continues, and the bug is never reported. The exception was being truncated to 80 characters and the traceback thrown away.

### Classification
Driven by **whether an exception was raised** — never by pattern-matching the reason string, which is prose written for an operator and changes freely.

### The black box
Path B writes the full traceback to `.jarvis/logs/ov-crash.log`, **appending** rather than truncating: an intermittent cockpit failure is far harder to diagnose than a constant one, and the earlier occurrences are what distinguish them.

The banner is plain ASCII with no markup — it renders at the moment the rich surface just proved it does not work, so it must not depend on anything the failure may have taken with it.

```
!! FATAL MOUNT EXCEPTION - DEGRADING TO SAFE MODE
!! ValueError: layout blew up
!! full traceback: /…/.jarvis/logs/ov-crash.log
```

### Append-only after a software crash
A crash mid-render leaves the terminal in an **unknown** state — possibly alt-screen, possibly raw mode, cursor anywhere — so the parachute assumes nothing about the screen.

A hardware downgrade on an otherwise healthy terminal **keeps its colour**; pinned by asserting the degrade call appears exactly once, inside that branch.

### Loud is not fatal
Nothing re-raises. An unwritable crash log returns `None` rather than turning a survivable crash into a process death — the log instruments the parachute, it must never be what breaks it.

### Also fixes a pre-existing failure
`test_line_renderer_resolves_stdout_dynamically` sliced 700 characters after `def _print_line` and broke when a comment grew. That measures prose length, not structure — the same defect as a proximity pin. Re-expressed against the AST; the invariant is unchanged.

My own new wiring test made the identical mistake and was rewritten the same way before it shipped.

### Tests
25 new. **456 green.**

### ⚠️ Still red, and not this change
`test_attaches_when_the_incumbent_simply_finishes_booting` monkeypatches `probe_socket` and `_live_incumbent` yet still times out after 24s — consistent with the recorded trap where a warm dev daemon on the machine holds the real repo lock. Environment-sensitive and pre-existing; left alone rather than guessed at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents software cockpit crashes from looking like routine hardware downgrades. Adds a mount circuit-breaker that logs full tracebacks, shows a clear banner, and forces append-only output on crash while keeping hardware downgrades quiet and colorful.

- New Features
  - Introduced `mount_breaker.announce()` as the single seam that classifies failures by whether an exception was raised (never by message text).
  - On software crash: append full traceback to `.jarvis/logs/ov-crash.log` (override with `JARVIS_OV_CRASH_LOG`), print a plain-ASCII fatal banner, then switch UI to append-only; hardware downgrade prints one quiet line and keeps color.
  - Never re-raises; if the crash log can’t be written, returns `None` to avoid escalating a survivable crash.
  - Routed `ov.py` through this seam and updated tests with AST-based assertions; added coverage for the circuit-breaker behavior.

<sup>Written for commit 323dcf19cd256f8b8043398795acf1ae91a56b1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

