### PR TITLE
feat(chat): the lane is a property of the payload, not of policy

### DIFF
--- a/backend/core/ouroboros/governance/adaptive_lane_router.py
+++ b/backend/core/ouroboros/governance/adaptive_lane_router.py
@@ -1,0 +1,256 @@
+"""The Adaptive Payload Router — the lane is a property of the payload.
+
+"Cheap-first or fast-first" is a false choice, and picking either one
+statically is wrong for half the traffic:
+
+* a two-word question routed to DW's async tier waits ~60s for its first
+  token, which is not a conversation;
+* a 40k-token context dump routed to Claude buys latency nobody asked for
+  at roughly ten times the price per token.
+
+The deciding fact is not policy, it is **weight**. This module measures the
+payload about to go on the wire and names the lane that suits it, leaving
+the CASCADE intact either way: the preferred tier is tried first and the
+other is still the fallback, so a lane choice can never become a single
+point of failure. A heavy query when DW is down still gets answered by
+Claude — slower to bill, but answered.
+
+Deliberately a pure decision function. It does not send, does not import a
+provider, and holds no state — so the rule can be unit-tested at a
+thousand payload sizes without a network, and the one place that DOES send
+(``rt_gate.gate_completion``) keeps sole authority over transport.
+
+DRY: the estimator is ``economic_router.estimate_tokens`` — the repo's
+existing chars/token heuristic, already trusted for the economic
+size-gate. Two estimators would eventually disagree about the same string,
+and the cheaper of the two disagreements is the one that routes money.
+
+Env:
+  * ``JARVIS_CHAT_ADAPTIVE_LANE_ENABLED``  master (default true)
+  * ``JARVIS_CHAT_HEAVY_TOKENS``           fast→heavy boundary (2000)
+  * ``JARVIS_CHAT_HEAVY_TTFT_HINT``        latency wording for the notice
+
+NEVER raises: an undecidable payload takes the FAST lane, because the
+failure a chat surface cannot absorb is silence.
+"""
+from __future__ import annotations
+
+import enum
+import logging
+import os
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+ADAPTIVE_LANE_SCHEMA_VERSION: str = "adaptive_lane.1"
+
+MASTER_FLAG_ENV_VAR: str = "JARVIS_CHAT_ADAPTIVE_LANE_ENABLED"
+HEAVY_TOKENS_ENV_VAR: str = "JARVIS_CHAT_HEAVY_TOKENS"
+TTFT_HINT_ENV_VAR: str = "JARVIS_CHAT_HEAVY_TTFT_HINT"
+
+#: The documented DW async time-to-first-token (CLAUDE.md: ~66s on the
+#: 0-APPLY soak class). A HINT the operator can correct, never a promise —
+#: which is why it is a string and not a computed SLA.
+DEFAULT_TTFT_HINT: str = "~60s"
+
+#: Where "a question" stops and "a context dump" starts. 2000 tokens is
+#: roughly 8k characters: comfortably above a grounded question (the
+#: grounding pack alone caps at 2400 chars) and comfortably below a pasted
+#: file or a multi-turn transcript.
+DEFAULT_HEAVY_TOKENS: int = 2000
+
+
+class Lane(str, enum.Enum):
+    """Which tier goes FIRST. The other remains the fallback."""
+
+    FAST = "fast"      # Claude-RT — low TTFT, higher $/token
+    HEAVY = "heavy"    # DW — async, far cheaper per token
+
+
+def is_adaptive_lane_enabled() -> bool:
+    """Master flag — default true. Off restores the global tier order
+    (``rt_gate.claude_first_enabled``) for every payload."""
+    raw = os.environ.get(MASTER_FLAG_ENV_VAR, "true")
+    return raw.strip().lower() not in ("0", "false", "no", "off")
+
+
+def heavy_token_threshold() -> int:
+    """The boundary, read live. A non-positive or malformed value means
+    "never heavy" rather than "always heavy": misconfiguration must
+    degrade toward the responsive lane, never toward a 60-second wait on
+    every keystroke."""
+    try:
+        value = int(os.environ.get(
+            HEAVY_TOKENS_ENV_VAR, str(DEFAULT_HEAVY_TOKENS),
+        ))
+    except (TypeError, ValueError):
+        return DEFAULT_HEAVY_TOKENS
+    return value if value > 0 else 0
+
+
+def ttft_hint() -> str:
+    try:
+        return (os.environ.get(TTFT_HINT_ENV_VAR, "").strip()
+                or DEFAULT_TTFT_HINT)
+    except Exception:  # noqa: BLE001
+        return DEFAULT_TTFT_HINT
+
+
+def estimate_payload_tokens(*parts: Any) -> int:
+    """Estimated token weight of everything about to go on the wire.
+
+    Variadic because the payload is assembled from pieces the caller
+    already holds — the grounded prompt, a system prompt, resolved ``@``
+    attachments — and asking the caller to concatenate them first would
+    make the measurement depend on their string handling rather than on
+    the content. Sequences are walked, so a list of attachment bodies
+    counts every one.
+
+    NEVER raises; an unmeasurable part contributes zero rather than
+    aborting the estimate."""
+    total_chars = 0
+    for part in parts:
+        try:
+            if part is None:
+                continue
+            if isinstance(part, str):
+                total_chars += len(part)
+            elif isinstance(part, (list, tuple, set)):
+                for item in part:
+                    total_chars += len(str(item or ""))
+            else:
+                total_chars += len(str(part))
+        except Exception:  # noqa: BLE001
+            continue
+    try:
+        from backend.core.ouroboros.governance.economic_router import (
+            estimate_tokens,
+        )
+        return int(estimate_tokens(total_chars))
+    except Exception:  # noqa: BLE001
+        # The same ~4 chars/token rule the estimator implements — used
+        # only if that module cannot be imported at all.
+        return max(0, total_chars // 4)
+
+
+def choose_lane(estimated_tokens: int) -> Lane:
+    """The rule, isolated so it can be tested at any size. NEVER raises."""
+    try:
+        if not is_adaptive_lane_enabled():
+            return Lane.FAST
+        threshold = heavy_token_threshold()
+        if threshold <= 0:
+            return Lane.FAST
+        return Lane.HEAVY if int(estimated_tokens) >= threshold else Lane.FAST
+    except Exception:  # noqa: BLE001
+        return Lane.FAST
+
+
+def prefer_for(lane: Lane) -> Optional[str]:
+    """The ``prefer`` token ``rt_gate.gate_completion`` understands, or
+    None when the global policy should decide (adaptive routing off)."""
+    try:
+        if not is_adaptive_lane_enabled():
+            return None
+        return "dw" if lane is Lane.HEAVY else "claude"
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def heavy_notice(estimated_tokens: int) -> str:
+    """What the operator is told when their query is shunted.
+
+    Says WHY (weight), WHERE (the async tier) and WHAT IT COSTS THEM
+    (latency) — a spinner that silently takes a minute reads as a hang,
+    and an operator who knows why will wait."""
+    try:
+        approx = f"{estimated_tokens / 1000:.1f}k" if (
+            estimated_tokens >= 1000
+        ) else str(int(estimated_tokens))
+        return (f"🐢 heavy context (~{approx} tokens) — routing to the "
+                f"async DW lane to protect cost ({ttft_hint()} to first "
+                f"token)")
+    except Exception:  # noqa: BLE001
+        return "🐢 heavy context — routing to the async DW lane"
+
+
+def route(
+    *parts: Any,
+    notify: Any = None,
+) -> "RouteDecision":
+    """Measure, decide, and (when heavy) tell the operator. NEVER raises.
+
+    The notice fires HERE rather than at the send site because this is the
+    moment the decision is made; emitting it later would race the request
+    it is meant to explain."""
+    tokens = estimate_payload_tokens(*parts)
+    lane = choose_lane(tokens)
+    decision = RouteDecision(
+        lane=lane,
+        estimated_tokens=tokens,
+        threshold=heavy_token_threshold(),
+        prefer=prefer_for(lane),
+    )
+    if lane is Lane.HEAVY and callable(notify):
+        try:
+            notify(heavy_notice(tokens))
+        except Exception:  # noqa: BLE001
+            logger.debug("[AdaptiveLane] notice degraded", exc_info=True)
+    logger.info(
+        "[AdaptiveLane] lane=%s tokens=~%d threshold=%d prefer=%s",
+        lane.value, tokens, decision.threshold, decision.prefer,
+    )
+    return decision
+
+
+class RouteDecision:
+    """The decision, as data — so a caller can log it, show it, or assert
+    on it without re-deriving the rule."""
+
+    __slots__ = ("lane", "estimated_tokens", "threshold", "prefer")
+
+    def __init__(
+        self, lane: Lane, estimated_tokens: int, threshold: int,
+        prefer: Optional[str],
+    ) -> None:
+        self.lane = lane
+        self.estimated_tokens = estimated_tokens
+        self.threshold = threshold
+        self.prefer = prefer
+
+    @property
+    def is_heavy(self) -> bool:
+        return self.lane is Lane.HEAVY
+
+    def to_dict(self) -> dict:
+        return {
+            "schema_version": ADAPTIVE_LANE_SCHEMA_VERSION,
+            "lane": self.lane.value,
+            "estimated_tokens": self.estimated_tokens,
+            "threshold": self.threshold,
+            "prefer": self.prefer,
+        }
+
+    def __repr__(self) -> str:  # pragma: no cover — debug aid
+        return (f"RouteDecision(lane={self.lane.value}, "
+                f"~{self.estimated_tokens}t, threshold={self.threshold})")
+
+
+__all__ = [
+    "ADAPTIVE_LANE_SCHEMA_VERSION",
+    "DEFAULT_HEAVY_TOKENS",
+    "DEFAULT_TTFT_HINT",
+    "HEAVY_TOKENS_ENV_VAR",
+    "Lane",
+    "MASTER_FLAG_ENV_VAR",
+    "RouteDecision",
+    "TTFT_HINT_ENV_VAR",
+    "choose_lane",
+    "estimate_payload_tokens",
+    "heavy_notice",
+    "heavy_token_threshold",
+    "is_adaptive_lane_enabled",
+    "prefer_for",
+    "route",
+    "ttft_hint",
+]

--- a/backend/core/ouroboros/governance/chat_cost_breaker.py
+++ b/backend/core/ouroboros/governance/chat_cost_breaker.py
@@ -116,16 +116,30 @@ class SessionCostLedger:
         self._lock = threading.Lock()
         self._spent: float = 0.0
         self._trips: int = 0
-        self._loaded = False
+        #: The path these figures were loaded FROM — not a bool.
+        #:
+        #: A bool made the ledger able to load from one file and persist to
+        #: another: the resolved path is read fresh on every write, so an
+        #: env change (a test isolating its own ledger, an operator
+        #: repointing JARVIS_CHAT_SPEND_LEDGER) left stale spend attached to
+        #: a new file. Keying the cache on the RESOLVED path — never on the
+        #: env string, never on "have we loaded" — is the same discipline
+        #: the crest cache learned: a cache key must fingerprint the config
+        #: it actually used.
+        self._loaded_path: Optional[str] = None
 
     # -- persistence -------------------------------------------------------
 
     def _load_once(self) -> None:
-        if self._loaded:
-            return
-        self._loaded = True
         try:
             path = _ledger_path()
+            key = str(path) if path is not None else ""
+            if self._loaded_path == key:
+                return
+            # A different book: start from ITS figures, not the last one's.
+            self._loaded_path = key
+            self._spent = 0.0
+            self._trips = 0
             if path is None or not path.is_file():
                 return
             data = json.loads(path.read_text(encoding="utf-8"))
@@ -198,7 +212,8 @@ class SessionCostLedger:
         """Operator re-arm. NEVER raises."""
         try:
             with self._lock:
-                self._loaded = True
+                path = _ledger_path()
+                self._loaded_path = str(path) if path is not None else ""
                 self._spent = 0.0
                 self._trips = 0
                 self._persist()

--- a/backend/core/ouroboros/governance/karen_answer_engine.py
+++ b/backend/core/ouroboros/governance/karen_answer_engine.py
@@ -158,7 +158,21 @@ class KarenQueryProvider:
                  f"{pack}\n\n" if pack else "")
                 + prompt
             )
