### PR TITLE
feat(ov): `ov restart` — reload the organism without hunting a pid

### DIFF
--- a/backend/core/ouroboros/battle_test/daemon_provenance.py
+++ b/backend/core/ouroboros/battle_test/daemon_provenance.py
@@ -105,15 +105,20 @@ def staleness_line(
             # Not a git checkout, or git is unavailable. Age alone is still
             # worth saying once it is large — "unknown" beats a confident
             # wrong answer about what code is loaded.
-            return (f"⚠ daemon booted {_age(age_s)} ago · commit unknown"
+            return (f"⚠ daemon booted {_age(age_s)} ago · commit unknown · "
+                    f"`ov restart` if it looks stale"
                     if age_s >= _age_threshold_s() else "")
         if head == commit:
             return ""                       # current; say nothing
 
         behind = _git("rev-list", "--count", f"{commit}..{head}", root=root)
         detail = f"{behind} commits behind" if behind.isdigit() else "behind HEAD"
+        # Name the COMMAND, not the intent. "restart to load current code"
+        # told an operator what to want; `ov restart` tells them what to
+        # type — and the gap between those two was four steps of `ps`, a
+        # transcribed pid, and a `kill`.
         return (f"⚠ daemon booted {_age(age_s)} ago on {commit[:7]} · "
-                f"{detail} · restart to load current code")
+                f"{detail} · run `ov restart` to load current code")
     except Exception:  # noqa: BLE001
         return ""
 

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -29,7 +29,7 @@ from typing import Any, Callable, List, Optional, Sequence
 from backend.core.ouroboros.ui.theme import build_console
 
 _VERBS = {"cockpit", "run", "daemon", "status", "attach", "system", "hive",
-          "doctor", "version"}
+          "doctor", "restart", "version"}
 _HELP_TOKENS = {"help", "--help", "-h"}
 _VERSION_TOKENS = {"version", "--version", "-V"}
 
@@ -258,6 +258,8 @@ def resolve(argv: Optional[Sequence[str]] = None) -> Invocation:
         return Invocation("hive")
     if verb == "doctor":
         return Invocation("doctor", list(rest))
+    if verb == "restart":
+        return Invocation("restart", list(rest))
     # cockpit (explicit or defaulted)
     return Invocation("cockpit", rest)
 
@@ -338,10 +340,102 @@ def _render_hydration(console: Any, payload: dict) -> None:
             console.print(line, markup=False, highlight=False)
         console.print(
             "⎿ type verbs or plain text · Ctrl+C detaches (the organism "
-            "keeps running)", markup=False, highlight=False,
+            "keeps running) · `ov restart` reloads it",
+            markup=False, highlight=False,
         )
     except Exception:
         pass
