### PR TITLE
fix(ov): the board called every CLI dead — reachability by execution

### DIFF
--- a/backend/core/ouroboros/battle_test/progress_board.py
+++ b/backend/core/ouroboros/battle_test/progress_board.py
@@ -51,7 +51,7 @@ from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple
 logger = logging.getLogger("Ouroboros.ProgressBoard")
 
 __all__ = [
-    "FeatureState", "FeatureRow", "BoardReading", "ProgressBoard",
+    "FeatureState", "FeatureRow", "BoardReading", "ProgressBoard", "ENTRY",
     "board_enabled", "scan_roots",
 ]
 
@@ -63,8 +63,9 @@ DARK = "dark"            # ON, present, imported by NOTHING in production
 LIVE = "live"            # ON, present, and something in production imports it
 OFF = "off"              # flag resolves off — deliberately dormant
 UNKNOWN = "unknown"      # cannot be measured; never a guess
+ENTRY = "entry"          # runs via `python -m` / console script, not imports
 
-_STATE_ORDER = (MISSING, DARK, LIVE, OFF, UNKNOWN)
+_STATE_ORDER = (MISSING, DARK, LIVE, ENTRY, OFF, UNKNOWN)
 
 
 class FeatureState:
@@ -75,6 +76,7 @@ class FeatureState:
     LIVE = LIVE
     OFF = OFF
     UNKNOWN = UNKNOWN
+    ENTRY = ENTRY
     ORDER = _STATE_ORDER
 
 
@@ -215,6 +217,9 @@ class ProgressBoard:
         self._flag_sites: Dict[str, str] = {}
         #: flag -> default literal as written at the call site.
         self._flag_defaults: Dict[str, Any] = {}
+        #: modules with a `__main__` guard — reachable by execution,
+        #: never by import.
+        self._entry_modules: Set[str] = set()
         self._scanned = 0
 
     # -- import graph ------------------------------------------------------
@@ -233,6 +238,7 @@ class ProgressBoard:
         counts: Dict[str, int] = {}
         flags: Dict[str, str] = {}
         defaults: Dict[str, Any] = {}
+        entries: Set[str] = set()
         prefix = flag_prefix()
         scanned = 0
         for root in scan_roots():
@@ -266,6 +272,8 @@ class ProgressBoard:
                     # feature shipped this session. Deriving from source makes
                     # the board complete by construction and immune to anyone
                     # forgetting to register.
+                    if _has_main_guard(tree):
+                        entries.add(_module_name(rel))
                     for flag, dflt in _flag_literals(tree, prefix):
                         if flag not in flags:
                             flags[flag] = rel
@@ -273,6 +281,7 @@ class ProgressBoard:
         self._importers = counts
         self._flag_sites = flags
         self._flag_defaults = defaults
+        self._entry_modules = entries
         self._scanned = scanned
         return scanned
 
@@ -378,10 +387,27 @@ class ProgressBoard:
             # Non-boolean flag: "on" is not a meaningful question, so the row
             # reports its VALUE rather than pretending to a state it does not
             # have.
+            #
+            # ENTRY is checked HERE as well as below, because this branch
+            # returns first: `JARVIS_COMMIT_GRANT_ONESHOT` has a non-boolean
+            # default, so it exited through this path and was reported dark
+            # even after entry-point detection shipped. A state check that
+            # only one of two exits consults is not a state check.
+            if importers == 0 and module in self._entry_modules:
+                return FeatureRow(flag, ENTRY, module_rel, category, None, 0,
+                                  "module entry point (__main__ guard)", value)
             state = DARK if importers == 0 else LIVE
             return FeatureRow(flag, state, module_rel, category, None,
                               importers, "non-boolean flag; state from graph",
                               value)
