### PR TITLE
feat(ov): context headroom in the status line

### DIFF
--- a/backend/core/ouroboros/battle_test/attach_heartbeat.py
+++ b/backend/core/ouroboros/battle_test/attach_heartbeat.py
@@ -37,6 +37,22 @@ from typing import Any, Dict, Optional
 HEARTBEAT_SCHEMA_VERSION = "heartbeat.v1"
 
 
+def _context_pct(op_id: str) -> float:
+    """Fraction of the prompt budget in use for *op_id*, 0.0 if unknown.
+
+    Zero means "no reading", not "empty" — the renderer treats it as absent
+    rather than as 0%, because a confident 0% on an op that is actually full
+    is worse than saying nothing.
+    """
+    try:
+        from backend.core.ouroboros.governance.tool_executor import (
+            context_utilisation,
+        )
+        return float(context_utilisation(op_id))
+    except Exception:  # noqa: BLE001
+        return 0.0
+
+
 def _pulse_glyph(now: float) -> str:
     """The pulse is O+V's OWN identity animation — the Ouroboros spinner
     (snake closing on its tail, bite, reopen), consumed from its ONE
@@ -163,6 +179,12 @@ def build_heartbeat_payload() -> Optional[Dict[str, Any]]:
             "phase": phase,
             "elapsed_s": round(elapsed_s, 1),
             "tokens_total": tokens_total,
+            # How full the op's context is. Read from the tool loop's OWN
+            # gauge — the same number it compares against the compaction
+            # threshold — so the status line and the compactor cannot
+            # disagree about whether earlier rounds are about to be
+            # summarised away.
+            "context_pct": _context_pct(op_id),
             "effort": effort,
             "provider": provider,
             "provider_label": provider_label,
@@ -219,6 +241,26 @@ def format_heartbeat_line(
         tokens = int(payload.get("tokens_total") or 0)
         if tokens > 0:
             parts.append(f"↓ {_fmt_tokens(tokens)} tokens")
+        # Context headroom, shown only once it MATTERS.
+        #
+        # Below the compaction threshold this is noise — every op starts near
+        # empty and the number would sit there teaching the operator to
+        # ignore it. Past the threshold it explains something they would
+        # otherwise experience as the model forgetting: earlier rounds are
+        # being summarised away to make room.
+        ctx = float(payload.get("context_pct") or 0.0)
+        if ctx > 0.0:
+            try:
+                from backend.core.ouroboros.governance.tool_executor import (
+                    compaction_threshold_fraction,
+                )
+                floor = compaction_threshold_fraction()
+            except Exception:  # noqa: BLE001
+                floor = 0.75
+            if ctx >= floor:
+                parts.append(f"ctx {int(ctx * 100)}% · compacting")
+            elif ctx >= floor * 0.8:
+                parts.append(f"ctx {int(ctx * 100)}%")
         label = str(
             payload.get("provider_label") or payload.get("provider") or ""
         )

--- a/backend/core/ouroboros/governance/tool_executor.py
+++ b/backend/core/ouroboros/governance/tool_executor.py
@@ -26,6 +26,7 @@ import enum
 import hashlib
 import json
 import logging
+from collections import OrderedDict
 import os
 import re
 import subprocess
@@ -4950,6 +4951,55 @@ _COMPACT_THRESHOLD_CHARS = int(
     )
 )  # Trigger compaction at 75% of max to avoid hard crash
 
+# ---------------------------------------------------------------------------
+# Context-utilisation gauge
+# ---------------------------------------------------------------------------
+#
+# The loop ALREADY measures this every round — `len(current_prompt)` against
+# `_COMPACT_THRESHOLD_CHARS` — and has only ever logged it. Publishing the
+# same number rather than computing a second one keeps ONE definition of "how
+# full is the context", so the status line and the compactor can never
+# disagree about whether an op is about to lose its earlier rounds.
+#
+# A gauge, not a ledger: last-writer-wins per op, bounded, and read
+# opportunistically. Nothing depends on it — a missed sample costs one frame
+# of a status line, never a decision.
+
+_CONTEXT_GAUGE: "OrderedDict[str, float]" = OrderedDict()
+_CONTEXT_GAUGE_MAX = 32
+
+
+def note_context_utilisation(op_id: str, used_chars: int) -> None:
+    """Record how full an op's prompt is, as a fraction. NEVER raises."""
+    try:
+        if not op_id:
+            return
+        pct = float(used_chars) / max(1, _MAX_PROMPT_CHARS)
+        key = str(op_id)
+        _CONTEXT_GAUGE.pop(key, None)
+        _CONTEXT_GAUGE[key] = max(0.0, min(1.0, pct))
+        while len(_CONTEXT_GAUGE) > _CONTEXT_GAUGE_MAX:
+            _CONTEXT_GAUGE.popitem(last=False)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def context_utilisation(op_id: str) -> float:
+    """Fraction of the prompt budget in use, or 0.0 if unknown."""
+    try:
+        return float(_CONTEXT_GAUGE.get(str(op_id or ""), 0.0))
+    except Exception:  # noqa: BLE001
+        return 0.0
+
+
+def compaction_threshold_fraction() -> float:
+    """The point at which context starts being compacted away."""
+    try:
+        return float(_COMPACT_THRESHOLD_CHARS) / max(1, _MAX_PROMPT_CHARS)
+    except Exception:  # noqa: BLE001
+        return 0.75
+
+
 
 # ── Slice 85 Phase 3 — cumulative convergence axis ──
 # The existing convergence nudges miss a model that EXPLORES forever by varying
