### PR TITLE
fix(ov): the deck had no column and no colour — both were per-line literals

### DIFF
--- a/backend/core/ouroboros/battle_test/moltbook_inline.py
+++ b/backend/core/ouroboros/battle_test/moltbook_inline.py
@@ -245,6 +245,27 @@ def decide_placement(
         return Placement(MUTED, reason="degraded", post=post)
 
 
+def _tint(text: str, tone: str) -> str:
+    """Colour the CHROME of a post — its glyph and its handle — and nothing else.
+
+    Deliberately narrow. The leading pad stays literal because placement math
+    upstream measures indentation with ``lstrip()``, and the body and ref stay
+    literal because a post's text is operator-supplied content that must not
+    be re-parsed as markup. Styling only the two tokens the eye scans for is
+    what lets a thread carry hierarchy without the deck growing a second
+    layout vocabulary.
+
+    Degrades to the plain token on any failure — a post rendering uncoloured
+    is a cosmetic loss; a post not rendering is a lost disagreement.
+    """
+    try:
+        from backend.core.ouroboros.ui.theme import semantic
+        style = semantic(tone)
+        return f"[{style}]{text}[/{style}]" if style else text
+    except Exception:  # noqa: BLE001
+        return text
+
+
 def render_post(post: Any, *, depth: int = 0, width: int = 78) -> List[str]:
     """The `💬` block for one post, in the nested `⎿` grammar.
 
@@ -268,10 +289,14 @@ def render_post(post: Any, *, depth: int = 0, width: int = 78) -> List[str]:
                 glyph = f"▸ {glyph}"
         pad = "  " + ("   " * max(0, int(depth)))
         lead = f"{pad}{glyph} {handle}"
+        # Room is measured on the PLAIN lead, before any styling — a clip
+        # computed against markup would count `[#3FB950]` as visible text and
+        # truncate every post by the length of its own colour tags.
         room = max(24, width - len(lead) - len(ref) - 4)
         if len(body) > room:
             body = body[: room - 1].rstrip() + "…"
-        line = f"{lead}  {body}"
+        line = f"{pad}{_tint(glyph, 'crit' if conflict else 'info')} " \
+               f"{_tint(handle, 'ink')}  {body}"
         if ref:
             line = f"{line}  {ref}"
         return [line]

--- a/backend/core/ouroboros/cli/ov_demo.py
+++ b/backend/core/ouroboros/cli/ov_demo.py
@@ -85,6 +85,20 @@ def _say(console: Any, text: str = "") -> None:
         pass
 
 
+def _markup(console: Any, text: str = "") -> None:
+    """Print a line the deck grammar composed — tags INTERPRETED.
+
+    Separate from :func:`_say` on purpose. `_say` suppresses markup because
+    board rows and error text are literal operator strings that must survive a
+    stray bracket; deck lines are the opposite, and printing them through
+    `_say` would show the operator `[grey50]847 lines[/grey50]`.
+    """
+    try:
+        console.print(text, highlight=False)
+    except Exception:  # noqa: BLE001
+        pass
+
+
 # ---------------------------------------------------------------------------
 # Scene: the progress board
 # ---------------------------------------------------------------------------
@@ -156,21 +170,52 @@ def _limit(argv: Sequence[str]) -> int:
 # Scene: the transcript
 # ---------------------------------------------------------------------------
 
-#: A synthetic op. Deliberately a FAILING one: the deck's whole grammar —
-#: `⎿` results, an agora thread reacting to a failure — only shows itself when
-#: something goes wrong, and a demo of the happy path shows the least
-#: interesting third of the surface.
+#: A synthetic op, as BEATS rather than as finished lines: `(kind, args)`
+#: pairs the deck grammar composes. Writing the lines out here is what let the
+#: `⎿` results and the diff beneath them disagree about which column a
+#: continuation body starts in — two literals, one column, nobody to notice.
+#:
+#: Deliberately a FAILING op: the deck's whole grammar — `⎿` results, an agora
+#: thread reacting to a failure — only shows itself when something goes wrong,
+#: and a demo of the happy path shows the least interesting third of it.
 _SCRIPT: List[Any] = [
-    ("op", "⏺ Read(backend/core/ouroboros/governance/risk_tier_floor.py)"),
-    ("res", "⎿ 847 lines"),
-    ("op", "⏺ Update(risk_tier_floor.py)"),
-    ("res", "⎿ +18 -3"),
-    ("diff", "+    except RiskFloorConfigError:"),
-    ("diff", "+        raise"),
-    ("diff", "-    except Exception:  # noqa: BLE001"),
-    ("op", "⏺ Validate(7759-86)"),
-    ("res", "⎿ ✗ 3 failed · test_scoped_paths, test_sandbox_dir"),
+    ("act", ("Read", "backend/core/ouroboros/governance/risk_tier_floor.py")),
+    ("det", ("Read 847 lines",)),
+    ("act", ("Update", "risk_tier_floor.py")),
+    ("det", ("Updated risk_tier_floor.py with 18 additions and 3 removals",)),
+    ("diff", (412, "+", "    except RiskFloorConfigError:")),
+    ("diff", (413, "+", "        raise")),
+    ("diff", (414, "-", "    except Exception:  # noqa: BLE001")),
+    ("act", ("Validate", "7759-86")),
+    ("det", ("✗ 3 failed · test_scoped_paths, test_sandbox_dir", "crit")),
 ]
+
+
+def _compose(kind: str, args: Sequence[Any]) -> str:
+    """One beat -> one deck line, through the SHARED grammar.
+
+    Every scene routes through here, so the transcript and the live cockpit
+    cannot drift into two column disciplines — which is exactly what they had
+    done: `  ⎿ ` (body at column 4) above `     + ` (body at column 5).
+    """
+    from backend.core.ouroboros.ui import deck_grammar as deck
+    try:
+        if kind == "act":
+            # `(verb, arg, tone)` — tone is keyword-only on the grammar so a
+            # call site cannot pass a colour where an argument belongs.
+            return deck.action(args[0], args[1] if len(args) > 1 else "",
+                               tone=(args[2] if len(args) > 2 else "ok"))
+        if kind == "det":
+            return deck.detail(args[0], tone=(args[1] if len(args) > 1
+                                              else "muted"))
+        if kind == "diff":
+            return deck.diff(*args)
+        if kind == "voice":
+            return deck.voice(*args)
+        return deck.blank()
+    except Exception:  # noqa: BLE001 — a demo must never be what breaks
+        logger.debug("[OvDemo] beat degraded: %s", kind, exc_info=True)
+        return ""
 
 #: The agora reacting to that failure, in the schema `moltbook_inline` expects.
 _THREAD: List[dict] = [
@@ -178,28 +223,35 @@ _THREAD: List[dict] = [
      "body": "three tests. you fixed the assert and broke the file."},
     {"handle": "@the-builder", "op_id": "op-7759-86",
      "body": "the containment check is right, the fixture is stale"},
+    # No `⚔` in the body: `render_post` derives the glyph from `kind`, and
+    # carrying it in the text too rendered `▸ ⚔ @cassandra  ⚔ REVIEW …`.
+    # A glyph that means "contested" means it once per line or it is noise.
     {"handle": "@cassandra", "op_id": "op-7759-86", "kind": "conflict",
-     "body": "⚔ REVIEW disagrees: that except clause still swallows I2"},
+     "body": "REVIEW disagrees: that except clause still swallows I2"},
 ]
 
 
 def scene_transcript(console: Any, argv: Sequence[str] = ()) -> int:
     """The CC-style deck, rendered by the cockpit's OWN renderers."""
     _rule(console, "transcript")
-    for kind, text in _SCRIPT:
-        if kind == "op":
-            _say(console, text)
-        elif kind == "res":
-            _say(console, f"  {text}")
-        else:
-            _say(console, f"     {text}")
+    # A blank line before each new action is the deck's only grouping cue.
+    # Without it nine correct lines read as one paragraph, which is what
+    # "it doesn't look like Claude Code" actually means most of the time.
+    for i, (kind, args) in enumerate(_SCRIPT):
+        if kind in ("act", "voice") and i:
+            _markup(console, "")
+        _markup(console, _compose(kind, args))
 
     try:
         from backend.core.ouroboros.battle_test.moltbook_inline import (
             render_thread,
         )
+        # `_markup`, not `_say`: the thread renderer tints its glyph and
+        # handle now, and printing that through a markup=False path shows the
+        # operator `[#58B0F8]💬[/#58B0F8]` — and then wraps the line, because
+        # the tags are counted as visible width.
         for line in render_thread(_THREAD, width=76):
-            _say(console, line)
+            _markup(console, line)
     except Exception as exc:  # noqa: BLE001
         _say(console, f"  (agora unavailable: {exc})")
 
@@ -255,36 +307,92 @@ def _dispatcher_for(verb: str) -> Any:
 # Scene: live
 # ---------------------------------------------------------------------------
 
-#: A scripted operation, as SECONDS-since-start paired with a deck line.
-#: Timings are the point — the deck's rhythm is most of what the cockpit feels
-#: like, and a burst of lines arriving at once looks nothing like an organism
+#: The scripted operation, as SECONDS-since-start paired with a BEAT. Timings
+#: are the point — the deck's rhythm is most of what the cockpit feels like,
+#: and a burst of lines arriving at once looks nothing like an organism
 #: working. Kept as data so the shape can be tuned without touching the driver.
-_LIVE_SCRIPT = [
-    (0.4, "⏺ Signal(test_failure) · risk_tier_floor.py"),
-    (1.0, "  ⎿ 2 source loci · 1 test locus"),
-    (2.0, "⏺ Read(governance/risk_tier_floor.py)"),
-    (2.8, "  ⎿ 847 lines"),
-    (3.4, "⏺ Search(\"except Exception\")"),
-    (4.2, "  ⎿ 19 matches in 1 file"),
-    (5.0, "🗣 the vision floor raises, and the caller swallows it"),
-    (6.2, "⏺ Update(risk_tier_floor.py)"),
-    (7.0, "  ⎿ +18 -3"),
-    (7.4, "     + except RiskFloorConfigError:"),
-    (7.7, "     +     raise"),
-    (8.0, "     - except Exception:  # noqa: BLE001"),
-    (9.2, "⏺ Validate(7759-86)"),
-    (10.8, "  ⎿ ✗ 3 failed · test_scoped_paths, test_sandbox_dir"),
-    (11.6, "  💬 @the-pit  three tests. you fixed the assert and broke the file."),
-    (12.6, "     ▸ @the-builder  the containment check is right, the fixture is stale"),
-    (13.8, "     ▸ ⚔ @cassandra  REVIEW disagrees: that clause still swallows I2"),
-    (15.2, "⏺ Repair(L2) · iteration 1/5"),
-    (16.8, "  ⎿ fixture rebuilt from the live seam"),
-    (18.0, "⏺ Validate(7759-86)"),
-    (19.4, "  ⎿ ✓ 47 passed"),
-    (20.4, "⏺ Gate(7759-86) · NOTIFY_APPLY"),
-    (21.2, "  ⎿ applied · verified · committed 90706b8"),
-    (22.4, "⏺ Complete(7759-86) · 22.4s · $0.011"),
+#:
+#: Beats, not lines, for the same reason the transcript uses them: the column
+#: discipline belongs to the grammar. The blank line that closes each block is
+#: DERIVED here rather than written, so a new block cannot be added without
+#: one.
+_LIVE_BEATS: List[Any] = [
+    (0.4, "act", ("Signal", "test_failure · risk_tier_floor.py")),
+    (1.0, "det", ("2 source loci · 1 test locus",)),
+    (2.0, "act", ("Read", "governance/risk_tier_floor.py")),
+    (2.8, "det", ("Read 847 lines",)),
+    (3.4, "act", ("Search", '"except Exception"')),
+    (4.2, "det", ("Found 19 matches in 1 file",)),
+    (5.0, "voice", ("the vision floor raises, and the caller swallows it",)),
+    (6.2, "act", ("Update", "risk_tier_floor.py")),
+    (7.0, "det", ("Updated risk_tier_floor.py with 18 additions and"
+                  " 3 removals",)),
+    (7.4, "diff", (412, "+", "    except RiskFloorConfigError:")),
+    (7.7, "diff", (413, "+", "        raise")),
+    (8.0, "diff", (414, "-", "    except Exception:  # noqa: BLE001")),
+    (9.2, "act", ("Validate", "7759-86", "crit")),
+    (10.8, "det", ("✗ 3 failed · test_scoped_paths, test_sandbox_dir",
+                   "crit")),
+    # The agora reacting, rendered by the REAL renderer — see `_agora_beats`.
+    (11.6, "agora", ()),
+    (15.2, "act", ("Repair", "L2 · iteration 1/5", "warn")),
+    (16.8, "det", ("fixture rebuilt from the live seam",)),
+    (18.0, "act", ("Validate", "7759-86")),
+    (19.4, "det", ("✓ 47 passed", "ok")),
+    (20.4, "act", ("Gate", "7759-86 · NOTIFY_APPLY")),
+    (21.2, "det", ("applied · verified · committed 90706b8", "ok")),
+    (22.4, "act", ("Complete", "7759-86 · 22.4s · $0.011")),
 ]
+
+#: When each agora line lands, once the thread renderer has produced them.
+#: A reply arriving a beat after the post is what makes the room read as
+#: people talking rather than as a block of text that appeared.
+_AGORA_AT = (11.6, 12.6, 13.8)
+
+
+def _agora_beats() -> List[Any]:
+    """The room's reaction, from `moltbook_inline` — never reimplemented here.
+
+    The live scene used to carry these three lines as literals, which meant
+    the one scene an operator actually WATCHES was the one scene that would
+    keep looking right after the real renderer regressed. Calling it is the
+    entire premise of this module.
+    """
+    try:
+        from backend.core.ouroboros.battle_test.moltbook_inline import (
+            render_thread,
+        )
+        lines = list(render_thread(_THREAD, width=76))
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[OvDemo] agora degraded", exc_info=True)
+        lines = [f"  (agora unavailable: {exc})"]
+    return [(_AGORA_AT[min(i, len(_AGORA_AT) - 1)], line)
+            for i, line in enumerate(lines)]
+
+
+def compose_live_script() -> List[Any]:
+    """`[(seconds, line), ...]` — the beats, composed and block-separated.
+
+    Called fresh by :func:`scene_live` rather than baked at import, so a
+    renderer swapped underneath (a test, a regression) is the one that shows.
+    """
+    out: List[Any] = []
+    for i, (at, kind, args) in enumerate(_LIVE_BEATS):
+        if kind == "agora":
+            out.extend(_agora_beats())
+            continue
+        # The separator rides the SAME timestamp as the line it precedes, so
+        # the block opens as one visual event instead of a gap that appears a
+        # beat early and reads as the deck stalling.
+        if kind in ("act", "voice") and i:
+            out.append((at, ""))
+        out.append((at, _compose(kind, args)))
+    return out
+
+
+#: Composed once at import for introspection (`--speed` docs, tests). The live
+#: scene recomposes; this is a snapshot, never the thing that renders.
+_LIVE_SCRIPT = compose_live_script()
 
 #: Windows during which the toolbar shows a token counter climbing, because in
 #: the real cockpit that is the ONLY sign the organism is thinking. A static
@@ -331,7 +439,8 @@ def _live_toolbar(started: Callable[[], float], clock: Callable[[], float]):
 
 async def _drive(mux: Any, app: Any, speed: float,
                  started: Callable[[], float],
-                 clock: Callable[[], float]) -> None:
+                 clock: Callable[[], float],
+                 script: Optional[Sequence[Any]] = None) -> None:
     """Feed the script in real time, then idle until the operator quits.
 
     Sleeps against the SCHEDULE rather than accumulating per-step delays: a
@@ -339,7 +448,7 @@ async def _drive(mux: Any, app: Any, speed: float,
     rhythm — the thing being demonstrated — would decay over the run.
     """
     import asyncio
-    for at, line in _LIVE_SCRIPT:
+    for at, line in (script if script is not None else _LIVE_SCRIPT):
         target = started() + (at / speed)
         while True:
             gap = target - clock()
@@ -443,10 +552,12 @@ def scene_live(console: Any, argv: Sequence[str] = ()) -> int:
     except Exception:  # noqa: BLE001
         pass
 
+    script = compose_live_script()
+
     async def _main() -> None:
         start[0] = clock()
         driver = asyncio.ensure_future(
-            _drive(mux, app, speed, lambda: start[0], clock))
+            _drive(mux, app, speed, lambda: start[0], clock, script))
         try:
             await app.run_async()
         finally:

--- a/backend/core/ouroboros/ui/deck_grammar.py
+++ b/backend/core/ouroboros/ui/deck_grammar.py
@@ -1,0 +1,214 @@
+"""The deck's column discipline, in ONE place, so lines cannot drift.
+
+Claude Code's transcript is legible because of three rules applied without
+exception, not because of its glyphs:
+
+1. **A block is an action plus what it produced.** ``⏺`` opens it, ``⎿``
+   continues it, and a BLANK LINE closes it. Without the blank the deck is a
+   wall of text and the eye has nothing to group on.
+2. **Every continuation body starts in the same column.** ``  ⎿  `` is two
+   spaces, the glyph, two spaces — a five-column body. A diff hunk under that
+   result starts in that same column. One constant, never a per-call-site
+   literal.
+3. **Hierarchy is carried by COLOR, not by indentation.** Dim chrome, ink
+   content, accent on the thing that changed. `OV_STYLE_GUIDE.md` §08 puts
+   "a flat wall of one green — no hierarchy" at the top of its Don't column,
+   and an unstyled line is exactly that: it inherits the terminal's default
+   foreground, so on a green-on-black profile the entire deck is one green.
+
+Rule 2 is why this module exists at all rather than being f-strings at the
+call sites. `ov demo live` shipped with ``"  ⎿ 847 lines"`` (one trailing
+space, body at column 4) directly above ``"     + except ..."`` (body at
+column 5), and the diff visibly stepped out from under the result it belonged
+to. Two literals, one column, and nothing to notice the disagreement — the
+same defect shape as two formatters computing width independently. Here the
+body column is computed once from the glyph's own printed width and both
+callers ask for it.
+
+Width, not length
+-----------------
+``💭`` is one codepoint and TWO terminal cells. Padding it with ``len()`` puts
+the following text one cell left of where the arithmetic claims, which is how
+``💭the vision floor raises`` reaches an operator's screen. Every lead here is
+padded by :func:`rich.cells.cell_len`, so a wide glyph keeps its space and a
+one-cell glyph keeps the CC column.
+
+Returns Rich markup, since every consumer (``BipartiteLayout.push_raw`` →
+``Text.from_markup``, ``SerpentFlow._op_line``) already speaks it. Caller text
+is escaped: a diff hunk containing ``[foo]`` is content, never a tag.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+logger = logging.getLogger("Ouroboros.DeckGrammar")
+
+__all__ = [
+    "ACTION_COLUMN", "DETAIL_COLUMN", "GUTTER_WIDTH",
+    "action", "detail", "voice", "diff", "blank", "body_column",
+]
+
+#: Where an action's text begins: ``⏺ Read(...)``. CC's column.
+ACTION_COLUMN: int = 2
+
+#: Indent of the continuation glyph under its action.
+_DETAIL_INDENT: int = 2
+
+#: Where a continuation's text begins: ``  ⎿  847 lines``. THE constant a
+#: result line and the diff hunk beneath it must both be derived from.
+DETAIL_COLUMN: int = 5
+
+#: Width of the diff line-number gutter. Right-aligned, so the numbers form a
+#: column instead of drifting as the file passes 999 lines.
+GUTTER_WIDTH: int = 4
+
+
+def body_column() -> int:
+    """The column a continuation body occupies. Ask, never hardcode."""
+    return DETAIL_COLUMN
+
+
+# ---------------------------------------------------------------------------
+# Primitives — every one of them degrades rather than raising. A deck line is
+# chrome; chrome must never be the thing that takes down the surface.
+# ---------------------------------------------------------------------------
+
+
+def _cells(text: str) -> int:
+    """Printed WIDTH of ``text``, not its codepoint count."""
+    try:
+        from rich.cells import cell_len
+        return int(cell_len(text))
+    except Exception:  # noqa: BLE001
+        return len(text)
+
+
+def _style(name: str) -> str:
+    """Resolve a semantic color name for the live terminal's color tier."""
+    try:
+        from backend.core.ouroboros.ui.theme import semantic
+        return semantic(name) or ""
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def _glyph(name: str) -> str:
+    """A themed mark, already ASCII-degraded when the locale demands it."""
+    try:
+        from backend.core.ouroboros.ui.theme import mark
+        return mark(name) or ""
+    except Exception:  # noqa: BLE001
+        return {"action": "*", "detail": "-", "voice": "K:"}.get(name, "")
+
+
+def _escape(text: Any) -> str:
+    """Caller text is CONTENT. ``except Exception:  # [BLE001]`` is a comment,
+    not a Rich tag, and a deck that renders it as one loses the line."""
+    try:
+        from rich.markup import escape
+        return escape(str(text))
+    except Exception:  # noqa: BLE001
+        return str(text)
+
+
+def _tint(text: str, style: str) -> str:
+    if not text or not style:
+        return text
+    return f"[{style}]{text}[/{style}]"
+
+
+def _lead(glyph: str, column: int) -> str:
+    """``glyph`` plus the spaces that land the next character on ``column``.
+
+    A glyph wider than the column keeps a single separating space — pushing
+    its text one cell right is the honest outcome, and is the whole reason
+    this is arithmetic on printed width rather than a literal.
+    """
+    return glyph + " " * max(1, column - _cells(glyph))
+
+
+# ---------------------------------------------------------------------------
+# The three line kinds
+# ---------------------------------------------------------------------------
+
+
+def action(verb: str, arg: str = "", *, tone: str = "ok") -> str:
+    """``⏺ Read(governance/risk_tier_floor.py)`` — opens a block.
+
+    The bullet carries the outcome (``ok`` / ``crit`` / ``warn``); the verb is
+    ink; the argument is muted, because WHICH file is context and WHAT
+    happened is the content. Colouring both the same is the flat wall.
+    """
+    try:
+        lead = _tint(_lead(_glyph("action"), ACTION_COLUMN), _style(tone))
+        head = _tint(_escape(verb), _style("ink"))
+        if arg:
+            paren = _style("faint")
+            head = (f"{head}{_tint('(', paren)}"
+                    f"{_tint(_escape(arg), _style('muted'))}"
+                    f"{_tint(')', paren)}")
+        return lead + head
+    except Exception:  # noqa: BLE001
+        return f"* {verb}"
+
+
+def detail(text: str, *, tone: str = "muted") -> str:
+    """``  ⎿  Read 847 lines`` — subordinate to the action above it.
+
+    ``tone`` is the RESULT's colour: ``ok`` for a pass, ``crit`` for a
+    failure, muted for the ordinary. That is what makes a red line findable
+    while scrolling, and it is derived from the outcome rather than picked.
+    """
+    try:
+        glyph = _tint(_glyph("detail"), _style("faint"))
+        pad = " " * max(1, DETAIL_COLUMN - _DETAIL_INDENT
+                        - _cells(_glyph("detail")))
+        return (" " * _DETAIL_INDENT + glyph + pad
+                + _tint(_escape(text), _style(tone)))
+    except Exception:  # noqa: BLE001
+        return f"  - {text}"
+
+
+def voice(text: str) -> str:
+    """``💭 the vision floor raises, and the caller swallows it``.
+
+    The organism's own reasoning, in the glyph `theme._GLYPHS` rations for it.
+    Two cells wide, so its body sits one column right of an action's — the
+    alternative was padding it as though it were one cell, which is how the
+    glyph ends up welded to the first word.
+    """
+    try:
+        lead = _lead(_glyph("voice"), ACTION_COLUMN)
+        style = " ".join(p for p in (_style("info"), "italic") if p)
+        return lead + _tint(_escape(text), style)
+    except Exception:  # noqa: BLE001
+        return f"  {text}"
+
+
+def diff(lineno: Optional[int], sign: str, code: str) -> str:
+    """``     412 +    except RiskFloorConfigError:`` — a hunk under a result.
+
+    Anchored on :data:`DETAIL_COLUMN`, so it cannot step out from under the
+    ``⎿`` summary that introduced it. The line number is what makes a hunk
+    reviewable rather than decorative: without it the operator knows a line
+    changed but not where to look.
+    """
+    try:
+        gutter = (f"{int(lineno):>{GUTTER_WIDTH}}" if lineno is not None
+                  else " " * GUTTER_WIDTH)
+        tone = {"+": "ok", "-": "crit"}.get(sign, "muted")
+        return (" " * DETAIL_COLUMN
+                + _tint(gutter, _style("faint")) + " "
+                + _tint(f"{sign} {_escape(code)}", _style(tone)))
+    except Exception:  # noqa: BLE001
+        return f"     {sign} {code}"
+
+
+def blank() -> str:
+    """The block separator. A line, not a formatting accident.
+
+    Every op block ends with one. It is the cheapest structure the deck has —
+    remove it and twenty correct lines read as one paragraph.
+    """
+    return ""