-            self._emit("⎿ thinking · asking claude (doubleword fallback)")
+            # ADAPTIVE LANE. The right provider is a property of the
+            # PAYLOAD, not of policy: a two-word question on DW's async
+            # tier waits ~60s for its first token, and a 40k-token dump
+            # on Claude buys latency nobody asked for at ~10x the price.
+            # Measured on the GROUNDED prompt — what actually goes on the
+            # wire, attachments and evidence included — so the estimate
+            # cannot drift from the request.
+            from backend.core.ouroboros.governance.adaptive_lane_router import (  # noqa: E501
+                route as _route_lane,
+            )
+            _decision = _route_lane(
+                grounded, _SYSTEM_PROMPT, notify=self._emit,
+            )
+            if not _decision.is_heavy:
+                self._emit("⎿ thinking · asking claude (doubleword fallback)")
             from backend.core.ouroboros.governance.rt_gate import (
                 gate_completion,
             )
@@ -185,6 +199,9 @@ class KarenQueryProvider:
                 system_prompt=_SYSTEM_PROMPT,
                 max_tokens=max_tokens or _answer_max_tokens(),
                 dw_model=_voice_model,
+                # Bias only — the other tier stays the fallback, so a
+                # heavy query still gets answered when DW is down.
+                prefer=_decision.prefer,
             ))
             if isinstance(answer, str) and answer.strip():
                 return answer.strip()

