### PR TITLE
feat(ov): the cockpit says "waiting" instead of showing a void on cold boot

### DIFF
--- a/backend/core/ouroboros/battle_test/cockpit_fsm.py
+++ b/backend/core/ouroboros/battle_test/cockpit_fsm.py
@@ -29,6 +29,11 @@ from typing import Callable, List, Optional, Sequence
 
 COCKPIT_FSM_SCHEMA_VERSION = "cockpit_fsm.1"
 
+#: Before the first byte of upstream telemetry. A cockpit attached to a
+#: cold-booting daemon renders faster than the daemon hydrates, and the
+#: honest state during that gap is "waiting", not "nothing is happening" —
+#: which is what a blank deck says.
+MODE_IGNITION = "ignition"
 MODE_FLOW = "flow"
 MODE_SELECT = "select"
 MODE_FOCUS_PREFIX = "focus:"

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import os
 import sys
+import time
 from dataclasses import dataclass, field
 from typing import Any, Callable, List, Optional, Sequence
 
@@ -525,6 +526,7 @@ class AttachUI:
         ``found: false`` is rendered as an explicit notice rather than as an
         empty pane: "this worker's output has aged out" and "this worker
         produced nothing" are different facts and must not look alike."""
+        self.note_upstream_activity()
         try:
             lane = str(payload.get("lane", ""))
             if self.fsm is not None and self.fsm.focused_lane != lane:
@@ -547,6 +549,7 @@ class AttachUI:
 
     def on_ambient(self, text: str, *, kind: str = "") -> None:
         """One ambient frame → the deck, then repaint. NEVER raises."""
+        self.note_upstream_activity()
         try:
             if self.deck is None:
                 return
@@ -577,9 +580,65 @@ class AttachUI:
         except Exception:  # noqa: BLE001
             pass
 
+    def _ignition_deadline(self) -> float:
+        """Seconds to wait for first telemetry before flagging unreachable."""
+        try:
+            return max(1.0, float(
+                os.environ.get("JARVIS_IGNITION_TIMEOUT_S", "10") or 10))
+        except (TypeError, ValueError):
+            return 10.0
+
+    def note_upstream_activity(self) -> bool:
+        """First byte from the daemon ends ignition. Returns True on the edge.
+
+        Called from every inbound callback rather than from a poller: the
+        bridge already delivers these, and a timer asking "has anything
+        arrived yet" would be a second source of truth for a question the
+        stream itself answers.
+
+        Idempotent — the transition happens once, on the first payload of any
+        kind. Which kind does not matter: a heartbeat, a lane registration and
+        an ambient line all prove the same thing, that the far end is alive.
+        """
+        if not self._igniting:
+            return False
+        self._igniting = False
+        return True
+
+    @property
+    def ignition_state(self) -> str:
+        """``ignition`` until the first payload, then the FSM's own mode."""
+        from backend.core.ouroboros.battle_test.cockpit_fsm import MODE_IGNITION
+        return MODE_IGNITION if self._igniting else self.fsm.mode
+
+    def _ignition_line(self) -> Optional[str]:
+        """The skeleton row, or None once telemetry has arrived.
+
+        A blank deck during a cold boot is indistinguishable from a healthy
+        idle organism with nothing to say — and from a dead socket. Saying
+        which one it is costs one line and removes the entire question.
+        """
+        if not self._igniting:
+            return None
+        if not self._ignition_started:
+            # Lazily anchored to the FIRST RENDER, not to construction: the
+            # clock that matters is how long the OPERATOR has been looking at
+            # an empty deck. A zero default would read as an instant timeout.
+            self._ignition_started = time.monotonic()
+        waited = time.monotonic() - self._ignition_started
+        if waited > self._ignition_deadline():
+            # Still nothing. Do not keep implying progress that is not
+            # happening; name the suspicion and let the operator act.
+            return ("  ⚠ daemon unreachable — no telemetry in "
+                    f"{int(waited)}s · 'detach' to leave")
+        return "  ⏺ awaiting daemon telemetry…"
+
     #: Set by the surface that has nowhere else to draw the palette. Default
     #: False so the cockpit, which floats it, never double-renders.
     palette_in_toolbar: bool = False
