### PR TITLE
fix(ov): the board's sort was hiding the signal it existed to surface

### DIFF
--- a/backend/core/ouroboros/battle_test/progress_board.py
+++ b/backend/core/ouroboros/battle_test/progress_board.py
@@ -152,6 +152,31 @@ class FeatureRow:
     value: Any = None
 
     @property
+    def kind(self) -> str:
+        """``switch`` or ``knob`` — a real distinction, not a formatting one.
+
+        A boolean-defaulted flag TURNS SOMETHING ON. A value-defaulted flag
+        (``"30"``, ``"notify_apply"``) TUNES something that is already on. An
+        unwired switch is a feature nobody connected; an unwired knob is a
+        dial on a module nobody imports — which is the SAME finding as its
+        module, repeated once per dial.
+
+        Sorting them together let twelve ``ADAPTATION_*`` thresholds crowd out
+        every interesting row, and gave a threshold the same glyph as a dead
+        feature.
+        """
+        # Name first for the AMBIGUOUS defaults only. A literal `True`, or a
+        # word like "true"/"on", is decisive on its own; "1" is not, and
+        # trusting it made every threshold-defaulting-to-1 look like a feature.
+        from_name = _kind_from_name(self.flag)
+        if from_name is not None and isinstance(self.value, str) \
+                and self.value.strip() in ("0", "1"):
+            return from_name
+        if self.enabled is not None:
+            return "switch"
+        return from_name or "knob"
+
+    @property
     def is_actionable(self) -> bool:
         """Worth an operator's attention right now."""
         return self.state in (MISSING, DARK)
@@ -194,7 +219,31 @@ class BoardReading:
         """MISSING then DARK — the rows that mean something is wrong."""
         return sorted(
             [r for r in self.rows if r.is_actionable],
-            key=lambda r: (_STATE_ORDER.index(r.state), r.flag),
+            # MISSING before DARK, switches before knobs, then grouped by
+            # module. Alphabetical-by-flag put `JARVIS_A*` first and nothing
+            # else was ever seen — the sort was hiding the signal it existed
+            # to surface.
+            key=lambda r: (_STATE_ORDER.index(r.state),
+                           0 if r.kind == "switch" else 1,
+                           r.module, r.flag),
+        )
+
+    @property
+    def actionable_modules(self) -> "List[Tuple[str, List[FeatureRow]]]":
+        """Actionable rows COLLAPSED BY MODULE, worst-first.
+
+        One unimported module holding twelve thresholds is ONE thing to fix,
+        and listing it twelve times is how a real finding gets buried under
+        its own repetitions.
+        """
+        grouped: Dict[str, List[FeatureRow]] = {}
+        for row in self.actionable:
+            grouped.setdefault(row.module or row.flag, []).append(row)
+        return sorted(
+            grouped.items(),
+            key=lambda kv: (_STATE_ORDER.index(kv[1][0].state),
+                            0 if any(r.kind == "switch" for r in kv[1]) else 1,
+                            -len(kv[1]), kv[0]),
         )
 
     def to_dict(self) -> Dict[str, Any]:
@@ -649,6 +698,47 @@ def _has_main_guard(tree: ast.AST) -> bool:
                     return True
     return False
 