--- a/backend/core/ouroboros/governance/rt_gate.py
+++ b/backend/core/ouroboros/governance/rt_gate.py
@@ -180,6 +180,7 @@ async def gate_completion(
     claude_provider: Any = None,
     dw_provider: Any = None,
     dw_model: Optional[str] = None,
+    prefer: Optional[str] = None,
 ) -> str:
     """Single-turn RT completion for a synchronous pipeline gate.
 
@@ -206,12 +207,23 @@ async def gate_completion(
             timeout_s=t, dw_provider=dw_provider, dw_model=dw_model,
         )
 
-    tiers = (_claude, _dw) if claude_first_enabled() else (_dw, _claude)
+    # PER-CALL tier order. `prefer` lets a caller that knows something
+    # about THIS payload (the adaptive lane router weighs it) put the
+    # right tier first, while the other stays the fallback — so a lane
+    # choice biases cost/latency and can never become a single point of
+    # failure. Unset → the global policy decides, exactly as before.
+    _pref = (prefer or "").strip().lower()
+    if _pref == "dw":
+        tiers = (_dw, _claude)
+    elif _pref == "claude":
+        tiers = (_claude, _dw)
+    else:
+        tiers = (_claude, _dw) if claude_first_enabled() else (_dw, _claude)
     for tier in tiers:
         raw = await tier()
         if raw:
             return raw
     raise GateProviderExhaustedError(
         f"gate_completion exhausted all RT tiers (caller={caller_id}, "
-        f"order={'claude,dw' if claude_first_enabled() else 'dw,claude'})"
+        f"order={'dw,claude' if tiers[0] is _dw else 'claude,dw'})"
     )

--- a/tests/governance/test_adaptive_lane_router.py
+++ b/tests/governance/test_adaptive_lane_router.py
@@ -1,0 +1,253 @@
+"""The Adaptive Payload Router — the lane is a property of the payload.
+
+The mandated contract:
+
+  1. a short query routes to the CLAUDE provider (low TTFT — a two-word
+     question on the async tier is not a conversation);
+  2. a massive query routes to the DW provider AND tells the operator why
+     they are about to wait.
+
+Plus the property that keeps a lane choice from becoming an outage: the
+preference is a BIAS, not a pin — the other tier is still the fallback, so
+a heavy query still gets answered when DW is down.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from backend.core.ouroboros.governance import adaptive_lane_router as alr
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    for var in (alr.MASTER_FLAG_ENV_VAR, alr.HEAVY_TOKENS_ENV_VAR,
+                alr.TTFT_HINT_ENV_VAR):
+        monkeypatch.delenv(var, raising=False)
+    yield
+
+
+_SHORT = "can you tell me what is O+V?"
+#: ~12.5k characters ≈ 3.1k tokens — comfortably past the 2k boundary.
+_HUGE = "x" * 12_500
+
+
+# --------------------------------------------------------------------------
+# 1. the estimate
+# --------------------------------------------------------------------------
+
+def test_estimate_uses_the_repo_heuristic() -> None:
+    assert alr.estimate_payload_tokens("a" * 4000) == 1000
+
+
+def test_estimate_walks_every_part_and_sequence() -> None:
+    """Attachments arrive as a list; each one is payload."""
+    both = alr.estimate_payload_tokens("a" * 400, ["b" * 400, "c" * 400])
+    assert both == 300
+
+
+def test_estimate_survives_junk() -> None:
+    assert alr.estimate_payload_tokens(None, 42, object()) >= 0
+
+
+# --------------------------------------------------------------------------
+# 2. the rule
+# --------------------------------------------------------------------------
+
+def test_short_payload_takes_the_fast_lane() -> None:
+    assert alr.choose_lane(alr.estimate_payload_tokens(_SHORT)) is alr.Lane.FAST
+
+
+def test_massive_payload_takes_the_heavy_lane() -> None:
+    assert alr.choose_lane(alr.estimate_payload_tokens(_HUGE)) is alr.Lane.HEAVY
+
+
+def test_boundary_is_inclusive_and_live(monkeypatch) -> None:
+    monkeypatch.setenv(alr.HEAVY_TOKENS_ENV_VAR, "100")
+    assert alr.choose_lane(99) is alr.Lane.FAST
+    assert alr.choose_lane(100) is alr.Lane.HEAVY
+    monkeypatch.setenv(alr.HEAVY_TOKENS_ENV_VAR, "1000")
+    assert alr.choose_lane(100) is alr.Lane.FAST      # no restart needed
+
+
+def test_misconfiguration_degrades_toward_responsiveness(
+    monkeypatch,
+) -> None:
+    """A bad threshold must never mean 'wait 60s on every keystroke'."""
+    monkeypatch.setenv(alr.HEAVY_TOKENS_ENV_VAR, "not-a-number")
+    assert alr.choose_lane(10_000) is alr.Lane.HEAVY   # default still applies
+    monkeypatch.setenv(alr.HEAVY_TOKENS_ENV_VAR, "0")
+    assert alr.choose_lane(10_000) is alr.Lane.FAST    # 0 = never heavy
+    monkeypatch.setenv(alr.HEAVY_TOKENS_ENV_VAR, "-5")
+    assert alr.choose_lane(10_000) is alr.Lane.FAST
+
+
+def test_master_flag_off_defers_to_global_policy(monkeypatch) -> None:
+    monkeypatch.setenv(alr.MASTER_FLAG_ENV_VAR, "false")
+    assert alr.choose_lane(999_999) is alr.Lane.FAST
+    assert alr.prefer_for(alr.Lane.FAST) is None       # gate decides
+
+
+def test_prefer_tokens_match_the_gate_vocabulary() -> None:
+    assert alr.prefer_for(alr.Lane.FAST) == "claude"
+    assert alr.prefer_for(alr.Lane.HEAVY) == "dw"
+
+
+# --------------------------------------------------------------------------
+# 3. THE MANDATED CONTRACT — routing + the UX notice, async
+# --------------------------------------------------------------------------
+
+def test_short_routes_to_claude_and_huge_routes_to_dw_with_notice() -> None:
+    """Drives the real gate with fake providers, asserting WHICH one was
+    consulted first — and that the loop never blocks."""
+    from backend.core.ouroboros.governance import rt_gate
+
+    async def scenario() -> None:
+        ticks = {"n": 0}
+
+        async def _heartbeat() -> None:
+            while True:
+                ticks["n"] += 1
+                await asyncio.sleep(0.005)
+
+        beat = asyncio.ensure_future(_heartbeat())
+        try:
+            for payload, expect_first, expect_heavy in (
+                (_SHORT, "claude", False),
+                (_HUGE, "dw", True),
+            ):
+                order: list = []
+                notices: list = []
+
+                async def _fake_claude(*_a, **_k):
+                    order.append("claude")
+                    return "claude-answer"
+
+                async def _fake_dw(*_a, **_k):
+                    order.append("dw")
+                    return "dw-answer"
+
+                decision = alr.route(payload, notify=notices.append)
+                assert decision.is_heavy is expect_heavy
+
+                # Patch the tier attempts, not the transport: the gate's
+                # own ordering logic is what we are asserting on.
+                import unittest.mock as mock
+                with mock.patch.object(rt_gate, "_try_claude", _fake_claude), \
+                        mock.patch.object(rt_gate, "_try_dw_rt", _fake_dw):
+                    answer = await rt_gate.gate_completion(
+                        payload, caller_id="test",
+                        prefer=decision.prefer,
+                    )
+                assert order[0] == expect_first, (payload[:20], order)
+                assert answer == f"{expect_first}-answer"
+
+                if expect_heavy:
+                    assert notices and "🐢" in notices[0]
+                    assert "async DW lane" in notices[0]
+                    assert alr.ttft_hint() in notices[0]
+                else:
+                    assert notices == []      # silence when nothing is odd
+
+            await asyncio.sleep(0.02)
+            assert ticks["n"] > 1             # the loop kept turning
+        finally:
+            beat.cancel()
+
+    asyncio.run(scenario())
+
+
+def test_preference_is_a_bias_not_a_pin() -> None:
+    """A heavy query when DW is DOWN must still be answered by Claude —
+    a lane choice can never become a single point of failure."""
+    from backend.core.ouroboros.governance import rt_gate
+    import unittest.mock as mock
+
+    async def scenario() -> str:
+        async def _dead_dw(*_a, **_k):
+            return None                      # tier unavailable
+
+        async def _live_claude(*_a, **_k):
+            return "claude-rescued"
+
+        with mock.patch.object(rt_gate, "_try_dw_rt", _dead_dw), \
+                mock.patch.object(rt_gate, "_try_claude", _live_claude):
+            return await rt_gate.gate_completion(
+                _HUGE, caller_id="test", prefer="dw",
+            )
+
+    assert asyncio.run(scenario()) == "claude-rescued"
+
+
+def test_unset_prefer_keeps_the_global_policy() -> None:
+    from backend.core.ouroboros.governance import rt_gate
+    import unittest.mock as mock
+
+    async def scenario() -> list:
+        order: list = []
+
+        async def _c(*_a, **_k):
+            order.append("claude")
+            return "a"
+
+        async def _d(*_a, **_k):
+            order.append("dw")
+            return "a"
+
+        with mock.patch.object(rt_gate, "_try_claude", _c), \
+                mock.patch.object(rt_gate, "_try_dw_rt", _d):
+            await rt_gate.gate_completion("hi", caller_id="t", prefer=None)
+        return order
+
+    # Default global policy is claude-first; the point is that None does
+    # not silently become a preference.
+    assert asyncio.run(scenario())[0] == "claude"
+
+
+# --------------------------------------------------------------------------
+# 4. the notice + the decision record
+# --------------------------------------------------------------------------
+
+def test_notice_explains_why_where_and_the_cost(monkeypatch) -> None:
+    monkeypatch.setenv(alr.TTFT_HINT_ENV_VAR, "~90s")
+    text = alr.heavy_notice(3100)
+    assert "3.1k tokens" in text          # why
+    assert "DW" in text                   # where
+    assert "~90s" in text                 # what it costs them
+
+
+def test_route_returns_an_inspectable_decision() -> None:
+    d = alr.route(_HUGE)
+    assert d.to_dict()["lane"] == "heavy"
+    assert d.to_dict()["prefer"] == "dw"
+    assert d.to_dict()["estimated_tokens"] > 2000
+    assert d.to_dict()["schema_version"] == alr.ADAPTIVE_LANE_SCHEMA_VERSION
+
+
+def test_a_failing_notify_never_breaks_routing() -> None:
+    def _boom(_m):
+        raise RuntimeError("hud gone")
+
+    assert alr.route(_HUGE, notify=_boom).is_heavy is True
+
+
+# --------------------------------------------------------------------------
+# 5. wiring
+# --------------------------------------------------------------------------
+
+def test_karen_measures_the_grounded_prompt_and_passes_prefer() -> None:
+    import inspect
+    from backend.core.ouroboros.governance import karen_answer_engine
+    src = inspect.getsource(karen_answer_engine.KarenQueryProvider.query)
+    assert "_route_lane(" in src
+    assert "grounded" in src.split("_route_lane(")[1][:80]   # the real wire
+    assert "prefer=_decision.prefer" in src
+
+
+def test_gate_exposes_a_per_call_preference() -> None:
+    import inspect
+    from backend.core.ouroboros.governance import rt_gate
+    sig = inspect.signature(rt_gate.gate_completion)
+    assert "prefer" in sig.parameters
+    assert sig.parameters["prefer"].default is None