+
+
+def _live_incumbent() -> Any:
+    """PID of the live single-flight holder, or None.
+
+    Delegates to `thin_client`, which owns the ONE reader the reaper,
+    preflight and ghost-socket check all share — so `ov restart` cannot form
+    a different opinion about whether a daemon exists than the code that
+    decides whether to ignite one.
+    """
+    try:
+        from backend.core.ouroboros.cli.thin_client import (
+            _live_incumbent as _probe,
+        )
+        return _probe()
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _restart_daemon(say: Any) -> int:
+    """Stop the running organism and ignite a fresh one. Returns an exit code.
+
+    This exists because the alternative was `ps`, reading a pid, `kill`, then
+    `ov` — four steps and a number the operator had to transcribe correctly,
+    performed most often when a daemon is stale and least often when they have
+    patience for it.
+
+    NOT bound to Ctrl+C, deliberately. The organism is PROACTIVE: it runs
+    sensors and autonomous operations, and detaching is meant to leave it
+    working. Killing on Ctrl+C would end a long soak every time someone
+    glanced at it — the persistence is the feature, and this is the escape
+    hatch, not a reversal of it.
+
+    Graceful first: SIGTERM lets the harness write its summary, flush
+    telemetry and release its lock, which is what makes the NEXT boot clean.
+    SIGKILL only if it will not leave — and a killed daemon leaves the ghost
+    socket this codebase now detects rather than wedges on.
+    """
+    import signal
+    import time as _t
+
+    pid = _live_incumbent()
+    if pid is None:
+        say("⎿ no organism running — igniting a fresh one")
+    else:
+        say(f"⏺ stopping organism (pid {pid}) — SIGTERM, letting it finish")
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pid = None
+        except PermissionError:
+            say(f"⚠ not permitted to stop pid {pid} — is it yours?")
+            return 1
+        except Exception as exc:  # noqa: BLE001
+            say(f"⚠ could not signal pid {pid}: {type(exc).__name__}")
+            return 1
+
+    if pid is not None:
+        # Wait for it to ACTUALLY go. Igniting while the old one still holds
+        # the single-flight lock is how two organisms briefly race for one
+        # socket — the class this codebase already paid for.
+        deadline = _t.monotonic() + _restart_grace_s()
+        while _t.monotonic() < deadline:
+            try:
+                os.kill(pid, 0)
+            except (ProcessLookupError, PermissionError):
+                break
+            _t.sleep(0.2)
+        else:
+            say("⎿ it did not stop in time — escalating to SIGKILL")
+            try:
+                os.kill(pid, signal.SIGKILL)
+                _t.sleep(0.5)
+            except Exception:  # noqa: BLE001
+                pass
+        say("⎿ organism stopped")
+    return 0
+
+
+def _restart_grace_s() -> float:
+    """How long a daemon gets to shut down cleanly before SIGKILL.
+
+    Generous by default: the harness writes a summary and flushes telemetry
+    on the way out, and cutting that short is what leaves the next boot
+    dirty. Env ``JARVIS_OV_RESTART_GRACE_S``.
+    """
+    try:
+        return max(1.0, float(
+            os.environ.get("JARVIS_OV_RESTART_GRACE_S", "15") or 15))
+    except (TypeError, ValueError):
+        return 15.0
 
 
 def _active_ops_line(ops: Any) -> str:
@@ -2212,6 +2306,20 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         return run_system(console)
     if inv.action == "hive":
         return run_hive(console)
+    if inv.action == "restart":
+        # Stop, then fall through to the normal cockpit path — which already
+        # knows how to ignite, wait for the socket and attach. Reusing it
+        # means `ov restart` and `ov` cannot drift apart in how they boot.
+        def _say(text: str) -> None:
+            try:
+                print(text, flush=True)
+            except Exception:  # noqa: BLE001
+                pass
+        rc = _restart_daemon(_say)
+        if rc != 0:
+            return rc
+        inv = Invocation("cockpit", [])
+
     if inv.action == "doctor":
         try:
             from backend.core.ouroboros.cli.ov_doctor import run_doctor

