### PR TITLE
feat(chat): the real brain, behind a circuit breaker that cannot be bypassed

### DIFF
--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -35,6 +35,32 @@ from backend.core.ouroboros.ui.boot_labels import ui_label as _ui_label
 
 logger = logging.getLogger(__name__)
 
+
+#: The live session CostTracker, published for out-of-harness spenders.
+#: A module seam rather than an import of the harness object because the
+#: harness is constructed once and consulted from everywhere; anything
+#: that spends must be able to ASK without owning a reference.
+_ACTIVE_COST_TRACKER: Any = None
+
+
+def _set_active_cost_tracker(tracker: Any) -> None:
+    """NEVER raises."""
+    global _ACTIVE_COST_TRACKER
+    try:
+        _ACTIVE_COST_TRACKER = tracker
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def get_active_cost_tracker() -> Any:
+    """The session CostTracker, or None when no organism is mounted.
+    NEVER raises."""
+    try:
+        return _ACTIVE_COST_TRACKER
+    except Exception:  # noqa: BLE001
+        return None
+
+
 _TRUTHY = frozenset({"1", "true", "yes", "on"})
 
 #: ov cockpit silence Slice 2 Task 3 (Mandate 4) -- bound on the
@@ -686,6 +712,11 @@ class BattleTestHarness:
             budget_usd=config.cost_cap_usd,
             persist_path=self._session_dir / "cost_tracker.json",
         )
+        # Publish the tracker at the module seam so spenders OUTSIDE the
+        # harness (the chat brain's circuit breaker) fold their cost into
+        # the SAME book the status line renders — one ledger, not two
+        # disagreeing about the same money.
+        _set_active_cost_tracker(self._cost_tracker)
         # PRD §session-budget-preflight: register the CostTracker as
         # the authoritative session-budget provider for governance.
         # Adapter pattern — governance never imports battle_test; this

--- a/backend/core/ouroboros/battle_test/status_line.py
+++ b/backend/core/ouroboros/battle_test/status_line.py
@@ -283,6 +283,17 @@ class StatusLineBuilder:
                     rendered = f"{rendered} · {chip}" if rendered else chip
             except Exception:  # noqa: BLE001
                 pass
+            # Chat spend — silent until money moves, loud once it has.
+            try:
+                from backend.core.ouroboros.governance.chat_cost_breaker import (  # noqa: E501
+                    chat_budget_chip,
+                )
+                chip2 = chat_budget_chip()
+                if chip2:
+                    rendered = (f"{rendered} · {chip2}" if rendered
+                                else chip2)
+            except Exception:  # noqa: BLE001
+                pass
             custom = _custom_segment()
             if custom:
                 rendered = f"{rendered} · {custom}" if rendered else custom

