### PR TITLE
fix(ov): 'not primed' is not 'zero verbs'

### DIFF
--- a/backend/core/ouroboros/battle_test/progress_board.py
+++ b/backend/core/ouroboros/battle_test/progress_board.py
@@ -174,6 +174,10 @@ class BoardReading:
     duration_s: float = 0.0
     degraded: str = ""
     verbs: Tuple[str, ...] = ()
+    #: False means discovery has not RUN — distinct from 'ran and
+    #: found none'. Collapsing the two rendered an unprimed registry
+    #: as 'verbs primed 0', which reads as 'this cockpit has no verbs'.
+    verbs_primed: bool = False
 
     def by_state(self, state: str) -> List[FeatureRow]:
         return [r for r in self.rows if r.state == state]
@@ -201,6 +205,7 @@ class BoardReading:
             "duration_s": round(self.duration_s, 3),
             "degraded": self.degraded,
             "verbs": len(self.verbs),
+            "verbs_primed": self.verbs_primed,
             "rows": [r.to_dict() for r in self.rows],
         }
 
@@ -308,7 +313,7 @@ class ProgressBoard:
                 return reading
             self.build_import_graph()
             reading.scanned_files = self._scanned
-            reading.verbs = self._load_verbs()
+            reading.verbs, reading.verbs_primed = self._load_verbs()
             # Registry specs ENRICH (description, category, declared default);
             # they no longer define the universe. A flag present in the source
             # but absent from the registry is a real feature, not a non-entity.
@@ -357,14 +362,22 @@ class ProgressBoard:
                          exc_info=True)
             return []
 
-    def _load_verbs(self) -> Tuple[str, ...]:
+    def _load_verbs(self) -> Tuple[Tuple[str, ...], bool]:
+        """(verbs, primed). Deliberately does NOT prime.
+
+        A read-only status view must not trigger the import walk that priming
+        performs — that is a side effect the operator did not ask for, and it
+        would make simply LOOKING at the board change what the process has
+        loaded. So the board reports what is true now, and says plainly when
+        discovery has not run.
+        """
         try:
             from backend.core.ouroboros.battle_test.repl_dispatch_registry import (
-                list_verbs,
+                list_verbs, registry_primed,
             )
-            return tuple(list_verbs())
+            return (tuple(list_verbs()), bool(registry_primed()))
         except Exception:  # noqa: BLE001
-            return ()
+            return ((), False)
 
     def _row_for(self, flag: str, site: str,
                  spec: Optional[Any] = None) -> FeatureRow:

--- a/backend/core/ouroboros/battle_test/repl_dispatch_registry.py
+++ b/backend/core/ouroboros/battle_test/repl_dispatch_registry.py
@@ -208,6 +208,27 @@ def list_verbs() -> Tuple[str, ...]:
         return tuple(sorted(_VERB_TO_DISPATCHER.keys()))
 
 
+def registry_primed() -> bool:
+    """Has discovery RUN? Distinct from "are there verbs".
+
+    Added because a consumer could not tell the two apart. `list_verbs()`
+    returns an empty tuple both when priming has not happened yet and when it
+    happened and found nothing — and the progress board rendered the first case
+    as `verbs primed 0`, which reads as "this cockpit has no verbs" rather than
+    "nobody has asked yet".
+
+    The alternative was for callers to read `_REGISTRY_PRIMED` directly. That
+    is the same private reach-around the risk-tier ladder has an authority
+    invariant against, and it would have made this module's internals part of
+    its contract by accident.
+
+    Read-only and side-effect-free ON PURPOSE: a status view must be able to
+    ask this WITHOUT triggering the import walk that priming performs.
+    """
+    with _REGISTRY_LOCK:
+        return bool(_REGISTRY_PRIMED)
+
+
 # ---------------------------------------------------------------------------
 # Verb-name extraction from module path
 # ---------------------------------------------------------------------------