+
+def switch_suffixes() -> Tuple[str, ...]:
+    """Name endings that mean a flag TURNS SOMETHING ON."""
+    raw = os.environ.get("JARVIS_PROGRESS_BOARD_SWITCH_SUFFIXES", "").strip()
+    if raw:
+        return tuple(x.strip().upper() for x in raw.split(",") if x.strip())
+    return ("_ENABLED", "_DISABLED", "_ON", "_OFF", "_ALLOW", "_ALLOWED",
+            "_REQUIRE", "_REQUIRED", "_FORCE", "_STRICT", "_DRY_RUN")
+
+
+def knob_suffixes() -> Tuple[str, ...]:
+    """Name endings that mean a flag TUNES something already on."""
+    raw = os.environ.get("JARVIS_PROGRESS_BOARD_KNOB_SUFFIXES", "").strip()
+    if raw:
+        return tuple(x.strip().upper() for x in raw.split(",") if x.strip())
+    return ("_S", "_MS", "_SEC", "_SECONDS", "_TIMEOUT", "_TTL", "_INTERVAL",
+            "_SIZE", "_MAX", "_MIN", "_LIMIT", "_THRESHOLD", "_PCT", "_RATIO",
+            "_COUNT", "_DEPTH", "_BUDGET", "_WIDTH", "_HEIGHT", "_PORT",
+            "_PATH", "_DIR", "_URL", "_HOST", "_MODE", "_LEVEL", "_TIER")
+
+
+def _kind_from_name(flag: str) -> Optional[str]:
+    """`switch` / `knob` from the flag's NAME, or None when it says nothing.
+
+    Needed because the default literal is not always decisive. `"1"` means
+    both "on" and "the number one", so a threshold defaulting to 1 was
+    classified as a switch — a real misreading, surfaced when a test fixture
+    happened to name one `JARVIS_DIAL_1`.
+
+    The name is the stronger signal precisely where the value is weakest, so
+    it is consulted FIRST and only for the ambiguous numeric cases.
+    """
+    name = str(flag or "").upper()
+    for suffix in switch_suffixes():
+        if name.endswith(suffix):
+            return "switch"
+    for suffix in knob_suffixes():
+        if name.endswith(suffix):
+            return "knob"
+    return None
+
 def _coerce_bool(value: Any) -> Optional[bool]:
     """A default literal's boolean meaning, or None if it has none.
 
@@ -735,38 +825,91 @@ def _resolve_enabled(flag: str, default: Any) -> Tuple[Optional[bool], Any]:
     return (None, raw)
 
 
-def render_board(reading: BoardReading, *, width: int = 78,
-                 limit: int = 0) -> List[str]:
-    """Operator-facing lines. Worst news first.
+def terminal_width(default: int = 78) -> int:
+    """Real width, asked at render time.
 
-    Deliberately not a full dump by default: 481 rows is not a status view, it
-    is a log. What an operator needs on sight is the count line and the rows
-    that mean something is wrong.
+    The previous default of 78 was a GUESS baked into a signature. Rows padded
+    to 44 columns plus an unclipped reason wrapped and broke the layout the
+    moment it met an actual terminal — invisible in every unit test, obvious in
+    one second of `ov demo board`.
     """
     try:
+        import shutil
+        return max(40, int(shutil.get_terminal_size((default, 24)).columns))
+    except Exception:  # noqa: BLE001
+        return default
+
+
+def render_board(reading: BoardReading, *, width: Optional[int] = None,
+                 limit: int = 0) -> List[str]:
+    """Operator-facing lines. Worst news first, one line per finding.
+
+    Not a full dump: 3,900 rows is a log, not a status view. What an operator
+    needs on sight is the count line and the things that are wrong — grouped by
+    module, because one unimported module holding twelve dials is one problem.
+    """
+    try:
+        cols = terminal_width() if width is None else max(40, int(width))
         counts = reading.counts
-        out: List[str] = [
-            f"  live {counts.get(LIVE, 0)}   dark {counts.get(DARK, 0)}   "
-            f"off {counts.get(OFF, 0)}   missing {counts.get(MISSING, 0)}   "
-            f"unknown {counts.get(UNKNOWN, 0)}"
-            f"    ({reading.scanned_files} files, "
-            f"{reading.duration_s:.1f}s)",
-        ]
+        head = (f"  live {counts.get(LIVE, 0)}   dark {counts.get(DARK, 0)}   "
+                f"dynamic {counts.get(DYNAMIC_LIVE, 0)}   "
+                f"entry {counts.get(ENTRY, 0)}   off {counts.get(OFF, 0)}")
+        out: List[str] = [head[:cols]]
+        out.append(f"  ({reading.scanned_files} files, "
+                   f"{reading.duration_s:.1f}s)"[:cols])
         if reading.degraded:
-            out.append(f"  ⚠ degraded: {reading.degraded}")
-        rows = reading.actionable
-        if not rows:
+            out.append(f"  ⚠ degraded: {reading.degraded}"[:cols])
+
+        groups = reading.actionable_modules
+        if not groups:
             out.append("  ✓ nothing enabled-but-inert")
             return out
