### PR TITLE
feat(ov): every surface completes the same vocabulary, and every key is the operator's to move

### DIFF
--- a/backend/core/ouroboros/battle_test/bipartite_layout.py
+++ b/backend/core/ouroboros/battle_test/bipartite_layout.py
@@ -557,6 +557,8 @@ def build_bipartite_application(
     header: Optional[Callable[[], str]] = None,
     header_height: int = 0,
     completer: Any = None,
+    history: Any = None,
+    auto_suggest: Any = None,
 ) -> Any:
     """Construct the full-screen ``prompt_toolkit.Application``: Zone 1 an ANSI
     window fed from ``mux.render_canvas_ansi()`` (re-rendered each frame, so
@@ -618,6 +620,18 @@ def build_bipartite_application(
         wrap_lines=False, style="class:command-deck",
         completer=completer,
         complete_while_typing=bool(completer is not None),
+        # Persistent recall on THE surface the operator actually types
+        # into. Without an explicit history the TextArea's buffer gets a
+        # fresh InMemoryHistory — Up-arrow forgot everything at detach,
+        # while the fallback PromptSession remembered. `auto_up` on the
+        # buffer already walks history when the caret is on the first
+        # line, so a History object is the ONLY missing piece.
+        **({"history": history} if history is not None else {}),
+        # History ghost-text (grey fish/CC-style suggestion). None when
+        # the operator disabled it — TextArea treats None as "no
+        # suggestions" natively.
+        **({"auto_suggest": auto_suggest} if auto_suggest is not None
+           else {}),
     )
 
     def _accept(buff) -> bool:
@@ -663,10 +677,33 @@ def build_bipartite_application(
     except Exception:  # noqa: BLE001
         pass
 
-    @kb.add("c-c")
-    @kb.add("c-d")
+    # Detach/exit through the remappable keymap (defaults unchanged:
+    # Ctrl+C / Ctrl+D). A mount rather than a literal `@kb.add("c-c")`
+    # so keybindings.json can move them and `/keys` can show them; the
+    # except-branch keeps the legacy hardcoded pair when the keymap
+    # module is unavailable — a cockpit the operator cannot LEAVE is
+    # the one regression this seam must never introduce.
     def _exit(event) -> None:
         event.app.exit()
+
+    try:
+        from backend.core.ouroboros.battle_test.keymap import KeymapMount
+        _mount = KeymapMount("cockpit")
+        _mount.action(
+            "app:detach", ("ctrl+c",), context="Global",
+            description="leave the cockpit; the daemon keeps running",
+        )(_exit)
+        _mount.action(
+            "app:exit", ("ctrl+d",), context="Global",
+            description="leave the cockpit",
+        )(_exit)
+        _mount_kb = _mount.key_bindings()
+        if _mount_kb is None:
+            raise RuntimeError("keymap mount unavailable")
+        kb = _merge_key_bindings(kb, _mount_kb)
+    except Exception:  # noqa: BLE001
+        kb.add("c-c")(_exit)
+        kb.add("c-d")(_exit)
 
     if extra_key_bindings is not None:
         try:
@@ -920,6 +957,8 @@ async def run_bipartite_repl(
     header: Optional[Callable[[], str]] = None,
     header_height: int = 0,
     completer: Any = None,
+    history: Any = None,
+    auto_suggest: Any = None,
 ) -> None:
     """Launch the full-screen Bipartite REPL: build the multiplexer, register it as
     the live Zone-1 sink (so any producer — the daemon's event router OR the
@@ -947,7 +986,7 @@ async def run_bipartite_repl(
         app = build_bipartite_application(
             mux, on_accept=on_accept, extra_key_bindings=extra_key_bindings,
             toolbar=toolbar, header=header, header_height=header_height,
-            completer=completer,
+            completer=completer, history=history, auto_suggest=auto_suggest,
         )
         if watch_alive is not None:
             watcher = asyncio.ensure_future(

--- a/backend/core/ouroboros/battle_test/input_continuation.py
+++ b/backend/core/ouroboros/battle_test/input_continuation.py
@@ -165,12 +165,29 @@ def install_newline_binding(kb: Any) -> bool:
         if kb is None or not multiline_enabled():
             return False
 
-        @kb.add("escape", "enter")
         def _newline(event: Any) -> None:
             try:
                 event.current_buffer.insert_text("\n")
             except Exception:  # noqa: BLE001
                 pass
+
+        # Through the remappable keymap (default unchanged: Alt+Enter),
+        # so keybindings.json can move the escape hatch and `/keys` can
+        # show it. The except-branch keeps the hardcoded default — the
+        # continuation rules above are only safe while a deliberate
+        # newline exists, so this binding may degrade but never vanish.
+        try:
+            from backend.core.ouroboros.battle_test.keymap import (
+                bind_action,
+            )
+            if not bind_action(
+                kb, "chat:newline", ("alt+enter",), _newline,
+                context="Chat",
+                description="insert a newline without submitting",
+            ):
+                raise RuntimeError("keymap yielded no newline binding")
+        except Exception:  # noqa: BLE001
+            kb.add("escape", "enter")(_newline)
 
         return True
     except Exception:  # noqa: BLE001

--- a/backend/core/ouroboros/battle_test/keymap.py
+++ b/backend/core/ouroboros/battle_test/keymap.py
@@ -1,0 +1,883 @@
+"""Operator-remappable keybindings for the O+V cockpit — one engine, every surface.
+
+The cockpit grew its keys the way most TUIs do: each surface hardcoded its
+own (`c-c`/`c-d` in the bipartite app, `c-o`/arrows/`escape` in the fallback
+PromptSession, `escape enter` in input_continuation). Three surfaces, three
+private key tables, no way for an operator to see them in one place — let
+alone change one.
+
+This module is the single seam all of that routes through:
+
+* **Actions, not keys.** A surface declares ``namespace:action`` entries with
+  DEFAULT keys as data (``("ctrl+c",)``); the effective keys are resolved at
+  bind time against the operator's config. No call-site carries a literal
+  prompt_toolkit key again.
+* **Operator config** at ``.jarvis/keybindings.json`` (repo) or
+  ``~/.jarvis/keybindings.json``, same shape as Claude Code's::
+
+      {
+        "$docs": "https://code.claude.com/docs/en/keybindings",
+        "bindings": [
+          {"context": "Chat", "bindings": {
+              "ctrl+j": "chat:newline",     // rebind
+              "ctrl+p": null                 // unbind a default
+          }}
+        ]
+      }
+
+* **Hot reload.** Mount-based consumers get a ``DynamicKeyBindings`` whose
+  bindings rebuild when the file's mtime changes — edits apply without
+  restarting the cockpit. Call-site consumers (``bind_action``) pick changes
+  up on the next attach.
+* **Validation, not silence.** Parse errors, unknown keys, reserved keys and
+  terminal-multiplexer conflicts become WARNINGS surfaced via ``/keys`` —
+  a broken config degrades to defaults, never to a dead cockpit.
+
+Keystroke syntax mirrors Claude Code's docs: modifiers ``ctrl+``/``shift+``/
+``alt+`` (aliases ``control``, ``opt``, ``option``, ``meta``), chords as
+space-separated sequences (``ctrl+x ctrl+e``), a standalone uppercase letter
+implies Shift, and special keys ``escape esc enter return tab space up down
+left right backspace delete home end pageup pagedown insert f1..f24``.
+``cmd``/``super``/``win`` are rejected with a warning — most terminals never
+deliver the Super modifier, and a binding that works only sometimes is worse
+than none.
+
+Env:
+  * ``JARVIS_KEYMAP_ENABLED``            master (default true; off = defaults only)
+  * ``JARVIS_KEYBINDINGS_FILE``          explicit config path
+  * ``JARVIS_KEYMAP_RELOAD_THROTTLE_S``  min seconds between mtime probes (default 1.0)
+
+NEVER raises into an input path: every public function degrades to the
+defaults it was given.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+KEYMAP_SCHEMA_VERSION: str = "keymap.1"
+
+MASTER_FLAG_ENV_VAR: str = "JARVIS_KEYMAP_ENABLED"
+CONFIG_PATH_ENV_VAR: str = "JARVIS_KEYBINDINGS_FILE"
+RELOAD_THROTTLE_ENV_VAR: str = "JARVIS_KEYMAP_RELOAD_THROTTLE_S"
+
+#: Contexts seeded up front so config validation has a vocabulary before any
+#: surface mounts. Surfaces may add their own via :func:`register_context`.
+_KNOWN_CONTEXTS: Dict[str, str] = {
+    "Global": "applies on every cockpit surface",
+    "Chat": "the operator prompt",
+    "Autocomplete": "the / palette is open",
+    "Deck": "deck selection / focus",
+    "Confirmation": "an Iron Gate or approval prompt is on screen",
+    "HistorySearch": "history search",
+}
+
+#: Keys that cannot be rebound, with the reason shown in the warning.
+RESERVED_KEYSTROKES: Dict[str, str] = {
+    "ctrl+m": "identical to Enter in terminals (both send CR)",
+}
+
+#: Rebindable, but the operator deserves a heads-up.
+TERMINAL_CONFLICTS: Dict[str, str] = {
+    "ctrl+b": "tmux prefix (tmux swallows it unless pressed twice)",
+    "ctrl+a": "GNU screen prefix",
+    "ctrl+z": "unix process suspend (SIGTSTP)",
+}
+
+
+def is_keymap_enabled() -> bool:
+    """Master flag — default TRUE. Off means defaults only (the config file
+    is neither read nor watched); the action seam itself stays live so no
+    call-site has to fork."""
+    return os.environ.get(MASTER_FLAG_ENV_VAR, "true").strip().lower() not in (
+        "0", "false", "no", "off",
+    )
+
+
+# ===========================================================================
+# Keystroke parser — Claude Code syntax → prompt_toolkit key sequences
+# ===========================================================================
+
+_MOD_ALIASES: Dict[str, str] = {
+    "ctrl": "ctrl", "control": "ctrl",
+    "shift": "shift",
+    "alt": "alt", "opt": "alt", "option": "alt", "meta": "alt",
+    "cmd": "cmd", "command": "cmd", "super": "cmd", "win": "cmd",
+}
+
+#: name → prompt_toolkit key. ``space`` maps to the literal character —
+#: prompt_toolkit treats any single printable char as a key of its own.
+_SPECIAL_KEYS: Dict[str, str] = {
+    "escape": "escape", "esc": "escape",
+    "enter": "enter", "return": "enter",
+    "tab": "tab",
+    "space": " ",
+    "up": "up", "down": "down", "left": "left", "right": "right",
+    "backspace": "backspace", "delete": "delete",
+    "home": "home", "end": "end",
+    "pageup": "pageup", "pagedown": "pagedown",
+    "insert": "insert",
+}
+_SPECIAL_KEYS.update({f"f{i}": f"f{i}" for i in range(1, 25)})
+
+#: Special keys that accept ``c-``/``s-`` prefixes in prompt_toolkit.
+_PREFIXABLE = frozenset({
+    "tab", "up", "down", "left", "right", "delete",
+    "home", "end", "pageup", "pagedown", "insert",
+})
+
+
+class KeystrokeError(ValueError):
+    """One keystroke string could not be translated. Collected as a
+    warning by config parsing; only raised out of :func:`parse_keystroke`
+    itself."""
+
+
+def _pt_keys_valid(keys: Tuple[str, ...]) -> bool:
+    """True when every step is a key prompt_toolkit will accept."""
+    try:
+        from prompt_toolkit.keys import ALL_KEYS, KEY_ALIASES
+    except ImportError:
+        return True  # headless — accept; binding never happens anyway
+    for k in keys:
+        if k in ALL_KEYS or k in KEY_ALIASES or len(k) == 1:
+            continue
+        return False
+    return True
+
+
+def _parse_single(token: str) -> Tuple[str, ...]:
+    """One non-chord token (``ctrl+shift+left``) → pt key step(s).
+
+    Alt is delivered by terminals as an escape prefix, so ``alt+x`` becomes
+    the two-step sequence ``("escape", "x")`` — prompt_toolkit's own model.
+    """
+    parts = [p.strip() for p in token.split("+") if p.strip()]
+    if not parts:
+        raise KeystrokeError(f"empty keystroke in {token!r}")
+    mods = set()
+    for p in parts[:-1]:
+        mod = _MOD_ALIASES.get(p.lower())
+        if mod is None:
+            raise KeystrokeError(f"unknown modifier {p!r} in {token!r}")
+        mods.add(mod)
+    base_raw = parts[-1]
+    if "cmd" in mods:
+        raise KeystrokeError(
+            f"{token!r}: cmd/super is not delivered by most terminals; "
+            "use ctrl or alt instead"
+        )
+
+    base = _SPECIAL_KEYS.get(base_raw.lower())
+    prefix: Tuple[str, ...] = ("escape",) if "alt" in mods else ()
+
+    if base is not None:
+        key = base
+        if base in _PREFIXABLE:
+            if "ctrl" in mods and "shift" in mods:
+                key = f"c-s-{base}"
+            elif "ctrl" in mods:
+                key = f"c-{base}"
+            elif "shift" in mods:
+                key = f"s-{base}"
+        elif mods - {"alt"}:
+            raise KeystrokeError(
+                f"{token!r}: {base_raw} does not combine with "
+                f"{'+'.join(sorted(mods - {'alt'}))}"
+            )
+        steps = prefix + (key,)
+    elif len(base_raw) == 1:
+        ch = base_raw
+        if "ctrl" in mods:
+            # ctrl+K == ctrl+k per Claude Code semantics (stylistic caps).
+            ch = ch.lower()
+            key = f"c-{ch}"
+        elif "shift" in mods:
+            key = ch.upper()
+        else:
+            # A standalone uppercase letter implies Shift — pass through.
+            key = ch
+        steps = prefix + (key,)
+    else:
+        raise KeystrokeError(f"unknown key {base_raw!r} in {token!r}")
+
+    if not _pt_keys_valid(steps):
+        raise KeystrokeError(
+            f"{token!r} maps to {steps!r}, which this terminal stack "
+            "cannot deliver"
+        )
+    return steps
+
+
+def parse_keystroke(spec: object) -> Tuple[str, ...]:
+    """``"ctrl+x ctrl+e"`` → ``("c-x", "c-e")``; ``"alt+enter"`` →
+    ``("escape", "enter")``. Chords are space-separated. Raises
+    :class:`KeystrokeError` on anything unparseable."""
+    text = str(spec or "").strip()
+    if not text:
+        raise KeystrokeError("empty keystroke")
+    steps: List[str] = []
+    for token in text.split():
+        steps.extend(_parse_single(token))
+    return tuple(steps)
+
+
+def _join_steps(steps: Tuple[str, ...]) -> str:
+    """Canonical string for a parsed key sequence. The literal space key
+    is spelled ``space`` so the join/split round-trip stays lossless."""
+    return " ".join("space" if s == " " else s for s in steps)
+
+
+def _split_canon(canon: str) -> Tuple[str, ...]:
+    """Inverse of :func:`_join_steps`."""
+    return tuple(" " if s == "space" else s for s in canon.split(" "))
+
+
+def canonical_keystroke(spec: object) -> str:
+    """Canonical form used for override matching — two spellings of the
+    same combo (``control+E`` / ``ctrl+e``) compare equal. Raises
+    :class:`KeystrokeError` on unparseable input."""
+    return _join_steps(parse_keystroke(spec))
+
+
+# ===========================================================================
+# Action catalog — what exists, discoverable via /keys
+# ===========================================================================
+
+
+@dataclass(frozen=True)
+class ActionSpec:
+    """One remappable action, registered by the surface that owns it."""
+
+    action: str
+    context: str
+    default_keys: Tuple[str, ...]
+    description: str = ""
+    schema_version: str = KEYMAP_SCHEMA_VERSION
+
+
+_CATALOG: Dict[str, ActionSpec] = {}
+_CATALOG_LOCK = threading.Lock()
+
+
+def register_context(name: str, description: str = "") -> None:
+    """Add a context to the known vocabulary. NEVER raises."""
+    try:
+        if isinstance(name, str) and name.strip():
+            _KNOWN_CONTEXTS.setdefault(name.strip(), str(description or ""))
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def register_action_spec(
+    action: str,
+    context: str,
+    default_keys: Tuple[str, ...],
+    description: str = "",
+) -> None:
+    """Record an action in the catalog (idempotent — first registration
+    wins so a remount doesn't churn descriptions). NEVER raises."""
+    try:
+        if not isinstance(action, str) or ":" not in action:
+            return
+        with _CATALOG_LOCK:
+            _CATALOG.setdefault(action, ActionSpec(
+                action=action,
+                context=str(context or "Chat"),
+                default_keys=tuple(str(k) for k in (default_keys or ())),
+                description=str(description or ""),
+            ))
+        register_context(context)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def action_catalog() -> Tuple[ActionSpec, ...]:
+    """Snapshot of every registered action, sorted for stable display."""
+    try:
+        with _CATALOG_LOCK:
+            specs = tuple(_CATALOG.values())
+        return tuple(sorted(specs, key=lambda s: (s.context, s.action)))
+    except Exception:  # noqa: BLE001
+        return ()
+
+
+# ===========================================================================
+# Config — load, validate, hot-reload
+# ===========================================================================
+
+
+@dataclass(frozen=True)
+class KeymapConfig:
+    """Parsed operator config. ``blocks`` maps context → {canonical key →
+    action-or-None}; ``raw_spelling`` remembers what the operator typed so
+    warnings and ``/keys`` show their words, not ours."""
+
+    path: Optional[str] = None
+    blocks: Dict[str, Dict[str, Optional[str]]] = field(default_factory=dict)
+    raw_spelling: Dict[str, str] = field(default_factory=dict)
+    warnings: Tuple[str, ...] = ()
+    schema_version: str = KEYMAP_SCHEMA_VERSION
+
+
+def resolve_config_path() -> Optional[Path]:
+    """First existing of: env override → ``<repo>/.jarvis/keybindings.json``
+    → ``~/.jarvis/keybindings.json``. The ENV path is returned even when the
+    file does not exist yet, so ``/keys init`` knows where to write."""
+    try:
+        env = os.environ.get(CONFIG_PATH_ENV_VAR, "").strip()
+        if env:
+            return Path(env).expanduser()
+        repo = Path(os.environ.get("JARVIS_REPO_PATH", ".")).resolve()
+        candidates = (
+            repo / ".jarvis" / "keybindings.json",
+            Path.home() / ".jarvis" / "keybindings.json",
+        )
+        for cand in candidates:
+            if cand.is_file():
+                return cand
+        return candidates[0]  # default write target
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def parse_config(text: object, *, path: Optional[str] = None) -> KeymapConfig:
+    """Parse + validate one config document. NEVER raises — structural
+    problems become warnings and the offending entry is skipped, so one bad
+    line costs one binding, not the file."""
+    warnings: List[str] = []
+    blocks: Dict[str, Dict[str, Optional[str]]] = {}
+    raw_spelling: Dict[str, str] = {}
+    try:
+        doc = json.loads(str(text or ""))
+    except Exception as exc:  # noqa: BLE001
+        return KeymapConfig(
+            path=path, warnings=(f"config is not valid JSON: {exc}",),
+        )
+    if not isinstance(doc, dict):
+        return KeymapConfig(
+            path=path, warnings=("config root must be an object",),
+        )
+    entries = doc.get("bindings")
+    if entries is None:
+        return KeymapConfig(path=path)
+    if not isinstance(entries, list):
+        return KeymapConfig(
+            path=path, warnings=('"bindings" must be an array of blocks',),
+        )
+    for i, block in enumerate(entries):
+        if not isinstance(block, dict):
+            warnings.append(f"bindings[{i}] is not an object — skipped")
+            continue
+        context = block.get("context")
+        if not isinstance(context, str) or not context.strip():
+            warnings.append(f'bindings[{i}] has no "context" — skipped')
+            continue
+        context = context.strip()
+        if context not in _KNOWN_CONTEXTS:
+            warnings.append(
+                f"bindings[{i}]: unknown context {context!r} "
+                f"(known: {', '.join(sorted(_KNOWN_CONTEXTS))})"
+            )
+        mapping = block.get("bindings")
+        if not isinstance(mapping, dict):
+            warnings.append(
+                f'bindings[{i}] ({context}) has no "bindings" map — skipped'
+            )
+            continue
+        dest = blocks.setdefault(context, {})
+        for raw_key, action in mapping.items():
+            low = str(raw_key).strip().lower()
+            if low in RESERVED_KEYSTROKES:
+                warnings.append(
+                    f"{context}: {raw_key!r} is reserved — "
+                    f"{RESERVED_KEYSTROKES[low]}"
+                )
+                continue
+            if low in TERMINAL_CONFLICTS:
+                warnings.append(
+                    f"{context}: {raw_key!r} conflicts with "
+                    f"{TERMINAL_CONFLICTS[low]}"
+                )
+            try:
+                canon = canonical_keystroke(raw_key)
+            except KeystrokeError as exc:
+                warnings.append(f"{context}: {exc}")
+                continue
+            if action is not None and (
+                not isinstance(action, str) or ":" not in action
+            ):
+                warnings.append(
+                    f"{context}: {raw_key!r} → {action!r} is not a "
+                    '"namespace:action" id or null'
+                )
+                continue
+            if canon in dest and dest[canon] != action:
+                warnings.append(
+                    f"{context}: duplicate binding for {raw_key!r} — "
+                    "last one wins"
+                )
+            dest[canon] = action
+            raw_spelling.setdefault(canon, str(raw_key))
+    return KeymapConfig(
+        path=path, blocks=blocks, raw_spelling=raw_spelling,
+        warnings=tuple(warnings),
+    )
+
+
+class KeymapStore:
+    """Config cache with throttled mtime-based hot reload.
+
+    ``generation`` bumps on every observed change; mounts compare it to
+    decide whether their compiled KeyBindings are stale. Thread-safe —
+    prompt_toolkit consults bindings from the UI thread while surfaces
+    mount from wherever they boot."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._config = KeymapConfig()
+        self._generation = 0
+        self._mtime: Optional[float] = None
+        self._path_seen: Optional[str] = None
+        self._last_probe = 0.0
+        self._loaded_once = False
+
+    @property
+    def generation(self) -> int:
+        return self._generation
+
+    @property
+    def config(self) -> KeymapConfig:
+        return self._config
+
+    def _throttle_s(self) -> float:
+        try:
+            return max(0.1, float(
+                os.environ.get(RELOAD_THROTTLE_ENV_VAR, "1.0")
+            ))
+        except (TypeError, ValueError):
+            return 1.0
+
+    def maybe_reload(self, *, force: bool = False) -> KeymapConfig:
+        """Re-read the config iff the file changed (path, mtime, or
+        deletion). Throttled so per-keystroke consumers cost a monotonic
+        read, not a stat. NEVER raises."""
+        try:
+            if not is_keymap_enabled():
+                # Master off: behave as "no config", but keep the seam live.
+                with self._lock:
+                    if self._config.blocks or self._config.warnings:
+                        self._config = KeymapConfig()
+                        self._generation += 1
+                    return self._config
+            now = time.monotonic()
+            with self._lock:
+                if (
+                    not force and self._loaded_once
+                    and (now - self._last_probe) < self._throttle_s()
+                ):
+                    return self._config
+                self._last_probe = now
+                path = resolve_config_path()
+                path_str = str(path) if path is not None else None
+                mtime: Optional[float] = None
+                if path is not None:
+                    try:
+                        mtime = path.stat().st_mtime
+                    except OSError:
+                        mtime = None
+                if (
+                    self._loaded_once
+                    and path_str == self._path_seen
+                    and mtime == self._mtime
+                ):
+                    return self._config
+                self._path_seen, self._mtime = path_str, mtime
+                self._loaded_once = True
+                if path is None or mtime is None:
+                    fresh = KeymapConfig(path=path_str)
+                else:
+                    try:
+                        text = path.read_text(encoding="utf-8")
+                    except OSError as exc:
+                        fresh = KeymapConfig(
+                            path=path_str,
+                            warnings=(f"config unreadable: {exc}",),
+                        )
+                    else:
+                        fresh = parse_config(text, path=path_str)
+                self._config = fresh
+                self._generation += 1
+                if fresh.warnings:
+                    logger.debug(
+                        "[Keymap] %d warning(s) loading %s: %s",
+                        len(fresh.warnings), path_str,
+                        "; ".join(fresh.warnings),
+                    )
+                return self._config
+        except Exception:  # noqa: BLE001
+            logger.debug("[Keymap] reload degraded", exc_info=True)
+            return self._config
+
+
+_STORE = KeymapStore()
+
+
+def get_store() -> KeymapStore:
+    return _STORE
+
+
+# ===========================================================================
+# Resolution — defaults × config → effective key sequences
+# ===========================================================================
+
+
+def _default_sequences(
+    default_keys: Tuple[str, ...],
+) -> List[Tuple[str, str]]:
+    """Parse declared defaults → [(canonical, spelled)] pairs, dropping any
+    the parser rejects (a surface typo'ing its OWN default should lose that
+    key, not the cockpit)."""
+    out: List[Tuple[str, str]] = []
+    for spec in default_keys:
+        try:
+            out.append((canonical_keystroke(spec), str(spec)))
+        except KeystrokeError:
+            logger.debug("[Keymap] bad default keystroke %r", spec)
+    return out
+
+
+def effective_key_sequences(
+    action: str,
+    default_keys: Tuple[str, ...],
+    *,
+    context: str = "Chat",
+) -> Tuple[Tuple[str, ...], ...]:
+    """The key sequences *action* should bind, after the operator's say.
+
+    Resolution:
+      1. start from the declared defaults;
+      2. drop any default the config re-assigns or nulls in this context
+         or in ``Global``;
+      3. add any config key mapped TO this action in this context or
+         ``Global``.
+
+    NEVER raises; on any internal failure returns the parsed defaults."""
+    defaults = _default_sequences(tuple(default_keys or ()))
+    try:
+        cfg = get_store().maybe_reload()
+        overrides: Dict[str, Optional[str]] = {}
+        for ctx in ("Global", context):
+            overrides.update(cfg.blocks.get(ctx, {}))
+        kept = [
+            canon for canon, _ in defaults
+            if canon not in overrides or overrides[canon] == action
+        ]
+        added = [
+            canon for canon, mapped in overrides.items()
+            if mapped == action and canon not in kept
+        ]
+        seen: set = set()
+        out: List[Tuple[str, ...]] = []
+        for canon in kept + added:
+            if canon in seen:
+                continue
+            seen.add(canon)
+            out.append(_split_canon(canon))
+        return tuple(out)
+    except Exception:  # noqa: BLE001
+        logger.debug("[Keymap] resolution degraded for %s", action,
+                     exc_info=True)
+        return tuple(_split_canon(c) for c, _ in defaults)
+
+
+# ===========================================================================
+# Consumption — mounts (hot-reloadable) + call-site binding (static)
+# ===========================================================================
+
+
+@dataclass
+class _MountEntry:
+    action: str
+    default_keys: Tuple[str, ...]
+    context: str
+    filter: Any
+    eager: Any
+    handler: Callable[..., Any]
+
+
+class KeymapMount:
+    """A surface's set of remappable actions, compiled lazily into
+    prompt_toolkit KeyBindings and recompiled when the config changes.
+
+    Usage::
+
+        mount = KeymapMount("cockpit")
+
+        @mount.action("app:detach", ("ctrl+c",), context="Global",
+                      description="leave the cockpit; daemon keeps running")
+        def _detach(event):
+            event.app.exit()
+
+        kb = merge_key_bindings([base_kb, mount.key_bindings()])
+
+    ``key_bindings()`` returns a ``DynamicKeyBindings`` — prompt_toolkit
+    consults it per key-processing pass, which is what makes a config edit
+    land WITHOUT remounting the Application."""
+
+    def __init__(self, surface: str) -> None:
+        self.surface = str(surface or "surface")
+        self._entries: List[_MountEntry] = []
+        self._lock = threading.Lock()
+        self._cache_gen = -1
+        self._cache_kb: Any = None
+
+    def action(
+        self,
+        action_id: str,
+        default_keys: Tuple[str, ...],
+        *,
+        context: str = "Chat",
+        description: str = "",
+        filter: Any = None,  # noqa: A002 — prompt_toolkit's own name
+        eager: Any = None,
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        """Decorator registering one remappable action on this mount."""
+
+        def deco(fn: Callable[..., Any]) -> Callable[..., Any]:
+            try:
+                register_action_spec(
+                    action_id, context, tuple(default_keys), description,
+                )
+                with self._lock:
+                    self._entries.append(_MountEntry(
+                        action=action_id,
+                        default_keys=tuple(default_keys),
+                        context=context,
+                        filter=filter,
+                        eager=eager,
+                        handler=fn,
+                    ))
+                    self._cache_gen = -1  # new entry → recompile
+            except Exception:  # noqa: BLE001
+                logger.debug("[Keymap] mount.action degraded", exc_info=True)
+            return fn
+
+        return deco
+
+    def _compile(self) -> Any:
+        from prompt_toolkit.key_binding import KeyBindings
+        kb = KeyBindings()
+        with self._lock:
+            entries = list(self._entries)
+        for entry in entries:
+            try:
+                sequences = effective_key_sequences(
+                    entry.action, entry.default_keys, context=entry.context,
+                )
+                kwargs: Dict[str, Any] = {}
+                if entry.filter is not None:
+                    kwargs["filter"] = entry.filter
+                if entry.eager is not None:
+                    kwargs["eager"] = entry.eager
+                for seq in sequences:
+                    kb.add(*seq, **kwargs)(entry.handler)
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "[Keymap] binding %s degraded", entry.action,
+                    exc_info=True,
+                )
+        return kb
+
+    def _current(self) -> Any:
+        try:
+            store = get_store()
+            store.maybe_reload()
+            with self._lock:
+                stale = (
+                    self._cache_kb is None
+                    or self._cache_gen != store.generation
+                )
+            if stale:
+                compiled = self._compile()
+                with self._lock:
+                    self._cache_kb = compiled
+                    self._cache_gen = store.generation
+            return self._cache_kb
+        except Exception:  # noqa: BLE001
+            logger.debug("[Keymap] mount refresh degraded", exc_info=True)
+            return self._cache_kb
+
+    def key_bindings(self) -> Any:
+        """The hot-reloadable KeyBindings for this mount. Returns a plain
+        empty KeyBindings when prompt_toolkit is unavailable."""
+        try:
+            from prompt_toolkit.key_binding.key_bindings import (
+                DynamicKeyBindings,
+            )
+            return DynamicKeyBindings(self._current)
+        except Exception:  # noqa: BLE001
+            try:
+                from prompt_toolkit.key_binding import KeyBindings
+                return KeyBindings()
+            except Exception:  # noqa: BLE001
+                return None
+
+
+def bind_action(
+    kb: Any,
+    action_id: str,
+    default_keys: Tuple[str, ...],
+    handler: Callable[..., Any],
+    *,
+    context: str = "Chat",
+    description: str = "",
+    filter: Any = None,  # noqa: A002
+    eager: Any = None,
+) -> bool:
+    """Call-site variant for modules that own their KeyBindings object:
+    resolves effective keys ONCE and binds them into *kb*. Registers the
+    action in the catalog either way. Config edits apply on the next
+    mount/attach rather than live — the trade for zero structural change
+    at the call site. NEVER raises; returns True when ≥1 key bound."""
+    try:
+        register_action_spec(action_id, context, tuple(default_keys),
+                             description)
+        if kb is None:
+            return False
+        sequences = effective_key_sequences(
+            action_id, tuple(default_keys), context=context,
+        )
+        kwargs: Dict[str, Any] = {}
+        if filter is not None:
+            kwargs["filter"] = filter
+        if eager is not None:
+            kwargs["eager"] = eager
+        bound = 0
+        for seq in sequences:
+            try:
+                kb.add(*seq, **kwargs)(handler)
+                bound += 1
+            except Exception:  # noqa: BLE001
+                logger.debug("[Keymap] bind %s %r degraded", action_id, seq,
+                             exc_info=True)
+        return bound > 0
+    except Exception:  # noqa: BLE001
+        logger.debug("[Keymap] bind_action degraded", exc_info=True)
+        return False
+
+
+# ===========================================================================
+# Introspection — the /keys verb reads these
+# ===========================================================================
+
+
+def describe_keymap() -> Dict[str, Any]:
+    """Everything an operator needs to see in one place: the effective
+    binding per action (with its source), the config path, and every
+    warning. Semantic validation (config actions nobody registered) happens
+    HERE rather than at load — surfaces register their actions as they
+    mount, so load-time checks would false-positive on boot order."""
+    cfg = get_store().maybe_reload(force=True)
+    rows: List[Dict[str, Any]] = []
+    known_actions = {s.action for s in action_catalog()}
+    for spec in action_catalog():
+        effective = effective_key_sequences(
+            spec.action, spec.default_keys, context=spec.context,
+        )
+        canon_defaults = tuple(c for c, _ in _default_sequences(
+            spec.default_keys,
+        ))
+        effective_canon = tuple(" ".join(seq) for seq in effective)
+        rows.append({
+            "context": spec.context,
+            "action": spec.action,
+            "keys": effective_canon,
+            "default_keys": spec.default_keys,
+            "customized": tuple(effective_canon) != canon_defaults,
+            "description": spec.description,
+        })
+    semantic: List[str] = []
+    for ctx, mapping in cfg.blocks.items():
+        for canon, action in mapping.items():
+            if action is not None and action not in known_actions:
+                spelled = cfg.raw_spelling.get(canon, canon)
+                semantic.append(
+                    f"{ctx}: {spelled!r} → unknown action {action!r}"
+                )
+    return {
+        "schema_version": KEYMAP_SCHEMA_VERSION,
+        "enabled": is_keymap_enabled(),
+        "config_path": cfg.path,
+        "config_present": bool(cfg.blocks) or bool(cfg.warnings),
+        "warnings": list(cfg.warnings) + semantic,
+        "contexts": dict(_KNOWN_CONTEXTS),
+        "actions": rows,
+    }
+
+
+CONFIG_TEMPLATE: str = """{
+  "$docs": "https://code.claude.com/docs/en/keybindings",
+  "bindings": [
+    {
+      "context": "Chat",
+      "bindings": {
+      }
+    }
+  ]
+}
+"""
+
+
+def write_config_template() -> Optional[str]:
+    """Create the config file (with parents) if it doesn't exist. Returns
+    the path written / already present, or None on failure. NEVER raises."""
+    try:
+        path = resolve_config_path()
+        if path is None:
+            return None
+        if path.is_file():
+            return str(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(CONFIG_TEMPLATE, encoding="utf-8")
+        get_store().maybe_reload(force=True)
+        return str(path)
+    except Exception:  # noqa: BLE001
+        logger.debug("[Keymap] template write failed", exc_info=True)
+        return None
+
+
+__all__ = [
+    "ActionSpec",
+    "CONFIG_PATH_ENV_VAR",
+    "CONFIG_TEMPLATE",
+    "KEYMAP_SCHEMA_VERSION",
+    "KeymapConfig",
+    "KeymapMount",
+    "KeymapStore",
+    "KeystrokeError",
+    "MASTER_FLAG_ENV_VAR",
+    "RESERVED_KEYSTROKES",
+    "TERMINAL_CONFLICTS",
+    "action_catalog",
+    "bind_action",
+    "canonical_keystroke",
+    "describe_keymap",
+    "effective_key_sequences",
+    "get_store",
+    "is_keymap_enabled",
+    "parse_config",
+    "parse_keystroke",
+    "register_action_spec",
+    "register_context",
+    "resolve_config_path",
+    "write_config_template",
+]

--- a/backend/core/ouroboros/battle_test/repl_completion.py
+++ b/backend/core/ouroboros/battle_test/repl_completion.py
@@ -68,7 +68,7 @@ from backend.core.ouroboros.battle_test.verb_usage import (
 )
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, FrozenSet, List, Optional, Tuple
+from typing import Any, Callable, FrozenSet, List, Optional, Tuple
 
 logger = logging.getLogger("Ouroboros.ReplCompletion")
 
@@ -85,6 +85,9 @@ MASTER_FLAG_ENV_VAR: str = "JARVIS_REPL_COMPLETION_ENABLED"
 HISTORY_PATH_ENV_VAR: str = "JARVIS_REPL_HISTORY_FILE"
 HISTORY_ENABLED_ENV_VAR: str = "JARVIS_REPL_HISTORY_ENABLED"
 INLINE_HELP_ENABLED_ENV_VAR: str = "JARVIS_REPL_INLINE_HELP_ENABLED"
+AUTOSUGGEST_ENABLED_ENV_VAR: str = "JARVIS_REPL_AUTOSUGGEST_ENABLED"
+COMPLETE_WHILE_TYPING_ENV_VAR: str = "JARVIS_REPL_COMPLETE_WHILE_TYPING"
+UNIFIED_REGISTRY_ENV_VAR: str = "JARVIS_UNIFIED_VERB_REGISTRY_ENABLED"
 
 
 # Default: project-local. Operators with multiple O+V projects get
@@ -142,6 +145,53 @@ def is_inline_help_enabled() -> bool:
         return False
     raw = os.environ.get(INLINE_HELP_ENABLED_ENV_VAR, "true")
     return raw.strip().lower() not in ("0", "false", "no", "off")
+
+
+def is_autosuggest_enabled() -> bool:
+    """``JARVIS_REPL_AUTOSUGGEST_ENABLED``. Default true. Gates the
+    history ghost-text (fish/CC-style grey suggestion completed with →).
+    Implicitly off when history is off — there is nothing to suggest
+    from. NEVER raises."""
+    if not is_history_enabled():
+        return False
+    raw = os.environ.get(AUTOSUGGEST_ENABLED_ENV_VAR, "true")
+    return raw.strip().lower() not in ("0", "false", "no", "off")
+
+
+def is_complete_while_typing_enabled() -> bool:
+    """``JARVIS_REPL_COMPLETE_WHILE_TYPING``. Default true — the palette
+    opens as the operator types ``/`` instead of demanding an explicit
+    Tab, matching the attach surfaces (both already pass
+    ``complete_while_typing=True``). Flip ``=false`` to restore
+    Tab-only completion on the daemon REPL. NEVER raises."""
+    raw = os.environ.get(COMPLETE_WHILE_TYPING_ENV_VAR, "true")
+    return raw.strip().lower() not in ("0", "false", "no", "off")
+
+
+def is_unified_registry_enabled() -> bool:
+    """``JARVIS_UNIFIED_VERB_REGISTRY_ENABLED``. Default true. Gates the
+    reconciliation of the two historic verb sources — ``discover_verbs``
+    (the daemon's ``_handle_*`` walk) and ``registry_from_dispatch``
+    (the 60-verb dispatch table + client verbs) — into ONE registry, so
+    every surface completes the same vocabulary. NEVER raises."""
+    raw = os.environ.get(UNIFIED_REGISTRY_ENV_VAR, "true")
+    return raw.strip().lower() not in ("0", "false", "no", "off")
+
+
+def build_auto_suggest() -> Optional[object]:
+    """History ghost-text, threaded so a large history file never lands
+    on a keystroke. Returns ``None`` when disabled or prompt_toolkit is
+    unavailable. NEVER raises."""
+    if not is_autosuggest_enabled():
+        return None
+    try:
+        from prompt_toolkit.auto_suggest import (
+            AutoSuggestFromHistory,
+            ThreadedAutoSuggest,
+        )
+        return ThreadedAutoSuggest(AutoSuggestFromHistory())
+    except Exception:  # noqa: BLE001
+        return None
 
 
 def resolve_history_path() -> Optional[Path]:
@@ -574,14 +624,23 @@ def list_arg_providers() -> Tuple[str, ...]:
         return ()
 
 
-# Regex covering the four arg_spec atom forms:
+# Regex covering the six arg_spec atom forms:
 #   <name>             — required positional
 #   [name]             — optional positional
 #   [--flag]           — optional flag, no value
 #   [--flag <value>]   — optional flag with value
+#   <a|b|c>            — required choice (STATIC values inline)
+#   [a|b|c]            — optional choice (STATIC values inline)
+# Choice atoms exist so a verb's MINED subcommand vocabulary
+# (verb_usage.mine_subcommands) can ride the same spec grammar the
+# doc-tag convention uses — per-verb static values with no parallel
+# table and no per-verb provider registration. Choice alternatives
+# are listed first so the atom regex prefers them over bare names.
 # Compiled once; pure-function consumers are thread-safe.
 _ARG_SPEC_ATOM_RE = re.compile(
-    r"<(?P<req>[a-zA-Z_][\w-]*)>"
+    r"<(?P<req_choice>[a-zA-Z_][\w-]*(?:\|[a-zA-Z_][\w-]*)+)>"
+    r"|\[(?P<opt_choice>[a-zA-Z_][\w-]*(?:\|[a-zA-Z_][\w-]*)+)\]"
+    r"|<(?P<req>[a-zA-Z_][\w-]*)>"
     r"|\[--(?P<flag>[a-zA-Z][\w-]*)(?:\s+<(?P<flag_val>[a-zA-Z_][\w-]*)>)?\]"
     r"|\[(?P<opt>[a-zA-Z_][\w-]*)\]"
 )
@@ -642,7 +701,18 @@ def parse_arg_spec(raw: object) -> Tuple[ArgPositionSpec, ...]:
     out: List[ArgPositionSpec] = []
     for match in _ARG_SPEC_ATOM_RE.finditer(text):
         gd = match.groupdict()
-        if gd.get("flag"):
+        if gd.get("req_choice") or gd.get("opt_choice"):
+            raw_choice = gd.get("req_choice") or gd.get("opt_choice") or ""
+            values = tuple(
+                v for v in (p.strip() for p in raw_choice.split("|")) if v
+            )
+            out.append(ArgPositionSpec(
+                name="subcommand",
+                required=bool(gd.get("req_choice")),
+                kind=ArgKind.STATIC,
+                static_values=values,
+            ))
+        elif gd.get("flag"):
             flag_name = gd["flag"]
             flag_val = gd.get("flag_val") or ""
             if flag_val:
@@ -772,10 +842,10 @@ def cursor_arg_position(buffer_text: object) -> Tuple[int, str]:
     stripped_left = text.lstrip()
     if not stripped_left.startswith("/"):
         return -1, ""
-    # Number of leading spaces consumed when lstripping — preserved
-    # so that downstream completers can compute start_position
-    # correctly if needed.
-    tokens = stripped_left.split(" ")
+    # Quote-aware split: '/attach "my file<cursor>' is ONE half-typed
+    # argument, not two. A naive split(" ") put the cursor in a
+    # phantom second position the moment a path contained a space.
+    tokens = _split_arg_tokens(stripped_left)
     # tokens[0] is the verb (e.g., "/cancel"); subsequent tokens
     # are arg slots. Trailing empty string means "started a new
     # token" (operator typed a space).
@@ -784,6 +854,31 @@ def cursor_arg_position(buffer_text: object) -> Tuple[int, str]:
     position_index = len(tokens) - 2  # tokens[1] is position 0
     prefix = tokens[-1]
     return position_index, prefix
+
+
+def _split_arg_tokens(text: str) -> List[str]:
+    """Split on spaces OUTSIDE quotes, preserving the naive-split
+    contract the completer depends on: a trailing unquoted space yields
+    a trailing ``""`` token ("operator started a new slot"), and quote
+    characters stay in the token (the prefix the operator actually
+    typed, byte-for-byte, so ``start_position`` math stays honest).
+    Unbalanced quotes — the mid-typing state — simply extend the final
+    token. NEVER raises."""
+    tokens: List[str] = [""]
+    quote = ""
+    for ch in text:
+        if quote:
+            tokens[-1] += ch
+            if ch == quote:
+                quote = ""
+        elif ch in ("'", '"'):
+            quote = ch
+            tokens[-1] += ch
+        elif ch == " ":
+            tokens.append("")
+        else:
+            tokens[-1] += ch
+    return tokens
 
 
 # ===========================================================================
@@ -1174,6 +1269,7 @@ def discover_verbs(repl_instance: object) -> VerbRegistry:
 
 def build_completer(
     registry: VerbRegistry, *, max_results: int = 8,
+    include_mentions: bool = True,
 ) -> Optional[object]:
     """Build a ``prompt_toolkit.completion.Completer`` that fires only
     when the input starts with ``/``. Returns ``None`` when
@@ -1281,6 +1377,14 @@ def build_completer(
     # mention on `@` word-boundary), so they never collide. When
     # mention completer is unavailable (polish off / prompt_toolkit
     # missing), fall through to slash-only.
+    #
+    # ``include_mentions=False`` exists for callers that bring their
+    # OWN mention completer (build_attach_completer merges the
+    # repo-rooted MentionPathCompleter) — without it the attach
+    # surface ran BOTH mention completers and every `@` prefix
+    # yielded duplicate candidates.
+    if not include_mentions:
+        return slash_completer
     try:
         from backend.core.ouroboros.battle_test.repl_input_polish import (
             build_mention_completer,
@@ -1366,6 +1470,8 @@ class CompletionWiring:
     history: Optional[object]
     enable_history_search: bool
     registry: VerbRegistry
+    auto_suggest: Optional[object] = None
+    complete_while_typing: bool = False
     schema_version: str = REPL_COMPLETION_SCHEMA_VERSION
 
 
@@ -1388,14 +1494,29 @@ def build_completion_wiring(
     NEVER raises. Always returns a wiring (even with ``None`` slots
     when prompt_toolkit / FS access is unavailable).
     """
-    registry = discover_verbs(repl_instance)
+    # ONE registry for every surface (gap #3 reconciliation): the daemon's
+    # discovered ``_handle_*`` verbs merged with the dispatch table it also
+    # routes to. Kill-switch inside unified_registry restores the split.
+    registry = unified_registry(repl_instance)
     completer: Optional[object] = None
     history: Optional[object] = None
+    auto_suggest: Optional[object] = None
     enable_search = False
 
     if is_completion_enabled():
         try:
-            completer = build_completer(registry)
+            # A browsable palette over the unified table — the historic
+            # default of 8 was a typo-suggestion cap, not a menu size.
+            completer = build_completer(registry, max_results=512)
+            if completer is not None:
+                # Off-thread for the same reason as the attach surface:
+                # first-completion work (registry walks, fs walks) must
+                # land between keystrokes, not on one.
+                try:
+                    from prompt_toolkit.completion import ThreadedCompleter
+                    completer = ThreadedCompleter(completer)
+                except ImportError:
+                    pass
         except Exception:  # noqa: BLE001
             logger.debug(
                 "[ReplCompletion] build_completer failed", exc_info=True,
@@ -1410,26 +1531,41 @@ def build_completion_wiring(
                 "[ReplCompletion] build_history failed", exc_info=True,
             )
 
+        try:
+            auto_suggest = build_auto_suggest()
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "[ReplCompletion] build_auto_suggest failed", exc_info=True,
+            )
+
     return CompletionWiring(
         completer=completer,
         history=history,
         enable_history_search=enable_search,
         registry=registry,
+        auto_suggest=auto_suggest,
+        complete_while_typing=(
+            completer is not None and is_complete_while_typing_enabled()
+        ),
     )
 
 
 __all__ = [
     "ArgKind",
     "ArgPositionSpec",
+    "AUTOSUGGEST_ENABLED_ENV_VAR",
+    "COMPLETE_WHILE_TYPING_ENV_VAR",
     "CompletionWiring",
     "HISTORY_ENABLED_ENV_VAR",
     "HISTORY_PATH_ENV_VAR",
     "INLINE_HELP_ENABLED_ENV_VAR",
     "MASTER_FLAG_ENV_VAR",
     "REPL_COMPLETION_SCHEMA_VERSION",
+    "UNIFIED_REGISTRY_ENV_VAR",
     "VerbCategory",
     "VerbDescriptor",
     "VerbRegistry",
+    "build_auto_suggest",
     "build_completer",
     "build_completion_wiring",
     "build_history",
@@ -1439,11 +1575,15 @@ __all__ = [
     "format_verb_hint",
     "fuzzy_match",
     "get_arg_candidates",
+    "is_autosuggest_enabled",
+    "is_complete_while_typing_enabled",
     "is_completion_enabled",
     "is_history_enabled",
     "is_inline_help_enabled",
+    "is_unified_registry_enabled",
     "list_arg_providers",
     "parse_arg_spec",
+    "unified_registry",
     "register_arg_provider",
     "resolve_help_for_buffer",
     "resolve_history_path",
@@ -1782,6 +1922,88 @@ class MentionPathCompleter:
         return hits[: self._max]
 
 
+def _dispatch_arg_spec(verb: str, fn: object) -> str:
+    """Arg spec for a dispatch verb — the piece that makes the ~330-line
+    arg-completion machinery LIVE on the attach surface, where every
+    dispatcher's Python signature is the uninformative ``(line)``.
+
+    Sources, most-authored first (same ranking philosophy as _describe):
+
+      1. a module-level ``__verb_args__ = {"cancel": "<op_id>"}`` dict —
+         the same one-place-per-module convention as ``__verb_help__`` /
+         ``__aliases__``, for verbs whose arguments aren't literals in
+         the function body;
+      2. the verb's MINED subcommand vocabulary rendered as a choice
+         atom (``[status|history|explain]``) — read from the code, so a
+         dispatcher that grows a subcommand completes it with no other
+         edit.
+
+    NEVER raises; "" means "no arg completion", which is where every
+    dispatch verb was before this seam."""
+    try:
+        import sys as _sys
+        mod = _sys.modules.get(getattr(fn, "__module__", "") or "")
+        authored = getattr(mod, "__verb_args__", None)
+        if isinstance(authored, dict):
+            spec = authored.get(verb) or authored.get(f"/{verb}")
+            if isinstance(spec, str) and spec.strip():
+                return spec.strip()
+        subs = mine_subcommands(fn)
+        if subs:
+            return "[" + "|".join(subs) + "]"
+    except Exception:  # noqa: BLE001
+        pass
+    return ""
+
+
+def unified_registry(repl_instance: object = None) -> VerbRegistry:
+    """THE verb registry — the reconciliation of the two historic sources
+    that drifted for four palette PRs:
+
+      * ``registry_from_dispatch()`` — the 60-verb dispatch table the
+        daemon actually routes to, plus the client-handled verbs;
+      * ``discover_verbs(repl_instance)`` — the daemon's ``_handle_*``
+        walk, which carries the metadata the dispatch table lacks
+        (doc-tag arg specs, aliases, examples, categories).
+
+    Merge policy per colliding slash form: the dispatch descriptor's
+    HUMANISED description wins unless it is UNDOCUMENTED and the
+    discovered one has prose; every other field prefers whichever side
+    actually has data. Kill-switch ``JARVIS_UNIFIED_VERB_REGISTRY_ENABLED=
+    false`` restores the legacy per-surface split. NEVER raises."""
+    if not is_unified_registry_enabled():
+        return discover_verbs(repl_instance)
+    try:
+        merged: dict = {
+            d.slash_form: d for d in registry_from_dispatch().verbs
+        }
+        for d in discover_verbs(repl_instance).verbs:
+            base = merged.get(d.slash_form)
+            if base is None:
+                merged[d.slash_form] = d
+                continue
+            description = base.description
+            if (not description or description == UNDOCUMENTED) and (
+                d.description
+            ):
+                description = d.description
+            merged[d.slash_form] = VerbDescriptor(
+                slash_form=base.slash_form,
+                handler_method=d.handler_method or base.handler_method,
+                description=description,
+                aliases=tuple(dict.fromkeys(base.aliases + d.aliases)),
+                examples=tuple(dict.fromkeys(base.examples + d.examples)),
+                arg_spec=base.arg_spec or d.arg_spec,
+                category=d.category if d.handler_method else base.category,
+            )
+        return VerbRegistry(
+            verbs=tuple(sorted(merged.values(), key=lambda v: v.slash_form))
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug("[Completion] unified registry degraded", exc_info=True)
+        return discover_verbs(repl_instance)
+
+
 def registry_from_dispatch() -> VerbRegistry:
     """Build a :class:`VerbRegistry` from the AUTO-DISCOVERED dispatch table.
 
@@ -1815,6 +2037,7 @@ def registry_from_dispatch() -> VerbRegistry:
                     slash_form=f"/{verb}",
                     handler_method="",
                     description=_describe(fn),
+                    arg_spec=_dispatch_arg_spec(verb, fn),
                 )
             )
     except Exception:  # noqa: BLE001
@@ -1863,6 +2086,11 @@ def build_attach_completer() -> Optional[object]:
         # to exceed the table.
         completer = build_completer(
             registry_from_dispatch(), max_results=512,
+            # The repo-rooted MentionPathCompleter below is this
+            # surface's `@` vocabulary — without this flag the polish
+            # module's cwd-rooted PathCompleter ALSO merged in and every
+            # mention completed twice.
+            include_mentions=False,
         )
         if completer is None:
             return None

--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -5959,7 +5959,26 @@ class SerpentREPL:
                         await _aio.sleep(0.02)
 
                 _aio.ensure_future(_attach_sprite_when_ready())
-                await run_bipartite_repl(on_accept=_on_accept)
+                # The daemon-side cockpit is a surface the operator TYPES
+                # into, and it ran with zero completion, zero persistent
+                # history and zero ghost-text while the attach cockpit
+                # had all three wired at ov.py — the two-surfaces split,
+                # again. Same wiring seam the legacy PromptSession below
+                # uses (DRY), so the vocabularies cannot diverge.
+                _bp_wiring = None
+                try:
+                    from backend.core.ouroboros.battle_test.repl_completion import (  # noqa: E501
+                        build_completion_wiring,
+                    )
+                    _bp_wiring = build_completion_wiring(self)
+                except Exception:  # noqa: BLE001
+                    _bp_wiring = None
+                await run_bipartite_repl(
+                    on_accept=_on_accept,
+                    completer=getattr(_bp_wiring, "completer", None),
+                    history=getattr(_bp_wiring, "history", None),
+                    auto_suggest=getattr(_bp_wiring, "auto_suggest", None),
+                )
                 return
         except Exception:  # noqa: BLE001 — cockpit failure NEVER bricks the REPL
             pass  # fall through to the legacy flowing loop below
@@ -6064,7 +6083,16 @@ class SerpentREPL:
                     discover_verbs as _qm_discover,
                     resolve_help_for_buffer as _qm_resolve,
                 )
-                _reg = _qm_discover(self)
+                # The verb set is static per-process — rebuilding the
+                # whole registry (an inspect.getmembers walk) on EVERY
+                # `?` keypress was pure waste on the key dispatch path.
+                _reg = getattr(self, "_qm_registry_cache", None)
+                if _reg is None:
+                    _reg = _qm_discover(self)
+                    try:
+                        self._qm_registry_cache = _reg
+                    except Exception:  # noqa: BLE001
+                        pass
                 _help_text = _qm_resolve(buf.text, _reg)
             except Exception:  # noqa: BLE001 — NEVER raise
                 _help_text = None
@@ -6254,6 +6282,7 @@ class SerpentREPL:
             "complete_while_typing": False,
             "enable_history_search": False,
         }
+        _auto_suggest = None
         try:
             from backend.core.ouroboros.battle_test.repl_completion import (
                 build_completion_wiring,
@@ -6261,11 +6290,19 @@ class SerpentREPL:
             _wiring = build_completion_wiring(self)
             if _wiring.completer is not None:
                 _completion_kwargs["completer"] = _wiring.completer
+                # Palette-as-you-type (default true, env
+                # JARVIS_REPL_COMPLETE_WHILE_TYPING) — the attach
+                # surfaces already behaved this way; Tab-only was a
+                # daemon-side historical accident, not a decision.
+                _completion_kwargs["complete_while_typing"] = (
+                    _wiring.complete_while_typing
+                )
             if _wiring.history is not None:
                 _completion_kwargs["history"] = _wiring.history
                 _completion_kwargs["enable_history_search"] = (
                     _wiring.enable_history_search
                 )
+            _auto_suggest = _wiring.auto_suggest
         except Exception:
             pass  # fail-closed — REPL still works without completion
 
@@ -6295,7 +6332,9 @@ class SerpentREPL:
             multiline=True,
             key_bindings=_repl_bindings,
             wrap_lines=True,
-            auto_suggest=None,
+            # History ghost-text from the wiring (None when disabled via
+            # JARVIS_REPL_AUTOSUGGEST_ENABLED — the legacy explicit-None).
+            auto_suggest=_auto_suggest,
             prompt_continuation=_continuation,
             bottom_toolbar=_live_bottom_toolbar,
             refresh_interval=_refresh_interval_kwarg,

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -1386,6 +1386,11 @@ async def _split_plane_loop(
         # would freeze the very keystroke that opened the menu.
         completer=_build_slash_completer(),
         complete_while_typing=True,
+        # Persistent recall + history ghost-text — the same
+        # .jarvis/repl_history every other surface reads, so a verb
+        # typed at the daemon REPL suggests here and vice versa.
+        history=_build_prompt_history(),
+        auto_suggest=_build_prompt_auto_suggest(),
         # Multi-line, with the CONDITION applied to the buffer below — the
         # same two-step the cockpit uses, from the same module, so the two
         # surfaces cannot disagree about when Enter means "go".
@@ -1515,6 +1520,57 @@ def _build_slash_completer() -> Any:
         return None
 
 
+def _build_prompt_history() -> Any:
+    """Persistent prompt history for the attach surfaces — the SAME
+    ``.jarvis/repl_history`` file the daemon REPL writes, so what the
+    operator typed at one surface recalls at every other. None when
+    disabled/unavailable. NEVER raises."""
+    try:
+        from backend.core.ouroboros.battle_test.repl_completion import (
+            build_history,
+        )
+        return build_history()
+    except Exception:  # noqa: BLE001 — a cockpit without recall still works
+        return None
+
+
+def _build_prompt_auto_suggest() -> Any:
+    """History ghost-text for the attach surfaces. None when disabled.
+    NEVER raises."""
+    try:
+        from backend.core.ouroboros.battle_test.repl_completion import (
+            build_auto_suggest,
+        )
+        return build_auto_suggest()
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _register_client_op_provider(ui: Any) -> None:
+    """Arg-completion candidates for ``<op_id>`` positions, resolved from
+    the op ids the bridge stream has ALREADY delivered to this client
+    (``ui._active_ops``) — the same source the Esc-interrupt gate trusts.
+    Completion never asks the daemon anything on a keystroke. NEVER
+    raises."""
+    try:
+        from backend.core.ouroboros.battle_test.repl_completion import (
+            register_arg_provider,
+        )
+
+        def _candidates(prefix: str) -> tuple:
+            try:
+                ops = getattr(ui, "_active_ops", None) or ()
+                return tuple(
+                    str(op) for op in ops if str(op).startswith(prefix or "")
+                )
+            except Exception:  # noqa: BLE001
+                return ()
+
+        register_arg_provider("op_id", _candidates)
+    except Exception:  # noqa: BLE001
+        pass
+
+
 def _build_selection_bindings(ui: Any, client: Any) -> Any:
     """Arrow/Enter/Esc for the selectable deck. NEVER raises.
 
@@ -1569,22 +1625,43 @@ def _build_selection_bindings(ui: Any, client: Any) -> Any:
             except Exception:  # noqa: BLE001
                 return False
 
-        @kb.add("c-o", filter=can_open)
+        # Every selection key routes through the remappable keymap
+        # (defaults unchanged) — `bind_action` resolves the operator's
+        # keybindings.json over the declared default, registers the
+        # action for `/keys`, and NEVER raises; when the config is
+        # absent this is byte-for-byte the old `@kb.add(...)`.
+        from backend.core.ouroboros.battle_test.keymap import bind_action
+
         def _open(event: Any) -> None:
             fsm.enter_select()
             ui.refresh()
 
-        @kb.add("up", filter=in_select)
+        bind_action(
+            kb, "deck:open", ("ctrl+o",), _open,
+            context="Deck", filter=can_open,
+            description="enter deck selection (empty buffer only)",
+        )
+
         def _up(event: Any) -> None:
             fsm.move(-1)
             ui.refresh()
 
-        @kb.add("down", filter=in_select)
+        bind_action(
+            kb, "deck:previous", ("up",), _up,
+            context="Deck", filter=in_select,
+            description="previous deck entry",
+        )
+
         def _down(event: Any) -> None:
             fsm.move(1)
             ui.refresh()
 
-        @kb.add("enter", filter=in_select)
+        bind_action(
+            kb, "deck:next", ("down",), _down,
+            context="Deck", filter=in_select,
+            description="next deck entry",
+        )
+
         def _enter(event: Any) -> None:
             lane = fsm.selected_lane()
             if fsm.focus_selected() and lane:
@@ -1596,6 +1673,12 @@ def _build_selection_bindings(ui: Any, client: Any) -> Any:
                     pass
             ui.refresh()
 
+        bind_action(
+            kb, "deck:focus", ("enter",), _enter,
+            context="Deck", filter=in_select,
+            description="focus the selected lane",
+        )
+
         # `eager` is a FILTER, not a flag. Eager means "fire now, do not wait
         # to see if this is the start of a longer sequence" — which is exactly
         # what would swallow the escape half of Alt+Enter. So Esc stays
@@ -1603,7 +1686,6 @@ def _build_selection_bindings(ui: Any, client: Any) -> Any:
         # they want to interrupt: watching, not typing) and yields the
         # sequence while they are composing. Both meanings survive, and which
         # one applies is decided by what the operator is visibly doing.
-        @kb.add("escape", filter=in_flow_working, eager=_not_composing())
         def _interrupt(event: Any) -> None:
             """Esc in FLOW interrupts the operator's own work.
 
@@ -1624,12 +1706,22 @@ def _build_selection_bindings(ui: Any, client: Any) -> Any:
             except Exception:  # noqa: BLE001
                 pass
 
-        @kb.add("escape", filter=not_flow, eager=_not_composing())
+        bind_action(
+            kb, "chat:interrupt", ("escape",), _interrupt,
+            context="Chat", filter=in_flow_working, eager=_not_composing(),
+            description="interrupt your own in-flight work (/cancel)",
+        )
+
         def _esc(event: Any) -> None:
             fsm.escape()
             ui.refresh()
 
-        @kb.add("c-p")
+        bind_action(
+            kb, "deck:escape", ("escape",), _esc,
+            context="Deck", filter=not_flow, eager=_not_composing(),
+            description="leave SELECT/FOCUS",
+        )
+
         def _release_gate(event: Any) -> None:
             """Surface a deferred approval on demand.
 
@@ -1649,6 +1741,12 @@ def _build_selection_bindings(ui: Any, client: Any) -> Any:
                     )
             except Exception:  # noqa: BLE001
                 pass
+
+        bind_action(
+            kb, "gate:review", ("ctrl+p",), _release_gate,
+            context="Chat",
+            description="surface a deferred approval on demand",
+        )
 
         try:
             from backend.core.ouroboros.battle_test.input_continuation import (
@@ -2005,6 +2103,11 @@ async def _bipartite_attach_loop(client: Any, console: Any, ui: Any) -> None:
             except Exception:  # noqa: BLE001
                 pass
 
+    # Dynamic op-id completion from the ops THIS client has already been
+    # told about — no bridge round-trip on a keystroke. Inert until a
+    # dispatch module declares an ``<op_id>`` position via __verb_args__.
+    _register_client_op_provider(ui)
+
     def _alive() -> bool:
         ok = bool(client.connected)
         if not ok:
@@ -2258,6 +2361,10 @@ async def _bipartite_attach_loop(client: Any, console: Any, ui: Any) -> None:
             # types into — the bipartite Application, not the split-plane
             # PromptSession the completer was first wired to.
             completer=_build_slash_completer(),
+            # Persistent recall + history ghost-text — the same history
+            # file every surface shares, so Up-arrow survives a detach.
+            history=_build_prompt_history(),
+            auto_suggest=_build_prompt_auto_suggest(),
             seed=[
                 "[bold]💭 Karen ▸[/bold] attached — I'm listening. verbs or "
                 "plain words both work · [cyan]wake[/cyan] arms my voice · "

--- a/backend/core/ouroboros/governance/keys_repl.py
+++ b/backend/core/ouroboros/governance/keys_repl.py
@@ -1,0 +1,148 @@
+"""``/keys`` REPL — the operator's window into the remappable keymap.
+
+Auto-discovered by ``repl_dispatch_registry`` via the naming cage (file ends
+``_repl.py``; verb from basename; dispatcher named
+``dispatch_keys_command``). Reads everything through
+``battle_test.keymap.describe_keymap()`` — this module renders, it never
+resolves, so the table can never drift from what the cockpit actually binds.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+KEYS_REPL_SCHEMA_VERSION: str = "keys_repl.1"
+
+__verb_help__ = {
+    "keys": "show and manage keyboard shortcuts (keybindings.json)",
+}
+
+_HELP = (
+    "/keys — keyboard shortcuts, resolved from defaults + your config\n"
+    "\n"
+    "Subcommands:\n"
+    "  /keys              effective bindings per context\n"
+    "  /keys warnings     config problems (parse errors, conflicts)\n"
+    "  /keys path         where the config file lives\n"
+    "  /keys init         create a starter keybindings.json\n"
+    "  /keys reload       force a config re-read now\n"
+    "  /keys help         this text\n"
+    "\n"
+    "Config format matches Claude Code's keybindings.json: blocks of\n"
+    '{"context": ..., "bindings": {"ctrl+e": "namespace:action", '
+    '"ctrl+u": null}}.\n'
+    "Edits hot-reload on cockpit surfaces; call-site bindings apply on the\n"
+    "next attach. Master flag: JARVIS_KEYMAP_ENABLED (default true).\n"
+)
+
+
+@dataclass(frozen=True)
+class KeysReplDispatchResult:
+    ok: bool
+    text: str
+    matched: bool = True
+    schema_version: str = KEYS_REPL_SCHEMA_VERSION
+
+
+def _table(info: dict) -> str:
+    lines = []
+    header = "keymap — {} action(s)".format(len(info.get("actions", ())))
+    if not info.get("enabled", True):
+        header += "  [JARVIS_KEYMAP_ENABLED=false — defaults only]"
+    lines.append(header)
+    path = info.get("config_path")
+    if path:
+        state = "loaded" if info.get("config_present") else "not present yet"
+        lines.append(f"config: {path} ({state})")
+    current_ctx = None
+    for row in info.get("actions", ()):
+        if row["context"] != current_ctx:
+            current_ctx = row["context"]
+            lines.append(f"\n[{current_ctx}]")
+        keys = ", ".join(row["keys"]) if row["keys"] else "(unbound)"
+        mark = " *" if row.get("customized") else ""
+        desc = row.get("description") or ""
+        lines.append(f"  {row['action']:<24} {keys:<22}{mark} {desc}".rstrip())
+    warn_count = len(info.get("warnings", ()))
+    if warn_count:
+        lines.append(
+            f"\n⚠ {warn_count} warning(s) — `/keys warnings` to list them"
+        )
+    if any(r.get("customized") for r in info.get("actions", ())):
+        lines.append("* customized in keybindings.json")
+    return "\n".join(lines)
+
+
+def dispatch_keys_command(line: str) -> KeysReplDispatchResult:
+    """Show and manage keyboard shortcuts.
+
+    Operator: show current keyboard shortcuts, warnings from your
+    keybindings.json, or create a starter config with `/keys init`.
+    """
+    try:
+        from backend.core.ouroboros.battle_test import keymap
+
+        tokens = (line or "").strip().lstrip("/").split()
+        sub = tokens[1].lower() if len(tokens) > 1 else ""
+
+        if sub in ("help", "-h", "--help"):
+            return KeysReplDispatchResult(ok=True, text=_HELP)
+
+        if sub == "path":
+            path = keymap.resolve_config_path()
+            return KeysReplDispatchResult(
+                ok=True,
+                text=(f"keybindings config: {path}"
+                      if path else "no config path resolvable"),
+            )
+
+        if sub == "init":
+            written = keymap.write_config_template()
+            if written:
+                return KeysReplDispatchResult(
+                    ok=True,
+                    text=(f"keybindings config ready at {written} — "
+                          "edits apply live on cockpit surfaces"),
+                )
+            return KeysReplDispatchResult(
+                ok=False, text="could not create the config file",
+            )
+
+        if sub == "reload":
+            keymap.get_store().maybe_reload(force=True)
+            info = keymap.describe_keymap()
+            warn = len(info.get("warnings", ()))
+            return KeysReplDispatchResult(
+                ok=True,
+                text=(f"keymap reloaded — {warn} warning(s)"
+                      if warn else "keymap reloaded — clean"),
+            )
+
+        if sub == "warnings":
+            info = keymap.describe_keymap()
+            warnings = info.get("warnings", ())
+            if not warnings:
+                return KeysReplDispatchResult(
+                    ok=True, text="keymap: no warnings",
+                )
+            body = "\n".join(f"  ⚠ {w}" for w in warnings)
+            return KeysReplDispatchResult(
+                ok=True, text=f"keymap warnings:\n{body}",
+            )
+
+        info = keymap.describe_keymap()
+        return KeysReplDispatchResult(ok=True, text=_table(info))
+    except Exception:  # noqa: BLE001
+        logger.debug("[KeysRepl] dispatch degraded", exc_info=True)
+        return KeysReplDispatchResult(
+            ok=False, text="keymap introspection unavailable",
+        )
+
+
+__all__ = [
+    "KEYS_REPL_SCHEMA_VERSION",
+    "KeysReplDispatchResult",
+    "dispatch_keys_command",
+]

--- a/tests/battle_test/test_completion_unification.py
+++ b/tests/battle_test/test_completion_unification.py
@@ -1,0 +1,312 @@
+"""Completion unification — one registry, one mention completer, every
+surface completing the same vocabulary.
+
+Pins the fixes for the audit gaps that let four palette PRs ship without
+the operator seeing them:
+
+  * gap #3 — ``discover_verbs`` (34) vs ``registry_from_dispatch`` (76)
+    never reconciled → :func:`unified_registry` merges them;
+  * gap #4 — TWO ``@``-mention completers merged into the attach path →
+    ``build_completer(include_mentions=False)``;
+  * gap #5 — dispatch verbs carried ``arg_spec=""`` so ~330 lines of arg
+    completion were inert on the attach surface → choice atoms mined
+    from the dispatcher body + the ``__verb_args__`` convention;
+  * gap #6 — no auto-suggest anywhere → ``build_auto_suggest``;
+  * gap #10 — ``cursor_arg_position`` split on every space, quoted or
+    not.
+"""
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from backend.core.ouroboros.battle_test import repl_completion as rc
+
+
+# --------------------------------------------------------------------------
+# 1. choice atoms — mined vocabularies ride the spec grammar
+# --------------------------------------------------------------------------
+
+def test_optional_choice_atom_parses_to_static() -> None:
+    (spec,) = rc.parse_arg_spec("[status|history|explain]")
+    assert spec.kind is rc.ArgKind.STATIC
+    assert spec.required is False
+    assert spec.static_values == ("status", "history", "explain")
+
+
+def test_required_choice_atom_parses_to_static() -> None:
+    specs = rc.parse_arg_spec("<on|off> [--immediate]")
+    assert specs[0].required is True
+    assert specs[0].static_values == ("on", "off")
+    assert specs[1].flag_form == "--immediate"
+
+
+def test_choice_candidates_prefix_filter() -> None:
+    (spec,) = rc.parse_arg_spec("[panel|banners|prefetch|status]")
+    assert rc.get_arg_candidates(spec, "p") == ("panel", "prefetch")
+
+
+def test_legacy_atoms_unchanged() -> None:
+    specs = rc.parse_arg_spec("<op_id> [--immediate]")
+    assert specs[0].name == "op_id" and specs[0].required
+    assert specs[1].flag_form == "--immediate"
+
+
+# --------------------------------------------------------------------------
+# 2. quote-aware cursor position
+# --------------------------------------------------------------------------
+
+def test_cursor_position_quoted_fragment_is_one_slot() -> None:
+    assert rc.cursor_arg_position('/attach "my fi') == (0, '"my fi')
+
+
+def test_cursor_position_closed_quote_then_new_slot() -> None:
+    idx, prefix = rc.cursor_arg_position('/attach "my file" ')
+    assert (idx, prefix) == (1, "")
+
+
+def test_cursor_position_naive_contract_preserved() -> None:
+    assert rc.cursor_arg_position("/cancel ") == (0, "")
+    assert rc.cursor_arg_position("/cancel ab c") == (1, "c")
+    assert rc.cursor_arg_position("plain text") == (-1, "")
+
+
+# --------------------------------------------------------------------------
+# 3. dispatch arg specs — authored beats mined, mined beats nothing
+# --------------------------------------------------------------------------
+
+def _fake_module(name: str, **attrs):
+    mod = types.ModuleType(name)
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    sys.modules[name] = mod
+    return mod
+
+
+def test_verb_args_convention_wins(monkeypatch) -> None:
+    mod = _fake_module("_fake_verbargs_mod", __verb_args__={
+        "cancel": "<op_id> [--immediate]",
+    })
+    def dispatch_cancel_command(line):  # noqa: ANN001, ARG001
+        if line == "status":
+            return 1
+        if line == "history":
+            return 2
+    dispatch_cancel_command.__module__ = mod.__name__
+    try:
+        spec = rc._dispatch_arg_spec("cancel", dispatch_cancel_command)
+        assert spec == "<op_id> [--immediate]"
+    finally:
+        del sys.modules[mod.__name__]
+
+
+def test_mined_subcommands_become_a_choice_atom() -> None:
+    def dispatch_demo_command(line):  # noqa: ANN001
+        sub = (line or "").strip()
+        if sub == "status":
+            return "s"
+        if sub == "history":
+            return "h"
+        return "?"
+    spec = rc._dispatch_arg_spec("demo", dispatch_demo_command)
+    assert spec == "[status|history]"
+    (pos,) = rc.parse_arg_spec(spec)
+    assert pos.static_values == ("status", "history")
+
+
+def test_no_vocabulary_means_no_spec() -> None:
+    def dispatch_empty_command(line):  # noqa: ANN001, ARG001
+        return None
+    assert rc._dispatch_arg_spec("empty", dispatch_empty_command) == ""
+
+
+def test_keys_verb_arrives_with_a_mined_spec() -> None:
+    """End-to-end: the real dispatch registry hands /keys a completable
+    subcommand vocabulary read from its own body."""
+    reg = rc.registry_from_dispatch()
+    verb = reg.find("/keys")
+    assert verb is not None
+    positions = rc.parse_arg_spec(verb.arg_spec)
+    assert positions and "warnings" in positions[0].static_values
+
+
+# --------------------------------------------------------------------------
+# 4. unified registry — the gap #3 reconciliation
+# --------------------------------------------------------------------------
+
+class _FakeRepl:
+    def _handle_cancel(self, op_id: str) -> None:
+        """Cancel an in-flight operation cooperatively."""
+
+    def _handle_bus(self) -> None:
+        """A DISCOVERED description for a verb dispatch also has."""
+
+
+def test_unified_registry_merges_both_sources() -> None:
+    reg = rc.unified_registry(_FakeRepl())
+    forms = {v.slash_form for v in reg.verbs}
+    # from discover_verbs: the _handle_ walk + builtins
+    assert "/cancel" in forms and "/help" in forms
+    # from the dispatch table
+    assert "/keys" in forms
+    # sorted, deduplicated
+    assert list(forms) and sorted(
+        v.slash_form for v in reg.verbs
+    ) == [v.slash_form for v in reg.verbs]
+
+
+def test_unified_registry_prefers_data_over_blanks() -> None:
+    reg = rc.unified_registry(_FakeRepl())
+    cancel = reg.find("/cancel")
+    # discover side derived <op_id> from the signature; dispatch side
+    # (custom-handler exclusion) has no entry — spec must survive.
+    assert "op_id" in cancel.arg_spec
+
+
+def test_unified_registry_kill_switch(monkeypatch) -> None:
+    monkeypatch.setenv(rc.UNIFIED_REGISTRY_ENV_VAR, "false")
+    reg = rc.unified_registry(_FakeRepl())
+    forms = {v.slash_form for v in reg.verbs}
+    assert "/cancel" in forms          # discovery still works
+    assert "/keys" not in forms        # dispatch merge is off
+
+
+def test_wiring_uses_the_unified_registry() -> None:
+    wiring = rc.build_completion_wiring(_FakeRepl())
+    forms = {v.slash_form for v in wiring.registry.verbs}
+    assert "/cancel" in forms and "/keys" in forms
+
+
+# --------------------------------------------------------------------------
+# 5. one mention completer per surface (gap #4)
+# --------------------------------------------------------------------------
+
+def test_include_mentions_false_returns_bare_slash_completer() -> None:
+    pytest.importorskip("prompt_toolkit")
+    reg = rc.VerbRegistry(verbs=(
+        rc.VerbDescriptor(slash_form="/x", handler_method="", description=""),
+    ))
+    bare = rc.build_completer(reg, include_mentions=False)
+    # A merged completer is a _MergedCompleter; the bare one is our own
+    # class. The attach path counts on this to add its repo-rooted
+    # mention completer WITHOUT doubling the polish one.
+    assert type(bare).__name__ == "_SlashCompleter"
+
+
+def test_attach_completer_has_exactly_one_mention_source() -> None:
+    pytest.importorskip("prompt_toolkit")
+    completer = rc.build_attach_completer()
+    assert completer is not None
+
+    mention_like = []
+
+    def _walk(c) -> None:
+        name = type(c).__name__
+        if "Mention" in name or "PathCompleter" in name:
+            mention_like.append(name)
+        for attr in ("completer", "completers", "_completer", "_completers"):
+            inner = getattr(c, attr, None)
+            if inner is None:
+                continue
+            if isinstance(inner, (list, tuple)):
+                for i in inner:
+                    _walk(i)
+            else:
+                _walk(inner)
+
+    _walk(completer)
+    assert mention_like == ["MentionPathCompleter"], mention_like
+
+
+# --------------------------------------------------------------------------
+# 6. auto-suggest + complete-while-typing wiring (gaps #6/#7)
+# --------------------------------------------------------------------------
+
+def test_auto_suggest_builds_threaded(monkeypatch) -> None:
+    pytest.importorskip("prompt_toolkit")
+    sugg = rc.build_auto_suggest()
+    assert type(sugg).__name__ == "ThreadedAutoSuggest"
+    monkeypatch.setenv(rc.AUTOSUGGEST_ENABLED_ENV_VAR, "false")
+    assert rc.build_auto_suggest() is None
+    monkeypatch.delenv(rc.AUTOSUGGEST_ENABLED_ENV_VAR)
+    monkeypatch.setenv(rc.HISTORY_ENABLED_ENV_VAR, "false")
+    assert rc.build_auto_suggest() is None  # nothing to suggest from
+
+
+def test_wiring_carries_auto_suggest_and_cwt(tmp_path, monkeypatch) -> None:
+    pytest.importorskip("prompt_toolkit")
+    monkeypatch.setenv(rc.HISTORY_PATH_ENV_VAR, str(tmp_path / "hist"))
+    wiring = rc.build_completion_wiring(None)
+    assert wiring.auto_suggest is not None
+    assert wiring.complete_while_typing is True
+    assert type(wiring.completer).__name__ == "ThreadedCompleter"
+    monkeypatch.setenv(rc.COMPLETE_WHILE_TYPING_ENV_VAR, "false")
+    wiring2 = rc.build_completion_wiring(None)
+    assert wiring2.complete_while_typing is False
+
+
+# --------------------------------------------------------------------------
+# 7. the bipartite cockpit gets history + ghost text (gaps #1/#2)
+# --------------------------------------------------------------------------
+
+def _build_app(**kwargs):
+    import contextlib
+    import io
+    from backend.core.ouroboros.battle_test.bipartite_layout import (
+        BipartiteLayout, build_bipartite_application,
+    )
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+        mux = BipartiteLayout(width=120, height=30, title="t")
+        app = build_bipartite_application(
+            mux, on_accept=lambda _t: None, **kwargs,
+        )
+    return app
+
+
+def _prompt_buffer(app):
+    from prompt_toolkit.layout.containers import Window
+    from prompt_toolkit.layout.controls import BufferControl
+    for w in app.layout.find_all_windows():
+        if isinstance(w, Window) and isinstance(w.content, BufferControl):
+            return w.content.buffer
+    return None
+
+
+def test_bipartite_prompt_carries_history_and_suggest() -> None:
+    pytest.importorskip("prompt_toolkit")
+    from prompt_toolkit.history import InMemoryHistory
+    hist = InMemoryHistory()
+    sugg = rc.build_auto_suggest()
+    app = _build_app(history=hist, auto_suggest=sugg)
+    buf = _prompt_buffer(app)
+    assert buf is not None
+    assert buf.history is hist
+    # TextArea wraps auto_suggest in a DynamicAutoSuggest indirection —
+    # resolve it and demand OUR object on the other side.
+    resolver = getattr(buf.auto_suggest, "get_auto_suggest", None)
+    resolved = resolver() if callable(resolver) else buf.auto_suggest
+    assert resolved is sugg
+
+
+def test_bipartite_prompt_defaults_stay_none_safe() -> None:
+    pytest.importorskip("prompt_toolkit")
+    app = _build_app()
+    assert _prompt_buffer(app) is not None
+
+
+def test_daemon_cockpit_fast_path_passes_the_wiring() -> None:
+    """serpent_flow's bipartite fast-path must hand the SAME wiring the
+    legacy PromptSession gets to run_bipartite_repl — pinned at source
+    level because the fast-path cannot run headless."""
+    import inspect
+    from backend.core.ouroboros.battle_test import serpent_flow
+    src = inspect.getsource(serpent_flow.SerpentREPL._loop)
+    assert "build_completion_wiring" in src
+    # The call site's kwargs contain nested parens (getattr defaults) —
+    # bound the window by the `return` that follows the await instead.
+    fast = src.split("await run_bipartite_repl(")[1].split("return")[0]
+    for kw in ("completer=", "history=", "auto_suggest="):
+        assert kw in fast, f"bipartite fast-path lost {kw}"

--- a/tests/battle_test/test_keymap.py
+++ b/tests/battle_test/test_keymap.py
@@ -1,0 +1,291 @@
+"""The remappable keymap — parser, config, resolution, hot reload, mounts.
+
+One engine, every surface: bipartite cockpit exit keys, ov selection
+bindings, and input_continuation's newline hatch all resolve their keys
+here. These tests pin the four contracts that make that safe:
+
+  1. the keystroke parser speaks Claude Code's syntax and refuses what a
+     terminal cannot deliver;
+  2. a broken config degrades to warnings + defaults, never to a dead
+     cockpit;
+  3. resolution honors unbind (null), rebinds, and Global blocks;
+  4. mounts recompile on config change (hot reload) and bind_action
+     falls back to declared defaults on any fault.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.battle_test import keymap as km
+
+
+@pytest.fixture()
+def config_file(tmp_path, monkeypatch):
+    """An isolated config file + a store that reloads instantly."""
+    path = tmp_path / "keybindings.json"
+    monkeypatch.setenv(km.CONFIG_PATH_ENV_VAR, str(path))
+    monkeypatch.setenv(km.RELOAD_THROTTLE_ENV_VAR, "0.1")
+    km.get_store().maybe_reload(force=True)
+    yield path
+    monkeypatch.delenv(km.CONFIG_PATH_ENV_VAR, raising=False)
+    km.get_store().maybe_reload(force=True)
+
+
+def _write(path: Path, doc: dict) -> None:
+    path.write_text(json.dumps(doc), encoding="utf-8")
+    km.get_store().maybe_reload(force=True)
+
+
+# --------------------------------------------------------------------------
+# 1. keystroke parser
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("spec,expected", [
+    ("ctrl+c", ("c-c",)),
+    ("control+E", ("c-e",)),            # aliases + stylistic caps
+    ("ctrl+K", ("c-k",)),               # modifier caps do NOT imply shift
+    ("K", ("K",)),                      # standalone uppercase implies shift
+    ("shift+k", ("K",)),
+    ("shift+tab", ("s-tab",)),
+    ("alt+enter", ("escape", "enter")),  # alt = escape prefix
+    ("opt+x", ("escape", "x")),
+    ("meta+p", ("escape", "p")),
+    ("ctrl+x ctrl+e", ("c-x", "c-e")),   # chord
+    ("escape", ("escape",)),
+    ("esc", ("escape",)),
+    ("return", ("enter",)),
+    ("space", (" ",)),
+    ("alt+space", ("escape", " ")),
+    ("ctrl+up", ("c-up",)),
+    ("ctrl+shift+left", ("c-s-left",)),
+    ("pageup", ("pageup",)),
+    ("f12", ("f12",)),
+    ("backspace", ("backspace",)),
+])
+def test_parser_translates_cc_syntax(spec, expected) -> None:
+    assert km.parse_keystroke(spec) == expected
+
+
+@pytest.mark.parametrize("bad", [
+    "", "   ",
+    "cmd+p",            # super is not delivered by most terminals
+    "wat+x",            # unknown modifier
+    "ctrl+",            # no base key
+    "ctrl+enter",       # enter does not take ctrl in a terminal
+    "shift+escape",     # escape does not take shift
+    "ctrl+notakey",
+])
+def test_parser_rejects_undeliverable(bad) -> None:
+    with pytest.raises(km.KeystrokeError):
+        km.parse_keystroke(bad)
+
+
+def test_canonical_form_unifies_spellings() -> None:
+    assert km.canonical_keystroke("control+E") == km.canonical_keystroke(
+        "ctrl+e"
+    )
+    # The literal space key round-trips losslessly through the canon.
+    assert km.canonical_keystroke("alt+space") == "escape space"
+
+
+# --------------------------------------------------------------------------
+# 2. config parse + validation — warnings, never a dead cockpit
+# --------------------------------------------------------------------------
+
+def test_invalid_json_is_one_warning_and_no_bindings() -> None:
+    cfg = km.parse_config("{nope")
+    assert cfg.blocks == {}
+    assert len(cfg.warnings) == 1
+    assert "JSON" in cfg.warnings[0]
+
+
+def test_structural_problems_cost_one_entry_each() -> None:
+    cfg = km.parse_config(json.dumps({"bindings": [
+        {"context": "Chat", "bindings": {
+            "ctrl+j": "chat:newline",       # good
+            "ctrl+m": "chat:submit",        # reserved → skipped
+            "ctrl+b": "deck:open",          # tmux conflict → kept + warned
+            "garbage+q": "x:y",             # unparseable → skipped
+            "ctrl+q": "notanaction",        # bad action id → skipped
+        }},
+        {"context": "Nowhere", "bindings": {"f5": "a:b"}},  # unknown ctx
+        "not-a-block",
+    ]}))
+    chat = cfg.blocks["Chat"]
+    assert chat["c-j"] == "chat:newline"
+    assert "c-m" not in chat                      # reserved never lands
+    assert chat["c-b"] == "deck:open"             # conflict is warn-only
+    assert any("reserved" in w for w in cfg.warnings)
+    assert any("tmux" in w for w in cfg.warnings)
+    assert any("unknown modifier" in w for w in cfg.warnings)
+    assert any("namespace:action" in w for w in cfg.warnings)
+    assert any("unknown context" in w for w in cfg.warnings)
+    assert any("not an object" in w for w in cfg.warnings)
+
+
+def test_null_unbinds_and_duplicates_warn() -> None:
+    cfg = km.parse_config(json.dumps({"bindings": [
+        {"context": "Chat", "bindings": {"alt+enter": None}},
+        {"context": "Chat", "bindings": {"alt+enter": "chat:newline"}},
+    ]}))
+    # last one wins, with a warning
+    assert cfg.blocks["Chat"]["escape enter"] == "chat:newline"
+    assert any("duplicate" in w for w in cfg.warnings)
+
+
+# --------------------------------------------------------------------------
+# 3. resolution — defaults × config
+# --------------------------------------------------------------------------
+
+def test_defaults_survive_an_absent_config(config_file) -> None:
+    assert km.effective_key_sequences(
+        "chat:newline", ("alt+enter",),
+    ) == (("escape", "enter"),)
+
+
+def test_null_unbind_removes_a_default(config_file) -> None:
+    _write(config_file, {"bindings": [
+        {"context": "Chat", "bindings": {"alt+enter": None}},
+    ]})
+    assert km.effective_key_sequences("chat:newline", ("alt+enter",)) == ()
+
+
+def test_rebind_moves_the_key(config_file) -> None:
+    _write(config_file, {"bindings": [
+        {"context": "Chat", "bindings": {
+            "alt+enter": None, "ctrl+j": "chat:newline",
+        }},
+    ]})
+    assert km.effective_key_sequences(
+        "chat:newline", ("alt+enter",),
+    ) == (("c-j",),)
+
+
+def test_reassigning_a_default_key_steals_it(config_file) -> None:
+    # ctrl+p moves from gate:review to another action — gate:review
+    # loses the key WITHOUT an explicit null.
+    _write(config_file, {"bindings": [
+        {"context": "Chat", "bindings": {"ctrl+p": "chat:newline"}},
+    ]})
+    assert km.effective_key_sequences("gate:review", ("ctrl+p",)) == ()
+    assert (("c-p",) in km.effective_key_sequences(
+        "chat:newline", ("alt+enter",),
+    ))
+
+
+def test_global_block_applies_to_every_context(config_file) -> None:
+    _write(config_file, {"bindings": [
+        {"context": "Global", "bindings": {"ctrl+o": None}},
+    ]})
+    assert km.effective_key_sequences(
+        "deck:open", ("ctrl+o",), context="Deck",
+    ) == ()
+
+
+def test_master_flag_off_means_defaults_only(config_file, monkeypatch):
+    _write(config_file, {"bindings": [
+        {"context": "Chat", "bindings": {"alt+enter": None}},
+    ]})
+    monkeypatch.setenv(km.MASTER_FLAG_ENV_VAR, "false")
+    km.get_store().maybe_reload(force=True)
+    assert km.effective_key_sequences(
+        "chat:newline", ("alt+enter",),
+    ) == (("escape", "enter"),)
+    monkeypatch.delenv(km.MASTER_FLAG_ENV_VAR)
+    km.get_store().maybe_reload(force=True)
+
+
+def test_a_bad_declared_default_drops_that_key_only() -> None:
+    seqs = km.effective_key_sequences(
+        "x:y", ("definitely+not+a+key", "ctrl+t"),
+    )
+    assert seqs == (("c-t",),)
+
+
+# --------------------------------------------------------------------------
+# 4. hot reload + mounts
+# --------------------------------------------------------------------------
+
+def test_store_generation_bumps_on_change(config_file) -> None:
+    store = km.get_store()
+    g0 = store.generation
+    _write(config_file, {"bindings": []})
+    assert store.generation > g0
+
+
+def test_mount_compiles_and_recompiles_on_config_change(config_file) -> None:
+    pytest.importorskip("prompt_toolkit")
+    mount = km.KeymapMount("test-surface")
+    fired = []
+    mount.action("app:detach", ("ctrl+c",), context="Global")(
+        lambda e: fired.append(1)
+    )
+    kb = mount.key_bindings()
+    assert kb.get_bindings_for_keys(("c-c",))
+    # Move the key; the SAME DynamicKeyBindings object must follow.
+    _write(config_file, {"bindings": [
+        {"context": "Global", "bindings": {
+            "ctrl+c": None, "ctrl+g": "app:detach",
+        }},
+    ]})
+    assert not kb.get_bindings_for_keys(("c-c",))
+    assert kb.get_bindings_for_keys(("c-g",))
+
+
+def test_bind_action_binds_defaults_into_a_plain_kb(config_file) -> None:
+    pytest.importorskip("prompt_toolkit")
+    from prompt_toolkit.key_binding import KeyBindings
+    kb = KeyBindings()
+    assert km.bind_action(
+        kb, "deck:open", ("ctrl+o",), lambda e: None, context="Deck",
+    )
+    assert kb.get_bindings_for_keys(("c-o",))
+
+
+def test_bind_action_survives_a_none_kb() -> None:
+    assert km.bind_action(None, "a:b", ("ctrl+t",), lambda e: None) is False
+
+
+# --------------------------------------------------------------------------
+# 5. introspection + template
+# --------------------------------------------------------------------------
+
+def test_describe_flags_unknown_config_actions(config_file) -> None:
+    km.register_action_spec("chat:newline", "Chat", ("alt+enter",), "nl")
+    _write(config_file, {"bindings": [
+        {"context": "Chat", "bindings": {"ctrl+y": "no:body"}},
+    ]})
+    info = km.describe_keymap()
+    assert any("unknown action" in w for w in info["warnings"])
+    row = next(r for r in info["actions"] if r["action"] == "chat:newline")
+    assert row["keys"] == ("escape enter",)
+    assert row["customized"] is False
+
+
+def test_template_write_and_keys_verb(config_file) -> None:
+    from backend.core.ouroboros.governance.keys_repl import (
+        dispatch_keys_command,
+    )
+    r = dispatch_keys_command("/keys init")
+    assert r.ok and str(config_file) in r.text
+    assert config_file.is_file()
+    # init is idempotent
+    assert dispatch_keys_command("/keys init").ok
+    assert dispatch_keys_command("/keys").ok
+    assert dispatch_keys_command("/keys path").ok
+    assert dispatch_keys_command("/keys reload").ok
+    assert dispatch_keys_command("/keys warnings").ok
+    assert "Subcommands" in dispatch_keys_command("/keys help").text
+
+
+def test_keys_verb_is_discoverable_by_the_dispatch_registry() -> None:
+    """The naming-cage contract: keys_repl.py + dispatch_keys_command →
+    the /keys verb registers with no other edit."""
+    from backend.core.ouroboros.battle_test.repl_dispatch_registry import (
+        _VERB_TO_DISPATCHER, prime_registry,
+    )
+    prime_registry()
+    assert "keys" in _VERB_TO_DISPATCHER

--- a/tests/cli/test_esc_interrupt.py
+++ b/tests/cli/test_esc_interrupt.py
@@ -154,14 +154,19 @@ def _ov_src() -> str:
 
 
 def test_esc_in_flow_interrupts() -> None:
+    """Esc-in-FLOW now routes through the remappable keymap — the pin
+    follows the seam: the action is declared with the escape default and
+    the SAME in_flow_working gate."""
     src = _ov_src()
-    assert 'kb.add("escape", filter=in_flow_working' in src
+    block = src.split('"chat:interrupt"')[1][:200]
+    assert '("escape",)' in block and "filter=in_flow_working" in block
 
 
 def test_the_existing_escape_still_leaves_select_and_focus() -> None:
     """One key, two meanings — and the older one must not be displaced."""
     src = _ov_src()
-    assert 'kb.add("escape", filter=not_flow' in src
+    block = src.split('"deck:escape"')[1][:200]
+    assert '("escape",)' in block and "filter=not_flow" in block
 
 
 def test_the_two_bindings_do_not_overlap() -> None:


### PR DESCRIPTION
## The root problem

`ov` has three input surfaces (daemon cockpit, attach cockpit, PromptSession fallback) that grew separately: two verb registries that never reconciled (34-verb `_handle_*` walk vs 76-verb dispatch table), two `@`-mention completers BOTH merged into the attach path, **zero completer on the daemon-side cockpit**, no persistent history or ghost-text on any bipartite surface, and ~330 lines of arg-completion machinery inert because every dispatch verb carried `arg_spec=""`. This split is how four palette PRs "fixed" completion without the operator seeing it.

## One engine, every surface

**Completion (`repl_completion.py`)**
- `unified_registry()` — dispatch ∪ discovered, richest metadata wins (`JARVIS_UNIFIED_VERB_REGISTRY_ENABLED`)
- Choice atoms `[status|history|explain]` in the arg-spec grammar: each verb's subcommand vocabulary is **mined from its own body** (`verb_usage.mine_subcommands`) — no parallel table. Authored `__verb_args__` module convention (mirrors `__verb_help__`/`__aliases__`) for specs like `<op_id>`
- Quote-aware cursor tokenizer, mention-completer dedupe, ThreadedCompleter everywhere, history ghost-text (`JARVIS_REPL_AUTOSUGGEST_ENABLED`), palette-as-you-type on the daemon (`JARVIS_REPL_COMPLETE_WHILE_TYPING`), one shared `.jarvis/repl_history`, `?` tooltip registry cached

**Keybindings (`keymap.py` + `/keys`)**
- Claude Code-style `keybindings.json`: contexts, `namespace:action`, CC keystroke syntax (modifiers, chords, uppercase-implies-shift), `null`-unbind, reserved-key + tmux/screen conflict validation as WARNINGS (never breakage), **mtime hot-reload** via `DynamicKeyBindings`
- Cockpit exit keys, deck selection, Esc-interrupt, gate review, Alt+Enter newline all route through it — no literal key left at a call site
- `/keys` verb (naming-cage auto-discovered) shows effective bindings/warnings, `init` writes a starter config — and proves the pipeline: its own palette arg-spec `[help|path|init|reload|warnings]` is mined from its own body

## Verification
- 68 new tests (`test_keymap.py`, `test_completion_unification.py`)
- Full input/completion surface (~770 tests) green; `test_esc_interrupt` source-pins updated to pin the keymap seam

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies verb completion and history across all `ov` input surfaces and adds a remappable keymap with hot reload. Completion is consistent everywhere, ghost-text and persistent recall are on, and operators can customize shortcuts safely.

- **New Features**
  - Completion: one unified verb registry (dispatch ∪ discovered), mined subcommands via choice atoms (e.g., `[status|history]`) and `__verb_args__`, quote‑aware arg parsing, single `@` completer on attach, threaded completers with palette‑as‑you‑type on the daemon, shared `.jarvis/repl_history` and history auto‑suggest.
  - Keybindings: `keybindings.json` (Claude Code syntax) with null‑unbind and validation warnings, mtime hot‑reload, `/keys` verb to view/init/reload and list warnings; cockpit exit, deck navigation/focus, chat interrupt, deck escape, and newline are now remappable actions.

- **Migration**
  - Optional: run `/keys init` to create `.jarvis/keybindings.json`.
  - Env toggles: `JARVIS_KEYMAP_ENABLED`, `JARVIS_REPL_AUTOSUGGEST_ENABLED`, `JARVIS_REPL_COMPLETE_WHILE_TYPING`, `JARVIS_UNIFIED_VERB_REGISTRY_ENABLED`.
  - No changes needed to keep current defaults.

<sup>Written for commit 2e0278b604a6a8eb6251c79044688817b43039bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

