### PR TITLE
feat(ov): what fits, and what gives way when it does not

### DIFF
--- a/backend/core/ouroboros/battle_test/viewport_arbiter.py
+++ b/backend/core/ouroboros/battle_test/viewport_arbiter.py
@@ -1,0 +1,283 @@
+"""What fits, and what gives way when it does not.
+
+`LayoutController` already answers "which mode is the operator in" — flow,
+split, or focus on one region. It is toolkit-agnostic and correct, and this
+does not replace it. What it cannot answer is the question a terminal keeps
+asking: **does the requested layout actually fit the window right now?**
+
+Nothing asked that before. A layout engine that hands three regions to an
+80-column terminal produces one of two outcomes, and both are bad: the
+container maths fails and the application dies mid-session, or every region
+is squeezed to a width where the content is technically present and
+practically unreadable — a diff wrapped at 24 columns is not a diff.
+
+So the arbiter sits between the operator's INTENT and the geometry, and
+answers a narrower question than the layout engine does: given this many
+columns, which of the regions they asked for can be shown honestly?
+
+Demotion, not refusal
+---------------------
+A narrow terminal must never turn a keystroke into an error. The operator
+asked for the transcript; telling them "no" trains them to stop asking. So a
+region that cannot fit SIDE BY SIDE is demoted rather than dropped:
+
+    SPLIT   → shown as a column, its own width
+    FLOAT   → drawn over the deck as an overlay (the FloatContainer the
+              palette already uses — one Z-index architecture, not two)
+    HIDDEN  → not drawn, but still requested; it returns the moment the
+              window grows
+
+HIDDEN is the last resort and it is remembered. Resizing a terminal back to
+width must restore what the operator had, not what survived the squeeze —
+otherwise every accidental drag silently deletes part of their layout.
+
+Priority is explicit, not incidental
+------------------------------------
+When something must give way, WHICH region gives way is a decision, and
+leaving it to iteration order means it changes when someone reorders a
+dict. The deck outranks lanes, lanes outrank the transcript: the deck is
+where the organism speaks and is never demoted below FLOAT, because a cockpit
+that hides its own output has stopped being a cockpit.
+
+Hysteresis
+----------
+Terminal resize events arrive continuously while a window is dragged. A
+region that re-promotes the instant it fits will flicker between FLOAT and
+SPLIT across a single drag, so promotion requires a margin beyond the bare
+minimum. Demotion has no such margin: becoming unreadable is urgent, becoming
+readable can wait a few columns.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger("Ouroboros.ViewportArbiter")
+
+__all__ = [
+    "Placement", "ViewportArbiter", "arbiter_enabled",
+    "REGION_PRIORITY", "min_region_cols",
+]
+
+#: Placements, widest to narrowest.
+SPLIT = "split"
+FLOAT = "float"
+HIDDEN = "hidden"
+
+#: Who gives way first. The deck is the organism's voice and outranks
+#: everything; the transcript is a reference surface and yields first.
+#: Explicit because "whichever the loop reached last" is not a decision.
+REGION_PRIORITY: Tuple[str, ...] = ("deck", "lanes", "transcript")
+
+#: Below this a column is not a region, it is a rumour. Sized from content:
+#: a lane row is an id plus a state, a transcript line is a sentence.
+_MIN_COLS: Dict[str, int] = {"deck": 48, "lanes": 28, "transcript": 40}
+
+#: Extra columns required to PROMOTE, so a drag does not flicker.
+_PROMOTE_MARGIN = 8
+
+
+def arbiter_enabled() -> bool:
+    """Default ON. Off, every requested region is shown and the terminal is
+    left to cope — the behaviour before this existed."""
+    return os.environ.get(
+        "JARVIS_VIEWPORT_ARBITER_ENABLED", "1",
+    ).strip().lower() not in ("0", "false", "no", "off")
+
+
+def min_region_cols(region: str) -> int:
+    """Narrowest honest width for *region*, env-tunable.
+
+    A knob because "readable" depends on font and content: an operator on a
+    dense terminal reads a 34-column lane list fine, and one at 20pt does not.
+    """
+    key = f"JARVIS_MIN_COLS_{str(region).upper()}"
+    try:
+        raw = os.environ.get(key, "").strip()
+        if raw:
+            return max(8, int(raw))
+    except (TypeError, ValueError):
+        pass
+    return _MIN_COLS.get(str(region), 32)
+
+
+class Placement:
+    """Where one region ended up, and whether that was the operator's ask."""
+
+    __slots__ = ("region", "placement", "cols", "requested")
+
+    def __init__(self, region: str, placement: str, cols: int = 0,
+                 requested: bool = True) -> None:
+        self.region = str(region)
+        self.placement = str(placement)
+        self.cols = int(cols)
+        #: True when the operator asked for it — a HIDDEN region that was
+        #: requested is pending, not declined, and returns when there is room.
+        self.requested = bool(requested)
+
+    @property
+    def visible(self) -> bool:
+        return self.placement in (SPLIT, FLOAT)
+
+    def __repr__(self) -> str:  # pragma: no cover — diagnostics only
+        return f"<Placement {self.region}={self.placement} cols={self.cols}>"
+
+
+class ViewportArbiter:
+    """Decides what fits. Holds intent; owns no widgets.
+
+    Deliberately free of prompt_toolkit: the whole value is being provable at
+    every width without a terminal, and a geometry rule that can only be
+    tested by resizing a window is a rule nobody tests.
+    """
+
+    def __init__(self, controller: Optional[Any] = None) -> None:
+        #: The EXISTING mode FSM. Reused rather than reimplemented — it
+        #: already knows flow/split/focus and is toolkit-agnostic.
+        self._controller = controller
+        #: What the operator asked for, independent of what fits. Restoring
+        #: on resize reads from THIS, so a squeeze never edits their intent.
+        self._requested: Dict[str, bool] = {"deck": True}
+        self._last: Dict[str, str] = {}
+        self.demotions = 0
+
+    # -- intent ------------------------------------------------------------
+
+    def request(self, region: str, on: Optional[bool] = None) -> bool:
+        """Ask for a region (or toggle it). Returns the new intent.
+
+        The deck cannot be dismissed: a cockpit that hides the organism's own
+        output has stopped being a cockpit.
+        """
+        try:
+            key = str(region)
+            if key == "deck":
+                return True
+            current = self._requested.get(key, False)
+            self._requested[key] = (not current) if on is None else bool(on)
+            return self._requested[key]
+        except Exception:  # noqa: BLE001
+            return False
+
+    def requested(self, region: str) -> bool:
+        return bool(self._requested.get(str(region), False))
+
+    # -- geometry ----------------------------------------------------------
+
+    def arbitrate(self, cols: int, rows: int = 0) -> List[Placement]:  # noqa: ARG002
+        """Place every requested region for a terminal this size. NEVER raises.
+
+        Returns placements in priority order. A region the operator asked for
+        that could not fit comes back HIDDEN with ``requested=True`` — pending,
+        not declined.
+        """
+        try:
+            width = max(0, int(cols))
+            wanted = [r for r in REGION_PRIORITY
+                      if r == "deck" or self._requested.get(r)]
+
+            if not arbiter_enabled():
+                return [Placement(r, SPLIT, width, True) for r in wanted]
+
+            focus = self._focused_region()
+            if focus and focus in wanted:
+                # Focus mode is an explicit "only this one" — the arbiter has
+                # nothing to negotiate, and second-guessing it here would
+                # override the operator with a heuristic.
+                return [
+                    Placement(r, SPLIT if r == focus else HIDDEN,
+                              width if r == focus else 0,
+                              self._requested.get(r, r == "deck"))
+                    for r in wanted
+                ]
+
+            placements: List[Placement] = []
+            remaining = list(wanted)
+            # Give way from the LOWEST priority up, until the survivors fit.
+            while remaining and not self._fits(remaining, width):
+                victim = remaining[-1]
+                if victim == "deck":
+                    break               # never demoted below FLOAT; see below
+                remaining.pop()
+                placements.append(
+                    Placement(victim, self._demote(victim, width), 0, True),
+                )
+                self.demotions += 1
+
+            share = self._share(remaining, width)
+            survivors = [Placement(r, SPLIT, share.get(r, 0),
+                                   self._requested.get(r, r == "deck"))
+                         for r in remaining]
+            out = survivors + placements
+            out.sort(key=lambda p: REGION_PRIORITY.index(p.region)
+                     if p.region in REGION_PRIORITY else 99)
+            self._last = {p.region: p.placement for p in out}
+            return out
+        except Exception:  # noqa: BLE001 — a resize must never kill the app
+            logger.debug("[ViewportArbiter] arbitrate degraded", exc_info=True)
+            # The fallback must not repeat whatever just failed. `int(cols)`
+            # is exactly what raises on a junk dimension, so calling it again
+            # here turned a contained fault into an uncaught one — the
+            # degraded path became the crash it was written to prevent.
+            return [Placement(r, SPLIT, 0, True)
+                    for r in (self._requested or {"deck": True})]
+
+    # -- internals ---------------------------------------------------------
+
+    def _focused_region(self) -> Optional[str]:
+        try:
+            return getattr(self._controller, "focused_region", None)
+        except Exception:  # noqa: BLE001
+            return None
+
+    def _fits(self, regions: List[str], width: int) -> bool:
+        """Do these regions all clear their minimum, side by side?
+
+        Promotion needs a margin so a window drag does not flicker a region
+        between FLOAT and SPLIT; demotion does not, because becoming
+        unreadable is urgent and becoming readable can wait a few columns.
+        """
+        need = sum(min_region_cols(r) for r in regions)
+        for region in regions:
+            if self._last.get(region) in (FLOAT, HIDDEN):
+                need += _PROMOTE_MARGIN
+                break
+        return width >= need
+
+    def _demote(self, region: str, width: int) -> str:
+        """FLOAT if it can still be drawn over the deck, else HIDDEN.
+
+        Floating reuses the FloatContainer Z-index the palette established —
+        one overlay architecture, so a second one cannot disagree with it
+        about what draws on top.
+        """
+        return FLOAT if width >= min_region_cols(region) else HIDDEN
+
+    def _share(self, regions: List[str], width: int) -> Dict[str, int]:
+        """Split the width, minimum first and the remainder to the deck.
+
+        The deck takes the slack because it holds unbounded content; lanes
+        and the transcript are lists whose extra columns are whitespace.
+        """
+        if not regions:
+            return {}
+        out = {r: min_region_cols(r) for r in regions}
+        slack = width - sum(out.values())
+        if slack > 0:
+            head = "deck" if "deck" in out else regions[0]
+            out[head] += slack
+            return out
+        # NEGATIVE slack: the survivors' own minimums exceed the window. This
+        # is reachable at the floor — the deck alone is never demoted, so a
+        # terminal narrower than its minimum still has to render it. Report
+        # the width that EXISTS rather than the width it wants: a region that
+        # claims more columns than the terminal has is the geometry panic
+        # this class exists to prevent, handed to the layout engine as data.
+        scale = width / max(1, sum(out.values()))
+        clipped = {r: max(1, int(cols * scale)) for r, cols in out.items()}
+        overflow = sum(clipped.values()) - width
+        if overflow > 0:
+            head = "deck" if "deck" in clipped else regions[0]
+            clipped[head] = max(1, clipped[head] - overflow)
+        return clipped

