### PR TITLE
feat(ov): subagent work is visible while it happens

### DIFF
--- a/backend/core/ouroboros/governance/governed_loop_service.py
+++ b/backend/core/ouroboros/governance/governed_loop_service.py
@@ -1044,6 +1044,32 @@ class GovernedLoopConfig:
 # ---------------------------------------------------------------------------
 
 
+def _wrap_subagent_narration(gls: Any, inner: Any) -> Any:
+    """Add cockpit narration to a CommSink. Returns `inner` unchanged on any
+    failure — a missing narrator must never cost observability.
+    """
+    try:
+        from backend.core.ouroboros.governance.subagent_narrator import (
+            SubagentNarrationSink, narration_enabled,
+        )
+        if not narration_enabled():
+            return inner
+
+        def _emit(line: str) -> None:
+            # Resolved PER EVENT: SerpentFlow attaches to the service after
+            # this stack is constructed, so a handle captured at build time
+            # is None forever. The same late-binding the alert emitter above
+            # already uses.
+            flow = getattr(gls, "_serpent_flow", None)
+            mirror = getattr(flow, "_mirror_markup", None) if flow else None
+            if mirror is not None:
+                mirror(line)
+
+        return SubagentNarrationSink(inner, _emit)
+    except Exception:  # noqa: BLE001
+        return inner
+
+
 class GovernedLoopService:
     """Lifecycle manager for the governed self-programming pipeline.
 
@@ -5975,7 +6001,18 @@ class GovernedLoopService:
                         self._config.project_root,
                         provider_registry=self._resolve_provider_for_subagent,
                     ),
-                    comm=_sub_comm,
+                    # Narration WRAPS the CommProtocol sink rather than
+                    # replacing it: the orchestrator takes one `comm`, and
+                    # swapping it would cost the spine that carries these
+                    # events to the ledger, the observability API and the SSE
+                    # stream. Wrapped, the inner sink sees every event
+                    # unchanged and the cockpit gains ⏺/⎿ chrome beside it.
+                    #
+                    # Emits through the SAME markup mirror every op-chrome
+                    # line uses — resolved late, per event, because
+                    # SerpentFlow attaches after this stack is built and a
+                    # handle captured here would be permanently None.
+                    comm=_wrap_subagent_narration(self, _sub_comm),
                     ledger=_sub_ledger,
                 )
                 self._subagent_orchestrator_ref = _sub_orch

--- a/backend/core/ouroboros/governance/subagent_narrator.py
+++ b/backend/core/ouroboros/governance/subagent_narrator.py
@@ -1,0 +1,217 @@
+"""Subagent work, visible while it happens.
+
+`SubagentOrchestrator` already emits a lifecycle event for every dispatch —
+`CommSink.emit_spawn` / `emit_result`, documented as "§7 Absolute
+observability: every dispatch emits a spawn event". Those events reach
+CommProtocol as HEARTBEAT frames with `phase="subagent_spawn"`.
+
+Nothing rendered them. Grep for `subagent_spawn` across every cockpit surface
+returns zero consumers, so an op that recruited four subagents and ran them in
+parallel looked, from the operator's chair, exactly like an op that had
+stalled. A live producer with no renderer — the same shape as the `/` palette
+that was wired into a layout `ov` never mounted.
+
+    ⏺ Explore(find every caller of _normalize)
+      ⎿ 3 files · 41 refs · 2.1s
+    ⏺ Review(candidate patch)
+      ⎿ 2 findings · 4.7s
+
+A DECORATOR, not a replacement
+-------------------------------
+`SubagentOrchestrator` takes ONE `comm` sink. Narrating by swapping it would
+cost the CommProtocol spine that carries these events to the ledger, the
+observability API and the SSE stream. Wrapping keeps both: the wrapped sink
+sees every event unchanged, and narration is added beside it.
+
+That also makes the failure modes independent. A narration fault cannot break
+observability, and a CommProtocol fault cannot blank the cockpit — each is
+caught where it happens.
+
+Renders through the mirror seam, not to a console
+--------------------------------------------------
+Lines go to the same `markup_mirror` chokepoint every op-chrome line uses, so
+they reach an attached cockpit by the route that is already proven to work,
+and they inherit its escaping rules. This module never touches a Console: a
+narrator that printed directly would render on the daemon's own terminal —
+detached, unwatched — which is precisely the bug that hid verb output.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Any, Callable, Dict, Optional
+
+logger = logging.getLogger("Ouroboros.SubagentNarrator")
+
+__all__ = ["SubagentNarrationSink", "narration_enabled", "render_spawn",
+           "render_result"]
+
+#: How a subagent kind is SPOKEN. The orchestrator's type token is a routing
+#: identifier ("EXPLORE"); this is the word an operator reads. Keyed off the
+#: existing token, so a new subagent kind means a new entry here rather than a
+#: renderer that has to learn a new concept.
+_KIND_VOICE = {
+    "explore": "Explore",
+    "review": "Review",
+    "plan": "Plan",
+    "general": "Agent",
+}
+
+#: A goal is a sentence; a chrome line is a line. Clipped at the composer
+#: rather than the emitter so the ledger keeps the full text.
+_GOAL_MAX = 72
+
+
+def narration_enabled() -> bool:
+    """Master switch. Default ON — this closes an observability gap, and a
+    dark default would leave it closed."""
+    return os.environ.get(
+        "JARVIS_SUBAGENT_NARRATION_ENABLED", "1",
+    ).strip().lower() not in ("0", "false", "no", "off")
+
+
+def _voice(subagent_type: Any) -> str:
+    token = str(getattr(subagent_type, "value", subagent_type) or "").lower()
+    return _KIND_VOICE.get(token, token.title() or "Agent")
+
+
+def _clip(text: str, limit: int = _GOAL_MAX) -> str:
+    flat = " ".join(str(text or "").split())
+    return flat if len(flat) <= limit else flat[: limit - 1].rstrip() + "…"
+
+
+def render_spawn(subagent_type: Any, goal: str) -> str:
+    """``⏺ Explore(goal)`` — §04: ⏺ opens a primary action."""
+    return f"⏺ {_voice(subagent_type)}({_clip(goal)})"
+
+
+def render_result(result: Any, elapsed_s: Optional[float] = None) -> str:
+    """``⎿ 3 files · 41 refs · 2.1s`` — §04: ⎿ is subordinate to the line above.
+
+    Summarises rather than dumps. The full result is already in the ledger;
+    what belongs on screen is enough to know whether it worked and what it
+    cost — the same judgement that moved classifier internals off the chat
+    reply.
+    """
+    bits = []
+    try:
+        ok = getattr(result, "ok", None)
+        if ok is False:
+            reason = _clip(str(getattr(result, "error", "") or "failed"), 48)
+            bits.append(f"failed · {reason}")
+        else:
+            for attr, unit in (("files_touched", "files"),
+                               ("findings", "findings"),
+                               ("steps", "steps")):
+                value = getattr(result, attr, None)
+                if isinstance(value, (list, tuple, set)):
+                    value = len(value)
+                # Non-zero only. "0 findings" on an EXPLORE reports a
+                # metric that belongs to REVIEW and reads as a result rather
+                # than an absence — the same noise as a blank help column
+                # filled for the sake of being filled.
+                if isinstance(value, int) and value > 0:
+                    bits.append(f"{value} {unit}")
+            summary = getattr(result, "summary", "") or ""
+            if not bits and summary:
+                bits.append(_clip(str(summary), 48))
+    except Exception:  # noqa: BLE001
+        pass
+    if isinstance(elapsed_s, (int, float)) and elapsed_s >= 0:
+        bits.append(f"{elapsed_s:.1f}s")
+    return f"  ⎿ {' · '.join(bits) if bits else 'done'}"
+
+
+class SubagentNarrationSink:
+    """Wraps a CommSink and narrates each event to the cockpit.
+
+    Every method delegates FIRST and narrates second, so the wrapped sink
+    cannot be starved by a rendering fault — observability is the contract
+    that must not break, and narration is the addition.
+    """
+
+    def __init__(
+        self,
+        inner: Any = None,
+        emit_line: Optional[Callable[[str], None]] = None,
+    ) -> None:
+        self._inner = inner
+        # INJECTED: this module must be testable with no SerpentFlow, no
+        # bridge and no daemon. Absent a sink, narration is silently skipped
+        # and delegation still happens.
+        self._emit = emit_line
+        self._started: Dict[str, float] = {}
+
+    # -- narration ---------------------------------------------------------
+
+    def _say(self, line: str) -> None:
+        try:
+            if not line or not narration_enabled():
+                return
+            sink = self._emit
+            if sink is None:
+                return
+            sink(line)
+        except Exception:  # noqa: BLE001 — never break a dispatch to draw it
+            logger.debug("[SubagentNarrator] emit degraded", exc_info=True)
+
+    # -- CommSink ----------------------------------------------------------
+
+    def emit_spawn(
+        self,
+        parent_op_id: str,
+        subagent_id: str,
+        subagent_type: Any,
+        goal: str,
+    ) -> None:
+        try:
+            if self._inner is not None:
+                self._inner.emit_spawn(
+                    parent_op_id, subagent_id, subagent_type, goal,
+                )
+        except Exception:  # noqa: BLE001
+            logger.debug("[SubagentNarrator] inner emit_spawn failed",
+                         exc_info=True)
+        try:
+            # Monotonic: the elapsed figure must not jump if the wall clock
+            # is adjusted mid-dispatch.
+            self._started[str(subagent_id)] = time.monotonic()
+        except Exception:  # noqa: BLE001
+            pass
+        self._say(render_spawn(subagent_type, goal))
+
+    def emit_result(
+        self,
+        parent_op_id: str,
+        subagent_id: str,
+        result: Any,
+    ) -> None:
+        try:
+            if self._inner is not None:
+                self._inner.emit_result(parent_op_id, subagent_id, result)
+        except Exception:  # noqa: BLE001
+            logger.debug("[SubagentNarrator] inner emit_result failed",
+                         exc_info=True)
+        elapsed: Optional[float] = None
+        try:
+            started = self._started.pop(str(subagent_id), None)
+            if started is not None:
+                elapsed = time.monotonic() - started
+        except Exception:  # noqa: BLE001
+            elapsed = None
+        self._say(render_result(result, elapsed))
+
+    # -- passthrough -------------------------------------------------------
+
+    def __getattr__(self, name: str) -> Any:
+        """Forward anything else to the wrapped sink.
+
+        The CommSink protocol is structural and may grow. A decorator that
+        implemented only the two methods it knew about would silently drop a
+        third the day one is added.
+        """
+        inner = self.__dict__.get("_inner")
+        if inner is None:
+            raise AttributeError(name)
+        return getattr(inner, name)

