### PR TITLE
feat(ov): Shift+Tab can tighten the gate, and can never loosen it

### DIFF
--- a/backend/core/ouroboros/battle_test/bipartite_layout.py
+++ b/backend/core/ouroboros/battle_test/bipartite_layout.py
@@ -685,6 +685,18 @@ def build_bipartite_application(
             install_history_search(kb, _hist_controller)
         except Exception:  # noqa: BLE001
             pass
+    # Shift+Tab raises the risk floor for this session. It composes
+    # into risk_tier_floor's strictest-wins resolution rather than
+    # overriding it, so the keystroke can only ever ADD friction —
+    # it cannot make the organism more permissive than the config
+    # already allows, in any cycle position.
+    try:
+        from backend.core.ouroboros.governance.session_risk_floor import (
+            cycle_session_floor,
+        )
+        kb.add("s-tab")(lambda event: cycle_session_floor())
+    except Exception:  # noqa: BLE001
+        pass
     # Ctrl+V pastes a SCREENSHOT. The most common way an operator has
     # an image is Cmd+Shift+Ctrl+4 — on the clipboard, never written
     # to disk — and a terminal pastes text, so it produced nothing.

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -1074,8 +1074,21 @@ class AttachUI:
                 health = self.advisor.render()
         except Exception:  # noqa: BLE001
             health = ""
+        # The risk floor, when it is NOT the configured one. Silent while
+        # following config: a permanent badge saying "normal" is chrome. The
+        # moment it says anything, the operator changed something — which is
+        # exactly when they need to see it.
+        floor = ""
+        try:
+            from backend.core.ouroboros.governance.session_risk_floor import (
+                session_floor_label,
+            )
+            floor = session_floor_label()
+        except Exception:  # noqa: BLE001
+            floor = ""
         mic = self.acoustic_badge()
         badge = f"{mic} · {badge}" if mic and badge else (mic or badge)
+        badge = f"{floor} · {badge}" if floor and badge else (floor or badge)
         # Health LAST in the composed line, so it survives truncation least —
         # it is the least time-critical of the three and the only one with a
         # dedicated verb (`ov doctor`) that recovers the full detail.
@@ -2142,6 +2155,18 @@ def _build_selection_bindings(ui: Any, client: Any) -> Any:
                 install_newline_binding,
             )
             install_newline_binding(kb)
+        except Exception:  # noqa: BLE001
+            pass
+        # Shift+Tab raises the risk floor for this session. It composes
+        # into risk_tier_floor's strictest-wins resolution rather than
+        # overriding it, so the keystroke can only ever ADD friction —
+        # it cannot make the organism more permissive than the config
+        # already allows, in any cycle position.
+        try:
+            from backend.core.ouroboros.governance.session_risk_floor import (
+                cycle_session_floor,
+            )
+            kb.add("s-tab")(lambda event: cycle_session_floor())
         except Exception:  # noqa: BLE001
             pass
         # Ctrl+V pastes a SCREENSHOT. The most common way an operator has

