### PR TITLE
feat(ov): a gate never interrupts a half-typed line

### DIFF
--- a/backend/core/ouroboros/battle_test/cockpit_attach.py
+++ b/backend/core/ouroboros/battle_test/cockpit_attach.py
@@ -82,6 +82,33 @@ AUDIO_CMDS = (
 _TRUTHY = ("1", "true", "yes", "on")
 
 
+def _accepts_kwarg(fn: Any, name: str) -> bool:
+    """Does *fn* declare a keyword parameter called *name*?
+
+    Keyword rather than a third positional: the answer's prompt_id is
+    OPTIONAL context, and threading it positionally would make every existing
+    two-argument sink's meaning depend on argument order it never agreed to.
+    A sink that wants it says so by name.
+
+    Defaults to False when the signature cannot be read — the sink is then
+    called exactly as it was before.
+    """
+    try:
+        import inspect
+        sig = inspect.signature(fn)
+        for p in sig.parameters.values():
+            if p.kind is inspect.Parameter.VAR_KEYWORD:
+                return True
+            if p.name == name and p.kind in (
+                inspect.Parameter.KEYWORD_ONLY,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            ):
+                return True
+        return False
+    except (TypeError, ValueError):
+        return False
+
+
 def _accepts_two_positional(fn: Any) -> bool:
     """Can *fn* be called with (text, session)?
 
@@ -213,6 +240,8 @@ class CockpitAttachBridge:
         #: SECOND time. A dispatch surface must never guess by re-running the
         #: thing it is dispatching.
         self._input_takes_session = _accepts_two_positional(self._on_input)
+        self._input_takes_prompt_id = _accepts_kwarg(self._on_input,
+                                                     "prompt_id")
         self._path = Path(path) if path is not None else attach_socket_path()
         self._server: Optional[asyncio.AbstractServer] = None
         self._sentinel_task: Optional[asyncio.Task] = None
@@ -436,6 +465,82 @@ class CockpitAttachBridge:
                 loop.call_soon_threadsafe(self._broadcast, msg)
         except Exception:  # noqa: BLE001
             logger.debug("[CockpitAttach] markup publish degraded", exc_info=True)
+
+    def publish_prompt(
+        self,
+        prompt_id: str,
+        text: str = "",
+        *,
+        risk: str = "",
+        timeout_s: float = 0.0,
+    ) -> None:
+        """Announce an OPEN interactive gate as structured data.
+
+        The question already travels as a mirrored ``markup`` line, and that
+        stays — it is what puts the gate in the transcript. But a line is
+        prose: a cockpit cannot tell it apart from any other ⏺ chrome, so it
+        cannot know a question is pending, which one, or when it dies.
+
+        With the id and the deadline on the wire, an attached cockpit can
+        defer the gate until its operator is not mid-sentence and still
+        answer the RIGHT op (`resolve` refuses a mismatched ``prompt_id``).
+        Broadcast, never session-addressed: an autonomous gate belongs to no
+        one terminal and every attached operator may answer it.
+
+        Thread-safe; strictly non-blocking; NEVER raises.
+        """
+        try:
+            prompt_id = str(prompt_id or "").strip()
+            if not prompt_id or not self._clients:
+                return
+            msg = {
+                "type": "prompt", "prompt_id": prompt_id,
+                "text": str(text or ""), "risk": str(risk or ""),
+                "timeout_s": float(timeout_s or 0.0), "ts": time.time(),
+            }
+            self.stats["prompts_published"] = (
+                self.stats.get("prompts_published", 0) + 1
+            )
+            self._dispatch(msg)
+        except Exception:  # noqa: BLE001
+            logger.debug("[CockpitAttach] prompt publish degraded",
+                         exc_info=True)
+
+    def publish_prompt_resolved(self, prompt_id: str) -> None:
+        """The gate is closed — answered here, elsewhere, or expired.
+
+        Without this a deferred gate would sit in a cockpit's queue and be
+        offered to the operator long after the organism stopped waiting. The
+        queue drops it on pop by deadline too, but only this says *why* and
+        says it immediately.
+        """
+        try:
+            prompt_id = str(prompt_id or "").strip()
+            if not prompt_id or not self._clients:
+                return
+            self._dispatch({
+                "type": "prompt_resolved", "prompt_id": prompt_id,
+                "ts": time.time(),
+            })
+        except Exception:  # noqa: BLE001
+            logger.debug("[CockpitAttach] prompt-resolved degraded",
+                         exc_info=True)
+
+    def _dispatch(self, msg: Dict[str, Any]) -> None:
+        """Hop to the server loop and broadcast. The cross-loop dance every
+        publisher above repeats by hand — written once so a new frame type
+        cannot get it subtly wrong."""
+        loop = self._loop
+        if loop is None or loop.is_closed():
+            return
+        try:
+            running = asyncio.get_running_loop()
+        except RuntimeError:
+            running = None
+        if running is loop:
+            self._broadcast(msg)
+        else:
+            loop.call_soon_threadsafe(self._broadcast, msg)
 
     def publish_audio_state(self, state: str) -> None:
         """Stream one audio-FSM state to every attached terminal
@@ -752,11 +857,17 @@ class CockpitAttachBridge:
                     text = str(frame.get("text", "")).strip()
                     if text:
                         self.stats["inputs_received"] += 1
+                        # Which gate this answers, when the cockpit says so.
+                        # Only forwarded to a sink that asked for it by name.
+                        _kw = {}
+                        _pid = str(frame.get("prompt_id", "")).strip()
+                        if _pid and self._input_takes_prompt_id:
+                            _kw["prompt_id"] = _pid
                         try:
                             if self._input_takes_session:
-                                self._on_input(text, _sid or None)
+                                self._on_input(text, _sid or None, **_kw)
                             else:
-                                self._on_input(text)
+                                self._on_input(text, **_kw)
                         except Exception:  # noqa: BLE001
                             logger.debug(
                                 "[CockpitAttach] input sink degraded",
@@ -813,6 +924,8 @@ class CockpitAttachClient:
         on_line: Optional[Callable[[str], None]] = None,
         on_markup: Optional[Callable[[str], None]] = None,
         on_telemetry: Optional[Callable[[Dict[str, Any]], None]] = None,
+        on_prompt: Optional[Callable[[Dict[str, Any]], None]] = None,
+        on_prompt_resolved: Optional[Callable[[str], None]] = None,
         on_audio_state: Optional[Callable[[str], None]] = None,
         on_thermal: Optional[Callable[[str], None]] = None,
         on_lane_history: Optional[Callable[[Dict[str, Any]], None]] = None,
@@ -827,6 +940,8 @@ class CockpitAttachClient:
         # escaped by conservative clients — never dropped).
         self._on_markup = on_markup
         self._on_telemetry = on_telemetry or (lambda _m: None)
+        self._on_prompt = on_prompt
+        self._on_prompt_resolved = on_prompt_resolved
         self._on_audio_state = on_audio_state or (lambda _s: None)
         self._on_thermal = on_thermal or (lambda _s: None)
         #: Focused-lane hydration payloads (D3). Absent handler = the client
@@ -941,7 +1056,7 @@ class CockpitAttachClient:
         except Exception:  # noqa: BLE001
             return False
 
-    def send_input(self, text: str) -> bool:
+    def send_input(self, text: str, prompt_id: Optional[str] = None) -> bool:
         """Pipe one operator line upstream. Non-blocking; False when
         detached. NEVER raises."""
         try:
@@ -955,6 +1070,12 @@ class CockpitAttachClient:
             # back rather than broadcasting it to every attached cockpit.
             frame = {"type": "input", "text": str(text),
                      "session": self.session_id}
+            if prompt_id:
+                # Tag the answer with the gate it was written for. A deferred
+                # verdict can outlive the slot it was meant for, and the
+                # daemon refuses a mismatch rather than landing "y" on
+                # whichever op happens to be armed now.
+                frame["prompt_id"] = str(prompt_id)
             w.write((json.dumps(frame, separators=(",", ":")) + "\n").encode())
             return True
         except Exception:  # noqa: BLE001
@@ -992,6 +1113,22 @@ class CockpitAttachClient:
                             pass
                     else:
                         self._safe_cb_text(cb, str(frame.get("text", "")))
+                elif ftype == "prompt":
+                    # An open gate, as data. A client with no handler is a
+                    # pre-shield cockpit: it already received the same
+                    # question as a markup line, so silence here is correct
+                    # and it behaves exactly as it did before.
+                    if self._on_prompt is not None:
+                        try:
+                            self._on_prompt(dict(frame))
+                        except Exception:  # noqa: BLE001
+                            pass
+                elif ftype == "prompt_resolved":
+                    if self._on_prompt_resolved is not None:
+                        self._safe_cb_text(
+                            self._on_prompt_resolved,
+                            str(frame.get("prompt_id", "")),
+                        )
                 elif ftype == "telemetry":
                     try:
                         self._on_telemetry(dict(frame))

--- a/backend/core/ouroboros/battle_test/focus_shield.py
+++ b/backend/core/ouroboros/battle_test/focus_shield.py
@@ -1,0 +1,347 @@
+"""A gate never interrupts a half-typed line.
+
+The organism raises `APPROVAL_REQUIRED` gates on its own schedule. The
+operator types on theirs. Those two clocks are independent, so sooner or
+later a gate arrives in the middle of a sentence — and the moment it does,
+whatever happens next has to be something the operator chose.
+
+The hazard is not a stolen cursor
+---------------------------------
+Nothing in the cockpit calls `set_focus`, so there is no focus to steal. The
+real race was on the DAEMON, and it was worse: `_on_input` offered every
+attached line to the pending gate BEFORE the REPL, and the gate consumed
+whatever it got. Typing ``go fix the flaky test`` while a gate was open
+approved an op the operator had not read, and the goal never reached the
+REPL. That is fixed at the source in `operator_prompt_bridge` — a verdict now
+has to be one bare word.
+
+This module is the other half: making sure the operator KNOWS a question is
+open, without the question seizing the screen mid-thought.
+
+The rule
+--------
+A gate arriving while the buffer holds text does not display. It is queued,
+and a badge appears in the toolbar::
+
+    [ ⚠ 1 pending approval · ctrl-p ]
+
+It surfaces when the operator is ready — explicitly with ``Ctrl+P``, or
+implicitly the moment their buffer goes empty (they submitted or cleared it).
+Either way the gate appears in a lull, and an Enter meant for their own line
+can never land on someone else's ``[y/n]``.
+
+Deferral makes staleness possible
+---------------------------------
+A queued gate is a gate nobody has answered yet, and the organism does not
+wait forever — `await_decision` stamps EXPIRED on its own timeout. So a
+queued prompt carries its deadline and is dropped on pop rather than shown:
+presenting a dead gate as actionable would let the operator believe they
+approved something they did not. Same reason the bridge refuses an answer
+whose `prompt_id` no longer holds the slot — deferral is exactly the window
+in which the slot can move on.
+
+No authority: this decides WHEN a question is visible, never what the answer
+is. Master: ``JARVIS_FOCUS_SHIELD_ENABLED`` (default on). Off = the previous
+behaviour, where a gate simply scrolled past in the deck.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import time
+from collections import deque
+from typing import Any, Callable, Deque, Dict, List, Optional
+
+logger = logging.getLogger("Ouroboros.FocusShield")
+
+__all__ = [
+    "PendingPrompt",
+    "FocusShield",
+    "focus_shield_enabled",
+    "parse_prompt_frame",
+]
+
+#: A cockpit is not a ticket queue. Past this, the OLDEST pending gates are
+#: dropped — they are the ones closest to expiring anyway, and an operator
+#: who has ignored eight approvals is not helped by a ninth.
+_MAX_PENDING = 8
+
+#: Used only when a frame carries no deadline of its own. Matches the
+#: `JARVIS_REVIEW_TIMEOUT_S` default so a queued gate and the op it belongs
+#: to disagree as little as possible.
+_DEFAULT_TIMEOUT_S = 300.0
+
+
+def focus_shield_enabled() -> bool:
+    """Default ON. Off, gates render inline exactly as they did before."""
+    return os.environ.get(
+        "JARVIS_FOCUS_SHIELD_ENABLED", "1",
+    ).strip().lower() not in ("0", "false", "no", "off")
+
+
+class PendingPrompt:
+    """One deferred question, and the deadline it is living under."""
+
+    __slots__ = ("prompt_id", "text", "risk", "timeout_s", "received_at")
+
+    def __init__(
+        self,
+        prompt_id: str,
+        text: str = "",
+        risk: str = "",
+        timeout_s: float = _DEFAULT_TIMEOUT_S,
+        received_at: float = 0.0,
+    ) -> None:
+        self.prompt_id = str(prompt_id or "")
+        self.text = str(text or "")
+        self.risk = str(risk or "")
+        try:
+            self.timeout_s = float(timeout_s)
+        except Exception:  # noqa: BLE001
+            self.timeout_s = _DEFAULT_TIMEOUT_S
+        self.received_at = float(received_at)
+
+    def seconds_left(self, now: float) -> float:
+        if self.timeout_s <= 0:
+            # No deadline declared — never auto-expire. Dropping a gate the
+            # daemon intends to hold open would be the shield inventing an
+            # expiry the organism never agreed to.
+            return float("inf")
+        return self.timeout_s - (now - self.received_at)
+
+    def expired(self, now: float) -> bool:
+        return self.seconds_left(now) <= 0
+
+    @property
+    def ref(self) -> str:
+        """The op's TAIL. UUIDv7 is time-ordered, so ops raised in the same
+        session share their leading bytes and differ only at the end."""
+        parts = [p for p in self.prompt_id.replace(":", "-").split("-") if p]
+        return "-".join(parts[-2:]) if len(parts) >= 3 else (
+            self.prompt_id or "op"
+        )
+
+    def __repr__(self) -> str:  # pragma: no cover — diagnostics only
+        return f"<PendingPrompt {self.prompt_id!r} risk={self.risk!r}>"
+
+
+def parse_prompt_frame(frame: Any) -> Optional[PendingPrompt]:
+    """Build a PendingPrompt from a wire frame. None if it is not one.
+
+    Tolerant by design: a frame from a newer daemon must not crash an older
+    cockpit, and a prompt with no id is unanswerable — the bridge would have
+    nothing to match — so it is refused rather than shown.
+    """
+    try:
+        if not isinstance(frame, dict):
+            return None
+        prompt_id = str(frame.get("prompt_id", "") or "").strip()
+        if not prompt_id:
+            return None
+        return PendingPrompt(
+            prompt_id=prompt_id,
+            text=str(frame.get("text", "") or ""),
+            risk=str(frame.get("risk", "") or ""),
+            timeout_s=frame.get("timeout_s", _DEFAULT_TIMEOUT_S),
+        )
+    except Exception:  # noqa: BLE001
+        return None
+
+
+class FocusShield:
+    """Decides when a pending question is allowed on screen."""
+
+    def __init__(
+        self,
+        *,
+        show: Optional[Callable[[PendingPrompt], None]] = None,
+        notify: Optional[Callable[[], None]] = None,
+        clock: Optional[Callable[[], float]] = None,
+        max_pending: int = _MAX_PENDING,
+    ) -> None:
+        # INJECTED sinks and clock: the FSM must be provable with no
+        # Application, no socket and no wall-clock dependence. The last
+        # focus-adjacent rule that read live global state returned the wrong
+        # answer under test and looked correct.
+        self._show = show
+        self._notify = notify
+        self._clock = clock or time.monotonic
+        self._queue: Deque[PendingPrompt] = deque(maxlen=max(1, max_pending))
+        self._showing: Optional[PendingPrompt] = None
+        self.dropped_expired = 0
+        self.dropped_overflow = 0
+
+    # -- arrival -----------------------------------------------------------
+
+    def offer(self, prompt: Any, *, composing: bool) -> str:
+        """Take delivery of a gate. Returns ``shown`` / ``queued`` / ``""``.
+
+        *composing* is the whole decision: it is the caller's answer to "does
+        the operator have text in their buffer right now". Passed in rather
+        than read from a global app, so the rule is testable and so the
+        cockpit and the plain client can answer it their own way.
+        """
+        try:
+            pending = (
+                prompt if isinstance(prompt, PendingPrompt)
+                else parse_prompt_frame(prompt)
+            )
+            if pending is None:
+                return ""
+            if pending.received_at <= 0:
+                pending.received_at = self._clock()
+
+            if not focus_shield_enabled():
+                # Shield off: straight to the surface, as before.
+                self._present(pending)
+                return "shown"
+
+            # Re-arming sends the same id again (the bridge re-arms whenever
+            # a line turns out not to be a verdict). Refresh rather than
+            # stack, or one unanswered gate becomes a queue of itself.
+            self._forget(pending.prompt_id)
+
+            if composing or self._showing is not None:
+                # Either the operator is mid-line, or a gate already holds
+                # the overlay. Both mean "not now".
+                if len(self._queue) == self._queue.maxlen:
+                    self.dropped_overflow += 1
+                self._queue.append(pending)
+                self._ping()
+                return "queued"
+
+            self._present(pending)
+            return "shown"
+        except Exception:  # noqa: BLE001 — a gate must never crash a cockpit
+            logger.debug("[FocusShield] offer degraded", exc_info=True)
+            return ""
+
+    # -- release -----------------------------------------------------------
+
+    def pop(self) -> Optional[PendingPrompt]:
+        """Surface the next live gate, or None.
+
+        Expired entries are discarded on the way out, never shown. A queued
+        gate whose deadline passed has already been decided by the organism
+        — presenting it would invite an answer that changes nothing while
+        reading as though it did.
+        """
+        try:
+            if self._showing is not None:
+                # One question at a time; the rest keep waiting.
+                return None
+            now = self._clock()
+            while self._queue:
+                candidate = self._queue.popleft()
+                if candidate.expired(now):
+                    self.dropped_expired += 1
+                    logger.info(
+                        "[FocusShield] dropped expired prompt %s",
+                        candidate.prompt_id,
+                    )
+                    continue
+                self._present(candidate)
+                self._ping()
+                return candidate
+            self._ping()
+            return None
+        except Exception:  # noqa: BLE001
+            logger.debug("[FocusShield] pop degraded", exc_info=True)
+            return None
+
+    def note_buffer(self, text: Any) -> Optional[PendingPrompt]:
+        """Call whenever the input buffer changes. Pops once it is empty.
+
+        This is the implicit half of the rule: the operator does not have to
+        learn a key. They send their line, the buffer empties, and the
+        question they were shielded from appears in the lull that follows.
+        """
+        try:
+            if str(text or "").strip():
+                return None
+            return self.pop()
+        except Exception:  # noqa: BLE001
+            return None
+
+    def dismiss(self, prompt_id: Any = None) -> None:
+        """The showing gate was answered, expired, or decided elsewhere."""
+        try:
+            if prompt_id is None or (
+                self._showing is not None
+                and self._showing.prompt_id == str(prompt_id)
+            ):
+                self._showing = None
+            self._forget(prompt_id)
+            self._ping()
+        except Exception:  # noqa: BLE001
+            pass
+
+    # -- state -------------------------------------------------------------
+
+    @property
+    def showing(self) -> Optional[PendingPrompt]:
+        return self._showing
+
+    @property
+    def pending_count(self) -> int:
+        """Live gates waiting. Expired ones are not counted — a badge that
+        advertises a dead approval is worse than no badge."""
+        try:
+            now = self._clock()
+            return sum(1 for p in self._queue if not p.expired(now))
+        except Exception:  # noqa: BLE001
+            return len(self._queue)
+
+    def badge(self) -> str:
+        """Toolbar fragment, or "" when there is nothing waiting."""
+        try:
+            count = self.pending_count
+            if count <= 0:
+                return ""
+            noun = "approval" if count == 1 else "approvals"
+            return f"⚠ {count} pending {noun} · ctrl-p"
+        except Exception:  # noqa: BLE001
+            return ""
+
+    def snapshot(self) -> List[Dict[str, Any]]:
+        """Queue contents for `/gates`-style inspection. Read-only."""
+        try:
+            now = self._clock()
+            return [
+                {
+                    "prompt_id": p.prompt_id,
+                    "ref": p.ref,
+                    "risk": p.risk,
+                    "seconds_left": round(p.seconds_left(now), 1),
+                }
+                for p in self._queue
+            ]
+        except Exception:  # noqa: BLE001
+            return []
+
+    # -- internals ---------------------------------------------------------
+
+    def _present(self, prompt: PendingPrompt) -> None:
+        self._showing = prompt
+        if self._show is not None:
+            try:
+                self._show(prompt)
+            except Exception:  # noqa: BLE001
+                logger.debug("[FocusShield] show sink raised", exc_info=True)
+
+    def _forget(self, prompt_id: Any) -> None:
+        if prompt_id is None:
+            return
+        key = str(prompt_id)
+        for existing in [p for p in self._queue if p.prompt_id == key]:
+            try:
+                self._queue.remove(existing)
+            except ValueError:
+                pass
+
+    def _ping(self) -> None:
+        if self._notify is not None:
+            try:
+                self._notify()
+            except Exception:  # noqa: BLE001
+                pass

--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -4519,7 +4519,8 @@ class BattleTestHarness:
                 except Exception:  # noqa: BLE001
                     return {}
 
-            def _on_input(text: str, session: Optional[str] = None) -> None:
+            def _on_input(text: str, session: Optional[str] = None,
+                          prompt_id: Optional[str] = None) -> None:
                 # Operator Prompt Bridge FIRST (2026-07-23): while an
                 # interactive gate ([Y/n] Iron Gate, endorse) is pending,
                 # the next attached-terminal line IS the answer — HITL
@@ -4529,7 +4530,9 @@ class BattleTestHarness:
                     from backend.core.ouroboros.battle_test.operator_prompt_bridge import (  # noqa: E501
                         get_operator_prompt_bridge,
                     )
-                    if get_operator_prompt_bridge().resolve(text):
+                    if get_operator_prompt_bridge().resolve(
+                        text, prompt_id=prompt_id,
+                    ):
                         return
                 except Exception:  # noqa: BLE001
                     pass
@@ -4582,6 +4585,21 @@ class BattleTestHarness:
                 # CC-style ⏺/⎿ tool blocks + diffs the local console
                 # renders (composition layer escapes model content).
                 try:
+                    # Interactive gates, as DATA. The question already
+                    # mirrors as a markup line; this adds the id + deadline a
+                    # cockpit needs to defer it safely and still answer the
+                    # right op. Wired at the bridge's arming seam, so every
+                    # gate that can be answered remotely is announced.
+                    try:
+                        from backend.core.ouroboros.battle_test.operator_prompt_bridge import (  # noqa: E501
+                            set_prompt_publisher,
+                        )
+                        set_prompt_publisher(
+                            bridge.publish_prompt,
+                            bridge.publish_prompt_resolved,
+                        )
+                    except Exception:  # noqa: BLE001
+                        pass
                     sf = getattr(self, "_serpent_flow", None)
                     if sf is not None:
                         sf.markup_mirror = bridge.publish_markup

--- a/backend/core/ouroboros/battle_test/operator_prompt_bridge.py
+++ b/backend/core/ouroboros/battle_test/operator_prompt_bridge.py
@@ -14,12 +14,30 @@ Design — one single-slot pending-prompt registry, raced not replaced:
   local ``prompt_async`` — FIRST answer wins, loser is cancelled. The
   local terminal loses nothing; the cockpit gains everything.
 * The harness's attach-input handler calls :meth:`resolve` BEFORE the
-  REPL dispatcher: while a prompt is pending, the next operator line from
-  ANY attached terminal is the answer, not chat. With no pending prompt,
-  ``resolve`` declines instantly and input flows to the REPL untouched.
+  REPL dispatcher: while a prompt is pending, an operator line that IS a
+  verdict answers it. With no pending prompt — or with a line that is not
+  a verdict — ``resolve`` declines and the text flows to the REPL untouched.
+
+  **This was originally "the next line, whatever it is."** That is a live
+  hazard once the organism raises gates asynchronously, because the operator
+  is typing a goal, not answering a question they may not have noticed:
+
+    - ``go fix the flaky test``  → first token ``go`` → **APPROVED** an
+      unrelated APPROVAL_REQUIRED op, and the goal never reached the REPL.
+    - ``stop the doc_staleness storm`` → **REJECTED** one.
+    - ``let's build the streaming next`` → not a verdict, yet still consumed:
+      silently dropped on the floor while the gate re-armed.
+
+  So a verdict must now be UNAMBIGUOUS: the whole line, one word, in the
+  shared vocabulary. A sentence is a goal. See :func:`is_bare_verdict`.
 * Single-slot by design: the FSM serializes interactive gates; a second
   ``begin`` supersedes (cancels) the first rather than queueing —
   superseded prompts fall back to their local surface.
+* Because the slot can be superseded between a prompt being SHOWN and being
+  ANSWERED, :meth:`resolve` accepts an optional ``prompt_id`` and refuses to
+  answer a different one. Without that check a deferred "y" — meant for the
+  gate the operator read — would land on whichever op happens to hold the
+  slot now. Approving the wrong op is the worst outcome this file can have.
 
 Zero authority (carries text, decides nothing); asyncio-native;
 NEVER raises anywhere. Master: ``JARVIS_OPERATOR_PROMPT_BRIDGE_ENABLED``
@@ -39,11 +57,101 @@ logger = logging.getLogger("Ouroboros.OperatorPromptBridge")
 _TRUTHY = ("1", "true", "yes", "on")
 
 
+def strict_verdicts_enabled() -> bool:
+    """Default ON. Off restores "any line answers", which is unsafe once
+    gates arrive asynchronously — kept only as a rollback."""
+    return os.environ.get(
+        "JARVIS_PROMPT_BRIDGE_STRICT_VERDICTS", "1",
+    ).strip().lower() in _TRUTHY
+
+
+def is_bare_verdict(text: Any) -> Optional[bool]:
+    """``True`` approve, ``False`` reject, ``None`` "not an answer".
+
+    The VOCABULARY is `approval_narrator.interpret_answer` — one definition
+    of what "yes" means, shared with the local terminal path. What is added
+    here is strictness about SHAPE: the whole line must be a single word.
+
+    That distinction is the entire safety property. `interpret_answer` reads
+    the first token, which is right at an explicit ``[y/n]`` prompt where the
+    operator is deliberately answering, and wrong for an unprompted line
+    typed by someone composing a goal — where ``go fix the flaky test``
+    would otherwise approve an op they never looked at.
+
+    Imported lazily: governance already imports this module, so a top-level
+    import would close the cycle. Falls back to a local vocabulary if that
+    import fails, because the bridge must keep working regardless.
+    """
+    try:
+        raw = str(text if text is not None else "").strip()
+        if not raw:
+            return None
+        if strict_verdicts_enabled() and len(raw.split()) != 1:
+            # A sentence is a goal, not a verdict. Punctuation is tolerated
+            # below ("y." / "no!") — an extra WORD is what disqualifies.
+            return None
+        token = raw.split()[0].strip(".,!;:'\"").lower()
+        if not token:
+            return None
+        try:
+            from backend.core.ouroboros.governance.approval_narrator import (
+                interpret_answer,
+            )
+            return interpret_answer(token)
+        except Exception:  # noqa: BLE001
+            if token in ("y", "yes", "approve", "ok", "go", "ship", "accept"):
+                return True
+            if token in ("n", "no", "reject", "stop", "deny", "cancel",
+                         "abort"):
+                return False
+            return None
+    except Exception:  # noqa: BLE001
+        return None
+
+
 def prompt_bridge_enabled() -> bool:
     """Master gate — default ON. Re-read at call time. NEVER raises."""
     return os.environ.get(
         "JARVIS_OPERATOR_PROMPT_BRIDGE_ENABLED", "1",
     ).strip().lower() in _TRUTHY
+
+
+#: Set once at harness boot to the attach server's publishers. Injected
+#: rather than imported because the server is an instance the harness owns —
+#: the same reason `markup_mirror` and `set_operator_dispatcher` are wired
+#: this way. Absent (unit tests, no cockpit), announcing is a silent no-op
+#: and the bridge behaves exactly as it always has.
+_ANNOUNCE: Optional[Any] = None
+_ANNOUNCE_DONE: Optional[Any] = None
+
+
+def set_prompt_publisher(
+    announce: Optional[Any], resolved: Optional[Any] = None,
+) -> None:
+    """Install the cockpit announce sinks. ``None`` disarms them."""
+    global _ANNOUNCE, _ANNOUNCE_DONE
+    _ANNOUNCE, _ANNOUNCE_DONE = announce, resolved
+
+
+def _announce(prompt_id: str, text: str, risk: str, timeout_s: float) -> None:
+    fn = _ANNOUNCE
+    if fn is None:
+        return
+    try:
+        fn(prompt_id, text, risk=risk, timeout_s=timeout_s)
+    except Exception:  # noqa: BLE001 — a gate must never fail on telemetry
+        logger.debug("[OperatorPromptBridge] announce degraded", exc_info=True)
+
+
+def _announce_done(prompt_id: str) -> None:
+    fn = _ANNOUNCE_DONE
+    if fn is None or not prompt_id:
+        return
+    try:
+        fn(prompt_id)
+    except Exception:  # noqa: BLE001
+        logger.debug("[OperatorPromptBridge] resolve-announce degraded",
+                     exc_info=True)
 
 
 class OperatorPromptBridge:
@@ -55,7 +163,14 @@ class OperatorPromptBridge:
 
     # -- prompt side ----------------------------------------------------
 
-    def begin(self, prompt_id: str) -> Optional[asyncio.Future]:
+    def begin(
+        self,
+        prompt_id: str,
+        *,
+        text: str = "",
+        risk: str = "",
+        timeout_s: float = 0.0,
+    ) -> Optional[asyncio.Future]:
         """Arm the slot for ``prompt_id`` and return the answer future
         (resolved with the operator's raw text). A prior pending prompt
         is superseded (its future cancelled — it falls back to its local
@@ -74,6 +189,16 @@ class OperatorPromptBridge:
                 self._pending = (str(prompt_id), fut)
             if prev is not None and not prev[1].done():
                 prev[1].cancel()
+                # A superseded gate is closed as far as cockpits are
+                # concerned; leaving it queued would offer the operator a
+                # question nothing is listening to.
+                _announce_done(prev[0])
+            # Announced HERE because arming the slot is exactly what makes a
+            # gate answerable from a cockpit. Announcing at the call sites
+            # instead would mean every future gate has to remember to, and
+            # the one that forgets is invisible — the wired-but-inert defect
+            # this codebase keeps finding.
+            _announce(str(prompt_id), text, risk, float(timeout_s or 0.0))
             return fut
         except Exception:  # noqa: BLE001
             return None
@@ -82,11 +207,15 @@ class OperatorPromptBridge:
         """Disarm the slot IF it still holds ``fut`` (a superseding
         prompt keeps its own slot). Always safe to call. NEVER raises."""
         try:
+            closed = None
             with self._lock:
                 if self._pending is not None and self._pending[1] is fut:
+                    closed = self._pending[0]
                     self._pending = None
             if fut is not None and not fut.done():
                 fut.cancel()
+            if closed:
+                _announce_done(closed)
         except Exception:  # noqa: BLE001
             pass
 
@@ -101,19 +230,55 @@ class OperatorPromptBridge:
         except Exception:  # noqa: BLE001
             return False
 
-    def resolve(self, text: Any) -> bool:
-        """Offer one operator line to the pending prompt. True when the
-        line was CONSUMED as the answer (caller must not route it to the
-        REPL); False when no prompt is pending. Thread-safe: marshals to
-        the future's loop. NEVER raises."""
+    @property
+    def pending_id(self) -> Optional[str]:
+        """Which prompt currently holds the slot, or None."""
         try:
+            with self._lock:
+                p = self._pending
+            return p[0] if p is not None and not p[1].done() else None
+        except Exception:  # noqa: BLE001
+            return None
+
+    def resolve(self, text: Any, prompt_id: Optional[str] = None) -> bool:
+        """Offer one operator line to the pending prompt.
+
+        True when the line was CONSUMED as the answer (caller must not route
+        it to the REPL). False when no prompt is pending, when the line is
+        not a verdict, or when *prompt_id* names a prompt that no longer
+        holds the slot.
+
+        Returning False for a non-verdict is the load-bearing part: the line
+        then reaches the REPL, which is where the operator meant it to go.
+        Consuming it — the original behaviour — dropped a typed goal on the
+        floor while the gate silently re-armed.
+
+        *prompt_id*, when given, must match the armed prompt. A deferred
+        answer can be sitting in a cockpit's queue while the slot moves on to
+        a different op, and landing "y" on the wrong gate is the worst thing
+        this class could do. Callers with no id (the local terminal, which
+        cannot be stale) keep the old behaviour.
+
+        Thread-safe: marshals to the future's loop. NEVER raises.
+        """
+        try:
+            answer = str(text if text is not None else "").strip()
+            if strict_verdicts_enabled() and is_bare_verdict(answer) is None:
+                # Not an answer — leave the gate armed and let the text pass
+                # through to the REPL untouched.
+                return False
             with self._lock:
                 p = self._pending
                 if p is None or p[1].done():
                     return False
+                if prompt_id is not None and p[0] != str(prompt_id):
+                    logger.info(
+                        "[OperatorPromptBridge] declined stale answer for %s "
+                        "(slot holds %s)", prompt_id, p[0],
+                    )
+                    return False
                 self._pending = None
             _pid, fut = p
-            answer = str(text if text is not None else "").strip()
 
             def _set() -> None:
                 if not fut.done():
@@ -128,6 +293,7 @@ class OperatorPromptBridge:
                 "[OperatorPromptBridge] prompt %s answered via attach",
                 _pid,
             )
+            _announce_done(_pid)
             return True
         except Exception:  # noqa: BLE001
             return False

--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -3908,6 +3908,17 @@ class SerpentFlow:
             )
             bridge_fut = get_operator_prompt_bridge().begin(
                 f"iron-gate:{short}",
+                text=str(description or f"Iron Gate({short}) — apply?"),
+                risk=str(risk_reason or "APPROVAL_REQUIRED"),
+                # No deadline declared, deliberately. This gate has none
+                # while a local [Y/n] prompt is alive (`_race_gate_answer`
+                # passes `timeout=None`), and only `_bridge_only_wait_s()`
+                # once that surface is dead — which is not known yet, here.
+                # Declaring the shorter bound would let a cockpit expire a
+                # gate the organism is still waiting on, so the queue is
+                # purged by the authoritative `prompt_resolved` instead,
+                # which `end()` fires on every exit path.
+                timeout_s=0.0,
             )
         except Exception:  # noqa: BLE001
             bridge_fut = None

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -628,6 +628,14 @@ class AttachUI:
 
     def __init__(self) -> None:
         self.audio_state: str = "OFFLINE"
+        # A gate that arrives mid-sentence waits. Constructed with the sinks
+        # it needs so the FSM never reaches for a live app: `_shield_show`
+        # renders, `refresh` repaints the badge.
+        self.shield = _build_shield(self)
+        #: Set once the attach client exists. LATE-BOUND for the same reason
+        #: the approval narrator's emit is: the markup sink is built after the
+        #: UI, so a handle captured here would be None forever.
+        self.markup_sink: Any = None
         self._app_ref: Any = None
         # Latest heartbeat frame (the CC-style pulse) + arrival clock —
         # rendered by toolbar() with client-side elapsed advance and a
@@ -992,7 +1000,16 @@ class AttachUI:
                         else " · esc back")
         except Exception:  # noqa: BLE001
             keys = ""
-        return f"{audio.lstrip(' ·')}{keys} · 'detach' to leave"
+        # A pending approval outranks every other hint here: it is the only
+        # one that says the organism is BLOCKED waiting on this operator.
+        # Placed first so it survives a narrow terminal truncating the tail.
+        badge = ""
+        try:
+            badge = self.shield.badge()
+        except Exception:  # noqa: BLE001
+            badge = ""
+        head = f"{badge} · " if badge else ""
+        return f"{head}{audio.lstrip(' ·')}{keys} · 'detach' to leave"
 
     def _mode_lines(self) -> Optional[List[str]]:
         """SELECT / FOCUS rendering, or None to fall through to the deck.
@@ -1239,6 +1256,27 @@ def _route_operator_line(client: Any, ui: Any, line: Any) -> str:
             # make the cockpit and the daemon disagree about what was said,
             # and the daemon is where attachment resolution belongs. This
             # confirms the operator was understood; it does not decide.
+            # A gate is on screen and this line is a verdict → it answers
+            # THAT gate, tagged with its id. The daemon refuses a mismatch,
+            # so a verdict written for a gate that has since been superseded
+            # is declined rather than landing on whichever op is armed now.
+            #
+            # Anything that is not a bare verdict falls straight through to
+            # the REPL: the operator answering "later, first fix the tests"
+            # is giving a goal, not a decision.
+            try:
+                shield = getattr(ui, "shield", None)
+                showing = getattr(shield, "showing", None) if shield else None
+                if showing is not None:
+                    from backend.core.ouroboros.battle_test.operator_prompt_bridge import (  # noqa: E501
+                        is_bare_verdict,
+                    )
+                    if is_bare_verdict(text) is not None:
+                        client.send_input(text, prompt_id=showing.prompt_id)
+                        shield.dismiss(showing.prompt_id)
+                        return "sent"
+            except Exception:  # noqa: BLE001
+                pass
             _mentions = _extract_mentions(text)
             if _mentions and ui is not None:
                 try:
@@ -1251,6 +1289,15 @@ def _route_operator_line(client: Any, ui: Any, line: Any) -> str:
                 except Exception:  # noqa: BLE001
                     pass
             client.send_input(text)
+            # The buffer is now empty, so a gate deferred while they were
+            # typing surfaces in the lull that follows. This is the half the
+            # operator never has to learn: they send their line and the
+            # question they were shielded from appears.
+            try:
+                if getattr(ui, "shield", None) is not None:
+                    ui.shield.note_buffer("")
+            except Exception:  # noqa: BLE001
+                pass
             return "sent"
         return "empty"
     except Exception:  # noqa: BLE001 — routing must never crash an input loop
@@ -1577,6 +1624,27 @@ def _build_selection_bindings(ui: Any, client: Any) -> Any:
             fsm.escape()
             ui.refresh()
 
+        @kb.add("c-p")
+        def _release_gate(event: Any) -> None:
+            """Surface a deferred approval on demand.
+
+            Ctrl+P was unbound — verified, not assumed — so this takes no
+            key away from anyone. The binding exists even with an empty
+            queue: a key that works only sometimes teaches the operator not
+            to trust it, so an empty pop simply says so.
+            """
+            try:
+                shield = getattr(ui, "shield", None)
+                if shield is None:
+                    return
+                if shield.pop() is None:
+                    ui.flash(
+                        "no pending approvals" if shield.pending_count == 0
+                        else "a gate is already on screen", seconds=2.0,
+                    )
+            except Exception:  # noqa: BLE001
+                pass
+
         try:
             from backend.core.ouroboros.battle_test.input_continuation import (
                 install_newline_binding,
@@ -1608,6 +1676,66 @@ def _not_composing() -> Any:
         return _cond
     except Exception:  # noqa: BLE001
         return True
+
+
+def _build_shield(ui: Any) -> Any:
+    """The client's deferral FSM, wired to this cockpit's surfaces."""
+    try:
+        from backend.core.ouroboros.battle_test.focus_shield import FocusShield
+
+        return FocusShield(
+            show=lambda prompt: _shield_show(ui, prompt),
+            notify=lambda: ui.refresh(),
+        )
+    except Exception:  # noqa: BLE001 — a cockpit without deferral still runs
+        return None
+
+
+def _shield_show(ui: Any, prompt: Any) -> None:
+    """Put a released gate on screen.
+
+    Renders through the SAME markup path every ⏺/⎿ line already takes rather
+    than inventing a second display: the gate then lands in the deck, in
+    order, in the scrollback the operator can page back through — and on the
+    bipartite surface it draws over the canvas Float the palette established,
+    with the deck still visible underneath.
+    """
+    try:
+        risk = f" · {prompt.risk}" if getattr(prompt, "risk", "") else ""
+        left = prompt.seconds_left(time.monotonic())
+        expiry = "" if left == float("inf") else f" · {int(left)}s left"
+        body = str(prompt.text or "approve?").replace("\n", " ").strip()
+        lines = [f"⏺ Iron Gate({prompt.ref}){risk}",
+                 f"  ⎿ {body}  [y/n]{expiry}"]
+        sink = getattr(ui, "markup_sink", None)
+        if callable(sink):
+            for line in lines:
+                # ADDRESSED: a question put to this operator belongs in their
+                # scrollback, not in the ambient deck where it would scroll
+                # away behind autonomous chatter.
+                sink(line, True)
+        else:
+            ui.flash(" ".join(lines), seconds=8.0)
+        ui.refresh()
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _on_prompt_frame(ui: Any, frame: Any) -> None:
+    """A gate arrived. Show it only if the operator is not mid-sentence.
+
+    `composing` is answered from the LIVE buffer at the moment of arrival —
+    the one fact that decides everything here, and the reason the FSM takes
+    it as an argument rather than reading a global it cannot be tested
+    against.
+    """
+    try:
+        shield = getattr(ui, "shield", None)
+        if shield is None:
+            return
+        shield.offer(frame, composing=bool(_buffer_text().strip()))
+    except Exception:  # noqa: BLE001
+        pass
 
 
 def _buffer_text() -> str:
@@ -2197,10 +2325,20 @@ def run_attach(console: Any) -> int:
             on_hydration=_on_hydration, on_line=_print_line,
             on_markup=_markup_sink,
             on_telemetry=ui.on_telemetry,
+            # Gates as DATA — the id + deadline the shield needs to defer one
+            # safely and still answer the right op.
+            on_prompt=lambda frame: _on_prompt_frame(ui, frame),
+            on_prompt_resolved=lambda pid: (
+                ui.shield.dismiss(pid) if ui.shield is not None else None
+            ),
             on_audio_state=ui.on_audio_state,
             on_lane_history=ui.on_lane_history,
             on_lane_reaped=ui.on_lane_reaped,
         )
+        # The shield renders released gates through the SAME markup path
+        # every other ⏺/⎿ line takes — one display, one ordering, and the
+        # gate lands in scrollback the operator can page back to.
+        ui.markup_sink = _markup_sink
         if not await client.connect():
             console.print(_NO_ORGANISM_MESSAGE, markup=False, highlight=False)
             return 1

--- a/backend/core/ouroboros/governance/approval_narrator.py
+++ b/backend/core/ouroboros/governance/approval_narrator.py
@@ -134,7 +134,12 @@ async def await_decision_with_operator(
             get_operator_prompt_bridge,
         )
         bridge = get_operator_prompt_bridge()
-        fut = bridge.begin(str(request_id))
+        fut = bridge.begin(
+            str(request_id),
+            text=render_gate_prompt(request_id, risk, reason, timeout_s),
+            risk=risk,
+            timeout_s=timeout_s,
+        )
     except Exception:  # noqa: BLE001
         bridge, fut = None, None
 

--- a/tests/cli/test_focus_shield.py
+++ b/tests/cli/test_focus_shield.py
@@ -1,0 +1,334 @@
+"""A gate never interrupts a half-typed line.
+
+The organism raises approval gates on its own schedule; the operator types on
+theirs. Sooner or later a gate lands mid-sentence, and what happens next has
+to be something the operator chose.
+
+The hazard was NOT a stolen cursor — nothing in the cockpit calls `set_focus`,
+so there was no focus to steal. It was on the daemon, and it was worse: every
+attached line was offered to the pending gate BEFORE the REPL, and the gate
+consumed whatever it got. These pin both halves of the fix.
+"""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import io
+
+import pytest
+
+from backend.core.ouroboros.battle_test.focus_shield import (
+    FocusShield, PendingPrompt, parse_prompt_frame,
+)
+from backend.core.ouroboros.battle_test.operator_prompt_bridge import (
+    get_operator_prompt_bridge, is_bare_verdict, reset_bridge_for_tests,
+)
+
+with contextlib.redirect_stderr(io.StringIO()):
+    from backend.core.ouroboros.cli import ov as _ov
+    from backend.core.ouroboros.cli.ov import (
+        AttachUI, _on_prompt_frame, _route_operator_line,
+    )
+
+_FRAME = {
+    "type": "prompt", "prompt_id": "iron-gate:7759-86",
+    "text": "apply candidate to test_runner.py",
+    "risk": "APPROVAL_REQUIRED", "timeout_s": 300,
+}
+
+
+class _Client:
+    def __init__(self) -> None:
+        self.sent: list = []
+
+    def send_input(self, text: str, prompt_id=None) -> bool:
+        self.sent.append((text, prompt_id))
+        return True
+
+    def send_audio(self, _c: str) -> bool:
+        return True
+
+
+@pytest.fixture
+def cockpit(monkeypatch: pytest.MonkeyPatch):
+    """A cockpit whose buffer contents the test controls."""
+    ui = AttachUI()
+    shown: list = []
+    ui.markup_sink = lambda text, addressed=False: shown.append(text)
+    state = {"buffer": ""}
+    monkeypatch.setattr(_ov, "_buffer_text", lambda: state["buffer"])
+    return ui, _Client(), shown, state
+
+
+# --------------------------------------------------------------------------
+# the mandate: arriving mid-sentence defers, emptying the buffer releases
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_a_gate_arriving_mid_sentence_does_not_take_the_screen(
+    cockpit,
+) -> None:
+    ui, _client, shown, state = cockpit
+    state["buffer"] = "go fix the flaky "
+
+    _on_prompt_frame(ui, _FRAME)
+    await asyncio.sleep(0)
+
+    assert shown == [], "the gate seized the screen mid-sentence"
+    assert ui.shield.pending_count == 1
+    assert ui.shield.showing is None
+
+
+@pytest.mark.asyncio
+async def test_the_operator_is_TOLD_a_gate_is_waiting(cockpit) -> None:
+    """Deferring silently would be worse than interrupting: the organism is
+    blocked and the operator has no way to know."""
+    ui, _client, _shown, state = cockpit
+    state["buffer"] = "typing"
+    _on_prompt_frame(ui, _FRAME)
+    await asyncio.sleep(0)
+
+    badge = ui.shield.badge()
+    assert "1 pending approval" in badge
+    assert "ctrl-p" in badge
+    assert badge in ui.toolbar() or badge in str(ui._key_hints())
+
+
+@pytest.mark.asyncio
+async def test_emptying_the_buffer_releases_the_gate(cockpit) -> None:
+    """The half the operator never has to learn."""
+    ui, client, shown, state = cockpit
+    state["buffer"] = "go fix the flaky "
+    _on_prompt_frame(ui, _FRAME)
+    await asyncio.sleep(0)
+    assert shown == []
+
+    _route_operator_line(client, ui, "go fix the flaky test in test_runner")
+    await asyncio.sleep(0)
+
+    assert ui.shield.showing is not None
+    assert any("Iron Gate" in line for line in shown)
+    assert ui.shield.badge() == "", "badge outlived the queue"
+
+
+@pytest.mark.asyncio
+async def test_an_idle_operator_is_not_made_to_press_a_key(cockpit) -> None:
+    """With an empty buffer there is nothing to protect — deferring then
+    would be ceremony, not safety."""
+    ui, _client, shown, state = cockpit
+    state["buffer"] = ""
+    _on_prompt_frame(ui, _FRAME)
+    await asyncio.sleep(0)
+
+    assert ui.shield.showing is not None
+    assert any("Iron Gate" in line for line in shown)
+
+
+# --------------------------------------------------------------------------
+# the keystroke race — the reason any of this exists
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_a_typed_GOAL_never_becomes_a_verdict(cockpit) -> None:
+    """THE bug. `go fix the flaky test` approved an unrelated op — its first
+    token is "go" — and the goal never reached the REPL at all."""
+    ui, client, _shown, state = cockpit
+    state["buffer"] = "go fix the flaky test"
+    _on_prompt_frame(ui, _FRAME)
+    await asyncio.sleep(0)
+
+    _route_operator_line(client, ui, "go fix the flaky test in test_runner")
+
+    text, prompt_id = client.sent[-1]
+    assert prompt_id is None, "a goal was submitted as an approval"
+    assert text == "go fix the flaky test in test_runner"
+
+
+@pytest.mark.asyncio
+async def test_the_daemon_declines_a_goal_and_lets_it_reach_the_repl() -> None:
+    """The daemon half, at the seam `harness._on_input` calls."""
+    reset_bridge_for_tests()
+    bridge = get_operator_prompt_bridge()
+    bridge.begin("iron-gate:7759-86")
+
+    for goal in ("go fix the flaky test", "stop the doc_staleness storm",
+                 "let's build the streaming next"):
+        assert bridge.resolve(goal) is False, f"{goal!r} was eaten by a gate"
+    assert bridge.waiting is True, "the gate should still be open"
+
+
+@pytest.mark.asyncio
+async def test_a_bare_verdict_still_answers() -> None:
+    reset_bridge_for_tests()
+    bridge = get_operator_prompt_bridge()
+    fut = bridge.begin("iron-gate:7759-86")
+    assert bridge.resolve("y") is True
+    await asyncio.sleep(0)
+    assert fut.result() == "y"
+
+
+@pytest.mark.asyncio
+async def test_an_answer_carries_the_gate_it_was_written_for(
+    cockpit,
+) -> None:
+    ui, client, _shown, state = cockpit
+    state["buffer"] = ""
+    _on_prompt_frame(ui, _FRAME)
+    await asyncio.sleep(0)
+
+    _route_operator_line(client, ui, "y")
+
+    assert client.sent[-1] == ("y", "iron-gate:7759-86")
+    assert ui.shield.showing is None
+
+
+@pytest.mark.asyncio
+async def test_a_deferred_answer_cannot_land_on_a_DIFFERENT_op() -> None:
+    """Deferral is exactly the window in which the slot moves on. Approving
+    the wrong op is the worst outcome this system can produce."""
+    reset_bridge_for_tests()
+    bridge = get_operator_prompt_bridge()
+    bridge.begin("iron-gate:AAAA")
+    bridge.begin("iron-gate:BBBB")          # supersedes while queued
+
+    assert bridge.resolve("y", prompt_id="iron-gate:AAAA") is False
+    assert bridge.resolve("y", prompt_id="iron-gate:BBBB") is True
+
+
+@pytest.mark.asyncio
+async def test_a_non_verdict_reply_to_a_SHOWN_gate_still_reaches_the_repl(
+    cockpit,
+) -> None:
+    """"later, first fix the tests" is a goal, not a decision."""
+    ui, client, _shown, state = cockpit
+    state["buffer"] = ""
+    _on_prompt_frame(ui, _FRAME)
+    await asyncio.sleep(0)
+
+    _route_operator_line(client, ui, "later, first fix the tests")
+
+    assert client.sent[-1][1] is None
+    assert ui.shield.showing is not None, "the gate was dismissed unanswered"
+
+
+# --------------------------------------------------------------------------
+# staleness — deferral makes it possible
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_an_expired_gate_is_never_offered() -> None:
+    """Presenting a dead gate would let the operator believe they approved
+    something they did not."""
+    clock = {"t": 1000.0}
+    shield = FocusShield(clock=lambda: clock["t"])
+    shield.offer(dict(_FRAME, timeout_s=30), composing=True)
+    assert shield.pending_count == 1
+
+    clock["t"] += 31
+    assert shield.pending_count == 0, "an expired gate was still advertised"
+    assert shield.pop() is None
+    assert shield.dropped_expired == 1
+
+
+@pytest.mark.asyncio
+async def test_a_gate_with_no_declared_deadline_never_expires() -> None:
+    """Inventing an expiry the organism never agreed to would drop a gate it
+    is still waiting on."""
+    clock = {"t": 0.0}
+    shield = FocusShield(clock=lambda: clock["t"])
+    shield.offer(dict(_FRAME, timeout_s=0), composing=True)
+    clock["t"] += 100_000
+    assert shield.pending_count == 1
+
+
+@pytest.mark.asyncio
+async def test_the_daemon_can_withdraw_a_gate(cockpit) -> None:
+    """Answered elsewhere, expired, or superseded — `prompt_resolved` purges
+    it immediately rather than waiting for a deadline to notice."""
+    ui, _client, _shown, state = cockpit
+    state["buffer"] = "typing"
+    _on_prompt_frame(ui, _FRAME)
+    await asyncio.sleep(0)
+    assert ui.shield.pending_count == 1
+
+    ui.shield.dismiss("iron-gate:7759-86")
+    assert ui.shield.pending_count == 0
+    assert ui.shield.badge() == ""
+
+
+# --------------------------------------------------------------------------
+# queue behaviour
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_re_arming_the_same_gate_does_not_stack_it() -> None:
+    """The bridge re-arms whenever a line turns out not to be a verdict; one
+    unanswered gate must not become a queue of itself."""
+    shield = FocusShield()
+    for _ in range(5):
+        shield.offer(_FRAME, composing=True)
+    assert shield.pending_count == 1
+
+
+@pytest.mark.asyncio
+async def test_a_second_gate_waits_behind_the_one_on_screen() -> None:
+    shield = FocusShield()
+    shield.offer(_FRAME, composing=False)
+    shield.offer(dict(_FRAME, prompt_id="iron-gate:BBBB"), composing=False)
+    assert shield.showing.prompt_id == "iron-gate:7759-86"
+    assert shield.pending_count == 1
+    assert shield.pop() is None, "two gates were on screen at once"
+
+    shield.dismiss("iron-gate:7759-86")
+    assert shield.pop().prompt_id == "iron-gate:BBBB"
+
+
+@pytest.mark.asyncio
+async def test_the_queue_is_bounded() -> None:
+    """A cockpit is not a ticket queue."""
+    shield = FocusShield(max_pending=3)
+    for i in range(10):
+        shield.offer(dict(_FRAME, prompt_id=f"gate-{i}"), composing=True)
+    assert shield.pending_count == 3
+    assert shield.dropped_overflow > 0
+
+
+# --------------------------------------------------------------------------
+# robustness
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("junk", [None, {}, {"type": "prompt"}, "string", 42])
+def test_a_malformed_frame_is_refused_not_crashed(junk) -> None:
+    """An unanswerable prompt — no id — has nothing for the bridge to match,
+    so it is refused rather than shown."""
+    assert parse_prompt_frame(junk) is None
+    assert FocusShield().offer(junk, composing=False) == ""
+
+
+def test_a_raising_render_sink_does_not_break_the_cockpit() -> None:
+    def _boom(_p):
+        raise RuntimeError("render died")
+
+    shield = FocusShield(show=_boom)
+    assert shield.offer(_FRAME, composing=False) == "shown"
+
+
+def test_the_op_ref_is_the_TAIL() -> None:
+    """UUIDv7 is time-ordered: ops from one session share their leading bytes
+    and differ only at the end."""
+    assert PendingPrompt("iron-gate:0198e4c1-7f2a-7d31-9f44-7759086").ref \
+        .endswith("7759086")
+
+
+def test_the_kill_switch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Off, a gate goes straight to the screen exactly as before."""
+    monkeypatch.setenv("JARVIS_FOCUS_SHIELD_ENABLED", "0")
+    shield = FocusShield()
+    assert shield.offer(_FRAME, composing=True) == "shown"
+
+
+def test_the_verdict_vocabulary_is_shared_not_copied() -> None:
+    """One definition of what "yes" means, or the surfaces drift."""
+    assert is_bare_verdict("y") is True
+    assert is_bare_verdict("no") is False
+    assert is_bare_verdict("go fix the tests") is None


### PR DESCRIPTION
## The hazard was not a stolen cursor

Nothing in the cockpit calls `set_focus`, so there was no focus to steal. The race was on the **daemon**, and it was worse: `_on_input` offered every attached line to the pending gate *before* the REPL, and the gate consumed whatever it got.

Measured against the real objects, not theorised:

| operator types (unaware a gate is open) | what happened |
|---|---|
| `go fix the flaky test` | first token `go` → **APPROVED** an op they never read; the goal never reached the REPL |
| `stop the doc_staleness storm` | **REJECTED** one |
| `let's build the streaming next` | not a verdict — still consumed, dropped on the floor while the gate silently re-armed |

That is the thing to fix before background agents run unattended.

## Two halves; the daemon one carries the safety

**`resolve()` consumes only an unambiguous verdict** — the whole line, one word. The vocabulary stays `approval_narrator.interpret_answer` (one definition, shared with the local terminal path); what's added is strictness about *shape*. Reading the first token is right at an explicit `[y/n]` prompt and wrong for an unprompted line from someone composing a goal. Everything else returns `False` and reaches the REPL, where it was aimed.

**`resolve()` also takes a `prompt_id` and refuses a mismatch.** Deferral is precisely the window in which the single slot can move on, and landing `y` on the wrong op is the worst thing this system can do.

## The client half — visible without seizing the screen

A gate arriving while the buffer holds text is queued, and the toolbar says so — placed **first**, so a narrow terminal truncating the tail can't hide it:

```
⚠ 1 pending approval · ctrl-p · voice: off ('wake') · 'detach' to leave
```

It surfaces when the operator is ready: `Ctrl+P` (verified unbound before taking it), or the moment their buffer empties — the half nobody has to learn. The answer is then tagged with the gate it was written for.

Proven end-to-end:

```
1. gate arrives WHILE COMPOSING     focus stolen? False · queued 1 · badge shown
2. they send their own line         ('go fix the flaky test…', None)   ← untagged
                                    ⏺ Iron Gate(7759-86) · APPROVAL_REQUIRED
                                      ⎿ apply candidate…  [y/n] · 299s left
3. they answer                      ('y', 'iron-gate:7759-86')          ← tagged
```

## Announced at one seam

`bridge.begin()` is exactly what makes a gate answerable from a cockpit, so the typed `prompt` frame is published **there** rather than at each call site — the site that forgets is the invisible one, which is the wired-but-inert defect this codebase keeps producing. `end()` and a superseding `begin()` both publish `prompt_resolved`, so a deferred gate is purged authoritatively instead of waiting for a deadline to notice.

## Edge cases deferral creates

- A queued gate carries its **deadline** and is dropped on pop rather than shown — presenting a dead gate would let someone believe they approved something they didn't.
- A gate declaring **no** deadline never expires; inventing one the organism never agreed to would drop a gate it's still waiting on. (The SerpentFlow gate genuinely has none while a local prompt lives, so it declares 0 and relies on `prompt_resolved`.)
- **Re-arming doesn't stack** — the bridge re-arms on every non-verdict, so one gate must not become a queue of itself.
- One gate on screen at a time; the rest wait. Queue is bounded.
- A non-verdict reply to a *shown* gate still reaches the REPL and leaves it armed.

## Reuse

The `markup_sink` chokepoint every ⏺/⎿ line already takes (gates land in scrollback, in order, and page back with the new viewport); the file's own arity-inspection convention for threading `prompt_id` only to sinks that ask by name; the late-binding idiom for a sink built after the UI.

Switches: `JARVIS_FOCUS_SHIELD_ENABLED=0`, `JARVIS_PROMPT_BRIDGE_STRICT_VERDICTS=0`.

## Verification

- **25 async tests.**
- **Mutation-tested**, all three safety properties: ignoring `composing` → 9 failures; consuming any line → the daemon test; dropping id-matching → the wrong-op test. Each caught by the test written for it.
- `Ctrl+P` asserted **registered**, not merely written.
- No new failures across `tests/cli` + `tests/battle_test`. The one suspicious name was measured over 8 runs on each tree and is flaky on both — **4/8 here, 2/8 on main** (a 1.0s thread-join under load). A single-shot check had made it look new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents approval gates from hijacking half‑typed lines and only accepts explicit, tagged verdicts. Gates defer while you’re typing, surface when you’re ready, and answers can’t land on the wrong op.

- **New Features**
  - Added a focus shield in `ov`: gates queue while composing, show a toolbar badge "⚠ 1 pending approval · ctrl-p", and surface on Ctrl+P or when the buffer empties.
  - Broadcast gate lifecycle frames from the attach server: `prompt` (id, text, risk, timeout) and `prompt_resolved`; wired at `bridge.begin/end()` so every answerable gate is announced once.
  - Cockpit tags answers with the gate’s `prompt_id`; the daemon forwards it only to sinks that opt in.

- **Bug Fixes**
  - `operator_prompt_bridge.resolve` now accepts only a single-word verdict; any other line goes to the REPL.
  - `resolve` refuses answers for a different `prompt_id`, blocking stale approvals from hitting the wrong op.
  - Deferred gates: expired ones are dropped on pop; gates with no deadline never auto-expire; one gate on screen at a time and the queue is bounded.
  - Kill switches: `JARVIS_FOCUS_SHIELD_ENABLED=0` (inline gates), `JARVIS_PROMPT_BRIDGE_STRICT_VERDICTS=0` (legacy “any line answers”).

<sup>Written for commit a36fab0a5a570227a271296ea1d06f96cecb2c4f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

