### PR TITLE
test(ov): the pulse test was pinned to a surface the pulse left

### DIFF
--- a/tests/battle_test/test_attach_heartbeat.py
+++ b/tests/battle_test/test_attach_heartbeat.py
@@ -4,7 +4,15 @@
 Covers: the pure formatter (pulse animation, elapsed advance, staleness,
 token/elapsed formatting, provider chip), the daemon composer's payload
 schema + provider labeling, the bridge telemetry roundtrip into the
-client's on_telemetry callback, and the AttachUI toolbar integration.
+client's on_telemetry callback, and the AttachUI integration — the live
+region above the caret, and that it reaches the callable prompt_toolkit
+renders.
+
+The pulse used to live in the bottom toolbar and moved above the caret in
+#70118; the tests here were left pointing at the old surface and went red for
+two days on a position that was deliberately changed. They now assert per
+surface — pulse in the live region, key hints in the toolbar — so a future
+move fails on the thing that moved rather than on everything at once.
 """
 
 from __future__ import annotations
@@ -186,16 +194,51 @@ async def test_telemetry_roundtrip_lands_in_on_telemetry(sock):
         await b.stop()
 
 
-def test_attach_ui_toolbar_shows_pulse_then_falls_back():
+def test_attach_ui_pulse_shows_then_falls_back():
+    """The pulse lives ABOVE the caret, in the live region — not the toolbar.
+
+    It moved there in #70118 on the same operator mandate that later moved the
+    bipartite cockpit's row (#70228): reading order runs downward, so status
+    belongs above the line you are typing. This test asserted the old position
+    and went red at that commit rather than at the one that broke something —
+    which is the failure mode a position assertion exists to prevent, so it now
+    pins the surface each piece actually owns.
+    """
     from backend.core.ouroboros.cli.ov import AttachUI
     ui = AttachUI()
-    idle = ui.toolbar()
-    assert "organism live" in idle             # idle fallback
+    assert "organism live" in ui._live_region()   # idle fallback
     ui.on_telemetry(_hb())
-    live = ui.toolbar()
+    live = ui._live_region()
     assert "Synthesizing…" in live and "DW-397B" in live
-    assert "'detach' to leave" in live         # chrome retained
-    ui.on_telemetry({"kind": "other", "x": 1})  # non-heartbeat ignored
-    assert "Synthesizing…" in ui.toolbar()
-    ui._heartbeat_arrived -= 60.0              # goes stale
-    assert "organism live" in ui.toolbar()
+    ui.on_telemetry({"kind": "other", "x": 1})    # non-heartbeat ignored
+    assert "Synthesizing…" in ui._live_region()
+    ui._heartbeat_arrived -= 60.0                 # goes stale
+    assert "organism live" in ui._live_region()
+
+
+def test_the_pulse_reaches_the_rendered_prompt():
+    """`_live_region` composing correctly is not the same as it being DRAWN.
+
+    Nothing proved the block reached `prompt()` — the callable wired into
+    `PromptSession(message=...)` at ov.py:1578, which is what prompt_toolkit
+    actually renders. Without this the region could be composed for no one and
+    every other test here would still pass.
+    """
+    from backend.core.ouroboros.cli.ov import AttachUI
+    ui = AttachUI()
+    ui.on_telemetry(_hb())
+    rendered = ui.prompt()
+    assert "Synthesizing…" in rendered
+    # Above the caret, not below it: the whole point of the move.
+    assert rendered.index("Synthesizing…") < rendered.rindex("›")
+
+
+def test_the_toolbar_keeps_the_key_hints():
+    """What genuinely does belong under the input: hints about the line you
+    are on. The pulse left; the chrome stayed."""
+    from backend.core.ouroboros.cli.ov import AttachUI
+    ui = AttachUI()
+    ui.on_telemetry(_hb())
+    toolbar = str(ui.toolbar())
+    assert "'detach' to leave" in toolbar
+    assert "Synthesizing…" not in toolbar


### PR DESCRIPTION
`test_attach_ui_toolbar_shows_pulse_then_falls_back` asserted `AttachUI.toolbar()` carries the heartbeat. It has not since #70118, which moved the pulse into `_live_region()` — the block above the caret — on the operator mandate that reading order runs downward: status, then the line you are typing. The toolbar deliberately kept only the key hints, which describe the line you are on.

That PR did not touch the test. It has been red on `main` since 2026-07-26, failing on a position that was changed on purpose.

## Split per surface

```
_live_region()  the pulse, its staleness fallback, non-heartbeat frames ignored
toolbar()       the key hints — and NOT the pulse
```

So a future move fails on the thing that moved, rather than on one assertion that mixes both.

## Plus the assertion nobody had written

`_live_region()` composing correctly is not the same as it being **drawn**. Nothing pinned that the block reaches `prompt()` — the callable wired into `PromptSession(message=...)` at `ov.py:1578`. Every existing test would have passed with the region composed for no one, which is the wired-but-inert shape this codebase keeps hitting.

Verified load-bearing by severing it in-process:

```
wired  : True
severed: False
```

## Verification

86 green across `test_attach_heartbeat` / `test_focus_shield` / `test_health_advisory` / `test_acoustic_degradation_sink` / `test_session_risk_floor` — the other `AttachUI` consumers, all of which assert on `_key_hints()` and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix failing AttachUI heartbeat tests by asserting the pulse in the live region above the caret (not the toolbar) and adding a check that the region is actually rendered via `prompt()`. This aligns tests with the move introduced in #70118.

- **Bug Fixes**
  - Pointed pulse assertions to `AttachUI._live_region()` and covered staleness and non-heartbeat frames; renamed to `test_attach_ui_pulse_shows_then_falls_back`.
  - Added `test_the_pulse_reaches_the_rendered_prompt` to confirm the live region reaches `prompt()` and renders above the caret.
  - Added `test_the_toolbar_keeps_the_key_hints` to ensure `toolbar()` shows only key hints and never the pulse; other `AttachUI` consumer tests remain green.

<sup>Written for commit 7df39567df6075189318d1a51bfc42c56c18c61f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