--- a/tests/cli/test_ov_restart.py
+++ b/tests/cli/test_ov_restart.py
@@ -1,0 +1,195 @@
+"""One command to reload the organism, without hunting a pid.
+
+The operator's actual pain: `ps`, read a pid, `kill <pid>`, `ov`. Four steps
+and a number to transcribe, performed most often when a daemon is stale and
+least often when there is patience for it.
+
+Their proposed fix was "Ctrl+C should kill it". That would break the property
+the whole design rests on — the organism is PROACTIVE, runs sensors and
+autonomous operations, and detaching is meant to leave it working. Killing on
+Ctrl+C ends a long soak every time someone glances at it. So the persistence
+stays and this is the escape hatch: an explicit verb, surfaced exactly where
+an operator discovers they need it.
+"""
+from __future__ import annotations
+
+import contextlib
+import io
+import os
+import signal
+from pathlib import Path
+from typing import Any, List
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[2]
+
+
+def _ov():
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+        from backend.core.ouroboros.cli import ov
+    return ov
+
+
+# --------------------------------------------------------------------------
+# 1. routing
+# --------------------------------------------------------------------------
+
+def test_restart_is_a_first_class_verb() -> None:
+    ov = _ov()
+    assert ov.resolve(["restart"]).action == "restart"
+    assert "restart" in ov._VERBS
+
+
+def test_the_other_verbs_are_unchanged() -> None:
+    ov = _ov()
+    for argv, action in ((["status"], "status"), ([], "cockpit"),
+                         (["doctor"], "doctor"), (["attach"], "attach")):
+        assert ov.resolve(argv).action == action
+
+
+def test_restart_reuses_the_cockpit_ignition_path() -> None:
+    """DRY, and it matters: a second ignition path would drift from `ov`'s in
+    how it waits for the socket, which is where this codebase has been bitten
+    before."""
+    src = (_REPO / "backend/core/ouroboros/cli/ov.py").read_text()
+    branch = src.split('if inv.action == "restart":')[1][:700]
+    assert 'Invocation("cockpit"' in branch, (
+        "restart does not fall through to the shared boot path"
+    )
+
+
+# --------------------------------------------------------------------------
+# 2. stopping is graceful first
+# --------------------------------------------------------------------------
+
+def test_it_asks_politely_before_it_insists(monkeypatch: pytest.MonkeyPatch) -> None:
+    """SIGTERM lets the harness write its summary, flush telemetry and
+    release its lock — which is what makes the NEXT boot clean."""
+    ov = _ov()
+    signals: List[Any] = []
+    monkeypatch.setattr(ov, "_live_incumbent", lambda: 4242)
+    monkeypatch.setattr(ov.os, "kill",
+                        lambda pid, sig: signals.append(sig) or
+                        (_ for _ in ()).throw(ProcessLookupError()))
+    said: List[str] = []
+    assert ov._restart_daemon(said.append) == 0
+    assert signals and signals[0] == signal.SIGTERM
+
+
+def test_it_waits_for_the_process_to_actually_go(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Igniting while the old one still holds the single-flight lock is how
+    two organisms race for one socket."""
+    ov = _ov()
+    monkeypatch.setenv("JARVIS_OV_RESTART_GRACE_S", "2")
+    monkeypatch.setattr(ov, "_live_incumbent", lambda: 4242)
+    probes = {"n": 0}
+
+    def _kill(pid: int, sig: int) -> None:
+        if sig == 0:                       # liveness probe
+            probes["n"] += 1
+            if probes["n"] < 3:
+                return                     # still alive
+            raise ProcessLookupError()
+
+    monkeypatch.setattr(ov.os, "kill", _kill)
+    said: List[str] = []
+    assert ov._restart_daemon(said.append) == 0
+    assert probes["n"] >= 2, "it did not poll for the process to exit"
+    assert any("stopped" in s for s in said)
+
+
+def test_a_daemon_that_will_not_leave_is_escalated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ov = _ov()
+    monkeypatch.setenv("JARVIS_OV_RESTART_GRACE_S", "1")
+    monkeypatch.setattr(ov, "_live_incumbent", lambda: 4242)
+    sent: List[int] = []
+    monkeypatch.setattr(ov.os, "kill", lambda pid, sig: sent.append(sig))
+    said: List[str] = []
+    ov._restart_daemon(said.append)
+    assert signal.SIGKILL in sent
+    assert any("SIGKILL" in s for s in said), "escalation was silent"
+
+
+def test_nothing_running_still_ignites(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`ov restart` on a cold machine must boot, not error."""
+    ov = _ov()
+    monkeypatch.setattr(ov, "_live_incumbent", lambda: None)
+    said: List[str] = []
+    assert ov._restart_daemon(said.append) == 0
+    assert any("igniting" in s for s in said)
+
+
+def test_someone_elses_daemon_is_refused(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A PermissionError means the pid is not ours. Escalating to SIGKILL
+    would be no more permitted and reporting success would be a lie."""
+    ov = _ov()
+    monkeypatch.setattr(ov, "_live_incumbent", lambda: 1)
+
+    def _denied(pid: int, sig: int) -> None:
+        raise PermissionError()
+
+    monkeypatch.setattr(ov.os, "kill", _denied)
+    said: List[str] = []
+    assert ov._restart_daemon(said.append) == 1
+    assert any("not permitted" in s for s in said)
+
+
+def test_the_grace_period_is_tunable_but_never_zero(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Zero would SIGKILL instantly, cutting the summary write that makes the
+    next boot clean."""
+    ov = _ov()
+    monkeypatch.setenv("JARVIS_OV_RESTART_GRACE_S", "0")
+    assert ov._restart_grace_s() >= 1.0
+    monkeypatch.setenv("JARVIS_OV_RESTART_GRACE_S", "junk")
+    assert ov._restart_grace_s() == 15.0
+
+
+# --------------------------------------------------------------------------
+# 3. Ctrl+C still detaches — the persistence is the feature
+# --------------------------------------------------------------------------
+
+def test_ctrl_c_does_not_kill_the_organism() -> None:
+    """The operator asked for this and it is the wrong mechanism: a proactive
+    organism that dies whenever someone glances at it cannot run a soak."""
+    src = (_REPO / "backend/core/ouroboros/cli/ov.py").read_text()
+    assert "Ctrl+C detaches (the organism " in src
+    assert "keeps running)" in src
+    restart_src = src.split("def _restart_daemon")[1][:1200]
+    assert "NOT bound to Ctrl+C" in restart_src, (
+        "the reason this is a verb rather than a signal handler is undocumented"
+    )
+
+
+# --------------------------------------------------------------------------
+# 4. it is discoverable at the moment it is needed
+# --------------------------------------------------------------------------
+
+def test_the_staleness_banner_names_the_command() -> None:
+    """A banner that says 'restart to load current code' tells an operator
+    what to WANT. This tells them what to TYPE."""
+    import json
+    import tempfile
+    import time
+
+    from backend.core.ouroboros.battle_test.daemon_provenance import (
+        staleness_line,
+    )
+    stamp = Path(tempfile.mkdtemp()) / "p.json"
+    stamp.write_text(json.dumps({
+        "pid": 1, "booted_at": time.time() - 7200, "commit": "0" * 40,
+    }))
+    assert "ov restart" in staleness_line(stamp)
+
+
+def test_the_attach_hint_teaches_it_without_a_stale_daemon() -> None:
+    """Otherwise it is only ever learned in the moment of frustration."""
+    src = (_REPO / "backend/core/ouroboros/cli/ov.py").read_text()
+    assert "`ov restart` reloads it" in src


### PR DESCRIPTION
The operator's pain: `ps`, read a pid, `kill <pid>`, `ov`. Four steps and a number to transcribe — performed most often when a daemon is stale, and least often when there's patience for it.

### Why not Ctrl+C
The proposed fix was *"Ctrl+C should kill it"*. That breaks the property the whole design rests on.

The organism is **proactive** — it runs sensors and autonomous operations, and detaching is meant to leave it working. Killing on Ctrl+C ends a long soak every time someone glances at it. **The persistence is the feature.** So Ctrl+C still detaches, and this is the explicit escape hatch.

### Graceful first
SIGTERM lets the harness write its summary, flush telemetry and release its lock — which is what makes the *next* boot clean.

Then it **waits** for the process to actually go: igniting while the old one still holds the single-flight lock is how two organisms race for one socket. SIGKILL only after the grace period, and the escalation is announced rather than silent.

Grace is floored at 1s — zero would cut the summary write the next boot depends on.

| case | behaviour |
|---|---|
| nothing running | still ignites — `ov restart` on a cold machine must boot, not error |
| `PermissionError` | refused, not escalated — SIGKILL is no more permitted, and reporting success would be a lie |
| won't exit | SIGKILL after grace, announced |

### Falls through to the cockpit path
Rather than growing a second ignition route, so `ov restart` and `ov` cannot drift apart in how they wait for the socket — a class this codebase has already paid for.

`_live_incumbent` delegates to thin_client's — the **one** reader the reaper, preflight and ghost-socket check share — so restart cannot form a different opinion about whether a daemon exists than the code deciding whether to ignite one.

*(A test caught this: the first version called a name that didn't exist in `ov`'s namespace and would have raised at runtime.)*

### Discoverable where it's needed
The staleness banner now names the **command** instead of the intent:

```
⚠ daemon booted 2h ago on 0000000 · behind HEAD · run `ov restart` to load current code
```

And the attach hint teaches it without requiring a stale daemon to discover it.

12 tests. **592 green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `ov restart` to reload the organism in one step. It stops the current daemon gracefully, then boots and attaches via the normal cockpit path, making restarts faster and safer.

- New Features
  - New `restart` verb in `ov`. Graceful stop with SIGTERM, waits, then SIGKILL after a configurable grace (env `JARVIS_OV_RESTART_GRACE_S`, min 1s).
  - Works if nothing is running (still ignites). Permission errors return non‑zero and do not escalate.
  - Reuses the cockpit ignition path to avoid drift. `_live_incumbent` delegates to `thin_client` to share liveness detection.
  - Updated UI: staleness banner now says “run `ov restart`”, and the attach hint adds “`ov restart` reloads it”.
  - 12 tests added for routing, graceful stop, escalation, and discoverability.

<sup>Written for commit 9cb96bb7a484d15c8594f3a1b42925a2998e35c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

