### PR TITLE
feat(ov): Enter submits, unless the text is visibly unfinished

### DIFF
--- a/backend/core/ouroboros/battle_test/bipartite_layout.py
+++ b/backend/core/ouroboros/battle_test/bipartite_layout.py
@@ -505,7 +505,21 @@ def build_bipartite_application(
     # why the completer built in D5 yielded 76 correct verbs and the operator
     # saw nothing: the menu had nowhere to exist.
     prompt = TextArea(
-        height=1, prompt=[("fg:#5ee06a bold", "❯ ")], multiline=False,
+        # Multi-line, with the CONDITION applied to the buffer just below.
+        #
+        # The old `multiline=False` did not only stop the operator typing a
+        # second line — it made a PASTED block lose its newlines, silently
+        # collapsing a stack trace into one line. That is data loss.
+        #
+        # Passing the condition HERE does not work, despite the parameter
+        # being annotated `FilterOrBool`: TextArea branches on the raw
+        # truthiness (`if multiline:`) before any `to_filter`, and a Filter
+        # raises ValueError on `__bool__`. So the literal True selects the
+        # growable branch — the falsy one hard-clamps `height = D.exact(1)`,
+        # which would put the caret below the fold on line two — and the
+        # buffer gets the real rule afterwards.
+        height=Dimension(min=1, max=8), multiline=True,
+        prompt=[("fg:#5ee06a bold", "❯ ")],
         wrap_lines=False, style="class:command-deck",
         completer=completer,
         complete_while_typing=bool(completer is not None),
@@ -520,8 +534,27 @@ def build_bipartite_application(
         return False  # clear the buffer after accept
 
     prompt.buffer.accept_handler = _accept
+    # Enter submits unless the text is visibly unfinished. `Buffer.multiline`
+    # is the library's OWN seam — it stores a Filter and `is_multiline` calls
+    # it per keystroke — so this needs no custom Enter binding to fight with.
+    try:
+        from backend.core.ouroboros.battle_test.input_continuation import (
+            continuation_filter,
+        )
+        prompt.buffer.multiline = continuation_filter(lambda: prompt.buffer.text)
+    except Exception:  # noqa: BLE001 — plain multiline still beats one line
+        logger.debug("[Bipartite] continuation rule degraded", exc_info=True)
 
     kb = KeyBindings()
+    # Alt+Enter, from the same module that decides when Enter continues — so
+    # the rule and its escape hatch can never be wired on different surfaces.
+    try:
+        from backend.core.ouroboros.battle_test.input_continuation import (
+            install_newline_binding,
+        )
+        install_newline_binding(kb)
+    except Exception:  # noqa: BLE001
+        pass
 
     @kb.add("c-c")
     @kb.add("c-d")

--- a/backend/core/ouroboros/battle_test/input_continuation.py
+++ b/backend/core/ouroboros/battle_test/input_continuation.py
@@ -1,0 +1,207 @@
+"""When Enter means "another line" instead of "go".
+
+A goal worth giving an autonomous organism is often longer than one line — a
+paragraph of context, a pasted traceback, a list of constraints. The prompt
+accepted exactly one line, so those had to be flattened by hand.
+
+And it was not only a limit on typing. With `multiline=False`, a PASTED block
+loses its newlines: an operator pasting a stack trace got it silently
+collapsed into one line, which is data loss rather than inconvenience.
+
+Enter still submits
+-------------------
+The obvious fix — turn multiline on — breaks submission: Enter starts
+inserting newlines and there is no longer a key that means "go". So the
+buffer is conditionally multiline. Enter submits UNLESS the text is visibly
+unfinished, and "unfinished" is decided by the same rules every REPL and shell
+already taught operators:
+
+  * a trailing backslash — the shell's own continuation mark;
+  * an unclosed code fence — pasting half a ``` block and having it submit is
+    the most annoying possible outcome;
+  * an unbalanced bracket — a half-typed dict or call.
+
+Alt+Enter always inserts a newline, for prose that ends in none of those.
+
+Why not "Enter always inserts, Ctrl+D submits"
+-----------------------------------------------
+Because the common case is one line. Making every short goal cost two
+keystrokes to save the rare long one is the wrong trade, and it breaks the
+muscle memory of every operator who has ever used a prompt.
+
+Detection is SYNTACTIC and cheap — no parsing, no language awareness. A rule
+that guesses wrong holds the operator's input hostage, so every ambiguous case
+resolves to SUBMIT: the escape hatch (Alt+Enter) is always available, whereas
+a prompt that refuses to submit has no escape at all.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+logger = logging.getLogger("Ouroboros.InputContinuation")
+
+__all__ = ["multiline_enabled", "wants_continuation",
+           "strip_continuations", "install_newline_binding",
+           "continuation_filter"]
+
+_OPENERS = {"(": ")", "[": "]", "{": "}"}
+_CLOSERS = {v: k for k, v in _OPENERS.items()}
+
+
+def multiline_enabled() -> bool:
+    """Default ON. A prompt that silently eats a pasted traceback is worse."""
+    return os.environ.get(
+        "JARVIS_INPUT_MULTILINE_ENABLED", "1",
+    ).strip().lower() not in ("0", "false", "no", "off")
+
+
+def _fence_is_open(text: str) -> bool:
+    """An odd number of ``` fences means one is still open."""
+    return text.count("```") % 2 == 1
+
+
+def _brackets_unbalanced(text: str) -> bool:
+    """Is a bracket left open?
+
+    Quoted spans are skipped, so a lone `(` inside a string — `"a (smiley"` —
+    does not trap the operator. Depth is clamped at zero: a stray closer is
+    someone's prose, not a reason to demand more input.
+    """
+    depth = 0
+    quote = ""
+    escaped = False
+    for ch in text:
+        if escaped:
+            escaped = False
+            continue
+        if ch == "\\":
+            escaped = True
+            continue
+        if quote:
+            if ch == quote:
+                quote = ""
+            continue
+        if ch in ("'", '"', "`"):
+            quote = ch
+            continue
+        if ch in _OPENERS:
+            depth += 1
+        elif ch in _CLOSERS:
+            depth = max(0, depth - 1)
+    return depth > 0
+
+
+def wants_continuation(text: Any) -> bool:
+    """Should Enter add a line rather than submit? NEVER raises.
+
+    False for anything ambiguous. A prompt that refuses to submit has no
+    escape hatch; one that submits early can be retyped, and Alt+Enter is
+    always there for a deliberate newline.
+    """
+    try:
+        if not multiline_enabled():
+            return False
+        raw = str(text or "")
+        if not raw.strip():
+            # Enter on an empty buffer submits (a no-op), rather than
+            # silently growing blank lines the operator cannot see.
+            return False
+        # A trailing backslash is the shell's continuation mark and the one
+        # signal operators reach for without being told. Checked on the raw
+        # line-end so trailing spaces do not defeat it.
+        if raw.rstrip(" \t").endswith("\\"):
+            return True
+        if _fence_is_open(raw):
+            return True
+        # Bracket balance counts ONLY once the operator is already composing
+        # something multi-line. On a first line it is prose far more often
+        # than code — "the smiley is (: nice" would otherwise trap them in a
+        # prompt that will not submit, which is the exact hostage-taking this
+        # module's rules exist to avoid. By the second line the intent is
+        # structural and balance is a real signal.
+        if "\n" not in raw:
+            return False
+        return _brackets_unbalanced(raw)
+    except Exception:  # noqa: BLE001 — a stuck prompt is the worst outcome
+        logger.debug("[InputContinuation] degraded", exc_info=True)
+        return False
+
+
+def strip_continuations(text: Any) -> str:
+    """Remove the backslashes that only meant "keep going".
+
+    The daemon should receive the goal, not the typing mechanics. A fence or a
+    bracket is CONTENT and survives untouched; a trailing `\\` is punctuation
+    for the prompt and would otherwise reach the model as noise.
+    """
+    try:
+        lines = str(text or "").split("\n")
+        out = []
+        for line in lines:
+            stripped = line.rstrip(" \t")
+            out.append(stripped[:-1].rstrip() if stripped.endswith("\\")
+                       else line)
+        return "\n".join(out)
+    except Exception:  # noqa: BLE001
+        return str(text or "")
+
+
+def install_newline_binding(kb: Any) -> bool:
+    """Bind Alt+Enter to "insert a newline, whatever the rule thinks".
+
+    Load-bearing rather than a convenience. Every ambiguous case in
+    `wants_continuation` resolves to SUBMIT, and that is only safe BECAUSE a
+    deliberate newline is always one keystroke away. prompt_toolkit ships no
+    `escape enter` binding of its own — verified against the installed
+    library, not assumed — so without this the escape hatch the rules above
+    promise does not exist.
+
+    NEVER raises: a cockpit whose Enter key works is worth more than one that
+    refused to start over a binding.
+    """
+    try:
+        if kb is None or not multiline_enabled():
+            return False
+
+        @kb.add("escape", "enter")
+        def _newline(event: Any) -> None:
+            try:
+                event.current_buffer.insert_text("\n")
+            except Exception:  # noqa: BLE001
+                pass
+
+        return True
+    except Exception:  # noqa: BLE001
+        logger.debug("[InputContinuation] newline binding degraded",
+                     exc_info=True)
+        return False
+
+
+def continuation_filter(get_text: Any) -> Any:
+    """A `Buffer.multiline` filter over *get_text*. NEVER raises.
+
+    Bound to ONE buffer's text rather than reading `get_app().current_buffer`.
+    The focused buffer is usually the prompt, but "usually" is how a rule ends
+    up consulting the wrong text the moment focus moves to a lane or a menu —
+    and a filter that reads the wrong buffer fails in the direction of a
+    prompt that will not submit.
+
+    Binding it also makes the rule testable with no running Application, which
+    is what caught this: the get_app() version silently returned False for
+    every case under test and looked like it worked.
+
+    Degrades to a filter that always says "submit", never to a bare bool —
+    `is_multiline` CALLS this value on every keystroke.
+    """
+    from prompt_toolkit.filters import Condition
+
+    @Condition
+    def _cond() -> bool:
+        try:
+            return wants_continuation(get_text())
+        except Exception:  # noqa: BLE001
+            return False
+
+    return _cond

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -1216,6 +1216,17 @@ def _route_operator_line(client: Any, ui: Any, line: Any) -> str:
         if text:
             if ui is not None and ui.should_flush_on_input():
                 client.send_audio("flush")
+            # The daemon receives the GOAL, not the typing mechanics. A
+            # trailing `\` told the PROMPT to keep the line open; upstream it
+            # is noise the model would read as content. Fences and brackets
+            # are content and travel untouched.
+            try:
+                from backend.core.ouroboros.battle_test.input_continuation import (  # noqa: E501
+                    strip_continuations,
+                )
+                text = strip_continuations(text)
+            except Exception:  # noqa: BLE001
+                pass
             # @path mentions, acknowledged HERE rather than silently relayed.
             #
             # `repl_input_polish` has parsed these since it shipped — but it
@@ -1224,7 +1235,7 @@ def _route_operator_line(client: Any, ui: Any, line: Any) -> str:
             # never called it, so `@backend/auth.py` travelled upstream as
             # ordinary prose.
             #
-            # The line is relayed UNCHANGED. Stripping the mention here would
+            # The mention itself is relayed UNCHANGED. Stripping it here would
             # make the cockpit and the daemon disagree about what was said,
             # and the daemon is where attachment resolution belongs. This
             # confirms the operator was understood; it does not decide.
@@ -1323,6 +1334,10 @@ async def _split_plane_loop(
         # would freeze the very keystroke that opened the menu.
         completer=_build_slash_completer(),
         complete_while_typing=True,
+        # Multi-line, with the CONDITION applied to the buffer below — the
+        # same two-step the cockpit uses, from the same module, so the two
+        # surfaces cannot disagree about when Enter means "go".
+        multiline=True,
         # The SAME Style the bipartite cockpit uses. Without it
         # prompt_toolkit paints its default filled light-grey listbox — the
         # loudest thing on a dark screen, and the exact look #70121 removed
@@ -1337,6 +1352,19 @@ async def _split_plane_loop(
     # are different LAYOUTS, and leaving the widget in place renders both at
     # once — a narrow floating column on top of the full-width page.
     _strip_native_menu(session.app)
+    # Enter submits unless the text is visibly unfinished. `Buffer.multiline`
+    # is prompt_toolkit's own seam — it holds a Filter that `is_multiline`
+    # calls per keystroke — so no custom Enter binding has to fight the
+    # library's. Bound to THIS buffer rather than `get_app().current_buffer`,
+    # which would consult whatever has focus.
+    try:
+        from backend.core.ouroboros.battle_test.input_continuation import (
+            continuation_filter,
+        )
+        _buf = session.default_buffer
+        _buf.multiline = continuation_filter(lambda: _buf.text)
+    except Exception:  # noqa: BLE001 — plain multiline still beats one line
+        pass
     # Consume prompt_toolkit's OWN cursor-position timeout rather than probing
     # the terminal again — a second probe races the first for the same reply
     # bytes and misclassifies healthy terminals. See append_only.py.
@@ -1516,7 +1544,14 @@ def _build_selection_bindings(ui: Any, client: Any) -> Any:
                     pass
             ui.refresh()
 
-        @kb.add("escape", filter=in_flow_working, eager=True)
+        # `eager` is a FILTER, not a flag. Eager means "fire now, do not wait
+        # to see if this is the start of a longer sequence" — which is exactly
+        # what would swallow the escape half of Alt+Enter. So Esc stays
+        # instant while the buffer is EMPTY (the state an operator is in when
+        # they want to interrupt: watching, not typing) and yields the
+        # sequence while they are composing. Both meanings survive, and which
+        # one applies is decided by what the operator is visibly doing.
+        @kb.add("escape", filter=in_flow_working, eager=_not_composing())
         def _interrupt(event: Any) -> None:
             """Esc in FLOW interrupts the operator's own work.
 
@@ -1537,14 +1572,42 @@ def _build_selection_bindings(ui: Any, client: Any) -> Any:
             except Exception:  # noqa: BLE001
                 pass
 
-        @kb.add("escape", filter=not_flow, eager=True)
+        @kb.add("escape", filter=not_flow, eager=_not_composing())
         def _esc(event: Any) -> None:
             fsm.escape()
             ui.refresh()
 
+        try:
+            from backend.core.ouroboros.battle_test.input_continuation import (
+                install_newline_binding,
+            )
+            install_newline_binding(kb)
+        except Exception:  # noqa: BLE001
+            pass
         return kb
     except Exception:  # noqa: BLE001 — a cockpit without selection still works
         return None
+
+
+def _not_composing() -> Any:
+    """True while the input buffer is empty. NEVER raises.
+
+    Defaults to True (eager) on any fault, preserving the instant Esc that
+    shipped before multi-line existed.
+    """
+    try:
+        from prompt_toolkit.filters import Condition
+
+        @Condition
+        def _cond() -> bool:
+            try:
+                return not _buffer_text().strip()
+            except Exception:  # noqa: BLE001
+                return True
+
+        return _cond
+    except Exception:  # noqa: BLE001
+        return True
 
 
 def _buffer_text() -> str:

--- a/tests/cli/test_multiline_input.py
+++ b/tests/cli/test_multiline_input.py
@@ -1,0 +1,382 @@
+"""Enter submits, unless the text is visibly unfinished.
+
+A goal worth giving an autonomous organism is often longer than one line — a
+paragraph of context, a pasted traceback, a list of constraints. The prompt
+accepted exactly one.
+
+And it was not only a typing limit: with `multiline=False` a PASTED block
+loses its newlines, so an operator pasting a stack trace got it silently
+collapsed into one line. That is data loss, not inconvenience.
+
+The obvious fix breaks submission — turn multiline on and Enter starts
+inserting newlines with no key left meaning "go". So the buffer is
+CONDITIONALLY multiline, using signals every shell and REPL already taught
+operators.
+
+Every ambiguous case resolves to SUBMIT. A prompt that refuses to submit has
+no escape hatch; one that submits early can be retyped.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from backend.core.ouroboros.battle_test.input_continuation import (
+    multiline_enabled,
+    strip_continuations,
+    wants_continuation,
+)
+
+_REPO = Path(__file__).resolve().parents[2]
+
+
+# --------------------------------------------------------------------------
+# 1. the common case still submits
+# --------------------------------------------------------------------------
+
+def test_a_one_line_goal_submits() -> None:
+    """Making every short goal cost two keystrokes to save the rare long one
+    is the wrong trade."""
+    assert wants_continuation("fix the flaky test") is False
+
+
+def test_an_empty_buffer_submits() -> None:
+    """Rather than silently growing blank lines the operator cannot see."""
+    assert wants_continuation("") is False
+    assert wants_continuation("   \n  ") is False
+
+
+# --------------------------------------------------------------------------
+# 2. the three "unfinished" signals
+# --------------------------------------------------------------------------
+
+def test_a_trailing_backslash_continues() -> None:
+    """The shell's own continuation mark — the one signal operators reach for
+    without being told."""
+    assert wants_continuation("fix these things: \\") is True
+
+
+def test_trailing_whitespace_does_not_defeat_the_backslash() -> None:
+    assert wants_continuation("continue \\   ") is True
+
+
+def test_an_open_code_fence_continues() -> None:
+    """Pasting half a ``` block and having it submit is the most annoying
+    possible outcome."""
+    assert wants_continuation("here:\n```python\nx = 1") is True
+
+
+def test_a_closed_fence_submits() -> None:
+    assert wants_continuation("here:\n```python\nx = 1\n```") is False
+
+
+def test_an_unbalanced_bracket_continues_ONCE_MULTILINE() -> None:
+    assert wants_continuation("def f(\n    x=1") is True
+
+
+def test_a_balanced_multiline_block_submits() -> None:
+    assert wants_continuation("def f(\n    x=1\n)") is False
+
+
+# --------------------------------------------------------------------------
+# 3. it never holds the operator hostage
+# --------------------------------------------------------------------------
+
+def test_prose_with_a_bracket_still_submits() -> None:
+    """THE trap this rule was written to avoid: "the smiley is (: nice" must
+    not trap someone in a prompt that will not submit. On a first line a
+    bracket is prose far more often than code."""
+    assert wants_continuation("the smiley is (: nice") is False
+    assert wants_continuation("call foo(bar") is False
+
+
+def test_a_bracket_inside_quotes_is_not_structure() -> None:
+    assert wants_continuation('say "a (thing" now\nand more') is False
+
+
+def test_a_stray_closer_is_not_a_reason_to_demand_input() -> None:
+    assert wants_continuation("stray ) closer\nsecond line") is False
+
+
+@pytest.mark.parametrize("junk", [None, 42, object(), b"bytes"])
+def test_it_never_raises(junk: Any) -> None:
+    assert isinstance(wants_continuation(junk), bool)
+
+
+def test_the_switch_returns_single_line_behaviour(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_INPUT_MULTILINE_ENABLED", "0")
+    assert multiline_enabled() is False
+    assert wants_continuation("unfinished \\") is False
+
+
+# --------------------------------------------------------------------------
+# 4. the daemon receives the goal, not the mechanics
+# --------------------------------------------------------------------------
+
+def test_continuation_backslashes_are_stripped() -> None:
+    """A trailing `\\` is punctuation for the prompt; it would reach the model
+    as noise."""
+    assert strip_continuations("line one \\\nline two") == "line one\nline two"
+
+
+def test_content_backslashes_survive() -> None:
+    """Only a LINE-ENDING backslash is mechanics. One mid-line is content."""
+    assert "\\d" in strip_continuations("match \\d+ digits")
+
+
+def test_fences_and_brackets_are_content_and_survive() -> None:
+    text = "here:\n```python\nx = f(1)\n```"
+    assert strip_continuations(text) == text
+
+
+def test_the_relay_strips_before_sending() -> None:
+    import contextlib
+    import io
+
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+        from backend.core.ouroboros.cli.ov import (
+            AttachUI, _route_operator_line,
+        )
+
+    class _Client:
+        def __init__(self) -> None:
+            self.sent: list = []
+
+        def send_input(self, text: str) -> bool:
+            self.sent.append(text)
+            return True
+
+        def send_audio(self, _c: str) -> bool:
+            return True
+
+    client = _Client()
+    _route_operator_line(client, AttachUI(), "line one \\\nline two")
+    assert client.sent == ["line one\nline two"]
+
+
+# --------------------------------------------------------------------------
+# 5. both surfaces, one rule — applied through the library's own seam
+# --------------------------------------------------------------------------
+
+def _multiline_kwarg(path: str) -> list:
+    src = (_REPO / path).read_text()
+    return [
+        kw.value
+        for node in ast.walk(ast.parse(src))
+        if isinstance(node, ast.Call)
+        for kw in node.keywords
+        if kw.arg == "multiline"
+    ]
+
+
+@pytest.mark.parametrize("path", [
+    "backend/core/ouroboros/cli/ov.py",
+    "backend/core/ouroboros/battle_test/bipartite_layout.py",
+])
+def test_no_prompt_is_hard_wired_single_line(path: str) -> None:
+    """AST, not a substring: both files' comments EXPLAIN the old
+    `multiline=False`, and a text search cannot tell an explanation from a
+    setting. Grepping source for a symbol that also appears in its own prose
+    has produced a false pass five times in this codebase."""
+    values = _multiline_kwarg(path)
+    assert values, f"{path} sets no multiline at all"
+    assert not [
+        v for v in values
+        if isinstance(v, ast.Constant) and v.value is False
+    ], "a prompt is still hard-wired single-line"
+
+
+@pytest.mark.parametrize("path", [
+    "backend/core/ouroboros/cli/ov.py",
+    "backend/core/ouroboros/battle_test/bipartite_layout.py",
+])
+def test_both_surfaces_apply_the_shared_rule(path: str) -> None:
+    """Two surfaces with two rules is how the palette ended up rendering
+    differently on each. One definition, or they drift."""
+    src = (_REPO / path).read_text()
+    imported = {
+        alias.name
+        for node in ast.walk(ast.parse(src))
+        if isinstance(node, ast.ImportFrom) for alias in node.names
+    }
+    assert "continuation_filter" in imported, f"{path} has its own rule"
+    assert "buffer.multiline = continuation_filter" in src.replace(
+        "_buf.multiline", "buffer.multiline",
+    ), f"{path} builds the filter but never applies it"
+
+
+def test_the_condition_is_passed_to_the_BUFFER_not_the_widget() -> None:
+    """`TextArea(multiline=<Condition>)` LOOKS right — the parameter is
+    annotated `FilterOrBool` — and raises ValueError at construction: the
+    widget branches on raw truthiness before any `to_filter`, and a Filter
+    refuses `__bool__`. The literal True selects the growable branch; the
+    falsy one hard-clamps `height = D.exact(1)` and would put the caret below
+    the fold on line two."""
+    from prompt_toolkit.filters import Condition
+    from prompt_toolkit.widgets import TextArea
+
+    with pytest.raises(ValueError):
+        TextArea(multiline=Condition(lambda: False))
+
+    for path in ("backend/core/ouroboros/cli/ov.py",
+                 "backend/core/ouroboros/battle_test/bipartite_layout.py"):
+        assert all(
+            isinstance(v, ast.Constant) and v.value is True
+            for v in _multiline_kwarg(path)
+        ), f"{path} passes a non-literal multiline to a widget"
+
+
+def test_the_filter_reads_ITS_buffer_not_whatever_has_focus() -> None:
+    """The first version read `get_app().current_buffer`. It returned False
+    for every case under test — no running Application — and looked correct.
+    Bound to one buffer, it is both right when focus moves and testable."""
+    from prompt_toolkit.buffer import Buffer
+
+    from backend.core.ouroboros.battle_test.input_continuation import (
+        continuation_filter,
+    )
+
+    mine, other = Buffer(), Buffer()
+    mine.multiline = continuation_filter(lambda: mine.text)
+    other.text = "unfinished \\"
+    mine.text = "fix the flaky test"
+    assert mine.multiline() is False, "it consulted the wrong buffer"
+    mine.text = "unfinished \\"
+    assert mine.multiline() is True
+
+
+def test_the_filter_is_callable_even_when_it_degrades() -> None:
+    """`is_multiline` CALLS this value on every keystroke — a bare bool would
+    raise on the next one."""
+    from backend.core.ouroboros.battle_test.input_continuation import (
+        continuation_filter,
+    )
+
+    def _explode() -> str:
+        raise RuntimeError("buffer gone")
+
+    filt = continuation_filter(_explode)
+    assert callable(filt)
+    assert filt() is False
+
+
+def test_a_pasted_block_keeps_its_newlines() -> None:
+    """The reason this is more than a UX limit: with a single-line buffer a
+    pasted traceback was silently collapsed to one line."""
+    from prompt_toolkit.buffer import Buffer
+
+    from backend.core.ouroboros.battle_test.input_continuation import (
+        continuation_filter,
+    )
+
+    buf = Buffer(multiline=True)
+    buf.multiline = continuation_filter(lambda: buf.text)
+    pasted = 'Traceback:\n  File "x.py", line 3\n    raise ValueError'
+    buf.insert_text(pasted)
+    assert buf.text.count("\n") == 2
+    assert buf.text == pasted
+
+
+# --------------------------------------------------------------------------
+# 6. the escape hatch is real
+# --------------------------------------------------------------------------
+#
+# Every ambiguous case above resolves to SUBMIT, and that is ONLY safe because
+# a deliberate newline is always one keystroke away. prompt_toolkit ships no
+# `escape enter` binding of its own — checked against the installed library —
+# so these prove the promise the rules depend on.
+
+def test_alt_enter_is_bound() -> None:
+    from prompt_toolkit.key_binding import KeyBindings
+
+    from backend.core.ouroboros.battle_test.input_continuation import (
+        install_newline_binding,
+    )
+
+    kb = KeyBindings()
+    assert install_newline_binding(kb) is True
+    combos = [tuple(str(k) for k in b.keys) for b in kb.bindings]
+    assert ("Keys.Escape", "Keys.ControlM") in combos
+
+
+def test_alt_enter_actually_inserts() -> None:
+    """A registered binding that does nothing is the wired-but-inert defect
+    this codebase keeps producing — so invoke the handler, don't just count
+    it."""
+    from prompt_toolkit.buffer import Buffer
+    from prompt_toolkit.key_binding import KeyBindings
+
+    from backend.core.ouroboros.battle_test.input_continuation import (
+        install_newline_binding,
+    )
+
+    kb = KeyBindings()
+    install_newline_binding(kb)
+    buf = Buffer()
+    buf.text = "first"
+    buf.cursor_position = len("first")
+
+    class _Event:
+        current_buffer = buf
+
+    kb.bindings[0].handler(_Event())
+    assert buf.text == "first\n"
+
+
+def test_the_switch_removes_the_binding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from prompt_toolkit.key_binding import KeyBindings
+
+    from backend.core.ouroboros.battle_test.input_continuation import (
+        install_newline_binding,
+    )
+
+    monkeypatch.setenv("JARVIS_INPUT_MULTILINE_ENABLED", "0")
+    kb = KeyBindings()
+    assert install_newline_binding(kb) is False
+    assert not kb.bindings
+
+
+def test_it_never_raises_on_a_bad_registry() -> None:
+    from backend.core.ouroboros.battle_test.input_continuation import (
+        install_newline_binding,
+    )
+
+    assert install_newline_binding(None) is False
+    assert install_newline_binding(object()) is False
+
+
+def test_both_surfaces_install_it() -> None:
+    for path in ("backend/core/ouroboros/cli/ov.py",
+                 "backend/core/ouroboros/battle_test/bipartite_layout.py"):
+        text = (_REPO / path).read_text()
+        called = {
+            node.func.id
+            for node in ast.walk(ast.parse(text))
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+        }
+        assert "install_newline_binding" in called, f"{path} has no escape hatch"
+
+
+def test_esc_yields_the_sequence_while_composing() -> None:
+    """`eager=True` means "fire now, don't wait for a longer sequence" — it
+    would swallow the escape half of Alt+Enter. Esc stays instant on an EMPTY
+    buffer and yields while the operator is typing."""
+    src = (_REPO / "backend/core/ouroboros/cli/ov.py").read_text()
+    unconditional = [
+        node.lineno
+        for node in ast.walk(ast.parse(src))
+        if isinstance(node, ast.Call)
+        for kw in node.keywords
+        if kw.arg == "eager"
+        and isinstance(kw.value, ast.Constant)
+        and kw.value.value is True
+    ]
+    assert not unconditional, f"eager Esc swallows Alt+Enter at {unconditional}"


### PR DESCRIPTION
## The gap

A goal worth giving an autonomous organism is often longer than one line — a paragraph of context, a pasted traceback, a list of constraints. Both input surfaces accepted exactly one.

It was **not only a typing limit**. With a single-line buffer a pasted block loses its newlines, so an operator pasting a stack trace got it silently collapsed into one line. That is data loss, not inconvenience.

## Why it isn't just `multiline=True`

Turn multiline on and Enter starts inserting newlines — there is no longer a key that means "go". So the buffer is **conditionally** multiline, using signals every shell and REPL already taught operators:

| signal | Enter |
|---|---|
| `fix the flaky test` | **submits** |
| `fix these things: \` | newline (shell's own continuation mark) |
| ` ```python ` unclosed | newline |
| `def f(` on line 2+ | newline |
| `the smiley is (: nice` | **submits** |

Every ambiguous case resolves to **SUBMIT**. A prompt that refuses to submit has no escape hatch; one that submits early can be retyped. That asymmetry is why bracket balance counts only once the text is *already* multi-line — on a first line a bracket is prose far more often than code.

## Three things that were not obvious

**`TextArea(multiline=<Condition>)` looks correct and raises `ValueError`.** The parameter is annotated `FilterOrBool`, but the widget branches on raw truthiness (`if multiline:`) before any `to_filter`, and a Filter refuses `__bool__`. Passing it would have crashed the cockpit at construction. The rule belongs on `Buffer.multiline` — the library's real seam, holding a Filter that `is_multiline` calls per keystroke — so no custom Enter binding has to fight the library's own.

**The filter is bound to *its* buffer, not `get_app().current_buffer`.** The first version read whatever had focus. It returned `False` for every case under test — no running Application — and looked like it worked.

**Alt+Enter did not exist.** The escape hatch the entire safety argument rests on is not shipped by prompt_toolkit; there is no `escape enter` binding anywhere in the library. Verified against the installed package rather than assumed. It is bound here — and the two eager `Esc` bindings now yield the sequence while the operator is composing. `eager` is a *filter*, and eager means "fire now, don't wait for a longer sequence" — precisely what would have swallowed it. Esc stays instant on an empty buffer, the state you're in when you want to interrupt.

## Shape

One definition (`input_continuation.py`), applied to both surfaces — two surfaces with two rules is how the `/` palette ended up rendering differently on each. Continuation marks are stripped before relay: the daemon receives the goal, not the mechanics.

Kill switch `JARVIS_INPUT_MULTILINE_ENABLED=0` restores single-line exactly.

## Verification

- **34 tests.** Every structural pin is AST-based — both files' comments now *explain* the old `multiline=False`, and a text search cannot tell an explanation from a setting (a false-pass this repo has produced five times).
- **Real PTY**: cockpit builds, prompt buffer found, rule applies (`plain → submits`, `cont → newline`), multi-line text held, Alt+Enter bound.
- **No new failures** across `tests/cli` + `tests/battle_test` — 3225 passing. The 23 reds are pre-existing at HEAD, confirmed file-by-file in an isolated clean-HEAD worktree rather than assumed from their names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Enter submit by default while allowing multi-line input when the text looks unfinished; Alt+Enter always inserts a newline. Prevents pasted blocks from losing newlines and keeps both input surfaces consistent.

- New Features
  - Conditional multi-line: continues on trailing backslash, open ``` fence, or unbalanced brackets (only after the first line).
  - One shared rule applied via `Buffer.multiline` filter in both surfaces; no custom Enter binding conflicts with `prompt_toolkit`.
  - Alt+Enter binding to insert a newline; Esc remains instant only when not composing to avoid swallowing Alt+Enter.
  - Continuation backslashes are stripped before relay so the daemon gets content, not typing mechanics.

- Migration
  - Behavior change: both prompts accept multi-line; Enter submits unless the text is visibly unfinished. Use Alt+Enter for a forced newline.
  - To restore single-line behavior, set `JARVIS_INPUT_MULTILINE_ENABLED=0`.

<sup>Written for commit 29d867fe9a6d645ae31d0e23e5eea752f27e6b2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