--- a/tests/governance/test_chat_cost_breaker.py
+++ b/tests/governance/test_chat_cost_breaker.py
@@ -153,6 +153,25 @@ def test_spend_survives_the_executor_that_spent_it(isolated) -> None:
     assert isolated.spent == pytest.approx(0.12)
 
 
+def test_ledger_rebinds_when_the_path_changes(tmp_path, monkeypatch) -> None:
+    """The bug this pins cost a phantom $1.00 on the developer's real
+    ledger: keyed on a BOOL, the ledger loaded from one file and then
+    persisted to another, carrying stale spend across books."""
+    a, b = tmp_path / "a.json", tmp_path / "b.json"
+    monkeypatch.setenv(cb.LEDGER_PATH_ENV_VAR, str(a))
+    ledger = cb.SessionCostLedger()
+    ledger.record(0.30)
+    assert ledger.spent == pytest.approx(0.30)
+    # Repoint mid-process — the figures must come from the NEW book.
+    monkeypatch.setenv(cb.LEDGER_PATH_ENV_VAR, str(b))
+    assert ledger.spent == 0.0
+    ledger.record(0.10)
+    assert ledger.spent == pytest.approx(0.10)
+    # ...and the first book is untouched by the second's spend.
+    monkeypatch.setenv(cb.LEDGER_PATH_ENV_VAR, str(a))
+    assert ledger.spent == pytest.approx(0.30)
+
+
 def test_ledger_is_file_backed_across_processes(isolated, tmp_path) -> None:
     """A daemon restart mid-runaway must not hand the next process a
     fresh allowance."""


