### PR TITLE
feat(ov): the cockpit shows which file each tool is touching

### DIFF
--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -600,6 +600,36 @@ def _parse_unified_diff(diff_text: str) -> tuple:
 # ══════════════════════════════════════════════════════════════
 
 
+def _tool_chrome_line(tool_name: str, args_summary: str = "") -> str:
+    """``⏺ Read(backend/core/…/thin_client.py)`` — one tool call, CC-style.
+
+    The tool token is a routing identifier (`read_file`); this is the verb an
+    operator reads. Keyed off the existing token so a new tool means one entry
+    here rather than a renderer that must learn a new concept, and an unknown
+    tool still renders under its own name rather than vanishing.
+
+    The ARGUMENT is the point. `⏺ Read()` says an op is busy; `⏺ Read(path)`
+    says what it is busy with, and that difference is the whole request.
+    Paths are shown from the RIGHT — the filename is what identifies a file,
+    and a left-clip of a deep repo path yields identical `backend/core/…`
+    prefixes for every entry.
+    """
+    verbs = {
+        "read_file": "Read", "search_code": "Search", "run_tests": "Test",
+        "bash": "Bash", "web_search": "WebSearch", "web_fetch": "Fetch",
+        "get_callers": "Callers", "list_symbols": "Symbols",
+        "glob_files": "Glob", "list_dir": "List", "git_log": "GitLog",
+        "git_diff": "GitDiff", "git_blame": "GitBlame",
+        "edit_file": "Update", "write_file": "Write", "ask_human": "Ask",
+    }
+    verb = verbs.get(str(tool_name or ""), str(tool_name or "Tool"))
+    arg = " ".join(str(args_summary or "").split())
+    if len(arg) > 56:
+        # Keep the tail: the filename identifies the file.
+        arg = "…" + arg[-55:]
+    return f"⏺ {verb}({arg})" if arg else f"⏺ {verb}"
+
+
 class SerpentFlow:
     """Ouroboros flowing CLI with 4-zone layout architecture.
 
@@ -2291,6 +2321,20 @@ class SerpentFlow:
                     f"[{_C['dim']} italic]🗣 {preamble}[/{_C['dim']} italic]",
                 )
 
+        # The MIRRORED half of the start event.
+        #
+        # `_start_status` renders a Rich spinner, which is local-only: it
+        # never passes through `_op_line`, the chokepoint that reaches an
+        # attached cockpit. So the tool NAME and its ARGUMENTS — which file
+        # is being read, which pattern is being searched — rendered on the
+        # daemon's own terminal and nowhere else. An operator saw an op
+        # working with no idea what it was touching.
+        #
+        # The spinner stays: it is the right affordance locally, where a
+        # transient in-place animation costs nothing. The cockpit gets a
+        # PERSISTENT line instead, because a remote surface has no spinner to
+        # erase and a vanishing status is worse than none.
+        self._op_line(op_id, _tool_chrome_line(tool_name, args_summary))
         self._start_status(
             f"{prefix}{icon} T{round_index + 1} {tool_name}{summary}",
             spinner=_active_spinner_name(),

--- a/tests/battle_test/test_tool_chrome_mirror.py
+++ b/tests/battle_test/test_tool_chrome_mirror.py
@@ -1,0 +1,140 @@
+"""Which file is it reading? The cockpit could not say.
+
+Venom's tool loop has always emitted a full per-call event — `op_id`,
+`tool_name`, `args_summary`, `result_preview`, `duration_ms` — through
+`ToolNarrationChannel` to CommProtocol. SerpentFlow renders the START of each
+call via `_start_status`, a Rich spinner.
+
+A spinner is local-only. It never passes through `_op_line`, the chokepoint
+that reaches an attached cockpit, so the tool NAME and its ARGUMENTS rendered
+on the daemon's own terminal and nowhere else. An operator saw an op working
+with no idea what it was touching:
+
+    ⏺ Explore(find every place we parse a socket path)
+      ⎿ 3 files · 2.1s          ← the summary, but never the steps
+
+The spinner stays — it is the right affordance locally. The cockpit gets a
+PERSISTENT line, because a remote surface has no spinner to erase and a
+vanishing status is worse than none.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from backend.core.ouroboros.battle_test.serpent_flow import _tool_chrome_line
+
+_REPO = Path(__file__).resolve().parents[2]
+_SRC = _REPO / "backend/core/ouroboros/battle_test/serpent_flow.py"
+
+
+# --------------------------------------------------------------------------
+# 1. the argument is the point
+# --------------------------------------------------------------------------
+
+def test_the_file_being_read_is_named() -> None:
+    """THE request. `⏺ Read()` says an op is busy; `⏺ Read(path)` says what
+    it is busy with."""
+    out = _tool_chrome_line("read_file", "backend/core/ouroboros/cli/thin_client.py")
+    assert out == "⏺ Read(backend/core/ouroboros/cli/thin_client.py)"
+
+
+def test_a_search_shows_its_pattern() -> None:
+    out = _tool_chrome_line("search_code", 'pattern="socket path" glob=*.py')
+    assert "socket path" in out and out.startswith("⏺ Search(")
+
+
+def test_a_command_shows_what_ran() -> None:
+    assert "pytest tests/cli -q" in _tool_chrome_line("bash", "pytest tests/cli -q")
+
+
+@pytest.mark.parametrize("token,verb", [
+    ("read_file", "Read"), ("search_code", "Search"), ("edit_file", "Update"),
+    ("write_file", "Write"), ("run_tests", "Test"), ("bash", "Bash"),
+    ("get_callers", "Callers"), ("ask_human", "Ask"),
+])
+def test_each_tool_is_SPOKEN_not_tokenised(token: str, verb: str) -> None:
+    """`read_file` is a routing identifier; `Read` is what an operator reads."""
+    assert _tool_chrome_line(token, "x").startswith(f"⏺ {verb}(")
+
+
+def test_an_unknown_tool_renders_under_its_own_name() -> None:
+    """A new tool must appear, not vanish — MCP tools arrive at runtime and
+    cannot be enumerated ahead of time."""
+    assert "mcp_github_search" in _tool_chrome_line("mcp_github_search", "q=x")
+
+
+# --------------------------------------------------------------------------
+# 2. long paths keep the part that identifies them
+# --------------------------------------------------------------------------
+
+def test_a_deep_path_is_clipped_from_the_LEFT() -> None:
+    """The filename identifies the file. Clipping the tail would give every
+    entry an identical `backend/core/…` prefix — the same defect as truncating
+    a UUIDv7 from the right."""
+    deep = "backend/core/ouroboros/governance/" + ("x" * 60) + "/thin_client.py"
+    out = _tool_chrome_line("read_file", deep)
+    assert "thin_client.py" in out
+    assert out.startswith("⏺ Read(…")
+
+
+def test_a_line_stays_a_line() -> None:
+    assert len(_tool_chrome_line("read_file", "y" * 400)) < 80
+
+
+def test_multiline_args_are_flattened() -> None:
+    """A newline inside chrome breaks the ⏺/⎿ pairing visually."""
+    assert "\n" not in _tool_chrome_line("bash", "line one\nline two")
+
+
+def test_a_tool_with_no_arguments_still_renders() -> None:
+    assert _tool_chrome_line("list_dir", "") == "⏺ List"
+
+
+@pytest.mark.parametrize("junk", [None, 42, object()])
+def test_it_never_raises(junk: Any) -> None:
+    assert isinstance(_tool_chrome_line(junk, junk), str)
+
+
+# --------------------------------------------------------------------------
+# 3. it reaches the cockpit, and the spinner survives
+# --------------------------------------------------------------------------
+
+def _start_event_body() -> str:
+    src = _SRC.read_text()
+    for node in ast.walk(ast.parse(src)):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and \
+                "_start_status(" in (ast.unparse(node) or ""):
+            body = ast.unparse(node)
+            if "_tool_chrome_line" in body:
+                return body
+    return ""
+
+
+def test_the_start_event_goes_through_the_MIRRORED_path() -> None:
+    """`_op_line` mirrors to attached cockpits; `_start_status` does not.
+    Asserted on the AST rather than a text window — a character slice measures
+    how much prose sits between two calls, which is not the invariant."""
+    body = _start_event_body()
+    assert body, "the tool-start renderer no longer emits chrome"
+    assert "_op_line" in body
+    assert "_tool_chrome_line" in body
+
+
+def test_the_local_spinner_is_KEPT() -> None:
+    """It is the right affordance locally, where an in-place animation costs
+    nothing. Removing it would trade one surface's quality for another's."""
+    assert "_start_status" in _start_event_body()
+
+
+def test_op_line_is_the_mirroring_chokepoint() -> None:
+    """The property this whole change depends on."""
+    src = _SRC.read_text()
+    for node in ast.walk(ast.parse(src)):
+        if isinstance(node, ast.FunctionDef) and node.name == "_op_line":
+            assert "_mirror_markup" in ast.unparse(node)
+            return
+    pytest.fail("_op_line is gone")


