### PR TITLE
feat(ov): agent view — who is working right now

### DIFF
--- a/backend/core/ouroboros/battle_test/agent_roster.py
+++ b/backend/core/ouroboros/battle_test/agent_roster.py
@@ -1,0 +1,333 @@
+"""Who is working right now — the cockpit's agent view.
+
+O+V dispatches subagents constantly: EXPLORE mapping callers, REVIEW trying
+to refute a fix, a swarm sharding a large file. Every one of them announces
+itself as a LINE in the deck (`op_subagent_spawn`) and another line when it
+returns. Lines scroll. Thirty seconds later the operator has no idea whether
+three agents are still running or all of them finished, and the only way to
+find out is to scroll back and mentally diff spawns against results.
+
+A line is an event. A roster is a STATE, and "who is working right now" is a
+state question::
+
+    ❯ ⏺ main
+      ◯ Explore  Map ov completion architecture
+
+Derived, not tracked separately
+-------------------------------
+Nothing new reports into this. It is fed from the two seams that already
+exist — the spawn and result renderers — because a second reporting path
+would eventually disagree with the deck about what happened, and then the
+roster becomes a thing you have to check against the transcript.
+
+Finishing is not guaranteed
+---------------------------
+An agent can die without returning: a provider timeout, a killed worker, a
+daemon restart mid-flight. A roster that only removes entries on a result
+would show ghosts forever, and a ghost is worse than an omission because it
+implies work is still happening.
+
+So a running entry has a deadline. Past it, it is reaped as `unknown` —
+stated as unknown rather than quietly deleted, since "we lost track of this"
+and "this finished" are different facts and only one of them is good news.
+
+Selection survives the roster changing
+--------------------------------------
+The operator can be pointing at row 3 when an agent two rows above them
+finishes. Selection is therefore held by AGENT ID, not by index: an index
+would silently move the cursor onto a different agent at the exact moment
+they press Enter.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Any, Callable, Dict, List, Optional
+
+logger = logging.getLogger("Ouroboros.AgentRoster")
+
+__all__ = ["AgentEntry", "AgentRoster", "agent_view_enabled", "format_duration"]
+
+#: Rows drawn before the roster collapses to a count. A cockpit footer is a
+#: glance, not a process table.
+_MAX_ROWS = 8
+
+#: Longest a running agent may go unheard from before it is presumed lost.
+_STALE_S = 900.0
+
+
+def agent_view_enabled() -> bool:
+    """Default ON. Off, subagent lines still render in the deck as before."""
+    return os.environ.get(
+        "JARVIS_AGENT_VIEW_ENABLED", "1",
+    ).strip().lower() not in ("0", "false", "no", "off")
+
+
+def _stale_after_s() -> float:
+    try:
+        return max(30.0, float(os.environ.get("JARVIS_AGENT_STALE_S", "")
+                               or _STALE_S))
+    except (TypeError, ValueError):
+        return _STALE_S
+
+
+def format_duration(seconds: float) -> str:
+    """``5m 39s`` — the shape an operator reads at a glance.
+
+    Sub-minute work keeps its seconds; hours drop them, because at that scale
+    nobody is counting and the extra token only costs width.
+    """
+    try:
+        total = max(0, int(round(float(seconds))))
+        if total < 60:
+            return f"{total}s"
+        if total < 3600:
+            return f"{total // 60}m {total % 60:02d}s"
+        return f"{total // 3600}h {(total % 3600) // 60:02d}m"
+    except (TypeError, ValueError):
+        return "0s"
+
+
+class AgentEntry:
+    """One dispatched agent, and what is known about it."""
+
+    __slots__ = ("agent_id", "kind", "goal", "state", "started", "finished",
+                 "detail")
+
+    def __init__(self, agent_id: str, kind: str = "", goal: str = "",
+                 started: float = 0.0) -> None:
+        self.agent_id = str(agent_id or "")
+        self.kind = str(kind or "agent")
+        self.goal = str(goal or "")
+        #: running | finished | failed | unknown
+        self.state = "running"
+        self.started = float(started)
+        self.finished: Optional[float] = None
+        self.detail = ""
+
+    @property
+    def running(self) -> bool:
+        return self.state == "running"
+
+    def elapsed(self, now: float) -> float:
+        end = self.finished if self.finished is not None else now
+        return max(0.0, end - self.started)
+
+    @property
+    def glyph(self) -> str:
+        # ⏺ filled = this session; ◯ hollow = delegated work happening
+        # elsewhere. Failure and loss are NOT the same mark: one reported
+        # back, the other never did.
+        return {"running": "◯", "finished": "⏺",
+                "failed": "✗", "unknown": "?"}.get(self.state, "◯")
+
+    def label(self, width: int = 48) -> str:
+        goal = " ".join(self.goal.split())
+        if len(goal) > width:
+            goal = goal[: width - 1].rstrip() + "…"
+        return goal
+
+    def __repr__(self) -> str:  # pragma: no cover — diagnostics only
+        return f"<AgentEntry {self.agent_id!r} {self.kind} {self.state}>"
+
+
+class AgentRoster:
+    """Live agents, ordered oldest-first, with a selection the operator owns."""
+
+    def __init__(
+        self,
+        clock: Optional[Callable[[], float]] = None,
+        max_rows: int = _MAX_ROWS,
+    ) -> None:
+        self._clock = clock or time.monotonic
+        self._entries: Dict[str, AgentEntry] = {}
+        self._order: List[str] = []
+        self._max = max(1, int(max_rows))
+        #: Held by ID, never by index — see the module docstring.
+        self._selected: Optional[str] = None
+        self.reaped = 0
+
+    # -- the feed ----------------------------------------------------------
+
+    def spawn(self, agent_id: str, kind: str = "", goal: str = "") -> None:
+        """An agent was dispatched. NEVER raises."""
+        try:
+            key = str(agent_id or "").strip()
+            if not key:
+                return
+            if key in self._entries:
+                # A re-spawn of the same id is a retry, not a second agent.
+                # Restarting its clock is more truthful than showing an
+                # elapsed time that spans an attempt which already ended.
+                self._entries[key].started = self._clock()
+                self._entries[key].state = "running"
+                return
+            self._entries[key] = AgentEntry(key, kind, goal, self._clock())
+            self._order.append(key)
+            self._evict()
+        except Exception:  # noqa: BLE001
+            logger.debug("[AgentRoster] spawn degraded", exc_info=True)
+
+    def finish(self, agent_id: str, state: str = "finished",
+               detail: str = "") -> Optional[AgentEntry]:
+        """An agent returned. Returns the entry, so the caller can announce
+        it — the notice and the roster then cannot disagree about duration."""
+        try:
+            entry = self._entries.get(str(agent_id or "").strip())
+            if entry is None or not entry.running:
+                return None
+            entry.state = state if state in ("finished", "failed") else "finished"
+            entry.finished = self._clock()
+            entry.detail = str(detail or "")
+            return entry
+        except Exception:  # noqa: BLE001
+            return None
+
+    def reap(self) -> int:
+        """Presume lost anything running past its deadline.
+
+        Marked `unknown`, not deleted: "we lost track of this" and "this
+        finished" are different facts, and only one of them is good news.
+        """
+        try:
+            now, limit, count = self._clock(), _stale_after_s(), 0
+            for entry in self._entries.values():
+                if entry.running and (now - entry.started) > limit:
+                    entry.state = "unknown"
+                    entry.finished = now
+                    count += 1
+            self.reaped += count
+            return count
+        except Exception:  # noqa: BLE001
+            return 0
+
+    # -- state -------------------------------------------------------------
+
+    @property
+    def entries(self) -> List[AgentEntry]:
+        return [self._entries[k] for k in self._order if k in self._entries]
+
+    @property
+    def running_count(self) -> int:
+        return sum(1 for e in self.entries if e.running)
+
+    def finished_notice(self, entry: Optional[AgentEntry]) -> str:
+        """``⏺ Agent "Map ov completion architecture" finished · 5m 39s``
+
+        Quotes the GOAL rather than the id, because that is what the operator
+        asked for and what they will recognise; the id means nothing to them.
+        """
+        try:
+            if entry is None:
+                return ""
+            verb = {"finished": "finished", "failed": "failed",
+                    "unknown": "lost"}.get(entry.state, "finished")
+            took = format_duration(entry.elapsed(self._clock()))
+            goal = entry.label(60) or entry.kind
+            tail = f" · {entry.detail}" if entry.detail else ""
+            return f'⏺ Agent "{goal}" {verb} · {took}{tail}'
+        except Exception:  # noqa: BLE001
+            return ""
+
+    # -- selection ---------------------------------------------------------
+
+    @property
+    def selected(self) -> Optional[AgentEntry]:
+        if self._selected is None:
+            return None
+        return self._entries.get(self._selected)
+
+    def select(self, offset: int) -> Optional[AgentEntry]:
+        """Move the cursor. Row 0 is `main` — the operator's own session,
+        which is always present and cannot be dispatched or reaped."""
+        try:
+            rows = self.entries
+            if not rows:
+                self._selected = None
+                return None
+            ids = [None] + [e.agent_id for e in rows]   # None == main
+            try:
+                index = ids.index(self._selected)
+            except ValueError:
+                index = 0
+            index = max(0, min(len(ids) - 1, index + int(offset)))
+            self._selected = ids[index]
+            return self.selected
+        except Exception:  # noqa: BLE001
+            return None
+
+    # -- render ------------------------------------------------------------
+
+    def render(self) -> List[str]:
+        """Footer rows, or [] when nothing has been dispatched.
+
+        An empty roster renders NOTHING — not "0 agents". A cockpit that
+        always shows a section for work that is not happening spends a row
+        saying nothing, every session, forever.
+        """
+        try:
+            if not agent_view_enabled():
+                return []
+            self.reap()
+            rows = self.entries
+            if not rows:
+                return []
+            lines = ["  ↑/↓ to select · Enter to view", ""]
+            cursor = "❯" if self._selected is None else " "
+            lines.append(f"{cursor} ⏺ main")
+            shown = rows[-self._max:]
+            for entry in shown:
+                mark = "❯" if self._selected == entry.agent_id else " "
+                label = entry.label()
+                took = ""
+                if not entry.running:
+                    took = f"  {format_duration(entry.elapsed(self._clock()))}"
+                lines.append(
+                    f"{mark} {entry.glyph} {entry.kind}  {label}{took}".rstrip()
+                )
+            hidden = len(rows) - len(shown)
+            if hidden > 0:
+                lines.append(f"    … {hidden} more")
+            return lines
+        except Exception:  # noqa: BLE001
+            logger.debug("[AgentRoster] render degraded", exc_info=True)
+            return []
+
+    # -- internals ---------------------------------------------------------
+
+    def _evict(self) -> None:
+        # Drop the oldest FINISHED entry first. A running agent is never
+        # evicted for age: it is the one thing on this list that is still
+        # true.
+        limit = self._max * 3
+        while len(self._order) > limit:
+            for key in list(self._order):
+                entry = self._entries.get(key)
+                if entry is None or not entry.running:
+                    self._order.remove(key)
+                    self._entries.pop(key, None)
+                    break
+            else:
+                return
+
+
+_ROSTER: Optional[AgentRoster] = None
+
+
+def get_agent_roster() -> AgentRoster:
+    """The process-wide roster.
+
+    A module singleton for the same reason the plan checklist is one: the
+    producer (SerpentFlow, at each spawn) and the consumer (the cockpit
+    footer) sit in different layers with no handle to each other.
+    """
+    global _ROSTER
+    if _ROSTER is None:
+        _ROSTER = AgentRoster()
+    return _ROSTER
+
+
+def reset_roster_for_tests() -> None:
+    global _ROSTER
+    _ROSTER = None

--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -3271,6 +3271,17 @@ class SerpentFlow:
         when the dispatch completes.
         """
         short_sub = subagent_id.rsplit("::", 1)[-1] if "::" in subagent_id else subagent_id
