### PR TITLE
feat(ov): a typed goal runs now and narrates itself

### DIFF
--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -4619,6 +4619,15 @@ class BattleTestHarness:
                                 write_provenance,
                             )
                             write_provenance()
+                            # Arm immediate dispatch for typed goals. Until
+                            # this runs the chat executor files them for the
+                            # Backlog sensor and the reply honestly says
+                            # "queued" — the degradation is visible, never
+                            # silent.
+                            from backend.core.ouroboros.governance.chat_repl_backlog_executor import (  # noqa: E501
+                                set_operator_dispatcher,
+                            )
+                            set_operator_dispatcher(self._submit_operator_goal)
                         except Exception:  # noqa: BLE001
                             pass
                         spooler.start()
@@ -4713,6 +4722,73 @@ class BattleTestHarness:
                 submit(envelope)
         except Exception:  # noqa: BLE001
             logger.debug("[QoS] emit routing degraded", exc_info=True)
+
+    def _submit_operator_goal(self, message: str, turn: Any) -> Optional[str]:
+        """A typed goal → intake, NOW. Returns the op id, or None to defer.
+
+        Routes through the SAME router every sensor uses — no private lane for
+        operator input, so one set of governance, dedup and WAL rules applies
+        to autonomous and human-originated work alike.
+
+        The envelope carries `operator_chat`: human-origin, SOVEREIGN,
+        IMMEDIATE-eligible. Previously a typed goal was written to
+        backlog.json and therefore claimed `source="backlog"` — a BACKGROUND,
+        cost-optimized, sensor-polled route. The token described where the
+        goal was stored rather than who asked for it.
+
+        Returns None rather than raising when intake is unreachable: the
+        caller then FILES the goal and says so. A queued goal is a
+        degradation; a dropped one is a betrayal.
+        """
+        try:
+            gls = getattr(self, "_governed_loop_service", None)
+            router = None
+            for _attr in ("_intake_router", "intake_router", "_router"):
+                router = getattr(gls, _attr, None)
+                if router is not None:
+                    break
+            if router is None:
+                return None
+            submit = (
+                getattr(router, "submit_envelope", None)
+                or getattr(router, "ingest", None)
+                or getattr(router, "emit", None)
+            )
+            if submit is None:
+                return None
+
+            from backend.core.ouroboros.governance.intake.intent_envelope import (  # noqa: E501
+                IntentEnvelope,
+            )
+            envelope = IntentEnvelope(
+                source="operator_chat",
+                description=str(message),
+                # HIGH, not critical: the operator is waiting, but a typed
+                # goal is not an emergency and must not outrank a genuine
+                # runtime alarm. IMMEDIATE eligibility comes from the SOURCE
+                # being human-origin; urgency does not need inflating to buy
+                # it, and inflating it would distort every priority queue the
+                # envelope passes through.
+                urgency="high",
+                evidence={
+                    "turn_id": str(getattr(turn, "turn_id", "") or ""),
+                    "session_id": str(getattr(turn, "session_id", "") or ""),
+                    "origin": "cockpit_chat",
+                },
+            )
+            result = submit(envelope)
+            if asyncio.iscoroutine(result):
+                # The caller is synchronous (the chat executor). Schedule and
+                # report the id we already hold, rather than blocking the loop
+                # waiting for intake to accept.
+                asyncio.ensure_future(result)
+                return str(getattr(envelope, "op_id", "") or
+                           getattr(envelope, "envelope_id", "") or "") or None
+            return str(result) if result else None
+        except Exception:  # noqa: BLE001
+            logger.debug("[OperatorGoal] immediate dispatch degraded",
+                         exc_info=True)
+            return None
 
     def _qos_note_override(self, kind: str = "sigint") -> None:
         """Operational-override hook (SIGINT / lease seizure) → QoS.

--- a/backend/core/ouroboros/governance/chat_repl_backlog_executor.py
+++ b/backend/core/ouroboros/governance/chat_repl_backlog_executor.py
@@ -54,7 +54,7 @@ import logging
 import os
 import time
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Callable, Any, Dict, List, Optional
 
 from backend.core.ouroboros.governance.backlog_auto_proposed_repl import (
     _append_to_backlog_json,
@@ -123,6 +123,39 @@ def _backlog_path(project_root: Path) -> Path:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# The operator-dispatch seam
+# ---------------------------------------------------------------------------
+#
+# ONE registry rather than a `submit_now=` parameter threaded through three
+# nested factories (chat_text_bridge → with_claude → with_backlog). Threading
+# it would mean every intermediate factory grows a parameter it does not use
+# and must remember to forward — and a factory that forgets produces an
+# executor that silently files goals instead of running them, which is
+# exactly the wired-but-inert failure this codebase keeps paying for.
+#
+# Same shape as `set_active_canvas` in bipartite_layout: the daemon installs
+# its capability once at boot; every consumer asks rather than being handed.
+
+_OPERATOR_DISPATCH: Optional[Callable[[str, Any], Optional[str]]] = None
+
+
+def set_operator_dispatcher(
+    fn: Optional[Callable[[str, Any], Optional[str]]],
+) -> None:
+    """Install the daemon's immediate-dispatch capability. None disarms it.
+
+    Called once at harness boot. Absent it, every goal is filed and the reply
+    honestly says so — the degradation is visible rather than silent.
+    """
+    global _OPERATOR_DISPATCH
+    _OPERATOR_DISPATCH = fn
+
+
+def get_operator_dispatcher() -> Optional[Callable[[str, Any], Optional[str]]]:
+    return _OPERATOR_DISPATCH
+
+
 class BacklogChatActionExecutor:
     """Concrete ChatActionExecutor that wires `dispatch_backlog`
     against the real `.jarvis/backlog.json` writer.
