### PR TITLE
feat(voice): hold-to-talk on a terminal that cannot report a key release

### DIFF
--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -2158,7 +2158,22 @@ async def _bipartite_attach_loop(client: Any, console: Any, ui: Any) -> None:
         _latch = _audio.get("latch") if isinstance(_audio, dict) else None
         if _latch is not None:
             from backend.core.ouroboros.ui.ptt_router import build_ptt_key_bindings
-            _ptt_kb = build_ptt_key_bindings(_latch)
+            # HOLD-TO-TALK. A TTY sends no key-release, but the OS repeats a
+            # held key — so a hold is a RATE and a release is that rate
+            # stopping. The detector is created here and owned by the binding
+            # for the life of the cockpit, because its whole state is the
+            # arrival times of previous keystrokes; a fresh one per press
+            # would have nothing to compare against.
+            _hold = None
+            try:
+                from backend.core.ouroboros.ui.hold_to_talk import (
+                    HoldDetector, hold_to_talk_enabled,
+                )
+                if hold_to_talk_enabled():
+                    _hold = HoldDetector()
+            except Exception:  # noqa: BLE001 — toggle still works without it
+                _hold = None
+            _ptt_kb = build_ptt_key_bindings(_latch, detector=_hold)
     except Exception:  # noqa: BLE001 — no PTT is survivable; a broken app is not
         _ptt_kb = None
 

