### PR TITLE
fix(ov): the palette is transparent because it SAYS so, not by omission

### DIFF
--- a/backend/core/ouroboros/battle_test/palette_render.py
+++ b/backend/core/ouroboros/battle_test/palette_render.py
@@ -37,10 +37,10 @@ def palette_rows() -> int:
     """Maximum entries drawn at once (``JARVIS_PALETTE_HEIGHT``)."""
     try:
         return max(3, min(30, int(
-            os.environ.get("JARVIS_PALETTE_HEIGHT", "6") or 6,
+            os.environ.get("JARVIS_PALETTE_HEIGHT", "4") or 4,
         )))
     except (TypeError, ValueError):
-        return 6
+        return 4
 
 
 def _ellipsis(text: str, width: int) -> str:
@@ -300,7 +300,7 @@ def build_palette_window(condition_style: str = "") -> Any:
             ),
             dont_extend_height=True,
             wrap_lines=False,
-            style=condition_style or "class:completion-menu",
+            style=condition_style or "bg:default",
         ),
         filter=Condition(lambda: _height() > 0),
     )

--- a/backend/core/ouroboros/ui/theme.py
+++ b/backend/core/ouroboros/ui/theme.py
@@ -739,27 +739,34 @@ def cockpit_prompt_style(tier: Optional[ColorTier] = None) -> Any:
             ink, muted, faint = p["ink"], p["muted"], p["faint"]
             green, purple = p["venom_green"], p["venom_purple"]
             rules = [
-                # No fill — and this time actually. Every rule below used to
-                # set `bg:{ground}`, which paints a solid block behind the
-                # whole palette; the comment claimed otherwise. Omitting bg
-                # lets the terminal's own background show through, so the
-                # palette reads as part of the page rather than a control
-                # dropped on top of it. Only the SELECTED row takes a fill.
-                ("completion-menu", f"{muted}"),
-                ("completion-menu.completion", f"{ink}"),
-                # Selection is a TINT, not reverse video — the eye tracks a
-                # highlight far better than an inverted block, and inverted
-                # text loses the accent colour that carries meaning.
+                # `bg:default` — the TERMINAL's background, stated EXPLICITLY.
+                #
+                # Two wrong answers preceded this one. `bg:{ground}` paints a
+                # slab of our own dark grey. Then OMITTING bg entirely, which
+                # looks like it should mean transparent and does not: an
+                # unspecified background INHERITS, and prompt_toolkit's own
+                # default for `completion-menu` is a light grey fill — so
+                # removing our colour handed the palette to pt's, which is
+                # louder than what it replaced.
+                #
+                # Only `bg:default` resolves to the terminal's real
+                # background, which is what makes the palette read as part of
+                # the page rather than a control sitting on top of it.
+                ("completion-menu", f"bg:default {muted}"),
+                ("completion-menu.completion", f"bg:default {ink}"),
+                # Selection is carried by the TEXT, not by a filled block.
+                # A green slab behind one row is the loudest thing on the
+                # screen and reads as a widget; Claude marks the current entry
+                # by brightening it, so the eye tracks colour and the row
+                # stays part of the same page.
                 ("completion-menu.completion.current",
-                 f"bg:{surface} {green} bold"),
-                # Descriptions in venom purple: subordinate to the verb name
-                # but legible, which is exactly CC's blue-on-black relationship.
-                ("completion-menu.meta.completion", f"{purple}"),
+                 f"bg:default {green} bold"),
+                ("completion-menu.meta.completion", f"bg:default {purple}"),
                 ("completion-menu.meta.completion.current",
-                 f"bg:{surface} {purple}"),
-                ("completion-menu.multi-column-meta", f"bg:{surface} {purple}"),
-                ("scrollbar.background", f"bg:{surface}"),
-                ("scrollbar.button", f"bg:{purple}"),
+                 f"bg:default {green}"),
+                ("completion-menu.multi-column-meta", f"bg:default {purple}"),
+                ("scrollbar.background", "bg:default"),
+                ("scrollbar.button", f"bg:default {purple}"),
                 # The default bottom-toolbar is reverse-video — a solid bar of
                 # colour across the width, which is the single loudest thing
                 # on the screen and says nothing.

--- a/tests/cli/test_bipartite_palette_overlay.py
+++ b/tests/cli/test_bipartite_palette_overlay.py
@@ -228,7 +228,7 @@ while time.time() - t0 < 100:
         _seen = re.sub(r"\x1b\[[0-9;?]*[a-zA-Z]", "",
                        out[mark:].decode("utf8", "replace"))
         _v = set(re.findall(r"^\s*(/\S+)\s{2,}\S", _seen, re.M))
-        if len(_v) >= 6 or time.time() - ts > 25:
+        if len(_v) >= 3 or time.time() - ts > 25:
             break
 raw = out.decode("utf8", "replace")
 print("RESULT_ROUTER=" + ("True" if "ROUTER=True" in raw else "False"))
@@ -288,7 +288,7 @@ def test_the_router_mounts_bipartite_and_the_overlay_paints(
     body = proc.stdout.split("RESULT_BODY_START", 1)[1]
     verbs = set(re.findall(r"^\s*(/\S+)\s{2,}\S", body, re.M))
     rows = [ln for ln in body.splitlines() if ln.strip().startswith("/")]
-    assert len(verbs) >= 5, (
+    assert len(verbs) >= 3, (
         f"'/' painted {len(rows)} palette rows on the cockpit — the overlay "
         f"is collapsed (a float honours its PREFERRED height, so a stale "
         f"preferred=1 renders exactly one entry)"


### PR DESCRIPTION
My last fix made it worse, and the reason is the useful part.

### Removing `bg:` does not mean transparent — it means **inherit**

prompt_toolkit's built-in default for `completion-menu` is a **light grey fill**. Deleting our dark `bg:{ground}` handed the palette to pt's default, which is louder than what it replaced. The result was a bright grey slab with ragged right edges wherever each row's padding ended.

Only `bg:default` resolves to the **terminal's** real background. Now stated explicitly on every completion class — including the Window's own style, which was still `class:completion-menu` and painting.

### Verified on painted output, not on the rules
Driving the real cockpit under a CPR-answering pty and scanning every SGR sequence for a background-setting code (`48;…`, `40-47`, `100-107`):

```
background-setting SGR codes found: NONE — fully transparent
```

That check matters because **three consecutive attempts at "no background" passed their tests while the screen stayed wrong.** Style rules are not evidence about pixels.

### Selection is carried by the text, not a block
A green slab behind one row is the loudest thing on the screen and reads as a widget. Brightening the entry keeps it part of the same page — what Claude Code does.

### Rows 6 → 4
Matching the handful visible in the reference screenshots.

### A test that was coupled to a UX knob
The overlay test asserted `>= 5` painted verbs, so lowering the row count made a passing test fail with nothing broken. It now asserts that a browsable list exists (`>= 3`) — the actual invariant.

**474 green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the completion palette truly transparent and quieter. Uses `bg:default`, switches selection to a text highlight, and reduces visible rows to 4 with aligned tests.

- **Bug Fixes**
  - Force `bg:default` on all `completion-menu` styles and the palette window so it uses the terminal background (avoids `prompt_toolkit`’s grey fill).
  - Selection is text-only (bright green, bold). Meta and scrollbar also use `bg:default`.
  - Default palette height is 4 (was 6). Tests now check for a browsable list (>= 3 items) instead of coupling to row count.

<sup>Written for commit d2dcd6d5cde3ab9d9f06149bb3ec314e7d21cb6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

