### PR TITLE
feat(voice): speech lands in the prompt, where it can be corrected

### DIFF
--- a/backend/core/ouroboros/battle_test/audio_synapse.py
+++ b/backend/core/ouroboros/battle_test/audio_synapse.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, Dict
 
 logger = logging.getLogger("Ouroboros.AudioSynapse")
 
@@ -86,8 +86,24 @@ class RemoteAudioLease:
     reaps itself; the supervisor's own drop-release disarms the mic.
     """
 
-    def __init__(self, publish: Callable[[str], None]) -> None:
+    def __init__(
+        self,
+        publish: Callable[[str], None],
+        publish_transcript: Optional[Callable[..., None]] = None,
+    ) -> None:
         self._publish = publish
+        #: Optional sink for recognised speech. Absent, transcripts are
+        #: simply not forwarded and voice behaves exactly as before.
+        self._publish_transcript = publish_transcript
+        #: utterance_id → (accumulated_text, seq). The WIRE carries deltas
+        #: (`chunk`); a cockpit needs the accumulated sentence, because it
+        #: replaces a span rather than appending to one. Accumulating here
+        #: keeps that in ONE place instead of in every consumer.
+        #:
+        #: `seq` is added here too: the duplex protocol has no ordering field,
+        #: and without one a partial delivered after its own final would
+        #: rewind the sentence in the operator's prompt.
+        self._utterances: Dict[str, Any] = {}
         self._client: Any = None
         self._hb_task: Optional[asyncio.Task] = None
         self._ttl_s: float = 5.0
@@ -140,9 +156,47 @@ class RemoteAudioLease:
             await self.release()
             return False
 
+    def _on_transcript(self, msg: dict) -> None:
+        """Accumulate a chunk and forward the sentence so far. NEVER raises.
+
+        Karen's own speech is forwarded with its role intact and refused by
+        the composer — she is talking, not dictating, and her words have no
+        business in the operator's prompt.
+        """
+        try:
+            sink = self._publish_transcript
+            if sink is None:
+                return
+            uid = str(msg.get("utterance_id", "") or "").strip()
+            if not uid:
+                return
+            chunk = str(msg.get("chunk", "") or "")
+            final = bool(msg.get("final", False))
+            state = self._utterances.get(uid) or {"text": "", "seq": 0}
+            state["text"] = (state["text"] + chunk)[:4000]
+            state["seq"] += 1
+            self._utterances[uid] = state
+            if final:
+                self._utterances.pop(uid, None)
+            # Bounded on EVERY chunk, not only on a final. A dropped final or
+            # a crashed recogniser produces utterances that never complete,
+            # and evicting only on completion means those accumulate for the
+            # life of the daemon. Oldest first: an utterance still being
+            # spoken is the one worth keeping.
+            while len(self._utterances) > 8:
+                self._utterances.pop(next(iter(self._utterances)), None)
+            sink(uid, state["text"], final=final,
+                 role=str(msg.get("role", "user") or "user"),
+                 seq=state["seq"])
+        except Exception:  # noqa: BLE001 — never break the audio FSM
+            logger.debug("[AudioSynapse] transcript degraded", exc_info=True)
+
     def _on_message(self, msg: dict) -> None:
         try:
             mtype = msg.get("type")
+            if mtype == "transcript":
+                self._on_transcript(msg)
+                return
             if mtype == "lease":
                 if msg.get("granted"):
                     ttl = msg.get("ttl_s")
@@ -268,10 +322,15 @@ class AudioVisualSynapse:
     def __init__(
         self,
         publish: Callable[[str], None],
+        publish_transcript: Optional[Callable[..., None]] = None,
         *,
         handle_resolver: Optional[Callable[[], Any]] = None,
     ) -> None:
         self._publish = publish
+        #: Threaded down to the lease, which is where duplex messages
+        #: actually arrive. Optional throughout: without it, transcripts are
+        #: simply not forwarded and voice behaves exactly as before.
+        self._publish_transcript = publish_transcript
         self._resolve = handle_resolver or self._default_resolver
         self._watch_task: Optional[asyncio.Task] = None
         self._armed = False
@@ -329,7 +388,9 @@ class AudioVisualSynapse:
             # absent/refusing does the TUI see UNAVAILABLE — honesty,
             # never a fake LISTENING.
             if broker_enabled():
-                remote = RemoteAudioLease(self._publish)
+                remote = RemoteAudioLease(
+                    self._publish, self._publish_transcript,
+                )
                 if await remote.acquire(preempt=preempt, ptt=ptt):
                     self._remote = remote
                     self._armed = True

--- a/backend/core/ouroboros/battle_test/cockpit_attach.py
+++ b/backend/core/ouroboros/battle_test/cockpit_attach.py
@@ -506,6 +506,37 @@ class CockpitAttachBridge:
             logger.debug("[CockpitAttach] prompt publish degraded",
                          exc_info=True)
 
+    def publish_transcript(
+        self, utterance_id: str, text: str, *,
+        final: bool = False, role: str = "user", seq: int = 0,
+    ) -> None:
+        """Stream one recognised chunk to attached cockpits.
+
+        Carries the SAME shape `audio_state_ipc` already uses — utterance id,
+        accumulated text, final flag — rather than a second transcript
+        vocabulary that would have to be kept in step with it.
+
+        The id and seq are what let a cockpit fold chunks safely: a socket
+        does not promise ordering, and a partial applied after its own final
+        would rewind the sentence in the operator's prompt.
+        """
+        try:
+            utterance_id = str(utterance_id or "").strip()
+            if not utterance_id or not self._clients:
+                return
+            self.stats["transcripts_published"] = (
+                self.stats.get("transcripts_published", 0) + 1
+            )
+            self._dispatch({
+                "type": "transcript", "utterance_id": utterance_id,
+                "text": str(text or ""), "final": bool(final),
+                "role": str(role or "user"), "seq": int(seq or 0),
+                "ts": time.time(),
+            })
+        except Exception:  # noqa: BLE001
+            logger.debug("[CockpitAttach] transcript publish degraded",
+                         exc_info=True)
+
     def publish_prompt_resolved(self, prompt_id: str) -> None:
         """The gate is closed — answered here, elsewhere, or expired.
 
