### PR TITLE
test: fakes that cannot drift from the functions they stand in for

### DIFF
--- a/tests/cli/test_mock_contract_enforcement.py
+++ b/tests/cli/test_mock_contract_enforcement.py
@@ -1,0 +1,201 @@
+"""Mock drift is caught by the machine, not by remembering.
+
+The bug this closes cost a 24-second timeout, a wrong diagnosis (IPC bleed
+from a live daemon), and a designed-but-unbuilt hermetic socket sandbox —
+before anyone noticed the fake returned a bool where the real
+``probe_socket`` returns a classification string.
+
+Nothing could have caught it. A fake IS the boundary in a unit test, so a
+fake that lies makes the test agree with the lie; the failure surfaces
+elsewhere wearing a disguise.
+
+"Remember to update the fakes" is a policy enforced by human memory, which is
+the thing that already failed. These tests pin the enforcement instead.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from tests.contract_fakes import (
+    ContractMismatchError,
+    autospec_fake,
+    contract_fake,
+    returns_match,
+)
+
+
+# --------------------------------------------------------------------------
+# 1. the exact historical bug
+# --------------------------------------------------------------------------
+
+async def test_the_probe_socket_drift_is_caught() -> None:
+    """MANDATE 4, against the real production signature.
+
+    ``probe_socket`` is annotated ``-> str`` and the caller compares
+    ``== "live"``. A bool can never satisfy that, and this is where it stops.
+    """
+    from backend.core.ouroboros.cli import thin_client as tc
+
+    state = {"n": 0}
+
+    def _drifted(_p: Any, **_k: Any) -> Any:
+        state["n"] += 1
+        return state["n"] > 2          # the original defect, verbatim
+
+    probe = contract_fake(tc.probe_socket, _drifted)
+    with pytest.raises(ContractMismatchError) as caught:
+        await probe("/tmp/x.sock", deep=True)
+    assert "probe_socket" in str(caught.value)
+    assert "str" in str(caught.value)
+
+
+async def test_the_corrected_fake_passes_unobstructed() -> None:
+    """The fix that made the suite green must not now be blocked."""
+    from backend.core.ouroboros.cli import thin_client as tc
+
+    state = {"n": 0}
+
+    def _correct(_p: Any, **_k: Any) -> Any:
+        state["n"] += 1
+        return "live" if state["n"] > 2 else "stale"
+
+    probe = contract_fake(tc.probe_socket, _correct)
+    assert await probe("/tmp/x.sock") == "stale"
+    assert await probe("/tmp/x.sock") == "stale"
+    assert await probe("/tmp/x.sock") == "live"
+
+
+def test_optional_int_boundaries_are_enforced() -> None:
+    """``_live_incumbent -> Optional[int]``: a PID or nothing."""
+    from backend.core.ouroboros.cli import thin_client as tc
+
+    assert contract_fake(tc._live_incumbent, lambda: 999)() == 999
+    assert contract_fake(tc._live_incumbent, lambda: None)() is None
+    with pytest.raises(ContractMismatchError):
+        contract_fake(tc._live_incumbent, lambda: "999")()
+
+
+# --------------------------------------------------------------------------
+# 2. the type rules
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("value,declared,ok", [
+    ("live", str, True),
+    (True, str, False),
+    (1, str, False),
+    (None, Optional[int], True),
+    (5, Optional[int], True),
+    ("5", Optional[int], False),
+    ([], List[str], True),
+    ({}, Dict[str, int], True),
+    ("x", Any, True),
+    (None, None, True),
+])
+def test_the_matcher(value: Any, declared: Any, ok: bool) -> None:
+    assert returns_match(value, declared) is ok
+
+
+def test_a_bool_is_not_accepted_as_an_int() -> None:
+    """``bool`` IS a subclass of ``int`` in Python, so ``Optional[int]`` would
+    silently accept ``True`` — precisely the confusion this exists to catch."""
+    assert returns_match(True, int) is False
+    assert returns_match(True, Optional[int]) is False
+    assert returns_match(1, int) is True
+
+
+def test_a_bool_return_is_still_allowed_where_bool_is_declared() -> None:
+    """The rule above must not make honest bools unrepresentable."""
+    from backend.core.ouroboros.cli import thin_client as tc
+
+    assert contract_fake(tc.ensure_daemon, lambda **_k: True) is not None
+    assert returns_match(True, bool) is True
+
+
+# --------------------------------------------------------------------------
+# 3. it stays out of the way
+# --------------------------------------------------------------------------
+
+def test_an_unannotated_target_is_passed_through_untouched() -> None:
+    """No annotation means nothing to enforce. Wrapping anyway would give
+    false confidence — the checker would look installed and check nothing."""
+    def unannotated(x):
+        return x
+
+    fake = lambda x: x                                   # noqa: E731
+    assert contract_fake(unannotated, fake) is fake
+
+
+def test_async_targets_yield_awaitable_doubles() -> None:
+    """The double must await the way production does, or the call site has to
+    know it is talking to a test."""
+    import inspect
+
+    from backend.core.ouroboros.cli import thin_client as tc
+
+    assert inspect.iscoroutinefunction(
+        contract_fake(tc.probe_socket, lambda *_a, **_k: "live")
+    )
+    assert not inspect.iscoroutinefunction(
+        contract_fake(tc._live_incumbent, lambda: None)
+    )
+
+
+async def test_an_async_fake_is_awaited_before_checking() -> None:
+    """Fakes are written both ways; both must be enforced."""
+    from backend.core.ouroboros.cli import thin_client as tc
+
+    async def _async_fake(*_a: Any, **_k: Any) -> Any:
+        return True                                      # wrong type
+
+    with pytest.raises(ContractMismatchError):
+        await contract_fake(tc.probe_socket, _async_fake)("/tmp/x")
+
+
+def test_arguments_reach_the_fake_unchanged() -> None:
+    from backend.core.ouroboros.cli import thin_client as tc
+
+    seen: List[Any] = []
+
+    def _fake(path: Any, **kwargs: Any) -> Any:
+        seen.append((path, kwargs))
+        return None
+
+    contract_fake(tc._live_incumbent, _fake)("/tmp/x", deep=True)
+    assert seen == [("/tmp/x", {"deep": True})]
+
+
+def test_an_exotic_annotation_does_not_produce_a_false_alarm() -> None:
+    """A checker that cries wolf gets switched off, and then protects
+    nothing. Unknown shapes are accepted rather than guessed at."""
+    from typing import Callable as C
+
+    def weird() -> C[[int], str]:            # type: ignore[empty-body]
+        ...
+
+    contract_fake(weird, lambda: "anything")()      # must not raise
+
+
+# --------------------------------------------------------------------------
+# 4. composed with signature enforcement
+# --------------------------------------------------------------------------
+
+def test_autospec_catches_the_other_half_of_drift() -> None:
+    """Signature enforcement catches being CALLED wrongly; return enforcement
+    catches ANSWERING wrongly. This bug was the second, and only the first
+    had a tool."""
+    from backend.core.ouroboros.cli import thin_client as tc
+
+    spec = autospec_fake(tc._live_incumbent, lambda: None)
+    spec()
+    with pytest.raises(TypeError):
+        spec("an argument _live_incumbent does not take")
+
+
+async def test_autospec_still_enforces_the_return_type() -> None:
+    from backend.core.ouroboros.cli import thin_client as tc
+
+    spec = autospec_fake(tc.probe_socket, lambda *_a, **_k: False)
+    with pytest.raises(ContractMismatchError):
+        await spec("/tmp/x")

--- a/tests/cli/test_ov_ignition_retry.py
+++ b/tests/cli/test_ov_ignition_retry.py
@@ -13,6 +13,8 @@ import asyncio
 
 import pytest
 
+from tests.contract_fakes import contract_fake
+
 from backend.core.ouroboros.cli import thin_client as tc
 
 
@@ -64,8 +66,13 @@ async def test_attaches_when_the_incumbent_simply_finishes_booting(monkeypatch):
         state["n"] += 1
         return "live" if state["n"] > 2 else "stale"
 
-    monkeypatch.setattr(tc, "probe_socket", _probe)
-    monkeypatch.setattr(tc, "_live_incumbent", lambda: 999)   # never releases
+    # Wrapped, so the bool-for-str drift that cost 24 seconds and a wrong
+    # diagnosis raises at the boundary instead of surfacing as a timeout.
+    monkeypatch.setattr(tc, "probe_socket", contract_fake(tc.probe_socket, _probe))
+    monkeypatch.setattr(
+        tc, "_live_incumbent",
+        contract_fake(tc._live_incumbent, lambda: 999),       # never releases
+    )
     monkeypatch.setattr(
         tc, "spawn_daemon",
         lambda **_k: pytest.fail("raced a live incumbent"),

--- a/tests/contract_fakes.py
+++ b/tests/contract_fakes.py
@@ -1,0 +1,166 @@
+"""Test doubles that cannot drift from the functions they stand in for.
+
+`test_attaches_when_the_incumbent_simply_finishes_booting` failed for 24
+seconds and looked exactly like IPC contention with a live daemon. It was a
+fake returning `state["n"] > 2` — a bool — where the real ``probe_socket``
+returns a classification string, so the production comparison ``== "live"``
+could never be true.
+
+Nothing could catch that. A fake IS the boundary in a unit test, so a fake
+that lies about the contract makes the test agree with it. The failure surfaces
+somewhere else entirely, wearing a disguise, and the more plausible the
+disguise the more expensive it gets — that one cost a hermetic-socket-sandbox
+design before the type mismatch was spotted.
+
+The fix has to be structural. "Remember to update the fakes" is a policy
+whose enforcement mechanism is human memory, which is the thing that already
+failed.
+
+    probe = contract_fake(tc.probe_socket, lambda _p, **_k: "live")
+    monkeypatch.setattr(tc, "probe_socket", probe)
+
+The wrapper checks what the fake RETURNS against the real function's declared
+return type, at call time, and raises ``ContractMismatchError`` the moment
+they disagree.
+
+Checked at call time, not at wrap time
+--------------------------------------
+A fake is usually a lambda or a closure with no annotations of its own, so
+there is nothing to inspect statically — and a fake whose return type varies
+by call (the retry-then-succeed shape this very bug lived in) is exactly the
+kind worth checking on every call rather than once.
+
+Deliberately not autospec alone
+-------------------------------
+``create_autospec(spec_set=True)`` enforces the SIGNATURE — how a double is
+called — and that is genuinely useful, so it is offered here too. It does not
+constrain what a double RETURNS, which is the half that broke. The two are
+complementary, and only one of them was missing.
+"""
+from __future__ import annotations
+
+import functools
+import inspect
+import typing
+from typing import Any, Callable, Optional
+
+__all__ = [
+    "ContractMismatchError",
+    "autospec_fake",
+    "contract_fake",
+    "returns_match",
+]
+
+
+class ContractMismatchError(TypeError):
+    """A test double returned something the real function cannot return."""
+
+
+def _declared_return(real: Any) -> Any:
+    """The real function's annotated return type, or None if it has none."""
+    try:
+        target = inspect.unwrap(real)
+        hints = typing.get_type_hints(target)
+        return hints.get("return")
+    except Exception:  # noqa: BLE001 — an unannotated target is not an error
+        return None
+
+
+def returns_match(value: Any, declared: Any) -> bool:
+    """Is *value* an acceptable instance of the *declared* return type?
+
+    Handles the shapes that actually appear on these boundaries: ``Any``,
+    ``None``, ``Optional[X]`` / unions, and plain classes. Anything exotic
+    (generics with parameters, protocols) is accepted rather than guessed at —
+    a contract checker that produces false alarms gets switched off, and then
+    it protects nothing.
+    """
+    try:
+        if declared is None or declared is Any or declared is inspect.Signature.empty:
+            return True
+        if declared is type(None):
+            return value is None
+
+        origin = typing.get_origin(declared)
+        if origin is typing.Union:
+            return any(returns_match(value, arg)
+                       for arg in typing.get_args(declared))
+        if origin is not None:
+            # A parameterised generic (List[str], Dict[str, int], ...):
+            # check the container, not its contents. Element-wise checking
+            # would mean walking arbitrarily large structures on every call.
+            return isinstance(value, origin) if inspect.isclass(origin) else True
+
+        if not inspect.isclass(declared):
+            return True
+
+        # bool is a subclass of int, so `Optional[int]` would silently accept
+        # True. That is precisely the confusion this module exists to catch,
+        # so the two are treated as distinct.
+        if declared is int and isinstance(value, bool):
+            return False
+        return isinstance(value, declared)
+    except Exception:  # noqa: BLE001
+        return True
+
+
+def _describe(declared: Any) -> str:
+    return getattr(declared, "__name__", None) or str(declared)
+
+
+def contract_fake(real: Callable[..., Any], fake: Callable[..., Any]) -> Any:
+    """Wrap *fake* so it must return what *real* declares it returns.
+
+    Preserves async-ness: an async real function yields an async wrapper, so
+    the double still awaits the way production does. Returns *fake* unchanged
+    when the real function carries no return annotation — there is nothing to
+    enforce, and pretending otherwise would give false confidence.
+    """
+    declared = _declared_return(real)
+    if declared is None:
+        return fake
+
+    name = getattr(real, "__qualname__", getattr(real, "__name__", repr(real)))
+
+    def _check(value: Any) -> Any:
+        if not returns_match(value, declared):
+            raise ContractMismatchError(
+                f"fake for {name}() returned {value!r} "
+                f"({type(value).__name__}), but {name}() is declared to "
+                f"return {_describe(declared)}. The production code branches "
+                f"on that type — a double that disagrees makes the test agree "
+                f"with the double instead of with the system."
+            )
+        return value
+
+    if inspect.iscoroutinefunction(real):
+        @functools.wraps(fake)
+        async def _async_wrapper(*args: Any, **kwargs: Any) -> Any:
+            result = fake(*args, **kwargs)
+            if inspect.isawaitable(result):
+                result = await result
+            return _check(result)
+        return _async_wrapper
+
+    @functools.wraps(fake)
+    def _wrapper(*args: Any, **kwargs: Any) -> Any:
+        return _check(fake(*args, **kwargs))
+    return _wrapper
+
+
+def autospec_fake(
+    real: Callable[..., Any], side_effect: Optional[Callable[..., Any]] = None,
+) -> Any:
+    """``create_autospec(spec_set=True)`` PLUS return-type enforcement.
+
+    Signature enforcement and return enforcement catch different halves of
+    mock drift — being called wrongly, and answering wrongly — and this bug
+    was the second. Composing them here means a call site gets both from one
+    helper instead of remembering to apply two.
+    """
+    from unittest.mock import create_autospec
+
+    spec = create_autospec(real, spec_set=True)
+    if side_effect is not None:
+        spec.side_effect = contract_fake(real, side_effect)
+    return spec


