### PR TITLE
feat(ov): model output streams to an attached cockpit

### DIFF
--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -894,9 +894,39 @@ class SerpentFlow:
                 register_stream_renderer,
             )
             self._stream_renderer: Optional[Any] = StreamRenderer(console=self.console)
+            # Model output reaches an ATTACHED cockpit too.
+            #
+            # `StreamRenderer` draws with Rich `Live`, an animated in-place
+            # widget: it needs a real TTY, and it cannot be mirrored — `Live`
+            # repaints by moving the cursor, and replaying those escapes on a
+            # remote surface corrupts it rather than animating it.
+            #
+            # So the local widget is untouched and a SECOND consumer of the
+            # same token feed emits committed text frames. Two renderings of
+            # one stream; neither a degraded copy of the other.
+            #
+            # The mirror is resolved per frame, not captured here: SerpentFlow
+            # is constructed before the bridge attaches, so a handle taken now
+            # would be None forever — the wired-but-inert shape.
+            try:
+                from backend.core.ouroboros.battle_test.stream_mirror import (
+                    StreamMirror, fan_out_tokens, stream_mirror_enabled,
+                )
+                if stream_mirror_enabled():
+                    self._stream_mirror = StreamMirror(
+                        lambda text: self._mirror_markup(text),
+                    )
+                    self._stream_renderer = fan_out_tokens(
+                        self._stream_renderer, self._stream_mirror,
+                    )
+                else:
+                    self._stream_mirror = None
+            except Exception:  # noqa: BLE001 — local streaming still works
+                self._stream_mirror = None
             register_stream_renderer(self._stream_renderer)
         except Exception:
             self._stream_renderer = None
+            self._stream_mirror = None
 
         # InlinePromptGate Slice 5b (2026-05-02) — phase-boundary
         # renderer boot wire-up. Subscribes a listener to the

