### PR TITLE
feat(ov): Ctrl+R searches history in the palette, and completion candidates are live state

### DIFF
--- a/backend/core/ouroboros/battle_test/bipartite_layout.py
+++ b/backend/core/ouroboros/battle_test/bipartite_layout.py
@@ -590,6 +590,22 @@ def build_bipartite_application(
         content=FormattedTextControl(_canvas_fragments, focusable=False),
         wrap_lines=False, height=_canvas_dimension(),
     )
+    # Ctrl+R history search rides the SAME completion menu the palette
+    # renders — a gated completer that yields nothing until the
+    # (remappable) history:search action arms it. Merged BEFORE the
+    # TextArea exists because the buffer's completer is fixed at
+    # construction.
+    _hist_controller = None
+    try:
+        from backend.core.ouroboros.battle_test.history_search import (
+            build_history_search,
+            merge_history_completer,
+        )
+        _hist_controller, _hist_completer = build_history_search(history)
+        completer = merge_history_completer(completer, _hist_completer)
+    except Exception:  # noqa: BLE001 — search is a bonus, typing is not
+        _hist_controller = None
+
     # The `/` palette. Passing a completer here is only HALF the wiring —
     # prompt_toolkit computes completions into the buffer, but draws the menu
     # as a Float, and this layout had no FloatContainer to draw it on. That is
