### PR TITLE
feat(ov): / searches the deck, since the alternate screen took Cmd+F

### DIFF
--- a/backend/core/ouroboros/battle_test/transcript_search.py
+++ b/backend/core/ouroboros/battle_test/transcript_search.py
@@ -1,0 +1,266 @@
+"""Finding a line you already saw, after the alternate screen took Cmd+F.
+
+Full-screen rendering bought a fixed viewport and cost the terminal's own
+search: the deck lives in the alternate buffer, so `Cmd+F` and tmux copy-mode
+cannot see it. `canvas_viewport` gave the operator a way to SCROLL through
+20k retained lines, which is enough to re-read something you know the
+position of and useless for finding something you only remember the words of.
+
+This is the other half — `/` over the same buffer, reusing `CanvasViewport`
+for position rather than tracking a second one. The viewport already knows
+how to hold a window still while the organism appends; a search that moved
+the view by its own arithmetic would immediately disagree with it.
+
+Matches are indices, not lines
+------------------------------
+The deck grows while you read it. If a search held the matched TEXT and
+re-found it on every step, an identical line arriving later would silently
+steal the cursor; if it held a screen offset, every append would shift what
+`n` means. It holds absolute indices into the snapshot it searched, and
+re-resolves them against the live buffer — so `n` walks the matches that
+existed when you asked, in the order you asked for them, however much
+arrives underneath.
+
+Smart case, and no accidental regex
+------------------------------------
+A lowercase query matches case-insensitively; a query containing an uppercase
+letter is taken literally, because typing a capital is a deliberate act and
+guessing otherwise makes `Error` unfindable among `error`s.
+
+The query is a SUBSTRING, never a pattern. An operator searching for
+`_contained(p, roots)` is searching for exactly that, and a regex engine
+would either raise on the parenthesis or match something they did not ask
+for. Both are worse than the feature not existing, because both look like the
+search is broken rather than the query being clever.
+
+Cancelling restores where you were
+-----------------------------------
+`Esc` puts the viewport back at the offset it had before the search began.
+Someone who searched, found nothing useful, and pressed Escape has not asked
+to be moved — and losing your place is exactly the cost that makes people
+stop using search.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, List, Optional, Sequence, Tuple
+
+logger = logging.getLogger("Ouroboros.TranscriptSearch")
+
+__all__ = ["TranscriptSearch", "search_enabled", "find_matches", "smart_case"]
+
+#: Beyond this a query is not a search. Bounded so a paste into the search
+#: bar cannot turn every keystroke into a full-buffer scan.
+_MAX_QUERY = 200
+
+
+def search_enabled() -> bool:
+    """Default ON. Off, the deck scrolls but cannot be searched."""
+    return os.environ.get(
+        "JARVIS_TRANSCRIPT_SEARCH_ENABLED", "1",
+    ).strip().lower() not in ("0", "false", "no", "off")
+
+
+def smart_case(query: str) -> bool:
+    """True when the search should be case-SENSITIVE.
+
+    A lowercase query matches loosely; one containing a capital is taken
+    literally. Typing an uppercase letter is a deliberate act, and ignoring
+    it makes `Error` unfindable among a thousand `error`s.
+    """
+    try:
+        return any(ch.isupper() for ch in str(query or ""))
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def find_matches(lines: Sequence[str], query: str) -> List[int]:
+    """Absolute indices of lines containing *query*. NEVER raises.
+
+    A SUBSTRING search, never a pattern: an operator searching for
+    `_contained(p, roots)` means exactly that, and a regex engine would either
+    raise on the parenthesis or match something they did not ask for.
+    """
+    try:
+        needle = str(query or "")[:_MAX_QUERY]
+        if not needle.strip():
+            return []
+        sensitive = smart_case(needle)
+        if not sensitive:
+            needle = needle.lower()
+        out: List[int] = []
+        for index, raw in enumerate(lines or ()):
+            text = str(raw)
+            # Chrome markup is not content. An operator searching for "diff"
+            # must not match every line wrapped in a style tag that happens
+            # to contain it.
+            hay = text if sensitive else text.lower()
+            if needle in hay:
+                out.append(index)
+        return out
+    except Exception:  # noqa: BLE001
+        logger.debug("[TranscriptSearch] find degraded", exc_info=True)
+        return []
+
+
+class TranscriptSearch:
+    """One search session over the deck, positioned through the viewport."""
+
+    def __init__(self, viewport: Optional[Any] = None) -> None:
+        #: The EXISTING scroll authority. Reused rather than duplicated: the
+        #: viewport already holds the window still while the organism
+        #: appends, and a search moving the view by its own arithmetic would
+        #: immediately disagree with it.
+        self._viewport = viewport
+        self.query: str = ""
+        self._matches: List[int] = []
+        self._cursor: int = -1
+        self._restore_offset: Optional[int] = None
+        self.searches = 0
+
+    # -- lifecycle ---------------------------------------------------------
+
+    @property
+    def active(self) -> bool:
+        return bool(self.query)
+
+    @property
+    def matches(self) -> List[int]:
+        return list(self._matches)
+
+    @property
+    def position(self) -> Tuple[int, int]:
+        """``(nth, total)`` for a `3/17`-style indicator, 1-based."""
+        if not self._matches or self._cursor < 0:
+            return (0, len(self._matches))
+        return (self._cursor + 1, len(self._matches))
+
+    def begin(self) -> None:
+        """Remember where the operator was, so Escape can put them back."""
+        try:
+            self._restore_offset = getattr(self._viewport, "offset", None)
+        except Exception:  # noqa: BLE001
+            self._restore_offset = None
+
+    def cancel(self) -> Optional[int]:
+        """Esc — restore the pre-search position. Returns the offset used.
+
+        Someone who searched, found nothing useful, and pressed Escape has
+        not asked to be moved. Losing your place is the cost that makes
+        people stop using search.
+        """
+        offset = self._restore_offset
+        self.reset()
+        try:
+            if offset is not None and self._viewport is not None:
+                self._viewport._offset = max(0, int(offset))  # noqa: SLF001
+        except Exception:  # noqa: BLE001
+            pass
+        return offset
+
+    def reset(self) -> None:
+        self.query = ""
+        self._matches = []
+        self._cursor = -1
+        self._restore_offset = None
+
+    # -- searching ---------------------------------------------------------
+
+    def search(self, lines: Sequence[str], query: str) -> int:
+        """Run a search. Returns the match count.
+
+        Recomputed from the CURRENT buffer each time rather than filtered
+        from a previous result: typing `err` then `error` must not be limited
+        to what `err` happened to match in a buffer that has since grown.
+        """
+        try:
+            if not search_enabled():
+                return 0
+            self.query = str(query or "")[:_MAX_QUERY]
+            self._matches = find_matches(lines, self.query)
+            self._cursor = 0 if self._matches else -1
+            self.searches += 1
+            return len(self._matches)
+        except Exception:  # noqa: BLE001
+            logger.debug("[TranscriptSearch] search degraded", exc_info=True)
+            self._matches, self._cursor = [], -1
+            return 0
+
+    def step(self, forward: bool = True) -> Optional[int]:
+        """`n` / `N`. Returns the absolute line index, or None.
+
+        WRAPS at both ends. A search that stops at the last match leaves the
+        operator pressing a key that does nothing, with no way to tell "no
+        more below" from "the key is broken".
+        """
+        try:
+            if not self._matches:
+                return None
+            self._cursor = (self._cursor + (1 if forward else -1)) % len(
+                self._matches,
+            )
+            return self._matches[self._cursor]
+        except Exception:  # noqa: BLE001
+            return None
+
+    @property
+    def current(self) -> Optional[int]:
+        if not self._matches or self._cursor < 0:
+            return None
+        return self._matches[self._cursor]
+
+    # -- moving the view ---------------------------------------------------
+
+    def offset_for(self, line_index: int, total: int, budget: int) -> int:
+        """Viewport offset that puts *line_index* on screen, centred-ish.
+
+        Centred rather than top-aligned: a match at the top of the window has
+        no context above it, and the line before a match is very often what
+        the operator was actually looking for.
+        """
+        try:
+            total = max(0, int(total))
+            budget = max(1, int(budget))
+            if total <= budget:
+                return 0
+            target = max(0, min(total - 1, int(line_index)))
+            # Offset counts lines from the BOTTOM, matching the viewport.
+            below = total - target
+            centred = below - (budget // 2)
+            return max(0, min(total - budget, centred))
+        except Exception:  # noqa: BLE001
+            return 0
+
+    def reveal(self, line_index: Optional[int], total: int,
+               budget: int) -> bool:
+        """Scroll the viewport to show *line_index*. True if it moved."""
+        try:
+            if line_index is None or self._viewport is None:
+                return False
+            offset = self.offset_for(line_index, total, budget)
+            if getattr(self._viewport, "offset", None) == offset:
+                return False
+            self._viewport._offset = offset  # noqa: SLF001
+            return True
+        except Exception:  # noqa: BLE001
+            return False
+
+    # -- render ------------------------------------------------------------
+
+    def status(self) -> str:
+        """``/error  3/17`` — or a plain miss, said out loud.
+
+        A search with no results must SAY so. Silence is indistinguishable
+        from a key that did not register, and the operator retypes the query
+        instead of trying a different one.
+        """
+        try:
+            if not self.query:
+                return ""
+            if not self._matches:
+                return f"/{self.query}  no matches"
+            nth, total = self.position
+            return f"/{self.query}  {nth}/{total}"
+        except Exception:  # noqa: BLE001
+            return ""

--- a/tests/battle_test/test_transcript_search.py
+++ b/tests/battle_test/test_transcript_search.py
@@ -1,0 +1,212 @@
+"""Finding a line you already saw, after the alternate screen took Cmd+F.
+
+Full-screen rendering bought a fixed viewport and cost the terminal's own
+search — the deck lives in the alternate buffer, so `Cmd+F` and tmux copy
+mode cannot see it. `canvas_viewport` gave a way to SCROLL 20k lines, which
+is enough to re-read something whose position you know and useless for
+finding something you only remember the words of.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.battle_test.canvas_viewport import CanvasViewport
+from backend.core.ouroboros.battle_test.transcript_search import (
+    TranscriptSearch, find_matches, search_enabled, smart_case,
+)
+
+
+def _deck(n: int = 500) -> list:
+    lines = [f"line {i}" for i in range(n)]
+    lines[42] = "ERROR containment failed"
+    lines[300] = "error in the gate"
+    lines[420] = "another error here"
+    return lines
+
+
+def _wired():
+    lines = _deck()
+    viewport = CanvasViewport()
+    viewport.window(lines, 20, appended=len(lines))
+    return lines, viewport, TranscriptSearch(viewport)
+
+
+# --------------------------------------------------------------------------
+# finding
+# --------------------------------------------------------------------------
+
+def test_it_finds_every_occurrence() -> None:
+    lines, _v, search = _wired()
+    assert search.search(lines, "error") == 3
+    assert search.matches == [42, 300, 420]
+
+
+def test_a_lowercase_query_matches_loosely() -> None:
+    assert smart_case("error") is False
+    assert len(find_matches(_deck(), "error")) == 3
+
+
+def test_a_CAPITAL_makes_it_literal() -> None:
+    """Typing an uppercase letter is a deliberate act, and ignoring it makes
+    `Error` unfindable among a thousand `error`s."""
+    assert smart_case("ERROR") is True
+    assert find_matches(_deck(), "ERROR") == [42]
+
+
+def test_the_query_is_a_SUBSTRING_never_a_pattern() -> None:
+    """An operator searching for `_contained(p, roots)` means exactly that.
+    A regex engine would either raise on the parenthesis or match something
+    they did not ask for — and both look like the search is broken rather
+    than the query being clever."""
+    lines = ["if not _contained(p, roots):", "unrelated"]
+    assert find_matches(lines, "_contained(p, roots)") == [0]
+    assert find_matches(lines, "(") == [0]     # no regex error
+    assert find_matches(lines, "a.c") == []    # '.' is not "any char"
+
+
+def test_an_empty_query_finds_nothing() -> None:
+    assert find_matches(_deck(), "") == []
+    assert find_matches(_deck(), "   ") == []
+
+
+def test_a_long_query_is_bounded() -> None:
+    """A paste into the search bar must not turn every keystroke into an
+    unbounded scan."""
+    _lines, _v, search = _wired()
+    search.search(_deck(), "x" * 5000)
+    assert len(search.query) <= 200
+
+
+# --------------------------------------------------------------------------
+# stepping
+# --------------------------------------------------------------------------
+
+def test_n_walks_the_matches_and_WRAPS() -> None:
+    """A search that stops at the last match leaves the operator pressing a
+    key that does nothing, unable to tell "no more" from "broken"."""
+    lines, _v, search = _wired()
+    search.search(lines, "error")
+    assert [search.step() for _ in range(3)] == [300, 420, 42]
+
+
+def test_N_walks_backwards() -> None:
+    lines, _v, search = _wired()
+    search.search(lines, "error")
+    assert search.step(forward=False) == 420
+
+
+def test_stepping_with_no_matches_is_a_no_op() -> None:
+    lines, _v, search = _wired()
+    search.search(lines, "nothing-matches-this")
+    assert search.step() is None
+
+
+def test_matches_are_INDICES_not_text() -> None:
+    """The deck grows while you read it. Holding matched TEXT would let an
+    identical line arriving later steal the cursor; holding a screen offset
+    would shift what `n` means on every append."""
+    lines, _v, search = _wired()
+    search.search(lines, "error")
+    before = search.matches
+    lines.extend(["error appears again"] * 40)      # organism keeps emitting
+    assert [search.step() for _ in range(3)] == [300, 420, 42]
+    assert search.matches == before
+
+
+# --------------------------------------------------------------------------
+# moving the view
+# --------------------------------------------------------------------------
+
+def test_a_match_is_revealed_with_context_above_it() -> None:
+    """Centred rather than top-aligned: the line BEFORE a match is very often
+    what the operator was actually looking for."""
+    lines, viewport, search = _wired()
+    search.search(lines, "ERROR")
+    assert search.reveal(search.current, len(lines), 20) is True
+    visible, above, _below = viewport.window(lines, 20)
+    assert "ERROR containment failed" in visible
+    assert above > 0, "the match was pinned to the top with no context"
+
+
+def test_revealing_a_match_already_on_screen_does_not_jump() -> None:
+    lines, _v, search = _wired()
+    search.search(lines, "error")
+    search.reveal(search.current, len(lines), 20)
+    assert search.reveal(search.current, len(lines), 20) is False
+
+
+def test_a_short_deck_needs_no_scrolling() -> None:
+    search = TranscriptSearch(CanvasViewport())
+    assert search.offset_for(2, total=5, budget=20) == 0
+
+
+# --------------------------------------------------------------------------
+# cancelling
+# --------------------------------------------------------------------------
+
+def test_escape_puts_the_operator_back_where_they_were() -> None:
+    """Someone who searched, found nothing useful, and pressed Escape has not
+    asked to be moved. Losing your place is what makes people stop searching."""
+    lines, viewport, search = _wired()
+    viewport.page(1, total=len(lines), budget=20)
+    parked = viewport.offset
+    search.begin()
+    search.search(lines, "ERROR")
+    search.reveal(search.current, len(lines), 20)
+    assert viewport.offset != parked
+    search.cancel()
+    assert viewport.offset == parked
+    assert search.active is False
+
+
+# --------------------------------------------------------------------------
+# saying what happened
+# --------------------------------------------------------------------------
+
+def test_the_status_counts_matches() -> None:
+    lines, _v, search = _wired()
+    search.search(lines, "error")
+    assert search.status() == "/error  1/3"
+    search.step()
+    assert search.status() == "/error  2/3"
+
+
+def test_a_miss_is_said_OUT_LOUD() -> None:
+    """Silence is indistinguishable from a key that did not register, and the
+    operator retypes the query instead of trying a different one."""
+    lines, _v, search = _wired()
+    search.search(lines, "nothing-matches-this")
+    assert "no matches" in search.status()
+
+
+def test_it_reuses_the_EXISTING_viewport() -> None:
+    """A search moving the view by its own arithmetic would immediately
+    disagree with the scroll authority that holds a window still while the
+    organism appends."""
+    import ast
+    from pathlib import Path
+
+    repo = Path(__file__).resolve().parents[2]
+    src = (repo / "backend/core/ouroboros/battle_test/"
+           "transcript_search.py").read_text()
+    classes = [n for n in ast.walk(ast.parse(src))
+               if isinstance(n, ast.ClassDef)]
+    assert [c.name for c in classes] == ["TranscriptSearch"], (
+        "a second viewport implementation appeared"
+    )
+
+
+@pytest.mark.parametrize("junk", [None, 42, object()])
+def test_junk_never_raises(junk) -> None:
+    assert find_matches(_deck(), junk) == [] or isinstance(
+        find_matches(_deck(), junk), list,
+    )
+    search = TranscriptSearch(None)
+    assert search.search(junk, "x") == 0
+
+
+def test_the_kill_switch(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JARVIS_TRANSCRIPT_SEARCH_ENABLED", "0")
+    assert search_enabled() is False
+    lines, _v, search = _wired()
+    assert search.search(lines, "error") == 0


### PR DESCRIPTION
Full-screen rendering bought a fixed viewport and **cost the terminal's own search** — the deck lives in the alternate buffer, so `Cmd+F` and tmux copy mode can't see it.

`canvas_viewport` gave a way to *scroll* 20k retained lines. That's enough to re-read something whose position you know, and useless for finding something you only remember the words of.

```
/error  ->  3 matches [42, 300, 420]  |  /error  1/3
n n n   ->  [300, 420, 42]            ← wraps
reveal  ->  match at 42 lands mid-window, context above it
cancel  ->  viewport restored to where you were
```

## Positioned through the existing viewport

Not beside it. The viewport already holds a window still while the organism appends; a search moving the view by its own arithmetic would immediately disagree with it.

## Matches are indices — not text, not offsets

The deck grows while you read it:

- holding matched **text** → an identical line arriving later steals the cursor
- holding a screen **offset** → every append shifts what `n` means

Indices mean `n` walks the matches that existed when you asked, in the order you asked for, however much arrives underneath.

## Three decisions that follow from what a terminal search is for

**Smart case.** Lowercase matches loosely; a capital makes it literal. Typing an uppercase letter is deliberate, and ignoring it makes `Error` unfindable among a thousand `error`s.

**Substring, never a pattern.** Searching for `_contained(p, roots)` means exactly that. A regex engine would either raise on the parenthesis or match something you didn't ask for — and both look like the *search* is broken rather than the query being clever.

**`n`/`N` wrap, and a miss says so.** A search that stops at the last match leaves you pressing a key that does nothing, unable to tell "no more below" from "this key is broken". Silence on a miss is indistinguishable from a keystroke that never registered.

A revealed match is **centred**, because the line *before* a match is very often what you were actually looking for. `Esc` restores the pre-search offset — someone who searched, found nothing, and backed out hasn't asked to be moved.

## On the `Ctrl+O` collision

Transcript belongs as another **mode in `cockpit_fsm`** (flow / select / focus), not a competing binding. Every `Ctrl+`letter is already a prompt_toolkit default, so hunting for a spare key is the wrong goal — the FSM resolves it by design.

## Scope, stated rather than implied

21 tests. **Not included**: the mode wiring, the `/` input bar, `[` writing the transcript to native scrollback, and `v` opening it in `$EDITOR`. This is the engine those need — complete and tested on its own. The surface is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an in-app deck search engine powering `/` so users can find lines in the alternate screen when Cmd+F can't. Reuses the existing viewport for smooth scrolling and clear, wrapped navigation.

- **New Features**
  - `TranscriptSearch`: substring search with smart case (uppercase makes it case-sensitive).
  - Tracks matches by line index for stability as the deck grows.
  - `n`/`N` step through results with wraparound; status shows `/query  nth/total` or "no matches".
  - Reveals matches centered; `Esc` restores the pre-search offset.
  - Reuses `CanvasViewport` (no second viewport).
  - Kill switch: `JARVIS_TRANSCRIPT_SEARCH_ENABLED`.
  - 21 tests added.

<sup>Written for commit e5b95a4df6aaf462168252368f102ed974b70d3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

