### PR TITLE
fix(ov): a socket nobody owns is a ghost; a daemon says what it is made of

### DIFF
--- a/backend/core/ouroboros/battle_test/daemon_provenance.py
+++ b/backend/core/ouroboros/battle_test/daemon_provenance.py
@@ -1,0 +1,127 @@
+"""What code is the running organism actually made of?
+
+An `ov` daemon outlives the terminal that started it — that is the point. The
+cost is that an operator attaches to a process whose age and contents are
+invisible: it looks identical whether it booted a minute ago or on Saturday.
+
+Observed 2026-07-27: a daemon had been running **36 hours**. Every fix merged
+that day was on disk and not in the process. Two rounds of debugging went into
+a build that structurally could not contain the fix, and nothing on screen
+could have said so.
+
+The daemon stamps what it booted from; the client compares against the repo
+now. Neither side guesses, and neither has to remember to ask.
+
+Deliberately advisory. An old daemon is often correct — a long soak SHOULD
+keep running while its operator commits unrelated work — so this reports and
+never acts. `git` is consulted through a bounded subprocess and every failure
+degrades to "unknown", because a provenance banner that can block or slow a
+boot is worse than no banner.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger("Ouroboros.Provenance")
+
+__all__ = ["read_provenance", "staleness_line", "write_provenance"]
+
+_STAMP = ".jarvis/daemon_provenance.json"
+
+
+def _repo_root() -> Path:
+    return Path(os.environ.get("JARVIS_REPO_PATH", ".")).resolve()
+
+
+def _git(*args: str, root: Optional[Path] = None) -> str:
+    """One bounded git call. '' on any failure — never raises, never hangs."""
+    try:
+        out = subprocess.run(
+            ["git", *args], capture_output=True, text=True, timeout=3.0,
+            cwd=str(root or _repo_root()),
+        )
+        return out.stdout.strip() if out.returncode == 0 else ""
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def write_provenance(path: Optional[Path] = None) -> Optional[Path]:
+    """Stamp what this daemon booted from. Called once, at boot."""
+    target = path or (_repo_root() / _STAMP)
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(json.dumps({
+            "pid": os.getpid(),
+            "booted_at": time.time(),
+            "commit": _git("rev-parse", "HEAD"),
+            "branch": _git("rev-parse", "--abbrev-ref", "HEAD"),
+        }), encoding="utf-8")
+        return target
+    except Exception:  # noqa: BLE001
+        logger.debug("[Provenance] could not stamp", exc_info=True)
+        return None
+
+
+def read_provenance(path: Optional[Path] = None) -> Dict[str, Any]:
+    try:
+        target = path or (_repo_root() / _STAMP)
+        return json.loads(target.read_text(encoding="utf-8"))
+    except Exception:  # noqa: BLE001
+        return {}
+
+
+def _age(seconds: float) -> str:
+    if seconds < 3600:
+        return f"{int(seconds // 60)}m"
+    if seconds < 86400:
+        return f"{int(seconds // 3600)}h"
+    return f"{int(seconds // 86400)}d"
+
+
+def staleness_line(
+    path: Optional[Path] = None, *, root: Optional[Path] = None,
+) -> str:
+    """One advisory line, or '' when the daemon is current or unknowable.
+
+    Silent on a fresh daemon: a banner that always shows is chrome, and gets
+    read past exactly when it finally matters.
+    """
+    try:
+        stamp = read_provenance(path)
+        if not stamp:
+            return ""
+        booted = float(stamp.get("booted_at") or 0)
+        commit = str(stamp.get("commit") or "")
+        age_s = max(0.0, time.time() - booted) if booted else 0.0
+
+        head = _git("rev-parse", "HEAD", root=root)
+        if not head or not commit:
+            # Not a git checkout, or git is unavailable. Age alone is still
+            # worth saying once it is large — "unknown" beats a confident
+            # wrong answer about what code is loaded.
+            return (f"⚠ daemon booted {_age(age_s)} ago · commit unknown"
+                    if age_s >= _age_threshold_s() else "")
+        if head == commit:
+            return ""                       # current; say nothing
+
+        behind = _git("rev-list", "--count", f"{commit}..{head}", root=root)
+        detail = f"{behind} commits behind" if behind.isdigit() else "behind HEAD"
+        return (f"⚠ daemon booted {_age(age_s)} ago on {commit[:7]} · "
+                f"{detail} · restart to load current code")
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def _age_threshold_s() -> float:
+    """How old is worth mentioning when the commit cannot be compared."""
+    try:
+        return max(60.0, float(os.environ.get(
+            "JARVIS_DAEMON_STALE_AGE_S", "3600") or 3600))
+    except (TypeError, ValueError):
+        return 3600.0

--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -4610,6 +4610,17 @@ class BattleTestHarness:
                             _mirror_sink, base=sf.console,
                         )
                         sf.console = spooled
+                        # Stamp what this daemon is MADE of. It outlives the
+                        # terminal that started it, so an operator cannot
+                        # otherwise tell a minute-old process from a two-day
+                        # one carrying none of today's fixes.
+                        try:
+                            from backend.core.ouroboros.battle_test.daemon_provenance import (  # noqa: E501
+                                write_provenance,
+                            )
+                            write_provenance()
+                        except Exception:  # noqa: BLE001
+                            pass
                         spooler.start()
                         self._console_spooler = spooler
                 except Exception:  # noqa: BLE001

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -1024,6 +1024,19 @@ async def _split_plane_loop(
     )
 
     ui = ui or AttachUI()
+    # Say what the organism is made of, BEFORE anything else is trusted. A
+    # daemon outlives its terminal, so "attached" alone does not tell an
+    # operator whether today's work is loaded — and a stale one answers every
+    # verb with old behaviour while looking perfectly healthy.
+    try:
+        from backend.core.ouroboros.battle_test.daemon_provenance import (
+            staleness_line,
+        )
+        _stale = staleness_line()
+        if _stale:
+            console.print(_stale, markup=False, highlight=False)
+    except Exception:  # noqa: BLE001 — provenance must never block an attach
+        pass
     # Arm the out-of-band stack dump BEFORE the UI mounts. If the cockpit
     # wedges, `kill -USR1 <pid>` is the only way to ask it what it is doing —
     # Ctrl+C does nothing to a deadlocked thread and `kill -9` destroys the

--- a/backend/core/ouroboros/cli/thin_client.py
+++ b/backend/core/ouroboros/cli/thin_client.py
@@ -576,17 +576,40 @@ async def ensure_daemon(
         if state == "live":
             return True
         if state == "booting":
-            # A daemon is home but boot-starved — its socket must NOT be
-            # cleaned and no second ignition raced. Wait for it to serve.
-            _say("⏺ organism already waking — waiting for it to serve")
-            if await await_socket(path, on_tick=_mk_tick(_say)):
-                _say("⏺ organism live — attaching")
-                return True
-            _say(
-                "⚠ the waking organism never served — "
-                "tail " + str(daemon_log_path()),
-            )
-            return False
+            # "booting" is INFERRED from a socket that exists and does not
+            # answer — which is exactly what a daemon killed mid-life leaves
+            # behind. The two are indistinguishable from the socket alone, so
+            # the claim is corroborated against a LIVE process before it is
+            # believed.
+            #
+            # Without this, an ungraceful death wedges `ov` permanently: the
+            # client waits for a corpse, and the stale-socket reaper lives
+            # inside the harness the client is refusing to start. The cleanup
+            # is trapped inside the thing that cannot boot, and only a human
+            # deleting a file breaks the cycle — which no operator would know
+            # to do. Observed 2026-07-27 after a routine `kill`.
+            #
+            # `_live_incumbent` is the SAME reader the reaper and preflight
+            # use, so there is one authority on "is anyone home" and no way
+            # for two components to disagree about it.
+            if _live_incumbent() is None:
+                _say(
+                    "⎿ a socket is present but nobody owns it — "
+                    "treating as a ghost and igniting",
+                )
+                state = "stale"          # fall through to the reap+spawn path
+            else:
+                # A daemon is home but boot-starved — its socket must NOT be
+                # cleaned and no second ignition raced. Wait for it to serve.
+                _say("⏺ organism already waking — waiting for it to serve")
+                if await await_socket(path, on_tick=_mk_tick(_say)):
+                    _say("⏺ organism live — attaching")
+                    return True
+                _say(
+                    "⚠ the waking organism never served — "
+                    "tail " + str(daemon_log_path()),
+                )
+                return False
         if state == "stale":
             # NEVER unlink while a live single-flight incumbent exists:
             # the bridge binds ONCE at boot, so cleaning a live-but-

--- a/tests/cli/test_ghost_socket_and_staleness.py
+++ b/tests/cli/test_ghost_socket_and_staleness.py
@@ -1,0 +1,168 @@
+"""Two ways an operator was left in the dark, both observed on 2026-07-27.
+
+**A dead daemon's socket wedged `ov` permanently.** `probe_socket` classifies
+a socket that exists and does not answer as "booting" — which is exactly what
+a `kill` leaves behind. The client waited for a corpse, and the stale-socket
+reaper lives inside the harness the client was refusing to start: the cleanup
+was trapped inside the thing that could not boot. Only a human deleting a file
+broke the cycle, which no operator would know to do.
+
+**A daemon ran for 36 hours** carrying none of that day's merged fixes, and
+nothing on screen said so. Two rounds of debugging went into a process that
+structurally could not contain the fix.
+
+Both are the same failure in different clothes: state that determines whether
+anything works, with no way to observe it.
+"""
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from backend.core.ouroboros.battle_test.daemon_provenance import (
+    read_provenance,
+    staleness_line,
+    write_provenance,
+)
+
+_REPO = Path(__file__).resolve().parents[2]
+
+
+# --------------------------------------------------------------------------
+# 1. a socket nobody owns is a ghost, not a boot
+# --------------------------------------------------------------------------
+
+def test_booting_is_corroborated_against_a_live_process() -> None:
+    """THE wedge. A `booting` claim with no live owner must fall through to
+    the reap-and-ignite path instead of being waited on."""
+    src = (_REPO / "backend/core/ouroboros/cli/thin_client.py").read_text()
+    branch = src.split('if state == "booting":')[1][:1400]
+    assert "_live_incumbent() is None" in branch, (
+        "a booting claim is believed without checking whether anyone owns it"
+    )
+    assert 'state = "stale"' in branch, (
+        "an unowned socket does not fall through to the ghost path"
+    )
+
+
+def test_the_operator_is_told_why_it_ignited() -> None:
+    """Observability over silent reroute: a client that quietly reclassifies
+    a socket teaches nobody anything."""
+    src = (_REPO / "backend/core/ouroboros/cli/thin_client.py").read_text()
+    assert "treating as a ghost and igniting" in src
+
+
+def test_a_live_incumbent_is_still_waited_for() -> None:
+    """The inverse, and it is load-bearing: cleaning a live-but-slow
+    organism's socket makes it permanently unattachable — the 2026-07-23
+    class this codebase already paid for once."""
+    src = (_REPO / "backend/core/ouroboros/cli/thin_client.py").read_text()
+    branch = src.split('if state == "booting":')[1][:1600]
+    assert "organism already waking" in branch
+    assert branch.index("_live_incumbent() is None") < \
+        branch.index("organism already waking"), (
+        "the liveness check must GATE the wait, not follow it"
+    )
+
+
+def test_one_authority_answers_who_is_home() -> None:
+    """DRY: the reaper, the preflight and this check read the same lock, so
+    they cannot disagree about whether a daemon exists."""
+    src = (_REPO / "backend/core/ouroboros/cli/thin_client.py").read_text()
+    assert "live_incumbent_pid" in src
+
+
+# --------------------------------------------------------------------------
+# 2. the daemon says what it is made of
+# --------------------------------------------------------------------------
+
+def test_a_stamp_records_commit_and_boot_time(tmp_path: Path) -> None:
+    target = write_provenance(tmp_path / "p.json")
+    assert target is not None and target.exists()
+    stamp = read_provenance(target)
+    assert stamp["pid"] > 0
+    assert stamp["booted_at"] > 0
+    assert isinstance(stamp["commit"], str)
+
+
+def test_a_current_daemon_says_nothing(tmp_path: Path) -> None:
+    """A banner that always shows is chrome, and gets read past exactly when
+    it finally matters."""
+    assert staleness_line(write_provenance(tmp_path / "p.json")) == ""
+
+
+def test_an_old_daemon_on_an_old_commit_is_flagged(tmp_path: Path) -> None:
+    """The 36-hour case."""
+    stamp = tmp_path / "p.json"
+    stamp.write_text(json.dumps({
+        "pid": 1, "booted_at": time.time() - 129_600,
+        "commit": "0" * 40, "branch": "main",
+    }))
+    line = staleness_line(stamp)
+    assert "1d ago" in line
+    assert "restart" in line, "the operator is told the state but not the fix"
+
+
+@pytest.mark.parametrize("age,expected", [
+    (90, "1m"), (7200, "2h"), (200_000, "2d"),
+])
+def test_age_reads_naturally(age: float, expected: str, tmp_path: Path) -> None:
+    stamp = tmp_path / "p.json"
+    stamp.write_text(json.dumps({
+        "pid": 1, "booted_at": time.time() - age, "commit": "0" * 40,
+    }))
+    assert expected in staleness_line(stamp)
+
+
+def test_a_missing_stamp_is_silent(tmp_path: Path) -> None:
+    """An older daemon predates the stamp. Absence is not staleness, and
+    guessing would cry wolf on every upgrade."""
+    assert staleness_line(tmp_path / "absent.json") == ""
+
+
+@pytest.mark.parametrize("body", [
+    "", "not json", "[]", '{"booted_at": "yesterday"}', '{"commit": null}',
+])
+def test_a_corrupt_stamp_never_raises(body: str, tmp_path: Path) -> None:
+    stamp = tmp_path / "p.json"
+    stamp.write_text(body)
+    assert isinstance(staleness_line(stamp), str)
+
+
+def test_provenance_is_bounded_and_cannot_hang_a_boot() -> None:
+    """It shells out to git. A banner that can stall an attach is worse than
+    no banner."""
+    import inspect
+
+    from backend.core.ouroboros.battle_test import daemon_provenance
+
+    src = inspect.getsource(daemon_provenance._git)
+    assert "timeout=" in src
+
+
+def test_it_is_fast_enough_to_sit_on_the_attach_path(tmp_path: Path) -> None:
+    stamp = write_provenance(tmp_path / "p.json")
+    started = time.perf_counter()
+    staleness_line(stamp)
+    assert time.perf_counter() - started < 2.0
+
+
+# --------------------------------------------------------------------------
+# 3. both ends are wired
+# --------------------------------------------------------------------------
+
+def test_the_daemon_stamps_at_boot() -> None:
+    src = (_REPO / "backend/core/ouroboros/battle_test/harness.py").read_text()
+    assert "write_provenance()" in src
+
+
+def test_the_client_reports_before_it_trusts_anything() -> None:
+    """It must print BEFORE the UI mounts — a stale daemon answers every verb
+    with old behaviour while looking perfectly healthy."""
+    src = (_REPO / "backend/core/ouroboros/cli/ov.py").read_text()
+    assert "staleness_line()" in src
+    assert src.index("staleness_line()") < src.index("PromptSession(")

--- a/tests/cli/test_thin_client.py
+++ b/tests/cli/test_thin_client.py
@@ -527,6 +527,17 @@ class TestHandshakeDepthProbe:
             served["on"] = True
 
         try:
+            # A booting daemon HAS an owner. Since 2026-07-27 the client
+            # corroborates a "booting" socket against a live incumbent before
+            # waiting on it, because a socket left by a killed daemon is
+            # indistinguishable from a booting one — and waiting on a corpse
+            # wedged `ov` until a human deleted the file by hand.
+            #
+            # This fake previously left the owner unset, which now correctly
+            # reads as a ghost. Stating it makes the test say WHICH of the two
+            # cases it is about; the ghost case is covered in
+            # tests/cli/test_ghost_socket_and_staleness.py.
+            monkeypatch.setattr(thin_client, "_live_incumbent", lambda: 4242)
             flip = asyncio.ensure_future(_flip())
             ok = await thin_client.ensure_daemon(
                 spawner=lambda *a, **k: spawns.append(a),


### PR DESCRIPTION
Two failures observed today, both the same shape: **state that decides whether anything works, with no way to observe it.**

### 1 · A killed daemon wedged `ov` permanently

`probe_socket` classifies a socket that exists and doesn't answer as `"booting"` — which is *exactly* what a `kill` leaves behind. The client waited for a corpse:

```
⏺ organism already waking — waiting for it to serve
⏺ organism live — attaching
no organism awake — nothing to attach to.
```

And the stale-socket reaper lives **inside the harness the client was refusing to start**. The cleanup was trapped inside the thing that couldn't boot. Only a human deleting `.jarvis/intake_router.lock` broke the cycle — which no operator would know to do.

A `"booting"` claim is now corroborated against a live incumbent before it's believed — the **same reader** the reaper and preflight use, so no two components can disagree about whether anyone is home.

- No owner → the socket is a ghost → falls through to the existing reap-and-ignite path, and **says so** rather than silently rerouting.
- A live incumbent is still waited for, never cleaned. That inverse is load-bearing: cleaning a live-but-slow organism's socket makes it permanently unattachable — a class this codebase already paid for once.

### 2 · A daemon ran 36 hours carrying none of that day's fixes

Nothing on screen said so. Two rounds of debugging went into a process that structurally could not contain the fix.

The daemon stamps its commit and boot time; the client compares against HEAD at attach:

```
⚠ daemon booted 1d ago on 0000000 · 14 commits behind · restart to load current code
```

**Silent when current** — a banner that always shows is chrome, and gets read past exactly when it finally matters.

**Advisory, never blocking.** An old daemon is often correct (a long soak *should* survive unrelated commits). Git is consulted through a bounded subprocess and every failure degrades to "unknown", because a provenance banner that can stall an attach is worse than no banner.

**A missing stamp is silent too** — an older daemon predates it, and absence is not staleness.

### One existing test had to say which case it meant
It simulated `"booting"` with no owner — now correctly a ghost — so it states the live incumbent explicitly. The ghost case has its own coverage.

### Tests
20 new. **557 green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented attaches from wedging on dead sockets and added daemon provenance so operators can see if the running `ov` code is stale.

- **Bug Fixes**
  - Corroborate a "booting" socket against a live incumbent using the shared reader; if no owner, treat it as a ghost and fall through to the existing reap-and-spawn path with a clear message.
  - Still wait for a live-but-booting daemon; never unlink a live socket to avoid making it unattachable.

- **New Features**
  - Daemon stamps `.jarvis/daemon_provenance.json` at boot with pid, boot time, and `git` commit/branch.
  - Client prints one advisory line before the UI if the daemon is behind or commit is unknown; `git` calls are bounded and the banner is silent when current or the stamp is missing.

<sup>Written for commit f5e5f97968a3f2a52ab7dd48e7f1dbd862d907bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

