### PR TITLE
feat(ov): the spinner belongs to the question you asked

### DIFF
--- a/backend/core/ouroboros/battle_test/bipartite_layout.py
+++ b/backend/core/ouroboros/battle_test/bipartite_layout.py
@@ -559,6 +559,7 @@ def build_bipartite_application(
     completer: Any = None,
     history: Any = None,
     auto_suggest: Any = None,
+    turn_spinner: Any = None,
 ) -> Any:
     """Construct the full-screen ``prompt_toolkit.Application``: Zone 1 an ANSI
     window fed from ``mux.render_canvas_ansi()`` (re-rendered each frame, so
@@ -822,6 +823,21 @@ def build_bipartite_application(
             logger.debug("[Bipartite] palette row unavailable", exc_info=True)
 
     rows += [canvas]
+    # The TURN row — the live spinner bound to the question the operator
+    # just asked, between the canvas and the prompt exactly where Claude
+    # Code puts it. A ConditionalContainer, so an idle cockpit is EXACTLY
+    # as tall as it was before this existed (Style Guide §07: one
+    # in-place spinner, never six stacked lines).
+    if turn_spinner is not None:
+        try:
+            from backend.core.ouroboros.battle_test.turn_spinner import (
+                build_turn_row,
+            )
+            _turn_row = build_turn_row(turn_spinner)
+            if _turn_row is not None:
+                rows += [_turn_row]
+        except Exception:  # noqa: BLE001
+            logger.debug("[Bipartite] turn row unavailable", exc_info=True)
     # The palette is NOT a row. See the FloatContainer below: as an HSplit row
     # it shares the ambient grid with the canvas, so every asynchronous Deck or
     # Lane frame arriving underneath forces the palette's geometry to be
@@ -1046,6 +1062,7 @@ async def run_bipartite_repl(
     completer: Any = None,
     history: Any = None,
     auto_suggest: Any = None,
+    turn_spinner: Any = None,
 ) -> None:
     """Launch the full-screen Bipartite REPL: build the multiplexer, register it as
     the live Zone-1 sink (so any producer — the daemon's event router OR the
@@ -1074,6 +1091,7 @@ async def run_bipartite_repl(
             mux, on_accept=on_accept, extra_key_bindings=extra_key_bindings,
             toolbar=toolbar, header=header, header_height=header_height,
             completer=completer, history=history, auto_suggest=auto_suggest,
+            turn_spinner=turn_spinner,
         )
         if watch_alive is not None:
             watcher = asyncio.ensure_future(

--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -6085,9 +6085,19 @@ class SerpentREPL:
                                 )
                     except Exception:  # noqa: BLE001
                         pass
-                    _aio.ensure_future(
+                    # The turn row, daemon-side. This surface AWAITS its
+                    # own dispatch, so the close signal is exact — no
+                    # reply-frame heuristic, no timeout guessing.
+                    _spinner = getattr(self, "_turn_spinner", None)
+                    if _spinner is not None and cleaned:
+                        _spinner.open(cleaned)
+                    _fut = _aio.ensure_future(
                         self._dispatch_repl_command(cleaned)
                     )
+                    if _spinner is not None and cleaned:
+                        _fut.add_done_callback(
+                            lambda _f: _spinner.note_reply()
+                        )
 
                 async def _attach_sprite_when_ready() -> None:
                     from backend.core.ouroboros.battle_test.sprite_engine import (
@@ -6109,6 +6119,28 @@ class SerpentREPL:
                 # had all three wired at ov.py — the two-surfaces split,
                 # again. Same wiring seam the legacy PromptSession below
                 # uses (DRY), so the vocabularies cannot diverge.
+                # Daemon-cockpit turn row: the same module the attach
+                # client mounts, fed by the same heartbeat payload builder
+                # (pure pull) and writing its tombstone into the canvas.
+                try:
+                    from backend.core.ouroboros.battle_test.turn_spinner import (  # noqa: E501
+                        TurnSpinner,
+                    )
+                    from backend.core.ouroboros.battle_test.attach_heartbeat import (  # noqa: E501
+                        build_heartbeat_payload,
+                    )
+
+                    def _emit_tombstone(line: str) -> None:
+                        canvas = get_active_canvas()
+                        if canvas is not None:
+                            canvas.push_raw(line)
+
+                    self._turn_spinner = TurnSpinner(
+                        heartbeat_fn=build_heartbeat_payload,
+                        emit_fn=_emit_tombstone,
+                    )
+                except Exception:  # noqa: BLE001
+                    self._turn_spinner = None
                 _bp_wiring = None
                 try:
                     from backend.core.ouroboros.battle_test.repl_completion import (  # noqa: E501
@@ -6122,6 +6154,7 @@ class SerpentREPL:
                     completer=getattr(_bp_wiring, "completer", None),
                     history=getattr(_bp_wiring, "history", None),
                     auto_suggest=getattr(_bp_wiring, "auto_suggest", None),
+                    turn_spinner=getattr(self, "_turn_spinner", None),
                 )
                 return
         except Exception:  # noqa: BLE001 — cockpit failure NEVER bricks the REPL

--- a/backend/core/ouroboros/battle_test/turn_spinner.py
+++ b/backend/core/ouroboros/battle_test/turn_spinner.py
@@ -1,0 +1,383 @@
+"""The turn spinner — one live line, bound to the question YOU asked.
+
+    ❯ can you tell me what is O+V?
+    ⏺ · Nesting… (10s · ↓ 63 tokens · DW-397B)      ← updates IN PLACE
+    ⏺ O+V is Ouroboros + Venom …                    ← resolves into the reply
+
+Every ingredient for this already existed and none of them were bound to a
+TURN. The pulse (`attach_heartbeat`) rendered in the bottom toolbar — a
+region that describes the ORGANISM, not your question; the `⏺` opener
+(`chat_response_style`) was a static line the daemon printed once; and the
+canvas is an append-only ring, so anything written there can only stack.
+The result: you pressed Enter and the transcript went silent while
+something pulsed in a corner. This module is the missing binding, not new
+machinery.
+
+Two properties make it a TURN spinner rather than a second toolbar:
+
+* **Turn-scoped enrichment.** The heartbeat is global — if the organism
+  was already synthesising an autonomous op when you hit Enter, printing
+  its token count under your question would be a fabrication. The frame
+  is adopted only when its own ``elapsed_s`` fits INSIDE this turn's age
+  (plus slack): work that predates your question describes itself, never
+  you. Otherwise the row falls back to an honest local clock.
+* **In place, never stacked.** The row is a live region between the
+  canvas and the prompt — Style Guide §07's "one in-place spinner, never
+  six stacked log lines". It occupies zero rows while idle, so a resting
+  cockpit is exactly as tall as it was.
+
+Resolution is total. A turn closes on the first addressed reply, on an
+interrupt, on daemon death, or on a hard ceiling — never on nothing. A
+spinner that can outlive its answer is worse than no spinner, because the
+operator reads it as "still working" forever.
+
+Env:
+  * ``JARVIS_TURN_SPINNER_ENABLED``     master (default true)
+  * ``JARVIS_TURN_MAX_S``               ceiling before honest give-up (600)
+  * ``JARVIS_TURN_TOMBSTONE_MIN_S``     duration worth recording (3.0)
+  * ``JARVIS_TURN_VERBS``               extra flavour verbs, comma-separated
+
+NEVER raises into a repaint, a key handler, or a frame callback.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Any, Callable, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+TURN_SPINNER_SCHEMA_VERSION: str = "turn_spinner.1"
+
+MASTER_FLAG_ENV_VAR: str = "JARVIS_TURN_SPINNER_ENABLED"
+MAX_TURN_ENV_VAR: str = "JARVIS_TURN_MAX_S"
+TOMBSTONE_MIN_ENV_VAR: str = "JARVIS_TURN_TOMBSTONE_MIN_S"
+VERBS_ENV_VAR: str = "JARVIS_TURN_VERBS"
+
+#: Flavour verbs for the local (pre-heartbeat) phase — the organism's own
+#: vocabulary, in the register of a colleague thinking out loud. DATA, like
+#: the emoji table and the social acks: extending the voice is an edit here,
+#: never a change to a renderer. Selection is a stable hash of the turn text,
+#: so the same question always animates the same way (auditable, and it
+#: stops the row flickering between words on consecutive repaints).
+TURN_VERBS: Tuple[str, ...] = (
+    "Thinking", "Considering", "Coiling", "Tracing", "Weighing",
+    "Sensing", "Digesting", "Circling", "Unwinding", "Reckoning",
+)
+
+#: How far a heartbeat's own elapsed may exceed this turn's age before it
+#: is judged to describe OTHER work. Generous enough to absorb IPC latency
+#: and the ~1 Hz frame cadence; far tighter than any real autonomous op.
+_ADOPTION_SLACK_S: float = 3.0
+
+
+def is_turn_spinner_enabled() -> bool:
+    """Master flag — default true. NEVER raises."""
+    raw = os.environ.get(MASTER_FLAG_ENV_VAR, "true")
+    return raw.strip().lower() not in ("0", "false", "no", "off")
+
+
+def _max_turn_s() -> float:
+    try:
+        return max(5.0, float(os.environ.get(MAX_TURN_ENV_VAR, "600")))
+    except (TypeError, ValueError):
+        return 600.0
+
+
+def _tombstone_min_s() -> float:
+    try:
+        return max(0.0, float(os.environ.get(TOMBSTONE_MIN_ENV_VAR, "3")))
+    except (TypeError, ValueError):
+        return 3.0
+
+
+def turn_verbs() -> Tuple[str, ...]:
+    """Builtin vocabulary + operator extras. NEVER raises."""
+    verbs = list(TURN_VERBS)
+    try:
+        extra = os.environ.get(VERBS_ENV_VAR, "").strip()
+        for word in extra.split(","):
+            word = word.strip()
+            if word:
+                verbs.append(word)
+    except Exception:  # noqa: BLE001
+        pass
+    return tuple(verbs)
+
+
+def _verb_for(text: str) -> str:
+    """Stable per-question pick. NEVER raises."""
+    try:
+        import hashlib
+        verbs = turn_verbs()
+        digest = hashlib.sha256(str(text or "").encode("utf-8")).digest()
+        return verbs[digest[0] % len(verbs)]
+    except Exception:  # noqa: BLE001
+        return "Thinking"
+
+
+def _fmt_elapsed(seconds: float) -> str:
+    """Reuses the heartbeat's own duration grammar so one turn cannot read
+    `9s` in the row and `0m 9s` in the toolbar."""
+    try:
+        from backend.core.ouroboros.battle_test.attach_heartbeat import (
+            _fmt_elapsed as _hb_fmt,
+        )
+        return _hb_fmt(seconds)
+    except Exception:  # noqa: BLE001
+        return f"{int(max(0.0, seconds))}s"
+
+
+def _pulse(now: float) -> str:
+    """O+V's identity spinner, from its ONE canonical definition — the same
+    frame every surface shows at the same instant."""
+    try:
+        from backend.core.ouroboros.battle_test.attach_heartbeat import (
+            _pulse_glyph,
+        )
+        return _pulse_glyph(now)
+    except Exception:  # noqa: BLE001
+        return "·"
+
+
+class TurnSpinner:
+    """One operator turn's live status. Single-slot by design: Claude Code
+    shows one spinner, and so does a cockpit — a second concurrent question
+    extends the open turn rather than opening a rival row.
+
+    Injectables (``now_fn``, ``heartbeat_fn``) keep the whole state machine
+    testable without a terminal or a daemon."""
+
+    def __init__(
+        self,
+        *,
+        heartbeat_fn: Optional[Callable[[], Any]] = None,
+        now_fn: Optional[Callable[[], float]] = None,
+        emit_fn: Optional[Callable[[str], None]] = None,
+    ) -> None:
+        self._heartbeat_fn = heartbeat_fn or (lambda: None)
+        self._now = now_fn or time.monotonic
+        self._emit = emit_fn or (lambda _t: None)
+        self._active = False
+        self._started_at = 0.0
+        self._text = ""
+        self._verb = "Thinking"
+        self._pending = 0
+        self._last_reason = ""
+
+    # -- state -------------------------------------------------------------
+
+    @property
+    def active(self) -> bool:
+        return self._active
+
+    @property
+    def pending(self) -> int:
+        """Submissions still unanswered — what makes a rapid second question
+        extend the row instead of silently replacing the first."""
+        return self._pending
+
+    def age(self) -> float:
+        return max(0.0, self._now() - self._started_at) if self._active else 0.0
+
+    # -- lifecycle ---------------------------------------------------------
+
+    def open(self, text: str = "") -> bool:
+        """A line was submitted and an answer is expected. Returns True when
+        the row is (now) live. NEVER raises."""
+        try:
+            if not is_turn_spinner_enabled():
+                return False
+            if self._active:
+                # A second question while the first is open: one row, honest
+                # count. Restarting the clock would erase how long the
+                # operator has actually been waiting.
+                self._pending += 1
+                return True
+            self._active = True
+            self._started_at = self._now()
+            self._text = str(text or "")
+            self._verb = _verb_for(self._text)
+            self._pending = 1
+            self._last_reason = ""
+            return True
+        except Exception:  # noqa: BLE001
+            logger.debug("[TurnSpinner] open degraded", exc_info=True)
+            return False
+
+    def note_reply(self) -> None:
+        """An addressed frame landed — one pending question is answered.
+        The row closes when the LAST one is. NEVER raises."""
+        try:
+            if not self._active:
+                return
+            self._pending = max(0, self._pending - 1)
+            if self._pending == 0:
+                self.close(reason="answered")
+        except Exception:  # noqa: BLE001
+            logger.debug("[TurnSpinner] note_reply degraded", exc_info=True)
+
+    def close(self, *, reason: str = "") -> None:
+        """Resolve the turn. Idempotent; safe from any path. Emits a
+        tombstone only when the wait was long enough to be worth recording —
+        a sub-second turn narrating its own duration is noise. NEVER
+        raises."""
+        try:
+            if not self._active:
+                return
+            elapsed = self.age()
+            self._active = False
+            self._pending = 0
+            self._last_reason = reason
+            if reason in ("answered", "") and elapsed >= _tombstone_min_s():
+                self._emit(f"  [dim]⎿ thought for {_fmt_elapsed(elapsed)}"
+                           f"[/dim]")
+            elif reason == "timeout":
+                self._emit(
+                    f"  [#e3b341]⎿ no answer after {_fmt_elapsed(elapsed)} — "
+                    f"the organism went quiet (it may still be working; "
+                    f"`/status` knows)[/#e3b341]"
+                )
+            elif reason == "interrupted":
+                self._emit(f"  [dim]⎿ interrupted after "
+                           f"{_fmt_elapsed(elapsed)}[/dim]")
+        except Exception:  # noqa: BLE001
+            logger.debug("[TurnSpinner] close degraded", exc_info=True)
+
+    def tick(self) -> None:
+        """Enforce the ceiling. Called from the render path, so it needs no
+        timer of its own — a row nobody is drawing needs no expiry. NEVER
+        raises."""
+        try:
+            if self._active and self.age() > _max_turn_s():
+                self.close(reason="timeout")
+        except Exception:  # noqa: BLE001
+            pass
+
+    # -- the row -----------------------------------------------------------
+
+    def _adopted_heartbeat(self) -> Optional[dict]:
+        """The heartbeat frame IF it describes this turn.
+
+        The whole honesty of the row lives here. A frame whose own elapsed
+        exceeds this turn's age is reporting work that started before the
+        question was asked — an autonomous op the organism began on its own.
+        Borrowing its token count would attribute someone else's work to the
+        operator's question."""
+        try:
+            payload = self._heartbeat_fn()
+            if not isinstance(payload, dict) or not payload.get("active"):
+                return None
+            hb_elapsed = float(payload.get("elapsed_s") or 0.0)
+            if hb_elapsed > self.age() + _ADOPTION_SLACK_S:
+                return None
+            return payload
+        except Exception:  # noqa: BLE001
+            return None
+
+    def render(self) -> str:
+        """The live row as Rich markup, or "" when idle. NEVER raises."""
+        try:
+            if not is_turn_spinner_enabled():
+                return ""
+            self.tick()
+            if not self._active:
+                return ""
+            now = self._now()
+            glyph = _pulse(now)
+            payload = self._adopted_heartbeat()
+            verb = self._verb
+            parts: List[str] = [_fmt_elapsed(self.age())]
+            if payload is not None:
+                verb = str(payload.get("verb") or verb)
+                tokens = int(payload.get("tokens_total") or 0)
+                if tokens > 0:
+                    try:
+                        from backend.core.ouroboros.battle_test.attach_heartbeat import (  # noqa: E501
+                            _fmt_tokens,
+                        )
+                        parts.append(f"↓ {_fmt_tokens(tokens)} tokens")
+                    except Exception:  # noqa: BLE001
+                        parts.append(f"↓ {tokens} tokens")
+                label = str(payload.get("provider_label")
+                            or payload.get("provider") or "")
+                if label:
+                    parts.append(label)
+            if self._pending > 1:
+                parts.append(f"{self._pending} queued")
+            return (f"[#43d6d0]{glyph}[/#43d6d0] "
+                    f"[#6c7d77]{verb}… ({' · '.join(parts)})[/#6c7d77]")
+        except Exception:  # noqa: BLE001
+            logger.debug("[TurnSpinner] render degraded", exc_info=True)
+            return ""
+
+
+def _markup_to_ansi(markup: str, width: int = 200) -> str:
+    """Rich markup → ANSI, the same way the canvas renders its own panel
+    (a StringIO Console at the terminal's colour depth). One conversion
+    idiom in this codebase, not two. NEVER raises — falls back to the
+    markup stripped of its tags, which still reads."""
+    try:
+        import io
+        from rich.console import Console
+        buf = io.StringIO()
+        Console(
+            file=buf, width=width, color_system="truecolor",
+            force_terminal=True, highlight=False, soft_wrap=True,
+        ).print(markup, end="")
+        return buf.getvalue()
+    except Exception:  # noqa: BLE001
+        try:
+            import re
+            return re.sub(r"\[/?[^\]]*\]", "", markup)
+        except Exception:  # noqa: BLE001
+            return markup
+
+
+def build_turn_row(spinner: TurnSpinner) -> Any:
+    """A prompt_toolkit container for the live row, or None.
+
+    ``ConditionalContainer`` rather than a zero-height Window: an idle
+    cockpit must be EXACTLY as tall as it was before this feature existed,
+    and a Window that renders an empty line still occupies a row. NEVER
+    raises."""
+    try:
+        from prompt_toolkit.filters import Condition
+        from prompt_toolkit.layout import ConditionalContainer, Window
+        from prompt_toolkit.layout.controls import FormattedTextControl
+
+        def _fragments() -> Any:
+            try:
+                markup = spinner.render()
+                if not markup:
+                    return []
+                from prompt_toolkit.formatted_text import ANSI
+                return ANSI(_markup_to_ansi(markup))
+            except Exception:  # noqa: BLE001
+                return []
+
+        return ConditionalContainer(
+            content=Window(
+                content=FormattedTextControl(_fragments, focusable=False),
+                height=1, wrap_lines=False,
+            ),
+            filter=Condition(lambda: bool(spinner.render())),
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug("[TurnSpinner] row unavailable", exc_info=True)
+        return None
+
+
+__all__ = [
+    "MASTER_FLAG_ENV_VAR",
+    "MAX_TURN_ENV_VAR",
+    "TOMBSTONE_MIN_ENV_VAR",
+    "TURN_SPINNER_SCHEMA_VERSION",
+    "TURN_VERBS",
+    "TurnSpinner",
+    "VERBS_ENV_VAR",
+    "build_turn_row",
+    "is_turn_spinner_enabled",
+    "turn_verbs",
+]

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -943,7 +943,23 @@ class AttachUI:
             return ""
 
     def _pulse_line(self) -> str:
-        """The CC-style working pulse, or the idle breadcrumb."""
+        """The CC-style working pulse, or the idle breadcrumb.
+
+        A live TURN outranks the ambient pulse here. The fallback surface
+        has no container to host a turn row, so its one region answers the
+        more specific question first: what is happening to MY question,
+        then what is happening to the organism."""
+        try:
+            spinner = getattr(self, "turn_spinner", None)
+            if spinner is not None and spinner.active:
+                from backend.core.ouroboros.battle_test.turn_spinner import (
+                    _markup_to_ansi,
+                )
+                row = spinner.render()
+                if row:
+                    return "  " + _markup_to_ansi(row)
+        except Exception:  # noqa: BLE001
+            pass
         try:
             from backend.core.ouroboros.battle_test.attach_heartbeat import (
                 format_heartbeat_line,
@@ -1357,6 +1373,16 @@ def _route_operator_line(client: Any, ui: Any, line: Any) -> str:
                     expand_paste_chips,
                 )
                 text = expand_paste_chips(text)
+            except Exception:  # noqa: BLE001
+                pass
+            # The turn opens HERE — the one place a line is proven to be
+            # leaving for the daemon. Opening at keypress would spin for
+            # client-local verbs (/deck, /keys) that no reply is coming
+            # for; opening after send would miss a reply that beat us.
+            try:
+                spinner = getattr(ui, "turn_spinner", None)
+                if spinner is not None:
+                    spinner.open(text)
             except Exception:  # noqa: BLE001
                 pass
             if ui is not None and ui.should_flush_on_input():
@@ -2172,6 +2198,9 @@ def _build_selection_bindings(ui: Any, client: Any) -> Any:
             """
             try:
                 client.send_input("/cancel")
+                spinner = getattr(ui, "turn_spinner", None)
+                if spinner is not None:
+                    spinner.close(reason="interrupted")
                 ui.flash("interrupting…", seconds=2.0)
             except Exception:  # noqa: BLE001
                 pass
@@ -2925,6 +2954,7 @@ async def _bipartite_attach_loop(client: Any, console: Any, ui: Any) -> None:
             # file every surface shares, so Up-arrow survives a detach.
             history=_build_prompt_history(),
             auto_suggest=_build_prompt_auto_suggest(),
+            turn_spinner=getattr(ui, "turn_spinner", None),
             seed=[
                 "[bold]💭 Karen ▸[/bold] attached — I'm listening. verbs or "
                 "plain words both work · [cyan]wake[/cyan] arms my voice · "
@@ -3066,6 +3096,15 @@ def run_attach(console: Any) -> int:
             characters. The daemon knows; it decided when it addressed the
             frame."""
             if addressed:
+                # An addressed frame IS the answer to something this
+                # cockpit asked — the honest close signal. Ambient frames
+                # (autonomous work) deliberately do NOT close a turn.
+                try:
+                    spinner = getattr(ui, "turn_spinner", None)
+                    if spinner is not None:
+                        spinner.note_reply()
+                except Exception:  # noqa: BLE001
+                    pass
                 _render_markup_frame(text, console)
                 return
             ui.on_ambient(text)
@@ -3101,6 +3140,20 @@ def run_attach(console: Any) -> int:
                 and ui.rewind.deliver(f)
             ),
         )
+        # The turn spinner — the live row bound to the operator's own
+        # question. Reads the heartbeat this UI already retains (pure
+        # pull, zero new state) and writes its tombstone through the
+        # SAME addressed markup sink every ⏺/⎿ line takes.
+        try:
+            from backend.core.ouroboros.battle_test.turn_spinner import (
+                TurnSpinner,
+            )
+            ui.turn_spinner = TurnSpinner(
+                heartbeat_fn=lambda: getattr(ui, "_heartbeat", None),
+                emit_fn=lambda line: _markup_sink(line, True),
+            )
+        except Exception:  # noqa: BLE001
+            ui.turn_spinner = None
         # The Transactional Viewport Lock's client half. Lives on the ui
         # so both attach surfaces reach it without new plumbing.
         try:

--- a/tests/battle_test/test_completion_unification.py
+++ b/tests/battle_test/test_completion_unification.py
@@ -444,7 +444,12 @@ def test_keys_daemon_subcommand_forwards() -> None:
     outcome = _route_operator_line(client, ui, "/keys daemon warnings")
     assert outcome == "sent"
     assert client.sent == ["/keys warnings"]
-    assert ui.lines == []
+    # The line DOES travel, so it earns a ❯ anchor like any other
+    # submitted message — what it must NOT do is render the CLIENT's
+    # keymap table locally, which is the thing `daemon` opted out of.
+    assert any("❯" in ln and "/keys daemon warnings" in ln
+               for ln in ui.lines)
+    assert not any("keymap —" in ln for ln in ui.lines)
 
 
 def test_daemon_cockpit_fast_path_passes_the_wiring() -> None:

--- a/tests/battle_test/test_turn_spinner.py
+++ b/tests/battle_test/test_turn_spinner.py
@@ -1,0 +1,267 @@
+"""The turn spinner — one live row, bound to the operator's own question.
+
+Pins the four properties that make it a TURN spinner rather than a second
+toolbar:
+
+  1. it exists only while a turn is open (an idle cockpit is unchanged);
+  2. it enriches from the heartbeat ONLY when that frame describes THIS
+     turn — an autonomous op that predates the question can never lend
+     its token count to it;
+  3. it resolves on every path (reply, interrupt, ceiling) — a spinner
+     that can outlive its answer reads as "still working" forever;
+  4. one row, whatever the traffic: a second question extends it.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.battle_test import turn_spinner as ts
+
+
+def _spinner(**kw):
+    clock = {"t": 1000.0}
+    state = {"hb": None, "emitted": []}
+    sp = ts.TurnSpinner(
+        heartbeat_fn=lambda: state["hb"],
+        now_fn=lambda: clock["t"],
+        emit_fn=state["emitted"].append,
+        **kw,
+    )
+    return sp, clock, state
+
+
+# --------------------------------------------------------------------------
+# 1. presence
+# --------------------------------------------------------------------------
+
+def test_idle_renders_nothing() -> None:
+    sp, _clock, _state = _spinner()
+    assert sp.render() == ""
+    assert sp.active is False
+
+
+def test_open_renders_a_local_clock_immediately() -> None:
+    sp, clock, _state = _spinner()
+    sp.open("what is O+V?")
+    clock["t"] += 4
+    row = sp.render()
+    assert "4s" in row and "…" in row
+    assert sp.active
+
+
+def test_master_flag_off_never_opens(monkeypatch) -> None:
+    monkeypatch.setenv(ts.MASTER_FLAG_ENV_VAR, "false")
+    sp, _clock, _state = _spinner()
+    assert sp.open("hi") is False
+    assert sp.render() == ""
+
+
+def test_verb_is_stable_per_question() -> None:
+    """A verb re-rolled on every repaint would flicker between words."""
+    sp1, _c1, _s1 = _spinner()
+    sp2, _c2, _s2 = _spinner()
+    sp1.open("identical question")
+    sp2.open("identical question")
+    assert sp1.render().split("…")[0] == sp2.render().split("…")[0]
+
+
+def test_operator_can_extend_the_vocabulary(monkeypatch) -> None:
+    monkeypatch.setenv(ts.VERBS_ENV_VAR, "Brooding, Percolating")
+    assert "Brooding" in ts.turn_verbs()
+    assert "Percolating" in ts.turn_verbs()
+
+
+# --------------------------------------------------------------------------
+# 2. turn-scoped honesty — THE property
+# --------------------------------------------------------------------------
+
+def test_heartbeat_inside_this_turn_is_adopted() -> None:
+    sp, clock, state = _spinner()
+    sp.open("what is O+V?")
+    clock["t"] += 5
+    state["hb"] = {
+        "active": True, "verb": "Synthesizing", "elapsed_s": 4.4,
+        "tokens_total": 1530, "provider_label": "DW-397B",
+    }
+    row = sp.render()
+    assert "Synthesizing" in row
+    assert "1.5k tokens" in row
+    assert "DW-397B" in row
+
+
+def test_heartbeat_that_predates_the_turn_is_refused() -> None:
+    """An autonomous op already running when the operator hit Enter must
+    never lend its token count to their question."""
+    sp, clock, state = _spinner()
+    sp.open("what is O+V?")
+    clock["t"] += 3
+    state["hb"] = {
+        "active": True, "verb": "Repairing", "elapsed_s": 900.0,
+        "tokens_total": 99999, "provider_label": "Claude",
+    }
+    row = sp.render()
+    assert "Repairing" not in row
+    assert "99999" not in row and "100.0k" not in row
+    assert "3s" in row              # the honest local clock survives
+
+
+def test_inactive_heartbeat_is_ignored() -> None:
+    sp, clock, state = _spinner()
+    sp.open("q")
+    clock["t"] += 2
+    state["hb"] = {"active": False, "verb": "Idle", "elapsed_s": 1.0}
+    assert "Idle" not in sp.render()
+
+
+def test_malformed_heartbeat_degrades_to_local_clock() -> None:
+    sp, clock, state = _spinner()
+    sp.open("q")
+    clock["t"] += 2
+    for bad in (None, "not-a-dict", {}, {"active": True, "elapsed_s": "x"}):
+        state["hb"] = bad
+        assert "2s" in sp.render()
+
+
+# --------------------------------------------------------------------------
+# 3. total resolution
+# --------------------------------------------------------------------------
+
+def test_reply_closes_the_turn_and_leaves_a_tombstone() -> None:
+    sp, clock, state = _spinner()
+    sp.open("q")
+    clock["t"] += 6
+    sp.note_reply()
+    assert sp.active is False
+    assert sp.render() == ""
+    assert any("thought for 6s" in line for line in state["emitted"])
+
+
+def test_a_fast_turn_leaves_no_tombstone() -> None:
+    """Sub-threshold turns narrating their own duration is noise."""
+    sp, clock, state = _spinner()
+    sp.open("q")
+    clock["t"] += 0.4
+    sp.note_reply()
+    assert state["emitted"] == []
+
+
+def test_ceiling_resolves_an_unanswered_turn(monkeypatch) -> None:
+    monkeypatch.setenv(ts.MAX_TURN_ENV_VAR, "30")
+    sp, clock, state = _spinner()
+    sp.open("q")
+    clock["t"] += 31
+    assert sp.render() == ""            # tick() fires from the render path
+    assert sp.active is False
+    assert any("no answer" in line for line in state["emitted"])
+    # honest about uncertainty: the daemon may still be working
+    assert any("may still be working" in line
+               for line in state["emitted"])
+
+
+def test_interrupt_resolves_with_its_own_voice() -> None:
+    sp, clock, state = _spinner()
+    sp.open("q")
+    clock["t"] += 9
+    sp.close(reason="interrupted")
+    assert sp.active is False
+    assert any("interrupted after 9s" in line for line in state["emitted"])
+
+
+def test_close_is_idempotent() -> None:
+    sp, clock, state = _spinner()
+    sp.open("q")
+    clock["t"] += 5
+    sp.close()
+    sp.close()
+    sp.note_reply()
+    assert len(state["emitted"]) == 1
+
+
+def test_reply_without_an_open_turn_is_a_noop() -> None:
+    sp, _clock, state = _spinner()
+    sp.note_reply()
+    assert sp.active is False and state["emitted"] == []
+
+
+# --------------------------------------------------------------------------
+# 4. one row, whatever the traffic
+# --------------------------------------------------------------------------
+
+def test_second_question_extends_rather_than_restarts() -> None:
+    sp, clock, _state = _spinner()
+    sp.open("first")
+    clock["t"] += 10
+    sp.open("second")
+    assert sp.pending == 2
+    row = sp.render()
+    assert "10s" in row              # the ORIGINAL wait, not a reset clock
+    assert "2 queued" in row
+
+
+def test_row_closes_only_when_the_last_answer_lands() -> None:
+    sp, clock, _state = _spinner()
+    sp.open("first")
+    sp.open("second")
+    sp.note_reply()
+    assert sp.active is True
+    sp.note_reply()
+    assert sp.active is False
+
+
+# --------------------------------------------------------------------------
+# 5. rendering + wiring
+# --------------------------------------------------------------------------
+
+def test_markup_to_ansi_emits_escapes_and_survives_junk() -> None:
+    out = ts._markup_to_ansi("[#43d6d0]hello[/#43d6d0]")
+    assert "hello" in out
+    assert "\x1b[" in out
+    assert "hello" in ts._markup_to_ansi("[unclosed hello")
+
+
+def test_row_is_a_conditional_container_not_a_reserved_line() -> None:
+    pytest.importorskip("prompt_toolkit")
+    from prompt_toolkit.layout import ConditionalContainer
+    sp, _clock, _state = _spinner()
+    row = ts.build_turn_row(sp)
+    assert isinstance(row, ConditionalContainer)
+
+
+def test_both_cockpits_mount_the_row() -> None:
+    import inspect
+    from backend.core.ouroboros.battle_test import bipartite_layout
+    src = inspect.getsource(bipartite_layout.build_bipartite_application)
+    # mounted ABOVE the prompt, like Claude Code
+    assert src.index("build_turn_row") < src.index("rows += [_rule(), prompt")
+    ov_src = Path(
+        __import__(
+            "backend.core.ouroboros.cli.ov", fromlist=["x"],
+        ).__file__
+    ).read_text()
+    assert "ui.turn_spinner = TurnSpinner(" in ov_src
+    assert 'turn_spinner=getattr(ui, "turn_spinner", None),' in ov_src
+
+
+def test_client_opens_on_send_and_closes_on_addressed_reply() -> None:
+    ov_src = Path(
+        __import__(
+            "backend.core.ouroboros.cli.ov", fromlist=["x"],
+        ).__file__
+    ).read_text()
+    # opens where the line is proven to be leaving for the daemon
+    route = ov_src.split("def _route_operator_line")[1].split("\ndef ")[0]
+    assert "spinner.open(text)" in route
+    # closes on the ADDRESSED branch only — ambient work must not close it
+    sink = ov_src.split("def _markup_sink")[1].split("\n        client =")[0]
+    assert "spinner.note_reply()" in sink
+    assert sink.index("spinner.note_reply()") < sink.index("ui.on_ambient")
+
+
+def test_daemon_cockpit_closes_on_its_own_dispatch() -> None:
+    import inspect
+    from backend.core.ouroboros.battle_test import serpent_flow
+    src = inspect.getsource(serpent_flow.SerpentREPL._loop)
+    assert "_turn_spinner" in src
+    assert "add_done_callback" in src


### PR DESCRIPTION
```
❯ can you tell me what is O+V?
🐍·○ Synthesizing… (10s · ↓ 1.5k tokens · DW-397B)     ← updates IN PLACE
⏺ O+V is Ouroboros + Venom …                          ← resolves into the reply
```

Claude Code's turn chrome — anchor, an in-place status line that ticks while it works, then the reply. **Every ingredient already existed in `ov` and none were bound to a TURN**: the pulse (`attach_heartbeat`) rendered in the bottom *toolbar* — a region describing the ORGANISM, not your question; the `⏺` opener was a static line; the canvas is append-only, so anything written there can only stack. You pressed Enter and the transcript went silent while something pulsed in a corner. This is the missing binding, not new machinery.

### Turn-scoped enrichment — the honesty property
The heartbeat is global. If the organism was already synthesising an autonomous op when you hit Enter, printing its token count under your question is a fabrication. A frame whose own `elapsed_s` exceeds this turn's age (plus IPC slack) is **refused**, and the row falls back to an honest local clock. Inside the turn it adopts verb / tokens / provider from the canonical payload — zero new state, pure pull.

### Total resolution
Closes on the first **addressed** reply (ambient autonomous frames deliberately never close a turn), on Esc-interrupt, and on a hard ceiling that says so honestly (`no answer after 10m — the organism went quiet (it may still be working; /status knows)`). A spinner that can outlive its answer reads as "still working" forever.

### Nuances handled
- **In place, never stacked** — a `ConditionalContainer`, so an idle cockpit is byte-for-byte as tall as before (Style Guide §07).
- **Rapid second question** extends the row (`2 queued`) instead of resetting the clock and erasing how long you've really waited.
- **Tombstone only past a threshold** — a sub-second turn narrating its own duration is noise.
- **Client-local verbs** (`/deck`, `/keys`) never open a turn: it opens where the line is *proven* to be leaving for the daemon.
- **Verbs are DATA** (`JARVIS_TURN_VERBS` extends them), picked by a stable hash of the question so the row can't flicker between words.
- **All three surfaces** from one module: attach cockpit (row), fallback PromptSession (its single region prefers the turn over the ambient pulse), and the daemon cockpit — which *awaits* its own dispatch, so its close signal is exact rather than heuristic.

22 new tests; 132-test sweep green. Also fixes a red I shipped in #70200 (the `/keys daemon` line legitimately earns an anchor; the test demanded otherwise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bind the working spinner to the turn you just sent. It shows one in-place row under the canvas, adopts heartbeat data only when it belongs to your turn, and closes on reply, interrupt, or timeout.

- **New Features**
  - Added `TurnSpinner` with turn-scoped enrichment: adopts verb/tokens/provider only if the heartbeat’s elapsed fits inside the turn; otherwise shows a local clock.
  - Mounted the row in the attach cockpit (`bipartite_layout`), the daemon cockpit (`serpent_flow`), and the CLI fallback region in `ov.py`. Idle state reserves no space.
  - Resolves on addressed reply, Esc-interrupt, or ceiling; emits a short tombstone only past a small threshold; queues rapid second questions (`2 queued`) without resetting the clock.
  - Env toggles: `JARVIS_TURN_SPINNER_ENABLED`, `JARVIS_TURN_MAX_S`, `JARVIS_TURN_TOMBSTONE_MIN_S`, `JARVIS_TURN_VERBS`.
  - New tests cover presence, honesty, resolution, and wiring.

- **Bug Fixes**
  - Lines sent with `/keys daemon …` now correctly earn the `❯` anchor while avoiding client-local keymap rendering.

<sup>Written for commit f10811b51aa3b4a76d1b098f01bfabedb81a20a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

