### PR TITLE
feat(ov): the cockpit shows the change, not a count of it

### DIFF
--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -716,6 +716,26 @@ def _clip_arg(text: str, limit: int = _ARG_MAX) -> str:
     return flat[: limit - 1].rstrip() + "…"
 
 
+def _extract_path_arg(args_summary: str) -> str:
+    """Pull the file path out of a tool's argument summary.
+
+    `args_summary` is free text — sometimes a bare path, sometimes
+    `path=... old=... new=...`. The path is the first token that looks like
+    one, which is more robust than assuming a position and cheaper than
+    parsing a format the tool layer does not promise.
+    """
+    text = " ".join(str(args_summary or "").split())
+    if not text:
+        return ""
+    for token in text.split(" "):
+        candidate = token.split("=", 1)[-1].strip("\"'`,")
+        if "/" in candidate or candidate.endswith(
+            (".py", ".md", ".json", ".yaml", ".yml", ".toml", ".txt", ".sh"),
+        ):
+            return candidate
+    return text.split(" ", 1)[0].split("=", 1)[-1]
+
+
 def _tool_chrome_line(
     tool_name: str, args_summary: str = "", mcp_servers: Any = None,
 ) -> str:
@@ -2510,25 +2530,27 @@ class SerpentFlow:
         status_mark = "" if status == "success" else f"  [{_C['death']}]✗[/{_C['death']}]"
 
         # ── CC-style blocks for write/edit tools ──
-        if tool_name == "edit_file" and status == "success":
-            # Render as ⏺ Update(path) with result preview as inline diff
-            path = args_summary[:60] if args_summary else "file"
-            self._op_line(
-                op_id,
-                f"[{_C['neural']}]⏺ Update[/{_C['neural']}]"
-                f"([{_C['file']}]{path}[/{_C['file']}]){dur}",
-            )
-            if result_preview:
-                # Count added/removed lines from result
-                lines = result_preview.split("\n")
-                n_changed = sum(1 for l in lines if l.strip())
-                self._op_line(
-                    op_id,
-                    f"[{_C['dim']}]⎿  edit applied ({n_changed} line{'s' if n_changed != 1 else ''} affected)[/{_C['dim']}]",
-                )
+        if tool_name in ("edit_file", "write_file") and status == "success":
+            # THE REAL DIFF, not a count.
+            #
+            # This printed "⎿ edit applied (12 lines affected)" — a number
+            # where the change belongs. `show_diff` has rendered numbered
+            # green/red hunks through `_op_line` (the mirrored path) all
+            # along; the tool loop simply never called it.
+            #
+            # It needs no diff text: after a successful edit the file ON DISK
+            # is the change, so `show_diff` falls back to `_get_git_diff`
+            # and reads it. Passing the tool's `result_preview` instead would
+            # be a second, weaker source for something git already knows
+            # exactly.
+            path = _extract_path_arg(args_summary)
+            self.show_diff(path or "file", op_id=op_id)
             return
 
-        if tool_name == "write_file" and status == "success":
+        if tool_name == "write_file" and status == "success" and False:
+            # Superseded above: write_file now renders its real diff. Left
+            # unreachable rather than deleted so the fallback shape stays
+            # visible to whoever revisits this branch.
             path = args_summary[:60] if args_summary else "file"
             self._op_line(
                 op_id,
@@ -4035,21 +4057,60 @@ class SerpentFlow:
             highlight=False,
         )
 
+    def _is_untracked(self, file_path: str) -> bool:
+        """Is this path outside git's index? NEVER raises.
+
+        Answered with `ls-files --error-unmatch`, which is a pure index
+        lookup — no working-tree scan, so it stays cheap inside a tool loop.
+        A non-zero exit means git has never heard of the file.
+        """
+        try:
+            result = subprocess.run(
+                ["git", "ls-files", "--error-unmatch", "--", file_path],
+                cwd=self._repo_path, capture_output=True, text=True,
+                timeout=2,
+            )
+            return result.returncode != 0
+        except Exception:  # noqa: BLE001
+            return False
+
     def _get_git_diff(self, file_path: str) -> str:
