### PR TITLE
feat(ov): @path mentions on the surface the operator types into

### DIFF
--- a/backend/core/ouroboros/battle_test/repl_completion.py
+++ b/backend/core/ouroboros/battle_test/repl_completion.py
@@ -1699,6 +1699,89 @@ def _root_logging_preserved():
             pass
 
 
+class MentionPathCompleter:
+    """Completes `@path` mentions against the repo.
+
+    A mention the operator cannot TYPE is a feature only someone who already
+    knows the tree can use. This makes `@bac<tab>` reach
+    `@backend/core/...`, which is the difference between a parser and a
+    surface.
+
+    Deliberately NOT prompt_toolkit's `PathCompleter`: that completes from
+    the process CWD and would happily offer `/etc/passwd`. Mentions name
+    files in the REPO the organism works on, so the walk is rooted there and
+    cannot climb out — a completer that offers what the daemon will then
+    refuse to read teaches the operator nothing.
+    """
+
+    def __init__(self, root: Optional[str] = None, max_results: int = 12) -> None:
+        self._root = root
+        self._max = max(1, int(max_results))
+
+    def _repo_root(self):
+        import pathlib as _p
+        if self._root:
+            return _p.Path(self._root)
+        return _p.Path(os.environ.get("JARVIS_REPO_PATH", ".")).resolve()
+
+    def get_completions(self, document: Any, _event: Any = None):
+        from prompt_toolkit.completion import Completion
+        try:
+            text = document.text_before_cursor or ""
+            at = text.rfind("@")
+            if at < 0:
+                return
+            # Only the token being typed — an `@` earlier in a finished
+            # sentence must not re-open the menu on every later keystroke.
+            fragment = text[at + 1:]
+            if " " in fragment or "\n" in fragment:
+                return
+            root = self._repo_root()
+            if not root.is_dir():
+                return
+            for path in self._walk(root, fragment):
+                yield Completion(path, start_position=-len(fragment))
+        except Exception:  # noqa: BLE001 — completion must never break typing
+            return
+
+    def _walk(self, root: Any, fragment: str) -> List[str]:
+        """Repo-relative paths matching *fragment*. Bounded and prefix-first.
+
+        Bounded because a mention completer that walks a large repo on every
+        keystroke stalls the very keystroke that opened it — the failure the
+        threaded completer exists to avoid, reintroduced one layer down.
+        """
+        import itertools
+        frag = fragment.lower()
+        hits: List[str] = []
+        skip = {".git", "node_modules", "__pycache__", ".venv", "venv",
+                ".mypy_cache", ".pytest_cache", "dist", "build"}
+        try:
+            walker = os.walk(str(root))
+            for dirpath, dirnames, filenames in itertools.islice(walker, 4000):
+                dirnames[:] = [d for d in dirnames
+                               if d not in skip and not d.startswith(".")]
+                rel_dir = os.path.relpath(dirpath, str(root))
+                for name in filenames:
+                    if name.startswith("."):
+                        continue
+                    rel = name if rel_dir == "." else os.path.join(rel_dir, name)
+                    low = rel.lower()
+                    if not frag or low.startswith(frag) or frag in low:
+                        hits.append(rel)
+                        if len(hits) >= self._max * 4:
+                            break
+                if len(hits) >= self._max * 4:
+                    break
+        except Exception:  # noqa: BLE001
+            return hits[: self._max]
+        # Prefix matches first — what the operator is typing beats what merely
+        # contains it — then shortest, since a shallower path is likelier the
+        # one meant.
+        hits.sort(key=lambda r: (0 if r.lower().startswith(frag) else 1, len(r)))
+        return hits[: self._max]
+
+
 def registry_from_dispatch() -> VerbRegistry:
     """Build a :class:`VerbRegistry` from the AUTO-DISCOVERED dispatch table.
 
@@ -1783,6 +1866,16 @@ def build_attach_completer() -> Optional[object]:
         )
         if completer is None:
             return None
+        # `/` opens verbs, `@` opens files. One surface, two vocabularies —
+        # dispatched on the sigil the operator typed rather than on a mode
+        # they have to enter.
+        try:
+            from prompt_toolkit.completion import merge_completers
+            completer = merge_completers(
+                [completer, MentionPathCompleter()],
+            )
+        except Exception:  # noqa: BLE001 — verbs alone still complete
+            pass
         try:
             from prompt_toolkit.completion import ThreadedCompleter
             return ThreadedCompleter(completer)

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -1145,6 +1145,32 @@ def _maybe_summon_audio_plane(client: Any, cmd: str) -> None:
         pass
 
 
+def _extract_mentions(text: str) -> list:
+    """The `@path` mentions in a line, via the ONE parser that defines them.
+
+    Delegates to `repl_input_polish.extract_attachments` rather than matching
+    `@\\S+` here: that module already decides what counts — `@here` is prose,
+    a real path is a mention — and a second rule would eventually disagree
+    with the daemon about which is which.
+    """
+    try:
+        from backend.core.ouroboros.battle_test.repl_input_polish import (
+            extract_attachments, is_polish_enabled,
+        )
+        if not is_polish_enabled():
+            return []
+        return list(extract_attachments(text).paths or ())
+    except Exception:  # noqa: BLE001
+        return []
+
+
+def _short_path(path: str) -> str:
+    """Filename plus its parent — enough to disambiguate, short enough to
+    sit in a flash message."""
+    parts = [p for p in str(path or "").split("/") if p]
+    return "/".join(parts[-2:]) if len(parts) >= 2 else (parts[-1] if parts else "")
+
+
 def _route_operator_line(client: Any, ui: Any, line: Any) -> str:
     """THE one operator-line router — shared by the legacy split-plane loop AND
     the Bipartite cockpit (DRY: verbs behave identically on both surfaces).