+        # Agent view is DERIVED from this same call, not reported separately.
+        # A second reporting path would eventually disagree with the deck
+        # about what happened, and then the roster is a thing you have to
+        # check against the transcript instead of trust.
+        try:
+            from backend.core.ouroboros.battle_test.agent_roster import (
+                get_agent_roster,
+            )
+            get_agent_roster().spawn(subagent_id, subagent_type, goal)
+        except Exception:  # noqa: BLE001
+            pass
         goal_str = f"  [{_C['dim']}]{goal[:70]}[/{_C['dim']}]" if goal else ""
         self._op_line(
             op_id,
@@ -3303,6 +3314,25 @@ class SerpentFlow:
         """
         short_sub = subagent_id.rsplit("::", 1)[-1] if "::" in subagent_id else subagent_id
         fallback_tag = f" [fallback→{provider_used or 'claude'}]" if fallback_triggered else ""
+
+        # Close the roster entry from the SAME call that renders the result,
+        # and announce it from the entry the roster closed — so the notice's
+        # duration and the footer's cannot drift apart.
+        try:
+            from backend.core.ouroboros.battle_test.agent_roster import (
+                get_agent_roster,
+            )
+            _roster = get_agent_roster()
+            _entry = _roster.finish(
+                subagent_id,
+                "finished" if status == "completed" else "failed",
+                detail=error_class or "",
+            )
+            _notice = _roster.finished_notice(_entry)
+            if _notice:
+                self._op_line(op_id, _notice)
+        except Exception:  # noqa: BLE001
+            pass
 
         # Marker + color by status
         if status == "completed":

--- a/tests/battle_test/test_agent_roster.py
+++ b/tests/battle_test/test_agent_roster.py
@@ -1,0 +1,213 @@
+"""Agent view — who is working right now.
+
+O+V dispatches subagents constantly, and each announced itself as a LINE in
+the deck. Lines scroll. Thirty seconds later the operator cannot tell whether
+three agents are still running or all of them finished without scrolling back
+and mentally diffing spawns against results.
+
+A line is an event; "who is working right now" is a STATE.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.battle_test.agent_roster import (
+    AgentRoster, format_duration,
+)
+
+
+class _Clock:
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+
+@pytest.fixture
+def roster():
+    clock = _Clock()
+    return AgentRoster(clock=clock), clock
+
+
+# --------------------------------------------------------------------------
+# the roster
+# --------------------------------------------------------------------------
+
+def test_an_empty_roster_renders_NOTHING(roster) -> None:
+    """Not "0 agents". A cockpit that always shows a section for work that is
+    not happening spends a row saying nothing, every session, forever."""
+    r, _c = roster
+    assert r.render() == []
+
+
+def test_dispatched_agents_appear_under_main(roster) -> None:
+    r, _c = roster
+    r.spawn("sub-3f2a", "Explore", "Map ov completion architecture")
+    lines = r.render()
+    assert "❯ ⏺ main" in lines
+    assert any("Explore" in ln and "Map ov completion" in ln for ln in lines)
+    assert "  ↑/↓ to select · Enter to view" in lines
+
+
+def test_a_running_agent_is_hollow_and_a_finished_one_is_filled(roster) -> None:
+    r, c = roster
+    r.spawn("a", "Explore", "goal")
+    assert any("◯" in ln for ln in r.render())
+    c.now += 5
+    r.finish("a")
+    assert any("⏺ Explore" in ln for ln in r.render())
+
+
+def test_failure_and_loss_are_different_marks(roster) -> None:
+    """One reported back; the other never did. Collapsing them hides which
+    agents the system lost track of."""
+    r, c = roster
+    r.spawn("a", "Review", "verify"); r.spawn("b", "Explore", "map")
+    r.finish("a", "failed")
+    c.now += 10_000
+    r.reap()
+    marks = "\n".join(r.render())
+    assert "✗" in marks and "?" in marks
+
+
+# --------------------------------------------------------------------------
+# finishing is not guaranteed
+# --------------------------------------------------------------------------
+
+def test_a_lost_agent_is_reaped_as_unknown_not_deleted(roster) -> None:
+    """A ghost is worse than an omission: it implies work is still
+    happening."""
+    r, c = roster
+    r.spawn("a", "Explore", "goal")
+    assert r.running_count == 1
+    c.now += 10_000
+    assert r.reap() == 1
+    assert r.running_count == 0
+    assert r.entries[0].state == "unknown"
+
+
+def test_a_respawn_is_a_retry_not_a_second_agent(roster) -> None:
+    r, c = roster
+    r.spawn("a", "Explore", "goal")
+    c.now += 100
+    r.spawn("a", "Explore", "goal")
+    assert len(r.entries) == 1
+    assert r.entries[0].elapsed(c.now) == 0.0, (
+        "elapsed spanned an attempt that already ended"
+    )
+
+
+def test_eviction_never_drops_a_RUNNING_agent(roster) -> None:
+    """It is the one thing on this list that is still true."""
+    r, c = roster
+    for i in range(60):
+        r.spawn(f"done-{i}", "Explore", "old")
+        r.finish(f"done-{i}")
+    r.spawn("live", "Review", "still working")
+    for i in range(60, 120):
+        r.spawn(f"done-{i}", "Explore", "old")
+        r.finish(f"done-{i}")
+    assert any(e.agent_id == "live" for e in r.entries)
+
+
+# --------------------------------------------------------------------------
+# selection survives the roster changing
+# --------------------------------------------------------------------------
+
+def test_selection_is_held_by_ID_not_index(roster) -> None:
+    """The operator can be pointing at row 3 when an agent two rows above
+    finishes. An index would move the cursor onto a different agent at the
+    exact moment they press Enter."""
+    r, c = roster
+    r.spawn("a", "Explore", "first")
+    r.spawn("b", "Review", "second")
+    r.select(2)                                    # main → a → b
+    assert r.selected.agent_id == "b"
+    r.spawn("c", "Explore", "third")               # roster grows
+    r.finish("a")                                  # one above changes state
+    assert r.selected.agent_id == "b", "the cursor moved under the operator"
+
+
+def test_selection_clamps_at_both_ends(roster) -> None:
+    r, _c = roster
+    r.spawn("a", "Explore", "goal")
+    r.select(-5)
+    assert r.selected is None, "row 0 is main"
+    r.select(99)
+    assert r.selected.agent_id == "a"
+
+
+def test_the_cursor_is_drawn_where_it_points(roster) -> None:
+    r, _c = roster
+    r.spawn("a", "Explore", "goal")
+    r.select(1)
+    lines = r.render()
+    assert any(ln.startswith("❯") and "Explore" in ln for ln in lines)
+    assert any(ln.strip().endswith("main") and not ln.startswith("❯")
+               for ln in lines)
+
+
+# --------------------------------------------------------------------------
+# the notice
+# --------------------------------------------------------------------------
+
+def test_the_finished_notice_quotes_the_GOAL(roster) -> None:
+    """That is what the operator asked for and will recognise; the id means
+    nothing to them."""
+    r, c = roster
+    r.spawn("sub-3f2a", "Explore", "Map ov completion architecture")
+    c.now += 339
+    notice = r.finished_notice(r.finish("sub-3f2a"))
+    assert notice == (
+        '⏺ Agent "Map ov completion architecture" finished · 5m 39s'
+    )
+
+
+def test_a_failed_agent_says_failed(roster) -> None:
+    r, c = roster
+    r.spawn("a", "Review", "verify the fix")
+    c.now += 61
+    notice = r.finished_notice(r.finish("a", "failed", detail="timeout"))
+    assert "failed" in notice and "timeout" in notice
+
+
+def test_finishing_twice_announces_once(roster) -> None:
+    """The result renderer can fire again on a retry path; a second notice
+    would tell the operator an agent finished that already had."""
+    r, _c = roster
+    r.spawn("a", "Explore", "goal")
+    assert r.finish("a") is not None
+    assert r.finish("a") is None
+
+
+@pytest.mark.parametrize("seconds,expected", [
+    (0, "0s"), (39, "39s"), (60, "1m 00s"), (339, "5m 39s"),
+    (3600, "1h 00m"), (7325, "2h 02m"),
+])
+def test_duration_formatting(seconds: float, expected: str) -> None:
+    assert format_duration(seconds) == expected
+
+
+# --------------------------------------------------------------------------
+# robustness — this renders under the prompt the operator reads constantly
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("junk", [None, "", "   "])
+def test_an_unidentifiable_spawn_is_refused(junk) -> None:
+    r = AgentRoster()
+    r.spawn(junk, "Explore", "goal")
+    assert r.entries == []
+
+
+def test_a_long_goal_is_clipped(roster) -> None:
+    r, _c = roster
+    r.spawn("a", "Explore", "x" * 500)
+    assert all(len(ln) < 200 for ln in r.render())
+
+
+def test_the_kill_switch(monkeypatch: pytest.MonkeyPatch, roster) -> None:
+    r, _c = roster
+    r.spawn("a", "Explore", "goal")
+    monkeypatch.setenv("JARVIS_AGENT_VIEW_ENABLED", "0")
+    assert r.render() == []


### PR DESCRIPTION
It has a name: Claude Code calls this **agent view**.

O+V dispatches subagents constantly — EXPLORE mapping callers, REVIEW trying to refute a fix, a swarm sharding a file. Each announced itself as a *line* in the deck and another line when it returned. Lines scroll. Thirty seconds later you can't tell whether three agents are still running or all of them finished without scrolling back and mentally diffing spawns against results.

A line is an event. "Who is working right now" is a **state**:

```
  ↑/↓ to select · Enter to view

❯ ⏺ main
  ◯ Explore  Map ov completion architecture
  ◯ Review   Verify the containment fix
```

and when one returns:

```
⏺ Agent "Map ov completion architecture" finished · 5m 39s
```

## Derived, not tracked separately

Fed from the two seams that already exist — `op_subagent_spawn` and `op_subagent_result`. A second reporting path would eventually disagree with the deck about what happened, and then the roster becomes a thing you check *against* the transcript rather than trust. The notice is built from the entry the roster just closed, so its duration and the footer's cannot drift apart.

## Finishing is not guaranteed

An agent can die without returning — provider timeout, killed worker, daemon restart mid-flight. A roster that only removes entries on a result shows **ghosts forever**, and a ghost is worse than an omission because it implies work is still happening.

So a running entry has a deadline and is reaped as `unknown` past it — *stated* as unknown rather than quietly deleted, because "we lost track of this" and "this finished" are different facts and only one is good news. Failure (`✗`) and loss (`?`) get different marks for the same reason.

## Selection survives the roster changing

Held by **agent id, never by index**. You can be pointing at row 3 when an agent two rows above finishes; an index would move the cursor onto a different agent at the exact moment you press Enter.

Eviction never drops a *running* agent — it's the one thing on the list that's still true. An empty roster renders nothing at all, not "0 agents": a section for work that isn't happening costs a row saying nothing, every session, forever.

Switches: `JARVIS_AGENT_VIEW_ENABLED=0`, `JARVIS_AGENT_STALE_S`.

## Verification

24 tests, including the id-vs-index cursor race, reaping, retry-vs-second-agent, double-finish announcing once, and that a 500-character goal cannot blow out a footer rendered under the prompt you read constantly. Two pre-existing `serpent_flow_inline_boot` failures are in the known baseline and unrelated.

**Follow-up, not folded in:** the `↑`/`↓` bindings and Enter-to-view need the cockpit layout region. The registry exposes `select()` and `render()` ready for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a live agent view in the cockpit to show who is working right now and emit a single, accurate finish notice per agent. It derives state from existing spawn/result events, so it stays in sync with the deck and removes the need to scroll to track active work.

- **New Features**
  - Adds an Agent Roster derived from `op_subagent_spawn` and `op_subagent_result`; no second reporting path.
  - Renders running/finished/failed/lost with clear marks (◯/⏺/✗/?), plus a one-line finish notice with duration.
  - Reaps stale agents as `unknown` after `JARVIS_AGENT_STALE_S` (default 15m) to prevent ghosts; never evicts running entries.
  - Selection is by agent id (not index) so the cursor is stable as the list changes; rows are capped with an “… N more” tail.
  - Toggle with `JARVIS_AGENT_VIEW_ENABLED`; access via `AgentRoster.select()` and `AgentRoster.render()`.
  - Integrated in `serpent_flow` to feed the roster and print the finish notice; 24 tests cover reaping, retries, selection, and formatting.

<sup>Written for commit c4297fd6600c2bd01d129c3f4132b3cc74e7d404. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

