### PR TITLE
feat(ov): the cockpit takes the screen, because it can finally hold the history

### DIFF
--- a/backend/core/ouroboros/battle_test/bipartite_layout.py
+++ b/backend/core/ouroboros/battle_test/bipartite_layout.py
@@ -36,6 +36,11 @@ from typing import Any, Callable, List, Optional, Tuple
 
 logger = logging.getLogger("Ouroboros.BipartiteLayout")
 
+from backend.core.ouroboros.battle_test.canvas_viewport import (
+    CanvasViewport, canvas_history_lines, install_scroll_bindings,
+    scrollback_enabled,
+)
+
 _DEFAULT_MAX_LINES = 500
 
 
@@ -54,6 +59,23 @@ def bipartite_enabled() -> bool:
     ).strip().lower() in ("1", "true", "yes", "on")
 
 
+def _real_tty() -> bool:
+    """A real interactive terminal, via the canonical helper.
+
+    ``sys.stdout.isatty()`` is False under the active ``patch_stdout`` proxy,
+    which is why `real_stdout_isatty` (reading ``sys.__stdout__``) exists. One
+    definition, used by both the launch gate and the alt-screen decision, so
+    they cannot disagree about what a terminal is.
+    """
+    try:
+        from backend.core.ouroboros.battle_test.presentation_restraint import (
+            real_stdout_isatty,
+        )
+        return real_stdout_isatty()
+    except Exception:  # noqa: BLE001
+        return False
+
+
 def fullscreen_enabled() -> bool:
     """Does the cockpit claim the terminal's ALTERNATE SCREEN?
 
@@ -63,22 +85,35 @@ def fullscreen_enabled() -> bool:
     nothing there, because the alternate buffer has no history and the primary
     buffer stopped receiving output the moment the cockpit mounted.
 
-    That made the cockpit's own canvas load-bearing: Zone 1 existed to replace
-    the scrollback the alt-screen had taken away, and it is a bounded ring, so
-    history beyond it was simply gone.
+    That made the cockpit's own canvas load-bearing, and it was not up to the
+    job: Zone 1 existed to replace the scrollback the alt-screen had taken
+    away, but it rendered only ``snap[-budget:]`` — the last screenful, with
+    no way to reach anything above it. Claiming the screen meant deleting the
+    session's history, so #70171 defaulted this OFF and let the terminal keep
+    what it was better at keeping.
 
-    Default FALSE. Outside the alternate screen the terminal keeps every line
-    the organism ever printed, scrollback works the way it does in every other
-    tool, and the canvas becomes a small live region rather than a substitute
-    for history the terminal was always better at holding.
+    **Default TRUE as of the scrollback viewport.** `canvas_viewport` turned
+    Zone 1 from a tail into a window over ~20k retained lines, with PgUp/PgDn,
+    Home/End and a view that holds still while the organism appends. The
+    canvas can now hold a session, so the objection that kept the cockpit out
+    of the alternate screen no longer applies — and full-screen is what makes
+    `ov` an instrument you are inside of rather than a command that scrolled
+    past. Exiting issues rmcup, so the shell comes back untouched, with the
+    scrollback that was there before the cockpit mounted.
 
-    ``JARVIS_BIPARTITE_FULLSCREEN=1`` restores the old behaviour — a fixed
-    viewport is genuinely better on a wall display or a dedicated monitor,
-    where nobody scrolls and a stable frame reads as an instrument panel.
+    ``JARVIS_BIPARTITE_FULLSCREEN=0`` returns to the inline cockpit for anyone
+    who would rather keep native scrollback (or is debugging with the shell's
+    output interleaved).
     """
-    return os.environ.get(
-        "JARVIS_BIPARTITE_FULLSCREEN", "",
-    ).strip().lower() in ("1", "true", "yes", "on")
+    raw = os.environ.get("JARVIS_BIPARTITE_FULLSCREEN", "").strip().lower()
+    if raw in ("0", "false", "no", "off"):
+        return False
+    if raw in ("1", "true", "yes", "on"):
+        return True
+    # Unset → on, but only where an alternate screen exists at all. A pipe or
+    # a dumb terminal has no smcup to issue, and claiming one there produces
+    # escape soup in a log file rather than a cockpit.
+    return _real_tty()
 
 
 def _canvas_dimension() -> Any:
@@ -108,7 +143,7 @@ def _canvas_dimension() -> Any:
 
 def _canvas_max_lines() -> int:
     try:
-        return max(16, int(os.environ.get("JARVIS_BIPARTITE_CANVAS_MAX_LINES", _DEFAULT_MAX_LINES)))
+        return canvas_history_lines()
     except (TypeError, ValueError):
         return _DEFAULT_MAX_LINES
 
@@ -132,7 +167,13 @@ class BipartiteLayout:
         # Reuse the bounded buffer primitive (DRY) — never the Live renderer.
         from backend.core.ouroboros.battle_test.split_layout import RegionBuffer
 
-        self._buffer = RegionBuffer(name="canvas", maxlen=max_lines or _canvas_max_lines())
+        # In the alternate screen this ring is the ONLY history that exists,
+        # so it is sized for a session rather than for a tail sitting beneath
+        # a terminal that still had its own scrollback.
+        self._buffer = RegionBuffer(
+            name="canvas", maxlen=max_lines or _canvas_max_lines(),
+        )
+        self._viewport = CanvasViewport()
         self._registry = registry
         self._width = max(10, int(width))
         self._height = max(3, int(height))
@@ -223,15 +264,45 @@ class BipartiteLayout:
 
     # -- rendering ------------------------------------------------------
 
-    def _visible_lines(self) -> List[str]:
-        # Auto-scroll: keep only the last (height - frame chrome) lines.
+    def _line_budget(self) -> int:
+        """Rows the canvas may draw into, frame chrome deducted."""
+        chrome = 4 if os.environ.get(
+            "JARVIS_BIPARTITE_BORDER", "",
+        ).strip().lower() in ("1", "true", "yes", "on") else 1
+        return max(1, self._height - chrome)
+
+    def scroll_metrics(self) -> tuple:
+        """``(total, budget)`` — what the scroll keys clamp against."""
         try:
-            chrome = 4 if os.environ.get("JARVIS_BIPARTITE_BORDER", "").strip().lower() in (
-                "1", "true", "yes", "on",
-            ) else 1
-            budget = max(1, self._height - chrome)   # frame chrome only when bordered
+            return len(self._buffer.snapshot()), self._line_budget()
+        except Exception:  # noqa: BLE001
+            return 0, 1
+
+    def _visible_lines(self) -> List[str]:
+        """The screenful the operator is LOOKING AT — the live tail while
+        following, an older window once they scroll back.
+
+        The status row replaces the topmost visible line rather than being
+        overlaid: losing one row of telemetry is a fair price for always
+        knowing whether you are watching "now", and it costs nothing while
+        following, when there is no status to show.
+        """
+        try:
+            budget = self._line_budget()
             snap = self._buffer.snapshot()
-            return list(snap[-budget:])
+            if not scrollback_enabled():
+                return list(snap[-budget:])
+            visible, above, below = self._viewport.window(
+                # push_count, not len(): once the ring saturates its length
+                # stops changing while the content keeps moving.
+                snap, budget, appended=self._buffer.push_count,
+            )
+            status = self._viewport.status(above, below)
+            if status:
+                return list(visible[1:]) + [
+                    f"[reverse dim] {status} [/reverse dim]",
+                ]
+            return list(visible)
         except Exception:  # noqa: BLE001
             return []
 
