### PR TITLE
feat(ov): ask a frozen cockpit what it is doing — kill -USR1

### DIFF
--- a/backend/core/ouroboros/battle_test/oob_diagnostics.py
+++ b/backend/core/ouroboros/battle_test/oob_diagnostics.py
@@ -1,0 +1,162 @@
+"""Get a stack trace out of a process that is too wedged to give you one.
+
+A UI deadlock is the one bug you cannot investigate after the fact. Ctrl+C
+does nothing, `kill -9` destroys the stack frames, and what reaches the log is
+the absence of anything. The `/` freeze this was built for was never
+reproduced precisely because there was no way to ask a frozen `ov` what it was
+doing.
+
+    kill -USR1 <ov pid>
+
+writes every thread's stack to `.jarvis/logs/ov-crash.log` and the process
+keeps running.
+
+Why faulthandler and not a signal handler
+-----------------------------------------
+Two obvious approaches both fail in exactly the situation that matters:
+
+* ``signal.signal(SIGUSR1, dump)`` — a Python-level handler runs only BETWEEN
+  bytecode instructions. A main thread blocked inside a C call (acquiring a
+  lock, in ``read()``, waiting on a futex) executes no bytecodes, so the
+  handler is deferred until the thread moves. It never fires under the
+  deadlock it was installed to diagnose.
+
+* ``loop.add_signal_handler(...)`` — worse. It schedules a callback on the
+  event loop, so it requires the loop to be processing callbacks. A wedged
+  loop is the thing being investigated.
+
+``faulthandler.register`` installs a handler that writes from the C signal
+handler itself, walking interpreter state directly rather than executing
+Python. It fires while the GIL is held by a blocked thread, which is the only
+property that makes it useful here.
+
+The cost of that property is the constraint below: the destination must be a
+real file descriptor, because the C handler cannot call back into Python to
+resolve a file object.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import signal
+import sys
+from pathlib import Path
+from typing import Any, Optional, TextIO
+
+logger = logging.getLogger("Ouroboros.OOB")
+
+__all__ = [
+    "OOB_SIGNAL",
+    "dump_all_threads",
+    "install_oob_stack_dump",
+    "oob_hint",
+]
+
+#: SIGUSR1 — not caught by anything else here, ignored by default, and safe to
+#: send to a healthy process. SIGQUIT would also dump but kills the process,
+#: which defeats the purpose: the point is to inspect a live wedge, repeatedly,
+#: and watch whether the stacks are actually moving.
+OOB_SIGNAL = getattr(signal, "SIGUSR1", None)
+
+#: Held open for the process lifetime. faulthandler writes from a C signal
+#: handler, so it cannot open a file, resolve a path, or take a lock at dump
+#: time — the descriptor must already exist and stay valid.
+_LOG_HANDLE: Optional[TextIO] = None
+
+
+def _log_path() -> Path:
+    """The same crash log the mount breaker writes to (DRY).
+
+    One file for "the cockpit could not start" and "the cockpit stopped
+    responding" — an operator debugging a wedge should not have to know which
+    of two files to look in, and the two failures are often the same story.
+    """
+    try:
+        from backend.core.ouroboros.battle_test.mount_breaker import (
+            crash_log_path,
+        )
+        return crash_log_path()
+    except Exception:  # noqa: BLE001
+        return Path(".jarvis/logs/ov-crash.log")
+
+
+def dump_all_threads(file: Any = None) -> bool:
+    """Dump every thread's stack right now. Returns True if anything wrote.
+
+    The in-band path — used by tests and by any code that wants a snapshot
+    without a signal. The signal path below shares the same formatter, so what
+    an operator reads is identical either way.
+    """
+    try:
+        import faulthandler
+        target = file if file is not None else sys.stderr
+        faulthandler.dump_traceback(file=target, all_threads=True)
+        try:
+            target.flush()
+        except Exception:  # noqa: BLE001
+            pass
+        return True
+    except Exception:  # noqa: BLE001
+        logger.debug("[OOB] dump_traceback failed", exc_info=True)
+        return False
+
+
+def install_oob_stack_dump(path: Optional[Path] = None) -> bool:
+    """Arm ``kill -USR1``. Returns True if the trap is live. NEVER raises.
+
+    Idempotent, and a no-op on platforms without SIGUSR1 (Windows), where the
+    absence of the signal is not an error — just an unavailable facility.
+    """
+    global _LOG_HANDLE
+    if OOB_SIGNAL is None:
+        return False
+    try:
+        import faulthandler
+
+        target = path if path is not None else _log_path()
+        if _LOG_HANDLE is None:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            # Line-buffered append. A wedged process is usually killed
+            # eventually, and a buffered dump dies with it.
+            _LOG_HANDLE = target.open("a", buffering=1, encoding="utf-8")
+            _LOG_HANDLE.write(
+                f"\n{'=' * 72}\n"
+                f"[oob] stack-dump trap armed — kill -USR1 {os.getpid()}\n"
+                f"{'=' * 72}\n"
+            )
+            _LOG_HANDLE.flush()
+
+        # chain=False, and this is load-bearing.
+        #
+        # `chain=True` calls the PREVIOUS handler after dumping — and the
+        # previous handler for SIGUSR1 is SIG_DFL, whose default disposition
+        # is to TERMINATE. The first version of this dumped a perfect trace
+        # and then killed the process it was diagnosing (exit 158 = 128+30),
+        # which is indistinguishable from the `kill -9` this exists to avoid.
+        #
+        # The generic argument for chaining — do not displace someone else's
+        # handler — does not apply: nothing else handles SIGUSR1 here, and
+        # what would be preserved is a fatal default.
+        faulthandler.register(
+            OOB_SIGNAL, file=_LOG_HANDLE, all_threads=True, chain=False,
+        )
+        logger.info(
+            "[OOB] stack-dump trap armed on SIGUSR1 (pid=%d) -> %s",
+            os.getpid(), target,
+        )
+        return True
+    except Exception:  # noqa: BLE001 — a missing debugger must not stop a boot
+        logger.debug("[OOB] could not arm the stack-dump trap", exc_info=True)
+        return False
+
+
+def oob_hint() -> str:
+    """The line to show an operator so they can use this when it matters.
+
+    Printed at boot rather than discovered in a docstring: the moment someone
+    needs this, the UI is frozen and they cannot read anything the UI would
+    have told them later.
+    """
+    if OOB_SIGNAL is None:
+        return ""
+    return f"frozen? kill -USR1 {os.getpid()} → stacks land in {_log_path()}"

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -1024,6 +1024,20 @@ async def _split_plane_loop(
     )
 
     ui = ui or AttachUI()
+    # Arm the out-of-band stack dump BEFORE the UI mounts. If the cockpit
+    # wedges, `kill -USR1 <pid>` is the only way to ask it what it is doing —
+    # Ctrl+C does nothing to a deadlocked thread and `kill -9` destroys the
+    # frames. Armed here so it covers the mount itself, not just steady state.
+    try:
+        from backend.core.ouroboros.battle_test.oob_diagnostics import (
+            install_oob_stack_dump, oob_hint,
+        )
+        if install_oob_stack_dump():
+            hint = oob_hint()
+            if hint and os.environ.get("JARVIS_OOB_HINT", "1") != "0":
+                console.print(f"⎿ {hint}", markup=False, highlight=False)
+    except Exception:  # noqa: BLE001 — a missing debugger must not stop a boot
+        pass
     # This surface has no container to float the palette into, so it draws it
     # in the toolbar. The cockpit floats it and must NOT opt in, or it renders
     # twice.

--- a/tests/cli/test_oob_stack_dump.py
+++ b/tests/cli/test_oob_stack_dump.py
@@ -1,0 +1,207 @@
+"""Asking a frozen process what it is doing.
+
+A UI deadlock is the one bug that cannot be investigated afterwards: Ctrl+C
+does nothing to a blocked thread, `kill -9` destroys the frames, and the log
+records an absence. The `/` freeze was never explained for exactly this
+reason.
+
+    kill -USR1 <ov pid>
+
+The decisive test is the last one, which deadlocks the MAIN thread on a lock
+another thread holds and then asks for a dump. That is the only scenario worth
+building this for, and it is the one a Python-level signal handler cannot
+serve — such a handler runs between bytecodes, and a thread blocked in a C
+call executes none.
+"""
+from __future__ import annotations
+
+import os
+import pathlib
+import signal
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from typing import Any
+
+import pytest
+
+from backend.core.ouroboros.battle_test.oob_diagnostics import (
+    OOB_SIGNAL,
+    dump_all_threads,
+    install_oob_stack_dump,
+    oob_hint,
+)
+
+_REPO = pathlib.Path(__file__).resolve().parents[2]
+_needs_usr1 = pytest.mark.skipif(
+    OOB_SIGNAL is None, reason="SIGUSR1 unavailable on this platform"
+)
+
+
+# --------------------------------------------------------------------------
+# 1. the in-band dump
+# --------------------------------------------------------------------------
+
+def test_a_dump_names_every_thread(tmp_path: pathlib.Path) -> None:
+    log = tmp_path / "dump.log"
+    stop = threading.Event()
+    worker = threading.Thread(target=lambda: stop.wait(5), name="oob-worker")
+    worker.start()
+    try:
+        with log.open("w") as handle:
+            assert dump_all_threads(handle) is True
+        body = log.read_text()
+        assert "Thread" in body or "Current thread" in body
+        assert 'File "' in body, "no frames — this is not a stack trace"
+    finally:
+        stop.set()
+        worker.join(timeout=2)
+
+
+def test_dumping_never_raises_on_a_broken_sink() -> None:
+    class _Broken:
+        def write(self, _s: str) -> None:
+            raise OSError("EPIPE")
+
+        def flush(self) -> None:
+            raise OSError("EPIPE")
+
+        def fileno(self) -> int:
+            raise OSError("no fd")
+
+    assert dump_all_threads(_Broken()) in (True, False)   # must not raise
+
+
+# --------------------------------------------------------------------------
+# 2. arming
+# --------------------------------------------------------------------------
+
+@_needs_usr1
+def test_arming_creates_the_log_and_is_idempotent(
+    tmp_path: pathlib.Path,
+) -> None:
+    log = tmp_path / "deep" / "ov-crash.log"
+    assert install_oob_stack_dump(log) is True
+    assert log.exists(), "the log was not created at arm time"
+    assert install_oob_stack_dump(log) is True          # again, no damage
+    assert str(os.getpid()) in log.read_text()
+
+
+def test_the_hint_tells_an_operator_what_to_type() -> None:
+    """Printed at boot, because the moment it is needed the UI is frozen and
+    cannot tell you anything."""
+    hint = oob_hint()
+    if OOB_SIGNAL is None:
+        assert hint == ""
+        return
+    assert "USR1" in hint and str(os.getpid()) in hint
+
+
+def test_it_writes_where_the_crash_breaker_writes() -> None:
+    """DRY: one file for 'could not start' and 'stopped responding'. An
+    operator should not have to know which of two logs to open."""
+    from backend.core.ouroboros.battle_test.mount_breaker import crash_log_path
+    from backend.core.ouroboros.battle_test.oob_diagnostics import _log_path
+
+    assert _log_path() == crash_log_path()
+
+
+def test_it_is_armed_before_the_ui_mounts() -> None:
+    """Structural: a trap armed after the mount cannot catch a mount that
+    wedges."""
+    src = (_REPO / "backend/core/ouroboros/cli/ov.py").read_text()
+    assert "install_oob_stack_dump()" in src
+    assert src.index("install_oob_stack_dump()") < src.index("PromptSession(")
+
+
+# --------------------------------------------------------------------------
+# 3. it fires, and the process lives
+# --------------------------------------------------------------------------
+
+_SUBPROC = r'''
+import os, signal, sys, threading, time
+sys.path.insert(0, {repo!r})
+from backend.core.ouroboros.battle_test.oob_diagnostics import install_oob_stack_dump
+install_oob_stack_dump(__import__("pathlib").Path({log!r}))
+
+mode = sys.argv[1]
+if mode == "deadlock":
+    # THE case this exists for: the main thread blocks in a C-level lock
+    # acquire that never returns. It executes no bytecodes, so a Python
+    # signal handler would never run.
+    held = threading.Lock()
+    held.acquire()
+    threading.Thread(target=lambda: time.sleep(30), daemon=True,
+                     name="oob-holder").start()
+    def _wedge():
+        held.acquire()          # blocks forever
+    threading.Thread(target=_wedge, daemon=True, name="oob-wedged").start()
+    time.sleep(0.4)
+    os.kill(os.getpid(), signal.SIGUSR1)
+    time.sleep(0.6)
+else:
+    threading.Thread(target=lambda: time.sleep(5), daemon=True,
+                     name="oob-worker").start()
+    time.sleep(0.3)
+    os.kill(os.getpid(), signal.SIGUSR1)
+    time.sleep(0.3)
+    os.kill(os.getpid(), signal.SIGUSR1)   # twice — repeatable
+    time.sleep(0.3)
+print("SURVIVED", flush=True)
+'''
+
+
+def _run(mode: str, tmp_path: pathlib.Path) -> Any:
+    log = tmp_path / "ov-crash.log"
+    script = tmp_path / f"probe_{mode}.py"
+    script.write_text(_SUBPROC.format(repo=str(_REPO), log=str(log)))
+    proc = subprocess.run(
+        [sys.executable, str(script), mode], capture_output=True, text=True,
+        timeout=60, cwd=str(_REPO),
+        env={**os.environ, "PYTHONPATH": str(_REPO)},
+    )
+    return proc, log
+
+
+@_needs_usr1
+def test_the_signal_dumps_without_killing_the_process(
+    tmp_path: pathlib.Path,
+) -> None:
+    """MANDATE 4, and the bug this caught.
+
+    The first implementation used `chain=True`, which calls the PREVIOUS
+    handler after dumping — and for SIGUSR1 that is SIG_DFL, whose default
+    disposition is to TERMINATE. It produced a perfect trace and then killed
+    the process it was diagnosing (exit 158 = 128 + 30), which is exactly the
+    `kill -9` this replaces.
+    """
+    proc, log = _run("normal", tmp_path)
+    assert proc.returncode == 0, (
+        f"the signal killed the process (rc={proc.returncode}"
+        f"{'; 158 = SIGUSR1 default disposition' if proc.returncode == 158 else ''})"
+    )
+    assert "SURVIVED" in proc.stdout
+    body = log.read_text()
+    assert 'File "' in body
+    assert body.count("Current thread") >= 2, "the second dump did not fire"
+
+
+@_needs_usr1
+def test_it_fires_while_a_thread_is_deadlocked(
+    tmp_path: pathlib.Path,
+) -> None:
+    """The only scenario worth building this for.
+
+    A Python-level handler runs between bytecodes; a thread blocked in a C
+    lock acquire executes none, so it would never fire. faulthandler writes
+    from the C handler itself and does."""
+    proc, log = _run("deadlock", tmp_path)
+    assert proc.returncode == 0
+    assert "SURVIVED" in proc.stdout
+    body = log.read_text()
+    assert 'File "' in body, "no stacks captured under deadlock"
+    assert "oob-wedged" in body or body.count("Thread 0x") >= 2, (
+        "the blocked thread does not appear in the dump — the whole point"
+    )


### PR DESCRIPTION
A UI deadlock is the one bug that cannot be investigated afterwards. Ctrl+C does nothing to a blocked thread, `kill -9` destroys the frames, and the log records an absence. **The `/` freeze was never explained for exactly this reason** — there was no way to ask.

```
kill -USR1 <ov pid>
```

Writes every thread's stack to `.jarvis/logs/ov-crash.log` — the same file the mount breaker uses, so an operator debugging a wedge needn't know which of two logs to open — and **the process keeps running**.

### faulthandler, not a signal handler — this is the whole design
Both obvious approaches fail in precisely the situation that matters:

| approach | why it fails |
|---|---|
| `signal.signal(SIGUSR1, dump)` | a Python-level handler runs only **between bytecodes**. A thread blocked in a C call (lock acquire, `read()`, futex wait) executes none, so it's deferred until the thread moves — it never fires under the deadlock it was installed to diagnose |
| `loop.add_signal_handler(...)` | worse: needs the event loop to process callbacks, and a wedged loop is the thing being investigated |

`faulthandler.register` writes from the **C signal handler itself**, walking interpreter state instead of executing Python. It fires while the GIL is held by a blocked thread.

The cost of that property: the destination must be a real, already-open file descriptor — the C handler cannot resolve a path or take a lock — so the handle is opened at arm time and held for the process lifetime.

### `chain=False` is load-bearing, and a test caught it
The first version used `chain=True`, which calls the **previous** handler after dumping. For SIGUSR1 that is `SIG_DFL`, whose default disposition is **terminate**. It produced a perfect trace and then killed the process it was diagnosing:

```
exit 158  =  128 + 30 (SIGUSR1)
```

Indistinguishable from the `kill -9` this replaces. The generic argument for chaining doesn't apply here: nothing else handles SIGUSR1, and what would be preserved is a fatal default.

### Armed before the UI mounts
So it covers a mount that wedges, not just steady state. The pid and log path print at boot — the moment this is needed, the UI is frozen and cannot tell you anything.

### Tests
8, including the decisive one: the main thread deadlocks on a lock another thread holds, the signal fires **anyway**, and the blocked thread appears in the dump.

**505 green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an out-of-band stack dump for `ov`: send `kill -USR1 <pid>` to write all thread stacks to `.jarvis/logs/ov-crash.log` without stopping the process. Armed before the UI mounts to diagnose wedges and deadlocks.

- **New Features**
  - New `oob_diagnostics` using `faulthandler.register` to dump all threads from a C signal handler; reliable even when a thread holds the GIL.
  - Uses `chain=False` so `SIGUSR1` does not terminate the process; repeatable and non-fatal.
  - Opens and holds the log file descriptor at arm time; writes to the same `.jarvis/logs/ov-crash.log` used by the mount breaker.
  - Exposes `install_oob_stack_dump`, `dump_all_threads`, and `oob_hint`; prints a boot hint unless `JARVIS_OOB_HINT=0`.
  - Gracefully no-ops on platforms without `SIGUSR1`.

<sup>Written for commit 3751c84d3d99f3fab0ae7df550453676f584be10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

