### PR TITLE
feat(ov): park a half-written goal, do something else, get it back

### DIFF
--- a/backend/core/ouroboros/battle_test/bipartite_layout.py
+++ b/backend/core/ouroboros/battle_test/bipartite_layout.py
@@ -685,6 +685,16 @@ def build_bipartite_application(
             install_history_search(kb, _hist_controller)
         except Exception:  # noqa: BLE001
             pass
+    # Ctrl+S parks a half-written goal so the operator can check something
+    # and come back to it — the prompt accepts paragraphs now, which makes it
+    # worth interrupting.
+    try:
+        from backend.core.ouroboros.battle_test.draft_stash import (
+            install_stash_binding,
+        )
+        install_stash_binding(kb, lambda: prompt.buffer)
+    except Exception:  # noqa: BLE001
+        pass
     # Scrollback keys. In the alternate screen the terminal no longer offers
     # its own, so these ARE the scrollback — not a convenience layered on it.
     try:

--- a/backend/core/ouroboros/battle_test/draft_stash.py
+++ b/backend/core/ouroboros/battle_test/draft_stash.py
@@ -1,0 +1,143 @@
+"""Park a half-written goal, do something else, get it back.
+
+The prompt accepts paragraphs now. That makes it worth interrupting: an
+operator two hundred characters into describing a repair notices they need to
+check `/posture` first, and their only options are to lose the draft or to
+finish it blind. Both are bad enough that people stop writing long goals,
+which quietly undoes multi-line input.
+
+`Ctrl+S` swaps the buffer with a held draft. Press it with text and the
+buffer empties, holding what was there; press it again with an empty buffer
+and the draft comes back, cursor where it was.
+
+A SWAP, not a stack
+-------------------
+The obvious design is a stack — stash, stash again, pop twice. It is wrong
+here for a reason that only shows up in use: a stack has no visible depth in
+a one-line prompt, so the operator cannot tell whether the next press returns
+the thing they want or something from ten minutes ago. A single slot is a
+thing you can hold in your head.
+
+The cost is that a second stash would overwrite the first, and silently
+destroying a draft is exactly what this exists to prevent. So it does not:
+stashing while the slot is occupied SWAPS them. Nothing is ever lost, and the
+operator gets the other draft rather than an error.
+
+Cursor position travels with the text
+-------------------------------------
+Restoring a paragraph with the caret at position 0 means hunting for where
+you were. The offset is part of the draft, clamped on restore because the
+buffer it returns to may not be the one it left.
+
+Not persisted, deliberately
+---------------------------
+A stash that survived a restart would be a second history with different
+rules — and history already exists, is durable, and is what "I want this
+back tomorrow" means. This is for the next ninety seconds.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Optional, Tuple
+
+logger = logging.getLogger("Ouroboros.DraftStash")
+
+__all__ = ["DraftStash", "stash_enabled", "install_stash_binding"]
+
+
+def stash_enabled() -> bool:
+    """Default ON. Off, Ctrl+S is left to the terminal."""
+    return os.environ.get(
+        "JARVIS_DRAFT_STASH_ENABLED", "1",
+    ).strip().lower() not in ("0", "false", "no", "off")
+
+
+class DraftStash:
+    """One held draft, swapped in and out of a buffer."""
+
+    def __init__(self) -> None:
+        self._text: Optional[str] = None
+        self._cursor: int = 0
+        self.swaps = 0
+
+    @property
+    def holding(self) -> bool:
+        return self._text is not None
+
+    @property
+    def preview(self) -> str:
+        """First line of what is held, for a toolbar hint."""
+        if not self._text:
+            return ""
+        first = self._text.strip().splitlines()[0] if self._text.strip() else ""
+        return first[:40] + ("…" if len(first) > 40 else "")
+
+    def toggle(self, text: str, cursor: int = 0) -> Tuple[str, int]:
+        """Swap the buffer with the slot. Returns ``(new_text, new_cursor)``.
+
+        Four cases, and all of them have to be non-destructive:
+
+        * text, empty slot   → park it, buffer clears
+        * empty, full slot   → restore it, slot clears
+        * text, full slot    → SWAP. Never overwrite: silently destroying a
+                               draft is what this exists to prevent
+        * empty, empty slot  → nothing to do, and no error either
+        """
+        try:
+            incoming = str(text or "")
+            held, held_cursor = self._text, self._cursor
+            if incoming.strip():
+                self._text, self._cursor = incoming, max(0, int(cursor))
+                self.swaps += 1
+                if held is None:
+                    return "", 0
+                return held, min(held_cursor, len(held))
+            if held is None:
+                return incoming, max(0, int(cursor))
+            self._text, self._cursor = None, 0
+            self.swaps += 1
+            # Clamped: the buffer it returns to may not be the one it left.
+            return held, min(held_cursor, len(held))
+        except Exception:  # noqa: BLE001 — a stash must never eat a draft
+            logger.debug("[DraftStash] toggle degraded", exc_info=True)
+            return str(text or ""), max(0, int(cursor or 0))
+
+    def clear(self) -> None:
+        self._text, self._cursor = None, 0
+
+
+def install_stash_binding(kb: Any, get_buffer: Any,
+                          stash: Optional[DraftStash] = None,
+                          notify: Optional[Any] = None) -> Optional[DraftStash]:
+    """Bind Ctrl+S to the swap. Returns the stash, or None. NEVER raises.
+
+    Ctrl+S is XOFF under a cooked terminal and would freeze output rather
+    than reach the application — but prompt_toolkit puts the input in raw
+    mode with `IXON` cleared, so the key arrives. Verified against the
+    library rather than assumed, because the failure mode is a terminal that
+    appears to hang.
+    """
+    try:
+        if kb is None or not stash_enabled():
+            return None
+        slot = stash or DraftStash()
+
+        @kb.add("c-s")
+        def _swap(event: Any) -> None:
+            try:
+                buf = get_buffer()
+                if buf is None:
+                    return
+                text, cursor = slot.toggle(buf.text, buf.cursor_position)
+                buf.text = text
+                buf.cursor_position = min(cursor, len(text))
+                if notify is not None:
+                    notify(slot)
+            except Exception:  # noqa: BLE001
+                logger.debug("[DraftStash] swap degraded", exc_info=True)
+
+        return slot
+    except Exception:  # noqa: BLE001
+        logger.debug("[DraftStash] install degraded", exc_info=True)
+        return None

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -1494,6 +1494,15 @@ async def _split_plane_loop(
         # typed at the daemon REPL suggests here and vice versa.
         history=_history,
         auto_suggest=_build_prompt_auto_suggest(),
+        # Up PREFIX-FILTERS on what has already been typed instead of walking
+        # the whole file. Without it a 2000-entry history is technically
+        # recallable and practically unusable — the operator presses Up
+        # eleven times looking for a goal they typed this morning.
+        enable_history_search=True,
+        # Ctrl+X Ctrl+E — readline's "finish this in $EDITOR". It matters
+        # most for exactly the long multi-line goals the prompt now accepts,
+        # where the terminal's one-line editing model runs out.
+        enable_open_in_editor=True,
         # Multi-line, with the CONDITION applied to the buffer below — the
         # same two-step the cockpit uses, from the same module, so the two
         # surfaces cannot disagree about when Enter means "go".
@@ -1892,6 +1901,16 @@ def _build_selection_bindings(ui: Any, client: Any) -> Any:
                 install_newline_binding,
             )
             install_newline_binding(kb)
+        except Exception:  # noqa: BLE001
+            pass
+        # Ctrl+S parks a draft. Bound on BOTH surfaces from one definition,
+        # because a feature wired to one while the operator types into the
+        # other is the defect this codebase keeps finding.
+        try:
+            from backend.core.ouroboros.battle_test.draft_stash import (
+                install_stash_binding,
+            )
+            install_stash_binding(kb, _prompt_buffer)
         except Exception:  # noqa: BLE001
             pass
         return kb

--- a/tests/cli/test_draft_stash.py
+++ b/tests/cli/test_draft_stash.py
@@ -1,0 +1,158 @@
+"""Park a half-written goal, do something else, get it back.
+
+The prompt accepts paragraphs now, which makes it worth interrupting — and
+without somewhere to put a draft, the only options are losing it or finishing
+it blind. Both are bad enough that people stop writing long goals, which
+quietly undoes multi-line input.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.battle_test.draft_stash import (
+    DraftStash, install_stash_binding, stash_enabled,
+)
+
+
+def test_it_parks_a_draft_and_clears_the_buffer() -> None:
+    stash = DraftStash()
+    assert stash.toggle("a half-written goal", 8) == ("", 0)
+    assert stash.holding is True
+
+
+def test_it_restores_with_the_cursor_where_it_was() -> None:
+    """Restoring a paragraph with the caret at 0 means hunting for where you
+    were."""
+    stash = DraftStash()
+    stash.toggle("line one\nline two", 12)
+    text, cursor = stash.toggle("", 0)
+    assert text == "line one\nline two"
+    assert cursor == 12
+    assert stash.holding is False
+
+
+def test_a_SECOND_stash_swaps_instead_of_overwriting() -> None:
+    """THE rule. A single slot is a thing you can hold in your head, but a
+    second stash would destroy the first — and silently destroying a draft is
+    exactly what this exists to prevent. So it swaps: nothing is ever lost,
+    and the operator gets the other draft rather than an error."""
+    stash = DraftStash()
+    stash.toggle("first draft", 5)
+    returned, cursor = stash.toggle("second draft", 3)
+    assert returned == "first draft"
+    assert cursor == 5
+    assert stash.preview.startswith("second draft")
+
+
+def test_toggling_an_empty_buffer_with_nothing_held_is_a_no_op() -> None:
+    """Not an error either — a key that scolds you for pressing it is a key
+    you stop pressing."""
+    stash = DraftStash()
+    assert stash.toggle("", 0) == ("", 0)
+    assert stash.holding is False
+
+
+def test_whitespace_alone_is_not_a_draft() -> None:
+    stash = DraftStash()
+    stash.toggle("   \n  ", 2)
+    assert stash.holding is False
+
+
+def test_multiline_survives_the_round_trip() -> None:
+    """The whole reason this exists is the long goals multi-line enabled."""
+    draft = "fix the containment check\nand also the coverage gate\n\nthen soak"
+    stash = DraftStash()
+    stash.toggle(draft, len(draft))
+    assert stash.toggle("", 0)[0] == draft
+
+
+def test_the_cursor_is_clamped_on_restore() -> None:
+    """The buffer it returns to may not be the one it left."""
+    stash = DraftStash()
+    stash.toggle("short", 9999)
+    _text, cursor = stash.toggle("", 0)
+    assert cursor <= len("short")
+
+
+@pytest.mark.parametrize("junk", [None, 42, object()])
+def test_junk_never_eats_the_draft(junk) -> None:
+    stash = DraftStash()
+    text, cursor = stash.toggle(junk, 0)
+    assert isinstance(text, str) and isinstance(cursor, int)
+
+
+# --------------------------------------------------------------------------
+# the binding
+# --------------------------------------------------------------------------
+
+def test_ctrl_s_is_bound_and_actually_swaps() -> None:
+    """Registered AND invoked — a binding that exists in source but does
+    nothing is this codebase's most repeated defect."""
+    from prompt_toolkit.buffer import Buffer
+    from prompt_toolkit.key_binding import KeyBindings
+
+    buf = Buffer(multiline=True)
+    buf.text = "a parked goal"
+    buf.cursor_position = 4
+    kb = KeyBindings()
+    stash = install_stash_binding(kb, lambda: buf)
+    assert stash is not None
+
+    combos = [tuple(str(k) for k in b.keys) for b in kb.bindings]
+    assert ("Keys.ControlS",) in combos
+
+    kb.bindings[0].handler(object())
+    assert buf.text == ""
+    kb.bindings[0].handler(object())
+    assert buf.text == "a parked goal"
+
+
+def test_ctrl_s_reaches_the_app_rather_than_freezing_the_terminal() -> None:
+    """Ctrl+S is XOFF under a cooked terminal and would freeze output instead
+    of arriving. prompt_toolkit puts the input in raw mode with IXON cleared —
+    verified against the library, because the failure mode is a terminal that
+    appears to hang."""
+    import inspect
+
+    from prompt_toolkit.input import vt100
+
+    assert "IXON" in inspect.getsource(vt100)
+
+
+def test_both_surfaces_bind_it() -> None:
+    import ast
+    from pathlib import Path
+
+    repo = Path(__file__).resolve().parents[2]
+    for path in ("backend/core/ouroboros/cli/ov.py",
+                 "backend/core/ouroboros/battle_test/bipartite_layout.py"):
+        src = (repo / path).read_text()
+        names = {a.name for n in ast.walk(ast.parse(src))
+                 if isinstance(n, ast.ImportFrom) for a in n.names}
+        assert "install_stash_binding" in names, f"{path} has no stash"
+
+
+def test_the_kill_switch(monkeypatch: pytest.MonkeyPatch) -> None:
+    from prompt_toolkit.key_binding import KeyBindings
+
+    monkeypatch.setenv("JARVIS_DRAFT_STASH_ENABLED", "0")
+    assert stash_enabled() is False
+    kb = KeyBindings()
+    assert install_stash_binding(kb, lambda: None) is None
+    assert not kb.bindings
+
+
+# --------------------------------------------------------------------------
+# the two arguments recovered from the closed PR
+# --------------------------------------------------------------------------
+
+def test_the_prompt_offers_history_search_and_an_editor() -> None:
+    """Both are prompt_toolkit built-ins that were simply never passed. Up
+    prefix-filters instead of walking 2000 entries, and Ctrl+X Ctrl+E finishes
+    a long goal in $EDITOR where the terminal's editing model runs out."""
+    from pathlib import Path
+
+    repo = Path(__file__).resolve().parents[2]
+    src = (repo / "backend/core/ouroboros/cli/ov.py").read_text()
+    assert "enable_history_search=True" in src
+    assert "enable_open_in_editor=True" in src


### PR DESCRIPTION
Three gaps from the audit — two of them **recovered from #70185**, which I closed as superseded when #70184 landed the history file. #70184 shipped `Ctrl+R` search but not these two, so they'd have been quietly lost.

## `Ctrl+S` — the draft stash

The prompt accepts paragraphs now, which makes it worth interrupting. Two hundred characters into describing a repair you notice you should check `/posture` first — and your only options were losing the draft or finishing it blind. Both are bad enough that people stop writing long goals, which quietly undoes multi-line input.

**A swap, not a stack.** A stack has no visible depth in a one-line prompt, so you can't tell whether the next press returns what you want or something from ten minutes ago. A single slot is a thing you can hold in your head.

The cost of one slot is that a second stash would overwrite the first — and silently destroying a draft is exactly what this exists to prevent. So it **swaps**:

```
park "first draft"   → buffer clears, slot holds it
stash "second draft" → returns "first draft"   ← never destroyed
```

Nothing is ever lost, and you get the other draft rather than an error. An empty toggle with nothing held is a no-op, not an error — a key that scolds you for pressing it is a key you stop pressing.

The cursor travels with the text, clamped on restore because the buffer it returns to may not be the one it left. **Not persisted, deliberately**: a stash surviving a restart would be a second history with different rules, and history already exists, is durable, and is what "I want this back tomorrow" means.

### The trap worth naming

`Ctrl+S` is **XOFF** under a cooked terminal — it would freeze output instead of reaching the application. prompt_toolkit clears `IXON` in raw mode so the key arrives. Verified against the library rather than assumed, because the failure mode is *a terminal that appears to hang*, and pinned by a test so a future input-layer change surfaces as a red rather than a mystery.

## The two recovered arguments

Both prompt_toolkit built-ins that were simply never passed:

- **`enable_history_search`** — Up prefix-filters on what you've typed instead of walking the whole file. The difference between 2000 entries being *recallable* and being *usable*.
- **`enable_open_in_editor`** — `Ctrl+X Ctrl+E` finishes a long goal in `$EDITOR`, where the terminal's one-line editing model runs out. Pairs directly with multi-line input.

Bound on **both** surfaces from one definition — a feature wired to one while the operator types into the other is the defect this codebase keeps finding.

## Verification

15 tests. The binding is asserted **registered and invoked** — a binding that exists in source but does nothing is the most repeated defect here. 819 `tests/cli` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Ctrl+S “draft stash” to swap a half-written prompt with a held draft, so you can check something and get your text back. Also enable history prefix search and open-in-editor to make long inputs easier.

- New Features
  - Ctrl+S “draft stash”: swaps buffer with a single held draft; never overwrites; cursor preserved; not persisted.
  - Bound on both prompt surfaces from one definition; works with `prompt_toolkit` raw mode.
  - Kill switch: set `JARVIS_DRAFT_STASH_ENABLED=0` to disable.
  - Prompt options enabled: `enable_history_search=True` and `enable_open_in_editor=True`.

<sup>Written for commit da598dc70871f93fe0b0dfae289453a21e6f4cf7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

