### PR TITLE
fix(audio): the degradation verdict had nowhere to go

### DIFF
--- a/backend/audio/acoustic_feedback.py
+++ b/backend/audio/acoustic_feedback.py
@@ -43,6 +43,34 @@ def _notify_adaptive_input(sample: Any) -> None:
         logger.debug("[Acoustic] adaptive sink degraded: %r", exc)
 
 
+_DEGRADATION_SINK: Optional[Callable[[str, dict], None]] = None
+
+
+def set_degradation_sink(
+    sink: Optional[Callable[[str, dict], None]],
+) -> None:
+    """Register (or clear) the surface that shows degradation to the operator.
+
+    Injected exactly like `set_adaptive_input_sink` above — the attach server
+    is an instance the harness owns, and this module must keep working with
+    no cockpit attached at all.
+    """
+    global _DEGRADATION_SINK
+    _DEGRADATION_SINK = sink
+
+
+def _notify_degradation(kind: str, payload: dict) -> None:
+    """Hand one verdict to the cockpit. NEVER raises: this sits on the STT
+    rejection path and must not be able to break recognition."""
+    sink = _DEGRADATION_SINK
+    if sink is None:
+        return
+    try:
+        sink(kind, dict(payload or {}))
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[Acoustic] degradation sink degraded: %r", exc)
+
+
 def _controller() -> Any:
     """Lazily built, with the emit and speak seams bound to the real bus and
     the real fast path — both looked up late so an audio host without either
@@ -53,13 +81,28 @@ def _controller() -> Any:
     from backend.audio.acoustic_quality import AcousticFeedbackController
 
     def _emit(kind: str, payload: dict) -> None:
-        # DRY: the audio-state UDS server is the existing event bus. No new
-        # transport, no second socket.
-        try:
-            from backend.audio.audio_state_ipc import broadcast
-            broadcast(kind, payload)
-        except (ImportError, AttributeError, OSError):
-            pass
+        """Publish one degradation verdict. NEVER raises.
+
+        This used to import `backend.audio.audio_state_ipc.broadcast` — a
+        module that does not exist (the real one lives under
+        `governance.comms.duplex`) and a function that does not exist there
+        either. Both failures landed in `except ImportError: pass`, so the
+        gate measured the room correctly, decided correctly, and published
+        into nothing. Every degradation event since it shipped was swallowed.
+
+        It publishes to an INJECTED sink instead. The duplex bus would be the
+        tidier destination — `SYS_TELEMETRY_DEGRADED` is already a member of
+        its closed `EVENT_KINDS` vocabulary — but `publish_event` exists only
+        as a method on a server instance with no module-level accessor, and
+        inventing one to reach it would be a second guess stacked on the
+        first. The sink is how this module already solves exactly this
+        problem for the device manager (`set_adaptive_input_sink`), and the
+        harness owns both instances.
+
+        The payload travels whole (diagnosis, crest, device): a badge that
+        cannot say WHY is a badge nobody acts on.
+        """
+        _notify_degradation(kind, payload)
 
     def _speak(line: str) -> None:
         # Routed through the SAME zero-cost path the phatic acknowledgements

--- a/backend/core/ouroboros/battle_test/cockpit_attach.py
+++ b/backend/core/ouroboros/battle_test/cockpit_attach.py
@@ -537,6 +537,30 @@ class CockpitAttachBridge:
             logger.debug("[CockpitAttach] transcript publish degraded",
                          exc_info=True)
 
+    def publish_acoustic(self, payload: Dict[str, Any]) -> None:
+        """Tell attached cockpits the microphone has gone bad.
+
+        Carries the verdict WHOLE — diagnosis, crest, device — because an
+        operator seeing "degraded" with no cause cannot tell a dropped
+        headset from a noisy room, and those have different fixes.
+        """
+        try:
+            if not self._clients:
+                return
+            self.stats["acoustic_published"] = (
+                self.stats.get("acoustic_published", 0) + 1
+            )
+            self._dispatch({
+                "type": "acoustic", "ts": time.time(),
+                "diagnosis": str(payload.get("diagnosis", "") or ""),
+                "crest_db": float(payload.get("crest_db", 0.0) or 0.0),
+                "device": str(payload.get("device", "") or ""),
+                "spoken": str(payload.get("spoken", "") or ""),
+            })
+        except Exception:  # noqa: BLE001
+            logger.debug("[CockpitAttach] acoustic publish degraded",
+                         exc_info=True)
+
     def publish_prompt_resolved(self, prompt_id: str) -> None:
         """The gate is closed — answered here, elsewhere, or expired.
 
