### PR TITLE
feat(ov): Esc Esc freezes the organism while you decide, and every pane knows the trust dial

### DIFF
--- a/backend/core/ouroboros/battle_test/cockpit_attach.py
+++ b/backend/core/ouroboros/battle_test/cockpit_attach.py
@@ -216,6 +216,8 @@ class CockpitAttachBridge:
         replay_provider: Optional[Callable[[], Any]] = None,
         on_input: Optional[Callable[[str], None]] = None,
         on_audio: Optional[Callable[[str], None]] = None,
+        on_autonomy: Optional[Callable[[str], None]] = None,
+        rewind_provider: Optional[Callable[[int], Any]] = None,
         path: Optional[Path] = None,
     ) -> None:
         self._status = status_provider or (lambda: {})
@@ -231,6 +233,21 @@ class CockpitAttachBridge:
         self._replay = replay_provider or (lambda: [])
         self._on_input = on_input or (lambda _t: None)
         self._on_audio = on_audio or (lambda _c: None)
+        #: The Transactional Viewport Lock's execution seam: called with
+        #: "pause" on the FIRST hold and "resume" when the LAST hold
+        #: releases. The harness wires this to the same intake pause the
+        #: pause/resume verbs use — one implementation, two entrances.
+        self._on_autonomy = on_autonomy or (lambda _a: None)
+        #: rewind_provider(limit) → serializable candidate list for the
+        #: Esc-Esc menu. Supplied by the harness from the EXISTING /undo
+        #: planner — this bridge never touches git.
+        self._rewind = rewind_provider or (lambda _n: [])
+        #: session → monotonic deadline. A REFCOUNT, not a flag: two panes
+        #: may hold rewind menus at once, and autonomy resumes only when
+        #: the last hold releases. The TTL is the dead-client failsafe —
+        #: an operator's crashed terminal must never freeze the organism
+        #: forever; _drop() also releases synchronously on disconnect.
+        self._autonomy_holds: Dict[str, float] = {}
         #: Does the input sink accept the originating session?
         #:
         #: Decided ONCE, by inspection. The obvious alternative — call with
@@ -465,6 +482,151 @@ class CockpitAttachBridge:
                 loop.call_soon_threadsafe(self._broadcast, msg)
         except Exception:  # noqa: BLE001
             logger.debug("[CockpitAttach] markup publish degraded", exc_info=True)
+
+    # ---- the Transactional Viewport Lock (autonomy pause refcount) ----
+
+    @staticmethod
+    def _autonomy_ttl_s() -> float:
+        """Dead-holder failsafe. A crashed terminal releases via _drop;
+        this covers the one it can't — a client alive on the socket but
+        wedged with its menu open. Env: JARVIS_AUTONOMY_LOCK_TTL_S."""
+        try:
+            return max(5.0, float(
+                os.environ.get("JARVIS_AUTONOMY_LOCK_TTL_S", "120"),
+            ))
+        except (TypeError, ValueError):
+            return 120.0
+
+    def _sweep_autonomy_holds(self) -> None:
+        now = time.monotonic()
+        for sid, deadline in list(self._autonomy_holds.items()):
+            if deadline <= now:
+                del self._autonomy_holds[sid]
+
+    def _autonomy_ctl(self, action: str, session: Optional[str]) -> None:
+        """One pause/resume request from one cockpit. Refcounted: the
+        daemon's execution intake pauses on the FIRST hold and resumes on
+        the LAST release — pane B's open rewind menu keeps the world
+        frozen even after pane A closes hers. Every transition (and every
+        no-op re-assert) re-broadcasts autonomy_state so all panes agree.
+        NEVER raises."""
+        try:
+            sid = str(session or "").strip() or "?anonymous"
+            was_held = bool(self._autonomy_holds)
+            self._sweep_autonomy_holds()
+            if action == "pause":
+                self._autonomy_holds[sid] = (
+                    time.monotonic() + self._autonomy_ttl_s()
+                )
+            elif action == "resume":
+                self._autonomy_holds.pop(sid, None)
+            else:
+                return
+            now_held = bool(self._autonomy_holds)
+            if now_held and not was_held:
+                self.stats["autonomy_pauses"] = (
+                    self.stats.get("autonomy_pauses", 0) + 1
+                )
+                try:
+                    self._on_autonomy("pause")
+                except Exception:  # noqa: BLE001
+                    logger.debug("[CockpitAttach] pause sink degraded",
+                                 exc_info=True)
+            elif was_held and not now_held:
+                try:
+                    self._on_autonomy("resume")
+                except Exception:  # noqa: BLE001
+                    logger.debug("[CockpitAttach] resume sink degraded",
+                                 exc_info=True)
+            self.publish_autonomy_state()
+        except Exception:  # noqa: BLE001
+            logger.debug("[CockpitAttach] autonomy ctl degraded",
+                         exc_info=True)
+
+    def publish_autonomy_state(self) -> None:
+        """Broadcast the lock's truth to every cockpit — held or free, and
+        by how many holders — so a pane that never touched Esc-Esc still
+        shows the ⏸ freeze another pane caused. NEVER raises."""
+        try:
+            self._sweep_autonomy_holds()
+            msg = {
+                "type": "autonomy_state",
+                "paused": bool(self._autonomy_holds),
+                "holders": len(self._autonomy_holds),
+                "ts": time.time(),
+            }
+            loop = self._loop
+            if loop is None or loop.is_closed():
+                return
+
+            def _emit() -> None:
+                from backend.core.ouroboros.battle_test.attach_session import (
+                    session_scope,
+                )
+                with session_scope(None):
+                    self._broadcast(msg)
+
+            try:
+                running = asyncio.get_running_loop()
+            except RuntimeError:
+                running = None
+            if running is loop:
+                _emit()
+            else:
+                loop.call_soon_threadsafe(_emit)
+        except Exception:  # noqa: BLE001
+            logger.debug("[CockpitAttach] autonomy state degraded",
+                         exc_info=True)
+
+    def _serve_rewind_list(
+        self, session: Optional[str], *, limit: Any = None,
+    ) -> None:
+        """Answer one Esc-Esc menu request with the LOCKED restore points.
+
+        Called after the requester's pause hold landed, so the list is a
+        static snapshot — nothing is mutating underneath it. The provider
+        is the harness's adapter over the EXISTING /undo planner; this
+        bridge never reads git. Addressed to the requester alone, like
+        lane history. NEVER raises."""
+        try:
+            try:
+                n = max(1, min(int(limit), 50)) if limit is not None else 10
+            except (TypeError, ValueError):
+                n = 10
+            try:
+                candidates = list(self._rewind(n) or [])
+            except Exception:  # noqa: BLE001
+                logger.debug("[CockpitAttach] rewind provider degraded",
+                             exc_info=True)
+                candidates = []
+            payload = {
+                "type": "rewind_list",
+                "candidates": candidates,
+                "locked": bool(self._autonomy_holds),
+                "ts": time.time(),
+            }
+            from backend.core.ouroboros.battle_test.attach_session import (
+                session_scope,
+            )
+            loop = self._loop
+            if loop is None or loop.is_closed():
+                return
+
+            def _emit() -> None:
+                with session_scope(session):
+                    self._broadcast(payload)
+
+            try:
+                running = asyncio.get_running_loop()
+            except RuntimeError:
+                running = None
+            if running is loop:
+                _emit()
+            else:
+                loop.call_soon_threadsafe(_emit)
+        except Exception:  # noqa: BLE001
+            logger.debug("[CockpitAttach] rewind list degraded",
+                         exc_info=True)
 
     def publish_history_append(
         self, text: str, *, origin_session: Optional[str] = None,
@@ -933,6 +1095,11 @@ class CockpitAttachBridge:
         for sid, sw in list(self._sessions.items()):
             if sw is w:
                 del self._sessions[sid]
+                # Safe resumption: a cockpit that dies with its rewind
+                # menu open must release its autonomy hold NOW, not at
+                # TTL expiry — a SIGKILL'd terminal cannot send resume.
+                if sid in self._autonomy_holds:
+                    self._autonomy_ctl("resume", sid)
         try:
             w.close()
         except Exception:  # noqa: BLE001
@@ -1018,6 +1185,20 @@ class CockpitAttachBridge:
                     text = str(frame.get("text", "")).strip()
                     if text:
                         self._sync_history(text, _sid or None)
+                elif ftype == "autonomy":
+                    # The Transactional Viewport Lock: pause on menu
+                    # open, resume on close/rollback — refcounted across
+                    # panes, TTL'd against wedged holders.
+                    self._autonomy_ctl(
+                        str(frame.get("action", "")).strip().lower(),
+                        _sid or None,
+                    )
+                elif ftype == "rewind_list":
+                    # Esc-Esc menu hydration — answered only to the
+                    # asking cockpit, from the locked snapshot.
+                    self._serve_rewind_list(
+                        _sid or None, limit=frame.get("limit"),
+                    )
                 elif ftype == "lane":
                     # Hydration request: the client focused a lane and wants
                     # its history. Answered ONLY to the asking cockpit —
@@ -1078,6 +1259,8 @@ class CockpitAttachClient:
         on_lane_history: Optional[Callable[[Dict[str, Any]], None]] = None,
         on_lane_reaped: Optional[Callable[[str], None]] = None,
         on_history_append: Optional[Callable[[str], None]] = None,
+        on_autonomy_state: Optional[Callable[[Dict[str, Any]], None]] = None,
+        on_rewind_list: Optional[Callable[[Dict[str, Any]], None]] = None,
         path: Optional[Path] = None,
     ) -> None:
         self._path = Path(path) if path is not None else attach_socket_path()
