### PR TITLE
feat(ov): the conversation grows up toward the prompt, the way Claude Code's does

### DIFF
--- a/backend/core/ouroboros/battle_test/bipartite_layout.py
+++ b/backend/core/ouroboros/battle_test/bipartite_layout.py
@@ -159,6 +159,27 @@ def _canvas_dimension() -> Any:
     return Dimension(min=0, max=rows, preferred=rows)
 
 
+def bottom_anchor_enabled() -> bool:
+    """Does the transcript grow UPWARD from the prompt?
+
+    Claude Code's geometry: the input box is fixed at the bottom and the
+    transcript fills toward it, so the newest line is always the one
+    directly above where you type and your eye never travels. A
+    top-aligned canvas puts the conversation at row 0 and leaves a void
+    between it and the prompt — which is what an operator reads as "it
+    does not flow like Claude".
+
+    Only meaningful in the alternate screen, where the canvas owns every
+    remaining row. Inline, the canvas is a bounded live region that must
+    still collapse to nothing when idle, so padding it would nail an
+    empty block open. ``JARVIS_BIPARTITE_BOTTOM_ANCHOR=0`` restores the
+    top-aligned canvas."""
+    raw = os.environ.get("JARVIS_BIPARTITE_BOTTOM_ANCHOR", "").strip().lower()
+    if raw in ("0", "false", "no", "off"):
+        return False
+    return fullscreen_enabled()
+
+
 def _canvas_max_lines() -> int:
     try:
         return canvas_history_lines()
@@ -309,7 +330,7 @@ class BipartiteLayout:
             budget = self._line_budget()
             snap = self._buffer.snapshot()
             if not scrollback_enabled():
-                return list(snap[-budget:])
+                return self._anchor(list(snap[-budget:]))
             visible, above, below = self._viewport.window(
                 # push_count, not len(): once the ring saturates its length
                 # stops changing while the content keeps moving.
@@ -317,12 +338,32 @@ class BipartiteLayout:
             )
             status = self._viewport.status(above, below)
             if status:
-                return list(visible[1:]) + [
+                return self._anchor(list(visible[1:]) + [
                     f"[reverse dim] {status} [/reverse dim]",
-                ]
-            return list(visible)
+                ])
+            return self._anchor(list(visible))
         except Exception:  # noqa: BLE001
             return []