@@ -957,6 +981,7 @@ class CockpitAttachClient:
         on_telemetry: Optional[Callable[[Dict[str, Any]], None]] = None,
         on_prompt: Optional[Callable[[Dict[str, Any]], None]] = None,
         on_transcript: Optional[Callable[[Dict[str, Any]], None]] = None,
+        on_acoustic: Optional[Callable[[Dict[str, Any]], None]] = None,
         on_prompt_resolved: Optional[Callable[[str], None]] = None,
         on_audio_state: Optional[Callable[[str], None]] = None,
         on_thermal: Optional[Callable[[str], None]] = None,
@@ -974,6 +999,7 @@ class CockpitAttachClient:
         self._on_telemetry = on_telemetry or (lambda _m: None)
         self._on_prompt = on_prompt
         self._on_transcript = on_transcript
+        self._on_acoustic = on_acoustic
         self._on_prompt_resolved = on_prompt_resolved
         self._on_audio_state = on_audio_state or (lambda _s: None)
         self._on_thermal = on_thermal or (lambda _s: None)
@@ -1162,6 +1188,12 @@ class CockpitAttachClient:
                     if self._on_transcript is not None:
                         try:
                             self._on_transcript(dict(frame))
+                        except Exception:  # noqa: BLE001
+                            pass
+                elif ftype == "acoustic":
+                    if self._on_acoustic is not None:
+                        try:
+                            self._on_acoustic(dict(frame))
                         except Exception:  # noqa: BLE001
                             pass
                 elif ftype == "prompt_resolved":

--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -4605,6 +4605,21 @@ class BattleTestHarness:
                         )
                     except Exception:  # noqa: BLE001
                         pass
+                    # The acoustic gate's verdict, on the operator's screen.
+                    # It has measured correctly all along and published into
+                    # a module that does not exist (#70180); this is the
+                    # surface that was waiting on the other end.
+                    try:
+                        from backend.audio.acoustic_feedback import (
+                            set_degradation_sink,
+                        )
+                        set_degradation_sink(
+                            lambda _kind, payload: bridge.publish_acoustic(
+                                payload,
+                            ),
+                        )
+                    except Exception:  # noqa: BLE001
+                        pass
                     sf = getattr(self, "_serpent_flow", None)
                     if sf is not None:
                         sf.markup_mirror = bridge.publish_markup

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -637,6 +637,11 @@ class AttachUI:
         self.shield = _build_shield(self)
         #: Owns the provisional span while speech is being recognised.
         self.composer = _build_composer()
+        #: Last acoustic verdict: (monotonic_ts, diagnosis, device). The
+        #: TIMESTAMP is the point — a microphone that recovers sends no
+        #: "recovered" event, so a badge with no decay would accuse a
+        #: perfectly good headset for the rest of the session.
+        self.acoustic: Any = None
         #: Set once the attach client exists. LATE-BOUND for the same reason
         #: the approval narrator's emit is: the markup sink is built after the
         #: UI, so a handle captured here would be None forever.
@@ -986,6 +991,49 @@ class AttachUI:
             pass
         return self._key_hints()
 