-        """Get git diff for a file."""
-        for args in (
-            ["git", "diff", "--cached", "--", file_path],
+        """The diff for a file, including one git does not track yet.
+
+        Two gaps this closes, both of which produced a silently empty diff:
+
+          * a NEW file is untracked, so every `git diff` form returns nothing
+            — exactly the case a `write_file` produces. `--no-index` against
+            /dev/null renders it as all-additions, which is what it is;
+          * three invocations at 5s each is up to 15 seconds inside a tool
+            loop that may edit repeatedly. The timeout is per-call and tight,
+            and the ladder stops at the first answer.
+
+        Returns "" on anything unreadable — `show_diff` then falls back to its
+        compact one-liner, so a missing diff costs a detail, never the line.
+        """
+        candidates = [
             ["git", "diff", "--", file_path],
-            ["git", "diff", "HEAD~1", "--", file_path],
-        ):
+            ["git", "diff", "--cached", "--", file_path],
+        ]
+        # `--no-index` against /dev/null renders ANY existing file as
+        # all-additions — including an UNCHANGED one. Gating it on the file
+        # actually being untracked is what keeps "nothing changed" meaning
+        # nothing changed; without the gate, every unmodified file an op
+        # touched would render as if it had just been written.
+        if self._is_untracked(file_path):
+            candidates.append(
+                ["git", "diff", "--no-index", "--", os.devnull, file_path],
+            )
+        for args in candidates:
             try:
                 result = subprocess.run(
                     args, cwd=self._repo_path,
-                    capture_output=True, text=True, timeout=5,
+                    capture_output=True, text=True, timeout=2,
                 )
                 if result.stdout.strip():
                     return result.stdout.strip()
-            except Exception:
+            except Exception:  # noqa: BLE001
                 continue
         return ""
 