+    #: True until the first upstream payload of any kind arrives.
+    _igniting: bool = True
+    _ignition_started: float = 0.0
 
     def degrade_to_append_only(self) -> None:
         """Strip this UI to a single caret and nothing else.
@@ -643,7 +702,12 @@ class AttachUI:
                 return "\n".join(head)
             rows = self.deck.rows()[:cap]
             if not rows:
-                return "\n".join(head)
+                # The cold-boot gap: the cockpit paints before the daemon has
+                # hydrated. A skeleton row here is the difference between
+                # "waiting" and an empty screen that could equally mean idle,
+                # wedged, or disconnected.
+                skeleton = self._ignition_line()
+                return "\n".join(head + ([skeleton] if skeleton else []))
             return "\n".join(
                 head + [
                     f"  {GLYPHS.get(sev, '·')} {text}" for sev, text in rows
@@ -794,6 +858,7 @@ class AttachUI:
         """Telemetry lane landing point — retain heartbeat frames for
         the toolbar pulse; other telemetry kinds pass untouched.
         NEVER raises."""
+        self.note_upstream_activity()
         try:
             if isinstance(frame, dict) and frame.get("kind") == "heartbeat":
                 import time as _time

--- a/tests/cli/test_ignition_skeleton.py
+++ b/tests/cli/test_ignition_skeleton.py
@@ -1,0 +1,169 @@
+"""A cockpit that attaches before its daemon hydrates says so.
+
+`ov` paints in milliseconds; a cold-booting daemon takes seconds. In that gap
+the deck has nothing to show, and a blank deck is indistinguishable from three
+very different situations: a healthy idle organism with nothing to say, a
+wedged one, and a socket that never connected.
+
+One line removes the whole question. The transition out of it is driven by the
+UDS callbacks that already exist — a timer asking "has anything arrived yet"
+would be a second source of truth for something the stream itself answers.
+"""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import io
+import time
+from typing import Any
+
+import pytest
+
+from backend.core.ouroboros.battle_test.cockpit_fsm import (
+    MODE_FLOW,
+    MODE_IGNITION,
+)
+
+
+def _ui() -> Any:
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+        from backend.core.ouroboros.cli.ov import AttachUI
+        return AttachUI()
+
+
+# --------------------------------------------------------------------------
+# 1. the skeleton
+# --------------------------------------------------------------------------
+
+def test_a_freshly_attached_cockpit_is_in_ignition() -> None:
+    assert _ui().ignition_state == MODE_IGNITION
+
+
+def test_the_skeleton_renders_instead_of_a_void() -> None:
+    """MANDATE 4(1): silent stream, so the operator sees waiting — not
+    nothing."""
+    assert "awaiting daemon telemetry" in _ui().prompt()
+
+
+def test_the_skeleton_is_one_line() -> None:
+    """It occupies the deck's space without becoming a splash screen."""
+    ui = _ui()
+    lines = [ln for ln in ui.prompt().splitlines() if "awaiting" in ln]
+    assert len(lines) == 1
+
+
+# --------------------------------------------------------------------------
+# 2. the handoff
+# --------------------------------------------------------------------------
+
+async def test_a_heartbeat_transitions_to_flow() -> None:
+    """MANDATE 4(2). The payload arrives on the bridge callback; the FSM
+    moves on that edge, not on a clock."""
+    ui = _ui()
+    assert ui.ignition_state == MODE_IGNITION
+    ui.on_telemetry({"type": "heartbeat", "phase": "GENERATE"})
+    await asyncio.sleep(0)
+    assert ui.ignition_state == MODE_FLOW
+    assert "awaiting daemon telemetry" not in ui.prompt()
+
+
+@pytest.mark.parametrize("deliver", [
+    lambda ui: ui.on_ambient("DW provider failover"),
+    lambda ui: ui.on_telemetry({"phase": "APPLY"}),
+    lambda ui: ui.on_lane_history({"lane": "unit/7", "lines": []}),
+])
+def test_any_payload_ends_ignition(deliver) -> None:
+    """A heartbeat, a lane registration and an ambient line all prove the
+    same thing — the far end is alive. Which arrives first is a race, so no
+    single one may be privileged."""
+    ui = _ui()
+    deliver(ui)
+    assert ui.ignition_state != MODE_IGNITION
+
+
+def test_the_transition_is_idempotent() -> None:
+    """It reports the EDGE, so later payloads cannot re-arm the skeleton."""
+    ui = _ui()
+    assert ui.note_upstream_activity() is True
+    assert ui.note_upstream_activity() is False
+    ui.on_ambient("more")
+    assert ui.ignition_state == MODE_FLOW
+
+
+def test_real_deck_content_survives_the_transition() -> None:
+    """The payload that ends ignition must not be swallowed by the handoff."""
+    ui = _ui()
+    ui.on_ambient("DW provider failover")
+    assert "failover" in ui.prompt()
+    assert "awaiting" not in ui.prompt()
+
+
+# --------------------------------------------------------------------------
+# 3. the timeout
+# --------------------------------------------------------------------------
+
+def test_prolonged_silence_is_named_not_implied() -> None:
+    """Continuing to show 'awaiting…' forever implies progress that is not
+    happening. After the window it says what it now suspects."""
+    ui = _ui()
+    ui.prompt()                                   # anchors the clock
+    ui._ignition_started = time.monotonic() - 30
+    line = ui._ignition_line() or ""
+    assert "unreachable" in line
+    assert "detach" in line, "no way out is offered"
+
+
+def test_the_window_is_tunable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JARVIS_IGNITION_TIMEOUT_S", "2")
+    ui = _ui()
+    ui.prompt()
+    ui._ignition_started = time.monotonic() - 3
+    assert "unreachable" in (ui._ignition_line() or "")
+
+
+def test_a_degenerate_window_cannot_fire_instantly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Zero would flag every cold boot unreachable before a daemon could
+    physically answer."""
+    monkeypatch.setenv("JARVIS_IGNITION_TIMEOUT_S", "0")
+    assert _ui()._ignition_deadline() >= 1.0
+
+
+def test_late_telemetry_still_clears_the_warning() -> None:
+    """A slow daemon is not a dead one — the warning is a suspicion, and it
+    must be retractable."""
+    ui = _ui()
+    ui.prompt()
+    ui._ignition_started = time.monotonic() - 30
+    assert "unreachable" in (ui._ignition_line() or "")
+    ui.on_ambient("late but alive")
+    assert ui._ignition_line() is None
+    assert "unreachable" not in ui.prompt()
+
+
+def test_the_clock_starts_at_first_render_not_construction() -> None:
+    """What matters is how long the OPERATOR has been looking at an empty
+    deck, not how long the object has existed."""
+    ui = _ui()
+    assert ui._ignition_started == 0.0
+    ui.prompt()
+    assert ui._ignition_started > 0.0
+
+
+# --------------------------------------------------------------------------
+# 4. no polling was introduced
+# --------------------------------------------------------------------------
+
+def test_no_second_source_of_truth_was_added() -> None:
+    """DRY, structural: the transition rides the existing UDS callbacks."""
+    import inspect
+
+    from backend.core.ouroboros.cli import ov
+
+    for name in ("on_ambient", "on_telemetry", "on_lane_history"):
+        body = inspect.getsource(getattr(ov.AttachUI, name))
+        assert "note_upstream_activity" in body, f"{name} does not hand off"
+    src = inspect.getsource(ov.AttachUI)
+    assert "asyncio.create_task" not in src.split("note_upstream_activity")[1][:400]


### PR DESCRIPTION
`ov` paints in milliseconds; a cold-booting daemon hydrates in seconds. In that gap the deck has nothing to show — and a blank deck is indistinguishable from three very different situations:

- a healthy idle organism with nothing to say
- a wedged one
- a socket that never connected

One line removes the whole question.

```
  ⏺ awaiting daemon telemetry…
```

### The transition
`MODE_IGNITION` is named where the other modes live. The cockpit starts there and leaves on the **first upstream payload of any kind** — a heartbeat, a lane registration, an ambient line. Which arrives first is a race, so none is privileged; all three prove the same thing, that the far end is alive.

**DRY:** hooked into the UDS callbacks that already deliver those payloads. A timer asking *"has anything arrived yet"* would be a second source of truth for a question the stream itself answers — and the two would eventually disagree.

The transition reports the **edge** and is idempotent, so later payloads cannot re-arm the skeleton mid-session.

### The clock
Anchored at **first render**, not construction. What matters is how long the *operator* has been looking at an empty deck, not how long the object has existed — and a zero default would have read as an instant timeout.

### The timeout is a suspicion, not a verdict
After the window (`JARVIS_IGNITION_TIMEOUT_S`, default 10s, floored at 1s because zero flags every cold boot before a daemon could physically answer):

```
  ⚠ daemon unreachable — no telemetry in 30s · 'detach' to leave
```

It stops implying progress that isn't happening, and offers a way out. **Late telemetry retracts it** and the session continues normally — a slow daemon is not a dead one.

### Tests
15 new. **513 green.** Includes a structural pin that no polling mechanism was introduced alongside the callbacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a single “⏺ awaiting daemon telemetry…” line on cold boot so the cockpit isn’t blank, then switch to normal view on the first upstream payload. Adds a tunable timeout that shows an “unreachable” warning with a detach hint; late telemetry clears it.

- **New Features**
  - Introduces `MODE_IGNITION`; cockpit starts in ignition and exits on first payload (heartbeat, ambient, or lane history).
  - Renders one line: “⏺ awaiting daemon telemetry…”; clock starts on first render.
  - Adds timeout via `JARVIS_IGNITION_TIMEOUT_S` (default 10s, floor 1s); then shows “⚠ daemon unreachable — no telemetry in Ns · 'detach' to leave”; late telemetry retracts it.
  - Wired into existing UDS callbacks (no polling); transition is idempotent and preserves the payload that ends ignition.
  - Tests: 15 new, covering ignition flow, timeout behavior, and absence of polling.

<sup>Written for commit 8833d3263cd026698429dcff07702fe662285b03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