+    def acoustic_badge(self) -> str:
+        """``🎙 mic: reverb (AirPods)`` while a verdict is fresh, else "".
+
+        Decays on a timer rather than waiting for an all-clear, because the
+        gate only fires on a RUN of bad utterances — silence afterwards is
+        indistinguishable from "fixed" and from "stopped talking". Fading is
+        the honest reading of that ambiguity; a sticky badge would assert
+        something the telemetry never said.
+        """
+        try:
+            snap = self.acoustic
+            if not snap:
+                return ""
+            import time as _t
+            seen, diagnosis, device = snap
+            import os as _o
+            ttl = float(_o.environ.get("JARVIS_ACOUSTIC_BADGE_TTL_S", "90"))
+            if _t.monotonic() - seen > max(5.0, ttl):
+                self.acoustic = None
+                return ""
+            where = f" ({device})" if device else ""
+            return f"🎙 mic: {diagnosis or 'degraded'}{where}"
+        except Exception:  # noqa: BLE001
+            return ""
+
+    def on_acoustic(self, frame: Any) -> None:
+        """A degradation verdict arrived. NEVER raises."""
+        try:
+            import time as _t
+            self.acoustic = (
+                _t.monotonic(),
+                str((frame or {}).get("diagnosis", "") or ""),
+                str((frame or {}).get("device", "") or ""),
+            )
+            spoken = str((frame or {}).get("spoken", "") or "")
+            if spoken:
+                # Karen says this aloud too; showing it means an operator
+                # who missed it — or has her muted — still learns why.
+                self.flash(f"🎙 {spoken}", seconds=8.0)
+            self.refresh()
+        except Exception:  # noqa: BLE001
+            pass
+
     def _key_hints(self) -> str:
         """The affordance list — what the line you are typing on can do."""
         note = self._TOOLBAR_NOTES.get(self.audio_state)
@@ -1013,6 +1061,12 @@ class AttachUI:
             badge = self.shield.badge()
         except Exception:  # noqa: BLE001
             badge = ""
+        # The microphone outranks even a pending approval: every OTHER thing
+        # on this line is still working. A degraded mic means the operator's
+        # words are not arriving at all, and everything they try next will
+        # fail for a reason they cannot see.
+        mic = self.acoustic_badge()
+        badge = f"{mic} · {badge}" if mic and badge else (mic or badge)
         head = f"{badge} · " if badge else ""
         return f"{head}{audio.lstrip(' ·')}{keys} · 'detach' to leave"
 
@@ -2398,6 +2452,7 @@ def run_attach(console: Any) -> int:
             # Speech, into the prompt where it can be corrected before it is
             # sent — rather than an utterance leaving unseen.
             on_transcript=lambda frame: _on_transcript_frame(ui, frame),
+            on_acoustic=ui.on_acoustic,
             on_prompt_resolved=lambda pid: (
                 ui.shield.dismiss(pid) if ui.shield is not None else None
             ),

