### PR TITLE
fix(ov): your message has a home, Karen greets once, and a stale binary confesses

### DIFF
--- a/backend/core/ouroboros/battle_test/daemon_provenance.py
+++ b/backend/core/ouroboros/battle_test/daemon_provenance.py
@@ -30,7 +30,8 @@ from typing import Any, Dict, Optional
 
 logger = logging.getLogger("Ouroboros.Provenance")
 
-__all__ = ["read_provenance", "staleness_line", "write_provenance"]
+__all__ = ["client_binary_warning", "read_provenance", "staleness_line",
+           "write_provenance"]
 
 _STAMP = ".jarvis/daemon_provenance.json"
 
@@ -130,3 +131,38 @@ def _age_threshold_s() -> float:
             "JARVIS_DAEMON_STALE_AGE_S", "3600") or 3600))
     except (TypeError, ValueError):
         return 3600.0
+
+
+def client_binary_warning() -> str:
+    """One loud line when the RUNNING ov imported code from somewhere
+    other than the repo it is operating on, or "".
+
+    The stale-shim trap: a pyenv/pip-installed copy of the package
+    shadows the editable install, and the operator watches a GHOST of an
+    older interface — old renderers, old bugs, hours lost to fixing what
+    is already fixed (the 2026-07-28 classifier-dump screenshot was
+    exactly this). Detected by provenance, not by version strings: the
+    imported ``backend`` package's filesystem root either IS the repo
+    (editable install / in-tree run, incl. worktrees whose env points at
+    the main checkout) or it is a copy that can silently rot.
+
+    NEVER raises; unknowable = silent."""
+    try:
+        import backend as _backend
+        code_root = Path(_backend.__file__).resolve().parent.parent
+        repo_raw = os.environ.get("JARVIS_REPO_PATH", "").strip()
+        repo = Path(repo_raw).resolve() if repo_raw else Path.cwd().resolve()
+        code_s, repo_s = str(code_root), str(repo)
+        if (
+            code_s == repo_s
+            or code_s.startswith(repo_s + os.sep)
+            or repo_s.startswith(code_s + os.sep)
+        ):
+            return ""
+        return (
+            f"⚠ stale ov binary — this process imported code from "
+            f"{code_root}, but the repo is {repo}. What you see may be an "
+            f"OLD interface. Fix: pip install -e {repo}"
+        )
+    except Exception:  # noqa: BLE001
+        return ""

--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -6065,8 +6065,28 @@ class SerpentREPL:
                 import asyncio as _aio
 
                 def _on_accept(text: str) -> None:
+                    cleaned = (text or "").strip()
+                    # CC-style message anchor on the DAEMON cockpit too —
+                    # the typed line lands in the canvas before anything
+                    # answers it (same contract as the attach client's
+                    # _echo_operator_line; one genre, every surface).
+                    try:
+                        import os as _os
+                        if cleaned and _os.environ.get(
+                            "JARVIS_OPERATOR_ECHO_ENABLED", "true",
+                        ).strip().lower() not in ("0", "false", "no",
+                                                  "off"):
+                            canvas = get_active_canvas()
+                            if canvas is not None:
+                                from rich.markup import escape as _esc
+                                canvas.push_raw(
+                                    "[bold #5ee06a]❯[/bold #5ee06a] "
+                                    f"[#dbe6e1]{_esc(cleaned)}[/#dbe6e1]"
+                                )
+                    except Exception:  # noqa: BLE001
+                        pass
                     _aio.ensure_future(
-                        self._dispatch_repl_command((text or "").strip())
+                        self._dispatch_repl_command(cleaned)
                     )
 
                 async def _attach_sprite_when_ready() -> None:

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -1288,6 +1288,11 @@ def _route_operator_line(client: Any, ui: Any, line: Any) -> str:
         if low in ("detach", "exit", "quit"):
             return "detach"
 
+        # The message anchor — every submitted line except shell mode,
+        # which opens its own ⏺ chrome with the command in the header.
+        if text and not text.startswith("!"):
+            _echo_operator_line(ui, text)
+
         # `!` shell mode (CC parity): one command on THIS machine, output
         # into this operator's scrollback. Runs in an executor — a slow
         # command never blocks a keystroke. A bare "!" falls through as