### PR DESCRIPTION
"Cheap-first or fast-first" is a false choice, and either static answer is wrong for half the traffic: a two-word question on DW's async tier waits ~60s for its first token, and a 40k-token context dump on Claude buys latency nobody asked for at ~10× the price. **The deciding fact is weight.**

## `adaptive_lane_router.py`
A pure decision function — no transport, no provider import, no state — so the rule is testable at any payload size without a network, and `rt_gate` keeps sole authority over sending.

| Payload | Lane | Why |
|---|---|---|
| `< JARVIS_CHAT_HEAVY_TOKENS` (2000) | **FAST** — Claude-RT first | duplex/voice, where TTFT *is* the product |
| `≥` threshold | **HEAVY** — DW first | price dominated by tokens, not by waiting |

Measured on the **grounded prompt** — what actually goes on the wire, Karen's evidence pack and resolved `@` attachments included — so the estimate can't drift from the request. The estimator is the repo's existing `economic_router.estimate_tokens`; two heuristics would eventually disagree about the same string, and the cheaper disagreement is the one that routes money.

## The preference is a bias, not a pin
`rt_gate.gate_completion` gains a per-call `prefer` that reorders its **existing** tiers. The other tier stays the fallback, so **a heavy query still gets answered by Claude when DW is down** — a lane choice can never become a single point of failure. Unset preserves the global policy byte-for-byte, and the exhausted-tiers error now reports the order actually attempted instead of re-deriving it from the global flag.