@@ -585,6 +606,7 @@ __all__ = [
     "RegistryReport",
     "list_verbs",
     "prime_registry",
+    "registry_primed",
     "repl_dispatch_autodiscovery_enabled",
     "reset_registry_for_tests",
     "try_dispatch",

--- a/backend/core/ouroboros/cli/ov_demo.py
+++ b/backend/core/ouroboros/cli/ov_demo.py
@@ -42,6 +42,30 @@ DEMO_HELP = """ov demo -- watch the cockpit, no model calls
 """
 
 
+
+def _ensure_primed() -> bool:
+    """Prime the verb registry once per process. Returns whether it is primed.
+
+    The demo is a demo of CAPABILITY — "what can this cockpit do" — so it
+    primes, exactly as the cockpit does at boot. The progress board deliberately
+    does not, because a read-only status view must not change what the process
+    has imported.
+
+    Both scenes route through here. When they primed independently, `ov demo
+    board` reported `verbs primed 0` and `ov demo transcript` reported 62 IN
+    THE SAME RUN, because only one of them had asked.
+    """
+    try:
+        from backend.core.ouroboros.battle_test.repl_dispatch_registry import (
+            prime_registry, registry_primed,
+        )
+        if not registry_primed():
+            prime_registry()
+        return bool(registry_primed())
+    except Exception:  # noqa: BLE001
+        logger.debug("[OvDemo] verb priming degraded", exc_info=True)
+        return False
+
 def _rule(console: Any, title: str) -> None:
     try:
         console.rule(f"[dim]{title}[/dim]")
@@ -80,6 +104,7 @@ def scene_board(console: Any, argv: Sequence[str] = ()) -> int:
         _say(console, f"  progress board unavailable: {exc}")
         return 1
 
+    _ensure_primed()
     _rule(console, "where ov stands")
     reading = ProgressBoard().read()
     for line in render_board(reading, limit=_limit(argv)):
@@ -94,9 +119,10 @@ def scene_board(console: Any, argv: Sequence[str] = ()) -> int:
         for row in dynamic[:6]:
             _say(console, f"    ◇ {row.flag[:44]:<44} {row.reason[:40]}")
     _say(console)
+    verbs = (f"{len(reading.verbs)} verbs" if reading.verbs_primed
+             else "verbs NOT primed")
     _say(console, f"  entry points {len(reading.by_state(ENTRY))}"
-                  f" · off {len(reading.by_state(OFF))}"
-                  f" · verbs primed {len(reading.verbs)}")
+                  f" · off {len(reading.by_state(OFF))} · {verbs}")
     _say(console, "  dark = enabled, on disk, imported by nothing. A SIGNAL,")
     _say(console, "  not a defect count: plugin discovery and dynamic import")
     _say(console, "  remain invisible to a static graph.")
