### PR TITLE
feat(ov): the wheel scrolls the deck, and the count says what you missed

### DIFF
--- a/backend/core/ouroboros/battle_test/bipartite_layout.py
+++ b/backend/core/ouroboros/battle_test/bipartite_layout.py
@@ -62,6 +62,21 @@ def bipartite_enabled() -> bool:
     ).strip().lower() in ("1", "true", "yes", "on")
 
 
+def mouse_enabled() -> bool:
+    """Should the cockpit capture mouse events?
+
+    Follows the alt-screen decision — without it the deck is not a scrollable
+    viewport and there is nothing for the wheel to move.
+    ``JARVIS_DISABLE_MOUSE=1`` opts out on its own, for anyone who relies on
+    native click-and-drag selection.
+    """
+    if os.environ.get("JARVIS_DISABLE_MOUSE", "").strip().lower() in (
+        "1", "true", "yes", "on",
+    ):
+        return False
+    return fullscreen_enabled()
+
+
 def _real_tty() -> bool:
     """A real interactive terminal, via the canonical helper.
 
@@ -818,11 +833,17 @@ def build_bipartite_application(
 
     app = Application(
         layout=PTLayout(root, focused_element=prompt),
-        # NOT unconditionally full-screen. The alternate screen buffer
-        # disables the terminal's native scrollback, which is the surface
-        # best placed to hold history — see `fullscreen_enabled`.
+        # Full-screen on a real terminal — the canvas holds the history the
+        # alternate screen takes away (see `fullscreen_enabled`).
         key_bindings=kb, full_screen=fullscreen_enabled(),
-        mouse_support=False,
+        # The wheel scrolls the deck. Capturing the mouse is a real trade:
+        # the terminal's own click-and-drag selection stops working while an
+        # application owns mouse events, which is the single most common
+        # friction point of a full-screen TUI. So it follows the alt-screen
+        # decision (there is nothing to scroll without it) and can be turned
+        # off on its own by an operator who selects text more than they
+        # scroll — keeping the flicker-free rendering either way.
+        mouse_support=mouse_enabled(),
         refresh_interval=0.1,
         **({"style": _style} if _style is not None else {}),
         **({"color_depth": _depth} if _depth is not None else {}),

--- a/backend/core/ouroboros/battle_test/canvas_viewport.py
+++ b/backend/core/ouroboros/battle_test/canvas_viewport.py
@@ -58,7 +58,8 @@ from typing import Any, List, Optional, Sequence, Tuple
 
 logger = logging.getLogger("Ouroboros.CanvasViewport")
 
-__all__ = ["CanvasViewport", "scrollback_enabled", "canvas_history_lines"]
+__all__ = ["CanvasViewport", "scrollback_enabled", "canvas_history_lines",
+           "scroll_speed", "install_scroll_bindings"]
 
 #: History the canvas keeps once it is the ONLY history there is. The old 500
 #: was sized for a tail beneath a terminal that still had its own scrollback;
@@ -72,6 +73,21 @@ def scrollback_enabled() -> bool:
     return os.environ.get(
         "JARVIS_CANVAS_SCROLLBACK_ENABLED", "1",
     ).strip().lower() not in ("0", "false", "no", "off")
+
+
+def scroll_speed() -> float:
+    """Lines moved per wheel notch.
+
+    Terminals disagree about wheel events: some send one per physical notch,
+    others amplify already. Nothing can detect which, so this is a knob rather
+    than a constant. 3 matches vim's default and is the value that feels right
+    in terminals that do NOT amplify.
+    """
+    try:
+        value = float(os.environ.get("JARVIS_SCROLL_SPEED", "3"))
+        return min(20.0, max(0.25, value))
+    except (TypeError, ValueError):
+        return 3.0
 
 
 def canvas_history_lines() -> int:
@@ -111,6 +127,10 @@ class CanvasViewport:
         #: UI can say "this is everything that is kept" rather than appearing
         #: to freeze. Truncation the operator cannot see reads as a bug.
         self.hit_top = False
+        #: Lines that arrived while the operator was reading history. Shown
+        #: as a count rather than left implicit — "there is newer output" is
+        #: the fact that decides whether they want to jump back to live.
+        self.new_since_paused = 0
 
     # -- state -------------------------------------------------------------
 
@@ -126,6 +146,7 @@ class CanvasViewport:
     def reset(self) -> None:
         self._offset = 0
         self.hit_top = False
+        self.new_since_paused = 0
 
     # -- movement ----------------------------------------------------------
 
@@ -162,7 +183,10 @@ class CanvasViewport:
         as dead. It was only visible because the test asserted on the lines
         rather than on the return value.
         """