+        if importers == 0 and module in self._entry_modules:
+            # Runs via `python -m` or a console script. Nothing imports
+            # `commit_authority_cli`, and it is emphatically not dead —
+            # the operator invoked it by hand this session. Reachability
+            # by EXECUTION is invisible to an import graph, and a board
+            # that calls every CLI dead is a board nobody reads twice.
+            return FeatureRow(flag, ENTRY, module_rel, category, enabled, 0,
+                              "module entry point (__main__ guard)", value)
         if importers == 0:
             return FeatureRow(
                 flag, DARK, module_rel, category, enabled, 0,
@@ -450,6 +476,29 @@ def _imported_modules(tree: ast.AST) -> Set[str]:
 
 
 
+
+
+def _has_main_guard(tree: ast.AST) -> bool:
+    """Does this module run itself?
+
+    `if __name__ == "__main__":` means the module is reachable by EXECUTION —
+    `python -m pkg.mod`, a console script, a subprocess call. An import graph
+    cannot see any of those, so without this every CLI in the tree reads as
+    inert. The board's own sampling caught this: `commit_authority_cli` was
+    reported dark in the same session the operator ran it by hand.
+    """
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.If):
+            continue
+        test = node.test
+        if (isinstance(test, ast.Compare)
+                and isinstance(test.left, ast.Name)
+                and test.left.id == "__name__"):
+            for comparator in test.comparators:
+                if (isinstance(comparator, ast.Constant)
+                        and comparator.value == "__main__"):
+                    return True
+    return False
 
 def _coerce_bool(value: Any) -> Optional[bool]:
     """A default literal's boolean meaning, or None if it has none.

--- a/tests/battle_test/test_progress_board.py
+++ b/tests/battle_test/test_progress_board.py
@@ -12,7 +12,7 @@ from pathlib import Path
 import pytest
 
 from backend.core.ouroboros.battle_test.progress_board import (
-    DARK, LIVE, OFF, ProgressBoard, _coerce_bool, _flag_literals,
+    DARK, ENTRY, LIVE, OFF, ProgressBoard, _coerce_bool, _flag_literals,
     _is_test_path, _module_name, board_enabled, render_board,
 )
 import ast
@@ -188,3 +188,55 @@ class TestHelpers:
 
     def test_production_paths_are_not(self):
         assert not _is_test_path("backend/core/ouroboros/orchestrator.py")
+
+
+class TestEntryPoints:
+    """Reachability by EXECUTION, which an import graph structurally cannot see.
+
+    Found by sampling the board's own output: `commit_authority_cli` was
+    reported dark in the same session the operator ran it by hand.
+    """
+
+    def test_main_guard_is_entry_not_dark(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("JARVIS_PROGRESS_BOARD_ROOTS", "backend")
+        _write(tmp_path, "backend/cli.py",
+               'import os\n'
+               'X = os.environ.get("JARVIS_CLI_ENABLED", "1")\n'
+               'if __name__ == "__main__":\n    pass\n')
+        rows = {r.flag: r for r in _board(tmp_path).read().rows}
+        assert rows["JARVIS_CLI_ENABLED"].state == ENTRY
+
+    def test_entry_wins_on_the_non_boolean_path_too(self, tmp_path,
+                                                    monkeypatch):
+        # The precedence bug: a non-boolean default returned from an earlier
+        # branch that never consulted entry-point status, so every CLI knob
+        # with a value default stayed dark. A state check only one of two
+        # exits consults is not a state check.
+        monkeypatch.setenv("JARVIS_PROGRESS_BOARD_ROOTS", "backend")
+        _write(tmp_path, "backend/cli.py",
+               'import os\n'
+               'X = os.environ.get("JARVIS_CLI_TIMEOUT", "30")\n'
+               'if __name__ == "__main__":\n    pass\n')
+        rows = {r.flag: r for r in _board(tmp_path).read().rows}
+        assert rows["JARVIS_CLI_TIMEOUT"].state == ENTRY
+
+    def test_an_imported_entry_point_is_live_not_entry(self, tmp_path,
+                                                       monkeypatch):
+        # ENTRY is the fallback for "nothing imports it". A real importer is
+        # stronger evidence and must win.
+        monkeypatch.setenv("JARVIS_PROGRESS_BOARD_ROOTS", "backend")
+        _write(tmp_path, "backend/cli.py",
+               'import os\n'
+               'X = os.environ.get("JARVIS_CLI_ENABLED", "1")\n'
+               'if __name__ == "__main__":\n    pass\n')
+        _write(tmp_path, "backend/caller.py", "from backend import cli\n")
+        rows = {r.flag: r for r in _board(tmp_path).read().rows}
+        assert rows["JARVIS_CLI_ENABLED"].state == LIVE
+
+    def test_plain_module_without_a_guard_stays_dark(self, tmp_path,
+                                                     monkeypatch):
+        monkeypatch.setenv("JARVIS_PROGRESS_BOARD_ROOTS", "backend")
+        _write(tmp_path, "backend/plain.py",
+               'import os\nos.environ.get("JARVIS_PLAIN_ENABLED", "1")\n')
+        rows = {r.flag: r for r in _board(tmp_path).read().rows}
+        assert rows["JARVIS_PLAIN_ENABLED"].state == DARK


### PR DESCRIPTION
Sampling 20 of the 692 dark rows found the board's own blind spot, and the proof was embarrassing: **`commit_authority_cli` was reported dark in the same session you ran it by hand** to grant commit authority.

A module invoked via `python -m` or a console script is reachable by **execution** and is never imported. An import graph structurally cannot see that — so every CLI in the tree read as inert. A board that calls every CLI dead is a board nobody reads twice.

## New `ENTRY` state

For modules carrying a `__main__` guard. Deliberately distinct from `LIVE`: *"runs when invoked"* and *"runs as part of the system"* are different facts, and an operator auditing what the organism does **autonomously** needs to tell them apart.

An imported entry point is `LIVE`, not `ENTRY` — `ENTRY` is the fallback for "nothing imports it", and real evidence must beat a fallback.

## A precedence bug in the same edit

Caught by re-measuring instead of assuming it worked. Entry status was consulted on the boolean path only, so a flag with a non-boolean default (`JARVIS_COMMIT_GRANT_ONESHOT`) returned from the earlier branch and stayed dark *even after entry detection shipped*.

**A state check that only one of two exits consults is not a state check.** First run after "fixing" it reported 9 entry modules. The real number is 136.

## Reading

| state | before | after |
|---|---|---|
| live | 3139 | 3139 |
| **dark** | **692** | **556** |
| entry | — | **136** |
| off | 151 | 151 |

39 tests.

## Honest limit

The remaining 556 is a **signal, not a defect count**. Dynamic import, registry priming via `inspect.getmembers` (which is how `repl_dispatch_registry` works), and plugin discovery are all invisible to this method. The sample's other two false positives were a package `__init__` re-export and a string-literal import.

`JARVIS_REGION_LAYOUT_ENABLED` remains correctly dark — #70213's container is genuinely still unmounted.

## `ov` installation, confirmed

It's a PEP 621 console script: `pyproject.toml [project.scripts]` → `ov = "backend.core.ouroboros.cli.ov:main"`, package `ouroboros-ov 0.1.0`, pyenv 3.11.10 shim.

So **`ov demo` should be a subcommand, not a second console script** — a new entry point needs `pip install -e .` to mint its shim, which is the documented stale-shim trap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an `ENTRY` state to the progress board to recognize modules that run via `python -m` or console scripts, so CLIs are no longer marked dark. Also fixes a precedence bug where flags with non-boolean defaults skipped entry detection.

- **New Features**
  - Detects `__main__` guards during source scan and marks unimported modules as `ENTRY`.
  - Imported entry points remain `LIVE`; `ENTRY` is a fallback only.
  - Adds `ENTRY` to state ordering and `FeatureState`.

- **Bug Fixes**
  - Applies the entry check on both boolean and non-boolean paths to prevent CLI flags with value defaults from being misclassified as dark.
  - Adds tests covering entry detection, precedence, and import vs entry behavior.

<sup>Written for commit b2e8d96a1f725bb837d64fb53e2aec1c63e8a9f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

