### PR TITLE
feat(ov): ov demo — watch the cockpit without paying for it

### DIFF
--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -29,7 +29,7 @@ from typing import Any, Callable, List, Optional, Sequence
 from backend.core.ouroboros.ui.theme import build_console
 
 _VERBS = {"cockpit", "run", "daemon", "status", "attach", "system", "hive",
-          "doctor", "restart", "version"}
+          "doctor", "demo", "restart", "version"}
 _HELP_TOKENS = {"help", "--help", "-h"}
 _VERSION_TOKENS = {"version", "--version", "-V"}
 
@@ -201,6 +201,7 @@ _HELP_TEXT = """ov -- Ouroboros + Venom, autonomous engineering organism
   ov status           last-session digest (no boot)
   ov doctor [--live]  8-edge connectivity matrix; --live fires the
                       trace-isolated synthetic tool probe end-to-end
+  ov demo [scene]     watch the cockpit with synthetic events
   ov attach           attach this terminal to the running organism
   ov version          version + milestone
   ov help             this message
@@ -261,6 +262,8 @@ def resolve(argv: Optional[Sequence[str]] = None) -> Invocation:
         return Invocation("hive")
     if verb == "doctor":
         return Invocation("doctor", list(rest))
+    if verb == "demo":
+        return Invocation("demo", list(rest))
     if verb == "restart":
         return Invocation("restart", list(rest))
     # cockpit (explicit or defaulted)
@@ -3504,6 +3507,15 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             return rc
         inv = Invocation("cockpit", [])
 
+    if inv.action == "demo":
+        # Lazy, like `doctor`: a demo that cannot import must not be able to
+        # cost the cockpit its boot path.
+        try:
+            from backend.core.ouroboros.cli.ov_demo import run_demo
+        except Exception as exc:  # noqa: BLE001
+            console.print(f"ov demo unavailable: {exc}", markup=False)
+            return 1
+        return run_demo(console, inv.delegate_argv)
     if inv.action == "doctor":
         try:
             from backend.core.ouroboros.cli.ov_doctor import run_doctor

--- a/backend/core/ouroboros/cli/ov_demo.py
+++ b/backend/core/ouroboros/cli/ov_demo.py
@@ -1,0 +1,260 @@
+"""`ov demo` — watch the cockpit without paying for it.
+
+Thirty-odd PRs of cockpit work shipped this month, verified by unit tests and
+one PTY probe. Almost none of it has been WATCHED running, because seeing it
+meant booting the organism and spending model calls to make something happen.
+
+So this drives the real surfaces with synthetic events. No provider, no
+network, no tokens. Two questions it answers that nothing else does:
+
+  ``ov demo board``      where does `ov` actually STAND — live / dark / dynamic
+  ``ov demo transcript`` what does the CC-style deck LOOK like
+
+The rule that makes it worth having
+-----------------------------------
+It calls the SAME renderers the cockpit calls. A demo with its own draw path
+is worse than no demo: it agrees with itself while the cockpit is broken, and
+that is the exact defect shape this codebase has hit repeatedly — a fake
+modelling a superseded seam, a producer with no consumer, a completer
+implementing the one method the library never calls. Every one passed its own
+tests.
+
+So `moltbook_inline.render_thread`, `verb_description.to_operator_voice` and
+`progress_board.render_board` are imported and called, never reimplemented. If
+a renderer regresses, this regresses with it — which is the entire point.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Callable, List, Optional, Sequence
+
+logger = logging.getLogger("Ouroboros.OvDemo")
+
+__all__ = ["run_demo", "demo_scenes", "DEMO_HELP"]
+
+DEMO_HELP = """ov demo -- watch the cockpit, no model calls
+
+  ov demo             board + transcript
+  ov demo board       what is LIVE vs DARK right now (derived from the tree)
+  ov demo transcript  the CC-style deck: ops, diffs, agora threads
+  ov demo scenes      list available scenes
+"""
+
+
+def _rule(console: Any, title: str) -> None:
+    try:
+        console.rule(f"[dim]{title}[/dim]")
+    except Exception:  # noqa: BLE001 — a demo must never be the thing that breaks
+        try:
+            console.print(f"-- {title} --", markup=False)
+        except Exception:  # noqa: BLE001
+            pass
+
+
+def _say(console: Any, text: str = "") -> None:
+    try:
+        console.print(text, markup=False, highlight=False)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Scene: the progress board
+# ---------------------------------------------------------------------------
+
+
+def scene_board(console: Any, argv: Sequence[str] = ()) -> int:
+    """Where `ov` stands, derived from the tree rather than from a checklist.
+
+    The scan is real (thousands of `ast.parse` calls, a few seconds). It is not
+    cached across invocations on purpose: a status view that shows yesterday's
+    answer is worse than one that takes four seconds, because the operator
+    cannot tell which they are looking at.
+    """
+    try:
+        from backend.core.ouroboros.battle_test.progress_board import (
+            DARK, DYNAMIC_LIVE, ENTRY, LIVE, OFF, ProgressBoard, render_board,
+        )
+    except Exception as exc:  # noqa: BLE001
+        _say(console, f"  progress board unavailable: {exc}")
+        return 1
+
+    _rule(console, "where ov stands")
+    reading = ProgressBoard().read()
+    for line in render_board(reading, limit=_limit(argv)):
+        _say(console, line)
+
+    # The states that are NOT plain live/dark carry the interesting news, and
+    # a count line alone buries them.
+    dynamic = reading.by_state(DYNAMIC_LIVE)
+    if dynamic:
+        _say(console)
+        _say(console, "  discovered at runtime (no inbound import):")
+        for row in dynamic[:6]:
+            _say(console, f"    ◇ {row.flag[:44]:<44} {row.reason[:40]}")
+    _say(console)
+    _say(console, f"  entry points {len(reading.by_state(ENTRY))}"
+                  f" · off {len(reading.by_state(OFF))}"
+                  f" · verbs primed {len(reading.verbs)}")
+    _say(console, "  dark = enabled, on disk, imported by nothing. A SIGNAL,")
+    _say(console, "  not a defect count: plugin discovery and dynamic import")
+    _say(console, "  remain invisible to a static graph.")
+    return 0
+
+
+def _limit(argv: Sequence[str]) -> int:
+    for arg in argv:
+        if arg.startswith("--limit="):
+            try:
+                return max(0, int(arg.split("=", 1)[1]))
+            except (TypeError, ValueError):
+                return 12
+    return 12
+
+
+# ---------------------------------------------------------------------------
+# Scene: the transcript
+# ---------------------------------------------------------------------------
+
+#: A synthetic op. Deliberately a FAILING one: the deck's whole grammar —
+#: `⎿` results, an agora thread reacting to a failure — only shows itself when
+#: something goes wrong, and a demo of the happy path shows the least
+#: interesting third of the surface.
+_SCRIPT: List[Any] = [
+    ("op", "⏺ Read(backend/core/ouroboros/governance/risk_tier_floor.py)"),
+    ("res", "⎿ 847 lines"),
+    ("op", "⏺ Update(risk_tier_floor.py)"),
+    ("res", "⎿ +18 -3"),
+    ("diff", "+    except RiskFloorConfigError:"),
+    ("diff", "+        raise"),
+    ("diff", "-    except Exception:  # noqa: BLE001"),
+    ("op", "⏺ Validate(7759-86)"),
+    ("res", "⎿ ✗ 3 failed · test_scoped_paths, test_sandbox_dir"),
+]
+
+#: The agora reacting to that failure, in the schema `moltbook_inline` expects.
+_THREAD: List[dict] = [
+    {"handle": "@the-pit", "op_id": "op-7759-86",
+     "body": "three tests. you fixed the assert and broke the file."},
+    {"handle": "@the-builder", "op_id": "op-7759-86",
+     "body": "the containment check is right, the fixture is stale"},
+    {"handle": "@cassandra", "op_id": "op-7759-86", "kind": "conflict",
+     "body": "⚔ REVIEW disagrees: that except clause still swallows I2"},
+]
+
+
+def scene_transcript(console: Any, argv: Sequence[str] = ()) -> int:
+    """The CC-style deck, rendered by the cockpit's OWN renderers."""
+    _rule(console, "transcript")
+    for kind, text in _SCRIPT:
+        if kind == "op":
+            _say(console, text)
+        elif kind == "res":
+            _say(console, f"  {text}")
+        else:
+            _say(console, f"     {text}")
+
+    try:
+        from backend.core.ouroboros.battle_test.moltbook_inline import (
+            render_thread,
+        )
+        for line in render_thread(_THREAD, width=76):
+            _say(console, line)
+    except Exception as exc:  # noqa: BLE001
+        _say(console, f"  (agora unavailable: {exc})")
+
+    _say(console)
+    _rule(console, "palette")
+    _demo_palette(console)
+    return 0
+
+
+def _demo_palette(console: Any) -> None:
+    """A few real verbs, described by the real normaliser.
+
+    Verbs come from the LIVE registry, so if priming collapses — as it once did
+    from 76 to 18 when an edit orphaned a decorator — this scene shrinks
+    visibly instead of quietly rendering a shorter list nobody counts.
+    """
+    try:
+        from backend.core.ouroboros.battle_test.repl_dispatch_registry import (
+            list_verbs, prime_registry,
+        )
+        from backend.core.ouroboros.battle_test.verb_description import (
+            to_operator_voice,
+        )
+        try:
+            prime_registry()
+        except Exception:  # noqa: BLE001
+            pass
+        verbs = list(list_verbs())
+        if not verbs:
+            _say(console, "  (no verbs primed — registry empty)")
+            return
+        for verb in verbs[:8]:
+            desc = ""
+            try:
+                fn = _dispatcher_for(verb)
+                desc = to_operator_voice(getattr(fn, "__doc__", ""), verb, 46)
+            except Exception:  # noqa: BLE001
+                desc = ""
+            _say(console, f"  /{verb:<20} {desc}")
+        _say(console, f"  … {len(verbs)} verbs primed")
+    except Exception as exc:  # noqa: BLE001
+        _say(console, f"  (palette unavailable: {exc})")
+
+
+def _dispatcher_for(verb: str) -> Any:
+    from backend.core.ouroboros.battle_test import repl_dispatch_registry as reg
+    table = getattr(reg, "_VERB_TO_DISPATCHER", {}) or {}
+    return table.get(verb)
+
+
+# ---------------------------------------------------------------------------
+# Router
+# ---------------------------------------------------------------------------
+
+#: scene name -> handler. A table, not an if-chain, so `ov demo scenes` is
+#: derived from what actually exists and cannot drift from it.
+_SCENES: "dict[str, Callable[[Any, Sequence[str]], int]]" = {
+    "board": scene_board,
+    "transcript": scene_transcript,
+}
+
+
+def demo_scenes() -> Sequence[str]:
+    return tuple(sorted(_SCENES))
+
+
+def run_demo(console: Any, argv: Optional[Sequence[str]] = None) -> int:
+    """`ov demo [scene] [--limit=N]`. Returns a process exit code."""
+    args = list(argv or ())
+    positional = [a for a in args if not a.startswith("-")]
+
+    if any(a in ("-h", "--help", "help") for a in args):
+        _say(console, DEMO_HELP)
+        return 0
+    if positional and positional[0] == "scenes":
+        for name in demo_scenes():
+            _say(console, f"  {name}")
+        return 0
+
+    if not positional:
+        rc = 0
+        for name in demo_scenes():
+            rc |= _SCENES[name](console, args)
+            _say(console)
+        return rc
+
+    scene = positional[0]
+    handler = _SCENES.get(scene)
+    if handler is None:
+        # Refuse, never silently ignore — the same discipline `ov doctor` uses
+        # for unknown flags (EX_USAGE).
+        near = [n for n in demo_scenes() if n.startswith(scene[:3])]
+        hint = f" — did you mean {near[0]!r}?" if near else ""
+        _say(console, f"unknown scene {scene!r}{hint}"
+                      f" (known: {', '.join(demo_scenes())})")
+        return 64
+    return handler(console, args)