@@ -1190,6 +1216,29 @@ def _route_operator_line(client: Any, ui: Any, line: Any) -> str:
         if text:
             if ui is not None and ui.should_flush_on_input():
                 client.send_audio("flush")
+            # @path mentions, acknowledged HERE rather than silently relayed.
+            #
+            # `repl_input_polish` has parsed these since it shipped — but it
+            # was wired into SerpentFlow's own REPL, which lives on a headless
+            # daemon nobody types into. The operator's actual input surface
+            # never called it, so `@backend/auth.py` travelled upstream as
+            # ordinary prose.
+            #
+            # The line is relayed UNCHANGED. Stripping the mention here would
+            # make the cockpit and the daemon disagree about what was said,
+            # and the daemon is where attachment resolution belongs. This
+            # confirms the operator was understood; it does not decide.
+            _mentions = _extract_mentions(text)
+            if _mentions and ui is not None:
+                try:
+                    ui.flash(
+                        f"attached {len(_mentions)} file"
+                        f"{'s' if len(_mentions) != 1 else ''}: "
+                        + ", ".join(_short_path(m) for m in _mentions[:3]),
+                        seconds=3.0,
+                    )
+                except Exception:  # noqa: BLE001
+                    pass
             client.send_input(text)
             return "sent"
         return "empty"