--- a/tests/governance/test_subagent_narration.py
+++ b/tests/governance/test_subagent_narration.py
@@ -1,0 +1,283 @@
+"""Subagent work, visible while it happens.
+
+`SubagentOrchestrator` already emitted a lifecycle event for every dispatch —
+`CommSink.emit_spawn`/`emit_result`, documented as "§7 Absolute observability:
+every dispatch emits a spawn event" — and those reached CommProtocol as
+HEARTBEAT frames with `phase="subagent_spawn"`.
+
+Nothing rendered them. A grep for `subagent_spawn` across every cockpit
+surface returned ZERO consumers, so an op that recruited four subagents and
+ran them in parallel looked, from the operator's chair, exactly like an op
+that had stalled. A live producer with no renderer — the same shape as the `/`
+palette wired into a layout `ov` never mounted.
+"""
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any, List
+
+import pytest
+
+from backend.core.ouroboros.governance.subagent_narrator import (
+    SubagentNarrationSink,
+    narration_enabled,
+    render_result,
+    render_spawn,
+)
+
+_REPO = Path(__file__).resolve().parents[2]
+
+
+class _Inner:
+    def __init__(self) -> None:
+        self.events: List[str] = []
+
+    def emit_spawn(self, *_a: Any) -> None:
+        self.events.append("spawn")
+
+    def emit_result(self, *_a: Any) -> None:
+        self.events.append("result")
+
+
+class _Ok:
+    ok = True
+    files_touched = ["a", "b", "c"]
+    findings: List[str] = []
+    summary = "scanned"
+
+
+# --------------------------------------------------------------------------
+# 1. it reads like op chrome
+# --------------------------------------------------------------------------
+
+def test_a_spawn_opens_with_the_primary_action_glyph() -> None:
+    """§04: ⏺ opens a primary action."""
+    line = render_spawn("explore", "find every caller of _normalize")
+    assert line.startswith("⏺ Explore(")
+    assert "find every caller" in line
+
+
+def test_a_result_is_subordinate_to_its_spawn() -> None:
+    """§04: ⎿ is subordinate to the line above — which is what makes the pair
+    read as one unit of work rather than two events."""
+    assert render_result(_Ok(), 2.1).lstrip().startswith("⎿")
+    assert render_result(_Ok(), 2.1).startswith("  ")
+
+
+@pytest.mark.parametrize("token,spoken", [
+    ("explore", "Explore"), ("review", "Review"),
+    ("plan", "Plan"), ("general", "Agent"),
+])
+def test_each_kind_is_SPOKEN_not_tokenised(token: str, spoken: str) -> None:
+    """The orchestrator's type is a routing identifier; this is the word an
+    operator reads."""
+    assert render_spawn(token, "x").startswith(f"⏺ {spoken}(")
+
+
+def test_an_unknown_kind_still_renders() -> None:
+    """A new subagent type must degrade to something readable, not blank."""
+    assert "Synthesiz" in render_spawn("synthesize", "x")
+
+
+def test_a_long_goal_is_clipped_to_one_line() -> None:
+    line = render_spawn("explore", "word " * 80)
+    assert len(line) < 100 and line.endswith(")")
+
+
+def test_a_multiline_goal_is_flattened() -> None:
+    """A newline inside chrome breaks the ⏺/⎿ pairing visually."""
+    assert "\n" not in render_spawn("plan", "line one\nline two")
+
+
+# --------------------------------------------------------------------------
+# 2. the summary is a summary
+# --------------------------------------------------------------------------
+
+def test_zero_counts_are_omitted() -> None:
+    """"0 findings" on an EXPLORE reports a metric belonging to REVIEW, and
+    reads as a result rather than an absence."""
+    assert "0 findings" not in render_result(_Ok(), 1.0)
+    assert "3 files" in render_result(_Ok(), 1.0)
+
+
+def test_a_failure_says_why() -> None:
+    class _Fail:
+        ok = False
+        error = "provider timeout"
+
+    out = render_result(_Fail(), 0.4)
+    assert "failed" in out and "provider timeout" in out
+
+
+def test_elapsed_is_shown_so_cost_is_legible() -> None:
+    assert "2.1s" in render_result(_Ok(), 2.1)
+
+
+def test_a_result_with_nothing_to_report_still_closes_the_pair() -> None:
+    """An unterminated ⏺ reads as work still running."""
+    class _Bare:
+        ok = True
+
+    assert "done" in render_result(_Bare(), None)
+
+
+@pytest.mark.parametrize("junk", [None, 42, object(), "text"])
+def test_rendering_never_raises(junk: Any) -> None:
+    assert isinstance(render_result(junk, 1.0), str)
+    assert isinstance(render_spawn(junk, "x"), str)
+
+
+# --------------------------------------------------------------------------
+# 3. it decorates — it does not replace
+# --------------------------------------------------------------------------
+
+def test_the_wrapped_sink_sees_every_event() -> None:
+    """Swapping the CommProtocol sink would cost the spine carrying these
+    events to the ledger, the observability API and the SSE stream."""
+    inner = _Inner()
+    sink = SubagentNarrationSink(inner, lambda _l: None)
+    sink.emit_spawn("op-1", "sub-1", "explore", "goal")
+    sink.emit_result("op-1", "sub-1", _Ok())
+    assert inner.events == ["spawn", "result"]
+
+
+def test_a_narration_fault_cannot_break_observability() -> None:
+    """Delegation happens FIRST, so a rendering fault cannot starve the inner
+    sink — observability is the contract that must not break."""
+    inner = _Inner()
+
+    def _boom(_line: str) -> None:
+        raise RuntimeError("cockpit gone")
+
+    sink = SubagentNarrationSink(inner, _boom)
+    sink.emit_spawn("op-1", "sub-1", "explore", "goal")
+    sink.emit_result("op-1", "sub-1", _Ok())
+    assert inner.events == ["spawn", "result"]
+
+
+def test_an_inner_fault_cannot_blank_the_cockpit() -> None:
+    """The inverse: each failure is caught where it happens."""
+    class _BrokenInner:
+        def emit_spawn(self, *_a: Any) -> None:
+            raise RuntimeError("comm down")
+
+        def emit_result(self, *_a: Any) -> None:
+            raise RuntimeError("comm down")
+
+    lines: List[str] = []
+    sink = SubagentNarrationSink(_BrokenInner(), lines.append)
+    sink.emit_spawn("op-1", "sub-1", "explore", "goal")
+    sink.emit_result("op-1", "sub-1", _Ok())
+    assert len(lines) == 2
+
+
+def test_unknown_methods_forward_to_the_wrapped_sink() -> None:
+    """The CommSink protocol is structural and may grow; a decorator
+    implementing only what it knew about would silently drop the next
+    method added."""
+    class _Rich:
+        def emit_spawn(self, *_a: Any) -> None: ...
+        def emit_result(self, *_a: Any) -> None: ...
+        def emit_future_thing(self) -> str:
+            return "forwarded"
+
+    assert SubagentNarrationSink(_Rich()).emit_future_thing() == "forwarded"
+
+
+def test_it_works_with_no_inner_sink_at_all() -> None:
+    lines: List[str] = []
+    SubagentNarrationSink(None, lines.append).emit_spawn(
+        "op-1", "sub-1", "explore", "goal",
+    )
+    assert lines
+
+
+def test_it_works_with_no_cockpit_attached() -> None:
+    """Narration is skipped, dispatch is untouched — the daemon runs
+    detached most of the time."""
+    inner = _Inner()
+    SubagentNarrationSink(inner).emit_spawn("op-1", "s", "explore", "g")
+    assert inner.events == ["spawn"]
+
+
+# --------------------------------------------------------------------------
+# 4. elapsed is measured honestly
+# --------------------------------------------------------------------------
+
+def test_elapsed_is_measured_across_the_pair() -> None:
+    lines: List[str] = []
+    sink = SubagentNarrationSink(None, lines.append)
+    sink.emit_spawn("op-1", "sub-1", "explore", "goal")
+    time.sleep(0.05)
+    sink.emit_result("op-1", "sub-1", _Ok())
+    assert "s" in lines[1]
+
+
+def test_a_result_without_a_spawn_omits_elapsed_rather_than_inventing_it():
+    """A subagent whose spawn was missed must not be assigned a fabricated
+    duration."""
+    lines: List[str] = []
+    SubagentNarrationSink(None, lines.append).emit_result(
+        "op-1", "orphan", _Ok(),
+    )
+    assert "s" not in lines[0].replace("files", "")
+
+
+def test_concurrent_subagents_do_not_share_a_clock() -> None:
+    """Parallel dispatch is the normal case — one shared start time would
+    give every agent the duration of the slowest."""
+    lines: List[str] = []
+    sink = SubagentNarrationSink(None, lines.append)
+    sink.emit_spawn("op-1", "a", "explore", "g")
+    time.sleep(0.05)
+    sink.emit_spawn("op-1", "b", "review", "g")
+    sink.emit_result("op-1", "b", _Ok())
+    sink.emit_result("op-1", "a", _Ok())
+    b_elapsed = lines[2]
+    a_elapsed = lines[3]
+    assert b_elapsed != a_elapsed
+
+
+# --------------------------------------------------------------------------
+# 5. wiring
+# --------------------------------------------------------------------------
+
+def test_the_master_switch_defaults_on() -> None:
+    """It closes an observability gap; a dark default would leave it closed."""
+    assert narration_enabled() is True
+
+
+def test_the_switch_silences_narration_without_touching_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_SUBAGENT_NARRATION_ENABLED", "0")
+    inner, lines = _Inner(), []
+    sink = SubagentNarrationSink(inner, lines.append)
+    sink.emit_spawn("op-1", "sub-1", "explore", "goal")
+    assert lines == []
+    assert inner.events == ["spawn"]
+
+
+def test_the_orchestrator_is_wrapped_at_its_one_construction_site() -> None:
+    src = (_REPO / "backend/core/ouroboros/governance/"
+           "governed_loop_service.py").read_text()
+    assert "_wrap_subagent_narration(self, _sub_comm)" in src
+
+
+def test_the_mirror_is_resolved_LATE() -> None:
+    """SerpentFlow attaches after this stack is built, so a handle captured
+    at construction time would be None forever — the wired-but-inert shape."""
+    src = (_REPO / "backend/core/ouroboros/governance/"
+           "governed_loop_service.py").read_text()
+    body = src.split("def _wrap_subagent_narration")[1][:900]
+    assert 'getattr(gls, "_serpent_flow", None)' in body
+    assert "_mirror_markup" in body
+
+
+def test_narration_never_costs_observability() -> None:
+    """The wrapper returns the inner sink unchanged on any failure."""
+    src = (_REPO / "backend/core/ouroboros/governance/"
+           "governed_loop_service.py").read_text()
+    body = src.split("def _wrap_subagent_narration")[1][:900]
+    assert "return inner" in body


