### PR TITLE
docs(ov): describe the verbs whose purpose the code actually states

### DIFF
--- a/backend/core/ouroboros/governance/bus_repl.py
+++ b/backend/core/ouroboros/governance/bus_repl.py
@@ -188,6 +188,7 @@ def _render_stats() -> str:
 def dispatch_bus_command(
     line: str,
 ) -> BusReplDispatchResult:
+    """L1 command bus throughput and counters."""
     if not _matches(line):
         return BusReplDispatchResult(
             ok=False, text="", matched=False,

--- a/backend/core/ouroboros/governance/dashboard_repl.py
+++ b/backend/core/ouroboros/governance/dashboard_repl.py
@@ -84,6 +84,7 @@ def _master_enabled() -> bool:
 def dispatch_dashboard_command(
     line: str,
 ) -> DashboardReplDispatchResult:
+    """Operator dashboard panes, heatmap and layout."""
     if not _matches(line):
         return DashboardReplDispatchResult(
             ok=False, text="", matched=False,

--- a/backend/core/ouroboros/governance/events_repl.py
+++ b/backend/core/ouroboros/governance/events_repl.py
@@ -164,6 +164,7 @@ def _render_stats() -> str:
 def dispatch_events_command(
     line: str,
 ) -> EventsReplDispatchResult:
+    """L1 event emitter throughput and counters."""
     if not _matches(line):
         return EventsReplDispatchResult(
             ok=False, text="", matched=False,

--- a/backend/core/ouroboros/governance/graph_repl.py
+++ b/backend/core/ouroboros/governance/graph_repl.py
@@ -327,6 +327,7 @@ def _render_stats() -> str:
 def dispatch_graph_command(
     line: str,
 ) -> GraphReplDispatchResult:
+    """L3 execution graph — units, edges and stats."""
     if not _matches(line):
         return GraphReplDispatchResult(
             ok=False, text="", matched=False,

--- a/backend/core/ouroboros/governance/monitor_repl.py
+++ b/backend/core/ouroboros/governance/monitor_repl.py
@@ -269,6 +269,7 @@ def _render_stats() -> str:
 def dispatch_monitor_command(
     line: str,
 ) -> MonitorReplDispatchResult:
+    """Recent monitor samples and counters."""
     if not _matches(line):
         return MonitorReplDispatchResult(
             ok=False, text="", matched=False,

--- a/backend/core/ouroboros/governance/proposals_repl.py
+++ b/backend/core/ouroboros/governance/proposals_repl.py
@@ -86,6 +86,7 @@ def _master_enabled() -> bool:
 def dispatch_proposals_command(
     line: str,
 ) -> ProposalsReplDispatchResult:
+    """Review, accept or reject proposed changes."""
     if not _matches(line):
         return ProposalsReplDispatchResult(
             ok=False, text="", matched=False,

--- a/backend/core/ouroboros/governance/session_browser.py
+++ b/backend/core/ouroboros/governance/session_browser.py
@@ -847,6 +847,7 @@ def dispatch_session_command(
     *,
     browser: Optional[SessionBrowser] = None,
 ) -> SessionDispatchResult:
+    """Browse, bookmark and replay past sessions."""
     if not _matches(line):
         return SessionDispatchResult(ok=False, text="", matched=False)
     try:


### PR DESCRIPTION
I enumerated the palette properly before writing anything, and the picture is smaller and sharper than "all the undocumented verbs" implied.

**78 palette verbs · 63 already carry prose · 15 have none.**

Those 15 are what renders as a subcommand list (`/dashboard  list · show · compact · pane`) — the honest bottom of the resolution ladder, not a bug.

Also worth knowing: **only 2 of 78 use an `Operator:` section**, so step 1 of the ladder has essentially never fired in production. Relevant before anyone invests in that convention.

## Described here (7)

The ones whose purpose the **code states** — subsystem header plus mined subcommand vocabulary:

```
/session      Browse, bookmark and replay past sessions
/bus          L1 command bus throughput and counters
/events       L1 event emitter throughput and counters
/graph        L3 execution graph — units, edges and stats
/monitor      Recent monitor samples and counters
/dashboard    Operator dashboard panes, heatmap and layout
/proposals    Review, accept or reject proposed changes
```

## Not described (8), deliberately

`/constellation` `/causal` `/embodied` `/ribbon` `/orchestra` `/introspect` `/forecast` `/format`

Their module headers are **provenance** — `§39 Tier-5 operator surface` — which is the genre the resolver already refuses. Their subcommands say what they *accept* without saying what they *show*:

| verb | subcommands | what's missing |
|---|---|---|
| `/constellation` | `panel · refresh · show · only · status` | what the panel displays |
| `/embodied` | `status · arch · aura · attention · portrait` | what these visualise |
| `/introspect` | `panel · dream · status` | whose introspection |
| `/ribbon` | `show · expand · refresh · status` | what the ribbon carries |
| `/orchestra` | `recent · status · cue` | what is being cued |
| `/forecast` | `status · trajectory · command` | forecasting what |
| `/causal` | `show` | show what |
| `/format` | `help · show · list` | formats of what |

Writing a line from the verb's *name* would produce exactly the confidently-wrong prose that `test_nothing_is_invented` was added to prevent two PRs ago. These need someone who knows what each surface displays — the mined evidence is above, so it's a five-minute job for whoever does.

## One mechanical note

Docstrings are inserted at each function's first **body** statement (`body[0].lineno`), not by matching the `def` line — the #70199 lesson, where a `def`-anchored insertion landed under a decorator and orphaned it.

834 `tests/cli` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add concise docstrings to seven operator verbs so CLI help shows accurate purposes based on the code, not guesses. Updated verbs: /session, /bus, /events, /graph, /monitor, /dashboard, /proposals; Tier-5 surfaces (e.g., /constellation, /embodied) are intentionally left undocumented to avoid misleading text.

<sup>Written for commit d08bf8ac70bef2929c8d16c5863300a4d40b39d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

