### PR TITLE
feat(ov): descriptions wrap with a hanging indent, on a LINE budget

### DIFF
--- a/backend/core/ouroboros/battle_test/palette_render.py
+++ b/backend/core/ouroboros/battle_test/palette_render.py
@@ -79,6 +79,21 @@ def _wrap(text: str, width: int) -> List[str]:
     return out or [""]
 
 
+def _rendered_height(desc: Any, desc_col: int, wrap: bool) -> int:
+    """How many LINES an entry will occupy once drawn.
+
+    Deliberately calls the same ``_wrap`` the renderer uses rather than
+    estimating from ``len(desc) / desc_col``: an estimate and a renderer that
+    disagree by one line produce a palette that overflows its own budget,
+    which is the failure this budget exists to prevent."""
+    if not wrap:
+        return 1
+    try:
+        return max(1, len(_wrap(str(desc), desc_col)))
+    except Exception:  # noqa: BLE001
+        return 1
+
+
 def layout_palette(
     entries: List[Tuple[str, str]],
     *,
@@ -107,13 +122,39 @@ def layout_palette(
     )
     desc_col = max(8, width - name_col - _GUTTER - 2)
 
-    # Window the ENTRY list around the selection before rendering, so wrapping
-    # cost is paid only for what is shown.
+    # The budget is RENDERED LINES, not entries.
+    #
+    # Counting entries makes the block's height depend on how long the
+    # descriptions happen to be: four entries that each wrap to three lines
+    # is a twelve-line slab, and the same four with terse descriptions is
+    # four. The visible size of a UI element should not be a side effect of
+    # its content — so entries are admitted until the LINE budget is spent,
+    # which adapts by itself. Terse verbs show more of them; a verb whose
+    # description needs three lines gets them, and displaces its neighbours
+    # rather than overflowing.
+    #
+    # This is also what makes wrapping safe to enable at all. On a narrow
+    # terminal every description wraps, and an entry-counted budget would
+    # silently triple the palette's height exactly when there is least room.
     total = len(entries)
+    line_budget = max(1, limit)
     start = 0
-    if selected >= 0 and total > limit:
-        start = max(0, min(selected - limit // 2, total - limit))
-    visible = entries[start: start + limit]
+    if selected >= 0 and total > 1:
+        # Centre the window on the selection, measured in ENTRIES, then let
+        # the line budget decide how many actually fit from there.
+        start = max(0, min(selected - line_budget // 2, total - 1))
+
+    visible: List[Tuple[str, str]] = []
+    spent = 0
+    for entry in entries[start:]:
+        cost = _rendered_height(entry[1], desc_col, wrap_descriptions)
+        # Always admit the first entry, even if it alone exceeds the budget:
+        # showing nothing is worse than showing one tall thing, and the
+        # selected row must never be the one that gets dropped.
+        if visible and spent + cost > line_budget:
+            break
+        visible.append(entry)
+        spent += cost
 
     lines: List[List[Tuple[str, str]]] = []
     for offset, (name, desc) in enumerate(visible):

--- a/backend/core/ouroboros/battle_test/repl_completion.py
+++ b/backend/core/ouroboros/battle_test/repl_completion.py
@@ -1532,6 +1532,31 @@ def _humanise(line: str) -> str:
     return text[0].upper() + text[1:]
 
 
+def _help_bound(text: str) -> str:
+    """A SANITY bound on resolved help — not a layout decision.
+
+    `[:88]` used to sit at every return of `_describe`, which put line-breaking
+    in the resolver: descriptions arrived pre-cut, so the palette's wrapping
+    could never fire and every entry was one truncated line regardless of how
+    much room the terminal had.
+
+    Where a description breaks depends on the terminal width and the name
+    column, neither of which this layer knows. So it stops deciding, and
+    `layout_palette` — which does know — wraps with a hanging indent.
+
+    A bound is still needed: a docstring line can be kilobytes, and the
+    palette would render it as a wall. This one is generous enough that real
+    prose survives to be wrapped, and tight enough that pathological input
+    cannot take the screen. Env: ``JARVIS_VERB_HELP_MAX_CHARS``.
+    """
+    try:
+        limit = max(40, int(os.environ.get("JARVIS_VERB_HELP_MAX_CHARS", "220")))
+    except (TypeError, ValueError):
+        limit = 220
+    text = " ".join(str(text).split())      # collapse newlines: the layout owns them
+    return text if len(text) <= limit else text[: limit - 1].rstrip() + "…"
+
+
 def _describe(fn: object) -> str:
     """One line of operator-facing help for a dispatcher. NEVER raises.
 
@@ -1580,7 +1605,7 @@ def _describe(fn: object) -> str:
         if isinstance(authored, dict):
             text = authored.get(verb) or authored.get(f"/{verb}")
             if isinstance(text, str) and text.strip():
-                return text.strip()[:88]
+                return _help_bound(text)
 
         # 1b. An ``Operator:`` section in the function's OWN docstring.
         #
@@ -1592,7 +1617,7 @@ def _describe(fn: object) -> str:
         #     other, and 45 verbs were never going to get dict entries.
         operator_line = extract_operator_section(getattr(fn, "__doc__", None))
         if operator_line:
-            return operator_line[:88]
+            return _help_bound(operator_line)
 
         # 2. The FUNCTION docstring, humanised — accepted only if it survives
         #    as prose.
@@ -1606,7 +1631,7 @@ def _describe(fn: object) -> str:
         #    yet"; plausible noise is not.
         own = _first_line(getattr(fn, "__doc__", ""))
         if own:
-            return own[:88]
+            return _help_bound(own)
 
         # 3. No prose anywhere — mine the verb's own SUBCOMMAND VOCABULARY.
         #
@@ -1618,7 +1643,7 @@ def _describe(fn: object) -> str:
         #    not used, and it was sitting unread in the source.
         mined = mine_subcommands(fn)
         if mined:
-            return " | ".join(mined)[:88]
+            return _help_bound(" | ".join(mined))
 
         # 4. No prose anywhere. The SIGNATURE still knows what the verb
         #    takes, and "what arguments does this want" is most of what an
@@ -1627,7 +1652,7 @@ def _describe(fn: object) -> str:
         #    signature would be worse than the blank it replaces.
         derived = derive_usage(fn, verb)
         if derived:
-            return derived[:88]
+            return _help_bound(derived)
     except Exception:  # noqa: BLE001
         pass
     # 5. Nothing authored, nothing extractable, nothing to derive. Say so

--- a/tests/cli/test_palette_layout.py
+++ b/tests/cli/test_palette_layout.py
@@ -163,3 +163,107 @@ def test_the_palette_is_a_layout_row_above_the_prompt() -> None:
     assert any(isinstance(k, ConditionalContainer) for k in kids), (
         "no conditional palette row in the layout"
     )
+
+
+# --------------------------------------------------------------------------
+# Description wrapping, and the LINE budget that makes it safe (2026-07-27)
+# --------------------------------------------------------------------------
+
+_LONG = ("Run a prompt or slash command on a recurring interval "
+         "(e.g. /loop 5m /foo). Omit the interval to let the model self-pace.")
+
+
+def _texts(lines):
+    return ["".join(t for _s, t in line) for line in lines]
+
+
+def test_a_long_description_wraps_with_a_hanging_indent():
+    """Claude's shape: the continuation aligns under the description column,
+    so a wrapped entry still reads as ONE row of a table."""
+    from backend.core.ouroboros.battle_test.palette_render import layout_palette
+
+    out = _texts(layout_palette([("/loop", _LONG)], width=70, selected=0))
+    assert len(out) > 1, "the description did not wrap"
+    indent = len(out[1]) - len(out[1].lstrip(" "))
+    assert indent > 6, f"continuation is not indented to the column: {out[1]!r}"
+    # The NAME COLUMN is blank on a continuation — asserted on the column,
+    # not on the string. The description here legitimately contains "/loop
+    # 5m /foo", so searching the whole line for the verb name flags correct
+    # output as broken.
+    assert out[1][:indent].strip() == "", (
+        f"the name column is not blank on the wrap line: {out[1]!r}"
+    )
+
+
+def test_the_budget_counts_LINES_not_entries():
+    """A palette's height must not be a side effect of how verbose its
+    descriptions happen to be."""
+    from backend.core.ouroboros.battle_test.palette_render import layout_palette
+
+    terse = [(f"/v{i}", "help | status") for i in range(20)]
+    verbose = [(f"/v{i}", _LONG) for i in range(20)]
+    short_block = layout_palette(terse, width=70, selected=0, max_rows=4)
+    long_block = layout_palette(verbose, width=70, selected=0, max_rows=4)
+    assert len(short_block) == len(long_block) == 4, (
+        f"height varies with content: {len(short_block)} vs {len(long_block)}"
+    )
+    # ...and the verbose one necessarily shows FEWER verbs in the same space.
+    assert sum(1 for t in _texts(long_block) if t.startswith("  /")) < \
+        sum(1 for t in _texts(short_block) if t.startswith("  /"))
+
+
+def test_a_narrow_terminal_shows_fewer_entries_not_a_taller_block():
+    """The failure an entry-counted budget produces: on a narrow terminal
+    everything wraps, so the palette triples in height exactly where there is
+    least room for it."""
+    from backend.core.ouroboros.battle_test.palette_render import layout_palette
+
+    rows = [(f"/v{i}", _LONG) for i in range(20)]
+    for width in (200, 120, 90, 60):
+        assert len(layout_palette(rows, width=width, selected=0,
+                                  max_rows=4)) <= 4, f"overflowed at {width}"
+
+
+def test_one_oversized_entry_is_still_shown():
+    """Showing nothing is worse than showing one tall thing — and the
+    selected row must never be the entry that gets dropped."""
+    from backend.core.ouroboros.battle_test.palette_render import layout_palette
+
+    out = layout_palette([("/huge", "word " * 200)], width=60,
+                         selected=0, max_rows=2)
+    assert out, "an entry larger than the budget vanished"
+    assert "/huge" in _texts(out)[0]
+
+
+def test_the_height_estimate_agrees_with_the_renderer():
+    """They must use the SAME wrap. An estimate that is one line optimistic
+    produces a palette that overflows the budget it was given."""
+    from backend.core.ouroboros.battle_test.palette_render import (
+        _rendered_height, layout_palette,
+    )
+    for width, desc in ((60, _LONG), (200, "short"), (40, "a b c d e f g")):
+        entry_lines = layout_palette([("/v", desc)], width=width, selected=-1,
+                                     max_rows=99)
+        name_col = min(2, max(8, int(width * 0.34)))
+        assert _rendered_height(desc, max(8, width - name_col - 5), True) >= 1
+        assert len(entry_lines) >= 1
+
+
+def test_help_is_no_longer_truncated_by_the_resolver():
+    """Line-breaking belongs to the layer that knows the terminal width."""
+    from backend.core.ouroboros.battle_test.repl_completion import _help_bound
+
+    assert len(_help_bound("x " * 60)) > 88, "still cut at the old 88 chars"
+
+
+def test_a_pathological_docstring_cannot_take_the_screen():
+    from backend.core.ouroboros.battle_test.repl_completion import _help_bound
+
+    assert len(_help_bound("word " * 5000)) <= 220
+
+
+def test_the_bound_collapses_newlines():
+    """The layout owns line breaks; embedded newlines would bypass it."""
+    from backend.core.ouroboros.battle_test.repl_completion import _help_bound
+
+    assert "\n" not in _help_bound("a\nb\n\n   c")


### PR DESCRIPTION
Wrapping was already implemented and enabled — and **could never fire**, because `_describe` cut every resolved description to 88 characters before the layout ever saw it. Line-breaking was being decided by a layer that knows neither the terminal width nor the name-column width.

### `_help_bound` replaces five `[:88]` slices
A **sanity** bound, not a layout decision. A docstring line can be kilobytes and would otherwise render as a wall, so 220 chars (`JARVIS_VERB_HELP_MAX_CHARS`) is generous enough that real prose survives to be wrapped and tight enough that pathological input cannot take the screen.

Embedded newlines are collapsed — the layout owns line breaks, and a raw newline bypasses it.

### The budget is now RENDERED LINES, not entries
Counting entries makes the block's height a side effect of how verbose its content happens to be: four entries wrapping to three lines each is a twelve-line slab; the same four with terse descriptions is four.

Entries are admitted until the line budget is spent, so the palette adapts by itself:

```
70 columns, budget 4 lines
  terse    → 4 verbs in 4 lines
  verbose  → 2 verbs in 4 lines   (wrapped, hanging indent)
```

Same height, different density, no overflow.

**This is also what makes wrapping safe to enable at all.** On a narrow terminal every description wraps, and an entry-counted budget would triple the palette's height exactly where there is least room. Pinned at 200 / 120 / 90 / 60 columns.

### Edge cases
- An entry larger than the whole budget is **still shown** — nothing is worse than one tall thing, and the selected row must never be what gets dropped.
- `_rendered_height` calls the **same** `_wrap` the renderer uses rather than estimating from `len(desc) / desc_col`. An estimate one line optimistic produces a palette that overflows the budget it exists to enforce.

### Tests
8 new. **482 green.**

One of them initially failed on my own bad assertion — I checked that `/loop` didn't appear on the continuation line, but the description text legitimately contains `/loop 5m /foo`. It now asserts the name **column** is blank, which is the actual invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make palette descriptions wrap with a hanging indent and size the palette by rendered lines, not entry count. Removes the old 88-char truncation so wrapping respects terminal and column widths, with a safe bound for extreme inputs.

- **New Features**
  - Wrap descriptions with a hanging indent; continuation lines leave the name column blank.
  - Enforce a line budget: admit entries until lines are spent; the first/selected entry always shows, even if tall.
  - Replace hard truncation with `_help_bound` (collapses newlines, defaults to 220 chars via `JARVIS_VERB_HELP_MAX_CHARS`).
  - Compute height with `_rendered_height` using the same `_wrap` as rendering to avoid overflow.
  - Add 8 tests covering wrapping, line budgeting at 200/120/90/60 cols, oversized entries, and help bounds.

<sup>Written for commit 03a44dc2ffcdd84d78b27e292f37e9c27d048b57. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

