### PR TITLE
feat(ov): Esc interrupts what YOU asked for

### DIFF
--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -4776,6 +4776,16 @@ class BattleTestHarness:
                     "origin": "cockpit_chat",
                 },
             )
+            # Record it BEFORE dispatch resolves: Esc must be able to target
+            # an op the moment the operator sees "dispatched", not after
+            # intake finishes accepting it.
+            try:
+                _oid = str(getattr(envelope, "op_id", "") or
+                           getattr(envelope, "envelope_id", "") or "")
+                if _oid and hasattr(gls, "note_operator_op"):
+                    gls.note_operator_op(_oid)
+            except Exception:  # noqa: BLE001
+                pass
             result = submit(envelope)
             if asyncio.iscoroutine(result):
                 # The caller is synchronous (the chat executor). Schedule and

--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -6913,6 +6913,29 @@ class SerpentREPL:
                 highlight=False,
             )
             return
+        # BARE cancel (Esc, or `/cancel` with no argument) targets the
+        # operator's OWN work, most recent first.
+        #
+        # Not "everything running": Esc means "stop what I asked for", not
+        # "stop the organism". One keystroke that reached autonomous work
+        # could kill a soak, and an operator who discovers that stops
+        # trusting the key — so the scope is narrow by construction rather
+        # than by warning.
+        if not str(op_id or "").strip():
+            mine = []
+            if hasattr(self._gls, "operator_ops_active"):
+                try:
+                    mine = self._gls.operator_ops_active() or []
+                except Exception:  # noqa: BLE001
+                    mine = []
+            if not mine:
+                self._flow.console.print(
+                    f"  [{_C['dim']}]nothing of yours is running — "
+                    f"autonomous work keeps going[/{_C['dim']}]",
+                    highlight=False,
+                )
+                return
+            op_id = mine[0]
         if hasattr(self._gls, "request_cancel"):
             found = self._gls.request_cancel(op_id)
             if found:

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -1407,6 +1407,24 @@ def _build_selection_bindings(ui: Any, client: Any) -> Any:
             lambda: fsm.mode == MODE_FLOW and not _buffer_text(),
         )
 
+        @Condition
+        def in_flow_working() -> bool:
+            """FLOW mode with work in flight.
+
+            Gated on work EXISTING so an idle Esc does nothing rather than
+            emitting a verb that reports "nothing to cancel" — a key that
+            answers when it was not asked trains the operator to ignore it.
+            """
+            try:
+                from backend.core.ouroboros.battle_test.cockpit_fsm import (
+                    MODE_FLOW,
+                )
+                if ui.fsm is None or ui.fsm.mode != MODE_FLOW:
+                    return False
+                return bool(getattr(ui, "_active_ops", None))
+            except Exception:  # noqa: BLE001
+                return False
+
         @kb.add("c-o", filter=can_open)
         def _open(event: Any) -> None:
             fsm.enter_select()
@@ -1433,6 +1451,27 @@ def _build_selection_bindings(ui: Any, client: Any) -> Any:
                 except Exception:  # noqa: BLE001
                     pass
             ui.refresh()
+
+        @kb.add("escape", filter=in_flow_working, eager=True)
+        def _interrupt(event: Any) -> None:
+            """Esc in FLOW interrupts the operator's own work.
+
+            Layered under the existing Esc, which leaves SELECT/FOCUS — that
+            binding is filtered to `not_flow`, so FLOW was free and no
+            conflict had to be resolved. One key, two meanings, disambiguated
+            by what is on screen rather than by a modifier the operator must
+            remember.
+
+            Sends the EXISTING `/cancel` verb rather than a new frame type:
+            bare cancel already means "my work" on the daemon, so the
+            keystroke and the typed verb resolve through one path and cannot
+            drift apart.
+            """
+            try:
+                client.send_input("/cancel")
+                ui.flash("interrupting…", seconds=2.0)
+            except Exception:  # noqa: BLE001
+                pass
 
         @kb.add("escape", filter=not_flow, eager=True)
         def _esc(event: Any) -> None:

--- a/backend/core/ouroboros/governance/governed_loop_service.py
+++ b/backend/core/ouroboros/governance/governed_loop_service.py
@@ -3386,6 +3386,49 @@ class GovernedLoopService:
             return self._bg_pool.get_result(op_id)
         return None
 
