### PR TITLE
feat(ov): chat replies in O+V's voice, not the classifier's state

### DIFF
--- a/backend/core/ouroboros/governance/chat_repl_dispatcher.py
+++ b/backend/core/ouroboros/governance/chat_repl_dispatcher.py
@@ -168,6 +168,21 @@ class ChatActionExecutor(Protocol):
 # ---------------------------------------------------------------------------
 
 
+def _chat_trace_enabled() -> bool:
+    """Is the classifier's reasoning shown inline?
+
+    Reads the environment at CALL time rather than at import, so a live
+    `/breadcrumbs verbose` takes effect on the next reply instead of the next
+    restart. Default off: an operator asking a question is the common case;
+    one debugging the router is the rare one, and the old output had that
+    backwards.
+    """
+    import os as _os
+    return _os.environ.get(
+        "JARVIS_CHAT_TRACE", "",
+    ).strip().lower() in ("1", "true", "yes", "on", "verbose")
+
+
 def render_decision(
     turn: ChatTurn,
     decision: ChatRoutingDecision,
@@ -448,6 +463,40 @@ class ChatReplDispatcher:
             return HISTORY_DEFAULT_N
         return min(n, HISTORY_MAX_N)
 
+    def _compose_operator_reply(
+        self,
+        turn: Any,
+        decision: Any,
+        *,
+        receipt: str = "",
+    ) -> str:
+        """The reply an operator reads. NEVER raises.
+
+        Falls back to `render_decision` on any failure: a formatting fault
+        must degrade to the older, uglier output rather than swallow a real
+        response.
+        """
+        try:
+            from backend.core.ouroboros.governance.chat_response_style import (
+                compose_reply,
+            )
+            return compose_reply(
+                str(decision.action),
+                message=str(decision.payload.get("message", "") or ""),
+                receipt=receipt,
+                social_reply=str(decision.payload.get("reply", "") or ""),
+                turn_id=str(getattr(turn, "turn_id", "") or ""),
+                session_id=str(getattr(turn, "session_id", "") or ""),
+                intent=getattr(getattr(decision, "intent", None), "name", ""),
+                confidence=getattr(decision, "confidence", None),
+                reasons=tuple(getattr(decision, "reasons", ()) or ()),
+                reason=str(getattr(decision, "reason", "") or ""),
+                verbose=_chat_trace_enabled(),
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug("[ChatReplDispatcher] style degraded", exc_info=True)
+            return render_decision(turn, decision)
+
     # ---- message dispatch ----
 
     def _dispatch_message(
@@ -463,7 +512,15 @@ class ChatReplDispatcher:
             verdict_override=verdict_override,
         )
 
-        rendered = render_decision(turn, decision)
+        # OPERATOR-facing composition, not the classifier's state dump.
+        #
+        # `render_decision` still exists and is still correct — for
+        # `/chat why <turn>`, where the routing internals ARE the answer the
+        # operator asked for. On the reply path they are not: intent,
+        # confidence and the matched heuristic describe how the decision was
+        # made, and presenting them as the response is the same defect the
+        # palette had when docstrings leaked into it as help.
+        rendered = self._compose_operator_reply(turn, decision)
 
         # No executor wired — Slice 3 returns just the decision.
         if self.executor is None or decision.action == "noop":
@@ -502,8 +559,8 @@ class ChatReplDispatcher:
                 )
         return ChatReplResult(
             status=ChatReplStatus.EXECUTOR_OK,
-            rendered_text=(
-                f"{rendered}\n[chat] => {response}"
+            rendered_text=self._compose_operator_reply(
+                turn, decision, receipt=str(response or ""),
             ),
             decision=decision,
             turn=turn,

--- a/backend/core/ouroboros/governance/chat_response_style.py
+++ b/backend/core/ouroboros/governance/chat_response_style.py
@@ -1,0 +1,206 @@
+"""A reply in O+V's voice, not a dump of how the reply was decided.
+
+What an operator types a goal and currently gets back::
+
+    [chat] · turn: chat-1dc4650228e7 · session: repl
+      intent: ACTION_REQUEST (conf=0.67)
+      action: backlog_dispatch
+      reasons: action_verb
+      message: read project_ov_unified_ipc_transceiver.md and build it
+      reason: action verb match (conf=0.67)
+    [chat] => logged-backlog-chat-1dc4650228e7
+
+Six lines, and not one answers the question the operator asked. It is the
+CLASSIFIER'S internal state — its confidence, its matched heuristic, its
+routing choice — presented as the response. The operator's own words are
+echoed back at them under a field name. And the only line describing what
+actually happened, ``=> logged-backlog-…``, uses a word ("logged") that hides
+the most important fact: nothing is running yet.
+
+This is the same defect the palette had when docstrings leaked into it as
+help — maintainer-facing text rendered in an operator-facing surface. The fix
+is the same: keep the information, change WHO it is addressed to and WHERE it
+appears.
+
+Three rules, and they map onto grammar that already exists
+-----------------------------------------------------------
+``docs/OV_STYLE_GUIDE.md`` §04 defines the glyphs and §05 the severity ladder
+that ``/breadcrumbs`` already filters by. The chat renderer simply never used
+either. So:
+
+1. **The acknowledgement is a sentence** (``⏺``) — what O+V understood, in
+   words, with no field names.
+2. **The work is op chrome** (``⎿``) — what it is doing about it, one line
+   per real step, the same shape a tool call renders in.
+3. **The classifier's reasoning is TRACE** (``·``, VERBOSE) — it does not
+   vanish, it drops below the breadcrumb floor and returns with ``/expand``.
+   Nobody debugging routing loses anything; everybody else stops reading it.
+
+And a fourth, which is honesty rather than style
+------------------------------------------------
+``backlog_dispatch`` files the goal for a sensor to collect on a later poll.
+Saying "logged" and stopping reads as *done*. A queued goal must say it is
+queued, and say what will collect it — otherwise the operator watches a still
+screen and concludes the organism ignored them. That was the actual complaint
+behind "it doesn't start doing the process".
+
+Pure formatting. This module decides nothing, dispatches nothing, and holds no
+state — it turns a decision that has already been made into lines. That is
+what keeps it testable without a daemon, and what stops presentation from
+quietly acquiring authority.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, List, Optional, Sequence
+
+logger = logging.getLogger("Ouroboros.ChatStyle")
+
+__all__ = [
+    "ACTION_VOICE",
+    "compose_reply",
+    "acknowledge",
+    "trace_lines",
+]
+
+#: What each routing action MEANS, said the way a colleague would say it.
+#:
+#: Keyed by the action the classifier already produces, so adding a route
+#: means adding a line here — not teaching a renderer about a new concept.
+#: The value is (verb-phrase, is_deferred). ``is_deferred`` is the honesty
+#: flag: True when the work will be collected later rather than started now,
+#: which is the difference between "on it" and "queued".
+ACTION_VOICE = {
+    "backlog_dispatch": ("adding that to the backlog", True),
+    "subagent_explore": ("sending a subagent to explore that", False),
+    "claude_query": ("thinking about that", False),
+    "context_attach": ("attaching that to the earlier turn", False),
+    "social_ack": ("", False),          # the reply IS the response
+    "noop": ("nothing to do here", False),
+}
+
+
+def _voice(action: str) -> tuple:
+    return ACTION_VOICE.get(action, (f"routing that to {action}", False))
+
+
+def acknowledge(action: str, message: str = "") -> str:
+    """The one line that says O+V heard you.
+
+    Deliberately does NOT echo the operator's message back. They just typed
+    it; repeating it under a field label is what made the old output read like
+    a form submission receipt rather than a reply.
+    """
+    phrase, _deferred = _voice(action)
+    if not phrase:
+        return ""
+    return f"⏺ {phrase}"
+
+
+def _queue_note(action: str, receipt: str = "") -> Optional[str]:
+    """Say plainly when work is queued rather than started.
+
+    ``backlog_dispatch`` hands the goal to a sensor that polls. "logged" hides
+    that; silence hides it worse. An operator staring at an unchanged screen
+    needs to know whether to wait or to worry.
+    """
+    _phrase, deferred = _voice(action)
+    if not deferred:
+        return None
+    ref = f" ({receipt})" if receipt else ""
+    return (f"⎿ queued{ref} — the Backlog sensor will pick it up on its "
+            f"next sweep")
+
+
+def trace_lines(
+    turn_id: str = "",
+    session_id: str = "",
+    intent: str = "",
+    confidence: Optional[float] = None,
+    reasons: Sequence[str] = (),
+    reason: str = "",
+    indent: str = "  ",
+) -> List[str]:
+    """The classifier's reasoning, as VERBOSE trace.
+
+    Not deleted — routing bugs are diagnosed from exactly these fields. Marked
+    ``·`` so the severity ladder in §05 filters it the way it filters every
+    other telemetry line, and ``/breadcrumbs verbose`` brings it back.
+
+    One line, not six. Six lines of internals outweigh the answer they
+    accompany no matter how they are styled.
+    """
+    bits: List[str] = []
+    if intent:
+        conf = f" {confidence:.2f}" if isinstance(confidence, (int, float)) else ""
+        bits.append(f"{intent.lower()}{conf}")
+    if reasons:
+        bits.append("/".join(str(r) for r in reasons))
+    elif reason:
+        bits.append(str(reason))
+    if turn_id:
+        # The TAIL of the id: chat turn ids share a prefix, so the leading
+        # characters distinguish nothing (same lesson as the op-id digest).
+        bits.append(turn_id.rsplit("-", 1)[-1])
+    if not bits:
+        return []
+    return [f"{indent}· {' · '.join(bits)}"]
+
+
+def compose_reply(
+    action: str,
+    *,
+    message: str = "",
+    receipt: str = "",
+    social_reply: str = "",
+    steps: Sequence[str] = (),
+    turn_id: str = "",
+    session_id: str = "",
+    intent: str = "",
+    confidence: Optional[float] = None,
+    reasons: Sequence[str] = (),
+    reason: str = "",
+    verbose: bool = False,
+) -> str:
+    """The whole reply: acknowledgement, work, then trace if asked for.
+
+    ``verbose`` is the ``/breadcrumbs``-style floor. Default False, because
+    the operator asking a question is the common case and the operator
+    debugging the router is the rare one — and the old output had that
+    backwards.
+
+    NEVER raises: a formatting fault must not swallow a real response, so any
+    failure degrades to the plain receipt.
+    """
+    try:
+        lines: List[str] = []
+
+        # A social turn's reply IS the response. Wrapping it in chrome would
+        # make "Hey." look like a system event.
+        if action == "social_ack" and social_reply:
+            lines.append(f"⏺ {social_reply}")
+        else:
+            head = acknowledge(action, message)
+            if head:
+                lines.append(head)
+
+            for step in steps:
+                text = str(step).strip()
+                if text:
+                    lines.append(f"  ⎿ {text}")
+
+            note = _queue_note(action, receipt)
+            if note:
+                lines.append(f"  {note.lstrip()}")
+            elif receipt and action != "noop":
+                lines.append(f"  ⎿ {receipt}")
+
+        if verbose:
+            lines.extend(trace_lines(
+                turn_id=turn_id, session_id=session_id, intent=intent,
+                confidence=confidence, reasons=reasons, reason=reason,
+            ))
+        return "\n".join(l for l in lines if l.strip())
+    except Exception:  # noqa: BLE001 — never lose a response to formatting
+        logger.debug("[ChatStyle] compose degraded", exc_info=True)
+        return str(receipt or social_reply or "")

--- a/tests/governance/test_chat_response_style.py
+++ b/tests/governance/test_chat_response_style.py
@@ -1,0 +1,223 @@
+"""A reply in O+V's voice, not a dump of how the reply was decided.
+
+What the operator got for a plain-language goal::
+
+    [chat] · turn: chat-1dc4650228e7 · session: repl
+      intent: ACTION_REQUEST (conf=0.67)
+      action: backlog_dispatch
+      reasons: action_verb
+      message: read project_ov_unified_ipc_transceiver.md and build it
+      reason: action verb match (conf=0.67)
+    [chat] => logged-backlog-chat-1dc4650228e7
+
+Six lines, none of which answer what was asked. It is the CLASSIFIER'S state —
+its confidence, its matched heuristic, its routing choice — presented as the
+response, with the operator's own words echoed back under a field name.
+
+Same defect as docstrings leaking into the palette as help: maintainer-facing
+text in an operator-facing surface. Same fix: keep the information, change who
+it addresses and where it lives.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from backend.core.ouroboros.governance.chat_response_style import (
+    ACTION_VOICE,
+    acknowledge,
+    compose_reply,
+    trace_lines,
+)
+
+
+# --------------------------------------------------------------------------
+# 1. the reply answers, it does not report on itself
+# --------------------------------------------------------------------------
+
+def test_the_classifier_state_is_not_the_reply() -> None:
+    """THE defect. None of intent / confidence / heuristic belongs in the
+    answer to a question."""
+    out = compose_reply(
+        "backlog_dispatch", receipt="backlog-chat-1dc",
+        turn_id="chat-1dc", intent="ACTION_REQUEST",
+        confidence=0.67, reasons=["action_verb"],
+    )
+    for leak in ("ACTION_REQUEST", "0.67", "action_verb", "intent:", "conf="):
+        assert leak not in out, f"{leak!r} leaked into the operator reply"
+
+
+def test_the_operator_message_is_not_echoed_back() -> None:
+    """They just typed it. Repeating it under a field label is what made the
+    old output read like a form-submission receipt."""
+    msg = "read project_ov_unified_ipc_transceiver.md and build it"
+    assert msg not in compose_reply("backlog_dispatch", message=msg)
+
+
+def test_the_reply_opens_with_a_sentence() -> None:
+    out = compose_reply("backlog_dispatch", receipt="r")
+    first = out.splitlines()[0]
+    assert first.startswith("⏺")
+    assert "backlog" in first.lower()
+    assert ":" not in first, "a field separator is not a sentence"
+
+
+def test_it_is_short() -> None:
+    """Six lines of internals outweigh the answer no matter how styled."""
+    out = compose_reply("backlog_dispatch", receipt="backlog-chat-1dc",
+                        turn_id="chat-1dc", intent="ACTION_REQUEST",
+                        confidence=0.67, reasons=["action_verb"])
+    assert len(out.splitlines()) <= 2
+
+
+# --------------------------------------------------------------------------
+# 2. queued work says it is queued
+# --------------------------------------------------------------------------
+
+def test_deferred_work_is_declared_not_disguised() -> None:
+    """`backlog_dispatch` hands the goal to a sensor that polls later.
+    "logged" reads as done; silence reads as ignored. THIS was the real
+    complaint behind "it doesn't start doing the process"."""
+    out = compose_reply("backlog_dispatch", receipt="backlog-chat-1dc")
+    assert "queued" in out
+    assert "Backlog sensor" in out, "nothing says what will collect it"
+    assert "logged" not in out
+
+
+def test_the_receipt_survives_so_the_work_is_traceable() -> None:
+    out = compose_reply("backlog_dispatch", receipt="backlog-chat-1dc")
+    assert "backlog-chat-1dc" in out
+
+
+def test_immediate_work_is_not_labelled_queued() -> None:
+    """The inverse matters: calling live work "queued" would teach the
+    operator to distrust the word."""
+    out = compose_reply("subagent_explore", steps=["spawned explorer"])
+    assert "queued" not in out
+
+
+@pytest.mark.parametrize("action", sorted(ACTION_VOICE))
+def test_every_known_action_has_a_voice(action: str) -> None:
+    """Adding a route means adding a line to ACTION_VOICE — not teaching a
+    renderer about a new concept."""
+    phrase, deferred = ACTION_VOICE[action]
+    assert isinstance(deferred, bool)
+    if action != "social_ack":
+        assert phrase, f"{action} has no operator-facing phrasing"
+
+
+def test_an_unknown_action_still_says_something_true() -> None:
+    """A new route must degrade to honest, not to blank."""
+    out = compose_reply("some_future_route", receipt="r")
+    assert "some_future_route" in out
+
+
+# --------------------------------------------------------------------------
+# 3. the reasoning is kept — as trace, below the floor
+# --------------------------------------------------------------------------
+
+def test_trace_is_hidden_by_default_and_returns_on_request() -> None:
+    """Not deleted: routing bugs are diagnosed from exactly these fields."""
+    kw: Any = dict(receipt="r", turn_id="chat-1dc", intent="ACTION_REQUEST",
+                   confidence=0.67, reasons=["action_verb"])
+    assert "0.67" not in compose_reply("backlog_dispatch", **kw)
+    verbose = compose_reply("backlog_dispatch", verbose=True, **kw)
+    assert "0.67" in verbose and "action_verb" in verbose
+
+
+def test_trace_uses_the_verbose_glyph_from_the_style_guide() -> None:
+    """§04: `·` is trace. §05's severity ladder — which /breadcrumbs already
+    filters by — then hides it without this module knowing how."""
+    line = trace_lines(intent="ACTION_REQUEST", confidence=0.5)[0]
+    assert line.strip().startswith("·")
+
+
+def test_trace_collapses_to_one_line() -> None:
+    assert len(trace_lines(
+        turn_id="chat-1dc4650228e7", session_id="repl",
+        intent="ACTION_REQUEST", confidence=0.67,
+        reasons=["action_verb", "imperative"], reason="action verb match",
+    )) == 1
+
+
+def test_the_turn_id_shows_its_distinguishing_END() -> None:
+    """Chat ids share a prefix — the same lesson the op-id digest learned."""
+    line = trace_lines(turn_id="chat-1dc4650228e7", intent="X")[0]
+    assert "1dc4650228e7" in line and "chat-1dc4650228e7" not in line
+
+
+def test_trace_with_nothing_to_say_emits_nothing() -> None:
+    assert trace_lines() == []
+
+
+# --------------------------------------------------------------------------
+# 4. a social turn is a reply, not an event
+# --------------------------------------------------------------------------
+
+def test_a_greeting_renders_as_speech() -> None:
+    out = compose_reply("social_ack", social_reply="Hey.")
+    assert out == "⏺ Hey."
+    assert "queued" not in out and "social_ack" not in out
+
+
+def test_a_social_turn_carries_no_chrome() -> None:
+    """Wrapping "Hey." in op chrome would make it look like a system event."""
+    assert "⎿" not in compose_reply("social_ack", social_reply="Hey.")
+
+
+# --------------------------------------------------------------------------
+# 5. it cannot swallow a response
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("junk", [None, 42, object(), ["x"]])
+def test_composition_never_raises(junk: Any) -> None:
+    assert isinstance(compose_reply(junk, receipt="r"), str)  # type: ignore[arg-type]
+
+
+def test_a_formatting_fault_still_yields_the_receipt() -> None:
+    """A style bug must never cost the operator a real answer."""
+    out = compose_reply("backlog_dispatch", receipt="backlog-chat-1dc",
+                        reasons=None)  # type: ignore[arg-type]
+    assert "backlog-chat-1dc" in out
+
+
+def test_acknowledge_alone_is_safe() -> None:
+    assert isinstance(acknowledge("anything"), str)
+
+
+# --------------------------------------------------------------------------
+# 6. wiring — and what deliberately did NOT change
+# --------------------------------------------------------------------------
+
+def test_render_decision_is_kept_for_chat_why() -> None:
+    """`/chat why <turn>` is where the routing internals ARE the answer. The
+    old renderer is correct there and must survive."""
+    from backend.core.ouroboros.governance.chat_repl_dispatcher import (
+        render_decision,
+    )
+    assert callable(render_decision)
+
+
+def test_the_reply_path_uses_the_composer() -> None:
+    import inspect
+    from pathlib import Path
+
+    src = (Path(__file__).resolve().parents[2]
+           / "backend/core/ouroboros/governance/chat_repl_dispatcher.py"
+           ).read_text()
+    assert "_compose_operator_reply(" in src
+    assert '[chat] => ' not in src, "the raw receipt line is still being emitted"
+
+
+def test_the_trace_floor_is_read_at_call_time(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """So a live `/breadcrumbs verbose` takes effect on the next reply rather
+    than the next restart."""
+    from backend.core.ouroboros.governance import chat_repl_dispatcher as d
+
+    monkeypatch.delenv("JARVIS_CHAT_TRACE", raising=False)
+    assert d._chat_trace_enabled() is False
+    monkeypatch.setenv("JARVIS_CHAT_TRACE", "verbose")
+    assert d._chat_trace_enabled() is True


### PR DESCRIPTION
Typing a plain-language goal returned six lines, none of which answered it:

```
[chat] · turn: chat-1dc4650228e7 · session: repl
  intent: ACTION_REQUEST (conf=0.67)
  action: backlog_dispatch
  reasons: action_verb
  message: read project_ov_unified_ipc_transceiver.md and build it
  reason: action verb match (conf=0.67)
[chat] => logged-backlog-chat-1dc4650228e7
```

That's the **classifier's internal state** — its confidence, its matched heuristic, its routing choice — presented as the response. The operator's own words are echoed back under a field name.

Same defect as docstrings leaking into the palette as help: maintainer-facing text in an operator-facing surface. Same fix — keep the information, change who it addresses and where it lives.

### After

```
⏺ adding that to the backlog
  ⎿ queued (backlog-chat-1dc) — the Backlog sensor will pick it up on its next sweep
```

### The style guide already had the grammar; the renderer never used it
`docs/OV_STYLE_GUIDE.md` §04 defines `⏺` open / `⎿` continue / `·` trace, and §05's severity ladder is exactly what `/breadcrumbs` already filters by.

The reasoning isn't deleted — routing bugs are diagnosed from those fields. It drops to a single `·` VERBOSE line and returns with `JARVIS_CHAT_TRACE`, read at **call** time so a live `/breadcrumbs verbose` lands on the next reply rather than the next restart:

```
⏺ adding that to the backlog
  ⎿ queued (backlog-chat-1dc) — the Backlog sensor will pick it up on its next sweep
  · action_request 0.67 · action_verb · 1dc4650228e7
```

### The fourth rule is honesty, not style
`backlog_dispatch` hands the goal to a sensor that polls **later**. "logged" reads as done; silence reads as ignored — and that was the real complaint behind *"it doesn't start doing the process."*

A queued goal now says it's queued and what will collect it. Live routes are **not** labelled queued, or the word stops meaning anything.

### Extensible without touching the renderer
`ACTION_VOICE` keys off the action the classifier already emits, so a new route is one line of phrasing — not teaching a renderer a new concept. An unknown action degrades to naming itself rather than to blank.

### Deliberately unchanged
`render_decision` is **kept**: `/chat why <turn>` is where the routing internals *are* the answer, and it's correct there.

Pure formatting — decides nothing, dispatches nothing, holds no state, and falls back to the old renderer on any fault, so a style bug can never swallow a real response.

### Tests
30 new. **441 green** across every chat/conversation suite. The 12 failures in the wider governance run are pre-existing (m10, crash recovery, replay capture) — verified failing with these changes stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make chat replies operator-friendly: show clear acknowledgements and steps in O+V’s voice instead of dumping classifier internals. Adds truthful “queued” messaging for deferred work and an opt-in verbose trace via `JARVIS_CHAT_TRACE`.

- New Features
  - Operator-facing replies using the style guide: ⏺ acknowledge, ⎿ steps, · trace (verbose only).
  - Deferred work says “queued” with a receipt and Backlog sensor note; live routes are not labeled queued.
  - `ACTION_VOICE` maps actions to human phrases; unknown actions degrade to “routing that to <action>”.
  - Social turns render as plain speech (⏺ <reply>) without chrome.
  - Verbose trace toggled at call time via `JARVIS_CHAT_TRACE`.

- Refactors
  - Dispatcher now uses `compose_reply`; on any fault, falls back to `render_decision`.
  - `render_decision` retained for `/chat why <turn>`, where routing internals are the answer.
  - Formatting-only change; no routing or execution logic altered.

<sup>Written for commit 68cb9353863ab9fcd2983864f543760f5a72ce3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

