### PR TITLE
feat(ov): tool verbs are derived, and paths keep both ends

### DIFF
--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -600,34 +600,136 @@ def _parse_unified_diff(diff_text: str) -> tuple:
 # ══════════════════════════════════════════════════════════════
 
 
-def _tool_chrome_line(tool_name: str, args_summary: str = "") -> str:
-    """``⏺ Read(backend/core/…/thin_client.py)`` — one tool call, CC-style.
+#: Built-in tools whose natural derivation would read WRONG. Everything else
+#: is derived, so this is an override list rather than a registry — a new
+#: tool needs an entry only when `read_file → Read File` is not what an
+#: operator should see.
+_VERB_OVERRIDE = {
+    "read_file": "Read", "search_code": "Search", "edit_file": "Update",
+    "write_file": "Write", "run_tests": "Test", "bash": "Bash",
+    "get_callers": "Callers", "list_symbols": "Symbols",
+    "glob_files": "Glob", "list_dir": "List", "web_search": "WebSearch",
+    "web_fetch": "Fetch", "ask_human": "Ask",
+}
 
-    The tool token is a routing identifier (`read_file`); this is the verb an
-    operator reads. Keyed off the existing token so a new tool means one entry
-    here rather than a renderer that must learn a new concept, and an unknown
-    tool still renders under its own name rather than vanishing.
+#: Path-shaped arguments are identified by their TAIL (the filename);
+#: commands and patterns by their HEAD (the verb and its first operands).
+#: One clip rule cannot serve both, and picking either alone silently
+#: destroys half the cases.
+_ARG_MAX = 56
 
-    The ARGUMENT is the point. `⏺ Read()` says an op is busy; `⏺ Read(path)`
-    says what it is busy with, and that difference is the whole request.
-    Paths are shown from the RIGHT — the filename is what identifies a file,
-    and a left-clip of a deep repo path yields identical `backend/core/…`
-    prefixes for every entry.
+
+def derive_verb(tool_name: str, mcp_servers: Any = None) -> str:
+    """The word an operator reads for a tool. Derived, not enumerated.
+
+    MCP tools arrive at RUNTIME — an operator can connect a server this
+    afternoon — so a fixed table cannot cover them and a lookup miss must not
+    render a raw routing token. `mcp_{server}_{tool}` (the canonical form from
+    `mcp_tool_client`) becomes `server·tool`.
+
+    Server names may themselves contain underscores, so the split is
+    ambiguous without the connection list. When one is supplied the longest
+    matching server wins — the same rule the client's own dispatcher uses.
+    Without it, the first segment is assumed and the tool still renders
+    honestly rather than not at all: a slightly mis-split label beats a raw
+    `mcp_github_search_issues`.
     """
-    verbs = {
-        "read_file": "Read", "search_code": "Search", "run_tests": "Test",
-        "bash": "Bash", "web_search": "WebSearch", "web_fetch": "Fetch",
-        "get_callers": "Callers", "list_symbols": "Symbols",
-        "glob_files": "Glob", "list_dir": "List", "git_log": "GitLog",
-        "git_diff": "GitDiff", "git_blame": "GitBlame",
-        "edit_file": "Update", "write_file": "Write", "ask_human": "Ask",
-    }
-    verb = verbs.get(str(tool_name or ""), str(tool_name or "Tool"))
-    arg = " ".join(str(args_summary or "").split())
-    if len(arg) > 56:
-        # Keep the tail: the filename identifies the file.
-        arg = "…" + arg[-55:]
-    return f"⏺ {verb}({arg})" if arg else f"⏺ {verb}"
+    token = str(tool_name or "").strip()
+    if not token:
+        return "Tool"
+    if token in _VERB_OVERRIDE:
+        return _VERB_OVERRIDE[token]
+    if token.startswith("mcp_"):
+        remainder = token[4:]
+        server = ""
+        try:
+            for name in sorted(mcp_servers or (), key=len, reverse=True):
+                if remainder.startswith(f"{name}_"):
+                    server = str(name)
+                    break
+        except Exception:  # noqa: BLE001
+            server = ""
+        if not server:
+            server = remainder.split("_", 1)[0]
+        tail = remainder[len(server) + 1:] if remainder.startswith(
+            f"{server}_") else remainder
+        return f"{server}·{tail}" if tail else server or token
+    # A plain snake_case tool: title-case it rather than showing the token.
+    return "".join(part.capitalize() for part in token.split("_")) or token
+
+
+def _looks_like_path(text: str) -> bool:
+    """Is this argument identified by its tail?
+
+    A path has separators and no spaces before the first one. A shell command
+    ("pytest tests/cli -q") also contains a slash, so the presence of one is
+    not enough — the discriminator is whether the FIRST token is itself the
+    path.
+    """
+    head = text.split(" ", 1)[0]
+    return "/" in head and not head.startswith("-")
+
+
+def elide_path(text: str, limit: int = _ARG_MAX) -> str:
+    """Shorten a path while keeping BOTH ends that identify it.
+
+    `…ouroboros/governance/thin_client.py` loses the repo it is in;
+    `backend/core/…` loses the file entirely. Whole SEGMENTS are elided from
+    the middle, so the result is still a readable path rather than a string
+    cut mid-word — the same rule that made op ids legible, applied to the
+    other axis.
+    """
+    if len(text) <= limit:
+        return text
+    parts = [p for p in text.split("/") if p]
+    if len(parts) <= 2:
+        # Nothing to elide between: keep the tail, which names the file.
+        return "…" + text[-(limit - 1):]
+    head, tail = parts[0], parts[-1]
+    minimal = f"{head}/…/{tail}"
+    if len(minimal) > limit:
+        # Even head/…/file is too long — the filename is the last thing to go.
+        return "…/" + tail[-(limit - 2):]
+
+    # Grow back toward the FILE: the segments nearest the filename carry the
+    # most meaning (`governance/chat_repl_dispatcher.py` locates it; `core/`
+    # barely narrows anything). Free context should buy the useful end.
+    best = minimal
+    for keep in range(1, len(parts) - 1):
+        candidate = f"{head}/…/" + "/".join(parts[-(keep + 1):])
+        if len(candidate) > limit:
+            break
+        best = candidate
+    # If every segment fits, there was nothing to elide after all.
+    whole = "/".join(parts)
+    return whole if len(whole) <= limit else best
+
+
+def _clip_arg(text: str, limit: int = _ARG_MAX) -> str:
+    """Clip an argument on the axis that preserves its meaning."""
+    flat = " ".join(str(text or "").split())
+    if len(flat) <= limit:
+        return flat
+    if _looks_like_path(flat):
+        return elide_path(flat, limit)
+    # A command or pattern: the HEAD identifies it, so the tail goes.
+    return flat[: limit - 1].rstrip() + "…"
+
+
+def _tool_chrome_line(
+    tool_name: str, args_summary: str = "", mcp_servers: Any = None,
+) -> str:
+    """``⏺ Read(backend/…/thin_client.py)`` — one tool call, CC-style.
+
+    The ARGUMENT is the point: `⏺ Read()` says an op is busy; `⏺ Read(path)`
+    says what it is busy with.
+    """
+    try:
+        verb = derive_verb(tool_name, mcp_servers)
+        arg = _clip_arg(args_summary)
+        return f"⏺ {verb}({arg})" if arg else f"⏺ {verb}"
+    except Exception:  # noqa: BLE001 — chrome must never break a tool round
+        return f"⏺ {tool_name or 'Tool'}"
 
 
 class SerpentFlow:

--- a/tests/battle_test/test_tool_chrome_mirror.py
+++ b/tests/battle_test/test_tool_chrome_mirror.py
@@ -62,23 +62,35 @@ def test_each_tool_is_SPOKEN_not_tokenised(token: str, verb: str) -> None:
 
 
 def test_an_unknown_tool_renders_under_its_own_name() -> None:
-    """A new tool must appear, not vanish — MCP tools arrive at runtime and
+    """SUPERSEDED same-day: this asserted the RAW token survived, which was
+    the weaker behaviour it was describing. An MCP tool now renders as
+    `server·tool`, so the invariant that matters — a new tool APPEARS rather
+    than vanishing — is expressed against identity instead of against the
+    routing string.
+
+    A new tool must appear, not vanish: MCP tools arrive at runtime and
     cannot be enumerated ahead of time."""
