### PR TITLE
fix(test): give the dispatcher suite a project root that exists

### DIFF
--- a/tests/governance/phase_runner/test_phase_dispatcher_terminals.py
+++ b/tests/governance/phase_runner/test_phase_dispatcher_terminals.py
@@ -57,6 +57,48 @@ _FIXED_TS = datetime(2026, 3, 7, 12, 0, tzinfo=timezone.utc)
 # ---------------------------------------------------------------------------
 
 
+#: The one target path this suite generates against. It was written out
+#: twice before — the candidate's `file_path` and the op's `target_files` —
+#: and a fixture root that disagrees with the candidate is not diagnosable by
+#: reading either one alone.
+_TARGET_REL = "backend/core/utils.py"
+
+#: Set per-test by `_materialise_project_root`. Module-level because
+#: `_build_cfg` is a plain function called from ~20 tests; threading a fixture
+#: through every signature would be a larger edit than the bug warrants.
+_FIXTURE_ROOT: Optional[Path] = None
+
+
+@pytest.fixture(autouse=True)
+def _materialise_project_root(tmp_path):
+    """Give the orchestrator a project root that actually EXISTS.
+
+    `project_root` was hardcoded to `/tmp/test-project-6b`, a directory
+    nothing creates. Every op therefore failed GENERATE with
+    `target_file_missing` and never reached the GATE / APPROVE / APPLY
+    terminals these tests assert on.
+
+    That went unnoticed because the cancel short-circuit terminated each op at
+    POSTMORTEM before GENERATE ran — one dead fake concealing another. Fixing
+    the CancelToken contract is what made this surface.
+
+    `tmp_path` rather than a fixed directory: a shared path under /tmp is
+    order-dependent state between sessions, and on this repo's node policy
+    /tmp is not writable at all.
+    """
+    global _FIXTURE_ROOT
+    target = tmp_path / _TARGET_REL
+    target.parent.mkdir(parents=True, exist_ok=True)
+    # Real, parseable content — VALIDATE runs an AST pass, so an empty
+    # placeholder would trade target_file_missing for a SyntaxError.
+    target.write_text("def hello():\n    pass\n", encoding="utf-8")
+    _FIXTURE_ROOT = tmp_path
+    try:
+        yield tmp_path
+    finally:
+        _FIXTURE_ROOT = None
+
+
 def _build_stack(
     *,
     can_write: Tuple[bool, str] = (True, "ok"),
@@ -125,7 +167,7 @@ def _build_generator(
         candidates = (
             {
                 "candidate_id": "c1",
-                "file_path": "backend/core/utils.py",
+                "file_path": _TARGET_REL,
                 "full_content": "def hello():\n    pass\n",
                 "rationale": "stub",
             },
@@ -141,7 +183,7 @@ def _build_generator(
 
 def _build_cfg(**overrides: Any) -> OrchestratorConfig:
     defaults = dict(
-        project_root=Path("/tmp/test-project-6b"),
+        project_root=_FIXTURE_ROOT or Path("/tmp/test-project-6b"),
         generation_timeout_s=5.0,
         validation_timeout_s=5.0,
         approval_timeout_s=5.0,
@@ -155,7 +197,7 @@ def _build_cfg(**overrides: Any) -> OrchestratorConfig:
 
 def _build_ctx(op_id: str = "op-test", **overrides: Any) -> OperationContext:
     defaults: dict = dict(
-        target_files=("backend/core/utils.py",),
+        target_files=(_TARGET_REL,),
         description="dispatch test",
         op_id=op_id,
         _timestamp=_FIXED_TS,


### PR DESCRIPTION
`project_root` was hardcoded to `Path("/tmp/test-project-6b")` — **a directory nothing creates**. Every op failed GENERATE with `target_file_missing: backend/core/utils.py` and never reached the GATE / APPROVE / APPLY terminals these tests assert on.

It went unnoticed because the `CancelToken` fake (fixed in #70215) short-circuited each op to POSTMORTEM before GENERATE ran. **One dead fake concealing another** — repairing the first is what made this visible.

## The fix

Materialised per-test from `tmp_path`, with the target file actually written:

- **Real parseable content**, since VALIDATE runs an AST pass — an empty placeholder would only trade `target_file_missing` for a `SyntaxError`.
- **`tmp_path` rather than a fixed directory**, because a shared `/tmp` path is order-dependent state between sessions, and this repo's node policy makes `/tmp` unwritable outright.
- **One constant** instead of two literals that had to agree with a third value (the root) for the suite to work at all. A disagreement between them is not diagnosable by reading any one of them.

## Status — still 9 red

`test_artifact_generation_threads_classify_to_validate` now passes and the failure **set** shifted, which is the signal that this was a real cause rather than a reshuffle.

The next one down is the same defect class again: `test_gate_can_write_denied_terminal` now reaches `COMPLETE` instead of `CANCELLED`, with dispatcher-off/on **parity intact**. Both paths agree, so the gate is not consulting `stack.can_write` at all — that fake is likely modelling a seam production no longer reads. `canary_not_promoted` is produced in `governance/integration.py:480`, which is where the next trace should start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix dispatcher tests by using a real, per-test project root and target file instead of a hardcoded `/tmp` path. This lets ops pass GENERATE and reach the expected GATE/APPROVE/APPLY terminals.

- **Bug Fixes**
  - Added an autouse fixture that sets `_FIXTURE_ROOT` to `tmp_path` and creates `backend/core/utils.py` with parseable content.
  - Replaced duplicated path literals with a `_TARGET_REL` constant and updated the generator, `target_files`, and config to use it.
  - Config now reads `project_root` from `_FIXTURE_ROOT` (not `Path('/tmp/test-project-6b')`), removing `/tmp` state and unwritable-node issues; failure set shifted and at least one test now passes.

<sup>Written for commit 5bea6cb69bbd5bd947417195e3efd7844a1180de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

