### PR TITLE
feat(ov): the plan ticks off as the work lands

### DIFF
--- a/backend/core/ouroboros/battle_test/plan_checklist.py
+++ b/backend/core/ouroboros/battle_test/plan_checklist.py
@@ -1,0 +1,265 @@
+"""The plan, ticked off as the work lands.
+
+    ⏺ Plan(4 changes)
+      ⎿ ☒ thin_client.py · extract the socket-path helper
+         ☒ harness.py · call the helper at bind time
+         ☐ attach_probe.py · call the helper at probe time
+         ☐ test_thin_client.py · pin one resolver
+
+The PLAN phase already produces exactly this. `plan_generator` emits schema
+`plan.1` with `ordered_changes` — a list of `{file_path, change_type,
+description}` — and `/show_plan` renders it on demand. What was missing is
+that an operator had to ASK, mid-flight, for the shape of work already
+decided.
+
+Completion is DERIVED, not tracked
+-----------------------------------
+Nothing reports "step 2 finished". But a plan item names a file, and a
+successful `edit_file` / `write_file` names the file it touched — the same
+events the diff renderer already intercepts. An item is done when its file has
+been written.
+
+That is a real inference rather than a guarantee, and it is stated as one: the
+checklist shows what has been TOUCHED, which is evidence of progress, not
+proof of correctness. VERIFY decides whether the work was right. A checklist
+that claimed otherwise would be the confident-and-wrong failure this codebase
+keeps finding.
+
+Deriving also means there is nothing to keep in sync. An alternative design —
+the orchestrator reporting step completion — would need a second source of
+truth about what happened, and the two would eventually disagree about an op
+that partially applied.
+
+Path matching
+-------------
+A plan says `backend/core/x.py`; a tool may report an absolute path, a
+repo-relative one, or a bare filename. Matching is by path SUFFIX on whole
+segments, so `core/x.py` matches `/repo/backend/core/x.py` and `x.py` matches
+both — while `ax.py` matches neither, which a plain `endswith` would get
+wrong.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, List, Optional, Sequence
+
+logger = logging.getLogger("Ouroboros.PlanChecklist")
+
+__all__ = [
+    "PlanChecklist", "checklist_enabled", "paths_match",
+    "register_plan", "note_file_touched",
+]
+
+#: Beyond this, a checklist stops being a glance and becomes a wall. The plan
+#: itself is never truncated — only what is drawn inline.
+_MAX_SHOWN = 12
+
+
+def checklist_enabled() -> bool:
+    """Default ON: the plan is already computed; hiding it is the anomaly."""
+    return os.environ.get(
+        "JARVIS_PLAN_CHECKLIST_ENABLED", "1",
+    ).strip().lower() not in ("0", "false", "no", "off")
+
+
+def paths_match(plan_path: str, touched_path: str) -> bool:
+    """Do these two path spellings name the same file?
+
+    Compared on whole SEGMENTS from the right. A plain `endswith` would call
+    `ax.py` a match for `x.py`, and a plain basename comparison would conflate
+    `cli/utils.py` with `governance/utils.py` — both wrong in the direction of
+    ticking something that did not happen.
+    """
+    try:
+        a = [p for p in str(plan_path or "").replace("\\\\", "/").split("/") if p]
+        b = [p for p in str(touched_path or "").replace("\\\\", "/").split("/") if p]
+        if not a or not b:
+            return False
+        shared = min(len(a), len(b))
+        return a[-shared:] == b[-shared:]
+    except Exception:  # noqa: BLE001
+        return False
+
+
+class PlanChecklist:
+    """One op's plan, and which of its files have been written."""
+
+    def __init__(self, ordered_changes: Sequence[Any] = ()) -> None:
+        self._items: List[Dict[str, Any]] = []
+        try:
+            for change in ordered_changes or ():
+                if isinstance(change, dict):
+                    path = str(change.get("file_path", "") or "")
+                    desc = str(change.get("description", "") or "")
+                    kind = str(change.get("change_type", "") or "")
+                else:
+                    path = str(getattr(change, "file_path", "") or "")
+                    desc = str(getattr(change, "description", "") or "")
+                    kind = str(getattr(change, "change_type", "") or "")
+                if path or desc:
+                    self._items.append(
+                        {"path": path, "desc": desc, "kind": kind,
+                         "done": False},
+                    )
+        except Exception:  # noqa: BLE001
+            logger.debug("[PlanChecklist] parse degraded", exc_info=True)
+
+    # -- state -------------------------------------------------------------
+
+    def mark_touched(self, path: str) -> bool:
+        """Tick the item naming *path*. True if this changed something.
+
+        Returns False for an already-ticked item so a re-edit does not
+        re-announce a step the operator has already seen completed — the
+        model revising the same file twice is normal, and narrating it twice
+        would read as two steps.
+        """
+        try:
+            for item in self._items:
+                if item["done"] or not item["path"]:
+                    continue
+                if paths_match(item["path"], path):
+                    item["done"] = True
+                    return True
+        except Exception:  # noqa: BLE001
+            pass
+        return False
+
+    @property
+    def total(self) -> int:
+        return len(self._items)
+
+    @property
+    def done(self) -> int:
+        return sum(1 for i in self._items if i["done"])
+
+    @property
+    def complete(self) -> bool:
+        return bool(self._items) and self.done == self.total
+
+    # -- render ------------------------------------------------------------
+
+    def render(self, max_shown: int = _MAX_SHOWN) -> List[str]:
+        """Chrome lines for the checklist, or [] when there is nothing to say.
+
+        A single-item plan renders nothing: "1 change" with one tick is a
+        checklist that never had a decision in it, and it would push the real
+        work off screen for no information.
+        """
+        if not checklist_enabled() or len(self._items) < 2:
+            return []
+        lines = [f"⏺ Plan({self.done}/{self.total} changes)"]
+        # UNFINISHED work first among the hidden: if a plan is longer than the
+        # window, the steps still to come are what an operator needs.
+        shown = self._items[:max_shown]
+        for idx, item in enumerate(shown):
+            box = "☒" if item["done"] else "☐"
+            label = item["path"] or item["desc"]
+            detail = ""
+            if item["path"] and item["desc"]:
+                # Separator rebuilt AFTER clipping: `_short` collapses
+                # whitespace, so composing " · desc" before clipping loses the
+                # leading space and yields "file.py· desc".
+                detail = f" · {_short(item['desc'], 44)}"
+            # ⎿ opens the subordinate block once; continuation rows align
+            # under it. Repeating the glyph per row makes a four-item plan
+            # read as four separate results rather than one list.
+            marker = "⎿" if idx == 0 else " "
+            lines.append(f"  {marker} {box} {_short(label)}{detail}")
+        hidden = len(self._items) - len(shown)
+        if hidden > 0:
+            remaining = sum(1 for i in self._items[max_shown:] if not i["done"])
+            lines.append(f"    … {hidden} more ({remaining} outstanding)")
+        return lines
+
+
+def _short(text: str, limit: int = 44) -> str:
+    flat = " ".join(str(text or "").split())
+    if len(flat) <= limit:
+        return flat
+    # Paths are identified by their tail; the leading directories are the
+    # part that repeats across every entry in a checklist.
+    if "/" in flat:
+        return "…" + flat[-(limit - 1):]
+    return flat[: limit - 1].rstrip() + "…"
+
+
+class ChecklistRegistry:
+    """Per-op checklists. Bounded — a cockpit is not a ledger."""
+
+    def __init__(self, max_ops: int = 32) -> None:
+        self._by_op: Dict[str, PlanChecklist] = {}
+        self._order: List[str] = []
+        self._max = max(1, int(max_ops))
+
+    def register(self, op_id: str, ordered_changes: Sequence[Any]) -> Optional[PlanChecklist]:
+        try:
+            checklist = PlanChecklist(ordered_changes)
+            if checklist.total < 2:
+                return None
+            key = str(op_id or "")
+            if key in self._by_op:
+                self._order.remove(key)
+            self._by_op[key] = checklist
+            self._order.append(key)
+            while len(self._order) > self._max:
+                self._by_op.pop(self._order.pop(0), None)
+            return checklist
+        except Exception:  # noqa: BLE001
+            return None
+
+    def get(self, op_id: str) -> Optional[PlanChecklist]:
+        return self._by_op.get(str(op_id or ""))
+
+    def clear(self, op_id: str) -> None:
+        key = str(op_id or "")
+        if self._by_op.pop(key, None) is not None:
+            try:
+                self._order.remove(key)
+            except ValueError:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# The process-wide registry
+# ---------------------------------------------------------------------------
+#
+# A module singleton for the same reason `set_operator_dispatcher` is one: the
+# producer (the orchestrator, at PLAN) and the consumer (SerpentFlow, at each
+# edit) are in different layers with no handle to each other, and threading
+# one through every intermediate would give each a parameter it does not use.
+
+_REGISTRY = ChecklistRegistry()
+
+
+def register_plan(op_id: str, ordered_changes: Sequence[Any]) -> Optional[PlanChecklist]:
+    """Called at PLAN completion. NEVER raises."""
+    try:
+        return _REGISTRY.register(op_id, ordered_changes)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def note_file_touched(op_id: str, path: str) -> List[str]:
+    """Called on a successful edit/write. Returns lines to render, or [].
+
+    Empty when nothing changed — a re-edit of an already-ticked file, an op
+    with no plan, or a single-item plan. Rendering only on a REAL transition
+    is what keeps the checklist a progress signal rather than a repeated
+    banner.
+    """
+    try:
+        checklist = _REGISTRY.get(op_id)
+        if checklist is None:
+            return []
+        if not checklist.mark_touched(path):
+            return []
+        return checklist.render()
+    except Exception:  # noqa: BLE001
+        return []
+
+
+def reset_registry_for_tests() -> None:
+    global _REGISTRY
+    _REGISTRY = ChecklistRegistry()