@@ -1752,6 +1757,35 @@ def _render_client_keys(ui: Any, line: str) -> None:
         elif ui is not None and hasattr(ui, "flash"):
             first = str(result.text or "").splitlines() or [""]
             ui.flash(f"{first[0]} — `/keys daemon` for the daemon view")
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _echo_operator_line(ui: Any, text: str) -> None:
+    """CC-style message anchor: what you typed lands in YOUR scrollback
+    as a ❯ block the moment you press Enter, so the exchange has a
+    visible head before anything answers it. Without this the only echo
+    of a question was whatever fragment a downstream renderer chose to
+    quote. Multi-line input indents its continuation under the glyph.
+    Env: JARVIS_OPERATOR_ECHO_ENABLED (default true). NEVER raises."""
+    try:
+        if os.environ.get(
+            "JARVIS_OPERATOR_ECHO_ENABLED", "true",
+        ).strip().lower() in ("0", "false", "no", "off"):
+            return
+        sink = getattr(ui, "markup_sink", None) if ui is not None else None
+        if not callable(sink):
+            return
+        try:
+            from rich.markup import escape as _escape
+        except Exception:  # noqa: BLE001
+            def _escape(s: str) -> str:
+                return s
+        lines = str(text or "").splitlines() or [""]
+        sink(f"[bold #5ee06a]❯[/bold #5ee06a] "
+             f"[#dbe6e1]{_escape(lines[0])}[/#dbe6e1]", True)
+        for ln in lines[1:]:
+            sink(f"  [#dbe6e1]{_escape(ln)}[/#dbe6e1]", True)
     except Exception:  # noqa: BLE001
         pass
 
@@ -2895,6 +2929,11 @@ async def _bipartite_attach_loop(client: Any, console: Any, ui: Any) -> None:
                 "[bold]💭 Karen ▸[/bold] attached — I'm listening. verbs or "
                 "plain words both work · [cyan]wake[/cyan] arms my voice · "
                 "[cyan]detach[/cyan] leaves the organism running",
+                # Boot warnings (stale-binary sentinel, …) must survive
+                # the alt-screen mount — a console print alone dies with
+                # the primary buffer the moment the cockpit takes over.
+                *(f"[bold #e3b341]{w}[/bold #e3b341]"
+                  for w in getattr(ui, "boot_warnings", ()) or ()),
             ],
         )
     finally:
@@ -3082,6 +3121,24 @@ def run_attach(console: Any) -> int:
             _bell_warn = tmux_bell_warning()
             if _bell_warn:
                 console.print(_bell_warn, markup=False, highlight=False)
+        except Exception:  # noqa: BLE001
+            pass
+        # The stale-shim sentinel: a pyenv/pip copy shadowing the editable
+        # install shows a GHOST of an older interface — old renderers, old
+        # bugs, hours lost re-fixing the fixed. Said loudly, at attach, on
+        # every surface (console now; cockpit seed via ui.boot_warnings).
+        try:
+            from backend.core.ouroboros.battle_test.daemon_provenance import (
+                client_binary_warning,
+            )
+            _stale_bin = client_binary_warning()
+            if _stale_bin:
+                console.print(_stale_bin, markup=False, highlight=False)
+                try:
+                    ui.boot_warnings = [*getattr(ui, "boot_warnings", ()),
+                                        _stale_bin]
+                except Exception:  # noqa: BLE001
+                    pass
         except Exception:  # noqa: BLE001
             pass
         # The shield renders released gates through the SAME markup path

--- a/backend/core/ouroboros/governance/conversation_orchestrator.py
+++ b/backend/core/ouroboros/governance/conversation_orchestrator.py
@@ -74,6 +74,41 @@ _SOCIAL_ACKS: Tuple[str, ...] = (
 )
 
 