### PR DESCRIPTION
```
⏺ Read(backend/core/ouroboros/cli/thin_client.py)
⏺ Search(pattern="socket path" glob=*.py)
⏺ Bash(pytest tests/cli -q)
```

### The data was always there
Venom's tool loop has always emitted a full per-call event — `op_id`, `tool_name`, `args_summary`, `result_preview`, `duration_ms` — through `ToolNarrationChannel` to CommProtocol.

SerpentFlow renders the **start** of each call via `_start_status`, a Rich spinner. **A spinner is local-only** — it never passes through `_op_line`, the chokepoint that reaches an attached cockpit. So the tool name and its arguments rendered on the daemon's own terminal and nowhere else.

The operator saw the subagent summary and never the steps:

```
⏺ Explore(find every place we parse a socket path)
  ⎿ 3 files · 2.1s          ← the result, but never the work
```

**Sixth instance this session** of the same defect: a producer rendering to a surface nobody watches.

### The spinner is kept
It's the right affordance locally, where an in-place animation costs nothing and vanishing is correct. The cockpit gets a **persistent** line instead — a remote surface has no spinner to erase, and a status that disappears is worse than none.

Trading one surface's quality for the other's would have been the easy wrong answer.

### Detail decisions
**Tools are spoken, not tokenised.** `read_file` is a routing identifier; `Read` is what an operator reads. Keyed off the existing token, so a new tool is one entry rather than a renderer learning a new concept — and an unknown tool renders under its own name rather than vanishing, which matters because **MCP tools arrive at runtime** and can't be enumerated ahead of time.