-    assert "mcp_github_search" in _tool_chrome_line("mcp_github_search", "q=x")
+    out = _tool_chrome_line("mcp_github_search", "q=x")
+    assert "github" in out and "search" in out
+    assert "mcp_" not in out, "the raw routing prefix leaked to the operator"
 
 
 # --------------------------------------------------------------------------
 # 2. long paths keep the part that identifies them
 # --------------------------------------------------------------------------
 
-def test_a_deep_path_is_clipped_from_the_LEFT() -> None:
-    """The filename identifies the file. Clipping the tail would give every
-    entry an identical `backend/core/…` prefix — the same defect as truncating
-    a UUIDv7 from the right."""
+def test_a_deep_path_keeps_BOTH_ends() -> None:
+    """SUPERSEDED same-day: this required the line to START with `…`, which
+    pinned a clip that threw the repo away. Keeping only the tail loses which
+    project the file is in; keeping only the head loses the file. Whole
+    segments are elided from the MIDDLE now, so both ends survive.
+
+    The filename still identifies the file — that part was right."""
     deep = "backend/core/ouroboros/governance/" + ("x" * 60) + "/thin_client.py"
     out = _tool_chrome_line("read_file", deep)
     assert "thin_client.py" in out
-    assert out.startswith("⏺ Read(…")
+    assert "backend" in out, "the repo root was thrown away"
+    assert "…" in out
 
 
 def test_a_line_stays_a_line() -> None:
@@ -138,3 +150,108 @@ def test_op_line_is_the_mirroring_chokepoint() -> None:
             assert "_mirror_markup" in ast.unparse(node)
             return
     pytest.fail("_op_line is gone")
+
+
+# --------------------------------------------------------------------------
+# 4. verbs are DERIVED, not enumerated  (2026-07-27)
+# --------------------------------------------------------------------------
+
+from backend.core.ouroboros.battle_test.serpent_flow import (  # noqa: E402
+    derive_verb,
+    elide_path,
+)
+
+
+def test_an_mcp_tool_renders_as_server_and_tool() -> None:
+    """MCP tools arrive at RUNTIME — an operator can connect a server this
+    afternoon — so a fixed table cannot cover them, and a lookup miss must
+    not render a raw routing token."""
+    assert derive_verb("mcp_github_search_issues") == "github·search_issues"
+
+
+def test_a_known_server_list_resolves_an_ambiguous_split() -> None:
+    """Server names may contain underscores, so `mcp_my_server_run_query` is
+    ambiguous without the connection list. Longest match wins — the same rule
+    the client's own dispatcher uses."""
+    assert derive_verb("mcp_my_server_run_query", ["my_server"]) == \
+        "my_server·run_query"
+
+
+def test_an_unknown_server_still_renders_honestly() -> None:
+    """A slightly mis-split label beats a raw `mcp_github_search_issues`."""
+    out = derive_verb("mcp_unknown_thing")
+    assert "·" in out and "mcp_" not in out
+
+
+def test_a_brand_new_builtin_is_title_cased_not_tokenised() -> None:
+    """No entry needed: derivation covers it."""
+    assert derive_verb("some_brand_new_tool") == "SomeBrandNewTool"
+
+
+def test_the_override_table_is_only_for_wrong_derivations() -> None:
+    """`edit_file` would derive to "EditFile"; operators read "Update". The
+    table is an override list, not a registry."""
+    assert derive_verb("edit_file") == "Update"
+    assert derive_verb("read_file") == "Read"
+
+
+@pytest.mark.parametrize("junk", ["", None, 42])
+def test_verb_derivation_never_returns_empty(junk: Any) -> None:
+    assert derive_verb(junk)
+
+
+# --------------------------------------------------------------------------
+# 5. paths keep BOTH ends; commands keep their head
+# --------------------------------------------------------------------------
+
+def test_a_long_path_elides_WHOLE_SEGMENTS() -> None:
+    """A mid-word cut yields `…xxxxx/deep_module.py` — the same defect as
+    truncating a UUIDv7 from the wrong end, on the other axis."""
+    out = elide_path("backend/core/ouroboros/governance/chat_repl_dispatcher.py")
+    assert out.startswith("backend/")
+    assert out.endswith("chat_repl_dispatcher.py")
+    assert "…" in out
+    for segment in out.split("/"):
+        assert segment == "…" or "…" not in segment, "a segment was cut in half"
+
+
+def test_elision_grows_back_toward_the_FILENAME() -> None:
+    """The segments nearest the file carry the most meaning: `governance/`
+    locates it, `core/` barely narrows anything. Free context should buy the
+    useful end."""
+    out = elide_path("backend/core/ouroboros/governance/chat_repl_dispatcher.py")
+    assert "governance" in out
+
+
+def test_a_path_that_fits_is_left_alone() -> None:
+    short = "backend/core/ouroboros/battle_test/serpent_flow.py"
+    assert elide_path(short) == short
+
+
+def test_a_single_enormous_filename_keeps_its_tail() -> None:
+    """Nothing to elide between — the extension and suffix still identify
+    it."""
+    out = elide_path("one_enormous_single_segment_filename_with_no_dirs.py" * 2)
+    assert out.endswith(".py") and out.startswith("…")
+
+
+def test_a_command_is_clipped_from_the_RIGHT() -> None:
+    """A shell command is identified by its head. Eliding `pytest` to keep
+    `--no-header` would be exactly backwards."""
+    out = _tool_chrome_line(
+        "bash", "pytest tests/cli/test_thin_client.py -q --tb=short -x --no-header",
+    )
+    assert "pytest" in out
+    assert out.rstrip(")").endswith("…")
+
+
+def test_a_command_containing_a_slash_is_not_mistaken_for_a_path() -> None:
+    """`pytest tests/cli -q` has a slash but is not a path — the
+    discriminator is whether the FIRST token is itself the path."""
+    out = _tool_chrome_line("bash", "pytest " + "tests/cli/x " * 20)
+    assert out.startswith("⏺ Bash(pytest")
+
+
+def test_a_bare_long_path_IS_treated_as_one() -> None:
+    out = _tool_chrome_line("read_file", "backend/core/ouroboros/" + "d/" * 20 + "f.py")
+    assert out.endswith("f.py)")