-        step = max(1, int(budget) - 1)
+        # HALF a screen, not a full one. A full page leaves nothing on
+        # screen to anchor against, so the reader loses their place at every
+        # press; half keeps the previous context in view.
+        step = max(1, int(budget) // 2)
         return self.scroll(-step if direction >= 0 else step,
                            total=total, budget=budget)
 
@@ -204,7 +228,9 @@ class CanvasViewport:
             marker = total if appended is None else int(appended)
             previous, self._last_appended = self._last_appended, marker
             if self._offset > 0 and previous is not None and marker > previous:
-                self._offset += marker - previous
+                arrived = marker - previous
+                self._offset += arrived
+                self.new_since_paused += arrived
 
             if total <= budget:
                 # Everything fits; there is no history to be inside of.
@@ -235,7 +261,12 @@ class CanvasViewport:
             older = f"↑ {hidden_above} older" if hidden_above > 0 else "↑ top"
             if self.hit_top and hidden_above <= 0:
                 older = "↑ oldest kept"
-            return f"{older} · {hidden_below} newer below · End to follow"
+            # What ARRIVED while they were reading is the fact that decides
+            # whether to jump back; the raw "lines below" count includes
+            # everything they scrolled past and answers a different question.
+            fresh = (f"{self.new_since_paused} new" if self.new_since_paused
+                     else f"{hidden_below} newer")
+            return f"{older} · {fresh} below · End to follow"
         except Exception:  # noqa: BLE001
             return ""
 
@@ -273,15 +304,32 @@ def install_scroll_bindings(
             lambda t, b: viewport.page(1, total=t, budget=b)))
         kb.add("pagedown")(_move(
             lambda t, b: viewport.page(-1, total=t, budget=b)))
-        # Wheel events arrive as scroll-up/scroll-down when mouse support is
-        # on; harmless to bind when it is not.
-        kb.add("s-up")(_move(
-            lambda t, b: viewport.scroll(-3, total=t, budget=b)))
-        kb.add("s-down")(_move(
-            lambda t, b: viewport.scroll(3, total=t, budget=b)))
-        kb.add("end")(_move(lambda _t, _b: viewport.to_bottom()))
-        kb.add("home")(_move(
-            lambda t, b: viewport.to_top(total=t, budget=b)))
+        # The MOUSE WHEEL. prompt_toolkit turns wheel events into these two
+        # keys once `mouse_support` is on, so the wheel and the keyboard move
+        # the same viewport through the same clamping — no second scroll path
+        # that can disagree about where the bottom is.
+        from prompt_toolkit.keys import Keys
+
+        def _notch(direction: int) -> Any:
+            def _fn(t: int, b: int) -> bool:
+                step = max(1, int(round(scroll_speed())))
+                return viewport.scroll(direction * step, total=t, budget=b)
+            return _fn
+
+        kb.add(Keys.ScrollUp)(_move(_notch(-1)))
+        kb.add(Keys.ScrollDown)(_move(_notch(1)))
+        kb.add("s-up")(_move(_notch(-1)))
+        kb.add("s-down")(_move(_notch(1)))
+
+        # Home/End AND their Ctrl variants. Both, deliberately: Ctrl+End is
+        # the conventional jump-to-latest, and a MacBook keyboard cannot send
+        # it at all (Ctrl+Fn+→ does not reach the app), so binding only that
+        # would leave this machine with no way back to live.
+        for key in ("end", "c-end"):
+            kb.add(key)(_move(lambda _t, _b: viewport.to_bottom()))
+        for key in ("home", "c-home"):
+            kb.add(key)(_move(
+                lambda t, b: viewport.to_top(total=t, budget=b)))
         return True
     except Exception:  # noqa: BLE001
         logger.debug("[CanvasViewport] bindings degraded", exc_info=True)