-        shown = rows if limit <= 0 else rows[:limit]
+
+        shown = groups if limit <= 0 else groups[:limit]
         out.append("")
-        for row in shown:
-            glyph = "✗" if row.state == MISSING else "◌"
-            name = row.flag[:44]
-            out.append(f"  {glyph} {name:<44} {row.state:<8} {row.reason}"[:width])
-        hidden = len(rows) - len(shown)
+        # Widest name we will actually print, so the reason column starts in
+        # the same place without being padded to a constant nobody measured.
+        # Bounded by the TERMINAL, not just by a constant. With long module
+        # paths the name column claimed the whole line, leaving the tail
+        # negative room — so the flag was chopped by the final `[:cols]` with
+        # no ellipsis, which reads as a different flag. At least 20 columns
+        # stay reserved for what the finding actually IS.
+        namew = min(48, max(12, cols - 26),
+                    max((len(_short(m)) for m, _ in shown), default=20))
+        for module, rows in shown:
+            first = rows[0]
+            glyph = "✗" if first.state == MISSING else "◌"
+            switches = [r for r in rows if r.kind == "switch"]
+            if switches:
+                tail = switches[0].flag
+                if len(rows) > 1:
+                    tail += f"  +{len(rows) - 1} more"
+            else:
+                tail = f"{len(rows)} knob{'s' if len(rows) != 1 else ''}"
+            # Budget the tail rather than truncating the finished line: a
+            # blind `line[:cols]` cut flag names mid-word (`JARVIS_MULTI_FACTOR_BOOS`),
+            # which reads as a DIFFERENT flag and is worse than an ellipsis.
+            room = cols - (namew + 6)
+            if room > 4 and len(tail) > room:
+                tail = tail[: room - 1] + "…"
+            name = _short(module, namew)
+            out.append(f"  {glyph} {name:<{namew}}  {tail}"[:cols])
+        hidden = len(groups) - len(shown)
         if hidden > 0:
-            out.append(f"    … {hidden} more")
+            out.append(f"    … {hidden} more module(s)"[:cols])
         return out
     except Exception:  # noqa: BLE001
         return ["  ⚠ board render degraded"]
+
+
+def _short(module: str, width: int = 48) -> str:
+    """Trim a module path from the LEFT — the tail identifies it.
+
+    Takes the budget as an argument because `f"{name:<{w}}"` PADS to a minimum
+    and never clips: a 48-character path stayed 48 characters inside a
+    14-column field, and the final `[:cols]` then ate the tail instead. The
+    name column has to enforce its own width.
+    """
+    text = str(module or "")
+    limit = max(4, int(width))
+    return text if len(text) <= limit else "…" + text[-(limit - 1):]

--- a/backend/core/ouroboros/cli/ov_demo.py
+++ b/backend/core/ouroboros/cli/ov_demo.py
@@ -116,8 +116,19 @@ def scene_board(console: Any, argv: Sequence[str] = ()) -> int:
     if dynamic:
         _say(console)
         _say(console, "  discovered at runtime (no inbound import):")
+        from backend.core.ouroboros.battle_test.progress_board import (
+            terminal_width,
+        )
+        cols = terminal_width()
+        # Same defect as render_board had: a padded column plus an unclipped
+        # reason wraps the moment it meets a real terminal. Two formatters, one
+        # bug — so both now ask the same source how wide the world is.
+        namew = min(44, max((len(r.flag) for r in dynamic[:6]), default=20))
         for row in dynamic[:6]:
-            _say(console, f"    ◇ {row.flag[:44]:<44} {row.reason[:40]}")
+            room = max(8, cols - namew - 8)
+            reason = row.reason if len(row.reason) <= room else (
+                row.reason[: room - 1] + "…")
+            _say(console, f"    ◇ {row.flag:<{namew}}  {reason}"[:cols])
     _say(console)
     verbs = (f"{len(reading.verbs)} verbs" if reading.verbs_primed
              else "verbs NOT primed")

--- a/tests/battle_test/test_progress_board.py
+++ b/tests/battle_test/test_progress_board.py
@@ -419,3 +419,91 @@ class TestRegistryPrimedAccessor:
         assert reg.registry_primed() is False   # still false — it did not prime
         reg.prime_registry()
         assert reg.registry_primed() is True