@@ -7045,6 +7095,10 @@ class ToolLoopCoordinator:
             # When the accumulated prompt crosses the soft threshold but is
             # still below the compaction ceiling, emit a single-line
             # telemetry warning and stash a structured hint on the next
+            # Publish utilisation every round — the watermark below fires
+            # once, but an operator watching a long op needs the number
+            # continuously, and it is already in hand.
+            note_context_utilisation(op_id, len(current_prompt))
             # round's instruction footer so the model knows to stop
             # fetching new context and write the patch. Lossless signal
             # that rides one round ahead of the lossy compactor.

--- a/tests/battle_test/test_context_headroom.py
+++ b/tests/battle_test/test_context_headroom.py
@@ -1,0 +1,163 @@
+"""Context headroom, from the number the tool loop already computes.
+
+**Per-op token count was NOT missing.** `attach_heartbeat` has rendered
+`↓ 15.9k tokens` from `ThinkingProgressObserver` since #70082, and it is
+live-proven. An earlier gap analysis in this session listed it as absent
+without checking — this suite pins that it exists so nobody rebuilds it.
+
+What WAS missing is context headroom. The tool loop compares
+`len(current_prompt)` against `_COMPACT_THRESHOLD_CHARS` every round and only
+ever logged the result, so an operator experienced compaction as the model
+suddenly forgetting earlier rounds, with nothing on screen to explain it.
+
+Publishing that same number — rather than computing a second one — keeps ONE
+definition of "how full is the context", so the status line and the compactor
+can never disagree.
+"""
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+from backend.core.ouroboros.battle_test.attach_heartbeat import (
+    format_heartbeat_line,
+)
+from backend.core.ouroboros.governance.tool_executor import (
+    compaction_threshold_fraction,
+    context_utilisation,
+    note_context_utilisation,
+)
+
+_REPO = Path(__file__).resolve().parents[2]
+
+
+def _line(pct: float, **over: Any) -> str:
+    payload: Dict[str, Any] = {
+        "active": True, "verb": "Synthesizing", "elapsed_s": 249.0,
+        "tokens_total": 15900, "provider_label": "DW-397B",
+        "context_pct": pct,
+    }
+    payload.update(over)
+    return format_heartbeat_line(payload, now_mono=0.0, arrival_mono=0.0)
+
+
+# --------------------------------------------------------------------------
+# 1. what already existed — pinned so it is not rebuilt
+# --------------------------------------------------------------------------
+
+def test_the_token_counter_already_exists() -> None:
+    """NOT a gap. Pinned because an earlier analysis called it missing."""
+    assert "15.9k tokens" in _line(0.0)
+
+
+def test_elapsed_and_provider_already_render() -> None:
+    out = _line(0.0)
+    assert "4m 9s" in out and "DW-397B" in out
+
+
+# --------------------------------------------------------------------------
+# 2. the gauge publishes, it does not recompute
+# --------------------------------------------------------------------------
+
+def test_utilisation_is_recorded_and_read_back() -> None:
+    note_context_utilisation("op-ctx-1", 1000)
+    assert context_utilisation("op-ctx-1") > 0.0
+
+
+def test_an_unknown_op_reads_zero_not_a_guess() -> None:
+    """Zero means "no reading", and the renderer treats it as absent — a
+    confident 0% on a full op is worse than saying nothing."""
+    assert context_utilisation("op-never-seen") == 0.0
+    assert "ctx" not in _line(0.0)
+
+
+def test_utilisation_is_clamped() -> None:
+    note_context_utilisation("op-huge", 10 ** 12)
+    assert 0.0 <= context_utilisation("op-huge") <= 1.0
+
+
+def test_the_gauge_is_bounded() -> None:
+    """A gauge, not a ledger."""
+    from backend.core.ouroboros.governance.tool_executor import _CONTEXT_GAUGE
+
+    for i in range(500):
+        note_context_utilisation(f"op-bound-{i}", 500)
+    assert len(_CONTEXT_GAUGE) <= 32
+
+
+def test_the_newest_reading_wins() -> None:
+    note_context_utilisation("op-seq", 100)
+    first = context_utilisation("op-seq")
+    note_context_utilisation("op-seq", 100000)
+    assert context_utilisation("op-seq") > first
+
+
+@pytest.mark.parametrize("junk", ["", None])
+def test_noting_junk_never_raises(junk: Any) -> None:
+    note_context_utilisation(junk, 100)
+    assert context_utilisation(junk) == 0.0
+
+
+def test_the_threshold_comes_from_the_compactors_own_config() -> None:
+    """One definition of "how full is too full" — the status line cannot
+    disagree with the thing that actually compacts."""
+    floor = compaction_threshold_fraction()
+    assert 0.0 < floor <= 1.0
+
+
+def test_the_loop_publishes_every_round_not_only_at_the_watermark() -> None:
+    """The watermark fires once; an operator watching a long op needs the
+    number continuously, and it is already in hand."""
+    import ast
+
+    src = (_REPO / "backend/core/ouroboros/governance/tool_executor.py").read_text()
+    assert "note_context_utilisation(op_id, len(current_prompt))" in src
+    # And it is published OUTSIDE the once-only watermark guard.
+    idx = src.index("note_context_utilisation(op_id, len(current_prompt))")
+    assert "_soft_overflow_warned" not in src[idx - 200:idx]
+
+
+# --------------------------------------------------------------------------
+# 3. shown only when it matters
+# --------------------------------------------------------------------------
+
+def test_an_early_op_shows_nothing() -> None:
+    """Every op starts near empty; a number sitting there teaches the
+    operator to ignore it."""
+    assert "ctx" not in _line(0.30)
+
+
+def test_approaching_the_threshold_shows_the_figure() -> None:
+    assert "ctx 62%" in _line(0.62)
+
+
+def test_past_the_threshold_explains_what_is_happening() -> None:
+    """Otherwise compaction is experienced as the model forgetting."""
+    out = _line(0.81)
+    assert "ctx 81%" in out and "compacting" in out
+
+
+def test_the_boundary_is_derived_not_hardcoded_in_the_renderer() -> None:
+    """If the compaction threshold moves, the display moves with it."""
+    floor = compaction_threshold_fraction()
+    assert "compacting" in _line(min(0.99, floor + 0.01))
+    assert "compacting" not in _line(max(0.0, floor - 0.05))
+
+
+def test_an_inactive_heartbeat_renders_nothing() -> None:
+    assert format_heartbeat_line({"context_pct": 0.9}) == ""
+
+
+def test_the_pulse_survives_a_missing_context_field() -> None:
+    """Older daemons send no such key — the frame must still render."""
+    payload = {"active": True, "verb": "Working", "elapsed_s": 1.0,
+               "tokens_total": 10}
+    assert format_heartbeat_line(payload, now_mono=0.0, arrival_mono=0.0)
+
+
+@pytest.mark.parametrize("junk", ["nonsense", None, {}, -1])
+def test_a_hostile_context_value_never_raises(junk: Any) -> None:
+    assert isinstance(_line(0.0, context_pct=junk), str)