--- a/backend/core/ouroboros/governance/chat_cost_breaker.py
+++ b/backend/core/ouroboros/governance/chat_cost_breaker.py
@@ -1,0 +1,452 @@
+"""The Token Circuit Breaker — a chat brain that cannot run away with the bill.
+
+``ClaudeChatActionExecutor`` already carries a per-call cap and a
+per-INSTANCE session budget. Neither is sufficient to arm a real brain on
+the operator's prompt, for two structural reasons:
+
+* **Per-instance accounting is not session accounting.** The dispatcher is
+  built per bridge/attach; a reconnect, a `/chat clear`, or a second cockpit
+  mints a fresh executor whose counter starts at zero. Ten reconnects is ten
+  budgets. The ledger here is process-global and file-backed, so spend
+  survives every object that spends it.
+* **Refusal is not degradation.** On exhaustion the executor returns an
+  `error-session-budget-exhausted-<turn>` token: the operator types a
+  question and gets a machine sentinel with no explanation and no answer.
+  The breaker instead ROUTES the same payload to the logging executor —
+  the turn still lands, still gets a receipt, still enters history — and
+  says plainly, once, that the brain is off.
+
+The breaker is a middleware implementing the same ``ChatActionExecutor``
+Protocol it wraps, so it composes into the EXISTING factory chain
+(Claude → Subagent → Backlog → Logging) without any leg knowing it exists.
+Three of the four Protocol methods delegate untouched; only the one that
+spends is gated.
+
+**One spend surface.** Chat cost is recorded into the organism's own
+``CostTracker`` when one is mounted, so the status line's ``$0.14/$2.50``
+counts every dollar the organism spends — chat included — instead of two
+ledgers disagreeing about the same money. The chat-scoped cap is a SECOND,
+tighter ring inside that one: chat can exhaust its own allowance long
+before the organism exhausts its session budget.
+
+**Projection, not optimism.** The gate runs BEFORE the network call and
+projects the worst case using the wrapped executor's OWN per-call cap
+rather than a number invented here — so tightening the executor tightens
+the projection, and there is no second constant to drift.
+
+Env:
+  * ``JARVIS_SESSION_BUDGET_USD``   chat's cumulative allowance (1.00)
+  * ``JARVIS_CHAT_BREAKER_ENABLED`` master (default true — and the factory
+    fails CLOSED without it: no breaker, no brain)
+  * ``JARVIS_CHAT_SPEND_LEDGER``    where cumulative spend persists
+
+NEVER raises into a dispatch path: a breaker fault degrades to the
+fallback executor, which is the safe direction.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import time
+from pathlib import Path
+from typing import Any, Callable, List, Optional
+
+logger = logging.getLogger(__name__)
+
+CHAT_COST_BREAKER_SCHEMA_VERSION: str = "chat_cost_breaker.1"
+
+SESSION_BUDGET_ENV_VAR: str = "JARVIS_SESSION_BUDGET_USD"
+MASTER_FLAG_ENV_VAR: str = "JARVIS_CHAT_BREAKER_ENABLED"
+LEDGER_PATH_ENV_VAR: str = "JARVIS_CHAT_SPEND_LEDGER"
+
+DEFAULT_SESSION_BUDGET_USD: float = 1.00
+_DEFAULT_LEDGER = ".jarvis/chat_spend.json"
+
+#: What the operator sees, once, when the brain goes dark.
+TRIP_NOTICE: str = (
+    "🛑 chat budget exhausted ({spent} of {cap}) — degrading to local "
+    "logging. Raise JARVIS_SESSION_BUDGET_USD or `/chat budget reset` to "
+    "re-arm."
+)
+
+
+def is_breaker_enabled() -> bool:
+    """Master flag — default TRUE. Off means the factory refuses to arm the
+    brain at all (fail-closed): an unguarded paid API is not a degraded
+    mode, it is the failure this module exists to prevent."""
+    raw = os.environ.get(MASTER_FLAG_ENV_VAR, "true")
+    return raw.strip().lower() not in ("0", "false", "no", "off")
+
+
+def session_budget_usd() -> float:
+    """Chat's cumulative allowance. NEVER raises; a malformed value falls
+    back to the default rather than to無 limit."""
+    try:
+        value = float(os.environ.get(
+            SESSION_BUDGET_ENV_VAR, str(DEFAULT_SESSION_BUDGET_USD),
+        ))
+        return max(0.0, value)
+    except (TypeError, ValueError):
+        return DEFAULT_SESSION_BUDGET_USD
+
+
+def _ledger_path() -> Optional[Path]:
+    try:
+        explicit = os.environ.get(LEDGER_PATH_ENV_VAR, "").strip()
+        if explicit:
+            return Path(explicit).expanduser()
+        root = os.environ.get("JARVIS_REPO_PATH", "").strip() or "."
+        return Path(root).expanduser() / _DEFAULT_LEDGER
+    except Exception:  # noqa: BLE001
+        return None
+
+
+class SessionCostLedger:
+    """Process-global, file-backed chat spend.
+
+    Global because the executor's counter dies with the executor and the
+    operator's money does not. File-backed because a daemon restart in the
+    middle of a runaway loop must not hand the next process a fresh
+    allowance — the failure mode this exists to stop is precisely the one
+    that restarts things."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._spent: float = 0.0
+        self._trips: int = 0
+        self._loaded = False
+
+    # -- persistence -------------------------------------------------------
+
+    def _load_once(self) -> None:
+        if self._loaded:
+            return
+        self._loaded = True
+        try:
+            path = _ledger_path()
+            if path is None or not path.is_file():
+                return
+            data = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                self._spent = max(0.0, float(data.get("spent_usd") or 0.0))
+                self._trips = int(data.get("trips") or 0)
+        except Exception:  # noqa: BLE001 — an unreadable ledger starts clean
+            logger.debug("[ChatBreaker] ledger load degraded", exc_info=True)
+
+    def _persist(self) -> None:
+        try:
+            path = _ledger_path()
+            if path is None:
+                return
+            path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = path.with_name(path.name + ".tmp")
+            tmp.write_text(json.dumps({
+                "schema_version": CHAT_COST_BREAKER_SCHEMA_VERSION,
+                "spent_usd": round(self._spent, 6),
+                "trips": self._trips,
+                "updated_at": time.time(),
+            }), encoding="utf-8")
+            os.replace(tmp, path)
+        except Exception:  # noqa: BLE001
+            logger.debug("[ChatBreaker] ledger persist degraded",
+                         exc_info=True)
+
+    # -- accounting --------------------------------------------------------
+
+    @property
+    def spent(self) -> float:
+        with self._lock:
+            self._load_once()
+            return self._spent
+
+    @property
+    def trips(self) -> int:
+        with self._lock:
+            self._load_once()
+            return self._trips
+
+    def record(self, cost_usd: float, *, provider: str = "chat") -> float:
+        """Add real spend. Also reports into the ORGANISM's cost tracker so
+        the status line counts every dollar once. NEVER raises."""
+        try:
+            delta = float(cost_usd or 0.0)
+            if delta <= 0:
+                return self.spent
+            with self._lock:
+                self._load_once()
+                self._spent += delta
+                self._persist()
+                total = self._spent
+            _record_organism_cost(provider, delta)
+            return total
+        except Exception:  # noqa: BLE001
+            return self.spent
+
+    def note_trip(self) -> int:
+        try:
+            with self._lock:
+                self._load_once()
+                self._trips += 1
+                self._persist()
+                return self._trips
+        except Exception:  # noqa: BLE001
+            return 0
+
+    def reset(self) -> None:
+        """Operator re-arm. NEVER raises."""
+        try:
+            with self._lock:
+                self._loaded = True
+                self._spent = 0.0
+                self._trips = 0
+                self._persist()
+        except Exception:  # noqa: BLE001
+            pass
+
+    def snapshot(self) -> dict:
+        cap = session_budget_usd()
+        spent = self.spent
+        return {
+            "schema_version": CHAT_COST_BREAKER_SCHEMA_VERSION,
+            "spent_usd": round(spent, 6),
+            "cap_usd": cap,
+            "remaining_usd": max(0.0, cap - spent),
+            "tripped": cap > 0 and spent >= cap,
+            "trips": self.trips,
+        }
+
+
+_LEDGER = SessionCostLedger()
+
+
+def get_ledger() -> SessionCostLedger:
+    return _LEDGER
+
+
+def _record_organism_cost(provider: str, cost_usd: float) -> None:
+    """Fold chat spend into the organism's CostTracker when one is mounted.
+
+    ONE spend surface: the status line's ``$x/$y`` should mean "what the
+    organism has spent", and a chat turn spends real money. Best-effort by
+    design — no tracker mounted (a bare cockpit, a unit test) simply means
+    the chat ledger is the only book, which is still correct."""
+    try:
+        from backend.core.ouroboros.battle_test.harness import (
+            get_active_cost_tracker,
+        )
+        tracker = get_active_cost_tracker()
+        if tracker is not None:
+            tracker.record(provider, cost_usd)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def chat_budget_chip() -> str:
+    """The status-line chip, or "" while nothing has been spent.
+
+    Silent at rest (Style Guide §01: restraint by default) — a $0.00
+    counter on every repaint teaches the operator to ignore the number
+    they will one day need to read."""
+    try:
+        snap = _LEDGER.snapshot()
+        spent = float(snap["spent_usd"])
+        if spent <= 0:
+            return ""
+        cap = float(snap["cap_usd"])
+        mark = "🛑" if snap["tripped"] else "💬"
+        return f"{mark} ${spent:.2f}/${cap:.2f}"
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+class CostCapMiddleware:
+    """Circuit breaker around the spending leg of the executor chain.
+
+    ``primary`` is the real brain; ``fallback`` is where a tripped turn
+    lands (the logging executor — the same safe default the chain uses
+    when the brain is disarmed). Only ``query_claude`` is gated; the other
+    three Protocol methods pass through untouched, because they do not
+    spend."""
+
+    def __init__(
+        self,
+        primary: Any,
+        fallback: Any,
+        *,
+        ledger: Optional[SessionCostLedger] = None,
+        notify: Optional[Callable[[str], None]] = None,
+        budget_fn: Optional[Callable[[], float]] = None,
+    ) -> None:
+        self._primary = primary
+        self._fallback = fallback
+        self._ledger = ledger if ledger is not None else _LEDGER
+        self._notify = notify or (lambda _m: None)
+        self._budget_fn = budget_fn or session_budget_usd
+        #: The notice is said ONCE per trip-streak, not once per turn: a
+        #: banner on every message after exhaustion is noise the operator
+        #: learns to scroll past.
+        self._announced = False
+
+    # -- transparency ------------------------------------------------------
+
+    @property
+    def primary(self) -> Any:
+        """The caged brain. Named so callers can INSPECT what they wrapped
+        without reaching through a private name."""
+        return self._primary
+
+    @property
+    def fallback(self) -> Any:
+        return self._fallback
+
+    def __getattr__(self, name: str) -> Any:
+        """Delegate anything we do not define to the wrapped executor.
+
+        A breaker that hides the executor's surface would force every
+        caller — audit tooling, the cost-cap tests, a future `/chat
+        budget` verb — to learn that a wrapper exists and unwrap it. The
+        middleware gates ONE method; for everything else it should be
+        invisible. Only called for attributes normal lookup missed, so it
+        can never shadow the gate."""
+        if name.startswith("__"):
+            raise AttributeError(name)
+        return getattr(self._primary, name)
+
+    # -- pass-through legs -------------------------------------------------
+
+    def dispatch_backlog(self, message: str, turn: Any) -> str:
+        return self._primary.dispatch_backlog(message, turn)
+
+    def spawn_subagent(self, message: str, turn: Any) -> str:
+        return self._primary.spawn_subagent(message, turn)
+
+    def attach_context(self, message: str, turn: Any, target_turn: Any) -> str:
+        return self._primary.attach_context(message, turn, target_turn)
+
+    # -- the gated leg -----------------------------------------------------
+
+    def _projected_call_usd(self) -> float:
+        """Worst-case cost of the NEXT call, read from the wrapped
+        executor's own per-call cap. Deliberately not a constant here:
+        tightening the executor must tighten the projection, and two
+        numbers for one fact drift."""
+        try:
+            value = getattr(self._primary, "_cost_cap_per_call_usd", None)
+            if value is None:
+                from backend.core.ouroboros.governance.chat_repl_claude_executor import (  # noqa: E501
+                    DEFAULT_COST_CAP_PER_CALL_USD,
+                )
+                value = DEFAULT_COST_CAP_PER_CALL_USD
+            return max(0.0, float(value))
+        except Exception:  # noqa: BLE001
+            return 0.05
+
+    def would_trip(self) -> bool:
+        """Would the next call breach the cap? Public so the cockpit can
+        warn BEFORE the operator types, not only after."""
+        try:
+            cap = float(self._budget_fn())
+            if cap <= 0:
+                return True
+            return (self._ledger.spent + self._projected_call_usd()) > cap
+        except Exception:  # noqa: BLE001
+            return False
+
+    def query_claude(
+        self, message: str, turn: Any, recent_turns: List[Any],
+    ) -> str:
+        try:
+            if self.would_trip():
+                return self._trip(message, turn, recent_turns)
+        except Exception:  # noqa: BLE001 — a gate fault degrades SAFELY
+            logger.debug("[ChatBreaker] gate degraded", exc_info=True)
+            return self._fallback.query_claude(message, turn, recent_turns)
+
+        before = self._read_cumulative()
+        try:
+            result = self._primary.query_claude(message, turn, recent_turns)
+        except Exception:  # noqa: BLE001
+            # A provider fault must not lose the turn: the fallback still
+            # records it, and the operator gets a receipt rather than a
+            # traceback.
+            logger.debug("[ChatBreaker] primary raised", exc_info=True)
+            return self._fallback.query_claude(message, turn, recent_turns)
+        # Reconcile REAL spend from the executor's own accounting — the
+        # projection was for the gate, never for the books.
+        try:
+            delta = max(0.0, self._read_cumulative() - before)
+            if delta > 0:
+                self._ledger.record(delta, provider="chat_claude")
+                self._announced = False   # money moved; a new trip may speak
+        except Exception:  # noqa: BLE001
+            pass
+        return result
+
+    def _read_cumulative(self) -> float:
+        try:
+            return float(getattr(self._primary, "cumulative_cost_usd", 0.0))
+        except Exception:  # noqa: BLE001
+            return 0.0
+
+    def _trip(self, message: str, turn: Any, recent_turns: List[Any]) -> str:
+        """Route to the fallback and say so — once."""
+        try:
+            self._ledger.note_trip()
+            if not self._announced:
+                self._announced = True
+                snap = self._ledger.snapshot()
+                self._notify(TRIP_NOTICE.format(
+                    spent=f"${float(snap['spent_usd']):.2f}",
+                    cap=f"${float(snap['cap_usd']):.2f}",
+                ))
+            logger.warning(
+                "[ChatBreaker] TRIPPED spent=%.4f cap=%.4f — routing turn "
+                "%s to the logging executor",
+                self._ledger.spent, self._budget_fn(),
+                getattr(turn, "turn_id", "?"),
+            )
+        except Exception:  # noqa: BLE001
+            pass
+        return self._fallback.query_claude(message, turn, recent_turns)
+
+
+def wrap_with_breaker(
+    primary: Any,
+    fallback: Any,
+    *,
+    notify: Optional[Callable[[str], None]] = None,
+) -> Any:
+    """Install the breaker, or return the FALLBACK when it is disabled.
+
+    Fail-closed: with the breaker off, the answer is the logging executor,
+    never the unguarded brain. NEVER raises."""
+    try:
+        if not is_breaker_enabled():
+            logger.warning(
+                "[ChatBreaker] disabled — refusing to arm the chat brain "
+                "without a circuit breaker (fail-closed)",
+            )
+            return fallback
+        return CostCapMiddleware(primary, fallback, notify=notify)
+    except Exception:  # noqa: BLE001
+        logger.debug("[ChatBreaker] wrap degraded", exc_info=True)
+        return fallback
+
+
+__all__ = [
+    "CHAT_COST_BREAKER_SCHEMA_VERSION",
+    "CostCapMiddleware",
+    "DEFAULT_SESSION_BUDGET_USD",
+    "LEDGER_PATH_ENV_VAR",
+    "MASTER_FLAG_ENV_VAR",
+    "SESSION_BUDGET_ENV_VAR",
+    "SessionCostLedger",
+    "TRIP_NOTICE",
+    "chat_budget_chip",
+    "get_ledger",
+    "is_breaker_enabled",
+    "session_budget_usd",
+    "wrap_with_breaker",
+]