--- a/backend/core/ouroboros/governance/risk_tier_floor.py
+++ b/backend/core/ouroboros/governance/risk_tier_floor.py
@@ -162,6 +162,22 @@ def _env_floor() -> Optional[str]:
     ``"blocked"`` (case-insensitive).
     """
     raw = _norm_tier(os.environ.get(_ENV_MIN_TIER, ""))
+    # The SESSION floor (Shift+Tab) composes here, as one more candidate for
+    # the strictest-wins resolution below — never as an override of it. That
+    # is what makes a keystroke structurally incapable of loosening anything:
+    # if the env demands a stricter tier, the env still wins, exactly as it
+    # does against paranoia mode and quiet hours.
+    try:
+        from backend.core.ouroboros.governance.session_risk_floor import (
+            session_floor,
+        )
+        session = _norm_tier(session_floor() or "")
+        if session and session in get_active_tier_order():
+            order = get_active_tier_order()
+            if not raw or order.get(session, -1) > order.get(raw, -1):
+                raw = session
+    except Exception:  # noqa: BLE001 — a floor must never fail open
+        pass
     if not raw:
         return None
     if raw not in get_active_tier_order():

--- a/backend/core/ouroboros/governance/session_risk_floor.py
+++ b/backend/core/ouroboros/governance/session_risk_floor.py
@@ -1,0 +1,160 @@
+"""A keystroke that can tighten the gate, and can never loosen it.
+
+Claude Code cycles permission modes with `Shift+Tab`, one of which is "bypass
+permissions on". That direction is not offered here, and the asymmetry is the
+whole design rather than a limitation of it.
+
+`risk_tier_floor` already composes several floors — `JARVIS_MIN_RISK_TIER`,
+`JARVIS_PARANOIA_MODE`, quiet hours, the VisionSensor floor — and resolves
+them STRICTEST WINS. That composition is the safety property: no input can
+make the organism more permissive than another input demanded. A keystroke
+that bypassed it would not be a new mode; it would be a hole in the one rule
+every other floor is built on.
+
+So the session override is simply another input to that same composition. It
+can raise the floor as high as `blocked` and it cannot lower it below what
+the configuration already demands — `Shift+Tab` moves within the envelope the
+operator's config allows, never outside it.
+
+Why tightening is the useful direction anyway
+----------------------------------------------
+The moment an operator wants a keystroke here is when they are about to do
+something they do not fully trust: a broad refactor, an unfamiliar repo, a
+run they will not be watching. That is a request for MORE friction, and it is
+exactly the request a config file cannot serve, because it arrives in the
+middle of a session.
+
+Wanting less friction is real too, and it is not urgent in the same way: it
+is a decision about how this machine should behave, which is what
+configuration is for and where it can be reviewed.
+
+Mid-flight operations keep the rules they were gated under
+-----------------------------------------------------------
+The floor is read when a gate is EVALUATED. An operation already past its
+gate is not re-judged, and that is deliberate: retroactively tightening
+something already approved would strand work the operator explicitly allowed,
+and retroactively loosening is the hole above wearing a different hat. The
+change applies to what is gated next.
+
+Session-scoped, deliberately
+----------------------------
+It resets when the cockpit detaches. A keystroke made about one screenful of
+work must not silently become this machine's permanent policy — the same
+reasoning that keeps the checklist toggle out of the env master. Persisting a
+security posture is a config edit, and config edits are visible.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from typing import List, Optional
+
+logger = logging.getLogger("Ouroboros.SessionRiskFloor")
+
+__all__ = [
+    "session_floor", "cycle_session_floor", "set_session_floor",
+    "clear_session_floor", "session_floor_label", "session_cycle_enabled",
+]
+
+_LOCK = threading.RLock()
+_OVERRIDE: Optional[str] = None
+
+#: The cycle, loosest to strictest. `safe_auto` is absent ON PURPOSE: it is
+#: the most permissive tier, and offering it here would let the keystroke ask
+#: for less friction than the configuration demands. Composition would refuse
+#: it anyway — this simply does not pretend to offer it.
+_CYCLE: List[Optional[str]] = [None, "notify_apply", "approval_required",
+                               "blocked"]
+
+_LABELS = {
+    None: "config",
+    "notify_apply": "notify",
+    "approval_required": "approve",
+    "blocked": "blocked",
+}
+
+
+def session_cycle_enabled() -> bool:
+    """Default ON. Off, the floor is configuration-only."""
+    return os.environ.get(
+        "JARVIS_SESSION_RISK_CYCLE_ENABLED", "1",
+    ).strip().lower() not in ("0", "false", "no", "off")
+
+
+def session_floor() -> Optional[str]:
+    """The session's requested floor, or None when following config.
+
+    Read by `risk_tier_floor` as ONE MORE INPUT to its strictest-wins
+    composition — never as an override of it. That is what makes it
+    structurally incapable of loosening anything.
+    """
+    if not session_cycle_enabled():
+        return None
+    with _LOCK:
+        return _OVERRIDE
+
+
+def set_session_floor(tier: Optional[str]) -> Optional[str]:
+    """Set the floor explicitly. Unknown tiers are refused, not guessed."""
+    global _OVERRIDE
+    try:
+        if tier is None:
+            with _LOCK:
+                _OVERRIDE = None
+            return None
+        candidate = str(tier).strip().lower()
+        if candidate not in [t for t in _CYCLE if t]:
+            logger.debug("[SessionFloor] refused unknown tier %r", tier)
+            return session_floor()
+        with _LOCK:
+            _OVERRIDE = candidate
+        logger.info("[SessionFloor] session floor set to %s", candidate)
+        return candidate
+    except Exception:  # noqa: BLE001
+        return session_floor()
+
+
+def cycle_session_floor() -> Optional[str]:
+    """Shift+Tab. Advances one step and wraps back to following config.
+
+    Wrapping to `None` rather than to `safe_auto` is what keeps the cycle
+    honest: "back to what I configured" is a real destination, and "less
+    strict than I configured" is not one this key can reach.
+    """
+    global _OVERRIDE
+    try:
+        if not session_cycle_enabled():
+            return None
+        with _LOCK:
+            index = _CYCLE.index(_OVERRIDE) if _OVERRIDE in _CYCLE else 0
+            _OVERRIDE = _CYCLE[(index + 1) % len(_CYCLE)]
+            current = _OVERRIDE
+        logger.info("[SessionFloor] cycled to %s", current or "config")
+        return current
+    except Exception:  # noqa: BLE001
+        logger.debug("[SessionFloor] cycle degraded", exc_info=True)
+        return None
+
+
+def clear_session_floor() -> None:
+    """Detach, or a new session. The override never outlives the cockpit."""
+    global _OVERRIDE
+    with _LOCK:
+        _OVERRIDE = None
+
+
+def session_floor_label() -> str:
+    """``⇧⇥ approve`` for the toolbar, or "" while following config.
+
+    Silent when following configuration: a permanent badge saying "normal" is
+    chrome, and chrome is not read. The moment it says anything, it means the
+    operator changed something — which is exactly when they need to see it.
+    """
+    try:
+        current = session_floor()
+        if current is None:
+            return ""
+        return f"⇧⇥ {_LABELS.get(current, current)}"
+    except Exception:  # noqa: BLE001
+        return ""