--- a/tests/audio/test_acoustic_degradation_sink.py
+++ b/tests/audio/test_acoustic_degradation_sink.py
@@ -1,0 +1,91 @@
+"""The degradation verdict has to reach somebody.
+
+The gate measured the room correctly and decided correctly, and then
+published into nothing: `_emit` imported `backend.audio.audio_state_ipc` — a
+module that does not exist, the real one being under
+`governance.comms.duplex` — and called a `broadcast` that does not exist
+there either. Both failures landed in `except (ImportError, ...): pass`, so
+every degradation event since it shipped was swallowed silently.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from backend.audio.acoustic_feedback import set_degradation_sink
+from backend.audio.acoustic_quality import (
+    DEGRADED_RUN, AcousticFeedbackController, QualitySample,
+)
+
+
+def _noise(seed: int = 7, n: int = 16000) -> np.ndarray:
+    """White noise — no syllabic envelope, low crest. The acoustic signature
+    of a fallback microphone in a room, which is what a dropped headset
+    leaves behind."""
+    return np.random.default_rng(seed).normal(0, 0.1, n).astype("float32")
+
+
+@pytest.fixture(autouse=True)
+def _clear_sink():
+    yield
+    set_degradation_sink(None)
+
+
+def test_white_noise_is_scored_as_degraded() -> None:
+    sample = QualitySample.from_audio(_noise(), 16000, device="FallbackMic")
+    assert sample.degraded is True
+    assert sample.crest_db < 15.0, "speech sits at 15-21dB crest"
+
+
+@pytest.mark.asyncio
+async def test_a_run_of_degraded_samples_reaches_the_sink() -> None:
+    """One bad utterance is a cough or a chair. A RUN is a room."""
+    seen: list = []
+    controller = AcousticFeedbackController(emit=lambda k, p: seen.append((k, p)))
+    sample = QualitySample.from_audio(_noise(), 16000, device="FallbackMic")
+
+    for _ in range(DEGRADED_RUN + 1):
+        controller.observe(sample)
+
+    assert seen, "the degradation verdict was swallowed again"
+    kind, payload = seen[0]
+    assert kind == "acoustic_degradation"
+    assert payload["device"] == "FallbackMic"
+    assert payload["crest_db"] < 15.0
+    assert payload["diagnosis"], "a badge that cannot say WHY is unactionable"
+    assert payload["spoken"], "Karen has nothing to say about it"
+
+
+@pytest.mark.asyncio
+async def test_one_bad_sample_alone_says_nothing() -> None:
+    seen: list = []
+    controller = AcousticFeedbackController(emit=lambda k, p: seen.append(k))
+    controller.observe(QualitySample.from_audio(_noise(), 16000))
+    assert seen == []
+
+
+@pytest.mark.asyncio
+async def test_the_sink_is_optional_and_faults_are_contained() -> None:
+    """This sits on the STT rejection path: it must not be able to break
+    recognition, with no sink or a broken one."""
+    def _boom(_kind, _payload):
+        raise RuntimeError("cockpit died")
+
+    set_degradation_sink(_boom)
+    from backend.audio.acoustic_feedback import _notify_degradation
+    _notify_degradation("acoustic_degradation", {"diagnosis": "reverb"})
+
+    set_degradation_sink(None)
+    _notify_degradation("acoustic_degradation", {"diagnosis": "reverb"})
+
+
+def test_the_dead_import_is_gone() -> None:
+    """The module it reached for has never existed. Pinned by NAME because
+    that is what was wrong — a path-shaped string nobody resolved."""
+    import backend.audio.acoustic_feedback as mod
+
+    src = (mod.__file__ or "")
+    assert src
+    text = open(src).read()
+    assert "from backend.audio.audio_state_ipc import" not in text
+    assert "set_degradation_sink" in text

--- a/tests/audio/test_acoustic_degradation_sink.py
+++ b/tests/audio/test_acoustic_degradation_sink.py
@@ -89,3 +89,65 @@ def test_the_dead_import_is_gone() -> None:
     text = open(src).read()
     assert "from backend.audio.audio_state_ipc import" not in text
     assert "set_degradation_sink" in text
+
+
+# --------------------------------------------------------------------------
+# the surface that was waiting on the other end
+# --------------------------------------------------------------------------
+
+def _ui():
+    import contextlib
+    import io
+
+    with contextlib.redirect_stderr(io.StringIO()):
+        from backend.core.ouroboros.cli.ov import AttachUI
+    return AttachUI()
+
+
+def test_a_verdict_reaches_the_toolbar() -> None:
+    ui = _ui()
+    ui.on_acoustic({"diagnosis": "reverb", "device": "MacBook Pro Microphone",
+                    "spoken": "The room's washing you out"})
+    badge = ui.acoustic_badge()
+    assert "reverb" in badge
+    assert "MacBook Pro Microphone" in badge, (
+        "a verdict with no device cannot distinguish a dropped headset from "
+        "a noisy room, and those have different fixes"
+    )
+    assert badge in ui._key_hints()
+
+
+def test_the_mic_badge_outranks_a_pending_approval() -> None:
+    """Everything else on that line is still working. A degraded mic means
+    the operator's words are not arriving at all."""
+    ui = _ui()
+    ui.on_acoustic({"diagnosis": "reverb", "device": "X"})
+    ui.shield.offer({"prompt_id": "iron-gate:1", "text": "apply?"},
+                    composing=True)
+    hints = ui._key_hints()
+    assert hints.index("🎙") < hints.index("⚠")
+
+
+def test_the_badge_decays() -> None:
+    """The gate fires on a RUN of bad utterances; silence afterwards is
+    indistinguishable from "fixed" and from "stopped talking". A sticky badge
+    would assert something the telemetry never said."""
+    import time
+
+    ui = _ui()
+    ui.on_acoustic({"diagnosis": "reverb", "device": "X"})
+    assert ui.acoustic_badge() != ""
+    ui.acoustic = (time.monotonic() - 10_000, "reverb", "X")
+    assert ui.acoustic_badge() == ""
+
+
+def test_no_verdict_shows_nothing() -> None:
+    assert _ui().acoustic_badge() == ""
+
+
+@pytest.mark.parametrize("junk", [None, {}, "x", 42])
+def test_a_junk_verdict_cannot_break_the_toolbar(junk) -> None:
+    ui = _ui()
+    ui.on_acoustic(junk)
+    assert isinstance(ui.acoustic_badge(), str)
+    assert isinstance(ui._key_hints(), str)


