### PR TITLE
fix(ov): the pulse is the organism breathing, not terminal furniture

### DIFF
--- a/backend/core/ouroboros/battle_test/bipartite_layout.py
+++ b/backend/core/ouroboros/battle_test/bipartite_layout.py
@@ -180,6 +180,24 @@ def bottom_anchor_enabled() -> bool:
     return fullscreen_enabled()
 
 
+def toolbar_above_prompt() -> bool:
+    """Does the pulse row sit above the ``❯`` input, or beneath it?
+
+    Above, by default. The toolbar carries the organism's liveness — spinner,
+    elapsed, tokens — and Claude Code puts that immediately above the input
+    box, adjacent to the transcript line it continues. prompt_toolkit's
+    ``bottom_toolbar`` idiom put it underneath, which is where a shell puts
+    ITS chrome, and the difference is whether the operator reads the pulse as
+    the organism working or as furniture.
+
+    ``JARVIS_BIPARTITE_TOOLBAR_BELOW=1`` restores the footer position for a
+    surface that genuinely wants a footer (persistent key hints rather than a
+    pulse). NEVER raises.
+    """
+    raw = os.environ.get("JARVIS_BIPARTITE_TOOLBAR_BELOW", "").strip().lower()
+    return raw not in ("1", "true", "yes", "on")
+
+
 def _canvas_max_lines() -> int:
     try:
         return canvas_history_lines()