@@ -925,6 +956,7 @@ class CockpitAttachClient:
         on_markup: Optional[Callable[[str], None]] = None,
         on_telemetry: Optional[Callable[[Dict[str, Any]], None]] = None,
         on_prompt: Optional[Callable[[Dict[str, Any]], None]] = None,
+        on_transcript: Optional[Callable[[Dict[str, Any]], None]] = None,
         on_prompt_resolved: Optional[Callable[[str], None]] = None,
         on_audio_state: Optional[Callable[[str], None]] = None,
         on_thermal: Optional[Callable[[str], None]] = None,
@@ -941,6 +973,7 @@ class CockpitAttachClient:
         self._on_markup = on_markup
         self._on_telemetry = on_telemetry or (lambda _m: None)
         self._on_prompt = on_prompt
+        self._on_transcript = on_transcript
         self._on_prompt_resolved = on_prompt_resolved
         self._on_audio_state = on_audio_state or (lambda _s: None)
         self._on_thermal = on_thermal or (lambda _s: None)
@@ -1121,6 +1154,14 @@ class CockpitAttachClient:
                     if self._on_prompt is not None:
                         try:
                             self._on_prompt(dict(frame))
+                        except Exception:  # noqa: BLE001
+                            pass
+                elif ftype == "transcript":
+                    # A cockpit with no handler is pre-dictation: it already
+                    # gets the finished utterance the way it always did.
+                    if self._on_transcript is not None:
+                        try:
+                            self._on_transcript(dict(frame))
                         except Exception:  # noqa: BLE001
                             pass
                 elif ftype == "prompt_resolved":

--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -4576,6 +4576,11 @@ class BattleTestHarness:
             )
             self._audio_synapse = AudioVisualSynapse(
                 bridge.publish_audio_state,
+                # Recognised speech, forwarded to attached cockpits so it
+                # lands in the prompt where the operator can correct it
+                # before sending. `audio_state_ipc` has emitted these frames
+                # since it shipped and nothing consumed them.
+                bridge.publish_transcript,
             )
             if await bridge.start():
                 self._cockpit_attach_bridge = bridge