--- a/tests/cli/test_file_mentions.py
+++ b/tests/cli/test_file_mentions.py
@@ -1,0 +1,200 @@
+"""`@path` mentions on the surface the operator actually types into.
+
+`repl_input_polish.extract_attachments` has parsed these since it shipped —
+but it was wired into SerpentFlow's own REPL, which lives on a headless daemon
+nobody types into. The operator's input surface never called it, so
+`@backend/auth.py` travelled upstream as ordinary prose.
+
+Ninth instance this session of a producer wired to a surface nobody watches.
+
+And a mention the operator cannot TYPE is a feature only someone who already
+knows the tree can use — so completion is half the work, not a nicety.
+"""
+from __future__ import annotations
+
+import contextlib
+import io
+from pathlib import Path
+from typing import Any, List
+
+import pytest
+
+from prompt_toolkit.document import Document
+
+from backend.core.ouroboros.battle_test.repl_completion import (
+    MentionPathCompleter,
+)
+
+_REPO = Path(__file__).resolve().parents[2]
+
+
+def _ov():
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+        from backend.core.ouroboros.cli import ov
+    return ov
+
+
+class _Client:
+    def __init__(self) -> None:
+        self.sent: List[str] = []
+
+    def send_input(self, text: str) -> bool:
+        self.sent.append(text)
+        return True
+
+    def send_audio(self, _cmd: str) -> bool:
+        return True
+
+
+def _complete(probe: str, limit: int = 5) -> List[str]:
+    c = MentionPathCompleter(root=str(_REPO))
+    return [x.text for x in c.get_completions(Document(probe), None)][:limit]
+
+
+# --------------------------------------------------------------------------
+# 1. the client recognises a mention
+# --------------------------------------------------------------------------
+
+def test_a_real_path_is_recognised() -> None:
+    assert _ov()._extract_mentions("look at @backend/core/auth.py please") == [
+        "backend/core/auth.py",
+    ]
+
+
+def test_prose_is_not_a_mention() -> None:
+    """`@here` is a word. The parser that already decides this is the ONE
+    that decides it — a second rule in the client would eventually disagree
+    with the daemon about which is which."""
+    assert _ov()._extract_mentions("hey @here can you look") == []
+
+
+def test_several_mentions_keep_their_order() -> None:
+    assert _ov()._extract_mentions("@a/b.py and @c/d.py") == ["a/b.py", "c/d.py"]
+
+
+@pytest.mark.parametrize("junk", ["", None, 42, "   "])
+def test_extraction_never_raises(junk: Any) -> None:
+    assert isinstance(_ov()._extract_mentions(junk), list)
+
+
+# --------------------------------------------------------------------------
+# 2. the line is relayed UNCHANGED
+# --------------------------------------------------------------------------
+
+def test_the_daemon_receives_the_original_line() -> None:
+    """Stripping the mention client-side would make the two surfaces disagree
+    about what was said — and attachment resolution belongs on the daemon,
+    which is where the files are."""
+    ov = _ov()
+    client, ui = _Client(), ov.AttachUI()
+    ov._route_operator_line(client, ui, "fix @backend/core/auth.py now")
+    assert client.sent == ["fix @backend/core/auth.py now"]
+
+
+def test_the_operator_is_told_they_were_understood() -> None:
+    """A mention that produces no acknowledgement is indistinguishable from
+    one that was read as prose."""
+    ov = _ov()
+    ui = ov.AttachUI()
+    ov._route_operator_line(_Client(), ui, "fix @backend/core/auth.py")
+    assert "attached" in ui.prompt()
+
+
+def test_a_line_with_no_mention_says_nothing() -> None:
+    ov = _ov()
+    ui = ov.AttachUI()
+    ov._route_operator_line(_Client(), ui, "just a normal goal")
+    assert "attached" not in ui.prompt()
+
+
+def test_the_acknowledgement_stays_short() -> None:
+    """Ten mentions must not push the deck off screen."""
+    ov = _ov()
+    ui = ov.AttachUI()
+    line = " ".join(f"@a/f{i}.py" for i in range(10))
+    ov._route_operator_line(_Client(), ui, line)
+    flash = [ln for ln in ui.prompt().splitlines() if "attached" in ln]
+    assert flash and len(flash[0]) < 120
+
+
+# --------------------------------------------------------------------------
+# 3. mentions are typeable
+# --------------------------------------------------------------------------
+
+def test_a_partial_path_completes() -> None:
+    out = _complete("see @thin_cl")
+    assert any("thin_client.py" in p for p in out)
+
+
+def test_a_directory_prefix_completes() -> None:
+    out = _complete("fix @backend/core/ouroboros/cli/o")
+    assert any(p.endswith("ov.py") for p in out)
+
+
+def test_prefix_matches_rank_above_mere_containment() -> None:
+    """What the operator is typing beats what merely contains it."""
+    out = _complete("@backend/core/ouroboros/cli/ov")
+    assert out and out[0].startswith("backend/core/ouroboros/cli/ov")
+
+
+def test_no_sigil_offers_nothing() -> None:
+    """Completion must not fire on ordinary prose."""
+    assert _complete("no sigil here") == []
+
+
+def test_a_finished_mention_stops_completing() -> None:
+    """An `@` earlier in a sentence must not re-open the menu on every later
+    keystroke."""
+    assert _complete("done @a/b.py and then") == []
+
+
+def test_results_are_bounded() -> None:
+    """A bare `@` matches everything; the menu must stay a menu."""
+    assert len(_complete("@", limit=999)) <= 12
+
+
+def test_it_is_rooted_in_the_REPO_not_the_cwd() -> None:
+    """prompt_toolkit's PathCompleter completes from the process CWD and
+    would offer `/etc/passwd`. Mentions name files the organism works on, so
+    the walk is rooted there and cannot climb out — a completer offering what
+    the daemon will refuse to read teaches nothing."""
+    import ast
+    import inspect
+    import textwrap
+
+    src = textwrap.dedent(inspect.getsource(MentionPathCompleter))
+    assert "JARVIS_REPO_PATH" in src
+    # AST, not substring: this class's own DOCSTRING explains that it is
+    # deliberately NOT PathCompleter, and a text search cannot tell that
+    # explanation from a use of it. (Use-vs-mention — the fifth time this
+    # trap has caught a test in this codebase.)
+    used = {
+        alias.name
+        for node in ast.walk(ast.parse(src))
+        if isinstance(node, (ast.Import, ast.ImportFrom))
+        for alias in node.names
+    }
+    assert "PathCompleter" not in used
+
+
+def test_noise_directories_are_skipped() -> None:
+    out = _complete("@", limit=999)
+    assert not any(".git/" in p or "__pycache__" in p for p in out)
+
+
+def test_completion_never_raises_on_a_bad_root() -> None:
+    c = MentionPathCompleter(root="/nonexistent/nowhere")
+    assert list(c.get_completions(Document("@x"), None)) == []
+
+
+def test_the_verb_palette_still_works_alongside_it() -> None:
+    """One surface, two vocabularies — `/` for verbs, `@` for files. Adding
+    the second must not cost the first."""
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+        from backend.core.ouroboros.cli.ov import _build_slash_completer
+        completer = _build_slash_completer()
+    inner = getattr(completer, "completer", completer)
+    out = [c.text for c in inner.get_completions(Document("/"), None)]
+    assert len(out) > 50


