### PR TITLE
feat(ov): the arbiter's decision, made into containers

### DIFF
--- a/backend/core/ouroboros/battle_test/region_layout.py
+++ b/backend/core/ouroboros/battle_test/region_layout.py
@@ -1,0 +1,222 @@
+"""The arbiter's decision, made into containers.
+
+`viewport_arbiter` answers "which regions fit this terminal, and how" and
+holds no widgets on purpose — the whole value of that separation is being
+provable at every width without a terminal. This is the other side: the
+prompt_toolkit consumer that turns those placements into a real container
+tree.
+
+Why this could not be a port
+-----------------------------
+`split_layout` already renders three regions — in **Rich**. A `rich.Layout`
+cannot mount inside a `prompt_toolkit.Application`; they are different
+rendering models with different ownership of the screen. So the cockpit's
+three-region surface was never "wiring up dead code", and calling it that
+was wrong: the Rich implementation belongs to SerpentFlow's own console and
+stays there. `LayoutController` — the mode FSM — IS toolkit-agnostic and is
+reused unchanged.
+
+The layout is a FUNCTION, not a structure
+------------------------------------------
+prompt_toolkit builds a container tree once, at Application construction.
+The arbiter's answer changes with every resize. Rebuilding the tree and
+reassigning `app.layout.container` on each SIGWINCH is the obvious bridge and
+it is wrong twice over: it discards focus and scroll state that live on the
+widgets, and it races the renderer, which may be midway through a frame that
+references the tree being replaced.
+
+`DynamicContainer` resolves it properly — it calls a factory on every render,
+so the tree is derived rather than mutated. Width flows in, containers flow
+out, and nothing is reassigned. A resize changes what the next frame draws
+and touches nothing that a frame in flight is holding.
+
+Floats over splits
+------------------
+A FLOAT placement draws over the deck rather than beside it, using the same
+`FloatContainer` the `/` palette established. One Z-index architecture: a
+second overlay mechanism would eventually disagree with the first about what
+draws on top, and the operator would meet that disagreement as a menu
+rendered underneath a panel.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Callable, Dict, List, Optional, Sequence
+
+logger = logging.getLogger("Ouroboros.RegionLayout")
+
+__all__ = ["build_region_tree", "region_layout_enabled", "RegionSources"]
+
+
+def region_layout_enabled() -> bool:
+    """Default ON. Off, the cockpit keeps its single-canvas layout."""
+    return os.environ.get(
+        "JARVIS_REGION_LAYOUT_ENABLED", "1",
+    ).strip().lower() not in ("0", "false", "no", "off")
+
+
+class RegionSources:
+    """Where each region's content comes from.
+
+    Callables, not containers: a region that is HIDDEN this frame must cost
+    nothing, and building its widget anyway would defeat the arbiter's whole
+    purpose of not drawing what does not fit.
+    """
+
+    def __init__(self, **factories: Callable[[], Any]) -> None:
+        self._factories: Dict[str, Callable[[], Any]] = dict(factories)
+
+    def get(self, region: str) -> Optional[Any]:
+        """Build one region's container, or None. NEVER raises.
+
+        A region whose factory fails is DROPPED rather than allowed to
+        propagate: one broken panel must not take the cockpit down with it,
+        and the arbiter has already guaranteed the deck survives.
+        """
+        try:
+            factory = self._factories.get(str(region))
+            return factory() if factory is not None else None
+        except Exception:  # noqa: BLE001
+            logger.debug("[RegionLayout] region %r failed to build", region,
+                         exc_info=True)
+            return None
+
+    @property
+    def names(self) -> List[str]:
+        return list(self._factories)
+
+
+def _dimension(cols: int) -> Any:
+    """Exact width for a split column.
+
+    EXACT, for the reason the prompt learned the hard way: a ranged dimension
+    advertises willingness to absorb slack, and `VSplit` distributes leftover
+    by weight to whichever child will take it. The arbiter already decided
+    these widths; a range would let the layout quietly overrule it.
+    """
+    from prompt_toolkit.layout.dimension import Dimension
+    return Dimension.exact(max(1, int(cols)))
+
+
+def build_region_tree(
+    placements: Sequence[Any],
+    sources: RegionSources,
+    *,
+    prompt: Optional[Any] = None,
+    extra_floats: Optional[Sequence[Any]] = None,
+) -> Any:
+    """One frame's container tree. NEVER raises.
+
+    Called from a `DynamicContainer` factory, so it runs on every render and
+    must stay cheap and total: an exception here is a blank cockpit, and a
+    slow path here is a slow cockpit.
+    """
+    try:
+        from prompt_toolkit.layout.containers import (
+            Float, FloatContainer, HSplit, VSplit, Window,
+        )
+
+        columns: List[Any] = []
+        floats: List[Any] = list(extra_floats or ())
+
+        for placement in placements or ():
+            kind = getattr(placement, "placement", "")
+            region = getattr(placement, "region", "")
+            if kind == "hidden":
+                continue
+            content = sources.get(region)
+            if content is None:
+                continue
+            if kind == "float":
+                # Over the deck, using the SAME FloatContainer the palette
+                # established. A second overlay mechanism would eventually
+                # disagree with the first about what draws on top.
+                floats.append(Float(
+                    content=content, top=1, right=2,
+                    width=_dimension(getattr(placement, "cols", 0) or 40),
+                ))
+                continue
+            # Width is applied by WRAPPING rather than set on the child, so a
+            # caller's container keeps whatever internal layout it has.
+            columns.append(_sized(content, getattr(placement, "cols", 0)))
+
+        if not columns:
+            # The arbiter guarantees the deck is never demoted below FLOAT,
+            # so an empty column list means every region floated. Something
+            # still has to own the screen underneath them.
+            columns = [Window()]
+
+        body: Any = columns[0] if len(columns) == 1 else VSplit(
+            columns, padding=1, padding_char="│",
+        )
+        rows: List[Any] = [body]
+        if prompt is not None:
+            rows.append(prompt)
+        root: Any = HSplit(rows)
+        if floats:
+            root = FloatContainer(content=root, floats=floats)
+        return root
+    except Exception:  # noqa: BLE001 — a render must never raise
+        logger.debug("[RegionLayout] build degraded", exc_info=True)
+        from prompt_toolkit.layout.containers import Window
+        return Window()
+
+
+def _sized(container: Any, cols: int) -> Any:
+    """Pin a column's width without disturbing its internals."""
+    try:
+        from prompt_toolkit.layout.containers import VSplit
+        if not cols:
+            return container
+        return VSplit([container], width=_dimension(cols))
+    except Exception:  # noqa: BLE001
+        return container
+
+
+def dynamic_region_container(
+    arbiter: Any,
+    sources: RegionSources,
+    *,
+    prompt: Optional[Any] = None,
+    size: Optional[Callable[[], Any]] = None,
+) -> Any:
+    """A container that re-derives its tree on every render. NEVER raises.
+
+    This is the seam that makes the whole design work. prompt_toolkit builds
+    a tree once; the arbiter's answer changes with every resize. Rebuilding
+    and reassigning `app.layout.container` would discard focus and scroll
+    state living on the widgets, and would race a renderer that may be midway
+    through a frame referencing the tree being replaced.
+
+    A factory has neither problem: width flows in, containers flow out, and
+    nothing is mutated.
+    """
+    from prompt_toolkit.layout.containers import DynamicContainer
+
+    def _current_size() -> Any:
+        if size is not None:
+            return size()
+        from prompt_toolkit.application.current import get_app
+        return get_app().output.get_size()
+
+    def _factory() -> Any:
+        try:
+            if not region_layout_enabled():
+                return sources.get("deck") or _blank()
+            dims = _current_size()
+            cols = int(getattr(dims, "columns", 0) or 0)
+            rows = int(getattr(dims, "rows", 0) or 0)
+            return build_region_tree(
+                arbiter.arbitrate(cols, rows), sources, prompt=prompt,
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug("[RegionLayout] factory degraded", exc_info=True)
+            return sources.get("deck") or _blank()
+
+    return DynamicContainer(_factory)
+
+
+def _blank() -> Any:
+    from prompt_toolkit.layout.containers import Window
+    return Window()

--- a/backend/core/ouroboros/governance/persona_governor.py
+++ b/backend/core/ouroboros/governance/persona_governor.py
@@ -1,0 +1,290 @@
+"""Acting on standing — contrarian injection, and asking to rotate.
+
+`persona_ledger` derives who was right and who agrees with whom, and
+deliberately decides nothing. This is the half that acts, and the split
+matters: deriving is arithmetic over recorded outcomes, while injecting a
+reviewer or replacing a persona changes how the organism reasons. Those are
+different kinds of act and belong behind different guarantees.
+
+Contrarian injection
+--------------------
+When a pair's concordance says their agreement has stopped carrying
+information, the next REVIEW is routed to a persona who was NOT part of that
+consensus, carrying a directive to attack the candidate rather than assess
+it.
+
+No tokens are spent manufacturing this. The directive is a fixed instruction
+and the reviewer is chosen from personas already configured — the defence is
+a routing decision, not a generated performance. Paying a model to invent
+disagreement would produce theatre, and theatre is what an echo chamber
+already has.
+
+Who gets chosen matters more than that someone does. Picking a member of the
+agreeing pair to argue against itself is not a second opinion; it is the same
+opinion wearing a costume. The reviewer must come from outside the consensus,
+and if nobody does, the defence reports that it cannot help rather than
+pretending.
+
+Rotation is REQUESTED, never taken
+-----------------------------------
+Replacing a persona changes the population the organism reasons with. That is
+a consequential, hard-to-reverse act on the system's own judgement, so it
+goes through the gate at `APPROVAL_REQUIRED` like any other — the same reason
+`Shift+Tab` can only tighten and workspace promotion defaults off.
+
+The request keys on CALIBRATION alone. Rotating on chemistry selects for
+agreement and converges the room on the echo chamber this module exists to
+prevent: the persona who disagrees constantly and is right most of the time
+is the most valuable one here, and a concordance-based cull removes her
+first.
+
+And it never proposes emptying the room. A defence that can remove its own
+last skeptic has removed the thing being defended.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+logger = logging.getLogger("Ouroboros.PersonaGovernor")
+
+__all__ = [
+    "ContrarianDirective", "RotationRequest", "PersonaGovernor",
+    "governor_enabled", "contrarian_cooldown_s", "min_room_size",
+]
+
+#: The directive handed to an injected reviewer. FIXED text, not generated:
+#: paying a model to invent disagreement produces theatre, and theatre is
+#: what an echo chamber already has.
+_CONTRARIAN_DIRECTIVE = (
+    "The reviewers on this op have agreed with each other on {rate} of recent "
+    "candidates, so their concurrence no longer carries information. Your job "
+    "is to ATTACK this candidate, not to assess it. Find the strongest "
+    "concrete objection: a case it breaks, an assumption it makes silently, a "
+    "path it does not cover. If after genuine effort you cannot find one, say "
+    "so plainly — a manufactured objection is worse than none, because it "
+    "teaches the operator to ignore you."
+)
+
+
+def governor_enabled() -> bool:
+    """Default ON. Off, findings are derived but never acted on."""
+    return os.environ.get(
+        "JARVIS_PERSONA_GOVERNOR_ENABLED", "1",
+    ).strip().lower() not in ("0", "false", "no", "off")
+
+
+def contrarian_cooldown_s() -> float:
+    """Minimum gap between injections.
+
+    Without it the defence fires on every op while concordance stays high —
+    and since a contrarian review costs a model call, an undamped defence
+    turns a measurement into a bill. It also gives the injected disagreement
+    time to move the number it is responding to.
+    """
+    try:
+        return max(0.0, float(
+            os.environ.get("JARVIS_CONTRARIAN_COOLDOWN_S", "") or 600.0,
+        ))
+    except (TypeError, ValueError):
+        return 600.0
+
+
+def min_room_size() -> int:
+    """Personas that must remain after a rotation.
+
+    A defence that can remove its own last skeptic has removed the thing
+    being defended.
+    """
+    try:
+        return max(2, int(os.environ.get("JARVIS_PERSONA_MIN_ROOM", "") or 3))
+    except (TypeError, ValueError):
+        return 3
+
+
+class ContrarianDirective:
+    """Route the next REVIEW to *persona* with an attacking brief."""
+
+    __slots__ = ("persona", "directive", "because", "pair")
+
+    def __init__(self, persona: str, directive: str, because: str,
+                 pair: Tuple[str, str]) -> None:
+        self.persona = persona
+        self.directive = directive
+        self.because = because
+        self.pair = pair
+
+    def __repr__(self) -> str:  # pragma: no cover — diagnostics only
+        return f"<Contrarian {self.persona} because {self.because!r}>"
+
+
+class RotationRequest:
+    """A REQUEST to replace a persona. Carries evidence, not authority."""
+
+    __slots__ = ("persona", "rate", "samples", "risk_tier", "reason")
+
+    def __init__(self, persona: str, rate: float, samples: int,
+                 reason: str) -> None:
+        self.persona = persona
+        self.rate = rate
+        self.samples = samples
+        #: Replacing a persona changes how the organism reasons — the same
+        #: tier a code mutation gets, for the same reason.
+        self.risk_tier = "approval_required"
+        self.reason = reason
+
+    def gate_payload(self) -> Dict[str, Any]:
+        """What the Iron Gate shows the operator.
+
+        States the EVIDENCE, not a verdict: an operator asked to approve a
+        rotation needs the record that prompted it, or they are approving the
+        system's opinion of itself.
+        """
+        return {
+            "kind": "persona_rotation",
+            "persona": self.persona,
+            "risk_tier": self.risk_tier,
+            "text": (f"rotate {self.persona}? "
+                     f"{round(self.rate * 100)}% of their last "
+                     f"{self.samples} calls landed"),
+            "reason": self.reason,
+        }
+
+
+class PersonaGovernor:
+    """Turns ledger findings into actions. Owns no personas of its own."""
+
+    def __init__(self, ledger: Optional[Any] = None,
+                 clock: Optional[Any] = None) -> None:
+        self._ledger = ledger
+        self._clock = clock or time.monotonic
+        self._lock = threading.RLock()
+        #: None until the first injection. Initialising to 0.0 would compare
+        #: against `time.monotonic()` — PROCESS UPTIME — so a fresh daemon
+        #: would suppress every injection for the first cooldown window,
+        #: silently disabling the defence exactly when a session starts.
+        self._last_injection: Optional[float] = None
+        self.injections = 0
+        self.rotations_requested = 0
+
+    def _get_ledger(self) -> Any:
+        if self._ledger is not None:
+            return self._ledger
+        from backend.core.ouroboros.governance.persona_ledger import (
+            get_persona_ledger,
+        )
+        return get_persona_ledger()
+
+    # -- contrarian injection ---------------------------------------------
+
+    def contrarian_for(
+        self, roster: Sequence[str],
+    ) -> Optional[ContrarianDirective]:
+        """A reviewer to inject, or None. NEVER raises.
+
+        *roster* is the personas actually available — passed in rather than
+        discovered, so the choice can be tested and so this cannot route to
+        someone the caller has no way to run.
+        """
+        try:
+            if not governor_enabled():
+                return None
+            with self._lock:
+                last = self._last_injection
+                if last is not None and (
+                    self._clock() - last
+                ) < contrarian_cooldown_s():
+                    return None
+
+            risks = self._get_ledger().echo_chamber_risk()
+            if not risks:
+                return None
+            a, b, reading = risks[0]
+
+            # From OUTSIDE the consensus. Asking a member of the agreeing
+            # pair to argue against itself is the same opinion in a costume.
+            outsiders = [p for p in roster if p and p not in (a, b)]
+            if not outsiders:
+                logger.debug(
+                    "[PersonaGovernor] echo risk %s/%s but no outsider to "
+                    "inject — reporting nothing rather than pretending", a, b,
+                )
+                return None
+
+            # The best-calibrated outsider: the defence is only as useful as
+            # the judgement of whoever it hands the argument to.
+            ledger = self._get_ledger()
+            outsiders.sort(key=lambda p: -ledger.calibration(p).rate)
+            with self._lock:
+                self._last_injection = self._clock()
+                self.injections += 1
+            return ContrarianDirective(
+                persona=outsiders[0],
+                directive=_CONTRARIAN_DIRECTIVE.format(rate=reading.pct),
+                because=f"{a} and {b} agreed on {reading.pct} of "
+                        f"{reading.samples} recent calls",
+                pair=(a, b),
+            )
+        except Exception:  # noqa: BLE001 — a defence must not break REVIEW
+            logger.debug("[PersonaGovernor] contrarian degraded", exc_info=True)
+            return None
+
+    # -- rotation ----------------------------------------------------------
+
+    def rotation_requests(
+        self, roster: Sequence[str],
+    ) -> List[RotationRequest]:
+        """Rotations to ASK about. Never performs one. NEVER raises.
+
+        Bounded by `min_room_size`: a defence that can remove its own last
+        skeptic has removed the thing being defended.
+        """
+        try:
+            if not governor_enabled():
+                return []
+            candidates = self._get_ledger().rotation_candidates()
+            if not candidates:
+                return []
+            present = [p for p in roster if p]
+            room = len(present)
+            out: List[RotationRequest] = []
+            for who, reading in candidates:
+                if who not in present:
+                    continue
+                if room - len(out) - 1 < min_room_size():
+                    logger.debug(
+                        "[PersonaGovernor] withholding rotation of %s — the "
+                        "room would fall below %d", who, min_room_size(),
+                    )
+                    break
+                out.append(RotationRequest(
+                    persona=who, rate=reading.rate, samples=reading.samples,
+                    reason=(f"{round(reading.rate * 100)}% of their last "
+                            f"{reading.samples} positions survived VERIFY"),
+                ))
+            self.rotations_requested += len(out)
+            return out
+        except Exception:  # noqa: BLE001
+            logger.debug("[PersonaGovernor] rotation degraded", exc_info=True)
+            return []
+
+
+_GOVERNOR: Optional[PersonaGovernor] = None
+_GOVERNOR_LOCK = threading.Lock()
+
+
+def get_persona_governor() -> PersonaGovernor:
+    global _GOVERNOR
+    with _GOVERNOR_LOCK:
+        if _GOVERNOR is None:
+            _GOVERNOR = PersonaGovernor()
+        return _GOVERNOR
+
+
+def reset_governor_for_tests() -> None:
+    global _GOVERNOR
+    with _GOVERNOR_LOCK:
+        _GOVERNOR = None

--- a/tests/battle_test/test_region_layout.py
+++ b/tests/battle_test/test_region_layout.py
@@ -1,0 +1,196 @@
+"""The arbiter's decision, made into containers.
+
+`viewport_arbiter` answers "which regions fit, and how" and holds no widgets
+on purpose. This is the prompt_toolkit consumer that was missing — the reason
+`/layout`, transcript mode and lanes all waited on the same thing.
+
+Not a port. `split_layout` renders three regions in RICH, and a `rich.Layout`
+cannot mount inside a `prompt_toolkit.Application`. Calling it dead code was
+wrong; it belongs to SerpentFlow's own console and stays there.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.battle_test.region_layout import (
+    RegionSources, build_region_tree, dynamic_region_container,
+    region_layout_enabled,
+)
+from backend.core.ouroboros.battle_test.viewport_arbiter import (
+    ViewportArbiter,
+)
+
+
+def _win(label: str = "x"):
+    from prompt_toolkit.layout.containers import Window
+    from prompt_toolkit.layout.controls import FormattedTextControl
+    return lambda: Window(FormattedTextControl(label))
+
+
+def _sources() -> RegionSources:
+    return RegionSources(deck=_win("DECK"), lanes=_win("LANES"),
+                         transcript=_win("TRANSCRIPT"))
+
+
+def _arbiter() -> ViewportArbiter:
+    arbiter = ViewportArbiter()
+    arbiter.request("lanes", True)
+    arbiter.request("transcript", True)
+    return arbiter
+
+
+def _size(cols: int, rows: int = 40):
+    return lambda: type("S", (), {"columns": cols, "rows": rows})
+
+
+# --------------------------------------------------------------------------
+# the tree follows the arbiter
+# --------------------------------------------------------------------------
+
+def test_a_wide_terminal_builds_three_columns() -> None:
+    from prompt_toolkit.layout.containers import HSplit
+
+    tree = build_region_tree(_arbiter().arbitrate(200, 40), _sources())
+    assert isinstance(tree, HSplit)
+
+
+def test_a_narrow_terminal_floats_instead_of_splitting() -> None:
+    """A FLOAT draws OVER the deck rather than beside it — the same
+    FloatContainer the `/` palette established."""
+    from prompt_toolkit.layout.containers import FloatContainer
+
+    tree = build_region_tree(_arbiter().arbitrate(80, 40), _sources())
+    assert isinstance(tree, FloatContainer)
+    assert tree.floats
+
+
+def test_hidden_regions_are_never_built() -> None:
+    """A region that does not fit must cost nothing — building its widget
+    anyway defeats the arbiter's entire purpose."""
+    built = []
+
+    def _tracking(label: str):
+        def _factory():
+            built.append(label)
+            return _win(label)()
+        return _factory
+
+    sources = RegionSources(deck=_tracking("deck"), lanes=_tracking("lanes"),
+                            transcript=_tracking("transcript"))
+    build_region_tree(_arbiter().arbitrate(20, 40), sources)
+    assert "transcript" not in built
+
+
+def test_the_prompt_is_appended_below_the_body() -> None:
+    from prompt_toolkit.layout.containers import HSplit
+
+    tree = build_region_tree(_arbiter().arbitrate(200, 40), _sources(),
+                             prompt=_win("PROMPT")())
+    assert isinstance(tree, HSplit)
+    assert len(tree.children) == 2
+
+
+# --------------------------------------------------------------------------
+# the layout is a FUNCTION, not a structure
+# --------------------------------------------------------------------------
+
+def test_a_resize_re_derives_rather_than_mutates() -> None:
+    """THE design point. Rebuilding and reassigning `app.layout.container` on
+    SIGWINCH discards focus and scroll state living on the widgets, and races
+    a renderer that may be midway through a frame referencing the tree being
+    replaced. A factory has neither problem."""
+    from prompt_toolkit.layout.containers import DynamicContainer, FloatContainer, HSplit
+
+    dims = {"cols": 200}
+    container = dynamic_region_container(
+        _arbiter(), _sources(),
+        size=lambda: type("S", (), {"columns": dims["cols"], "rows": 40}),
+    )
+    assert isinstance(container, DynamicContainer)
+
+    wide = container.get_container()
+    dims["cols"] = 40
+    narrow = container.get_container()
+
+    assert isinstance(wide, HSplit)
+    assert isinstance(narrow, FloatContainer)
+    assert wide is not narrow, "the tree was mutated instead of re-derived"
+
+
+def test_the_factory_never_raises_into_the_renderer() -> None:
+    """An exception in a render factory is a blank cockpit."""
+    class _Exploding:
+        def arbitrate(self, *_a, **_k):
+            raise RuntimeError("arbiter died")
+
+    container = dynamic_region_container(_Exploding(), _sources(),
+                                         size=_size(120))
+    assert container.get_container() is not None
+
+
+def test_a_broken_region_is_dropped_not_propagated() -> None:
+    """One broken panel must not take the cockpit down with it."""
+    def _boom():
+        raise RuntimeError("panel died")
+
+    sources = RegionSources(deck=_win("DECK"), lanes=_boom,
+                            transcript=_win("T"))
+    assert build_region_tree(_arbiter().arbitrate(200, 40), sources) is not None
+
+
+# --------------------------------------------------------------------------
+# widths come from the arbiter, not from prompt_toolkit
+# --------------------------------------------------------------------------
+
+def test_column_widths_are_EXACT() -> None:
+    """A ranged dimension advertises willingness to absorb slack, and VSplit
+    hands leftover to whichever child will take it — the prompt learned this
+    the hard way. The arbiter already decided these widths."""
+    from prompt_toolkit.layout.dimension import Dimension
+
+    from backend.core.ouroboros.battle_test.region_layout import _dimension
+
+    dim = _dimension(28)
+    assert dim.min == dim.max == dim.preferred == 28
+
+
+def test_everything_floating_still_leaves_something_underneath() -> None:
+    """The arbiter guarantees the deck is never demoted below FLOAT, but the
+    builder must not assume it — a tree with no body has nothing to draw on."""
+    from backend.core.ouroboros.battle_test.viewport_arbiter import (
+        FLOAT, Placement,
+    )
+
+    tree = build_region_tree(
+        [Placement("deck", FLOAT, 40), Placement("lanes", FLOAT, 28)],
+        _sources(),
+    )
+    assert tree is not None
+
+
+def test_no_regions_at_all_is_survivable() -> None:
+    assert build_region_tree([], _sources()) is not None
+
+
+def test_the_kill_switch(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JARVIS_REGION_LAYOUT_ENABLED", "0")
+    assert region_layout_enabled() is False
+    container = dynamic_region_container(_arbiter(), _sources(),
+                                         size=_size(200))
+    assert container.get_container() is not None
+
+
+def test_it_does_NOT_import_rich() -> None:
+    """`split_layout` is Rich and stays SerpentFlow's. Mixing the two
+    rendering models is what made this a build rather than a port."""
+    import ast
+    from pathlib import Path
+
+    repo = Path(__file__).resolve().parents[2]
+    src = (repo / "backend/core/ouroboros/battle_test/"
+           "region_layout.py").read_text()
+    imported = {
+        (n.module or "") for n in ast.walk(ast.parse(src))
+        if isinstance(n, ast.ImportFrom)
+    }
+    assert not any("rich" in name for name in imported)

--- a/tests/governance/test_persona_governor.py
+++ b/tests/governance/test_persona_governor.py
@@ -1,0 +1,175 @@
+"""Acting on standing — injecting a contrarian, and ASKING to rotate.
+
+`persona_ledger` derives and decides nothing. This is the half that acts, and
+the split matters: deriving is arithmetic over recorded outcomes, while
+injecting a reviewer or replacing a persona changes how the organism reasons.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from backend.core.ouroboros.governance.persona_governor import (
+    PersonaGovernor, contrarian_cooldown_s, min_room_size,
+)
+from backend.core.ouroboros.governance.persona_ledger import (
+    FOR, PersonaLedger, sample_floor,
+)
+
+_ROOM = ["@yes-man", "@me-too", "@cassandra", "@the-pit"]
+
+
+def _echo_room() -> PersonaLedger:
+    """Two who always agree and are usually wrong; one skeptic who lands."""
+    ledger = PersonaLedger()
+    for i in range(sample_floor() + 4):
+        ledger.note_position(f"op-{i}", "@yes-man", FOR)
+        ledger.note_position(f"op-{i}", "@me-too", FOR)
+        ledger.settle(f"op-{i}", verified=(i % 5 == 0))
+    for i in range(sample_floor() + 4):
+        ledger.note_position(f"s-{i}", "@cassandra", FOR)
+        ledger.settle(f"s-{i}", verified=True)
+    return ledger
+
+
+def _gov(ledger=None, clock=None):
+    return PersonaGovernor(ledger=ledger or _echo_room(), clock=clock)
+
+
+# --------------------------------------------------------------------------
+# contrarian injection
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_unchallenged_consensus_injects_a_contrarian() -> None:
+    directive = _gov().contrarian_for(_ROOM)
+    assert directive is not None
+    assert "agreed on 100%" in directive.because
+    assert "ATTACK" in directive.directive
+
+
+def test_the_contrarian_comes_from_OUTSIDE_the_consensus() -> None:
+    """Asking a member of the agreeing pair to argue against itself is not a
+    second opinion; it is the same opinion wearing a costume."""
+    directive = _gov().contrarian_for(_ROOM)
+    assert directive.persona not in ("@yes-man", "@me-too")
+
+
+def test_the_best_CALIBRATED_outsider_is_chosen() -> None:
+    """The defence is only as useful as the judgement of whoever it hands the
+    argument to."""
+    assert _gov().contrarian_for(_ROOM).persona == "@cassandra"
+
+
+def test_with_no_outsider_it_reports_nothing_rather_than_pretending() -> None:
+    assert _gov().contrarian_for(["@yes-man", "@me-too"]) is None
+
+
+def test_the_directive_is_FIXED_not_generated() -> None:
+    """Paying a model to invent disagreement produces theatre, and theatre is
+    what an echo chamber already has."""
+    import inspect
+
+    from backend.core.ouroboros.governance import persona_governor
+
+    src = inspect.getsource(persona_governor)
+    assert "_CONTRARIAN_DIRECTIVE" in src
+    for banned in ("await ", "acompletion", "generate("):
+        assert banned not in inspect.getsource(
+            persona_governor.PersonaGovernor.contrarian_for,
+        )
+
+
+def test_the_directive_forbids_a_manufactured_objection() -> None:
+    """"I could not find one" must be an allowed answer, or the contrarian
+    learns to invent — and an invented objection teaches the operator to
+    ignore the one that matters."""
+    assert "cannot find one" in _gov().contrarian_for(_ROOM).directive
+
+
+# --------------------------------------------------------------------------
+# the cooldown
+# --------------------------------------------------------------------------
+
+def test_a_cooldown_damps_repeat_injections() -> None:
+    """A contrarian review costs a model call; an undamped defence turns a
+    measurement into a bill."""
+    clock = {"t": 1000.0}
+    gov = _gov(clock=lambda: clock["t"])
+    assert gov.contrarian_for(_ROOM) is not None
+    assert gov.contrarian_for(_ROOM) is None
+    clock["t"] += contrarian_cooldown_s() + 1
+    assert gov.contrarian_for(_ROOM) is not None
+
+
+def test_the_FIRST_injection_is_never_blocked_by_process_uptime() -> None:
+    """`time.monotonic()` is uptime, so an epoch-zero `_last_injection` would
+    suppress every injection for the first cooldown window — silently
+    disabling the defence exactly when a session starts."""
+    gov = _gov(clock=lambda: 5.0)
+    assert gov.contrarian_for(_ROOM) is not None
+
+
+# --------------------------------------------------------------------------
+# rotation is REQUESTED, never taken
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_low_calibration_requests_a_gate_without_blocking() -> None:
+    async def _derive():
+        return _gov().rotation_requests(_ROOM)
+
+    requests = await asyncio.wait_for(_derive(), timeout=1.0)
+    assert requests
+    payload = requests[0].gate_payload()
+    assert payload["risk_tier"] == "approval_required"
+    assert payload["kind"] == "persona_rotation"
+
+
+def test_the_gate_payload_carries_EVIDENCE_not_a_verdict() -> None:
+    """An operator asked to approve a rotation needs the record that prompted
+    it, or they are approving the system's opinion of itself."""
+    payload = _gov().rotation_requests(_ROOM)[0].gate_payload()
+    assert "landed" in payload["text"]
+    assert "survived VERIFY" in payload["reason"]
+
+
+def test_a_disagreeable_persona_who_is_RIGHT_is_never_proposed() -> None:
+    proposed = [r.persona for r in _gov().rotation_requests(_ROOM)]
+    assert "@cassandra" not in proposed
+
+
+def test_it_never_proposes_emptying_the_room() -> None:
+    """A defence that can remove its own last skeptic has removed the thing
+    being defended."""
+    small = ["@yes-man", "@me-too", "@cassandra"]
+    assert len(small) - len(_gov().rotation_requests(small)) >= min_room_size()
+
+
+def test_a_persona_not_in_the_room_is_not_proposed() -> None:
+    assert _gov().rotation_requests(["@cassandra", "@the-pit", "@x"]) == []
+
+
+# --------------------------------------------------------------------------
+# robustness
+# --------------------------------------------------------------------------
+
+def test_an_empty_ledger_acts_on_nothing() -> None:
+    gov = PersonaGovernor(ledger=PersonaLedger())
+    assert gov.contrarian_for(_ROOM) is None
+    assert gov.rotation_requests(_ROOM) == []
+
+
+@pytest.mark.parametrize("roster", [[], [""], None])
+def test_a_degenerate_roster_never_raises(roster) -> None:
+    gov = _gov()
+    assert gov.contrarian_for(roster or []) is None
+    assert gov.rotation_requests(roster or []) == []
+
+
+def test_the_kill_switch(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JARVIS_PERSONA_GOVERNOR_ENABLED", "0")
+    gov = _gov()
+    assert gov.contrarian_for(_ROOM) is None
+    assert gov.rotation_requests(_ROOM) == []


### PR DESCRIPTION
`viewport_arbiter` has decided which regions fit a terminal since #70187, and **nothing consumed it**. This is the missing consumer — and it's why `/layout`, transcript mode and lanes were all waiting on the same thing.

## Not a port — I had that wrong

`split_layout` renders three regions in **Rich**, and a `rich.Layout` cannot mount inside a `prompt_toolkit.Application`. Different rendering models, different ownership of the screen.

So the cockpit's three-region surface was never "dead code needing wiring" — the Rich implementation belongs to SerpentFlow's own console and stays there. `LayoutController`, the mode FSM, *is* toolkit-agnostic and is reused unchanged.

## The layout is a function, not a structure

prompt_toolkit builds a container tree **once**, at Application construction. The arbiter's answer changes with **every resize**.

Rebuilding the tree and reassigning `app.layout.container` on SIGWINCH is the obvious bridge, and it's wrong twice: it discards focus and scroll state that live on the widgets, and it races a renderer that may be midway through a frame referencing the tree being replaced.

`DynamicContainer` resolves it properly — a factory called on every render, so the tree is **derived rather than mutated**. Width flows in, containers flow out, nothing is reassigned.

Verified under a real PTY:

```
200c  HSplit          ['split', 'split', 'split']
 80c  FloatContainer  ['split', 'split', 'float']
 40c  FloatContainer  ['split', 'float', 'float']
```

## Three details that matter

**Region content is supplied as callables, not containers.** A hidden region must cost nothing — building its widget anyway defeats the arbiter's entire purpose of not drawing what doesn't fit. A factory that raises has its region dropped: one broken panel must not take the cockpit down, and the arbiter already guarantees the deck survives.

**Column widths are `Dimension.exact`.** A ranged dimension advertises willingness to absorb slack, and `VSplit` hands leftover to whichever child will take it — the prompt learned that in #70175, as an eight-row black slab. The arbiter already decided these widths; a range would let the layout quietly overrule it.

**Floats reuse the palette's `FloatContainer`.** One Z-index architecture — a second overlay mechanism would eventually disagree with the first about what draws on top, and you'd meet that disagreement as a menu rendered *underneath* a panel.

## Verification

12 tests, including that a resize re-derives rather than mutates, that a render factory never raises into the renderer, and that this module imports no Rich.

## Not wired yet, deliberately

`build_bipartite_application` still builds its single-canvas root. Mounting this changes the surface you stare at, and the three features waiting on it — nested task tree, collapse/expand, transcript mode — all mount **through** this seam. It's worth landing the seam correctly and watching it live before hanging three features off it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Builds the `prompt_toolkit` region layout that consumes `viewport_arbiter` and adds a `PersonaGovernor` to inject a contrarian and request persona rotations. This lands the seam and tests; it is not mounted in the cockpit yet.

- **New Features**
  - `region_layout` for `prompt_toolkit`: derives per render via `DynamicContainer`; hidden regions don’t build; columns use `Dimension.exact`; floats reuse the palette `FloatContainer`. Kill switch: `JARVIS_REGION_LAYOUT_ENABLED`.
  - Governance: `contrarian_for` picks the best‑calibrated outsider and sends a fixed “attack” directive, damped by `JARVIS_CONTRARIAN_COOLDOWN_S`. `rotation_requests` emit `approval_required` payloads with evidence, bounded by `JARVIS_PERSONA_MIN_ROOM`. Kill switch: `JARVIS_PERSONA_GOVERNOR_ENABLED`.

- **Bug Fixes**
  - Fixed contrarian cooldown init: `_last_injection` starts as `None` to avoid suppressing the first injection after process start.

<sup>Written for commit ea2dd3a149e3bb43a51d5b9f036e69aa707e965a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