## UX transparency
A shunt emits one line saying **why** (weight), **where** (async DW lane) and **what it costs** (a TTFT hint, env-correctable) through the print chokepoint that already mirrors to attached cockpits — a spinner that silently takes a minute reads as a hang.

Misconfiguration degrades toward *responsiveness*: a malformed threshold falls back to the default, a non-positive one means "never heavy" — because the failure a chat surface cannot absorb is a 60-second wait on every keystroke.

## Also fixes a real bug in #70207 that this work surfaced
`SessionCostLedger` keyed its load on a **bool**, so it could load from one ledger file and persist to another when the resolved path changed mid-process, carrying stale spend across books. It left the real repo ledger at `$1.00 / 12 trips` — pure test artifact, never real spend — which **would have tripped the breaker on the operator's very first message now that the brain is armed.** The cache is now keyed on the **resolved path** (the same discipline the crest cache learned: fingerprint the config you actually used, never a bool and never an env string). Phantom ledger removed; regression pinned.

## Verification
17 new tests including the mandated async contract — short → Claude, massive → DW **plus** the delay notice, with a heartbeat task proving the event loop never blocked — and the bias-not-a-pin rescue. 316-test chat sweep green; a broad governance sweep shows an identical failure set to clean `main` (zero new reds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes chat requests by payload weight, not global policy, to send small prompts to the fast lane (Claude-RT) and large contexts to the cheap lane (DW), with a brief user notice when heavy. Also fixes a ledger cache bug that could mix spend between files.

- **New Features**
  - Added `adaptive_lane_router.py` to estimate tokens of the grounded prompt and choose the lane using `JARVIS_CHAT_HEAVY_TOKENS` (default 2000).
  - `rt_gate.gate_completion` now accepts `prefer` (`"claude"`/`"dw"`) to bias tier order per call; the other tier remains the fallback; errors report the actual order tried.
  - `karen_answer_engine` uses the router and passes `prefer`; when heavy it emits a one-line notice with `JARVIS_CHAT_HEAVY_TTFT_HINT` (default "~60s"). `JARVIS_CHAT_ADAPTIVE_LANE_ENABLED` is on by default; malformed or ≤0 thresholds route fast.

- **Bug Fixes**
  - `SessionCostLedger` now keys its load cache on the resolved ledger path, preventing spend carryover when `JARVIS_CHAT_SPEND_LEDGER` changes mid-process.

<sup>Written for commit 79be4be7dda1f7781af2eead7799bb8f9e57b67b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

