### PR TITLE
feat(ov): the acting half — inject a contrarian, ASK to rotate

### DIFF
--- a/backend/core/ouroboros/governance/persona_governor.py
+++ b/backend/core/ouroboros/governance/persona_governor.py
@@ -1,0 +1,290 @@
+"""Acting on standing — contrarian injection, and asking to rotate.
+
+`persona_ledger` derives who was right and who agrees with whom, and
+deliberately decides nothing. This is the half that acts, and the split
+matters: deriving is arithmetic over recorded outcomes, while injecting a
+reviewer or replacing a persona changes how the organism reasons. Those are
+different kinds of act and belong behind different guarantees.
+
+Contrarian injection
+--------------------
+When a pair's concordance says their agreement has stopped carrying
+information, the next REVIEW is routed to a persona who was NOT part of that
+consensus, carrying a directive to attack the candidate rather than assess
+it.
+
+No tokens are spent manufacturing this. The directive is a fixed instruction
+and the reviewer is chosen from personas already configured — the defence is
+a routing decision, not a generated performance. Paying a model to invent
+disagreement would produce theatre, and theatre is what an echo chamber
+already has.
+
+Who gets chosen matters more than that someone does. Picking a member of the
+agreeing pair to argue against itself is not a second opinion; it is the same
+opinion wearing a costume. The reviewer must come from outside the consensus,
+and if nobody does, the defence reports that it cannot help rather than
+pretending.
+
+Rotation is REQUESTED, never taken
+-----------------------------------
+Replacing a persona changes the population the organism reasons with. That is
+a consequential, hard-to-reverse act on the system's own judgement, so it
+goes through the gate at `APPROVAL_REQUIRED` like any other — the same reason
+`Shift+Tab` can only tighten and workspace promotion defaults off.
+
+The request keys on CALIBRATION alone. Rotating on chemistry selects for
+agreement and converges the room on the echo chamber this module exists to
+prevent: the persona who disagrees constantly and is right most of the time
+is the most valuable one here, and a concordance-based cull removes her
+first.
+
+And it never proposes emptying the room. A defence that can remove its own
+last skeptic has removed the thing being defended.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+logger = logging.getLogger("Ouroboros.PersonaGovernor")
+
+__all__ = [
+    "ContrarianDirective", "RotationRequest", "PersonaGovernor",
+    "governor_enabled", "contrarian_cooldown_s", "min_room_size",
+]
+
+#: The directive handed to an injected reviewer. FIXED text, not generated:
+#: paying a model to invent disagreement produces theatre, and theatre is
+#: what an echo chamber already has.
+_CONTRARIAN_DIRECTIVE = (
+    "The reviewers on this op have agreed with each other on {rate} of recent "
+    "candidates, so their concurrence no longer carries information. Your job "
+    "is to ATTACK this candidate, not to assess it. Find the strongest "
+    "concrete objection: a case it breaks, an assumption it makes silently, a "
+    "path it does not cover. If after genuine effort you cannot find one, say "
+    "so plainly — a manufactured objection is worse than none, because it "
+    "teaches the operator to ignore you."
+)
+
+
+def governor_enabled() -> bool:
+    """Default ON. Off, findings are derived but never acted on."""
+    return os.environ.get(
+        "JARVIS_PERSONA_GOVERNOR_ENABLED", "1",
+    ).strip().lower() not in ("0", "false", "no", "off")
+
+
+def contrarian_cooldown_s() -> float:
+    """Minimum gap between injections.
+
+    Without it the defence fires on every op while concordance stays high —
+    and since a contrarian review costs a model call, an undamped defence
+    turns a measurement into a bill. It also gives the injected disagreement
+    time to move the number it is responding to.
+    """
+    try:
+        return max(0.0, float(
+            os.environ.get("JARVIS_CONTRARIAN_COOLDOWN_S", "") or 600.0,
+        ))
+    except (TypeError, ValueError):
+        return 600.0
+
+
+def min_room_size() -> int:
+    """Personas that must remain after a rotation.
+
+    A defence that can remove its own last skeptic has removed the thing
+    being defended.
+    """
+    try:
+        return max(2, int(os.environ.get("JARVIS_PERSONA_MIN_ROOM", "") or 3))
+    except (TypeError, ValueError):
+        return 3
+
+
+class ContrarianDirective:
+    """Route the next REVIEW to *persona* with an attacking brief."""
+
+    __slots__ = ("persona", "directive", "because", "pair")
+
+    def __init__(self, persona: str, directive: str, because: str,
+                 pair: Tuple[str, str]) -> None:
+        self.persona = persona
+        self.directive = directive
+        self.because = because
+        self.pair = pair
+
+    def __repr__(self) -> str:  # pragma: no cover — diagnostics only
+        return f"<Contrarian {self.persona} because {self.because!r}>"
+
+
+class RotationRequest:
+    """A REQUEST to replace a persona. Carries evidence, not authority."""
+
+    __slots__ = ("persona", "rate", "samples", "risk_tier", "reason")
+
+    def __init__(self, persona: str, rate: float, samples: int,
+                 reason: str) -> None:
+        self.persona = persona
+        self.rate = rate
+        self.samples = samples
+        #: Replacing a persona changes how the organism reasons — the same
+        #: tier a code mutation gets, for the same reason.
+        self.risk_tier = "approval_required"
+        self.reason = reason
+
+    def gate_payload(self) -> Dict[str, Any]:
+        """What the Iron Gate shows the operator.
+
+        States the EVIDENCE, not a verdict: an operator asked to approve a
+        rotation needs the record that prompted it, or they are approving the
+        system's opinion of itself.
+        """
+        return {
+            "kind": "persona_rotation",
+            "persona": self.persona,
+            "risk_tier": self.risk_tier,
+            "text": (f"rotate {self.persona}? "
+                     f"{round(self.rate * 100)}% of their last "
+                     f"{self.samples} calls landed"),
+            "reason": self.reason,
+        }
+
+
+class PersonaGovernor:
+    """Turns ledger findings into actions. Owns no personas of its own."""
+
+    def __init__(self, ledger: Optional[Any] = None,
+                 clock: Optional[Any] = None) -> None:
+        self._ledger = ledger
+        self._clock = clock or time.monotonic
+        self._lock = threading.RLock()
+        #: None until the first injection. Initialising to 0.0 would compare
+        #: against `time.monotonic()` — PROCESS UPTIME — so a fresh daemon
+        #: would suppress every injection for the first cooldown window,
+        #: silently disabling the defence exactly when a session starts.
+        self._last_injection: Optional[float] = None
+        self.injections = 0
+        self.rotations_requested = 0
+
+    def _get_ledger(self) -> Any:
+        if self._ledger is not None:
+            return self._ledger
+        from backend.core.ouroboros.governance.persona_ledger import (
+            get_persona_ledger,
+        )
+        return get_persona_ledger()
+
+    # -- contrarian injection ---------------------------------------------
+
+    def contrarian_for(
+        self, roster: Sequence[str],
+    ) -> Optional[ContrarianDirective]:
+        """A reviewer to inject, or None. NEVER raises.
+
+        *roster* is the personas actually available — passed in rather than
+        discovered, so the choice can be tested and so this cannot route to
+        someone the caller has no way to run.
+        """
+        try:
+            if not governor_enabled():
+                return None
+            with self._lock:
+                last = self._last_injection
+                if last is not None and (
+                    self._clock() - last
+                ) < contrarian_cooldown_s():
+                    return None
+
+            risks = self._get_ledger().echo_chamber_risk()
+            if not risks:
+                return None
+            a, b, reading = risks[0]
+
+            # From OUTSIDE the consensus. Asking a member of the agreeing
+            # pair to argue against itself is the same opinion in a costume.
+            outsiders = [p for p in roster if p and p not in (a, b)]
+            if not outsiders:
+                logger.debug(
+                    "[PersonaGovernor] echo risk %s/%s but no outsider to "
+                    "inject — reporting nothing rather than pretending", a, b,
+                )
+                return None
+
+            # The best-calibrated outsider: the defence is only as useful as
+            # the judgement of whoever it hands the argument to.
+            ledger = self._get_ledger()
+            outsiders.sort(key=lambda p: -ledger.calibration(p).rate)
+            with self._lock:
+                self._last_injection = self._clock()
+                self.injections += 1
+            return ContrarianDirective(
+                persona=outsiders[0],
+                directive=_CONTRARIAN_DIRECTIVE.format(rate=reading.pct),
+                because=f"{a} and {b} agreed on {reading.pct} of "
+                        f"{reading.samples} recent calls",
+                pair=(a, b),
+            )
+        except Exception:  # noqa: BLE001 — a defence must not break REVIEW
+            logger.debug("[PersonaGovernor] contrarian degraded", exc_info=True)
+            return None
+
+    # -- rotation ----------------------------------------------------------
+
+    def rotation_requests(
+        self, roster: Sequence[str],
+    ) -> List[RotationRequest]:
+        """Rotations to ASK about. Never performs one. NEVER raises.
+
+        Bounded by `min_room_size`: a defence that can remove its own last
+        skeptic has removed the thing being defended.
+        """
+        try:
+            if not governor_enabled():
+                return []
+            candidates = self._get_ledger().rotation_candidates()
+            if not candidates:
+                return []
+            present = [p for p in roster if p]
+            room = len(present)
+            out: List[RotationRequest] = []
+            for who, reading in candidates:
+                if who not in present:
+                    continue
+                if room - len(out) - 1 < min_room_size():
+                    logger.debug(
+                        "[PersonaGovernor] withholding rotation of %s — the "
+                        "room would fall below %d", who, min_room_size(),
+                    )
+                    break
+                out.append(RotationRequest(
+                    persona=who, rate=reading.rate, samples=reading.samples,
+                    reason=(f"{round(reading.rate * 100)}% of their last "
+                            f"{reading.samples} positions survived VERIFY"),
+                ))
+            self.rotations_requested += len(out)
+            return out
+        except Exception:  # noqa: BLE001
+            logger.debug("[PersonaGovernor] rotation degraded", exc_info=True)
+            return []
+
+
+_GOVERNOR: Optional[PersonaGovernor] = None
+_GOVERNOR_LOCK = threading.Lock()
+
+
+def get_persona_governor() -> PersonaGovernor:
+    global _GOVERNOR
+    with _GOVERNOR_LOCK:
+        if _GOVERNOR is None:
+            _GOVERNOR = PersonaGovernor()
+        return _GOVERNOR
+
+
+def reset_governor_for_tests() -> None:
+    global _GOVERNOR
+    with _GOVERNOR_LOCK:
+        _GOVERNOR = None

--- a/tests/governance/test_persona_governor.py
+++ b/tests/governance/test_persona_governor.py
@@ -1,0 +1,175 @@
+"""Acting on standing — injecting a contrarian, and ASKING to rotate.
+
+`persona_ledger` derives and decides nothing. This is the half that acts, and
+the split matters: deriving is arithmetic over recorded outcomes, while
+injecting a reviewer or replacing a persona changes how the organism reasons.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from backend.core.ouroboros.governance.persona_governor import (
+    PersonaGovernor, contrarian_cooldown_s, min_room_size,
+)
+from backend.core.ouroboros.governance.persona_ledger import (
+    FOR, PersonaLedger, sample_floor,
+)
+
+_ROOM = ["@yes-man", "@me-too", "@cassandra", "@the-pit"]
+
+
+def _echo_room() -> PersonaLedger:
+    """Two who always agree and are usually wrong; one skeptic who lands."""
+    ledger = PersonaLedger()
+    for i in range(sample_floor() + 4):
+        ledger.note_position(f"op-{i}", "@yes-man", FOR)
+        ledger.note_position(f"op-{i}", "@me-too", FOR)
+        ledger.settle(f"op-{i}", verified=(i % 5 == 0))
+    for i in range(sample_floor() + 4):
+        ledger.note_position(f"s-{i}", "@cassandra", FOR)
+        ledger.settle(f"s-{i}", verified=True)
+    return ledger
+
+
+def _gov(ledger=None, clock=None):
+    return PersonaGovernor(ledger=ledger or _echo_room(), clock=clock)
+
+
+# --------------------------------------------------------------------------
+# contrarian injection
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_unchallenged_consensus_injects_a_contrarian() -> None:
+    directive = _gov().contrarian_for(_ROOM)
+    assert directive is not None
+    assert "agreed on 100%" in directive.because
+    assert "ATTACK" in directive.directive
+
+
+def test_the_contrarian_comes_from_OUTSIDE_the_consensus() -> None:
+    """Asking a member of the agreeing pair to argue against itself is not a
+    second opinion; it is the same opinion wearing a costume."""
+    directive = _gov().contrarian_for(_ROOM)
+    assert directive.persona not in ("@yes-man", "@me-too")
+
+
+def test_the_best_CALIBRATED_outsider_is_chosen() -> None:
+    """The defence is only as useful as the judgement of whoever it hands the
+    argument to."""
+    assert _gov().contrarian_for(_ROOM).persona == "@cassandra"
+
+
+def test_with_no_outsider_it_reports_nothing_rather_than_pretending() -> None:
+    assert _gov().contrarian_for(["@yes-man", "@me-too"]) is None
+
+
+def test_the_directive_is_FIXED_not_generated() -> None:
+    """Paying a model to invent disagreement produces theatre, and theatre is
+    what an echo chamber already has."""
+    import inspect
+
+    from backend.core.ouroboros.governance import persona_governor
+
+    src = inspect.getsource(persona_governor)
+    assert "_CONTRARIAN_DIRECTIVE" in src
+    for banned in ("await ", "acompletion", "generate("):
+        assert banned not in inspect.getsource(
+            persona_governor.PersonaGovernor.contrarian_for,
+        )
+
+
+def test_the_directive_forbids_a_manufactured_objection() -> None:
+    """"I could not find one" must be an allowed answer, or the contrarian
+    learns to invent — and an invented objection teaches the operator to
+    ignore the one that matters."""
+    assert "cannot find one" in _gov().contrarian_for(_ROOM).directive
+
+
+# --------------------------------------------------------------------------
+# the cooldown
+# --------------------------------------------------------------------------
+
+def test_a_cooldown_damps_repeat_injections() -> None:
+    """A contrarian review costs a model call; an undamped defence turns a
+    measurement into a bill."""
+    clock = {"t": 1000.0}
+    gov = _gov(clock=lambda: clock["t"])
+    assert gov.contrarian_for(_ROOM) is not None
+    assert gov.contrarian_for(_ROOM) is None
+    clock["t"] += contrarian_cooldown_s() + 1
+    assert gov.contrarian_for(_ROOM) is not None
+
+
+def test_the_FIRST_injection_is_never_blocked_by_process_uptime() -> None:
+    """`time.monotonic()` is uptime, so an epoch-zero `_last_injection` would
+    suppress every injection for the first cooldown window — silently
+    disabling the defence exactly when a session starts."""
+    gov = _gov(clock=lambda: 5.0)
+    assert gov.contrarian_for(_ROOM) is not None
+
+
+# --------------------------------------------------------------------------
+# rotation is REQUESTED, never taken
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_low_calibration_requests_a_gate_without_blocking() -> None:
+    async def _derive():
+        return _gov().rotation_requests(_ROOM)
+
+    requests = await asyncio.wait_for(_derive(), timeout=1.0)
+    assert requests
+    payload = requests[0].gate_payload()
+    assert payload["risk_tier"] == "approval_required"
+    assert payload["kind"] == "persona_rotation"
+
+
+def test_the_gate_payload_carries_EVIDENCE_not_a_verdict() -> None:
+    """An operator asked to approve a rotation needs the record that prompted
+    it, or they are approving the system's opinion of itself."""
+    payload = _gov().rotation_requests(_ROOM)[0].gate_payload()
+    assert "landed" in payload["text"]
+    assert "survived VERIFY" in payload["reason"]
+
+
+def test_a_disagreeable_persona_who_is_RIGHT_is_never_proposed() -> None:
+    proposed = [r.persona for r in _gov().rotation_requests(_ROOM)]
+    assert "@cassandra" not in proposed
+
+
+def test_it_never_proposes_emptying_the_room() -> None:
+    """A defence that can remove its own last skeptic has removed the thing
+    being defended."""
+    small = ["@yes-man", "@me-too", "@cassandra"]
+    assert len(small) - len(_gov().rotation_requests(small)) >= min_room_size()
+
+
+def test_a_persona_not_in_the_room_is_not_proposed() -> None:
+    assert _gov().rotation_requests(["@cassandra", "@the-pit", "@x"]) == []
+
+
+# --------------------------------------------------------------------------
+# robustness
+# --------------------------------------------------------------------------
+
+def test_an_empty_ledger_acts_on_nothing() -> None:
+    gov = PersonaGovernor(ledger=PersonaLedger())
+    assert gov.contrarian_for(_ROOM) is None
+    assert gov.rotation_requests(_ROOM) == []
+
+
+@pytest.mark.parametrize("roster", [[], [""], None])
+def test_a_degenerate_roster_never_raises(roster) -> None:
+    gov = _gov()
+    assert gov.contrarian_for(roster or []) is None
+    assert gov.rotation_requests(roster or []) == []
+
+
+def test_the_kill_switch(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JARVIS_PERSONA_GOVERNOR_ENABLED", "0")
+    gov = _gov()
+    assert gov.contrarian_for(_ROOM) is None
+    assert gov.rotation_requests(_ROOM) == []


### PR DESCRIPTION
`persona_ledger` derives and decides nothing. This acts — and the split matters: deriving is arithmetic over recorded outcomes, while injecting a reviewer or replacing a persona changes how the organism *reasons*.

```
contrarian -> @cassandra
  because  : @me-too and @yes-man agreed on 100% of 12 recent calls
rotation   : rotate @yes-man? 25% of their last 12 calls landed | approval_required
no outsider     -> None          ← reports it cannot help
room floor holds-> []            ← won't empty the room
```

## Contrarian injection

**No tokens are spent manufacturing this.** The directive is fixed text and the reviewer comes from the configured roster — the defence is a *routing* decision, not a generated performance. Paying a model to invent disagreement produces theatre, and theatre is what an echo chamber already has.

**Who is chosen matters more than that someone is.** A member of the agreeing pair arguing against itself is the same opinion in a costume, so the reviewer comes from *outside* the consensus. When nobody does, it reports that it cannot help rather than pretending. Among outsiders it picks the best-**calibrated** — the defence is only as useful as the judgement of whoever it hands the argument to.

The directive explicitly permits *"I could not find one."* Without that the contrarian learns to invent, and a manufactured objection is worse than none: it teaches you to ignore the one that matters.

## Rotation is requested, never taken

Replacing a persona changes the population the organism reasons with — consequential and hard to reverse — so it emits an `APPROVAL_REQUIRED` payload carrying **evidence** rather than a verdict. An operator asked to approve a rotation needs the record that prompted it, or they're approving the system's opinion of itself.

Keyed on calibration alone, bounded by `min_room_size`: **a defence that can remove its own last skeptic has removed the thing being defended.**

## One production bug found by running it

`_last_injection` initialised to `0.0` compares against `time.monotonic()` — **process uptime**. A fresh daemon would suppress every injection for the first cooldown window, silently disabling the defence exactly when a session starts. Now None-until-first-use, and pinned by a test.

The cooldown itself exists because a contrarian review costs a model call — an undamped defence turns a measurement into a bill — and it gives the injected disagreement time to move the number it's responding to.

## Verification

36 tests across both halves, including the mandate's two: concordance above threshold trips the defence, and low calibration yields a gate request through a path that awaits nothing.

**Not wired**, stated rather than implied: the orchestrator calling `contrarian_for` at REVIEW dispatch and `rotation_requests` at the gate seam, plus the TUI chips. This is the decision layer, complete and provable on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `PersonaGovernor` to act on `persona_ledger` findings by injecting a contrarian reviewer and requesting persona rotations with operator approval. This reduces echo-chamber risk without auto-removing personas.

- **New Features**
  - Contrarian injection: routes the next review to the best-calibrated outsider from the given roster with a fixed “attack” directive (allows “cannot find one”); respects a cooldown and returns nothing if no outsider exists.
  - Rotation requests: proposes replacements for low-calibration personas via an `approval_required` gate payload that carries evidence; never drops below `min_room_size` or suggests personas not in the room.
  - Controls and safety: kill switch via env (`JARVIS_PERSONA_GOVERNOR_ENABLED`), configurable cooldown (`JARVIS_CONTRARIAN_COOLDOWN_S`), and room-size bound (`JARVIS_PERSONA_MIN_ROOM`); never raises and degrades to no-ops.

- **Bug Fixes**
  - Fixed startup suppression: `_last_injection` now starts as `None` (not `0.0`) so the first session isn’t blocked by process uptime.

<sup>Written for commit 92e8465fab2ece063da98b5a265fbd3824db5a11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