+
+    def _anchor(self, lines: List[str]) -> List[str]:
+        """Pad the TOP so the newest line lands against the prompt.
+
+        Padding rather than a Rich alignment because the canvas body is a
+        Group of independently-styled lines with no shared container to
+        align — and because blank leading rows are exactly what the
+        alternate screen shows above a short conversation anyway. NEVER
+        raises: an unpadded canvas is merely top-aligned, not broken."""
+        try:
+            if not lines or not bottom_anchor_enabled():
+                # An EMPTY canvas keeps its idle message and its resting
+                # hero: padding zero lines to a screenful would replace
+                # "the organism rests" with a wall of blanks.
+                return lines
+            budget = self._line_budget()
+            missing = budget - len(lines)
+            return ([""] * missing) + lines if missing > 0 else lines
+        except Exception:  # noqa: BLE001
+            return lines
 
     def render_canvas(self) -> Any:
         """Zone 1 — a rounded ``rich.panel.Panel`` of the tail telemetry. Never
@@ -1113,6 +1154,7 @@ async def run_bipartite_repl(
 __all__ = [
     "BipartiteLayout",
     "bipartite_enabled",
+    "bottom_anchor_enabled",
     "build_bipartite_application",
     "get_active_canvas",
     "run_bipartite_repl",

--- a/tests/battle_test/test_bottom_anchor.py
+++ b/tests/battle_test/test_bottom_anchor.py
@@ -1,0 +1,126 @@
+"""Transcript geometry — the conversation grows UP toward the prompt.
+
+Claude Code's layout: the input box is fixed at the bottom and the
+transcript fills toward it, so the newest line is always the one directly
+above where you type. Our canvas was top-aligned, which put the
+conversation at row 0 and left a screen-high void between it and the
+prompt — the thing an operator reads as "it doesn't flow like Claude".
+
+Padding, not alignment: the canvas body is a Group of independently
+styled lines with no shared container to align, and blank leading rows
+are exactly what an alternate screen shows above a short conversation.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.battle_test import bipartite_layout as bl
+
+
+@pytest.fixture()
+def fullscreen(monkeypatch):
+    monkeypatch.setenv("JARVIS_BIPARTITE_FULLSCREEN", "1")
+    monkeypatch.delenv("JARVIS_BIPARTITE_BOTTOM_ANCHOR", raising=False)
+    monkeypatch.delenv("JARVIS_BIPARTITE_BORDER", raising=False)
+    yield
+
+
+def _mux(height: int = 30):
+    return bl.BipartiteLayout(width=100, height=height, title="t")
+
+
+# --------------------------------------------------------------------------
+# 1. the geometry
+# --------------------------------------------------------------------------
+
+def test_short_conversation_sits_against_the_prompt(fullscreen) -> None:
+    mux = _mux()
+    mux.push_raw("❯ can you tell me what is O+V?")
+    mux.push_raw("⏺ thinking about that")
+    lines = mux._visible_lines()
+    assert len(lines) == mux._line_budget()      # fills the region
+    assert lines[-1] == "⏺ thinking about that"  # newest against the prompt
+    assert lines[0] == ""                        # the void is ABOVE
+    assert [ln for ln in lines if ln][0].startswith("❯")
+
+
+def test_a_full_screen_is_untouched(fullscreen) -> None:
+    mux = _mux()
+    for i in range(200):
+        mux.push_raw(f"line {i}")
+    lines = mux._visible_lines()
+    assert len(lines) == mux._line_budget()
+    assert "" not in lines                       # nothing to pad
+    assert lines[-1] == "line 199"
+
+
+def test_idle_keeps_its_message_not_a_wall_of_blanks(fullscreen) -> None:
+    """Padding zero lines to a screenful would replace 'the organism
+    rests' with an empty screen."""
+    mux = _mux()
+    assert mux._visible_lines() == []
+
+
+def test_growth_is_upward(fullscreen) -> None:
+    mux = _mux()
+    mux.push_raw("first")
+    top_before = mux._visible_lines().index("first")
+    mux.push_raw("second")
+    assert mux._visible_lines().index("first") == top_before - 1
+    assert mux._visible_lines()[-1] == "second"
+
+
+# --------------------------------------------------------------------------
+# 2. the gates
+# --------------------------------------------------------------------------
+
+def test_kill_switch_restores_top_alignment(fullscreen, monkeypatch) -> None:
+    monkeypatch.setenv("JARVIS_BIPARTITE_BOTTOM_ANCHOR", "0")
+    mux = _mux()
+    mux.push_raw("only line")
+    assert mux._visible_lines() == ["only line"]
+
+
+def test_inline_mode_never_anchors(monkeypatch) -> None:
+    """Inline, the canvas is a bounded live region that must collapse to
+    nothing when idle — padding would nail an empty block open."""
+    monkeypatch.setenv("JARVIS_BIPARTITE_FULLSCREEN", "0")
+    assert bl.bottom_anchor_enabled() is False
+    mux = _mux()
+    mux.push_raw("only line")
+    assert mux._visible_lines() == ["only line"]
+
+
+# --------------------------------------------------------------------------
+# 3. it must not disturb what already worked
+# --------------------------------------------------------------------------
+
+def test_scroll_metrics_report_real_content_only(fullscreen) -> None:
+    """The viewport clamps against the RING, not against padding — a
+    padded canvas that reported 29 lines would let the operator scroll
+    into blank space."""
+    mux = _mux()
+    for i in range(5):
+        mux.push_raw(f"line {i}")
+    total, _budget = mux.scroll_metrics()
+    assert total == 5
+
+
+def test_scrolled_back_view_still_anchors_without_losing_status(
+    fullscreen,
+) -> None:
+    mux = _mux()
+    for i in range(120):
+        mux.push_raw(f"line {i}")
+    total, budget = mux.scroll_metrics()
+    mux._viewport.scroll(-5, total=total, budget=budget)
+    lines = mux._visible_lines()
+    assert len(lines) == budget
+    assert "reverse dim" in lines[-1]        # the scroll status survives
+
+
+def test_render_survives_anchoring(fullscreen) -> None:
+    mux = _mux()
+    mux.push_raw("❯ hello")
+    out = mux.render_canvas_ansi()
+    assert "hello" in out


### PR DESCRIPTION
From an operator screenshot: the exchange sat at the **top** of the screen with a screen-high void between it and the input row.

Claude Code's geometry is the opposite, and it is the whole reason its transcript "flows": **the input box is fixed at the bottom and the conversation fills toward it**, so the newest line is always the one directly above where you type and the eye never travels. Our canvas drew from row 0 — with `Dimension(weight=1)` in the alternate screen it owns every remaining row, so two lines of conversation rendered two lines from the top and left the rest empty.

`_anchor()` pads the TOP of the visible slice to the row budget, applied at the ONE place the slice is composed (`_visible_lines`), so the following tail, the scrolled-back window, and the no-scrollback path all inherit it and cannot disagree. Padding rather than a Rich alignment because the canvas body is a `Group` of independently styled lines with no shared container to align — and blank leading rows are exactly what an alternate screen shows above a short conversation anyway.

**Bounded by what it must not break:**
- **Fullscreen only.** Inline, the canvas is a bounded live region that must still collapse to zero rows when idle; padding would nail an empty block open.
- **An empty canvas is never padded**, so the resting hero and the `idle — waiting for the organism to act` line survive instead of becoming a wall of blanks.
- **Padding happens after windowing**, so `scroll_metrics` still reports real content and the viewport cannot scroll into blank space.
- The scrolled-back status row is preserved.
- `JARVIS_BIPARTITE_BOTTOM_ANCHOR=0` restores top alignment.

9 new tests; 138-test layout sweep green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the conversation grow upward toward the prompt in fullscreen, matching Claude Code’s flow. The newest line now appears directly above the input, eliminating the gap.

- **New Features**
  - Bottom-anchored transcript in fullscreen via `_anchor()` top-padding applied in `_visible_lines` after windowing.
  - Guardrails: fullscreen only; empty canvas isn’t padded; scroll metrics reflect real content; scrolled-back status row preserved; inline mode unchanged.
  - Opt-out with `JARVIS_BIPARTITE_BOTTOM_ANCHOR=0`.
  - Added `bottom_anchor_enabled()` and new tests for geometry, gates, and scroll behavior.

<sup>Written for commit b8162dcb372061b686c6ce7762074dd5a7e66c39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