@@ -145,11 +178,17 @@ class BacklogChatActionExecutor:
         self,
         project_root: Path,
         fallback: Optional[ChatActionExecutor] = None,
+        submit_now: Optional[Callable[[str, ChatTurn], Optional[str]]] = None,
     ) -> None:
         self._project_root = Path(project_root)
         self._fallback: ChatActionExecutor = (
             fallback or LoggingChatActionExecutor()
         )
+        # INJECTED, not imported: this module writes JSON and must stay
+        # testable without an intake router, an event loop or a daemon. The
+        # harness supplies the real submitter; absent one, the backlog write
+        # below remains the behaviour — degraded, but never lost.
+        self._submit_now = submit_now
         # Audit list — tests + operator inspection. Each entry is the
         # task_id returned (or the failure token).
         self.calls: List[str] = []
@@ -164,6 +203,41 @@ class BacklogChatActionExecutor:
         deduplicates on task_id so the FSM only fires once.
         """
         msg_clipped = (message or "")[:MAX_BACKLOG_DESCRIPTION_CHARS]
+
+        # IMMEDIATE PATH — a human is watching the screen.
+        #
+        # Writing to backlog.json makes the goal carry source="backlog",
+        # which routes BACKGROUND (DW only, cost-optimized) and waits for a
+        # sensor sweep. That is right for the Backlog SENSOR mining a task
+        # list and wrong for someone who just pressed Enter: the token
+        # described where the goal was STORED, not who ASKED for it.
+        #
+        # When a submitter is wired, the goal enters intake as
+        # `operator_chat` — human-origin, SOVEREIGN, IMMEDIATE-eligible —
+        # and the op runs now, narrating itself through the same chrome
+        # every autonomous op uses.
+        # Explicit injection wins (tests, callers that know better); the
+        # registry is the daemon's standing answer.
+        submitter = self._submit_now or get_operator_dispatcher()
+        if submitter is not None and msg_clipped.strip():
+            try:
+                op_id = submitter(msg_clipped, turn)
+                if op_id:
+                    self.calls.append(str(op_id))
+                    logger.info(
+                        "[BacklogChatExecutor] turn=%s dispatched IMMEDIATE "
+                        "op=%s (source=operator_chat)", turn.turn_id, op_id,
+                    )
+                    return str(op_id)
+            except Exception as exc:  # noqa: BLE001
+                # Fall through to the durable write. An intake fault must
+                # never LOSE an operator's goal — a queued goal is a
+                # degradation; a dropped one is a betrayal.
+                logger.warning(
+                    "[BacklogChatExecutor] turn=%s immediate dispatch failed "
+                    "(%s) — falling back to backlog", turn.turn_id, exc,
+                )
+
         if not msg_clipped.strip():
             logger.warning(
                 "[BacklogChatExecutor] turn=%s empty message — refusing "
@@ -238,6 +312,7 @@ class BacklogChatActionExecutor:
 
 def build_chat_repl_dispatcher_with_backlog(
     *,
+    submit_now: Optional[Callable[[str, "ChatTurn"], Optional[str]]] = None,
     project_root: Optional[Path] = None,
     orchestrator: Optional[ConversationOrchestrator] = None,
     fallback_executor: Optional[ChatActionExecutor] = None,
@@ -270,6 +345,11 @@ def build_chat_repl_dispatcher_with_backlog(
     wired_executor: ChatActionExecutor = BacklogChatActionExecutor(
         project_root=root,
         fallback=fallback_executor or LoggingChatActionExecutor(),
+        # None here is the honest default: with no submitter the goal is
+        # filed, and the reply SAYS it was filed. The harness supplies the
+        # real one, so the immediate path turns on where intake exists rather
+        # than being assumed everywhere.
+        submit_now=submit_now,
     )
     return build_chat_repl_dispatcher(
         orchestrator=orchestrator,
@@ -280,6 +360,8 @@ def build_chat_repl_dispatcher_with_backlog(
 
 __all__ = [
     "BacklogChatActionExecutor",
+    "set_operator_dispatcher",
+    "get_operator_dispatcher",
     "MAX_BACKLOG_DESCRIPTION_CHARS",
     "build_chat_repl_dispatcher_with_backlog",
     "is_enabled",

--- a/backend/core/ouroboros/governance/chat_response_style.py
+++ b/backend/core/ouroboros/governance/chat_response_style.py
@@ -71,6 +71,13 @@ __all__ = [
 #: flag: True when the work will be collected later rather than started now,
 #: which is the difference between "on it" and "queued".
 ACTION_VOICE = {
+    # backlog_dispatch is now TWO outcomes wearing one action name: the goal
+    # either entered intake and is running, or it was filed for a sensor
+    # sweep. The receipt shape tells them apart (`op-…` vs `chat:…`), and
+    # saying "queued" about live work — or "on it" about filed work — is
+    # exactly the dishonesty the queue note exists to prevent. Resolved at
+    # render time by `_dispatched_now`, not by a second action token, so the
+    # classifier is not asked to predict what the executor will manage.
     "backlog_dispatch": ("adding that to the backlog", True),
     "subagent_explore": ("sending a subagent to explore that", False),
     "claude_query": ("thinking about that", False),
@@ -78,6 +85,12 @@ ACTION_VOICE = {
     "social_ack": ("", False),          # the reply IS the response
     "noop": ("nothing to do here", False),
 }
+
+
+def _short_ref(ref: str) -> str:
+    """The distinguishing TAIL of an op id — UUIDv7 shares its prefix."""
+    parts = [p for p in str(ref).split("-") if p]
+    return "-".join(parts[-2:]) if len(parts) >= 3 else str(ref)
 
 
 def _voice(action: str) -> tuple:
@@ -97,6 +110,18 @@ def acknowledge(action: str, message: str = "") -> str:
     return f"⏺ {phrase}"
 
 
+def _dispatched_now(receipt: str) -> bool:
+    """Did this goal actually START, or was it filed?
+
+    An op-id means intake accepted it and a worker has it. A `chat:` task-id
+    means it landed in backlog.json for the Backlog sensor to collect. Read
+    off the receipt the executor returns, because the executor is the only
+    layer that knows which path it took.
+    """
+    ref = str(receipt or "").strip()
+    return bool(ref) and (ref.startswith("op-") or ref.startswith("op_"))
+
+
 def _queue_note(action: str, receipt: str = "") -> Optional[str]:
     """Say plainly when work is queued rather than started.
 
