### PR TITLE
feat(ov): the agent view, mounted — and the boundary that kept it dark

### DIFF
--- a/backend/core/ouroboros/battle_test/agent_roster.py
+++ b/backend/core/ouroboros/battle_test/agent_roster.py
@@ -37,6 +37,36 @@ The operator can be pointing at row 3 when an agent two rows above them
 finishes. Selection is therefore held by AGENT ID, not by index: an index
 would silently move the cursor onto a different agent at the exact moment
 they press Enter.
+
+The roster lives in one process and is READ in another
+------------------------------------------------------
+This is the constraint that shapes everything below. The producer is the
+daemon — `SerpentFlow` calls :meth:`AgentRoster.spawn` as each subagent is
+dispatched. The consumer is a cockpit, which under ``ov attach`` is a
+DIFFERENT PROCESS with its own empty module singleton. Mounting a render call
+in the client would draw an empty roster forever, and it would look exactly
+like a system that never dispatches agents.
+
+So the module is split the way ``attach_heartbeat`` is split — two pure
+halves over one schema:
+
+* :meth:`AgentRoster.snapshot` — the daemon serialises its live state.
+* :func:`render_roster` — a PURE function over that snapshot, which the
+  in-process cockpit and the remote client both call.
+
+:meth:`AgentRoster.render` is a thin delegation to the same function, so
+there is exactly one place that decides what a roster looks like.
+
+Elapsed, never a timestamp
+--------------------------
+A snapshot carries ``elapsed_s`` per agent, never ``started``.
+``time.monotonic()`` is an arbitrary per-process origin: shipping one across
+the bridge and subtracting it from the reader's clock yields a duration that
+is wrong by however long the two processes have been alive, and wrong in a
+way that looks plausible. Durations are computed where the clock lives.
+
+Between frames the reader advances running agents by the snapshot's own age,
+so seconds tick smoothly at 1 Hz instead of stepping.
 """
 from __future__ import annotations
 
@@ -47,7 +77,15 @@ from typing import Any, Callable, Dict, List, Optional
 
 logger = logging.getLogger("Ouroboros.AgentRoster")
 
-__all__ = ["AgentEntry", "AgentRoster", "agent_view_enabled", "format_duration"]
+__all__ = [
+    "ROSTER_SCHEMA_VERSION", "AgentEntry", "AgentRoster", "agent_view_enabled",
+    "format_duration", "render_roster", "roster_hint",
+]
+
+#: Additive schema. A reader that does not know a field ignores it; a reader
+#: that expects one it does not get renders without it. Bumped only if a
+#: field's MEANING changes, never for an addition.
+ROSTER_SCHEMA_VERSION = "roster.v1"
 
 #: Rows drawn before the roster collapses to a count. A cockpit footer is a
 #: glance, not a process table.
@@ -55,6 +93,16 @@ _MAX_ROWS = 8
 
 #: Longest a running agent may go unheard from before it is presumed lost.
 _STALE_S = 900.0
+
+#: Narrowest goal column worth printing. Below this a label is all ellipsis
+#: and the row costs a line to say nothing.
+_MIN_LABEL = 18
+
+#: The roster's own keys, declared to the ONE registry that knows what this
+#: cockpit binds. Registered rather than printed so `/keys` can list them and
+#: the rendered hint has a single source — the defect the registry exists to
+#: prevent is a footer that advertises a key nothing binds.
+_ROSTER_ACTIONS = (("↑/↓", "select"), ("Enter", "view"))
 
 
 def agent_view_enabled() -> bool:
@@ -70,6 +118,96 @@ def _stale_after_s() -> float:
                                or _STALE_S))
     except (TypeError, ValueError):
         return _STALE_S
+
+
+def _max_rows() -> int:
+    """Rows drawn before collapsing to a count. Re-read at call time, so a
+    resized cockpit or a changed preference takes effect without a restart."""
+    try:
+        return max(1, min(64, int(os.environ.get(
+            "JARVIS_AGENT_VIEW_ROWS", "") or _MAX_ROWS)))
+    except (TypeError, ValueError):
+        return _MAX_ROWS
+
+
+def roster_wire_rows() -> int:
+    """Rows a SNAPSHOT carries, as distinct from rows a cockpit DRAWS.
+
+    These are different questions and conflating them caps the wrong one. The
+    producer cannot know how tall its readers are — a 60-row terminal and a
+    24-row one attach to the same daemon — so if it serialises only what the
+    smallest could draw, the roomy client is silently truncated by a peer's
+    screen. It therefore ships a generous window and lets each reader fold to
+    its own budget.
+
+    Generous, not unbounded: this rides a 1 Hz frame, so the window is what
+    stops a 400-worker swarm from putting 400 rows on the wire every second
+    for a reader that can draw twenty.
+    """
+    try:
+        return max(1, min(128, int(os.environ.get(
+            "JARVIS_AGENT_VIEW_WIRE_ROWS", "") or 24)))
+    except (TypeError, ValueError):
+        return 24
+
+
+def _screen_share() -> float:
+    """Fraction of the terminal the roster may take before it folds.
+
+    A share, not a row count, because the constraint is proportional: eleven
+    rows is a footer on a 60-row terminal and half the cockpit on a 24-row
+    one, and the operator opened the cockpit to watch the DECK. Tunable, but
+    clamped — a roster permitted the whole screen is a process table, and this
+    is a glance.
+    """
+    try:
+        return max(0.05, min(0.75, float(os.environ.get(
+            "JARVIS_AGENT_VIEW_SCREEN_SHARE", "") or 0.35)))
+    except (TypeError, ValueError):
+        return 0.35
+
+
+def roster_line_budget(term_rows: Optional[int]) -> Optional[int]:
+    """Terminal rows the roster may occupy, or None when height is unknown.
+
+    None rather than a guess: :func:`render_roster` folds only when it is
+    given a budget, so an unknown height degrades to "show the snapshot's own
+    window" — the behaviour before there was a budget at all — instead of
+    folding against a number nobody measured.
+    """
+    try:
+        if not term_rows or int(term_rows) <= 0:
+            return None
+        return max(_CHROME_ROWS + 2, int(int(term_rows) * _screen_share()))
+    except (TypeError, ValueError):
+        return None
+
+
+def _register_keys() -> None:
+    """Publish the roster's keys to the canonical registry. NEVER raises."""
+    try:
+        from backend.core.ouroboros.governance.keybinding_registry import (
+            register_keybinding,
+        )
+        for key, action in _ROSTER_ACTIONS:
+            register_keybinding(
+                key=key, action=action,
+                source_file="battle_test/agent_roster.py",
+            )
+    except Exception:  # noqa: BLE001 — an unregistered key still works
+        logger.debug("[AgentRoster] key registration degraded", exc_info=True)
+
+
+def roster_hint() -> str:
+    """``↑/↓ to select · Enter to view`` — composed from the registered keys.
+
+    Read back from the declaration rather than written twice, so a rebind
+    cannot leave the cockpit advertising a key that no longer does anything.
+    """
+    try:
+        return " · ".join(f"{k} to {a}" for k, a in _ROSTER_ACTIONS)
+    except Exception:  # noqa: BLE001
+        return ""
 
 
 def format_duration(seconds: float) -> str:
@@ -128,6 +266,21 @@ class AgentEntry:
             goal = goal[: width - 1].rstrip() + "…"
         return goal
 
+    def as_row(self, now: float) -> Dict[str, Any]:
+        """This agent as a transport-safe dict.
+
+        ``elapsed_s``, never ``started`` — see the module docstring. The goal
+        is carried UNCLIPPED: how much of it fits is the reader's question,
+        because the reader is the one who knows how wide its terminal is.
+        """
+        return {
+            "id": self.agent_id,
+            "kind": self.kind,
+            "goal": self.goal,
+            "state": self.state,
+            "elapsed_s": round(self.elapsed(now), 1),
+        }
+
     def __repr__(self) -> str:  # pragma: no cover — diagnostics only
         return f"<AgentEntry {self.agent_id!r} {self.kind} {self.state}>"
 
@@ -138,15 +291,26 @@ class AgentRoster:
     def __init__(
         self,
         clock: Optional[Callable[[], float]] = None,
-        max_rows: int = _MAX_ROWS,
+        max_rows: Optional[int] = None,
     ) -> None:
         self._clock = clock or time.monotonic
         self._entries: Dict[str, AgentEntry] = {}
         self._order: List[str] = []
-        self._max = max(1, int(max_rows))
+        #: ``None`` = follow the env at call time, so an operator who widens
+        #: the window mid-session gets it. An explicit int PINS the window,
+        #: which is what a test wants and what an embedding surface with a
+        #: fixed budget of rows wants.
+        self._max: Optional[int] = (
+            max(1, int(max_rows)) if max_rows else None
+        )
         #: Held by ID, never by index — see the module docstring.
         self._selected: Optional[str] = None
         self.reaped = 0
+        _register_keys()
+
+    @property
+    def _window(self) -> int:
+        return self._max if self._max is not None else _max_rows()
 
     # -- the feed ----------------------------------------------------------
 
@@ -259,40 +423,52 @@ class AgentRoster:
 
     # -- render ------------------------------------------------------------
 
-    def render(self) -> List[str]:
-        """Footer rows, or [] when nothing has been dispatched.
+    def snapshot(self, *, max_rows: Optional[int] = None) -> Dict[str, Any]:
+        """The roster as a transport-safe dict — the daemon's half.
 