@@ -179,15 +205,12 @@ def _demo_palette(console: Any) -> None:
     """
     try:
         from backend.core.ouroboros.battle_test.repl_dispatch_registry import (
-            list_verbs, prime_registry,
+            list_verbs,
         )
         from backend.core.ouroboros.battle_test.verb_description import (
             to_operator_voice,
         )
-        try:
-            prime_registry()
-        except Exception:  # noqa: BLE001
-            pass
+        _ensure_primed()
         verbs = list(list_verbs())
         if not verbs:
             _say(console, "  (no verbs primed — registry empty)")

--- a/tests/battle_test/test_progress_board.py
+++ b/tests/battle_test/test_progress_board.py
@@ -340,3 +340,82 @@ class TestSemanticShadowGraph:
         board = _board(tmp_path)
         rows = {r.flag: r for r in (await board.read_async()).rows}
         assert rows["JARVIS_ASYNC_VERB_ENABLED"].state == DYNAMIC_LIVE
+
+
+class TestVerbPrimingIsNotACount:
+    """`ov demo board` said `verbs primed 0` while `ov demo transcript` said 62
+    IN THE SAME RUN. Only one of them had asked the registry to prime, and
+    `list_verbs()` returns an empty tuple both when discovery has not run and
+    when it ran and found nothing.
+
+    A count cannot express "nobody asked yet".
+    """
+
+    def test_board_reports_unprimed_distinctly_from_empty(self, tmp_path,
+                                                          monkeypatch):
+        from backend.core.ouroboros.battle_test import (
+            repl_dispatch_registry as reg,
+        )
+        monkeypatch.setenv("JARVIS_PROGRESS_BOARD_ROOTS", "nonexistent")
+        reg.reset_registry_for_tests()
+        reading = _board(tmp_path).read()
+        assert reading.verbs == ()
+        assert reading.verbs_primed is False
+
+    def test_reading_the_board_does_NOT_prime(self, tmp_path, monkeypatch):
+        # The load-bearing property. A read-only status view must not trigger
+        # the import walk priming performs — looking at the board would then
+        # change what the process has loaded, and the board would be reporting
+        # on a system its own observation had altered.
+        from backend.core.ouroboros.battle_test import (
+            repl_dispatch_registry as reg,
+        )
+        monkeypatch.setenv("JARVIS_PROGRESS_BOARD_ROOTS", "nonexistent")
+        reg.reset_registry_for_tests()
+
+        called = {"n": 0}
+        real = reg.prime_registry
+
+        def _spy(*a, **k):  # noqa: ANN002, ANN003
+            called["n"] += 1
+            return real(*a, **k)
+
+        monkeypatch.setattr(reg, "prime_registry", _spy)
+        _board(tmp_path).read()
+        assert called["n"] == 0, "the board primed the registry as a side effect"
+
+    def test_primed_state_is_reported_when_it_is_true(self, tmp_path,
+                                                      monkeypatch):
+        from backend.core.ouroboros.battle_test import (
+            repl_dispatch_registry as reg,
+        )
+        monkeypatch.setenv("JARVIS_PROGRESS_BOARD_ROOTS", "nonexistent")
+        reg.reset_registry_for_tests()
+        reg.prime_registry()
+        assert _board(tmp_path).read().verbs_primed is True
+
+    def test_to_dict_carries_the_distinction(self, tmp_path, monkeypatch):
+        # A JSON consumer must not have to re-derive it from a zero.
+        monkeypatch.setenv("JARVIS_PROGRESS_BOARD_ROOTS", "nonexistent")
+        assert "verbs_primed" in _board(tmp_path).read().to_dict()
+
+
+class TestRegistryPrimedAccessor:
+    def test_public_accessor_exists_rather_than_a_reach_around(self):
+        # Callers needed this and the only alternative was reading the private
+        # `_REGISTRY_PRIMED` — the same reach-around the risk-tier ladder has an
+        # authority invariant against.
+        from backend.core.ouroboros.battle_test import (
+            repl_dispatch_registry as reg,
+        )
+        assert "registry_primed" in reg.__all__
+
+    def test_accessor_is_side_effect_free(self, monkeypatch):
+        from backend.core.ouroboros.battle_test import (
+            repl_dispatch_registry as reg,
+        )
+        reg.reset_registry_for_tests()
+        assert reg.registry_primed() is False
+        assert reg.registry_primed() is False   # still false — it did not prime
+        reg.prime_registry()
+        assert reg.registry_primed() is True


### PR DESCRIPTION
`ov demo board` printed **`verbs primed 0`** while `ov demo transcript` printed **62** — in the same run.

Caught by actually running the thing, which is what the demo was built for. It caught me on its first outing.

## Root cause

`list_verbs()` returns an empty tuple in **two different worlds**: discovery hasn't run yet, and discovery ran and found nothing. A count cannot express *"nobody asked yet"*, so the board rendered an unprimed registry as "this cockpit has no verbs."

The transcript scene primed before reading. The board scene didn't. Same process, two answers.

## Fixed at the layer that owns the fact

`repl_dispatch_registry.registry_primed()` — a new **public, side-effect-free** accessor. The distinction was previously visible only in the private `_REGISTRY_PRIMED`, and reaching for that is the same private reach-around the risk-tier ladder has an authority invariant against. It would have made this module's internals part of its contract by accident.

`BoardReading` now carries `verbs_primed` alongside the count — and in `to_dict()`, so a JSON consumer doesn't have to re-derive it from a zero — and renders `verbs NOT primed` instead of a misleading number.

## The board still does not prime

There's a test asserting it. A read-only status view must not trigger the import walk that priming performs — otherwise **looking at the board changes what the process has loaded**, and the board is reporting on a system its own observation altered.

The demo *does* prime, because a demo of capability should, exactly as the cockpit does at boot. Both scenes now route through **one** `_ensure_primed()` seam — priming independently is precisely how they came to disagree.

## Result

```
ov demo board       → entry points 136 · off 151 · 62 verbs
ov demo transcript  → … 62 verbs primed
```

65 tests.

## Still open from the same run

- `render_board`'s `DYNAMIC_LIVE` rows wrap and break the column layout — I pad to 44 chars without clipping to terminal width, and never rendered it at a real width.
- The dark list sorts alphabetically, so twelve `ADAPTATION_*` tuning knobs crowd out the interesting rows. A threshold and an unwired feature share a glyph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inconsistent verb reporting by distinguishing “registry not primed” from “no verbs,” and unifies demo priming without side effects for consistent output across scenes.

- **Bug Fixes**
  - Added `registry_primed()` (public, side-effect-free) in `repl_dispatch_registry` and exported it in `__all__`.
  - `ProgressBoard` now tracks `verbs_primed` and includes it in `to_dict()`; renders “verbs NOT primed” when discovery hasn’t run.
  - Board read is strictly read-only: `_load_verbs()` returns `(verbs, primed)` and never primes.
  - Demo scenes now prime via a single `_ensure_primed()` function so `ov demo board` and `ov demo transcript` agree.
  - Tests added for unprimed vs empty distinction, no side effects, and JSON output.

<sup>Written for commit a41ffe65199ecca7d24bf04161a83cdfac84261c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

