### PR TITLE
feat(ov): one line, above the prompt, when something is wrong

### DIFF
--- a/backend/core/ouroboros/cli/health_advisory.py
+++ b/backend/core/ouroboros/cli/health_advisory.py
@@ -1,0 +1,193 @@
+"""One line, above the prompt, when something is wrong.
+
+`ov doctor` proves the whole chain and prints a table. It is the right tool
+for "what exactly is broken", and the wrong one for "is anything broken" —
+because it only answers when asked, and the operator asks after they have
+already lost time to a symptom they could not explain.
+
+So the cockpit carries a single advisory line::
+
+    ✘ hydration severed · run `ov doctor`
+
+A PROJECTION, not a second opinion
+----------------------------------
+The verdicts come from `ov_doctor._verdicts_from_hydration` — the doctor's own
+function, reading the same hydration frame the cockpit already receives at
+attach. Nothing is re-probed and no second set of thresholds exists, so the
+badge and the doctor cannot disagree about whether the organism is healthy.
+Two health surfaces that can contradict each other are worse than one, because
+the operator then has to decide which to believe.
+
+That also means this costs nothing: the frame arrives regardless, and the
+advisory is derived from bytes already in hand.
+
+One line, worst first
+---------------------
+There is room for one advisory, so it shows the most severe — SEVERED before
+DEGRADED — and says how many others are waiting rather than cycling through
+them. A line that changes every second is read as noise.
+
+ABSENT is never shown. An optional surface nobody configured is not a fault,
+and reporting it trains the operator to ignore the line, which costs them the
+one time it matters.
+
+Saying what to DO
+-----------------
+Every advisory names its remedy. `✘ hydration severed` alone leaves the
+operator exactly where they started; the verb that investigates it is the
+whole point of surfacing the problem at all.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger("Ouroboros.HealthAdvisory")
+
+__all__ = ["HealthAdvisor", "advisory_enabled", "advisories_from_hydration"]
+
+
+def advisory_enabled() -> bool:
+    """Default ON. Off, the cockpit is silent about health until asked."""
+    return os.environ.get(
+        "JARVIS_HEALTH_ADVISORY_ENABLED", "1",
+    ).strip().lower() not in ("0", "false", "no", "off")
+
+
+#: Severity order. ABSENT and SKIPPED are deliberately missing — see below.
+_RANK: Dict[str, int] = {"SEVERED": 2, "DEGRADED": 1}
+
+
+def _min_rank() -> int:
+    """Lowest severity worth one line of the operator's screen.
+
+    SEVERED only, by default. Measured against a real hydration frame, the
+    doctor reports DEGRADED for perfectly ordinary conditions — "no fabrics
+    block (older daemon?)", "no liquidity data in hydration" — because its
+    table has room to explain them and this line does not. Surfacing those
+    would put a warning on screen during a completely healthy session, and a
+    line that always complains is one the operator stops reading. Then it
+    fails exactly when it finally has something true to say.
+
+    `JARVIS_HEALTH_ADVISORY_MIN=degraded` opts into the noisier reading.
+    """
+    raw = os.environ.get("JARVIS_HEALTH_ADVISORY_MIN", "").strip().lower()
+    return 1 if raw in ("degraded", "warn", "all", "1") else 2
+
+
+def advisories_from_hydration(
+    payload: Optional[Dict[str, Any]],
+) -> List[Tuple[int, str, str]]:
+    """``[(rank, edge, detail), …]`` worst-first. NEVER raises.
+
+    Delegates entirely to the doctor's verdict builder. If that import fails
+    the cockpit simply has nothing to say about health, which is the correct
+    degradation: inventing a local health check here is exactly how the two
+    surfaces would start disagreeing.
+    """
+    try:
+        if not advisory_enabled():
+            return []
+        from backend.core.ouroboros.cli.ov_doctor import (
+            _verdicts_from_hydration,
+        )
+        out: List[Tuple[int, str, str]] = []
+        for verdict in _verdicts_from_hydration(payload) or []:
+            state = getattr(getattr(verdict, "state", None), "value", "")
+            rank = _RANK.get(str(state), 0)
+            if rank < _min_rank():
+                # OK is not news. ABSENT is an optional surface nobody
+                # configured — reporting it trains the operator to ignore
+                # this line, which costs them the one time it matters.
+                # SKIPPED is downstream of a severed edge already shown.
+                continue
+            out.append((rank, str(getattr(verdict, "edge", "")),
+                        str(getattr(verdict, "detail", ""))))
+        out.sort(key=lambda row: -row[0])
+        return out
+    except Exception:  # noqa: BLE001
+        logger.debug("[HealthAdvisory] derive degraded", exc_info=True)
+        return []
+
+
+class HealthAdvisor:
+    """Holds the current advisory and renders one line for it."""
+
+    def __init__(self, remedy: str = "ov doctor") -> None:
+        self._rows: List[Tuple[int, str, str]] = []
+        self._remedy = str(remedy or "ov doctor")
+        #: Set once the operator has seen it and acted; cleared by the next
+        #: hydration that still reports a fault, so dismissing is not the same
+        #: as fixing.
+        self._muted = False
+
+    # -- input -------------------------------------------------------------
+
+    def observe_hydration(self, payload: Any) -> bool:
+        """Fold one hydration frame in. True when the advisory CHANGED.
+
+        Returning the change lets the caller repaint only on a transition
+        rather than on every heartbeat — the line is stable text, and
+        redrawing it at frame rate is how a status line becomes a flicker.
+        """
+        try:
+            rows = advisories_from_hydration(
+                payload if isinstance(payload, dict) else None,
+            )
+            changed = rows != self._rows
+            if changed:
+                self._rows = rows
+                # A NEW fault un-mutes: the operator dismissed the previous
+                # one, not this one.
+                self._muted = False
+            return changed
+        except Exception:  # noqa: BLE001
+            return False
+
+    def mute(self) -> None:
+        """Acknowledge the current advisory without pretending it is fixed."""
+        self._muted = True
+
+    # -- state -------------------------------------------------------------
+
+    @property
+    def healthy(self) -> bool:
+        return not self._rows
+
+    @property
+    def worst(self) -> Optional[Tuple[int, str, str]]:
+        return self._rows[0] if self._rows else None
+
+    @property
+    def count(self) -> int:
+        return len(self._rows)
+
+    # -- render ------------------------------------------------------------
+
+    def render(self, width: int = 0) -> str:
+        """``✘ hydration severed · run `ov doctor``` or "" when healthy.
+
+        Empty when there is nothing wrong — a health line that is always
+        present is chrome, and chrome is not read.
+        """
+        try:
+            if self._muted or not self._rows:
+                return ""
+            rank, edge, detail = self._rows[0]
+            glyph = "✘" if rank >= 2 else "▲"
+            # The edge names are numbered for the doctor's table ("3
+            # hydration"); the number is a row index there and noise here.
+            label = " ".join(str(edge).split()[1:]) or str(edge)
+            body = f"{label}: {detail}" if detail else label
+            more = f" (+{len(self._rows) - 1})" if len(self._rows) > 1 else ""
+            line = f"{glyph} {body}{more} · run `{self._remedy}`"
+            if width and len(line) > width > 12:
+                # Clip the DETAIL, never the remedy: an advisory that loses
+                # its verb is a complaint the operator cannot act on.
+                keep = max(0, width - len(f"{glyph} … · run `{self._remedy}`"))
+                line = (f"{glyph} {body[:keep].rstrip()}… · "
+                        f"run `{self._remedy}`")
+            return line
+        except Exception:  # noqa: BLE001
+            return ""

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -642,6 +642,9 @@ class AttachUI:
         #: "recovered" event, so a badge with no decay would accuse a
         #: perfectly good headset for the rest of the session.
         self.acoustic: Any = None
+        #: Health, derived from the doctor's OWN verdicts on the hydration
+        #: frame this cockpit already receives — not a second opinion.
+        self.advisor = _build_advisor()
         #: Set once the attach client exists. LATE-BOUND for the same reason
         #: the approval narrator's emit is: the markup sink is built after the
         #: UI, so a handle captured here would be None forever.
@@ -1065,8 +1068,18 @@ class AttachUI:
         # on this line is still working. A degraded mic means the operator's
         # words are not arriving at all, and everything they try next will
         # fail for a reason they cannot see.
+        health = ""
+        try:
+            if self.advisor is not None:
+                health = self.advisor.render()
+        except Exception:  # noqa: BLE001
+            health = ""
         mic = self.acoustic_badge()
         badge = f"{mic} · {badge}" if mic and badge else (mic or badge)
+        # Health LAST in the composed line, so it survives truncation least —
+        # it is the least time-critical of the three and the only one with a
+        # dedicated verb (`ov doctor`) that recovers the full detail.
+        badge = f"{badge} · {health}" if badge and health else (badge or health)
         head = f"{badge} · " if badge else ""
         return f"{head}{audio.lstrip(' ·')}{keys} · 'detach' to leave"
 
@@ -1735,6 +1748,15 @@ def _not_composing() -> Any:
         return _cond
     except Exception:  # noqa: BLE001
         return True
+
+
+def _build_advisor() -> Any:
+    """The health advisory line, or None if unavailable."""
+    try:
+        from backend.core.ouroboros.cli.health_advisory import HealthAdvisor
+        return HealthAdvisor()
+    except Exception:  # noqa: BLE001 — a cockpit without it still attaches
+        return None
 
 
 def _build_composer() -> Any:
@@ -2416,6 +2438,16 @@ def run_attach(console: Any) -> int:
 
         def _on_hydration(payload: dict) -> None:
             _render_hydration(console, payload)
+            # Health, from the SAME frame — the doctor's own verdicts on the
+            # bytes already in hand. No second probe, no second thresholds,
+            # so the line and `ov doctor` cannot disagree.
+            try:
+                if ui.advisor is not None and ui.advisor.observe_hydration(
+                    payload,
+                ):
+                    ui.refresh()
+            except Exception:  # noqa: BLE001
+                pass
             try:
                 state = (payload.get("audio") or {}).get("state", "")
                 if state:

--- a/tests/cli/test_health_advisory.py
+++ b/tests/cli/test_health_advisory.py
@@ -1,0 +1,150 @@
+"""One line, above the prompt, when something is wrong.
+
+`ov doctor` proves the whole chain and prints a table — the right tool for
+"what exactly is broken", the wrong one for "is anything broken", because it
+only answers when asked, and the operator asks after they have already lost
+time to a symptom they could not explain.
+"""
+from __future__ import annotations
+
+import contextlib
+import io
+
+import pytest
+
+from backend.core.ouroboros.cli.health_advisory import (
+    HealthAdvisor, advisories_from_hydration,
+)
+
+with contextlib.redirect_stderr(io.StringIO()):
+    from backend.core.ouroboros.cli.ov import AttachUI
+
+_HEALTHY = {
+    "audio": {"state": "OFFLINE"}, "lanes": {}, "fabrics": {},
+    "providers": {}, "session": "s-1",
+}
+
+
+def test_an_ORDINARY_session_says_nothing() -> None:
+    """Measured against a real frame, the doctor reports DEGRADED for
+    perfectly ordinary conditions — "no fabrics block (older daemon?)", "no
+    liquidity data" — because its TABLE has room to explain them and this
+    line does not. Surfacing those would warn during a completely healthy
+    session, and a line that always complains is one nobody reads. Then it
+    fails exactly when it finally has something true to say."""
+    advisor = HealthAdvisor()
+    advisor.observe_hydration(_HEALTHY)
+    assert advisor.render() == ""
+
+
+def test_degraded_can_be_opted_into(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JARVIS_HEALTH_ADVISORY_MIN", "degraded")
+    assert advisories_from_hydration(_HEALTHY), "the noisier reading is gone"
+
+
+def test_a_severed_edge_surfaces_with_its_remedy() -> None:
+    """`✘ hydration severed` alone leaves the operator where they started."""
+    advisor = HealthAdvisor()
+    advisor.observe_hydration(None)
+    line = advisor.render()
+    assert line.startswith("✘")
+    assert "hydration" in line
+    assert "ov doctor" in line, "an advisory with no verb is a complaint"
+
+
+def test_it_is_a_PROJECTION_of_the_doctors_own_verdicts() -> None:
+    """Two health surfaces that can contradict each other are worse than one:
+    the operator then has to decide which to believe."""
+    import inspect
+
+    from backend.core.ouroboros.cli import health_advisory
+
+    src = inspect.getsource(health_advisory)
+    assert "_verdicts_from_hydration" in src
+    derived = advisories_from_hydration(None)
+    assert derived and derived[0][1].endswith("hydration")
+
+
+def test_optional_surfaces_are_never_reported() -> None:
+    """ABSENT is not a fault. Reporting it trains the operator to ignore the
+    line, which costs them the one time it matters."""
+    rows = advisories_from_hydration(_HEALTHY)
+    assert all(rank > 0 for rank, _e, _d in rows)
+
+
+def test_the_worst_advisory_wins_and_the_rest_are_counted() -> None:
+    """There is room for one. A line that cycles is read as noise."""
+    advisor = HealthAdvisor()
+    advisor._rows = [(1, "4 fabrics", "impaired"), (2, "3 hydration", "gone")]
+    advisor._rows.sort(key=lambda r: -r[0])
+    line = advisor.render()
+    assert line.startswith("✘") and "hydration" in line
+    assert "+1" in line
+
+
+def test_a_degraded_edge_uses_a_softer_glyph() -> None:
+    advisor = HealthAdvisor()
+    advisor._rows = [(1, "4 fabrics", "impaired")]
+    assert advisor.render().startswith("▲")
+
+
+def test_severe_still_surfaces_by_default() -> None:
+    """Raising the floor must not silence the thing the line exists for."""
+    assert advisories_from_hydration(None), "a severed chain went unreported"
+
+
+def test_clipping_keeps_the_remedy() -> None:
+    """An advisory that loses its verb is a complaint the operator cannot
+    act on."""
+    advisor = HealthAdvisor()
+    advisor._rows = [(2, "3 hydration", "x" * 400)]
+    line = advisor.render(width=60)
+    assert "ov doctor" in line
+    assert len(line) <= 70
+
+
+def test_muting_acknowledges_without_pretending_it_is_fixed() -> None:
+    advisor = HealthAdvisor()
+    advisor.observe_hydration(None)
+    assert advisor.render() != ""
+    advisor.mute()
+    assert advisor.render() == ""
+    assert advisor.healthy is False, "muted is not healthy"
+
+
+def test_a_NEW_fault_un_mutes() -> None:
+    """They dismissed the previous one, not this one."""
+    advisor = HealthAdvisor()
+    advisor.observe_hydration(None)
+    advisor.mute()
+    advisor._rows = []
+    advisor.observe_hydration({"lanes": {}})
+    if advisor.count:
+        assert advisor.render() != ""
+
+
+def test_it_reports_a_CHANGE_so_the_line_does_not_flicker() -> None:
+    """Stable text redrawn at frame rate is how a status line becomes a
+    flicker."""
+    advisor = HealthAdvisor()
+    assert advisor.observe_hydration(None) is True
+    assert advisor.observe_hydration(None) is False
+
+
+def test_the_advisory_reaches_the_status_line() -> None:
+    ui = AttachUI()
+    ui.advisor.observe_hydration(None)
+    assert ui.advisor.render() in ui._key_hints()
+
+
+@pytest.mark.parametrize("junk", [None, {}, "string", 42, []])
+def test_junk_cannot_break_the_status_line(junk) -> None:
+    ui = AttachUI()
+    ui.advisor.observe_hydration(junk)
+    assert isinstance(ui.advisor.render(), str)
+    assert isinstance(ui._key_hints(), str)
+
+
+def test_the_kill_switch(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JARVIS_HEALTH_ADVISORY_ENABLED", "0")
+    assert advisories_from_hydration(None) == []


### PR DESCRIPTION
```
✘ hydration: no frame served · run `ov doctor`
```

`ov doctor` proves the whole chain and prints a table. It's the right tool for *"what exactly is broken"* and the wrong one for *"is anything broken"* — because it only answers when asked, and you ask after you've already lost time to a symptom you couldn't explain.

## A projection, not a second opinion

The verdicts come from `ov_doctor._verdicts_from_hydration` — the doctor's **own** function, reading the same hydration frame the cockpit already receives at attach. Nothing is re-probed and no second thresholds exist, so the line and the doctor cannot disagree about whether the organism is healthy.

Two health surfaces that can contradict each other are worse than one: you then have to decide which to believe. It also costs nothing — the frame arrives regardless.

## SEVERED only by default — the load-bearing decision

I ran it against a real hydration frame before choosing a threshold, and the doctor reports **DEGRADED for perfectly ordinary conditions**:

```
(1, '4 hive fabrics', 'no fabrics block (older daemon?)')
(1, '6 providers',    'no liquidity data in hydration')
```

Its *table* has room to explain those. One line does not. Surfacing them would put a warning on screen during a completely healthy session — and a line that always complains is one you stop reading, which means it fails at the exact moment it finally has something true to say.

`JARVIS_HEALTH_ADVISORY_MIN=degraded` opts into the noisier reading.

## The rest follows from having one line

- **Worst first**, the others counted (`+2`) rather than cycled — a line that changes every second is noise.
- **ABSENT never shown** — an optional surface nobody configured is not a fault.
- **Clipping eats the detail, never the remedy** — an advisory without its verb is a complaint you can't act on.
- **Muting acknowledges without pretending**: `healthy` stays `False`, and a *new* fault un-mutes, since you dismissed the previous one and not this one.
- `observe_hydration` reports whether the advisory **changed**, so the caller repaints on a transition rather than at frame rate.

Placed last in the composed status line — least time-critical of the three badges, and the only one with a dedicated verb that recovers the full detail.

## Verification

19 tests, including that an ordinary session stays silent, that raising the floor doesn't silence a severed chain, and that junk can't break the line you read constantly. 804 `tests/cli` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a single health advisory line above the prompt that shows the worst issue and tells the operator to run `ov doctor`. This speeds up diagnosis, stays quiet during healthy sessions, and uses the doctor’s own verdicts without extra probes.

- **New Features**
  - Derives advisories from `ov_doctor._verdicts_from_hydration`; no second thresholds or re-probing.
  - Shows only the worst issue, with a "+N" count for others; default threshold is SEVERED. Opt into DEGRADED with `JARVIS_HEALTH_ADVISORY_MIN=degraded`. Kill switch: `JARVIS_HEALTH_ADVISORY_ENABLED=0`.
  - Stable render: updates only on change, supports mute/unmute, clips detail but preserves “run `ov doctor`”, and appears last in the status line.
  - Added `backend/core/ouroboros/cli/health_advisory.py`, integrated into `AttachUI`, and included 19 tests.

<sup>Written for commit 91c8bf8c727e282d174750b00dcf83623a0c8170. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

