### PR TITLE
feat(ov): the history file is owned, bounded, deduped — and one object per process

### DIFF
--- a/backend/core/ouroboros/battle_test/repl_completion.py
+++ b/backend/core/ouroboros/battle_test/repl_completion.py
@@ -1406,20 +1406,109 @@ def build_completer(
 # ===========================================================================
 
 
+HISTORY_MAX_ENTRIES_ENV_VAR: str = "JARVIS_REPL_HISTORY_MAX_ENTRIES"
+
+#: One history object per resolved file path. Several surfaces live in ONE
+#: process (the client's cockpit + fallback + ghost-text + Ctrl+R search all
+#: build history); handing each its own ``FileHistory`` on the same path
+#: means multiple write-behind caches racing on one file and Up-arrow state
+#: that disagrees between widgets. Keyed by path so tests with tmp files
+#: stay isolated.
+_HISTORY_SINGLETONS: "dict[str, object]" = {}
+
+
+def _history_max_entries() -> int:
+    """Bound on stored entries — deep enough that yesterday's goal is
+    reachable, bounded so the file cannot grow without limit across a
+    long-lived install. Env: ``JARVIS_REPL_HISTORY_MAX_ENTRIES``."""
+    try:
+        return max(50, int(
+            os.environ.get(HISTORY_MAX_ENTRIES_ENV_VAR, "2000")
+        ))
+    except (TypeError, ValueError):
+        return 2000
+
+
+def _trim_history_file(path: Path, max_entries: int) -> None:
+    """Keep the newest *max_entries*. Rewritten atomically (tmp +
+    ``os.replace``) so a crash mid-trim cannot leave a truncated or empty
+    history. Entry-aware: ``FileHistory`` writes a ``# timestamp`` comment
+    line per entry followed by ``+``-prefixed content, so ENTRIES are
+    counted by their comment lines, never by raw lines. NEVER raises —
+    a failed trim must not cost the operator their history."""
+    try:
+        if not path.exists():
+            return
+        lines = path.read_text(errors="replace").splitlines(keepends=True)
+        starts = [i for i, ln in enumerate(lines) if ln.startswith("#")]
+        if len(starts) <= max_entries:
+            return
+        cut = starts[len(starts) - max_entries]
+        tmp = path.with_name(path.name + ".tmp")
+        tmp.write_text("".join(lines[cut:]))
+        os.replace(tmp, path)
+    except Exception:  # noqa: BLE001
+        logger.debug("[ReplCompletion] history trim degraded", exc_info=True)
+
+
+def _make_file_history_class():
+    """The deduplicating ``FileHistory`` subclass, created lazily so this
+    module stays importable without prompt_toolkit."""
+    from prompt_toolkit.history import FileHistory
+
+    class _DedupedFileHistory(FileHistory):
+        """Refuses blanks and immediate repeats.
+
+        A history full of one repeated command is one the operator stops
+        pressing Up on. Nothing else is filtered: a heuristic that
+        silently dropped some commands would leave the operator unable
+        to trust that Up shows what they actually did."""
+
+        def append_string(self, string: str) -> None:
+            try:
+                candidate = str(string or "")
+                if not candidate.strip():
+                    return
+                try:
+                    strings = self.get_strings()
+                    last = strings[-1] if strings else None
+                except Exception:  # noqa: BLE001
+                    last = None
+                if candidate == last:
+                    return
+                super().append_string(candidate)
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "[ReplCompletion] history append degraded",
+                    exc_info=True,
+                )
+
+    return _DedupedFileHistory
+
+
+def reset_history_cache_for_tests() -> None:
+    """Drop the history singletons. Test hook only."""
+    _HISTORY_SINGLETONS.clear()
+
+
 def build_history(
     path: Optional[Path] = None,
 ) -> Optional[object]:
-    """Construct a ``prompt_toolkit.history.History`` instance.
+    """THE ``prompt_toolkit.history.History`` for a surface.
 