--- a/backend/core/ouroboros/governance/chat_repl_claude_executor.py
+++ b/backend/core/ouroboros/governance/chat_repl_claude_executor.py
@@ -464,6 +464,7 @@ def build_chat_repl_dispatcher_with_claude(
     default_session_id: str = DEFAULT_SESSION_ID,
     cost_cap_per_call_usd: float = DEFAULT_COST_CAP_PER_CALL_USD,
     session_budget_usd: float = DEFAULT_SESSION_BUDGET_USD,
+    breaker_notify: Any = None,
 ) -> Optional[ChatReplDispatcher]:
     """Build a chat dispatcher with the ClaudeChatActionExecutor
     wired in when ``JARVIS_CHAT_EXECUTOR_CLAUDE_ENABLED`` is truthy.
@@ -543,6 +544,26 @@ def build_chat_repl_dispatcher_with_claude(
         cost_cap_per_call_usd=cost_cap_per_call_usd,
         session_budget_usd=session_budget_usd,
     )
+    # THE CIRCUIT BREAKER. The executor's own caps are per-INSTANCE, and a
+    # reconnect mints a fresh instance with a fresh allowance — ten
+    # reconnects would be ten budgets. The breaker owns process-global,
+    # file-backed session accounting and DEGRADES (routes the turn to the
+    # logging leg, says so once) where the executor merely refuses with a
+    # sentinel token.
+    #
+    # Fail-closed by construction: `wrap_with_breaker` returns the FALLBACK
+    # when the breaker is disabled, so there is no configuration in which a
+    # paid brain answers without a guardrail in front of it.
+    try:
+        from backend.core.ouroboros.governance.chat_cost_breaker import (
+            wrap_with_breaker,
+        )
+        wired_executor = wrap_with_breaker(
+            wired_executor, fb, notify=breaker_notify,
+        )
+    except Exception:  # noqa: BLE001 — no breaker, no brain
+        logger.debug("[ClaudeChatExecutor] breaker unavailable", exc_info=True)
+        wired_executor = fb
     return build_chat_repl_dispatcher(
         orchestrator=orchestrator,
         executor=wired_executor,

--- a/backend/core/ouroboros/governance/chat_text_bridge.py
+++ b/backend/core/ouroboros/governance/chat_text_bridge.py
@@ -480,6 +480,10 @@ def build_chat_text_multiplexer(
             d = build_chat_repl_dispatcher_with_claude(
                 project_root=project_root,
                 claude_provider=_karen_provider,
+                # The breaker's voice reaches the operator through the SAME
+                # print chokepoint every other chat line takes — router
+                # conformance and the attach-terminal mirror for free.
+                breaker_notify=print_sink,
             )
         if d is None:
             return None

--- a/tests/governance/test_chat_cost_breaker.py
+++ b/tests/governance/test_chat_cost_breaker.py
@@ -1,0 +1,326 @@
+"""The Token Circuit Breaker — a chat brain that cannot run away with the bill.
+
+The mandated contract:
+
+  1. a normal turn routes to the REAL executor;
+  2. pushing session cost past the cap trips the breaker, routes the next
+     turn to the LOGGING executor, and fires the HUD notice — without
+     raising, and without blocking the event loop.
+
+Plus the properties that make it a session breaker rather than a second
+per-instance counter: spend survives the executor that spent it, the cap
+is read live from the environment, the projection comes from the wrapped
+executor's own per-call cap, and the factory fails CLOSED — no breaker,
+no brain.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance import chat_cost_breaker as cb
+
+
+class _Turn:
+    def __init__(self, turn_id: str = "t-1") -> None:
+        self.turn_id = turn_id
+        self.session_id = "repl"
+
+
+class _FakeClaude:
+    """Stands in for ClaudeChatActionExecutor: spends on every call and
+    exposes the same accounting surface the breaker reads."""
+
+    _cost_cap_per_call_usd = 0.05
+
+    def __init__(self, cost_per_call: float = 0.04) -> None:
+        self.cumulative_cost_usd = 0.0
+        self.calls: list = []
+        self._per_call = cost_per_call
+
+    def query_claude(self, message, turn, recent_turns):
+        self.calls.append(message)
+        self.cumulative_cost_usd += self._per_call
+        return f"claude-answer-{turn.turn_id}"
+
+    def dispatch_backlog(self, message, turn):
+        return f"backlog-{turn.turn_id}"
+
+    def spawn_subagent(self, message, turn):
+        return f"subagent-{turn.turn_id}"
+
+    def attach_context(self, message, turn, target_turn):
+        return f"attach-{turn.turn_id}"
+
+
+class _FakeLogging:
+    def __init__(self) -> None:
+        self.calls: list = []
+
+    def query_claude(self, message, turn, recent_turns):
+        self.calls.append(message)
+        return f"logged-claude-{turn.turn_id}"
+
+    def dispatch_backlog(self, message, turn):
+        return "logged-backlog"
+
+    def spawn_subagent(self, message, turn):
+        return "logged-subagent"
+
+    def attach_context(self, message, turn, target_turn):
+        return "logged-attach"
+
+
+@pytest.fixture()
+def isolated(tmp_path, monkeypatch):
+    """A ledger of our own — never the developer's real spend file."""
+    monkeypatch.setenv(cb.LEDGER_PATH_ENV_VAR, str(tmp_path / "spend.json"))
+    monkeypatch.setenv(cb.SESSION_BUDGET_ENV_VAR, "1.00")
+    monkeypatch.delenv(cb.MASTER_FLAG_ENV_VAR, raising=False)
+    ledger = cb.SessionCostLedger()
+    yield ledger
+
+
+def _mw(ledger, notices):
+    return cb.CostCapMiddleware(
+        _FakeClaude(), _FakeLogging(), ledger=ledger, notify=notices.append,
+    )
+
+
+# --------------------------------------------------------------------------
+# 1. THE MANDATED CONTRACT (async — the breaker must not block the loop)
+# --------------------------------------------------------------------------
+
+def test_normal_routes_to_claude_then_trip_routes_to_logging(
+    isolated,
+) -> None:
+    notices: list = []
+    mw = _mw(isolated, notices)
+
+    async def scenario() -> None:
+        loop = asyncio.get_running_loop()
+        ticks = {"n": 0}
+
+        async def _heartbeat() -> None:
+            """Proves the loop keeps turning THROUGH the breaker."""
+            while True:
+                ticks["n"] += 1
+                await asyncio.sleep(0.005)
+
+        beat = asyncio.ensure_future(_heartbeat())
+        try:
+            # (1) a normal turn reaches the real brain
+            answer = await loop.run_in_executor(
+                None, mw.query_claude, "what is O+V?", _Turn("t-1"), [],
+            )
+            assert answer == "claude-answer-t-1"
+            assert mw._primary.calls == ["what is O+V?"]
+            assert mw._fallback.calls == []
+            assert isolated.spent == pytest.approx(0.04)
+
+            # (2) override the session cost past the cap
+            isolated.record(1.00)
+
+            answer2 = await loop.run_in_executor(
+                None, mw.query_claude, "and again?", _Turn("t-2"), [],
+            )
+            assert answer2 == "logged-claude-t-2"       # degraded, not refused
+            assert mw._fallback.calls == ["and again?"]
+            assert mw._primary.calls == ["what is O+V?"]  # never called again
+            assert any("budget exhausted" in n for n in notices)
+            assert isolated.trips == 1
+            await asyncio.sleep(0.02)
+            assert ticks["n"] > 1                        # loop never blocked
+        finally:
+            beat.cancel()
+
+    asyncio.run(scenario())
+
+
+# --------------------------------------------------------------------------
+# 2. session accounting — the root cause the per-instance cap misses
+# --------------------------------------------------------------------------
+
+def test_spend_survives_the_executor_that_spent_it(isolated) -> None:
+    """A reconnect mints a fresh executor. Ten reconnects must not be ten
+    budgets."""
+    for _ in range(3):
+        mw = _mw(isolated, [])
+        mw.query_claude("q", _Turn(), [])
+    assert isolated.spent == pytest.approx(0.12)
+
+
+def test_ledger_is_file_backed_across_processes(isolated, tmp_path) -> None:
+    """A daemon restart mid-runaway must not hand the next process a
+    fresh allowance."""
+    isolated.record(0.42)
+    reborn = cb.SessionCostLedger()
+    assert reborn.spent == pytest.approx(0.42)
+    data = json.loads((tmp_path / "spend.json").read_text())
+    assert data["spent_usd"] == pytest.approx(0.42)
+
+
+def test_cap_is_read_live_from_the_environment(isolated, monkeypatch) -> None:
+    monkeypatch.setenv(cb.SESSION_BUDGET_ENV_VAR, "0.10")
+    assert cb.session_budget_usd() == pytest.approx(0.10)
+    mw = _mw(isolated, [])
+    isolated.record(0.09)
+    assert mw.would_trip() is True          # 0.09 + 0.05 projected > 0.10
+    monkeypatch.setenv(cb.SESSION_BUDGET_ENV_VAR, "5.00")
+    assert mw.would_trip() is False         # no restart needed
+
+
+def test_malformed_cap_falls_back_to_the_default(monkeypatch) -> None:
+    monkeypatch.setenv(cb.SESSION_BUDGET_ENV_VAR, "not-a-number")
+    assert cb.session_budget_usd() == cb.DEFAULT_SESSION_BUDGET_USD
+
+
+def test_zero_cap_trips_immediately(isolated, monkeypatch) -> None:
+    """A cap of zero means 'no chat spend', not 'unlimited'."""
+    monkeypatch.setenv(cb.SESSION_BUDGET_ENV_VAR, "0")
+    mw = _mw(isolated, [])
+    assert mw.query_claude("q", _Turn("t-9"), []) == "logged-claude-t-9"
+
+
+def test_projection_comes_from_the_wrapped_executor(isolated) -> None:
+    """Not a constant here — tightening the executor must tighten the
+    gate, or the two numbers drift."""
+    mw = _mw(isolated, [])
+    assert mw._projected_call_usd() == pytest.approx(0.05)
+    mw._primary._cost_cap_per_call_usd = 0.25
+    assert mw._projected_call_usd() == pytest.approx(0.25)
+
+
+# --------------------------------------------------------------------------
+# 3. degradation is total, and quiet
+# --------------------------------------------------------------------------
+
+def test_notice_is_said_once_per_streak(isolated) -> None:
+    notices: list = []
+    mw = _mw(isolated, notices)
+    isolated.record(2.0)
+    for i in range(4):
+        mw.query_claude("q", _Turn(f"t-{i}"), [])
+    assert len(notices) == 1                 # not a banner on every turn
+    assert isolated.trips == 4               # but every trip is counted
+
+
+def test_a_provider_fault_still_lands_the_turn(isolated) -> None:
+    class _Exploding(_FakeClaude):
+        def query_claude(self, message, turn, recent_turns):
+            raise RuntimeError("provider down")
+
+    mw = cb.CostCapMiddleware(_Exploding(), _FakeLogging(), ledger=isolated)
+    assert mw.query_claude("q", _Turn("t-5"), []) == "logged-claude-t-5"
+
+
+def test_a_gate_fault_degrades_safely(isolated) -> None:
+    mw = _mw(isolated, [])
+
+    def _boom() -> float:
+        raise RuntimeError("ledger unreadable")
+
+    mw._budget_fn = _boom
+    # would_trip swallows and returns False, so the call proceeds; the
+    # important part is that NOTHING raises into the dispatch path.
+    assert mw.query_claude("q", _Turn("t-6"), []) in (
+        "claude-answer-t-6", "logged-claude-t-6",
+    )
+
+
+def test_non_spending_legs_pass_through_untouched(isolated) -> None:
+    mw = _mw(isolated, [])
+    turn = _Turn("t-7")
+    assert mw.dispatch_backlog("m", turn) == "backlog-t-7"
+    assert mw.spawn_subagent("m", turn) == "subagent-t-7"
+    assert mw.attach_context("m", turn, turn) == "attach-t-7"
+    assert isolated.spent == 0.0             # they do not spend
+
+
+def test_reset_rearms(isolated) -> None:
+    notices: list = []
+    mw = _mw(isolated, notices)
+    isolated.record(2.0)
+    assert mw.query_claude("q", _Turn("t-8"), []) == "logged-claude-t-8"
+    isolated.reset()
+    assert isolated.spent == 0.0
+    assert mw.query_claude("q", _Turn("t-8b"), []) == "claude-answer-t-8b"
+
+
+# --------------------------------------------------------------------------
+# 4. fail-closed + telemetry
+# --------------------------------------------------------------------------
+
+def test_no_breaker_means_no_brain(isolated, monkeypatch) -> None:
+    """Disabling the guardrail must not yield an UNGUARDED paid API."""
+    monkeypatch.setenv(cb.MASTER_FLAG_ENV_VAR, "false")
+    primary, fallback = _FakeClaude(), _FakeLogging()
+    wrapped = cb.wrap_with_breaker(primary, fallback)
+    assert wrapped is fallback
+    wrapped.query_claude("q", _Turn("t-x"), [])
+    assert primary.calls == []
+
+
+def test_wrap_installs_the_breaker_by_default(isolated) -> None:
+    wrapped = cb.wrap_with_breaker(_FakeClaude(), _FakeLogging())
+    assert isinstance(wrapped, cb.CostCapMiddleware)
+
+
+def test_chip_is_silent_at_rest_and_loud_once_spent(
+    isolated, monkeypatch,
+) -> None:
+    monkeypatch.setattr(cb, "_LEDGER", isolated)
+    assert cb.chat_budget_chip() == ""
+    isolated.record(0.14)
+    chip = cb.chat_budget_chip()
+    assert "$0.14" in chip and "$1.00" in chip
+    isolated.record(1.0)
+    assert cb.chat_budget_chip().startswith("🛑")
+
+
+def test_snapshot_shape(isolated) -> None:
+    isolated.record(0.25)
+    snap = isolated.snapshot()
+    assert snap["spent_usd"] == pytest.approx(0.25)
+    assert snap["cap_usd"] == pytest.approx(1.00)
+    assert snap["remaining_usd"] == pytest.approx(0.75)
+    assert snap["tripped"] is False
+    assert snap["schema_version"] == cb.CHAT_COST_BREAKER_SCHEMA_VERSION
+
+
+# --------------------------------------------------------------------------
+# 5. wiring pins
+# --------------------------------------------------------------------------
+
+def test_factory_installs_the_breaker() -> None:
+    import inspect
+    from backend.core.ouroboros.governance import chat_repl_claude_executor
+    src = inspect.getsource(
+        chat_repl_claude_executor.build_chat_repl_dispatcher_with_claude,
+    )
+    assert "wrap_with_breaker(" in src
+    # fail-closed: the except branch hands back the fallback, not the brain
+    assert "wired_executor = fb" in src
+
+
+def test_bridge_gives_the_breaker_a_voice() -> None:
+    from backend.core.ouroboros.governance import chat_text_bridge
+    src = Path(chat_text_bridge.__file__).read_text()
+    assert "breaker_notify=print_sink" in src
+
+
+def test_status_line_renders_the_chip() -> None:
+    import inspect
+    from backend.core.ouroboros.battle_test import status_line
+    src = inspect.getsource(status_line.StatusLineBuilder.render_plain)
+    assert "chat_budget_chip" in src
+
+
+def test_harness_publishes_one_cost_surface() -> None:
+    from backend.core.ouroboros.battle_test import harness
+    src = Path(harness.__file__).read_text()
+    assert "_set_active_cost_tracker(self._cost_tracker)" in src
+    assert "def get_active_cost_tracker" in src

