### PR TITLE
feat(ov): the room's commentary, attached to the work it is about

### DIFF
--- a/backend/core/ouroboros/battle_test/moltbook_inline.py
+++ b/backend/core/ouroboros/battle_test/moltbook_inline.py
@@ -1,0 +1,322 @@
+"""The room's commentary, attached to the work it is about.
+
+Moltbook posts already carry `op_id` and `reply_to` — the schema was built
+for attribution from the start. So a post is not ambient chatter that happens
+to coexist with an operation; it BELONGS to one, and can render under it in
+the same `⎿` grammar a tool result uses::
+
+    ⏺ Validate(7759-86)
+      ⎿ ✗ 3 failed · test_scoped_paths, test_sandbox_dir
+      💬 @the-pit    three tests. you fixed the assert and broke the file.
+         ▸ @the-builder   the containment check is right, the fixture is stale
+
+Adjacency is the whole value. The same sentence in a side panel is
+decoration; under the failure it is commentary, and scanning for `💬` finds
+every moment something went sideways. When a persona speaks only on events,
+their presence IS the error signal.
+
+The race this has to survive
+----------------------------
+A reaction is formulated asynchronously. By the time it arrives, the
+operation it is about may have scrolled out of the deck's window — or been
+evicted from the ring entirely. Mutating a line that is no longer on screen
+is how a TUI tears: the write lands in a buffer region the renderer has
+already committed, and the frame is corrupt until something forces a full
+repaint.
+
+So placement is DECIDED before anything is written:
+
+* **INLINE** — the parent's line is inside the current window. Inject under
+  it, in the nested grammar, and invalidate normally.
+* **GHOST** — the parent has scrolled away or been evicted. Do not touch it.
+  Append a pointer at the live tail instead::
+
+      💬 @cassandra commented on 7759-86 ↑
+
+  which is honest about what happened and costs one line, versus a scroll
+  jump that would yank the operator away from what they were reading.
+* **MUTED** — posture says the room should be quiet.
+
+Reading the room
+----------------
+Under `HARDEN` — an incident, a soak, a production repair — banter is
+actively harmful: it competes for attention with the thing that is going
+wrong. Only `⚔` conflict posts survive that gate, because a disagreement
+between REVIEW and GENERATE is not banter; it is the system telling the
+operator its own components do not agree.
+
+This is what separates a team that reads the room from a channel you mute in
+week two, and it is the reason the gate is on POSTURE rather than on a
+verbosity flag: the organism already knows when it is in trouble.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+logger = logging.getLogger("Ouroboros.MoltbookInline")
+
+__all__ = [
+    "Placement", "decide_placement", "find_anchor", "inline_enabled",
+    "is_conflict", "posture_allows", "render_ghost", "render_post",
+    "render_thread", "thread_collapse_after",
+    "INLINE", "GHOST", "MUTED",
+]
+
+#: Placements.
+INLINE = "inline"
+GHOST = "ghost"
+MUTED = "muted"
+
+#: Replies drawn before a thread folds. Two is enough to see that an argument
+#: happened and who is on which side; the rest is available on demand and
+#: must never bury a diff.
+_COLLAPSE_AFTER = 2
+
+#: Postures under which only conflict survives.
+_QUIET_POSTURES = ("HARDEN",)
+
+
+class Placement:
+    """Where a post goes, and why — the reason is kept for the log."""
+
+    __slots__ = ("kind", "anchor_index", "reason", "post")
+
+    def __init__(self, kind: str, anchor_index: int = -1, reason: str = "",
+                 post: Any = None) -> None:
+        self.kind = kind
+        #: Deck line index of the parent op, or -1.
+        self.anchor_index = anchor_index
+        self.reason = reason
+        self.post = post
+
+    @property
+    def inline(self) -> bool:
+        return self.kind == INLINE
+
+    def __repr__(self) -> str:  # pragma: no cover — diagnostics only
+        return f"<Placement {self.kind} at={self.anchor_index} {self.reason!r}>"
+
+
+def inline_enabled() -> bool:
+    """Default ON. Off, posts stay out of the deck entirely."""
+    return os.environ.get(
+        "JARVIS_MOLTBOOK_INLINE_ENABLED", "1",
+    ).strip().lower() not in ("0", "false", "no", "off")
+
+
+def thread_collapse_after() -> int:
+    try:
+        return max(1, int(os.environ.get("JARVIS_MOLTBOOK_COLLAPSE_AFTER", "")
+                          or _COLLAPSE_AFTER))
+    except (TypeError, ValueError):
+        return _COLLAPSE_AFTER
+
+
+def is_conflict(post: Any) -> bool:
+    """Does this post carry a disagreement?
+
+    A `⚔` is REVIEW contesting GENERATE — the system reporting that its own
+    components do not agree. That is not banter and must never be muted.
+    """
+    try:
+        if isinstance(post, dict):
+            kind = str(post.get("kind", "") or "")
+            body = str(post.get("body", "") or "")
+        else:
+            kind = str(getattr(post, "kind", "") or "")
+            body = str(getattr(post, "body", "") or "")
+        return kind.lower() in ("conflict", "contest", "dispute") or "⚔" in body
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def posture_allows(post: Any, posture: str = "") -> bool:
+    """May the room speak, given the organism's current posture?
+
+    Gated on POSTURE rather than a verbosity flag because the organism
+    already knows when it is in trouble — and an operator fighting an
+    incident should not have to remember to turn the jokes off first.
+    """
+    try:
+        if str(posture or "").strip().upper() not in _QUIET_POSTURES:
+            return True
+        return is_conflict(post)
+    except Exception:  # noqa: BLE001
+        return True
+
+
+def _post_field(post: Any, name: str, default: str = "") -> str:
+    try:
+        if isinstance(post, dict):
+            return str(post.get(name, default) or default)
+        return str(getattr(post, name, default) or default)
+    except Exception:  # noqa: BLE001
+        return default
+
+
+def find_anchor(deck_lines: Sequence[str], op_id: str) -> int:
+    """Last line of *op_id*'s BLOCK, or -1.
+
+    Not the header line. An op emits a header and then continuation lines —
+    `⎿ ✗ 3 failed`, diff hunks — and only the header carries the id. Anchoring
+    on the id alone puts a comment BETWEEN an operation and its own result,
+    which reads as though the room interrupted the machine mid-sentence.
+
+    So the block is walked forward from the header through everything
+    indented under it, and the comment lands after the whole thing. A line
+    starting a new top-level `⏺` ends the block.
+
+    The short form is the op's TAIL PAIR (`7759-86`), never its last segment
+    alone: UUIDv7 tails are two or three digits, and `86` matches `line 86`.
+    """
+    try:
+        needle = str(op_id or "").strip()
+        if not needle:
+            return -1
+        parts = [p for p in needle.replace(":", "-").split("-") if p]
+        short = "-".join(parts[-2:]) if len(parts) >= 3 else ""
+        header = -1
+        for index, raw in enumerate(deck_lines or ()):
+            text = str(raw)
+            if needle in text or (len(short) >= 5 and short in text):
+                header = index
+        if header < 0:
+            return -1
+        # The block is everything INDENTED under the header. That is the
+        # deck's actual grammar — `⏺` sits at column zero and `⎿`, diff hunks
+        # and `💬` are all indented beneath it — and it terminates reliably,
+        # which "until the next ⏺" does not: any unindented line at all ends
+        # the block, so a comment can never be separated from its op by
+        # unrelated output that happened to arrive between them.
+        end = header
+        for index in range(header + 1, len(deck_lines)):
+            text = str(deck_lines[index])
+            if not text.startswith((" ", "\t")) or not text.strip():
+                break
+            end = index
+        return end
+    except Exception:  # noqa: BLE001
+        return -1
+
+
+def decide_placement(
+    post: Any,
+    deck_lines: Sequence[str],
+    *,
+    window: Optional[Tuple[int, int]] = None,
+    posture: str = "",
+) -> Placement:
+    """Where this post goes. NEVER raises, NEVER mutates anything.
+
+    *window* is ``(start, end)`` — the absolute deck indices currently drawn,
+    which the caller reads from the viewport rather than assuming. Deciding
+    BEFORE writing is the whole safety property: an inline injection aimed at
+    a line the renderer has already committed is what tears a frame.
+    """
+    try:
+        if not inline_enabled():
+            return Placement(MUTED, reason="disabled", post=post)
+        if not posture_allows(post, posture):
+            return Placement(MUTED, reason="posture_quiet", post=post)
+
+        op_id = _post_field(post, "op_id")
+        if not op_id:
+            # No anchor at all. It cannot be commentary on anything, so it
+            # would land beside work it has nothing to do with.
+            return Placement(GHOST, reason="unattributed", post=post)
+
+        anchor = find_anchor(deck_lines, op_id)
+        if anchor < 0:
+            # Evicted from the ring, or never rendered here.
+            return Placement(GHOST, reason="anchor_evicted", post=post)
+
+        if window is not None:
+            start, end = int(window[0]), int(window[1])
+            if not (start <= anchor < end):
+                # Scrolled away. Touching it would write into a region the
+                # renderer has already committed.
+                return Placement(GHOST, anchor, "anchor_offscreen", post)
+
+        return Placement(INLINE, anchor, "visible", post)
+    except Exception:  # noqa: BLE001 — a comment must never break the deck
+        logger.debug("[MoltbookInline] placement degraded", exc_info=True)
+        return Placement(MUTED, reason="degraded", post=post)
+
+
+def render_post(post: Any, *, depth: int = 0, width: int = 78) -> List[str]:
+    """The `💬` block for one post, in the nested `⎿` grammar.
+
+    A reply is drawn with `▸` and one more indent, so threading falls out of
+    the same column discipline tool results already use — no second layout
+    vocabulary for the operator to learn.
+    """
+    try:
+        handle = _post_field(post, "handle") or "@someone"
+        body = " ".join(_post_field(post, "body").split())
+        ref = _post_field(post, "ref")
+        # `▸` already says "reply", so a second marker beside it is noise.
+        # `⚔` is NOT noise at any depth — a contested reply is the one an
+        # operator most needs to spot while scanning.
+        conflict = is_conflict(post)
+        if depth and not conflict:
+            glyph = "▸"
+        else:
+            glyph = "⚔" if conflict else "💬"
+            if depth:
+                glyph = f"▸ {glyph}"
+        pad = "  " + ("   " * max(0, int(depth)))
+        lead = f"{pad}{glyph} {handle}"
+        room = max(24, width - len(lead) - len(ref) - 4)
+        if len(body) > room:
+            body = body[: room - 1].rstrip() + "…"
+        line = f"{lead}  {body}"
+        if ref:
+            line = f"{line}  {ref}"
+        return [line]
+    except Exception:  # noqa: BLE001
+        return []
+
+
+def render_thread(posts: Sequence[Any], *, width: int = 78) -> List[str]:
+    """A post and its replies, folding once an argument gets long.
+
+    Two replies show that a disagreement happened and who is on each side.
+    Beyond that it is available on demand — an argument must never bury the
+    diff it is about.
+    """
+    try:
+        rows = list(posts or ())
+        if not rows:
+            return []
+        out = render_post(rows[0], depth=0, width=width)
+        limit = thread_collapse_after()
+        for reply in rows[1:1 + limit]:
+            out.extend(render_post(reply, depth=1, width=width))
+        hidden = max(0, len(rows) - 1 - limit)
+        if hidden:
+            out.append(f"    💬 {hidden} more repl{'y' if hidden == 1 else 'ies'}"
+                       f"          ⏎ to expand")
+        return out
+    except Exception:  # noqa: BLE001
+        return []
+
+
+def render_ghost(post: Any) -> str:
+    """``💬 @cassandra commented on 7759-86 ↑`` — one line, at the live tail.
+
+    Honest about what happened, and it costs one line. The alternative — a
+    scroll jump to the parent — would yank the operator away from whatever
+    they were reading to show them a joke.
+    """
+    try:
+        handle = _post_field(post, "handle") or "@someone"
+        op_id = _post_field(post, "op_id")
+        parts = [p for p in op_id.replace(":", "-").split("-") if p]
+        ref = "-".join(parts[-2:]) if len(parts) >= 3 else (op_id or "an op")
+        glyph = "⚔" if is_conflict(post) else "💬"
+        where = f" on {ref}" if op_id else ""
+        return f"  {glyph} {handle} commented{where} ↑"
+    except Exception:  # noqa: BLE001
+        return ""

--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -1621,6 +1621,80 @@ class SerpentFlow:
         )
         self.console.print()
 
+    def post_inline(self, post: Any) -> str:
+        """Render one Moltbook post into the deck. Returns its placement.
+
+        Reuses `_op_line` — the SAME chokepoint every ⏺/⎿ line already
+        mirrors through — rather than adding a second renderer, so a comment
+        travels the mirror, the op buffer and `/expand` exactly as tool
+        chrome does.
+
+        Placement is DECIDED before anything is written. A reaction is
+        formulated asynchronously, so by the time it lands its parent may
+        have scrolled out of the window or been evicted from the ring, and
+        mutating a committed region is what tears a frame.
+        """
+        try:
+            from backend.core.ouroboros.battle_test.moltbook_inline import (
+                GHOST, INLINE, decide_placement, render_ghost, render_post,
+            )
+
+            deck, window = self._deck_snapshot()
+            placement = decide_placement(
+                post, deck, window=window, posture=self._current_posture(),
+            )
+            if placement.kind == INLINE:
+                for line in render_post(post):
+                    self._op_line(str(getattr(post, "op_id", "")
+                                      or (post or {}).get("op_id", "")), line)
+                return INLINE
+            if placement.kind == GHOST:
+                # The tail, not the parent. A scroll jump to show a joke
+                # would yank the operator off whatever they were reading.
+                ghost = render_ghost(post)
+                if ghost:
+                    self._op_line("", ghost)
+                return GHOST
+            return placement.kind
+        except Exception:  # noqa: BLE001 — a comment must never break the deck
+            logger.debug("[Moltbook] inline render degraded", exc_info=True)
+            return "muted"
+
+    def _deck_snapshot(self) -> tuple:
+        """``(lines, (start, end))`` — the deck and the window ACTUALLY drawn.
+
+        Read from the canvas rather than assumed, because "is the parent still
+        visible" is the only question that decides inline vs ghost.
+        """
+        try:
+            mux = getattr(self, "_bipartite_mux", None) or getattr(
+                self, "_canvas", None,
+            )
+            if mux is None:
+                return ([], None)
+            lines = list(mux._buffer.snapshot())          # noqa: SLF001
+            total, budget = mux.scroll_metrics()
+            offset = getattr(mux._viewport, "offset", 0)  # noqa: SLF001
+            end = max(0, total - offset)
+            return (lines, (max(0, end - budget), end))
+        except Exception:  # noqa: BLE001
+            return ([], None)
+
+    def _current_posture(self) -> str:
+        """The organism's posture, or "" when unknown.
+
+        Unknown resolves to "speak" — a missing signal must not silence the
+        room, because the gate exists to quiet banter during trouble, not to
+        require proof of calm.
+        """
+        try:
+            from backend.core.ouroboros.governance.posture_store import (
+                current_posture,
+            )
+            return str(getattr(current_posture(), "value", "") or "")
+        except Exception:  # noqa: BLE001
+            return ""
+
     def _op_line(self, op_id: str, text: str) -> None:
         """Print a line within an active op block, prefixed with │.
 

