### PR TITLE
fix(ov): the rewind completer speaks the async protocol prompt_toolkit actually calls

### DIFF
--- a/backend/core/ouroboros/battle_test/rewind_menu.py
+++ b/backend/core/ouroboros/battle_test/rewind_menu.py
@@ -199,7 +199,22 @@ class RewindController:
         self._failsafe = None
 
 
-class RewindCompleter:
+def _completer_base() -> Any:
+    """prompt_toolkit's ``Completer``, or ``object`` when unavailable.
+
+    INHERITING is load-bearing, not tidy (same lesson history_search
+    learned live): prompt_toolkit consumes completers through
+    ``get_completions_async``, which only the base class supplies by
+    wrapping the sync method. A duck-typed completer passes every direct
+    test and raises AttributeError on the first real keystroke."""
+    try:
+        from prompt_toolkit.completion import Completer
+        return Completer
+    except Exception:  # noqa: BLE001
+        return object
+
+
+class RewindCompleter(_completer_base()):  # type: ignore[misc]
     """Feeds the locked restore points into the palette while armed.
 
     Selecting one INSERTS ``/undo N`` — the same typed verb the daemon

--- a/tests/battle_test/test_autonomy_lock.py
+++ b/tests/battle_test/test_autonomy_lock.py
@@ -293,6 +293,24 @@ def test_rewind_completer_offers_undo_verbs_only_while_armed() -> None:
     assert [c.text for c in completions] == ["/undo 1", "/undo 2"]
 
 
+def test_outer_merged_completers_speak_the_async_protocol() -> None:
+    """prompt_toolkit consumes OUTER-merged completers through
+    ``get_completions_async`` — only the ``Completer`` base supplies it.
+    A duck-typed completer passes every direct test and raises
+    AttributeError on the first REAL keystroke (history_search learned
+    this live). Pin every completer we merge at the outer level."""
+    pytest.importorskip("prompt_toolkit")
+    from backend.core.ouroboros.battle_test.history_search import (
+        HistoryCompleter,
+        HistorySearchController,
+    )
+    for completer in (
+        rm.RewindCompleter(rm.RewindController(_FakeClient())),
+        HistoryCompleter(HistorySearchController(), None),
+    ):
+        assert hasattr(completer, "get_completions_async"), type(completer)
+
+
 def test_master_flag_off_takes_no_hold(monkeypatch) -> None:
     monkeypatch.setenv(rm.MASTER_FLAG_ENV_VAR, "false")
     client = _FakeClient()


### PR DESCRIPTION
Follow-up to #70193, applying the live-fire lesson from history_search's upstream hot-fix: outer-merged completers must INHERIT `Completer` — prompt_toolkit consumes them via `get_completions_async`, which only the base class supplies, so a duck-typed completer passes every direct test and breaks on the first real keystroke. `RewindCompleter` now inherits (lazy base, headless-importable), plus a pin asserting every outer-merged completer carries the async method. (`MentionPathCompleter` is safe by composition — inside `ThreadedCompleter` the async wrapper runs children synchronously.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Transactional Viewport Lock and a rewind menu: Esc Esc pauses autonomy, shows a locked list of restore points, and resumes on close. Also adds a trust dial (/trust + Shift+Tab), a gate arrival bell, and a small client action set (!, ?, Ctrl+G), all wired across both attach surfaces.

- New Features
  - Transactional Viewport Lock: pause/resume via bridge `autonomy` frames; refcounted, TTL-backed (`JARVIS_AUTONOMY_LOCK_TTL_S`), releases on disconnect; broadcasts `autonomy_state` to all panes.
  - Rewind menu (Esc Esc): requests `rewind_list` from the existing /undo planner, renders in the palette; selection inserts “/undo N”; client-side failsafe (`JARVIS_REWIND_REPLY_TIMEOUT_S`); master flag `JARVIS_REWIND_MENU_ENABLED`.
  - Trust dial (`/trust`): cycles or sets `JARVIS_MIN_RISK_TIER`; Shift+Tab sends “/trust cycle”; status line shows a chip when raised.
  - Gate bell: rings BEL and posts OSC-9 on gate arrival (`JARVIS_GATE_BELL_ENABLED`).
  - Client actions: `!` runs one shell command on the operator’s machine (async, output to scrollback), `?` shows keymap (empty prompt), `Ctrl+G` edits the prompt in $EDITOR; all remappable and mounted on both chat surfaces.
  - Bridge/client API: adds `on_autonomy_state`, `on_rewind_list`, `send_autonomy()`, and `send_rewind_request()`; `CockpitAttach` serves locked rewind lists and manages the autonomy refcount.
  - Tests: end-to-end lock semantics over a real UDS, TTL/disconnect/failsafe releases, rewind completions, trust dial behavior, and surface wiring pins.

- Refactors
  - Unified client keybindings via a shared `_client_extra_bindings`; composed the gated rewind source with the existing palette using `merge_rewind_completer`; status line now appends the trust chip; adjusted `_ov` layout to merge extra bindings and completers on both surfaces.

<sup>Written for commit be10016c531ad0b3c4123294029e9c527440d6db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