### PR DESCRIPTION
`repl_input_polish.extract_attachments` has parsed `@path` mentions since it shipped — wired into SerpentFlow's own REPL, which lives on a **headless daemon nobody types into**. The operator's actual input surface never called it, so `@backend/auth.py` travelled upstream as ordinary prose.

**Ninth instance this session** of a producer wired to a surface nobody watches.

### The line is relayed unchanged
Stripping the mention client-side would make the two surfaces disagree about what was said — and attachment resolution belongs on the daemon, which is where the files are.

The client **confirms** the operator was understood; it doesn't decide:

```
attached 1 file: core/auth.py
```

A mention producing no acknowledgement is indistinguishable from one read as prose.

Extraction delegates to the module that already defines what counts — `@here` is prose, a real path is a mention. A second rule in the client would eventually disagree with the daemon about which is which.

### And mentions are now typeable
A mention the operator cannot **type** is a feature only someone who already knows the tree can use — so completion is half the work, not a nicety.

```
@thin_cl  →  backend/core/ouroboros/cli/thin_client.py
              tests/cli/test_thin_client.py
```

`/` still opens verbs. One surface, two vocabularies, dispatched on the **sigil** rather than on a mode the operator has to enter.

### Deliberately not PathCompleter
prompt_toolkit's completes from the process **CWD** and would offer `/etc/passwd`. Mentions name files in the **repo** the organism works on, so the walk is rooted there and cannot climb out — a completer offering what the daemon will then refuse to read teaches the operator nothing.

Bounded, prefix-first, noise directories skipped: an unbounded walk on every keystroke stalls the very keystroke that opened it — the failure the threaded completer exists to avoid, reintroduced one layer down. A **finished** mention stops completing, so an `@` earlier in a sentence doesn't re-open the menu on every later character.

### Tests
21. **653 passing.**

One of my own tests failed on use-vs-mention for the **fifth** time here: it grepped for `PathCompleter` in a class whose docstring explains it deliberately isn't one. Rewritten against the AST — the form that survives its own prose.

### Remaining
Unbounded scrollback · image/paste input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `@path` mentions to the operator’s input surface. Lines are still sent unchanged to the daemon, and the UI now confirms attached files.

- **New Features**
  - Mention detection: delegates to `repl_input_polish.extract_attachments`; real paths are mentions, `@here` is prose; order preserved.
  - UI feedback: flashes “attached N file(s): name/...”, without altering the line sent upstream.
  - Autocomplete: new `MentionPathCompleter` merged with the `/` verb palette; repo-rooted via `JARVIS_REPO_PATH` or repo root; bounded results; skips noise dirs; prefix-first ranking; stops after a finished mention; does not use `prompt_toolkit`’s `PathCompleter`.

<sup>Written for commit f14f09a134df282ee92c68b5c5deaf22a4501737. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