--- a/tests/battle_test/test_edit_diff_reaches_cockpit.py
+++ b/tests/battle_test/test_edit_diff_reaches_cockpit.py
@@ -1,0 +1,216 @@
+"""The cockpit shows the change, not a count of it.
+
+A successful `edit_file` rendered:
+
+    ⏺ Update(backend/…/thin_client.py)
+      ⎿ edit applied (12 lines affected)
+
+A NUMBER where the change belongs. `show_diff` has rendered numbered green/red
+hunks through `_op_line` — the mirrored path — all along; the tool loop simply
+never called it. Seventh instance this session of a good renderer the live path
+does not reach.
+
+It needs no diff text passed in: after a successful edit the file ON DISK is
+the change, so `show_diff` falls back to `_get_git_diff` and reads it. Handing
+it the tool's `result_preview` instead would be a second, weaker source for
+something git knows exactly.
+"""
+from __future__ import annotations
+
+import ast
+import pathlib
+import subprocess
+import tempfile
+from typing import Any, List
+
+import pytest
+
+from backend.core.ouroboros.battle_test.serpent_flow import (
+    SerpentFlow,
+    _extract_path_arg,
+)
+
+_REPO = pathlib.Path(__file__).resolve().parents[2]
+_SRC = _REPO / "backend/core/ouroboros/battle_test/serpent_flow.py"
+
+
+@pytest.fixture()
+def git_repo(tmp_path: pathlib.Path) -> pathlib.Path:
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=False)
+    subprocess.run(["git", "config", "user.email", "t@t"], cwd=tmp_path,
+                   check=False)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=tmp_path,
+                   check=False)
+    (tmp_path / "mod.py").write_text("def f():\n    return 1\n")
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=False)
+    subprocess.run(["git", "commit", "-qm", "init"], cwd=tmp_path, check=False)
+    return tmp_path
+
+
+def _flow(repo: pathlib.Path) -> Any:
+    flow = SerpentFlow.__new__(SerpentFlow)
+    flow._repo_path = str(repo)
+    return flow
+
+
+# --------------------------------------------------------------------------
+# 1. a change is readable, including one git does not track yet
+# --------------------------------------------------------------------------
+
+def test_a_modified_file_yields_its_diff(git_repo: pathlib.Path) -> None:
+    (git_repo / "mod.py").write_text("def f():\n    return 2\n")
+    diff = _flow(git_repo)._get_git_diff("mod.py")
+    assert "-    return 1" in diff and "+    return 2" in diff
+
+
+def test_a_BRAND_NEW_file_renders_as_additions(git_repo: pathlib.Path) -> None:
+    """THE gap: an untracked file produces nothing from every plain `git
+    diff` form — and that is exactly what `write_file` creates. Rendering it
+    as all-additions is what it is."""
+    (git_repo / "brand_new.py").write_text("print('hello')\n")
+    diff = _flow(git_repo)._get_git_diff("brand_new.py")
+    assert diff, "a new file produced no diff at all"
+    assert "+print('hello')" in diff
+
+
+def test_a_staged_change_is_found(git_repo: pathlib.Path) -> None:
+    (git_repo / "mod.py").write_text("def f():\n    return 9\n")
+    subprocess.run(["git", "add", "mod.py"], cwd=git_repo, check=False)
+    assert "return 9" in _flow(git_repo)._get_git_diff("mod.py")
+
+
+def test_an_unchanged_file_yields_nothing(git_repo: pathlib.Path) -> None:
+    """Empty is correct here — `show_diff` then falls back to its compact
+    one-liner, so a missing diff costs a detail, never the line."""
+    assert _flow(git_repo)._get_git_diff("mod.py") == ""
+
+
+def test_an_unchanged_TRACKED_file_is_not_shown_as_new(
+    git_repo: pathlib.Path,
+) -> None:
+    """The bug this test caught: `--no-index` against /dev/null renders ANY
+    existing file as all-additions, so an untouched tracked file appeared to
+    have just been written. The fallback is gated on the file genuinely being
+    untracked."""
+    flow = _flow(git_repo)
+    assert flow._is_untracked("mod.py") is False
+    assert flow._get_git_diff("mod.py") == ""
+
+
+def test_an_untracked_file_is_recognised(git_repo: pathlib.Path) -> None:
+    (git_repo / "fresh.py").write_text("x = 1\n")
+    assert _flow(git_repo)._is_untracked("fresh.py") is True
+
+
+def test_the_untracked_check_is_an_index_lookup() -> None:
+    """`ls-files --error-unmatch` reads the index only — no working-tree
+    scan, so it stays cheap inside a tool loop that edits repeatedly."""
+    import ast
+
+    for node in ast.walk(ast.parse(_SRC.read_text())):
+        if isinstance(node, ast.FunctionDef) and node.name == "_is_untracked":
+            body = ast.unparse(node)
+            assert "ls-files" in body and "--error-unmatch" in body
+            return
+    pytest.fail("_is_untracked is gone")
+
+
+def test_a_missing_file_never_raises(git_repo: pathlib.Path) -> None:
+    assert isinstance(_flow(git_repo)._get_git_diff("nope.py"), str)
+
+
+def test_outside_a_git_repo_never_raises(tmp_path: pathlib.Path) -> None:
+    (tmp_path / "loose.py").write_text("x = 1\n")
+    assert isinstance(_flow(tmp_path)._get_git_diff("loose.py"), str)
+
+
+def test_the_lookup_is_time_bounded() -> None:
+    """Three invocations at 5s each is up to 15 seconds inside a tool loop
+    that may edit repeatedly."""
+    src = _SRC.read_text()
+    for node in ast.walk(ast.parse(src)):
+        if isinstance(node, ast.FunctionDef) and node.name == "_get_git_diff":
+            body = ast.unparse(node)
+            assert "timeout=2" in body, "the per-call timeout was loosened"
+            return
+    pytest.fail("_get_git_diff is gone")
+
+
+# --------------------------------------------------------------------------
+# 2. the path is found in free-text arguments
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("args,expected", [
+    ("backend/core/x.py", "backend/core/x.py"),
+    ("path=backend/core/x.py old=foo new=bar", "backend/core/x.py"),
+    ('"a/b/c.md"', "a/b/c.md"),
+    ("file.py", "file.py"),
+])
+def test_the_path_is_extracted(args: str, expected: str) -> None:
+    """`args_summary` is free text — sometimes a bare path, sometimes
+    `path=… old=… new=…`. Finding the path-shaped token is more robust than
+    assuming a position in a format the tool layer does not promise."""
+    assert _extract_path_arg(args) == expected
+
+
+@pytest.mark.parametrize("junk", ["", None, 42, "   "])
+def test_path_extraction_never_raises(junk: Any) -> None:
+    assert isinstance(_extract_path_arg(junk), str)
+
+
+# --------------------------------------------------------------------------
+# 3. the live edit path calls the real renderer
+# --------------------------------------------------------------------------
+
+def _tool_result_body() -> str:
+    src = _SRC.read_text()
+    for node in ast.walk(ast.parse(src)):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and \
+                node.name == "op_tool_call":
+            return ast.unparse(node)
+    return ""
+
+
+def test_a_successful_edit_renders_the_DIFF_not_a_count() -> None:
+    body = _tool_result_body()
+    assert body, "op_tool_call is gone"
+    assert "self.show_diff(" in body, "the tool path still bypasses show_diff"
+    assert "edit applied (" not in body, "the count line is still being emitted"
+
+
+def test_write_file_goes_through_the_same_renderer() -> None:
+    """A new file is a change too — and the one an operator most wants to
+    see, since nothing existed to compare against before."""
+    body = _tool_result_body()
+    assert '"edit_file", "write_file"' in body or \
+        "'edit_file', 'write_file'" in body
+
+
+def test_no_diff_text_is_threaded_from_the_tool() -> None:
+    """The file on disk IS the change. `result_preview` would be a second,
+    weaker source for something git knows exactly."""
+    body = _tool_result_body()
+    assert "show_diff(path or 'file', op_id=op_id)" in body.replace('"', "'")
+
+
+def test_show_diff_still_reaches_the_cockpit() -> None:
+    """The property this whole change rests on: `_op_line` mirrors, a plain
+    console print does not."""
+    src = _SRC.read_text()
+    for node in ast.walk(ast.parse(src)):
+        if isinstance(node, ast.FunctionDef) and node.name == "show_diff":
+            assert "_op_line" in ast.unparse(node)
+            return
+    pytest.fail("show_diff is gone")
+
+
+def test_a_diffless_change_still_prints_its_header() -> None:
+    """Degradation, not disappearance: `show_diff` falls back to a compact
+    one-liner when no diff can be read."""
+    src = _SRC.read_text()
+    for node in ast.walk(ast.parse(src)):
+        if isinstance(node, ast.FunctionDef) and node.name == "show_diff":
+            body = ast.unparse(node)
+            assert "if not diff_text" in body
+            return
+    pytest.fail("show_diff is gone")


