### PR TITLE
fix(ov): an orphaned decorator, and a column sized for the wrong name

### DIFF
--- a/backend/core/ouroboros/battle_test/palette_render.py
+++ b/backend/core/ouroboros/battle_test/palette_render.py
@@ -32,6 +32,46 @@ _NAME_COL_MAX_FRACTION = 0.34
 #: Gutter between the name column and the description column.
 _GUTTER = 3
 
+#: Share of visible names the column must fit WITHOUT overflowing. Sizing to
+#: the longest instead lets a single outlier dictate the layout: with
+#: `/backlog_auto_proposed` (22 chars) on screen, `/anticipate` was followed
+#: by fourteen spaces of dead gutter, and the eye has to cross all of it on
+#: every row to reach the description.
+_NAME_FIT_QUANTILE = 0.8
+
+
+def name_fit_quantile() -> float:
+    """How much of the list the name column must fit. Env-tunable.
+
+    A knob because it trades two real costs against each other: a lower value
+    tightens the common rows and ragged-wraps more outliers; a higher one
+    aligns everything and spends the width on gutter.
+    """
+    try:
+        raw = os.environ.get("JARVIS_PALETTE_NAME_QUANTILE", "").strip()
+        return min(1.0, max(0.1, float(raw))) if raw else _NAME_FIT_QUANTILE
+    except (TypeError, ValueError):
+        return _NAME_FIT_QUANTILE
+
+
+def _name_column(names: List[str]) -> int:
+    """Width that fits MOST names, not every name.
+
+    An outlier keeps its full text and simply starts its description one
+    gutter later — one ragged row, instead of every row paying for it. The
+    name is never clipped: it is the thing the operator has to type, and a
+    palette that hides half of `/backlog_auto_prop…` has stopped being a
+    palette.
+    """
+    try:
+        lengths = sorted(len(n) for n in names if n)
+        if not lengths:
+            return 0
+        index = int(round((len(lengths) - 1) * name_fit_quantile()))
+        return lengths[max(0, min(len(lengths) - 1, index))]
+    except Exception:  # noqa: BLE001
+        return max((len(n) for n in names), default=0)
+
 
 def palette_rows() -> int:
     """Maximum entries drawn at once (``JARVIS_PALETTE_HEIGHT``)."""