+    def note_operator_op(self, op_id: str) -> None:
+        """Remember an op the OPERATOR asked for. NEVER raises.
+
+        Esc means "stop what I asked for", not "stop the organism". The
+        distinction is load-bearing: a bare cancel that reached autonomous
+        work would let one keystroke kill a soak, and an operator who learns
+        that stops trusting the key.
+
+        Bounded: this is a recency hint for interrupt targeting, not a
+        ledger. The authoritative record of what ran lives in the op ledger.
+        """
+        try:
+            if not op_id:
+                return
+            ring = getattr(self, "_operator_ops", None)
+            if ring is None:
+                from collections import deque
+                ring = deque(maxlen=16)
+                self._operator_ops = ring
+            ring.append(str(op_id))
+        except Exception:  # noqa: BLE001
+            pass
+
+    def operator_ops_active(self) -> list:
+        """Operator-initiated ops still running, most recent FIRST.
+
+        Intersected with `_active_ops` so a finished op is never offered as an
+        interrupt target — cancelling something already done would report
+        success and change nothing, which is worse than reporting nothing to
+        cancel.
+        """
+        try:
+            ring = getattr(self, "_operator_ops", None) or ()
+            active = self._active_ops
+            seen, out = set(), []
+            for op_id in reversed(list(ring)):
+                if op_id in active and op_id not in seen:
+                    seen.add(op_id)
+                    out.append(op_id)
+            return out
+        except Exception:  # noqa: BLE001
+            return []
+
     def request_cancel(self, op_id: str) -> bool:
         """Request cooperative cancellation of an in-flight operation.
 

--- a/tests/cli/test_esc_interrupt.py
+++ b/tests/cli/test_esc_interrupt.py
@@ -1,0 +1,213 @@
+"""Esc stops what YOU asked for — not the organism.
+
+`request_cancel` and the `/cancel <op-id>` verb both predate this. What was
+missing is a keystroke: interrupting meant reading an op id off a moving
+screen and typing it, at exactly the moment you want something to stop.
+
+The scope decision is the load-bearing one. A bare cancel that reached
+autonomous work would let ONE keystroke kill a soak — and an operator who
+discovers that stops trusting the key. So Esc targets operator-initiated ops
+only, narrow by construction rather than by warning.
+
+Layering came free: the existing Esc binding is filtered to `not_flow`
+(leave SELECT/FOCUS), so FLOW was unclaimed. One key, two meanings,
+disambiguated by what is on screen rather than by a modifier to remember.
+"""
+from __future__ import annotations
+
+import ast
+from collections import deque
+from pathlib import Path
+from typing import Any, List
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[2]
+_OV = _REPO / "backend/core/ouroboros/cli/ov.py"
+_GLS = _REPO / "backend/core/ouroboros/governance/governed_loop_service.py"
+_FLOW = _REPO / "backend/core/ouroboros/battle_test/serpent_flow.py"
+
+
+class _GLS:
+    """The two methods the interrupt path needs, on a real-ish shape."""
+
+    def __init__(self) -> None:
+        self._active_ops: set = set()
+        self._cancel_requested: set = set()
+
+    # bound methods lifted from the real service
+    from backend.core.ouroboros.governance.governed_loop_service import (  # noqa: E402
+        GovernedLoopService as _Real,
+    )
+    note_operator_op = _Real.note_operator_op
+    operator_ops_active = _Real.operator_ops_active
+    request_cancel = _Real.request_cancel
+
+
+# --------------------------------------------------------------------------
+# 1. scope — it cancels YOUR work
+# --------------------------------------------------------------------------
+
+def test_only_operator_ops_are_offered_as_targets() -> None:
+    """THE decision. Autonomous work must survive a keystroke."""
+    gls = _GLS()
+    gls._active_ops = {"op-mine", "op-autonomous-sensor"}
+    gls.note_operator_op("op-mine")
+    assert gls.operator_ops_active() == ["op-mine"]
+
+
+def test_the_most_recent_op_is_first() -> None:
+    """Esc means "stop the thing I just started", not an arbitrary one."""
+    gls = _GLS()
+    gls._active_ops = {"op-a", "op-b"}
+    gls.note_operator_op("op-a")
+    gls.note_operator_op("op-b")
+    assert gls.operator_ops_active()[0] == "op-b"
+
+
+def test_a_finished_op_is_never_offered() -> None:
+    """Cancelling something already done would report success and change
+    nothing — worse than reporting nothing to cancel."""
+    gls = _GLS()
+    gls.note_operator_op("op-done")
+    gls._active_ops = set()
+    assert gls.operator_ops_active() == []
+
+
+def test_nothing_of_mine_running_yields_no_target() -> None:
+    gls = _GLS()
+    gls._active_ops = {"op-autonomous"}
+    assert gls.operator_ops_active() == []
+
+
+def test_the_recency_ring_is_bounded() -> None:
+    """A recency hint for interrupt targeting, not a ledger."""
+    gls = _GLS()
+    for i in range(200):
+        gls.note_operator_op(f"op-{i}")
+    assert len(gls._operator_ops) <= 16
+    assert isinstance(gls._operator_ops, deque)
+
+
+def test_duplicates_do_not_multiply_targets() -> None:
+    gls = _GLS()
+    gls._active_ops = {"op-x"}
+    for _ in range(5):
+        gls.note_operator_op("op-x")
+    assert gls.operator_ops_active() == ["op-x"]
+
+
+@pytest.mark.parametrize("junk", ["", None])
+def test_noting_junk_never_raises(junk: Any) -> None:
+    gls = _GLS()
+    gls.note_operator_op(junk)
+    assert gls.operator_ops_active() == []
+
+
+def test_a_cancel_actually_registers() -> None:
+    """The path end to end: recorded → offered → cancelled."""
+    gls = _GLS()
+    gls._active_ops = {"op-mine"}
+    gls.note_operator_op("op-mine")
+    assert gls.request_cancel(gls.operator_ops_active()[0]) is True
+    assert "op-mine" in gls._cancel_requested
+
+
+# --------------------------------------------------------------------------
+# 2. a bare cancel means "mine"
+# --------------------------------------------------------------------------
+
+def _cancel_body() -> str:
+    for node in ast.walk(ast.parse(_FLOW.read_text())):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and \
+                node.name == "_handle_cancel":
+            return ast.unparse(node)
+    return ""
+
+
+def test_bare_cancel_resolves_to_operator_ops() -> None:
+    body = _cancel_body()
+    assert body, "_handle_cancel is gone"
+    assert "operator_ops_active" in body
+
+
+def test_bare_cancel_with_nothing_of_yours_says_so() -> None:
+    """And says autonomous work continues — otherwise silence reads as "it
+    didn't work"."""
+    body = _cancel_body()
+    assert "nothing of yours is running" in body
+    assert "autonomous work keeps going" in body
+
+
+def test_an_explicit_op_id_still_targets_that_op() -> None:
+    """`/cancel <op-id>` predates this and must be untouched."""
+    body = _cancel_body()
+    assert "request_cancel" in body
+
+
+# --------------------------------------------------------------------------
+# 3. the keystroke
+# --------------------------------------------------------------------------
+
+def _ov_src() -> str:
+    return _OV.read_text()
+
+
+def test_esc_in_flow_interrupts() -> None:
+    src = _ov_src()
+    assert 'kb.add("escape", filter=in_flow_working' in src
+
+
+def test_the_existing_escape_still_leaves_select_and_focus() -> None:
+    """One key, two meanings — and the older one must not be displaced."""
+    src = _ov_src()
+    assert 'kb.add("escape", filter=not_flow' in src
+
+
+def test_the_two_bindings_do_not_overlap() -> None:
+    """`not_flow` and `in_flow_working` are disjoint by construction, so no
+    precedence rule has to be remembered."""
+    src = _ov_src()
+    assert "def in_flow_working() -> bool:" in src
+    body = src.split("def in_flow_working() -> bool:")[1][:600]
+    assert "MODE_FLOW" in body
+
+
+def test_an_idle_esc_does_nothing() -> None:
+    """A key that answers when it was not asked trains the operator to ignore
+    it."""
+    body = _ov_src().split("def in_flow_working() -> bool:")[1][:600]
+    assert '_active_ops' in body
+
+
+def test_it_reuses_the_cancel_verb_rather_than_a_new_frame() -> None:
+    """The keystroke and the typed verb resolve through ONE path, so they
+    cannot drift apart."""
+    src = _ov_src()
+    assert 'client.send_input("/cancel")' in src
+
+
+def test_the_operator_gets_feedback() -> None:
+    """An interrupt with no acknowledgement is indistinguishable from a
+    dropped keystroke."""
+    assert 'ui.flash("interrupting' in _ov_src()
+
+
+def test_the_harness_records_the_op_it_dispatches() -> None:
+    """Recorded BEFORE dispatch resolves: Esc must be able to target an op
+    the moment the operator sees "dispatched"."""
+    import ast
+
+    # AST, not a character window. A fixed slice measures how much prose sits
+    # between two calls — which is not the invariant, and is the mistake this
+    # test made on its first run.
+    src = (_REPO / "backend/core/ouroboros/battle_test/harness.py").read_text()
+    body = ""
+    for node in ast.walk(ast.parse(src)):
+        if isinstance(node, ast.FunctionDef) and \
+                node.name == "_submit_operator_goal":
+            body = ast.unparse(node)
+            break
+    assert body, "_submit_operator_goal is gone"
+    assert "note_operator_op" in body
+    assert body.index("note_operator_op") < body.index("submit(envelope)")