--- a/backend/core/ouroboros/ui/theme.py
+++ b/backend/core/ouroboros/ui/theme.py
@@ -513,12 +513,23 @@ _SEMANTIC_TRUE: Mapping[str, str] = {
     "info": "#58B0F8", "verbose": "#6C7D77", "muted": "#6C7D77",
     "ok": "#3FB950", "ok_bold": "bold #5EE06A", "venom_green": "#5EE06A",
     "venom_purple": "#A371F7", "cyan": "#43D6D0", "cyan_bold": "bold #43D6D0",
+    # The §09 ground/ink ladder, which the palette defined but nothing could
+    # ASK for. Without a resolvable name, "primary text" had to be spelled as
+    # no style at all -- and an unstyled line takes the terminal profile's
+    # foreground, so a green-on-black terminal rendered the whole deck in the
+    # one colour §08 reserves for outcomes. Naming it is what makes the
+    # dim -> ink -> accent hierarchy expressible.
+    "ink": PALETTE["ink"], "faint": PALETTE["faint"],
 }
 _SEMANTIC_STD: Mapping[str, str] = {
     "crit": "red", "crit_bold": "bold red", "warn": "yellow",
     "info": "cyan", "verbose": "bright_black", "muted": "dim",
     "ok": "green", "ok_bold": "bold green", "venom_green": "green",
     "venom_purple": "magenta", "cyan": "cyan", "cyan_bold": "bold cyan",
+    # 16 colours cannot say #DBE6E1. "default" is the honest degradation --
+    # the terminal's own foreground -- rather than picking white and fighting
+    # a palette we cannot see.
+    "ink": "default", "faint": "bright_black",
 }
 
 