--- a/backend/core/ouroboros/battle_test/stream_mirror.py
+++ b/backend/core/ouroboros/battle_test/stream_mirror.py
@@ -1,0 +1,231 @@
+"""Model output, streamed to an attached cockpit.
+
+`StreamRenderer` shows tokens arriving as the model thinks — the difference
+between watching work happen and reading a report of it. It renders through
+Rich `Live`, an animated in-place widget, which means two things:
+
+  * it needs a real interactive TTY, so a `--headless` daemon falls through to
+    the plain path;
+  * it cannot be mirrored. `Live` repaints a region by moving the cursor, and
+    a remote surface has no cursor to move — replaying those escapes would
+    corrupt the cockpit rather than animate it.
+
+So the local widget is left exactly as it is, and this ADDS a second consumer
+of the same token feed that emits **committed text frames** instead. The
+cockpit gets prose; the local terminal keeps its animation. Neither is a
+degraded version of the other — they are different renderings of one stream.
+
+Why frames and not tokens
+--------------------------
+One bridge write per token would put thousands of frames on the socket for a
+single reply, and an attached client would spend its time parsing JSON rather
+than drawing. Tokens accumulate and flush on a boundary — either enough text
+to be worth sending, or a natural break in the prose.
+
+`find_commit_boundary` from `stream_renderer` decides where prose can be cut
+safely. Reusing it means the cockpit breaks text at the same places the local
+renderer commits it, so the two surfaces never disagree about what has been
+"said" — and markdown that spans a boundary (a fenced block, a list) is not
+severed mid-structure.
+
+Backpressure
+------------
+The flush is bounded and drop-oldest, for the reason the console spooler is:
+an attached cockpit that stops reading must never become a memory leak in the
+organism, and when it falls behind the RECENT text is what the operator is
+waiting for.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Any, Callable, List, Optional
+
+logger = logging.getLogger("Ouroboros.StreamMirror")
+
+__all__ = ["StreamMirror", "stream_mirror_enabled", "fan_out_tokens"]
+
+#: Flush when this much text has accumulated, even without a clean boundary.
+#: A long unbroken paragraph must not sit unsent while the operator waits.
+_FLUSH_CHARS = 160
+
+#: …or when this long has passed since the last flush. Bounds latency for a
+#: slow stream, where char count alone would hold text indefinitely.
+_FLUSH_INTERVAL_S = 0.35
+
+#: Never buffer more than this. A cockpit that stops reading is a bug in the
+#: cockpit, not a reason for the daemon to grow.
+_MAX_BUFFER_CHARS = 8192
+
+
+def stream_mirror_enabled() -> bool:
+    """Default ON: this closes the last structural gap in the transcript."""
+    return os.environ.get(
+        "JARVIS_STREAM_MIRROR_ENABLED", "1",
+    ).strip().lower() not in ("0", "false", "no", "off")
+
+
+class StreamMirror:
+    """Accumulates tokens and emits committed text frames to the cockpit."""
+
+    def __init__(
+        self,
+        emit: Optional[Callable[[str], None]] = None,
+        *,
+        flush_chars: int = _FLUSH_CHARS,
+        flush_interval_s: float = _FLUSH_INTERVAL_S,
+        clock: Optional[Callable[[], float]] = None,
+    ) -> None:
+        # INJECTED sink and clock: this must be testable with no bridge, no
+        # daemon and no wall-clock dependence.
+        self._emit = emit
+        self._flush_chars = max(1, int(flush_chars))
+        self._interval = max(0.0, float(flush_interval_s))
+        self._clock = clock or time.monotonic
+        self._buf: List[str] = []
+        self._size = 0
+        self._last_flush = self._clock()
+        self.frames_emitted = 0
+        self.chars_dropped = 0
+
+    # -- token side --------------------------------------------------------
+
+    def on_token(self, text: Any) -> None:
+        """Accept one token. NEVER raises, never blocks."""
+        try:
+            chunk = str(text or "")
+            if not chunk:
+                return
+            self._buf.append(chunk)
+            self._size += len(chunk)
+            if self._size > _MAX_BUFFER_CHARS:
+                # Drop from the FRONT: when a cockpit falls behind, the recent
+                # text is what the operator is waiting for.
+                dropped = self._size - _MAX_BUFFER_CHARS
+                joined = "".join(self._buf)[dropped:]
+                self._buf = [joined]
+                self._size = len(joined)
+                self.chars_dropped += dropped
+            if self._size >= self._flush_chars:
+                self.flush()
+            elif (self._clock() - self._last_flush) >= self._interval:
+                # A TIME-triggered flush must actually emit. Requiring a
+                # boundary here defeats the timer: a slow model producing
+                # short, unpunctuated text would hold it forever and the
+                # operator would watch a still screen. The deadline is the
+                # whole point, so it overrides the preference for a clean cut.
+                self.flush(force=True)
+        except Exception:  # noqa: BLE001 — a mirror must never break a stream
+            logger.debug("[StreamMirror] token degraded", exc_info=True)
+
+    def _should_flush(self) -> bool:
+        if self._size >= self._flush_chars:
+            return True
+        return (self._clock() - self._last_flush) >= self._interval
+
+    def flush(self, force: bool = False) -> None:
+        """Emit what has accumulated, cut at a safe boundary. NEVER raises.
+
+        ``force`` emits even without a boundary — used by the latency timer,
+        where waiting for a clean cut would defeat the deadline it exists to
+        enforce.
+        """
+        try:
+            if not self._buf:
+                return
+            text = "".join(self._buf)
+            head, tail = self._split_at_boundary(text, force=force)
+            if not head:
+                # No safe cut yet and not over the hard cap — keep waiting
+                # rather than severing a fenced block or a half-written list.
+                return
+            self._buf = [tail] if tail else []
+            self._size = len(tail)
+            self._last_flush = self._clock()
+            sink = self._emit
+            if sink is not None and head.strip():
+                sink(head)
+                self.frames_emitted += 1
+        except Exception:  # noqa: BLE001
+            logger.debug("[StreamMirror] flush degraded", exc_info=True)
+
+    def _split_at_boundary(self, text: str, force: bool = False) -> tuple:
+        """(committed, remainder) using the renderer's own boundary rule.
+
+        Falls back to sending everything when the rule cannot find a cut and
+        the buffer is already large — holding text hostage to a boundary that
+        never arrives is worse than one awkward break.
+        """
+        try:
+            from backend.core.ouroboros.battle_test.stream_renderer import (
+                find_commit_boundary,
+            )
+            idx = find_commit_boundary(text)
+            if idx and 0 < idx <= len(text):
+                return text[:idx], text[idx:]
+        except Exception:  # noqa: BLE001
+            pass
+        if force or len(text) >= self._flush_chars:
+            return text, ""
+        return "", text
+
+    # -- lifecycle ---------------------------------------------------------
+
+    def end(self) -> None:
+        """Stream finished — emit whatever is left, boundary or not."""
+        try:
+            if self._buf:
+                text = "".join(self._buf)
+                self._buf, self._size = [], 0
+                self._last_flush = self._clock()
+                sink = self._emit
+                if sink is not None and text.strip():
+                    sink(text)
+                    self.frames_emitted += 1
+        except Exception:  # noqa: BLE001
+            logger.debug("[StreamMirror] end degraded", exc_info=True)
+
+    @property
+    def pending_chars(self) -> int:
+        return self._size
+
+
+def fan_out_tokens(renderer: Any, mirror: StreamMirror) -> Any:
+    """Wrap a StreamRenderer so tokens reach BOTH it and the mirror.
+
+    A decorator rather than a replacement, for the same reason the subagent
+    narrator wraps its comm sink: the local `Live` widget is correct where it
+    runs, and the registry holds ONE renderer. Providers keep calling
+    `get_stream_renderer().on_token` and are never told there are now two
+    consumers.
+
+    Delegates to the real renderer FIRST — the local terminal is the surface
+    that has always worked, and a mirror fault must not degrade it.
+    """
+    if renderer is None:
+        return renderer
+
+    class _FannedOut:
+        def on_token(self, text: Any) -> None:
+            try:
+                renderer.on_token(text)
+            except Exception:  # noqa: BLE001
+                logger.debug("[StreamMirror] inner on_token failed",
+                             exc_info=True)
+            mirror.on_token(text)
+
+        def end(self) -> None:
+            try:
+                renderer.end()
+            except Exception:  # noqa: BLE001
+                logger.debug("[StreamMirror] inner end failed", exc_info=True)
+            mirror.end()
+
+        def __getattr__(self, name: str) -> Any:
+            # Everything else — start(), notify(), flush(), the counters —
+            # belongs to the real renderer. Reimplementing its surface would
+            # mean silently dropping whatever it grows next.
+            return getattr(renderer, name)
+
+    return _FannedOut()

--- a/tests/battle_test/test_stream_mirror.py
+++ b/tests/battle_test/test_stream_mirror.py
@@ -1,0 +1,280 @@
+"""Model output reaches an attached cockpit.
+
+`StreamRenderer` shows tokens arriving as the model thinks — the difference
+between watching work happen and reading a report of it. It draws with Rich
+`Live`, an animated in-place widget, so it needs a real TTY and CANNOT be
+mirrored: `Live` repaints by moving the cursor, and replaying those escapes on
+a remote surface corrupts it rather than animating it.
+
+The local widget is therefore untouched, and a SECOND consumer of the same
+token feed emits committed text frames. Two renderings of one stream; neither
+a degraded copy of the other.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Any, List
+
+import pytest
+
+from backend.core.ouroboros.battle_test.stream_mirror import (
+    StreamMirror,
+    fan_out_tokens,
+    stream_mirror_enabled,
+)
+
+_REPO = Path(__file__).resolve().parents[2]
+_SRC = _REPO / "backend/core/ouroboros/battle_test/serpent_flow.py"
+
+
+def _mirror(frames: List[str], t: Any = None) -> StreamMirror:
+    clock = t if t is not None else (lambda: 0.0)
+    return StreamMirror(frames.append, clock=clock)
+
+
+# --------------------------------------------------------------------------
+# 1. tokens become frames, not a flood
+# --------------------------------------------------------------------------
+
+def test_tokens_are_batched_into_frames() -> None:
+    """One bridge write per token would put thousands of frames on the socket
+    for a single reply, and the client would parse JSON instead of drawing."""
+    frames: List[str] = []
+    m = _mirror(frames)
+    for _ in range(200):
+        m.on_token("word ")
+    m.end()
+    assert frames, "nothing was emitted"
+    assert len(frames) < 30, f"{len(frames)} frames for 200 tokens — a flood"
+
+
+def test_the_whole_text_survives_batching() -> None:
+    """Batching must not lose prose."""
+    frames: List[str] = []
+    m = _mirror(frames)
+    words = [f"w{i} " for i in range(120)]
+    for w in words:
+        m.on_token(w)
+    m.end()
+    joined = "".join(frames)
+    assert "w0 " in joined and "w119 " in joined
+
+
+def test_a_slow_stream_still_flushes_on_TIME() -> None:
+    """Char count alone would hold text indefinitely when the model is slow —
+    the operator would watch a still screen while tokens trickled in."""
+    frames: List[str] = []
+    clock = {"t": 0.0}
+    m = _mirror(frames, lambda: clock["t"])
+    m.on_token("a short sentence that ends here. ")
+    clock["t"] = 10.0
+    m.on_token("more ")
+    assert frames, "a slow stream never flushed"
+
+
+def test_end_emits_the_remainder_boundary_or_not() -> None:
+    """A tail with no clean cut must not be silently swallowed."""
+    frames: List[str] = []
+    m = _mirror(frames)
+    m.on_token("no terminator here")
+    m.end()
+    assert "".join(frames).strip() == "no terminator here"
+
+
+def test_end_on_an_empty_stream_emits_nothing() -> None:
+    frames: List[str] = []
+    _mirror(frames).end()
+    assert frames == []
+
+
+def test_whitespace_only_is_not_a_frame() -> None:
+    frames: List[str] = []
+    m = _mirror(frames)
+    m.on_token("   \n  ")
+    m.end()
+    assert frames == []
+
+
+# --------------------------------------------------------------------------
+# 2. it cuts where the local renderer cuts
+# --------------------------------------------------------------------------
+
+def test_it_uses_the_renderers_own_boundary_rule() -> None:
+    """Reusing `find_commit_boundary` means both surfaces break text at the
+    same places, so they never disagree about what has been "said" — and
+    markdown spanning a boundary is not severed mid-structure."""
+    src = (_REPO / "backend/core/ouroboros/battle_test/"
+           "stream_mirror.py").read_text()
+    imported = {
+        alias.name
+        for node in ast.walk(ast.parse(src))
+        if isinstance(node, ast.ImportFrom) for alias in node.names
+    }
+    assert "find_commit_boundary" in imported
+
+
+def test_a_long_unbroken_paragraph_is_not_held_hostage() -> None:
+    """Holding text for a boundary that never arrives is worse than one
+    awkward break."""
+    frames: List[str] = []
+    m = _mirror(frames)
+    m.on_token("x" * 500)
+    assert frames, "a boundaryless paragraph was never sent"
+
+
+# --------------------------------------------------------------------------
+# 3. a stalled cockpit cannot grow the daemon
+# --------------------------------------------------------------------------
+
+def test_the_buffer_is_bounded() -> None:
+    """An attached cockpit that stops reading must never become a memory leak
+    in the organism."""
+    # flush_chars huge so the char trigger never fires, and a frozen clock so
+    # the timer never fires — the only way text genuinely accumulates.
+    m = StreamMirror(None, flush_chars=10 ** 9, clock=lambda: 0.0)
+    for _ in range(5000):
+        m.on_token("0123456789")
+    assert m.pending_chars <= 8192
+    assert m.chars_dropped > 0
+
+
+def test_dropping_keeps_the_RECENT_text() -> None:
+    """When a cockpit falls behind, the recent text is what the operator is
+    waiting for — the same rule as the console spooler."""
+    frames: List[str] = []
+    m = StreamMirror(frames.append, flush_chars=10 ** 9, clock=lambda: 0.0)
+    for i in range(3000):
+        m.on_token(f"{i:06d} ")
+    m.end()
+    assert "2999" in "".join(frames)
+
+
+@pytest.mark.parametrize("junk", [None, 42, object(), b"bytes"])
+def test_a_hostile_token_never_raises(junk: Any) -> None:
+    frames: List[str] = []
+    _mirror(frames).on_token(junk)
+
+
+def test_a_failing_sink_cannot_break_the_stream() -> None:
+    def _boom(_text: str) -> None:
+        raise RuntimeError("cockpit gone")
+
+    m = StreamMirror(_boom, clock=lambda: 0.0)
+    for _ in range(50):
+        m.on_token("word ")
+    m.end()          # must not raise
+
+
+# --------------------------------------------------------------------------
+# 4. the local renderer is untouched
+# --------------------------------------------------------------------------
+
+def test_the_local_renderer_still_receives_every_token() -> None:
+    """`Live` is correct where it runs. This ADDS a consumer; it does not
+    redirect one."""
+    seen: List[str] = []
+
+    class _Renderer:
+        def on_token(self, text: str) -> None:
+            seen.append(text)
+
+        def end(self) -> None:
+            seen.append("END")
+
+    frames: List[str] = []
+    w = fan_out_tokens(_Renderer(), _mirror(frames))
+    w.on_token("a ")
+    w.on_token("b ")
+    w.end()
+    assert seen == ["a ", "b ", "END"]
+
+
+def test_the_local_renderer_is_fed_FIRST() -> None:
+    """The terminal that has always worked must not be starved by a mirror
+    fault."""
+    seen: List[str] = []
+
+    class _Renderer:
+        def on_token(self, text: str) -> None:
+            seen.append(text)
+
+        def end(self) -> None: ...
+
+    def _boom(_t: str) -> None:
+        raise RuntimeError("bridge down")
+
+    w = fan_out_tokens(_Renderer(), StreamMirror(_boom, clock=lambda: 0.0))
+    for _ in range(50):
+        w.on_token("word ")
+    assert len(seen) == 50
+
+
+def test_an_inner_fault_cannot_blank_the_cockpit() -> None:
+    class _Broken:
+        def on_token(self, _t: str) -> None:
+            raise RuntimeError("Live crashed")
+
+        def end(self) -> None:
+            raise RuntimeError("Live crashed")
+
+    frames: List[str] = []
+    w = fan_out_tokens(_Broken(), _mirror(frames))
+    w.on_token("still visible remotely. ")
+    w.end()
+    assert frames
+
+
+def test_everything_else_passes_through() -> None:
+    """`start()`, `notify()`, the counters — reimplementing the renderer's
+    surface would silently drop whatever it grows next."""
+    class _Renderer:
+        def on_token(self, _t: str) -> None: ...
+        def end(self) -> None: ...
+        def start(self, op_id: str, provider: str = "") -> str:
+            return f"started:{op_id}"
+
+        @property
+        def token_count(self) -> int:
+            return 7
+
+    w = fan_out_tokens(_Renderer(), _mirror([]))
+    assert w.start("op-1") == "started:op-1"
+    assert w.token_count == 7
+
+
+def test_a_missing_renderer_is_returned_untouched() -> None:
+    assert fan_out_tokens(None, _mirror([])) is None
+
+
+# --------------------------------------------------------------------------
+# 5. wiring
+# --------------------------------------------------------------------------
+
+def test_the_switch_defaults_on() -> None:
+    assert stream_mirror_enabled() is True
+
+
+def test_the_switch_leaves_local_streaming_alone(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_STREAM_MIRROR_ENABLED", "0")
+    assert stream_mirror_enabled() is False
+    src = _SRC.read_text()
+    assert "if stream_mirror_enabled():" in src
+    assert "register_stream_renderer(self._stream_renderer)" in src
+
+
+def test_the_fan_out_is_registered_not_a_replacement() -> None:
+    """Providers keep calling `get_stream_renderer().on_token` and are never
+    told there are now two consumers."""
+    src = _SRC.read_text()
+    assert "fan_out_tokens(" in src
+    assert "register_stream_renderer(self._stream_renderer)" in src
+
+
+def test_the_mirror_is_resolved_PER_FRAME() -> None:
+    """SerpentFlow is constructed before the bridge attaches, so a handle
+    captured at build time would be None forever."""
+    src = _SRC.read_text()
+    assert "lambda text: self._mirror_markup(text)" in src


### PR DESCRIPTION
The last structural gap in the transcript. `StreamRenderer` shows tokens arriving as the model thinks — the difference between **watching work happen** and **reading a report of it** — and none of it reached an attached operator.

### It cannot simply be mirrored
`Live` is an animated in-place widget: it repaints by moving the cursor, and replaying those escapes on a remote surface **corrupts** it rather than animating it. It also requires a real TTY, which a `--headless` daemon doesn't have.

So the local widget is untouched, and a **second consumer** of the same token feed emits committed **text frames**. Two renderings of one stream; neither a degraded copy of the other.

Providers keep calling `get_stream_renderer().on_token` and are never told there are now two consumers — `fan_out_tokens` wraps the registered renderer (same decorator shape as the subagent narrator) and delegates to the real one **first**, so a mirror fault cannot starve the terminal that has always worked.

### Frames, not tokens
One bridge write per token would put thousands of frames on the socket for a single reply, and the client would spend its time parsing JSON rather than drawing.

Text accumulates and flushes on a boundary — and the boundary is **`find_commit_boundary`, the renderer's own rule**, so both surfaces break text at the same places and markdown spanning a cut isn't severed mid-structure.

### A test caught a real bug in the latency path
The timer fired, but the flush still demanded a clean boundary — so a slow model producing short, unpunctuated text would hold it **forever**, with the operator watching a still screen while tokens trickled in.

A time-triggered flush now **forces** emission: the deadline is the whole point, so it overrides the preference for a clean cut.

### Bounded, drop-oldest
An attached cockpit that stops reading must never become a memory leak in the organism — and when it falls behind, the **recent** text is what the operator is waiting for.

### Resolved per frame
SerpentFlow is built before the bridge attaches, so a handle captured at construction would be `None` forever. That's the wired-but-inert shape this session has now closed **eight** times.

### Tests
24. **723 passing** across stream / serpent / cli; the 2 inline-boot banner failures are pre-existing.

### Next in this arc
Esc to interrupt · live todo checklist · token usage in the status line · unbounded scrollback · image/paste input · `@file` mentions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streams model output to an attached cockpit via a frame-based mirror while keeping the local `Live` TTY animation intact. Tokens are fanned out, batched into text frames, and flushed by size or time with a bounded, drop-oldest buffer.

- New Features
  - Added `StreamMirror` to accumulate tokens and emit committed text frames using `find_commit_boundary`.
  - Wrapped the registered renderer with `fan_out_tokens` so the local `Live` updates first and the cockpit receives the same stream.
  - Flush on ~160 chars or ~0.35s; 8KB cap with drop-oldest; sink resolved per frame; toggle via `JARVIS_STREAM_MIRROR_ENABLED` (default on).

- Bug Fixes
  - Timer-driven flush now forces emission when no safe boundary exists to prevent stalls on slow, unpunctuated streams.

<sup>Written for commit 56a76cb3c40fbdec721d8a57ea53c3af26d839d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

