### PR TITLE
fix(test): the dispatcher tests were never running the pipeline they assert on

### DIFF
--- a/tests/governance/phase_runner/conftest.py
+++ b/tests/governance/phase_runner/conftest.py
@@ -1,0 +1,74 @@
+"""Isolation for the phase-runner suite.
+
+Two different hazards live here, and conflating them is why
+`test_phase_dispatcher_terminals.py` behaved differently in isolation than in
+a full run.
+
+Leaking OUT vs depending IN
+---------------------------
+The usual test-pollution shape is state leaking *out* of a test and breaking a
+later one — isolation passes, the suite fails. This file exhibited the
+inverse: 15 failures alone, 2 in-suite. It was not leaking; it *depended* on
+ambient state something else happened to establish. A blanket
+"reset everything to pristine" fixture would have made it fail MORE, which is
+worth stating plainly because that is the reflex the symptom invites.
+
+The actual cause was a fake, not a fixture: `_build_stack` modelled the legacy
+`is_cancel_requested` cancel surface and never learned about the per-op
+`CancelToken` registry added by W3(7) Slice 2, so `is_cancelled` auto-vivified
+truthy and every op looked cancelled. That is fixed at the fake.
+
+What genuinely can leak
+-----------------------
+`cancel_token_var` is a module-level `ContextVar` the dispatcher binds for the
+duration of a run and resets in a `finally`. Under `asyncio` task isolation
+that reset is usually redundant — which is exactly why a gap here would stay
+invisible for a long time. But a test that raises between `set()` and the
+reset, or one that drives the dispatcher outside a task boundary, leaves a
+stale token bound for whatever runs next. The next test then sees an op that
+some *other* test cancelled.
+
+So this snapshots and restores it around every test in the package. It is
+deliberately narrow: it pins the one piece of ambient state this suite is
+known to share, rather than asserting a pristine world the suite does not
+actually want.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cancel_token_var():
+    """Snapshot + restore the ambient cancel ContextVar around each test.
+
+    Restores by TOKEN where possible — `ContextVar.reset(token)` returns the
+    variable to the exact state it had before this test's `set()`, including
+    "was never set at all", which assigning `None` cannot express. A variable
+    explicitly bound to None is not the same as an unbound one, and the
+    dispatcher's `pctx.cancel_token is None` check is sensitive to which of
+    those it meets.
+    """
+    try:
+        from backend.core.ouroboros.governance.cancel_token import (
+            cancel_token_var,
+        )
+    except Exception:  # noqa: BLE001 — never block the suite on an import
+        yield
+        return
+
+    # `set()` here so we hold a token that can restore the *unset* state too.
+    sentinel = cancel_token_var.set(None)
+    try:
+        yield
+    finally:
+        try:
+            cancel_token_var.reset(sentinel)
+        except (ValueError, RuntimeError):
+            # Reset across a different Context — the token is not valid here.
+            # Fall back to clearing, which is still strictly better than
+            # leaving another test's cancelled op bound.
+            try:
+                cancel_token_var.set(None)
+            except Exception:  # noqa: BLE001
+                pass

--- a/tests/governance/phase_runner/test_phase_dispatcher_terminals.py
+++ b/tests/governance/phase_runner/test_phase_dispatcher_terminals.py
@@ -30,6 +30,10 @@ from backend.core.ouroboros.governance.approval_provider import (
     ApprovalResult,
     ApprovalStatus,
 )
+# `spec=` is load-bearing, not decoration: it is what makes the NEXT surface
+# added to CancelToken fail loudly in this fake instead of auto-vivifying into
+# a truthy Mock the way `is_cancelled` did.
+from backend.core.ouroboros.governance.cancel_token import CancelToken
 from backend.core.ouroboros.governance.op_context import (
     GenerationResult,
     OperationContext,
@@ -79,6 +83,28 @@ def _build_stack(
             success=change_success, rolled_back=False, op_id="op-test",
         ))
     stack.governed_loop_service.is_cancel_requested.return_value = cancel_requested
+    # W3(7) Slice 2 added a SECOND cancel surface — the per-op CancelToken
+    # registry — and this shared fake was never taught about it. The
+    # dispatcher reads `getattr(token, "is_cancelled", False)`, and on an
+    # auto-vivified MagicMock that attribute is a truthy Mock, so EVERY op
+    # in this file looked cancelled and routed to POSTMORTEM before reaching
+    # the terminal each test actually asserts on.
+    #
+    # The dispatcher's own comment states the contract it expects from unit
+    # tests: "they construct an orchestrator without a stack / GLS and the
+    # registry property returns None". A MagicMock can never return None, so
+    # the fake silently violated the assumption the production code documents.
+    #
+    # Driven by the SAME `cancel_requested` knob as the legacy surface, so
+    # the two can never disagree about whether this op was cancelled — a fake
+    # that models one surface and auto-vivifies the other is how this class
+    # of bug arrives in the first place.
+    _token = MagicMock(spec=CancelToken)
+    _token.is_cancelled = cancel_requested
+    _token.get_record.return_value = None
+    stack.governed_loop_service._cancel_token_registry.get_or_create.return_value = (
+        _token
+    )
     stack.learning_bridge = MagicMock()
     stack.learning_bridge.publish = AsyncMock(return_value=None)
     stack.security_reviewer = MagicMock()


### PR DESCRIPTION
`test_phase_dispatcher_terminals` failed **15 in isolation but 2 in-suite** — the *inverse* of leak-out pollution. It doesn't leak state; it *depends* on ambient state something else establishes. A blanket snapshot-and-restore fixture would have made it fail more, which is the reflex the symptom invites.

## Root cause: a new production surface, an un-updated shared fake

W3(7) Slice 2 added a per-op `CancelToken` registry alongside the legacy `is_cancel_requested` surface. `_build_stack` models the legacy one and was never taught the new one, so:

```python
getattr(_cancel_token, "is_cancelled", False)   # truthy auto-vivified Mock
```

Every op looked cancelled and routed to POSTMORTEM **before reaching the terminal each test asserts on**.

The dispatcher documents the contract it expects from unit tests:

> *"they construct an orchestrator without a stack / GLS and the registry property returns None"*

A `MagicMock` can never return `None`. The fake silently violated an assumption the production code states in a comment. **Production is correct and unchanged.**

## Evidence the tests were inert

Isolation runtime went **1.05s → 5m22s**. They were short-circuiting to POSTMORTEM instantly, never exercising the pipeline. A one-second run of twenty full-orchestrator terminals should have been the tell.

## The fix

The fake now models the current contract, driven by the **same** `cancel_requested` knob as the legacy surface so the two can never disagree, with `spec=CancelToken` so the *next* surface added fails loudly instead of auto-vivifying.

Adds `tests/governance/phase_runner/conftest.py` snapshotting `cancel_token_var` around each test — the one genuinely shared ambient surface. Restored by **token**, so "never set" stays distinguishable from "set to None"; the dispatcher's `pctx.cancel_token is None` check is sensitive to which it meets.

## Read this before merging

Isolation failures go **15 → 9**. The remaining 9 are **real assertions being evaluated for the first time**, not regressions — they are what the short-circuit was hiding. They are not fixed here and need their own pass.

This trades a quiet green for an honest red. That is the right trade, but it is a trade, and it should be a deliberate choice rather than a side effect.

Separately verified: the 7 failures in `test_slice4b_runner_parity` / `test_plan_runner_default_claims_wiring` are **pre-existing** and reproduce identically on clean `origin/main` (64217321e0). The new conftest does not cause them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dispatcher terminal tests so they run the real pipeline instead of short-circuiting to POSTMORTEM. Updates the shared fake to model the per-op cancel token and isolates the ambient cancel ContextVar, revealing real failures that were previously hidden.

- **Bug Fixes**
  - Teach `_build_stack` to use a registry-provided mock with `spec=CancelToken`; wire `is_cancelled` to `cancel_requested` and return `None` from `get_record` to prevent truthy auto-vivified mocks.
  - Add `tests/governance/phase_runner/conftest.py` to snapshot/restore `cancel_token_var` per test using the token, preserving unset vs `None` semantics and avoiding cross-test leakage.
  - No production changes. Tests now exercise real paths; remaining failures will be addressed separately.

<sup>Written for commit 548d636c015e026d2b0da209885c89f35411ed73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