--- a/tests/ui/test_deck_grammar.py
+++ b/tests/ui/test_deck_grammar.py
@@ -1,0 +1,141 @@
+"""The deck's column discipline — the property that made it necessary.
+
+`ov demo live` shipped with a result line whose body sat at column 4 and a
+diff hunk beneath it whose body sat at column 5, because each was a separate
+f-string at a separate call site and nothing compared them. These tests assert
+the COLUMNS agree, on the rendered text rather than on the markup, because the
+column is what the operator sees and the tags are not.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.ui import deck_grammar as deck
+from backend.core.ouroboros.ui import theme
+
+
+@pytest.fixture(autouse=True)
+def _truecolor(monkeypatch):
+    """Pin the tier so every assertion runs against a STYLED line.
+
+    Under a captured stdout the tier is NONE and every style resolves to the
+    empty string — the one condition in which a column bug caused by markup
+    could not possibly show up.
+    """
+    monkeypatch.setattr(theme, "_active_tier_cache", theme.ColorTier.TRUECOLOR)
+    yield
+
+
+def _plain(markup: str) -> str:
+    """What the terminal actually prints — tags resolved away."""
+    from rich.text import Text
+    return Text.from_markup(markup).plain
+
+
+def _column_of(line: str, marker: str) -> int:
+    """Cell index where ``marker`` starts, on the rendered line.
+
+    Measured in CELLS, not codepoints: a wide glyph earlier in the line moves
+    the column without moving the index, and the codepoint answer would be the
+    one that looks right in a test and wrong on a terminal.
+    """
+    from rich.cells import cell_len
+    plain = _plain(line)
+    return cell_len(plain[: plain.index(marker)])
+
+
+class TestColumns:
+    def test_action_body_sits_in_claude_codes_column(self):
+        assert _plain(deck.action("Read", "foo.py")).startswith("⏺ Read(")
+
+    def test_detail_body_and_diff_body_share_one_column(self):
+        """THE regression. Two literals, one column, no one to notice.
+
+        A four-digit line number fills the gutter exactly, so its left edge IS
+        the hunk's left edge — the column the result above it must also start
+        in for the diff to read as belonging to that result.
+        """
+        result = deck.detail("Read 847 lines")
+        hunk = deck.diff(1234, "+", "    except Foo:")
+        assert _column_of(result, "Read") == deck.DETAIL_COLUMN
+        assert _column_of(hunk, "1234") == deck.DETAIL_COLUMN
+
+    def test_detail_keeps_two_spaces_after_the_glyph(self):
+        # `  ⎿  text`, not `  ⎿ text`. One space is where the drift started.
+        assert _plain(deck.detail("x")) == "  ⎿  x"
+
+    def test_a_wide_glyph_keeps_its_space(self):
+        """`💭` is one codepoint and TWO cells.
+
+        Padded by `len()` it welds to the first word — `💭the vision floor` —
+        which is exactly how it reached an operator's screen.
+        """
+        plain = _plain(deck.voice("the vision floor raises"))
+        assert plain.startswith("💭 the vision floor")
+
+    def test_the_line_number_gutter_is_a_column_not_a_prefix(self):
+        wide = _plain(deck.diff(9, "+", "x"))
+        narrow = _plain(deck.diff(1234, "+", "x"))
+        assert wide.index("+") == narrow.index("+")
+
+
+class TestHierarchy:
+    """§08's first Don't: 'a flat wall of one green — no hierarchy'."""
+
+    def test_chrome_and_content_are_not_the_same_colour(self):
+        line = deck.detail("Read 847 lines")
+        assert theme.semantic("faint") in line   # the ⎿
+        assert theme.semantic("muted") in line   # the text
+
+    def test_outcome_tone_reaches_the_bullet(self):
+        assert theme.semantic("crit") in deck.action("Validate", tone="crit")
+        assert theme.semantic("ok") in deck.action("Validate")
+
+    def test_additions_and_removals_are_told_apart(self):
+        assert theme.semantic("ok") in deck.diff(1, "+", "x")
+        assert theme.semantic("crit") in deck.diff(1, "-", "x")
+
+
+class TestContentIsNeverMarkup:
+    def test_a_bracket_in_a_diff_survives(self):
+        """`rows[0]` is code. A deck that eats it has lost the line."""
+        assert "rows[0]" in _plain(deck.diff(1, "+", "    return rows[0]"))
+
+    def test_a_bracketed_tag_shaped_string_is_not_a_tag(self):
+        assert _plain(deck.detail("[bold]not a tag[/bold]")).endswith(
+            "[bold]not a tag[/bold]")
+
+
+class TestNeverRaises:
+    """Chrome must never be what takes the surface down."""
+
+    @pytest.mark.parametrize("call", [
+        lambda: deck.action(None),                      # type: ignore[arg-type]
+        lambda: deck.detail(None),                      # type: ignore[arg-type]
+        lambda: deck.diff("nonsense", "+", "x"),        # type: ignore[arg-type]
+        lambda: deck.voice(None),                       # type: ignore[arg-type]
+    ])
+    def test_junk_degrades(self, call):
+        assert isinstance(call(), str)
+
+    def test_a_dead_theme_still_yields_a_readable_line(self, monkeypatch):
+        def _boom(*_a, **_k):
+            raise RuntimeError("theme down")
+
+        monkeypatch.setattr(theme, "semantic", _boom)
+        # Uncoloured, but still in the right column and still legible.
+        assert _plain(deck.detail("847 lines")) == "  ⎿  847 lines"
+
+
+class TestDegradation:
+    def test_ascii_locale_keeps_the_geometry(self, monkeypatch):
+        """A no-UTF-8 terminal loses the glyphs, never the columns."""
+        monkeypatch.setattr(theme, "supports_unicode", lambda *a, **k: False)
+        assert _column_of(deck.diff(1234, "+", "x"), "1234") == (
+            deck.DETAIL_COLUMN)
+        assert _column_of(deck.detail("x"), "x") == deck.DETAIL_COLUMN
+        assert "⎿" not in _plain(deck.detail("x"))
+
+    def test_no_colour_tier_still_composes(self, monkeypatch):
+        monkeypatch.setattr(theme, "_active_tier_cache", theme.ColorTier.NONE)
+        assert deck.detail("847 lines") == "  ⎿  847 lines"


### PR DESCRIPTION
`ov demo live` rendered as a flat green wall with the diff stepping out from under the result it belonged to. Both defects have the same cause: the script was hand-written deck lines, so nothing owned the column and nothing owned the style.

`  ⎿ 847 lines` put its body at column 4; `     + except …` put its at column 5. Two f-strings, one column, nothing to notice the disagreement — the same shape as two formatters computing width independently. And an unstyled line takes the terminal profile's foreground, so on green-on-black the entire deck was the one colour `OV_STYLE_GUIDE.md` §08 reserves for outcomes.

## What owns it now

`ui/deck_grammar.py` — `action` / `detail` / `diff` / `voice` / `blank`, with the continuation column computed **once** from the glyph's own printed width and both callers deriving from it. Padding is `cell_len`, not `len` — `💭` is one codepoint and two cells, which is how `💭the vision floor raises` reached the screen.

Falling out of that:

- a blank line closes every block, **derived** from the beat kind rather than written
- hunks carry line numbers; results carry their verb (`Read 847 lines`, not `847 lines`)
- `🗣` → `💭` — `theme._GLYPHS` rations `🗣` for the OPERATOR's words, not the organism's
- the live scene's three agora lines were hardcoded; they call `moltbook_inline.render_thread` now, which is the module's whole premise. That also dropped a duplicated `⚔` (in the post body *and* derived from `kind`)
- `semantic()` gained `ink`/`faint` — `PALETTE` defined them but nothing could ask for them, so "primary text" had to be spelled as no style at all

## Before / after

```
⏺ Read(governance/risk_tier_floor.py)      ⏺ Read(governance/risk_tier_floor.py)
  ⎿ 847 lines                                ⎿  Read 847 lines
⏺ Update(risk_tier_floor.py)
  ⎿ +18 -3                                 ⏺ Update(risk_tier_floor.py)
     + except RiskFloorConfigError:          ⎿  Updated risk_tier_floor.py with 18 additions and 3 removals
🗣 the vision floor raises…                       412 +     except RiskFloorConfigError:
```

## Verification

- Real pty at 100×42: columns hold, chrome dims, block separation lands, `q` exits with rmcup
- 17 new tests in `tests/ui/test_deck_grammar.py` pin the columns on **rendered** text, not on markup — under a captured stdout the tier is NONE and every style resolves to empty, the one condition in which a markup-caused column bug could not show
- 98 green across `test_ov_demo` / `test_moltbook_inline` / `test_theme`; `test_theme_guard::test_ui_package_has_no_literal_styling` fails on `alt_screen.py`'s raw CSI escapes, confirmed red at clean HEAD in a detached worktree

Not touched: the prompt's rules chrome, and `bottom_anchor_enabled()` — pinning the newest line against the prompt is deliberate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the deck’s misaligned continuation column and flat “all green” styling by routing all transcript lines through a shared grammar with semantic colors. The demo now renders consistent columns and hierarchy, and the live scene uses the real thread renderer.

- **Bug Fixes**
  - Centralized deck formatting in `backend/core/ouroboros/ui/deck_grammar.py` to compute a single continuation column using cell width; result and diff bodies align, hunks include right-aligned line numbers, and blocks auto-close with a blank line.
  - Applied semantic styles (`ink`, `faint`, `ok`, `crit`) so chrome vs content are readable across terminal themes; tinted only glyphs/handles in `moltbook_inline` and switched the organism’s voice glyph to `💭`.

- **Refactors**
  - Reworked `ov_demo.py` to emit beats and compose lines via the grammar, print with `_markup`, and render the agora via `moltbook_inline.render_thread`; live script composes at runtime to avoid drift.
  - Added `tests/ui/test_deck_grammar.py` to pin rendered column positions; exposed `ink`/`faint` in `ui/theme.py`.

<sup>Written for commit 4067c8907c0a6620d6d9d36af2dc0dc3d6105f32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

