### PR TITLE
feat(ov): the semantic shadow graph — seeing what inspect will find

### DIFF
--- a/backend/core/ouroboros/battle_test/progress_board.py
+++ b/backend/core/ouroboros/battle_test/progress_board.py
@@ -52,6 +52,7 @@ logger = logging.getLogger("Ouroboros.ProgressBoard")
 
 __all__ = [
     "FeatureState", "FeatureRow", "BoardReading", "ProgressBoard", "ENTRY",
+    "DYNAMIC_LIVE",
     "board_enabled", "scan_roots",
 ]
 
@@ -64,8 +65,9 @@ LIVE = "live"            # ON, present, and something in production imports it
 OFF = "off"              # flag resolves off — deliberately dormant
 UNKNOWN = "unknown"      # cannot be measured; never a guess
 ENTRY = "entry"          # runs via `python -m` / console script, not imports
+DYNAMIC_LIVE = "dynamic" # discovered at runtime by a registry, not imported
 
-_STATE_ORDER = (MISSING, DARK, LIVE, ENTRY, OFF, UNKNOWN)
+_STATE_ORDER = (MISSING, DARK, LIVE, DYNAMIC_LIVE, ENTRY, OFF, UNKNOWN)
 
 
 class FeatureState:
@@ -77,6 +79,7 @@ class FeatureState:
     OFF = OFF
     UNKNOWN = UNKNOWN
     ENTRY = ENTRY
+    DYNAMIC_LIVE = DYNAMIC_LIVE
     ORDER = _STATE_ORDER
 
 
@@ -220,6 +223,8 @@ class ProgressBoard:
         #: modules with a `__main__` guard — reachable by execution,
         #: never by import.
         self._entry_modules: Set[str] = set()
+        #: module -> why a runtime registry would discover it.
+        self._shadow_edges: Dict[str, str] = {}
         self._scanned = 0
 
     # -- import graph ------------------------------------------------------
@@ -239,6 +244,7 @@ class ProgressBoard:
         flags: Dict[str, str] = {}
         defaults: Dict[str, Any] = {}
         entries: Set[str] = set()
+        shadows: Dict[str, str] = {}
         prefix = flag_prefix()
         scanned = 0
         for root in scan_roots():
@@ -274,6 +280,9 @@ class ProgressBoard:
                     # forgetting to register.
                     if _has_main_guard(tree):
                         entries.add(_module_name(rel))
+                    marker = _semantic_marker(tree, rel)
+                    if marker:
+                        shadows[_module_name(rel)] = marker
                     for flag, dflt in _flag_literals(tree, prefix):
                         if flag not in flags:
                             flags[flag] = rel
@@ -282,6 +291,7 @@ class ProgressBoard:
         self._flag_sites = flags
         self._flag_defaults = defaults
         self._entry_modules = entries
+        self._shadow_edges = shadows
         self._scanned = scanned
         return scanned
 
@@ -393,6 +403,13 @@ class ProgressBoard:
             # default, so it exited through this path and was reported dark
             # even after entry-point detection shipped. A state check that
             # only one of two exits consults is not a state check.
+            if importers == 0 and module in self._shadow_edges:
+                # A runtime registry finds this by convention. NOT live:
+                # 'discovered by a registry' and 'imported by a caller'
+                # are different facts, and collapsing them would hide the
+                # day the registry stops being primed.
+                return FeatureRow(flag, DYNAMIC_LIVE, module_rel, category,
+                                  None, 0, self._shadow_edges[module], value)
             if importers == 0 and module in self._entry_modules:
                 return FeatureRow(flag, ENTRY, module_rel, category, None, 0,
                                   "module entry point (__main__ guard)", value)
@@ -400,6 +417,13 @@ class ProgressBoard:
             return FeatureRow(flag, state, module_rel, category, None,
                               importers, "non-boolean flag; state from graph",
                               value)
+        if importers == 0 and module in self._shadow_edges:
+            # A runtime registry finds this by convention. NOT live:
+            # 'discovered by a registry' and 'imported by a caller'
+            # are different facts, and collapsing them would hide the
+            # day the registry stops being primed.
+            return FeatureRow(flag, DYNAMIC_LIVE, module_rel, category,
+                              enabled, 0, self._shadow_edges[module], value)
         if importers == 0 and module in self._entry_modules:
             # Runs via `python -m` or a console script. Nothing imports
             # `commit_authority_cli`, and it is emphatically not dead —
@@ -477,6 +501,118 @@ def _imported_modules(tree: ast.AST) -> Set[str]:
 
 
 