+#: session_id → monotonic time of the last social greeting issued. A
+#: greeting is a HANDSHAKE, not a loop: four stacked "Hey. I'm listening"
+#: lines read as a bot talking to itself (operator screenshot,
+#: 2026-07-28). Within the cooldown the reply collapses to one quiet
+#: acknowledgment instead of another opener.
+_LAST_GREET: dict = {}
+
+
+def _regreet_cooldown_s() -> float:
+    import os
+    try:
+        return max(0.0, float(
+            os.environ.get("JARVIS_CHAT_REGREET_COOLDOWN_S", "300"),
+        ))
+    except (TypeError, ValueError):
+        return 300.0
+
+
+def _social_reply_for_session(message: str, session_id: str) -> str:
+    """The rotation on first contact; "Still here." inside the cooldown.
+    NEVER raises."""
+    try:
+        import time as _time
+        now = _time.monotonic()
+        last = _LAST_GREET.get(str(session_id))
+        _LAST_GREET[str(session_id)] = now
+        if len(_LAST_GREET) > 64:
+            _LAST_GREET.pop(next(iter(_LAST_GREET)), None)
+        if last is not None and (now - last) < _regreet_cooldown_s():
+            return "Still here."
+    except Exception:  # noqa: BLE001
+        pass
+    return _social_reply(message)
+
+
 def _social_reply(message: str) -> str:
     """Stable per-message pick from the ack rotation. NEVER raises."""
     try:
@@ -280,6 +315,7 @@ class ConversationOrchestrator:
                 message=message,
                 verdict=verdict,
                 previous=previous,
+                session_id=session_id,
             )
 
             turn = ChatTurn(
@@ -380,6 +416,7 @@ class ConversationOrchestrator:
         message: str,
         verdict: IntentClassification,
         previous: Optional[ChatTurn],
+        session_id: str = "default",
     ) -> ChatRoutingDecision:
         msg = str(message or "")
         clipped = msg[:MAX_PAYLOAD_TEXT_CHARS]
@@ -406,7 +443,8 @@ class ConversationOrchestrator:
                 confidence=verdict.confidence,
                 reasons=verdict.reasons,
                 payload={"message": clipped,
-                         "reply": _social_reply(clipped)},
+                         "reply": _social_reply_for_session(
+                             clipped, session_id)},
                 reason="L0 zero-entropy social gate",
                 truncated=verdict.truncated,
             )