@@ -1103,6 +1286,11 @@ class CockpitAttachClient:
         #: Another terminal's line, for Up-arrow parity. Absent handler =
         #: a pre-sync cockpit; the frame is simply not dispatched.
         self._on_history_append = on_history_append
+        #: The viewport lock's truth (paused/holders) — every pane shows
+        #: the freeze, whoever caused it.
+        self._on_autonomy_state = on_autonomy_state
+        #: The Esc-Esc menu's hydration payload (locked restore points).
+        self._on_rewind_list = on_rewind_list
         #: This cockpit's identity for the life of the attachment. Declared
         #: on every outbound frame so the daemon can address answers back to
         #: the terminal that asked, instead of to all of them.
@@ -1209,6 +1397,38 @@ class CockpitAttachClient:
         except Exception:  # noqa: BLE001
             return False
 
+    def send_autonomy(self, action: str) -> bool:
+        """Acquire ("pause") or release ("resume") this cockpit's hold on
+        the Transactional Viewport Lock. Non-blocking; False when
+        detached or the action is outside the taxonomy. NEVER raises."""
+        try:
+            action = str(action or "").strip().lower()
+            if action not in ("pause", "resume"):
+                return False
+            w = self._writer
+            if not self.connected or w is None or w.is_closing():
+                return False
+            frame = {"type": "autonomy", "action": action,
+                     "session": self.session_id}
+            w.write((json.dumps(frame, separators=(",", ":")) + "\n").encode())
+            return True
+        except Exception:  # noqa: BLE001
+            return False
+
+    def send_rewind_request(self, limit: int = 10) -> bool:
+        """Ask the daemon for the locked restore-point list. NEVER
+        raises."""
+        try:
+            w = self._writer
+            if not self.connected or w is None or w.is_closing():
+                return False
+            frame = {"type": "rewind_list", "limit": int(limit),
+                     "session": self.session_id}
+            w.write((json.dumps(frame, separators=(",", ":")) + "\n").encode())
+            return True
+        except Exception:  # noqa: BLE001
+            return False
+
     def send_history(self, text: str) -> bool:
         """Report one CLIENT-HANDLED line upstream for history fan-out.
 
@@ -1287,6 +1507,18 @@ class CockpitAttachClient:
                             pass
                     else:
                         self._safe_cb_text(cb, str(frame.get("text", "")))
+                elif ftype == "autonomy_state":
+                    if self._on_autonomy_state is not None:
+                        try:
+                            self._on_autonomy_state(dict(frame))
+                        except Exception:  # noqa: BLE001
+                            pass
+                elif ftype == "rewind_list":
+                    if self._on_rewind_list is not None:
+                        try:
+                            self._on_rewind_list(dict(frame))
+                        except Exception:  # noqa: BLE001
+                            pass
                 elif ftype == "history_append":
                     # Another terminal's line. Drop our own echo — the
                     # daemon excludes the originator by session binding,

--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -4566,6 +4566,48 @@ class BattleTestHarness:
                 except Exception:  # noqa: BLE001
                     return {}
 
+            def _on_autonomy(action: str) -> None:
+                # The Transactional Viewport Lock's execution seam — the
+                # SAME intake pause the pause/resume verbs flip (DRY: one
+                # implementation, two entrances). The bridge refcounts and
+                # only calls on edge transitions; the idempotence guards
+                # here are belt + braces.
+                try:
+                    if action == "pause" and not self._intake_paused:
+                        self._repl_cmd_pause()
+                    elif action == "resume" and self._intake_paused:
+                        self._repl_cmd_resume()
+                except Exception:  # noqa: BLE001
+                    logger.debug("[Attach] autonomy sink degraded",
+                                 exc_info=True)
+
+            def _rewind_provider(limit: int) -> list:
+                # The Esc-Esc menu's data — the EXISTING /undo planner in
+                # preview mode, serialized. No second snapshot system.
+                try:
+                    from backend.core.ouroboros.battle_test.undo_command import (  # noqa: E501
+                        UndoPlanner,
+                    )
+                    plan = UndoPlanner(
+                        Path(self._config.repo_path),
+                        governed_loop_service=self._governed_loop_service,
+                    ).plan(limit, mode="preview")
+                    return [
+                        {
+                            "n": i + 1,
+                            "sha": t.short_sha,
+                            "label": t.display_label,
+                            "is_ov": t.is_ov,
+                            "insertions": t.insertions,
+                            "deletions": t.deletions,
+                        }
+                        for i, t in enumerate(plan.targets)
+                    ]
+                except Exception:  # noqa: BLE001
+                    logger.debug("[Attach] rewind provider degraded",
+                                 exc_info=True)
+                    return []
+
             bridge = CockpitAttachBridge(
                 status_provider=_status_provider,
                 ops_provider=_ops_provider,
@@ -4573,6 +4615,8 @@ class BattleTestHarness:
                 fabrics_provider=_fabrics_provider,
                 on_input=_on_input,
                 on_audio=lambda cmd: self._dispatch_audio_cmd(cmd),
+                on_autonomy=_on_autonomy,
+                rewind_provider=_rewind_provider,
             )
             self._audio_synapse = AudioVisualSynapse(
                 bridge.publish_audio_state,

--- a/backend/core/ouroboros/battle_test/rewind_menu.py
+++ b/backend/core/ouroboros/battle_test/rewind_menu.py
@@ -1,0 +1,298 @@
+"""Esc-Esc rewind — a locked list of restore points, in the palette.
+
+CC's rewind menu meets O+V's reality: the daemon keeps WORKING while a
+menu is open, so by the time the operator picks a restore point the world
+it described may be gone. Refreshing the menu faster is a workaround
+wearing a fix's clothes — the root cause is active background autonomy
+during a user-intervention event. So opening the menu takes the
+**Transactional Viewport Lock**:
+
+  1. Esc-Esc (empty prompt) → this client sends ``autonomy: pause`` and a
+     ``rewind_list`` request over the bridge;
+  2. the daemon suspends intake (refcounted across panes, TTL'd against
+     wedged holders, released on disconnect) and answers — addressed to
+     this cockpit alone — with a STATIC snapshot of the /undo planner's
+     restore points;
+  3. the menu renders through the SAME gated-completer palette Float that
+     history search uses — no second overlay system;
+  4. selecting a point inserts ``/undo N`` into the prompt (an explicit
+     Enter confirms a git revert — a rollback should never be one
+     accidental keystroke), and CLOSING the menu — accept or dismiss —
+     releases the hold. The daemon's TTL and disconnect-release back this
+     up, and a daemon that never answers (pre-rewind build) trips a local
+     failsafe that releases the hold and says so.
+
+Env: ``JARVIS_REWIND_MENU_ENABLED`` (default true),
+``JARVIS_REWIND_REPLY_TIMEOUT_S`` (failsafe, default 5).
+
+NEVER raises into key dispatch, the read loop, or a repaint.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Any, Callable, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+REWIND_MENU_SCHEMA_VERSION: str = "rewind_menu.1"
+
+MASTER_FLAG_ENV_VAR: str = "JARVIS_REWIND_MENU_ENABLED"
+REPLY_TIMEOUT_ENV_VAR: str = "JARVIS_REWIND_REPLY_TIMEOUT_S"
+
+REWIND_ACTION: str = "app:rewind"
+REWIND_DEFAULT_KEYS = ("esc esc",)
+
+
+def is_rewind_menu_enabled() -> bool:
+    """Master flag — default true. NEVER raises."""
+    raw = os.environ.get(MASTER_FLAG_ENV_VAR, "true")
+    return raw.strip().lower() not in ("0", "false", "no", "off")
+
+
+def _reply_timeout_s() -> float:
+    try:
+        return max(1.0, float(os.environ.get(REPLY_TIMEOUT_ENV_VAR, "5")))
+    except (TypeError, ValueError):
+        return 5.0
+
+
+class RewindController:
+    """The lock's client half + the menu's state machine.
+
+    Lifecycle: ``open()`` acquires the hold and requests the snapshot;
+    ``deliver()`` (wired to the client's ``on_rewind_list``) renders it;
+    ``close()`` releases the hold exactly once, whatever path led there —
+    accept, Esc, empty list, reply timeout."""
+
+    def __init__(
+        self,
+        client: Any,
+        *,
+        notify: Optional[Callable[[str], None]] = None,
+    ) -> None:
+        self._client = client
+        self._notify = notify or (lambda _m: None)
+        self.armed = False
+        self.candidates: List[Dict[str, Any]] = []
+        self._menu_opened = False
+        self._hold_released = True
+        self._watched_buffers: set = set()
+        self._failsafe: Any = None
+
+    # -- lifecycle ---------------------------------------------------------
+
+    def open(self) -> bool:
+        """Acquire the viewport lock and request the snapshot. NEVER
+        raises; False when disabled/detached (no hold is taken)."""
+        try:
+            if not is_rewind_menu_enabled() or self.armed:
+                return False
+            if not self._client.send_autonomy("pause"):
+                return False
+            self._hold_released = False
+            self.armed = True
+            self._menu_opened = False
+            self.candidates = []
+            if not self._client.send_rewind_request():
+                self.close(reason="request failed")
+                return False
+            self._notify("⏸ autonomy held — fetching restore points…")
+            self._arm_failsafe()
+            return True
+        except Exception:  # noqa: BLE001
+            logger.debug("[Rewind] open degraded", exc_info=True)
+            self.close(reason="open degraded")
+            return False
+
+    def deliver(self, frame: Dict[str, Any]) -> None:
+        """The daemon's addressed snapshot arrived — render it. NEVER
+        raises."""
+        try:
+            if not self.armed:
+                return
+            self._cancel_failsafe()
+            raw = frame.get("candidates")
+            self.candidates = [c for c in (raw or []) if isinstance(c, dict)]
+            if not self.candidates:
+                self._notify("nothing to rewind — no reverted-able commits")
+                self.close(reason="empty")
+                return
+            from prompt_toolkit.application.current import get_app_or_none
+            app = get_app_or_none()
+            if app is None:
+                self.close(reason="no app")
+                return
+            buf = app.current_buffer
+            self._watch(buf)
+            self._menu_opened = True
+            buf.start_completion(select_first=False)
+            app.invalidate()
+        except Exception:  # noqa: BLE001
+            logger.debug("[Rewind] deliver degraded", exc_info=True)
+            self.close(reason="deliver degraded")
+
+    def close(self, *, reason: str = "") -> None:
+        """Release the hold EXACTLY ONCE. Safe from any path. NEVER
+        raises."""
+        try:
+            self.armed = False
+            self._menu_opened = False
+            self._cancel_failsafe()
+            if not self._hold_released:
+                self._hold_released = True
+                try:
+                    self._client.send_autonomy("resume")
+                except Exception:  # noqa: BLE001
+                    pass
+                self._notify("▶ autonomy released"
+                             + (f" ({reason})" if reason else ""))
+        except Exception:  # noqa: BLE001
+            logger.debug("[Rewind] close degraded", exc_info=True)
+
+    # -- plumbing ----------------------------------------------------------
+
+    def _watch(self, buffer: Any) -> None:
+        """Auto-release on menu close — the buffer's own event, so accept
+        and Esc and clear all release without enumeration."""
+        try:
+            if id(buffer) in self._watched_buffers:
+                return
+            self._watched_buffers.add(id(buffer))
+
+            def _on_change(buf: Any) -> None:
+                try:
+                    if (
+                        self.armed and self._menu_opened
+                        and buf.complete_state is None
+                    ):
+                        self.close()
+                except Exception:  # noqa: BLE001
+                    self.close()
+
+            buffer.on_completions_changed += _on_change
+        except Exception:  # noqa: BLE001
+            logger.debug("[Rewind] watch degraded", exc_info=True)
+
+    def _arm_failsafe(self) -> None:
+        """A daemon that never answers (pre-rewind build, wedged loop)
+        must not leave autonomy frozen on a hold nobody can see."""
+        try:
+            loop = asyncio.get_event_loop()
+
+            def _fire() -> None:
+                if self.armed and not self._menu_opened:
+                    self._notify("rewind unavailable on this daemon")
+                    self.close(reason="no reply")
+
+            self._failsafe = loop.call_later(_reply_timeout_s(), _fire)
+        except Exception:  # noqa: BLE001
+            self._failsafe = None
+
+    def _cancel_failsafe(self) -> None:
+        try:
+            if self._failsafe is not None:
+                self._failsafe.cancel()
+        except Exception:  # noqa: BLE001
+            pass
+        self._failsafe = None
+
+
+class RewindCompleter:
+    """Feeds the locked restore points into the palette while armed.
+
+    Selecting one INSERTS ``/undo N`` — the same typed verb the daemon
+    already knows how to execute transactionally — so the keystroke path
+    and the typed path cannot drift, and a git revert always takes an
+    explicit Enter."""
+
+    def __init__(self, controller: RewindController) -> None:
+        self._controller = controller
+
+    def get_completions(self, document: Any, _event: Any = None):
+        ctl = self._controller
+        if not ctl.armed or not ctl.candidates:
+            return
+        try:
+            from prompt_toolkit.completion import Completion
+        except ImportError:
+            return
+        try:
+            replace = -len(document.text_before_cursor or "")
+            for cand in ctl.candidates:
+                n = cand.get("n")
+                label = str(cand.get("label", ""))
+                ins = cand.get("insertions", 0)
+                dels = cand.get("deletions", 0)
+                yield Completion(
+                    text=f"/undo {n}",
+                    start_position=replace,
+                    display=f"{n}. {label}",
+                    display_meta=f"⏪ +{ins} −{dels}",
+                )
+        except Exception:  # noqa: BLE001
+            logger.debug("[Rewind] completion degraded", exc_info=True)
+            return
+
+
+def merge_rewind_completer(
+    base_completer: Any, controller: Optional[RewindController],
+) -> Any:
+    """Compose the gated rewind source ahead of a surface's completer —
+    same shape as merge_history_completer. NEVER raises."""
+    if controller is None:
+        return base_completer
+    rc = RewindCompleter(controller)
+    if base_completer is None:
+        return rc
+    try:
+        from prompt_toolkit.completion import merge_completers
+        return merge_completers([rc, base_completer])
+    except Exception:  # noqa: BLE001
+        return base_completer
+
+
+def install_rewind_binding(kb: Any, controller: RewindController) -> bool:
+    """Bind the remappable ``app:rewind`` action (default Esc Esc, fires
+    only on an EMPTY prompt — a draft's double-Esc still means "clear").
+    NEVER raises."""
+    try:
+        from prompt_toolkit.filters import Condition
+
+        @Condition
+        def _empty_prompt() -> bool:
+            try:
+                from prompt_toolkit.application.current import (
+                    get_app_or_none,
+                )
+                app = get_app_or_none()
+                return app is not None and not app.current_buffer.text
+            except Exception:  # noqa: BLE001
+                return False
+
+        def _open(event: Any) -> None:
+            controller.open()
+
+        from backend.core.ouroboros.battle_test.keymap import bind_action
+        return bind_action(
+            kb, REWIND_ACTION, REWIND_DEFAULT_KEYS, _open,
+            context="Chat", filter=_empty_prompt,
+            description="open the rewind menu (pauses autonomy while open)",
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug("[Rewind] install degraded", exc_info=True)
+        return False
+
+
+__all__ = [
+    "MASTER_FLAG_ENV_VAR",
+    "REWIND_ACTION",
+    "REWIND_DEFAULT_KEYS",
+    "REWIND_MENU_SCHEMA_VERSION",
+    "RewindCompleter",
+    "RewindController",
+    "install_rewind_binding",
+    "is_rewind_menu_enabled",
+    "merge_rewind_completer",
+]

--- a/backend/core/ouroboros/battle_test/status_line.py
+++ b/backend/core/ouroboros/battle_test/status_line.py
@@ -232,7 +232,22 @@ class StatusLineBuilder:
             return ""
         try:
             snap = self.snapshot()
-            return _format_plain(snap, compact=compact_mode_enabled())
+            rendered = _format_plain(snap, compact=compact_mode_enabled())
+            # The trust dial's chip — appended at THIS seam because every
+            # surface (daemon toolbar, attach heartbeat, both cockpits)
+            # mirrors this one line, so a Shift+Tab in any pane shows in
+            # all of them within a heartbeat. Empty at the safe_auto
+            # resting state so the line stays calm.
+            try:
+                from backend.core.ouroboros.governance.trust_repl import (
+                    floor_chip,
+                )
+                chip = floor_chip()
+                if chip:
+                    rendered = f"{rendered} · {chip}" if rendered else chip
+            except Exception:  # noqa: BLE001
+                pass
+            return rendered
         except Exception:  # noqa: BLE001
             logger.debug(
                 "[StatusLine] plain render failed", exc_info=True,

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -1274,6 +1274,16 @@ def _route_operator_line(client: Any, ui: Any, line: Any) -> str:
         low = text.lower()
         if low in ("detach", "exit", "quit"):
             return "detach"
+
+        # `!` shell mode (CC parity): one command on THIS machine, output
+        # into this operator's scrollback. Runs in an executor — a slow
+        # command never blocks a keystroke. A bare "!" falls through as
+        # ordinary text.
+        if text.startswith("!") and text[1:].strip():
+            import asyncio as _aio
+            _aio.ensure_future(_run_client_shell(ui, client, text))
+            return "handled"
+
         audio_verbs = AUDIO_VERBS
         # /deck sizing is a CLIENT concern — two cockpits on different
         # terminals want different amounts of screen, and the daemon has no
@@ -1480,6 +1490,25 @@ async def _split_plane_loop(
             install_history_search(_kb, _hist_controller)
     except Exception:  # noqa: BLE001 — search is a bonus, typing is not
         _hist_controller = None
+    # Rewind source + the client action set — the SAME composition the
+    # bipartite surface mounts, so the two cannot diverge.
+    try:
+        from backend.core.ouroboros.battle_test.rewind_menu import (
+            merge_rewind_completer,
+        )
+        _completer = merge_rewind_completer(
+            _completer, getattr(ui, "rewind", None),
+        )
+    except Exception:  # noqa: BLE001
+        pass
+    _extra_kb = _client_extra_bindings(ui, client)
+    if _extra_kb is not None:
+        try:
+            from prompt_toolkit.key_binding import merge_key_bindings
+            _kb = (merge_key_bindings([_kb, _extra_kb])
+                   if _kb is not None else _extra_kb)
+        except Exception:  # noqa: BLE001
+            pass
     # ONE persistent session, dynamic prompt + rigid footer toolbar:
     # both are callables re-evaluated on every repaint, so an
     # audio_state frame morphs the footer via app.invalidate() while
@@ -1695,6 +1724,188 @@ def _render_client_keys(ui: Any, line: str) -> None:
         elif ui is not None and hasattr(ui, "flash"):
             first = str(result.text or "").splitlines() or [""]
             ui.flash(f"{first[0]} — `/keys daemon` for the daemon view")
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _ring_gate_bell() -> None:
+    """An Iron Gate opened while the operator may be in another pane —
+    ring the terminal (BEL) and post an OSC-9 notification (iTerm2/kitty
+    forward it to the OS). Writes to the REAL stdout, bypassing any
+    patched proxy; a non-TTY gets nothing. Env: JARVIS_GATE_BELL_ENABLED
+    (default true). NEVER raises."""
+    try:
+        if os.environ.get("JARVIS_GATE_BELL_ENABLED", "true").strip().lower() \
+                in ("0", "false", "no", "off"):
+            return
+        out = sys.__stdout__
+        if out is None or not out.isatty():
+            return
+        out.write("\x1b]9;O+V: Iron Gate awaiting approval\x07\a")
+        out.flush()
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _on_autonomy_state_frame(ui: Any, frame: Any) -> None:
+    """The viewport lock's broadcast truth — every pane shows the freeze,
+    whoever caused it. NEVER raises."""
+    try:
+        paused = bool(frame.get("paused"))
+        holders = int(frame.get("holders", 0) or 0)
+        try:
+            ui.autonomy_paused = paused
+        except Exception:  # noqa: BLE001
+            pass
+        if paused:
+            ui.flash(f"⏸ autonomy held ({holders} viewer"
+                     f"{'s' if holders != 1 else ''})", seconds=4.0)
+        else:
+            ui.flash("▶ autonomy flowing", seconds=2.0)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+async def _run_client_shell(ui: Any, client: Any, text: str) -> None:
+    """``!`` shell mode — run one command on THIS terminal's machine,
+    render its output into the operator's scrollback, report the line to
+    distributed history. Off the event loop (executor) so a slow command
+    never freezes a keystroke. NEVER raises."""
+    import asyncio
+    import subprocess
+
+    cmd = text[1:].strip()
+
+    def _run() -> str:
+        try:
+            proc = subprocess.run(
+                cmd, shell=True, capture_output=True, text=True, timeout=30,
+            )
+            body = (proc.stdout or "") + (proc.stderr or "")
+            tail = f"\n[exit {proc.returncode}]" if proc.returncode else ""
+            return (body.rstrip() or "(no output)") + tail
+        except subprocess.TimeoutExpired:
+            return "(timed out after 30s)"
+        except Exception as exc:  # noqa: BLE001
+            return f"(shell failed: {exc})"
+
+    try:
+        loop = asyncio.get_running_loop()
+        output = await loop.run_in_executor(None, _run)
+        sink = getattr(ui, "markup_sink", None) if ui is not None else None
+        try:
+            from rich.markup import escape as _escape
+        except Exception:  # noqa: BLE001
+            def _escape(s: str) -> str:
+                return s
+        if callable(sink):
+            sink(_escape(f"⏺ ! {cmd}"), True)
+            for ln in output.splitlines()[:200]:
+                sink("  " + _escape(ln), True)
+        elif ui is not None and hasattr(ui, "flash"):
+            ui.flash(output.splitlines()[0] if output else "(done)")
+        _report_local_history(client, text)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _client_extra_bindings(ui: Any, client: Any) -> Any:
+    """The client-side action set both attach surfaces mount — every key
+    remappable via keybindings.json, every action ALSO reachable as a
+    typed verb so keystroke and verb are one code path. Returns a
+    KeyBindings or None. NEVER raises."""
+    try:
+        from prompt_toolkit.filters import Condition
+        from prompt_toolkit.key_binding import KeyBindings
+
+        from backend.core.ouroboros.battle_test.keymap import bind_action
+
+        kb = KeyBindings()
+
+        @Condition
+        def _empty_buffer() -> bool:
+            try:
+                from prompt_toolkit.application.current import get_app_or_none
+                app = get_app_or_none()
+                return app is not None and not app.current_buffer.text
+            except Exception:  # noqa: BLE001
+                return False
+
+        def _cycle_trust(event: Any) -> None:
+            try:
+                client.send_input("/trust cycle")
+                ui.flash("⛨ cycling trust dial…", seconds=2.0)
+            except Exception:  # noqa: BLE001
+                pass
+
+        bind_action(
+            kb, "app:cycleTrust", ("shift+tab",), _cycle_trust,
+            context="Chat",
+            description="cycle the autonomy trust dial (/trust cycle)",
+        )
+
+        def _show_help(event: Any) -> None:
+            _render_client_keys(ui, "/keys")
+
+        bind_action(
+            kb, "app:help", ("?",), _show_help,
+            context="Chat", filter=_empty_buffer,
+            description="show keyboard shortcuts (empty prompt only)",
+        )
+
+        def _external_editor(event: Any) -> None:
+            _edit_in_external_editor(event)
+
+        bind_action(
+            kb, "chat:externalEditor", ("ctrl+g",), _external_editor,
+            context="Chat",
+            description="edit the prompt in $EDITOR",
+        )
+
+        rewind = getattr(ui, "rewind", None)
+        if rewind is not None:
+            try:
+                from backend.core.ouroboros.battle_test.rewind_menu import (
+                    install_rewind_binding,
+                )
+                install_rewind_binding(kb, rewind)
+            except Exception:  # noqa: BLE001
+                pass
+        return kb
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _edit_in_external_editor(event: Any) -> None:
+    """Ctrl+G — compose in $EDITOR; the buffer comes back as the prompt.
+    Suspends the TUI for the editor's lifetime via prompt_toolkit's own
+    seam. NEVER raises."""
+    try:
+        import subprocess
+        import tempfile
+
+        buf = event.app.current_buffer
+        editor = (os.environ.get("VISUAL") or os.environ.get("EDITOR")
+                  or "vi")
+
+        def _edit() -> None:
+            try:
+                with tempfile.NamedTemporaryFile(
+                    "w+", suffix=".ov-prompt", delete=False,
+                ) as fh:
+                    fh.write(buf.text)
+                    path = fh.name
+                subprocess.run([*editor.split(), path], check=False)
+                with open(path, "r", encoding="utf-8", errors="replace") as fh:
+                    content = fh.read().rstrip("\n")
+                os.unlink(path)
+                buf.text = content
+                buf.cursor_position = len(content)
+            except Exception:  # noqa: BLE001
+                pass
+
+        from prompt_toolkit.application import run_in_terminal
+        run_in_terminal(_edit)
     except Exception:  # noqa: BLE001
         pass
 
@@ -2071,12 +2282,19 @@ def _prompt_buffer() -> Any:
 def _on_prompt_frame(ui: Any, frame: Any) -> None:
     """A gate arrived. Show it only if the operator is not mid-sentence.
 
+    The bell rings REGARDLESS of composing state — an operator in another
+    tmux pane cannot see a deferred badge, and a gate that expires unseen
+    auto-REJECTs. The Global Bell Arbiter's clear-side already exists:
+    resolution in ANY terminal broadcasts `prompt_resolved`, and every
+    client's shield dismisses the badge.
+
     `composing` is answered from the LIVE buffer at the moment of arrival —
     the one fact that decides everything here, and the reason the FSM takes
     it as an argument rather than reading a global it cannot be tested
     against.
     """
     try:
+        _ring_gate_bell()
         shield = getattr(ui, "shield", None)
         if shield is None:
             return
@@ -2545,6 +2763,30 @@ async def _bipartite_attach_loop(client: Any, console: Any, ui: Any) -> None:
             pass
         return base
 
+    # Client action set (trust cycle, ?, Ctrl+G, Esc-Esc rewind) merged
+    # with PTT through the layout's ONE extra-bindings seam.
+    _extra_kb = _client_extra_bindings(ui, client)
+    if _ptt_kb is not None and _extra_kb is not None:
+        try:
+            from prompt_toolkit.key_binding import merge_key_bindings
+            _extra_kb = merge_key_bindings([_ptt_kb, _extra_kb])
+        except Exception:  # noqa: BLE001
+            _extra_kb = _ptt_kb
+    elif _extra_kb is None:
+        _extra_kb = _ptt_kb
+
+    # The rewind menu rides the same palette the verb completions use.
+    _completer = _build_slash_completer()
+    try:
+        from backend.core.ouroboros.battle_test.rewind_menu import (
+            merge_rewind_completer,
+        )
+        _completer = merge_rewind_completer(
+            _completer, getattr(ui, "rewind", None),
+        )
+    except Exception:  # noqa: BLE001
+        pass
+
     try:
         await run_bipartite_repl(
             on_accept=_on_accept,
@@ -2553,11 +2795,12 @@ async def _bipartite_attach_loop(client: Any, console: Any, ui: Any) -> None:
             watch_alive=_alive,
             header=header_render,
             header_height=header_height,
-            extra_key_bindings=_ptt_kb,
+            extra_key_bindings=_extra_kb,
             # The `/` palette. THIS is the surface the operator actually
             # types into — the bipartite Application, not the split-plane
-            # PromptSession the completer was first wired to.
-            completer=_build_slash_completer(),
+            # PromptSession the completer was first wired to. (Composed
+            # above with the gated rewind source.)
+            completer=_completer,
             # Persistent recall + history ghost-text — the same history
             # file every surface shares, so Up-arrow survives a detach.
             history=_build_prompt_history(),
@@ -2723,7 +2966,27 @@ def run_attach(console: Any) -> int:
             # process's history singleton, so Up in this pane recalls
             # what was just typed in that one (tmux split parity).
             on_history_append=_build_history_injector(),
+            # The viewport lock's broadcast truth — a freeze any pane
+            # causes is visible in this one.
+            on_autonomy_state=lambda f: _on_autonomy_state_frame(ui, f),
+            # Esc-Esc menu hydration, delivered to the controller bound
+            # just below (late-bound: the controller needs the client).
+            on_rewind_list=lambda f: (
+                getattr(ui, "rewind", None) is not None
+                and ui.rewind.deliver(f)
+            ),
         )
+        # The Transactional Viewport Lock's client half. Lives on the ui
+        # so both attach surfaces reach it without new plumbing.
+        try:
+            from backend.core.ouroboros.battle_test.rewind_menu import (
+                RewindController,
+            )
+            ui.rewind = RewindController(
+                client, notify=lambda m: ui.flash(m, seconds=3.0),
+            )
+        except Exception:  # noqa: BLE001
+            ui.rewind = None
         # The shield renders released gates through the SAME markup path
         # every other ⏺/⎿ line takes — one display, one ordering, and the
         # gate lands in scrollback the operator can page back to.

--- a/backend/core/ouroboros/governance/trust_repl.py
+++ b/backend/core/ouroboros/governance/trust_repl.py
@@ -1,0 +1,157 @@
+"""``/trust`` REPL — the operator's autonomy dial, one keystroke away.
+
+Auto-discovered by ``repl_dispatch_registry`` via the naming cage. Cycles
+or sets the risk-tier floor (``risk_tier_floor.py``): the runtime value IS
+the ``JARVIS_MIN_RISK_TIER`` environment variable — every gate already
+reads it fresh per operation, so setting it here changes the very next
+GATE decision with no new plumbing and no second source of truth.
+
+``Shift+Tab`` in an attached cockpit sends ``/trust cycle`` through the
+normal input path, so the keystroke and the typed verb are ONE code path:
+mirrored output, distributed history, and the status-line chip all update
+everywhere the same way.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+TRUST_REPL_SCHEMA_VERSION: str = "trust_repl.1"
+
+__verb_help__ = {
+    "trust": "cycle or set the autonomy trust dial (risk-tier floor)",
+}
+
+_ENV_MIN_TIER = "JARVIS_MIN_RISK_TIER"
+
+#: The dial's positions, loosest → strictest. ``safe_auto`` is the
+#: no-floor resting state (green ops auto-apply as classified).
+_CYCLE = ("safe_auto", "notify_apply", "approval_required")
+
+_GLYPH = {
+    "safe_auto": "🟢",
+    "notify_apply": "🟡",
+    "approval_required": "🟠",
+}
+
+_HELP = (
+    "/trust — the autonomy trust dial (risk-tier floor)\n"
+    "\n"
+    "Subcommands:\n"
+    "  /trust                    current floor + what it means\n"
+    "  /trust cycle              next position (Shift+Tab does this)\n"
+    "  /trust safe_auto          no floor — tiers as classified\n"
+    "  /trust notify_apply       every apply shows a diff first\n"
+    "  /trust approval_required  nothing lands without a human\n"
+    "  /trust status             alias for bare /trust\n"
+    "  /trust help               this text\n"
+    "\n"
+    "The floor COMPOSES with paranoia mode and quiet hours — strictest\n"
+    "wins (risk_tier_floor.py). This changes the very next GATE decision.\n"
+)
+
+
+@dataclass(frozen=True)
+class TrustReplDispatchResult:
+    ok: bool
+    text: str
+    matched: bool = True
+    schema_version: str = TRUST_REPL_SCHEMA_VERSION
+
+
+def current_floor() -> str:
+    """The dial's position, normalized. NEVER raises."""
+    raw = os.environ.get(_ENV_MIN_TIER, "").strip().lower()
+    return raw if raw in _CYCLE else "safe_auto"
+
+
+def floor_chip() -> str:
+    """The status-line chip: empty at rest so the line stays calm, loud
+    when the operator has raised the floor. NEVER raises."""
+    tier = current_floor()
+    if tier == "safe_auto":
+        return ""
+    return f"{_GLYPH.get(tier, '')}⛨ {tier}"
+
+
+def _describe(tier: str) -> str:
+    return {
+        "safe_auto": "no floor — green auto-applies, yellow previews, "
+                     "orange waits for you",
+        "notify_apply": "floor NOTIFY_APPLY — every apply shows its diff "
+                        "before landing",
+        "approval_required": "floor APPROVAL_REQUIRED — nothing lands "
+                             "without a human verdict",
+    }.get(tier, tier)
+
+
+def _set_floor(tier: str) -> str:
+    if tier == "safe_auto":
+        os.environ.pop(_ENV_MIN_TIER, None)
+    else:
+        os.environ[_ENV_MIN_TIER] = tier
+    logger.info("[Trust] risk-tier floor -> %s", tier)
+    return f"{_GLYPH.get(tier, '')} trust dial → {tier}: {_describe(tier)}"
+
+
+def dispatch_trust_command(line: str) -> TrustReplDispatchResult:
+    """Cycle or set the autonomy trust dial.
+
+    Operator: show or change how much the organism may do without you —
+    cycle with Shift+Tab, or set a floor by name.
+    """
+    try:
+        tokens = (line or "").strip().lstrip("/").split()
+        sub = tokens[1].lower() if len(tokens) > 1 else ""
+
+        if sub in ("help", "-h", "--help"):
+            return TrustReplDispatchResult(ok=True, text=_HELP)
+
+        if sub == "cycle":
+            here = _CYCLE.index(current_floor())
+            nxt = _CYCLE[(here + 1) % len(_CYCLE)]
+            return TrustReplDispatchResult(ok=True, text=_set_floor(nxt))
+
+        if sub in _CYCLE:
+            return TrustReplDispatchResult(ok=True, text=_set_floor(sub))
+
+        if sub in ("", "status"):
+            tier = current_floor()
+            extras = []
+            try:
+                from backend.core.ouroboros.governance.risk_tier_floor import (  # noqa: E501
+                    paranoia_mode_enabled,
+                    quiet_hours_active,
+                )
+                if paranoia_mode_enabled():
+                    extras.append("paranoia mode ON")
+                if quiet_hours_active():
+                    extras.append("quiet hours active")
+            except Exception:  # noqa: BLE001
+                pass
+            tail = f"  ({', '.join(extras)})" if extras else ""
+            return TrustReplDispatchResult(
+                ok=True,
+                text=(f"{_GLYPH.get(tier, '')} trust: {tier} — "
+                      f"{_describe(tier)}{tail}"),
+            )
+
+        return TrustReplDispatchResult(
+            ok=False,
+            text=f"unknown /trust subcommand {sub!r} — try /trust help",
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug("[TrustRepl] dispatch degraded", exc_info=True)
+        return TrustReplDispatchResult(ok=False, text="trust dial unavailable")
+
+
+__all__ = [
+    "TRUST_REPL_SCHEMA_VERSION",
+    "TrustReplDispatchResult",
+    "current_floor",
+    "dispatch_trust_command",
+    "floor_chip",
+]

--- a/tests/battle_test/test_autonomy_lock.py
+++ b/tests/battle_test/test_autonomy_lock.py
@@ -1,0 +1,369 @@
+"""The Transactional Viewport Lock + Tier-1 safety suite.
+
+The mandated contract, end to end over a REAL UDS bridge:
+
+  * a ``PAUSE_AUTONOMY`` payload suspends the daemon's execution loop —
+    a mock worker stops mutating the moment the hold lands, and stays
+    stopped until ``RESUME_AUTONOMY``;
+  * the hold is a REFCOUNT: two panes' menus keep the world frozen until
+    the LAST one closes;
+  * safe resumption on every path: explicit resume, client disconnect
+    (SIGKILL'd terminal), TTL expiry (wedged holder), and a daemon that
+    never answers the menu request (client-side failsafe);
+  * ``autonomy_state`` broadcasts so every pane shows the freeze;
+  * ``rewind_list`` answers the asking cockpit from the locked snapshot.
+
+Plus the trust dial's cycle contract and the surface-wiring pins for the
+bell, ``!`` shell mode, and Shift+Tab.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import socket
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.battle_test import rewind_menu as rm
+from backend.core.ouroboros.governance import trust_repl
+
+
+def _uds_dir() -> str:
+    return tempfile.mkdtemp(prefix="alock-", dir="/tmp")
+
+
+def _can_bind_uds() -> bool:
+    try:
+        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            s.bind(os.path.join(_uds_dir(), "probe.sock"))
+            return True
+        finally:
+            s.close()
+    except (PermissionError, OSError):
+        return False
+
+
+async def _wait_for(cond, timeout: float = 3.0) -> None:
+    deadline = asyncio.get_event_loop().time() + timeout
+    while not cond():
+        if asyncio.get_event_loop().time() > deadline:
+            raise AssertionError("condition not met before timeout")
+        await asyncio.sleep(0.01)
+
+
+class _MockOrganism:
+    """A background 'execution loop' that mutates state unless paused —
+    the thing the viewport lock exists to freeze."""
+
+    def __init__(self) -> None:
+        self.paused = False
+        self.mutations: list = []
+        self.transitions: list = []
+        self._task = None
+
+    def on_autonomy(self, action: str) -> None:
+        self.transitions.append(action)
+        self.paused = action == "pause"
+
+    async def run(self) -> None:
+        while True:
+            if not self.paused:
+                self.mutations.append(len(self.mutations))
+            await asyncio.sleep(0.005)
+
+
+# --------------------------------------------------------------------------
+# 1. the mandated core — PAUSE freezes the loop until RESUME
+# --------------------------------------------------------------------------
+
+@pytest.mark.skipif(not _can_bind_uds(),
+                    reason="cannot bind a unix socket in this environment")
+def test_pause_suspends_the_execution_loop_until_resume() -> None:
+    pytest.importorskip("prompt_toolkit")
+    from backend.core.ouroboros.battle_test.cockpit_attach import (
+        CockpitAttachBridge,
+        CockpitAttachClient,
+    )
+
+    sock = Path(_uds_dir()) / "bridge.sock"
+    organism = _MockOrganism()
+    a_states: list = []
+    b_states: list = []
+
+    async def scenario() -> None:
+        bridge = CockpitAttachBridge(
+            on_autonomy=organism.on_autonomy,
+            rewind_provider=lambda n: [
+                {"n": 1, "sha": "abc123def0",
+                 "label": "abc123def0 [O+V] feat: x",
+                 "is_ov": True, "insertions": 4, "deletions": 1},
+            ][:n],
+            path=sock,
+        )
+        assert await bridge.start()
+        worker = asyncio.ensure_future(organism.run())
+        try:
+            a = CockpitAttachClient(
+                path=sock, on_autonomy_state=a_states.append,
+            )
+            b = CockpitAttachClient(
+                path=sock, on_autonomy_state=b_states.append,
+            )
+            assert await a.connect() and await b.connect()
+
+            # -- A pauses: the loop freezes
+            await _wait_for(lambda: organism.mutations)
+            assert a.send_autonomy("pause")
+            await _wait_for(lambda: organism.paused)
+            frozen_at = len(organism.mutations)
+            await asyncio.sleep(0.08)
+            assert len(organism.mutations) == frozen_at, (
+                "the execution loop mutated while the viewport lock was held"
+            )
+
+            # -- REFCOUNT: B also holds; A's release does not unfreeze
+            assert b.send_autonomy("pause")
+            await asyncio.sleep(0.02)
+            assert a.send_autonomy("resume")
+            await asyncio.sleep(0.08)
+            assert organism.paused
+            assert len(organism.mutations) == frozen_at
+
+            # -- last hold releases: the loop flows again
+            assert b.send_autonomy("resume")
+            await _wait_for(lambda: not organism.paused)
+            await _wait_for(
+                lambda: len(organism.mutations) > frozen_at,
+            )
+            # exactly ONE pause + ONE resume crossed the seam (edges only)
+            assert organism.transitions == ["pause", "resume"]
+
+            # -- every pane saw the truth
+            await _wait_for(lambda: len(a_states) >= 4 and len(b_states) >= 4)
+            assert a_states[0]["paused"] is True
+            assert a_states[-1]["paused"] is False
+            assert any(s.get("holders") == 2 for s in b_states)
+
+            # -- the locked snapshot answers the requester
+            got: list = []
+            a2 = CockpitAttachClient(path=sock, on_rewind_list=got.append)
+            assert await a2.connect()
+            assert a2.send_rewind_request(limit=5)
+            await _wait_for(lambda: got)
+            assert got[0]["candidates"][0]["sha"] == "abc123def0"
+            await a2.close()
+            await a.close()
+            await b.close()
+        finally:
+            worker.cancel()
+            await bridge.stop()
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.skipif(not _can_bind_uds(),
+                    reason="cannot bind a unix socket in this environment")
+def test_disconnect_releases_a_dead_holders_lock() -> None:
+    pytest.importorskip("prompt_toolkit")
+    from backend.core.ouroboros.battle_test.cockpit_attach import (
+        CockpitAttachBridge,
+        CockpitAttachClient,
+    )
+
+    sock = Path(_uds_dir()) / "bridge.sock"
+    organism = _MockOrganism()
+
+    async def scenario() -> None:
+        bridge = CockpitAttachBridge(
+            on_autonomy=organism.on_autonomy, path=sock,
+        )
+        assert await bridge.start()
+        try:
+            a = CockpitAttachClient(path=sock)
+            assert await a.connect()
+            assert a.send_autonomy("pause")
+            await _wait_for(lambda: organism.paused)
+            # SIGKILL'd terminal: no resume frame will ever come
+            await a.close()
+            await _wait_for(lambda: not organism.paused)
+            assert organism.transitions == ["pause", "resume"]
+        finally:
+            await bridge.stop()
+
+    asyncio.run(scenario())
+
+
+def test_ttl_expiry_releases_a_wedged_holder(monkeypatch) -> None:
+    """No sockets needed — the refcount logic is exercised directly."""
+    from backend.core.ouroboros.battle_test.cockpit_attach import (
+        CockpitAttachBridge,
+    )
+    monkeypatch.setenv("JARVIS_AUTONOMY_LOCK_TTL_S", "5")
+    transitions: list = []
+    bridge = CockpitAttachBridge(on_autonomy=transitions.append)
+    bridge._autonomy_ctl("pause", "wedged-pane")
+    assert transitions == ["pause"]
+    # time passes beyond the TTL…
+    bridge._autonomy_holds["wedged-pane"] = 0.0
+    # …and the next lock event sweeps the corpse and resumes
+    bridge._autonomy_ctl("resume", "someone-else")
+    assert transitions == ["pause", "resume"]
+
+
+# --------------------------------------------------------------------------
+# 2. the client half — open/deliver/close release exactly once
+# --------------------------------------------------------------------------
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.autonomy: list = []
+        self.rewinds = 0
+
+    def send_autonomy(self, action):
+        self.autonomy.append(action)
+        return True
+
+    def send_rewind_request(self, limit=10):
+        self.rewinds += 1
+        return True
+
+
+def test_controller_open_acquires_and_close_releases_once() -> None:
+    async def scenario() -> None:
+        client = _FakeClient()
+        ctl = rm.RewindController(client)
+        assert ctl.open()
+        assert client.autonomy == ["pause"] and client.rewinds == 1
+        ctl.close()
+        ctl.close()   # double-close must not double-release
+        assert client.autonomy == ["pause", "resume"]
+
+    asyncio.run(scenario())
+
+
+def test_controller_empty_delivery_releases() -> None:
+    async def scenario() -> None:
+        client = _FakeClient()
+        ctl = rm.RewindController(client)
+        assert ctl.open()
+        ctl.deliver({"candidates": []})
+        assert client.autonomy == ["pause", "resume"]
+
+    asyncio.run(scenario())
+
+
+def test_controller_failsafe_releases_when_daemon_never_answers(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv(rm.REPLY_TIMEOUT_ENV_VAR, "1")
+
+    async def scenario() -> None:
+        client = _FakeClient()
+        ctl = rm.RewindController(client)
+        assert ctl.open()
+        await asyncio.sleep(1.3)
+        assert client.autonomy == ["pause", "resume"]
+        assert not ctl.armed
+
+    asyncio.run(scenario())
+
+
+def test_rewind_completer_offers_undo_verbs_only_while_armed() -> None:
+    pytest.importorskip("prompt_toolkit")
+    from prompt_toolkit.document import Document
+
+    async def scenario() -> list:
+        client = _FakeClient()
+        ctl = rm.RewindController(client)
+        comp = rm.RewindCompleter(ctl)
+        assert list(comp.get_completions(Document("", 0), None)) == []
+        ctl.open()
+        ctl.candidates = [
+            {"n": 1, "label": "abc [O+V] feat: x",
+             "insertions": 4, "deletions": 1},
+            {"n": 2, "label": "def [O+V] fix: y",
+             "insertions": 2, "deletions": 2},
+        ]
+        return list(comp.get_completions(Document("", 0), None))
+
+    completions = asyncio.run(scenario())
+    assert [c.text for c in completions] == ["/undo 1", "/undo 2"]
+
+
+def test_master_flag_off_takes_no_hold(monkeypatch) -> None:
+    monkeypatch.setenv(rm.MASTER_FLAG_ENV_VAR, "false")
+    client = _FakeClient()
+    ctl = rm.RewindController(client)
+    assert ctl.open() is False
+    assert client.autonomy == []
+
+
+# --------------------------------------------------------------------------
+# 3. the trust dial
+# --------------------------------------------------------------------------
+
+@pytest.fixture()
+def clean_floor(monkeypatch):
+    monkeypatch.delenv("JARVIS_MIN_RISK_TIER", raising=False)
+    yield
+    os.environ.pop("JARVIS_MIN_RISK_TIER", None)
+
+
+def test_trust_cycle_walks_the_dial(clean_floor) -> None:
+    assert trust_repl.current_floor() == "safe_auto"
+    trust_repl.dispatch_trust_command("/trust cycle")
+    assert trust_repl.current_floor() == "notify_apply"
+    trust_repl.dispatch_trust_command("/trust cycle")
+    assert trust_repl.current_floor() == "approval_required"
+    trust_repl.dispatch_trust_command("/trust cycle")
+    assert trust_repl.current_floor() == "safe_auto"
+    assert os.environ.get("JARVIS_MIN_RISK_TIER") is None
+
+
+def test_trust_floor_feeds_the_real_gate(clean_floor) -> None:
+    trust_repl.dispatch_trust_command("/trust notify_apply")
+    from backend.core.ouroboros.governance.risk_tier_floor import _env_floor
+    assert _env_floor() == "notify_apply"
+
+
+def test_trust_chip_quiet_at_rest_loud_when_raised(clean_floor) -> None:
+    assert trust_repl.floor_chip() == ""
+    trust_repl.dispatch_trust_command("/trust approval_required")
+    assert "approval_required" in trust_repl.floor_chip()
+
+
+def test_status_line_carries_the_chip(clean_floor) -> None:
+    import inspect
+    from backend.core.ouroboros.battle_test import status_line
+    src = inspect.getsource(status_line.StatusLineBuilder.render_plain)
+    assert "floor_chip" in src
+
+
+# --------------------------------------------------------------------------
+# 4. surface wiring pins — bell, shell mode, shift+tab
+# --------------------------------------------------------------------------
+
+def _ov_src() -> str:
+    import backend.core.ouroboros.cli.ov as ov
+    return Path(ov.__file__).read_text()
+
+
+def test_gate_arrival_rings_the_bell() -> None:
+    src = _ov_src()
+    block = src.split("def _on_prompt_frame")[1]
+    assert "_ring_gate_bell()" in block.split("def ")[0]
+
+
+def test_shell_mode_and_client_actions_are_wired() -> None:
+    src = _ov_src()
+    assert "_run_client_shell(ui, client, text)" in src
+    assert '"app:cycleTrust", ("shift+tab",)' in src
+    assert '"app:help", ("?",)' in src
+    assert '"chat:externalEditor", ("ctrl+g",)' in src
+    assert "install_rewind_binding" in src
+    # mounted on BOTH surfaces
+    assert src.count("_client_extra_bindings(ui, client)") >= 2
+    assert src.count("merge_rewind_completer(") >= 2

--- a/tests/cli/test_ov_rms_stream.py
+++ b/tests/cli/test_ov_rms_stream.py
@@ -183,7 +183,11 @@ def test_the_subscription_is_released_on_exit():
     src = Path(
         "backend/core/ouroboros/cli/ov.py",
     ).read_text(encoding="utf-8")
-    tail = src[src.index("await run_bipartite_repl("):][:2000]
+    # Window bounded by the NEXT function def rather than a byte count —
+    # a byte budget silently un-pins the contract every time the call
+    # gains a kwarg (it did, twice, in the completion arc).
+    tail = src[src.index("await run_bipartite_repl("):]
+    tail = tail[: tail.index("\ndef ")] if "\ndef " in tail else tail
     assert "finally:" in tail and "rms_client" in tail
 
 


### PR DESCRIPTION
## The Tier-1 safety suite — CC's interface ideas, concurrency-first

### Transactional Viewport Lock (`Esc Esc` rewind)
A rewind menu over a still-working organism describes a world that may be gone by the time you pick. Refreshing faster is a workaround; the root cause is **active background autonomy during a user-intervention event**, so opening the menu controls the daemon's state machine:

- Esc Esc (empty prompt) → typed `autonomy: pause` frame → the daemon suspends intake through the **same seam the pause/resume verbs flip** (one implementation, two entrances) → a **static snapshot** of the `/undo` planner's restore points comes back addressed to the asking cockpit → the menu renders through the same gated-completer palette Float history search uses (no second overlay system).
- Selecting inserts `/undo N` — a git revert always takes an explicit Enter, and executes through the existing transactional undo machinery (no duplicated snapshot logic).
- **The hold is a refcount with total-release coverage**: menu close (accept *or* dismiss, via the buffer's own `on_completions_changed`), client disconnect (a SIGKILL'd terminal releases synchronously in `_drop`), TTL expiry (wedged holder, `JARVIS_AUTONOMY_LOCK_TTL_S`), and a client-side no-reply failsafe for pre-rewind daemons. Two panes' menus keep the world frozen until the last closes. `autonomy_state` broadcasts so every pane shows the ⏸.

### Global Bell Arbiter
Iron Gate arrival now rings BEL + posts OSC-9 (iTerm2/kitty forward to the OS notification center) — load-bearing for a proactive organism, since a gate that expires unseen auto-REJECTs. The clear side already existed (`prompt_resolved` broadcasts + `shield.dismiss`, #70161); it's now documented as the arbiter's other half at the seam.

### Shift+Tab trust dial, synced everywhere
`/trust` cycles/sets the risk-tier floor. The runtime value **is** `JARVIS_MIN_RISK_TIER`, which every gate already reads fresh per op — no second source of truth. Shift+Tab sends `/trust cycle` through the normal input path, so keystroke and verb are one code path (mirrored output + distributed history), and the floor's chip rides `StatusLineBuilder.render_plain` — the one line every surface mirrors.

### Tier-2 riders (same keymap infrastructure)
`!` shell mode (executor-run, never blocks a keystroke), `?` on empty prompt → keymap table, Ctrl+G → `$EDITOR`. All remappable via keybindings.json; both attach surfaces mount one action set.

### Verification
14 new tests including the mandated freeze contract over a **real** UDS bridge: a mock organism's execution loop stops mutating the moment PAUSE lands, stays frozen under refcount when one of two holders releases, flows again on the last RESUME — with exactly one edge transition each way. Disconnect-release, TTL-release, failsafe-release, empty-list-release, and double-close idempotence all pinned. ~530-test surface green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Esc Esc now pauses autonomy across panes and shows a locked rewind menu; the world resumes when you close it. Added a global gate bell, a synced trust dial (Shift+Tab, /trust), and client-side actions (`!`, `?`, Ctrl+G), with end-to-end tests.

- **New Features**
  - Transactional Viewport Lock (Esc Esc, empty prompt): refcounted pause/resume via the existing intake seam; releases on menu close, client disconnect, TTL (`JARVIS_AUTONOMY_LOCK_TTL_S`), or no-reply failsafe. Broadcasts `autonomy_state` so every pane shows the pause.
  - Rewind menu: server returns a locked snapshot from the existing `/undo` planner; rendered in the existing palette; selecting inserts `/undo N`. Master flag `JARVIS_REWIND_MENU_ENABLED`, reply timeout `JARVIS_REWIND_REPLY_TIMEOUT_S`.
  - Global Bell Arbiter: on gate arrival, ring BEL and post OSC-9 (env `JARVIS_GATE_BELL_ENABLED`).
  - Trust dial: new `/trust` REPL to cycle/set the risk-tier floor; writes `JARVIS_MIN_RISK_TIER`, which gates already read per op. Shift+Tab sends `/trust cycle`. Status line shows a chip when the floor is raised.
  - Client actions (remappable, mounted on both attach surfaces): `!` runs one local shell command (executor-backed, output to scrollback + history), `?` (empty prompt) shows keybindings, Ctrl+G opens $EDITOR.
  - Tests: 14 new tests cover pause/resume over a real UDS bridge (refcount, disconnect/TTL/failsafe releases, single edge transitions), rewind snapshot delivery, trust dial behavior, and keybinding/wiring.

<sup>Written for commit be10016c531ad0b3c4123294029e9c527440d6db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