### PR DESCRIPTION
Wiring the badge turned up something larger than a missing badge.

`AcousticFeedbackController` measures the room correctly and decides correctly — a run of degraded samples, a complaint cooldown, a diagnosis, a spoken line. Then it published into nothing:

```python
from backend.audio.audio_state_ipc import broadcast   # ← does not exist
broadcast(kind, payload)                              # ← nor does this
```

`backend.audio.audio_state_ipc` **does not exist** — the real module lives under `governance.comms.duplex` — and `broadcast` isn't there either. Both failures landed in `except (ImportError, AttributeError, OSError): pass`.

So **every acoustic degradation event since the feature shipped was swallowed.** Only the log line and Karen's spoken complaint survived; nothing structural ever heard about it.

That's the root cause of "we have no visibility when the headset drops." Not a missing surface — a severed emit.

## The repair

An injected sink — the pattern this same module already uses for the device manager (`set_adaptive_input_sink`), so no new convention.

The duplex bus would be tidier, since `SYS_TELEMETRY_DEGRADED` is *already* a member of its closed `EVENT_KINDS` vocabulary. But `publish_event` exists only as a method on a server instance with no module-level accessor, and inventing one to reach it would be a second guess stacked on the first. I removed that path rather than ship a second dead import.

The payload travels whole — `diagnosis`, `crest_db`, `device`, the spoken line — because a badge that cannot say *why* is a badge nobody acts on.

## What I deliberately did not build

No DSP, no dereverberation, no spectral subtraction. PRD §24.6 is explicit that crest is a physical property of mic distance and that *"V1 exists to remove the variable, not to work around it."* This measures and reports; it does not manipulate.

Also worth flagging: the spec framed the trip condition as crest *below* 20 dB. The module's own measurements say the opposite —

```
at seating distance   rms 0.0033   crest 37.8dB   modulation 0.196
at close range        rms 0.0114   crest 19.5dB   modulation 0.431
```

— far-field capture produces *more* crest, because only the consonant peaks clear the noise floor. The existing `sqi()` already weights modulation first and crest second, so I left the thresholds alone rather than invert a working detector.

## Verification

5 tests. White noise (crest 12.2 dB, no syllabic envelope — the signature a fallback microphone leaves) trips the gate, and the verdict now reaches the sink with its diagnosis intact:

```
[Acoustic] degradation: reverb (sqi=0.73 mod=0.178 crest=12.2dB)
  → "The room's washing you out — I can hear something but not what."
emitted to cockpit sink: ('acoustic_degradation', 'reverb', 12.2)
```

A single bad sample still says nothing — a cough is not a room. Sink faults are contained, since this sits on the STT rejection path and must never break recognition. The dead import is pinned **by name**, because a path-shaped string nobody resolved is exactly what failed.

One pre-existing failure (`test_trinity_doctor::…_without_torch`) reproduces identically with this change reverted *and* my test file removed — `tests/audio/` pollutes `sys.modules` for a test asserting torch is absent. Not from this change; my first isolation check was inconclusive and I re-ran it properly.

**Follow-up, not folded in:** binding this sink to the cockpit toolbar is a separate change. The emit had to reach something before a surface could render it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dropped acoustic degradation events by replacing a dead import with an injected sink and wiring it to the cockpit. Verdicts now travel as `acoustic` frames and render a decaying mic badge with diagnosis and device (completes #70180).

- **Bug Fixes**
  - Replaced nonexistent `backend.audio.audio_state_ipc.broadcast` with an injected sink (`set_degradation_sink` → `_notify_degradation`) that never raises.
  - Preserves full payload (`diagnosis`, `crest_db`, `device`, `spoken`) and removes the dead import; tests cover delivery, single-bad-sample ignored, optional sink, and fault containment.

- **New Features**
  - Harness binds the sink to the attach bridge; emits `acoustic` frames via `publish_acoustic`, handled by `on_acoustic` on the client.
  - Cockpit shows “🎙 mic: {diagnosis} ({device})” first on the toolbar, decays by `JARVIS_ACOUSTIC_BADGE_TTL_S` (90s), and flashes `spoken` for visibility.
  - No app changes needed; binding occurs during attach and hosts without a cockpit are unaffected.

<sup>Written for commit 0bd1388443c79f5d17c53bee889c44ecdad1d803. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