--- a/tests/battle_test/test_chat_surface_polish.py
+++ b/tests/battle_test/test_chat_surface_polish.py
@@ -1,0 +1,196 @@
+"""The chat surface reads like a conversation, not a bot's diary.
+
+Born from the 2026-07-28 operator screenshot: four stacked Karen
+greetings, a raw classifier dump as the "reply", and the typed question
+homeless. Root causes and their pins:
+
+  * the raw dump came from a STALE BINARY (the pyenv-shim trap) — the
+    current renderer was already right, and the sentinel now says so
+    loudly instead of letting a ghost interface masquerade as current;
+  * greetings had no memory — the orchestrator now collapses a re-greet
+    inside the cooldown to one quiet "Still here.";
+  * the typed line now lands as a ❯ anchor block the moment Enter is
+    pressed, on BOTH cockpit surfaces.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance import conversation_orchestrator as co
+
+
+# --------------------------------------------------------------------------
+# 1. greeting dedupe
+# --------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _fresh_greet_ledger():
+    co._LAST_GREET.clear()
+    yield
+    co._LAST_GREET.clear()
+
+
+def _social_action(orch, session):
+    turn, decision = orch.dispatch("hey", session_id=session)
+    assert decision.action == "social_ack"
+    return decision.payload.get("reply", "")
+
+
+def test_regreet_collapses_to_still_here() -> None:
+    orch = co.ConversationOrchestrator()
+    first = _social_action(orch, "s1")
+    assert first and first != "Still here."
+    assert _social_action(orch, "s1") == "Still here."
+    assert _social_action(orch, "s1") == "Still here."
+
+
+def test_sessions_greet_independently() -> None:
+    orch = co.ConversationOrchestrator()
+    _social_action(orch, "s1")
+    other = _social_action(orch, "s2")
+    assert other != "Still here."   # a NEW terminal deserves a hello
+
+
+def test_cooldown_expiry_restores_the_rotation(monkeypatch) -> None:
+    monkeypatch.setenv("JARVIS_CHAT_REGREET_COOLDOWN_S", "0")
+    orch = co.ConversationOrchestrator()
+    _social_action(orch, "s1")
+    assert _social_action(orch, "s1") != "Still here."
+
+
+def test_greet_ledger_is_bounded() -> None:
+    orch = co.ConversationOrchestrator()
+    for i in range(80):
+        _social_action(orch, f"s{i}")
+    assert len(co._LAST_GREET) <= 64
+
+
+# --------------------------------------------------------------------------
+# 2. the reply genre is voice + VERBOSE trace (regression pin for the
+#    screenshot's dump — already true on main, must stay true)
+# --------------------------------------------------------------------------
+
+def test_claude_query_reply_is_voice_not_classifier_dump() -> None:
+    from backend.core.ouroboros.governance.chat_response_style import (
+        compose_reply,
+    )
+    reply = compose_reply(
+        "claude_query", message="how you doing?",
+        receipt="logged-claude-chat-abc(ctx=5)",
+        turn_id="chat-abc", session_id="repl",
+        intent="EXPLANATION", confidence=0.33,
+        reasons=("question_shape",), reason="explanation verb",
+        verbose=False,
+    )
+    # the operator-facing line is prose, the machine facts are absent
+    assert "intent:" not in reply
+    assert "conf=0.33" not in reply
+    assert "question_shape" not in reply
+
+
+# --------------------------------------------------------------------------
+# 3. the ❯ message anchor
+# --------------------------------------------------------------------------
+
+class _SinkUI:
+    def __init__(self):
+        self.lines = []
+        self.markup_sink = lambda ln, addressed=False: self.lines.append(ln)
+
+    def flash(self, *_a, **_k):
+        pass
+
+    def should_flush_on_input(self):
+        return False
+
+
+class _NullClient:
+    connected = True
+
+    def send_input(self, _t):
+        return True
+
+    def send_audio(self, _c):
+        return True
+
+    def send_history(self, _t):
+        return True
+
+
+def test_submitted_text_lands_as_an_anchor_block() -> None:
+    from backend.core.ouroboros.cli.ov import _route_operator_line
+    ui = _SinkUI()
+    outcome = _route_operator_line(_NullClient(), ui, "how you doing?")
+    assert outcome == "sent"
+    assert any("❯" in ln and "how you doing?" in ln for ln in ui.lines)
+
+
+def test_multiline_anchor_indents_continuations() -> None:
+    from backend.core.ouroboros.cli.ov import _echo_operator_line
+    ui = _SinkUI()
+    _echo_operator_line(ui, "line one\nline two")
+    assert "❯" in ui.lines[0] and "line one" in ui.lines[0]
+    assert "❯" not in ui.lines[1] and "line two" in ui.lines[1]
+
+
+def test_anchor_escapes_markup_and_respects_kill_switch(
+    monkeypatch,
+) -> None:
+    from backend.core.ouroboros.cli.ov import _echo_operator_line
+    ui = _SinkUI()
+    _echo_operator_line(ui, "[red]not a tag[/red]")
+    assert "\\[red]" in ui.lines[0]
+    monkeypatch.setenv("JARVIS_OPERATOR_ECHO_ENABLED", "false")
+    before = len(ui.lines)
+    _echo_operator_line(ui, "silent")
+    assert len(ui.lines) == before
+
+
+def test_shell_mode_owns_its_own_chrome() -> None:
+    from pathlib import Path as _P
+    import backend.core.ouroboros.cli.ov as ov
+    src = _P(ov.__file__).read_text()
+    block = src.split("The message anchor")[1][:220]
+    assert 'not text.startswith("!")' in block
+
+
+def test_daemon_cockpit_echoes_too() -> None:
+    import inspect
+    from backend.core.ouroboros.battle_test import serpent_flow
+    src = inspect.getsource(serpent_flow.SerpentREPL._loop)
+    accept = src.split("def _on_accept")[1]
+    accept = accept.split("_aio.ensure_future")[0]
+    assert "❯" in accept and "JARVIS_OPERATOR_ECHO_ENABLED" in accept
+
+
+# --------------------------------------------------------------------------
+# 4. the stale-binary sentinel
+# --------------------------------------------------------------------------
+
+def test_sentinel_silent_when_code_is_the_repo(monkeypatch) -> None:
+    from backend.core.ouroboros.battle_test.daemon_provenance import (
+        client_binary_warning,
+    )
+    import backend as b
+    code_root = Path(b.__file__).resolve().parent.parent
+    monkeypatch.setenv("JARVIS_REPO_PATH", str(code_root))
+    assert client_binary_warning() == ""
+
+
+def test_sentinel_loud_when_code_is_a_shadow_copy(monkeypatch, tmp_path):
+    from backend.core.ouroboros.battle_test.daemon_provenance import (
+        client_binary_warning,
+    )
+    monkeypatch.setenv("JARVIS_REPO_PATH", str(tmp_path))
+    warning = client_binary_warning()
+    assert "stale ov binary" in warning
+    assert "pip install -e" in warning
+
+
+def test_sentinel_reaches_both_attach_surfaces() -> None:
+    import backend.core.ouroboros.cli.ov as ov
+    src = Path(ov.__file__).read_text()
+    assert "client_binary_warning" in src
+    assert "boot_warnings" in src           # survives the alt-screen mount


### PR DESCRIPTION
Born from the operator's screenshot (four stacked greetings + a raw classifier dump as the chat "reply" + the typed question homeless). Three root causes, one crucial finding:

## The dump was a ghost
The screenshot's `[chat] · turn: … intent: EXPLANATION (conf=0.33)` formatter **does not exist in current code** — #70158's voice renderer already replaced it. The terminal was running a pyenv/pip shadow copy of an older build (the documented stale-shim trap). New **`client_binary_warning()`**: when the running `ov` imported code from outside the repo it operates on, one loud line at attach — on the console **and** seeded into the cockpit canvas so the alt-screen mount can't swallow it. A ghost interface can never again masquerade as current while renderers that are already fixed get "re-fixed". A regression pin keeps the `claude_query` reply free of `intent:`/`conf=`/reason tokens forever.

## The ❯ message anchor (CC parity)
What you type lands in your scrollback as a `❯ how you doing?` block the moment you press Enter — the exchange has a visible head before anything answers, on **both** surfaces (attach client via the addressed markup sink, escaped; daemon cockpit via canvas push at `_on_accept`). Multi-line input indents under the glyph; `!` shell keeps its own ⏺ chrome; `JARVIS_OPERATOR_ECHO_ENABLED` kill-switch.

## A greeting is a handshake, not a loop
The social path now remembers per session: a re-greet inside `JARVIS_CHAT_REGREET_COOLDOWN_S` (300s default) collapses to one quiet "Still here." — a NEW terminal still gets a real hello. Bounded ledger; cooldown expiry restores the rotation.

13 new tests; 580-test chat+surface sweep green.

**Operator action after merge:** run `pip install -e .` (or purge the pyenv shim) so the live `ov` stops showing the old interface — the sentinel will tell you if it's still stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a visible ❯ anchor for submitted messages, prevents repeat greetings, and warns loudly when the running `ov` binary is stale. Also pins reply formatting to voice-only (no classifier dumps).

- **New Features**
  - Echoes operator input as a “❯ message” block on both the attach client and daemon cockpit; escapes markup, indents multiline, respects `JARVIS_OPERATOR_ECHO_ENABLED`, and excludes `!` shell commands.
  - Per-session greeting cooldown (`JARVIS_CHAT_REGREET_COOLDOWN_S`, default 300s): repeat greets collapse to “Still here.”; ledger is bounded.
  - Stale-binary sentinel `client_binary_warning()` at attach prints to console and seeds cockpit; guides to `pip install -e .` if code is shadowed.

- **Migration**
  - If installed via pyenv/pip, run `pip install -e .` to ensure `ov` loads repo code; the sentinel will alert if a stale copy is used.

<sup>Written for commit 44c3a062b75daadf7892c2eeaa51b5a909e2018a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

