### PR TITLE
fix(shutdown): stop importing torch at exit; guard the handlers

### DIFF
--- a/backend/core/resilience/graceful_shutdown.py
+++ b/backend/core/resilience/graceful_shutdown.py
@@ -1120,7 +1120,10 @@ def should_reject_operation(category: str = "default") -> bool:
 # v95.12: Multiprocessing Resource Cleanup
 # =============================================================================
 
-import atexit
+import atexit  # noqa: F401 — kept for callers that unregister
+from backend.core.ouroboros.governance.exit_guard import (
+    guarded_atexit_register,
+)
 import weakref
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 
@@ -1164,7 +1167,7 @@ class MultiprocessingResourceTracker:
         }
 
         # Register atexit handler for emergency cleanup
-        atexit.register(self._emergency_cleanup)
+        guarded_atexit_register(self._emergency_cleanup)
         logger.debug("[v95.12] MultiprocessingResourceTracker initialized")
 
     def register_executor(
@@ -2402,10 +2405,24 @@ def cleanup_all_semaphores_sync() -> Dict[str, Any]:
         results["errors"].append(f"MP children: {e}")
 
     # Step 3: Terminate torch multiprocessing children
+    #
+    # LOOK UP, never IMPORT. This ran at interpreter shutdown and imported
+    # torch — seconds of C-extension loading, executed while the interpreter
+    # is already tearing itself down. Two consequences, both observed:
+    #
+    #   * it stretches the shutdown window from microseconds to seconds, which
+    #     is what let a Ctrl+C land INSIDE the handler and print a traceback
+    #     over the goodbye (the operator report this fixes);
+    #   * import machinery at shutdown is running on partially collected
+    #     module state, so the failure modes are exotic and unreproducible.
+    #
+    # It is also unnecessary by construction: torch can only have
+    # multiprocessing children if torch was already imported. If it is absent
+    # from sys.modules there is nothing to clean, so importing it to look
+    # CREATES the very subsystem it then tears down.
     try:
-        import torch.multiprocessing as torch_mp
-
-        if hasattr(torch_mp, 'active_children'):
+        torch_mp = sys.modules.get("torch.multiprocessing")
+        if torch_mp is not None and hasattr(torch_mp, 'active_children'):
             for child in torch_mp.active_children():
                 with suppress(Exception):
                     if child.is_alive():
@@ -2582,7 +2599,7 @@ def _register_semaphore_cleanup_atexit():
             pass  # Best effort at exit
 
     # Register our cleanup - it will run FIRST due to LIFO ordering
-    atexit.register(_final_semaphore_cleanup)
+    guarded_atexit_register(_final_semaphore_cleanup)
 
 
 # Auto-register on import - this happens after multiprocessing is imported
@@ -2660,7 +2677,7 @@ def _register_thread_cleanup_atexit():
             logger.debug(f"[v117.0] atexit thread cleanup error: {e}")
 
     # Register our cleanup (LIFO ordering means it runs before Python's thread check)
-    atexit.register(_final_thread_cleanup)
+    guarded_atexit_register(_final_thread_cleanup)
     logger.debug("[v117.0] Thread cleanup atexit handler registered")
 
 

--- a/tests/cli/test_shutdown_quiet_on_ctrl_c.py
+++ b/tests/cli/test_shutdown_quiet_on_ctrl_c.py
@@ -1,0 +1,138 @@
+"""Ctrl+C at exit must not print a traceback over the goodbye.
+
+The operator report:
+
+    ^CException ignored in atexit callback: <_final_semaphore_cleanup>
+    ...
+      File ".../graceful_shutdown.py", line 2406, in cleanup_all_semaphores_sync
+        import torch.multiprocessing as torch_mp
+    ...
+    KeyboardInterrupt:
+
+Two independent defects produced that, and either alone is enough to bring it
+back:
+
+1. The handler IMPORTED TORCH at interpreter shutdown — seconds of
+   C-extension loading during teardown, which is what stretched the shutdown
+   window wide enough for a Ctrl+C to land inside it. It is also unnecessary:
+   torch can only own multiprocessing children if torch was already imported,
+   so importing it to check CREATES the subsystem it then tears down.
+
+2. The handler was registered raw, so `KeyboardInterrupt` — a BaseException,
+   which no `except Exception` catches — escaped into atexit's reporter.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[2]
+_SRC = _REPO / "backend/core/resilience/graceful_shutdown.py"
+
+
+# --------------------------------------------------------------------------
+# 1. no heavyweight import at shutdown
+# --------------------------------------------------------------------------
+
+def test_the_cleanup_does_not_import_torch() -> None:
+    """Look up, never import. Asserted on the shipped source because the
+    import was three call-frames deep in a path only exercised at exit."""
+    src = _SRC.read_text()
+    assert "import torch.multiprocessing as torch_mp" not in src, (
+        "torch is imported again inside a shutdown handler"
+    )
+    assert 'sys.modules.get("torch.multiprocessing")' in src
+
+
+def test_running_the_cleanup_leaves_torch_unloaded() -> None:
+    """The behavioural half: a process that never used torch must not acquire
+    it by shutting down."""
+    proc = subprocess.run(
+        [sys.executable, "-c",
+         "import sys;"
+         "import backend.core.resilience.graceful_shutdown as gs;"
+         "gs.cleanup_all_semaphores_sync();"
+         "print('TORCH' if 'torch' in sys.modules else 'CLEAN')"],
+        capture_output=True, text=True, timeout=120, cwd=str(_REPO),
+        env={**os.environ, "PYTHONPATH": str(_REPO)},
+    )
+    assert "CLEAN" in proc.stdout, (
+        f"shutdown pulled torch into a process that never used it: "
+        f"{proc.stdout[-200:]}{proc.stderr[-300:]}"
+    )
+
+
+def test_torch_children_are_still_reaped_when_torch_IS_loaded() -> None:
+    """The fix must not silently stop doing the job. When torch is genuinely
+    present the same branch runs — proven with a stand-in module so the test
+    does not cost a real torch import."""
+    probe = (
+        "import sys, types;"
+        "m = types.ModuleType('torch.multiprocessing');"
+        "seen = [];"
+        "m.active_children = lambda: seen.append(1) or [];"
+        "sys.modules['torch.multiprocessing'] = m;"
+        "import backend.core.resilience.graceful_shutdown as gs;"
+        "gs.cleanup_all_semaphores_sync();"
+        "print('REAPED' if seen else 'SKIPPED')"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", probe], capture_output=True, text=True,
+        timeout=120, cwd=str(_REPO),
+        env={**os.environ, "PYTHONPATH": str(_REPO)},
+    )
+    assert "REAPED" in proc.stdout, (
+        f"torch children are no longer reaped when torch IS loaded: "
+        f"{proc.stdout[-200:]}"
+    )
+
+
+# --------------------------------------------------------------------------
+# 2. nothing escapes the handler
+# --------------------------------------------------------------------------
+
+def test_the_shutdown_handlers_are_guarded() -> None:
+    """`KeyboardInterrupt` is a BaseException — the `except Exception` these
+    handlers already carried never caught it, which is why the traceback
+    appeared despite the guards being visible in the source."""
+    src = _SRC.read_text()
+    assert "guarded_atexit_register(" in src
+    assert "atexit.register(_final_semaphore_cleanup)" not in src
+    assert "atexit.register(_final_thread_cleanup)" not in src
+
+
+@pytest.mark.timeout(120)
+def test_ctrl_c_during_exit_prints_nothing(tmp_path: Path) -> None:
+    """The end-to-end symptom: SIGINT delivered while an exit handler runs.
+
+    Guarded, the process leaves silently. Unguarded, atexit prints
+    'Exception ignored in atexit callback' plus a full traceback over the
+    operator's goodbye."""
+    script = tmp_path / "exiting.py"
+    script.write_text(
+        "import os, signal, sys, time\n"
+        f"sys.path.insert(0, {str(_REPO)!r})\n"
+        "from backend.core.ouroboros.governance.exit_guard import "
+        "guarded_atexit_register\n"
+        "def slow_cleanup():\n"
+        "    # Stands in for a handler that takes real time — which is what\n"
+        "    # gives a Ctrl+C a window to land in.\n"
+        "    os.kill(os.getpid(), signal.SIGINT)\n"
+        "    time.sleep(0.2)\n"
+        "guarded_atexit_register(slow_cleanup)\n"
+        "print('BODY_DONE', flush=True)\n"
+    )
+    proc = subprocess.run(
+        [sys.executable, str(script)], capture_output=True, text=True,
+        timeout=60, cwd=str(_REPO),
+        env={**os.environ, "PYTHONPATH": str(_REPO)},
+    )
+    assert "BODY_DONE" in proc.stdout
+    assert "Exception ignored in atexit" not in proc.stderr, (
+        f"the traceback is back:\n{proc.stderr[-600:]}"
+    )
+    assert "KeyboardInterrupt" not in proc.stderr


### PR DESCRIPTION
The operator's Ctrl+C printed a traceback over the goodbye:

```
^CException ignored in atexit callback: <_final_semaphore_cleanup>
  File ".../graceful_shutdown.py", line 2406, in cleanup_all_semaphores_sync
    import torch.multiprocessing as torch_mp
KeyboardInterrupt:
```

Two independent defects, and **either alone brings it back**.

### 1 · The handler imported torch at interpreter shutdown
Seconds of C-extension loading executed while the interpreter is tearing itself down — precisely what stretched the shutdown window from microseconds to long enough for a Ctrl+C to land inside it. The traceback is nine frames deep in `typing`/`packaging` machinery because that's simply where the interrupt happened to arrive mid-import.

It's also **unnecessary by construction**: torch can only own multiprocessing children if torch was already imported.

```python
torch_mp = sys.modules.get("torch.multiprocessing")   # zero cost when absent
```

Importing it to check *creates* the subsystem it then tears down.

Pinned both ways — a process that never touched torch stays clean, **and** children are still reaped when torch genuinely is loaded (verified with a stand-in module, so the test doesn't cost a real torch import).

### 2 · The handlers were registered raw
`KeyboardInterrupt` is a `BaseException`, which no `except Exception` catches — which is why the traceback appeared despite guards being visible in the source. Routed through `guarded_atexit_register` (#70144), the same seam already covering the child reaper and the advisor executor.

### End-to-end
SIGINT delivered *while an exit handler runs*, asserting stderr carries no `Exception ignored in atexit callback`.

**510 green.**

### Follow-up — surveyed, not fixed
Eight more raw `atexit.register` sites in `backend/core`: `thread_manager` ×3, `embedding_service` ×2, `lifecycle_manager`, `vm_lifecycle_manager`, `cross_repo_cleanup`.

Same class, same one-line fix — but they sit in modules this change doesn't otherwise touch, and a blind sweep risks import cycles I couldn't verify here. Worth doing deliberately rather than opportunistically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop importing `torch` during interpreter shutdown and guard exit handlers to remove the “Exception ignored in atexit callback” traceback on Ctrl+C. Shutdown is now quick and quiet; processes that never use `torch` stay clean, and `torch` children are still reaped when present.

- **Bug Fixes**
  - Look up `torch.multiprocessing` via `sys.modules.get(...)` instead of importing it at exit.
  - Use `guarded_atexit_register(...)` for final semaphore and thread cleanup to prevent `KeyboardInterrupt` from leaking to stderr.
  - Added tests to verify no `torch` import at shutdown, reaping when `torch` is loaded, and silent SIGINT during exit.

<sup>Written for commit 1b35a35277c910ffb267e3ffa5637a03be481423. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