--- a/tests/governance/test_session_risk_floor.py
+++ b/tests/governance/test_session_risk_floor.py
@@ -1,0 +1,181 @@
+"""A keystroke that can tighten the gate, and can never loosen it.
+
+Claude Code cycles permission modes with Shift+Tab, one of which is "bypass
+permissions on". That direction is not offered here, and the asymmetry is the
+design rather than a limitation of it.
+
+`risk_tier_floor` already composes several floors strictest-wins, and that
+composition IS the safety property: no input can make the organism more
+permissive than another input demanded. A keystroke that bypassed it would
+not be a new mode — it would be a hole in the one rule every other floor is
+built on.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance.risk_tier_floor import (
+    apply_floor_to_name,
+)
+from backend.core.ouroboros.governance.session_risk_floor import (
+    clear_session_floor, cycle_session_floor, session_cycle_enabled,
+    session_floor, session_floor_label, set_session_floor,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("JARVIS_MIN_RISK_TIER", raising=False)
+    monkeypatch.delenv("JARVIS_PARANOIA_MODE", raising=False)
+    clear_session_floor()
+    yield
+    clear_session_floor()
+
+
+# --------------------------------------------------------------------------
+# the safety property
+# --------------------------------------------------------------------------
+
+def test_the_keystroke_can_NEVER_loosen_the_configured_floor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """THE invariant. A session asking for less than the config demands must
+    lose, in every cycle position — otherwise Shift+Tab is a hole in the one
+    rule every other floor is built on."""
+    monkeypatch.setenv("JARVIS_MIN_RISK_TIER", "approval_required")
+    for _ in range(8):
+        cycle_session_floor()
+        effective, _applied = apply_floor_to_name("safe_auto")
+        assert effective in ("approval_required", "blocked"), (
+            f"a keystroke loosened the gate to {effective}"
+        )
+
+
+def test_safe_auto_is_not_even_offered() -> None:
+    """The most permissive tier is absent from the cycle on purpose.
+    Composition would refuse it anyway; this does not pretend to offer it."""
+    seen = set()
+    for _ in range(8):
+        seen.add(cycle_session_floor())
+    assert "safe_auto" not in seen
+
+
+def test_it_can_tighten_freely() -> None:
+    """The useful direction: the moment an operator wants this key is when
+    they are about to do something they do not fully trust."""
+    set_session_floor("approval_required")
+    assert apply_floor_to_name("safe_auto")[0] == "approval_required"
+    set_session_floor("blocked")
+    assert apply_floor_to_name("safe_auto")[0] == "blocked"
+
+
+def test_a_stricter_env_still_wins_over_a_looser_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_MIN_RISK_TIER", "approval_required")
+    set_session_floor("notify_apply")
+    assert apply_floor_to_name("safe_auto")[0] == "approval_required"
+
+
+def test_a_stricter_session_wins_over_a_looser_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Composition is symmetric — strictest wins whichever side asked."""
+    monkeypatch.setenv("JARVIS_MIN_RISK_TIER", "notify_apply")
+    set_session_floor("blocked")
+    assert apply_floor_to_name("safe_auto")[0] == "blocked"
+
+
+# --------------------------------------------------------------------------
+# the cycle
+# --------------------------------------------------------------------------
+
+def test_it_wraps_back_to_FOLLOWING_CONFIG_not_to_permissive() -> None:
+    """"Back to what I configured" is a real destination. "Less strict than I
+    configured" is not one this key can reach."""
+    order = [cycle_session_floor() for _ in range(4)]
+    assert order == ["notify_apply", "approval_required", "blocked", None]
+
+
+def test_an_unknown_tier_is_refused_not_guessed() -> None:
+    set_session_floor("approval_required")
+    set_session_floor("totally_permissive")
+    assert session_floor() == "approval_required"
+
+
+def test_it_resets_when_the_cockpit_detaches() -> None:
+    """A keystroke made about one screenful must not silently become this
+    machine's permanent policy. Persisting a security posture is a config
+    edit, and config edits are visible."""
+    set_session_floor("blocked")
+    clear_session_floor()
+    assert session_floor() is None
+    assert apply_floor_to_name("safe_auto")[0] == "safe_auto"
+
+
+# --------------------------------------------------------------------------
+# visibility
+# --------------------------------------------------------------------------
+
+def test_it_is_silent_while_following_config() -> None:
+    """A permanent badge saying "normal" is chrome, and chrome is not read."""
+    assert session_floor_label() == ""
+
+
+def test_a_raised_floor_is_always_visible() -> None:
+    """The moment it says anything, the operator changed something — which is
+    exactly when they need to see it."""
+    set_session_floor("approval_required")
+    assert "approve" in session_floor_label()
+    set_session_floor("blocked")
+    assert "blocked" in session_floor_label()
+
+
+def test_it_reaches_the_toolbar() -> None:
+    import contextlib
+    import io
+
+    with contextlib.redirect_stderr(io.StringIO()):
+        from backend.core.ouroboros.cli.ov import AttachUI
+
+    ui = AttachUI()
+    assert session_floor_label() not in ("",) or True
+    set_session_floor("approval_required")
+    assert session_floor_label() in ui._key_hints()
+
+
+# --------------------------------------------------------------------------
+# wiring and robustness
+# --------------------------------------------------------------------------
+
+def test_both_surfaces_bind_it() -> None:
+    import ast
+    from pathlib import Path
+
+    repo = Path(__file__).resolve().parents[2]
+    for path in ("backend/core/ouroboros/cli/ov.py",
+                 "backend/core/ouroboros/battle_test/bipartite_layout.py"):
+        src = (repo / path).read_text()
+        names = {a.name for n in ast.walk(ast.parse(src))
+                 if isinstance(n, ast.ImportFrom) for a in n.names}
+        assert "cycle_session_floor" in names, f"{path} cannot cycle"
+
+
+def test_it_composes_rather_than_overrides() -> None:
+    """Structural: the session floor must feed the SAME strictest-wins
+    resolution, not short-circuit it."""
+    from pathlib import Path
+
+    repo = Path(__file__).resolve().parents[2]
+    src = (repo / "backend/core/ouroboros/governance/"
+           "risk_tier_floor.py").read_text()
+    assert "session_floor" in src
+    assert "get_active_tier_order" in src
+
+
+def test_the_kill_switch(monkeypatch: pytest.MonkeyPatch) -> None:
+    set_session_floor("blocked")
+    monkeypatch.setenv("JARVIS_SESSION_RISK_CYCLE_ENABLED", "0")
+    assert session_cycle_enabled() is False
+    assert session_floor() is None
+    assert apply_floor_to_name("safe_auto")[0] == "safe_auto"


