### PR TITLE
feat(ov): mount the region layout — the seam finally has a consumer

### DIFF
--- a/backend/core/ouroboros/battle_test/bipartite_layout.py
+++ b/backend/core/ouroboros/battle_test/bipartite_layout.py
@@ -589,6 +589,42 @@ def _palette_multicolumn() -> bool:
             .strip().lower() in ("1", "true", "yes", "on"))
 
 
+
+def _mount_region_layout(rows: "list") -> Any:
+    """Derive the root from the arbiter, or fall back to the plain HSplit.
+
+    NEVER raises. This is the root container of the operator's daily surface;
+    a status-quo fallback is always available and is strictly better than a
+    cockpit that will not boot.
+
+    `rows[0]` is the canvas — the deck region. The prompt and toolbar rows are
+    NOT regions: they are chrome that must survive every arbitration, so they
+    stay in the outer HSplit rather than becoming columns the arbiter could
+    decide to hide at 40 columns.
+    """
+    from prompt_toolkit.layout import HSplit
+    try:
+        from backend.core.ouroboros.battle_test.region_layout import (
+            RegionSources, dynamic_region_container, region_layout_enabled,
+        )
+        from backend.core.ouroboros.battle_test.viewport_arbiter import (
+            ViewportArbiter, arbiter_enabled,
+        )
+        if not (region_layout_enabled() and arbiter_enabled()) or not rows:
+            return HSplit(rows)
+
+        body, chrome = rows[0], list(rows[1:])
+        # Only `deck` has a source today. `lanes` and `transcript` return None,
+        # and `build_region_tree` DROPS a region whose factory yields None —
+        # so an unsupplied region costs nothing rather than drawing an empty
+        # panel that looks like a bug.
+        sources = RegionSources(deck=lambda: body)
+        derived = dynamic_region_container(ViewportArbiter(), sources)
+        return HSplit([derived] + chrome)
+    except Exception:  # noqa: BLE001
+        logger.debug("[Bipartite] region layout mount degraded", exc_info=True)
+        return HSplit(rows)
+
 def build_bipartite_application(
     mux: BipartiteLayout,
     *,
@@ -911,7 +947,25 @@ def build_bipartite_application(
             content=FormattedTextControl(_toolbar_fragments, focusable=False),
             height=1, wrap_lines=False,
         ))
-    root: Any = HSplit(rows)
+    # ── Region layout mount (PR #70213's seam, finally consumed) ──────
+    #
+    # `viewport_arbiter` has decided placements since #70187 and
+    # `region_layout.dynamic_region_container` has been able to build them
+    # since #70213 — with nothing reading either. `JARVIS_REGION_LAYOUT_ENABLED`
+    # read DARK on the progress board, which is exactly what that state is for.
+    #
+    # Mounted CONSERVATIVELY on purpose. The arbiter arbitrates over
+    # ("deck", "lanes", "transcript"), and only `deck` has a widget source
+    # today — the nested task tree, collapse/expand and transcript mode are the
+    # features that will supply the other two. So the derived tree is TODAY'S
+    # tree, and the observable surface does not move.
+    #
+    # That is the point, not a limitation. A layout change and a feature change
+    # landing together is unbisectable when the cockpit misbehaves, and this
+    # cockpit is the thing the operator stares at all day. The seam goes live,
+    # `DynamicContainer` starts re-deriving per frame, and the next slice hangs
+    # regions off a surface that has already been watched.
+    root: Any = _mount_region_layout(rows)
     if _palette is not None:
         # Z-INDEX OVERLAY, not a row.
         #