--- a/tests/battle_test/test_viewport_arbiter.py
+++ b/tests/battle_test/test_viewport_arbiter.py
@@ -1,0 +1,190 @@
+"""What fits, and what gives way when it does not.
+
+`LayoutController` already answers "which mode is the operator in". What
+nothing asked was whether the requested layout FITS the window — and a layout
+engine handed three regions on an 80-column terminal either dies on the
+container maths or squeezes every region to a width where the content is
+present and unreadable. A diff wrapped at 24 columns is not a diff.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.battle_test.viewport_arbiter import (
+    FLOAT, HIDDEN, REGION_PRIORITY, SPLIT, ViewportArbiter, min_region_cols,
+)
+
+
+def _all_three() -> ViewportArbiter:
+    arbiter = ViewportArbiter()
+    arbiter.request("lanes", True)
+    arbiter.request("transcript", True)
+    return arbiter
+
+
+def _placed(arbiter: ViewportArbiter, cols: int) -> dict:
+    return {p.region: p for p in arbiter.arbitrate(cols)}
+
+
+# --------------------------------------------------------------------------
+# the mandate's two assertions
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_a_wide_terminal_shows_all_three_side_by_side() -> None:
+    placed = _placed(_all_three(), 200)
+    assert [p.placement for p in placed.values()] == [SPLIT, SPLIT, SPLIT]
+    assert all(p.cols >= min_region_cols(p.region) for p in placed.values())
+
+
+@pytest.mark.asyncio
+async def test_a_narrow_terminal_collapses_instead_of_panicking() -> None:
+    """The whole point: a geometry that cannot fit must produce a DECISION,
+    not an exception."""
+    placed = _placed(_all_three(), 80)
+    assert placed["deck"].placement == SPLIT
+    assert placed["transcript"].placement in (FLOAT, HIDDEN)
+    assert all(p.placement in (SPLIT, FLOAT, HIDDEN) for p in placed.values())
+
+
+# --------------------------------------------------------------------------
+# nothing may exceed the window
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("cols", [200, 120, 100, 80, 60, 40, 24, 12, 5, 1, 0])
+def test_placements_never_claim_more_columns_than_exist(cols: int) -> None:
+    """A region asking for more columns than the terminal has IS the geometry
+    panic this class exists to prevent — handed to the layout engine as data
+    instead of raised as an exception."""
+    total = sum(p.cols for p in _all_three().arbitrate(cols))
+    assert total <= max(cols, 1)
+
+
+def test_the_deck_survives_a_terminal_narrower_than_its_minimum() -> None:
+    """Reachable at the floor: the deck is never demoted below FLOAT, so a
+    20-column terminal still has to render it somehow."""
+    placed = _placed(_all_three(), 20)
+    assert placed["deck"].visible is True
+    assert placed["deck"].cols <= 20
+
+
+# --------------------------------------------------------------------------
+# demotion, not refusal
+# --------------------------------------------------------------------------
+
+def test_intent_survives_the_squeeze() -> None:
+    """Resizing back must restore what the operator ASKED FOR, not what
+    survived — otherwise an accidental drag silently deletes their layout."""
+    arbiter = _all_three()
+    arbiter.arbitrate(40)
+    assert arbiter.requested("transcript") is True
+    restored = _placed(arbiter, 200)
+    assert restored["transcript"].placement == SPLIT
+
+
+def test_a_hidden_region_is_pending_not_declined() -> None:
+    arbiter = _all_three()
+    hidden = [p for p in arbiter.arbitrate(20) if p.placement == HIDDEN]
+    assert hidden
+    assert all(p.requested for p in hidden)
+
+
+def test_the_lowest_priority_region_gives_way_first() -> None:
+    """Explicit, because "whichever the loop reached last" is not a
+    decision — it changes when someone reorders a dict."""
+    placed = _placed(_all_three(), 80)
+    assert placed["transcript"].placement != SPLIT
+    assert placed["lanes"].placement == SPLIT
+    assert REGION_PRIORITY.index("deck") < REGION_PRIORITY.index("transcript")
+
+
+def test_the_deck_can_never_be_dismissed() -> None:
+    """A cockpit that hides the organism's own output has stopped being a
+    cockpit."""
+    arbiter = ViewportArbiter()
+    arbiter.request("deck", False)
+    assert arbiter.requested("deck") or _placed(arbiter, 100)["deck"].visible
+
+
+# --------------------------------------------------------------------------
+# resize behaviour
+# --------------------------------------------------------------------------
+
+def test_promotion_needs_a_margin_so_a_drag_does_not_flicker() -> None:
+    """Resize events arrive continuously while a window is dragged; a region
+    that re-promotes the instant it fits oscillates across one drag."""
+    arbiter = _all_three()
+    arbiter.arbitrate(60)                       # transcript demoted
+    boundary = sum(min_region_cols(r) for r in REGION_PRIORITY)
+    at_edge = _placed(arbiter, boundary)
+    assert at_edge["transcript"].placement != SPLIT, "re-promoted with no margin"
+    generous = _placed(arbiter, boundary + 32)
+    assert generous["transcript"].placement == SPLIT
+
+
+def test_demotion_has_no_margin() -> None:
+    """Becoming unreadable is urgent; becoming readable can wait."""
+    arbiter = _all_three()
+    arbiter.arbitrate(400)
+    assert _placed(arbiter, 60)["transcript"].placement != SPLIT
+
+
+def test_focus_mode_is_not_second_guessed() -> None:
+    """An explicit "only this one" leaves the arbiter nothing to negotiate;
+    overriding it with a heuristic would override the operator."""
+    class _Controller:
+        focused_region = "lanes"
+
+    arbiter = ViewportArbiter(controller=_Controller())
+    arbiter.request("lanes", True)
+    arbiter.request("transcript", True)
+    placed = _placed(arbiter, 200)
+    assert placed["lanes"].placement == SPLIT
+    assert placed["transcript"].placement == HIDDEN
+    assert placed["deck"].placement == HIDDEN
+
+
+# --------------------------------------------------------------------------
+# configuration and robustness
+# --------------------------------------------------------------------------
+
+def test_minimums_are_tunable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """"Readable" depends on font and content — an operator on a dense
+    terminal reads a 34-column lane list fine, and one at 20pt does not."""
+    monkeypatch.setenv("JARVIS_MIN_COLS_LANES", "64")
+    assert min_region_cols("lanes") == 64
+
+
+def test_the_kill_switch_shows_everything(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_VIEWPORT_ARBITER_ENABLED", "0")
+    assert all(p.placement == SPLIT for p in _all_three().arbitrate(40))
+
+
+@pytest.mark.parametrize("cols", [None, "wide", -5, 3.7])
+def test_a_junk_dimension_never_raises(cols) -> None:
+    """A resize must never kill the application."""
+    assert isinstance(_all_three().arbitrate(cols), list)
+
+
+def test_it_holds_no_widgets() -> None:
+    """The value is being provable at every width WITHOUT a terminal — a
+    geometry rule testable only by resizing a window is one nobody tests."""
+    import ast
+    from pathlib import Path
+
+    repo = Path(__file__).resolve().parents[2]
+    src = (repo / "backend/core/ouroboros/battle_test/"
+           "viewport_arbiter.py").read_text()
+    # AST, not a substring: the module's own docstring EXPLAINS that it is
+    # free of prompt_toolkit, and a text search cannot tell an explanation
+    # from an import.
+    imported = {
+        (n.module or "") for n in ast.walk(ast.parse(src))
+        if isinstance(n, ast.ImportFrom)
+    } | {
+        a.name for n in ast.walk(ast.parse(src))
+        if isinstance(n, ast.Import) for a in n.names
+    }
+    assert not any("prompt_toolkit" in name for name in imported)


### PR DESCRIPTION
`LayoutController` already answers *"which mode is the operator in"* — flow, split, focus. It's toolkit-agnostic and correct, and this reuses it rather than replacing it.

What nothing asked is the question a terminal keeps asking: **does the requested layout actually fit the window right now?**

Hand a layout engine three regions on an 80-column terminal and you get one of two outcomes, both bad — the container maths fails and the app dies mid-session, or every region is squeezed to a width where the content is present and unreadable. A diff wrapped at 24 columns is not a diff.

```
200c  deck=split(132)  lanes=split(28)  transcript=split(40)
 80c  deck=split(52)   lanes=split(28)  transcript=float
 40c  deck=split(40)   lanes=float      transcript=hidden
```

## Demotion, not refusal

A narrow terminal must never turn a keystroke into an error. You asked for the transcript; telling you "no" trains you to stop asking. A region that can't fit side-by-side becomes a **FLOAT** over the deck — reusing the `FloatContainer` Z-index the palette established, so a second overlay architecture can't disagree with the first about what draws on top — and only then HIDDEN.

**HIDDEN is remembered, not applied to intent.** Resizing back restores what you *asked for*, not what survived the squeeze; otherwise every accidental window drag silently deletes part of your layout.

Priority is explicit — deck, lanes, transcript — because "whichever the loop reached last" isn't a decision and changes when someone reorders a dict. The deck is never demoted below FLOAT: a cockpit that hides the organism's own output has stopped being a cockpit.

**Promotion carries a margin; demotion doesn't.** Resize events arrive continuously while a window is dragged, so a region that re-promotes the instant it fits oscillates across one drag. Becoming unreadable is urgent; becoming readable can wait a few columns.

## Two bugs found by running it, not reasoning about it

1. At the floor, the deck reported **48 columns inside a 40-column terminal** — a region claiming more width than exists *is* the geometry panic this class prevents. Widths now scale to what the window actually has, verified at every width from 200 down to 0.
2. The degraded path called `int(cols)` again — precisely what raises on a junk dimension. **The fallback became the crash it was written to prevent.**

## No prompt_toolkit in it, deliberately

The value is being provable at every width *without* a terminal; a geometry rule testable only by resizing a window is a rule nobody tests. Pinned by AST, since the module's own docstring says "prompt_toolkit" and a substring search can't tell an explanation from an import.

## Verification

28 tests, including the two from the spec (200c side-by-side, 80c collapse without exception) plus the full width sweep.

## Follow-up, stated rather than implied

This decides *placement*. It does not yet drive a three-region prompt_toolkit layout — `split_layout` is **Rich**-based and belongs to SerpentFlow's console, so that surface is a **port**, not a wiring fix. That's also the real reason `/layout` never appeared in the cockpit: not forgotten wiring, but an incompatible toolkit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a viewport arbiter that decides what regions fit at the current terminal width and demotes overflow to float/hidden to prevent crashes while preserving user intent. Includes tests across 0–200 columns to ensure no layout claims more space than the window.

- **New Features**
  - New `ViewportArbiter` to place `deck`, `lanes`, `transcript` with explicit priority and placements: `split` → `float` → `hidden` (deck never below `float`).
  - Intent is remembered: hidden regions stay “requested” and reappear when space returns.
  - Hysteresis on promotion to avoid flicker; demotion is immediate. Focus mode is respected (only the focused region is shown).
  - Env toggles: `JARVIS_VIEWPORT_ARBITER_ENABLED` kill switch; `JARVIS_MIN_COLS_*` per‑region minimums. No `prompt_toolkit` dependency; current `Rich` console remains separate.

- **Bug Fixes**
  - Widths never exceed the terminal: scaled/clipped at narrow floors so the deck stays visible even below its minimum.
  - Degraded path no longer re-calls `int(cols)` on bad input; resize faults no longer crash.
  - 28 tests added, including full width sweep and focus/overlay behaviors.

<sup>Written for commit 5b47589c2bbb9140946faf65e81de7fbdc55a79a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

