### PR TITLE
feat(ov): the transcript can be searched, jumped, and trusted — even inside tmux

### DIFF
--- a/backend/core/ouroboros/battle_test/transcript_hatches.py
+++ b/backend/core/ouroboros/battle_test/transcript_hatches.py
@@ -1,0 +1,315 @@
+"""Transcript escape hatches — the cockpit is honest about its scrollback.
+
+Claiming the alternate screen made the canvas ring (~20k retained lines)
+the ONLY history there is — and a ring you can page but not search is a
+transcript in a locked box. These are CC's transcript-viewer keys mapped
+onto the ring the cockpit already keeps:
+
+  * ``[``  — write the WHOLE retained transcript to the terminal's
+    PRIMARY scrollback (run_in_terminal leaves the alternate screen, so
+    the print lands where Cmd+F / tmux copy-mode can search it);
+  * ``v``  — the same transcript, in ``$EDITOR``;
+  * ``{`` / ``}`` — jump the viewport between BLOCK MARKERS (⏺ action
+    opens, ❯ operator lines) instead of paging blind;
+  * ``Ctrl+L`` — force a full repaint (the garbled-screen recovery key a
+    full-screen app taking async IPC owes its operator);
+  * ``Ctrl+O`` — flip live narration between on ↔ verbose via the
+    EXISTING ``/narrate`` verb through the normal input path (mirrored,
+    history-synced — one code path with the typed form).
+
+``[``/``v``/``{``/``}`` are printable characters, so they bind ONLY while
+the viewport is scrolled back (PgUp is the doorway) — at the live tail
+they type as themselves, and a hand-written ``{`` can never teleport the
+view. All remappable via keybindings.json.
+
+Also here: the tmux passthrough probe — the OSC-9 gate bell is silently
+swallowed inside tmux without ``allow-passthrough on``, and a bell that
+fires into a void is worse than none because the operator TRUSTS it.
+
+NEVER raises into key dispatch or a repaint.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import re
+from typing import Any, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+TRANSCRIPT_HATCHES_SCHEMA_VERSION: str = "transcript_hatches.1"
+
+#: Plain-text prefixes that open a block worth jumping to.
+_BLOCK_MARKERS = ("⏺", "❯", "⚡", "◆")
+
+_MARKUP_RE = re.compile(r"\[/?[a-zA-Z0-9 #_.,=-]*\]")
+
+
+def _strip_markup(line: str) -> str:
+    """Rich markup → plain text; regex fallback keeps this dependency-free
+    on the hot path. NEVER raises."""
+    try:
+        from rich.text import Text
+        return Text.from_markup(line).plain
+    except Exception:  # noqa: BLE001
+        try:
+            return _MARKUP_RE.sub("", line)
+        except Exception:  # noqa: BLE001
+            return line
+
+
+def _canvas() -> Any:
+    try:
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            get_active_canvas,
+        )
+        return get_active_canvas()
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def transcript_lines() -> List[str]:
+    """The retained transcript, oldest→newest, markup stripped. Empty when
+    no cockpit canvas is live (fallback surface). NEVER raises."""
+    try:
+        mux = _canvas()
+        if mux is None:
+            return []
+        snap = mux._buffer.snapshot()  # noqa: SLF001 — the ring IS the transcript
+        return [_strip_markup(str(ln)) for ln in snap]
+    except Exception:  # noqa: BLE001
+        logger.debug("[Hatches] transcript read degraded", exc_info=True)
+        return []
+
+
+def _viewport_state() -> Optional[Tuple[Any, int, int]]:
+    """(viewport, total, budget) for the live canvas, or None."""
+    try:
+        mux = _canvas()
+        if mux is None:
+            return None
+        total, budget = mux.scroll_metrics()
+        return mux._viewport, int(total), int(budget)  # noqa: SLF001
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def is_scrolled_back() -> bool:
+    """True while the operator is reading history — the state in which the
+    printable hatch keys are live. NEVER raises."""
+    try:
+        state = _viewport_state()
+        return state is not None and not state[0].following
+    except Exception:  # noqa: BLE001
+        return False
+
+
+# ---------------------------------------------------------------------------
+# the hatches
+# ---------------------------------------------------------------------------
+
+
+def dump_to_scrollback(event: Any) -> None:
+    """``[`` — the whole ring into the PRIMARY buffer, natively searchable.
+    NEVER raises."""
+    try:
+        lines = transcript_lines()
+        if not lines:
+            return
+
+        def _print() -> None:
+            print(f"\n───── O+V transcript · {len(lines)} retained lines "
+                  "(searchable here; the cockpit resumes below) ─────")
+            for ln in lines:
+                print(ln)
+            print("───── end transcript ─────\n")
+
+        from prompt_toolkit.application import run_in_terminal
+        run_in_terminal(_print)
+    except Exception:  # noqa: BLE001
+        logger.debug("[Hatches] dump degraded", exc_info=True)
+
+
+def open_in_editor(event: Any) -> None:
+    """``v`` — the transcript in $EDITOR. NEVER raises."""
+    try:
+        import subprocess
+        import tempfile
+
+        lines = transcript_lines()
+        if not lines:
+            return
+        editor = (os.environ.get("VISUAL") or os.environ.get("EDITOR")
+                  or "vi")
+
+        def _edit() -> None:
+            try:
+                with tempfile.NamedTemporaryFile(
+                    "w", suffix=".ov-transcript", delete=False,
+                ) as fh:
+                    fh.write("\n".join(lines) + "\n")
+                    path = fh.name
+                subprocess.run([*editor.split(), path], check=False)
+                os.unlink(path)
+            except Exception:  # noqa: BLE001
+                pass
+
+        from prompt_toolkit.application import run_in_terminal
+        run_in_terminal(_edit)
+    except Exception:  # noqa: BLE001
+        logger.debug("[Hatches] editor degraded", exc_info=True)
+
+
+def jump_block(event: Any, direction: int) -> None:
+    """``{``/``}`` — move the viewport to the previous/next block marker.
+    Paging finds a place; this finds a THING. NEVER raises."""
+    try:
+        state = _viewport_state()
+        if state is None:
+            return
+        viewport, total, budget = state
+        lines = transcript_lines()
+        if not lines:
+            return
+        top = max(0, total - budget - viewport.offset)
+        markers = [
+            i for i, ln in enumerate(lines)
+            if ln.lstrip().startswith(_BLOCK_MARKERS)
+        ]
+        if direction < 0:
+            candidates = [i for i in markers if i < top]
+            target = candidates[-1] if candidates else None
+        else:
+            candidates = [i for i in markers if i > top]
+            target = candidates[0] if candidates else None
+        if target is None:
+            return
+        new_offset = max(0, total - budget - target)
+        # scroll() computes want = offset - lines → aim it exactly.
+        viewport.scroll(
+            viewport.offset - new_offset, total=total, budget=budget,
+        )
+        mux = _canvas()
+        if mux is not None:
+            mux._invalidate_now()  # noqa: SLF001 — the scroll keys' own move
+    except Exception:  # noqa: BLE001
+        logger.debug("[Hatches] jump degraded", exc_info=True)
+
+
+def force_redraw(event: Any) -> None:
+    """``Ctrl+L`` — recover a garbled screen. NEVER raises."""
+    try:
+        event.app.renderer.clear()
+        event.app.invalidate()
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def install_transcript_hatches(kb: Any, ui: Any, client: Any) -> bool:
+    """Mount the hatch actions (all keybindings.json-remappable). NEVER
+    raises; returns True when ≥1 bound."""
+    try:
+        from prompt_toolkit.filters import Condition
+
+        from backend.core.ouroboros.battle_test.keymap import bind_action
+
+        scrolled = Condition(is_scrolled_back)
+        bound = 0
+
+        bound += bind_action(
+            kb, "transcript:dump", ("[",), dump_to_scrollback,
+            context="Transcript", filter=scrolled,
+            description="write the transcript to native scrollback "
+                        "(while scrolled)",
+        )
+        bound += bind_action(
+            kb, "transcript:editor", ("v",), open_in_editor,
+            context="Transcript", filter=scrolled,
+            description="open the transcript in $EDITOR (while scrolled)",
+        )
+        bound += bind_action(
+            kb, "transcript:prevBlock", ("{",),
+            lambda e: jump_block(e, -1),
+            context="Transcript", filter=scrolled,
+            description="jump to the previous ⏺/❯ block (while scrolled)",
+        )
+        bound += bind_action(
+            kb, "transcript:nextBlock", ("}",),
+            lambda e: jump_block(e, +1),
+            context="Transcript", filter=scrolled,
+            description="jump to the next ⏺/❯ block (while scrolled)",
+        )
+        bound += bind_action(
+            kb, "app:redraw", ("ctrl+l",), force_redraw,
+            context="Global",
+            description="force a full repaint (garbled-screen recovery)",
+        )
+
+        def _toggle_narrate(event: Any) -> None:
+            try:
+                verbose = not bool(getattr(ui, "_narrate_verbose", False))
+                ui._narrate_verbose = verbose
+                client.send_input(
+                    "/narrate verbose" if verbose else "/narrate on",
+                )
+                ui.flash(
+                    "🗣 narration: verbose" if verbose
+                    else "🗣 narration: normal", seconds=2.0,
+                )
+            except Exception:  # noqa: BLE001
+                pass
+
+        bound += bind_action(
+            kb, "narrate:toggle", ("ctrl+o",), _toggle_narrate,
+            context="Global",
+            description="toggle live narration normal ↔ verbose (/narrate)",
+        )
+        return bound > 0
+    except Exception:  # noqa: BLE001
+        logger.debug("[Hatches] install degraded", exc_info=True)
+        return False
+
+
+# ---------------------------------------------------------------------------
+# tmux — the bell's delivery path
+# ---------------------------------------------------------------------------
+
+
+def tmux_bell_warning(*, timeout_s: float = 1.0) -> str:
+    """A one-line warning when tmux would swallow the gate bell, or "".
+
+    Probed, not assumed: outside tmux, or with passthrough already on,
+    silence is correct. NEVER raises."""
+    try:
+        if not os.environ.get("TMUX"):
+            return ""
+        if os.environ.get(
+            "JARVIS_GATE_BELL_ENABLED", "true",
+        ).strip().lower() in ("0", "false", "no", "off"):
+            return ""
+        import subprocess
+        proc = subprocess.run(
+            ["tmux", "show", "-gv", "allow-passthrough"],
+            capture_output=True, text=True, timeout=timeout_s,
+        )
+        value = (proc.stdout or "").strip().lower()
+        if value in ("on", "all"):
+            return ""
+        return ("⚠ tmux swallows the gate bell — add "
+                "`set -g allow-passthrough on` to ~/.tmux.conf "
+                "(then: tmux source-file ~/.tmux.conf)")
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+__all__ = [
+    "TRANSCRIPT_HATCHES_SCHEMA_VERSION",
+    "dump_to_scrollback",
+    "force_redraw",
+    "install_transcript_hatches",
+    "is_scrolled_back",
+    "jump_block",
+    "open_in_editor",
+    "tmux_bell_warning",
+    "transcript_lines",
+]

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -1871,6 +1871,16 @@ def _client_extra_bindings(ui: Any, client: Any) -> Any:
                 install_rewind_binding(kb, rewind)
             except Exception:  # noqa: BLE001
                 pass
+        # The transcript escape hatches: [ v { } while scrolled, Ctrl+L
+        # repaint, Ctrl+O narration toggle — the "see what it is doing /
+        # what it did" cluster.
+        try:
+            from backend.core.ouroboros.battle_test.transcript_hatches import (
+                install_transcript_hatches,
+            )
+            install_transcript_hatches(kb, ui, client)
+        except Exception:  # noqa: BLE001
+            pass
         return kb
     except Exception:  # noqa: BLE001
         return None
@@ -3014,6 +3024,17 @@ def run_attach(console: Any) -> int:
             )
         except Exception:  # noqa: BLE001
             ui.rewind = None
+        # A bell that fires into tmux's void is worse than none — the
+        # operator TRUSTS it. Probe once at attach and say so plainly.
+        try:
+            from backend.core.ouroboros.battle_test.transcript_hatches import (
+                tmux_bell_warning,
+            )
+            _bell_warn = tmux_bell_warning()
+            if _bell_warn:
+                console.print(_bell_warn, markup=False, highlight=False)
+        except Exception:  # noqa: BLE001
+            pass
         # The shield renders released gates through the SAME markup path
         # every other ⏺/⎿ line takes — one display, one ordering, and the
         # gate lands in scrollback the operator can page back to.

--- a/tests/battle_test/test_transcript_hatches.py
+++ b/tests/battle_test/test_transcript_hatches.py
@@ -1,0 +1,135 @@
+"""Transcript escape hatches — the ring becomes searchable, navigable,
+and honest about tmux.
+
+Pins: markup stripping, the ring→transcript read, block-jump offset math
+against the REAL viewport, the scrolled-only gate on printable keys, the
+tmux passthrough probe, and the keymap mounting of all six actions.
+"""
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from backend.core.ouroboros.battle_test import transcript_hatches as th
+
+
+@pytest.fixture()
+def live_canvas():
+    from backend.core.ouroboros.battle_test.bipartite_layout import (
+        BipartiteLayout,
+        set_active_canvas,
+    )
+    mux = BipartiteLayout(width=80, height=12, title="t")
+    set_active_canvas(mux)
+    yield mux
+    set_active_canvas(None)
+
+
+def test_strip_markup() -> None:
+    assert th._strip_markup("[bold]⏺ hi[/bold]") == "⏺ hi"
+    assert th._strip_markup("plain") == "plain"
+
+
+def test_transcript_lines_reads_the_ring(live_canvas) -> None:
+    live_canvas.push_raw("[cyan]⏺ op one[/cyan]")
+    live_canvas.push_raw("  ⎿ detail")
+    lines = th.transcript_lines()
+    assert lines[-2:] == ["⏺ op one", "  ⎿ detail"]
+
+
+def test_no_canvas_means_empty_not_error() -> None:
+    assert th.transcript_lines() == []
+    assert th.is_scrolled_back() is False
+
+
+def test_jump_block_moves_the_viewport_to_a_marker(live_canvas) -> None:
+    for i in range(30):
+        live_canvas.push_raw(f"· trace {i}")
+    live_canvas.push_raw("⏺ the block")
+    for i in range(30):
+        live_canvas.push_raw(f"· more {i}")
+    vp = live_canvas._viewport
+    total, budget = live_canvas.scroll_metrics()
+    # scroll back a little so the hatch keys are live, then jump up
+    vp.scroll(-5, total=total, budget=budget)
+    assert th.is_scrolled_back()
+    th.jump_block(None, -1)
+    lines = th.transcript_lines()
+    total, budget = live_canvas.scroll_metrics()
+    top = max(0, total - budget - vp.offset)
+    assert lines[top].startswith("⏺")
+    # and } walks forward again without leaving the ring
+    th.jump_block(None, +1)
+    assert vp.offset >= 0
+
+
+def test_scrolled_gate_tracks_the_viewport(live_canvas) -> None:
+    for i in range(40):
+        live_canvas.push_raw(f"line {i}")
+    assert th.is_scrolled_back() is False
+    total, budget = live_canvas.scroll_metrics()
+    live_canvas._viewport.scroll(-3, total=total, budget=budget)
+    assert th.is_scrolled_back() is True
+
+
+def test_tmux_probe_silent_outside_tmux(monkeypatch) -> None:
+    monkeypatch.delenv("TMUX", raising=False)
+    assert th.tmux_bell_warning() == ""
+
+
+def test_tmux_probe_warns_when_passthrough_off(monkeypatch) -> None:
+    monkeypatch.setenv("TMUX", "/tmp/tmux-1/default,1,0")
+
+    def _fake_run(*_a, **_k):
+        class _P:
+            stdout = "off\n"
+        return _P()
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    assert "allow-passthrough" in th.tmux_bell_warning()
+
+
+def test_tmux_probe_silent_when_passthrough_on(monkeypatch) -> None:
+    monkeypatch.setenv("TMUX", "/tmp/tmux-1/default,1,0")
+
+    def _fake_run(*_a, **_k):
+        class _P:
+            stdout = "on\n"
+        return _P()
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    assert th.tmux_bell_warning() == ""
+
+
+def test_tmux_probe_silent_when_bell_disabled(monkeypatch) -> None:
+    monkeypatch.setenv("TMUX", "x")
+    monkeypatch.setenv("JARVIS_GATE_BELL_ENABLED", "false")
+    assert th.tmux_bell_warning() == ""
+    monkeypatch.delenv("JARVIS_GATE_BELL_ENABLED")
+
+
+def test_all_six_actions_mount_through_the_keymap() -> None:
+    pytest.importorskip("prompt_toolkit")
+    from prompt_toolkit.key_binding import KeyBindings
+
+    class _UI:
+        def flash(self, *_a, **_k):
+            pass
+
+    class _Client:
+        def send_input(self, _t):
+            return True
+
+    kb = KeyBindings()
+    assert th.install_transcript_hatches(kb, _UI(), _Client())
+    for keys in (("[",), ("v",), ("{",), ("}",), ("c-l",), ("c-o",)):
+        assert kb.get_bindings_for_keys(keys), keys
+
+
+def test_hatches_are_wired_into_the_client_action_set() -> None:
+    from pathlib import Path
+    import backend.core.ouroboros.cli.ov as ov
+    src = Path(ov.__file__).read_text()
+    assert "install_transcript_hatches(kb, ui, client)" in src
+    assert "tmux_bell_warning()" in src


### PR DESCRIPTION
The "see what it is doing / what it did" cluster from the CC transcript-viewer docs, mapped onto the canvas ring the cockpit already keeps (~20k retained lines) — no new storage, no second viewer widget.

- **`[`** writes the whole retained transcript to the terminal's **primary** scrollback via `run_in_terminal` (the alt screen took native Cmd+F / tmux copy-mode search away; this hands it back on demand). **`v`** opens it in `$EDITOR`.
- **`{` / `}`** jump the viewport between block markers (⏺ action opens, ❯ operator lines) — paging finds a place, this finds a *thing*. All four printable keys bind **only while scrolled back** (PgUp is the doorway), so a hand-typed `{` at the live prompt types as itself.
- **Ctrl+L** — full-repaint recovery key. **Ctrl+O** — flips live narration normal ↔ verbose through the existing `/narrate` verb over the normal input path (keystroke and typed verb stay one mirrored, history-synced code path).
- **tmux honesty probe**: the OSC-9 gate bell (#70193) is silently swallowed inside tmux without `allow-passthrough on` — and a bell the operator trusts but never hears is worse than none. Probed (not assumed) once at attach; one line with the exact fix when it would be swallowed.

All six actions are keybindings.json-remappable (new `Transcript` context), mounted through the one client action set both attach surfaces share. 11 new tests: real-viewport jump math, scrolled-only gate, ring reads, tmux probe truth table, keymap mounts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the retained transcript (~20k lines) searchable and navigable, and add a tmux check so operators aren’t misled by a swallowed gate bell. Adds scoped keybindings to dump/open the transcript, jump between blocks, repaint, and toggle narration.

- **New Features**
  - Search: `[` dumps the whole transcript to the terminal’s primary scrollback via `run_in_terminal`; `v` opens it in `$EDITOR`.
  - Navigate: `{`/`}` jump between block markers (⏺, ❯) in the viewport.
  - Scope: printable keys only work while scrolled back; at the live prompt they type normally.
  - Reliability: `Ctrl+L` forces a full repaint; `Ctrl+O` toggles narration normal ↔ verbose via `/narrate`.
  - tmux: probe at attach and print a one-line fix when `allow-passthrough` is off to avoid a silent, swallowed bell.
  - Config: all actions are remappable in `keybindings.json` under the new `Transcript` context; uses the existing canvas ring (no new storage).

<sup>Written for commit 85181e6ffa411b2da4c3803ecec44ff36c351573. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