--- a/tests/battle_test/test_canvas_viewport.py
+++ b/tests/battle_test/test_canvas_viewport.py
@@ -207,3 +207,101 @@ def test_the_pre_existing_knob_still_wins(
 def test_the_kill_switch(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("JARVIS_CANVAS_SCROLLBACK_ENABLED", "0")
     assert scrollback_enabled() is False
+
+
+# --------------------------------------------------------------------------
+# fullscreen-rendering parity: the wheel, half pages, and what arrived
+# --------------------------------------------------------------------------
+
+def test_paging_moves_HALF_a_screen() -> None:
+    """A full page leaves nothing on screen to anchor against, so the reader
+    loses their place at every press."""
+    v = CanvasViewport()
+    v.window(_lines(500), 20)
+    v.page(1, total=500, budget=20)
+    assert v.offset == 10
+
+
+def test_the_wheel_moves_by_the_configured_speed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Terminals disagree about wheel events — some send one per notch,
+    others amplify. Nothing can detect which, so it is a knob."""
+    from backend.core.ouroboros.battle_test.canvas_viewport import scroll_speed
+
+    assert scroll_speed() == 3.0, "vim's default"
+    monkeypatch.setenv("JARVIS_SCROLL_SPEED", "0.25")
+    assert scroll_speed() == 0.25
+    monkeypatch.setenv("JARVIS_SCROLL_SPEED", "999")
+    assert scroll_speed() == 20.0, "clamped"
+    monkeypatch.setenv("JARVIS_SCROLL_SPEED", "nonsense")
+    assert scroll_speed() == 3.0
+
+
+def test_it_counts_what_ARRIVED_while_reading() -> None:
+    """"3 new" answers "should I jump back to live". The raw lines-below
+    count includes everything already scrolled past and answers a different
+    question."""
+    v = CanvasViewport()
+    history = _lines(500)
+    v.window(history, 11, appended=500)
+    v.page(1, total=500, budget=11)
+    history += _lines(30, start=500)
+    _vis, above, below = v.window(history, 11, appended=530)
+
+    assert v.new_since_paused == 30
+    assert "30 new" in v.status(above, below)
+
+
+def test_returning_to_live_clears_the_count() -> None:
+    v = CanvasViewport()
+    v.window(_lines(500), 11, appended=500)
+    v.page(1, total=500, budget=11)
+    v.window(_lines(530), 11, appended=530)
+    assert v.new_since_paused > 0
+    v.to_bottom()
+    assert v.new_since_paused == 0
+
+
+def test_following_never_accrues_a_count() -> None:
+    """Nothing is "new" to someone already watching it."""
+    v = CanvasViewport()
+    v.window(_lines(100), 10, appended=100)
+    v.window(_lines(200), 10, appended=200)
+    assert v.new_since_paused == 0
+
+
+def test_the_wheel_and_the_keyboard_share_one_viewport() -> None:
+    """Bound to the same clamped object rather than a second scroll path
+    that could disagree about where the bottom is."""
+    from prompt_toolkit.key_binding import KeyBindings
+    from prompt_toolkit.keys import Keys
+
+    from backend.core.ouroboros.battle_test.canvas_viewport import (
+        install_scroll_bindings,
+    )
+
+    v = CanvasViewport()
+    kb = KeyBindings()
+    assert install_scroll_bindings(kb, v, lambda: (500, 11)) is True
+    combos = {tuple(str(k) for k in b.keys) for b in kb.bindings}
+    for key in ("Keys.ScrollUp", "Keys.ScrollDown", "Keys.PageUp",
+                "Keys.PageDown", "Keys.End", "Keys.Home"):
+        assert (key,) in combos, f"{key} unbound"
+
+
+def test_BOTH_end_and_ctrl_end_return_to_live() -> None:
+    """Ctrl+End is conventional, and a MacBook keyboard cannot send it —
+    Ctrl+Fn+→ does not reach the app. Binding only that would leave this
+    machine with no way back to live."""
+    from prompt_toolkit.key_binding import KeyBindings
+
+    from backend.core.ouroboros.battle_test.canvas_viewport import (
+        install_scroll_bindings,
+    )
+
+    kb = KeyBindings()
+    install_scroll_bindings(kb, CanvasViewport(), lambda: (500, 11))
+    combos = {tuple(str(k) for k in b.keys) for b in kb.bindings}
+    assert ("Keys.End",) in combos and ("Keys.ControlEnd",) in combos
+    assert ("Keys.Home",) in combos and ("Keys.ControlHome",) in combos

--- a/tests/battle_test/test_prompt_sizing.py
+++ b/tests/battle_test/test_prompt_sizing.py
@@ -202,3 +202,41 @@ def test_the_terminal_renders_one_row_for_an_empty_prompt(
     assert "EMPTY=1" in proc.stdout, "the empty prompt is a slab again"
     assert "ONE=1" in proc.stdout
     assert "THREE=3" in proc.stdout
+
+
+# --------------------------------------------------------------------------
+# mouse capture — the trade it makes
+# --------------------------------------------------------------------------
+
+def test_the_cockpit_captures_the_mouse_when_it_owns_the_screen(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from backend.core.ouroboros.battle_test.bipartite_layout import (
+        mouse_enabled,
+    )
+
+    monkeypatch.delenv("JARVIS_DISABLE_MOUSE", raising=False)
+    monkeypatch.setenv("JARVIS_BIPARTITE_FULLSCREEN", "1")
+    assert mouse_enabled() is True
+    monkeypatch.setenv("JARVIS_BIPARTITE_FULLSCREEN", "0")
+    assert mouse_enabled() is False, (
+        "capturing the mouse without a scrollable deck takes the terminal's "
+        "own selection away and gives nothing back"
+    )
+
+
+def test_the_mouse_can_be_declined_on_its_own(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Capturing the mouse stops the terminal's native click-and-drag
+    selection — the most common friction point of a full-screen TUI. An
+    operator who selects more than they scroll keeps the rendering and drops
+    the capture."""
+    from backend.core.ouroboros.battle_test.bipartite_layout import (
+        fullscreen_enabled, mouse_enabled,
+    )
+
+    monkeypatch.setenv("JARVIS_BIPARTITE_FULLSCREEN", "1")
+    monkeypatch.setenv("JARVIS_DISABLE_MOUSE", "1")
+    assert mouse_enabled() is False
+    assert fullscreen_enabled() is True, "rendering is kept either way"


### PR DESCRIPTION
Measured `ov` against [the fullscreen-rendering doc](https://code.claude.com/docs/en/fullscreen) rather than against a screenshot. Most of that spec landed over the last few PRs. Three behaviours were missing — one of them the first thing an operator reaches for.

## Already there (#70173, #70175, #70176)

- **Alternate screen buffer** — the doc's core mechanism: *"It draws the interface on the terminal's alternate screen buffer, like `vim` or `htop`."*
- **Input fixed at the bottom** — the doc's own test for whether fullscreen is active: *"If the input doesn't move while Claude is working, fullscreen rendering is active."* Ours doesn't move; it's exactly as tall as what you typed.
- **In-app scrolling with auto-follow** that holds the view still while the organism keeps emitting.

## What this adds

**The mouse wheel.** `mouse_support=False`, so the wheel did nothing. Now bound through `Keys.ScrollUp`/`ScrollDown` — the keys prompt_toolkit synthesises from wheel events — into the *same* viewport the keyboard moves. One clamped object, so wheel and PgUp can't disagree about where the bottom is.

Capturing the mouse is a real trade, and the doc is blunt about it: *"When Claude Code captures mouse events, your terminal's native copy-on-select stops working."* So capture follows the alt-screen decision — without a scrollable deck there's nothing for the wheel to move, and taking selection away would give nothing back — and `JARVIS_DISABLE_MOUSE=1` declines it while keeping the rendering.

Wheel distance is `JARVIS_SCROLL_SPEED` (default 3, vim's), clamped 0.25–20. A knob rather than a constant because terminals disagree about whether they amplify, and nothing can detect which.

**Half-page paging.** PgUp moved a full screen minus one line. A full page leaves nothing on screen to anchor against, so you lose your place at every press.

**What arrived while you were reading.** The status row counted lines *below* the viewport — which includes everything you already scrolled past, and answers a different question. It now counts what arrived since auto-follow paused:

```
↑ 470 older · 30 new below · End to follow
```

Returning to the tail clears it. Someone already watching is never told anything is new.

**`Ctrl+Home`/`Ctrl+End` alongside `Home`/`End`**, not instead of. Ctrl+End is conventional, and a MacBook keyboard *cannot send it* — `Ctrl+Fn+→` doesn't reach the application, a caveat the doc calls out. Binding only that would leave this machine with no way back to live.

Also corrects a comment above the `Application` that still explained why full-screen was off, three PRs after it was turned on.

## Not yet at parity

Stated rather than folded in silently: transcript mode with `/` search, `[` to write the conversation back into native scrollback for `Cmd+F`, click-to-position-cursor, and in-app selection. Separate builds.

## Verification

41 tests. Mouse capture, wheel bindings and the full key set verified **under a real PTY** — `app.mouse_support()` true and every scroll key present on the Application — because a binding that exists in source but never reaches the app is this codebase's most repeated defect. No new failures beyond the known-flaky watchdog test (measured 4/8 here vs 2/8 on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable mouse wheel scrolling and clearer “new output” indicators in the fullscreen deck for smoother reading. Also adds half-page paging and conventional keybindings to jump around quickly.

- New Features
  - Mouse wheel scroll in fullscreen; bound via `prompt_toolkit` `Keys.ScrollUp`/`Keys.ScrollDown` (and `s-up`/`s-down`) to the same clamped viewport as the keyboard.
  - PgUp/PgDn now move half a screen to keep context visible.
  - Status row shows “X new below” since auto-follow paused; clears when you return to live.
  - Supports Home/End and `Ctrl+Home`/`Ctrl+End`; End jumps to live.

- Migration
  - To keep native text selection, set `JARVIS_DISABLE_MOUSE=1` (fullscreen rendering remains on).
  - Tune wheel distance with `JARVIS_SCROLL_SPEED` (default 3, clamped 0.25–20).

<sup>Written for commit 64afeb12dd90280ccc518a684296f6ebed5cd60d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