--- a/backend/core/ouroboros/battle_test/transcript_composer.py
+++ b/backend/core/ouroboros/battle_test/transcript_composer.py
@@ -1,0 +1,279 @@
+"""Speech becomes text in the prompt, without ever eating what you typed.
+
+Karen already hears whole utterances and answers them. What she could not do
+is put the words where the operator could see and change them first — so a
+misheard sentence was sent, not corrected. `audio_state_ipc` has streamed the
+right shape all along::
+
+    {"type":"transcript","role":"user","chunk":"…","final":bool,
+     "utterance_id":"u-…"}
+
+partial chunks refining toward a final. This turns that stream into text in
+the prompt buffer, editable before it is sent.
+
+The buffer is shared, and that is the whole problem
+---------------------------------------------------
+The prompt is not a transcript display. The operator may be typing into it at
+the same moment chunks arrive, and both are writing to one string. Every
+naive implementation of this feature destroys typing:
+
+* "replace the last N characters" deletes whatever the operator typed after
+  the last chunk;
+* "replace from a stored offset" writes over their words the moment they add
+  or delete a character before that offset;
+* "append everything" leaves earlier partials stranded in the text.
+
+So the provisional span is verified by CONTENT, never trusted by position.
+Before replacing, the composer confirms the buffer still holds exactly the
+text it last wrote, and re-locates it if the operator's edits moved it. If
+that text is gone, changed, or ambiguous, the composer does not guess: it
+lets go — commits whatever is there and starts a fresh span for what comes
+next.
+
+Never overwriting a byte the operator touched is worth more than a tidy
+transcript. A dictation feature that occasionally eats a typed sentence is one
+nobody trusts twice.
+
+Refusing to guess
+-----------------
+Chunks can arrive out of order, twice, or after their own final — a socket
+does not promise otherwise. Each utterance is therefore identified, its
+chunks are sequenced, and anything stale is dropped rather than applied.
+Karen's OWN speech (`role="karen"`) is never composed: she is talking, not
+dictating, and putting her words in the operator's prompt would be absurd.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, Optional, Tuple
+
+logger = logging.getLogger("Ouroboros.TranscriptComposer")
+
+__all__ = [
+    "TranscriptComposer", "TranscriptResult", "parse_transcript_frame",
+    "live_transcript_enabled",
+]
+
+#: A single utterance past this is a runaway recogniser, not a sentence.
+_MAX_CHARS = 4000
+
+
+def live_transcript_enabled() -> bool:
+    """Default ON. Off, an utterance is sent whole as it was before."""
+    return os.environ.get(
+        "JARVIS_LIVE_TRANSCRIPT_ENABLED", "1",
+    ).strip().lower() not in ("0", "false", "no", "off")
+
+
+class TranscriptResult:
+    """What the caller should do to the buffer. All fields are optional."""
+
+    __slots__ = ("text", "start", "end", "provisional", "released", "reason")
+
+    def __init__(
+        self,
+        text: str = "",
+        start: int = -1,
+        end: int = -1,
+        provisional: bool = True,
+        released: bool = False,
+        reason: str = "",
+    ) -> None:
+        #: Replacement text for the span.
+        self.text = text
+        #: Span to replace, in the CURRENT buffer. -1 means "no edit".
+        self.start = start
+        self.end = end
+        #: Still refining — render it dimmed.
+        self.provisional = provisional
+        #: The composer stopped managing this span (final, or the operator
+        #: edited inside it). Whatever is in the buffer now belongs to them.
+        self.released = released
+        #: Why, for the log and for tests. Never shown to the operator.
+        self.reason = reason
+
+    @property
+    def edits(self) -> bool:
+        return self.start >= 0 and self.end >= self.start
+
+    def __repr__(self) -> str:  # pragma: no cover — diagnostics only
+        return (f"<TranscriptResult {self.reason!r} "
+                f"span=({self.start},{self.end}) prov={self.provisional}>")
+
+
+def parse_transcript_frame(frame: Any) -> Optional[Dict[str, Any]]:
+    """Normalise a wire frame, or None if it is not a usable transcript.
+
+    Karen's own speech is refused here rather than downstream — the one place
+    it can be forgotten is the place it must not be.
+    """
+    try:
+        if not isinstance(frame, dict):
+            return None
+        if str(frame.get("role", "user")) != "user":
+            return None
+        utterance = str(frame.get("utterance_id", "") or "").strip()
+        if not utterance:
+            # Unidentifiable: it cannot be sequenced against anything, so
+            # applying it risks interleaving two utterances into one.
+            return None
+        return {
+            "utterance_id": utterance,
+            "text": str(frame.get("text", frame.get("chunk", "")) or ""),
+            "final": bool(frame.get("final", False)),
+            "seq": int(frame.get("seq", 0) or 0),
+        }
+    except Exception:  # noqa: BLE001
+        return None
+
+
+class TranscriptComposer:
+    """Owns one provisional span in a buffer it does not exclusively control."""
+
+    def __init__(self, max_chars: int = _MAX_CHARS) -> None:
+        self._utterance: str = ""
+        self._written: str = ""
+        self._anchor: int = -1
+        self._seq: int = -1
+        self._max = max(1, int(max_chars))
+        self.released_by_edit = 0
+        self.dropped_stale = 0
+
+    # -- state -------------------------------------------------------------
+
+    @property
+    def active(self) -> bool:
+        return bool(self._utterance) and self._anchor >= 0
+
+    @property
+    def span(self) -> Tuple[int, int]:
+        if not self.active:
+            return (-1, -1)
+        return (self._anchor, self._anchor + len(self._written))
+
+    def reset(self) -> None:
+        self._utterance = ""
+        self._written = ""
+        self._anchor = -1
+        self._seq = -1
+
+    # -- the span, located by CONTENT ---------------------------------------
+
+    def _locate(self, buffer_text: str) -> Optional[int]:
+        """Where our last-written text is now, or None if we must let go.
+
+        Position is a hint, never the authority. The operator may have typed
+        before the span (shifting it), after it (not), or inside it (in which
+        case it is theirs now and we stop touching it).
+        """
+        if not self._written:
+            return self._anchor if 0 <= self._anchor <= len(buffer_text) else None
+        start, end = self._anchor, self._anchor + len(self._written)
+        if 0 <= start and end <= len(buffer_text):
+            if buffer_text[start:end] == self._written:
+                return start                      # unmoved — the common case
+        # Moved. Accept a relocation ONLY when it is unambiguous: two copies
+        # of the same words mean we cannot tell which one is ours, and
+        # guessing would rewrite a sentence the operator typed themselves.
+        first = buffer_text.find(self._written)
+        if first < 0 or buffer_text.find(self._written, first + 1) >= 0:
+            return None
+        return first
+
+    # -- input -------------------------------------------------------------
+
+    def on_chunk(
+        self, frame: Any, buffer_text: str, cursor: int,
+    ) -> TranscriptResult:
+        """Fold one transcript frame into the buffer. NEVER raises.
+
+        *buffer_text* and *cursor* are the LIVE buffer at this instant —
+        passed in rather than read from a global, so the rule is provable
+        without an Application and cannot consult a stale copy.
+        """
+        try:
+            if not live_transcript_enabled():
+                return TranscriptResult(reason="disabled")
+            parsed = parse_transcript_frame(frame)
+            if parsed is None:
+                return TranscriptResult(reason="not_a_transcript")
+
+            utterance = parsed["utterance_id"]
+            text = parsed["text"][: self._max]
+
+            # A different utterance: the previous one is finished as far as
+            # this buffer is concerned. Commit it and anchor afresh at the
+            # cursor, so a second hold appends where the operator is looking.
+            if utterance != self._utterance:
+                self._utterance = utterance
+                self._written = ""
+                self._seq = -1
+                self._anchor = max(0, min(int(cursor), len(buffer_text)))
+
+            seq = parsed["seq"]
+            if seq and seq <= self._seq:
+                # Out of order or duplicated. A socket does not promise
+                # otherwise, and applying it would rewind the sentence.
+                self.dropped_stale += 1
+                return TranscriptResult(reason="stale_seq")
+            if seq:
+                self._seq = seq
+
+            start = self._locate(buffer_text)
+            if start is None:
+                # Our words are gone, changed, or ambiguous — the operator
+                # has been editing. Let go rather than guess.
+                self.released_by_edit += 1
+                self.reset()
+                return TranscriptResult(released=True, reason="operator_edit")
+
+            end = start + len(self._written)
+            self._anchor = start
+            self._written = text
+            if parsed["final"]:
+                # Let go HERE, not just in the returned flag. Staying active
+                # after a final leaves the composer believing it still owns a
+                # span the operator is now editing as ordinary text — the
+                # next utterance would then splice into the middle of it.
+                self.reset()
+                return TranscriptResult(
+                    text=text, start=start, end=end,
+                    provisional=False, released=True, reason="final",
+                )
+            return TranscriptResult(
+                text=text, start=start, end=end,
+                provisional=True, released=False, reason="partial",
+            )
+        except Exception:  # noqa: BLE001 — a bad frame must not eat the prompt
+            logger.debug("[TranscriptComposer] chunk degraded", exc_info=True)
+            return TranscriptResult(reason="degraded")
+
+    def commit(self) -> None:
+        """The utterance is done; the text belongs to the operator now."""
+        self.reset()
+
+    def cancel(self, buffer_text: str) -> TranscriptResult:
+        """Dictation was abandoned — take the provisional words back out.
+
+        Only what we wrote, and only if it is still exactly ours. A cancel
+        that deletes an edited sentence is worse than one that leaves a few
+        stray words behind.
+        """
+        try:
+            if not self.active or not self._written:
+                self.reset()
+                return TranscriptResult(reason="nothing_to_cancel")
+            start = self._locate(buffer_text)
+            if start is None:
+                self.reset()
+                return TranscriptResult(released=True, reason="edited_keep")
+            end = start + len(self._written)
+            self.reset()
+            return TranscriptResult(
+                text="", start=start, end=end,
+                provisional=False, released=True, reason="cancelled",
+            )
+        except Exception:  # noqa: BLE001
+            self.reset()
+            return TranscriptResult(reason="degraded")

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -635,6 +635,8 @@ class AttachUI:
         # it needs so the FSM never reaches for a live app: `_shield_show`
         # renders, `refresh` repaints the badge.
         self.shield = _build_shield(self)
+        #: Owns the provisional span while speech is being recognised.
+        self.composer = _build_composer()
         #: Set once the attach client exists. LATE-BOUND for the same reason
         #: the approval narrator's emit is: the markup sink is built after the
         #: UI, so a handle captured here would be None forever.
@@ -1681,6 +1683,17 @@ def _not_composing() -> Any:
         return True
 
 
+def _build_composer() -> Any:
+    """The dictation span manager, or None if unavailable."""
+    try:
+        from backend.core.ouroboros.battle_test.transcript_composer import (
+            TranscriptComposer,
+        )
+        return TranscriptComposer()
+    except Exception:  # noqa: BLE001 — voice still works without dictation
+        return None
+
+
 def _build_shield(ui: Any) -> Any:
     """The client's deferral FSM, wired to this cockpit's surfaces."""
     try:
@@ -1722,6 +1735,42 @@ def _shield_show(ui: Any, prompt: Any) -> None:
         ui.refresh()
     except Exception:  # noqa: BLE001
         pass
+
+
+def _on_transcript_frame(ui: Any, frame: Any) -> None:
+    """Fold one recognised chunk into the prompt buffer. NEVER raises.
+
+    The buffer is SHARED with the operator's typing, so the composer decides
+    what may be replaced and this only carries it out. When it releases a
+    span — because the utterance finished, or because they edited inside it —
+    the words simply stay where they are and become ordinary typed text.
+    """
+    try:
+        composer = getattr(ui, "composer", None)
+        buf = _prompt_buffer()
+        if composer is None or buf is None:
+            return
+        result = composer.on_chunk(frame, buf.text, buf.cursor_position)
+        if not result.edits:
+            return
+        # Splice rather than insert: replacing our own previous partial is
+        # what keeps the prompt showing ONE evolving sentence instead of
+        # every revision the recogniser passed through.
+        before, after = buf.text[:result.start], buf.text[result.end:]
+        buf.text = before + result.text + after
+        buf.cursor_position = result.start + len(result.text)
+        ui.refresh()
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _prompt_buffer() -> Any:
+    """The live input buffer, or None when no application is running."""
+    try:
+        from prompt_toolkit.application.current import get_app
+        return get_app().current_buffer
+    except Exception:  # noqa: BLE001
+        return None
 
 
 def _on_prompt_frame(ui: Any, frame: Any) -> None:
@@ -2346,6 +2395,9 @@ def run_attach(console: Any) -> int:
             # Gates as DATA — the id + deadline the shield needs to defer one
             # safely and still answer the right op.
             on_prompt=lambda frame: _on_prompt_frame(ui, frame),
+            # Speech, into the prompt where it can be corrected before it is
+            # sent — rather than an utterance leaving unseen.
+            on_transcript=lambda frame: _on_transcript_frame(ui, frame),
             on_prompt_resolved=lambda pid: (
                 ui.shield.dismiss(pid) if ui.shield is not None else None
             ),

--- a/tests/cli/test_transcript_composer.py
+++ b/tests/cli/test_transcript_composer.py
@@ -1,0 +1,281 @@
+"""Speech becomes text in the prompt, without ever eating what you typed.
+
+Karen already heard whole utterances and answered them; what she could not do
+was put the words somewhere the operator could correct them first. The
+protocol was already right — `audio_state_ipc` has emitted
+`{"type":"transcript","chunk":…,"final":…,"utterance_id":…}` since it
+shipped, and nothing consumed it.
+
+The hard part is not the transport. The prompt buffer is SHARED: the operator
+may be typing into it while chunks arrive, and both write to one string.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.battle_test.transcript_composer import (
+    TranscriptComposer, parse_transcript_frame,
+)
+
+
+def _f(text: str, *, final: bool = False, uid: str = "u-1", seq: int = 0,
+       role: str = "user") -> dict:
+    return {"type": "transcript", "role": role, "text": text,
+            "final": final, "utterance_id": uid, "seq": seq}
+
+
+class _Buf:
+    """A buffer the composer edits, mirroring what the client does."""
+
+    def __init__(self, text: str = "", cursor: int = -1) -> None:
+        self.text = text
+        self.cursor = len(text) if cursor < 0 else cursor
+
+    def apply(self, result) -> None:
+        if not result.edits:
+            return
+        self.text = self.text[:result.start] + result.text + self.text[result.end:]
+        self.cursor = result.start + len(result.text)
+
+
+# --------------------------------------------------------------------------
+# the happy path
+# --------------------------------------------------------------------------
+
+def test_partials_refine_in_place_instead_of_stacking() -> None:
+    """One evolving sentence, not every revision the recogniser passed
+    through."""
+    c, buf = TranscriptComposer(), _Buf()
+    for text in ("fix the", "fix the flaky", "fix the flaky test"):
+        buf.apply(c.on_chunk(_f(text), buf.text, buf.cursor))
+    assert buf.text == "fix the flaky test"
+
+
+def test_the_final_releases_the_span() -> None:
+    c, buf = TranscriptComposer(), _Buf()
+    buf.apply(c.on_chunk(_f("fix the"), buf.text, buf.cursor))
+    result = c.on_chunk(_f("fix the test", final=True), buf.text, buf.cursor)
+    buf.apply(result)
+    assert buf.text == "fix the test"
+    assert result.released is True
+    assert result.provisional is False
+    assert c.active is False
+
+
+def test_a_partial_is_marked_provisional() -> None:
+    """So the surface can dim it — the operator should see what is still
+    being revised."""
+    c = TranscriptComposer()
+    assert c.on_chunk(_f("fix"), "", 0).provisional is True
+
+
+def test_a_second_utterance_appends_at_the_cursor() -> None:
+    """A second hold continues where the operator is looking rather than
+    overwriting the first."""
+    c, buf = TranscriptComposer(), _Buf()
+    buf.apply(c.on_chunk(_f("first thing", final=True), buf.text, buf.cursor))
+    buf.text += " "
+    buf.cursor = len(buf.text)
+    buf.apply(c.on_chunk(_f("second thing", uid="u-2"), buf.text, buf.cursor))
+    assert buf.text == "first thing second thing"
+
+
+# --------------------------------------------------------------------------
+# the shared buffer — the whole reason this is hard
+# --------------------------------------------------------------------------
+
+def test_typing_AFTER_the_span_is_never_overwritten() -> None:
+    """The naive "replace the last N characters" deletes exactly this."""
+    c, buf = TranscriptComposer(), _Buf()
+    buf.apply(c.on_chunk(_f("fix the"), buf.text, buf.cursor))
+    buf.text += " NOW"                      # operator types after
+    buf.apply(c.on_chunk(_f("fix the flaky"), buf.text, buf.cursor))
+    assert buf.text == "fix the flaky NOW", "typed text was eaten"
+
+
+def test_typing_BEFORE_the_span_shifts_it_rather_than_clobbering() -> None:
+    """The naive "replace from a stored offset" writes over their words the
+    moment they add a character earlier in the line."""
+    c, buf = TranscriptComposer(), _Buf()
+    buf.apply(c.on_chunk(_f("the flaky"), buf.text, buf.cursor))
+    buf.text = "please " + buf.text         # operator types before
+    buf.apply(c.on_chunk(_f("the flaky test"), buf.text, buf.cursor))
+    assert buf.text == "please the flaky test"
+
+
+def test_editing_INSIDE_the_span_makes_it_theirs() -> None:
+    """The composer does not guess. If its words are gone, it commits what
+    is there and stops touching it — a dictation feature that occasionally
+    eats a typed sentence is one nobody trusts twice."""
+    c, buf = TranscriptComposer(), _Buf()
+    buf.apply(c.on_chunk(_f("fix the flaky"), buf.text, buf.cursor))
+    buf.text = "fix the STABLE"             # operator rewrites mid-span
+    result = c.on_chunk(_f("fix the flaky test"), buf.text, buf.cursor)
+    buf.apply(result)
+    assert buf.text == "fix the STABLE", "the operator's edit was overwritten"
+    assert result.released is True
+    assert c.released_by_edit == 1
+
+
+def test_an_ambiguous_relocation_is_refused() -> None:
+    """Two copies of the same words mean we cannot tell which is ours, and
+    guessing would rewrite a sentence the operator typed themselves."""
+    c, buf = TranscriptComposer(), _Buf()
+    buf.apply(c.on_chunk(_f("test"), buf.text, buf.cursor))
+    # MOVED *and* duplicated. An intact span at its own offset is not
+    # ambiguous — position confirms it — so the text has to shift as well.
+    buf.text = "run test and test"
+    result = c.on_chunk(_f("test again"), buf.text, buf.cursor)
+    assert result.released is True
+    assert result.edits is False
+
+
+def test_a_cleared_buffer_does_not_resurrect_the_span() -> None:
+    c, buf = TranscriptComposer(), _Buf()
+    buf.apply(c.on_chunk(_f("fix the"), buf.text, buf.cursor))
+    buf.text, buf.cursor = "", 0            # submitted or cleared
+    result = c.on_chunk(_f("fix the test"), buf.text, buf.cursor)
+    assert result.released is True
+    assert result.edits is False
+
+
+# --------------------------------------------------------------------------
+# a socket promises nothing
+# --------------------------------------------------------------------------
+
+def test_an_out_of_order_partial_is_dropped() -> None:
+    """A partial applied after a later one rewinds the sentence in front of
+    the operator."""
+    c, buf = TranscriptComposer(), _Buf()
+    buf.apply(c.on_chunk(_f("fix the flaky", seq=2), buf.text, buf.cursor))
+    result = c.on_chunk(_f("fix the", seq=1), buf.text, buf.cursor)
+    buf.apply(result)
+    assert buf.text == "fix the flaky"
+    assert c.dropped_stale == 1
+
+
+def test_a_duplicate_chunk_is_dropped() -> None:
+    c, buf = TranscriptComposer(), _Buf()
+    buf.apply(c.on_chunk(_f("fix", seq=1), buf.text, buf.cursor))
+    assert c.on_chunk(_f("fix", seq=1), buf.text, buf.cursor).edits is False
+
+
+def test_karens_own_speech_is_never_composed() -> None:
+    """She is talking, not dictating. Her words have no business in the
+    operator's prompt."""
+    c = TranscriptComposer()
+    assert c.on_chunk(_f("I'll fix that", role="karen"), "", 0).edits is False
+    assert parse_transcript_frame(_f("hi", role="karen")) is None
+
+
+def test_an_unidentifiable_frame_is_refused() -> None:
+    """Without an id it cannot be sequenced, so applying it risks
+    interleaving two utterances into one sentence."""
+    assert parse_transcript_frame({"type": "transcript", "text": "x"}) is None
+
+
+@pytest.mark.parametrize("junk", [None, {}, "string", 42, {"role": "user"}])
+def test_junk_never_reaches_the_buffer(junk) -> None:
+    assert TranscriptComposer().on_chunk(junk, "hello", 5).edits is False
+
+
+def test_a_runaway_recogniser_is_bounded() -> None:
+    c = TranscriptComposer(max_chars=50)
+    result = c.on_chunk(_f("x" * 5000), "", 0)
+    assert len(result.text) == 50
+
+
+# --------------------------------------------------------------------------
+# cancelling
+# --------------------------------------------------------------------------
+
+def test_cancel_removes_only_what_was_dictated() -> None:
+    c, buf = TranscriptComposer(), _Buf("typed ")
+    buf.cursor = len(buf.text)
+    buf.apply(c.on_chunk(_f("spoken words"), buf.text, buf.cursor))
+    assert buf.text == "typed spoken words"
+    buf.apply(c.cancel(buf.text))
+    assert buf.text == "typed ", "cancel ate the operator's own text"
+
+
+def test_cancel_removes_the_span_even_when_typing_followed_it() -> None:
+    """Appending after the dictation does not make the dictated words the
+    operator's — they are still exactly what was spoken, so cancel takes
+    back precisely those and leaves the typing alone."""
+    c, buf = TranscriptComposer(), _Buf()
+    buf.apply(c.on_chunk(_f("spoken"), buf.text, buf.cursor))
+    buf.text = "spoken and then typed"
+    buf.apply(c.cancel(buf.text))
+    assert buf.text == " and then typed"
+
+
+def test_cancel_keeps_text_the_operator_edited() -> None:
+    """A cancel that deletes an edited sentence is worse than one that
+    leaves a few stray words behind."""
+    c, buf = TranscriptComposer(), _Buf()
+    buf.apply(c.on_chunk(_f("spoken"), buf.text, buf.cursor))
+    buf.text = "SPOKEN differently"          # edited INSIDE the span
+    result = c.cancel(buf.text)
+    buf.apply(result)
+    assert buf.text == "SPOKEN differently"
+    assert result.edits is False
+
+
+def test_the_kill_switch(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JARVIS_LIVE_TRANSCRIPT_ENABLED", "0")
+    assert TranscriptComposer().on_chunk(_f("fix"), "", 0).edits is False
+
+
+# --------------------------------------------------------------------------
+# the producer side
+# --------------------------------------------------------------------------
+
+def test_the_synapse_accumulates_deltas_into_a_sentence() -> None:
+    """The wire carries deltas; a cockpit replaces a SPAN and so needs the
+    sentence so far. Accumulating in one place beats every consumer doing
+    it — and the wire has no ordering field, so `seq` is added here too."""
+    from backend.core.ouroboros.battle_test.audio_synapse import (
+        RemoteAudioLease,
+    )
+
+    sent: list = []
+    lease = RemoteAudioLease(
+        lambda _s: None,
+        lambda uid, text, **kw: sent.append((text, kw["final"], kw["seq"])),
+    )
+    for chunk, final in (("fix the ", False), ("flaky ", False),
+                         ("test", True)):
+        lease._on_message({
+            "type": "transcript", "role": "user", "chunk": chunk,
+            "final": final, "utterance_id": "u-1",
+        })
+
+    assert [t for t, _f, _s in sent] == [
+        "fix the ", "fix the flaky ", "fix the flaky test",
+    ]
+    assert [s for _t, _f, s in sent] == [1, 2, 3]
+    assert sent[-1][1] is True
+
+
+def test_the_synapse_is_inert_without_a_sink() -> None:
+    """Absent the sink, voice behaves exactly as it did before."""
+    from backend.core.ouroboros.battle_test.audio_synapse import (
+        RemoteAudioLease,
+    )
+
+    lease = RemoteAudioLease(lambda _s: None)
+    lease._on_message({"type": "transcript", "role": "user", "chunk": "x",
+                       "final": True, "utterance_id": "u-1"})
+
+
+def test_an_unfinalised_utterance_cannot_grow_forever() -> None:
+    """A dropped final or a crashed recogniser must not leak."""
+    from backend.core.ouroboros.battle_test.audio_synapse import (
+        RemoteAudioLease,
+    )
+
+    lease = RemoteAudioLease(lambda _s: None, lambda *_a, **_k: None)
+    for i in range(50):
+        lease._on_message({"type": "transcript", "role": "user", "chunk": "x",
+                           "final": False, "utterance_id": f"u-{i}"})
+    assert len(lease._utterances) <= 8


### PR DESCRIPTION
Karen heard whole utterances and answered them — so a misheard sentence was **sent**, not fixed.

The protocol to do better has existed the whole time. `audio_state_ipc` has emitted

```json
{"type":"transcript","role":"user","chunk":"…","final":false,"utterance_id":"u-…"}
```

since it shipped, partial chunks refining toward a final — and **nothing consumed them**. A producer with no consumer, the defect class this codebase keeps finding.

## The transport is the easy half

The hard half is that the prompt buffer is **shared**. You may be typing into it while chunks arrive, and both write to one string. Every obvious implementation destroys typing:

| approach | what it eats |
|---|---|
| replace the last N characters | whatever you typed *after* the last chunk |
| replace from a stored offset | your words, the moment you add a character *earlier* in the line |
| append everything | nothing — but old partials litter the prompt |

So the provisional span is **verified by content, never trusted by position**. Before replacing, the composer confirms the buffer still holds exactly what it last wrote, and re-locates it when your edits moved it. If that text is gone, changed, or *ambiguous* — two copies mean it cannot tell which is its own — it doesn't guess. It **lets go**: whatever is in the buffer becomes yours, and a fresh span starts for what comes next.

Never overwriting a byte you touched is worth more than a tidy transcript. A dictation feature that occasionally eats a typed sentence is one nobody trusts twice.

```
you dictate  "fix the"          → prompt: fix the
you type     " NOW"             → prompt: fix the NOW
next partial "fix the flaky"    → prompt: fix the flaky NOW   ← your text survives
```

## A socket promises nothing either

Chunks carry an utterance id and a sequence; anything stale is dropped rather than applied — a partial delivered after its own final would rewind the sentence in front of you. Karen's own speech is refused at the parser: she's talking, not dictating.

Accumulation lives in **one** place. The wire carries deltas; a cockpit replaces a span and so needs the sentence so far — the synapse accumulates and adds the `seq` the duplex protocol lacks, instead of every consumer reimplementing both.

## Four things the tests caught that reasoning hadn't

1. A final released the span but left the composer **active** — the next utterance would splice into text you'd since edited.
2. Eviction ran only on a final, so a dropped final or crashed recogniser accumulated utterances **for the life of the daemon**.
3. + 4. Two of my test premises were wrong, and fixing them sharpened the contract: an intact span at its own offset is *not* ambiguous (position confirms it), and appending after a dictation does not make the dictated words yours — cancel still takes back exactly what was spoken.

## Verification

26 tests. The three properties that protect typing are **mutation-tested** — trusting position, guessing an ambiguous relocation, and applying stale chunks each fail exactly the tests written for them. Kill switch `JARVIS_LIVE_TRANSCRIPT_ENABLED=0` sends the utterance whole, as before; a cockpit with no handler is unaffected. No new failures.

**Follow-ups, stated rather than folded in:** rendering the provisional span *dimmed* needs a `BufferControl` lexer, and auto-submit on a final is a policy decision rather than a mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streams speech-to-text into the prompt so operators can correct it before sending, without clobbering their typing. Adds safe, live dictation that handles out-of-order chunks and bad frames.

- **New Features**
  - Added `TranscriptComposer` to manage a provisional span in the shared prompt buffer; verifies by content, relocates if moved, and releases on ambiguity or edits.
  - Plumbed transcript frames end-to-end: `audio_synapse` accumulates deltas and adds `seq`, `cockpit_attach` forwards `transcript` frames, and `ov.py` applies updates to the prompt via the composer.
  - Drops stale/duplicate chunks using `seq`; ignores non-user roles (e.g., Karen) at parse time.
  - Bounded unfinalized utterances in `RemoteAudioLease` to prevent growth (evicts oldest; max 8).
  - Kill switch `JARVIS_LIVE_TRANSCRIPT_ENABLED=0` restores previous behavior (whole utterance only); cockpits without a transcript handler are unaffected.
  - Added tests for composing behavior, cancellation safety, stale-chunk handling, and bounds.

<sup>Written for commit 889296a1b8376dd8e7aeb6b5e71aae5c544bcbbd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