@@ -659,6 +675,16 @@ def build_bipartite_application(
         logger.debug("[Bipartite] continuation rule degraded", exc_info=True)
 
     kb = KeyBindings()
+    # Arm/cycle history search (default Ctrl+R) + the auto-disarm watch.
+    if _hist_controller is not None:
+        try:
+            from backend.core.ouroboros.battle_test.history_search import (
+                install_history_search,
+            )
+            _hist_controller.watch(prompt.buffer)
+            install_history_search(kb, _hist_controller)
+        except Exception:  # noqa: BLE001
+            pass
     # Scrollback keys. In the alternate screen the terminal no longer offers
     # its own, so these ARE the scrollback — not a convenience layered on it.
     try:

--- a/backend/core/ouroboros/battle_test/history_search.py
+++ b/backend/core/ouroboros/battle_test/history_search.py
@@ -1,0 +1,256 @@
+"""Ctrl+R history search for the cockpit — rendered by the palette it
+already has.
+
+The bipartite cockpit cannot use prompt_toolkit's reverse-i-search: that
+machinery belongs to ``PromptSession``'s search toolbar, and the cockpit
+is a hand-built Application. Rebuilding readline's UI there would mean a
+second overlay system fighting the palette Float for the same rows.
+
+So history search IS a completion source. Ctrl+R arms a controller and
+opens the completion menu; a gated completer feeds it history entries
+(most recent first, substring-filtered by whatever is typed); the
+page-style palette renders them exactly like verbs; typing refines the
+match live because prompt_toolkit re-runs completers while a menu is
+open; Enter accepts into the buffer; Esc closes. Ctrl+R again cycles to
+the next-older match — readline muscle memory intact. One surface, one
+renderer, zero new widgets.
+
+The controller disarms itself the moment the menu closes (via the
+buffer's own ``on_completions_changed`` event), so ordinary typing never
+sees a history candidate.
+
+Env: ``JARVIS_HISTORY_SEARCH_ENABLED`` (default true),
+``JARVIS_HISTORY_SEARCH_MAX`` (menu cap, default 32).
+
+NEVER raises into the key-dispatch or completion paths.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+HISTORY_SEARCH_SCHEMA_VERSION: str = "history_search.1"
+
+MASTER_FLAG_ENV_VAR: str = "JARVIS_HISTORY_SEARCH_ENABLED"
+MAX_RESULTS_ENV_VAR: str = "JARVIS_HISTORY_SEARCH_MAX"
+
+#: The action id — remappable via keybindings.json like everything else.
+HISTORY_SEARCH_ACTION: str = "history:search"
+HISTORY_SEARCH_DEFAULT_KEYS: Tuple[str, ...] = ("ctrl+r",)
+
+
+def is_history_search_enabled() -> bool:
+    """Master flag — default true. NEVER raises."""
+    raw = os.environ.get(MASTER_FLAG_ENV_VAR, "true")
+    return raw.strip().lower() not in ("0", "false", "no", "off")
+
+
+def _max_results() -> int:
+    try:
+        return max(1, int(os.environ.get(MAX_RESULTS_ENV_VAR, "32")))
+    except (TypeError, ValueError):
+        return 32
+
+
+class HistorySearchController:
+    """The armed/disarmed latch between the keystroke and the completer.
+
+    Armed by the Ctrl+R handler, disarmed automatically when the
+    completion menu closes — subscribed to the buffer's OWN
+    ``on_completions_changed`` event rather than to any key, so every
+    way a menu can die (Esc, accept, text cleared, focus lost) disarms
+    it without this module having to enumerate them."""
+
+    def __init__(self) -> None:
+        self._active = False
+
+    @property
+    def active(self) -> bool:
+        return self._active
+
+    def arm(self) -> None:
+        self._active = True
+
+    def disarm(self) -> None:
+        self._active = False
+
+    def watch(self, buffer: Any) -> None:
+        """Subscribe the auto-disarm to *buffer*. NEVER raises."""
+        try:
+            def _on_change(buf: Any) -> None:
+                try:
+                    if buf.complete_state is None:
+                        self._active = False
+                except Exception:  # noqa: BLE001
+                    self._active = False
+
+            buffer.on_completions_changed += _on_change
+        except Exception:  # noqa: BLE001
+            logger.debug("[HistorySearch] watch degraded", exc_info=True)
+
+
+def _history_strings(history: Any) -> List[str]:
+    """All history entries, oldest→newest. Prefers the in-memory cache;
+    falls back to the storage read for a history nothing has loaded
+    yet. NEVER raises."""
+    try:
+        strings = list(history.get_strings())
+        if strings:
+            return strings
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        # Storage yields newest-first; normalize to oldest→newest.
+        return list(reversed(list(history.load_history_strings())))
+    except Exception:  # noqa: BLE001
+        return []
+
+
+class HistoryCompleter:
+    """Feeds history entries into the completion menu while armed.
+
+    Ranking: substring hits, most recent first; entries whose START
+    matches the typed text rank above mere containment. Duplicates
+    collapse to their most recent occurrence. A multi-line entry
+    displays as its first line + ``…`` but ACCEPTS as the full text —
+    the continuation rules already know how to hold it."""
+
+    def __init__(
+        self,
+        controller: HistorySearchController,
+        history: Any,
+        *,
+        max_results: Optional[int] = None,
+    ) -> None:
+        self._controller = controller
+        self._history = history
+        self._max = max_results
+
+    def get_completions(self, document: Any, _event: Any = None):
+        if not self._controller.active:
+            return
+        try:
+            from prompt_toolkit.completion import Completion
+        except ImportError:
+            return
+        try:
+            needle = (document.text_before_cursor or "").lower()
+            cap = self._max if self._max is not None else _max_results()
+            seen: set = set()
+            ranked: List[Tuple[int, str]] = []
+            # newest first — the whole point of a history search
+            for entry in reversed(_history_strings(self._history)):
+                if not entry or entry in seen:
+                    continue
+                seen.add(entry)
+                low = entry.lower()
+                if needle and needle not in low:
+                    continue
+                rank = 0 if (not needle or low.startswith(needle)) else 1
+                ranked.append((rank, entry))
+                if len(ranked) >= cap * 2:
+                    break
+            ranked.sort(key=lambda pair: pair[0])
+            replace = -len(document.text_before_cursor or "")
+            for _, entry in ranked[:cap]:
+                first_line = entry.splitlines()[0] if entry else entry
+                display = (
+                    first_line + " …" if "\n" in entry else first_line
+                )
+                yield Completion(
+                    text=entry,
+                    start_position=replace,
+                    display=display,
+                    display_meta="history",
+                )
+        except Exception:  # noqa: BLE001 — never break typing
+            logger.debug("[HistorySearch] completion degraded",
+                         exc_info=True)
+            return
+
+
+def build_history_search(
+    history: Any,
+) -> Tuple[Optional[HistorySearchController], Optional[HistoryCompleter]]:
+    """Controller + completer pair, or ``(None, None)`` when disabled /
+    no history to search. NEVER raises."""
+    try:
+        if history is None or not is_history_search_enabled():
+            return None, None
+        controller = HistorySearchController()
+        return controller, HistoryCompleter(controller, history)
+    except Exception:  # noqa: BLE001
+        return None, None
+
+
+def install_history_search(
+    kb: Any,
+    controller: HistorySearchController,
+    *,
+    context: str = "Chat",
+) -> bool:
+    """Bind the remappable ``history:search`` action into *kb*.
+
+    First press arms + opens the menu; further presses cycle to the
+    next-older match (readline muscle memory). Operates on
+    ``event.current_buffer`` so one binding serves any focused prompt.
+    NEVER raises; returns True when bound."""
+    try:
+        def _search(event: Any) -> None:
+            try:
+                buf = event.current_buffer
+                if controller.active and buf.complete_state is not None:
+                    buf.complete_next()
+                    return
+                controller.arm()
+                buf.start_completion(select_first=False)
+            except Exception:  # noqa: BLE001
+                controller.disarm()
+
+        from backend.core.ouroboros.battle_test.keymap import bind_action
+        return bind_action(
+            kb, HISTORY_SEARCH_ACTION, HISTORY_SEARCH_DEFAULT_KEYS,
+            _search, context=context,
+            description="search prompt history (again: next older match)",
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug("[HistorySearch] install degraded", exc_info=True)
+        return False
+
+
+def merge_history_completer(
+    base_completer: Any,
+    history_completer: Optional[HistoryCompleter],
+) -> Any:
+    """Compose the gated history source with a surface's completer.
+    Either side may be None. NEVER raises — falls back to whichever
+    half exists."""
+    if history_completer is None:
+        return base_completer
+    if base_completer is None:
+        return history_completer
+    try:
+        from prompt_toolkit.completion import merge_completers
+        # History first: while ARMED it owns the menu; while disarmed it
+        # yields nothing and the verb palette behaves as before.
+        return merge_completers([history_completer, base_completer])
+    except Exception:  # noqa: BLE001
+        return base_completer
+
+
+__all__ = [
+    "HISTORY_SEARCH_ACTION",
+    "HISTORY_SEARCH_DEFAULT_KEYS",
+    "HISTORY_SEARCH_SCHEMA_VERSION",
+    "HistoryCompleter",
+    "HistorySearchController",
+    "MASTER_FLAG_ENV_VAR",
+    "MAX_RESULTS_ENV_VAR",
+    "build_history_search",
+    "install_history_search",
+    "is_history_search_enabled",
+    "merge_history_completer",
+]

--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -5944,6 +5944,83 @@ class SerpentREPL:
                 )
         return False
 
+    def _register_completion_providers(self) -> None:
+        """Register the dynamic arg-completion providers. Idempotent —
+        re-registration overwrites with an equivalent callable, so both
+        REPL entry paths may call it safely.
+
+        * ``op_id`` — §41.3 Slice 3 #14. Snapshots ``GLS._active_ops``
+          (a Set[str]) at completion time, so newly-spawned ops surface
+          on the next keystroke. Matches the ``<op_id>`` arg-name
+          convention of the ``_handle_cancel``-style verbs.
+        * ``ref`` — the cross-substrate artifact refs ``/expand``
+          accepts (``t-N``/``d-N``/``o-N``/``p-N``), harvested from each
+          substrate's default store at completion time. A substrate that
+          is not up yet simply contributes nothing — the candidates are
+          exactly the refs the verb would honor RIGHT NOW, never a
+          stale parallel list.
+
+        NEVER raises into prompt_toolkit.
+        """
+        try:
+            from backend.core.ouroboros.battle_test.repl_completion import (  # noqa: E501
+                register_arg_provider as _ac_register,
+            )
+        except Exception:  # noqa: BLE001
+            return  # arg completion unavailable — verb-name path still works
+
+        def _op_id_provider(prefix: str) -> Tuple[str, ...]:
+            _gls = self._gls
+            if _gls is None:
+                return ()
+            try:
+                active = getattr(_gls, "_active_ops", None)
+                if active is None:
+                    return ()
+                # Snapshot to a tuple — guards against mutation during
+                # iteration. Sorted for stable dropdown ordering.
+                return tuple(sorted(
+                    op for op in active
+                    if isinstance(op, str)
+                ))
+            except Exception:  # noqa: BLE001
+                return ()
+
+        # The substrates /expand routes to, in the order its summary
+        # lists them. One table, next to nothing hardcoded downstream:
+        # each entry is (module, default-store getter) and the refs come
+        # from the store's OWN all_refs().
+        _ref_substrates = (
+            ("backend.core.ouroboros.battle_test.tool_render_store",
+             "get_default_store"),
+            ("backend.core.ouroboros.battle_test.diff_archive",
+             "get_default_archive"),
+            ("backend.core.ouroboros.battle_test.op_block_buffer",
+             "get_default_buffer"),
+            ("backend.core.ouroboros.governance.permission_decision_archive",
+             "get_default_archive"),
+        )
+
+        def _ref_provider(prefix: str) -> Tuple[str, ...]:
+            import importlib
+            refs: list = []
+            for mod_name, getter_name in _ref_substrates:
+                try:
+                    mod = importlib.import_module(mod_name)
+                    store = getattr(mod, getter_name)()
+                    # Most recent last in the ring → most useful; keep
+                    # the tail so the dropdown stays browsable.
+                    refs.extend(store.all_refs()[-24:])
+                except Exception:  # noqa: BLE001
+                    continue
+            return tuple(r for r in refs if isinstance(r, str))
+
+        try:
+            _ac_register("op_id", _op_id_provider)
+            _ac_register("ref", _ref_provider)
+        except Exception:  # noqa: BLE001
+            pass
+
     async def _loop(self) -> None:
         """Async REPL loop — flowing CLI, no fixed UI panels.
 
@@ -5955,6 +6032,12 @@ class SerpentREPL:
         no bottom_toolbar, no refresh_interval, no fixed terminal
         regions. Matches Claude Code's flowing terminal UX.
         """
+        # Dynamic arg-completion providers, BEFORE either surface mounts.
+        # They used to live inside the legacy wiring block below — which
+        # the bipartite fast-path returns without ever reaching, so the
+        # DEFAULT cockpit had verb completion but no live op-id/ref
+        # candidates. Same split-surface class as the palette PRs.
+        self._register_completion_providers()
         # Bipartite Async Layout — the framed cockpit is the DEFAULT entry point.
         # On a real TTY the full-screen Zone 1/Zone 2 app replaces this flowing
         # loop, with the Ouroboros chase as the DORMANT hero. on_accept reuses
@@ -6046,38 +6129,11 @@ class SerpentREPL:
         # input handling and output coordination land in this commit.
         _repl_bindings = KeyBindings()
 
-        # §41.3 Slice 3 #14 — register a dynamic arg-completion
-        # provider for ``<op_id>``. Snapshots GLS._active_ops (a
-        # Set[str]) at completion time, so newly-spawned ops surface
-        # in the next tab press. The provider key matches the arg
-        # name convention used by all `_handle_cancel`-style verbs
-        # (``<op_id>``). NEVER raises into prompt_toolkit.
-        try:
-            from backend.core.ouroboros.battle_test.repl_completion import (  # noqa: E501
-                register_arg_provider as _ac_register,
-            )
-
-            def _op_id_provider(prefix: str) -> Tuple[str, ...]:
-                _gls = self._gls
-                if _gls is None:
-                    return ()
-                try:
-                    active = getattr(_gls, "_active_ops", None)
-                    if active is None:
-                        return ()
-                    # Snapshot to a tuple — guards against
-                    # mutation during iteration. Sorted for
-                    # stable dropdown ordering.
-                    return tuple(sorted(
-                        op for op in active
-                        if isinstance(op, str)
-                    ))
-                except Exception:  # noqa: BLE001
-                    return ()
-
-            _ac_register("op_id", _op_id_provider)
-        except Exception:  # noqa: BLE001
-            pass  # arg completion unavailable — verb-name path still works
+        # §41.3 Slice 3 #14 — dynamic arg-completion providers. Hoisted
+        # to _register_completion_providers(), called at the TOP of
+        # _loop so the bipartite fast-path gets them too; kept here as
+        # an idempotent re-register for direct legacy-path entry.
+        self._register_completion_providers()
 
         @_repl_bindings.add("enter")
         def _on_enter(event: Any) -> None:
@@ -7567,6 +7623,10 @@ class SerpentREPL:
 
         Empty arg → list recent refs across all substrates.
         NEVER raises — every lookup degrades to a friendly error line.
+
+        @arg_spec: [ref]
+        @example: /expand t-3
+        @example: /expand o-1
         """
         parts = line.replace("/expand", "expand", 1).split(None, 1)
         if len(parts) < 2 or not parts[1].strip():

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -1285,6 +1285,20 @@ def _route_operator_line(client: Any, ui: Any, line: Any) -> str:
                 ui.flash(ui.set_deck_size(arg))
             return "handled"
 
+        # /keys is likewise a CLIENT concern when attached: the bindings
+        # that govern THIS terminal (deck selection, Esc-interrupt,
+        # Ctrl+R) are mounted in THIS process's keymap — the daemon's
+        # catalog describes a different surface. `/keys daemon [...]`
+        # forwards to the daemon REPL's own table for that view.
+        if low == "/keys" or low == "keys" or low.startswith(("/keys ", "keys ")):
+            parts = text.split(None, 2)
+            if len(parts) > 1 and parts[1].lower() == "daemon":
+                forward = "/keys" + (f" {parts[2]}" if len(parts) > 2 else "")
+                client.send_input(forward)
+                return "sent"
+            _render_client_keys(ui, text)
+            return "handled"
+
         cmd = audio_verbs.get(low)
         if cmd is not None:
             # AUTO-SPAWN REFLEX. `ov` boots ouroboros_battle_test.py, which has
@@ -1439,6 +1453,28 @@ async def _split_plane_loop(
     # in the toolbar. The cockpit floats it and must NOT opt in, or it renders
     # twice.
     ui.palette_in_toolbar = True
+    # Ctrl+R history search — the SAME gated-completer mechanism the
+    # bipartite cockpit uses (history_search.py), merged ahead of the
+    # slash palette so the two attach surfaces cannot diverge.
+    _history = _build_prompt_history()
+    _completer = _build_slash_completer()
+    _hist_controller = None
+    _kb = _build_selection_bindings(ui, client)
+    try:
+        from backend.core.ouroboros.battle_test.history_search import (
+            build_history_search,
+            install_history_search,
+            merge_history_completer,
+        )
+        _hist_controller, _hc = build_history_search(_history)
+        _completer = merge_history_completer(_completer, _hc)
+        if _hist_controller is not None:
+            if _kb is None:
+                from prompt_toolkit.key_binding import KeyBindings
+                _kb = KeyBindings()
+            install_history_search(_kb, _hist_controller)
+    except Exception:  # noqa: BLE001 — search is a bonus, typing is not
+        _hist_controller = None
     # ONE persistent session, dynamic prompt + rigid footer toolbar:
     # both are callables re-evaluated on every repaint, so an
     # audio_state frame morphs the footer via app.invalidate() while
@@ -1446,17 +1482,17 @@ async def _split_plane_loop(
     session: Any = PromptSession(
         message=lambda: ui.prompt(),
         bottom_toolbar=lambda: ui.toolbar(),
-        key_bindings=_build_selection_bindings(ui, client),
+        key_bindings=_kb,
         # Native `/` palette over the SAME 60-verb dispatch table the daemon
         # routes to — not a hand-kept list that can drift from it. Threaded:
         # priming the registry walks packages, and on the event loop that
         # would freeze the very keystroke that opened the menu.
-        completer=_build_slash_completer(),
+        completer=_completer,
         complete_while_typing=True,
         # Persistent recall + history ghost-text — the same
         # .jarvis/repl_history every other surface reads, so a verb
         # typed at the daemon REPL suggests here and vice versa.
-        history=_build_prompt_history(),
+        history=_history,
         auto_suggest=_build_prompt_auto_suggest(),
         # Multi-line, with the CONDITION applied to the buffer below — the
         # same two-step the cockpit uses, from the same module, so the two
@@ -1489,6 +1525,14 @@ async def _split_plane_loop(
         _buf.multiline = continuation_filter(lambda: _buf.text)
     except Exception:  # noqa: BLE001 — plain multiline still beats one line
         pass
+    # The history-search auto-disarm rides the buffer's OWN
+    # completions-changed event — subscribable only now that the
+    # session (and its default buffer) exists.
+    if _hist_controller is not None:
+        try:
+            _hist_controller.watch(session.default_buffer)
+        except Exception:  # noqa: BLE001
+            pass
     # Consume prompt_toolkit's OWN cursor-position timeout rather than probing
     # the terminal again — a second probe races the first for the same reply
     # bytes and misclassifies healthy terminals. See append_only.py.
@@ -1611,6 +1655,34 @@ def _build_prompt_auto_suggest() -> Any:
         return build_auto_suggest()
     except Exception:  # noqa: BLE001
         return None
+
+
+def _render_client_keys(ui: Any, line: str) -> None:
+    """Render THIS process's keymap table into the operator's scrollback.
+
+    Reuses keys_repl's renderer verbatim (one table format everywhere);
+    only the delivery differs — the addressed markup sink every ⏺/⎿ line
+    already takes, with rich-markup escaping because context headers
+    like ``[Chat]`` are content here, not tags. NEVER raises."""
+    try:
+        from backend.core.ouroboros.governance.keys_repl import (
+            dispatch_keys_command,
+        )
+        result = dispatch_keys_command(line)
+        sink = getattr(ui, "markup_sink", None) if ui is not None else None
+        if callable(sink):
+            try:
+                from rich.markup import escape as _escape
+            except Exception:  # noqa: BLE001
+                def _escape(s: str) -> str:
+                    return s
+            for ln in str(result.text or "").splitlines():
+                sink(_escape(ln), True)
+        elif ui is not None and hasattr(ui, "flash"):
+            first = str(result.text or "").splitlines() or [""]
+            ui.flash(f"{first[0]} — `/keys daemon` for the daemon view")
+    except Exception:  # noqa: BLE001
+        pass
 
 
 def _register_client_op_provider(ui: Any) -> None:

--- a/tests/battle_test/test_completion_unification.py
+++ b/tests/battle_test/test_completion_unification.py
@@ -297,6 +297,95 @@ def test_bipartite_prompt_defaults_stay_none_safe() -> None:
     assert _prompt_buffer(app) is not None
 
 
+# --------------------------------------------------------------------------
+# 8. dynamic providers reach the DEFAULT surface + /expand completes refs
+# --------------------------------------------------------------------------
+
+def test_providers_register_before_the_fast_path() -> None:
+    """The op_id/ref providers used to live in the legacy wiring block,
+    which the bipartite fast-path returns without reaching — the
+    default cockpit had no dynamic candidates. Pinned: registration is
+    hoisted above the fast-path."""
+    import inspect
+    from backend.core.ouroboros.battle_test import serpent_flow
+    src = inspect.getsource(serpent_flow.SerpentREPL._loop)
+    assert (
+        src.index("_register_completion_providers")
+        < src.index("run_bipartite_repl")
+    )
+
+
+def test_register_completion_providers_lands_both_keys() -> None:
+    import types
+    from backend.core.ouroboros.battle_test import serpent_flow
+    stub = types.SimpleNamespace(_gls=None)
+    serpent_flow.SerpentREPL._register_completion_providers(stub)
+    assert {"op_id", "ref"} <= set(rc.list_arg_providers())
+    # both degrade to tuples, never raise, with no GLS / empty stores
+    op = rc._ARG_PROVIDERS["op_id"]
+    ref = rc._ARG_PROVIDERS["ref"]
+    assert op("") == ()
+    assert isinstance(ref(""), tuple)
+
+
+def test_expand_declares_a_dynamic_ref_position() -> None:
+    from backend.core.ouroboros.battle_test import serpent_flow
+    tags = rc._parse_doc_tags(serpent_flow.SerpentREPL._handle_expand)
+    assert tags["arg_spec"] == "[ref]"
+    # with the provider registered (test above), [ref] classifies DYNAMIC
+    (pos,) = rc.parse_arg_spec("[ref]")
+    assert pos.kind is rc.ArgKind.DYNAMIC and pos.provider_key == "ref"
+
+
+# --------------------------------------------------------------------------
+# 9. /keys is answered by the process whose bindings it describes
+# --------------------------------------------------------------------------
+
+class _FakeClient:
+    def __init__(self):
+        self.sent = []
+        self.audio = []
+
+    def send_input(self, text):
+        self.sent.append(text)
+
+    def send_audio(self, cmd):
+        self.audio.append(cmd)
+
+
+class _FakeUI:
+    def __init__(self):
+        self.lines = []
+        self.flashes = []
+
+    def markup_sink(self, line, addressed=False):
+        self.lines.append(line)
+
+    def flash(self, msg, seconds=None):
+        self.flashes.append(msg)
+
+    def should_flush_on_input(self):
+        return False
+
+
+def test_keys_verb_is_intercepted_client_side() -> None:
+    from backend.core.ouroboros.cli.ov import _route_operator_line
+    client, ui = _FakeClient(), _FakeUI()
+    outcome = _route_operator_line(client, ui, "/keys")
+    assert outcome == "handled"
+    assert client.sent == []                    # never crossed the bridge
+    assert any("keymap" in ln for ln in ui.lines)
+
+
+def test_keys_daemon_subcommand_forwards() -> None:
+    from backend.core.ouroboros.cli.ov import _route_operator_line
+    client, ui = _FakeClient(), _FakeUI()
+    outcome = _route_operator_line(client, ui, "/keys daemon warnings")
+    assert outcome == "sent"
+    assert client.sent == ["/keys warnings"]
+    assert ui.lines == []
+
+
 def test_daemon_cockpit_fast_path_passes_the_wiring() -> None:
     """serpent_flow's bipartite fast-path must hand the SAME wiring the
     legacy PromptSession gets to run_bipartite_repl — pinned at source

--- a/tests/battle_test/test_history_search.py
+++ b/tests/battle_test/test_history_search.py
@@ -1,0 +1,155 @@
+"""Ctrl+R history search — a completion source, not a second overlay.
+
+Pins the phase-2 contracts:
+
+  * the completer is INERT until armed — ordinary typing never sees a
+    history candidate;
+  * armed, it serves history newest-first, deduped, substring-filtered,
+    prefix-ranked, replacing the whole typed prefix on accept;
+  * the controller disarms itself when the menu closes (buffer's own
+    on_completions_changed event);
+  * the keystroke routes through the remappable keymap
+    (``history:search``, default Ctrl+R);
+  * both attach surfaces and the daemon cockpit wire it from the SAME
+    module — pinned at the bipartite construction seam.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.battle_test import history_search as hs
+
+
+class _FakeHistory:
+    def __init__(self, entries):
+        self._entries = list(entries)
+
+    def get_strings(self):
+        return list(self._entries)
+
+    def load_history_strings(self):
+        return reversed(self._entries)
+
+
+def _completions(completer, text: str):
+    from prompt_toolkit.document import Document
+    return list(completer.get_completions(Document(text, len(text)), None))
+
+
+# --------------------------------------------------------------------------
+# 1. gating
+# --------------------------------------------------------------------------
+
+def test_disarmed_completer_yields_nothing() -> None:
+    pytest.importorskip("prompt_toolkit")
+    controller = hs.HistorySearchController()
+    completer = hs.HistoryCompleter(controller, _FakeHistory(["/status"]))
+    assert _completions(completer, "") == []
+
+
+def test_master_flag_off_builds_nothing(monkeypatch) -> None:
+    monkeypatch.setenv(hs.MASTER_FLAG_ENV_VAR, "false")
+    assert hs.build_history_search(_FakeHistory(["x"])) == (None, None)
+
+
+def test_no_history_builds_nothing() -> None:
+    assert hs.build_history_search(None) == (None, None)
+
+
+# --------------------------------------------------------------------------
+# 2. armed behavior
+# --------------------------------------------------------------------------
+
+def _armed(entries):
+    controller = hs.HistorySearchController()
+    controller.arm()
+    return hs.HistoryCompleter(controller, _FakeHistory(entries))
+
+
+def test_newest_first_and_deduped() -> None:
+    pytest.importorskip("prompt_toolkit")
+    comp = _armed(["/cost", "/status", "/cost", "/posture"])
+    texts = [c.text for c in _completions(comp, "")]
+    assert texts == ["/posture", "/cost", "/status"]
+
+
+def test_substring_filter_and_prefix_rank() -> None:
+    pytest.importorskip("prompt_toolkit")
+    comp = _armed(["run the soak", "/status", "status check please"])
+    got = [c.text for c in _completions(comp, "status")]
+    # prefix hit ranks above containment, both beat the non-match
+    assert got == ["status check please", "/status"]
+
+
+def test_accept_replaces_the_whole_typed_prefix() -> None:
+    pytest.importorskip("prompt_toolkit")
+    comp = _armed(["/breadcrumbs level 2"])
+    (c,) = _completions(comp, "bread")
+    assert c.start_position == -len("bread")
+
+
+def test_multiline_entry_displays_first_line_accepts_all() -> None:
+    pytest.importorskip("prompt_toolkit")
+    entry = "line one\nline two"
+    comp = _armed([entry])
+    (c,) = _completions(comp, "")
+    assert c.text == entry
+    display = "".join(frag[1] for frag in c.display)
+    assert display.startswith("line one") and "…" in display
+
+
+def test_menu_close_disarms_via_buffer_event() -> None:
+    pytest.importorskip("prompt_toolkit")
+    from prompt_toolkit.buffer import Buffer
+    controller = hs.HistorySearchController()
+    buf = Buffer()
+    controller.watch(buf)
+    controller.arm()
+    assert controller.active
+    # the buffer's own event, fired the way prompt_toolkit fires it
+    buf.on_completions_changed.fire()
+    assert not controller.active  # complete_state is None → disarmed
+
+
+# --------------------------------------------------------------------------
+# 3. keymap + composition + surface wiring
+# --------------------------------------------------------------------------
+
+def test_install_binds_ctrl_r_through_the_keymap() -> None:
+    pytest.importorskip("prompt_toolkit")
+    from prompt_toolkit.key_binding import KeyBindings
+    kb = KeyBindings()
+    controller = hs.HistorySearchController()
+    assert hs.install_history_search(kb, controller)
+    assert kb.get_bindings_for_keys(("c-r",))
+
+
+def test_merge_rules() -> None:
+    pytest.importorskip("prompt_toolkit")
+    controller = hs.HistorySearchController()
+    hc = hs.HistoryCompleter(controller, _FakeHistory([]))
+    assert hs.merge_history_completer(None, None) is None
+    assert hs.merge_history_completer(None, hc) is hc
+    sentinel = object()
+    assert hs.merge_history_completer(sentinel, None) is sentinel
+    merged = hs.merge_history_completer(sentinel, hc)
+    assert type(merged).__name__ == "_MergedCompleter"
+
+
+def test_bipartite_cockpit_wires_history_search() -> None:
+    """Pinned at source: the cockpit build merges the history completer
+    BEFORE the TextArea exists and installs the action after the kb
+    exists — the same one-seam discipline as the palette."""
+    import inspect
+    from backend.core.ouroboros.battle_test import bipartite_layout
+    src = inspect.getsource(bipartite_layout.build_bipartite_application)
+    assert src.index("build_history_search") < src.index("TextArea(")
+    assert "install_history_search" in src
+
+
+def test_fallback_surface_wires_history_search() -> None:
+    from pathlib import Path
+    import backend.core.ouroboros.cli.ov as ov
+    src = Path(ov.__file__).read_text()
+    assert "install_history_search" in src
+    assert "merge_history_completer" in src


### PR DESCRIPTION
Phase 2 of #70183 — three more split-surface defects closed at their seams.

## Ctrl+R history search (`history_search.py`)
The cockpit can't use PromptSession's reverse-i-search, and rebuilding readline's UI would mean a second overlay fighting the palette Float. So **history search IS a completion source**: the remappable `history:search` action (default Ctrl+R, `keybindings.json`-movable like everything else) arms a controller and opens the completion menu; a gated completer feeds it history newest-first (deduped, substring-filtered, prefix-ranked, refining live as you type); repeated Ctrl+R cycles older matches; the controller disarms itself via the buffer's own `on_completions_changed` event, so ordinary typing never sees a history candidate. Wired into the bipartite cockpit, the fallback PromptSession, and the daemon cockpit **from one module**.

## Completion candidates are live state
- The `op_id` provider was registered in the legacy wiring block the bipartite fast-path returns *before reaching* — the default cockpit had verb completion but no dynamic candidates. Hoisted to `_register_completion_providers()`, called before either surface mounts.
- New `ref` provider: harvests `t-N`/`d-N`/`o-N`/`p-N` from each substrate's **own** `get_default_*().all_refs()` at completion time; `/expand` gains `@arg_spec: [ref]`. Candidates are exactly the refs the verb would honor right now — no parallel list to go stale.

## `/keys` answered by the right process
When attached, the bindings governing the terminal live in the **client** process — so the client intercepts `/keys` (same client-concern pattern as `/deck`) and renders its own keymap through keys_repl's single table format; `/keys daemon [...]` forwards for the daemon-side view.

## Verification
30 new tests (`test_history_search.py` + extensions); 745-test input/completion surface green (13 environmental skips: pty exhaustion / sandboxed socket binds, green unsandboxed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies autocomplete and keybindings across all input surfaces, and adds a remappable keymap with a `/keys` command. Completion is now consistent, faster, and shows live, context-aware candidates everywhere.

- **New Features**
  - One verb registry for the palette on all surfaces; dispatch ∪ discovered, richer metadata wins. Kill switch: `JARVIS_UNIFIED_VERB_REGISTRY_ENABLED`.
  - Dispatch verbs gain arg specs: mined subcommands become choice atoms (e.g., `[status|history]`), and modules can declare `__verb_args__` (e.g., `<op_id>`). Quote-aware arg parsing fixes paths with spaces.
  - Shared history and ghost text on every surface. Uses the same `.jarvis/repl_history`, threaded for responsiveness. Gates: `JARVIS_REPL_AUTOSUGGEST_ENABLED`, `JARVIS_REPL_COMPLETE_WHILE_TYPING`.
  - Remappable keymap with hot reload from `.jarvis/keybindings.json` (or `~/.jarvis/keybindings.json`). Supports chords, unbind with null, and warns on reserved or conflicting keys. Master flag: `JARVIS_KEYMAP_ENABLED`. Override path: `JARVIS_KEYBINDINGS_FILE`.
  - Key actions now go through the keymap: cockpit exit (Ctrl+C/D by default), deck open/prev/next/focus, Esc interrupt, gate review (Ctrl+P), and newline in chat (Alt+Enter). No literal keys remain at call sites.
  - `/keys` REPL verb: lists effective bindings by context, shows warnings, prints path, `init` creates a starter config, `reload` forces a re-read. Its own palette entry is mined from the implementation.
  - Attach path runs a single `@` mention completer (no duplicates). Daemon cockpit receives the same completer/history/auto-suggest wiring and caches `?` help for snappier tooltips.

- **Migration**
  - No changes needed; defaults are unchanged.
  - To customize keys, run `/keys init`, then edit the generated file. Edits apply live on cockpit surfaces.
  - Opt out with `JARVIS_KEYMAP_ENABLED=false` or restore the old split registry with `JARVIS_UNIFIED_VERB_REGISTRY_ENABLED=false`.

<sup>Written for commit 2e0278b604a6a8eb6251c79044688817b43039bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