@@ -546,6 +617,14 @@ def build_bipartite_application(
         logger.debug("[Bipartite] continuation rule degraded", exc_info=True)
 
     kb = KeyBindings()
+    # Scrollback keys. In the alternate screen the terminal no longer offers
+    # its own, so these ARE the scrollback — not a convenience layered on it.
+    try:
+        install_scroll_bindings(
+            kb, mux._viewport, mux.scroll_metrics, mux._invalidate_now,
+        )
+    except Exception:  # noqa: BLE001
+        pass
     # Alt+Enter, from the same module that decides when Enter continues — so
     # the rule and its escape hatch can never be wired on different surfaces.
     try:
@@ -761,15 +840,7 @@ def should_run_bipartite() -> bool:
     canonical ``real_stdout_isatty`` — a plain ``sys.stdout.isatty`` is False under
     the active ``patch_stdout`` proxy). Headless / piped / CI never enters the
     full-screen mode. Never raises."""
-    if not bipartite_enabled():
-        return False
-    try:
-        from backend.core.ouroboros.battle_test.presentation_restraint import (
-            real_stdout_isatty,
-        )
-        return real_stdout_isatty()
-    except Exception:  # noqa: BLE001
-        return False
+    return bipartite_enabled() and _real_tty()
 
 
 async def _alive_watcher(

--- a/backend/core/ouroboros/battle_test/canvas_viewport.py
+++ b/backend/core/ouroboros/battle_test/canvas_viewport.py
@@ -1,0 +1,288 @@
+"""Scrollback for a cockpit that owns the whole screen.
+
+Taking the alternate screen is what makes `ov` feel like an instrument rather
+than a command that scrolled past — but smcup **disables the terminal's native
+scrollback**. The primary buffer stops receiving output the moment the cockpit
+mounts, so an operator scrolling up to re-read what the organism did an hour
+ago finds nothing there.
+
+That is why full-screen was defaulted OFF in #70171, and it is the actual
+problem to solve. Turning the flag back on without this would not deliver a
+full-screen cockpit; it would delete the history and call it a feature.
+
+So the canvas stops being a tail and becomes a VIEWPORT: a window onto a much
+longer history, with an offset the operator moves. `_visible_lines` used to
+return ``snap[-budget:]`` — the last screenful, always. Now it returns the
+screenful the operator is looking at.
+
+Following, and the one rule that matters
+----------------------------------------
+At the bottom (offset 0) the view FOLLOWS: new telemetry appears as it
+arrives, which is what a live cockpit should do when nobody is reading
+history.
+
+Scrolled up, it does **not** follow. The organism emits continuously, and a
+view that drifted on every incoming line would make reading anything older
+physically impossible — the text would slide out from under the reader
+several times a second.
+
+The offset is measured from the bottom, so it names a distance from the
+NEWEST line — and every append moves the newest line. To keep the same
+absolute text under the reader, the offset is advanced by exactly the number
+of lines appended since the last frame.
+
+That count has to come from the ring's monotonic ``push_count``, not from the
+change in length, and this is the part that is easy to get wrong. Once the
+ring is saturated every append also drops a line off the front, so the length
+stops changing while the content keeps moving. A length-delta compensation is
+therefore correct while the ring is filling and silently stops working the
+moment it is full — the regime a long session spends all its time in.
+
+Both errors were live here before they were caught: first `PgUp` walked the
+view from line 489 to 529 as telemetry arrived, and the length-delta fix that
+followed still walked it from 180 to 220 once the ring hit its cap.
+
+Leaving history is explicit (`End`, or scrolling back down). Nothing the
+organism does can steal the view.
+
+No authority, no rendering: this decides WHICH slice is visible and nothing
+else. It holds no lines, imports no prompt_toolkit, and is therefore provable
+without a terminal — the property that the last focus-adjacent rule in this
+codebase failed to have.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, List, Optional, Sequence, Tuple
+
+logger = logging.getLogger("Ouroboros.CanvasViewport")
+
+__all__ = ["CanvasViewport", "scrollback_enabled", "canvas_history_lines"]
+
+#: History the canvas keeps once it is the ONLY history there is. The old 500
+#: was sized for a tail beneath a terminal that still had its own scrollback;
+#: in the alternate screen that assumption is gone. ~20k lines is minutes of
+#: dense telemetry and a few MB at most — cheap next to losing the session.
+_DEFAULT_HISTORY_LINES = 20000
+
+
+def scrollback_enabled() -> bool:
+    """Default ON. Off pins the canvas to the tail, as it behaved before."""
+    return os.environ.get(
+        "JARVIS_CANVAS_SCROLLBACK_ENABLED", "1",
+    ).strip().lower() not in ("0", "false", "no", "off")
+
+
+def canvas_history_lines() -> int:
+    """How many lines the canvas retains.
+
+    Honours the pre-existing ``JARVIS_BIPARTITE_CANVAS_MAX_LINES`` so an
+    operator who already tuned it is not overridden — reusing the knob that
+    exists rather than introducing a second one that silently wins.
+    """
+    for name in ("JARVIS_CANVAS_HISTORY_LINES",
+                 "JARVIS_BIPARTITE_CANVAS_MAX_LINES"):
+        raw = os.environ.get(name, "").strip()
+        if raw:
+            try:
+                return max(64, int(raw))
+            except (TypeError, ValueError):
+                continue
+    return _DEFAULT_HISTORY_LINES
+
+
+class CanvasViewport:
+    """Which slice of the history is on screen, and how the operator moves it.
+
+    ``offset`` counts lines from the BOTTOM: 0 is live/following, larger means
+    further back. Measuring from the bottom rather than the top is what lets
+    the view hold still while the organism appends — a top-anchored index
+    would drift under the reader as the ring rotated.
+    """
+
+    def __init__(self) -> None:
+        self._offset = 0
+        #: Last monotonic append count seen by `window`. None until the first
+        #: frame, so the first render cannot mistake pre-existing history for
+        #: lines that arrived while the operator was reading.
+        self._last_appended: Optional[int] = None
+        #: Set when a scroll is attempted past the oldest retained line, so the
+        #: UI can say "this is everything that is kept" rather than appearing
+        #: to freeze. Truncation the operator cannot see reads as a bug.
+        self.hit_top = False
+
+    # -- state -------------------------------------------------------------
+
+    @property
+    def offset(self) -> int:
+        return self._offset
+
+    @property
+    def following(self) -> bool:
+        """True when pinned to the live tail."""
+        return self._offset <= 0
+
+    def reset(self) -> None:
+        self._offset = 0
+        self.hit_top = False
+
+    # -- movement ----------------------------------------------------------
+
+    def scroll(self, lines: int, *, total: int, budget: int) -> bool:
+        """Move by *lines* (negative = toward history). True if it moved.
+
+        Clamped at both ends against the CURRENT total, so a scroll issued
+        while the ring is short cannot strand the viewport in empty space
+        above the first line.
+        """
+        try:
+            budget = max(1, int(budget))
+            total = max(0, int(total))
+            ceiling = max(0, total - budget)
+            want = self._offset - int(lines)
+            new = max(0, min(ceiling, want))
+            self.hit_top = want > ceiling and ceiling > 0
+            if new == self._offset:
+                return False
+            self._offset = new
+            return True
+        except Exception:  # noqa: BLE001 — scrolling must never break a repaint
+            logger.debug("[CanvasViewport] scroll degraded", exc_info=True)
+            return False
+
+    def page(self, direction: int, *, total: int, budget: int) -> bool:
+        """One screenful. ``direction`` +1 is PgUp (older), -1 is PgDn.
+
+        Overlaps by one line so nothing falls between consecutive pages.
+
+        Note the sign flip into `scroll`, which takes NEGATIVE for older.
+        The first cut passed the direction straight through, so `PgUp` moved
+        toward the tail — where the viewport already was — and the key read
+        as dead. It was only visible because the test asserted on the lines
+        rather than on the return value.
+        """
+        step = max(1, int(budget) - 1)
+        return self.scroll(-step if direction >= 0 else step,
+                           total=total, budget=budget)
+
+    def to_top(self, *, total: int, budget: int) -> bool:
+        return self.scroll(-max(0, int(total)), total=total, budget=budget)
+
+    def to_bottom(self) -> bool:
+        """Return to live. The one move that is always available."""
+        if self._offset == 0:
+            return False
+        self.reset()
+        return True
+
+    # -- the slice ---------------------------------------------------------
+
+    def window(
+        self, lines: Sequence[str], budget: int, appended: Optional[int] = None,
+    ) -> Tuple[List[str], int, int]:
+        """``(visible, hidden_above, hidden_below)`` for this frame.
+
+        Re-clamps against the live total on every call rather than trusting
+        the stored offset: the ring drops old lines as it rotates, so an
+        offset that was valid when the operator scrolled can point past the
+        start a second later. Clamping HERE means the ring and the viewport
+        cannot disagree about what exists.
+        """
+        try:
+            budget = max(1, int(budget))
+            snap = list(lines or ())
+            total = len(snap)
+
+            # Hold the view still while the organism appends. Only while
+            # scrolled — at the tail, following is the whole point.
+            #
+            # `appended` is the ring's monotonic push count. Falling back to
+            # the length is strictly worse (it goes blind once the ring is
+            # saturated) and exists only so the class stays usable against a
+            # plain list in tests.
+            marker = total if appended is None else int(appended)
+            previous, self._last_appended = self._last_appended, marker
+            if self._offset > 0 and previous is not None and marker > previous:
+                self._offset += marker - previous
+
+            if total <= budget:
+                # Everything fits; there is no history to be inside of.
+                self._offset = 0
+                return snap, 0, 0
+            ceiling = total - budget
+            if self._offset > ceiling:
+                self._offset = ceiling
+            end = total - self._offset
+            start = max(0, end - budget)
+            return snap[start:end], start, total - end
+        except Exception:  # noqa: BLE001
+            logger.debug("[CanvasViewport] window degraded", exc_info=True)
+            tail = list(lines or ())[-max(1, int(budget)):]
+            return tail, 0, 0
+
+    def status(self, hidden_above: int, hidden_below: int) -> str:
+        """One line telling the operator they are not looking at "now".
+
+        Rendered only while scrolled: a permanent indicator would be chrome
+        that costs a row and says nothing 99% of the time. Naming the key is
+        deliberate — a reader who cannot find their way back to live has been
+        trapped by the feature, not helped by it.
+        """
+        try:
+            if hidden_below <= 0:
+                return ""
+            older = f"↑ {hidden_above} older" if hidden_above > 0 else "↑ top"
+            if self.hit_top and hidden_above <= 0:
+                older = "↑ oldest kept"
+            return f"{older} · {hidden_below} newer below · End to follow"
+        except Exception:  # noqa: BLE001
+            return ""
+
+
+def install_scroll_bindings(
+    kb: Any,
+    viewport: CanvasViewport,
+    metrics: Any,
+    invalidate: Optional[Any] = None,
+) -> bool:
+    """Bind the movement keys every pager already taught operators.
+
+    *metrics* is a callable returning ``(total, budget)`` — injected rather
+    than reached for, so the bindings work against whatever surface owns the
+    canvas and stay testable without one.
+
+    NEVER raises: a cockpit that starts without scroll keys is far better
+    than one that does not start.
+    """
+    try:
+        if kb is None or not scrollback_enabled():
+            return False
+
+        def _move(fn: Any) -> Any:
+            def _handler(event: Any) -> None:
+                try:
+                    total, budget = metrics()
+                    if fn(total, budget) and invalidate is not None:
+                        invalidate()
+                except Exception:  # noqa: BLE001
+                    pass
+            return _handler
+
+        kb.add("pageup")(_move(
+            lambda t, b: viewport.page(1, total=t, budget=b)))
+        kb.add("pagedown")(_move(
+            lambda t, b: viewport.page(-1, total=t, budget=b)))
+        # Wheel events arrive as scroll-up/scroll-down when mouse support is
+        # on; harmless to bind when it is not.
+        kb.add("s-up")(_move(
+            lambda t, b: viewport.scroll(-3, total=t, budget=b)))
+        kb.add("s-down")(_move(
+            lambda t, b: viewport.scroll(3, total=t, budget=b)))
+        kb.add("end")(_move(lambda _t, _b: viewport.to_bottom()))
+        kb.add("home")(_move(
+            lambda t, b: viewport.to_top(total=t, budget=b)))
+        return True
+    except Exception:  # noqa: BLE001
+        logger.debug("[CanvasViewport] bindings degraded", exc_info=True)
+        return False