### PR DESCRIPTION
```
🐍··○ Synthesizing… (4m 9s · ↓ 15.9k tokens · ctx 81% · compacting · DW-397B)
```

### The token counter was NOT missing
`attach_heartbeat` has rendered `↓ 15.9k tokens` from `ThinkingProgressObserver` since #70082, and it's live-proven.

An earlier gap analysis **in this session** listed it as absent without checking. Building it again would have produced a second counter disagreeing with the first — pinned by a test now so nobody rebuilds it.

### What was genuinely missing
The tool loop compares `len(current_prompt)` against `_COMPACT_THRESHOLD_CHARS` **every round** and only ever *logged* the result — the percentage was already computed one line from where it was thrown away.

So an operator experienced compaction as the model suddenly forgetting earlier rounds, with nothing on screen to explain why.

### Published, not recomputed
The gauge exposes the loop's **own** number, so the status line and the compactor cannot disagree about whether earlier rounds are about to be summarised away.

The display threshold reads `compaction_threshold_fraction()` — the compactor's own config — so moving the threshold moves the display with it, rather than leaving a stale constant in a renderer.

### Shown only when it matters
| utilisation | display |
|---|---|
| 30% | *(silent — every op starts near empty)* |
| 62% | `ctx 62%` |
| 81% | `ctx 81% · compacting` |