### PR DESCRIPTION
Two weaknesses in yesterday's chrome, each the seed of a class of bad output.

### The verb table was a 16-entry literal
So an MCP tool rendered its routing token:

```
⏺ mcp_github_search_issues(repo=… state=open)     ← plumbing
⏺ github·search_issues(repo=… state=open)         ← now
```

MCP servers connect at **runtime** — an operator can add one this afternoon — so no fixed table can cover them, and a lookup miss must not fall back to showing plumbing.

**Derivation replaces enumeration.** `mcp_{server}_{tool}` (the canonical form from `mcp_tool_client`) becomes `server·tool`; a plain snake_case tool title-cases itself. The remaining table is an **override list** — entries exist only where derivation reads wrong (`edit_file` would give *"EditFile"*; operators read *"Update"*).

Server names may themselves contain underscores, making the split ambiguous. Given a connection list the **longest match wins** — the same rule the client's own dispatcher uses. Without one, the first segment is assumed and the tool still renders honestly: a slightly mis-split label beats a raw routing token.

### The path clip cut mid-segment
`…xxxxx/deep_module.py` — the same defect as truncating a UUIDv7 from the wrong end, on the other axis. And it threw the repo away entirely.

Whole **segments** are now elided from the middle, so both ends survive. The regrowth walks back toward the **filename** rather than the root — `governance/` locates a file, `core/` barely narrows anything, so free space should buy the useful end:

```
backend/…/ouroboros/governance/chat_repl_dispatcher.py
```

### Paths and commands are clipped on different axes
One rule cannot serve both: **a path is identified by its tail, a command by its head.** Eliding `pytest` to preserve `--no-header` would be exactly backwards.

```
⏺ Bash(pytest tests/cli/test_thin_client.py -q --tb=short -x -…)
```

The discriminator is whether the **first token** is itself a path — `pytest tests/cli` contains a slash and is not one.

### Two of my own same-day tests were superseded
One required the raw `mcp_` token to survive; the other required the line to *start* with `…`. Both pinned the weaker behaviour they were describing, so they were rewritten against the invariant rather than patched to pass.

### Tests
37. **972 passing**; the 2 inline-boot banner failures are pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Derives human-friendly tool verbs (including MCP tools) and updates path clipping to keep both ends, making tool output clearer and more reliable.

- **New Features**
  - Tool verbs are derived instead of enumerated: `mcp_{server}_{tool}` → `server·tool` (e.g., `github·search_issues`), and plain snake_case tools are title-cased.
  - Ambiguous MCP server splits are resolved with a known connection list (longest match wins). Without a list, the first segment is used so labels still render cleanly.
  - Added a small override list for wrong natural derivations (e.g., `edit_file` → "Update").
  - Arguments clip by type: paths elide whole middle segments to preserve both ends and grow context toward the filename; commands clip from the right to preserve the head.

- **Bug Fixes**
  - Unknown MCP tools no longer display raw `mcp_` routing tokens.
  - Paths are no longer cut mid-segment or reduced to identical `backend/core/…` prefixes.
  - Tests updated to assert derived verbs and bidirectional path elision.

<sup>Written for commit c932cc5546abe5e65c1829d5aacebed6375ad385. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