@@ -117,7 +157,7 @@ def layout_palette(
 
     names = [n for n, _d in entries]
     name_col = min(
-        max((len(n) for n in names), default=0),
+        _name_column(names),
         max(8, int(width * _NAME_COL_MAX_FRACTION)),
     )
     desc_col = max(8, width - name_col - _GUTTER - 2)
@@ -164,10 +204,24 @@ def layout_palette(
                 else "class:completion-menu.completion")
         meta = ("class:completion-menu.meta.completion.current" if current
                 else "class:completion-menu.meta.completion")
-        shown = _ellipsis(str(name), name_col)
+        # The name is NEVER clipped. It is the thing the operator has to
+        # type, and `/backlog_auto_prop…` has stopped being a palette entry.
+        # A name wider than the column OVERFLOWS: it keeps its full text, its
+        # description starts one gutter later, and that single row is ragged
+        # — which is strictly cheaper than every row paying for the outlier.
+        # An outlier overflows the COLUMN but never the fraction cap. Two
+        # invariants bound this and both are right: a palette line must fit
+        # the terminal, and one pathological name must not swallow the
+        # screen. Clipping at the cap satisfies both while still letting an
+        # ordinary long verb — `/backlog_auto_proposed` at 22 against a cap
+        # of 34 — keep its full text, which is the case that motivated this.
+        shown = _ellipsis(str(name), max(8, int(width * _NAME_COL_MAX_FRACTION)))
         pad = " " * max(0, name_col - len(shown))
-        body = _wrap(str(desc), desc_col) if wrap_descriptions else [
-            _ellipsis(str(desc), desc_col)
+        # Re-measured PER ROW, so an overflowing name cannot push its
+        # description past the terminal edge.
+        row_desc_col = max(8, width - len(shown) - len(pad) - _GUTTER - 2)
+        body = _wrap(str(desc), row_desc_col) if wrap_descriptions else [
+            _ellipsis(str(desc), row_desc_col)
         ]
         lines.append([
             (base, f"  {shown}{pad}"),

--- a/backend/core/ouroboros/battle_test/repl_completion.py
+++ b/backend/core/ouroboros/battle_test/repl_completion.py
@@ -1938,7 +1938,6 @@ def _describe(fn: object) -> str:
     return UNDOCUMENTED
 
 
-@contextlib.contextmanager
 def _operator_voice(text: str, verb: str) -> str:
     """Normalise a description to the operator's voice. Degrades to *text*."""
     try:
@@ -1950,6 +1949,7 @@ def _operator_voice(text: str, verb: str) -> str:
         return text
 
 
+@contextlib.contextmanager
 def _root_logging_preserved():
     """Hold the root logger harmless across an arbitrary-module import walk.
 

--- a/tests/battle_test/test_palette_spacing.py
+++ b/tests/battle_test/test_palette_spacing.py
@@ -1,0 +1,105 @@
+"""The column fits most names, not every name.
+
+Sizing to the longest visible name lets one outlier dictate the layout. With
+`/backlog_auto_proposed` (22 chars) on screen, `/anticipate` was followed by
+FOURTEEN spaces of dead gutter — and the eye crosses all of it on every row
+to reach the description.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.battle_test.palette_render import (
+    _GUTTER, _name_column, layout_palette, name_fit_quantile,
+)
+
+_NAMES = ["/anticipate", "/autobiography", "/backlog_auto_proposed",
+          "/breadcrumbs"]
+_ENTRIES = [
+    ("/anticipate", "Show what the organism expects to happen next"),
+    ("/autobiography", "Read or refresh the organism-authored history"),
+    ("/backlog_auto_proposed", "List and approve auto-proposed backlog items"),
+    ("/breadcrumbs", "Set/show the feed verbosity"),
+]
+
+
+def _rows(width: int = 100) -> list:
+    return ["".join(t for _s, t in row).rstrip()
+            for row in layout_palette(_ENTRIES, width=width, max_rows=8)]
+
+
+def test_one_outlier_does_not_stretch_every_row() -> None:
+    """THE fix. The longest name is 22; sizing to it gave `/anticipate`
+    fourteen spaces of gutter."""
+    assert _name_column(_NAMES) < max(len(n) for n in _NAMES)
+
+
+def test_the_common_rows_sit_close_to_their_descriptions() -> None:
+    row = next(r for r in _rows() if "/anticipate" in r)
+    gap = len(row) - len(row.lstrip())
+    inner = row.strip()
+    spaces = len(inner) - len(inner.replace("  ", " ", 1))
+    assert "  " in inner
+    before_desc = inner.index("Show")
+    assert before_desc - len("/anticipate") < 12, (
+        f"still {before_desc - len('/anticipate')} spaces of dead gutter"
+    )
+    assert gap >= 0
+
+
+def test_a_long_name_is_NEVER_clipped() -> None:
+    """It is the thing the operator has to type. `/backlog_auto_prop…` has
+    stopped being a palette entry."""
+    joined = "\n".join(_rows())
+    assert "/backlog_auto_proposed" in joined
+    assert "…" not in joined.split("List and approve")[0]
+
+
+def test_an_overflowing_name_goes_ragged_rather_than_shrinking_others() -> None:
+    """One ragged row is strictly cheaper than every row paying for the
+    outlier."""
+    rows = _rows()
+    outlier = next(r for r in rows if "/backlog_auto_proposed" in r)
+    common = next(r for r in rows if "/anticipate" in r)
+    assert outlier.index("List") > common.index("Show")
+
+
+def test_an_overflowing_row_stays_inside_the_terminal() -> None:
+    """Re-measured per row, so a long name cannot push its description past
+    the edge."""
+    for width in (60, 80, 100, 140):
+        for row in _rows(width):
+            assert len(row) <= width, f"row overran {width} cols"
+
+
+def test_uniform_names_are_unaffected() -> None:
+    """When nothing is an outlier the column is the max, as before."""
+    names = ["/one", "/two", "/six"]
+    assert _name_column(names) == max(len(n) for n in names)
+
+
+def test_descriptions_still_wrap_on_a_narrow_terminal() -> None:
+    rows = _rows(60)
+    assert any(r.strip().startswith("next") or r.strip().startswith("history")
+               for r in rows), "wrapping stopped working"
+
+
+def test_the_quantile_is_tunable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """It trades two real costs: lower tightens common rows and ragged-wraps
+    more outliers; higher aligns everything and spends width on gutter."""
+    monkeypatch.setenv("JARVIS_PALETTE_NAME_QUANTILE", "1.0")
+    assert name_fit_quantile() == 1.0
+    assert _name_column(_NAMES) == max(len(n) for n in _NAMES)
+    monkeypatch.setenv("JARVIS_PALETTE_NAME_QUANTILE", "0.1")
+    assert _name_column(_NAMES) < max(len(n) for n in _NAMES)
+
+
+def test_the_gutter_is_preserved_for_every_row() -> None:
+    for row in _rows():
+        inner = row.strip()
+        assert " " * _GUTTER in inner or "  " in inner
+
+
+@pytest.mark.parametrize("names", [[], ["/x"], ["", ""]])
+def test_degenerate_name_lists_never_raise(names) -> None:
+    assert isinstance(_name_column(names), int)


### PR DESCRIPTION
Two fixes. **The first is a regression I merged in #70199 and didn't catch.**

## The orphaned decorator

#70199 inserted a helper anchored on `def _root_logging_preserved():` — and that function carries `@contextlib.contextmanager` on the line *above* it. The helper landed **between them**:

```python
@contextlib.contextmanager
def _operator_voice(text, verb) -> str:   # ← wrong function decorated
```

So every description call returned a context manager instead of a string, and `_root_logging_preserved` silently lost its decorator — collapsing registry priming from 76 verbs to **18**.

I stated "819 cli green" in that commit message without the regression output having actually appeared. It hadn't run. The transferable lesson is the anchor: **matching on a `def` line is unsafe wherever decorators exist**, because the syntactic unit starts above the line you matched.

## The column was sized for the wrong name

`name_col = max(len(visible names))` lets one outlier dictate the layout. With `/backlog_auto_proposed` (22 chars) on screen, `/anticipate` was followed by **fourteen spaces** of dead gutter — and your eye crosses all of it on every row.

Now it fits *most* names — an 80th-percentile width, tunable via `JARVIS_PALETTE_NAME_QUANTILE`, because that knob trades two real costs: lower tightens common rows and ragged-wraps more outliers; higher aligns everything and spends width on gutter.

```
/anticipate      Show what the organism expects next
/autobiography   Read or refresh the history
/backlog_auto_proposed   List and approve proposed items
/breadcrumbs     Set/show the feed verbosity
```

An outlier keeps its full text and starts its description one gutter later — **one ragged row instead of every row paying for it**. The name matters more than the alignment, because it's what you have to type.

## Where that ambition had to stop

Two existing tests were right to bound it: a palette line must fit the terminal, and one pathological name must not swallow the screen. Clipping at the **fraction cap** satisfies both while still letting an ordinary long verb — 22 against a cap of 34 — keep every character. Description width is re-measured *per row*, so an overflowing name can't push its own description past the edge.

## Verification

11 spacing tests, plus the 29 recovered by the decorator fix. 861 `tests/cli` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a decorator regression that broke `_root_logging_preserved` and restores registry priming. Also updates palette rendering to size the name column for most names so a single long command doesn’t stretch every row; long names stay visible and rows stay within terminal width.

- **Bug Fixes**
  - Reattached `@contextlib.contextmanager` to `_root_logging_preserved` (removed from `_operator_voice`), so descriptions return strings again and priming is restored.
  - Name column now uses an 80th‑percentile width via `_name_column()`; tunable with `JARVIS_PALETTE_NAME_QUANTILE`.
  - Long names are never clipped; they can overflow their column but not the overall fraction cap, and description width is measured per row to keep lines inside the terminal.
  - Added spacing tests covering quantile sizing, overflow behavior, wrapping, and degenerate inputs.

<sup>Written for commit c21541d3a6e40a88d07af705c78aec72c7aa128c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

