### PR TITLE
fix(governance): a refusal is not a failure — I2 was swallowed by its own guard

### DIFF
--- a/backend/core/ouroboros/governance/posture_observer.py
+++ b/backend/core/ouroboros/governance/posture_observer.py
@@ -294,9 +294,21 @@ class SignalCollector:
         self._cost_burn_cache: Optional[Tuple[Tuple[int, int], float]] = None
 
     def _git_subjects(self, n: int) -> List[str]:
-        """Legacy sync entry — retained for backwards compat with the
-        sync ``commit_ratios`` / ``build_bundle`` path. Production
-        chunked-async cycle uses :meth:`_git_subjects_async`."""
+        """The PRODUCTION git-log path, sync by design.
+
+        Slice 257 inverted what this docstring used to claim. The async
+        variant resolved HEAD via ``asyncio.create_subprocess_exec``, which
+        forks on the event-loop thread — from this large multi-threaded
+        process, concurrent with Oracle's pool, that fork blocked the loop
+        33–108s and the heartbeat froze. ``subprocess.run`` releases the GIL
+        while the child runs, so dispatched through ``_offload_signal`` it
+        blocks a worker thread and never the loop.
+
+        So this is not a legacy shim: it is the live path, and
+        :meth:`_git_subjects_async` is retired with no production callers.
+        The old wording survived the fix and pointed the reader at the
+        abandoned implementation — which is exactly how the Slice 52 tests
+        came to patch a seam nothing calls."""
         try:
             result = subprocess.run(
                 ["git", "log", f"-{n}", "--pretty=format:%s"],

--- a/backend/core/ouroboros/governance/risk_tier_floor.py
+++ b/backend/core/ouroboros/governance/risk_tier_floor.py
@@ -79,6 +79,27 @@ _VISION_SENSOR_HARD_FLOOR = "notify_apply"
 
 _TRUTHY = frozenset({"1", "true", "yes", "on"})
 
+
+class RiskFloorConfigError(ValueError):
+    """The operator asked for a floor the lattice forbids.
+
+    Structurally distinct from a subsystem failure, and the distinction is
+    load-bearing. The fail-closed handler in :func:`apply_floor_to_name`
+    exists so that an *erroring* subsystem can never open the floor — but a
+    deliberate refusal is not an error, it IS the floor working. Catching
+    both with one ``except Exception`` inverted the guarantee: setting
+    ``JARVIS_VISION_SENSOR_RISK_FLOOR=safe_auto`` raised I2's ValueError,
+    the handler swallowed it, and with ``MIN_RISK_TIER`` unset the fallback
+    returned ``None`` — so a vision-originated op reached ``safe_auto``,
+    precisely what I2 forbids. The misconfiguration meant to be loud was
+    the quietest path through the module.
+
+    A ValueError raised BY the floor logic is an assertion about
+    configuration and must reach the operator. Everything else still
+    fails closed.
+    """
+
+
 # Canonical ordering — safer-is-higher. Used only for comparison; the
 # orchestrator continues to import RiskTier from risk_engine for its
 # own handling so this module stays dependency-free.
@@ -320,7 +341,7 @@ def _vision_floor_from_env() -> str:
         )
         return _VISION_SENSOR_HARD_FLOOR
     if _order[raw] < _order[_VISION_SENSOR_HARD_FLOOR]:
-        raise ValueError(
+        raise RiskFloorConfigError(
             f"{_ENV_VISION_FLOOR}={raw!r} cannot be lower than "
             f"{_VISION_SENSOR_HARD_FLOOR!r}. Vision-originated ops are "
             "forbidden from reaching safe_auto (Invariant I2 in "
@@ -721,6 +742,14 @@ def apply_floor_to_name(
             target_repo=target_repo,
             crosses_repo=crosses_repo,
         )
+    except RiskFloorConfigError:
+        # NOT a failure — this IS the floor working. The operator asked for
+        # something the lattice forbids, and fail-closed must not convert
+        # that refusal into silence. Swallowing it here let a vision op
+        # reach safe_auto whenever MIN_RISK_TIER was unset, because the
+        # fallback then returned None. The loudest misconfiguration in the
+        # module was travelling its quietest path.
+        raise
     except Exception:  # noqa: BLE001
         # Slice 163 — FAIL-CLOSED. A failure computing the recommendation must NOT
         # silently bypass the operator's deliberate governance posture. Fall back to
@@ -774,6 +803,35 @@ def apply_floor_to_risk_tier(
         }.get(effective)
         if tgt is not None and risk_tier.value < tgt.value:
             return tgt
+        return risk_tier
+    except RiskFloorConfigError:
+        # The enum path cannot raise — gate sites depend on that contract —
+        # but returning the input unchanged would reopen the hole this
+        # module exists to close: the operator's illegal value would simply
+        # be ignored and the op would keep whatever tier it arrived with.
+        #
+        # So the illegal value is discarded and the invariant it tried to
+        # undercut is applied instead. NOT an escalation to the strictest
+        # tier: over-escalating on a config error trains operators to
+        # dismiss the gate, and the hard floor is precisely the guarantee
+        # that was being violated. Loud in the log, correct in the lattice.
+        try:
+            from backend.core.ouroboros.governance.risk_engine import RiskTier
+            logger.error(
+                "[RiskFloor] illegal %s discarded — falling back to the %s "
+                "hard floor it tried to undercut (Invariant I2)",
+                _ENV_VISION_FLOOR, _VISION_SENSOR_HARD_FLOOR,
+            )
+            hard = {
+                "notify_apply": RiskTier.NOTIFY_APPLY,
+                "approval_required": RiskTier.APPROVAL_REQUIRED,
+                "blocked": RiskTier.BLOCKED,
+            }.get(_VISION_SENSOR_HARD_FLOOR)
+            if hard is not None and risk_tier.value < hard.value:
+                return hard
+        except Exception:  # noqa: BLE001
+            logger.debug("[RiskFloor] hard-floor fallback degraded",
+                         exc_info=True)
         return risk_tier
     except Exception:  # noqa: BLE001 — fail-soft; never break the gate
         return risk_tier

--- a/tests/governance/test_risk_floor_config_error_invariant.py
+++ b/tests/governance/test_risk_floor_config_error_invariant.py
@@ -1,0 +1,134 @@
+"""A refusal is not a failure — and fail-closed must not confuse them.
+
+`apply_floor_to_name` wraps `recommended_floor` in a fail-closed handler so
+that an *erroring* subsystem can never open the governance floor. That is
+correct. But it caught `Exception`, and Invariant I2 signals an illegal
+configuration by RAISING — so the one deliberate refusal in the module was
+swallowed by the guard meant to enforce it.
+
+The consequence was live, not theoretical::
+
+    JARVIS_VISION_SENSOR_RISK_FLOOR=safe_auto, MIN_RISK_TIER unset
+        → ('safe_auto', None)
+
+A vision-originated op reached `safe_auto`, precisely what I2 forbids. The
+loudest misconfiguration in the module travelled its quietest path.
+
+These pin the distinction structurally: a `RiskFloorConfigError` is an
+assertion about configuration and must reach the operator, while every other
+failure still fails closed.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance.risk_engine import RiskTier
+from backend.core.ouroboros.governance.risk_tier_floor import (
+    RiskFloorConfigError,
+    apply_floor_to_name,
+    apply_floor_to_risk_tier,
+    get_active_tier_order,
+)
+
+_ENV_VISION = "JARVIS_VISION_SENSOR_RISK_FLOOR"
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    # MIN_RISK_TIER unset is the DANGEROUS case, not an edge case: it is the
+    # default install, and it is what turned the swallowed error into a
+    # silent safe_auto rather than a merely-wrong-but-strict floor.
+    for var in (_ENV_VISION, "JARVIS_MIN_RISK_TIER", "JARVIS_PARANOIA_MODE",
+                "JARVIS_AUTO_APPLY_QUIET_HOURS"):
+        monkeypatch.delenv(var, raising=False)
+
+
+class TestConfigErrorReachesTheOperator:
+    def test_name_path_raises_rather_than_silently_passing(self, monkeypatch):
+        monkeypatch.setenv(_ENV_VISION, "safe_auto")
+        with pytest.raises(RiskFloorConfigError, match="cannot be lower"):
+            apply_floor_to_name("safe_auto", signal_source="vision_sensor")
+
+    def test_config_error_is_a_valueerror(self):
+        # Callers written against the documented `ValueError` contract must
+        # keep working; the subclass adds precision without breaking them.
+        assert issubclass(RiskFloorConfigError, ValueError)
+
+    def test_enum_path_never_raises_but_never_passes_safe_auto(
+        self, monkeypatch,
+    ):
+        # Gate sites depend on "NEVER raises". Honouring that by returning
+        # the input unchanged would reopen the hole, so the illegal value is
+        # discarded and the undercut invariant applied instead.
+        monkeypatch.setenv(_ENV_VISION, "safe_auto")
+        out = apply_floor_to_risk_tier(
+            RiskTier.SAFE_AUTO, signal_source="vision_sensor",
+        )
+        assert out is not RiskTier.SAFE_AUTO
+        assert out is RiskTier.NOTIFY_APPLY
+
+    def test_enum_path_does_not_weaken_an_already_stricter_tier(
+        self, monkeypatch,
+    ):
+        # Falling back to the hard floor must never DEMOTE an op that already
+        # sits above it — the lattice only ever joins upward.
+        monkeypatch.setenv(_ENV_VISION, "safe_auto")
+        out = apply_floor_to_risk_tier(
+            RiskTier.BLOCKED, signal_source="vision_sensor",
+        )
+        assert out is RiskTier.BLOCKED
+
+
+class TestFailClosedStillHolds:
+    def test_unexpected_failure_still_falls_back_to_env_floor(
+        self, monkeypatch,
+    ):
+        # The Slice 163 guarantee is untouched: a genuinely erroring
+        # subsystem must not let an op auto-apply below the configured floor.
+        import backend.core.ouroboros.governance.risk_tier_floor as mod
+
+        monkeypatch.setenv("JARVIS_MIN_RISK_TIER", "approval_required")
+
+        def boom(*_a, **_k):
+            raise RuntimeError("subsystem down")
+
+        monkeypatch.setattr(mod, "recommended_floor", boom)
+        effective, applied = apply_floor_to_name("safe_auto")
+        assert effective == "approval_required"
+        assert applied == "approval_required"
+
+    def test_non_vision_signal_is_unaffected_by_a_bad_vision_env(
+        self, monkeypatch,
+    ):
+        # The refusal must be scoped to the ops the invariant governs; a bad
+        # vision floor cannot become a global outage.
+        monkeypatch.setenv(_ENV_VISION, "safe_auto")
+        effective, applied = apply_floor_to_name(
+            "safe_auto", signal_source="test_failure",
+        )
+        assert effective == "safe_auto"
+        assert applied is None
+
+
+class TestLatticeOrderingIsStrict:
+    def test_order_is_strictly_monotonic_and_total(self):
+        # The property the ladder actually has to have: safer-is-higher, no
+        # ties. A tie would make "strictest wins" ambiguous and let a
+        # composition resolve either way depending on dict order.
+        order = get_active_tier_order()
+        ladder = ["safe_auto", "notify_apply", "approval_required",
+                  "critical_elevation", "blocked"]
+        ranks = [order[name] for name in ladder]
+        assert ranks == sorted(ranks), "ladder is not monotonic"
+        assert len(set(ranks)) == len(ranks), "ladder has ties"
+
+    def test_no_tier_outranks_blocked(self):
+        order = get_active_tier_order()
+        assert order["blocked"] == max(order.values())
+
+    def test_accessor_returns_a_copy(self):
+        # The public accessor exists so callers never touch `_ORDER`; handing
+        # out the live dict would make that distinction cosmetic.
+        first = get_active_tier_order()
+        first["safe_auto"] = 99
+        assert get_active_tier_order()["safe_auto"] == 0

--- a/tests/governance/test_slice33_arc1_posture_chunked_async.py
+++ b/tests/governance/test_slice33_arc1_posture_chunked_async.py
@@ -96,9 +96,21 @@ def test_ast_pin_build_bundle_async_present_with_per_signal_wires() -> None:
             assert "posture.signal." in body, (
                 "build_bundle_async missing per-signal callsite labels"
             )
-            assert "asyncio.to_thread" in body or "to_thread" in body, (
-                "build_bundle_async not dispatching signals to threads"
-            )
+            # The INVARIANT is "every collector runs off the loop", not any
+            # particular way of achieving it. Pinning the literal
+            # `asyncio.to_thread` made this fail when Tier-2b converged the
+            # dispatch onto the unified `cooperative_fs_io.offload` substrate
+            # via `_offload_signal` — a strictly better mechanism, since it
+            # shares the advisor-blast pool instead of spawning a bespoke one.
+            #
+            # A pin that names the mechanism breaks every time the mechanism
+            # improves, which teaches the next engineer to weaken the pin
+            # rather than to check the property. So the property is what is
+            # asserted, and any of the sanctioned off-loop dispatchers satisfy it.
+            assert (
+                "to_thread" in body or "_offload_signal" in body
+                or "offload(" in body
+            ), "build_bundle_async not dispatching signals off the event loop"
             assert "sleep(0)" in body, (
                 "build_bundle_async missing cooperative yields"
             )

--- a/tests/governance/test_slice52_posture_delta_cache.py
+++ b/tests/governance/test_slice52_posture_delta_cache.py
@@ -33,15 +33,15 @@ async def test_caches_commit_ratios_when_head_unchanged(tmp_path, monkeypatch):
     sc = _make(tmp_path)
     calls = {"subjects": 0}
 
-    async def fake_subjects(n):  # noqa: ANN001
+    def fake_subjects(n):  # noqa: ANN001
         calls["subjects"] += 1
         return ["feat: a", "fix: b", "feat: c", "refactor: d"]
 
-    async def fake_head():
+    def fake_head():
         return "deadbeef1234"
 
-    monkeypatch.setattr(sc, "_git_subjects_async", fake_subjects)
-    monkeypatch.setattr(sc, "_git_head_async", fake_head)
+    monkeypatch.setattr(sc, "_git_subjects", fake_subjects)
+    monkeypatch.setattr(sc, "_git_head", fake_head)
 
     r1 = await sc.commit_ratios_async()
     r2 = await sc.commit_ratios_async()
@@ -60,15 +60,15 @@ async def test_recomputes_when_head_advances(tmp_path, monkeypatch):
     calls = {"subjects": 0}
     heads = iter(["h1", "h2"])  # HEAD moves between the two calls
 
-    async def fake_subjects(n):  # noqa: ANN001
+    def fake_subjects(n):  # noqa: ANN001
         calls["subjects"] += 1
         return ["feat: a"]
 
-    async def fake_head():
+    def fake_head():
         return next(heads)
 
-    monkeypatch.setattr(sc, "_git_subjects_async", fake_subjects)
-    monkeypatch.setattr(sc, "_git_head_async", fake_head)
+    monkeypatch.setattr(sc, "_git_subjects", fake_subjects)
+    monkeypatch.setattr(sc, "_git_head", fake_head)
 
     await sc.commit_ratios_async()
     await sc.commit_ratios_async()
@@ -81,15 +81,15 @@ async def test_never_caches_when_head_unresolvable(tmp_path, monkeypatch):
     sc = _make(tmp_path)
     calls = {"subjects": 0}
 
-    async def fake_subjects(n):  # noqa: ANN001
+    def fake_subjects(n):  # noqa: ANN001
         calls["subjects"] += 1
         return ["feat: a"]
 
-    async def fake_head():
+    def fake_head():
         return ""  # no git / detached — unresolvable
 
-    monkeypatch.setattr(sc, "_git_subjects_async", fake_subjects)
-    monkeypatch.setattr(sc, "_git_head_async", fake_head)
+    monkeypatch.setattr(sc, "_git_subjects", fake_subjects)
+    monkeypatch.setattr(sc, "_git_head", fake_head)
 
     await sc.commit_ratios_async()
     await sc.commit_ratios_async()
@@ -103,15 +103,15 @@ async def test_empty_history_baseline_is_cached_safely(tmp_path, monkeypatch):
     sc = _make(tmp_path)
     calls = {"subjects": 0}
 
-    async def fake_subjects(n):  # noqa: ANN001
+    def fake_subjects(n):  # noqa: ANN001
         calls["subjects"] += 1
         return []  # empty history
 
-    async def fake_head():
+    def fake_head():
         return "abc"
 
-    monkeypatch.setattr(sc, "_git_subjects_async", fake_subjects)
-    monkeypatch.setattr(sc, "_git_head_async", fake_head)
+    monkeypatch.setattr(sc, "_git_subjects", fake_subjects)
+    monkeypatch.setattr(sc, "_git_head", fake_head)
 
     r1 = await sc.commit_ratios_async()
     r2 = await sc.commit_ratios_async()

--- a/tests/governance/test_wiring_3_risk_tier_ladder_extended.py
+++ b/tests/governance/test_wiring_3_risk_tier_ladder_extended.py
@@ -407,6 +407,19 @@ class TestAuthorityInvariants:
     def test_no_external_imports_of_underscore_order(self):
         # `_ORDER` is module-private; no live caller should import it
         # directly. This pin guards against accidental reach-around.
+        #
+        # Checked by AST, not by substring. The original detector did
+        # `if "_ORDER" in src` across the whole file once any import from
+        # risk_tier_floor was present — so `second_order_doll_metric.py`
+        # failed on its OWN constant, `SECOND_ORDER_DOLL_METRIC_ENABLED`,
+        # while actually importing the public `get_active_tier_order`. The
+        # invariant held; the detector could not tell use from mention, and
+        # reported the module that was obeying it.
+        #
+        # An authority invariant that cries wolf is worse than none: it
+        # trains the reader to dismiss exactly the signal that matters.
+        import ast
+
         violations = []
         backend_dir = _REPO_ROOT / "backend"
         for path in backend_dir.rglob("*.py"):
@@ -416,15 +429,23 @@ class TestAuthorityInvariants:
             if rel == "backend/core/ouroboros/governance/risk_tier_floor.py":
                 continue
             try:
-                src = path.read_text(encoding="utf-8")
-            except (OSError, UnicodeDecodeError):
+                tree = ast.parse(path.read_text(encoding="utf-8"))
+            except (OSError, UnicodeDecodeError, SyntaxError):
                 continue
-            if "from backend.core.ouroboros.governance.risk_tier_floor import" in src:
-                # Only legitimate import is `apply_floor_to_name` (and
-                # other public APIs). _ORDER must not appear.
-                if "_ORDER" in src:
-                    violations.append(rel)
+            for node in ast.walk(tree):
+                # `from ...risk_tier_floor import _ORDER`
+                if isinstance(node, ast.ImportFrom) and "risk_tier_floor" in (
+                    node.module or ""
+                ):
+                    if any(a.name == "_ORDER" for a in node.names):
+                        violations.append(f"{rel} (import)")
+                # `risk_tier_floor._ORDER` — reach-around via the module
+                # object, which an import-name check alone would miss.
+                elif isinstance(node, ast.Attribute) and node.attr == "_ORDER":
+                    base = node.value
+                    if isinstance(base, ast.Name) and "risk_tier_floor" in base.id:
+                        violations.append(f"{rel} (attribute)")
         assert not violations, (
-            f"External callers import private _ORDER directly:\n  "
+            f"External callers reach private _ORDER directly:\n  "
             + "\n  ".join(violations)
         )


### PR DESCRIPTION
Seven of the ten red governance tests. Only one was the bug it looked like.

## The real defect — vision ops could reach `safe_auto`

`_vision_floor_from_env` raises when the operator asks for a floor below `notify_apply`, exactly as Invariant I2 requires. But `apply_floor_to_name` wraps `recommended_floor` in Slice 163's `except Exception: floor = _env_floor()` — so **the refusal was caught by the guard meant to enforce it**. With `MIN_RISK_TIER` unset (the default install) the fallback returns `None`:

```
JARVIS_VISION_SENSOR_RISK_FLOOR=safe_auto  ->  ('safe_auto', None)
```

Proven live before the fix. The loudest misconfiguration in the module was travelling its quietest path.

Fail-closed exists so an *erroring* subsystem cannot open the floor. A deliberate refusal is not an error — it **is** the floor working. `RiskFloorConfigError` makes that distinction structural; the handler re-raises it and everything else still falls back.

`apply_floor_to_risk_tier` documents "NEVER raises" and gate sites depend on that, so it cannot propagate — but returning the input unchanged would reopen the hole. It now discards the illegal value and applies the hard floor that value tried to undercut. Deliberately *not* an escalation to the strictest tier: over-escalating on a config error trains operators to dismiss the gate.

## The `_ORDER` invariant was never broken

`second_order_doll_metric.py` imports the **public** `get_active_tier_order`. The test did `if "_ORDER" in src` across the whole file and matched that module's own constant `SECOND_ORDER_DOLL_METRIC_ENABLED` — so it reported the one module *obeying* the rule.

Now AST-based, and it also catches reach-around via attribute access, which an import-name check alone would miss. An authority invariant that cries wolf is worse than none: it trains the reader to dismiss exactly the signal that matters.

## Four posture tests patched a dead seam

Slice 257 moved `commit_ratios_async` onto the **sync** git helpers dispatched through `_offload_signal`, because the async variants forked on the event-loop thread (33–108s block, frozen heartbeat, watchdog SIGKILL). The tests still patched `_git_head_async`/`_git_subjects_async` — **zero production callers**. The fakes never ran; real `git` hit `tmp_path`.

`_git_subjects`' docstring still called itself "legacy" and named the dead async method as production. That inversion survived the fix and is *how* the tests came to patch nothing.

The slice33 AST pin asserted the literal `asyncio.to_thread` and broke when Tier-2b converged onto the unified offload substrate. It now asserts the off-loop **property** — a pin that names the mechanism breaks every time the mechanism improves, teaching the reader to weaken the pin rather than check the property.

## Verification

68 existing + 9 new tests green. New `test_risk_floor_config_error_invariant.py` pins the refusal/failure distinction, that the enum path never returns `SAFE_AUTO` nor demotes a stricter tier, that Slice 163 fail-closed still holds, and that the ladder is strictly monotonic with no ties.

## Not in this PR

Three tests in `test_phase_dispatcher_terminals.py` remain red. They fail **15 in isolation vs 2 in-suite** — the inverse of leak-out pollution, so the file *depends* on state another test establishes rather than leaking its own. A snapshot-and-restore fixture would make it fail more. That deserves its own slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes governance floor handling so a deliberate config refusal is surfaced instead of swallowed, preventing vision-originated ops from reaching `safe_auto` under a bad env value. Also tightens the authority invariant check and repoints posture tests to the live git path.

- Bug Fixes
  - Introduced `RiskFloorConfigError`; `_vision_floor_from_env` raises it, `apply_floor_to_name` re-raises it, and unexpected errors still fail-closed.
  - `apply_floor_to_risk_tier` never raises; on an illegal vision floor it discards the value and applies the vision hard floor (no over-escalation).
  - Replaced the `_ORDER` substring check with an AST-based detector that catches both direct imports and attribute access.

- Refactors
  - Clarified `_git_subjects` as the production sync path; tests now patch `_git_subjects`/`_git_head`, and the off-loop dispatch pin checks the property instead of `asyncio.to_thread`.
  - Added `tests/governance/test_risk_floor_config_error_invariant.py`; updated affected tests. All green.

<sup>Written for commit 90706b84d81d868d3dc15c21ce222417f4b93a4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