### PR DESCRIPTION
`request_cancel` and `/cancel <op-id>` both predate this. What was missing is a **keystroke** — interrupting meant reading an op id off a moving screen and typing it, at exactly the moment you want something to stop.

With streaming live (#70165), there's now work worth interrupting.

### The scope decision is the load-bearing one
A bare cancel that reached autonomous work would let **one keystroke kill a soak** — and an operator who discovers that stops trusting the key. So Esc targets **operator-initiated ops only**: narrow by construction rather than by warning.

That distinction is only possible because #70159 gave typed goals an honest source. The GLS keeps a bounded recency ring of ops the operator asked for, intersected with `_active_ops` so a **finished** op is never offered — cancelling something already done would report success and change nothing, which is worse than reporting nothing to cancel.

### Layering came free
The existing Esc binding is filtered to `not_flow` (leave SELECT/FOCUS), so **FLOW was unclaimed**. One key, two meanings, disambiguated by what's on screen rather than by a modifier to remember — and the two filters are disjoint by construction, so there's no precedence rule to get wrong.

An **idle** Esc does nothing: the filter requires work in flight. A key that answers when it wasn't asked trains the operator to ignore it.

### One path, not two
The keystroke sends the **existing** `/cancel` verb rather than a new frame type, and bare cancel means "mine" on the daemon side. The key and the typed verb resolve identically and cannot drift apart.

```
nothing of yours is running — autonomous work keeps going
```

The op is recorded **before** dispatch resolves, so Esc can target it the moment you see "dispatched" rather than after intake finishes accepting it.

### Tests
19. **635 passing** across cli + stream.

One of my own tests failed first on a 2600-character window that didn't reach the call it was ordering against — rewritten against the AST. Fourth time a character-slice pin has been wrong here; the AST form is the one that survives a comment.

### Remaining in this arc
Live todo checklist · token usage in status · unbounded scrollback · image/paste input · `@file` mentions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Esc now interrupts the work you started in FLOW, without touching autonomous tasks. It reuses the existing `/cancel` path so Esc and typed `/cancel` behave the same.

- **New Features**
  - Esc in FLOW interrupts only operator-initiated ops; idle Esc does nothing.
  - Sends `/cancel` with no arg; daemon targets your most recent running op and says “nothing of yours is running — autonomous work keeps going” if none.
  - GLS keeps a bounded ring (16) of your op IDs, intersected with `_active_ops` to avoid finished targets.
  - Harness records the op ID before dispatch so Esc can hit right after “dispatched”.
  - Existing Esc for SELECT/FOCUS (`not_flow`) is unchanged.
  - UI flashes “interrupting…” for quick feedback.
  - Added tests for scope, targeting order, non-overlap of bindings, and verb reuse.

<sup>Written for commit f514538f43777ae7fb3d4551be93863d50f9a0d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