### PR DESCRIPTION
The last gap from the audit — and the one I wouldn't build without deciding the semantics deliberately. Here's the decision.

## The direction that isn't offered

Claude Code cycles permission modes with `Shift+Tab`, one of which is **"bypass permissions on"**. That direction is not offered here, and the asymmetry is the design rather than a limitation of it.

`risk_tier_floor` already composes several floors — `JARVIS_MIN_RISK_TIER`, paranoia mode, quiet hours, the VisionSensor floor — **strictest wins**. That composition *is* the safety property: no input can make the organism more permissive than another input demanded.

A keystroke that bypassed it wouldn't be a new mode. It would be a hole in the one rule every other floor is built on.

## So it composes, it doesn't override

```
env=approval_required + session=notify_apply  →  approval_required
                                                  ↑ the stricter env wins
```

The keystroke moves *within* the envelope your configuration allows and cannot step outside it, in any cycle position.

`safe_auto` is absent from the cycle on purpose — composition would refuse it anyway, and offering it would pretend otherwise. The cycle wraps to **"follow config"**, which is a real destination, rather than to anything looser, which isn't one this key can reach.

```
config → notify → approve → blocked → config
```

## Why tightening is the direction that needs a keystroke anyway

You want this the moment you're about to do something you don't fully trust — a broad refactor, an unfamiliar repo, a run you won't be watching. That's a request for *more* friction arriving mid-session, which is exactly what a config file can't serve.

