### PR TITLE
feat(ov): what you typed last time, on both surfaces, from one file

### DIFF
--- a/backend/core/ouroboros/battle_test/bipartite_layout.py
+++ b/backend/core/ouroboros/battle_test/bipartite_layout.py
@@ -77,6 +77,23 @@ def mouse_enabled() -> bool:
     return fullscreen_enabled()
 
 
+def _shared_history() -> Any:
+    """The history BOTH surfaces read and write, or None.
+
+    A TextArea otherwise gets the bare `InMemoryHistory` prompt_toolkit hands
+    every widget: empty at start, gone at exit. Up recalled nothing, and
+    `Ctrl+R` — which prompt_toolkit has been providing all along — searched an
+    empty list.
+    """
+    try:
+        from backend.core.ouroboros.battle_test.input_history import (
+            shared_history,
+        )
+        return shared_history()
+    except Exception:  # noqa: BLE001
+        return None
+
+
 def _real_tty() -> bool:
     """A real interactive terminal, via the canonical helper.
 
@@ -594,6 +611,12 @@ def build_bipartite_application(
     # why the completer built in D5 yielded 76 correct verbs and the operator
     # saw nothing: the menu had nowhere to exist.
     prompt = TextArea(
+        # History at CONSTRUCTION, not assigned afterwards. A Buffer builds
+        # its `_working_lines` from whatever history it was given when it
+        # was created, so a later assignment swaps the object without
+        # repopulating what Up walks — the history is then present,
+        # correct, and unreachable.
+        history=_shared_history(),
         # Multi-line, with the CONDITION applied to the buffer just below.
         #
         # The old `multiline=False` did not only stop the operator typing a
@@ -641,10 +664,20 @@ def build_bipartite_application(
         # inflate. Same module as the continuation rule: how the prompt
         # behaves while composing lives in one place.
         prompt.window.height = prompt_height(lambda: prompt.buffer.text)
+        prompt.buffer.load_history_if_not_yet_loaded()
     except Exception:  # noqa: BLE001 — plain multiline still beats one line
         logger.debug("[Bipartite] continuation rule degraded", exc_info=True)
 
     kb = KeyBindings()
+    # Up/Down: history from the first line, cursor movement inside a
+    # paragraph. `auto_up`/`auto_down` encode exactly that rule.
+    try:
+        from backend.core.ouroboros.battle_test.input_history import (
+            install_history_bindings,
+        )
+        install_history_bindings(kb, lambda: prompt.buffer)
+    except Exception:  # noqa: BLE001
+        pass
     # Scrollback keys. In the alternate screen the terminal no longer offers
     # its own, so these ARE the scrollback — not a convenience layered on it.
     try:

--- a/backend/core/ouroboros/battle_test/input_history.py
+++ b/backend/core/ouroboros/battle_test/input_history.py
@@ -1,0 +1,207 @@
+"""What you typed last time, on both surfaces, from one file.
+
+`ov` had no command history. Not "no search UI" — no history at all: the
+`PromptSession` was built without a `history=` argument and the cockpit's
+`TextArea` got the bare `InMemoryHistory` prompt_toolkit hands every widget,
+which starts empty and dies with the process. Pressing Up recalled nothing.
+
+That matters more than the shortcuts around it, because prompt_toolkit
+already ships every readline binding the audit went looking for — `Ctrl+A`,
+`Ctrl+E`, `Ctrl+K`, `Ctrl+U`, `Ctrl+W`, `Ctrl+Y`, `Alt+B`, `Alt+F`, `Ctrl+_`
+and `Ctrl+R` are all loaded and live. `Ctrl+R` was not missing; it was
+searching an empty list. Adding history is what turns the whole cluster on.
+
+One file, both surfaces
+-----------------------
+The cockpit and the plain client are different widgets, and this codebase has
+found the same class of bug in that split more than once — a feature wired to
+one surface while the operator types into the other. A goal typed in the
+cockpit must be recallable from the fallback and the reverse, so both read
+and write ONE `FileHistory`.
+
+Up is not always history
+------------------------
+The prompt is multi-line now. `Up` inside a paragraph has to move the cursor,
+or editing a pasted block is impossible — history is only the right meaning
+on the FIRST line. `Buffer.auto_up`/`auto_down` encode exactly that rule, so
+they are bound rather than `history_backward`, which would yank a
+half-composed paragraph away mid-edit.
+
+What is not stored
+------------------
+Blank lines, and anything identical to the entry before it — a history full
+of one repeated command is one you stop pressing Up on.
+
+The file is the operator's typing, so it is created with owner-only
+permissions. Nothing is filtered beyond that: a heuristic that silently
+dropped some commands would leave the operator unable to trust that Up shows
+what they actually did, which is worse than a file they can delete.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger("Ouroboros.InputHistory")
+
+__all__ = ["history_enabled", "history_path", "shared_history",
+           "install_history_bindings"]
+
+#: Entries kept. Deep enough that yesterday's goal is still reachable,
+#: bounded so the file cannot grow without limit across a long-lived install.
+_MAX_ENTRIES = 2000
+
+
+def history_enabled() -> bool:
+    """Default ON. Off, each session starts blank as it did before."""
+    return os.environ.get(
+        "JARVIS_INPUT_HISTORY_ENABLED", "1",
+    ).strip().lower() not in ("0", "false", "no", "off")
+
+
+def history_path() -> Path:
+    """Where the operator's typing lives.
+
+    Under `.jarvis/` beside the other durable state this organism keeps, so
+    it is discoverable and deletable in the place an operator already looks.
+    """
+    override = os.environ.get("JARVIS_INPUT_HISTORY_PATH", "").strip()
+    if override:
+        return Path(override).expanduser()
+    root = os.environ.get("JARVIS_REPO_PATH", "").strip() or "."
+    return Path(root).expanduser() / ".jarvis" / "input_history"
+
+
+def _trim(path: Path, max_entries: int = _MAX_ENTRIES) -> None:
+    """Keep the tail. Rewritten atomically so a crash mid-trim cannot leave
+    the operator with a truncated or empty history."""
+    try:
+        if not path.exists():
+            return
+        lines = path.read_text(errors="replace").splitlines(keepends=True)
+        # FileHistory writes a `# timestamp` line then `+`-prefixed content;
+        # counting ENTRIES means counting the comment lines that start them.
+        starts = [i for i, ln in enumerate(lines) if ln.startswith("#")]
+        if len(starts) <= max_entries:
+            return
+        cut = starts[len(starts) - max_entries]
+        tmp = path.with_suffix(".tmp")
+        tmp.write_text("".join(lines[cut:]))
+        os.replace(tmp, path)
+    except Exception:  # noqa: BLE001 — a trim failure must not cost history
+        logger.debug("[InputHistory] trim degraded", exc_info=True)
+
+
+_HISTORY: Any = None
+
+
+def shared_history() -> Any:
+    """The ONE history both surfaces read and write. None when unavailable.
+
+    A module singleton because the two surfaces are constructed in different
+    places and neither owns the other; handing each its own `FileHistory` for
+    the same path would give two write-behind caches racing on one file.
+    """
+    global _HISTORY
+    if not history_enabled():
+        return None
+    if _HISTORY is not None:
+        return _HISTORY
+    try:
+        from prompt_toolkit.history import FileHistory
+
+        path = history_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        _trim(path)
+        if not path.exists():
+            path.touch(mode=0o600)
+        else:
+            try:
+                os.chmod(path, 0o600)
+            except OSError:
+                pass
+        _HISTORY = _DedupedFileHistory(str(path))
+        return _HISTORY
+    except Exception:  # noqa: BLE001 — a cockpit without history still runs
+        logger.debug("[InputHistory] unavailable", exc_info=True)
+        return None
+
+
+def _build_deduped_base() -> Any:
+    from prompt_toolkit.history import FileHistory
+    return FileHistory
+
+
+class _DedupedFileHistory:  # pragma: no cover — thin delegation
+    """`FileHistory` that refuses blanks and immediate repeats.
+
+    Composition rather than a subclass so the concrete class is resolved at
+    construction: importing prompt_toolkit at module scope would make this
+    module unimportable in an environment without it, and history is the
+    first thing a headless caller does not need.
+    """
+
+    def __init__(self, path: str) -> None:
+        self._inner = _build_deduped_base()(path)
+
+    def append_string(self, text: str) -> None:
+        try:
+            candidate = str(text or "")
+            if not candidate.strip():
+                return
+            try:
+                last = next(reversed(list(self._inner.get_strings())), None)
+            except Exception:  # noqa: BLE001
+                last = None
+            if candidate == last:
+                # A history full of one repeated command is one the operator
+                # stops pressing Up on.
+                return
+            self._inner.append_string(candidate)
+        except Exception:  # noqa: BLE001
+            logger.debug("[InputHistory] append degraded", exc_info=True)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._inner, name)
+
+
+def install_history_bindings(kb: Any, get_buffer: Any) -> bool:
+    """Bind Up/Down to history-aware navigation. NEVER raises.
+
+    `auto_up`/`auto_down`, not `history_backward`/`history_forward`: the
+    prompt is multi-line, so `Up` inside a paragraph must move the cursor and
+    recall history only from the first line. Binding the raw history verbs
+    would yank a half-composed paragraph away mid-edit.
+    """
+    try:
+        if kb is None or not history_enabled():
+            return False
+
+        def _nav(up: bool) -> Any:
+            def _handler(event: Any) -> None:
+                try:
+                    buf = get_buffer()
+                    if buf is None:
+                        return
+                    count = getattr(event, "arg", 1) or 1
+                    if up:
+                        buf.auto_up(count=count)
+                    else:
+                        buf.auto_down(count=count)
+                except Exception:  # noqa: BLE001
+                    pass
+            return _handler
+
+        kb.add("up")(_nav(True))
+        kb.add("down")(_nav(False))
+        return True
+    except Exception:  # noqa: BLE001
+        logger.debug("[InputHistory] bindings degraded", exc_info=True)
+        return False
+
+
+def reset_for_tests() -> None:
+    global _HISTORY
+    _HISTORY = None

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -1457,6 +1457,18 @@ async def _split_plane_loop(
         # same two-step the cockpit uses, from the same module, so the two
         # surfaces cannot disagree about when Enter means "go".
         multiline=True,
+        # THE SAME history object the cockpit uses — one file, both surfaces,
+        # so a goal typed on either is recallable from the other. Without
+        # this the session had no history at all: Up recalled nothing and
+        # Ctrl+R (a prompt_toolkit built-in, always live) searched an empty
+        # list. `enable_history_search` makes Up prefix-filter on what has
+        # already been typed, which is what makes a long history usable.
+        history=_shared_history(),
+        enable_history_search=True,
+        # Ctrl+X Ctrl+E — the readline-native "finish this in $EDITOR",
+        # which matters most for exactly the long multi-line goals the
+        # prompt now accepts.
+        enable_open_in_editor=True,
         # The SAME Style the bipartite cockpit uses. Without it
         # prompt_toolkit paints its default filled light-grey listbox — the
         # loudest thing on a dark screen, and the exact look #70121 removed
@@ -1748,6 +1760,17 @@ def _not_composing() -> Any:
         return _cond
     except Exception:  # noqa: BLE001
         return True
+
+
+def _shared_history() -> Any:
+    """The history both surfaces share. None degrades to no history."""
+    try:
+        from backend.core.ouroboros.battle_test.input_history import (
+            shared_history,
+        )
+        return shared_history()
+    except Exception:  # noqa: BLE001
+        return None
 
 
 def _build_advisor() -> Any:

--- a/tests/cli/test_input_history.py
+++ b/tests/cli/test_input_history.py
@@ -1,0 +1,180 @@
+"""What you typed last time — on both surfaces, from one file.
+
+`ov` had no command history. Not "no search UI" — none at all: the
+`PromptSession` was built without a `history=` argument and the cockpit's
+`TextArea` got the bare `InMemoryHistory` prompt_toolkit hands every widget,
+which starts empty and dies with the process.
+
+That matters more than the shortcuts around it. Every readline binding the
+audit went looking for — Ctrl+A/E/K/U/W/Y, Alt+B/F, Ctrl+_ and Ctrl+R — is
+already loaded and live in prompt_toolkit's defaults. `Ctrl+R` was never
+missing; it was searching an empty list.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+
+import pytest
+
+from backend.core.ouroboros.battle_test.input_history import (
+    history_enabled, history_path, reset_for_tests, shared_history,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("JARVIS_INPUT_HISTORY_PATH", str(tmp_path / "hist"))
+    reset_for_tests()
+    yield
+    reset_for_tests()
+
+
+# --------------------------------------------------------------------------
+# the foundation the shortcuts stand on
+# --------------------------------------------------------------------------
+
+def test_the_readline_cluster_was_ALREADY_shipped() -> None:
+    """Documents why this PR is about history and not bindings: rebuilding
+    keys prompt_toolkit already provides would be pure duplication."""
+    from prompt_toolkit.key_binding.defaults import load_key_bindings
+
+    combos = {tuple(str(k) for k in b.keys)
+              for b in load_key_bindings().bindings}
+    for combo in [("Keys.ControlA",), ("Keys.ControlE",), ("Keys.ControlK",),
+                  ("Keys.ControlU",), ("Keys.ControlW",), ("Keys.ControlY",),
+                  ("Keys.Escape", "b"), ("Keys.Escape", "f"),
+                  ("Keys.ControlUnderscore",), ("Keys.ControlR",)]:
+        assert combo in combos, f"{combo} is NOT a prompt_toolkit default"
+
+
+@pytest.mark.asyncio
+async def test_up_recalls_what_was_typed() -> None:
+    """The whole point. Loaded ASYNCHRONOUSLY by prompt_toolkit, which is why
+    a synchronous probe of this reports an empty buffer and looks broken."""
+    from prompt_toolkit.buffer import Buffer
+
+    history = shared_history()
+    history.append_string("fix the flaky test")
+    history.append_string("run the soak")
+
+    buf = Buffer(history=history, multiline=True)
+    buf.load_history_if_not_yet_loaded()
+    for _ in range(200):
+        await asyncio.sleep(0.005)
+        if len(buf._working_lines) > 1:
+            break
+
+    buf.text, buf.cursor_position = "", 0
+    buf.auto_up()
+    assert buf.text == "run the soak"
+    buf.auto_up()
+    assert buf.text == "fix the flaky test"
+
+
+@pytest.mark.asyncio
+async def test_up_moves_the_CURSOR_inside_a_paragraph() -> None:
+    """The prompt is multi-line now. `Up` mid-paragraph must move the cursor,
+    or editing a pasted block is impossible — `auto_up` encodes that, and
+    binding `history_backward` instead would yank a half-composed paragraph
+    away mid-edit."""
+    from prompt_toolkit.buffer import Buffer
+
+    history = shared_history()
+    history.append_string("an older goal")
+    buf = Buffer(history=history, multiline=True)
+    buf.load_history_if_not_yet_loaded()
+    for _ in range(200):
+        await asyncio.sleep(0.005)
+        if len(buf._working_lines) > 1:
+            break
+
+    buf.text = "line one\nline two"
+    buf.cursor_position = len(buf.text)
+    buf.auto_up()
+    assert buf.text == "line one\nline two", "history stole a live paragraph"
+    assert buf.cursor_position < len("line one\nline two")
+
+
+# --------------------------------------------------------------------------
+# one file, both surfaces
+# --------------------------------------------------------------------------
+
+def test_both_surfaces_share_ONE_history_object() -> None:
+    """A goal typed in the cockpit must be recallable from the fallback and
+    the reverse; this codebase has found the two-surface split bug before."""
+    assert shared_history() is shared_history()
+
+
+def test_both_surfaces_ASK_for_it() -> None:
+    import ast
+    from pathlib import Path
+
+    repo = Path(__file__).resolve().parents[2]
+    for path in ("backend/core/ouroboros/cli/ov.py",
+                 "backend/core/ouroboros/battle_test/bipartite_layout.py"):
+        src = (repo / path).read_text()
+        names = {a.name for n in ast.walk(ast.parse(src))
+                 if isinstance(n, ast.ImportFrom) for a in n.names}
+        assert "shared_history" in names, f"{path} has no history"
+
+
+def test_history_is_passed_at_CONSTRUCTION() -> None:
+    """A Buffer builds its working lines from the history it was GIVEN when
+    created. Assigning afterwards swaps the object without repopulating what
+    Up walks — present, correct, and unreachable."""
+    from pathlib import Path
+
+    repo = Path(__file__).resolve().parents[2]
+    src = (repo / "backend/core/ouroboros/battle_test/"
+           "bipartite_layout.py").read_text()
+    assert "history=_shared_history()" in src
+    assert "prompt.buffer.history =" not in src
+
+
+# --------------------------------------------------------------------------
+# what is stored
+# --------------------------------------------------------------------------
+
+def test_blanks_and_repeats_are_refused() -> None:
+    """A history full of one repeated command is one you stop pressing Up
+    on."""
+    h = shared_history()
+    h.append_string("run the soak")
+    h.append_string("run the soak")
+    h.append_string("   ")
+    h.append_string("")
+    assert list(h.get_strings()) == ["run the soak"]
+
+
+def test_the_file_is_owner_only() -> None:
+    """It is a verbatim record of the operator's typing."""
+    shared_history().append_string("something")
+    assert oct(os.stat(history_path()).st_mode & 0o777) == "0o600"
+
+
+def test_it_survives_a_new_session() -> None:
+    """Asserted on the FILE, not on `get_strings()` — prompt_toolkit loads a
+    FileHistory asynchronously, so a fresh instance reports empty until a
+    loop drains it. Checking the in-memory list here would test the loader's
+    laziness rather than persistence."""
+    shared_history().append_string("yesterday's goal")
+    reset_for_tests()
+    assert "yesterday's goal" in history_path().read_text()
+
+
+def test_the_kill_switch(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JARVIS_INPUT_HISTORY_ENABLED", "0")
+    reset_for_tests()
+    assert history_enabled() is False
+    assert shared_history() is None
+
+
+def test_an_unwritable_path_degrades_instead_of_crashing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cockpit that will not start because it could not open a history
+    file is worse than one with no history."""
+    monkeypatch.setenv("JARVIS_INPUT_HISTORY_PATH", "/proc/nope/hist")
+    reset_for_tests()
+    assert shared_history() is None


### PR DESCRIPTION
I called this "the readline cluster — Ctrl+R search, word motion, kill and yank." Checking before building changed the answer:

```
  Ctrl+A   built-in: True      Alt+B    built-in: True
  Ctrl+E   built-in: True      Alt+F    built-in: True
  Ctrl+K   built-in: True      Ctrl+_   built-in: True
  Ctrl+U   built-in: True      Ctrl+R   built-in: True
  Ctrl+W   built-in: True      Ctrl+Y   built-in: True
```

**Every one of them was already loaded and live**, straight out of prompt_toolkit's defaults. Rebuilding them would have been pure duplication.

## What was actually missing

The thing they all stand on. `ov` had **no command history at all** — the `PromptSession` was constructed without a `history=` argument, and the cockpit's `TextArea` got the bare `InMemoryHistory` prompt_toolkit hands every widget: empty at start, gone at exit.

Up recalled nothing. `Ctrl+R` was never missing — it was searching an empty list.

*(Memory recorded "FileHistory + Ctrl+R" as shipped. It was — on SerpentFlow's daemon REPL, which is not the surface you type into.)*

## One file, both surfaces

This codebase has repeatedly found a feature wired to one surface while the operator typed into the other. So the cockpit and the plain client share **one** `FileHistory` singleton: a goal typed in either is recallable from the other, and two write-behind caches never race on one file.

## Two things the wiring had to get right

**History is passed at construction.** A `Buffer` builds its `_working_lines` from the history it was *given when created*, so assigning `buffer.history` afterwards swaps the object without repopulating what Up walks — present, correct, and unreachable. That was my first cut, and it looked wired.

**`auto_up`/`auto_down`, not `history_backward`/`history_forward`.** The prompt is multi-line now, so `Up` inside a paragraph must move the cursor and recall history only from the first line. The raw history verbs would yank a half-composed paragraph away mid-edit.

Plus `enable_history_search` (Up prefix-filters on what you've typed — what keeps 2000 entries usable) and `enable_open_in_editor` for `Ctrl+X Ctrl+E`, which matters most for exactly the long multi-line goals the prompt now accepts.

## What's stored

Blanks and immediate repeats refused — a history full of one repeated command is one you stop pressing Up on. The file is your verbatim typing, so it's created `0600` and trimmed atomically. **Nothing else is filtered**: a heuristic that silently dropped some commands would leave you unable to trust that Up shows what you actually did. An unwritable path degrades to no history rather than refusing to start.

## Verification

11 tests. The recall tests are **async by necessity** — prompt_toolkit loads a `FileHistory` asynchronously, so a synchronous probe reports an empty buffer and makes correct wiring look broken. That cost a debugging round here, and the test comment says so. One test pins that the readline bindings *are* prompt_toolkit defaults, so nobody re-adds them later.

815 `tests/cli` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds persistent, shared input history for ov across the cockpit and CLI, backed by one file. This enables reliable Up/Down recall and Ctrl+R search, with multiline-aware navigation and secure, deduped storage.

- **New Features**
  - Shared `FileHistory` singleton for both surfaces; stored at `.jarvis/input_history` (0600) and trimmed to 2000 entries.
  - History passed at construction; Up/Down bound to `auto_up`/`auto_down` for multiline editing. `Ctrl+R` now searches real history using `prompt_toolkit` defaults.
  - Enabled `enable_history_search` and `enable_open_in_editor` (Ctrl+X Ctrl+E).
  - Storage: drop blanks and immediate repeats; no other filtering. Async loading handled.
  - Config: disable with `JARVIS_INPUT_HISTORY_ENABLED=0`; override path via `JARVIS_INPUT_HISTORY_PATH`. Unwritable path degrades to no history.

<sup>Written for commit b4e24939648c6a126f36700c680a5c31065a9bad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