--- a/backend/core/ouroboros/governance/moltbook.py
+++ b/backend/core/ouroboros/governance/moltbook.py
@@ -491,9 +491,47 @@ def _replies_per_min() -> int:
         return 6
 
 
-def _reply_budget_ok(resident: str, now: float) -> bool:
-    """Cooldown + global window admission. Thread-safe. NEVER raises."""
+def _posture_permits_banter(kind: str = "", body: str = "") -> bool:
+    """Should the room speak at all right now?
+
+    Gated on POSTURE, not on a verbosity flag. Under HARDEN — an incident, a
+    soak, a production repair — banter is actively harmful: it competes for
+    attention with the thing going wrong, and an operator fighting a failure
+    should not first have to remember to turn the jokes off.
+
+    A `⚔` conflict always passes. REVIEW contesting GENERATE is not banter;
+    it is the system reporting that its own components disagree, which is
+    exactly the signal an incident needs.
+
+    Unknown posture resolves to SPEAK. A missing signal must not silence the
+    room — the gate exists to quiet noise during trouble, not to demand proof
+    of calm.
+    """
     try:
+        from backend.core.ouroboros.battle_test.moltbook_inline import (
+            posture_allows,
+        )
+        from backend.core.ouroboros.governance.posture_store import (
+            current_posture,
+        )
+        posture = str(getattr(current_posture(), "value", "") or "")
+        return posture_allows({"kind": kind, "body": body}, posture)
+    except Exception:  # noqa: BLE001 — never silence on a lookup failure
+        return True
+
+
+def _reply_budget_ok(resident: str, now: float,
+                     kind: str = "", body: str = "") -> bool:
+    """Posture + cooldown + global window admission. Thread-safe. NEVER raises.
+
+    Posture is checked FIRST and cheapest: refusing here means the reaction is
+    never formulated at all, rather than generated and then dropped at the
+    renderer — the muted post would still have cost a model call and still
+    have consumed the resident's cooldown.
+    """
+    try:
+        if not _posture_permits_banter(kind, body):
+            return False
         with _REPLY_STATE_LOCK:
             if now - _LAST_REPLY_AT.get(resident, 0.0) < _reply_cooldown_s():
                 return False

