### PR TITLE
fix(ov): the attach summary answers questions instead of dumping fields

### DIFF
--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -332,26 +332,137 @@ def _render_hydration(console: Any, payload: dict) -> None:
             markup=False, highlight=False,
         )
         if ops:
-            console.print(
-                f"⎿ active ops: {', '.join(str(o) for o in ops[:4])}",
-                markup=False, highlight=False,
-            )
-        providers = liq.get("providers") or {}
-        for name, row in list(providers.items())[:3]:
-            tokens = row.get("tokens_remaining")
-            tok_txt = f"{tokens:,} tokens" if tokens is not None else "undeclared"
-            console.print(
-                f"⎿ liquidity {name}: {tok_txt}",
-                markup=False, highlight=False,
-            )
-        if liq.get("any_exhausted"):
-            console.print("⚠ a provider runway is dry", markup=False)
+            console.print(_active_ops_line(ops), markup=False, highlight=False)
+        for line in _liquidity_lines(liq.get("providers") or {},
+                                     any_exhausted=liq.get("any_exhausted")):
+            console.print(line, markup=False, highlight=False)
         console.print(
             "⎿ type verbs or plain text · Ctrl+C detaches (the organism "
             "keeps running)", markup=False, highlight=False,
         )
     except Exception:
         pass
+
+
+def _active_ops_line(ops: Any) -> str:
+    """What the organism is working on, in a form a human can hold.
+
+    This printed full UUIDv7s — ``op-019fa4d2-246e-7759-86,
+    op-019fa4d2-2468-794f-bc, ...`` — three of which fill a line and none of
+    which an operator can distinguish, because UUIDv7 is time-ordered and
+    same-millisecond ops share their entire prefix. The identifying bytes are
+    at the END, which is exactly where the truncation cut.
+
+    So the SUFFIX is shown: it is the part that actually differs. The count
+    leads, because "how many" is the question a glance is asking, and the
+    total is stated when more are running than are listed — a silent
+    truncation reads as "that is all of them".
+    """
+    try:
+        items = [str(o) for o in (ops or []) if str(o).strip()]
+    except Exception:  # noqa: BLE001
+        return "⎿ active ops: (unreadable)"
+    if not items:
+        return "⎿ active ops: none"
+
+    def _short(op_id: str) -> str:
+        # Whole trailing SEGMENTS, never a raw character slice: cutting
+        # mid-segment yields "-7759-86" with a leading dash that reads as a
+        # typo. Two segments is enough to distinguish same-millisecond ops,
+        # which share every earlier byte.
+        parts = [p for p in op_id.split("-") if p]
+        if len(parts) >= 3:
+            return "-".join(parts[-2:])
+        return parts[-1] if parts else op_id
+
+    shown = items[:4]
+    body = ", ".join(_short(o) for o in shown)
+    more = len(items) - len(shown)
+    suffix = f" (+{more} more)" if more > 0 else ""
+    return f"⎿ {len(items)} active op{'s' if len(items) != 1 else ''}: {body}{suffix}"
+
+
+def _liquidity_lines(providers: Any, *, any_exhausted: Any = None) -> list:
+    """Provider runways, ordered by what an operator needs to act on.
+
+    Three defects this replaces, and they compounded:
+
+      * ``⚠ a provider runway is dry`` named NOTHING. The per-provider rows
+        that answer "which one" were already in hand, so the warning withheld
+        an answer it was holding.
+      * the rows were sliced ``[:3]`` in DICT ORDER — arbitrary, so an
+        exhausted provider sitting fourth was never displayed, and the warning
+        then referred to something invisible.
+      * ``5,000,000 tokens`` beside "a runway is dry" reads as a contradiction
+        until you know they describe different providers.
+
+    So the list is ordered by URGENCY rather than by whatever order the dict
+    happened to have: exhausted first, then the thinnest runway. Truncation
+    now drops what matters least instead of whatever sorted last, and an
+    exhausted provider can never be the row that gets cut.
+    """
+    lines: list = []
+    try:
+        rows = list((providers or {}).items())
+    except Exception:  # noqa: BLE001
+        return lines
+
+    def _remaining(row: Any) -> Any:
+        try:
+            return row.get("tokens_remaining")
+        except Exception:  # noqa: BLE001
+            return None
+
+    def _dry(row: Any) -> bool:
+        try:
+            if row.get("exhausted"):
+                return True
+        except Exception:  # noqa: BLE001
+            return False
+        left = _remaining(row)
+        return isinstance(left, (int, float)) and left <= 0
+
+    # Sort key: dry first, then thinnest. `None` (undeclared) sorts last —
+    # an unknown runway is not evidence of a problem, and promoting it would
+    # push a real one off the list.
+    def _key(item: Any) -> Any:
+        _name, row = item
+        left = _remaining(row)
+        known = isinstance(left, (int, float))
+        return (0 if _dry(row) else 1, 0 if known else 1,
+                left if known else 0)
+
+    try:
+        rows.sort(key=_key)
+    except Exception:  # noqa: BLE001
+        pass
+
+    dry_names = [n for n, r in rows if _dry(r)]
+    # Always show every dry provider, plus enough healthy ones for context.
+    shown = max(3, len(dry_names))
+    for name, row in rows[:shown]:
+        left = _remaining(row)
+        if isinstance(left, (int, float)):
+            amount = f"{int(left):,} tokens"
+        else:
+            amount = "undeclared"
+        mark = " ← dry" if _dry(row) else ""
+        lines.append(f"⎿ liquidity {name}: {amount}{mark}")
+
+    if dry_names:
+        # NAME them. "a provider" is the one thing the operator cannot look up.
+        lines.append(
+            f"⚠ runway exhausted: {', '.join(dry_names)} — "
+            f"routing will fall through to the remaining providers"
+        )
+    elif any_exhausted:
+        # The aggregate flag disagrees with every row we can see. Say that,
+        # rather than repeating a claim nothing supports.
+        lines.append(
+            "⚠ a runway is reported dry but no provider row shows it — "
+            "run /provider for the authoritative view"
+        )
+    return lines
 
 
 def _can_run_split_plane() -> bool:

--- a/tests/cli/test_attach_digest.py
+++ b/tests/cli/test_attach_digest.py
@@ -1,0 +1,158 @@
+"""The attach summary answers questions instead of dumping fields.
+
+From a real boot:
+
+    ⎿ active ops: op-019fa4d2-246e-7759-86, op-019fa4d2-2468-794f-bc, ...
+    ⎿ liquidity anthropic: 5,000,000 tokens
+    ⚠ a provider runway is dry
+
+Three problems, and they compound. The warning names nothing — while the
+per-provider rows that answer "which one" are already in hand. Those rows were
+sliced `[:3]` in DICT ORDER, so an exhausted provider sitting fourth was never
+shown and the warning referred to something invisible. And "5,000,000 tokens"
+beside "a runway is dry" reads as a contradiction until you know they describe
+different providers.
+
+The op ids were UUIDv7 — time-ordered, so same-millisecond ops share their
+entire prefix. The identifying bytes are at the END, which is exactly where
+the truncation cut.
+"""
+from __future__ import annotations
+
+import contextlib
+import io
+from typing import Any
+
+import pytest
+
+
+def _fns():
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+        from backend.core.ouroboros.cli.ov import (
+            _active_ops_line, _liquidity_lines,
+        )
+    return _active_ops_line, _liquidity_lines
+
+
+# --------------------------------------------------------------------------
+# 1. the warning names the provider
+# --------------------------------------------------------------------------
+
+def test_the_dry_provider_is_named() -> None:
+    """'a provider' is the one thing the operator cannot look up."""
+    _ops, liq = _fns()
+    lines = liq({"anthropic": {"tokens_remaining": 5_000_000},
+                 "doubleword": {"tokens_remaining": 0}}, any_exhausted=True)
+    warning = [l for l in lines if l.startswith("⚠")]
+    assert warning and "doubleword" in warning[0]
+    assert "a provider runway is dry" not in warning[0]
+
+
+def test_an_exhausted_provider_can_never_be_truncated_away() -> None:
+    """THE compounding bug: the rows were sliced in dict order, so the
+    warning could reference a provider that was never displayed."""
+    _ops, liq = _fns()
+    providers = {f"p{i}": {"tokens_remaining": 1_000_000} for i in range(6)}
+    providers["last-and-dry"] = {"tokens_remaining": 0}
+    body = "\n".join(liq(providers, any_exhausted=True))
+    assert "last-and-dry" in body, "the dry provider was cut from the list"
+
+
+def test_dry_providers_sort_first() -> None:
+    _ops, liq = _fns()
+    lines = liq({"healthy": {"tokens_remaining": 9_000_000},
+                 "empty": {"tokens_remaining": 0}}, any_exhausted=True)
+    rows = [l for l in lines if l.startswith("⎿")]
+    assert "empty" in rows[0]
+
+
+def test_the_thinnest_runway_ranks_above_the_fattest() -> None:
+    _ops, liq = _fns()
+    rows = [l for l in liq({"fat": {"tokens_remaining": 9_000_000},
+                            "thin": {"tokens_remaining": 12}})
+            if l.startswith("⎿")]
+    assert "thin" in rows[0]
+
+
+def test_an_undeclared_runway_is_not_treated_as_a_problem() -> None:
+    """Unknown is not evidence of exhaustion, and promoting it would push a
+    real problem off the list."""
+    _ops, liq = _fns()
+    lines = liq({"unknown": {"tokens_remaining": None},
+                 "empty": {"tokens_remaining": 0}}, any_exhausted=True)
+    rows = [l for l in lines if l.startswith("⎿")]
+    assert "empty" in rows[0]
+    assert "undeclared" in "\n".join(rows)
+    assert "unknown" not in [l for l in lines if l.startswith("⚠")][0]
+
+
+def test_a_dry_row_is_marked_where_it_is_read() -> None:
+    """The mark sits ON the row, so the number and its meaning are read
+    together rather than two lines apart."""
+    _ops, liq = _fns()
+    rows = [l for l in liq({"empty": {"tokens_remaining": 0}}) if "empty" in l]
+    assert "dry" in rows[0]
+
+
+def test_a_flag_no_row_supports_is_reported_as_a_disagreement() -> None:
+    """Repeating an unsupported claim is how a warning loses its meaning."""
+    _ops, liq = _fns()
+    warning = [l for l in liq({"anthropic": {"tokens_remaining": 9}},
+                              any_exhausted=True) if l.startswith("⚠")]
+    assert warning and "no provider row shows it" in warning[0]
+
+
+def test_a_healthy_organism_gets_no_warning() -> None:
+    _ops, liq = _fns()
+    assert [l for l in liq({"a": {"tokens_remaining": 5}}) if l.startswith("⚠")] == []
+
+
+@pytest.mark.parametrize("junk", [None, {}, [], "nonsense", {"x": None}])
+def test_liquidity_never_raises(junk: Any) -> None:
+    _ops, liq = _fns()
+    assert isinstance(liq(junk), list)
+
+
+# --------------------------------------------------------------------------
+# 2. op ids a human can tell apart
+# --------------------------------------------------------------------------
+
+def test_the_distinguishing_END_of_a_uuidv7_is_kept() -> None:
+    """UUIDv7 is time-ordered: same-millisecond ops share every leading byte,
+    so a prefix distinguishes nothing."""
+    ops, _liq = _fns()
+    line = ops(["op-019fa4d2-246e-7759-86", "op-019fa4d2-2468-794f-bc"])
+    assert "7759-86" in line and "794f-bc" in line
+    assert "019fa4d2" not in line, "the shared prefix is still being printed"
+
+
+def test_whole_segments_never_a_character_slice() -> None:
+    """A mid-segment cut yields '-7759-86', whose leading dash reads as a
+    typo."""
+    ops, _liq = _fns()
+    assert ": -" not in ops(["op-019fa4d2-246e-7759-86"])
+
+
+def test_the_count_leads_because_that_is_the_glance_question() -> None:
+    ops, _liq = _fns()
+    assert ops(["a-b-c"]).startswith("⎿ 1 active op:")
+    assert ops(["a-b-c", "d-e-f"]).startswith("⎿ 2 active ops:")
+
+
+def test_hidden_ops_are_declared_not_silently_dropped() -> None:
+    """A silent truncation reads as 'that is all of them'."""
+    ops, _liq = _fns()
+    line = ops([f"op-x-y-{i}" for i in range(9)])
+    assert "9 active ops" in line and "+5 more" in line
+
+
+def test_an_empty_roster_says_so() -> None:
+    ops, _liq = _fns()
+    assert "none" in ops([])
+
+
+@pytest.mark.parametrize("junk", [None, [None], ["", "  "], [123], "str"])
+def test_the_ops_line_never_raises(junk: Any) -> None:
+    ops, _liq = _fns()
+    assert isinstance(ops(junk), str)