+
+
+# ---------------------------------------------------------------------------
+# The semantic shadow graph
+# ---------------------------------------------------------------------------
+#
+# Static AST cannot evaluate `inspect.getmembers`. But it does not have to:
+# a runtime registry only finds what it can RECOGNISE, and what it recognises
+# is a convention written into the source. Detect the convention and you have
+# the edge the import graph is missing — without importing or executing
+# anything.
+#
+# The markers below were MEASURED, not assumed. `repl_dispatch_registry`
+# has no `@verb` decorator; it walks curated packages for modules named
+# `*_repl` (or `repl` inside a sub-package) and picks up module-level
+# callables named `dispatch_<verb>_command`. Guessing a plausible-looking
+# decorator would have produced a detector that matched nothing and reported
+# a confident zero.
+
+
+def marker_functions() -> Tuple[str, ...]:
+    """Function-name prefixes/suffixes a registry discovers by convention.
+
+    ``prefix*suffix`` form. Env-overridable because a second registry with a
+    different convention should be a config change, not a code change.
+    """
+    raw = os.environ.get("JARVIS_PROGRESS_BOARD_FN_MARKERS", "").strip()
+    if raw:
+        return tuple(x.strip() for x in raw.split(",") if x.strip())
+    return ("dispatch_*_command",)
+
+
+def marker_modules() -> Tuple[str, ...]:
+    """Module basenames that a discovery walk treats as registrable."""
+    raw = os.environ.get("JARVIS_PROGRESS_BOARD_MODULE_MARKERS", "").strip()
+    if raw:
+        return tuple(x.strip() for x in raw.split(",") if x.strip())
+    return ("*_repl", "repl")
+
+
+def marker_decorators() -> frozenset:
+    """Decorator names that register their target at import time.
+
+    Empty by default HERE — this codebase's REPL registry uses naming, not
+    decorators. Populated by env for subsystems that do, rather than shipping
+    a speculative list that quietly matches nothing.
+    """
+    raw = os.environ.get("JARVIS_PROGRESS_BOARD_DECORATORS", "").strip()
+    return frozenset(x.strip() for x in raw.split(",") if x.strip())
+
+
+def marker_base_classes() -> frozenset:
+    """Base classes whose subclasses a registry collects."""
+    raw = os.environ.get("JARVIS_PROGRESS_BOARD_BASES", "").strip()
+    return frozenset(x.strip() for x in raw.split(",") if x.strip())
+
+
+def _glob_match(name: str, pattern: str) -> bool:
+    """`a*b` without importing fnmatch's full machinery per node."""
+    if "*" not in pattern:
+        return name == pattern
+    head, _, tail = pattern.partition("*")
+    return (name.startswith(head) and name.endswith(tail)
+            and len(name) >= len(head) + len(tail))
+
+
+def _semantic_marker(tree: ast.AST, rel: str) -> str:
+    """Why a runtime registry would find this module, or ''.
+
+    Returns a REASON, not a boolean: an operator told a module is
+    dynamically live deserves to know which convention made it so, or the
+    state is just a different flavour of guess.
+    """
+    stem = Path(rel).stem
+    module_hit = any(_glob_match(stem, pat) for pat in marker_modules())
+
+    decorators = marker_decorators()
+    bases = marker_base_classes()
+    fn_pats = marker_functions()
+
+    for node in getattr(tree, "body", ()):  # MODULE level only
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            for pat in fn_pats:
+                if _glob_match(node.name, pat):
+                    return f"registry convention: {node.name}()"
+            for dec in node.decorator_list:
+                nm = _decorator_name(dec)
+                if nm and nm in decorators:
+                    return f"decorator @{nm}"
+        elif isinstance(node, ast.ClassDef):
+            for dec in node.decorator_list:
+                nm = _decorator_name(dec)
+                if nm and nm in decorators:
+                    return f"decorator @{nm}"
+            for base in node.bases:
+                nm = _decorator_name(base)
+                if nm and nm in bases:
+                    return f"subclass of {nm}"
+    if module_hit:
+        return f"module naming convention: {stem}"
+    return ""
+
+
+def _decorator_name(node: ast.AST) -> str:
+    """Last dotted segment of a decorator/base expression."""
+    if isinstance(node, ast.Call):
+        node = node.func
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return ""
 
 def _has_main_guard(tree: ast.AST) -> bool:
     """Does this module run itself?

--- a/tests/battle_test/test_progress_board.py
+++ b/tests/battle_test/test_progress_board.py
@@ -12,7 +12,7 @@ from pathlib import Path
 import pytest
 
 from backend.core.ouroboros.battle_test.progress_board import (
-    DARK, ENTRY, LIVE, OFF, ProgressBoard, _coerce_bool, _flag_literals,
+    DARK, DYNAMIC_LIVE, ENTRY, LIVE, OFF, ProgressBoard, _coerce_bool, _flag_literals,
     _is_test_path, _module_name, board_enabled, render_board,
 )
 import ast
@@ -240,3 +240,103 @@ class TestEntryPoints:
                'import os\nos.environ.get("JARVIS_PLAIN_ENABLED", "1")\n')
         rows = {r.flag: r for r in _board(tmp_path).read().rows}
         assert rows["JARVIS_PLAIN_ENABLED"].state == DARK
+
+
+class TestSemanticShadowGraph:
+    """Static AST cannot evaluate `inspect.getmembers` — but it does not need to.
+
+    A runtime registry only finds what it can RECOGNISE, and what it recognises
+    is a convention written into the source. Detect the convention and you have
+    the edge the import graph is missing, with no import and no execution.
+
+    The markers here were MEASURED. `repl_dispatch_registry` has no `@verb`
+    decorator: it walks for modules named `*_repl` carrying module-level
+    `dispatch_<verb>_command` callables. A detector built on a plausible-looking
+    decorator would have matched nothing and reported a confident zero.
+    """
+
+    def test_registry_convention_beats_zero_importers(self, tmp_path,
+                                                      monkeypatch):
+        monkeypatch.setenv("JARVIS_PROGRESS_BOARD_ROOTS", "backend")
+        _write(tmp_path, "backend/thing_repl.py",
+               'import os\n'
+               'X = os.environ.get("JARVIS_THING_ENABLED", "1")\n'
+               'def dispatch_thing_command(line):\n    return None\n')
+        rows = {r.flag: r for r in _board(tmp_path).read().rows}
+        row = rows["JARVIS_THING_ENABLED"]
+        assert row.state == DYNAMIC_LIVE
+        assert "dispatch_thing_command" in row.reason
+
+    def test_module_naming_convention_alone_is_enough(self, tmp_path,
+                                                      monkeypatch):
+        monkeypatch.setenv("JARVIS_PROGRESS_BOARD_ROOTS", "backend")
+        _write(tmp_path, "backend/lonely_repl.py",
+               'import os\nos.environ.get("JARVIS_LONELY_ENABLED", "1")\n')
+        rows = {r.flag: r for r in _board(tmp_path).read().rows}
+        assert rows["JARVIS_LONELY_ENABLED"].state == DYNAMIC_LIVE
+
+    def test_decorator_marker_is_configurable_not_hardcoded(self, tmp_path,
+                                                            monkeypatch):
+        # A second registry with a different convention must be a config
+        # change, not a code change.
+        monkeypatch.setenv("JARVIS_PROGRESS_BOARD_ROOTS", "backend")
+        monkeypatch.setenv("JARVIS_PROGRESS_BOARD_DECORATORS", "verb")
+        _write(tmp_path, "backend/plugin.py",
+               'import os\n'
+               'X = os.environ.get("JARVIS_PLUGIN_ENABLED", "1")\n'
+               '@verb\ndef handler():\n    return None\n')
+        rows = {r.flag: r for r in _board(tmp_path).read().rows}
+        row = rows["JARVIS_PLUGIN_ENABLED"]
+        assert row.state == DYNAMIC_LIVE
+        assert "@verb" in row.reason
+
+    def test_base_class_marker(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("JARVIS_PROGRESS_BOARD_ROOTS", "backend")
+        monkeypatch.setenv("JARVIS_PROGRESS_BOARD_BASES", "BaseSensor")
+        _write(tmp_path, "backend/sensor.py",
+               'import os\n'
+               'X = os.environ.get("JARVIS_SENSOR_ENABLED", "1")\n'
+               'class Thing(BaseSensor):\n    pass\n')
+        rows = {r.flag: r for r in _board(tmp_path).read().rows}
+        assert rows["JARVIS_SENSOR_ENABLED"].state == DYNAMIC_LIVE
+
+    def test_nested_function_does_NOT_count(self, tmp_path, monkeypatch):
+        # A registry walks MODULE-level members. A conventionally-named inner
+        # function is unreachable by `getmembers`, and treating it as a marker
+        # would launder dark modules into live ones — the exact failure the
+        # vendored-venv exclusion already had to fix once.
+        monkeypatch.setenv("JARVIS_PROGRESS_BOARD_ROOTS", "backend")
+        _write(tmp_path, "backend/inner.py",
+               'import os\n'
+               'X = os.environ.get("JARVIS_INNER_ENABLED", "1")\n'
+               'def outer():\n'
+               '    def dispatch_inner_command(line):\n        return None\n')
+        rows = {r.flag: r for r in _board(tmp_path).read().rows}
+        assert rows["JARVIS_INNER_ENABLED"].state == DARK
+
+    def test_a_real_importer_still_wins(self, tmp_path, monkeypatch):
+        # DYNAMIC_LIVE is the fallback for "nothing imports it". Direct
+        # evidence must beat an inference.
+        monkeypatch.setenv("JARVIS_PROGRESS_BOARD_ROOTS", "backend")
+        _write(tmp_path, "backend/thing_repl.py",
+               'import os\n'
+               'X = os.environ.get("JARVIS_THING_ENABLED", "1")\n'
+               'def dispatch_thing_command(line):\n    return None\n')
+        _write(tmp_path, "backend/caller.py", "from backend import thing_repl\n")
+        rows = {r.flag: r for r in _board(tmp_path).read().rows}
+        assert rows["JARVIS_THING_ENABLED"].state == LIVE
+
+    @pytest.mark.asyncio
+    async def test_async_read_classifies_shadow_modules_identically(
+        self, tmp_path, monkeypatch,
+    ):
+        # The mandated async assertion: a file with NO inbound imports but a
+        # registry-recognisable marker is DYNAMIC_LIVE off the event loop too.
+        monkeypatch.setenv("JARVIS_PROGRESS_BOARD_ROOTS", "backend")
+        _write(tmp_path, "backend/async_repl.py",
+               'import os\n'
+               'X = os.environ.get("JARVIS_ASYNC_VERB_ENABLED", "1")\n'
+               'def dispatch_async_command(line):\n    return None\n')
+        board = _board(tmp_path)
+        rows = {r.flag: r for r in (await board.read_async()).rows}
+        assert rows["JARVIS_ASYNC_VERB_ENABLED"].state == DYNAMIC_LIVE


### PR DESCRIPTION
Static AST cannot evaluate `inspect.getmembers`. **It doesn't have to.** A runtime registry only finds what it can *recognise*, and what it recognises is a convention written into the source. Detect the convention and you have the edge the import graph is missing — no import, no execution, no side effects.

## The marker was measured, not assumed

**There is no `@verb` decorator in this codebase.** `repl_dispatch_registry.prime_registry` walks curated packages for modules named `*_repl` (or `repl` inside a sub-package) carrying **module-level** callables named `dispatch_<verb>_command`.

A detector built on a plausible-looking decorator would have matched nothing and reported a confident zero — the same shape as the `_ORDER` invariant that reported the one module obeying it.

## `DYNAMIC_LIVE` is deliberately not `LIVE`

*"Discovered by a registry"* and *"imported by a caller"* are different facts. Collapsing them would hide the day the registry stops being primed — which is exactly what happened when a decorator-orphaning edit collapsed priming from **76 verbs to 18** and nothing raised.

## Rules

- Markers are **env-configurable** (functions / module names / decorators / base classes) so a second registry is a config change, not a code change.
- Decorator and base-class sets ship **empty** rather than speculative — a list that quietly matches nothing looks like a working detector.
- **Nested functions do not count.** A registry walks module-level members; treating an inner function as a marker would launder dark modules into live ones.
- **A real importer still wins.** `DYNAMIC_LIVE` is the fallback for "nothing imports it"; direct evidence beats inference.

## Consulted at both return paths

The `ENTRY` state shipped consulting one of two exits and silently mis-stated every non-boolean flag. Repeating that here would be inexcusable — so both paths are covered and tested.

The line-anchored insert was itself necessary because the 8-space anchor also matched *inside* the 12-space line; `count()` saw 2 and the guard fired before anything was written.

## Reading

| state | count |
|---|---|
| live | 3139 |
| **dynamic** | **4** |
| entry | 136 |
| dark | 556 |
| off | 151 |

Only 4 because most `*_repl` modules *are* imported and were already `LIVE` — these are the genuinely shadow-only ones, each carrying the reason it was recognised (`dispatch_compact_command`, `graduate_repl`, …).

46 tests, including the mandated async assertion that a file with no inbound imports but a registry-recognisable marker classifies as `DYNAMIC_LIVE` off the event loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a semantic shadow graph to detect modules discoverable by runtime registries without imports. Introduces a new `DYNAMIC_LIVE` state and shows the specific marker that made a module discoverable.

- New Features
  - New `DYNAMIC_LIVE` state when a module has zero importers but matches registry conventions; the reason is shown (e.g., function name or module naming).
  - Default markers: module-level functions matching `dispatch_*_command` and module basenames `*_repl` or `repl`.
  - Markers are env-configurable via `JARVIS_PROGRESS_BOARD_FN_MARKERS`, `JARVIS_PROGRESS_BOARD_MODULE_MARKERS`, `JARVIS_PROGRESS_BOARD_DECORATORS`, and `JARVIS_PROGRESS_BOARD_BASES`; decorator/base lists default to empty.
  - Precedence rules: real imports still yield `LIVE`; nested functions do not count; async reads classify the same as sync.

- Bug Fixes
  - ENTRY classification now checks both return paths for non-boolean flags, fixing prior misreporting.

<sup>Written for commit 4709e6166b2fada3b08bcbd05940a0fb2c5e0b95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