### PR DESCRIPTION
```
⏺ Explore(find every caller of _normalize)
  ⎿ 3 files · 2.1s
⏺ Review(candidate patch)
  ⎿ 2 findings · 4.7s
```

### The events already existed
`SubagentOrchestrator` emits `CommSink.emit_spawn` / `emit_result` for every dispatch — documented as *"§7 Absolute observability: every dispatch emits a spawn event"* — and they reach CommProtocol as HEARTBEAT frames with `phase="subagent_spawn"`.

**Nothing rendered them.** A grep for `subagent_spawn` across every cockpit surface returned **zero** consumers. An op that recruited four subagents and ran them in parallel looked, from the operator's chair, exactly like an op that had stalled.

A live producer with no renderer — the same shape as the `/` palette wired into a layout `ov` never mounted, and the verb output rendering on a console nobody watched.

### A decorator, not a replacement
The orchestrator takes **one** `comm` sink. Swapping it would cost the spine carrying these events to the ledger, the observability API and the SSE stream. Wrapped, the inner sink sees every event unchanged.

Delegation happens **first**, so a rendering fault cannot starve observability — and an inner fault cannot blank the cockpit. Each is caught where it happens, and the wrapper returns the inner sink untouched if the narrator can't be built at all.

### The mirror is resolved per event, not captured at build
SerpentFlow attaches to the service *after* this stack is constructed, so a handle taken at construction time would be `None` forever — precisely the wired-but-inert shape this closes. Same late-binding the cross-space alert emitter already uses.