### PR DESCRIPTION
The bool-for-str drift cost a 24-second timeout, a wrong diagnosis (IPC bleed from a live daemon), and a designed hermetic socket sandbox — before anyone noticed the type mismatch.

**Nothing could have caught it.** A fake IS the boundary in a unit test, so a fake that lies makes the test agree with the lie; the failure surfaces elsewhere wearing a disguise, and the more plausible the disguise the more expensive it gets.

"Remember to update the fakes" is a policy enforced by human memory — the thing that already failed. So it is enforced by the machine:

```python
probe = contract_fake(tc.probe_socket, lambda _p, **_k: "live")
monkeypatch.setattr(tc, "probe_socket", probe)
```

`contract_fake` compares what the double **returns** against the real function's declared return type and raises `ContractMismatchError` at the boundary.

### Design decisions worth stating

**Checked at call time, not wrap time.** Fakes are lambdas and closures with no annotations to inspect — and the ones worth checking vary their return by call, which is the retry-then-succeed shape this bug lived in.

**`bool` is not accepted as `int`.** It's a subclass, so `Optional[int]` would silently accept `True` — the same confusion this exists to catch.

**Unknown annotation shapes are accepted, not guessed at.** A checker that cries wolf gets switched off, and then it protects nothing.

**Unannotated targets pass through untouched**, rather than being wrapped into something that looks installed and checks nothing.

**`autospec_fake` composes both halves.** `create_autospec(spec_set=True)` enforces the signature — being *called* wrongly. The return check enforces *answering* wrongly. This bug was the second, and only the first had a tool.

### Wired, not merely available
Applied to the test that actually drifted, so the net is live.

### Tests
22 new, including the historical defect reproduced verbatim against the real `probe_socket` signature:

```python
return state["n"] > 2      # → ContractMismatchError: declared to return str
```

**479 passed, 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add contract-enforced test fakes that validate return types at call time to prevent mock drift. This turns the `probe_socket` bool-for-str mismatch into a clear `ContractMismatchError` instead of a timeout.

- **New Features**
  - Added `contract_fake` to check a fake’s return against the real function’s annotated return; preserves async, passes through unannotated targets, treats `bool` distinct from `int`, and accepts unknown shapes.
  - Added `autospec_fake` to combine `create_autospec(spec_set=True)` with return-type checks, enforcing both call signature and return value.
  - Wired into `tests/cli/test_ov_ignition_retry.py` to catch the historical drift at the boundary.
  - Added 22 tests covering rules, async handling, and the original defect; suite remains green.

<sup>Written for commit 2655715700b3d7703149658d1bc1554b891657a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