-        An empty roster renders NOTHING — not "0 agents". A cockpit that
-        always shows a section for work that is not happening spends a row
-        saying nothing, every session, forever.
+        REAPS first, because the process holding the entries is the only one
+        that can honestly decide an agent has gone quiet. A reader that reaped
+        on its own would be guessing from a frame that is already a second
+        old, and would eventually mark an agent lost that the daemon can see
+        is running.
+
+        Bounded to the visible window plus a ``hidden`` count. The whole point
+        of the cap is that a 200-worker swarm must not turn a 1 Hz frame into
+        a 200-row payload — the operator cannot read 200 rows either way, so
+        the truthful summary is cheaper AND better.
         """
         try:
             if not agent_view_enabled():
-                return []
+                return {"schema_version": ROSTER_SCHEMA_VERSION, "rows": [],
+                        "total": 0, "running": 0, "hidden": 0}
             self.reap()
+            now = self._clock()
             rows = self.entries
-            if not rows:
-                return []
-            lines = ["  ↑/↓ to select · Enter to view", ""]
-            cursor = "❯" if self._selected is None else " "
-            lines.append(f"{cursor} ⏺ main")
-            shown = rows[-self._max:]
-            for entry in shown:
-                mark = "❯" if self._selected == entry.agent_id else " "
-                label = entry.label()
-                took = ""
-                if not entry.running:
-                    took = f"  {format_duration(entry.elapsed(self._clock()))}"
-                lines.append(
-                    f"{mark} {entry.glyph} {entry.kind}  {label}{took}".rstrip()
-                )
-            hidden = len(rows) - len(shown)
-            if hidden > 0:
-                lines.append(f"    … {hidden} more")
-            return lines
+            window = int(max_rows) if max_rows else self._window
+            shown = rows[-window:] if window > 0 else []
+            return {
+                "schema_version": ROSTER_SCHEMA_VERSION,
+                "rows": [e.as_row(now) for e in shown],
+                "total": len(rows),
+                "running": sum(1 for e in rows if e.running),
+                "hidden": max(0, len(rows) - len(shown)),
+            }
         except Exception:  # noqa: BLE001
-            logger.debug("[AgentRoster] render degraded", exc_info=True)
-            return []
+            logger.debug("[AgentRoster] snapshot degraded", exc_info=True)
+            return {"schema_version": ROSTER_SCHEMA_VERSION, "rows": [],
+                    "total": 0, "running": 0, "hidden": 0}
+
+    def render(self, *, width: Optional[int] = None) -> List[str]:
+        """Footer rows for the IN-PROCESS cockpit.
+
+        A thin delegation to :func:`render_roster` over this roster's own
+        snapshot. Local and remote readers therefore cannot drift into two
+        opinions about what a roster looks like — which they would, because
+        the two would be edited months apart.
+        """
+        return render_roster(
+            self.snapshot(), selected=self._selected, width=width,
+        )
 
     # -- internals ---------------------------------------------------------
 
@@ -300,7 +476,7 @@ class AgentRoster:
         # Drop the oldest FINISHED entry first. A running agent is never
         # evicted for age: it is the one thing on this list that is still
         # true.
-        limit = self._max * 3
+        limit = self._window * 3
         while len(self._order) > limit:
             for key in list(self._order):
                 entry = self._entries.get(key)
@@ -310,6 +486,114 @@ class AgentRoster:
                     break
             else:
                 return
+
+
+# ---------------------------------------------------------------------------
+# The reader's half — pure, stdlib-only, shared by both processes
+# ---------------------------------------------------------------------------
+
+
+#: state → mark. Failure and loss are NOT the same: one reported back, the
+#: other never did. Defined once here because the reader may be holding a
+#: snapshot from a process whose AgentEntry class it never imported.
+_GLYPHS = {"running": "◯", "finished": "⏺", "failed": "✗", "unknown": "?"}
+
+
+def _clip(text: Any, width: int) -> str:
+    goal = " ".join(str(text or "").split())
+    if width > 0 and len(goal) > width:
+        return goal[: width - 1].rstrip() + "…"
+    return goal
+
+
+#: Rows the roster spends on itself: the hint, its blank, and `main`.
+_CHROME_ROWS = 3
+
+
+def render_roster(
+    snapshot: Optional[Dict[str, Any]],
+    *,
+    selected: Optional[str] = None,
+    age_s: float = 0.0,
+    width: Optional[int] = None,
+    max_lines: Optional[int] = None,
+) -> List[str]:
+    """Footer rows for a roster snapshot, from any process. NEVER raises.
+
+    An empty roster renders NOTHING — not "0 agents". A cockpit that always
+    shows a section for work that is not happening spends a row saying
+    nothing, every session, forever.
+
+    ``age_s`` is how long ago the snapshot was taken. Running agents advance
+    by it, so a 1 Hz frame still shows seconds ticking; finished ones do not,
+    because their duration is settled and inventing motion in it would be a
+    lie the reader has no way to check.
+
+    ``width`` is the reader's terminal, so the goal column is sized where the
+    terminal is known rather than guessed at the producer. A snapshot rendered
+    into an 80-column client and a 200-column one differ in what they clip,
+    and neither producer could have known which.
+
+    ``max_lines`` is how many TERMINAL ROWS the roster may occupy — a
+    different question from how many agents the snapshot holds, and the one a
+    30-row cockpit running a 40-worker swarm actually needs answered. Rows
+    beyond the budget are folded into the "… N more" count rather than
+    silently dropped, because a roster that quietly shows six of forty is
+    worse than one that says so.
+    """
+    try:
+        if not agent_view_enabled() or not isinstance(snapshot, dict):
+            return []
+        rows = [r for r in (snapshot.get("rows") or ()) if isinstance(r, dict)]
+        if not rows:
+            return []
+        age = max(0.0, float(age_s or 0.0))
+        # Fold to fit BEFORE anything is formatted: the count line has to
+        # include what the height budget dropped, and it cannot if the drop
+        # happens after the total was written.
+        folded = 0
+        if max_lines is not None:
+            # Budget the "… N more" row up front. Reserving it only when
+            # something overflows costs a row exactly when the overflow is
+            # one — and then the reservation causes a second overflow.
+            budget = int(max_lines) - _CHROME_ROWS - 1
+            if budget < 1:
+                return []
+            if len(rows) > budget:
+                folded = len(rows) - budget
+                rows = rows[-budget:]
+        # Chrome is `❯ ◯ Kind  ` plus a duration column. Whatever is left is
+        # the goal's, floored so a narrow terminal drops the goal entirely
+        # rather than printing three characters and an ellipsis.
+        cols = int(width) if width and int(width) > 0 else 80
+        kind_w = max((len(str(r.get("kind") or "")) for r in rows), default=8)
+        room = cols - (kind_w + 16)
+        label_w = room if room >= _MIN_LABEL else 0
+
+        lines = [f"  {roster_hint()}", ""]
+        lines.append(f"{'❯' if selected is None else ' '} ⏺ main")
+        for row in rows:
+            state = str(row.get("state") or "running")
+            mark = "❯" if selected and selected == row.get("id") else " "
+            glyph = _GLYPHS.get(state, "◯")
+            elapsed = float(row.get("elapsed_s") or 0.0)
+            if state == "running":
+                elapsed += age
+            took = f"  {format_duration(elapsed)}"
+            label = _clip(row.get("goal"), label_w) if label_w else ""
+            body = f"{row.get('kind') or 'agent'}  {label}".rstrip()
+            lines.append(f"{mark} {glyph} {body}{took}".rstrip())
+        # What the PRODUCER withheld plus what the height budget folded. Two
+        # separate elisions, one honest number — reporting either alone would
+        # undercount, and the operator reads this to decide whether they are
+        # looking at all of it.
+        hidden = int(snapshot.get("hidden") or 0) + folded
+        if hidden > 0:
+            lines.append(f"    … {hidden} more")
+        return lines
+    except Exception:  # noqa: BLE001
+        logger.debug("[AgentRoster] render degraded", exc_info=True)
+        return []
 
 
 _ROSTER: Optional[AgentRoster] = None

--- a/backend/core/ouroboros/battle_test/attach_heartbeat.py
+++ b/backend/core/ouroboros/battle_test/attach_heartbeat.py
@@ -92,12 +92,23 @@ def heartbeat_interval_s() -> float:
         return 1.0
 
 
-def _stale_after_s() -> float:
+def heartbeat_stale_after_s() -> float:
+    """How long a frame stays believable — THE definition of "lost contact".
+
+    Public because more than the pulse depends on it. Anything rendered from
+    a heartbeat frame — the pulse, the agent roster — must retire on the same
+    window, or the cockpit ends up showing a dead daemon's agents as running
+    underneath an idle pulse, and each surface would be individually correct.
+    """
     try:
         return max(2.0, float(os.environ.get(
             "JARVIS_ATTACH_HEARTBEAT_STALE_S", "10")))
     except (TypeError, ValueError):
         return 10.0
+
+
+def _stale_after_s() -> float:
+    return heartbeat_stale_after_s()
 
 
 # ---------------------------------------------------------------------------
@@ -170,10 +181,33 @@ def build_heartbeat_payload() -> Optional[Dict[str, Any]]:
         except Exception:  # noqa: BLE001 — a laneless heartbeat still beats
             lanes = []
 
+        # The agent roster rides here for the same reason lanes do, and for
+        # one more: the roster is a module SINGLETON in the daemon, and the
+        # cockpit that must draw it is a different process under `ov attach`.
+        # A client rendering its own `get_agent_roster()` would draw an empty
+        # roster forever — indistinguishable from a system that never
+        # dispatches agents. Serialising it here is what makes the agent view
+        # true remotely rather than only in-process.
+        try:
+            from backend.core.ouroboros.battle_test.agent_roster import (
+                get_agent_roster, roster_wire_rows,
+            )
+            # The WIRE window, not the display window. This daemon cannot see
+            # its readers' terminals, and two of them may differ by forty
+            # rows — serialising only what the smallest could draw would
+            # truncate the roomy one by a peer's screen size.
+            agents = get_agent_roster().snapshot(max_rows=roster_wire_rows())
+        except Exception:  # noqa: BLE001 — a rosterless heartbeat still beats
+            agents = None
+
         return {
             "kind": "heartbeat",
             "schema_version": HEARTBEAT_SCHEMA_VERSION,
             "lanes": lanes,
+            # Additive under heartbeat.v1: an older client that has never
+            # heard of `agents` ignores the key, and a newer client that does
+            # not receive one renders no roster. Neither is a version error.
+            "agents": agents,
             "active": active,
             "verb": verb,
             "phase": phase,

--- a/backend/core/ouroboros/battle_test/bipartite_layout.py
+++ b/backend/core/ouroboros/battle_test/bipartite_layout.py
@@ -643,6 +643,64 @@ def _mount_region_layout(rows: "list") -> Any:
         logger.debug("[Bipartite] region layout mount degraded", exc_info=True)
         return HSplit(rows)
 
+def build_agent_row(rows: Callable[[], Any]) -> Any:
+    """The agent view — a container that is EXACTLY as tall as the roster.
+
+    ``Dimension.exact``, computed per repaint, for the reason the prompt
+    learned the hard way: ``HSplit`` hands each child its preferred size and
+    distributes the leftover by weight, so a child whose ``max`` exceeds its
+    ``preferred`` absorbs the slack. A range here would nail an eight-row
+    black slab open above the prompt on an idle cockpit.
+
+    Paired with a ``ConditionalContainer`` so zero agents costs zero rows —
+    an idle cockpit must be exactly as tall as it was before the agent view
+    existed, and a Window rendering an empty string still occupies a line.
+
+    ``rows`` is a callable returning the CURRENT roster lines, so the source
+    (a local singleton in-process, a heartbeat snapshot remotely) is the
+    caller's concern and this container never learns which one it is drawing.
+    NEVER raises — returns None, and the layout omits the row.
+    """
+    try:
+        from prompt_toolkit.filters import Condition
+        from prompt_toolkit.layout import ConditionalContainer, Window
+        from prompt_toolkit.layout.controls import FormattedTextControl
+        from prompt_toolkit.layout.dimension import Dimension
+
+        def _current() -> list:
+            try:
+                return [str(x) for x in (rows() or ())]
+            except Exception:  # noqa: BLE001
+                return []
+
+        def _fragments() -> Any:
+            try:
+                lines = _current()
+                if not lines:
+                    return []
+                from prompt_toolkit.formatted_text import ANSI
+                return ANSI("\n".join(lines))
+            except Exception:  # noqa: BLE001
+                return []
+
+        def _height() -> Any:
+            try:
+                return Dimension.exact(max(1, len(_current())))
+            except Exception:  # noqa: BLE001
+                return Dimension.exact(1)
+
+        return ConditionalContainer(
+            content=Window(
+                content=FormattedTextControl(_fragments, focusable=False),
+                height=_height, wrap_lines=False,
+            ),
+            filter=Condition(lambda: bool(_current())),
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug("[Bipartite] agent row unavailable", exc_info=True)
+        return None
+
+
 def build_bipartite_application(
     mux: BipartiteLayout,
     *,
@@ -655,6 +713,7 @@ def build_bipartite_application(
     history: Any = None,
     auto_suggest: Any = None,
     turn_spinner: Any = None,
+    agent_rows: Optional[Callable[[], Any]] = None,
 ) -> Any:
     """Construct the full-screen ``prompt_toolkit.Application``: Zone 1 an ANSI
     window fed from ``mux.render_canvas_ansi()`` (re-rendered each frame, so
@@ -933,6 +992,16 @@ def build_bipartite_application(
                 rows += [_turn_row]
         except Exception:  # noqa: BLE001
             logger.debug("[Bipartite] turn row unavailable", exc_info=True)
+    # WHO is working, directly above WHAT is happening to my turn. Both sit
+    # under the deck and above the prompt because they answer questions about
+    # the present, and the deck is the past.
+    if agent_rows is not None:
+        try:
+            _agent_row = build_agent_row(agent_rows)
+            if _agent_row is not None:
+                rows += [_agent_row]
+        except Exception:  # noqa: BLE001
+            logger.debug("[Bipartite] agent row unavailable", exc_info=True)
     # The palette is NOT a row. See the FloatContainer below: as an HSplit row
     # it shares the ambient grid with the canvas, so every asynchronous Deck or
     # Lane frame arriving underneath forces the palette's geometry to be
@@ -1193,6 +1262,7 @@ async def run_bipartite_repl(
     history: Any = None,
     auto_suggest: Any = None,
     turn_spinner: Any = None,
+    agent_rows: Optional[Callable[[], Any]] = None,
 ) -> None:
     """Launch the full-screen Bipartite REPL: build the multiplexer, register it as
     the live Zone-1 sink (so any producer — the daemon's event router OR the
@@ -1221,7 +1291,7 @@ async def run_bipartite_repl(
             mux, on_accept=on_accept, extra_key_bindings=extra_key_bindings,
             toolbar=toolbar, header=header, header_height=header_height,
             completer=completer, history=history, auto_suggest=auto_suggest,
-            turn_spinner=turn_spinner,
+            turn_spinner=turn_spinner, agent_rows=agent_rows,
         )
         if watch_alive is not None:
             watcher = asyncio.ensure_future(

--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -736,6 +736,32 @@ def _extract_path_arg(args_summary: str) -> str:
     return text.split(" ", 1)[0].split("=", 1)[-1]
 
 
+def _local_agent_rows() -> list:
+    """Roster rows from THIS process's singleton, sized to this terminal.
+
+    The daemon's own cockpit reads the roster directly — no bridge, no
+    snapshot age — because the entries are right here. `render_roster` still
+    takes the snapshot, so the local and remote surfaces run identical code
+    over identical data and cannot diverge in appearance.
+
+    NEVER raises: the agent view is chrome, and chrome does not get to take
+    down the REPL.
+    """
+    try:
+        import shutil
+        from backend.core.ouroboros.battle_test.agent_roster import (
+            get_agent_roster, render_roster, roster_line_budget,
+        )
+        size = shutil.get_terminal_size(fallback=(100, 30))
+        return render_roster(
+            get_agent_roster().snapshot(),
+            width=max(20, int(size.columns)),
+            max_lines=roster_line_budget(max(4, int(size.lines))),
+        )
+    except Exception:  # noqa: BLE001
+        return []
+
+
 def _tool_chrome_line(
     tool_name: str, args_summary: str = "", mcp_servers: Any = None,
 ) -> str:
@@ -6229,6 +6255,12 @@ class SerpentREPL:
                     history=getattr(_bp_wiring, "history", None),
                     auto_suggest=getattr(_bp_wiring, "auto_suggest", None),
                     turn_spinner=getattr(self, "_turn_spinner", None),
+                    # In-process, so the LOCAL roster is the live one — this
+                    # is the process that dispatches. Same renderer as the
+                    # remote cockpit, different source, which is the entire
+                    # reason `render_roster` takes a snapshot rather than a
+                    # roster: neither surface can drift into its own look.
+                    agent_rows=_local_agent_rows,
                 )
                 return
         except Exception:  # noqa: BLE001 — cockpit failure NEVER bricks the REPL

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -672,6 +672,10 @@ class AttachUI:
         # carried — never a client-side cache, so the cursor always resolves
         # against what the daemon currently holds.
         self._lanes: List[dict] = []
+        #: The daemon's agent roster, as of the last heartbeat. A SNAPSHOT,
+        #: not a local roster: this process dispatches nothing, so it has no
+        #: business holding agent state of its own.
+        self._agents: dict = {}
         self._focus_lines: List[str] = []
         self._focus_note: str = ""
         self._flash_text: str = ""
@@ -925,7 +929,7 @@ class AttachUI:
                 GLYPHS,
                 deck_enabled,
             )
-            head = [pulse] + ([flash] if flash else [])
+            head = [pulse] + ([flash] if flash else []) + self._agent_lines()
             cap = {"off": 0, "compact": 2, "full": 99}.get(self._deck_size, 99)
             if self.deck is None or not deck_enabled() or cap == 0:
                 return "\n".join(head)
@@ -944,6 +948,62 @@ class AttachUI:
             )
         except Exception:  # noqa: BLE001
             return ""
+
+    def _agent_lines(self) -> List[str]:
+        """Who is working right now, from the daemon's last snapshot.
+
+        Three properties this has to get right, and each of them is a way the
+        surface could lie:
+
+        **Staleness retires the roster, silence does not.** If the daemon dies
+        mid-dispatch the last frame we hold says three agents are running, and
+        it will say that forever. So the roster expires on the SAME window the
+        pulse uses — one clock, one definition of "we have lost contact",
+        rather than a second timeout to keep in sync.
+
+        **Elapsed advances between frames.** Frames arrive at ~1 Hz. Without
+        the age correction, every running agent's duration would freeze for a
+        second and jump, which reads as a stalled system.
+
+        **Width comes from here.** The client knows its terminal; the daemon
+        that composed the snapshot does not. Passing it means the goal column
+        is clipped to the screen the operator is actually looking at.
+
+        NEVER raises — an unrenderable roster costs its rows, not the cockpit.
+        """
+        try:
+            import time as _time
+            from backend.core.ouroboros.battle_test.agent_roster import (
+                render_roster, roster_line_budget,
+            )
+            from backend.core.ouroboros.battle_test.attach_heartbeat import (
+                heartbeat_stale_after_s,
+            )
+            age = max(0.0, _time.monotonic() - float(self._heartbeat_arrived))
+            if not self._heartbeat_arrived or age > heartbeat_stale_after_s():
+                return []
+            size = self._terminal_size()
+            return render_roster(
+                self._agents, age_s=age, width=size[0],
+                max_lines=roster_line_budget(size[1]),
+            )
+        except Exception:  # noqa: BLE001
+            return []
+
+    def _terminal_size(self) -> tuple:
+        """``(columns, rows)``, or ``(None, None)`` when it cannot be known.
+
+        None rather than a guess: both consumers treat an unknown dimension as
+        "do not constrain on it", and two different fallbacks for the same
+        unknown is how a client and its renderer end up disagreeing about how
+        much room there is.
+        """
+        try:
+            import shutil
+            size = shutil.get_terminal_size()
+            return max(20, int(size.columns)), max(4, int(size.lines))
+        except Exception:  # noqa: BLE001
+            return None, None
 
     def _pulse_line(self) -> str:
         """The CC-style working pulse, or the idle breadcrumb.
@@ -1197,6 +1257,19 @@ class AttachUI:
                 lanes = frame.get("lanes")
                 if isinstance(lanes, list):
                     self._lanes = [x for x in lanes if isinstance(x, dict)]
+                # The agent roster, same wholesale-replacement rule: the
+                # daemon's snapshot IS the truth. Merging would resurrect
+                # agents it has already reaped, and a resurrected agent
+                # claims work is still happening.
+                #
+                # A frame WITHOUT the key leaves the last roster standing —
+                # that is an older daemon, not an emptied roster, and the
+                # staleness window below is what retires it. A frame with an
+                # explicit empty snapshot clears it, because that daemon is
+                # saying "nothing is running".
+                agents = frame.get("agents")
+                if isinstance(agents, dict):
+                    self._agents = agents
         except Exception:
             pass
 
@@ -2958,6 +3031,14 @@ async def _bipartite_attach_loop(client: Any, console: Any, ui: Any) -> None:
             history=_build_prompt_history(),
             auto_suggest=_build_prompt_auto_suggest(),
             turn_spinner=getattr(ui, "turn_spinner", None),
+            # WHO is working. Bound to the AttachUI rather than to the roster
+            # singleton: this process dispatches nothing, so its own roster is
+            # permanently empty, and rendering it would show an organism that
+            # never delegates. The UI holds the daemon's snapshot instead.
+            agent_rows=(
+                ui._agent_lines if ui is not None
+                and hasattr(ui, "_agent_lines") else None
+            ),
             seed=[
                 "[bold]💭 Karen ▸[/bold] attached — I'm listening. verbs or "
                 "plain words both work · [cyan]wake[/cyan] arms my voice · "

--- a/tests/battle_test/test_agent_view_wiring.py
+++ b/tests/battle_test/test_agent_view_wiring.py
@@ -1,0 +1,454 @@
+"""The agent view, mounted — and the two-process property that gates it.
+
+`AgentRoster` shipped complete: fed from both seams, reaped, bounded, tested.
+`render()` had ZERO production callers, so none of it reached a screen. The
+naive fix — call `render()` from the cockpit — would have looked correct in
+every unit test and drawn an empty roster forever in the surface operators
+actually use, because under `ov attach` the cockpit is a DIFFERENT PROCESS
+from the daemon that dispatches the agents.
+
+So the tests that matter here are not "does it render". They are:
+
+  * does the roster survive the process boundary,
+  * does it retire when the daemon behind it stops answering,
+  * and does the mount cost nothing when nothing is running.
+
+Each of these has a failure mode that reads as normal operation, which is why
+they are pinned rather than eyeballed.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from backend.core.ouroboros.battle_test.agent_roster import (
+    AgentRoster,
+    render_roster,
+    reset_roster_for_tests,
+)
+
+
+class _Clock:
+    def __init__(self) -> None:
+        self.now = 1000.0
+
+    def __call__(self) -> float:
+        return self.now
+
+
+@pytest.fixture(autouse=True)
+def _isolated():
+    reset_roster_for_tests()
+    yield
+    reset_roster_for_tests()
+
+
+@pytest.fixture
+def busy():
+    """A daemon-side roster with two running agents and one finished."""
+    clock = _Clock()
+    roster = AgentRoster(clock=clock)
+    roster.spawn("s1", "Explore", "Map ov completion architecture")
+    clock.now += 40
+    roster.spawn("s2", "Review", "Refute the risk_tier_floor fix")
+    clock.now += 5
+    roster.finish("s2", "finished")
+    return roster, clock
+
+
+# ---------------------------------------------------------------------------
+# The property the whole design exists for
+# ---------------------------------------------------------------------------
+
+
+class TestCrossesTheProcessBoundary:
+    def test_a_reader_with_no_roster_of_its_own_still_sees_the_agents(self, busy):
+        """THE regression.
+
+        The attach client dispatches nothing, so its module singleton is
+        permanently empty. Rendering that would show an organism that never
+        delegates — indistinguishable from one that delegates constantly.
+        """
+        roster, _clock = busy
+        wire = json.loads(json.dumps(roster.snapshot()))   # the bridge
+
+        from backend.core.ouroboros.battle_test.agent_roster import (
+            get_agent_roster,
+        )
+        assert get_agent_roster().render() == [], (
+            "a fresh process must have an empty local roster — if this fails "
+            "the test is not proving anything about the boundary"
+        )
+
+        lines = render_roster(wire, width=100)
+        assert any("Explore" in ln for ln in lines)
+        assert any("Refute the risk_tier_floor fix" in ln for ln in lines)
+
+    def test_the_snapshot_carries_no_clock_of_its_own(self, busy):
+        """`time.monotonic()` is an arbitrary per-process origin.
+
+        Shipping one and subtracting it from the reader's clock yields a
+        duration wrong by however long the two processes have been alive —
+        and wrong in a way that looks entirely plausible.
+        """
+        roster, _clock = busy
+        for row in roster.snapshot()["rows"]:
+            assert "started" not in row and "finished" not in row
+            assert "elapsed_s" in row
+
+    def test_the_snapshot_survives_json(self, busy):
+        roster, _clock = busy
+        snap = roster.snapshot()
+        assert json.loads(json.dumps(snap)) == snap
+
+    def test_local_and_remote_render_identically(self, busy):
+        """One renderer, two sources. Two renderers would be edited months
+        apart and the surfaces would quietly stop agreeing."""
+        roster, _clock = busy
+        assert roster.render(width=100) == render_roster(
+            roster.snapshot(), width=100,
+        )
+
+
+# ---------------------------------------------------------------------------
+# A dead daemon must not leave ghosts running
+# ---------------------------------------------------------------------------
+
+
+class TestStaleness:
+    def test_a_stale_frame_retires_the_roster(self, busy, monkeypatch):
+        """If the daemon dies mid-dispatch, the last frame says three agents
+        are running and will say so forever. The roster expires on the SAME
+        window as the pulse — one definition of "lost contact", not two that
+        drift."""
+        import time
+        from backend.core.ouroboros.cli.ov import AttachUI
+
+        roster, _clock = busy
+        ui = AttachUI()
+        ui.on_telemetry({
+            "kind": "heartbeat", "active": True,
+            "agents": roster.snapshot(),
+        })
+        assert ui._agent_lines(), "a fresh frame should render"
+
+        # Reach past the staleness window without waiting for it.
+        ui._heartbeat_arrived = time.monotonic() - 10_000
+        assert ui._agent_lines() == []
+
+    def test_a_frame_without_agents_does_not_clear_the_roster(self, busy):
+        """An older daemon that has never heard of `agents` is not a daemon
+        reporting an empty roster. Clearing on absence would blank the view
+        against a peer that simply predates the field."""
+        from backend.core.ouroboros.cli.ov import AttachUI
+
+        roster, _clock = busy
+        ui = AttachUI()
+        ui.on_telemetry({"kind": "heartbeat", "active": True,
+                         "agents": roster.snapshot()})
+        before = ui._agent_lines()
+        ui.on_telemetry({"kind": "heartbeat", "active": True})   # no key
+        assert ui._agent_lines() == before
+
+    def test_an_explicit_empty_snapshot_does_clear_it(self, busy):
+        """That daemon IS saying "nothing is running", which is news."""
+        from backend.core.ouroboros.cli.ov import AttachUI
+
+        roster, _clock = busy
+        ui = AttachUI()
+        ui.on_telemetry({"kind": "heartbeat", "active": True,
+                         "agents": roster.snapshot()})
+        assert ui._agent_lines()
+        ui.on_telemetry({"kind": "heartbeat", "active": True,
+                         "agents": {"rows": [], "total": 0, "hidden": 0}})
+        assert ui._agent_lines() == []
+
+
+# ---------------------------------------------------------------------------
+# Elapsed between frames
+# ---------------------------------------------------------------------------
+
+
+class TestElapsed:
+    def test_running_agents_advance_between_frames(self, busy):
+        """Frames arrive at ~1 Hz. Without the age correction every duration
+        freezes for a second then jumps, which reads as a stalled system."""
+        roster, _clock = busy
+        snap = roster.snapshot()
+        fresh = render_roster(snap, age_s=0.0, width=100)
+        later = render_roster(snap, age_s=5.0, width=100)
+        assert "45s" in "\n".join(fresh)
+        assert "50s" in "\n".join(later)
+
+    def test_a_finished_agent_does_not_invent_motion(self, busy):
+        """Its duration is settled. Advancing it would be a claim the reader
+        has no way to check and the daemon never made."""
+        roster, _clock = busy
+        snap = roster.snapshot()
+        review = [ln for ln in render_roster(snap, age_s=90.0, width=100)
+                  if "Review" in ln]
+        assert review and "5s" in review[0]
+
+
+# ---------------------------------------------------------------------------
+# Cost when nothing is happening
+# ---------------------------------------------------------------------------
+
+
+class TestCostsNothingWhenIdle:
+    def test_an_empty_roster_renders_no_rows(self):
+        assert render_roster({"rows": [], "total": 0, "hidden": 0}) == []
+        assert render_roster(None) == []
+        assert render_roster("not a snapshot") == []       # type: ignore[arg-type]
+
+    def test_the_cockpit_row_collapses_to_nothing(self):
+        """`ConditionalContainer`, not a zero-height Window: a Window that
+        renders an empty string still occupies a row, and an idle cockpit
+        must be EXACTLY as tall as it was before this existed."""
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            build_agent_row,
+        )
+        row = build_agent_row(lambda: [])
+        assert row is not None
+        assert row.filter() is False
+
+    def test_the_row_is_exactly_as_tall_as_the_roster(self):
+        """`Dimension.exact`. A range like (min=0, max=8) reads as "grow if
+        needed" and does the opposite — HSplit distributes leftover rows by
+        weight, so a child whose max exceeds its preferred absorbs the slack
+        and nails an eight-row slab open above the prompt."""
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            build_agent_row,
+        )
+        lines = ["a", "b", "c", "d"]
+        row = build_agent_row(lambda: lines)
+        assert row.filter() is True
+        height = row.content.height()
+        assert height.min == height.max == height.preferred == len(lines)
+
+    def test_a_raising_source_costs_the_rows_not_the_cockpit(self):
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            build_agent_row,
+        )
+
+        def _boom():
+            raise RuntimeError("roster down")
+
+        row = build_agent_row(_boom)
+        assert row is not None and row.filter() is False
+
+
+# ---------------------------------------------------------------------------
+# Bounds and adaptation
+# ---------------------------------------------------------------------------
+
+
+class TestBoundedAndAdaptive:
+    def test_a_swarm_does_not_become_a_two_hundred_row_frame(self):
+        """The cap is not only about screen space. This rides a 1 Hz
+        heartbeat, and an unbounded roster would put 200 rows on the wire
+        every second for an operator who cannot read 200 rows."""
+        clock = _Clock()
+        roster = AgentRoster(clock=clock, max_rows=8)
+        for i in range(200):
+            roster.spawn(f"w{i}", "Chunk", f"shard {i}")
+        snap = roster.snapshot()
+        assert len(snap["rows"]) == 8
+        assert snap["hidden"] == snap["total"] - 8
+        assert any("more" in ln for ln in render_roster(snap, width=100))
+
+    def test_the_window_follows_the_environment(self, monkeypatch):
+        """No hardcoded row budget: an operator with a tall terminal can ask
+        for more without a code change or a restart."""
+        clock = _Clock()
+        roster = AgentRoster(clock=clock)          # None == follow the env
+        for i in range(12):
+            roster.spawn(f"w{i}", "Chunk", f"shard {i}")
+        monkeypatch.setenv("JARVIS_AGENT_VIEW_ROWS", "3")
+        assert len(roster.snapshot()["rows"]) == 3
+        monkeypatch.setenv("JARVIS_AGENT_VIEW_ROWS", "10")
+        assert len(roster.snapshot()["rows"]) == 10
+
+    def test_a_narrow_terminal_drops_the_goal_rather_than_lying(self, busy):
+        """Three characters and an ellipsis is not a goal. The kind and the
+        duration still answer "is something running", which is the question
+        the roster exists for."""
+        roster, _clock = busy
+        lines = render_roster(roster.snapshot(), width=30)
+        body = [ln for ln in lines if "Explore" in ln][0]
+        assert "Map" not in body
+        assert "40s" in body or "45s" in body
+
+    def test_width_is_the_readers_call(self, busy):
+        """The daemon that composed the snapshot cannot know the terminal the
+        snapshot will be drawn into — and two clients may differ."""
+        roster, _clock = busy
+        wide = render_roster(roster.snapshot(), width=200)
+        narrow = render_roster(roster.snapshot(), width=50)
+        assert wide != narrow
+
+
+# ---------------------------------------------------------------------------
+# The wiring itself
+# ---------------------------------------------------------------------------
+
+
+class TestTheMount:
+    def test_the_heartbeat_carries_the_roster(self, monkeypatch):
+        """Proven by BREAKING the composer and watching the payload lose the
+        field — a truthy check would pass just as well against a hardcoded
+        dict, which is the wiring failure being guarded."""
+        import backend.core.ouroboros.battle_test.agent_roster as ar
+        from backend.core.ouroboros.battle_test import attach_heartbeat as hb
+
+        sentinel = {"schema_version": "roster.v1", "rows": [
+            {"id": "x", "kind": "Explore", "goal": "SENTINEL",
+             "state": "running", "elapsed_s": 1.0}],
+            "total": 1, "running": 1, "hidden": 0}
+
+        class _Fake:
+            def snapshot(self, **_kw):
+                return sentinel
+
+        monkeypatch.setattr(ar, "get_agent_roster", lambda: _Fake())
+
+        class _Snap:
+            phase = "GENERATE"
+            primary_op_id = ""
+            phase_detail = ""
+            provider = ""
+            route = ""
+
+        class _Builder:
+            def snapshot(self):
+                return _Snap()
+
+        monkeypatch.setattr(
+            "backend.core.ouroboros.battle_test.status_line"
+            ".get_status_line_builder", lambda: _Builder(),
+        )
+        payload = hb.build_heartbeat_payload()
+        assert payload is not None
+        assert payload["agents"] == sentinel
+
+    def test_the_cockpit_is_handed_the_clients_snapshot_not_its_own_roster(self):
+        """The bug this whole change exists to avoid, pinned at the seam: the
+        callable the cockpit renders must read the AttachUI, which holds the
+        daemon's frame — never `get_agent_roster()`, which in this process is
+        empty by construction."""
+        import inspect
+        from backend.core.ouroboros.cli.ov import _bipartite_attach_loop
+
+        # Scoped to the ONE function that mounts the cockpit, not the module:
+        # a module-wide search would be satisfied by any mention anywhere and
+        # would keep passing after the seam moved.
+        src = inspect.getsource(_bipartite_attach_loop)
+        idx = src.find("agent_rows=")
+        assert idx > 0, "the cockpit never receives an agent_rows source"
+        wiring = src[idx:idx + 240]
+        assert "_agent_lines" in wiring
+        assert "get_agent_roster" not in wiring
+
+    def test_the_keys_reach_the_canonical_registry(self):
+        """A footer that advertises a key nothing binds is the defect the
+        registry exists to prevent, so the hint is composed from the same
+        declaration that registers them."""
+        from backend.core.ouroboros.battle_test.agent_roster import roster_hint
+        from backend.core.ouroboros.governance import keybinding_registry as kr
+
+        AgentRoster()                       # registration happens on init
+        actions = {e.action for e in kr.list_all()}
+        assert {"select", "view"} <= actions
+        assert roster_hint() == "↑/↓ to select · Enter to view"
+
+
+class TestMasterFlag:
+    def test_off_costs_nothing_anywhere(self, busy, monkeypatch):
+        roster, _clock = busy
+        monkeypatch.setenv("JARVIS_AGENT_VIEW_ENABLED", "0")
+        assert roster.render() == []
+        assert roster.snapshot()["rows"] == []
+        assert render_roster({"rows": [{"id": "a", "kind": "k", "goal": "g",
+                                        "state": "running",
+                                        "elapsed_s": 1.0}]}) == []
+
+
+class TestHeightBudget:
+    """A 40-worker swarm on a 24-row cockpit must not become the cockpit."""
+
+    def _swarm(self, n: int):
+        clock = _Clock()
+        roster = AgentRoster(clock=clock, max_rows=n)
+        for i in range(n):
+            roster.spawn(f"w{i}", "Chunk", f"shard {i}")
+        return roster
+
+    def test_the_roster_folds_to_its_row_budget(self):
+        from backend.core.ouroboros.battle_test.agent_roster import (
+            roster_line_budget,
+        )
+        snap = self._swarm(40).snapshot()
+        budget = roster_line_budget(24)
+        lines = render_roster(snap, width=100, max_lines=budget)
+        assert lines and len(lines) <= budget
+
+    def test_what_the_budget_folded_is_counted_not_dropped(self):
+        """Two separate elisions — the producer's window and the height
+        budget — and one honest number. Reporting either alone undercounts,
+        and the operator reads this to decide if they are seeing all of it."""
+        roster = self._swarm(40)
+        snap = roster.snapshot(max_rows=10)      # producer already withheld 30
+        assert snap["hidden"] == 30
+        # 9 rows − 3 chrome − 1 count row = 5 agents drawn, so 5 more fold.
+        lines = render_roster(snap, width=100, max_lines=9)
+        more = [ln for ln in lines if "more" in ln]
+        assert more and "35" in more[0]          # 30 withheld + 5 folded
+
+    def test_an_unknown_height_does_not_fold_against_a_guess(self):
+        from backend.core.ouroboros.battle_test.agent_roster import (
+            roster_line_budget,
+        )
+        assert roster_line_budget(None) is None
+        assert roster_line_budget(0) is None
+        snap = self._swarm(12).snapshot(max_rows=12)
+        assert len(render_roster(snap, width=100, max_lines=None)) == 12 + 3
+
+    def test_the_share_is_proportional_not_a_row_count(self):
+        """Eleven rows is a footer on a 60-row terminal and half the cockpit
+        on a 24-row one."""
+        from backend.core.ouroboros.battle_test.agent_roster import (
+            roster_line_budget,
+        )
+        assert roster_line_budget(60) > roster_line_budget(24)
+
+    def test_an_impossible_budget_renders_nothing_rather_than_chrome(self):
+        """Three rows of hint and `main` with no agents under them is a
+        header for a list that is not there."""
+        snap = self._swarm(5).snapshot()
+        assert render_roster(snap, width=100, max_lines=3) == []
+
+    def test_the_wire_window_is_not_the_display_window(self):
+        """A 60-row client and a 24-row one attach to the same daemon.
+
+        If the producer serialised only what the smallest reader could draw,
+        the roomy one would be truncated by a peer's screen size — a coupling
+        neither operator could see or explain.
+        """
+        from backend.core.ouroboros.battle_test.agent_roster import (
+            roster_line_budget, roster_wire_rows,
+        )
+        snap = self._swarm(40).snapshot(max_rows=roster_wire_rows())
+        tall = render_roster(snap, width=100,
+                             max_lines=roster_line_budget(60))
+        small = render_roster(snap, width=100,
+                              max_lines=roster_line_budget(24))
+        assert len(tall) > len(small), (
+            "the tall terminal must draw more — if these match, the wire "
+            "window is capping the display instead of the screen"
+        )
+        # And both still account for every agent they did not draw.
+        for lines in (tall, small):
+            drawn = sum(1 for ln in lines if "Chunk" in ln)
+            more = [ln for ln in lines if "more" in ln]
+            assert more and str(40 - drawn) in more[0]


### PR DESCRIPTION
`AgentRoster` shipped complete — fed from both seams, reaped, bounded, 24 tests green. `render()` had **zero production callers**, so none of it ever reached a screen. Its own docstring names the problem it was built for — *"thirty seconds later the operator has no idea whether three agents are still running"* — and that was still true, because the fix was never mounted.

## The obvious fix is wrong

Calling `render()` from the cockpit passes every unit test and draws an empty roster forever. Under `ov attach` the cockpit is a **different process** from the daemon that dispatches; `get_agent_roster()` is a module singleton, so the client's is empty by construction. An organism that delegates constantly and one that never delegates would look identical.

So the module is split the way `attach_heartbeat` already is — two pure halves over one schema:

```
AgentRoster.snapshot()   the daemon serialises its live state
render_roster()          a PURE function over that snapshot
```

`render()` becomes a delegation to the same function, so local and remote surfaces cannot drift into two opinions about what a roster looks like. The snapshot rides the existing 1 Hz heartbeat exactly as `lanes` already does — no new transport, no second lifecycle.

## Elapsed, never a timestamp

`time.monotonic()` is an arbitrary per-process origin. Shipping one and subtracting it from the reader's clock yields a duration wrong by however long the two processes have been alive — and wrong in a way that looks entirely plausible. Durations are computed where the clock lives; the reader advances *running* agents by the frame's own age so seconds tick at 1 Hz instead of stepping. Finished agents don't advance — their duration is settled.

## What the edges cost

| Edge | Handling |
|---|---|
| **Dead daemon** | Roster retires on the SAME window as the pulse (`heartbeat_stale_after_s`, now public). One definition of "lost contact", not two that drift — otherwise a dead daemon's agents render as running underneath an idle pulse, each surface individually correct |
| **Older peer** | A frame *without* `agents` leaves the roster standing (an older daemon, not an emptied roster); an explicit empty snapshot clears it |
| **Mismatched terminals** | Wire window ≠ display window. The daemon can't see its readers' terminals and two may differ by forty rows, so it ships a generous window (`JARVIS_AGENT_VIEW_WIRE_ROWS`, 24) and each reader folds to its own budget |
| **Small screen, big swarm** | Height budget is a proportional share (`JARVIS_AGENT_VIEW_SCREEN_SHARE`, 0.35), not a row count — eleven rows is a footer on a 60-row terminal and half the cockpit on a 24-row one. Folded rows join the producer's withheld count into ONE honest `… N more` |
| **Narrow terminal** | Drops the goal rather than printing three characters and an ellipsis; kind + duration still answer "is something running" |
| **Idle** | `Dimension.exact` + `ConditionalContainer` — zero agents costs zero rows. A range would nail an eight-row slab open above the prompt (the lesson `prompt_height` already learned) |
| **Rebinds** | The roster's keys are registered with `keybinding_registry` and the hint is read back from that declaration, so the footer cannot advertise a key nothing binds |

## What it looks like

```
  ↑/↓ to select · Enter to view

❯ ⏺ main
  ◯ Explore  Map ov completion architecture  7s
  ⏺ Review  Refute the risk_tier_floor fix  3s
  ◯ Plan  Order the multi-file patch  5s
🐍 Watching…
────────────────────────────────────────
❯
```

Mounted on both surfaces from one seam — `build_bipartite_application(agent_rows=...)` — fed by the AttachUI's snapshot remotely and the live singleton in-process.

## Verification

- 27 new tests in `tests/battle_test/test_agent_view_wiring.py`, written against the failure modes that read as normal operation (empty-forever, ghost agents, frozen durations, silent truncation)
- The heartbeat wiring test proves the mount by **breaking the composer** and watching the field vanish — a truthy check would pass against a hardcoded dict, which is the exact wiring failure being guarded
- The cockpit seam is pinned by identity: `agent_rows` must read `_agent_lines`, never `get_agent_roster`
- 185 green across roster / heartbeat / bipartite / turn-spinner / region-mount / prompt-sizing / thin-client / ov-demo
- Live-verified in a 96×30 pty against the real `build_bipartite_application`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mounts the agent roster in both local and attach cockpits by shipping a snapshot on the heartbeat and rendering it with a shared pure function. Fixes the “empty roster in attach” bug and shows live, screen-aware agent status.

- **New Features**
  - Heartbeat carries `agents` snapshot (`roster.v1`) from `AgentRoster.snapshot(max_rows=roster_wire_rows())`.
  - Cockpit renders via `render_roster(...)`; wired with `build_bipartite_application(agent_rows=...)` (local: `_local_agent_rows`, attach: `AttachUI._agent_lines`).
  - Durations use `elapsed_s` plus frame age; no cross-process timestamps.
  - Staleness matches the pulse via `heartbeat_stale_after_s`; missing `agents` leaves last roster; empty snapshot clears it.
  - Screen-aware folding: width set by client; height via `roster_line_budget(term_rows)` with `JARVIS_AGENT_VIEW_ROWS`, `JARVIS_AGENT_VIEW_WIRE_ROWS`, `JARVIS_AGENT_VIEW_SCREEN_SHARE`. Folded rows counted as `… N more`; narrow terminals drop the goal column.
  - Keys registered in `keybinding_registry`; hint comes from `roster_hint()`.

- **Refactors**
  - Split `AgentRoster` into `snapshot()` (daemon) and `render_roster()` (pure); `render()` delegates to the pure renderer.
  - Added `build_agent_row(...)` using `ConditionalContainer` + `Dimension.exact` so idle costs zero rows and height matches content.
  - Exposed `heartbeat_stale_after_s()`; added helpers: `roster_wire_rows()`, `roster_line_budget()`, `roster_hint()`.
  - 27 new tests verify cross-process wiring, staleness, elapsed behavior, and UI folding.

<sup>Written for commit 2bf7fe6674244b48caf568a67592f29e85efe3fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