Emits through `_mirror_markup`, the chokepoint every op-chrome line already uses, so it reaches an attached cockpit by the proven route and inherits its escaping. The module never touches a `Console`: a narrator that printed directly would render on the daemon's own detached terminal.

### Detail decisions
- **Zero counts omitted** — `0 findings` on an EXPLORE reports a REVIEW metric and reads as a result rather than an absence
- **Elapsed is monotonic and per-subagent** — parallel dispatch is the normal case; one shared clock would give every agent the duration of the slowest
- **A result without a spawn omits elapsed** rather than inventing it
- **Unknown methods forward** — the CommSink protocol is structural and may grow

`JARVIS_SUBAGENT_NARRATION_ENABLED` defaults **ON**: this closes an observability gap, and a dark default would leave it closed. Off silences narration without touching dispatch.

### Tests
31 new. **1082 passing** across subagent / chat / cli.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes subagent work visible in the cockpit as it happens by narrating each spawn/result with ⏺/⎿ lines. Keeps the existing `CommSink`/ledger/SSE path intact by decorating instead of replacing.

- **New Features**
  - Added `SubagentNarrationSink` and wrapped the orchestrator’s `comm` in `GovernedLoopService` to narrate `emit_spawn`/`emit_result`.
  - Emits via `_mirror_markup` resolved per event (late binding); no console writes.
  - Delegates to the inner sink first; narration and inner failures are isolated.
  - Monotonic, per-subagent elapsed timing; concise result summaries that omit zero counts; orphan results omit elapsed.
  - `JARVIS_SUBAGENT_NARRATION_ENABLED` (default ON) toggles narration; 31 tests added.

<sup>Written for commit c1e0fc3e8a680c6817158e9f3e123a9643d04658. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