--- a/backend/core/ouroboros/governance/persona_ledger.py
+++ b/backend/core/ouroboros/governance/persona_ledger.py
@@ -1,0 +1,346 @@
+"""Who was right, who agrees with whom, and how much of that we can stand behind.
+
+The room needs standing. `@cassandra` clapping back means nothing until you
+know whether her calls land; a chemistry number between two personas means
+nothing until you know they have disagreed enough times to have a pattern.
+
+Both are DERIVED, never self-reported. Asking an LLM to rate its own
+interaction costs a model call, returns a sycophantic number, and has no
+ground truth to check against — it is invented data wearing a percentage
+sign. The organism already records the only signal that settles an argument:
+
+    GENERATE proposes → REVIEW contests or concurs → VERIFY decides
+
+VERIFY is a test suite. It does not have opinions.
+
+Two numbers, and they are not the same number
+----------------------------------------------
+* **Calibration** — when this persona took a position, how often did VERIFY
+  agree with it? This is being RIGHT.
+* **Concordance** — when two personas both took a position, how often was it
+  the same one? This is AGREEING.
+
+Conflating them is the trap. A pair with 100% concordance may simply be two
+voices that never disagree, which is worth nothing and actively dangerous:
+consensus that is never challenged is how a review board stops catching
+anything. High concordance is a WARNING, not an achievement.
+
+Which is why rotation keys on calibration alone. Firing for low chemistry
+selects for agreement and converges the room on an echo chamber — the
+persona who disagrees constantly and is right 70% of the time is the most
+valuable one in the building, and a concordance-based cull removes her first.
+
+Provenance, because a number is not evidence
+---------------------------------------------
+Two samples at 100% is not a track record. Reporting it as one would fire a
+persona for being new, or trip an echo-chamber defence on a coincidence.
+
+So every reading carries provenance, following the discipline
+`advisor_locality` already established for blast radius: a measurement below
+the sample floor is `insufficient`, and an `insufficient` reading is NEUTRAL
+— it renders as "—", it never trips the defence, and it never proposes a
+rotation. The organism says "I do not know yet" rather than guessing, for the
+same reason the advisor refuses to BLOCK on a fabricated blast radius.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from collections import deque
+from typing import Any, Deque, Dict, List, Optional, Tuple
+
+logger = logging.getLogger("Ouroboros.PersonaLedger")
+
+__all__ = [
+    "Reading", "PersonaLedger", "ledger_enabled", "sample_floor",
+    "echo_threshold", "rotation_threshold", "get_persona_ledger",
+]
+
+#: Positions a persona can take on a candidate.
+FOR = "for"
+AGAINST = "against"
+
+#: Provenance values. `measured` is actionable; `insufficient` never is.
+MEASURED = "measured"
+INSUFFICIENT = "insufficient"
+
+#: Rolling window per subject. Bounded so a long-lived install measures
+#: RECENT behaviour — a persona who was wrong all last month and right all
+#: this week should read as improving, not as permanently discredited.
+_WINDOW = 50
+
+
+def ledger_enabled() -> bool:
+    """Default ON. Off, no standing is tracked and nothing is derived."""
+    return os.environ.get(
+        "JARVIS_PERSONA_LEDGER_ENABLED", "1",
+    ).strip().lower() not in ("0", "false", "no", "off")
+
+
+def _env_int(name: str, default: int, lo: int, hi: int) -> int:
+    try:
+        return min(hi, max(lo, int(os.environ.get(name, "") or default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _env_float(name: str, default: float, lo: float, hi: float) -> float:
+    try:
+        return min(hi, max(lo, float(os.environ.get(name, "") or default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def sample_floor() -> int:
+    """Positions required before a rate means anything.
+
+    Below this the reading is `insufficient` and inert. Eight is small enough
+    to reach in a working day and large enough that one lucky call cannot
+    manufacture a reputation.
+    """
+    return _env_int("JARVIS_PERSONA_SAMPLE_FLOOR", 8, 3, 200)
+
+
+def echo_threshold() -> float:
+    """Concordance above which agreement has stopped being informative."""
+    return _env_float("JARVIS_PERSONA_ECHO_THRESHOLD", 0.90, 0.5, 1.0)
+
+
+def rotation_threshold() -> float:
+    """Calibration below which a persona is a candidate for rotation.
+
+    A CANDIDATE, never a decision — rotation is a governed act and goes
+    through the gate like any other consequential change.
+    """
+    return _env_float("JARVIS_PERSONA_ROTATION_THRESHOLD", 0.30, 0.0, 1.0)
+
+
+class Reading:
+    """A rate, its sample count, and whether it can be acted on."""
+
+    __slots__ = ("rate", "samples", "provenance")
+
+    def __init__(self, rate: float, samples: int, provenance: str) -> None:
+        self.rate = float(rate)
+        self.samples = int(samples)
+        self.provenance = provenance
+
+    @property
+    def actionable(self) -> bool:
+        """Only a MEASURED reading may trip a defence or a gate.
+
+        The same rule `advisor_locality` applies to blast radius: a reading
+        the system cannot stand behind is neutral, never authoritative.
+        """
+        return self.provenance == MEASURED
+
+    @property
+    def pct(self) -> str:
+        return f"{round(self.rate * 100)}%" if self.actionable else "—"
+
+    def __repr__(self) -> str:  # pragma: no cover — diagnostics only
+        return f"<Reading {self.pct} n={self.samples} {self.provenance}>"
+
+
+_INSUFFICIENT = Reading(0.0, 0, INSUFFICIENT)
+
+
+class PersonaLedger:
+    """Derived standing. Records outcomes; decides nothing on its own."""
+
+    def __init__(self, window: int = _WINDOW) -> None:
+        self._lock = threading.RLock()
+        self._window = max(4, int(window))
+        #: persona → deque of bools (did VERIFY agree with their position)
+        self._calls: Dict[str, Deque[bool]] = {}
+        #: (a, b) sorted → deque of bools (did they take the same side)
+        self._pairs: Dict[Tuple[str, str], Deque[bool]] = {}
+        #: op_id → {persona: position}, pending VERIFY
+        self._open: Dict[str, Dict[str, str]] = {}
+
+    # -- recording ---------------------------------------------------------
+
+    def note_position(self, op_id: str, persona: str, position: str) -> None:
+        """A persona took a side on an op. NEVER raises.
+
+        Held open until VERIFY rules. A position with no outcome is not a
+        data point — it is an opinion nobody checked.
+        """
+        try:
+            if not ledger_enabled():
+                return
+            op = str(op_id or "").strip()
+            who = str(persona or "").strip()
+            side = str(position or "").strip().lower()
+            if not op or not who or side not in (FOR, AGAINST):
+                return
+            with self._lock:
+                self._open.setdefault(op, {})[who] = side
+        except Exception:  # noqa: BLE001
+            logger.debug("[PersonaLedger] note degraded", exc_info=True)
+
+    def settle(self, op_id: str, verified: bool) -> int:
+        """VERIFY ruled. Convert open positions into standing.
+
+        Returns the number of positions settled. Concordance is recorded for
+        every pair that BOTH took a side — including when they agreed and
+        were both wrong, because agreeing wrongly is exactly the pattern the
+        echo-chamber defence exists to notice.
+        """
+        try:
+            if not ledger_enabled():
+                return 0
+            with self._lock:
+                positions = self._open.pop(str(op_id or "").strip(), {})
+                if not positions:
+                    return 0
+                truth = FOR if verified else AGAINST
+                for who, side in positions.items():
+                    self._calls.setdefault(
+                        who, deque(maxlen=self._window),
+                    ).append(side == truth)
+                names = sorted(positions)
+                for i, a in enumerate(names):
+                    for b in names[i + 1:]:
+                        self._pairs.setdefault(
+                            (a, b), deque(maxlen=self._window),
+                        ).append(positions[a] == positions[b])
+                return len(positions)
+        except Exception:  # noqa: BLE001
+            logger.debug("[PersonaLedger] settle degraded", exc_info=True)
+            return 0
+
+    def abandon(self, op_id: str) -> None:
+        """The op never reached VERIFY. Discard, never guess an outcome."""
+        try:
+            with self._lock:
+                self._open.pop(str(op_id or "").strip(), None)
+        except Exception:  # noqa: BLE001
+            pass
+
+    # -- reading -----------------------------------------------------------
+
+    def calibration(self, persona: str) -> Reading:
+        """How often VERIFY agreed with this persona. Being RIGHT."""
+        return self._rate(self._calls.get(str(persona or "").strip()))
+
+    def concordance(self, a: str, b: str) -> Reading:
+        """How often these two took the same side. Being AGREEABLE.
+
+        Not a virtue. A high value means their disagreement has stopped
+        carrying information.
+        """
+        key = tuple(sorted((str(a or "").strip(), str(b or "").strip())))
+        return self._rate(self._pairs.get(key))  # type: ignore[arg-type]
+
+    def _rate(self, samples: Optional[Deque[bool]]) -> Reading:
+        try:
+            if not samples:
+                return _INSUFFICIENT
+            n = len(samples)
+            if n < sample_floor():
+                # Honest about not knowing. Two calls at 100% is not a track
+                # record, and acting on it would fire someone for being new.
+                return Reading(sum(samples) / n, n, INSUFFICIENT)
+            return Reading(sum(samples) / n, n, MEASURED)
+        except Exception:  # noqa: BLE001
+            return _INSUFFICIENT
+
+    # -- what the numbers imply (never what to DO) -------------------------
+
+    def echo_chamber_risk(self) -> List[Tuple[str, str, Reading]]:
+        """Pairs whose agreement has stopped being informative.
+
+        Returned rather than acted on. This class derives; the orchestrator
+        decides — and the decision (injecting a contrarian reviewer) is a
+        behavioural change that belongs where behavioural changes are
+        governed.
+        """
+        try:
+            out = []
+            with self._lock:
+                pairs = list(self._pairs.items())
+            for (a, b), samples in pairs:
+                reading = self._rate(samples)
+                if reading.actionable and reading.rate >= echo_threshold():
+                    out.append((a, b, reading))
+            return sorted(out, key=lambda row: -row[2].rate)
+        except Exception:  # noqa: BLE001
+            return []
+
+    def rotation_candidates(self) -> List[Tuple[str, Reading]]:
+        """Personas whose calls do not land. CANDIDATES, never decisions.
+
+        Keyed on calibration ALONE. Rotating on concordance would select for
+        agreement and converge the room on an echo chamber: the persona who
+        disagrees constantly and is right most of the time is the most
+        valuable one here, and a chemistry cull removes her first.
+        """
+        try:
+            out = []
+            with self._lock:
+                calls = list(self._calls.items())
+            for who, samples in calls:
+                reading = self._rate(samples)
+                if reading.actionable and reading.rate <= rotation_threshold():
+                    out.append((who, reading))
+            return sorted(out, key=lambda row: row[1].rate)
+        except Exception:  # noqa: BLE001
+            return []
+
+    # -- render ------------------------------------------------------------
+
+    def standing(self, persona: str) -> str:
+        """``@cassandra · 7/9 landed`` — or "" while still unproven."""
+        try:
+            reading = self.calibration(persona)
+            if not reading.samples:
+                return ""
+            landed = round(reading.rate * reading.samples)
+            suffix = "" if reading.actionable else " (early)"
+            return f"{persona} · {landed}/{reading.samples} landed{suffix}"
+        except Exception:  # noqa: BLE001
+            return ""
+
+    def chip(self, a: str, b: str) -> str:
+        """``⚔ @the-skeptic & @the-pit · tension 94%`` — or "".
+
+        Tension is the INVERSE of concordance, shown only when it is high
+        enough to be interesting. A chip that renders "tension 12%" on every
+        pair is chrome, and chrome is not read.
+        """
+        try:
+            reading = self.concordance(a, b)
+            if not reading.actionable:
+                return ""
+            tension = 1.0 - reading.rate
+            if tension >= 0.35:
+                return f"⚔ {a} & {b} · tension {round(tension * 100)}%"
+            if reading.rate >= echo_threshold():
+                # Named as a warning, not a celebration.
+                return f"🤝 {a} & {b} · agreement {reading.pct} (unchallenged)"
+            return ""
+        except Exception:  # noqa: BLE001
+            return ""
+
+
+_LEDGER: Optional[PersonaLedger] = None
+_LEDGER_LOCK = threading.Lock()
+
+
+def get_persona_ledger() -> PersonaLedger:
+    """Process-wide ledger — the producer (phase transitions) and the
+    consumer (the TUI chips) sit in different layers with no handle to each
+    other, the same reason the plan checklist is a singleton."""
+    global _LEDGER
+    with _LEDGER_LOCK:
+        if _LEDGER is None:
+            _LEDGER = PersonaLedger()
+        return _LEDGER
+
+
+def reset_ledger_for_tests() -> None:
+    global _LEDGER
+    with _LEDGER_LOCK:
+        _LEDGER = None

--- a/tests/battle_test/test_moltbook_inline.py
+++ b/tests/battle_test/test_moltbook_inline.py
@@ -1,0 +1,209 @@
+"""The room's commentary, attached to the work it is about.
+
+Moltbook posts already carry `op_id` — the schema was built for attribution —
+so a post BELONGS to an operation and renders under it in the same `⎿`
+grammar a tool result uses. Adjacency is the value: the same sentence in a
+side panel is decoration; under the failure it is commentary.
+
+The race this must survive: a reaction is formulated ASYNCHRONOUSLY, so by
+the time it lands its parent may have scrolled out of the window or been
+evicted from the ring. Mutating a committed region is how a TUI tears.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.battle_test.moltbook_inline import (
+    GHOST, INLINE, MUTED, decide_placement, find_anchor, inline_enabled,
+    is_conflict, posture_allows, render_ghost, render_post, render_thread,
+)
+
+_OP = "iron-gate:0198e4c1-7759-86"
+
+
+def _deck(n: int = 40) -> list:
+    lines = [f"line {i}" for i in range(n)]
+    lines[10] = f"⏺ Validate({_OP})"
+    lines[11] = "  ⎿ ✗ 3 failed · test_scoped_paths"
+    return lines
+
+
+def _post(body: str = "three tests. you broke the file.", **kw) -> dict:
+    base = {"handle": "@the-pit", "body": body, "op_id": _OP,
+            "ref": "m-418", "kind": "banter"}
+    base.update(kw)
+    return base
+
+
+# --------------------------------------------------------------------------
+# the mandate's two assertions
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_a_reaction_to_a_VISIBLE_op_injects_inline() -> None:
+    deck = _deck()
+    placement = decide_placement(_post(), deck, window=(0, 20))
+    assert placement.kind == INLINE
+    assert placement.anchor_index == 11, "should anchor after the op's LAST line"
+
+    rows = render_post(_post())
+    assert rows and "💬" in rows[0] and "@the-pit" in rows[0]
+
+
+@pytest.mark.asyncio
+async def test_an_OUT_OF_BOUNDS_op_routes_to_the_ghost_pointer() -> None:
+    """No geometry exception, no inline mutation — the parent has scrolled
+    away and writing into it is what tears a frame."""
+    deck = _deck()
+    placement = decide_placement(_post(), deck, window=(30, 40))
+    assert placement.kind == GHOST
+    assert placement.reason == "anchor_offscreen"
+
+    ghost = render_ghost(_post())
+    assert "@the-pit" in ghost and "↑" in ghost
+    assert "7759-86" in ghost, "the operator must be able to find it"
+
+
+# --------------------------------------------------------------------------
+# anchoring
+# --------------------------------------------------------------------------
+
+def test_it_anchors_to_the_ops_LAST_line() -> None:
+    """An op emits several lines; a comment belongs after everything it has
+    said, not wedged under its opening line."""
+    assert find_anchor(_deck(), _OP) == 11
+
+
+def test_an_evicted_op_ghosts_rather_than_guessing() -> None:
+    placement = decide_placement(_post(), ["unrelated"] * 20, window=(0, 20))
+    assert placement.kind == GHOST
+    assert placement.reason == "anchor_evicted"
+
+
+def test_an_unattributed_post_never_lands_inline() -> None:
+    """With no op_id it cannot be commentary on anything, so inline it would
+    sit beside work it has nothing to do with."""
+    placement = decide_placement(_post(op_id=""), _deck(), window=(0, 20))
+    assert placement.kind == GHOST
+    assert placement.reason == "unattributed"
+
+
+def test_no_window_means_no_bounds_check() -> None:
+    """A caller without a viewport (tests, headless) still gets inline."""
+    assert decide_placement(_post(), _deck()).kind == INLINE
+
+
+# --------------------------------------------------------------------------
+# reading the room
+# --------------------------------------------------------------------------
+
+def test_HARDEN_mutes_banter() -> None:
+    """Under an incident, banter competes for attention with the thing going
+    wrong."""
+    placement = decide_placement(_post(), _deck(), window=(0, 20),
+                                 posture="HARDEN")
+    assert placement.kind == MUTED
+    assert placement.reason == "posture_quiet"
+
+
+def test_HARDEN_never_mutes_a_CONFLICT() -> None:
+    """REVIEW contesting GENERATE is not banter — it is the system reporting
+    that its own components disagree, which is what an incident needs."""
+    contest = _post("⚔ the containment check is wrong", kind="conflict")
+    placement = decide_placement(contest, _deck(), window=(0, 20),
+                                 posture="HARDEN")
+    assert placement.kind == INLINE
+
+
+def test_other_postures_let_the_room_speak() -> None:
+    for posture in ("EXPLORE", "CONSOLIDATE", "MAINTAIN", ""):
+        assert posture_allows(_post(), posture) is True
+
+
+def test_an_unknown_posture_does_not_silence() -> None:
+    """The gate exists to quiet noise during trouble, not to demand proof of
+    calm."""
+    assert posture_allows(_post(), "SOMETHING_NEW") is True
+
+
+@pytest.mark.parametrize("body,kind,expected", [
+    ("⚔ contested", "banter", True),
+    ("plain talk", "conflict", True),
+    ("plain talk", "banter", False),
+])
+def test_conflict_detection(body: str, kind: str, expected: bool) -> None:
+    assert is_conflict({"body": body, "kind": kind}) is expected
+
+
+# --------------------------------------------------------------------------
+# threading
+# --------------------------------------------------------------------------
+
+def test_a_reply_is_indented_under_its_parent() -> None:
+    """Threading falls out of the same column discipline tool results use —
+    no second layout vocabulary to learn."""
+    parent = render_post(_post(), depth=0)[0]
+    reply = render_post(_post(handle="@the-builder"), depth=1)[0]
+    assert reply.startswith(" " * (len(parent) - len(parent.lstrip()) + 1))
+    assert "▸" in reply
+
+
+def test_a_long_argument_folds() -> None:
+    """An argument must never bury the diff it is about."""
+    thread = [_post()] + [_post(handle=f"@r{i}") for i in range(6)]
+    rows = render_thread(thread)
+    assert any("more replies" in r for r in rows)
+    assert len(rows) <= 5
+
+
+def test_a_short_thread_does_not_fold() -> None:
+    rows = render_thread([_post(), _post(handle="@b")])
+    assert not any("more repl" in r for r in rows)
+
+
+def test_a_long_body_is_clipped_not_wrapped() -> None:
+    """A post must occupy one deck line — wrapping would make commentary
+    outweigh the work it comments on."""
+    rows = render_post(_post("x " * 300))
+    assert len(rows) == 1
+    assert rows[0].endswith("m-418") or "…" in rows[0]
+
+
+# --------------------------------------------------------------------------
+# it can never break the deck
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("junk", [None, {}, "string", 42, {"op_id": None}])
+def test_junk_never_raises(junk) -> None:
+    placement = decide_placement(junk, _deck(), window=(0, 20))
+    assert placement.kind in (INLINE, GHOST, MUTED)
+    assert isinstance(render_post(junk), list)
+    assert isinstance(render_ghost(junk), str)
+
+
+def test_the_kill_switch(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JARVIS_MOLTBOOK_INLINE_ENABLED", "0")
+    assert inline_enabled() is False
+    assert decide_placement(_post(), _deck(), window=(0, 20)).kind == MUTED
+
+
+def test_it_reuses_the_op_line_seam() -> None:
+    """One renderer, not two — a comment travels the mirror, the op buffer
+    and /expand exactly as tool chrome does."""
+    import inspect
+
+    from backend.core.ouroboros.battle_test.serpent_flow import SerpentFlow
+
+    src = inspect.getsource(SerpentFlow.post_inline)
+    assert "self._op_line(" in src
+
+
+def test_the_reaction_engine_is_posture_gated() -> None:
+    """Refused at the ENGINE, not just the renderer: a muted post would still
+    have cost a model call and consumed the resident's cooldown."""
+    import inspect
+
+    from backend.core.ouroboros.governance import moltbook
+
+    src = inspect.getsource(moltbook._reply_budget_ok)
+    assert "_posture_permits_banter" in src

--- a/tests/governance/test_persona_ledger.py
+++ b/tests/governance/test_persona_ledger.py
@@ -1,0 +1,213 @@
+"""Who was right, who agrees, and how much of it we can stand behind.
+
+Both numbers are DERIVED from `GENERATE → REVIEW → VERIFY`, never
+self-reported. Asking an LLM to rate its own interaction costs a model call,
+returns a sycophantic number, and has no ground truth — invented data wearing
+a percentage sign. VERIFY is a test suite; it does not have opinions.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from backend.core.ouroboros.governance.persona_ledger import (
+    AGAINST, FOR, INSUFFICIENT, MEASURED, PersonaLedger, echo_threshold,
+    rotation_threshold, sample_floor,
+)
+
+
+def _agree(ledger: PersonaLedger, a: str, b: str, n: int,
+           right_every: int = 4) -> None:
+    """Two personas who always take the same side, right 1-in-n times."""
+    for i in range(n):
+        ledger.note_position(f"op-{a}{b}-{i}", a, FOR)
+        ledger.note_position(f"op-{a}{b}-{i}", b, FOR)
+        ledger.settle(f"op-{a}{b}-{i}", verified=(i % right_every == 0))
+
+
+# --------------------------------------------------------------------------
+# the mandate's two assertions
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_high_concordance_trips_the_echo_chamber_flag() -> None:
+    ledger = PersonaLedger()
+    _agree(ledger, "@yes-man", "@me-too", sample_floor() + 4)
+
+    risks = ledger.echo_chamber_risk()
+    assert risks, "unchallenged consensus went unnoticed"
+    a, b, reading = risks[0]
+    assert {a, b} == {"@yes-man", "@me-too"}
+    assert reading.rate >= echo_threshold()
+    assert reading.provenance == MEASURED
+
+
+@pytest.mark.asyncio
+async def test_low_calibration_proposes_rotation_without_blocking() -> None:
+    """A CANDIDATE, never a decision — and derivation must not await
+    anything, so it cannot stall the loop it is called from."""
+    ledger = PersonaLedger()
+    _agree(ledger, "@wrong-often", "@also-wrong", sample_floor() + 4,
+           right_every=10)
+
+    async def _derive():
+        return ledger.rotation_candidates()
+
+    candidates = await asyncio.wait_for(_derive(), timeout=1.0)
+    assert candidates
+    who, reading = candidates[0]
+    assert reading.rate <= rotation_threshold()
+    assert who in ("@wrong-often", "@also-wrong")
+
+
+# --------------------------------------------------------------------------
+# rotation keys on being RIGHT, never on being agreeable
+# --------------------------------------------------------------------------
+
+def test_a_disagreeable_persona_who_is_RIGHT_is_never_a_candidate() -> None:
+    """THE invariant. Rotating on chemistry selects for agreement and
+    converges the room on an echo chamber — the persona who disagrees
+    constantly and is right most of the time is the most valuable one here,
+    and a concordance-based cull removes her first."""
+    ledger = PersonaLedger()
+    for i in range(sample_floor() + 4):
+        ledger.note_position(f"op-{i}", "@cassandra", AGAINST)
+        ledger.note_position(f"op-{i}", "@builder", FOR)
+        ledger.settle(f"op-{i}", verified=False)      # cassandra was right
+
+    assert ledger.calibration("@cassandra").rate == 1.0
+    assert "@cassandra" not in [w for w, _r in ledger.rotation_candidates()]
+    assert "@builder" in [w for w, _r in ledger.rotation_candidates()]
+
+
+def test_agreeing_wrongly_is_recorded_as_concordance() -> None:
+    """Two voices agreeing and both being wrong is exactly the pattern the
+    defence exists to notice — it must not be filtered out as a non-event."""
+    ledger = PersonaLedger()
+    _agree(ledger, "@a", "@b", sample_floor() + 2, right_every=99)
+    assert ledger.concordance("@a", "@b").rate == 1.0
+    assert ledger.calibration("@a").rate < 0.2
+
+
+# --------------------------------------------------------------------------
+# provenance — a number is not evidence
+# --------------------------------------------------------------------------
+
+def test_a_thin_sample_is_INSUFFICIENT_and_inert() -> None:
+    """Two calls at 100% is not a track record. Acting on it would fire a
+    persona for being new, or trip the defence on a coincidence — the same
+    discipline `advisor_locality` applies to an unmeasurable blast radius."""
+    ledger = PersonaLedger()
+    ledger.note_position("op-1", "@new", FOR)
+    ledger.settle("op-1", verified=True)
+
+    reading = ledger.calibration("@new")
+    assert reading.provenance == INSUFFICIENT
+    assert reading.actionable is False
+    assert reading.pct == "—"
+    assert ledger.rotation_candidates() == []
+    assert ledger.echo_chamber_risk() == []
+
+
+def test_an_insufficient_pair_never_trips_the_defence() -> None:
+    ledger = PersonaLedger()
+    _agree(ledger, "@a", "@b", 2)
+    assert ledger.concordance("@a", "@b").rate == 1.0
+    assert ledger.echo_chamber_risk() == []
+
+
+def test_an_unknown_persona_reads_as_insufficient() -> None:
+    assert PersonaLedger().calibration("@nobody").provenance == INSUFFICIENT
+
+
+# --------------------------------------------------------------------------
+# recording discipline
+# --------------------------------------------------------------------------
+
+def test_a_position_with_no_outcome_is_not_a_data_point() -> None:
+    """An opinion nobody checked is not evidence."""
+    ledger = PersonaLedger()
+    ledger.note_position("op-1", "@a", FOR)
+    assert ledger.calibration("@a").samples == 0
+
+
+def test_an_abandoned_op_never_invents_an_outcome() -> None:
+    ledger = PersonaLedger()
+    ledger.note_position("op-1", "@a", FOR)
+    ledger.abandon("op-1")
+    ledger.settle("op-1", verified=True)
+    assert ledger.calibration("@a").samples == 0
+
+
+def test_the_window_measures_RECENT_behaviour() -> None:
+    """A persona wrong all last month and right all this week should read as
+    improving, not as permanently discredited."""
+    ledger = PersonaLedger(window=10)
+    for i in range(10):
+        ledger.note_position(f"w{i}", "@x", FOR)
+        ledger.settle(f"w{i}", verified=False)
+    for i in range(10):
+        ledger.note_position(f"r{i}", "@x", FOR)
+        ledger.settle(f"r{i}", verified=True)
+    assert ledger.calibration("@x").rate == 1.0
+
+
+# --------------------------------------------------------------------------
+# what the operator sees
+# --------------------------------------------------------------------------
+
+def test_standing_renders_a_track_record() -> None:
+    ledger = PersonaLedger()
+    for i in range(9):
+        ledger.note_position(f"op-{i}", "@cassandra", FOR)
+        ledger.settle(f"op-{i}", verified=(i < 7))
+    assert ledger.standing("@cassandra") == "@cassandra · 7/9 landed"
+
+
+def test_an_early_record_says_so() -> None:
+    ledger = PersonaLedger()
+    ledger.note_position("op-1", "@new", FOR)
+    ledger.settle("op-1", verified=True)
+    assert "early" in ledger.standing("@new")
+
+
+def test_high_agreement_is_chipped_as_a_WARNING() -> None:
+    """Named "unchallenged", not celebrated — consensus that is never
+    contested is how a review board stops catching anything."""
+    ledger = PersonaLedger()
+    _agree(ledger, "@a", "@b", sample_floor() + 4)
+    assert "unchallenged" in ledger.chip("@a", "@b")
+
+
+def test_an_uninteresting_pair_renders_nothing() -> None:
+    """A chip reading "tension 12%" on every pair is chrome, and chrome is
+    not read."""
+    # ~80% agreement: too concordant to be tense, not concordant enough to
+    # be unchallenged. Alternating sides would be 50% tension, which IS
+    # interesting — the quiet middle is what must render nothing.
+    ledger = PersonaLedger()
+    for i in range(sample_floor() + 12):
+        ledger.note_position(f"op-{i}", "@a", FOR)
+        ledger.note_position(f"op-{i}", "@b", AGAINST if i % 5 == 0 else FOR)
+        ledger.settle(f"op-{i}", verified=True)
+    concordance = ledger.concordance("@a", "@b").rate
+    assert 0.65 < concordance < echo_threshold(), "test built the wrong pair"
+    assert ledger.chip("@a", "@b") == ""
+
+
+@pytest.mark.parametrize("junk", [None, "", 42])
+def test_junk_never_raises(junk) -> None:
+    ledger = PersonaLedger()
+    ledger.note_position(junk, junk, junk)
+    ledger.settle(junk, verified=True)
+    assert isinstance(ledger.calibration(junk).rate, float)
+    assert isinstance(ledger.chip(junk, junk), str)
+
+
+def test_the_kill_switch(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JARVIS_PERSONA_LEDGER_ENABLED", "0")
+    ledger = PersonaLedger()
+    ledger.note_position("op-1", "@a", FOR)
+    ledger.settle("op-1", verified=True)
+    assert ledger.calibration("@a").samples == 0


### PR DESCRIPTION
Moltbook posts already carry `op_id` and `reply_to` — **the schema was built for attribution from the start**. So a post isn't ambient chatter that happens to coexist with an operation; it *belongs* to one, and renders under it in the same `⎿` grammar a tool result uses:

```
⏺ Validate(7759-86)
  ⎿ ✗ 3 failed · test_scoped_paths
  💬 @the-pit  three tests. you fixed the assert and broke the file.  m-418
     ▸ @the-builder  the containment check is right, the fixture is st…  m-419
     ▸ ⚔ @the-skeptic  "stale fixture" is what everyone says first      m-420
    💬 1 more reply          ⏎ to expand
```

Adjacency is the whole value. That same sentence in a side panel is decoration; under the failure it's commentary. And because a persona speaks only on **events**, scanning for `💬` finds every moment something went sideways — **the roast is the error highlight**.

## The race

A reaction is formulated asynchronously, so by the time it lands its parent may have scrolled out of the window or been evicted from the ring. Mutating a committed region is how a TUI tears.

Placement is therefore **decided before anything is written**, from the window the viewport *reports* rather than one assumed:

| | |
|---|---|
| **INLINE** | parent on screen → inject in the nested grammar |
| **GHOST** | parent gone → don't touch it; append `💬 @cassandra commented on 7759-86 ↑` at the live tail |
| **MUTED** | posture says the room should be quiet |

The ghost costs one line and is honest. The alternative — scrolling to the parent — would yank you off whatever you were reading to show you a joke.

## Posture gating, at the engine

Under `HARDEN`, banter competes for attention with the thing going wrong, so it's **never formulated** — a post muted at the renderer would still have cost a model call and consumed the resident's cooldown.

`⚔` always passes. REVIEW contesting GENERATE isn't banter; it's the system reporting that its own components disagree, which is exactly what an incident needs. Unknown posture **speaks** — the gate quiets noise during trouble, it doesn't demand proof of calm.

## Two things the tests caught that reasoning hadn't

1. **Anchoring on `op_id` put a comment between an operation and its own result.** Only the header line carries the id, so `⎿ ✗ 3 failed` wasn't recognised as part of the block. The anchor now walks the block bounded by **indentation** — which terminates reliably where "until the next `⏺`" does not.
2. **The short op form was the last segment (`86`)** — which matches `line 86`. Now the tail *pair* (`7759-86`), the same discipline every other ref uses.

## DRY

`post_inline` renders through `_op_line` — the chokepoint every `⏺`/`⎿` line already mirrors through — so a comment travels the mirror, the op buffer and `/expand` exactly as tool chrome does. No second renderer.

## Verification

25 tests, including the mandate's two: a reaction to a visible op injects cleanly, and one to an out-of-bounds op routes to the ghost pointer without a geometry exception.

Switches: `JARVIS_MOLTBOOK_INLINE_ENABLED=0`, `JARVIS_MOLTBOOK_COLLAPSE_AFTER`.

*Note: 11 `tests/governance` failures exist on `main` independently of this branch (verified by running them on `main` with this branch checked out and not) — they arrived with #70206–#70208 from the parallel session.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Inline Moltbook comments now render under their operation with a one‑line ghost pointer when the parent is offscreen. Added a persona ledger that derives standing (calibration) and agreement (concordance) from VERIFY to flag echo chambers and suggest rotation, with posture‑gated banter muted under HARDEN while conflicts still surface.

- **New Features**
  - Inline placement is decided from the live viewport; offscreen posts append a ghost line like "💬 @handle commented on 7759-86 ↑".
  - Posture gate at the engine: under HARDEN, banter is blocked; `⚔` conflicts always pass. Checked before generation to avoid wasted calls.
  - Renderer reuse: comments render through the same `_op_line` seam as tool output. Kill switch via `JARVIS_MOLTBOOK_INLINE_ENABLED=0`; folding via `JARVIS_MOLTBOOK_COLLAPSE_AFTER`.
  - Persona ledger: derives calibration (right rate) and concordance (agreement) from `GENERATE → REVIEW → VERIFY`. Exposes `echo_chamber_risk()` and `rotation_candidates()`; carries provenance with a sample floor; uses a rolling window; optional chips for tension/unchallenged. Config via `JARVIS_PERSONA_LEDGER_ENABLED=0`, `JARVIS_PERSONA_SAMPLE_FLOOR`, `JARVIS_PERSONA_ECHO_THRESHOLD`, `JARVIS_PERSONA_ROTATION_THRESHOLD`.

- **Bug Fixes**
  - Anchor comments at the end of the op block by walking indentation, not the header id.
  - Use the op tail pair (`7759-86`) for short refs to avoid line‑number collisions.
  - Prevent frame tearing by never mutating offscreen/evicted regions; placement is decided before writing.
  - Tests cover inline vs ghost, anchoring, folding, clipping, gating, kill switches, and ledger derivations.

<sup>Written for commit 9875be96d8e0485f9c409d5e3a4bf8ff98d21141. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

