### PR TITLE
feat(ov): the Iron Gate asks, and an attached operator can answer

### DIFF
--- a/backend/core/ouroboros/governance/approval_narrator.py
+++ b/backend/core/ouroboros/governance/approval_narrator.py
@@ -1,0 +1,192 @@
+"""The Iron Gate asks, and an attached operator can answer.
+
+An APPROVAL_REQUIRED op pauses at APPROVE and waits. That much was correct:
+`CLIApprovalProvider.await_decision` already wraps the wait in
+`asyncio.wait_for` and stamps EXPIRED on timeout, so nothing hangs — the
+orphan prevention has been right all along, and the daemon has never blocked
+on stdin.
+
+What was missing is that **nobody was ever asked**. The gate emitted a comm
+heartbeat with `phase="approve"` — which no cockpit surface renders — and then
+sat silently until it expired. An operator watching the deck saw an op stop
+moving and had no way to know a question was pending, let alone answer it.
+
+Two finished components, never joined:
+
+* `OperatorPromptBridge` (#70085) — a single-slot pending-prompt registry whose
+  future resolves from attached-terminal input. `harness._on_input` already
+  consults it BEFORE the REPL. It had **zero callers of `begin()`**: a receive
+  path with no sender, so `waiting` was permanently False and every keystroke
+  fell through to the REPL.
+* `_mirror_markup` — the chokepoint every ⏺/⎿ line already reaches the cockpit
+  through.
+
+This joins them. It adds no transport, no polling, and no second timeout.
+
+Why race rather than replace
+-----------------------------
+`await_decision` is still the authority on the outcome — it owns the timeout,
+the EXPIRED stamp and the ledger semantics. The bridge is raced ALONGSIDE it as
+a faster path to the same decision: an operator answering `y` calls the
+provider's own `approve()`, which sets the event `await_decision` is already
+waiting on. One source of truth for what was decided; two ways to reach it.
+
+Replacing the wait would have meant reimplementing expiry, and a second timeout
+that disagrees with the first is worse than no second path at all.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Any, Callable, Optional
+
+logger = logging.getLogger("Ouroboros.ApprovalNarrator")
+
+__all__ = [
+    "approval_narration_enabled",
+    "interpret_answer",
+    "render_gate_prompt",
+    "await_decision_with_operator",
+]
+
+#: Answers that mean yes. Everything unrecognised is NOT a yes — an approval
+#: must be affirmative and deliberate, so ambiguity resolves to rejection
+#: rather than to the more convenient reading.
+_YES = frozenset({"y", "yes", "approve", "ok", "go", "ship", "accept"})
+_NO = frozenset({"n", "no", "reject", "stop", "deny", "cancel", "abort"})
+
+
+def approval_narration_enabled() -> bool:
+    """Default ON: an unanswerable gate is the failure this closes."""
+    return os.environ.get(
+        "JARVIS_APPROVAL_NARRATION_ENABLED", "1",
+    ).strip().lower() not in ("0", "false", "no", "off")
+
+
+def interpret_answer(text: Any) -> Optional[bool]:
+    """``True`` approve, ``False`` reject, ``None`` "that wasn't an answer".
+
+    None matters: an operator typing an unrelated command while a gate is
+    pending must not have it read as a verdict. The caller leaves the gate
+    armed and lets the text flow on to the REPL, rather than consuming a
+    keystroke that was never a decision.
+    """
+    try:
+        token = str(text or "").strip().lower()
+        if not token:
+            return None
+        first = token.split()[0]
+        if first in _YES:
+            return True
+        if first in _NO:
+            return False
+        return None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def render_gate_prompt(
+    op_id: str, risk: str = "", reason: str = "", timeout_s: float = 0.0,
+) -> str:
+    """``⏺ Iron Gate(7759-86) ⎿ approve? [y/n] · expires in 300s``
+
+    The op ref is the TAIL — same reason as everywhere else: UUIDv7 shares its
+    prefix, so the leading bytes distinguish nothing. Stating the expiry is
+    what makes the silence honest: the operator learns both that a question is
+    open and that not answering IS an answer.
+    """
+    parts = [p for p in str(op_id or "").split("-") if p]
+    ref = "-".join(parts[-2:]) if len(parts) >= 3 else (op_id or "op")
+    head = f"⏺ Iron Gate({ref})"
+    if risk:
+        head += f" · {risk}"
+    detail = f" · {reason}" if reason else ""
+    expiry = f" · expires in {int(timeout_s)}s" if timeout_s > 0 else ""
+    return f"{head}\n  ⎿ approve? [y/n]{detail}{expiry}"
+
+
+async def await_decision_with_operator(
+    provider: Any,
+    request_id: str,
+    timeout_s: float,
+    *,
+    emit: Optional[Callable[[str], None]] = None,
+    risk: str = "",
+    reason: str = "",
+) -> Any:
+    """`await_decision`, plus a cockpit that can answer it.
+
+    Falls back to `provider.await_decision(...)` verbatim whenever narration is
+    disabled, the bridge is unavailable, or anything at all goes wrong. The
+    gate's behaviour without an attached operator must be byte-identical to
+    what it was — this can only ADD a way to answer, never change what happens
+    when nobody does.
+    """
+    plain = provider.await_decision(request_id, timeout_s)
+    if not approval_narration_enabled():
+        return await plain
+
+    bridge = None
+    fut = None
+    try:
+        from backend.core.ouroboros.battle_test.operator_prompt_bridge import (
+            get_operator_prompt_bridge,
+        )
+        bridge = get_operator_prompt_bridge()
+        fut = bridge.begin(str(request_id))
+    except Exception:  # noqa: BLE001
+        bridge, fut = None, None
+
+    if emit is not None:
+        try:
+            emit(render_gate_prompt(request_id, risk, reason, timeout_s))
+        except Exception:  # noqa: BLE001
+            logger.debug("[ApprovalNarrator] prompt emit degraded",
+                         exc_info=True)
+
+    if fut is None:
+        # No bridge — the gate behaves exactly as before.
+        return await plain
+
+    decision_task = asyncio.ensure_future(plain)
+    try:
+        while True:
+            done, _pending = await asyncio.wait(
+                {decision_task, fut},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if decision_task in done:
+                # Decided elsewhere (a verb, another terminal, or expiry).
+                return decision_task.result()
+
+            # The operator typed something while the gate was open.
+            answer = interpret_answer(fut.result() if not fut.cancelled() else "")
+            if answer is None:
+                # Not a verdict. Re-arm and let the text reach the REPL —
+                # consuming a keystroke that was never an answer would make
+                # the cockpit feel possessed.
+                fut = bridge.begin(str(request_id)) if bridge else None
+                if fut is None:
+                    return await decision_task
+                continue
+            try:
+                if answer:
+                    await provider.approve(request_id, "operator")
+                else:
+                    await provider.reject(request_id, "operator", "declined")
+            except Exception:  # noqa: BLE001
+                logger.debug("[ApprovalNarrator] decision relay failed",
+                             exc_info=True)
+            # The provider's own event is now set; await_decision returns the
+            # authoritative result rather than one synthesised here.
+            return await decision_task
+    except Exception:  # noqa: BLE001
+        logger.debug("[ApprovalNarrator] operator path degraded", exc_info=True)
+        return await decision_task
+    finally:
+        try:
+            if bridge is not None:
+                bridge.end(fut)
+        except Exception:  # noqa: BLE001
+            pass

--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -1674,6 +1674,40 @@ class _LiveWorkGateResult(NamedTuple):
 # ---------------------------------------------------------------------------
 
 
+def _await_approval_with_operator(orch: Any, request_id: str, ctx: Any) -> Any:
+    """Await the gate decision, letting an attached cockpit answer it.
+
+    Degrades to the plain provider wait on ANY failure: the gate's behaviour
+    with nobody attached must stay byte-identical, so this can only ADD a way
+    to answer.
+    """
+    timeout_s = orch._config.approval_timeout_s
+    try:
+        from backend.core.ouroboros.governance.approval_narrator import (
+            await_decision_with_operator,
+        )
+
+        def _emit(line: str) -> None:
+            # Same late-bound mirror the subagent narrator uses: SerpentFlow
+            # attaches after the stack is built, so a handle captured at
+            # construction time would be None forever.
+            flow = getattr(orch, "_serpent_flow", None) or getattr(
+                getattr(orch, "_gls", None), "_serpent_flow", None,
+            )
+            mirror = getattr(flow, "_mirror_markup", None) if flow else None
+            if mirror is not None:
+                mirror(line)
+
+        return await_decision_with_operator(
+            orch._approval_provider, request_id, timeout_s,
+            emit=_emit,
+            risk=str(getattr(getattr(ctx, "risk_tier", None), "name", "") or ""),
+            reason=str(getattr(ctx, "approval_reason", "") or ""),
+        )
+    except Exception:  # noqa: BLE001
+        return orch._approval_provider.await_decision(request_id, timeout_s)
+
+
 class GovernedOrchestrator:
     """Central coordinator for the governed self-programming pipeline.
 