@@ -919,7 +937,7 @@ def build_bipartite_application(
     # it shares the ambient grid with the canvas, so every asynchronous Deck or
     # Lane frame arriving underneath forces the palette's geometry to be
     # recomputed along with everything else.
-    rows += [_rule(), prompt, _rule()]
+    _toolbar_row = None
     if toolbar is not None:
         # A one-row morphing footer (e.g. the attach client's AttachUI.toolbar —
         # audio state, detach hint). Re-evaluated each repaint; a failing
@@ -943,10 +961,27 @@ def build_bipartite_application(
             except Exception:  # noqa: BLE001
                 return [("", "")]
 
-        rows.append(Window(
+        _toolbar_row = Window(
             content=FormattedTextControl(_toolbar_fragments, focusable=False),
             height=1, wrap_lines=False,
-        ))
+        )
+
+    # The pulse belongs ABOVE the input, which is where Claude Code puts it and
+    # where the eye already is: the operator is reading the newest deck line,
+    # and "still working, 42s, 33k tokens" is the continuation of that line,
+    # not a footer. Below the prompt it is separated from what it describes by
+    # the whole input frame, and it reads as terminal chrome — something the
+    # shell put there — rather than as the organism still breathing.
+    #
+    # It also keeps the geometry honest: the canvas bottom-anchors so the
+    # newest event lands against the prompt, and a row wedged underneath meant
+    # the LAST thing before the input was a status bar the deck did not own.
+    if _toolbar_row is not None and toolbar_above_prompt():
+        rows += [_toolbar_row, _rule(), prompt, _rule()]
+    else:
+        rows += [_rule(), prompt, _rule()]
+        if _toolbar_row is not None:
+            rows.append(_toolbar_row)
     # ── Region layout mount (PR #70213's seam, finally consumed) ──────
     #
     # `viewport_arbiter` has decided placements since #70187 and

--- a/tests/cli/test_bipartite_attach.py
+++ b/tests/cli/test_bipartite_attach.py
@@ -210,6 +210,83 @@ def test_cockpit_app_constructs_with_toolbar():
     assert app2 is not None
 
 
+def _row_order(app) -> list:
+    """The root HSplit's children, flattened to a list of ids.
+
+    Walks containers rather than asserting on a fixed index: the palette
+    overlay, the header and the turn row all come and go, and a test pinned to
+    `rows[3]` would break on a change that moved nothing the operator sees.
+    """
+    seen = []
+
+    def _walk(node):
+        seen.append(node)
+        for attr in ("children", "content", "container"):
+            child = getattr(node, attr, None)
+            if isinstance(child, (list, tuple)):
+                for c in child:
+                    _walk(c)
+            elif child is not None and child is not node:
+                _walk(child)
+
+    _walk(app.layout.container)
+    return seen
+
+
+def test_the_pulse_sits_above_the_prompt():
+    """Operator mandate 2026-07-28: the snake goes ABOVE the `❯`.
+
+    prompt_toolkit's `bottom_toolbar` idiom puts the liveness row under the
+    input, which is where a SHELL puts its chrome. Claude Code puts the pulse
+    immediately above the box, continuing the transcript line it belongs to.
+    """
+    from backend.core.ouroboros.battle_test.bipartite_layout import (
+        BipartiteLayout, build_bipartite_application,
+    )
+    app = build_bipartite_application(
+        BipartiteLayout(width=80, height=20),
+        on_accept=lambda t: None, toolbar=lambda: "PULSE-SENTINEL",
+    )
+    nodes = _row_order(app)
+    # The prompt is located by IDENTITY, not by its `❯`: the caret lives on a
+    # BufferControl's prompt margin, so a text scan finds the toolbar and
+    # silently reports the input row missing.
+    prompt_window = app.layout.current_window
+    assert prompt_window in nodes, "the focused prompt is not in the layout"
+    caret = nodes.index(prompt_window)
+
+    pulse = None
+    for i, node in enumerate(nodes):
+        text = getattr(getattr(node, "content", None), "text", None)
+        if not callable(text):
+            continue
+        try:
+            if "PULSE-SENTINEL" in str(text()):
+                pulse = i
+                break
+        except Exception:  # noqa: BLE001
+            continue
+    assert pulse is not None, "the toolbar row never rendered"
+    assert pulse < caret, (
+        "the pulse rendered BELOW the prompt — it is the organism breathing, "
+        "not terminal furniture"
+    )
+
+
+def test_the_footer_position_is_still_reachable(monkeypatch):
+    """A surface whose toolbar is genuinely a footer (persistent key hints,
+    not a pulse) keeps the old geometry behind one env flag."""
+    from backend.core.ouroboros.battle_test import bipartite_layout as bl
+
+    monkeypatch.setenv("JARVIS_BIPARTITE_TOOLBAR_BELOW", "1")
+    assert bl.toolbar_above_prompt() is False
+    app = bl.build_bipartite_application(
+        bl.BipartiteLayout(width=80, height=20),
+        on_accept=lambda t: None, toolbar=lambda: "PULSE-SENTINEL",
+    )
+    assert app is not None
+
+
 # ---------------------------------------------------------------------------
 # (5) CC-style header + borderless canvas (operator mandate 2026-07-23)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The snake, the elapsed clock and the token counter rendered **below** the `❯`, because prompt_toolkit's idiom for a one-row status strip is called `bottom_toolbar` and the row was appended after the input framing on that name alone.

Claude Code puts it immediately **above** the box, and the reason is where the eye already is: the operator is reading the newest deck line, and "still working, 42s, 33k tokens" is the continuation of that line. Under the prompt it is separated from what it describes by the entire input frame, and it reads as chrome the shell put there.

It also made the bottom-anchor geometry dishonest. The canvas pads its top so the newest event lands against the prompt (`bottom_anchor_enabled`); a status row wedged underneath meant the last thing before the input was a bar the deck did not own.

```
before                                    after
  ⎿  applied · verified · committed …       ⎿  applied · verified · committed …
──────────────────────────────────        🐍···○ Watching… (0m 42s · ↓ 33.0k …)
❯                                         ──────────────────────────────────
──────────────────────────────────        ❯
🐍···○ Watching… (0m 42s · ↓ 33.0k …)     ──────────────────────────────────
```

Applies to every surface built on `build_bipartite_application` — `ov demo live` and `ov attach` — so the two agree, which was the point of sharing the builder.

## Notes

- `JARVIS_BIPARTITE_TOOLBAR_BELOW=1` restores the footer position for a surface whose toolbar genuinely IS a footer (persistent key hints rather than a pulse)
- `rows[0]` stays the canvas, so `_mount_region_layout`'s contract — chrome survives arbitration, the deck is the only region — is unchanged
- The regression test locates the prompt by **identity** (`layout.current_window`), not by its `❯`: the caret lives on a BufferControl's prompt margin, so a text scan finds the toolbar and reports the input row missing. Proven load-bearing — it fails with the escape hatch set

## Verification

118 green across `test_region_layout_mount` / `test_turn_spinner` / `test_prompt_sizing` / `test_native_scrollback` / `test_bipartite_attach` / `test_bipartite_palette_overlay` / `test_palette_on_attach_surface` / `test_ov_demo`, plus a pty run at 100×30 showing the pulse above the rule. `test_attach_heartbeat::test_attach_ui_toolbar_shows_pulse_then_falls_back` fails, confirmed red at clean `main` in a detached worktree — it asserts on toolbar *content*, which this does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move the pulse/status row (spinner, elapsed time, token count) to render above the `❯` prompt so it reads as a continuation of the latest line and fixes the bottom-anchor geometry. Adds an opt-out env flag to keep it below for surfaces that use a real footer.

- **Bug Fixes**
  - Default: render the pulse above the prompt for all `build_bipartite_application` surfaces (`ov demo live`, `ov attach`).
  - Keeps the region-layout contract unchanged; the canvas stays `rows[0]`.
  - Env escape hatch: set `JARVIS_BIPARTITE_TOOLBAR_BELOW=1` to place the toolbar under the prompt.
  - Tests added to assert pulse-above-prompt and the footer override behavior.

<sup>Written for commit 49e73e65265d2114d74576393295c86b988b4699. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