--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -2575,6 +2575,18 @@ class SerpentFlow:
             # exactly.
             path = _extract_path_arg(args_summary)
             self.show_diff(path or "file", op_id=op_id)
+            # Tick the plan. Completion is DERIVED from the file landing
+            # rather than reported by the orchestrator: a second source of
+            # truth about what happened would eventually disagree with this
+            # one about an op that partially applied.
+            try:
+                from backend.core.ouroboros.battle_test.plan_checklist import (
+                    note_file_touched,
+                )
+                for line in note_file_touched(op_id, path):
+                    self._op_line(op_id, line)
+            except Exception:  # noqa: BLE001
+                pass
             return
 
         if tool_name == "write_file" and status == "success" and False:

--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -4892,6 +4892,20 @@ class GovernedOrchestrator:
                         )
                     except Exception:
                         pass
+                    # The plan is a CHECKLIST — register it so the cockpit
+                    # can tick items as files land, instead of the operator
+                    # having to run /show_plan mid-flight to see the shape of
+                    # work already decided.
+                    try:
+                        from backend.core.ouroboros.battle_test.plan_checklist import (  # noqa: E501
+                            register_plan,
+                        )
+                        register_plan(
+                            ctx.op_id,
+                            getattr(_plan_result, "ordered_changes", []) or [],
+                        )
+                    except Exception:  # noqa: BLE001 — a checklist is additive
+                        pass
                     logger.info(
                         "[Orchestrator] PLAN complete for op=%s: complexity=%s, "
                         "%d ordered changes, %.1fs",

--- a/tests/battle_test/test_plan_checklist.py
+++ b/tests/battle_test/test_plan_checklist.py
@@ -1,0 +1,237 @@
+"""The plan, ticked off as the work lands.
+
+The PLAN phase already produces exactly this — `plan_generator` emits schema
+`plan.1` with `ordered_changes`, and `/show_plan` renders it on demand. What
+was missing is that an operator had to ASK, mid-flight, for the shape of work
+already decided.
+
+Completion is DERIVED, not reported: a plan item names a file, and a
+successful edit names the file it touched. That is an inference about
+PROGRESS, not a claim of correctness — VERIFY decides whether the work was
+right, and a checklist implying otherwise would be the confident-and-wrong
+failure this codebase keeps finding.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Any, List
+
+import pytest
+
+from backend.core.ouroboros.battle_test.plan_checklist import (
+    PlanChecklist,
+    note_file_touched,
+    paths_match,
+    register_plan,
+    reset_registry_for_tests,
+)
+
+_REPO = Path(__file__).resolve().parents[2]
+
+_PLAN = [
+    {"file_path": "backend/core/cli/thin_client.py",
+     "description": "extract the socket-path helper", "change_type": "modify"},
+    {"file_path": "backend/core/battle_test/harness.py",
+     "description": "call it at bind time", "change_type": "modify"},
+    {"file_path": "tests/cli/test_thin_client.py",
+     "description": "pin one resolver", "change_type": "create"},
+]
+
+
+@pytest.fixture(autouse=True)
+def _clean():
+    reset_registry_for_tests()
+    yield
+    reset_registry_for_tests()
+
+
+# --------------------------------------------------------------------------
+# 1. path matching cannot tick the wrong thing
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("plan,touched,expected", [
+    ("core/x.py", "/repo/backend/core/x.py", True),
+    ("x.py", "/repo/backend/core/x.py", True),
+    ("backend/core/x.py", "core/x.py", True),
+    # A plain endswith would call this a match.
+    ("x.py", "ax.py", False),
+    # A basename comparison would conflate these.
+    ("cli/utils.py", "governance/utils.py", False),
+    ("", "x.py", False),
+    ("x.py", "", False),
+])
+def test_paths_match_on_whole_segments(
+    plan: str, touched: str, expected: bool,
+) -> None:
+    """Both failure directions tick something that did not happen."""
+    assert paths_match(plan, touched) is expected
+
+
+@pytest.mark.parametrize("junk", [None, 42, object()])
+def test_matching_never_raises(junk: Any) -> None:
+    assert isinstance(paths_match(junk, junk), bool)
+
+
+# --------------------------------------------------------------------------
+# 2. the checklist tracks real progress
+# --------------------------------------------------------------------------
+
+def test_items_start_unticked() -> None:
+    c = PlanChecklist(_PLAN)
+    assert c.total == 3 and c.done == 0
+    assert "☐" in "\n".join(c.render())
+
+
+def test_touching_a_file_ticks_its_item() -> None:
+    c = PlanChecklist(_PLAN)
+    assert c.mark_touched("/repo/backend/core/cli/thin_client.py") is True
+    assert c.done == 1
+    assert "☒ backend/core/cli/thin_client.py" in "\n".join(c.render())
+
+
+def test_a_re_edit_does_not_re_announce() -> None:
+    """The model revising the same file twice is normal; narrating it twice
+    would read as two steps."""
+    c = PlanChecklist(_PLAN)
+    assert c.mark_touched("harness.py") is True
+    assert c.mark_touched("harness.py") is False
+    assert c.done == 1
+
+
+def test_an_unplanned_file_ticks_nothing() -> None:
+    """Touching a file the plan never mentioned is not progress against the
+    plan — it may be the model going somewhere unplanned, which is exactly
+    what an operator should notice."""
+    c = PlanChecklist(_PLAN)
+    assert c.mark_touched("some/other/file.py") is False
+    assert c.done == 0
+
+
+def test_completion_is_reported() -> None:
+    c = PlanChecklist(_PLAN)
+    for item in _PLAN:
+        c.mark_touched(item["file_path"])
+    assert c.complete is True
+    assert "3/3" in c.render()[0]
+
+
+# --------------------------------------------------------------------------
+# 3. it stays a glance
+# --------------------------------------------------------------------------
+
+def test_a_single_item_plan_renders_nothing() -> None:
+    """One change with one tick is a checklist that never had a decision in
+    it, and it would push real work off screen for no information."""
+    assert PlanChecklist([{"file_path": "a.py", "description": "x"}]).render() == []
+
+
+def test_an_empty_plan_renders_nothing() -> None:
+    assert PlanChecklist([]).render() == []
+
+
+def test_a_long_plan_is_windowed_and_says_what_remains() -> None:
+    """A silent truncation reads as "that is the whole plan"."""
+    big = [{"file_path": f"f{i}.py", "description": f"step {i}"}
+           for i in range(40)]
+    out = "\n".join(PlanChecklist(big).render())
+    assert "more" in out and "outstanding" in out
+    assert len(PlanChecklist(big).render()) < 20
+
+
+def test_the_subordinate_glyph_opens_the_block_once() -> None:
+    """Repeating ⎿ per row makes one list read as several separate results."""
+    lines = PlanChecklist(_PLAN).render()
+    assert lines[1].strip().startswith("⎿")
+    assert not lines[2].strip().startswith("⎿")
+
+
+def test_the_separator_survives_clipping() -> None:
+    """`_short` collapses whitespace, so composing " · desc" BEFORE clipping
+    yields "file.py· desc"."""
+    out = "\n".join(PlanChecklist(_PLAN).render())
+    assert "py · " in out
+    assert "py· " not in out
+
+
+def test_a_malformed_change_is_skipped_not_fatal() -> None:
+    c = PlanChecklist([{"nonsense": 1}, {"file_path": "a.py", "description": "x"},
+                       {"file_path": "b.py", "description": "y"}])
+    assert c.total == 2
+
+
+def test_dataclass_style_changes_are_accepted() -> None:
+    """`ordered_changes` may arrive as objects rather than dicts."""
+    class _Change:
+        file_path = "a/b.py"
+        description = "do the thing"
+        change_type = "modify"
+
+    assert PlanChecklist([_Change(), _Change()]).total == 2
+
+
+# --------------------------------------------------------------------------
+# 4. the registry, and both wiring seams
+# --------------------------------------------------------------------------
+
+def test_a_tick_renders_only_on_a_REAL_transition() -> None:
+    """Rendering on every edit would make the checklist a repeated banner
+    rather than a progress signal."""
+    register_plan("op-1", _PLAN)
+    assert note_file_touched("op-1", "thin_client.py")
+    assert note_file_touched("op-1", "thin_client.py") == []
+
+
+def test_an_op_with_no_plan_renders_nothing() -> None:
+    """Trivial ops skip planning — silence is correct."""
+    assert note_file_touched("op-never-planned", "x.py") == []
+
+
+def test_the_registry_is_bounded() -> None:
+    for i in range(200):
+        register_plan(f"op-{i}", _PLAN)
+    # The oldest are evicted; the newest still resolve.
+    assert note_file_touched("op-199", "thin_client.py")
+    assert note_file_touched("op-0", "thin_client.py") == []
+
+
+def test_plan_registration_happens_at_PLAN_completion() -> None:
+    src = (_REPO / "backend/core/ouroboros/governance/orchestrator.py").read_text()
+    assert "register_plan(" in src
+
+
+def test_the_tick_happens_where_the_diff_is_rendered() -> None:
+    """One seam: the edit event already carries the path, and reusing it
+    means there is no second source of truth about what was touched."""
+    src = (_REPO / "backend/core/ouroboros/battle_test/serpent_flow.py").read_text()
+    body = ""
+    for node in ast.walk(ast.parse(src)):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and \
+                node.name == "op_tool_call":
+            body = ast.unparse(node)
+            break
+    assert "note_file_touched" in body
+    assert "show_diff" in body
+
+
+def test_checklist_lines_go_through_the_MIRRORED_path() -> None:
+    """`_op_line` reaches an attached cockpit; a console print does not."""
+    src = (_REPO / "backend/core/ouroboros/battle_test/serpent_flow.py").read_text()
+    for node in ast.walk(ast.parse(src)):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and \
+                node.name == "op_tool_call":
+            body = ast.unparse(node)
+            idx = body.index("note_file_touched")
+            assert "_op_line" in body[idx:idx + 400]
+            return
+    pytest.fail("op_tool_call is gone")
+
+
+def test_the_switch_defaults_on(monkeypatch: pytest.MonkeyPatch) -> None:
+    from backend.core.ouroboros.battle_test.plan_checklist import (
+        checklist_enabled,
+    )
+    assert checklist_enabled() is True
+    monkeypatch.setenv("JARVIS_PLAN_CHECKLIST_ENABLED", "0")
+    assert checklist_enabled() is False
+    assert PlanChecklist(_PLAN).render() == []


### PR DESCRIPTION
```
⏺ Plan(2/4 changes)
  ⎿ ☒ backend/core/cli/thin_client.py · extract the socket-path helper
    ☒ backend/core/battle_test/harness.py · call it at bind time
    ☐ backend/core/cli/attach_probe.py · call it at probe time
    ☐ tests/cli/test_thin_client.py · pin one resolver
```

### The PLAN phase already produced exactly this
`plan_generator` emits schema `plan.1` with `ordered_changes` — `{file_path, change_type, description}` — and `/show_plan` renders it on demand. What was missing is that an operator had to **ask**, mid-flight, for the shape of work already decided.

### Completion is derived, not reported
Nothing emits *"step 2 finished"*. But a plan item names a file, and a successful edit names the file it touched — **the same event the diff renderer already intercepts**.

One seam, no second source of truth: an orchestrator that *also* reported step completion would eventually disagree with the file system about an op that partially applied.

And it's an inference about **progress**, not a claim of correctness. The checklist shows what has been *touched*; VERIFY decides whether the work was right. A checklist implying otherwise would be the confident-and-wrong failure this codebase keeps finding.

### Matching is on whole path segments, from the right
| comparison | naive result | correct |
|---|---|---|
| `x.py` vs `ax.py` | `endswith` → match | **no** |
| `cli/utils.py` vs `governance/utils.py` | basename → match | **no** |
| `core/x.py` vs `/repo/backend/core/x.py` | — | **yes** |

Both naive forms fail toward ticking something that didn't happen — the direction that matters.

### Touching an unplanned file ticks nothing
That's the model going somewhere the plan didn't, and it's exactly what an operator should **notice** rather than have absorbed into a progress bar.

### Restraint
- A **re-edit doesn't re-announce** — the model revising one file twice is normal; narrating it twice would read as two steps. Rendering only on a real transition keeps this a progress signal rather than a repeated banner.
- A **single-item plan renders nothing** — one change with one tick is a checklist that never had a decision in it.
- A **long plan is windowed** and says how many remain outstanding, because a silent truncation reads as *"that is the whole plan"*.

### Tests
29. **724 passing** across checklist / diff / chrome / stream / cli.

### Remaining
Token usage in status · unbounded scrollback · image/paste input · `@file` mentions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a live plan checklist that ticks items as file edits land, so operators see progress without running `/show_plan`. Completion is inferred from successful writes and shown alongside diffs.

- **New Features**
  - Added `PlanChecklist` with `register_plan` and `note_file_touched`; matches files by right-side path segments to avoid false positives.
  - Wired into `orchestrator` (register plan at PLAN completion) and `serpent_flow` (tick on successful edit and render via `_op_line`).
  - Behavior: ignores unplanned files, doesn’t re-announce re-edits, hides single-item plans, windows long plans and shows remaining.
  - Bounded registry and a feature flag (`JARVIS_PLAN_CHECKLIST_ENABLED`, default on); tests cover matching and rendering.

<sup>Written for commit fdb86934b74268d6e3648ea33a06a4080149d2cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

