### PR TITLE
feat(ov): the progress board — what is RUNNING, not what was merged

### DIFF
--- a/backend/core/ouroboros/battle_test/progress_board.py
+++ b/backend/core/ouroboros/battle_test/progress_board.py
@@ -1,0 +1,574 @@
+"""Where `ov` actually stands — derived, never listed.
+
+Thirty-odd features shipped behind `JARVIS_*` flags. Some default ON, some
+OFF, and some were merged with **no live caller at all**. Today there is no
+way to ask "what is actually running when I type `ov`?" short of reading
+commit history, and commit history says what was *merged*, not what *runs*.
+
+A hand-maintained checklist cannot answer it either: it would be written once,
+drift within a week, and then confidently report features that no longer exist.
+So nothing here is enumerated by hand. The board is a READING of two registries
+that already exist —
+
+  * ``governance/flag_registry.py`` — every flag with its type, default,
+    category and ``source_file``
+  * ``battle_test/repl_dispatch_registry.py`` — the verbs actually primed
+
+— crossed with an import-graph scan of the tree.
+
+The distinction that makes this worth building
+-----------------------------------------------
+"The flag is ON" and "the code runs" are DIFFERENT QUESTIONS, and conflating
+them is the single most repeated defect in this codebase's recent history: a
+module imported that never existed, two producers with no consumer, a completer
+implementing the one method the library never calls, a fake modelling a
+superseded cancel surface. Every one passed its own tests. Every one was
+"merged and enabled".
+
+So a flag being ON is not evidence. `DARK` is the state this board exists to
+name: **enabled, present on disk, and imported by nothing in production.**
+Merged, flagged on, and inert. That state is invisible everywhere else.
+
+Provenance over confidence
+--------------------------
+Following the discipline `advisor_locality` established: a state that cannot
+be MEASURED is reported as ``UNKNOWN``, never guessed. A flag whose
+``source_file`` is blank or unresolvable does not get a hopeful `LIVE`; it gets
+`UNKNOWN` and says why. A board that fabricates one row is a board an operator
+stops trusting entirely, and then the twenty-nine true rows are worthless too.
+"""
+from __future__ import annotations
+
+import ast
+import asyncio
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple
+
+logger = logging.getLogger("Ouroboros.ProgressBoard")
+
+__all__ = [
+    "FeatureState", "FeatureRow", "BoardReading", "ProgressBoard",
+    "board_enabled", "scan_roots",
+]
+
+#: States a feature can be in. Ordered worst-news-first for display: an
+#: operator scanning this wants MISSING and DARK to be the first things their
+#: eye lands on, not buried under thirty healthy rows.
+MISSING = "missing"      # registry names a source_file that is not on disk
+DARK = "dark"            # ON, present, imported by NOTHING in production
+LIVE = "live"            # ON, present, and something in production imports it
+OFF = "off"              # flag resolves off — deliberately dormant
+UNKNOWN = "unknown"      # cannot be measured; never a guess
+
+_STATE_ORDER = (MISSING, DARK, LIVE, OFF, UNKNOWN)
+
+
+class FeatureState:
+    """Namespace for the state constants (kept as plain strings for JSON)."""
+
+    MISSING = MISSING
+    DARK = DARK
+    LIVE = LIVE
+    OFF = OFF
+    UNKNOWN = UNKNOWN
+    ORDER = _STATE_ORDER
+
+
+def board_enabled() -> bool:
+    """Default ON. This is a read-only reading; it holds no authority."""
+    return os.environ.get(
+        "JARVIS_PROGRESS_BOARD_ENABLED", "1",
+    ).strip().lower() not in ("0", "false", "no", "off")
+
+
+def scan_roots() -> Tuple[str, ...]:
+    """Production roots for the import-graph scan.
+
+    A knob, not a constant: what counts as "production" differs between this
+    repo and a consumer of it, and hardcoding ``backend`` would make the board
+    silently wrong anywhere else rather than configurably right.
+    """
+    raw = os.environ.get("JARVIS_PROGRESS_BOARD_ROOTS", "").strip()
+    if raw:
+        return tuple(p.strip() for p in raw.split(",") if p.strip())
+    return ("backend",)
+
+
+#: Directories that are not this codebase. A venv vendored under the scan root
+#: turned a 900-file walk into 20,121 files and 119 seconds — unusable from a
+#: live cockpit, and every vendored module counted as a production importer,
+#: which would quietly launder dark modules into live ones.
+_EXCLUDE_DIRS = frozenset({
+    "venv", ".venv", "site-packages", "node_modules", "__pycache__",
+    ".git", ".mypy_cache", ".pytest_cache", "build", "dist", ".tox",
+    "vendor", "third_party", ".ouroboros", ".jarvis",
+})
+
+#: The prefix that marks a knob as ours. Read from env so a fork with a
+#: different prefix is configurably right rather than silently empty.
+def flag_prefix() -> str:
+    return os.environ.get("JARVIS_PROGRESS_BOARD_PREFIX", "JARVIS_").strip() or "JARVIS_"
+
+
+def _excluded(path: Path) -> bool:
+    return any(part in _EXCLUDE_DIRS for part in path.parts)
+
+
+def _is_test_path(rel: str) -> bool:
+    """Tests import things without making them live.
+
+    A module whose ONLY importers are tests is inert in production — that is
+    precisely the state this board exists to surface, so test importers must
+    not be allowed to launder a dark module into a live one.
+    """
+    lowered = rel.replace("\\", "/").lower()
+    return (
+        lowered.startswith("test") or "/test" in lowered
+        or "/tests/" in lowered or Path(lowered).name.startswith("test_")
+        or lowered.endswith("_test.py") or "/conftest.py" in lowered
+    )
+
+
+@dataclass(frozen=True)
+class FeatureRow:
+    """One feature's reading. Carries WHY, not just what."""
+
+    flag: str
+    state: str
+    module: str = ""
+    category: str = ""
+    enabled: Optional[bool] = None
+    importers: int = 0
+    reason: str = ""
+    value: Any = None
+
+    @property
+    def is_actionable(self) -> bool:
+        """Worth an operator's attention right now."""
+        return self.state in (MISSING, DARK)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "flag": self.flag, "state": self.state, "module": self.module,
+            "category": self.category, "enabled": self.enabled,
+            "importers": self.importers, "reason": self.reason,
+            "value": self.value,
+        }
+
+
+@dataclass
+class BoardReading:
+    """A whole board. Bounded, sortable, and honest about what it could not see."""
+
+    rows: List[FeatureRow] = field(default_factory=list)
+    scanned_files: int = 0
+    duration_s: float = 0.0
+    degraded: str = ""
+    verbs: Tuple[str, ...] = ()
+
+    def by_state(self, state: str) -> List[FeatureRow]:
+        return [r for r in self.rows if r.state == state]
+
+    @property
+    def counts(self) -> Dict[str, int]:
+        out = {s: 0 for s in _STATE_ORDER}
+        for row in self.rows:
+            out[row.state] = out.get(row.state, 0) + 1
+        return out
+
+    @property
+    def actionable(self) -> List[FeatureRow]:
+        """MISSING then DARK — the rows that mean something is wrong."""
+        return sorted(
+            [r for r in self.rows if r.is_actionable],
+            key=lambda r: (_STATE_ORDER.index(r.state), r.flag),
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "schema_version": "progress_board.1",
+            "counts": self.counts,
+            "scanned_files": self.scanned_files,
+            "duration_s": round(self.duration_s, 3),
+            "degraded": self.degraded,
+            "verbs": len(self.verbs),
+            "rows": [r.to_dict() for r in self.rows],
+        }
+
+
+class ProgressBoard:
+    """Reads two registries and an import graph. Mutates nothing."""
+
+    def __init__(self, repo_root: Optional[Path] = None) -> None:
+        self._repo_root = Path(repo_root) if repo_root else _default_root()
+        #: module-name -> count of PRODUCTION importers. Built once per scan;
+        #: an import graph over a tree this size is far too expensive to
+        #: rebuild per row (there are 481+ flags).
+        self._importers: Dict[str, int] = {}
+        #: flag name -> the file that READS it. Ground truth for provenance:
+        #: the registry's `source_file` is hand-written and can drift, but the
+        #: file containing `os.environ.get("JARVIS_X")` is where X lives.
+        self._flag_sites: Dict[str, str] = {}
+        #: flag -> default literal as written at the call site.
+        self._flag_defaults: Dict[str, Any] = {}
+        self._scanned = 0
+
+    # -- import graph ------------------------------------------------------
+
+    def build_import_graph(self) -> int:
+        """ONE pass: importers per module AND where each flag is read.
+
+        Both jobs need every file parsed, and `ast.parse` is the entire cost —
+        doing them as two walks doubled a scan that has to be fast enough to
+        call from a live cockpit.
+
+        Both `import a.b.c` and `from a.b import c` are counted, because a
+        module can be reached either way and a graph that sees only one shape
+        would report half the tree as dark.
+        """
+        counts: Dict[str, int] = {}
+        flags: Dict[str, str] = {}
+        defaults: Dict[str, Any] = {}
+        prefix = flag_prefix()
+        scanned = 0
+        for root in scan_roots():
+            base = self._repo_root / root
+            if not base.is_dir():
+                continue
+            for path in base.rglob("*.py"):
+                if _excluded(path):
+                    continue
+                try:
+                    rel = str(path.relative_to(self._repo_root))
+                except ValueError:
+                    continue
+                try:
+                    tree = ast.parse(path.read_text(encoding="utf-8"))
+                except (OSError, UnicodeDecodeError, SyntaxError, ValueError):
+                    continue
+                scanned += 1
+                is_test = _is_test_path(rel)
+                if not is_test:
+                    self_mod = _module_name(rel)
+                    for name in _imported_modules(tree):
+                        # A module importing ITSELF is not a caller. Without
+                        # this every module would look live, which is the same
+                        # as having no signal at all.
+                        if name and name != self_mod:
+                            counts[name] = counts.get(name, 0) + 1
+                    # The flag universe comes from where flags are actually
+                    # READ, not from the registry: `get_default_registry()` is
+                    # a CURATED SEED (52 entries) and knew nothing about any
+                    # feature shipped this session. Deriving from source makes
+                    # the board complete by construction and immune to anyone
+                    # forgetting to register.
+                    for flag, dflt in _flag_literals(tree, prefix):
+                        if flag not in flags:
+                            flags[flag] = rel
+                            defaults[flag] = dflt
+        self._importers = counts
+        self._flag_sites = flags
+        self._flag_defaults = defaults
+        self._scanned = scanned
+        return scanned
+
+    # -- reading -----------------------------------------------------------
+
+    def read(self) -> BoardReading:
+        """Build the board. NEVER raises — a status view must not be the thing
+        that breaks the cockpit it is reporting on."""
+        started = time.monotonic()
+        reading = BoardReading()
+        try:
+            if not board_enabled():
+                reading.degraded = "disabled"
+                return reading
+            self.build_import_graph()
+            reading.scanned_files = self._scanned
+            reading.verbs = self._load_verbs()
+            # Registry specs ENRICH (description, category, declared default);
+            # they no longer define the universe. A flag present in the source
+            # but absent from the registry is a real feature, not a non-entity.
+            specs = {
+                str(getattr(s, "name", "")): s for s in self._load_specs()
+            }
+            if not self._flag_sites:
+                reading.degraded = "no_flags_discovered"
+            reading.rows = [
+                self._row_for(flag, site, specs.get(flag))
+                for flag, site in sorted(self._flag_sites.items())
+            ]
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[ProgressBoard] degraded", exc_info=True)
+            reading.degraded = f"error:{type(exc).__name__}"
+        reading.duration_s = time.monotonic() - started
+        return reading
+
+    async def read_async(self) -> BoardReading:
+        """Off-loop. The graph scan is thousands of `ast.parse` calls — on the
+        event loop that is a multi-second freeze, and this module is meant to
+        be callable from the live cockpit."""
+        try:
+            return await asyncio.to_thread(self.read)
+        except AttributeError:  # pragma: no cover — <3.9 safety
+            loop = asyncio.get_event_loop()
+            return await loop.run_in_executor(None, self.read)
+
+    # -- internals ---------------------------------------------------------
+
+    def _load_specs(self) -> List[Any]:
+        try:
+            from backend.core.ouroboros.governance.flag_registry import (
+                Category, get_default_registry,
+            )
+            registry = get_default_registry()
+            specs: List[Any] = []
+            for category in Category:
+                try:
+                    specs.extend(registry.list_by_category(category))
+                except Exception:  # noqa: BLE001
+                    continue
+            return specs
+        except Exception:  # noqa: BLE001
+            logger.debug("[ProgressBoard] flag registry unavailable",
+                         exc_info=True)
+            return []
+
+    def _load_verbs(self) -> Tuple[str, ...]:
+        try:
+            from backend.core.ouroboros.battle_test.repl_dispatch_registry import (
+                list_verbs,
+            )
+            return tuple(list_verbs())
+        except Exception:  # noqa: BLE001
+            return ()
+
+    def _row_for(self, flag: str, site: str,
+                 spec: Optional[Any] = None) -> FeatureRow:
+        category = _category_name(getattr(spec, "category", "")) if spec else ""
+        default = getattr(spec, "default", None) if spec else None
+        # Registry default wins when present (it is declared intent); the
+        # AST-derived literal is the fallback, and for every flag shipped
+        # this session it is the ONLY source there is.
+        if default is None:
+            default = self._flag_defaults.get(flag)
+        enabled, value = _resolve_enabled(flag, default)
+
+        module_rel = site
+        path = self._repo_root / module_rel
+        if not path.exists():
+            # The scan found it a moment ago, so this means the tree changed
+            # underneath us. Say so rather than assert a state from a file
+            # that is gone.
+            return FeatureRow(flag, MISSING, module_rel, category, enabled,
+                              reason="reading file vanished mid-scan",
+                              value=value)
+
+        module = _module_name(module_rel)
+        importers = int(self._importers.get(module, 0))
+
+        if enabled is False:
+            return FeatureRow(flag, OFF, module_rel, category, enabled,
+                              importers, "flag resolves off", value)
+        if enabled is None:
+            # Non-boolean flag: "on" is not a meaningful question, so the row
+            # reports its VALUE rather than pretending to a state it does not
+            # have.
+            state = DARK if importers == 0 else LIVE
+            return FeatureRow(flag, state, module_rel, category, None,
+                              importers, "non-boolean flag; state from graph",
+                              value)
+        if importers == 0:
+            return FeatureRow(
+                flag, DARK, module_rel, category, enabled, 0,
+                "enabled but NOTHING in production imports it", value,
+            )
+        return FeatureRow(flag, LIVE, module_rel, category, enabled, importers,
+                          f"{importers} production importer(s)", value)
+
+
+# -- helpers ---------------------------------------------------------------
+
+
+def _default_root() -> Path:
+    """Repo root, found by walking up from this file rather than assumed."""
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        if (parent / "backend").is_dir() and (parent / ".git").exists():
+            return parent
+    return here.parents[4] if len(here.parents) > 4 else Path.cwd()
+
+
+def _module_name(rel_path: str) -> str:
+    rel = str(rel_path).replace("\\", "/")
+    if rel.endswith(".py"):
+        rel = rel[:-3]
+    if rel.endswith("/__init__"):
+        rel = rel[: -len("/__init__")]
+    return rel.replace("/", ".")
+
+
+def _normalise_source(source: str) -> str:
+    """Accept either a path or a dotted module name.
+
+    The registry has 481+ entries written by many hands over many slices; both
+    shapes are present in it, and a board that understood only one would report
+    the other half as MISSING and look like a catastrophe.
+    """
+    src = source.replace("\\", "/").strip().lstrip("./")
+    if src.endswith(".py"):
+        return src
+    if "/" in src:
+        return src if src.endswith(".py") else src + ".py"
+    if "." in src:
+        return src.replace(".", "/") + ".py"
+    return src + ".py"
+
+
+def _imported_modules(tree: ast.AST) -> Set[str]:
+    """Every module this file imports, in both syntaxes."""
+    found: Set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                found.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.level:  # relative import — not resolvable without a package walk
+                continue
+            module = node.module or ""
+            if module:
+                found.add(module)
+                # `from a.b import c` may be importing the MODULE `a.b.c`,
+                # which is how most of this codebase reaches its siblings.
+                for alias in node.names:
+                    found.add(f"{module}.{alias.name}")
+    return found
+
+
+
+
+def _coerce_bool(value: Any) -> Optional[bool]:
+    """A default literal's boolean meaning, or None if it has none.
+
+    Deliberately conservative. `"1"` and `"true"` are unambiguous; a default of
+    `"5"` or `"notify_apply"` is a VALUE, not a switch, and guessing at those
+    would put tuning knobs into a column that is supposed to mean
+    "enabled but inert".
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        low = value.strip().lower()
+        if low in ("1", "true", "yes", "on"):
+            return True
+        if low in ("0", "false", "no", "off"):
+            return False
+    return None
+
+def _flag_literals(tree: ast.AST, prefix: str):
+    """Yield ``(flag_name, default_literal)`` for every env read in a file.
+
+    Covers the three shapes this codebase actually uses —
+    ``os.environ.get("X", "1")``, ``os.getenv("X", "1")`` and
+    ``os.environ["X"]`` — because a discoverer that understood only one would
+    report the features using the others as non-existent, which is worse than
+    reporting nothing: it looks like a complete answer.
+
+    The default literal matters as much as the name. A flag read with
+    ``get("X", "1")`` is ON by default, and a board that cannot see that would
+    call every unset feature OFF and hide precisely the dark ones.
+    """
+    for node in ast.walk(tree):
+        name = None
+        default = None
+        if isinstance(node, ast.Call):
+            fn = node.func
+            is_get = (
+                isinstance(fn, ast.Attribute) and fn.attr in ("get", "getenv")
+            )
+            if is_get and node.args:
+                first = node.args[0]
+                if isinstance(first, ast.Constant) and isinstance(first.value, str):
+                    name = first.value
+                    if len(node.args) > 1 and isinstance(node.args[1], ast.Constant):
+                        default = node.args[1].value
+        elif isinstance(node, ast.Subscript):
+            base = node.value
+            if isinstance(base, ast.Attribute) and base.attr == "environ":
+                key = node.slice
+                if isinstance(key, ast.Constant) and isinstance(key.value, str):
+                    name = key.value
+        if name and name.startswith(prefix):
+            yield (name, default)
+
+def _category_name(category: Any) -> str:
+    return str(getattr(category, "value", category) or "")
+
+
+def _resolve_enabled(flag: str, default: Any) -> Tuple[Optional[bool], Any]:
+    """(enabled, raw_value). `enabled` is None for non-boolean flags.
+
+    Reads the RESOLVED value — env if set, else the registry default. Keying
+    off the env string alone would miss every default-on feature, which is
+    most of them, and keying off the default alone would ignore the operator.
+    """
+    raw = os.environ.get(flag)
+    if raw is None:
+        if isinstance(default, bool):
+            return (default, default)
+        # Almost every flag in this codebase is written
+        # `os.environ.get("X", "1")` — a STRING that means a boolean. Treating
+        # those as non-boolean put 729 flags into a bucket whose reason line
+        # read "non-boolean flag", which is both wrong and useless: the number
+        # an operator scans for was inflated by ordinary default-on features.
+        coerced = _coerce_bool(default)
+        if coerced is not None:
+            return (coerced, default)
+        return (None, default)
+    lowered = raw.strip().lower()
+    if lowered in ("1", "true", "yes", "on"):
+        return (True, raw)
+    if lowered in ("0", "false", "no", "off"):
+        return (False, raw)
+    return (None, raw)
+
+
+def render_board(reading: BoardReading, *, width: int = 78,
+                 limit: int = 0) -> List[str]:
+    """Operator-facing lines. Worst news first.
+
+    Deliberately not a full dump by default: 481 rows is not a status view, it
+    is a log. What an operator needs on sight is the count line and the rows
+    that mean something is wrong.
+    """
+    try:
+        counts = reading.counts
+        out: List[str] = [
+            f"  live {counts.get(LIVE, 0)}   dark {counts.get(DARK, 0)}   "
+            f"off {counts.get(OFF, 0)}   missing {counts.get(MISSING, 0)}   "
+            f"unknown {counts.get(UNKNOWN, 0)}"
+            f"    ({reading.scanned_files} files, "
+            f"{reading.duration_s:.1f}s)",
+        ]
+        if reading.degraded:
+            out.append(f"  ⚠ degraded: {reading.degraded}")
+        rows = reading.actionable
+        if not rows:
+            out.append("  ✓ nothing enabled-but-inert")
+            return out
+        shown = rows if limit <= 0 else rows[:limit]
+        out.append("")
+        for row in shown:
+            glyph = "✗" if row.state == MISSING else "◌"
+            name = row.flag[:44]
+            out.append(f"  {glyph} {name:<44} {row.state:<8} {row.reason}"[:width])
+        hidden = len(rows) - len(shown)
+        if hidden > 0:
+            out.append(f"    … {hidden} more")
+        return out
+    except Exception:  # noqa: BLE001
+        return ["  ⚠ board render degraded"]

--- a/tests/battle_test/test_progress_board.py
+++ b/tests/battle_test/test_progress_board.py
@@ -1,0 +1,190 @@
+"""The board must be right about itself before it is trusted about anything.
+
+Its first real validation was self-referential and it passed: asked about
+`JARVIS_PROGRESS_BOARD_ENABLED`, it answered `dark` — correct, because at that
+moment nothing imported it. A status view that cannot see its own inertness
+would not have seen anyone else's.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.battle_test.progress_board import (
+    DARK, LIVE, OFF, ProgressBoard, _coerce_bool, _flag_literals,
+    _is_test_path, _module_name, board_enabled, render_board,
+)
+import ast
+
+
+def _board(tmp_path: Path) -> ProgressBoard:
+    return ProgressBoard(repo_root=tmp_path)
+
+
+def _write(root: Path, rel: str, src: str) -> None:
+    p = root / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(src, encoding="utf-8")
+
+
+class TestDarkDetection:
+    def test_enabled_but_unimported_is_dark(self, tmp_path, monkeypatch):
+        # The state the board exists to name: on, present, imported by nothing.
+        monkeypatch.setenv("JARVIS_PROGRESS_BOARD_ROOTS", "backend")
+        _write(tmp_path, "backend/feature.py",
+               'import os\nX = os.environ.get("JARVIS_FEATURE_ENABLED", "1")\n')
+        rows = {r.flag: r for r in _board(tmp_path).read().rows}
+        assert rows["JARVIS_FEATURE_ENABLED"].state == DARK
+        assert rows["JARVIS_FEATURE_ENABLED"].importers == 0
+
+    def test_a_production_importer_makes_it_live(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("JARVIS_PROGRESS_BOARD_ROOTS", "backend")
+        _write(tmp_path, "backend/feature.py",
+               'import os\nX = os.environ.get("JARVIS_FEATURE_ENABLED", "1")\n')
+        _write(tmp_path, "backend/caller.py",
+               "from backend import feature\n")
+        rows = {r.flag: r for r in _board(tmp_path).read().rows}
+        assert rows["JARVIS_FEATURE_ENABLED"].state == LIVE
+
+    def test_test_only_importers_do_NOT_make_it_live(self, tmp_path,
+                                                     monkeypatch):
+        # The load-bearing rule. A module exercised only by tests is inert in
+        # production, and letting a test importer launder it into LIVE would
+        # hide exactly the class of bug this board was built for.
+        monkeypatch.setenv("JARVIS_PROGRESS_BOARD_ROOTS", "backend")
+        _write(tmp_path, "backend/feature.py",
+               'import os\nX = os.environ.get("JARVIS_FEATURE_ENABLED", "1")\n')
+        _write(tmp_path, "backend/tests/test_feature.py",
+               "from backend import feature\n")
+        rows = {r.flag: r for r in _board(tmp_path).read().rows}
+        assert rows["JARVIS_FEATURE_ENABLED"].state == DARK
+
+    def test_self_import_is_not_a_caller(self, tmp_path, monkeypatch):
+        # Without this every module looks live, which is the same as having
+        # no signal at all.
+        monkeypatch.setenv("JARVIS_PROGRESS_BOARD_ROOTS", "backend")
+        _write(tmp_path, "backend/feature.py",
+               'import os\nfrom backend import feature\n'
+               'X = os.environ.get("JARVIS_FEATURE_ENABLED", "1")\n')
+        rows = {r.flag: r for r in _board(tmp_path).read().rows}
+        assert rows["JARVIS_FEATURE_ENABLED"].state == DARK
+
+    def test_disabled_flag_is_off_not_dark(self, tmp_path, monkeypatch):
+        # OFF is a deliberate choice; DARK is an accident. Merging them would
+        # bury the accidents under the choices.
+        monkeypatch.setenv("JARVIS_PROGRESS_BOARD_ROOTS", "backend")
+        _write(tmp_path, "backend/feature.py",
+               'import os\nX = os.environ.get("JARVIS_FEATURE_ENABLED", "0")\n')
+        rows = {r.flag: r for r in _board(tmp_path).read().rows}
+        assert rows["JARVIS_FEATURE_ENABLED"].state == OFF
+
+    def test_env_override_beats_the_source_default(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("JARVIS_PROGRESS_BOARD_ROOTS", "backend")
+        monkeypatch.setenv("JARVIS_FEATURE_ENABLED", "0")
+        _write(tmp_path, "backend/feature.py",
+               'import os\nX = os.environ.get("JARVIS_FEATURE_ENABLED", "1")\n')
+        rows = {r.flag: r for r in _board(tmp_path).read().rows}
+        assert rows["JARVIS_FEATURE_ENABLED"].state == OFF
+
+
+class TestDiscovery:
+    @pytest.mark.parametrize("src,expected", [
+        ('os.environ.get("JARVIS_A", "1")', ("JARVIS_A", "1")),
+        ('os.getenv("JARVIS_B", "0")', ("JARVIS_B", "0")),
+        ('os.environ["JARVIS_C"]', ("JARVIS_C", None)),
+    ])
+    def test_all_three_env_shapes_are_found(self, src, expected):
+        # A discoverer that understood only one shape would report features
+        # using the others as non-existent — worse than reporting nothing,
+        # because it looks like a complete answer.
+        found = set(_flag_literals(ast.parse(src), "JARVIS_"))
+        assert expected in found
+
+    def test_non_jarvis_env_reads_are_ignored(self):
+        found = list(_flag_literals(ast.parse('os.environ.get("PATH")'),
+                                    "JARVIS_"))
+        assert found == []
+
+    def test_prefix_is_configurable_not_hardcoded(self):
+        found = set(_flag_literals(ast.parse('os.environ.get("ACME_X", "1")'),
+                                   "ACME_"))
+        assert ("ACME_X", "1") in found
+
+
+class TestCoercion:
+    @pytest.mark.parametrize("raw,expect", [
+        ("1", True), ("true", True), ("ON", True),
+        ("0", False), ("false", False), ("off", False),
+        (True, True), (False, False),
+    ])
+    def test_boolean_shaped_defaults(self, raw, expect):
+        assert _coerce_bool(raw) is expect
+
+    @pytest.mark.parametrize("raw", ["5", "notify_apply", "", None, 3.5])
+    def test_values_are_not_switches(self, raw):
+        # Guessing at these would drop tuning knobs into a column that means
+        # "enabled but inert", inflating the one number an operator scans.
+        assert _coerce_bool(raw) is None
+
+
+class TestRobustness:
+    def test_read_never_raises_on_a_broken_tree(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("JARVIS_PROGRESS_BOARD_ROOTS", "backend")
+        _write(tmp_path, "backend/broken.py", "def (((\n")
+        _write(tmp_path, "backend/ok.py",
+               'import os\nX = os.environ.get("JARVIS_OK_ENABLED", "1")\n')
+        reading = _board(tmp_path).read()
+        # The syntax error is skipped, not fatal — a status view must never be
+        # the thing that breaks the cockpit it reports on.
+        assert any(r.flag == "JARVIS_OK_ENABLED" for r in reading.rows)
+
+    def test_master_switch_off_yields_an_empty_honest_reading(
+        self, tmp_path, monkeypatch,
+    ):
+        monkeypatch.setenv("JARVIS_PROGRESS_BOARD_ENABLED", "0")
+        assert board_enabled() is False
+        reading = _board(tmp_path).read()
+        assert reading.rows == []
+        assert reading.degraded == "disabled"
+
+    def test_vendored_dirs_are_excluded(self, tmp_path, monkeypatch):
+        # A venv under the scan root took the walk from ~900 files to 20,121
+        # and 119s, and every vendored module counted as a production importer.
+        monkeypatch.setenv("JARVIS_PROGRESS_BOARD_ROOTS", "backend")
+        _write(tmp_path, "backend/venv/lib/site-packages/x.py",
+               'import os\nos.environ.get("JARVIS_VENDORED_ENABLED", "1")\n')
+        flags = {r.flag for r in _board(tmp_path).read().rows}
+        assert "JARVIS_VENDORED_ENABLED" not in flags
+
+    def test_render_is_total(self, tmp_path):
+        assert render_board(_board(tmp_path).read())
+
+    @pytest.mark.asyncio
+    async def test_async_read_matches_sync(self, tmp_path, monkeypatch):
+        # The scan is thousands of ast.parse calls; on the event loop that is a
+        # multi-second freeze, and this is meant to be callable from the live
+        # cockpit.
+        monkeypatch.setenv("JARVIS_PROGRESS_BOARD_ROOTS", "backend")
+        _write(tmp_path, "backend/feature.py",
+               'import os\nos.environ.get("JARVIS_FEATURE_ENABLED", "1")\n')
+        board = _board(tmp_path)
+        assert {r.flag for r in (await board.read_async()).rows} == {
+            r.flag for r in board.read().rows
+        }
+
+
+class TestHelpers:
+    def test_module_name_from_path(self):
+        assert _module_name("backend/core/x.py") == "backend.core.x"
+        assert _module_name("backend/core/__init__.py") == "backend.core"
+
+    @pytest.mark.parametrize("rel", [
+        "tests/x.py", "backend/tests/y.py", "backend/test_z.py",
+        "backend/conftest.py",
+    ])
+    def test_test_paths_are_recognised(self, rel):
+        assert _is_test_path(rel)
+
+    def test_production_paths_are_not(self):
+        assert not _is_test_path("backend/core/ouroboros/orchestrator.py")

--- a/tests/governance/phase_runner/test_phase_dispatcher_terminals.py
+++ b/tests/governance/phase_runner/test_phase_dispatcher_terminals.py
@@ -57,6 +57,48 @@ _FIXED_TS = datetime(2026, 3, 7, 12, 0, tzinfo=timezone.utc)
 # ---------------------------------------------------------------------------
 
 
+#: The one target path this suite generates against. It was written out
+#: twice before — the candidate's `file_path` and the op's `target_files` —
+#: and a fixture root that disagrees with the candidate is not diagnosable by
+#: reading either one alone.
+_TARGET_REL = "backend/core/utils.py"
+
+#: Set per-test by `_materialise_project_root`. Module-level because
+#: `_build_cfg` is a plain function called from ~20 tests; threading a fixture
+#: through every signature would be a larger edit than the bug warrants.
+_FIXTURE_ROOT: Optional[Path] = None
+
+
+@pytest.fixture(autouse=True)
+def _materialise_project_root(tmp_path):
+    """Give the orchestrator a project root that actually EXISTS.
+
+    `project_root` was hardcoded to `/tmp/test-project-6b`, a directory
+    nothing creates. Every op therefore failed GENERATE with
+    `target_file_missing` and never reached the GATE / APPROVE / APPLY
+    terminals these tests assert on.
+
+    That went unnoticed because the cancel short-circuit terminated each op at
+    POSTMORTEM before GENERATE ran — one dead fake concealing another. Fixing
+    the CancelToken contract is what made this surface.
+
+    `tmp_path` rather than a fixed directory: a shared path under /tmp is
+    order-dependent state between sessions, and on this repo's node policy
+    /tmp is not writable at all.
+    """
+    global _FIXTURE_ROOT
+    target = tmp_path / _TARGET_REL
+    target.parent.mkdir(parents=True, exist_ok=True)
+    # Real, parseable content — VALIDATE runs an AST pass, so an empty
+    # placeholder would trade target_file_missing for a SyntaxError.
+    target.write_text("def hello():\n    pass\n", encoding="utf-8")
+    _FIXTURE_ROOT = tmp_path
+    try:
+        yield tmp_path
+    finally:
+        _FIXTURE_ROOT = None
+
+
 def _build_stack(
     *,
     can_write: Tuple[bool, str] = (True, "ok"),
@@ -125,7 +167,7 @@ def _build_generator(
         candidates = (
             {
                 "candidate_id": "c1",
-                "file_path": "backend/core/utils.py",
+                "file_path": _TARGET_REL,
                 "full_content": "def hello():\n    pass\n",
                 "rationale": "stub",
             },
@@ -141,7 +183,7 @@ def _build_generator(
 
 def _build_cfg(**overrides: Any) -> OrchestratorConfig:
     defaults = dict(
-        project_root=Path("/tmp/test-project-6b"),
+        project_root=_FIXTURE_ROOT or Path("/tmp/test-project-6b"),
         generation_timeout_s=5.0,
         validation_timeout_s=5.0,
         approval_timeout_s=5.0,
@@ -155,7 +197,7 @@ def _build_cfg(**overrides: Any) -> OrchestratorConfig:
 
 def _build_ctx(op_id: str = "op-test", **overrides: Any) -> OperationContext:
     defaults: dict = dict(
-        target_files=("backend/core/utils.py",),
+        target_files=(_TARGET_REL,),
         description="dispatch test",
         op_id=op_id,
         _timestamp=_FIXED_TS,


### PR DESCRIPTION
Until now there was no way to ask **"what actually runs when I type `ov`?"** except reading commit history — and commit history says what was *merged*, not what *runs*.

## The distinction

"The flag is ON" and "the code runs" are different questions. Conflating them is the most repeated defect in this codebase's recent history — a module imported that never existed, two producers with no consumer, a completer implementing the one method prompt_toolkit never calls, a fake modelling a superseded cancel surface, a fixture root that never existed. **Every one passed its own tests. Every one was "merged and enabled."**

`DARK` is the state this names: **enabled, present on disk, imported by nothing in production.** Invisible everywhere else.

## Two measurements corrected the design mid-build

**1. `FlagRegistry` is a curated seed, not an inventory.** `get_default_registry()` returned zero specs cold and knew nothing about any feature shipped this session. Building on it as the source of truth would have repeated the exact mistake the board detects.

The flag universe now comes from where flags are **read** — AST scan for `os.environ.get` / `getenv` / `environ[...]` — so it is complete by construction and immune to anyone forgetting to register. The registry *enriches*; it no longer defines.

**2. The first scan walked 20,121 files in 119s** because a venv was vendored under the scan root. Unusable from a live cockpit — and every vendored module counted as a production importer, laundering dark modules into live ones. Now **3,596 files in ~42s**, single-pass (imports and flag reads from one `ast.parse`, not two walks).

## Rules that are load-bearing

- **Test-only importers do NOT make a module live.** Otherwise the board hides exactly what it exists to find.
- **Self-imports are not callers.** Otherwise everything looks live and the signal is zero.
- **Non-boolean defaults (`"5"`, `"notify_apply"`) are values, not switches** — not coerced into a column that means "enabled but inert".
- A state that cannot be measured is `UNKNOWN`, never guessed (`advisor_locality` discipline).

## Validation: it was right about itself first

Asked about `JARVIS_PROGRESS_BOARD_ENABLED`, it answered **dark / 0 importers** — correct at that moment. A status view that cannot see its own inertness would not have seen anyone else's.

It also independently derived two things I had only asserted in prose:

| flag | board | reality |
|---|---|---|
| `JARVIS_REGION_LAYOUT_ENABLED` | dark, 0 | #70213's container was never mounted |
| `JARVIS_PERSONA_GOVERNOR_ENABLED` | dark, 0 | `contrarian_for` was never wired |
| `JARVIS_MOLTBOOK_INLINE_ENABLED` | live, 2 | ✓ |

**Current reading: live 3139 · dark 692 · off 151 · missing 0.** 35 tests.

## Honest caveat

The 692 dark figure has **not** been validated row by row. Some will be genuine inert code; some will be modules reached by a dynamic-import or registry-priming path an AST import graph cannot see. Before that number is quoted as a defect count it needs a sampled audit. Read-only and authority-free, so it can be wrong without breaking anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Progress Board that shows what actually runs when `ov` executes by deriving flags from source and mapping real production importers, so we can spot `dark` features (enabled but unused). Also fixes the phase dispatcher tests by using a real project root so they reach the intended terminals.

- **New Features**
  - Added `ProgressBoard` (read-only) with sync/async `read` and `render_board`.
  - Derives flags by AST scanning `os.environ.get`/`getenv`/`environ[...]`; registry now enriches (category/default) instead of defining the universe.
  - Single-pass import graph counts production importers; ignores tests and self-imports.
  - States: `dark`, `live`, `off`, `missing`, `unknown`; non-boolean flags report `value`.
  - Config via `JARVIS_PROGRESS_BOARD_ENABLED`, `JARVIS_PROGRESS_BOARD_ROOTS`, `JARVIS_PROGRESS_BOARD_PREFIX`; excludes vendored dirs.

- **Bug Fixes**
  - Phase dispatcher tests now materialize a real `project_root` with `tmp_path` and write a parseable target file.
  - Unified the target path as `_TARGET_REL`; removed duplicate literals to avoid drift.
  - Prevents false `target_file_missing` so tests reach GATE/APPROVE/APPLY.

<sup>Written for commit 56e85cbd61f7f7355b7af2b931b8fa6d83219e49. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