--- a/tests/cli/test_ov_demo.py
+++ b/tests/cli/test_ov_demo.py
@@ -1,0 +1,173 @@
+"""`ov demo` — the surface that lets the cockpit be watched without paying.
+
+The value is entirely in calling the REAL renderers. A demo with its own draw
+path agrees with itself while the cockpit is broken, which is the defect shape
+this codebase keeps hitting. So these tests pin the wiring and the routing;
+they deliberately do NOT assert on rendered text, because a test that pins the
+demo's output would have to be updated whenever a renderer legitimately
+changes, and people update such tests by copying the new output — which
+silently blesses regressions.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.cli.ov import resolve
+from backend.core.ouroboros.cli.ov_demo import (
+    DEMO_HELP, demo_scenes, run_demo,
+)
+
+
+class _Recorder:
+    """Console double. Records rather than draws."""
+
+    def __init__(self) -> None:
+        self.lines: list = []
+
+    def print(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
+        self.lines.append(str(args[0]) if args else "")
+
+    def rule(self, text: str = "") -> None:
+        self.lines.append(f"--{text}--")
+
+    @property
+    def text(self) -> str:
+        return "\n".join(self.lines)
+
+
+class TestRouting:
+    def test_ov_resolves_demo_as_a_verb(self):
+        inv = resolve(["demo"])
+        assert inv.action == "demo"
+
+    def test_scene_is_forwarded_verbatim(self):
+        # Mirrors `doctor`, which also forwards its rest untouched — the demo
+        # owns its own argument grammar rather than teaching `resolve` about it.
+        inv = resolve(["demo", "transcript", "--limit=3"])
+        assert inv.action == "demo"
+        assert inv.delegate_argv == ["transcript", "--limit=3"]
+
+    def test_bare_ov_is_still_the_cockpit(self):
+        # A new verb must not shadow the default path.
+        assert resolve([]).action == "cockpit"
+
+
+class TestSceneDispatch:
+    def test_help_is_free_and_boots_nothing(self):
+        console = _Recorder()
+        assert run_demo(console, ["--help"]) == 0
+        assert "ov demo" in console.text
+
+    def test_scenes_are_derived_not_listed(self):
+        console = _Recorder()
+        assert run_demo(console, ["scenes"]) == 0
+        for name in demo_scenes():
+            assert name in console.text
+
+    def test_unknown_scene_refuses_with_ex_usage(self):
+        # Refuse, never silently ignore — `ov doctor`'s discipline for unknown
+        # flags. A demo that quietly runs the wrong scene teaches the operator
+        # that the argument does not matter.
+        console = _Recorder()
+        assert run_demo(console, ["nonsense"]) == 64
+
+    def test_near_miss_gets_a_suggestion(self):
+        console = _Recorder()
+        run_demo(console, ["tra"])
+        assert "transcript" in console.text
+
+    def test_transcript_scene_runs_clean(self):
+        console = _Recorder()
+        assert run_demo(console, ["transcript"]) == 0
+        assert console.lines
+
+
+class TestRealRenderersAreUsed:
+    def test_transcript_calls_the_agora_renderer(self, monkeypatch):
+        """The load-bearing property: it must not draw its own version.
+
+        Asserted by BREAKING the real renderer and proving the demo notices.
+        Checking that some text appeared would pass just as well against a
+        hardcoded string, which is precisely the failure being guarded.
+        """
+        import backend.core.ouroboros.battle_test.moltbook_inline as mb
+
+        called = {"n": 0}
+
+        def _spy(posts, **kwargs):  # noqa: ANN001, ANN003
+            called["n"] += 1
+            return ["SENTINEL"]
+
+        monkeypatch.setattr(mb, "render_thread", _spy)
+        console = _Recorder()
+        run_demo(console, ["transcript"])
+        assert called["n"] == 1
+        assert "SENTINEL" in console.text
+
+    def test_a_broken_renderer_degrades_instead_of_crashing(self, monkeypatch):
+        import backend.core.ouroboros.battle_test.moltbook_inline as mb
+
+        def _boom(*_a, **_k):  # noqa: ANN002, ANN003
+            raise RuntimeError("renderer down")
+
+        monkeypatch.setattr(mb, "render_thread", _boom)
+        console = _Recorder()
+        # A demo must never be the thing that breaks — but it must SAY so,
+        # not silently draw a shorter deck that looks fine.
+        assert run_demo(console, ["transcript"]) == 0
+        assert "agora unavailable" in console.text
+
+
+class TestBoardScene:
+    def test_board_scene_runs_and_reports(self, tmp_path, monkeypatch):
+        # Scoped to an empty root so the test does not walk the whole tree.
+        monkeypatch.setenv("JARVIS_PROGRESS_BOARD_ROOTS", "nonexistent")
+        console = _Recorder()
+        assert run_demo(console, ["board"]) == 0
+        assert "live" in console.text
+
+    def test_board_degrades_when_the_board_is_unavailable(self, monkeypatch):
+        import backend.core.ouroboros.cli.ov_demo as demo
+
+        real_import = __builtins__["__import__"] if isinstance(
+            __builtins__, dict) else __builtins__.__import__
+
+        def _fail(name, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+            if "progress_board" in name:
+                raise ImportError("board gone")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.__import__", _fail)
+        console = _Recorder()
+        assert demo.scene_board(console) == 1
+        assert "unavailable" in console.text
+
+
+class TestNoModelCalls:
+    def test_demo_module_never_reaches_a_provider(self):
+        """The cost guarantee, enforced structurally rather than promised.
+
+        Every scene is synthetic. A future scene that reaches for a provider
+        to make the deck 'more realistic' would reintroduce exactly the cost
+        this exists to avoid, and would do it invisibly.
+        """
+        import ast
+        import pathlib
+
+        src = pathlib.Path(
+            "backend/core/ouroboros/cli/ov_demo.py",
+        ).read_text(encoding="utf-8")
+        tree = ast.parse(src)
+        banned = ("providers", "candidate_generator", "doubleword",
+                  "anthropic", "openai", "requests", "httpx", "urllib")
+        for node in ast.walk(tree):
+            names = []
+            if isinstance(node, ast.Import):
+                names = [a.name for a in node.names]
+            elif isinstance(node, ast.ImportFrom):
+                names = [node.module or ""]
+            for name in names:
+                assert not any(b in name.lower() for b in banned), (
+                    f"ov_demo must not import {name!r} — the whole point is "
+                    f"that watching the cockpit costs nothing"
+                )


### PR DESCRIPTION
Thirty-odd PRs of cockpit work shipped this month, verified by unit tests and one PTY probe. **Almost none of it has been watched**, because seeing it meant booting the organism and spending model calls to make anything happen.

```
ov demo board       where ov STANDS — live/dark/dynamic/entry, derived from the tree
ov demo transcript  what the CC-style deck LOOKS like
ov demo scenes      what's available
```

No provider, no network, no tokens.

## The rule that makes it worth having

**It calls the same renderers the cockpit calls.** A demo with its own draw path is worse than no demo — it agrees with itself while the cockpit is broken, which is the exact defect shape this codebase keeps hitting (a fake modelling a superseded seam, a producer with no consumer, a completer implementing the one method the library never calls).

`moltbook_inline.render_thread`, `verb_description.to_operator_voice`, `progress_board.render_board` and the live verb registry are imported and called, never reimplemented. If a renderer regresses, this regresses with it.

Pinned **structurally**, not promised:
- One test **breaks** the real agora renderer and asserts the demo notices. A text-presence assertion would pass equally against a hardcoded string — precisely the failure being guarded.
- An AST test **forbids** `ov_demo` from importing any provider/network module, so a future scene can't quietly reintroduce the cost this exists to avoid.

## It already found something

The palette scene renders `/canvas` and `/coherence` as **"Line and dispatch"** — a contentless docstring slipping past `is_contentless()` because it clears the 12-character floor. Invisible in a unit test; obvious in two seconds of looking at the real surface.

That is the entire argument for building this, demonstrated on its first run.

## Wiring

A **sibling verb** at all four points the existing verbs use — `_VERBS`, `resolve()`, the `main()` dispatch chain, `_HELP_TEXT` — with a lazy import like `doctor`, so a broken demo can never cost the cockpit its boot path.

A **subcommand, not a second console script**: a new `[project.scripts]` entry needs `pip install -e .` to mint its shim, which is the documented stale-shim trap. `ov demo` works with the shim you already have.

Scenes are a **table**, so `ov demo scenes` is derived from what exists and cannot drift. An unknown scene returns `EX_USAGE` (64) with a suggestion — refuse, never silently ignore.

13 tests.

## Not in this PR

Step 3, mounting `dynamic_region_container`, is still open. `JARVIS_REGION_LAYOUT_ENABLED` remains `dark` on the board — which is now the completion signal for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `ov demo` to watch the cockpit with synthetic events, offline and free of provider/network costs. It uses the same renderers as the cockpit so UI regressions are visible without booting the organism.

- **New Features**
  - Adds `demo` verb to `ov` (lazy-loaded like `doctor`); help updated.
  - Scenes:
    - `ov demo board` — live/dark/dynamic/entry from the tree via `progress_board.render_board` (supports `--limit=N`).
    - `ov demo transcript` — CC-style deck + agora thread via `moltbook_inline.render_thread`, plus a real verb palette via `verb_description.to_operator_voice`.
    - `ov demo scenes` — lists available scenes.
  - Calls real renderers and the live verb registry; degrades with a clear message if a renderer is unavailable instead of crashing.
  - Guarantees zero provider/network usage; an AST test forbids importing providers; 13 tests cover routing and renderer wiring.
  - Unknown scene exits with EX_USAGE (64) and suggests a near match.

- **Migration**
  - Use `ov demo`, `ov demo board`, `ov demo transcript`, or `ov demo scenes`; no boot, network, or tokens required.
  - No config changes; works with the existing console shim.

<sup>Written for commit 40b3ecd0cafc29d9455df0be8bf853193692bec5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