+
+
+class TestRenderRespectsTheTerminal:
+    """`width: int = 78` was a GUESS baked into a signature.
+
+    Rows padded to 44 columns plus an unclipped reason wrapped and broke the
+    layout the moment they met a real terminal — invisible in every unit test,
+    obvious in one second of `ov demo board`.
+    """
+
+    def _reading(self, tmp_path, monkeypatch, n=30):
+        monkeypatch.setenv("JARVIS_PROGRESS_BOARD_ROOTS", "backend")
+        for i in range(n):
+            _write(tmp_path, f"backend/pkg{i}/mod_with_a_very_long_name.py",
+                   "import os\n"
+                   f'os.environ.get("JARVIS_A_VERY_LONG_FLAG_NAME_{i}", "1")\n')
+        return _board(tmp_path).read()
+
+    @pytest.mark.parametrize("cols", [40, 60, 80, 120, 200])
+    def test_no_line_ever_exceeds_the_width(self, tmp_path, monkeypatch, cols):
+        reading = self._reading(tmp_path, monkeypatch)
+        for line in render_board(reading, width=cols):
+            assert len(line) <= cols, f"{cols}c overflow: {line!r}"
+
+    def test_width_is_asked_at_render_time_not_hardcoded(self):
+        from backend.core.ouroboros.battle_test.progress_board import (
+            terminal_width,
+        )
+        assert terminal_width() >= 40
+
+    def test_a_truncated_name_ends_in_an_ellipsis(self, tmp_path, monkeypatch):
+        # A blind `line[:cols]` cut flag names mid-word, which reads as a
+        # DIFFERENT flag — worse than an ellipsis, because it is plausible.
+        reading = self._reading(tmp_path, monkeypatch)
+        body = [l for l in render_board(reading, width=48) if "◌" in l]
+        assert body
+        assert any("…" in l for l in body)
+
+
+class TestSwitchesAndKnobsAreDifferentFindings:
+    def test_boolean_default_is_a_switch(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("JARVIS_PROGRESS_BOARD_ROOTS", "backend")
+        _write(tmp_path, "backend/f.py",
+               'import os\nos.environ.get("JARVIS_F_ENABLED", "1")\n')
+        row = {r.flag: r for r in _board(tmp_path).read().rows}["JARVIS_F_ENABLED"]
+        assert row.kind == "switch"
+
+    def test_value_default_is_a_knob(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("JARVIS_PROGRESS_BOARD_ROOTS", "backend")
+        _write(tmp_path, "backend/f.py",
+               'import os\nos.environ.get("JARVIS_F_TIMEOUT", "30")\n')
+        row = {r.flag: r for r in _board(tmp_path).read().rows}["JARVIS_F_TIMEOUT"]
+        assert row.kind == "knob"
+
+    def test_switches_sort_before_knobs(self, tmp_path, monkeypatch):
+        # Alphabetical-by-flag put twelve `JARVIS_A*` thresholds first and
+        # nothing else was ever seen. The sort was hiding the signal it existed
+        # to surface.
+        monkeypatch.setenv("JARVIS_PROGRESS_BOARD_ROOTS", "backend")
+        _write(tmp_path, "backend/aaa_knob.py",
+               'import os\nos.environ.get("JARVIS_AAA_TIMEOUT", "30")\n')
+        _write(tmp_path, "backend/zzz_switch.py",
+               'import os\nos.environ.get("JARVIS_ZZZ_ENABLED", "1")\n')
+        actionable = _board(tmp_path).read().actionable
+        kinds = [r.kind for r in actionable]
+        assert kinds.index("switch") < kinds.index("knob")
+
+    def test_one_module_of_knobs_is_ONE_finding(self, tmp_path, monkeypatch):
+        # Twelve dials on one unimported module is one thing to fix. Listing it
+        # twelve times is how a real finding gets buried under its own repeats.
+        monkeypatch.setenv("JARVIS_PROGRESS_BOARD_ROOTS", "backend")
+        body = "import os\n" + "".join(
+            f'os.environ.get("JARVIS_TUNE_{i}_MS", "{i + 2}")\n' for i in range(12))
+        _write(tmp_path, "backend/dials.py", body)
+        reading = _board(tmp_path).read()
+        assert len(reading.actionable) == 12
+        assert len(reading.actionable_modules) == 1
+
+    def test_a_module_with_a_switch_outranks_a_module_of_knobs(
+        self, tmp_path, monkeypatch,
+    ):
+        monkeypatch.setenv("JARVIS_PROGRESS_BOARD_ROOTS", "backend")
+        _write(tmp_path, "backend/aaa_dials.py", "import os\n" + "".join(
+            f'os.environ.get("JARVIS_DIAL_{i}_MS", "{i + 2}")\n' for i in range(9)))
+        _write(tmp_path, "backend/zzz_feature.py",
+               'import os\nos.environ.get("JARVIS_FEATURE_ENABLED", "1")\n')
+        first = _board(tmp_path).read().actionable_modules[0]
+        assert "zzz_feature" in first[0]


### PR DESCRIPTION
Two presentation bugs from watching `ov demo board` actually run — plus a modelling bug the fix exposed.

## Sort

Alphabetical-by-flag put twelve `JARVIS_ADAPTATION_*` thresholds at the top and **nothing else was ever seen**. Worse, a tuning dial wore the same glyph as an unwired feature.

Those aren't the same finding. A boolean flag **turns something on**; a value flag **tunes something already on**. And one unimported module holding twelve dials is **one** thing to fix — listing it twelve times is how a real finding gets buried under its own repetitions.

Rows now carry `kind` (switch/knob), `actionable` sorts switches first, `actionable_modules` collapses by module.

**547 dark rows → 163 modules**, switch-bearing modules first.

## The modelling bug the fix exposed

`_coerce_bool("1")` is `True`, so **any threshold defaulting to 1 was classified as a switch** — surfaced when a test fixture happened to be named `JARVIS_DIAL_1`.

`"1"` genuinely means both *"on"* and *"the number one"*; the literal cannot settle it. The flag's **name** can — so name-suffix evidence (env-configurable, both directions) decides the ambiguous numeric cases only. A literal `True`, or a word like `"on"`, stays decisive on its own.

## Width — three layers of one bug

`width: int = 78` was a guess baked into a signature. Now asked at render time via `shutil`. Each further layer was found only by rendering at 40 columns:

1. A blind `line[:cols]` cut flag names **mid-word** (`JARVIS_MULTI_FACTOR_BOOS`) — which reads as a *different* flag, worse than an ellipsis because it's plausible.
2. `f"{name:<{w}}"` **pads** to a minimum and never **clips**, so a 48-char path stayed 48 chars inside a 14-column field and the final truncation ate the tail instead.

Both columns now enforce their own budget. `ov_demo`'s dynamic block formatted independently and wrapped for the same reason — it now asks the same width source. Two formatters, one bug.

```
  ◌ …ing_engine.py  JARVIS_MULTI_FACTOR…
  ◌ …chestrator.py  JARVIS_PRIME_ADOPT_…
  ◌ …primitives.py  JARVIS_FSYNC_WRITES…
```

86 tests, including no-line-exceeds-width at 40/60/80/120/200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the board so real issues surface: distinguish switches vs knobs, sort by severity and group by module, and render within the actual terminal width to avoid wrap and mid-word truncation.

- **Bug Fixes**
  - Sorting: switches before knobs, then grouped by module; added `actionable_modules` to collapse repeats (e.g., 547 dark rows → 163 modules).
  - Modeling: resolve ambiguous `"1"` defaults using name suffixes; env overrides via `JARVIS_PROGRESS_BOARD_SWITCH_SUFFIXES`/`JARVIS_PROGRESS_BOARD_KNOB_SUFFIXES`; literal booleans still decisive.
  - Rendering: dynamic `terminal_width()` via `shutil`; left-ellipsis truncation for long module paths; each column enforces its own budget; updated `ov_demo` to use the same width source.
  - API additions: `FeatureRow.kind` (`switch`/`knob`), `_short()`, and `actionable_modules` on the board reading.
  - Tests: ensure no line exceeds width at 40/60/80/120/200 cols and validate switch/knob behavior.

<sup>Written for commit 6c84b7487280a54c20bbfa7e7cec55172cd77457. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

