### PR TITLE
feat(ov): the palette says what a verb is FOR, in the operator's voice

### DIFF
--- a/backend/core/ouroboros/battle_test/repl_completion.py
+++ b/backend/core/ouroboros/battle_test/repl_completion.py
@@ -1879,7 +1879,7 @@ def _describe(fn: object) -> str:
         #     other, and 45 verbs were never going to get dict entries.
         operator_line = extract_operator_section(getattr(fn, "__doc__", None))
         if operator_line:
-            return _help_bound(operator_line)
+            return _help_bound(_operator_voice(operator_line, verb))
 
         # 2. The FUNCTION docstring, humanised — accepted only if it survives
         #    as prose.
@@ -1893,7 +1893,14 @@ def _describe(fn: object) -> str:
         #    yet"; plausible noise is not.
         own = _first_line(getattr(fn, "__doc__", ""))
         if own:
-            return _help_bound(own)
+            # Normalised to the OPERATOR's voice. A docstring is written for
+            # an implementer and it shows — "Parse /breadcrumbs and set/show
+            # the feed verbosity" opens with the verb the FUNCTION performs
+            # and then repeats the verb name, which is already the left-hand
+            # column. Subtractive only: no word appears that the author did
+            # not write, because a palette that paraphrases can be
+            # confidently wrong and the operator acts on it.
+            return _help_bound(_operator_voice(own, verb))
 
         # 3. No prose anywhere — mine the verb's own SUBCOMMAND VOCABULARY.
         #
@@ -1905,7 +1912,11 @@ def _describe(fn: object) -> str:
         #    not used, and it was sitting unread in the source.
         mined = mine_subcommands(fn)
         if mined:
-            return _help_bound(" | ".join(mined))
+            # A middot reads as a LIST of options; a pipe reads as grammar
+            # borrowed from a usage string. This row is not a usage string —
+            # it is the honest answer to "nobody wrote a description, but the
+            # verb does accept these".
+            return _help_bound(" · ".join(mined))
 
         # 4. No prose anywhere. The SIGNATURE still knows what the verb
         #    takes, and "what arguments does this want" is most of what an
@@ -1928,6 +1939,17 @@ def _describe(fn: object) -> str:
 
 
 @contextlib.contextmanager
