### PR TITLE
fix(ov): the palette renders once, transparently, like Claude Code's

### DIFF
--- a/backend/core/ouroboros/battle_test/bipartite_layout.py
+++ b/backend/core/ouroboros/battle_test/bipartite_layout.py
@@ -528,8 +528,21 @@ def build_bipartite_application(
         # audio state, detach hint). Re-evaluated each repaint; a failing
         # callable renders empty rather than crashing the frame.
         def _toolbar_fragments():
+            # ``toolbar()`` returns EITHER a plain string (key hints) or a
+            # formatted-text fragment list (#70140, the palette on the
+            # PromptSession surface). This wrapped it in str() unconditionally,
+            # so a fragment list rendered as its Python repr —
+            # `[('class:completion-menu.completion', '  /anticipate ...` —
+            # printed across the bottom of the cockpit.
+            #
+            # Producer/consumer contract drift, the same shape as the mock
+            # drift that cost a day: one side widened its return type and the
+            # other kept assuming the old one.
             try:
-                return [("class:bottom-toolbar", str(toolbar() or ""))]
+                value = toolbar()
+                if isinstance(value, list):
+                    return value          # already fragments; pass through
+                return [("class:bottom-toolbar", str(value or ""))]
             except Exception:  # noqa: BLE001
                 return [("", "")]
 

--- a/backend/core/ouroboros/battle_test/palette_render.py
+++ b/backend/core/ouroboros/battle_test/palette_render.py
@@ -37,10 +37,10 @@ def palette_rows() -> int:
     """Maximum entries drawn at once (``JARVIS_PALETTE_HEIGHT``)."""
     try:
         return max(3, min(30, int(
-            os.environ.get("JARVIS_PALETTE_HEIGHT", "12") or 12,
+            os.environ.get("JARVIS_PALETTE_HEIGHT", "6") or 6,
         )))
     except (TypeError, ValueError):
-        return 12
+        return 6
 
 
 def _ellipsis(text: str, width: int) -> str:

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -577,6 +577,10 @@ class AttachUI:
         except Exception:  # noqa: BLE001
             pass
 
+    #: Set by the surface that has nowhere else to draw the palette. Default
+    #: False so the cockpit, which floats it, never double-renders.
+    palette_in_toolbar: bool = False
+
     def degrade_to_append_only(self) -> None:
         """Strip this UI to a single caret and nothing else.
 
@@ -684,6 +688,11 @@ class AttachUI:
             # No toolbar: prompt_toolkit anchors it to the bottom of the
             # screen, which is an absolute position by definition.
             return ""
+        if not self.palette_in_toolbar:
+            # The cockpit floats the palette as a Z-index overlay, so drawing
+            # it here too would render it twice. Only the PromptSession
+            # surface — which has nowhere to put a container — opts in.
+            return self._key_hints()
         try:
             from backend.core.ouroboros.battle_test.palette_render import (
                 palette_fragments,
@@ -693,6 +702,10 @@ class AttachUI:
                 return fragments
         except Exception:  # noqa: BLE001 — hints are the safe fallback
             pass
+        return self._key_hints()
+
+    def _key_hints(self) -> str:
+        """The affordance list — what the line you are typing on can do."""
         note = self._TOOLBAR_NOTES.get(self.audio_state)
         if note is not None:
             audio = f" · {note}"
@@ -946,6 +959,10 @@ async def _split_plane_loop(
     )
 
     ui = ui or AttachUI()
+    # This surface has no container to float the palette into, so it draws it
+    # in the toolbar. The cockpit floats it and must NOT opt in, or it renders
+    # twice.
+    ui.palette_in_toolbar = True
     # ONE persistent session, dynamic prompt + rigid footer toolbar:
     # both are callables re-evaluated on every repaint, so an
     # audio_state frame morphs the footer via app.invalidate() while

--- a/backend/core/ouroboros/ui/theme.py
+++ b/backend/core/ouroboros/ui/theme.py
@@ -739,9 +739,14 @@ def cockpit_prompt_style(tier: Optional[ColorTier] = None) -> Any:
             ink, muted, faint = p["ink"], p["muted"], p["faint"]
             green, purple = p["venom_green"], p["venom_purple"]
             rules = [
-                # No fill. The menu floats on the terminal, CC-style.
-                ("completion-menu", f"bg:{ground} {muted}"),
-                ("completion-menu.completion", f"bg:{ground} {ink}"),
+                # No fill — and this time actually. Every rule below used to
+                # set `bg:{ground}`, which paints a solid block behind the
+                # whole palette; the comment claimed otherwise. Omitting bg
+                # lets the terminal's own background show through, so the
+                # palette reads as part of the page rather than a control
+                # dropped on top of it. Only the SELECTED row takes a fill.
+                ("completion-menu", f"{muted}"),
+                ("completion-menu.completion", f"{ink}"),
                 # Selection is a TINT, not reverse video — the eye tracks a
                 # highlight far better than an inverted block, and inverted
                 # text loses the accent colour that carries meaning.
@@ -749,7 +754,7 @@ def cockpit_prompt_style(tier: Optional[ColorTier] = None) -> Any:
                  f"bg:{surface} {green} bold"),
                 # Descriptions in venom purple: subordinate to the verb name
                 # but legible, which is exactly CC's blue-on-black relationship.
-                ("completion-menu.meta.completion", f"bg:{ground} {purple}"),
+                ("completion-menu.meta.completion", f"{purple}"),
                 ("completion-menu.meta.completion.current",
                  f"bg:{surface} {purple}"),
                 ("completion-menu.multi-column-meta", f"bg:{surface} {purple}"),

--- a/tests/cli/test_palette_on_attach_surface.py
+++ b/tests/cli/test_palette_on_attach_surface.py
@@ -169,7 +169,13 @@ def test_the_toolbar_renders_the_palette_while_completing(
         pr, "palette_fragments",
         lambda max_rows=None: [("class:completion-menu.completion", "  /molt")],
     )
-    toolbar = _ui().toolbar()
+    ui = _ui()
+    # The opt-in now belongs to the SURFACE: only PromptSession, which has no
+    # container to float a palette into, draws it in the toolbar. The cockpit
+    # floats it and must not, or it renders twice — which is exactly what
+    # shipped, as a Python repr across the bottom of the screen.
+    ui.palette_in_toolbar = True
+    toolbar = ui.toolbar()
     assert not isinstance(toolbar, str), (
         "the toolbar ignored an active completion and drew hints"
     )


### PR DESCRIPTION
Three defects, read off the screenshot against Claude Code's.

### 1 · A Python repr printed across the bottom of the cockpit

```
[('class:completion-menu.completion', '  /anticipate  '), ('class:completion-menu.meta…
```

`bipartite_layout._toolbar_fragments` wrapped `toolbar()` in `str()`. Correct until #70140 widened that return type to *"a string **or** a formatted-text fragment list"* for the PromptSession palette — and the consumer kept assuming the old one.

Producer/consumer contract drift: the same shape as the mock drift that cost a day, one layer up. Fragment lists now pass through.

### 2 · The palette rendered twice on the cockpit
Once correctly as the Z-index float, once as that repr.

The UI was deciding for itself to put the palette in the toolbar. That decision belongs to the **surface** — only `PromptSession` lacks anywhere to float a container. `palette_in_toolbar` now defaults `False` and is opted into at exactly one call site.

### 3 · The grey block behind the palette
Every style rule set `bg:{ground}` — directly beneath a comment reading:

```python
# No fill. The menu floats on the terminal, CC-style.
("completion-menu", f"bg:{ground} {muted}"),
```

It painted a solid slab. Claude's palette is transparent: the terminal's own background shows through and only the **selected** row takes a tint. That is what makes it read as part of the page rather than a control dropped on top of it.

The comment described the intent, the code did the opposite, and nothing caught it — a background colour is not something assertions look at.

### Also
Twelve rows → **six**. Claude shows a handful: enough to browse, not a wall.

**474 green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the command palette so it renders once as a transparent overlay, matching Claude Code. Prevents the Python repr leak, removes the grey slab, and shows 6 rows by default.

- Bug Fixes
  - Preserve formatted-text fragments from `toolbar()` instead of casting to `str()`, preventing the repr from printing.
  - Add `palette_in_toolbar` opt-in (default false); only the PromptSession/attach surface enables it to avoid double-rendering.
  - Remove background fills on palette styles so the terminal background shows through; only the selected row gets a tint.
  - Reduce default palette height from 12 to 6 rows, including env var fallback.

<sup>Written for commit 565efe110335e2bafc04a48693a004d79365b80b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