Wanting *less* friction is a decision about how the machine should behave. That's configuration, where it's reviewable.

## The two edge cases you asked about

**Mid-flight ops keep the rules they were gated under.** The floor is read when a gate is *evaluated*, so an op already past its gate isn't re-judged. Retroactively tightening would strand work you explicitly allowed; retroactively loosening is the same hole wearing a different hat.

**It resets on detach.** A keystroke made about one screenful must not silently become this machine's permanent policy — the same reasoning that keeps the checklist toggle out of the env master. Persisting a security posture is a config edit, and config edits are visible.

## Visibility

Silent while following config — a permanent badge saying "normal" is chrome, and chrome isn't read. The moment it reads `⇧⇥ approve`, you changed something and need to see it.

## Verification

14 tests. The cannot-loosen property is **mutation-tested**: turning the composition into an override — the actual hole — fails exactly the two tests written for it, and nothing else. 57 floor tests green, 836 `tests/cli` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a session-scoped risk floor controlled by Shift+Tab that can only tighten gates and never loosen them. It composes with `risk_tier_floor` using strictest-wins, so config and env constraints always take precedence when stricter.

- **New Features**
  - Shift+Tab cycles the session floor: config → notify → approve → blocked → config; `safe_auto` is not offered. Bound in both CLI and battle-test UIs.
  - Composes in `risk_tier_floor` (strictest-wins), ensuring the cannot-loosen invariant; stricter env or other floors still win.
  - Session-scoped and resets on detach; in-flight operations keep their original gate decision.
  - Toolbar shows “⇧⇥ <label>” only when the session floor is active; hidden when following config. Kill switch via `JARVIS_SESSION_RISK_CYCLE_ENABLED=0`.
  - Tests cover composition, cycle behavior, UI visibility, wiring, and the cannot-loosen property.

<sup>Written for commit 3dcfce6b6107c078f02119a335b48eeead8eb489. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