+def _operator_voice(text: str, verb: str) -> str:
+    """Normalise a description to the operator's voice. Degrades to *text*."""
+    try:
+        from backend.core.ouroboros.battle_test.verb_description import (
+            to_operator_voice,
+        )
+        return to_operator_voice(text, verb) or text
+    except Exception:  # noqa: BLE001
+        return text
+
+
 def _root_logging_preserved():
     """Hold the root logger harmless across an arbitrary-module import walk.
 

--- a/backend/core/ouroboros/battle_test/verb_description.py
+++ b/backend/core/ouroboros/battle_test/verb_description.py
@@ -1,0 +1,166 @@
+"""What a verb is FOR, in one line, in the operator's voice.
+
+The palette was answering the wrong question. Scanning it produced::
+
+    /anticipate              help | panel | banners | prefetch | status
+    /autobiography           help | status | refresh | commit | escapes
+    /breadcrumbs             Parse /breadcrumbs and set/show the feed verbosity
+
+Two different faults produced those three rows, and only one of them is a
+bug.
+
+`/anticipate` shows a subcommand list because it has NO PROSE AT ALL. The
+resolution ladder in `repl_completion` already ranks prose above subcommands
+— an operator section, then the docstring, THEN mined subcommands — so that
+row is the honest bottom of the ladder, not a mis-ranking. The fix for it is
+someone writing a sentence, and no amount of formatting substitutes.
+
+`/breadcrumbs` is the actual defect. It HAS prose and the prose is in the
+wrong voice: "Parse /breadcrumbs and set/show the feed verbosity" opens with
+the verb the FUNCTION performs rather than the one the operator does, and
+then repeats the verb name that is already the left-hand column — a third of
+the line spent restating what they just read.
+
+Normalising is deliberately SUBTRACTIVE. Implementation openers are stripped,
+the verb's own name is stripped, the result is sentence-cased and unpunctuated.
+Nothing is invented: no word appears that the author did not write. A palette
+that paraphrases is a palette that can be confidently wrong, and the operator
+acts on it.
+
+    "Parse /breadcrumbs and set/show the feed verbosity"
+        → "Set or show the feed verbosity"
+
+When subtraction leaves nothing meaningful, the original survives untouched.
+A slightly awkward true line beats a tidy invented one.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import re
+from typing import Optional
+
+logger = logging.getLogger("Ouroboros.VerbDescription")
+
+__all__ = ["to_operator_voice", "describe_width", "prose_first_enabled"]
+
+#: Openers that describe what the FUNCTION does rather than what the operator
+#: gets. Stripped with their trailing connective so the remainder still reads
+#: as a sentence. Ordered longest-first so "Parse and dispatch" does not lose
+#: only its first word.
+_IMPL_OPENERS = (
+    "parse and dispatch", "parse and handle", "handle and dispatch",
+    "parse", "handle", "dispatch", "implement", "process", "route",
+    "execute", "perform", "run the", "entry point for", "entrypoint for",
+    "helper for", "wrapper for", "callback for", "hook for",
+)
+
+#: Connectives left dangling after an opener is removed.
+_DANGLING = re.compile(r"^(?:and\s+|then\s+|to\s+|the\s+|a\s+|an\s+)+", re.I)
+
+
+def prose_first_enabled() -> bool:
+    """Default ON. Off restores subcommands-before-prose ranking."""
+    return os.environ.get(
+        "JARVIS_PALETTE_PROSE_FIRST", "1",
+    ).strip().lower() not in ("0", "false", "no", "off")
+
+
+def describe_width() -> int:
+    """Columns the description may occupy before it is clipped.
+
+    A knob rather than a constant: the right width depends on terminal size
+    and on how long the longest verb name is, and both vary per install.
+    """
+    try:
+        return max(24, int(os.environ.get("JARVIS_PALETTE_DESC_WIDTH", "58")))
+    except (TypeError, ValueError):
+        return 58
+
+
+def _strip_verb_name(text: str, verb: str) -> str:
+    """Deal with the verb's own name in the opening.
+
+    Two cases, and conflating them destroys sentences:
+
+    * ``"the /posture verb — status, override"`` — the name is being NAMED.
+      It is already the left-hand column, so the whole phrase goes.
+    * ``"/attach a file or image"`` — the name IS the sentence's verb. Only
+      the slash goes. Deleting it here produced "File or image to the next
+      generation", which reads as a fragment about files rather than an
+      instruction to attach one.
+
+    The discriminator is what FOLLOWS the name: an article or a preposition
+    means it was doing grammatical work and must stay.
+    """
+    name = str(verb or "").lstrip("/").strip()
+    if not name:
+        return text
+    named = re.compile(
+        rf"^(?:the\s+)?/?{re.escape(name)}\s+verb\b[\s:,—-]*", re.IGNORECASE,
+    )
+    if named.search(text):
+        return named.sub("", text, count=1)
+    acting = re.compile(
+        rf"^/{re.escape(name)}\b(?=\s+(?:a|an|the|to|for|with|from|into|on)\b)",
+        re.IGNORECASE,
+    )
+    if acting.search(text):
+        return acting.sub(name, text, count=1)
+    return re.compile(
+        rf"^/?{re.escape(name)}\b[\s:,—-]*", re.IGNORECASE,
+    ).sub("", text, count=1)
+
+
+def to_operator_voice(text: Optional[str], verb: str = "",
+                      width: Optional[int] = None) -> str:
+    """One line describing what *verb* is for. NEVER raises.
+
+    SUBTRACTIVE only — no word appears that the author did not write. A
+    palette that paraphrases can be confidently wrong, and the operator acts
+    on it. When subtraction leaves nothing meaningful the original survives:
+    a slightly awkward true line beats a tidy invented one.
+    """
+    try:
+        raw = " ".join(str(text or "").split())
+        if not raw:
+            return ""
+        original = raw
+
+        # First sentence only. A palette row is one line, and everything
+        # after the first full stop is detail the operator did not ask for
+        # while scanning.
+        head = re.split(r"(?<=[.!?])\s+", raw, maxsplit=1)[0]
+
+        lowered = head.lower()
+        for opener in _IMPL_OPENERS:
+            if lowered.startswith(opener):
+                head = head[len(opener):]
+                break
+
+        # Dangling articles are cleared BEFORE the name check as well as
+        # after: "Handle the /posture verb" leaves "the /posture verb", and
+        # the named-form pattern has to see it to recognise it.
+        head = _DANGLING.sub("", head.strip())
+        head = _strip_verb_name(head.strip(), verb)
+        head = _DANGLING.sub("", head.strip())
+        head = head.strip(" .:;,—-")
+
+        if len(head) < 3:
+            # Subtraction ate the sentence. Fall back to the author's words
+            # rather than emit a fragment.
+            head = original.strip(" .")
+
+        # Sentence case: uppercase the first letter ONLY. Title-casing would
+        # mangle identifiers, and lowering the rest would mangle `DW`, `L2`,
+        # `APPROVAL_REQUIRED` and every other term that carries meaning in
+        # its capitals.
+        if head and head[0].islower():
+            head = head[0].upper() + head[1:]
+
+        limit = describe_width() if width is None else max(8, int(width))
+        if len(head) > limit:
+            head = head[: limit - 1].rstrip(" .,;:—-") + "…"
+        return head
+    except Exception:  # noqa: BLE001
+        return " ".join(str(text or "").split())[: describe_width()]

