### PR TITLE
fix(test): the ignition fake returns what probe_socket actually returns

### DIFF
--- a/tests/cli/test_ov_ignition_retry.py
+++ b/tests/cli/test_ov_ignition_retry.py
@@ -53,8 +53,16 @@ async def test_attaches_when_the_incumbent_simply_finishes_booting(monkeypatch):
     state = {"n": 0}
 
     async def _probe(_p, **_k):
+        # The REAL probe_socket returns a CLASSIFICATION STRING, and
+        # _await_ignition_window compares `== "live"`. This fake returned a
+        # bool, so the comparison could never be true and the test burned the
+        # entire retry budget before failing — which read exactly like a
+        # 24-second IPC timeout bleeding in from a host daemon.
+        #
+        # It was never the host. A fake that does not mirror the real
+        # contract cannot fail in a way that points at itself.
         state["n"] += 1
-        return state["n"] > 2
+        return "live" if state["n"] > 2 else "stale"
 
     monkeypatch.setattr(tc, "probe_socket", _probe)
     monkeypatch.setattr(tc, "_live_incumbent", lambda: 999)   # never releases


### PR DESCRIPTION
**457/457.** The last red test was never IPC bleed from the host daemon.

### The actual cause

`_await_ignition_window` does:

```python
if await probe_socket(path, deep=True) == "live":
```

`probe_socket` returns a **classification string**. The test's fake returned `state["n"] > 2` — a **bool**. The comparison could never be true, so the test burned the entire retry budget before failing.

### Why it looked like environment bleed
A 24-second wall-clock timeout in a test that touches sockets reads exactly like a collision with a live UDS — and the machine genuinely did have a warm daemon holding the repo lock. The symptom matched the wrong cause precisely.

It reproduces with the daemon running, and passes with the daemon running:

```
24.4s  →  3.1s
```

Nothing about the host changed.

### No hermetic socket fixture was built, deliberately
It was scoped to fix this failure, and this failure is not what it treats. An autouse fixture redirecting `JARVIS_SOCKET_DIR` across the suite would have left the stale fake in place — still comparing a bool against a string — and would have been credited with a fix it did not make.

Isolation from host daemons is worth having on its own merits. It is not this bug, and I'd rather propose it as its own change than let it absorb the credit here.

### The part worth keeping
The comment two lines above the comparison already warned about this exact trap — *"`== 'live'`, NOT truthiness"*. The fake predated the contract change, and no test could catch it: **a fake that does not mirror the real contract cannot fail in a way that points at itself.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the ignition test fake to return the same classification strings as the real `probe_socket`, allowing `_await_ignition_window` to correctly match `"live"` and avoid burning the retry budget. Removes a misleading timeout that looked like host daemon IPC bleed; runtime drops from ~24s to ~3s.

<sup>Written for commit 70472daa69c2427f9c8391ef16859332c8858659. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

