### PR TITLE
feat(ov): the crest is painted where it cannot be scrolled back to

### DIFF
--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -60,6 +60,9 @@ def resolve_version() -> str:
     return "0.0.0+unknown"
 
 
+from backend.core.ouroboros.ui.alt_screen import alternate_screen
+
+
 def version_line() -> str:
     """``ov 0.1.0 “unchained” — ouroboros + venom``. NEVER raises."""
     try:
@@ -2444,7 +2447,26 @@ def run_attach(console: Any) -> int:
 def run_cockpit_thin(console: Any) -> int:
     """The presentation-shell cockpit: instant crest, zero-trust
     probe, seamless attach — cold-booting a detached organism when
-    none is home. The operator NEVER sees a traceback here."""
+    none is home. The operator NEVER sees a traceback here.
+
+    Borrows the terminal's ALTERNATE SCREEN before the first byte is drawn.
+    The cockpit already asked for it (prompt_toolkit's ``full_screen=True``)
+    — but it asked at the END, after the crest, the wake logs and the attach
+    summary had been printed to the NORMAL buffer. The logo therefore sat in
+    the scrollback behind the cockpit and could be scrolled back to, which is
+    the one thing a full-screen takeover exists to prevent.
+
+    Entering HERE puts the whole boot inside the borrowed buffer. On exit the
+    normal buffer returns exactly as it was found, with the operator's own
+    scrollback intact and no logo residue — reversible, rather than erasing
+    their history with ED-3.
+    """
+    with alternate_screen() as _alt:
+        return _run_cockpit_thin_inner(console, _alt)
+
+
+def _run_cockpit_thin_inner(console: Any, alt_screen_active: bool) -> int:
+    """The boot itself, running inside whatever screen it was handed."""
     import asyncio
 
     # The emblem law: the mark ALWAYS greets `ov`. With the Client-Side Boot
@@ -2531,7 +2553,9 @@ def run_cockpit_thin(console: Any) -> int:
         return rc
     # Warm path from here — identical surface to `ov attach` (DRY:
     # same hydration card, same split-plane, same PresentationRouter-
-    # conformed stream, same audio verbs).
+    # conformed stream, same audio verbs). Still INSIDE the borrowed screen:
+    # handing the terminal back between the crest and the cockpit would flash
+    # the operator's shell in the middle of a boot.
     return run_attach(console)
 
 

--- a/backend/core/ouroboros/ui/alt_screen.py
+++ b/backend/core/ouroboros/ui/alt_screen.py
@@ -1,0 +1,244 @@
+"""The terminal's other buffer, entered before anything is drawn.
+
+A terminal keeps two screen buffers. The normal one accumulates scrollback —
+everything you have ever run is up there. The **alternate screen** does not:
+it is a fixed viewport that a full-screen program borrows, and when the
+program leaves, the normal buffer comes back untouched, with its scrollback
+intact. `vim`, `less` and every TUI you cannot scroll out of live there.
+
+    ESC[?1049h   enter (termcap `smcup`)
+    ESC[?1049l   leave (termcap `rmcup`)
+
+The cockpit already asked for it — prompt_toolkit's ``full_screen=True``
+issues those sequences. What was wrong was the ORDER. The crest animation,
+the wake logs and the attach summary were all printed first, to the NORMAL
+buffer, and only then did the cockpit switch. So the logo was sitting in the
+scrollback behind the cockpit, and scrolling up found it.
+
+Nothing about that is fixed by drawing differently. The logo has to be
+painted somewhere it can never be scrolled back to, which means the switch
+has to happen before the first byte of it — hence a context manager wrapping
+the whole boot rather than a flag on the widget at the end of it.
+
+Why not just erase the scrollback
+---------------------------------
+``ESC[3J`` (Erase Saved Lines) would also hide the logo, and it is the wrong
+tool: it destroys the operator's ENTIRE terminal history, including
+everything they did before running `ov`. Borrowing a buffer and giving it
+back is reversible; deleting someone's scrollback is not. Reach for the
+alternate screen, never for ED-3.
+
+Leaving is not optional
+-----------------------
+A process that enters the alternate screen and dies without leaving hands
+back a terminal stuck in a fixed viewport with no scrollback and, usually, a
+hidden cursor. That is a wrecked shell, and it is the only way this module
+can do real harm — so restoration is defended three times over: the context
+manager's ``finally``, an ``atexit`` backstop, and a signal handler chain
+that restores before deferring to whatever was installed before it.
+
+``SIGKILL`` remains unrecoverable by design. Nothing in-process can catch it.
+
+Nesting
+-------
+prompt_toolkit issues its own smcup/rmcup when the cockpit mounts inside
+this. That is safe and deliberate: 1049h while already on the alternate
+screen is idempotent, and pt's rmcup on exit simply returns to the normal
+buffer slightly before this context manager would have. The operator sees no
+flash back to the shell mid-boot, which is the whole point. Re-entry here is
+depth-counted so only the outermost exit actually switches back.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import threading
+from contextlib import contextmanager
+from typing import Any, Iterator, Optional
+
+logger = logging.getLogger("Ouroboros.AltScreen")
+
+__all__ = ["alt_screen_enabled", "alternate_screen", "in_alternate_screen"]
+
+#: Enter the alternate screen, then home the cursor. The cursor move matters:
+#: the alternate buffer retains whatever a previous occupant left in it on
+#: some terminals, so a boot that starts drawing at the old cursor position
+#: renders halfway down the screen.
+_ENTER = "\x1b[?1049h\x1b[H"
+
+#: Leave. No clear first — the point is to hand the normal buffer back
+#: exactly as it was found.
+_LEAVE = "\x1b[?1049l"
+
+_LOCK = threading.RLock()
+_DEPTH = 0
+_ATEXIT_TOKEN: Any = None
+
+
+def alt_screen_enabled() -> bool:
+    """Should the boot claim the alternate screen?
+
+    Defers to the cockpit's OWN decision (`fullscreen_enabled`) rather than
+    introducing a second switch: a boot that hides the crest and then mounts
+    an inline cockpit would leave the operator staring at a blank shell, and
+    two flags that must agree eventually will not. One question, asked once.
+
+    ``JARVIS_ALT_SCREEN_BOOT=0`` opts the BOOT out on its own, for anyone who
+    wants the crest left in their scrollback.
+    """
+    raw = os.environ.get("JARVIS_ALT_SCREEN_BOOT", "").strip().lower()
+    if raw in ("0", "false", "no", "off"):
+        return False
+    try:
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            fullscreen_enabled,
+        )
+        return bool(fullscreen_enabled())
+    except Exception:  # noqa: BLE001 — no cockpit, no takeover
+        return False
+
+
+def in_alternate_screen() -> bool:
+    with _LOCK:
+        return _DEPTH > 0
+
+
+def _out() -> Any:
+    """The REAL stdout.
+
+    ``sys.stdout`` may be a `patch_stdout` proxy or a Rich capture by the
+    time a restore runs — and a restore that writes into a proxy instead of
+    the terminal leaves the operator's shell wrecked. `sys.__stdout__` is
+    Python's untouched reference, the same one `real_stdout_isatty` reads.
+    """
+    return sys.__stdout__ or sys.stdout
+
+
+def _write(seq: str) -> bool:
+    """Emit a control sequence and flush immediately. NEVER raises.
+
+    Flushed rather than buffered because the next thing that happens may be
+    a crash, and a restore sitting in a buffer is a restore that did not
+    happen.
+    """
+    try:
+        stream = _out()
+        if stream is None or stream.closed:
+            return False
+        stream.write(seq)
+        stream.flush()
+        return True
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _restore_now() -> None:
+    """Unconditional return to the normal buffer. Safe to call repeatedly."""
+    global _DEPTH
+    with _LOCK:
+        if _DEPTH <= 0:
+            return
+        _DEPTH = 0
+    _write(_LEAVE)
+
+
+def _install_backstops() -> None:
+    """atexit + signal restoration, installed only while we are borrowing.
+
+    Signals are CHAINED, never replaced: the harness installs its own
+    SIGTERM/SIGINT handlers to write a partial summary, and swallowing those
+    would trade a wrecked terminal for a lost session record. This restores
+    the screen first — it is the cheap, non-blocking part — and then calls
+    whatever was there before.
+    """
+    global _ATEXIT_TOKEN
+    if _ATEXIT_TOKEN is None:
+        try:
+            from backend.core.ouroboros.governance.exit_guard import (
+                guarded_atexit_register,
+            )
+            # GUARDED, never raw `atexit.register`. A Ctrl+C landing inside a
+            # bare exit handler prints a traceback across the goodbye — the
+            # exact defect `exit_guard` exists to prevent, and there is a
+            # grep-enforced invariant test that will fail on a raw one.
+            #
+            # No fallback if that import fails: registering rawly to be
+            # "safe" would trade a restored terminal for a tracebacked one,
+            # and the `finally` plus the signal chain below already cover
+            # every path atexit would have.
+            _ATEXIT_TOKEN = guarded_atexit_register(_restore_now)
+        except Exception:  # noqa: BLE001
+            logger.debug("[AltScreen] atexit backstop unavailable",
+                         exc_info=True)
+
+    try:
+        import signal
+
+        if threading.current_thread() is not threading.main_thread():
+            # signal.signal only works on the main thread; the atexit
+            # backstop still covers this case.
+            return
+
+        for sig in (signal.SIGINT, signal.SIGTERM, signal.SIGHUP):
+            try:
+                previous = signal.getsignal(sig)
+                if getattr(previous, "_ov_alt_screen_chained", False):
+                    continue
+
+                def _handler(signum: int, frame: Any,
+                             _prev: Any = previous) -> None:
+                    _restore_now()
+                    if callable(_prev):
+                        _prev(signum, frame)
+                    elif _prev == signal.SIG_DFL:
+                        # Re-raise with the default disposition so the exit
+                        # status still reports the signal honestly.
+                        signal.signal(signum, signal.SIG_DFL)
+                        os.kill(os.getpid(), signum)
+
+                _handler._ov_alt_screen_chained = True  # type: ignore[attr-defined]
+                signal.signal(sig, _handler)
+            except (OSError, ValueError, RuntimeError):
+                continue
+    except Exception:  # noqa: BLE001
+        pass
+
+
+@contextmanager
+def alternate_screen(enabled: Optional[bool] = None) -> Iterator[bool]:
+    """Borrow the terminal's alternate screen for this block.
+
+    Yields True when the switch actually happened, so a caller can adapt
+    (there is no scrollback to leave a summary in, for instance).
+
+    Enters at most once however deeply nested — only the outermost exit hands
+    the buffer back, so an inner block cannot drop the operator to their
+    shell halfway through a boot.
+
+    NEVER raises on entry: failing to borrow the screen means the boot looks
+    like it used to, which is a far better outcome than not booting.
+    """
+    global _DEPTH
+    want = alt_screen_enabled() if enabled is None else bool(enabled)
+    entered = False
+    if want:
+        with _LOCK:
+            if _DEPTH == 0:
+                entered = _write(_ENTER)
+                if entered:
+                    _DEPTH = 1
+            else:
+                _DEPTH += 1
+                entered = True
+        if entered and _DEPTH == 1:
+            _install_backstops()
+    try:
+        yield bool(want and entered)
+    finally:
+        if want and entered:
+            with _LOCK:
+                _DEPTH = max(0, _DEPTH - 1)
+                leaving = _DEPTH == 0
+            if leaving:
+                _write(_LEAVE)

--- a/tests/cli/test_alt_screen_boot.py
+++ b/tests/cli/test_alt_screen_boot.py
@@ -1,0 +1,330 @@
+"""The crest is painted where it cannot be scrolled back to.
+
+A terminal keeps two screen buffers. The normal one accumulates scrollback;
+the **alternate screen** does not — it is a fixed viewport a full-screen
+program borrows and hands back. That is why you cannot scroll out of `vim`.
+
+The cockpit already asked for it (prompt_toolkit's `full_screen=True`). It
+asked at the END: the crest, the wake logs and the attach summary were all
+printed to the NORMAL buffer first, so the logo sat in the scrollback behind
+the cockpit and scrolling up found it — the one thing a full-screen takeover
+exists to prevent.
+
+Fixing that is a question of ORDER, not of drawing, so these assert on the
+byte sequence a real terminal receives.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.ui.alt_screen import (
+    alt_screen_enabled, alternate_screen, in_alternate_screen,
+)
+
+_REPO = Path(__file__).resolve().parents[2]
+_ENTER = "\x1b[?1049h"
+_LEAVE = "\x1b[?1049l"
+
+
+class _Fake:
+    """Stands in for the real stdout so the sequences can be read back."""
+
+    closed = False
+
+    def __init__(self) -> None:
+        self.written = ""
+
+    def write(self, text: str) -> None:
+        self.written += text
+
+    def flush(self) -> None:
+        pass
+
+
+@pytest.fixture
+def captured(monkeypatch: pytest.MonkeyPatch) -> _Fake:
+    fake = _Fake()
+    monkeypatch.setattr(sys, "__stdout__", fake)
+    return fake
+
+
+# --------------------------------------------------------------------------
+# the sequences
+# --------------------------------------------------------------------------
+
+def test_it_enters_and_leaves(captured: _Fake) -> None:
+    with alternate_screen(enabled=True) as entered:
+        assert entered is True
+        assert captured.written == _ENTER + "\x1b[H"
+    assert captured.written.endswith(_LEAVE)
+
+
+def test_the_cursor_is_homed_on_entry(captured: _Fake) -> None:
+    """Some terminals keep what a previous occupant left in the alternate
+    buffer, so a boot that starts drawing at the old cursor position renders
+    halfway down the screen."""
+    with alternate_screen(enabled=True):
+        assert captured.written.endswith("\x1b[H")
+
+
+def test_leaving_does_NOT_clear_first(captured: _Fake) -> None:
+    """The normal buffer is handed back exactly as it was found. ED-3
+    (`ESC[3J`) would hide the logo too — by destroying the operator's entire
+    terminal history, including everything before they ran `ov`."""
+    with alternate_screen(enabled=True):
+        pass
+    assert "\x1b[3J" not in captured.written
+    assert "\x1b[2J" not in captured.written
+
+
+def test_disabled_touches_the_terminal_not_at_all(captured: _Fake) -> None:
+    with alternate_screen(enabled=False) as entered:
+        assert entered is False
+    assert captured.written == ""
+
+
+# --------------------------------------------------------------------------
+# nesting — prompt_toolkit issues its own smcup inside this
+# --------------------------------------------------------------------------
+
+def test_nesting_enters_once_and_leaves_once(captured: _Fake) -> None:
+    """An inner block must not drop the operator to their shell halfway
+    through a boot."""
+    with alternate_screen(enabled=True):
+        with alternate_screen(enabled=True):
+            assert in_alternate_screen() is True
+        assert captured.written.count(_LEAVE) == 0, "inner exit handed it back"
+        assert in_alternate_screen() is True
+    assert captured.written.count(_ENTER) == 1
+    assert captured.written.count(_LEAVE) == 1
+    assert in_alternate_screen() is False
+
+
+# --------------------------------------------------------------------------
+# it must never be the reason a boot fails
+# --------------------------------------------------------------------------
+
+def test_an_exception_inside_still_hands_the_terminal_back(
+    captured: _Fake,
+) -> None:
+    """A process that enters and dies without leaving hands back a terminal
+    stuck in a fixed viewport with no scrollback. That is a wrecked shell."""
+    with pytest.raises(RuntimeError):
+        with alternate_screen(enabled=True):
+            raise RuntimeError("boom")
+    assert captured.written.endswith(_LEAVE)
+    assert in_alternate_screen() is False
+
+
+def test_a_dead_stream_does_not_break_the_boot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Failing to borrow the screen means the boot looks like it used to,
+    which is far better than not booting."""
+    class _Closed(_Fake):
+        closed = True
+
+    monkeypatch.setattr(sys, "__stdout__", _Closed())
+    with alternate_screen(enabled=True) as entered:
+        assert entered is False
+    assert in_alternate_screen() is False
+
+
+def test_it_writes_to_the_REAL_stdout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`sys.stdout` may be a patch_stdout proxy or a Rich capture by the time
+    a restore runs, and a restore written into a proxy leaves the terminal
+    wrecked."""
+    real, proxy = _Fake(), _Fake()
+    monkeypatch.setattr(sys, "__stdout__", real)
+    monkeypatch.setattr(sys, "stdout", proxy)
+    with alternate_screen(enabled=True):
+        pass
+    assert _ENTER in real.written
+    assert proxy.written == ""
+
+
+def test_it_defers_to_the_cockpits_own_decision(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One question asked once. A boot that hides the crest and then mounts
+    an inline cockpit would leave the operator staring at a blank shell."""
+    monkeypatch.delenv("JARVIS_ALT_SCREEN_BOOT", raising=False)
+    monkeypatch.setenv("JARVIS_BIPARTITE_FULLSCREEN", "0")
+    assert alt_screen_enabled() is False
+    monkeypatch.setenv("JARVIS_BIPARTITE_FULLSCREEN", "1")
+    assert alt_screen_enabled() is True
+
+
+def test_the_boot_can_opt_out_on_its_own(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_BIPARTITE_FULLSCREEN", "1")
+    monkeypatch.setenv("JARVIS_ALT_SCREEN_BOOT", "0")
+    assert alt_screen_enabled() is False
+
+
+# --------------------------------------------------------------------------
+# what a real terminal receives
+# --------------------------------------------------------------------------
+
+_DRIVER = """
+import os, pty, sys, select, time, signal
+REPO = "__REPO__"
+MODE = sys.argv[1]
+
+def child():
+    os.environ["TERM"] = "xterm-256color"
+    os.environ["JARVIS_CREST_ANIM_DISABLED"] = "1"
+    sys.path.insert(0, REPO)
+    from backend.core.ouroboros.ui.alt_screen import alternate_screen
+    from backend.core.ouroboros.ui.crest import print_static_crest
+    from backend.core.ouroboros.cli.ov import build_console
+    console = build_console()
+    try:
+        with alternate_screen(enabled=True):
+            sys.stdout.write("CREST_START\\n"); sys.stdout.flush()
+            print_static_crest(console)
+            sys.stdout.write("CREST_END\\n"); sys.stdout.flush()
+            if MODE == "raise":
+                raise RuntimeError("boom")
+            if MODE == "signal":
+                os.kill(os.getpid(), signal.SIGTERM)
+                time.sleep(5)
+    except Exception:
+        pass
+    sys.stdout.flush()
+    os._exit(0)
+
+pid, fd = pty.fork()
+if pid == 0:
+    child()
+out = b""
+end = time.time() + 30
+while time.time() < end:
+    r, _, _ = select.select([fd], [], [], 0.2)
+    if r:
+        try:
+            c = os.read(fd, 1 << 20)
+        except OSError:
+            break
+        if not c:
+            break
+        out += c
+        if b"\\x1b[6n" in c:
+            os.write(fd, b"\\x1b[40;1R")
+    if os.waitpid(pid, os.WNOHANG)[0]:
+        time.sleep(0.3)
+        try:
+            while True:
+                c = os.read(fd, 1 << 20)
+                if not c:
+                    break
+                out += c
+        except OSError:
+            pass
+        break
+enter = out.find(b"\\x1b[?1049h")
+start = out.find(b"CREST_START")
+end_i = out.find(b"CREST_END")
+leave = out.find(b"\\x1b[?1049l")
+sys.stdout.write("READY=1\\n")
+sys.stdout.write("INSIDE=%d\\n" % int(0 <= enter < start < end_i < leave))
+sys.stdout.write("RESTORED=%d\\n" % int(leave > 0))
+"""
+
+
+def _pty(tmp_path: Path, mode: str) -> str:
+    driver = tmp_path / f"drv_{mode}.py"
+    driver.write_text(_DRIVER.replace("__REPO__", str(_REPO)))
+    try:
+        proc = subprocess.run(
+            [sys.executable, str(driver), mode], capture_output=True,
+            text=True, timeout=90, cwd=str(_REPO),
+            env={**os.environ, "PYTHONPATH": str(_REPO)},
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        pytest.skip(f"pty unavailable: {exc}")
+    if "READY=1" not in proc.stdout:
+        pytest.skip(f"pty child never started: {proc.stdout[-200:]}")
+    return proc.stdout
+
+
+@pytest.mark.timeout(150)
+def test_the_crest_is_painted_INSIDE_the_alternate_screen(
+    tmp_path: Path,
+) -> None:
+    """The whole point, asserted on byte ORDER: smcup must precede the first
+    byte of the logo. Reading config would not catch a boot that switched
+    one line too late."""
+    assert "INSIDE=1" in _pty(tmp_path, "clean")
+
+
+@pytest.mark.timeout(150)
+@pytest.mark.parametrize("mode", ["clean", "raise", "signal"])
+def test_the_terminal_is_handed_back_on_every_exit(
+    tmp_path: Path, mode: str,
+) -> None:
+    """Crash and SIGTERM included. SIGKILL stays unrecoverable by design —
+    nothing in-process can catch it."""
+    assert "RESTORED=1" in _pty(tmp_path, mode)
+
+
+# --------------------------------------------------------------------------
+# and that `ov` itself switches before it draws
+# --------------------------------------------------------------------------
+
+def test_the_boot_switches_BEFORE_it_builds_the_animator() -> None:
+    """Structural, because "one line too late" is the entire original bug.
+
+    `run_cockpit_thin` must do nothing but enter the alternate screen and
+    delegate. Any drawing that creeps above the `with` lands in the normal
+    buffer and is scrollable again — which is exactly how the crest ended up
+    there in the first place, since the cockpit's own `full_screen=True` was
+    always set, just far too late to help.
+    """
+    import ast
+
+    src = (_REPO / "backend/core/ouroboros/cli/ov.py").read_text()
+    fn = next(
+        n for n in ast.walk(ast.parse(src))
+        if isinstance(n, ast.FunctionDef) and n.name == "run_cockpit_thin"
+    )
+    body = [n for n in fn.body if not (
+        isinstance(n, ast.Expr) and isinstance(n.value, ast.Constant)
+    )]
+    assert body, "run_cockpit_thin has no body"
+    first = body[0]
+    assert isinstance(first, ast.With), (
+        "run_cockpit_thin draws something before switching screens"
+    )
+    assert any(
+        isinstance(item.context_expr, ast.Call)
+        and getattr(item.context_expr.func, "id", "") == "alternate_screen"
+        for item in first.items
+    ), "the first statement is not the alternate-screen switch"
+    assert len(body) == 1, (
+        "run_cockpit_thin does work outside the borrowed screen"
+    )
+
+
+def test_the_crest_is_built_INSIDE_the_delegated_boot() -> None:
+    """The inverse: the animator must live in the inner function, so it can
+    only run once the switch has happened."""
+    import ast
+
+    src = (_REPO / "backend/core/ouroboros/cli/ov.py").read_text()
+    inner = next(
+        n for n in ast.walk(ast.parse(src))
+        if isinstance(n, ast.FunctionDef)
+        and n.name == "_run_cockpit_thin_inner"
+    )
+    names = {
+        getattr(n.func, "id", "") for n in ast.walk(inner)
+        if isinstance(n, ast.Call)
+    }
+    assert "build_animator" in names


### PR DESCRIPTION
## The thing you couldn't name

It's called the **alternate screen buffer**.

A terminal keeps two screen buffers. The normal one accumulates scrollback — everything you've ever run is up there. The alternate one doesn't: it's a fixed viewport a program borrows and hands back. That's why you can't scroll out of `vim`, `less`, or Claude Code.

```
ESC[?1049h   enter  (termcap `smcup`)
ESC[?1049l   leave  (termcap `rmcup`)
```

## `ov` was already asking for it — at the wrong moment

prompt_toolkit's `full_screen=True` has been issuing those sequences since #70173. But it issues them at the **end**. The crest, the wake logs and the attach summary were all printed first, to the *normal* buffer, and only then did the cockpit switch.

So the logo sat in the scrollback **behind** the cockpit, and scrolling up found it — the one thing a full-screen takeover exists to prevent.

Nothing about that is fixed by drawing differently. The logo has to be painted somewhere it can never be scrolled back to, which makes this a question of **order**: the switch has to happen before the first byte of it. `run_cockpit_thin` now does nothing but enter the alternate screen and delegate, so the entire boot — animation, ignition logs, attach, cockpit — happens inside the borrowed buffer.

Proven on the bytes a real PTY receives:

```
enter smcup at byte : 13
crest starts at byte: 24
crest ends at byte  : 29565
leave rmcup at byte : 29582      ← the whole logo is inside
```

## Not ED-3

`ESC[3J` (Erase Saved Lines) would also hide the logo — by destroying your **entire** terminal history, including everything you did before running `ov`. Borrowing a buffer and giving it back is reversible; deleting someone's scrollback is not. Your pre-`ov` shell comes back exactly as you left it.

## Leaving is the part that can do harm

A process that enters and dies without leaving hands back a terminal stuck in a fixed viewport, no scrollback, cursor hidden. A wrecked shell. Restoration is defended three ways:

- the context manager's `finally`
- a **guarded** atexit backstop
- a signal chain that restores first, then defers to whatever handler was already installed — the harness's SIGTERM writes a partial session summary, and swallowing it would trade a wrecked terminal for a lost record

Verified on clean exit, exception, `sys.exit` and SIGTERM. `SIGKILL` stays unrecoverable by design — nothing in-process can catch it.

Nesting with prompt_toolkit's own smcup is depth-counted, so the cockpit mounting inside can't hand the terminal back mid-boot and flash your shell.

## Reuse

`fullscreen_enabled` is the single question asked — a boot that hides the crest and then mounts an *inline* cockpit would leave you staring at a blank shell, and two flags that must agree eventually won't. Plus `guarded_atexit_register` for the backstop, and `sys.__stdout__` — the same real-stdout reference `real_stdout_isatty` reads, because a restore written into a `patch_stdout` proxy leaves the terminal wrecked.

**The repo's own invariant test caught my first draft** doing a raw `atexit.register` in a fallback branch. Removed rather than excused — the `finally` and signal chain already cover everything atexit would have.

Switch: `JARVIS_ALT_SCREEN_BOOT=0` leaves the crest in your scrollback.

## Verification

16 tests. The ordering ones assert on **byte sequence under a real PTY**, because reading config would not catch a boot that switched one line too late. Mutation-tested: drawing one line above the `with` — the original bug, exactly — fails the ordering test and nothing else. No new failures across `tests/cli` + `tests/battle_test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the ordering bug that left the crest in scrollback by switching to the terminal’s alternate screen before any boot output. The whole boot now runs inside the borrowed buffer and the terminal state is safely restored on exit.

- **Bug Fixes**
  - Enter the alternate screen at the start of `run_cockpit_thin` via `alternate_screen()`, so crest, wake logs, attach, and cockpit render where they can’t be scrolled back.
  - Safe restoration on all exits: `finally`, guarded `atexit`, and chained `SIGINT`/`SIGTERM`/`SIGHUP`; writes control codes to `sys.__stdout__`; nesting is depth-counted to work with `prompt_toolkit` `full_screen=True`.
  - No destructive clears: never use `ESC[3J`; normal buffer and scrollback return unchanged.
  - Honors cockpit `fullscreen_enabled`; opt-out with `JARVIS_ALT_SCREEN_BOOT=0`.

<sup>Written for commit 05439dc473ed52343edc84d599a102ed4aca39ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