--- a/tests/battle_test/test_canvas_viewport.py
+++ b/tests/battle_test/test_canvas_viewport.py
@@ -1,0 +1,209 @@
+"""The cockpit owns the screen, so it has to own the history too.
+
+Taking the alternate screen disables the terminal's native scrollback. That
+is why full-screen was defaulted off in #70171 — Zone 1 rendered
+``snap[-budget:]``, the last screenful, with nothing reachable above it, so
+claiming the screen deleted the session.
+
+These pin the viewport that removes the objection, and in particular the two
+bugs it took to get "the view holds still" actually working. Both were live,
+and both looked fine from the outside.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.battle_test.canvas_viewport import (
+    CanvasViewport, canvas_history_lines, scrollback_enabled,
+)
+
+
+def _lines(n: int, start: int = 0) -> list:
+    return [f"line {i}" for i in range(start, start + n)]
+
+
+# --------------------------------------------------------------------------
+# following
+# --------------------------------------------------------------------------
+
+def test_it_follows_the_tail_by_default() -> None:
+    """A live cockpit should show now, when nobody is reading history."""
+    v = CanvasViewport()
+    visible, above, below = v.window(_lines(100), 10)
+    assert v.following is True
+    assert visible[-1] == "line 99"
+    assert below == 0 and above == 90
+
+
+def test_short_history_is_shown_whole() -> None:
+    v = CanvasViewport()
+    visible, above, below = v.window(_lines(3), 10)
+    assert visible == ["line 0", "line 1", "line 2"]
+    assert (above, below) == (0, 0)
+
+
+# --------------------------------------------------------------------------
+# movement
+# --------------------------------------------------------------------------
+
+def test_pageup_moves_toward_history() -> None:
+    """The direction bug: `page(1)` first computed `offset - step`, which
+    moves toward the TAIL — where the viewport already was — so PgUp was a
+    dead key. Asserting on the returned lines alone missed it, because the
+    lines were correct for a viewport that had not moved."""
+    v = CanvasViewport()
+    v.window(_lines(500), 11)
+    assert v.page(1, total=500, budget=11) is True
+    assert v.offset > 0
+    assert v.following is False
+
+
+def test_end_always_returns_to_live() -> None:
+    v = CanvasViewport()
+    v.window(_lines(500), 11)
+    v.page(1, total=500, budget=11)
+    assert v.to_bottom() is True
+    assert v.following is True
+    visible, _a, below = v.window(_lines(500), 11)
+    assert visible[-1] == "line 499" and below == 0
+
+
+def test_it_cannot_scroll_above_the_oldest_line() -> None:
+    v = CanvasViewport()
+    v.to_top(total=50, budget=10)
+    visible, above, _b = v.window(_lines(50), 10)
+    assert above == 0
+    assert visible[0] == "line 0"
+
+
+def test_scrolling_down_at_the_tail_is_a_no_op() -> None:
+    v = CanvasViewport()
+    assert v.scroll(5, total=100, budget=10) is False
+    assert v.following is True
+
+
+# --------------------------------------------------------------------------
+# the rule that matters: the view holds still
+# --------------------------------------------------------------------------
+
+def test_the_view_holds_still_while_the_ring_grows() -> None:
+    """Bug #1. The organism emits continuously. A view that drifted on every
+    incoming line would make reading anything older impossible — the text
+    slides out from under the reader several times a second."""
+    v = CanvasViewport()
+    history = _lines(500)
+    v.window(history, 11)
+    v.page(1, total=500, budget=11)
+    before, _a, _b = v.window(history, 11, appended=500)
+
+    history += _lines(140, start=500)          # telemetry keeps arriving
+    after, _a, _b = v.window(history, 11, appended=640)
+
+    assert after == before, "the view drifted while the operator was reading"
+
+
+def test_the_view_holds_still_once_the_ring_is_SATURATED() -> None:
+    """Bug #2, and the one that mattered more.
+
+    The first fix compensated by the change in LENGTH. That works while the
+    ring is filling and silently stops the moment it is full: every append
+    then also drops a line off the front, so the length freezes while the
+    content keeps moving — and a long session spends all its time in that
+    regime. The view walked from line 180 to 220 with the length-delta fix
+    in place. Compensation has to come from the monotonic append count.
+    """
+    v = CanvasViewport()
+    cap, budget = 200, 11
+    history = _lines(cap)
+    v.window(history, budget, appended=cap)
+    v.page(1, total=cap, budget=budget)
+    before, _a, _b = v.window(history, budget, appended=cap)
+
+    for i in range(140):                        # saturated: push == drop
+        history = history[1:] + [f"line {cap + i}"]
+    assert len(history) == cap, "the ring must be saturated for this to test"
+    after, _a, _b = v.window(history, budget, appended=cap + 140)
+
+    assert after == before, "bottom-anchoring drifted once the ring was full"
+
+
+def test_following_is_NOT_frozen_by_the_compensation() -> None:
+    """The compensation must apply only while scrolled — at the tail,
+    following is the entire point of a live cockpit."""
+    v = CanvasViewport()
+    v.window(_lines(100), 10, appended=100)
+    visible, _a, _b = v.window(_lines(140), 10, appended=140)
+    assert visible[-1] == "line 139"
+    assert v.following is True
+
+
+def test_the_first_frame_is_not_mistaken_for_new_lines() -> None:
+    """`_last_appended` starts None so pre-existing history cannot be read as
+    having arrived while the operator was reading."""
+    v = CanvasViewport()
+    v.scroll(-5, total=500, budget=10)
+    visible, _a, _b = v.window(_lines(500), 10, appended=500)
+    assert visible[-1] == "line 494"
+
+
+# --------------------------------------------------------------------------
+# telling the operator where they are
+# --------------------------------------------------------------------------
+
+def test_no_status_while_following() -> None:
+    """Permanent chrome would cost a row to say nothing 99% of the time."""
+    v = CanvasViewport()
+    _v, above, below = v.window(_lines(100), 10)
+    assert v.status(above, below) == ""
+
+
+def test_the_status_names_the_way_back() -> None:
+    """A reader who cannot find their way back to live has been trapped by
+    the feature rather than helped by it."""
+    v = CanvasViewport()
+    v.window(_lines(500), 11)
+    v.page(1, total=500, budget=11)
+    _vis, above, below = v.window(_lines(500), 11)
+    status = v.status(above, below)
+    assert "End" in status
+    assert str(below) in status
+
+
+def test_re_clamping_survives_a_ring_that_shrank() -> None:
+    """The ring drops lines as it rotates, so an offset valid a moment ago
+    can point past the start. Clamping in `window` is what keeps the ring and
+    the viewport from disagreeing about what exists."""
+    v = CanvasViewport()
+    v.scroll(-400, total=500, budget=10)
+    visible, above, _b = v.window(_lines(20), 10)
+    assert len(visible) == 10
+    assert above == 0
+
+
+@pytest.mark.parametrize("junk", [None, "", 0, -5])
+def test_it_never_raises_on_junk(junk) -> None:
+    v = CanvasViewport()
+    assert isinstance(v.window(_lines(20), junk or 1), tuple)
+    assert isinstance(v.scroll(1, total=junk or 0, budget=junk or 1), bool)
+
+
+# --------------------------------------------------------------------------
+# configuration
+# --------------------------------------------------------------------------
+
+def test_history_is_sized_for_a_session_not_a_tail() -> None:
+    assert canvas_history_lines() >= 10000
+
+
+def test_the_pre_existing_knob_still_wins(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An operator who already tuned the canvas must not be silently
+    overridden by a second knob that means the same thing."""
+    monkeypatch.setenv("JARVIS_BIPARTITE_CANVAS_MAX_LINES", "750")
+    assert canvas_history_lines() == 750
+
+
+def test_the_kill_switch(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JARVIS_CANVAS_SCROLLBACK_ENABLED", "0")
+    assert scrollback_enabled() is False

--- a/tests/battle_test/test_native_scrollback.py
+++ b/tests/battle_test/test_native_scrollback.py
@@ -17,6 +17,7 @@ Application would pass any test that only read the config.
 from __future__ import annotations
 
 import os
+from typing import Optional
 import subprocess
 import sys
 from pathlib import Path
@@ -158,14 +159,16 @@ except Exception: pass
 '''
 
 
-def _run_pty(tmp_path: Path, fullscreen: bool) -> str:
-    driver = tmp_path / f"drv_{int(fullscreen)}.py"
+def _run_pty(tmp_path: Path, fullscreen: Optional[bool]) -> str:
+    """Drive the cockpit under a real PTY. *fullscreen* None = unset (the
+    DEFAULT path), True/False = the explicit opt-in / opt-out."""
+    driver = tmp_path / f"drv_{fullscreen}.py"
     driver.write_text(_PTY_DRIVER)
     env = {**os.environ, "PYTHONPATH": str(_REPO)}
-    if fullscreen:
-        env["JARVIS_BIPARTITE_FULLSCREEN"] = "1"
-    else:
+    if fullscreen is None:
         env.pop("JARVIS_BIPARTITE_FULLSCREEN", None)
+    else:
+        env["JARVIS_BIPARTITE_FULLSCREEN"] = "1" if fullscreen else "0"
     try:
         proc = subprocess.run(
             [sys.executable, str(driver)], capture_output=True, text=True,
@@ -181,13 +184,32 @@ def _run_pty(tmp_path: Path, fullscreen: bool) -> str:
 
 
 @pytest.mark.timeout(150)
-def test_the_terminal_is_NOT_switched_by_default(tmp_path: Path) -> None:
-    """`ESC[?1049h` is what a terminal acts on. A config value that failed to
-    reach the Application would pass any test that only read the config."""
+def test_the_terminal_IS_switched_by_default(tmp_path: Path) -> None:
+    """The cockpit claims the alternate screen on a real terminal.
+
+    This assertion is the REVERSE of what it was. #70171 defaulted
+    full-screen off because the alternate screen disables native scrollback
+    and Zone 1 was a tail — `snap[-budget:]`, with nothing reachable above
+    it — so claiming the screen deleted the session's history.
+
+    `canvas_viewport` removed that objection: Zone 1 is now a window over
+    ~20k retained lines with PgUp/PgDn/Home/End. With history safe inside the
+    cockpit, taking the screen is what makes `ov` an instrument you are in
+    rather than a command that scrolled past.
+
+    `ESC[?1049h` is what a terminal actually acts on — a config value that
+    never reached the Application would pass any test that only read config.
+    """
+    assert "RESULT_ALT=1" in _run_pty(tmp_path, fullscreen=None)
+
+
+@pytest.mark.timeout(150)
+def test_opting_out_keeps_the_primary_screen(tmp_path: Path) -> None:
+    """The escape hatch for anyone who wants native scrollback back, and the
+    inverse that proves the assertion above measures something."""
     assert "RESULT_ALT=0" in _run_pty(tmp_path, fullscreen=False)
 
 
 @pytest.mark.timeout(150)
-def test_opting_in_DOES_switch_the_terminal(tmp_path: Path) -> None:
-    """The inverse proves the assertion above is measuring something."""
+def test_opting_in_explicitly_still_switches(tmp_path: Path) -> None:
     assert "RESULT_ALT=1" in _run_pty(tmp_path, fullscreen=True)


### PR DESCRIPTION
> **Stacked on #70172.** Base is `feat/multiline-input`; merge that first and this retargets to `main`.

## What you were looking at

`ov` played its crest and then rendered the cockpit **inline, underneath the splash it had just drawn** — two logos on screen, the version stated twice, and an interface that read as a command that scrolled past rather than an instrument you're inside of.

The two logos were never two bugs. They were one missing transition.

## Why this isn't a flag flip

#70171 defaulted full-screen **off** for a real reason: the alternate screen disables the terminal's native scrollback, and Zone 1 — the canvas meant to replace it — rendered `snap[-budget:]`. The last screenful, nothing above it reachable.

Flipping the flag alone would not have delivered a full-screen cockpit. It would have deleted the session's history and called it a feature.

So the canvas stops being a tail and becomes a **viewport**: a window over ~20k retained lines, `PgUp`/`PgDn`/`Home`/`End`, and a status row that appears *only* while scrolled and names the way back. History is now safe inside the cockpit, so the objection is gone and the alternate screen becomes the default on a real terminal. Exit issues rmcup; the shell returns untouched.

## Holding the view still — two wrong answers first

Both were live, and both looked fine from the outside:

1. **`page(1)` computed `offset - step`** — moving toward the tail the viewport was already pinned to. PgUp was a dead key that returned perfectly plausible lines, which is why asserting on the lines alone missed it.
2. **Compensating by the change in LENGTH** works while the ring fills and stops the moment it saturates: every append then also drops a line off the front, so the length freezes while the content keeps moving. The view walked from line 180 → 220 with that "fix" in place — in the regime a long session spends *all* its time in.

The right answer is the ring's monotonic `push_count`, which `RegionBuffer` already tracked. And only while scrolled — at the tail, following is the entire point of a live cockpit.

## Reuse over addition

- `RegionBuffer.push_count` — already existed; no second counter.
- `JARVIS_BIPARTITE_CANVAS_MAX_LINES` — still honoured, so an operator who already tuned the canvas isn't silently overridden by a new knob meaning the same thing.
- One shared `_real_tty()` so the launch gate and the alt-screen decision cannot disagree about what a terminal is.

Piped, dumb, and CI keep the inline path — there's no smcup to issue there, and claiming one writes escape soup into a log file.

Switches: `JARVIS_BIPARTITE_FULLSCREEN=0` restores the inline cockpit; `JARVIS_CANVAS_SCROLLBACK_ENABLED=0` pins the canvas back to the tail.

## Verification

- **20 new tests**, plus the contract test from #70171 **reversed** — it now asserts `ESC[?1049h` *is* emitted by default, checked against a real PTY, since a config value that never reached the Application would pass anything that only read config.
- **Mutation-tested.** Reintroducing each of the three bugs fails exactly the test written for it and nothing else: length-delta → only the saturated test; no compensation → both hold-still tests; inverted `page` → the direction test.
- No new failures across `tests/cli` + `tests/battle_test`. The remaining reds are the pre-existing set confirmed at clean HEAD; `test_bounded_shutdown_watchdog.py` is ordering-dependent (all three of its tests fail in isolation on both trees) and touches nothing here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the cockpit take the terminal’s alternate screen by default on real TTYs, enabled by a canvas-backed scrollback viewport (~20k lines) with PgUp/PgDn/Home/End and wheel support. History stays inside the cockpit, and exiting restores the shell unchanged.

- New Features
  - Added `CanvasViewport`: bottom-anchored window over retained lines; view holds steady while appending via `RegionBuffer.push_count`; status row shows only while scrolled.
  - Installed scroll bindings (PgUp/PgDn/Home/End and wheel).
  - Default full-screen on real TTYs via `_real_tty()`; piped/dumb/CI stay inline. Opt out with `JARVIS_BIPARTITE_FULLSCREEN=0`.
  - History size via `JARVIS_CANVAS_HISTORY_LINES` or `JARVIS_BIPARTITE_CANVAS_MAX_LINES` (defaults to ~20k). Kill switch: `JARVIS_CANVAS_SCROLLBACK_ENABLED=0`.

- Bug Fixes
  - Fixed PgUp direction and removed scroll drift after ring saturation by using the monotonic append count; viewport re-clamps against the live ring.
  - Unified terminal detection with one `_real_tty()` for launch and alt-screen.
  - Tests: new viewport suite; reversed PTY contract now asserts `ESC[?1049h` by default, plus explicit opt-in/out coverage.

<sup>Written for commit 3d836bce501ae04dd0b7d1ed40ef304412700188. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