Below ~80% of the threshold a number just sits there teaching the operator to ignore it. Past the threshold it stops being trivia and starts explaining behaviour.

**Zero means "no reading", not "empty"** — treated as absent, since a confident 0% on a full op is worse than saying nothing. A frame without the field still renders, so an older daemon degrades rather than blanking the pulse.

A **gauge, not a ledger**: bounded, last-writer-wins, read opportunistically. Nothing depends on it — a missed sample costs one frame of a status line, never a decision.

### Tests
21. **673 passing**; the 1 attach-heartbeat toolbar failure is pre-existing (verified identical with this change stashed).

### Remaining
Unbounded scrollback · image/paste input · `@file` mentions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds context headroom to the status line so operators can see when compaction is about to occur and why earlier rounds are being summarized. Publishes the tool loop’s own utilisation and uses the compactor’s threshold for a consistent display.

- **New Features**
  - Added `note_context_utilisation`, `context_utilisation`, and `compaction_threshold_fraction` to publish prompt usage and read the active compaction threshold.
  - Heartbeat now includes `context_pct` and shows:
    - `ctx NN%` when near the threshold.
    - `ctx NN% · compacting` at or above the threshold.
    - Silent below ~80% of the threshold.
  - Gauge is bounded (32 ops), last-writer-wins, and treats zero as “no reading.” Missing `context_pct` is handled gracefully for older daemons.

<sup>Written for commit e54e094bfaaf285816b6fec5a1fbe572457f99bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