-    Defaults to a ``FileHistory`` at ``.jarvis/repl_history``. Falls
-    back to ``InMemoryHistory`` when the file isn't writable. Returns
-    ``None`` when prompt_toolkit isn't available OR history is
-    disabled via :func:`is_history_enabled`.
+    Defaults to a deduplicating ``FileHistory`` at
+    ``.jarvis/repl_history`` — ONE instance per path per process (see
+    ``_HISTORY_SINGLETONS``), created with owner-only permissions (the
+    file is the operator's typing) and trimmed atomically to
+    ``JARVIS_REPL_HISTORY_MAX_ENTRIES`` on first open. Falls back to
+    ``InMemoryHistory`` when the file isn't writable. Returns ``None``
+    when prompt_toolkit isn't available OR history is disabled via
+    :func:`is_history_enabled`.
     """
     if not is_history_enabled():
         return None
     try:
-        from prompt_toolkit.history import FileHistory, InMemoryHistory
+        from prompt_toolkit.history import InMemoryHistory
     except ImportError:
         return None
 
@@ -1430,14 +1519,31 @@ def build_history(
         except Exception:  # noqa: BLE001
             return None
 
+    key = str(eff_path)
+    cached = _HISTORY_SINGLETONS.get(key)
+    if cached is not None:
+        return cached
+
     try:
+        _trim_history_file(eff_path, _history_max_entries())
+        # Owner-only, whether the file is new or inherited from an
+        # earlier install that created it with the default umask.
+        try:
+            if not eff_path.exists():
+                eff_path.touch(mode=0o600)
+            else:
+                os.chmod(eff_path, 0o600)
+        except OSError:
+            pass
         # FileHistory writes atomically per command — no buffering
         # contention with concurrent SIGINT.
-        return FileHistory(str(eff_path))
+        history = _make_file_history_class()(key)
+        _HISTORY_SINGLETONS[key] = history
+        return history
     except Exception:  # noqa: BLE001
         logger.debug(
             "[ReplCompletion] FileHistory(%r) failed; using in-memory",
-            str(eff_path), exc_info=True,
+            key, exc_info=True,
         )
         try:
             return InMemoryHistory()
@@ -1557,6 +1663,7 @@ __all__ = [
     "COMPLETE_WHILE_TYPING_ENV_VAR",
     "CompletionWiring",
     "HISTORY_ENABLED_ENV_VAR",
+    "HISTORY_MAX_ENTRIES_ENV_VAR",
     "HISTORY_PATH_ENV_VAR",
     "INLINE_HELP_ENABLED_ENV_VAR",
     "MASTER_FLAG_ENV_VAR",
@@ -1585,6 +1692,7 @@ __all__ = [
     "parse_arg_spec",
     "unified_registry",
     "register_arg_provider",
+    "reset_history_cache_for_tests",
     "resolve_help_for_buffer",
     "resolve_history_path",
     "suggest_for_typo",

--- a/tests/battle_test/test_completion_unification.py
+++ b/tests/battle_test/test_completion_unification.py
@@ -338,6 +338,62 @@ def test_expand_declares_a_dynamic_ref_position() -> None:
 
 
 # --------------------------------------------------------------------------
+# 8b. history hardening — singleton, perms, dedupe, bounded file
+# --------------------------------------------------------------------------
+
+@pytest.fixture()
+def history_file(tmp_path, monkeypatch):
+    path = tmp_path / "hist"
+    monkeypatch.setenv(rc.HISTORY_PATH_ENV_VAR, str(path))
+    rc.reset_history_cache_for_tests()
+    yield path
+    rc.reset_history_cache_for_tests()
+
+
+def test_history_is_a_per_path_singleton(history_file) -> None:
+    pytest.importorskip("prompt_toolkit")
+    a = rc.build_history()
+    b = rc.build_history()
+    assert a is b  # two surfaces, ONE write-behind cache per file
+
+
+def test_history_file_is_owner_only(history_file) -> None:
+    pytest.importorskip("prompt_toolkit")
+    import stat
+    rc.build_history()
+    mode = stat.S_IMODE(history_file.stat().st_mode)
+    assert mode == 0o600
+
+
+def test_history_refuses_blanks_and_immediate_repeats(history_file) -> None:
+    pytest.importorskip("prompt_toolkit")
+    hist = rc.build_history()
+    hist.append_string("/status")
+    hist.append_string("/status")     # immediate repeat — dropped
+    hist.append_string("   ")         # blank — dropped
+    hist.append_string("/cost")
+    hist.append_string("/status")     # NOT consecutive — kept
+    assert hist.get_strings() == ["/status", "/cost", "/status"]
+
+
+def test_history_file_is_bounded_and_trim_is_entry_aware(
+    history_file, monkeypatch,
+) -> None:
+    pytest.importorskip("prompt_toolkit")
+    monkeypatch.setenv(rc.HISTORY_MAX_ENTRIES_ENV_VAR, "50")
+    # Write 120 entries in FileHistory's own on-disk grammar.
+    lines = []
+    for i in range(120):
+        lines.append(f"\n# 2026-07-27 00:00:{i:02d}\n")
+        lines.append(f"+cmd-{i}\n")
+    history_file.write_text("".join(lines))
+    hist = rc.build_history()
+    kept = list(hist.load_history_strings())   # newest-first
+    assert len(kept) == 50
+    assert kept[0] == "cmd-119" and kept[-1] == "cmd-70"
+
+
+# --------------------------------------------------------------------------
 # 9. /keys is answered by the process whose bindings it describes
 # --------------------------------------------------------------------------
 


### PR DESCRIPTION
Reconciliation PR: a parallel session built `feat/input-history` solving the same "ov has no history" gap that #70183/#70184 closed. Rather than land two history systems, this grafts that branch's four **genuine deltas** into `build_history()` — the one seam every surface already reads (daemon REPL, cockpit, fallback, ghost-text, Ctrl+R search) — which supersedes the branch:

- **Per-path singleton** — several surfaces build history inside one process; separate `FileHistory` objects on the same path are write-behind caches racing on one file, with Up-arrow state that disagrees between widgets.
- **Owner-only `0600`**, new or inherited from an earlier install's umask — the file is the operator's typing.
- **Blank + immediate-repeat filtering** on append; nothing else is filtered, so Up always shows what the operator actually did.
- **Bounded file** — atomic, entry-aware trim to `JARVIS_REPL_HISTORY_MAX_ENTRIES` (default 2000) on first open; a crash mid-trim cannot truncate the history.

With this merged, `feat/input-history` can be closed: its remaining content duplicates #70183/#70184 (shared FileHistory on all surfaces, Up/auto_up recall, Ctrl+R).

4 new tests; completion surface suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes REPL history owned, deduped, bounded, and one-object-per-process. This removes racing caches across surfaces and keeps history private and trustworthy.

- **New Features**
  - Per-path singleton `FileHistory` shared by all in-process surfaces (daemon REPL, cockpit, fallback, ghost-text, Ctrl+R).
  - Owner-only `0600` permissions on the history file (new or existing).
  - Dedupes blanks and immediate repeats via a custom `prompt_toolkit` `FileHistory` subclass; all other commands are kept.
  - Bounded history with atomic, entry-aware trim to `JARVIS_REPL_HISTORY_MAX_ENTRIES` (default 2000, min 50) on first open; falls back to `InMemoryHistory` if needed.

<sup>Written for commit f97c4138ab6bfadf69f26499a21d3e1d1d93ce35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