@@ -105,7 +130,7 @@ def _queue_note(action: str, receipt: str = "") -> Optional[str]:
     needs to know whether to wait or to worry.
     """
     _phrase, deferred = _voice(action)
-    if not deferred:
+    if not deferred or _dispatched_now(receipt):
         return None
     ref = f" ({receipt})" if receipt else ""
     return (f"⎿ queued{ref} — the Backlog sensor will pick it up on its "
@@ -180,9 +205,17 @@ def compose_reply(
         if action == "social_ack" and social_reply:
             lines.append(f"⏺ {social_reply}")
         else:
-            head = acknowledge(action, message)
-            if head:
-                lines.append(head)
+            if _dispatched_now(receipt):
+                # It is RUNNING. Say so, and hand the operator the ref the op
+                # chrome will narrate under — so the ⏺/⎿ lines that follow
+                # are recognisably the answer to what they just typed.
+                lines.append("⏺ on it")
+                lines.append(f"  ⎿ dispatched {_short_ref(receipt)} · "
+                             f"immediate · watching")
+            else:
+                head = acknowledge(action, message)
+                if head:
+                    lines.append(head)
 
             for step in steps:
                 text = str(step).strip()
@@ -190,9 +223,14 @@ def compose_reply(
                     lines.append(f"  ⎿ {text}")
 
             note = _queue_note(action, receipt)
+            if _dispatched_now(receipt):
+                note = None                      # already said above
             if note:
                 lines.append(f"  {note.lstrip()}")
-            elif receipt and action != "noop":
+            elif receipt and action != "noop" and not _dispatched_now(receipt):
+                # Not repeated when dispatched: the ref is already on the
+                # "dispatched …" line, and printing the full id underneath it
+                # is the UUID-noise the digest work removed everywhere else.
                 lines.append(f"  ⎿ {receipt}")
 
         if verbose:

--- a/backend/core/ouroboros/governance/intake/intent_envelope.py
+++ b/backend/core/ouroboros/governance/intake/intent_envelope.py
@@ -97,6 +97,10 @@ _VALID_SOURCES = frozenset({
     # Resurrected > Normal) and trigger preemption of a running resurrected op.
     "cli_emergency",
     "human_override",
+    # A goal typed into the cockpit. Human-origin like voice_human, and
+    # attributable separately so observability can tell a spoken goal from a
+    # typed one — the same reason cli_emergency is distinct from both.
+    "operator_chat",
     # Added 2026-07-01 for the Autonomous FSM Checkpoint/Resume hydrator. A
     # suspended op (checkpointed on the wall-clock cap / Spot preemption) is
     # re-injected at the NEXT ignition's intake boot with its preserved
@@ -111,7 +115,9 @@ _VALID_URGENCIES = frozenset({"critical", "high", "normal", "low"})
 # a resurrected hibernation survivor (which itself outranks all normal work). The
 # host always keeps ultimate control. Lives here (a leaf module) so both the
 # IntakeRouter and the BackgroundAgentPool import it without a cycle.
-SOVEREIGN_SOURCES = frozenset({"voice_human", "cli_emergency", "human_override"})
+SOVEREIGN_SOURCES = frozenset({
+    "voice_human", "cli_emergency", "human_override", "operator_chat",
+})
 
 # F2 Slice 2 — allowed values for the optional ``routing_override``
 # envelope field. Empty string is the "no override" sentinel (default).

--- a/backend/core/ouroboros/governance/intent/signals.py
+++ b/backend/core/ouroboros/governance/intent/signals.py
@@ -94,6 +94,18 @@ class SignalSource(str, Enum):
     SWE_BENCH_PRO = "swe_bench_pro"
     TEST_COVERAGE = "test_coverage"
     VOICE_HUMAN = "voice_human"
+    # A goal TYPED by the operator into the cockpit. Distinct from
+    # voice_human (spoken) and from backlog (a task list mined by a sensor):
+    # all three are different ORIGINS, and the origin is what routing reads.
+    #
+    # Before this existed, a typed goal was written to backlog.json and
+    # therefore carried source="backlog" — which sits in _BACKGROUND_SOURCES
+    # ("DW only, no Claude fallback... cost-optimization-first") and is
+    # collected on a later sensor sweep. Correct for the Backlog SENSOR
+    # mining a list; wrong for a human who just pressed Enter and is watching
+    # the screen. The token described where the goal was STORED rather than
+    # who ASKED for it.
+    OPERATOR_CHAT = "operator_chat"
     CLI_EMERGENCY = "cli_emergency"
     HUMAN_OVERRIDE = "human_override"
     # Proactive desktop-topology origin (2026-07-19): an operator-

--- a/backend/core/ouroboros/governance/urgency_router.py
+++ b/backend/core/ouroboros/governance/urgency_router.py
@@ -123,6 +123,17 @@ class ProviderRoute(str, Enum):
 _IMMEDIATE_SOURCES = frozenset({
     "test_failure",
     "voice_human",
+    # A goal TYPED by the operator, who is watching the screen right now.
+    # This is the same class as voice_human — a human asked — and it belongs
+    # here for the same reason: §5 routes human-originated signals IMMEDIATE
+    # because a person is waiting on the answer.
+    #
+    # It does NOT widen the cost surface the way the bt-2026-04-13 regression
+    # did. That was seven autonomous sensors mislabelling themselves as
+    # `runtime_health` and firing unattended. This source can only be
+    # produced by someone pressing Enter, so its rate is bounded by human
+    # typing speed, and IMMEDIATE still requires an urgent signal on top.
+    "operator_chat",
     "runtime_health",
 })
 

--- a/tests/governance/test_chat_response_style.py
+++ b/tests/governance/test_chat_response_style.py
@@ -221,3 +221,58 @@ def test_the_trace_floor_is_read_at_call_time(
     assert d._chat_trace_enabled() is False
     monkeypatch.setenv("JARVIS_CHAT_TRACE", "verbose")
     assert d._chat_trace_enabled() is True
+
+
+# --------------------------------------------------------------------------
+# 7. immediate dispatch — "on it", not "queued"  (2026-07-27)
+# --------------------------------------------------------------------------
+
+def test_a_running_op_says_on_it_not_queued() -> None:
+    """An op-id receipt means intake accepted the goal and a worker has it.
+    Calling that "queued" is the same dishonesty in the opposite direction."""
+    out = compose_reply("backlog_dispatch", receipt="op-019fa4d2-246e-7759-86")
+    assert "on it" in out
+    assert "queued" not in out
+    assert "Backlog sensor" not in out
+
+
+def test_a_filed_goal_still_says_queued() -> None:
+    """The fallback path is unchanged — and must stay honest about waiting."""
+    out = compose_reply("backlog_dispatch", receipt="chat:chat-1dc")
+    assert "queued" in out and "Backlog sensor" in out
+    # Asserted on the ACKNOWLEDGEMENT LINE, not the whole reply: "on it" is a
+    # substring of "…pick it up on its next sweep", so a naive `not in`
+    # flags correct output as broken.
+    assert out.splitlines()[0] == "⏺ adding that to the backlog"
+
+
+def test_the_two_paths_are_told_apart_by_the_RECEIPT() -> None:
+    """Not by a second action token: the classifier cannot predict which path
+    the executor will manage, and asking it to would put routing knowledge in
+    the wrong layer."""
+    from backend.core.ouroboros.governance.chat_response_style import (
+        _dispatched_now,
+    )
+    assert _dispatched_now("op-019fa4d2-246e") is True
+    assert _dispatched_now("chat:chat-1dc") is False
+    assert _dispatched_now("") is False
+    assert _dispatched_now("error-append-failed-x") is False
+
+
+def test_the_operator_gets_the_ref_the_chrome_will_narrate_under() -> None:
+    """So the ⏺/⎿ op lines that follow are recognisably the answer to what
+    they just typed, rather than unrelated autonomous traffic."""
+    out = compose_reply("backlog_dispatch", receipt="op-019fa4d2-246e-7759-86")
+    assert "7759-86" in out
+
+
+def test_the_full_uuid_is_not_repeated_underneath() -> None:
+    """The digest work removed UUID noise everywhere else; this must not
+    reintroduce it."""
+    out = compose_reply("backlog_dispatch", receipt="op-019fa4d2-246e-7759-86")
+    assert out.count("019fa4d2") == 0
+
+
+def test_immediate_replies_stay_two_lines() -> None:
+    out = compose_reply("backlog_dispatch", receipt="op-019fa4d2-246e-7759-86")
+    assert len(out.splitlines()) == 2

--- a/tests/governance/test_operator_chat_immediate.py
+++ b/tests/governance/test_operator_chat_immediate.py
@@ -1,0 +1,214 @@
+"""A typed goal is a human asking, not a task-list entry.
+
+`dispatch_backlog` wrote the goal to backlog.json, so it carried
+`source="backlog"` — which sits in `_BACKGROUND_SOURCES` ("DW only, no Claude
+fallback... cost-optimization-first") and is collected on a later sensor
+sweep. Correct for the Backlog SENSOR mining a list. Wrong for someone who
+just pressed Enter and is watching the screen.
+
+The token described where the goal was STORED, not who ASKED for it — the same
+class of defect `intent_envelope.py` already names: "Honest-source token:
+decoupled test-coverage work MUST NOT masquerade as `test_failure`/`backlog`."
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, List, Optional
+
+import pytest
+
+from backend.core.ouroboros.governance.intake.intent_envelope import (
+    SOVEREIGN_SOURCES,
+    _VALID_SOURCES,
+)
+from backend.core.ouroboros.governance.intent.signals import SignalSource
+from backend.core.ouroboros.governance.urgency_router import (
+    _BACKGROUND_SOURCES,
+    _IMMEDIATE_SOURCES,
+)
+
+
+# --------------------------------------------------------------------------
+# 1. the honest token
+# --------------------------------------------------------------------------
+
+def test_a_typed_goal_has_its_own_source() -> None:
+    assert SignalSource.OPERATOR_CHAT.value == "operator_chat"
+    assert "operator_chat" in _VALID_SOURCES
+
+
+def test_it_routes_IMMEDIATE_like_every_other_human_origin() -> None:
+    """§5: human-originated signals route IMMEDIATE because a person is
+    waiting on the answer. A typed goal is that, exactly as a spoken one is."""
+    assert "operator_chat" in _IMMEDIATE_SOURCES
+    assert "voice_human" in _IMMEDIATE_SOURCES
+
+
+def test_it_is_no_longer_background() -> None:
+    """THE defect: `backlog` is cost-optimized and polled. A watched goal
+    must not inherit that."""
+    assert "operator_chat" not in _BACKGROUND_SOURCES
+    assert "backlog" in _BACKGROUND_SOURCES, "the sensor route must remain"
+
+
+def test_it_holds_sovereign_primacy() -> None:
+    """The host keeps ultimate control — a typed goal outranks a resurrected
+    op for the same reason a spoken one does."""
+    assert "operator_chat" in SOVEREIGN_SOURCES
+
+
+def test_it_is_distinct_from_voice_and_from_backlog() -> None:
+    """Attributable separately, so observability can tell a spoken goal from
+    a typed one from a mined one."""
+    assert len({"operator_chat", "voice_human", "backlog"}) == 3
+
+
+def test_the_immediate_set_stays_tight() -> None:
+    """The bt-2026-04-13 regression was seven autonomous sensors mislabelling
+    themselves and firing unattended. This source can only be produced by a
+    keystroke, but the set must still not sprawl."""
+    assert len(_IMMEDIATE_SOURCES) <= 5
+
+
+# --------------------------------------------------------------------------
+# 2. the executor dispatches now, and never loses the goal
+# --------------------------------------------------------------------------
+
+class _Turn:
+    turn_id = "chat-1dc4650228e7"
+    session_id = "repl"
+
+
+def _executor(tmp_path: Path, submit: Any = None) -> Any:
+    from backend.core.ouroboros.governance.chat_repl_backlog_executor import (
+        BacklogChatActionExecutor,
+    )
+    return BacklogChatActionExecutor(tmp_path, submit_now=submit)
+
+
+def test_a_wired_submitter_dispatches_immediately(tmp_path: Path) -> None:
+    seen: List[Any] = []
+
+    def _submit(msg: str, turn: Any) -> str:
+        seen.append((msg, turn.turn_id))
+        return "op-019fa4d2-246e-7759-86"
+
+    out = _executor(tmp_path, _submit).dispatch_backlog("fix the tests", _Turn())
+    assert out.startswith("op-")
+    assert seen and seen[0][0] == "fix the tests"
+    assert not (tmp_path / "backlog.json").exists(), (
+        "it filed the goal as well as running it — duplicate work"
+    )
+
+
+def test_without_a_submitter_the_old_path_is_untouched(tmp_path: Path) -> None:
+    """Injected, not imported: this module must stay usable with no intake,
+    no event loop and no daemon."""
+    out = _executor(tmp_path).dispatch_backlog("fix the tests", _Turn())
+    assert out == "chat:chat-1dc4650228e7"
+
+
+def test_an_intake_fault_falls_back_rather_than_dropping(tmp_path: Path) -> None:
+    """A queued goal is a degradation. A dropped one is a betrayal."""
+    def _boom(_msg: str, _turn: Any) -> str:
+        raise RuntimeError("intake unreachable")
+
+    out = _executor(tmp_path, _boom).dispatch_backlog("fix the tests", _Turn())
+    assert out == "chat:chat-1dc4650228e7", "the goal was lost"
+
+
+def test_a_submitter_returning_nothing_falls_back(tmp_path: Path) -> None:
+    """Intake declining is not an exception — it must still not lose the
+    goal."""
+    out = _executor(tmp_path, lambda _m, _t: None).dispatch_backlog("x", _Turn())
+    assert out == "chat:chat-1dc4650228e7"
+
+
+def test_an_empty_goal_is_never_dispatched(tmp_path: Path) -> None:
+    """Refusing empty input predates this and must survive it — otherwise a
+    stray Enter fires an IMMEDIATE Claude op."""
+    calls: List[Any] = []
+    out = _executor(tmp_path, lambda m, t: calls.append(m) or "op-x").dispatch_backlog(
+        "   ", _Turn(),
+    )
+    assert calls == [], "an empty goal reached intake"
+    assert out.startswith("error-empty-message")
+
+
+# --------------------------------------------------------------------------
+# 3. the seam is armed by the daemon, not assumed everywhere
+# --------------------------------------------------------------------------
+
+def test_the_registry_arms_and_disarms(tmp_path: Path) -> None:
+    """ONE seam rather than a parameter threaded through three nested
+    factories — an intermediate factory that forgets to forward produces an
+    executor that silently files goals, which is the wired-but-inert failure
+    this codebase keeps paying for."""
+    from backend.core.ouroboros.governance.chat_repl_backlog_executor import (
+        set_operator_dispatcher,
+    )
+    try:
+        assert _executor(tmp_path).dispatch_backlog("x", _Turn()).startswith("chat:")
+        set_operator_dispatcher(lambda _m, _t: "op-019fa4d2-246e-7759-86")
+        assert _executor(tmp_path).dispatch_backlog("x", _Turn()).startswith("op-")
+    finally:
+        set_operator_dispatcher(None)
+    assert _executor(tmp_path).dispatch_backlog("x", _Turn()).startswith("chat:")
+
+
+def test_explicit_injection_outranks_the_registry(tmp_path: Path) -> None:
+    """Tests and knowing callers must be able to override the daemon's
+    standing answer."""
+    from backend.core.ouroboros.governance.chat_repl_backlog_executor import (
+        set_operator_dispatcher,
+    )
+    try:
+        set_operator_dispatcher(lambda _m, _t: "op-from-registry")
+        out = _executor(tmp_path, lambda _m, _t: "op-explicit").dispatch_backlog(
+            "x", _Turn(),
+        )
+        assert out == "op-explicit"
+    finally:
+        set_operator_dispatcher(None)
+
+
+def test_the_daemon_arms_it_at_boot() -> None:
+    """Structural: an unarmed seam files every goal — correct, but not what
+    was built."""
+    src = (Path(__file__).resolve().parents[2]
+           / "backend/core/ouroboros/battle_test/harness.py").read_text()
+    assert "set_operator_dispatcher(self._submit_operator_goal)" in src
+
+
+def test_the_submitter_uses_the_router_every_sensor_uses() -> None:
+    """DRY, and governance: no private lane for operator input, so one set of
+    dedup / WAL / priority rules covers autonomous and human work alike."""
+    import inspect
+
+    from backend.core.ouroboros.battle_test.harness import BattleTestHarness
+
+    src = inspect.getsource(BattleTestHarness._submit_operator_goal)
+    assert '"_intake_router", "intake_router", "_router"' in src
+    assert 'source="operator_chat"' in src
+
+
+def test_urgency_is_high_not_critical() -> None:
+    """The operator is waiting, but a typed goal is not an emergency and must
+    not outrank a runtime alarm. IMMEDIATE eligibility comes from the SOURCE
+    being human-origin — inflating urgency to buy it would distort every
+    priority queue the envelope passes through."""
+    import inspect
+
+    from backend.core.ouroboros.battle_test.harness import BattleTestHarness
+
+    src = inspect.getsource(BattleTestHarness._submit_operator_goal)
+    assert 'urgency="high"' in src
+    assert 'urgency="critical"' not in src
+
+
+def test_an_unreachable_intake_returns_none_rather_than_raising() -> None:
+    """So the caller files the goal and says so."""
+    from backend.core.ouroboros.battle_test.harness import BattleTestHarness
+
+    bare = BattleTestHarness.__new__(BattleTestHarness)
+    assert bare._submit_operator_goal("fix the tests", _Turn()) is None


### PR DESCRIPTION
Typing a goal filed it and stopped. The organism looked idle because it **was** idle — nothing had been dispatched.

### Root cause: the source token described where the goal was STORED, not who ASKED
`dispatch_backlog` wrote to `backlog.json`, so the goal carried `source="backlog"` — which sits in `_BACKGROUND_SOURCES`:

> *"DW only, no Claude fallback… cost-optimization-first"*

Collected on a later sensor sweep. Correct for the Backlog **sensor** mining a task list. Wrong for a human who just pressed Enter and is watching the screen.

`intent_envelope.py` already names this class of defect — *"Honest-source token: decoupled test-coverage work MUST NOT masquerade as `test_failure`/`backlog`"* — and already carries `cli_emergency` / `human_override` as siblings of `voice_human` so *"a typed operator override is attributable separately"*. A typed **goal** was the missing member.

### `operator_chat`
Human-origin · SOVEREIGN (the host keeps ultimate control) · IMMEDIATE-eligible — the same treatment `voice_human` gets, for the same reason.

It doesn't widen the cost surface the way the bt-2026-04-13 regression did: that was seven autonomous sensors mislabelling themselves and firing unattended. **This source can only be produced by a keystroke.**

Urgency is **high, not critical**. The operator is waiting, but a typed goal is not an emergency and must not outrank a runtime alarm. IMMEDIATE eligibility comes from the *source* being human-origin — inflating urgency to buy it would distort every priority queue the envelope passes through.

### Dispatch rides the router every sensor uses
One set of governance, dedup and WAL rules covers autonomous and human work alike. No private lane for operator input.

### One seam, not a threaded parameter
`set_operator_dispatcher` follows the `set_active_canvas` precedent — the daemon installs its capability once at boot.

Threading `submit_now=` through three nested factories (`chat_text_bridge` → `with_claude` → `with_backlog`) would give each an argument it doesn't use and must remember to forward. One that forgets produces an executor that silently files goals — the wired-but-inert failure this codebase keeps paying for.

### The goal is never lost
Intake unreachable, declining, or raising all fall back to the durable backlog write. **A queued goal is a degradation; a dropped one is a betrayal.** An empty message is still refused before it can fire an IMMEDIATE op.

### The reply tells the two apart by RECEIPT SHAPE
Not by a second action token — the classifier can't predict which path the executor will take, and asking it to would put routing knowledge in the wrong layer.

```
⏺ on it
  ⎿ dispatched 7759-86 · immediate · watching
```
```
⏺ adding that to the backlog
  ⎿ queued (chat:…) — the Backlog sensor will pick it up on its next sweep
```

The op then narrates itself through the same `⏺`/`⎿` chrome every autonomous op uses — which is what was actually missing: **not the chrome, but an op for it to narrate.**

### Tests
53. **1072 passing** across chat / conversation / urgency / cli. The 8 urgency-router failures and the `intake_layer_cu_wiring` hang are pre-existing — both verified identical with these changes stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Typed goals now dispatch immediately via the standard intake router as `operator_chat` and narrate themselves; no more silent backlog filing that looks idle. Replies show “on it” when running, or “queued” when filed.

- **New Features**
  - Added `operator_chat` intent source; marked SOVEREIGN and IMMEDIATE-eligible; urgency set to `high` (not `critical`).
  - Immediate dispatch rides the existing router (same governance/dedup/WAL); no private lane for operator input.
  - Introduced `set_operator_dispatcher`/`get_operator_dispatcher` seam; harness arms it at boot. Explicit injection supported; absent seam degrades to backlog write.
  - `BacklogChatActionExecutor` attempts immediate dispatch first and never loses goals: intake failures/declines fall back to `backlog.json`; empty messages still rejected.
  - Chat reply updates: detect op-id receipts and output “⏺ on it” with “⎿ dispatched <short-ref> · immediate · watching”; backlog path continues to say “queued”.
  - Tests cover routing and sovereignty, dispatcher seam behavior, durable fallback, and reply rendering.

<sup>Written for commit 0f80df478d98ebd054c72d74ee2871acd1fe0ba6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

