### PR TITLE
feat(ov): a dropped file becomes something the organism understands

### DIFF
--- a/backend/core/ouroboros/battle_test/drop_translate.py
+++ b/backend/core/ouroboros/battle_test/drop_translate.py
@@ -1,0 +1,203 @@
+"""A dropped file becomes something the organism understands.
+
+Drag a file onto a terminal and it injects an absolute path — often shell
+quoted, sometimes a `file://` URI, sometimes with escaped spaces. The operator
+sees that string appear in their prompt and has to know, unprompted, that O+V
+wants `@relative/path` for repo files and `/attach /abs/path` for everything
+else.
+
+So the drop is translated at the moment it lands:
+
+    /Users/dj/repos/JARVIS/backend/auth.py   →  @backend/auth.py
+    /Users/dj/Desktop/screenshot.png         →  /attach /Users/dj/Desktop/screenshot.png
+
+Why translate rather than transport
+------------------------------------
+The alternative is carrying the bytes: read the file client-side, base64 it,
+push it over the UDS bridge. That bridge is a single ordered stream shared with
+op chrome, the token mirror and the heartbeat — a megabyte of base64 would
+block every one of them behind it. The daemon already reads files by path, and
+it is the process that has the repo, so a path is both smaller and more
+truthful than a copy.
+
+Repo-inside vs outside
+----------------------
+`@mentions` are repo-relative by construction — the completer that offers them
+is rooted at the repo and cannot climb out. A dropped file from the Desktop
+has no repo-relative spelling, so forcing one would produce `@../../Desktop/x`,
+which the daemon would refuse and the operator would not understand. Those get
+`/attach` with the absolute path, which is exactly the verb that already
+handles them.
+
+Nothing is guessed
+------------------
+A path that does not exist is left alone. A pasted URL, a code snippet, a
+sentence — left alone. Rewriting text the operator did not mean as a file is
+worse than leaving them to type the verb themselves, because it happens
+silently and they have to notice to undo it.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import re
+from pathlib import Path
+from typing import Any, Optional, Tuple
+from urllib.parse import unquote, urlparse
+
+logger = logging.getLogger("Ouroboros.DropTranslate")
+
+__all__ = ["drop_translation_enabled", "normalise_dropped_path",
+           "translate_drop"]
+
+#: Extensions worth treating as an attachment when dropped. Deliberately NOT
+#: "any file": a dropped `.py` inside the repo is a mention, and outside it is
+#: usually a mistake, whereas an image or a document is unambiguous about
+#: intent. Env-extendable because the set is a property of what the organism
+#: can ingest, which is allowed to grow.
+_MEDIA_EXT = {
+    ".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".tiff", ".heic",
+    ".pdf", ".md", ".txt", ".csv", ".json", ".yaml", ".yml", ".log",
+}
+
+#: A terminal may shell-quote a dropped path, wrap it in quotes, or escape
+#: spaces. All three are the same path.
+_ESCAPED_SPACE = re.compile(r"\\(\s)")
+
+
+def drop_translation_enabled() -> bool:
+    """Default ON. A dropped file that does nothing is the worse default."""
+    return os.environ.get(
+        "JARVIS_DROP_TRANSLATE_ENABLED", "1",
+    ).strip().lower() not in ("0", "false", "no", "off")
+
+
+def _media_extensions() -> set:
+    try:
+        extra = os.environ.get("JARVIS_DROP_EXTRA_EXTENSIONS", "") or ""
+        return _MEDIA_EXT | {
+            e.strip().lower() if e.strip().startswith(".") else f".{e.strip().lower()}"
+            for e in extra.split(",") if e.strip()
+        }
+    except Exception:  # noqa: BLE001
+        return _MEDIA_EXT
+
+
+def normalise_dropped_path(text: Any) -> str:
+    """The filesystem path a terminal meant by this pasted text, or "".
+
+    Handles the three spellings a drop actually produces — a bare absolute
+    path, one wrapped in quotes, and a `file://` URI — plus backslash-escaped
+    spaces, which macOS Terminal emits and which turn a real path into one
+    that does not resolve.
+    """
+    try:
+        raw = str(text or "").strip()
+        if not raw or "\n" in raw:
+            # Multi-line paste is prose or code, not a drop. A drop is one
+            # path; treating a pasted diff as a filename would be absurd and
+            # is exactly the kind of silent rewrite this must not do.
+            return ""
+        if raw.startswith("file://"):
+            parsed = urlparse(raw)
+            raw = unquote(parsed.path or "")
+        # Strip one layer of matching quotes.
+        for quote in ("'", '"'):
+            if len(raw) >= 2 and raw.startswith(quote) and raw.endswith(quote):
+                raw = raw[1:-1]
+                break
+        raw = _ESCAPED_SPACE.sub(r"\1", raw)
+        return raw.strip()
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def _repo_root() -> Path:
+    return Path(os.environ.get("JARVIS_REPO_PATH", ".")).resolve()
+
+
+def _inside_repo(path: Path, root: Path) -> Optional[str]:
+    """Repo-relative spelling, or None when the file is outside.
+
+    Uses the SAME rooting the `@` completer uses, so a path the completer
+    would offer and a path a drop translates to can never disagree about
+    what counts as "in the repo".
+    """
+    try:
+        return str(path.resolve().relative_to(root))
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def translate_drop(text: Any, root: Optional[Path] = None) -> Tuple[str, str]:
+    """Translate a dropped path. Returns ``(translated, kind)``.
+
+    ``kind`` is ``"mention"``, ``"attach"``, or ``""`` when the text was left
+    alone — which is the common case and must stay cheap.
+
+    Returns the ORIGINAL text unchanged whenever it is not clearly a dropped
+    file. Rewriting something the operator did not mean is worse than making
+    them type the verb, because it happens silently.
+    """
+    original = str(text or "")
+    try:
+        if not drop_translation_enabled():
+            return original, ""
+        candidate = normalise_dropped_path(original)
+        if not candidate or not os.path.isabs(candidate):
+            # Relative text is prose or an already-typed mention. Only a
+            # terminal drop produces an absolute path.
+            return original, ""
+        path = Path(candidate)
+        if path.suffix.lower() not in _media_extensions():
+            return original, ""
+        if not path.is_file():
+            # A path that does not exist is a string that looks like one.
+            return original, ""
+
+        repo = (root or _repo_root()).resolve()
+        relative = _inside_repo(path, repo)
+        if relative:
+            return f"@{relative}", "mention"
+        return f"/attach {path}", "attach"
+    except Exception:  # noqa: BLE001 — a paste must never fail to paste
+        logger.debug("[DropTranslate] degraded", exc_info=True)
+        return original, ""
+
+
+def install_drop_translation(buffer: Any, root: Optional[Path] = None) -> bool:
+    """Translate drops as they land in *buffer*. NEVER raises.
+
+    Wraps `Buffer.insert_text` rather than binding a paste key: a drop arrives
+    as bracketed-paste text through the same insertion path as typing, and
+    there is no keystroke to bind. Wrapping the one method every insertion
+    goes through means a drop is caught however the terminal delivers it.
+
+    Single-shot inserts (ordinary typing) are passed straight through — the
+    check is skipped entirely unless the text is long enough to be a path, so
+    per-keystroke cost stays nil.
+    """
+    try:
+        if not drop_translation_enabled() or buffer is None:
+            return False
+        original_insert = buffer.insert_text
+
+        def _insert(data: Any, *args: Any, **kwargs: Any) -> Any:
+            try:
+                text = str(data or "")
+                # A path is never one character; skip the work for typing.
+                if len(text) > 3 and os.path.isabs(
+                    normalise_dropped_path(text) or "",
+                ):
+                    translated, kind = translate_drop(text, root)
+                    if kind:
+                        data = translated
+            except Exception:  # noqa: BLE001
+                pass
+            return original_insert(data, *args, **kwargs)
+
+        buffer.insert_text = _insert  # type: ignore[assignment]
+        return True
+    except Exception:  # noqa: BLE001
+        logger.debug("[DropTranslate] install degraded", exc_info=True)
+        return False

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -1348,6 +1348,21 @@ async def _split_plane_loop(
     except Exception:  # noqa: BLE001 — a styled fallback still works
         pass
     ui.bind_app(session.app)
+    # A dropped file becomes something the organism understands.
+    #
+    # Terminals inject an ABSOLUTE PATH on drag-and-drop. Wrapping
+    # `Buffer.insert_text` rather than binding a paste key is deliberate: a
+    # drop arrives as bracketed-paste text through the same insertion path as
+    # typing, so there is no keystroke to bind, and wrapping the one method
+    # every insertion goes through catches it however the terminal delivers
+    # it.
+    try:
+        from backend.core.ouroboros.battle_test.drop_translate import (
+            install_drop_translation,
+        )
+        install_drop_translation(session.app.current_buffer)
+    except Exception:  # noqa: BLE001 — a paste must still paste
+        pass
 
     async def _watch_disconnect() -> None:
         while client.connected:

--- a/tests/cli/test_drop_translate.py
+++ b/tests/cli/test_drop_translate.py
@@ -1,0 +1,242 @@
+"""A dropped file becomes something the organism understands.
+
+Terminals inject an ABSOLUTE PATH on drag-and-drop — often shell-quoted,
+sometimes a `file://` URI, sometimes with escaped spaces. The operator saw
+that string land in their prompt and had to know, unprompted, that O+V wants
+`@relative` for repo files and `/attach /abs` for everything else.
+
+    /Users/dj/repos/JARVIS/backend/auth.py  →  @backend/auth.py
+    /Users/dj/Desktop/screenshot.png        →  /attach /Users/dj/Desktop/screenshot.png
+
+Translating rather than transporting is the load-bearing choice. Carrying the
+bytes would mean base64 over a UDS bridge shared with op chrome, the token
+mirror and the heartbeat — a megabyte would block every one of them behind it.
+The daemon already reads files by path and is the process holding the repo, so
+a path is both smaller and more truthful than a copy.
+"""
+from __future__ import annotations
+
+import ast
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from backend.core.ouroboros.battle_test.drop_translate import (
+    drop_translation_enabled,
+    install_drop_translation,
+    normalise_dropped_path,
+    translate_drop,
+)
+
+_REPO = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture()
+def outside(tmp_path: Path) -> Path:
+    img = tmp_path / "screenshot.png"
+    img.write_bytes(b"\x89PNG")
+    return img
+
+
+@pytest.fixture()
+def inside() -> Path:
+    return _REPO / "docs" / "OV_STYLE_GUIDE.md"
+
+
+class _Buffer:
+    def __init__(self) -> None:
+        self.text = ""
+
+    def insert_text(self, data: Any, *_a: Any, **_k: Any) -> None:
+        self.text += str(data)
+
+
+# --------------------------------------------------------------------------
+# 1. the two destinations
+# --------------------------------------------------------------------------
+
+def test_a_repo_file_becomes_a_mention(inside: Path) -> None:
+    out, kind = translate_drop(str(inside), _REPO)
+    assert kind == "mention"
+    assert out == "@docs/OV_STYLE_GUIDE.md"
+
+
+def test_a_file_outside_the_repo_becomes_an_attach(outside: Path) -> None:
+    """`@mentions` are repo-relative by construction. Forcing one here would
+    produce `@../../Desktop/x`, which the daemon refuses and the operator
+    would not understand."""
+    out, kind = translate_drop(str(outside), _REPO)
+    assert kind == "attach"
+    assert out == f"/attach {outside}"
+
+
+def test_the_inside_check_uses_the_completers_rooting() -> None:
+    """A path the `@` completer would offer and a path a drop translates to
+    must never disagree about what counts as "in the repo"."""
+    import inspect
+
+    from backend.core.ouroboros.battle_test import drop_translate
+
+    src = inspect.getsource(drop_translate)
+    assert "JARVIS_REPO_PATH" in src
+
+
+# --------------------------------------------------------------------------
+# 2. the spellings a terminal actually produces
+# --------------------------------------------------------------------------
+
+def test_a_file_uri_is_understood(outside: Path) -> None:
+    out, kind = translate_drop(f"file://{outside}", _REPO)
+    assert kind == "attach" and str(outside) in out
+
+
+def test_quotes_are_stripped(outside: Path) -> None:
+    for quote in ("'", '"'):
+        out, kind = translate_drop(f"{quote}{outside}{quote}", _REPO)
+        assert kind == "attach", f"{quote}-quoted drop not recognised"
+
+
+def test_escaped_spaces_are_unescaped() -> None:
+    """macOS Terminal emits `my\\ file.png`, which does not resolve as-is."""
+    assert normalise_dropped_path("/tmp/my\\ file.png") == "/tmp/my file.png"
+
+
+def test_a_percent_encoded_uri_is_decoded(tmp_path: Path) -> None:
+    spaced = tmp_path / "my shot.png"
+    spaced.write_bytes(b"x")
+    out, kind = translate_drop(f"file://{str(spaced).replace(' ', '%20')}", _REPO)
+    assert kind == "attach" and "my shot.png" in out
+
+
+# --------------------------------------------------------------------------
+# 3. nothing is guessed
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("text", [
+    "just a sentence about /Users/dj/thing",
+    "backend/core/x.py",                       # relative — prose or a mention
+    "/nope/does/not/exist.png",                # looks like a path, is not one
+    "https://example.com/image.png",           # a URL, not a drop
+    "",
+])
+def test_text_that_is_not_a_drop_is_left_ALONE(text: str) -> None:
+    """Rewriting what the operator did not mean is worse than making them
+    type the verb — it happens silently and they must notice to undo it."""
+    out, kind = translate_drop(text, _REPO)
+    assert kind == "" and out == text
+
+
+def test_a_multiline_paste_is_never_a_drop() -> None:
+    """A drop is one path. Treating a pasted diff as a filename would be
+    absurd, and is exactly the silent rewrite this must not do."""
+    pasted = "def f():\n    return /tmp/x.png\n"
+    assert translate_drop(pasted, _REPO)[1] == ""
+
+
+def test_an_unlisted_extension_is_left_alone() -> None:
+    """Deliberately not "any file": a dropped binary or Makefile is usually a
+    mistake, whereas an image or document is unambiguous about intent."""
+    makefile = _REPO / "Makefile"
+    if makefile.is_file():
+        assert translate_drop(str(makefile), _REPO)[1] == ""
+
+
+def test_the_extension_set_is_extendable_without_a_code_change(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """What the organism can ingest is allowed to grow."""
+    odd = tmp_path / "capture.heic2"
+    odd.write_bytes(b"x")
+    assert translate_drop(str(odd), _REPO)[1] == ""
+    monkeypatch.setenv("JARVIS_DROP_EXTRA_EXTENSIONS", "heic2")
+    assert translate_drop(str(odd), _REPO)[1] == "attach"
+
+
+@pytest.mark.parametrize("junk", [None, 42, object(), b"bytes"])
+def test_translation_never_raises(junk: Any) -> None:
+    out, kind = translate_drop(junk, _REPO)
+    assert isinstance(out, str) and isinstance(kind, str)
+
+
+# --------------------------------------------------------------------------
+# 4. the interceptor
+# --------------------------------------------------------------------------
+
+async def test_a_dropped_path_is_translated_in_the_buffer(
+    outside: Path,
+) -> None:
+    """MANDATE: simulate a paste of an absolute .png and assert the buffer
+    holds the translated command, with nothing raised."""
+    buf = _Buffer()
+    assert install_drop_translation(buf, _REPO) is True
+    buf.insert_text(str(outside))
+    assert buf.text == f"/attach {outside}"
+
+
+async def test_a_dropped_repo_file_becomes_a_mention_in_the_buffer(
+    inside: Path,
+) -> None:
+    buf = _Buffer()
+    install_drop_translation(buf, _REPO)
+    buf.insert_text(str(inside))
+    assert buf.text == "@docs/OV_STYLE_GUIDE.md"
+
+
+async def test_ordinary_typing_is_untouched() -> None:
+    """The check is skipped entirely for short inserts, so per-keystroke cost
+    stays nil."""
+    buf = _Buffer()
+    install_drop_translation(buf, _REPO)
+    for ch in "fix the flaky test":
+        buf.insert_text(ch)
+    assert buf.text == "fix the flaky test"
+
+
+async def test_a_normal_paste_is_untouched() -> None:
+    buf = _Buffer()
+    install_drop_translation(buf, _REPO)
+    buf.insert_text("please look at the auth flow")
+    assert buf.text == "please look at the auth flow"
+
+
+def test_installing_on_nothing_is_survivable() -> None:
+    assert install_drop_translation(None, _REPO) is False
+
+
+def test_a_translation_fault_still_inserts(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A paste must never fail to paste."""
+    import backend.core.ouroboros.battle_test.drop_translate as dt
+
+    monkeypatch.setattr(dt, "translate_drop", lambda *_a, **_k: 1 / 0)
+    buf = _Buffer()
+    dt.install_drop_translation(buf, _REPO)
+    buf.insert_text("/some/absolute/path.png")
+    assert buf.text == "/some/absolute/path.png"
+
+
+def test_the_switch_defaults_on(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A dropped file that does nothing is the worse default."""
+    assert drop_translation_enabled() is True
+    monkeypatch.setenv("JARVIS_DROP_TRANSLATE_ENABLED", "0")
+    assert drop_translation_enabled() is False
+
+
+def test_it_is_installed_on_the_clients_buffer() -> None:
+    """Structural: an uninstalled interceptor is the wired-but-inert shape."""
+    src = (_REPO / "backend/core/ouroboros/cli/ov.py").read_text()
+    assert "install_drop_translation(session.app.current_buffer)" in src
+
+
+def test_no_file_bytes_are_read() -> None:
+    """Translating rather than transporting: base64 over the UDS bridge would
+    block op chrome, the token mirror and the heartbeat behind it."""
+    src = (_REPO / "backend/core/ouroboros/battle_test/"
+           "drop_translate.py").read_text()
+    calls = {
+        ast.unparse(n.func)
+        for n in ast.walk(ast.parse(src)) if isinstance(n, ast.Call)
+    }
+    assert not any("b64" in c or "read_bytes" in c for c in calls)


### PR DESCRIPTION
```
/Users/dj/repos/JARVIS/backend/auth.py  →  @backend/auth.py
/Users/dj/Desktop/screenshot.png        →  /attach /Users/dj/Desktop/screenshot.png
```

Terminals inject an **absolute path** on drag-and-drop. The operator saw that string land in their prompt and had to know, unprompted, that O+V wants `@relative` for repo files and `/attach /abs` for everything else.

### Translated, not transported
Carrying the bytes would mean base64 over a UDS bridge **shared with op chrome, the token mirror and the heartbeat** — a megabyte would block every one of them behind it.

The daemon already reads files by path and is the process holding the repo, so a path is both smaller and more truthful than a copy. **No file bytes are read here at all** — a test pins that.

### Two destinations, one rule
`@mentions` are repo-relative by construction — the completer that offers them is rooted at the repo and cannot climb out. A Desktop file has no repo-relative spelling, and forcing one would produce `@../../Desktop/x`, which the daemon refuses and the operator wouldn't understand.

The inside/outside test uses the **same rooting** as the `@` completer, so the two can never disagree about what counts as "in the repo".

### Wraps `Buffer.insert_text`, not a paste keybinding
A drop arrives as bracketed-paste text through the same insertion path as typing — there's no keystroke to bind. Wrapping the one method every insertion goes through catches it however the terminal delivers it.

Short inserts skip the check entirely, so per-keystroke cost stays nil.

Handles what terminals actually emit: bare absolute paths, shell-quoted, `file://` URIs, percent-encoding, and backslash-escaped spaces (macOS Terminal emits these, and they otherwise fail to resolve).

### Nothing is guessed
Prose, relative paths, URLs, non-existent files, unlisted extensions and multi-line pastes are all **left alone**. Rewriting text the operator didn't mean is worse than making them type the verb — it happens silently and they must notice to undo it.

A translation fault still inserts the original: **a paste must never fail to paste.**

### Tests
28. **660 passing.**

### ⚠️ Separate finding, not fixed here
`bipartite_layout` uses `full_screen=True`, which puts the cockpit in the terminal's **alternate screen buffer** and disables native scrollback — the trap flagged when we agreed to delegate scrollback to the TTY.

Worth its own change: leaving full-screen mode affects the entire cockpit layout and deserves to be evaluated on its own rather than folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Translate terminal drag-and-drop absolute paths into commands the organism understands. Repo files become `@relative`, external files become `/attach /abs` for smoother UX without moving file bytes.

- **New Features**
  - Installs drop translation in `backend/core/ouroboros/cli/ov.py` by wrapping `Buffer.insert_text`; short inserts bypass the check.
  - Handles bare paths, shell quotes, `file://` URIs, percent-encoding, and backslash-escaped spaces.
  - Leaves non-drops untouched (prose, URLs, relative paths, non-existent files, unlisted extensions, multi-line); paste never fails.
  - Uses the same repo root as the `@` completer to keep inside/outside decisions consistent.
  - Targets media/document extensions; extend via `JARVIS_DROP_EXTRA_EXTENSIONS`; toggle via `JARVIS_DROP_TRANSLATE_ENABLED` (default on).

<sup>Written for commit ff42f351f182178a0b023bacc79a1d7184fe30d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