### PR DESCRIPTION
A successful edit rendered a **number** where the change belongs:

```
⏺ Update(backend/…/thin_client.py)
  ⎿ edit applied (12 lines affected)
```

`show_diff` has rendered numbered green/red hunks through `_op_line` — the mirrored path — all along. The tool loop simply never called it.

**Seventh instance this session** of a good renderer the live path doesn't reach.

### No diff text is threaded from the tool
After a successful edit, the file **on disk** is the change — so `show_diff` falls back to `_get_git_diff` and reads it. Passing the tool's `result_preview` instead would be a second, weaker source for something git knows exactly, and the two would eventually disagree.

`write_file` routes through the same renderer. A new file is a change too, and the one an operator most wants to see, since nothing existed to compare against before.

### A new file produced no diff at all
Every plain `git diff` form returns nothing for an untracked path — exactly what `write_file` creates. `--no-index` against `/dev/null` renders it as all-additions, which is what it is.

### …and that fallback was too eager
**A test caught it.** `--no-index` renders *any* existing file as all-additions, including an **unchanged** one — so every untouched file an op merely read would have appeared freshly written.

It's now gated on the file genuinely being untracked, answered by `ls-files --error-unmatch`: a pure index lookup with no working-tree scan, so it stays cheap inside a loop that edits repeatedly.

### Bounded cost
The ladder was three invocations at 5s each — up to **15 seconds per edit** inside a tool loop. Per-call timeout is now 2s, and it still stops at the first answer.

### Degradation preserved
An unreadable diff falls back to `show_diff`'s compact one-liner, so a missing diff costs a detail and never the line.

### Tests
23. **1099 passing**; the 2 inline-boot banner failures are pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render real, line-by-line diffs in the cockpit after successful `edit_file` and `write_file`, replacing the "lines affected" count. New files now show proper diffs, and diff lookup is faster.

- **New Features**
  - Call `show_diff` for successful edits/writes; no `result_preview` threading.
  - Extract file path from free‑text `args_summary`.

- **Bug Fixes**
  - New, untracked files diff against `/dev/null` only when truly untracked (via `git ls-files --error-unmatch`), preventing false all-additions on unchanged files.
  - Diff retrieval is faster (2s per call, early exit) and still falls back to the one-line header; tests cover edits, new files, and untracked checks.

<sup>Written for commit 44b85f2678cc96678130d396dbeb7c3a05585647. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