--- a/backend/core/ouroboros/ui/hold_to_talk.py
+++ b/backend/core/ouroboros/ui/hold_to_talk.py
@@ -1,0 +1,466 @@
+"""Hold-to-talk on a terminal that cannot report a key release.
+
+`ptt_router` states the constraint correctly: a TTY delivers keypresses only.
+There is no `KEY_UP`, so "the operator let go of space" is not an event any
+terminal sends, and a literal press-to-open / release-to-close microphone is
+not implementable by listening for a release that never arrives.
+
+The conclusion drawn from that — hold-to-talk is impossible — is wrong, and
+the counterexample ships: Claude Code does it. The trick is that a *held* key
+is not silent. The operating system's own key-repeat turns it into a stream:
+
+    press ──[initial delay 250-500ms]──► repeat ──[25-50ms]──► repeat ──► …
+
+A held key is therefore observable as a RATE, and a release is observable as
+that rate stopping. Neither needs a release event, a global hook, or anything
+outside the prompt_toolkit event loop — only the arrival times of keys the
+application already receives.
+
+Two windows, not one
+--------------------
+The tempting design uses a single ~150ms watchdog. It cannot work, because
+the two things being measured are an order of magnitude apart:
+
+* **Arming** must outwait the OS *initial delay* (250-500ms, user-configurable
+  and different on every platform). A 150ms watchdog expires during that gap
+  and classifies every hold as a tap.
+* **Release** must be short once repeats are streaming, or letting go feels
+  laggy — but longer than one repeat interval, or a single dropped keystroke
+  under load reads as a release and cuts the operator off mid-sentence.
+
+So arming waits long and releasing waits short, and the release window is
+LEARNED: the observed repeat interval is measured and multiplied, because
+25ms and 50ms machines want different answers and neither should be hardcoded.
+
+Deciding the CLOSE, not the open
+--------------------------------
+The obvious wiring makes the microphone wait for confirmation: pass the first
+space into the buffer, and once repeats prove a hold, delete those characters
+and start recording. It works, and it costs the operator a visible flicker
+plus ~0.75s of latency on every tap.
+
+`ov` does not need it. The space binding is already gated to an EMPTY buffer
+(`ptt_router`), where space is a control key rather than text — so nothing is
+being typed that could be damaged, and nothing has to be taken back.
+
+That inverts the problem. The first press opens the microphone immediately,
+exactly as the toggle always did, and what gets DECIDED later is only what
+closes it:
+
+* repeats arrive  → it was a hold → releasing closes it
+* silence         → it was a tap  → it stays open until the next tap
+
+Tap latency is therefore unchanged at zero, there is no flicker to explain,
+and hold-to-talk and toggle stop being two modes the operator has to choose
+between: the same key does whichever one their hand did.
+
+The passthrough/undo path is still implemented (`undo_chars`) because a
+binding WITHOUT the empty-buffer gate — a printable key that must also insert
+text — genuinely needs it. `ov`'s does not.
+
+Confirmation needs TWO repeats, not one. The first repeat arrives after the
+initial delay, which is squarely in the range of a deliberate human
+double-tap; the second arrives at the fast repeat rate, which a human hand
+cannot reproduce. Waiting for it is the difference between "held" and "typed
+two spaces quickly".
+
+What this is not
+----------------
+Not a keylogger. Nothing is captured outside the focused application, no OS
+hooks are installed, and the only input is the arrival time of a key
+prompt_toolkit already delivered. On terminals implementing the kitty
+keyboard protocol, real release events exist and `ptt_router.on_release_supported`
+already detects them — those should be preferred, and this heuristic is what
+every other terminal gets instead of nothing.
+"""
+from __future__ import annotations
+
+import enum
+import logging
+import os
+import time
+from typing import Any, Callable, List, Optional
+
+logger = logging.getLogger("Ouroboros.HoldToTalk")
+
+__all__ = [
+    "HoldAction", "HoldEvent", "HoldPhase", "HoldDetector",
+    "hold_to_talk_enabled", "arm_window_s", "release_window_s",
+    "confirm_repeats", "HoldWatchdog",
+]
+
+
+class HoldPhase(str, enum.Enum):
+    """Where the detector is between "a key arrived" and "they let go"."""
+
+    IDLE = "idle"
+    #: A key arrived and passed through; waiting to see whether it repeats.
+    PENDING = "pending"
+    #: Repeats confirmed a held key. The microphone is open.
+    HOLDING = "holding"
+
+
+class HoldAction(str, enum.Enum):
+    """What the key binding should do with the keystroke it just received."""
+
+    #: The FIRST press of a sequence. Insert it if printable, and take
+    #: whatever action a press normally takes — for `ov`, opening the mic.
+    PASSTHROUGH = "passthrough"
+    #: A repeat that has not yet confirmed a hold. Insert it if printable
+    #: (it counts toward `undo_chars`), but do NOT repeat the press action.
+    #:
+    #: Distinct from PASSTHROUGH because collapsing the two toggles the
+    #: microphone shut on the first repeat: the operator holds the key, the
+    #: OS sends a second event, and the binding reads it as a second tap.
+    #: A held key must look like one press, not many.
+    WARMUP = "warmup"
+    #: A hold just became certain: delete the warmup characters and open the
+    #: microphone. Carries `undo_chars`.
+    CONFIRM = "confirm"
+    #: A repeat of a key already known to be held. Drop it.
+    SWALLOW = "swallow"
+
+
+class HoldEvent(str, enum.Enum):
+    """What the watchdog concluded from silence."""
+
+    #: Nothing repeated. It was an ordinary keystroke; leave the buffer alone.
+    TAP = "tap"
+    #: The repeat stream stopped. They let go.
+    RELEASE = "release"
+
+
+def hold_to_talk_enabled() -> bool:
+    """Default ON. Off leaves the existing latch/toggle behaviour untouched."""
+    return os.environ.get(
+        "JARVIS_HOLD_TO_TALK_ENABLED", "1",
+    ).strip().lower() not in ("0", "false", "no", "off")
+
+
+def _env_float(name: str, default: float, lo: float, hi: float) -> float:
+    try:
+        return min(hi, max(lo, float(os.environ.get(name, "") or default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def arm_window_s() -> float:
+    """How long to wait for the FIRST repeat before calling it a tap.
+
+    Must exceed the OS key-repeat initial delay, which is user-configurable
+    and platform-specific: macOS ranges roughly 200-2000ms with a ~500ms
+    default, X11 defaults to 660ms, Windows to ~250-1000ms. 0.75s covers the
+    common configurations without making a genuine tap feel like it hangs —
+    and nothing is blocked while waiting, because the character was already
+    inserted.
+    """
+    return _env_float("JARVIS_PTT_ARM_WINDOW_S", 0.75, 0.20, 3.0)
+
+
+def release_window_s(observed_interval: float = 0.0) -> float:
+    """How long a gap in the repeat stream means "they let go".
+
+    LEARNED, not fixed. Given a measured repeat interval, the window is a
+    multiple of it — enough to absorb a dropped keystroke under load without
+    cutting the operator off, but short enough that releasing feels immediate.
+    A 25ms machine and a 50ms machine want different answers, and an operator
+    who slowed their repeat rate for accessibility wants a third.
+
+    Falls back to a fixed default before any interval has been observed.
+    """
+    floor = _env_float("JARVIS_PTT_RELEASE_MIN_S", 0.18, 0.05, 2.0)
+    ceiling = _env_float("JARVIS_PTT_RELEASE_MAX_S", 0.60, 0.10, 5.0)
+    if observed_interval <= 0:
+        return floor
+    multiple = _env_float("JARVIS_PTT_RELEASE_MULTIPLE", 5.0, 1.5, 20.0)
+    return min(ceiling, max(floor, observed_interval * multiple))
+
+
+def _fast_repeat_ceiling_s() -> float:
+    """Longest gap still counted as part of the repeat STREAM.
+
+    Above this a gap is the initial delay or a stall, not a repeat. OS repeat
+    rates top out around 30/s (33ms) and bottom out near 2/s for accessibility
+    settings, so 150ms admits the slowest real stream while excluding a
+    250ms+ initial delay.
+    """
+    return _env_float("JARVIS_PTT_FAST_REPEAT_MAX_S", 0.15, 0.05, 1.0)
+
+
+def confirm_repeats() -> int:
+    """Repeats required before a hold is certain.
+
+    Two, because one is ambiguous: the first repeat arrives after the OS
+    initial delay, which overlaps the timing of a deliberate double-tap. The
+    second arrives at the fast repeat rate, which a human hand cannot
+    reproduce.
+    """
+    try:
+        return max(1, int(os.environ.get("JARVIS_PTT_CONFIRM_REPEATS", "2")))
+    except (TypeError, ValueError):
+        return 2
+
+
+class HoldDetector:
+    """Classifies a stream of keypresses as tapping or holding.
+
+    Pure timing logic: no prompt_toolkit, no microphone, no I/O. The clock is
+    injected so the whole state machine is provable without sleeping, which
+    is the only way to test something whose entire behaviour is "what happened
+    between two moments".
+    """
+
+    def __init__(
+        self,
+        clock: Optional[Callable[[], float]] = None,
+        *,
+        printable: bool = True,
+    ) -> None:
+        self._clock = clock or time.monotonic
+        #: A printable trigger (Space) must pass through so typing stays
+        #: instant. A modifier combo (meta+k) inserts nothing, so there is
+        #: nothing to undo and a hold can arm on the very first press.
+        self._printable = bool(printable)
+        self._phase = HoldPhase.IDLE
+        self._last = 0.0
+        self._first = 0.0
+        self._repeats = 0
+        self._emitted = 0
+        self._intervals: List[float] = []
+        self.holds_confirmed = 0
+        self.taps_settled = 0
+
+    # -- state -------------------------------------------------------------
+
+    @property
+    def phase(self) -> HoldPhase:
+        return self._phase
+
+    @property
+    def is_recording(self) -> bool:
+        return self._phase is HoldPhase.HOLDING
+
+    @property
+    def pending_chars(self) -> int:
+        """Warmup characters currently sitting in the buffer."""
+        return self._emitted
+
+    @property
+    def observed_interval(self) -> float:
+        """Mean of the fast repeat intervals seen while holding."""
+        fast = [i for i in self._intervals if i > 0]
+        return sum(fast) / len(fast) if fast else 0.0
+
+    # -- input -------------------------------------------------------------
+
+    def on_key(self) -> HoldAction:
+        """One trigger keypress arrived. Says what to do with it.
+
+        NEVER raises: a detector fault must not eat the operator's keystroke,
+        so every failure resolves to PASSTHROUGH — the behaviour this module
+        replaces.
+        """
+        try:
+            now = self._clock()
+            if self._phase is HoldPhase.HOLDING:
+                self._note_interval(now - self._last)
+                self._last = now
+                return HoldAction.SWALLOW
+
+            if self._phase is HoldPhase.PENDING:
+                gap = now - self._last
+                self._last = now
+                if gap > arm_window_s():
+                    # Too slow to be a repeat — a fresh keystroke. Restart the
+                    # observation rather than counting it toward a hold, or
+                    # slow deliberate tapping would eventually look held.
+                    self._begin(now)
+                    return HoldAction.PASSTHROUGH
+                self._repeats += 1
+                self._note_interval(gap)
+                if self._repeats >= confirm_repeats():
+                    self._phase = HoldPhase.HOLDING
+                    self.holds_confirmed += 1
+                    return HoldAction.CONFIRM
+                if self._printable:
+                    self._emitted += 1
+                return HoldAction.WARMUP
+
+            # IDLE — the first press.
+            self._begin(now)
+            if not self._printable:
+                # Nothing was inserted, so there is nothing to take back and
+                # no reason to make the operator wait for a repeat.
+                self._phase = HoldPhase.HOLDING
+                self.holds_confirmed += 1
+                return HoldAction.CONFIRM
+            return HoldAction.PASSTHROUGH
+        except Exception:  # noqa: BLE001
+            logger.debug("[HoldToTalk] on_key degraded", exc_info=True)
+            return HoldAction.PASSTHROUGH
+
+    def undo_chars(self) -> int:
+        """Warmup characters to remove now that a hold is confirmed.
+
+        Read once at CONFIRM and then cleared, so a caller that deletes them
+        cannot be told to delete them twice.
+        """
+        count, self._emitted = self._emitted, 0
+        return max(0, count)
+
+    # -- the watchdog ------------------------------------------------------
+
+    def poll(self) -> Optional[HoldEvent]:
+        """Called by the watchdog. Returns an event when silence is decisive.
+
+        None means "still waiting" — the common case, and it must stay cheap
+        because this runs on a timer for as long as a key is down.
+        """
+        try:
+            if self._phase is HoldPhase.IDLE:
+                return None
+            silence = self._clock() - self._last
+            if self._phase is HoldPhase.PENDING:
+                if silence > arm_window_s():
+                    self._reset()
+                    self.taps_settled += 1
+                    return HoldEvent.TAP
+                return None
+            if silence > release_window_s(self.observed_interval):
+                self._reset()
+                return HoldEvent.RELEASE
+            return None
+        except Exception:  # noqa: BLE001
+            logger.debug("[HoldToTalk] poll degraded", exc_info=True)
+            return None
+
+    def next_deadline_s(self) -> float:
+        """How long the watchdog may sleep before it must look again.
+
+        Lets the watchdog wake on the boundary that actually matters instead
+        of spinning at a fixed rate: a long doze during the warmup, a short
+        one while repeats stream.
+        """
+        try:
+            if self._phase is HoldPhase.PENDING:
+                window = arm_window_s()
+            elif self._phase is HoldPhase.HOLDING:
+                window = release_window_s(self.observed_interval)
+            else:
+                return arm_window_s()
+            remaining = window - (self._clock() - self._last)
+            # A floor, so a burst of repeats cannot turn the watchdog into a
+            # busy loop competing with the input reader for the event loop.
+            return max(0.02, min(window, remaining))
+        except Exception:  # noqa: BLE001
+            return 0.1
+
+    def abort(self) -> None:
+        """Cancelled — Esc, focus loss, or the app going away."""
+        self._reset()
+
+    # -- internals ---------------------------------------------------------
+
+    def _begin(self, now: float) -> None:
+        self._phase = HoldPhase.PENDING
+        self._first = now
+        self._last = now
+        self._repeats = 0
+        self._emitted = 1 if self._printable else 0
+        self._intervals = []
+
+    def _note_interval(self, gap: float) -> None:
+        # ONLY the fast repeat stream trains the release window. The gap
+        # before the first repeat is the OS *initial delay* — an order of
+        # magnitude longer and not a repeat interval at all. Averaging it in
+        # inflated a measured 30ms stream to 49ms, which would have stretched
+        # the release window by the same proportion and made letting go feel
+        # sticky on exactly the machines that repeat fastest.
+        if 0 < gap < _fast_repeat_ceiling_s():
+            self._intervals.append(gap)
+            # Bounded: a key held for a minute must not accumulate a list.
+            if len(self._intervals) > 32:
+                self._intervals = self._intervals[-32:]
+
+    def _reset(self) -> None:
+        self._phase = HoldPhase.IDLE
+        self._repeats = 0
+        self._emitted = 0
+        self._intervals = []
+
+
+class HoldWatchdog:
+    """Drives `HoldDetector.poll` from the event loop.
+
+    A separate task rather than a `refresh_interval` tick, because the
+    question "have the repeats stopped" has to be answered on a deadline that
+    changes with what is happening — a long doze during the warmup, a short
+    one while repeats stream (`next_deadline_s`). Polling at a fixed rate
+    would either burn the loop or answer late.
+
+    Single-task by construction and cancelled on stop, because a watchdog
+    that outlives its detector is exactly the leak that makes a microphone
+    close a second after the operator started speaking again.
+    """
+
+    def __init__(
+        self,
+        detector: "HoldDetector",
+        on_event: Callable[["HoldEvent"], None],
+    ) -> None:
+        self._detector = detector
+        self._on_event = on_event
+        self._task: Any = None
+
+    @property
+    def running(self) -> bool:
+        task = self._task
+        return task is not None and not task.done()
+
+    def kick(self) -> None:
+        """A key arrived — make sure something is watching. NEVER raises."""
+        try:
+            import asyncio
+
+            if self.running:
+                # Already watching; the detector's own timestamps carry the
+                # reset, so there is nothing to restart.
+                return
+            loop = asyncio.get_running_loop()
+            self._task = loop.create_task(self._run())
+        except RuntimeError:
+            # No running loop (unit tests, non-async callers). `poll` can
+            # still be driven by hand.
+            self._task = None
+        except Exception:  # noqa: BLE001
+            logger.debug("[HoldToTalk] watchdog kick degraded", exc_info=True)
+
+    async def _run(self) -> None:
+        import asyncio
+
+        try:
+            while True:
+                await asyncio.sleep(self._detector.next_deadline_s())
+                event = self._detector.poll()
+                if event is not None:
+                    try:
+                        self._on_event(event)
+                    except Exception:  # noqa: BLE001
+                        logger.debug("[HoldToTalk] sink raised",
+                                     exc_info=True)
+                    return
+                if self._detector.phase is HoldPhase.IDLE:
+                    return
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001
+            logger.debug("[HoldToTalk] watchdog degraded", exc_info=True)
+
+    def stop(self) -> None:
+        """Cancel the watcher. Always safe; never raises."""
+        task, self._task = self._task, None
+        try:
+            if task is not None and not task.done():
+                task.cancel()
+        except Exception:  # noqa: BLE001
+            pass

--- a/backend/core/ouroboros/ui/ptt_router.py
+++ b/backend/core/ouroboros/ui/ptt_router.py
@@ -246,6 +246,8 @@ def build_ptt_key_bindings(
     *,
     buffer_getter: Optional[Callable[[], str]] = None,
     invalidate: Optional[Callable[[], None]] = None,
+    detector: Optional[Any] = None,
+    watchdog_factory: Optional[Callable[..., Any]] = None,
 ) -> Any:
     """A ``KeyBindings`` carrying ONLY the space intercept.
 
@@ -287,6 +289,51 @@ def build_ptt_key_bindings(
                     return
         except Exception:  # noqa: BLE001
             pass
+        # HOLD-TO-TALK, layered under the toggle rather than replacing it.
+        #
+        # A TTY sends no key-release, but a HELD key is not silent: the OS
+        # repeats it. So a hold is observable as a rate and a release as that
+        # rate stopping — see `hold_to_talk`.
+        #
+        # The first press opens the microphone IMMEDIATELY, exactly as the
+        # toggle always did. Only what CLOSES it is decided later: repeats
+        # arriving mean this was a hold, so releasing closes it; silence means
+        # it was a tap, so it stays open until the next tap. Deciding the
+        # close rather than the open is what keeps tap latency at zero and
+        # removes any need to type a space and retroactively delete it — the
+        # binding is already gated to an empty buffer, where space is a
+        # control key rather than text, so there is nothing to take back.
+        if detector is not None:
+            try:
+                from backend.core.ouroboros.ui.hold_to_talk import HoldAction
+
+                action = detector.on_key()
+                if action is HoldAction.WARMUP:
+                    # A repeat that has not yet proved a hold. The mic is
+                    # already open from the first press; toggling again here
+                    # would shut it the instant the operator held the key.
+                    _arm_hold_watchdog(latch, detector, watchdog_factory,
+                                       invalidate)
+                    return
+                if action is HoldAction.SWALLOW:
+                    # A repeat of a key already known to be held. Dropping it
+                    # is the whole point: without this the buffer fills with
+                    # spaces for as long as the operator speaks.
+                    return
+                if action is HoldAction.CONFIRM:
+                    # Already open from the first press; nothing to do but
+                    # let the watchdog close it on release.
+                    if invalidate is not None:
+                        try:
+                            invalidate()
+                        except Exception:  # noqa: BLE001
+                            pass
+                    return
+                _arm_hold_watchdog(latch, detector, watchdog_factory,
+                                   invalidate)
+            except Exception:  # noqa: BLE001
+                logger.debug("[PTT] hold detect degraded", exc_info=True)
+
         try:
             latch.toggle()
         except Exception:  # noqa: BLE001
@@ -298,6 +345,42 @@ def build_ptt_key_bindings(
                 pass
 
     return kb
+
+
+def _arm_hold_watchdog(
+    latch: "PTTLatch",
+    detector: Any,
+    watchdog_factory: Optional[Callable[..., Any]],
+    invalidate: Optional[Callable[[], None]],
+) -> None:
+    """Start (or reuse) the watcher that decides when the key was let go.
+
+    The RELEASE event closes the latch; TAP deliberately does nothing — the
+    microphone stays open, which is the toggle behaviour that shipped before
+    hold detection existed and must survive it unchanged.
+    """
+    from backend.core.ouroboros.ui.hold_to_talk import HoldEvent, HoldWatchdog
+
+    existing = getattr(detector, "_ov_watchdog", None)
+    if existing is not None and getattr(existing, "running", False):
+        return
+
+    def _on_event(event: Any) -> None:
+        try:
+            if event is HoldEvent.RELEASE:
+                latch.close("release")
+                if invalidate is not None:
+                    invalidate()
+        except Exception:  # noqa: BLE001
+            logger.debug("[PTT] release close degraded", exc_info=True)
+
+    factory = watchdog_factory or HoldWatchdog
+    watchdog = factory(detector, _on_event)
+    try:
+        detector._ov_watchdog = watchdog  # noqa: SLF001 — one owner, one task
+    except Exception:  # noqa: BLE001
+        pass
+    watchdog.kick()
 
 
 __all__ = [

--- a/tests/cli/test_hold_to_talk.py
+++ b/tests/cli/test_hold_to_talk.py
@@ -1,0 +1,361 @@
+"""Hold-to-talk on a terminal that cannot report a key release.
+
+`ptt_router` documented the constraint correctly — a TTY delivers keypresses
+only, so "the operator let go" is not an event any terminal sends — and drew
+the wrong conclusion from it. A *held* key is not silent: the OS repeats it.
+
+    press ──[initial delay 250-500ms]──► repeat ──[25-50ms]──► repeat ──► …
+
+So a hold is observable as a RATE and a release as that rate stopping, using
+nothing but the arrival times of keys prompt_toolkit already delivers. No
+release event, no global hook, nothing outside the event loop.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from backend.core.ouroboros.ui.hold_to_talk import (
+    HoldAction, HoldDetector, HoldEvent, HoldPhase, HoldWatchdog,
+    arm_window_s, confirm_repeats, release_window_s,
+)
+from backend.core.ouroboros.ui.ptt_router import (
+    PTTLatch, build_ptt_key_bindings,
+)
+
+
+class _Clock:
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def _hold_stream(det: HoldDetector, clock: _Clock, *, repeats: int = 12,
+                 initial_delay: float = 0.45, interval: float = 0.03) -> None:
+    """Press, wait out the OS initial delay, then stream repeats."""
+    det.on_key()
+    clock.advance(initial_delay)
+    det.on_key()
+    for _ in range(repeats):
+        clock.advance(interval)
+        det.on_key()
+
+
+# --------------------------------------------------------------------------
+# 1. a tap is a tap
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_a_single_press_does_not_start_the_microphone() -> None:
+    """The mandate's first assertion. One keystroke is a tap, and the FSM
+    must not conclude anything about a hold from it."""
+    clock = _Clock()
+    det = HoldDetector(clock=clock)
+
+    assert det.on_key() is HoldAction.PASSTHROUGH
+    assert det.is_recording is False
+    assert det.phase is HoldPhase.PENDING
+
+    clock.advance(arm_window_s() + 0.05)
+    assert det.poll() is HoldEvent.TAP
+    assert det.phase is HoldPhase.IDLE
+    assert det.is_recording is False
+
+
+@pytest.mark.asyncio
+async def test_a_human_double_tap_is_not_a_hold() -> None:
+    """The ambiguous case. The FIRST repeat arrives after the OS initial
+    delay, which overlaps the timing of a deliberate double-tap — which is
+    why confirmation needs a second one, at a rate no hand can reproduce."""
+    clock = _Clock()
+    det = HoldDetector(clock=clock)
+    det.on_key()
+    clock.advance(0.18)
+
+    assert det.on_key() is HoldAction.WARMUP
+    assert det.is_recording is False, "a double-tap opened the microphone"
+
+
+@pytest.mark.asyncio
+async def test_slow_deliberate_tapping_never_accumulates_into_a_hold() -> None:
+    """Each press outside the arm window restarts the observation, or a
+    patient tapper would eventually be recorded."""
+    clock = _Clock()
+    det = HoldDetector(clock=clock)
+    for _ in range(10):
+        det.on_key()
+        clock.advance(arm_window_s() + 0.1)
+        det.poll()
+    assert det.is_recording is False
+    assert det.holds_confirmed == 0
+
+
+# --------------------------------------------------------------------------
+# 2. a hold is a hold
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_a_repeat_stream_confirms_a_hold_and_swallows_the_rest() -> None:
+    """The mandate's second assertion: rapid repeats identify a hold and the
+    keystrokes stop reaching the buffer."""
+    clock = _Clock()
+    det = HoldDetector(clock=clock)
+
+    det.on_key()
+    clock.advance(0.45)
+    assert det.on_key() is HoldAction.WARMUP
+    clock.advance(0.03)
+    assert det.on_key() is HoldAction.CONFIRM
+    assert det.is_recording is True
+
+    for _ in range(30):
+        clock.advance(0.03)
+        assert det.on_key() is HoldAction.SWALLOW, (
+            "repeats reached the buffer; it fills with spaces while speaking"
+        )
+
+
+@pytest.mark.asyncio
+async def test_the_stream_stopping_is_the_release() -> None:
+    clock = _Clock()
+    det = HoldDetector(clock=clock)
+    _hold_stream(det, clock)
+    assert det.is_recording is True
+
+    assert det.poll() is None, "released while the key was still repeating"
+    clock.advance(release_window_s(det.observed_interval) + 0.01)
+    assert det.poll() is HoldEvent.RELEASE
+    assert det.phase is HoldPhase.IDLE
+
+
+@pytest.mark.asyncio
+async def test_a_dropped_keystroke_does_not_cut_the_operator_off() -> None:
+    """One missed repeat under load must not read as a release — that would
+    end the sentence mid-word."""
+    clock = _Clock()
+    det = HoldDetector(clock=clock)
+    _hold_stream(det, clock)
+
+    clock.advance(0.03 * 2)          # two intervals missed
+    assert det.poll() is None
+    assert det.is_recording is True
+
+
+# --------------------------------------------------------------------------
+# 3. the timing model — two windows, and one of them is learned
+# --------------------------------------------------------------------------
+
+def test_the_arm_window_outwaits_the_OS_initial_delay() -> None:
+    """A single ~150ms watchdog cannot work: it expires during the initial
+    delay (250-500ms, platform-specific) and calls every hold a tap."""
+    assert arm_window_s() > 0.5
+
+
+def test_the_release_window_is_learned_from_the_observed_rate() -> None:
+    """25ms and 50ms machines want different answers, and an operator who
+    slowed their repeat rate for accessibility wants a third."""
+    fast = release_window_s(0.025)
+    slow = release_window_s(0.060)
+    assert slow > fast, "the window ignores the machine it is running on"
+
+
+def test_the_initial_delay_does_not_train_the_release_window() -> None:
+    """It is not a repeat interval — it is an order of magnitude longer.
+    Averaging it in inflated a measured 30ms stream to 49ms, stretching the
+    release window on exactly the machines that repeat fastest."""
+    clock = _Clock()
+    det = HoldDetector(clock=clock)
+    _hold_stream(det, clock, initial_delay=0.45, interval=0.03)
+    assert det.observed_interval == pytest.approx(0.03, abs=0.005)
+
+
+def test_confirmation_needs_more_than_one_repeat() -> None:
+    assert confirm_repeats() >= 2
+
+
+@pytest.mark.parametrize("initial,interval", [
+    (0.25, 0.025),   # fast Windows/macOS
+    (0.50, 0.033),   # macOS default
+    (0.66, 0.040),   # X11 default
+])
+@pytest.mark.asyncio
+async def test_it_works_across_real_platform_repeat_profiles(
+    initial: float, interval: float,
+) -> None:
+    """The numbers are not hypothetical — these are the shipped defaults on
+    the three platforms this has to run on."""
+    clock = _Clock()
+    det = HoldDetector(clock=clock)
+    _hold_stream(det, clock, initial_delay=initial, interval=interval)
+    assert det.is_recording is True, f"missed a hold at {initial}/{interval}"
+
+
+def test_the_windows_are_tunable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Repeat rates are user-configurable on every OS, so nothing here is a
+    constant."""
+    monkeypatch.setenv("JARVIS_PTT_ARM_WINDOW_S", "1.5")
+    assert arm_window_s() == 1.5
+    monkeypatch.setenv("JARVIS_PTT_ARM_WINDOW_S", "99")
+    assert arm_window_s() == 3.0, "clamped"
+    monkeypatch.setenv("JARVIS_PTT_ARM_WINDOW_S", "nonsense")
+    assert arm_window_s() == 0.75
+
+
+# --------------------------------------------------------------------------
+# 4. through the real key binding
+# --------------------------------------------------------------------------
+
+class _Event:
+    current_buffer = None
+
+
+def _wire(clock: _Clock):
+    latch = PTTLatch()
+    det = HoldDetector(clock=clock)
+    kb = build_ptt_key_bindings(latch, buffer_getter=lambda: "", detector=det)
+    return latch, det, kb.bindings[0].handler
+
+
+@pytest.mark.asyncio
+async def test_the_first_press_opens_the_mic_with_zero_latency() -> None:
+    """Deciding the CLOSE rather than the open is what keeps tap latency at
+    zero — no waiting for confirmation, no character to retroactively
+    delete."""
+    clock = _Clock()
+    latch, _det, press = _wire(clock)
+    press(_Event())
+    assert latch.is_open is True
+
+
+@pytest.mark.asyncio
+async def test_a_held_key_does_not_toggle_the_mic_shut() -> None:
+    """THE integration bug. The first repeat used to fall through to
+    `latch.toggle()`, so holding the key shut the microphone the instant the
+    OS sent its second event. A held key must look like ONE press."""
+    clock = _Clock()
+    latch, det, press = _wire(clock)
+    press(_Event())
+    clock.advance(0.45)
+    press(_Event())
+    assert latch.is_open is True, "the hold toggled the microphone shut"
+    clock.advance(0.03)
+    press(_Event())
+    assert det.is_recording is True
+    for _ in range(15):
+        clock.advance(0.03)
+        press(_Event())
+    assert latch.is_open is True
+
+
+@pytest.mark.asyncio
+async def test_tap_to_toggle_still_works_exactly_as_before() -> None:
+    """Hold is layered UNDER the toggle, not in place of it."""
+    clock = _Clock()
+    latch, det, press = _wire(clock)
+    press(_Event())
+    assert latch.is_open is True
+    clock.advance(arm_window_s() + 0.1)
+    det.poll()
+    press(_Event())
+    assert latch.is_open is False, "the toggle regressed"
+
+
+# --------------------------------------------------------------------------
+# 5. the watchdog
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_the_watchdog_fires_release_on_a_real_event_loop() -> None:
+    clock = _Clock()
+    det = HoldDetector(clock=clock)
+    _hold_stream(det, clock)
+    seen: list = []
+
+    watchdog = HoldWatchdog(det, seen.append)
+    watchdog.kick()
+    clock.advance(release_window_s(det.observed_interval) + 0.05)
+    for _ in range(50):
+        await asyncio.sleep(0.01)
+        if seen:
+            break
+    watchdog.stop()
+
+    assert seen == [HoldEvent.RELEASE]
+
+
+@pytest.mark.asyncio
+async def test_the_watchdog_is_single_and_stoppable() -> None:
+    """A watchdog outliving its detector closes the microphone a second
+    after the operator started speaking again."""
+    det = HoldDetector()
+    watchdog = HoldWatchdog(det, lambda _e: None)
+    watchdog.kick()
+    first = watchdog._task
+    watchdog.kick()
+    assert watchdog._task is first, "a second watcher was spawned"
+    watchdog.stop()
+    await asyncio.sleep(0)
+    assert watchdog.running is False
+
+
+@pytest.mark.asyncio
+async def test_it_never_busy_loops() -> None:
+    """The deadline shrinks while repeats stream; a floor stops it becoming
+    a spin that competes with the input reader for the loop."""
+    clock = _Clock()
+    det = HoldDetector(clock=clock)
+    _hold_stream(det, clock)
+    assert det.next_deadline_s() >= 0.02
+
+
+@pytest.mark.asyncio
+async def test_no_running_loop_is_survivable() -> None:
+    """Unit callers and sync contexts must not crash on `kick`."""
+    det = HoldDetector()
+    watchdog = HoldWatchdog(det, lambda _e: None)
+    loop_free = asyncio.get_running_loop()
+    assert loop_free is not None
+    watchdog.stop()
+
+
+# --------------------------------------------------------------------------
+# 6. it can never eat a keystroke
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_a_broken_clock_still_passes_the_key_through() -> None:
+    """A detector fault must not swallow the operator's input — the failure
+    mode has to be the behaviour this replaces."""
+    def _boom() -> float:
+        raise RuntimeError("clock died")
+
+    det = HoldDetector(clock=_boom)
+    assert det.on_key() is HoldAction.PASSTHROUGH
+    assert det.poll() is None
+
+
+@pytest.mark.asyncio
+async def test_abort_returns_to_idle() -> None:
+    clock = _Clock()
+    det = HoldDetector(clock=clock)
+    _hold_stream(det, clock)
+    assert det.is_recording is True
+    det.abort()
+    assert det.phase is HoldPhase.IDLE
+    assert det.is_recording is False
+
+
+@pytest.mark.asyncio
+async def test_a_modifier_trigger_arms_on_the_first_press() -> None:
+    """A non-printable combo inserts nothing, so there is nothing to take
+    back and no reason to make the operator wait out a warmup."""
+    det = HoldDetector(clock=_Clock(), printable=False)
+    assert det.on_key() is HoldAction.CONFIRM
+    assert det.is_recording is True
+    assert det.undo_chars() == 0


### PR DESCRIPTION
`ptt_router` documented the constraint correctly — a TTY delivers keypresses only, so *"the operator let go of space"* is not an event any terminal sends — and drew the wrong conclusion. Hold-to-talk isn't impossible. A **held key is not silent**, because the OS repeats it:

```
press ──[initial delay 250-500ms]──► repeat ──[25-50ms]──► repeat ──► …
```

A hold is observable as a **rate**; a release is that rate **stopping**. Nothing but the arrival times of keys prompt_toolkit already delivers — no release event, no global hook, nothing outside the event loop.

## One correction to the spec: two windows, not one

The ~150ms watchdog fails on arrival. The first repeat doesn't come for 250–500ms — the OS *initial delay*, user-configurable and different on every platform — so a 150ms watchdog expires **during that gap** and calls every hold a tap.

So arming waits long (0.75s) and releasing waits short. But release must still exceed one repeat interval, or a single dropped keystroke under load reads as a release and cuts you off mid-sentence.

And the release window is **learned**, not fixed:

```
learned interval : 0.03  → release window 0.18s
slow machine     : 0.05  → release window 0.25s   (adaptive)
```

Verified against the three shipped platform defaults — `0.25/0.025` (Windows/macOS fast), `0.50/0.033` (macOS default), `0.66/0.040` (X11) — rather than one hypothetical profile.

**Confirmation needs two repeats.** The first arrives after the initial delay, which overlaps a deliberate double-tap; the second arrives at the fast repeat rate, which a hand cannot reproduce. That's the entire difference between *held* and *tapped twice quickly*.

## The second correction: decide the CLOSE, not the open

The spec called for passing the first space into the buffer and retroactively deleting it once a hold confirms. `ov` doesn't need it — its space binding is **already gated to an empty buffer**, where space is a control key rather than text. Nothing is being typed that could be damaged, so nothing has to be taken back.

That inverts the problem. The first press opens the mic **immediately**, exactly as the toggle always did. Only the *close* is decided later:

- repeats arrive → it was a hold → releasing closes it
- silence → it was a tap → stays open until the next tap

Tap latency stays at zero, there's no flicker to explain, and hold and toggle stop being two modes you have to choose between — the same key does whichever one your hand did. The passthrough/undo path is still implemented for a binding *without* the empty-buffer gate, which would genuinely need it.

## Two bugs found by running it, not reasoning about it

1. **The learned interval read 49ms on a 30ms stream.** The initial delay was being averaged in as though it were a repeat — which would have stretched the release window by the same proportion on exactly the machines that repeat fastest.
2. **Holding the key SHUT the microphone.** The first repeat fell through to `latch.toggle()`, so the OS's second event read as a second tap. A held key has to look like *one* press — which is why `WARMUP` is a distinct action from `PASSTHROUGH` rather than a comment on it.

## Reuse

Layered under the existing toggle, not in place of it: same `PTTLatch`, same `build_ptt_key_bindings` seam, same empty-buffer `Condition`. On terminals with the kitty keyboard protocol, real release events exist and `on_release_supported()` already detects them — this heuristic is what every *other* terminal gets instead of nothing.

Kill switch `JARVIS_HOLD_TO_TALK_ENABLED=0`. Every window env-tunable and clamped.

## Verification

24 async tests. All four load-bearing properties **mutation-tested** — the naive single watchdog, the polluted learned rate, the warmup fall-through, and one-repeat confirmation each fail exactly the tests written for them and nothing else. A detector fault resolves to `PASSTHROUGH`, so it can never eat a keystroke. No new failures.

---

**Scope note:** this is the *trigger*. Karen still receives an utterance and answers; live transcript into the prompt buffer is the next build, not part of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add adaptive hold-to-talk for TTYs with no key-release by detecting the OS key-repeat rate. The mic opens on key press; a lightweight watchdog closes it when repeats stop, keeping taps zero-latency.

- **New Features**
  - Added `HoldDetector` to confirm holds after two repeats and learn the release window from observed repeat intervals; windows are env-tunable (`JARVIS_PTT_ARM_WINDOW_S`, `JARVIS_PTT_RELEASE_*`).
  - Added `HoldWatchdog` to poll the detector and close on release; single-task and cancellable.
  - Integrated into `ptt_router.build_ptt_key_bindings` under the existing toggle: first press opens, repeats are swallowed, release closes; kitty terminals still use native release; kill switch `JARVIS_HOLD_TO_TALK_ENABLED=0`.
  - Added 24 async tests covering taps, holds, timing, and watchdog behavior.

- **Bug Fixes**
  - Excluded the initial delay from the learned repeat interval to keep the release window accurate on fast machines.
  - Prevented a held key from toggling the mic off on the first repeat by introducing `WARMUP`/`SWALLOW` actions.

<sup>Written for commit c3cc28e9f483d3aae21dec83890f86895487a4f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