--- a/tests/battle_test/test_region_layout_mount.py
+++ b/tests/battle_test/test_region_layout_mount.py
@@ -1,0 +1,100 @@
+"""The mount — #70213's seam, finally consumed.
+
+`viewport_arbiter` decided placements from #70187 and
+`region_layout.dynamic_region_container` could build them from #70213, with
+NOTHING reading either. `JARVIS_REGION_LAYOUT_ENABLED` read DARK on the
+progress board for two PRs, which is precisely what that state exists to say.
+
+These pin the two properties that make the mount safe to leave on: the root
+still renders at every width, and the observable surface has not moved.
+"""
+from __future__ import annotations
+
+import os
+import pty
+
+import pytest
+
+from prompt_toolkit.layout.containers import Window
+
+from backend.core.ouroboros.battle_test.bipartite_layout import (
+    BipartiteLayout, _mount_region_layout, build_bipartite_application,
+)
+
+
+def _render_at(cols: int, app) -> str:
+    """Render on a REAL pty output.
+
+    prompt_toolkit's geometry differs under a dummy output, and the 8-row
+    prompt slab was invisible until a real terminal drew it.
+    """
+    from prompt_toolkit.data_structures import Size
+    from prompt_toolkit.output.vt100 import Vt100_Output
+
+    _master, slave = pty.openpty()
+    try:
+        out = Vt100_Output(open(slave, "w", closefd=False),
+                           lambda: Size(rows=30, columns=cols))
+        app.output = out
+        app.renderer.output = out
+        app._redraw()
+        return type(app.layout.container).__name__
+    finally:
+        os.close(_master)
+
+
+@pytest.mark.parametrize("cols", [200, 120, 80, 40])
+def test_renders_without_geometry_panic(cols):
+    os.environ.setdefault("TERM", "xterm-256color")
+    app = build_bipartite_application(BipartiteLayout(), on_accept=lambda t: None)
+    assert _render_at(cols, app)
+
+
+class TestConservativeMount:
+    def test_chrome_is_never_a_region(self):
+        # The prompt and toolbar must survive every arbitration. As columns
+        # they would be something the arbiter could decide to hide at 40 cols,
+        # and a cockpit that drops its prompt is not a narrower cockpit.
+        rows = [Window(), Window(), Window()]
+        root = _mount_region_layout(rows)
+        assert type(root).__name__ == "HSplit"
+        assert len(root.children) == len(rows)
+
+    def test_falls_back_when_the_flag_is_off(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_REGION_LAYOUT_ENABLED", "0")
+        rows = [Window(), Window()]
+        root = _mount_region_layout(rows)
+        assert type(root).__name__ == "HSplit"
+
+    def test_empty_rows_do_not_explode(self):
+        assert _mount_region_layout([]) is not None
+
+    def test_mount_never_raises(self, monkeypatch):
+        # This is the ROOT container of the daily surface. A status-quo
+        # fallback always beats a cockpit that will not boot.
+        import backend.core.ouroboros.battle_test.region_layout as rl
+
+        def _boom(*_a, **_k):
+            raise RuntimeError("arbiter down")
+
+        monkeypatch.setattr(rl, "dynamic_region_container", _boom)
+        root = _mount_region_layout([Window(), Window()])
+        assert type(root).__name__ == "HSplit"
+
+
+class TestSeamIsLive:
+    def test_bipartite_actually_imports_the_region_layout(self):
+        # The whole point. A seam with no consumer is what the board calls
+        # DARK, and this module spent two PRs in that state.
+        import ast
+        import pathlib
+
+        src = pathlib.Path(
+            "backend/core/ouroboros/battle_test/bipartite_layout.py",
+        ).read_text(encoding="utf-8")
+        modules = {
+            n.module or "" for n in ast.walk(ast.parse(src))
+            if isinstance(n, ast.ImportFrom)
+        }
+        assert any("region_layout" in m for m in modules)
+        assert any("viewport_arbiter" in m for m in modules)


### PR DESCRIPTION
`viewport_arbiter` has decided placements since **#70187**, and `region_layout.dynamic_region_container` has been able to build them since **#70213** — with **nothing reading either**.

`JARVIS_REGION_LAYOUT_ENABLED` read **DARK** on the progress board for two PRs. That is exactly what the state exists to say, and it is now the completion signal:

```
JARVIS_REGION_LAYOUT_ENABLED -> ('live', 1)
```

## Mounted conservatively, on purpose

The arbiter arbitrates over `(deck, lanes, transcript)` and **only `deck` has a widget source today** — the nested task tree, collapse/expand and transcript mode are the features that will supply the other two. `build_region_tree` *drops* a region whose factory yields `None`, so an unsupplied region costs nothing rather than drawing an empty panel that reads as a bug.

**The derived tree is today's tree. The observable surface does not move.**

That's the point, not a limitation. A layout change and a feature change landing together is unbisectable when the cockpit misbehaves — and this cockpit is what you stare at all day. The seam goes live, `DynamicContainer` starts re-deriving per frame, and the next slice hangs regions off a surface that has already been watched.

## Chrome is never a region

The prompt and toolbar stay in the outer `HSplit`. As columns they'd be something the arbiter could decide to hide at 40 cols — and a cockpit that drops its prompt is not a narrower cockpit.

`_mount_region_layout` never raises. This is the root container of the daily surface; a status-quo fallback always beats a cockpit that won't boot.

## Verified under a real pty

```
 200c  root=HSplit  rendered=OK
 120c  root=HSplit  rendered=OK
  80c  root=HSplit  rendered=OK
  40c  root=HSplit  rendered=OK
```

Real `Vt100_Output`, not a dummy — prompt_toolkit's geometry differs under a dumb output, and the 8-row prompt slab was invisible until a real terminal drew it.

## A test bug worth recording

The first version of these tests used string placeholders for rows. `HSplit` rejects non-containers, so they exercised a `ValueError` path instead of the mount — and made the fail-safe look broken when it wasn't. Fixed to real `Window`s.

9 new tests + 12 existing region-layout tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mounts the region layout in the bipartite UI, consuming placements from `viewport_arbiter` via `region_layout.dynamic_region_container`. Enables `JARVIS_REGION_LAYOUT_ENABLED` with a safe fallback, keeping the current UI unchanged.

- **New Features**
  - Added `_mount_region_layout` that never raises; falls back to plain `HSplit` when disabled or on errors.
  - Only `deck` is sourced; `lanes`/`transcript` are dropped when None (no empty panels).
  - Prompt and toolbar stay outside regions (chrome is never a region).
  - Verified rendering on a real pty at 200/120/80/40 cols; no geometry issues.
  - New tests cover fallback behavior, flag off, empty rows, arbiter errors, and that `region_layout` is actually imported.

<sup>Written for commit f6b4f58e807248633ecff3bf58f3338e6a8b00d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