--- a/tests/battle_test/test_verb_description.py
+++ b/tests/battle_test/test_verb_description.py
@@ -1,0 +1,131 @@
+"""What a verb is FOR, in one line, in the operator's voice.
+
+The palette rendered rows like::
+
+    /breadcrumbs   Parse /breadcrumbs and set/show the feed verbosity
+
+A docstring is written for an implementer and it shows: it opens with the
+verb the FUNCTION performs rather than the one the operator does, then
+repeats the verb name that is already the left-hand column.
+
+Normalising is SUBTRACTIVE only. No word appears that the author did not
+write, because a palette that paraphrases can be confidently wrong and the
+operator acts on it.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.battle_test.verb_description import (
+    describe_width, to_operator_voice,
+)
+
+
+@pytest.mark.parametrize("text,verb,expected", [
+    ("Parse /breadcrumbs and set/show the feed verbosity", "breadcrumbs",
+     "Set/show the feed verbosity"),
+    ("Dispatch /vision subcommands to the vision REPL.", "vision",
+     "Subcommands to the vision REPL"),
+    ("Show the current governor caps and recent throttles.", "governor",
+     "Show the current governor caps and recent throttles"),
+])
+def test_implementation_openers_are_stripped(text, verb, expected) -> None:
+    assert to_operator_voice(text, verb) == expected
+
+
+def test_a_NAMED_verb_phrase_goes_entirely() -> None:
+    """"the /posture verb — status, override" is naming the verb, which is
+    already the left-hand column."""
+    assert to_operator_voice(
+        "Handle the /posture verb — status, override, history.", "posture",
+    ) == "Status, override, history"
+
+
+def test_an_ACTING_verb_name_SURVIVES() -> None:
+    """THE case that destroyed sentences. In "/attach a file or image" the
+    name IS the sentence's verb — deleting it produced "File or image to the
+    next generation", a fragment about files rather than an instruction to
+    attach one. The discriminator is what follows: an article or preposition
+    means it was doing grammatical work."""
+    assert to_operator_voice(
+        "/attach a file or image to the next generation.", "attach",
+    ) == "Attach a file or image to the next generation"
+    assert to_operator_voice(
+        "/cancel an in-flight operation by id.", "cancel",
+    ) == "Cancel an in-flight operation by id"
+
+
+def test_nothing_is_invented() -> None:
+    """A palette that paraphrases can be confidently wrong."""
+    source = "Show the current governor caps and recent throttles."
+    result = to_operator_voice(source, "governor")
+    for word in result.rstrip("…").split():
+        assert word.lower().strip(".,;:") in source.lower(), (
+            f"the word {word!r} was not written by the author"
+        )
+
+
+def test_only_the_first_sentence_is_used() -> None:
+    """A palette row is one line; everything after the first full stop is
+    detail nobody asked for while scanning."""
+    result = to_operator_voice(
+        "Show the posture. It also writes an audit entry and emits SSE.",
+        "posture",
+    )
+    assert "audit" not in result
+
+
+def test_capitals_that_carry_meaning_survive() -> None:
+    """Title-casing would mangle identifiers; lowering would mangle DW, L2
+    and APPROVAL_REQUIRED."""
+    result = to_operator_voice(
+        "Return the DW provider liquidity for each lane.", "provider",
+    )
+    assert "DW" in result
+
+
+def test_a_fragment_falls_back_to_the_authors_words() -> None:
+    """When subtraction eats the sentence, a slightly awkward true line
+    beats a tidy invented one."""
+    assert to_operator_voice("Parse", "parse") != ""
+    assert to_operator_voice("/posture", "posture") != ""
+
+
+def test_it_is_clipped_but_never_mid_punctuation() -> None:
+    long = "Show " + "the current governor caps " * 12
+    result = to_operator_voice(long, "governor")
+    assert len(result) <= describe_width()
+    assert result.endswith("…")
+
+
+def test_the_width_is_tunable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JARVIS_PALETTE_DESC_WIDTH", "30")
+    assert describe_width() == 30
+
+
+@pytest.mark.parametrize("junk", [None, "", "   ", 42])
+def test_junk_never_raises(junk) -> None:
+    assert isinstance(to_operator_voice(junk, "x"), str)
+
+
+def test_the_palette_uses_it() -> None:
+    import ast
+    from pathlib import Path
+
+    repo = Path(__file__).resolve().parents[2]
+    src = (repo / "backend/core/ouroboros/battle_test/"
+           "repl_completion.py").read_text()
+    names = {a.name for n in ast.walk(ast.parse(src))
+             if isinstance(n, ast.ImportFrom) for a in n.names}
+    assert "to_operator_voice" in names
+
+
+def test_subcommand_rows_read_as_a_LIST_not_a_usage_string() -> None:
+    """A pipe borrows grammar from a usage string. These rows are the honest
+    answer to "nobody wrote a description, but it does accept these"."""
+    from pathlib import Path
+
+    repo = Path(__file__).resolve().parents[2]
+    src = (repo / "backend/core/ouroboros/battle_test/"
+           "repl_completion.py").read_text()
+    assert '" · ".join(mined)' in src


### PR DESCRIPTION
```
before:  /breadcrumbs   Parse /breadcrumbs and set/show the feed verbosity
after:   /breadcrumbs   Set/show the feed verbosity
```

## Two faults, one bug

The three rows in that screenshot came from different causes, and separating them matters because the fixes differ.

**`/anticipate` isn't a bug.** It shows `help | panel | banners | prefetch | status` because it has **no prose at all**. The ladder already ranks prose above subcommands — operator section, then docstring, *then* mined subcommands. That row is the honest bottom of the ladder, not a mis-ranking. The fix is someone writing a sentence; no formatting substitutes, and pretending otherwise would mean inventing one.

*(I initially told you the ladder ranked subcommands above prose. It doesn't — I checked, and it was already correct.)*

**`/breadcrumbs` is the real defect.** It has prose, in the wrong voice. A docstring is written for an implementer: it opens with the verb the *function* performs rather than the one you do, then repeats the verb name that's already the left-hand column.

## Subtractive only

Implementation openers go, the naming of the verb goes, the result is sentence-cased and unpunctuated — and **no word appears that the author didn't write**. A palette that paraphrases can be confidently wrong, and you act on it. When subtraction leaves a fragment, the author's words survive: a slightly awkward true line beats a tidy invented one.

```
/breadcrumbs   Set/show the feed verbosity
/posture       Status, override, history
/attach        Attach a file or image to the next generation
/cancel        Cancel an in-flight operation by id
/provider      Return the DW provider liquidity for each lane
```

## The nuance that cost a round

The verb's own name is **sometimes the sentence's verb**. Stripping it from `/attach a file or image…` produced `File or image to the next generation` — a fragment about files rather than an instruction to attach one.

The discriminator is what *follows* the name: an article or preposition means it's doing grammatical work and only the slash may go. A name followed by the word "verb" is being *named*, and the whole phrase goes.

Sentence case uppercases the first letter **only** — title-casing mangles identifiers, and lowering the rest mangles `DW`, `L2`, `APPROVAL_REQUIRED`.

Subcommand fallback rows now join on a middot rather than a pipe: a pipe borrows grammar from a usage string, and these aren't usage strings.

## Verification

17 tests, including one asserting **nothing is invented** — every word in the output must appear in the source — and one pinning the acting-verb-name case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make palette descriptions say what each verb is for in the operator’s voice, not the implementer’s. Improves scanability and fixes cases like “Parse /breadcrumbs…” to “Set/show the feed verbosity”.

- **New Features**
  - Normalizes docstrings to operator voice using subtractive rules; no invented words.
  - Strips implementation openers and redundant verb names; keeps acting verb names; applies sentence case (first letter only).
  - Joins mined subcommands with a middot instead of a pipe for list readability.
  - Keeps prose-first ranking; adds tunable width via JARVIS_PALETTE_DESC_WIDTH (default 58).
  - Adds tests covering voice normalization, verb-name handling, clipping, and palette integration.

<sup>Written for commit 4c6c88bd5f2c6b367d45525894610dab1b795ccf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