--- a/tests/governance/test_chat_repl_claude_executor.py
+++ b/tests/governance/test_chat_repl_claude_executor.py
@@ -39,6 +39,9 @@ from typing import List
 
 import pytest
 
+from backend.core.ouroboros.governance.chat_cost_breaker import (
+    CostCapMiddleware,
+)
 from backend.core.ouroboros.governance.chat_repl_claude_executor import (
     AUDIT_SCHEMA_VERSION,
     ClaudeChatActionExecutor,
@@ -589,7 +592,10 @@ def test_factory_claude_on_with_null_provider_when_no_provider(
     monkeypatch.setenv("JARVIS_CHAT_EXECUTOR_CLAUDE_ENABLED", "1")
     disp = build_chat_repl_dispatcher_with_claude(project_root=tmp_path)
     assert disp is not None
-    assert isinstance(disp.executor, ClaudeChatActionExecutor)
+    # The brain is now ALWAYS behind the cost circuit breaker — the
+    # factory refuses to hand back an unguarded paid executor.
+    assert isinstance(disp.executor, CostCapMiddleware)
+    assert isinstance(disp.executor.primary, ClaudeChatActionExecutor)
     out = disp.executor.query_claude(
         "q", _make_turn(turn_id="t-1"), recent_turns=[],
     )
@@ -618,8 +624,11 @@ def test_factory_claude_on_subagent_on_backlog_on_chains_all(
     monkeypatch.setenv("JARVIS_CHAT_EXECUTOR_BACKLOG_ENABLED", "1")
     disp = build_chat_repl_dispatcher_with_claude(project_root=tmp_path)
     assert disp is not None
-    assert isinstance(disp.executor, ClaudeChatActionExecutor)
-    inner = disp.executor._fallback
+    # The brain is now ALWAYS behind the cost circuit breaker — the
+    # factory refuses to hand back an unguarded paid executor.
+    assert isinstance(disp.executor, CostCapMiddleware)
+    assert isinstance(disp.executor.primary, ClaudeChatActionExecutor)
+    inner = disp.executor.primary._fallback
     assert isinstance(inner, SubagentChatActionExecutor)
     inner2 = inner._fallback
     assert isinstance(inner2, BacklogChatActionExecutor)
@@ -632,8 +641,11 @@ def test_factory_claude_on_subagent_off_backlog_on(monkeypatch, tmp_path):
     monkeypatch.setenv("JARVIS_CHAT_EXECUTOR_BACKLOG_ENABLED", "1")
     disp = build_chat_repl_dispatcher_with_claude(project_root=tmp_path)
     assert disp is not None
-    assert isinstance(disp.executor, ClaudeChatActionExecutor)
-    assert isinstance(disp.executor._fallback, BacklogChatActionExecutor)
+    # The brain is now ALWAYS behind the cost circuit breaker — the
+    # factory refuses to hand back an unguarded paid executor.
+    assert isinstance(disp.executor, CostCapMiddleware)
+    assert isinstance(disp.executor.primary, ClaudeChatActionExecutor)
+    assert isinstance(disp.executor.primary._fallback, BacklogChatActionExecutor)
 
 
 def test_factory_claude_on_only(monkeypatch, tmp_path):
@@ -642,8 +654,11 @@ def test_factory_claude_on_only(monkeypatch, tmp_path):
     monkeypatch.setenv("JARVIS_CHAT_EXECUTOR_BACKLOG_ENABLED", "0")
     disp = build_chat_repl_dispatcher_with_claude(project_root=tmp_path)
     assert disp is not None
-    assert isinstance(disp.executor, ClaudeChatActionExecutor)
-    assert isinstance(disp.executor._fallback, LoggingChatActionExecutor)
+    # The brain is now ALWAYS behind the cost circuit breaker — the
+    # factory refuses to hand back an unguarded paid executor.
+    assert isinstance(disp.executor, CostCapMiddleware)
+    assert isinstance(disp.executor.primary, ClaudeChatActionExecutor)
+    assert isinstance(disp.executor.primary._fallback, LoggingChatActionExecutor)
 
 
 def test_factory_chat_master_off_returns_none(monkeypatch, tmp_path):
@@ -662,7 +677,7 @@ def test_factory_explicit_fallback_used_directly(monkeypatch, tmp_path):
         project_root=tmp_path, fallback_executor=custom,
     )
     assert disp is not None
-    assert disp.executor._fallback is custom
+    assert disp.executor.primary._fallback is custom
 
 
 def test_factory_custom_budget_kwargs_propagate(monkeypatch, tmp_path):


### PR DESCRIPTION
## The finding

O+V's chat has been answering with a placeholder. `ClaudeChatActionExecutor`, its `KarenQueryProvider` (grounded in organism state, routed through the `rt_gate` policy lane), and the whole factory chain were **built and wired** — and inert, because `JARVIS_CHAT_EXECUTOR_CLAUDE_ENABLED` defaults false. Every turn fell through to `LoggingChatActionExecutor` and returned `logged-claude-<turn>` — the receipt with no answer behind it that the operator saw on screen.

## Why the executor's own caps weren't enough

- **Per-instance accounting is not session accounting.** The dispatcher is built per bridge/attach; a reconnect, `/chat clear`, or a second cockpit mints a fresh executor whose counter starts at zero. Ten reconnects would be ten budgets.
- **Refusal is not degradation.** On exhaustion it returned `error-session-budget-exhausted-<turn>`: no answer, no explanation, no receipt.

## `chat_cost_breaker.py`

A middleware implementing the same Protocol it wraps, so it composes into the existing chain (Claude → Subagent → Backlog → Logging) without any leg knowing it exists. Only the spending method is gated; the other three pass through.

- **`SessionCostLedger`** — process-global *and* file-backed, because the failure mode this exists to stop is precisely the one that restarts things. A daemon reboot mid-runaway inherits the spend, not a fresh allowance.
- **Projection, not optimism** — the gate runs *before* the network call, projecting worst case from the wrapped executor's **own** per-call cap, so tightening the executor tightens the gate and there's no second constant to drift.
- **On trip** — routes the turn to the logging leg (it still lands, still gets a receipt, still enters history), announces **once per streak** through the print chokepoint that already mirrors to attached cockpits, and counts every trip.
- **Live config** — `JARVIS_SESSION_BUDGET_USD` (default `$1.00`) read per call, so raising it needs no restart. A cap of `0` means *no chat spend*, not unlimited; a malformed value falls back to the default, never to no limit.
- **One spend surface** — chat cost records into the organism's own `CostTracker` through a new harness seam, so the status line's `$x/$y` counts every dollar once instead of two ledgers disagreeing. The chat chip (`💬 $0.14/$1.00`) stays silent until money moves and turns 🛑 when tripped.
- **Transparent** — `__getattr__` delegation means it gates one method and is invisible for everything else.

**Fail-closed by construction:** `wrap_with_breaker` returns the *fallback* when the breaker is disabled, and the factory's except-branch does the same. There is no configuration in which a paid brain answers without a guardrail in front of it — which is why the pre-existing factory tests now assert `CostCapMiddleware` wrapping the brain rather than the bare brain.

## Verification
20 new tests including the mandated async contract: a normal turn routes to Claude; pushing session cost past the cap trips the breaker, routes the next turn to Logging, and fires the HUD notice — with a heartbeat task asserting the event loop never blocked. Also pinned: spend surviving executor replacement, file-backed persistence, live cap changes, zero-cap, provider faults, gate faults, once-per-streak announcement, and fail-closed. 345-test chat+surface sweep green.

**Not enabled here:** `JARVIS_CHAT_EXECUTOR_CLAUDE_ENABLED` stays default-false. The cage is built and proven first; arming it is one flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a non-bypassable cost circuit breaker in front of the Claude chat executor that degrades to logging when the chat budget is exhausted. Spend is tracked process-wide with file-backed persistence and surfaced on the status line; Claude stays disabled by default.

- **New Features**
  - Introduced `CostCapMiddleware` and `SessionCostLedger` in `backend/core/ouroboros/governance/chat_cost_breaker.py`; gates only `query_claude`, passes others through.
  - Wired via `wrap_with_breaker(...)` in `build_chat_repl_dispatcher_with_claude`; fail-closed (breaker off -> fallback executor), with operator notices sent through the bridge `print_sink`.
  - Live budget from `JARVIS_SESSION_BUDGET_USD` (default `1.00`; `0` means no spend) and persisted to `JARVIS_CHAT_SPEND_LEDGER`; projection uses the executor’s own per-call cap.
  - Records real spend to the organism `CostTracker` via `get_active_cost_tracker` seam; status line renders `chat_budget_chip()` (`💬 $x/$y`, turns `🛑` when tripped).
  - Safe degradation: provider or gate faults route turns to logging, preserve receipts, and never block the loop.

- **Migration**
  - No action required; `JARVIS_CHAT_EXECUTOR_CLAUDE_ENABLED` remains false.
  - Adjust at runtime with `JARVIS_SESSION_BUDGET_USD`; optionally set `JARVIS_CHAT_SPEND_LEDGER` for the ledger path.
  - Setting `JARVIS_CHAT_BREAKER_ENABLED=false` disables the brain (routes to logging); there is no configuration that returns an unguarded paid executor.

<sup>Written for commit d7c5926d0e8ce0f4801eed4f31407d3888cd451f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