**Long paths clip from the LEFT.** The filename identifies the file; clipping the tail would give every entry an identical `backend/core/…` prefix — the same defect as truncating a UUIDv7 from the right.

```
⏺ Read(…xxxxxxxxxxxxxxxxxxxx/deep_module.py)
```

### Tests
22 new, asserted against the AST rather than character windows. **937 passing** across serpent_flow / tool_render / cli.

The 2 inline-boot banner failures are pre-existing — verified identical with this change stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The cockpit now shows a persistent line for each tool call (e.g., ⏺ Read(path)), so operators can see which file, pattern, or command a tool is touching. The local spinner stays; the cockpit gets context instead of silence.

- New Features
  - Mirrors tool-start events through `SerpentFlow`’s `_op_line` and formats them via `_tool_chrome_line` (e.g., ⏺ Verb(args)).
  - Maps tool tokens to readable verbs (`read_file`→Read, `search_code`→Search, etc.); unknown tools render under their own name.
  - Shows arguments; flattens whitespace; clips long paths from the left to preserve filenames; keeps lines short.
  - Keeps the local `_start_status` spinner; cockpit receives a persistent entry.
  - Adds tests for formatting, clipping, unknown tools, and an AST check ensuring both `_op_line` and `_start_status` are called.

<sup>Written for commit 0a65c122f0e6868db56ff63147d886962ebefe94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