@@ -10279,8 +10313,18 @@ class GovernedOrchestrator:
                     )
 
                 request_id = await self._approval_provider.request(ctx)
-                decision: ApprovalResult = await self._approval_provider.await_decision(
-                    request_id, self._config.approval_timeout_s
+                # The gate ASKS now. `await_decision` remains the authority on
+                # the outcome — it owns the timeout, the EXPIRED stamp and the
+                # ledger semantics — and the operator path is raced alongside
+                # it as a faster route to the SAME decision: answering `y`
+                # calls the provider's own approve(), which sets the event
+                # await_decision is already waiting on.
+                #
+                # Before this, the gate emitted a comm heartbeat nothing
+                # rendered and then sat silently until it expired. Nothing
+                # hung; nobody was ever asked.
+                decision: ApprovalResult = await _await_approval_with_operator(
+                    self, request_id, ctx,
                 )
 
                 if decision.status is ApprovalStatus.EXPIRED:

--- a/tests/governance/test_approval_narrator.py
+++ b/tests/governance/test_approval_narrator.py
@@ -1,0 +1,301 @@
+"""The Iron Gate asks, and an attached operator can answer.
+
+An APPROVAL_REQUIRED op pauses at APPROVE and waits — correctly.
+`CLIApprovalProvider.await_decision` already wraps that wait in
+`asyncio.wait_for` and stamps EXPIRED on timeout, so nothing ever hung and the
+daemon has never blocked on stdin.
+
+What was missing is that NOBODY WAS EVER ASKED. The gate emitted a comm
+heartbeat with `phase="approve"` that no cockpit surface renders, then sat
+silently until it expired.
+
+Two finished components had never been joined:
+
+  * `OperatorPromptBridge` (#70085) — a pending-prompt registry whose future
+    resolves from attached-terminal input, already consulted by
+    `harness._on_input` BEFORE the REPL. It had ZERO callers of `begin()`: a
+    receive path with no sender, so `waiting` was permanently False.
+  * `_mirror_markup` — the chokepoint every ⏺/⎿ line already reaches the
+    cockpit through.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any, List, Optional
+
+import pytest
+
+from backend.core.ouroboros.battle_test.operator_prompt_bridge import (
+    get_operator_prompt_bridge,
+    reset_bridge_for_tests,
+)
+from backend.core.ouroboros.governance.approval_narrator import (
+    approval_narration_enabled,
+    await_decision_with_operator,
+    interpret_answer,
+    render_gate_prompt,
+)
+
+_REPO = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture(autouse=True)
+def _clean():
+    reset_bridge_for_tests()
+    yield
+    reset_bridge_for_tests()
+
+
+class _Provider:
+    """Mirrors CLIApprovalProvider's contract: an Event the wait observes."""
+
+    def __init__(self) -> None:
+        self.decided: Optional[str] = None
+        self.event = asyncio.Event()
+        self.calls: List[str] = []
+
+    async def await_decision(self, _rid: str, timeout_s: float) -> str:
+        try:
+            await asyncio.wait_for(self.event.wait(), timeout=timeout_s)
+        except asyncio.TimeoutError:
+            self.decided = "EXPIRED"
+        return f"result:{self.decided}"
+
+    async def approve(self, _rid: str, who: str) -> None:
+        self.calls.append(f"approve:{who}")
+        self.decided = "APPROVED"
+        self.event.set()
+
+    async def reject(self, _rid: str, who: str, why: str) -> None:
+        self.calls.append(f"reject:{who}:{why}")
+        self.decided = "REJECTED"
+        self.event.set()
+
+
+async def _answer(text: str, delay: float = 0.03) -> None:
+    await asyncio.sleep(delay)
+    get_operator_prompt_bridge().resolve(text)
+
+
+# --------------------------------------------------------------------------
+# 1. the question is asked
+# --------------------------------------------------------------------------
+
+def test_the_prompt_names_the_op_and_the_deadline() -> None:
+    """Stating the expiry is what makes the silence honest: the operator
+    learns both that a question is open and that not answering IS an answer."""
+    out = render_gate_prompt("op-019fa4d2-246e-7759-86", "APPROVAL_REQUIRED",
+                             "credential shape introduced", 300)
+    assert "7759-86" in out
+    assert "approve? [y/n]" in out
+    assert "300s" in out
+    assert "credential shape introduced" in out
+
+
+def test_the_op_ref_is_the_distinguishing_tail() -> None:
+    """UUIDv7 shares its prefix — the same lesson as the op digest."""
+    out = render_gate_prompt("op-019fa4d2-246e-7759-86")
+    assert "019fa4d2" not in out
+
+
+def test_it_opens_and_closes_the_glyph_pair() -> None:
+    out = render_gate_prompt("op-1-2-3", timeout_s=60)
+    assert out.startswith("⏺ Iron Gate(")
+    assert "⎿" in out
+
+
+async def test_the_prompt_reaches_the_cockpit() -> None:
+    lines: List[str] = []
+    provider = _Provider()
+    task = asyncio.ensure_future(await_decision_with_operator(
+        provider, "op-1", 5, emit=lines.append,
+    ))
+    await _answer("y")
+    await task
+    assert lines and "approve?" in lines[0]
+
+
+# --------------------------------------------------------------------------
+# 2. the operator's answer decides it
+# --------------------------------------------------------------------------
+
+async def test_yes_approves_through_the_providers_own_method() -> None:
+    """One source of truth for the outcome: the operator path calls the
+    provider's approve(), which sets the event await_decision is waiting on."""
+    provider = _Provider()
+    task = asyncio.ensure_future(
+        await_decision_with_operator(provider, "op-1", 5),
+    )
+    await _answer("y")
+    assert await task == "result:APPROVED"
+    assert provider.calls == ["approve:operator"]
+
+
+async def test_no_rejects() -> None:
+    provider = _Provider()
+    task = asyncio.ensure_future(
+        await_decision_with_operator(provider, "op-1", 5),
+    )
+    await _answer("n")
+    assert await task == "result:REJECTED"
+
+
+@pytest.mark.parametrize("word,expected", [
+    ("y", True), ("yes", True), ("approve", True), ("  OK  ", True),
+    ("n", False), ("no", False), ("reject", False), ("abort", False),
+])
+def test_the_vocabulary_is_forgiving(word: str, expected: bool) -> None:
+    assert interpret_answer(word) is expected
+
+
+def test_an_unrecognised_answer_is_not_a_yes() -> None:
+    """Approval must be affirmative and deliberate: ambiguity resolves to
+    rejection, never to the more convenient reading."""
+    for junk in ("maybe", "later", "?", "sure thing pal", None, 42):
+        assert interpret_answer(junk) is not True
+
+
+# --------------------------------------------------------------------------
+# 3. an unrelated command is not a verdict
+# --------------------------------------------------------------------------
+
+async def test_typing_a_verb_while_a_gate_is_open_is_not_an_answer() -> None:
+    """Consuming a keystroke that was never a decision would make the cockpit
+    feel possessed — and could approve a patch by accident."""
+    provider = _Provider()
+    task = asyncio.ensure_future(
+        await_decision_with_operator(provider, "op-1", 5),
+    )
+    await _answer("/posture status")
+    await asyncio.sleep(0.05)
+    assert not task.done(), "an unrelated command resolved the gate"
+    assert provider.calls == []
+    await _answer("y")
+    assert await task == "result:APPROVED"
+
+
+async def test_the_gate_stays_armed_after_a_non_answer() -> None:
+    provider = _Provider()
+    task = asyncio.ensure_future(
+        await_decision_with_operator(provider, "op-1", 5),
+    )
+    await _answer("hello")
+    await asyncio.sleep(0.05)
+    assert get_operator_prompt_bridge().waiting is True
+    await _answer("n")
+    await task
+
+
+# --------------------------------------------------------------------------
+# 4. it can only ADD a way to answer
+# --------------------------------------------------------------------------
+
+async def test_expiry_still_wins_when_nobody_answers() -> None:
+    """The orphan prevention predates this and must be untouched."""
+    provider = _Provider()
+    assert await await_decision_with_operator(
+        provider, "op-1", 0.05,
+    ) == "result:EXPIRED"
+
+
+async def test_a_decision_made_elsewhere_ends_the_wait() -> None:
+    """Another terminal, a verb, or the ledger — the gate is not owned by the
+    attached cockpit."""
+    provider = _Provider()
+    task = asyncio.ensure_future(
+        await_decision_with_operator(provider, "op-1", 5),
+    )
+    await asyncio.sleep(0.02)
+    await provider.approve("op-1", "another-surface")
+    assert await task == "result:APPROVED"
+
+
+async def test_the_switch_off_falls_back_verbatim(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_APPROVAL_NARRATION_ENABLED", "0")
+    assert approval_narration_enabled() is False
+    provider = _Provider()
+    assert await await_decision_with_operator(
+        provider, "op-1", 0.05,
+    ) == "result:EXPIRED"
+
+
+async def test_an_emit_fault_cannot_break_the_gate() -> None:
+    def _boom(_line: str) -> None:
+        raise RuntimeError("cockpit gone")
+
+    provider = _Provider()
+    task = asyncio.ensure_future(
+        await_decision_with_operator(provider, "op-1", 5, emit=_boom),
+    )
+    await _answer("y")
+    assert await task == "result:APPROVED"
+
+
+async def test_the_slot_is_released_afterwards() -> None:
+    """A gate that leaves the bridge armed would swallow the next keystroke."""
+    provider = _Provider()
+    task = asyncio.ensure_future(
+        await_decision_with_operator(provider, "op-1", 5),
+    )
+    await _answer("y")
+    await task
+    assert get_operator_prompt_bridge().waiting is False
+
+
+# --------------------------------------------------------------------------
+# 5. wiring
+# --------------------------------------------------------------------------
+
+def test_the_approve_phase_uses_it() -> None:
+    src = (_REPO / "backend/core/ouroboros/governance/orchestrator.py").read_text()
+    assert "_await_approval_with_operator(" in src
+
+
+def test_the_orchestrator_degrades_to_the_plain_wait() -> None:
+    """With nobody attached the gate must behave byte-identically."""
+    import ast
+
+    src = (_REPO / "backend/core/ouroboros/governance/orchestrator.py").read_text()
+    # AST, not a character window: a fixed slice measures how much prose sits
+    # between the def and the fallback, which is not the invariant.
+    body = ""
+    for node in ast.walk(ast.parse(src)):
+        if isinstance(node, ast.FunctionDef) and \
+                node.name == "_await_approval_with_operator":
+            body = ast.unparse(node)
+            break
+    assert body, "the wrapper is gone"
+    assert "await_decision(request_id, timeout_s)" in body
+
+
+def test_the_bridges_begin_finally_has_a_caller() -> None:
+    """#70085 shipped a receive path with no sender — `waiting` was
+    permanently False and every keystroke fell through to the REPL."""
+    src = (_REPO / "backend/core/ouroboros/governance/"
+           "approval_narrator.py").read_text()
+    assert "bridge.begin(" in src
+    assert "get_operator_prompt_bridge" in src
+
+
+def test_the_timeout_is_not_reimplemented() -> None:
+    """A second timeout that disagrees with the first is worse than no second
+    path at all — await_decision stays the authority."""
+    import ast
+
+    src = (_REPO / "backend/core/ouroboros/governance/"
+           "approval_narrator.py").read_text()
+    # Checked on CODE, not on the file text. The module docstring explains
+    # that `await_decision` already wraps the wait in `asyncio.wait_for` —
+    # and a substring search cannot tell that explanation from a second
+    # implementation of it. (Use-vs-mention: the fourth time this trap has
+    # caught a test in this codebase.)
+    tree = ast.parse(src)
+    calls = {
+        ast.unparse(n.func)
+        for n in ast.walk(tree) if isinstance(n, ast.Call)
+    }
+    assert "asyncio.wait_for" not in calls, "a competing timeout was added"
+    assert any("await_decision" in c for c in calls)


### PR DESCRIPTION
```
⏺ Iron Gate(7759-86) · APPROVAL_REQUIRED
  ⎿ approve? [y/n] · credential shape introduced · expires in 300s
```

### Correcting my own earlier diagnosis
I said the daemon blocks on unreachable stdin and hangs the worker. **It does not.** `await_decision` already wraps the wait in `asyncio.wait_for` and stamps `EXPIRED` on timeout — the orphan prevention has been correct all along, and no stdin is involved.

What was actually missing: **nobody was ever asked.** The gate emitted a comm heartbeat with `phase="approve"` that no cockpit surface renders, then sat silently until it expired. An operator watching the deck saw an op stop moving with no way to know a question was pending.

### Two finished components, never joined
- **`OperatorPromptBridge`** (#70085) — a pending-prompt registry whose future resolves from attached-terminal input, already consulted by `harness._on_input` *before* the REPL. It had **zero callers of `begin()`**: a receive path with no sender, so `waiting` was permanently False and every keystroke fell through to the REPL.
- **`_mirror_markup`** — the chokepoint every `⏺`/`⎿` line already reaches the cockpit through.

This joins them. No new transport, no polling, no second timeout.

### Raced, not replaced
`await_decision` stays the authority on the outcome — it owns the timeout, the EXPIRED stamp and the ledger semantics. The operator path is a faster route to the **same** decision: answering `y` calls the provider's own `approve()`, which sets the event `await_decision` is already waiting on.

One source of truth; two ways to reach it. Reimplementing the wait would have meant a second timeout that can disagree with the first — worse than no second path at all.

### An unrelated command is not a verdict
`interpret_answer` returns `None` for anything not clearly yes or no; the gate stays armed and the text flows on to the REPL. Consuming a keystroke that was never a decision would make the cockpit feel possessed — and could approve a patch by accident.

**Ambiguity resolves to NOT-approved.** An approval must be affirmative and deliberate.

### It can only ADD a way to answer
Degrades to the plain provider wait on any failure — disabled, no bridge, emit fault, anything. With nobody attached the gate behaves byte-identically.

### Tests
26, including expiry-still-wins, decision-made-elsewhere, and slot-released-afterwards (a gate leaving the bridge armed would swallow the next keystroke).

Two of my own structural tests failed first and were rewritten against the AST: one measured a character window, and one grepped for `asyncio.wait_for` in a file whose **docstring** explains that `await_decision` already uses it — the use-vs-mention trap, for the fourth time in this codebase.

20 `battle_test` failures in the wider run are pre-existing — verified identical with this change stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Approval gates now prompt attached operators with a clear [y/n] question and expiry, and accept answers from the cockpit. Operator input is raced against `await_decision` so timeouts and ledger semantics stay the same.

- **New Features**
  - Join `OperatorPromptBridge` with `_mirror_markup` to render “approve? [y/n]” using the op tail and the timeout.
  - Safe answer handling: forgiving yes/no vocabulary; unrelated commands return `None` and flow to the REPL.
  - Keep `await_decision` authoritative; operator replies call provider `approve()`/`reject()` and let the original wait resolve.
  - Graceful fallback: if narration is disabled or the bridge fails, behavior remains byte-identical.
  - Orchestrator uses `_await_approval_with_operator` and emits via the late-bound cockpit mirror.

<sup>Written for commit ea42a0a63f171c1e4108db0c897880f8014b8b18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