### PR DESCRIPTION
From a real boot:

```
⎿ active ops: op-019fa4d2-246e-7759-86, op-019fa4d2-2468-794f-bc, op-019fa4d2-24a2-796c-a6
⎿ liquidity anthropic: 5,000,000 tokens
⚠ a provider runway is dry
```

### The warning named nothing
…while the per-provider rows that answer *which one* were already in hand. It withheld an answer it was holding.

### And those rows were sliced `[:3]` in dict order
So an exhausted provider sitting fourth was **never displayed**, and the warning referred to something invisible. That's the compounding failure: an arbitrary truncation can cut exactly the row the warning is about.

Ordering is now by **urgency** — dry first, then thinnest runway — so truncation drops what matters least and a dry provider can never be the row that goes.

Undeclared runways sort **last**: unknown is not evidence of exhaustion, and promoting it would push a real problem off the list.

The dry mark sits **on the row**, so the number and its meaning are read together. `5,000,000 tokens` beside `a runway is dry` read as a contradiction until you knew they described different providers.

When the aggregate flag disagrees with every visible row, it says *that* rather than repeating a claim nothing supports — a warning that can't be corroborated is how warnings stop being read.

### Op ids showed the wrong end
UUIDv7 is **time-ordered**: same-millisecond ops share their entire prefix. The identifying bytes are at the END — exactly where the truncation cut. Three ids filled a line and none could be told apart.

Now trailing **segments** are shown (never a character slice, which yields `-7759-86` and a leading dash that reads as a typo), the count leads because that's what a glance is asking, and hidden ops are declared rather than silently dropped.

### After

```
⎿ 3 active ops: 7759-86, 794f-bc, 796c-a6
⎿ liquidity doubleword: 0 tokens ← dry
⎿ liquidity anthropic: 5,000,000 tokens
⚠ runway exhausted: doubleword — routing will fall through to the remaining providers
```

23 tests. **580 green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the attach summary so it answers real questions: it now names exhausted providers, orders liquidity by urgency, and shows readable op IDs with counts. This removes vague warnings and prevents critical providers from being hidden by truncation.

- Bug Fixes
  - Liquidity: sort by urgency (dry first, then lowest tokens; unknown last).
  - Always show all dry providers and mark them "← dry" on the row.
  - Warning names the exhausted providers; if the aggregate flag disagrees with rows, say so.
  - Active ops: show count first and trailing UUIDv7 segments (whole segments), never mid-segment slices.
  - Declare hidden ops with "+N more"; handle empty or unreadable input safely.

<sup>Written for commit 5ce8a6573a563c7b0393fa0fcdb06df090f8f17c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

