### PR TITLE
feat(ov): `/` search over the transcript — and the ring that moved under it

### DIFF
--- a/backend/core/ouroboros/battle_test/bipartite_layout.py
+++ b/backend/core/ouroboros/battle_test/bipartite_layout.py
@@ -643,8 +643,14 @@ def _mount_region_layout(rows: "list") -> Any:
         logger.debug("[Bipartite] region layout mount degraded", exc_info=True)
         return HSplit(rows)
 
-def build_agent_row(rows: Callable[[], Any]) -> Any:
-    """The agent view — a container that is EXACTLY as tall as the roster.
+def build_dynamic_rows(rows: Callable[[], Any]) -> Any:
+    """A strip that is EXACTLY as tall as whatever it currently holds.
+
+    ONE geometry primitive for every variable-height strip the cockpit grows
+    — the agent view, the search bar, and whatever comes next. Each of those
+    is the same two problems (how tall am I, do I exist at all) and solving
+    them per strip is how a layout ends up with three subtly different answers
+    to "collapse when empty".
 
     ``Dimension.exact``, computed per repaint, for the reason the prompt
     learned the hard way: ``HSplit`` hands each child its preferred size and
@@ -697,8 +703,13 @@ def build_agent_row(rows: Callable[[], Any]) -> Any:
             filter=Condition(lambda: bool(_current())),
         )
     except Exception:  # noqa: BLE001
-        logger.debug("[Bipartite] agent row unavailable", exc_info=True)
+        logger.debug("[Bipartite] dynamic rows unavailable", exc_info=True)
         return None
+
+
+#: The agent view was the first caller and named the primitive; the name is
+#: kept so its regression spine keeps pointing at the thing it pins.
+build_agent_row = build_dynamic_rows
 
 
 def build_bipartite_application(
@@ -714,6 +725,7 @@ def build_bipartite_application(
     auto_suggest: Any = None,
     turn_spinner: Any = None,
     agent_rows: Optional[Callable[[], Any]] = None,
+    search_rows: Optional[Callable[[], Any]] = None,
 ) -> Any:
     """Construct the full-screen ``prompt_toolkit.Application``: Zone 1 an ANSI
     window fed from ``mux.render_canvas_ansi()`` (re-rendered each frame, so
@@ -997,11 +1009,21 @@ def build_bipartite_application(
     # the present, and the deck is the past.
     if agent_rows is not None:
         try:
-            _agent_row = build_agent_row(agent_rows)
+            _agent_row = build_dynamic_rows(agent_rows)
             if _agent_row is not None:
                 rows += [_agent_row]
         except Exception:  # noqa: BLE001
             logger.debug("[Bipartite] agent row unavailable", exc_info=True)
+    # The search bar sits DIRECTLY above the prompt — closest to the caret,
+    # because while it is open it is what the keyboard is talking to, and the
+    # eye should not have to hunt for the thing currently receiving its keys.
+    if search_rows is not None:
+        try:
+            _search_row = build_dynamic_rows(search_rows)
+            if _search_row is not None:
+                rows += [_search_row]
+        except Exception:  # noqa: BLE001
+            logger.debug("[Bipartite] search row unavailable", exc_info=True)
     # The palette is NOT a row. See the FloatContainer below: as an HSplit row
     # it shares the ambient grid with the canvas, so every asynchronous Deck or
     # Lane frame arriving underneath forces the palette's geometry to be
@@ -1263,6 +1285,7 @@ async def run_bipartite_repl(
     auto_suggest: Any = None,
     turn_spinner: Any = None,
     agent_rows: Optional[Callable[[], Any]] = None,
+    search_rows: Optional[Callable[[], Any]] = None,
 ) -> None:
     """Launch the full-screen Bipartite REPL: build the multiplexer, register it as
     the live Zone-1 sink (so any producer — the daemon's event router OR the
@@ -1292,6 +1315,7 @@ async def run_bipartite_repl(
             toolbar=toolbar, header=header, header_height=header_height,
             completer=completer, history=history, auto_suggest=auto_suggest,
             turn_spinner=turn_spinner, agent_rows=agent_rows,
+            search_rows=search_rows,
         )
         if watch_alive is not None:
             watcher = asyncio.ensure_future(
@@ -1316,6 +1340,7 @@ __all__ = [
     "bottom_anchor_enabled",
     "build_bipartite_application",
     "get_active_canvas",
+    "build_dynamic_rows",
     "run_bipartite_repl",
     "set_active_canvas",
     "should_run_bipartite",

--- a/backend/core/ouroboros/battle_test/transcript_hatches.py
+++ b/backend/core/ouroboros/battle_test/transcript_hatches.py
@@ -160,18 +160,64 @@ def open_in_editor(event: Any) -> None:
         logger.debug("[Hatches] editor degraded", exc_info=True)
 
 
+def viewport_top() -> Optional[int]:
+    """Index of the transcript line currently at the top of the viewport.
+
+    The single conversion between "where the operator is looking" and "which
+    line that is" — every jump reads it and every jump writes through
+    :func:`scroll_to_index`, so the two cannot disagree about which end
+    ``offset`` counts from. NEVER raises.
+    """
+    try:
+        state = _viewport_state()
+        if state is None:
+            return None
+        viewport, total, budget = state
+        return max(0, total - budget - viewport.offset)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def scroll_to_index(index: int, *, context: int = 0) -> bool:
+    """Put transcript line ``index`` at the top of the viewport.
+
+    ``context`` lifts the target down the screen by that many rows, so a
+    search hit lands with what came BEFORE it visible. A match at the very
+    top of the screen is technically found and practically useless: the lines
+    that explain it are the ones just above.
+
+    Returns whether the viewport moved. NEVER raises.
+    """
+    try:
+        state = _viewport_state()
+        if state is None:
+            return False
+        viewport, total, budget = state
+        target = max(0, int(index) - max(0, int(context)))
+        new_offset = max(0, total - budget - target)
+        # scroll() computes want = offset - lines → aim it exactly.
+        moved = viewport.scroll(
+            viewport.offset - new_offset, total=total, budget=budget,
+        )
+        mux = _canvas()
+        if mux is not None:
+            mux._invalidate_now()  # noqa: SLF001 — the scroll keys' own move
+        return bool(moved)
+    except Exception:  # noqa: BLE001
+        logger.debug("[Hatches] scroll_to_index degraded", exc_info=True)
+        return False
+
+
 def jump_block(event: Any, direction: int) -> None:
     """``{``/``}`` — move the viewport to the previous/next block marker.
     Paging finds a place; this finds a THING. NEVER raises."""
     try:
-        state = _viewport_state()
-        if state is None:
+        top = viewport_top()
+        if top is None:
             return
-        viewport, total, budget = state
         lines = transcript_lines()
         if not lines:
             return
-        top = max(0, total - budget - viewport.offset)
         markers = [
             i for i, ln in enumerate(lines)
             if ln.lstrip().startswith(_BLOCK_MARKERS)
@@ -184,14 +230,7 @@ def jump_block(event: Any, direction: int) -> None:
             target = candidates[0] if candidates else None
         if target is None:
             return
-        new_offset = max(0, total - budget - target)
-        # scroll() computes want = offset - lines → aim it exactly.
-        viewport.scroll(
-            viewport.offset - new_offset, total=total, budget=budget,
-        )
-        mux = _canvas()
-        if mux is not None:
-            mux._invalidate_now()  # noqa: SLF001 — the scroll keys' own move
+        scroll_to_index(target)
     except Exception:  # noqa: BLE001
         logger.debug("[Hatches] jump degraded", exc_info=True)
 
@@ -201,6 +240,324 @@ def force_redraw(event: Any) -> None:
     try:
         event.app.renderer.clear()
         event.app.invalidate()
+    except Exception:  # noqa: BLE001
+        pass
+
+
+# ---------------------------------------------------------------------------
+# `/` search — the hatch this module's own docstring called for
+# ---------------------------------------------------------------------------
+#
+# "A ring you can page but not search is a transcript in a locked box." That
+# sentence has opened this file since it shipped, above four hatches and no
+# search. `TranscriptSearch` was written — smart case, wrapping `n`/`N`, Esc
+# restoring your place, 21 tests — and never bound to a key.
+#
+# It mounts HERE rather than in a module of its own because this is already
+# the transcript key cluster: `[`, `v`, `{`, `}` bind under the same
+# scrolled-back doorway, read the same ring through the same accessor, and
+# move the view through the same `scroll_to_index`. A second module would
+# have to reimplement all four of those to have a `/`.
+
+
+#: One session per process, lazily made. The search holds a cursor and a
+#: restore point across keystrokes, so it cannot be rebuilt per press —
+#: `n` means nothing without the search that preceded it.
+_SEARCH: Any = None
+
+
+def get_search() -> Any:
+    """The live search session, bound to the canvas viewport. NEVER raises."""
+    global _SEARCH
+    try:
+        from backend.core.ouroboros.battle_test.transcript_search import (
+            TranscriptSearch,
+        )
+        state = _viewport_state()
+        viewport = state[0] if state is not None else None
+        if _SEARCH is None:
+            _SEARCH = TranscriptSearch(viewport)
+        elif viewport is not None and _SEARCH._viewport is not viewport:  # noqa: SLF001
+            # The cockpit was rebuilt (detach → reattach, resize remount) and
+            # this is a NEW viewport. Rebinding beats keeping a session that
+            # would scroll a container nothing is drawing.
+            _SEARCH = TranscriptSearch(viewport)
+        return _SEARCH
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def reset_search_for_tests() -> None:
+    global _SEARCH
+    _SEARCH = None
+
+
+def _ring_state() -> Tuple[int, int]:
+    """``(push_count, retained)`` — the ring's monotonic counter and depth.
+
+    Read together with the lines in one pass wherever both are needed, so a
+    push landing between two reads cannot skew every ordinal by one. That
+    skew only appears under load, which is exactly when a search is used.
+    """
+    try:
+        mux = _canvas()
+        if mux is None:
+            return 0, 0
+        buf = mux._buffer                      # noqa: SLF001 — the ring
+        retained = int(buf.line_count)
+        return int(getattr(buf, "push_count", retained)), retained
+    except Exception:  # noqa: BLE001
+        return 0, 0
+
+
+def search_is_armed() -> bool:
+    """True while the operator is typing a query. NEVER raises."""
+    try:
+        return bool(_ARMED[0])
+    except Exception:  # noqa: BLE001
+        return False
+
+
+#: A one-slot latch rather than an attribute on the session: "the bar is
+#: open" and "a query exists" are different states, and conflating them makes
+#: `n` after closing the bar impossible to express.
+_ARMED = [False]
+
+
+def search_status() -> List[str]:
+    """The search bar, or [] when it is closed.
+
+    Returned as ROWS so it mounts through the same dynamic-rows container the
+    agent view uses — one geometry primitive, not a bespoke widget per strip.
+    """
+    try:
+        search = get_search()
+        if search is None:
+            return []
+        if not search_is_armed() and not search.query:
+            return []
+        status = search.status() or f"/{search.query}"
+        return [f"  {status}" + ("▏" if search_is_armed() else "")]
+    except Exception:  # noqa: BLE001
+        return []
+
+
+def _reveal_current(search: Any) -> None:
+    """Scroll to the cursor's match, honestly about eviction. NEVER raises."""
+    try:
+        push, retained = _ring_state()
+        index = search.resolve(
+            search.current, push_count=push, retained=retained,
+        )
+        if index is None:
+            return
+        state = _viewport_state()
+        if state is None:
+            return
+        _viewport, total, budget = state
+        search.reveal(index, total, budget)
+        mux = _canvas()
+        if mux is not None:
+            mux._invalidate_now()              # noqa: SLF001
+    except Exception:  # noqa: BLE001
+        logger.debug("[Hatches] reveal degraded", exc_info=True)
+
+
+def _run_search(search: Any) -> None:
+    """Re-run the query against the CURRENT ring and reveal the first hit.
+
+    Re-run on every keystroke rather than filtered from the previous result:
+    the buffer grows while the operator types, and a filtered search would be
+    confined to whatever the shorter prefix happened to match a second ago.
+    """
+    try:
+        from backend.core.ouroboros.battle_test.transcript_search import (
+            base_ordinal,
+        )
+        # Counter and lines in ONE pass, then the base derived from that pair
+        # — reading them apart would let a push land between and skew every
+        # ordinal by one.
+        push, retained = _ring_state()
+        lines = transcript_lines()
+        search.search(lines, search.query,
+                      base=base_ordinal(push, len(lines) or retained))
+        _reveal_current(search)
+    except Exception:  # noqa: BLE001
+        logger.debug("[Hatches] search degraded", exc_info=True)
+
+
+def install_transcript_search(kb: Any, ui: Any = None) -> int:
+    """Bind `/` `n` `N` and the query capture. Returns the count bound.
+
+    The grammar is CC's, and each key is filtered so it can only fire in the
+    state where it is unambiguous:
+
+      ``/``          arms the bar — while SCROLLED BACK, where `/` cannot be
+                     the command palette because the operator is reading
+                     history rather than issuing commands. No new mode: the
+                     scroll state already distinguishes them.
+      ``<any>``      the query, while armed. Printable characters only, so a
+                     control sequence never lands in a search string.
+      ``backspace``  edit it; on the last character the bar closes, because
+                     an empty bar is a mode with nothing in it.
+      ``enter``      keep the position and close — the operator found it.
+      ``escape``     close AND restore the pre-search offset.
+      ``n`` / ``N``  walk the matches after the bar is closed, which is where
+                     CC puts them and the only place they are unambiguous:
+                     while the bar is open, `n` is a letter.
+
+    NEVER raises.
+    """
+    try:
+        from prompt_toolkit.filters import Condition
+
+        from backend.core.ouroboros.battle_test.keymap import bind_action
+        from backend.core.ouroboros.battle_test.transcript_search import (
+            search_enabled,
+        )
+
+        armed = Condition(search_is_armed)
+        scrolled_idle = Condition(
+            lambda: is_scrolled_back() and not search_is_armed()
+                    and search_enabled()
+        )
+
+        def _flash(text: str) -> None:
+            try:
+                if ui is not None and hasattr(ui, "flash"):
+                    ui.flash(text, seconds=2.0)
+            except Exception:  # noqa: BLE001
+                pass
+
+        def _open(event: Any) -> None:
+            search = get_search()
+            if search is None:
+                return
+            search.reset()
+            search.begin()                    # remember where we were
+            _ARMED[0] = True
+            _repaint()
+
+        def _type(event: Any) -> None:
+            search = get_search()
+            if search is None:
+                return
+            ch = getattr(event, "data", "") or ""
+            # Printable only. A stray escape sequence arriving as data would
+            # otherwise be searched for, and the operator would see a query
+            # they never typed.
+            if len(ch) != 1 or not ch.isprintable():
+                return
+            search.query += ch
+            _run_search(search)
+            _repaint()
+
+        def _backspace(event: Any) -> None:
+            search = get_search()
+            if search is None:
+                return
+            search.query = search.query[:-1]
+            if not search.query:
+                _close(restore=False)
+                return
+            _run_search(search)
+            _repaint()
+
+        def _accept(event: Any) -> None:
+            _ARMED[0] = False                 # keep the query for n / N
+            _repaint()
+
+        def _cancel(event: Any) -> None:
+            _close(restore=True)
+
+        def _close(*, restore: bool) -> None:
+            search = get_search()
+            _ARMED[0] = False
+            if search is None:
+                return
+            if restore:
+                search.cancel()
+            else:
+                search.reset()
+            _repaint()
+
+        def _step(forward: bool):
+            def _handler(event: Any) -> None:
+                search = get_search()
+                if search is None or not search.matches:
+                    return
+                push, retained = _ring_state()
+                # Walk until a match that still EXISTS, at most one full lap.
+                for _ in range(len(search.matches)):
+                    ordinal = search.step(forward)
+                    if search.resolve(
+                        ordinal, push_count=push, retained=retained,
+                    ) is not None:
+                        _reveal_current(search)
+                        _repaint()
+                        return
+                _flash("⚠ every match has scrolled out of the transcript")
+            return _handler
+
+        bound = 0
+        bound += bind_action(
+            kb, "transcript:search", ("/",), _open,
+            context="Transcript", filter=scrolled_idle,
+            description="search the transcript (while scrolled)",
+        )
+        # The query capture binds DIRECTLY, not through `bind_action`.
+        #
+        # `<any>` is a wildcard, not a key, and the registry is right to
+        # refuse it: an action is something an operator can rebind, and
+        # "every key on the keyboard" is not a chord anyone can express in
+        # keybindings.json. Routing it through the catalog would either
+        # require teaching the normaliser a fake key or advertise a
+        # rebindable action that silently ignores the rebind.
+        #
+        # So the six real keys stay remappable and this one — the search bar
+        # consuming its own input while open — is a plain binding.
+        try:
+            from prompt_toolkit.keys import Keys
+            kb.add(Keys.Any, filter=armed)(_type)
+            bound += 1
+        except Exception:  # noqa: BLE001
+            logger.debug("[Hatches] query capture degraded", exc_info=True)
+        bound += bind_action(
+            kb, "transcript:searchBack", ("backspace",), _backspace,
+            context="Transcript", filter=armed,
+            description="edit the search query",
+        )
+        bound += bind_action(
+            kb, "transcript:searchAccept", ("enter",), _accept,
+            context="Transcript", filter=armed, eager=True,
+            description="keep the found position and close the search bar",
+        )
+        bound += bind_action(
+            kb, "transcript:searchCancel", ("escape",), _cancel,
+            context="Transcript", filter=armed, eager=True,
+            description="close the search and go back where you were",
+        )
+        bound += bind_action(
+            kb, "transcript:nextMatch", ("n",), _step(True),
+            context="Transcript", filter=scrolled_idle,
+            description="jump to the next match (while scrolled)",
+        )
+        bound += bind_action(
+            kb, "transcript:prevMatch", ("N",), _step(False),
+            context="Transcript", filter=scrolled_idle,
+            description="jump to the previous match (while scrolled)",
+        )
+        return bound
+    except Exception:  # noqa: BLE001
+        logger.debug("[Hatches] search install degraded", exc_info=True)
+        return 0
+
+
+def _repaint() -> None:
+    try:
+        mux = _canvas()
+        if mux is not None:
+            mux._invalidate_now()              # noqa: SLF001
     except Exception:  # noqa: BLE001
         pass
 
@@ -264,6 +621,8 @@ def install_transcript_hatches(kb: Any, ui: Any, client: Any) -> bool:
             context="Global",
             description="toggle live narration normal ↔ verbose (/narrate)",
         )
+        # The search this file has asked for since its first line.
+        bound += install_transcript_search(kb, ui)
         return bound > 0
     except Exception:  # noqa: BLE001
         logger.debug("[Hatches] install degraded", exc_info=True)
@@ -305,6 +664,13 @@ def tmux_bell_warning(*, timeout_s: float = 1.0) -> str:
 __all__ = [
     "TRANSCRIPT_HATCHES_SCHEMA_VERSION",
     "dump_to_scrollback",
+    "get_search",
+    "install_transcript_search",
+    "reset_search_for_tests",
+    "scroll_to_index",
+    "search_is_armed",
+    "search_status",
+    "viewport_top",
     "force_redraw",
     "install_transcript_hatches",
     "is_scrolled_back",

--- a/backend/core/ouroboros/battle_test/transcript_search.py
+++ b/backend/core/ouroboros/battle_test/transcript_search.py
@@ -11,15 +11,28 @@ for position rather than tracking a second one. The viewport already knows
 how to hold a window still while the organism appends; a search that moved
 the view by its own arithmetic would immediately disagree with it.
 
-Matches are indices, not lines
-------------------------------
+Matches are ordinals, not lines and not indices
+------------------------------------------------
 The deck grows while you read it. If a search held the matched TEXT and
 re-found it on every step, an identical line arriving later would silently
 steal the cursor; if it held a screen offset, every append would shift what
-`n` means. It holds absolute indices into the snapshot it searched, and
-re-resolves them against the live buffer — so `n` walks the matches that
-existed when you asked, in the order you asked for them, however much
-arrives underneath.
+`n` means.
+
+An index into the snapshot is not enough either, and this is the subtle one.
+The deck is a bounded RING: once it saturates, every push also drops the
+oldest line, so index 8,412 addresses a different line one second later. The
+failure is silent and confident — `n` scrolls somewhere real, showing content
+that looks plausible, and nothing indicates the cursor moved off the match.
+An append-only list never shows it, which is precisely why it survives being
+tested.
+
+So a match is an ORDINAL: how many lines the ring had ever seen when that one
+arrived, derived from the buffer's own monotonic `push_count`. Resolving one
+back to an index accounts for everything pushed since, and a line that has
+aged out resolves to `None` — reported as gone rather than approximated.
+
+For a plain list the base ordinal is 0 and an ordinal IS an index, so nothing
+about searching a static buffer changed.
 
 Smart case, and no accidental regex
 ------------------------------------
@@ -48,7 +61,10 @@ from typing import Any, List, Optional, Sequence, Tuple
 
 logger = logging.getLogger("Ouroboros.TranscriptSearch")
 
-__all__ = ["TranscriptSearch", "search_enabled", "find_matches", "smart_case"]
+__all__ = [
+    "TranscriptSearch", "base_ordinal", "find_matches", "resolve_ordinal",
+    "search_enabled", "smart_case",
+]
 
 #: Beyond this a query is not a search. Bounded so a paste into the search
 #: bar cannot turn every keystroke into a full-buffer scan.
@@ -104,6 +120,42 @@ def find_matches(lines: Sequence[str], query: str) -> List[int]:
         return []
 
 
+def base_ordinal(push_count: int, retained: int) -> int:
+    """Ordinal of the OLDEST line still in the ring.
+
+    ``push_count`` is monotonic and ``retained`` is bounded, so their
+    difference is exactly how many lines have already fallen off the end —
+    the origin every stored match is measured from. A buffer that has not
+    saturated yet has dropped nothing, so the base is 0 and an ordinal is an
+    index. NEVER raises.
+    """
+    try:
+        return max(0, int(push_count) - int(retained))
+    except (TypeError, ValueError):
+        return 0
+
+
+def resolve_ordinal(
+    ordinal: Optional[int], *, push_count: int, retained: int,
+) -> Optional[int]:
+    """Current ring index for ``ordinal``, or None once it has aged out.
+
+    None is the entire value of this function. A match the ring has since
+    evicted is not a match at some nearby index: clamping would scroll to
+    whatever line happens to occupy that slot now, which is a confident jump
+    to the wrong place with nothing to signal it. NEVER raises.
+    """
+    try:
+        if ordinal is None:
+            return None
+        index = int(ordinal) - base_ordinal(push_count, retained)
+        if index < 0 or index >= max(0, int(retained)):
+            return None
+        return index
+    except (TypeError, ValueError):
+        return None
+
+
 class TranscriptSearch:
     """One search session over the deck, positioned through the viewport."""
 
@@ -117,6 +169,9 @@ class TranscriptSearch:
         self._matches: List[int] = []
         self._cursor: int = -1
         self._restore_offset: Optional[int] = None
+        #: Ordinal of the oldest line in the buffer that was searched. 0 for a
+        #: static list, so an ordinal and an index coincide there.
+        self._base: int = 0
         self.searches = 0
 
     # -- lifecycle ---------------------------------------------------------
@@ -167,18 +222,29 @@ class TranscriptSearch:
 
     # -- searching ---------------------------------------------------------
 
-    def search(self, lines: Sequence[str], query: str) -> int:
+    def search(
+        self, lines: Sequence[str], query: str, *, base: int = 0,
+    ) -> int:
         """Run a search. Returns the match count.
 
         Recomputed from the CURRENT buffer each time rather than filtered
         from a previous result: typing `err` then `error` must not be limited
         to what `err` happened to match in a buffer that has since grown.
+
+        ``base`` is the ordinal of ``lines[0]`` — :func:`base_ordinal` over
+        the live ring. It defaults to 0, which is correct for any buffer that
+        has not evicted anything and keeps a static list behaving exactly as
+        before; pass the real base and every stored match survives eviction.
         """
         try:
             if not search_enabled():
                 return 0
             self.query = str(query or "")[:_MAX_QUERY]
-            self._matches = find_matches(lines, self.query)
+            offset = max(0, int(base))
+            self._base = offset
+            self._matches = [
+                offset + i for i in find_matches(lines, self.query)
+            ]
             self._cursor = 0 if self._matches else -1
             self.searches += 1
             return len(self._matches)
@@ -186,6 +252,21 @@ class TranscriptSearch:
             logger.debug("[TranscriptSearch] search degraded", exc_info=True)
             self._matches, self._cursor = [], -1
             return 0
+
+    def resolve(
+        self, ordinal: Optional[int], *, push_count: int, retained: int,
+    ) -> Optional[int]:
+        """Where a stored match lives NOW, or None once the ring dropped it.
+
+        The re-resolution this class's docstring always promised. Held
+        separately from :meth:`step` so walking the matches and locating them
+        stay independent: `n` must advance the cursor even when the line it
+        lands on has aged out, or an evicted match in the middle of a result
+        set would wedge the walk.
+        """
+        return resolve_ordinal(
+            ordinal, push_count=push_count, retained=retained,
+        )
 
     def step(self, forward: bool = True) -> Optional[int]:
         """`n` / `N`. Returns the absolute line index, or None.

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -1973,6 +1973,23 @@ async def _run_client_shell(ui: Any, client: Any, text: str) -> None:
         pass
 
 
+def _transcript_search_rows() -> Any:
+    """The `/` search bar renderer, or None when the hatches are unavailable.
+
+    Resolved ONCE at mount rather than probed per repaint, and returns None
+    rather than an empty lambda when the module is missing — a strip whose
+    provider can never yield anything should not be in the layout at all.
+    NEVER raises.
+    """
+    try:
+        from backend.core.ouroboros.battle_test.transcript_hatches import (
+            search_status,
+        )
+        return search_status
+    except Exception:  # noqa: BLE001
+        return None
+
+
 def _client_extra_bindings(ui: Any, client: Any) -> Any:
     """The client-side action set both attach surfaces mount — every key
     remappable via keybindings.json, every action ALSO reachable as a
@@ -3039,6 +3056,11 @@ async def _bipartite_attach_loop(client: Any, console: Any, ui: Any) -> None:
                 ui._agent_lines if ui is not None
                 and hasattr(ui, "_agent_lines") else None
             ),
+            # The `/` search bar. Read from the hatches module rather than
+            # held here: the search session belongs to the transcript key
+            # cluster that drives it, and a copy of its state on the UI would
+            # be a second opinion about what the operator is typing.
+            search_rows=_transcript_search_rows(),
             seed=[
                 "[bold]💭 Karen ▸[/bold] attached — I'm listening. verbs or "
                 "plain words both work · [cyan]wake[/cyan] arms my voice · "

--- a/tests/battle_test/test_transcript_search_mount.py
+++ b/tests/battle_test/test_transcript_search_mount.py
@@ -1,0 +1,193 @@
+"""`/` search, mounted — and the ring that moves underneath it.
+
+`TranscriptSearch` shipped complete: smart case, wrapping `n`/`N`, Esc
+restoring your place, 21 tests. It had ZERO production callers, so
+`transcript_hatches` opened with "a ring you can page but not search is a
+transcript in a locked box" above four hatches and no search.
+
+Mounting it exposed a second defect its own docstring had already claimed was
+handled: matches were stored as INDICES into the snapshot searched, and the
+canvas is a bounded RING. Once it saturates, every push drops the oldest line
+and every stored index addresses something else. The existing suite searched a
+plain `list`, which only grows — so the whole class was invisible to it.
+
+These tests use a real `RegionBuffer` for exactly that reason.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.battle_test.split_layout import RegionBuffer
+from backend.core.ouroboros.battle_test.transcript_search import (
+    TranscriptSearch, base_ordinal, resolve_ordinal,
+)
+
+
+def _ring(size: int = 100, hits=(12, 40, 88)) -> RegionBuffer:
+    ring = RegionBuffer(name="canvas", maxlen=size)
+    for i in range(size):
+        ring.push(f"line {i}" + ("  ERROR here" if i in hits else ""))
+    return ring
+
+
+def _search(ring: RegionBuffer, query: str):
+    lines = list(ring.snapshot())
+    search = TranscriptSearch()
+    search.search(lines, query,
+                  base=base_ordinal(ring.push_count, len(lines)))
+    return search
+
+
+class TestTheRingMovesUnderneath:
+    def test_a_match_survives_eviction(self):
+        """THE regression. The old index-based store would have pointed at
+        whatever line slid into that slot — real content, plausible, wrong."""
+        ring = _ring()
+        search = _search(ring, "error")
+        for i in range(100, 150):              # organism keeps working
+            ring.push(f"line {i}")
+
+        lines = list(ring.snapshot())
+        index = resolve_ordinal(
+            search.matches[-1],
+            push_count=ring.push_count, retained=len(lines),
+        )
+        assert index is not None
+        assert "line 88" in lines[index], (
+            "the surviving match must still address the line it matched"
+        )
+
+    def test_an_evicted_match_resolves_to_None_not_to_a_neighbour(self):
+        """Clamping would scroll to whatever occupies that slot now — a
+        confident jump to the wrong place, with nothing to signal it."""
+        ring = _ring()
+        search = _search(ring, "error")
+        for i in range(100, 150):
+            ring.push(f"line {i}")
+        lines = list(ring.snapshot())
+
+        gone = search.matches[0]               # ordinal 12, long since dropped
+        assert resolve_ordinal(
+            gone, push_count=ring.push_count, retained=len(lines),
+        ) is None
+        # And the line now sitting at the old index is somebody else entirely.
+        assert "ERROR" not in lines[12]
+
+    def test_an_unsaturated_ring_needs_no_translation(self):
+        """A buffer that has dropped nothing has base 0, so an ordinal IS an
+        index — which is why every existing test kept passing untouched."""
+        ring = RegionBuffer(name="canvas", maxlen=1000)
+        for i in range(50):
+            ring.push(f"line {i}")
+        assert base_ordinal(ring.push_count, 50) == 0
+        assert resolve_ordinal(7, push_count=50, retained=50) == 7
+
+    def test_walking_skips_the_evicted_and_lands_on_the_living(self):
+        """An evicted match in the middle of a result set must not wedge the
+        walk — `n` advances the cursor whether or not the line still exists,
+        and the caller keeps stepping until one resolves."""
+        ring = _ring()
+        search = _search(ring, "error")
+        for i in range(100, 150):
+            ring.push(f"line {i}")
+        retained = len(list(ring.snapshot()))
+
+        landed = []
+        for _ in range(len(search.matches)):
+            ordinal = search.step(True)
+            if resolve_ordinal(ordinal, push_count=ring.push_count,
+                               retained=retained) is not None:
+                landed.append(ordinal)
+        assert landed == [88], "only the surviving match is reachable"
+
+
+class TestTheMount:
+    def test_the_search_is_bound_to_keys(self):
+        """The defect being closed: a complete search nothing could reach."""
+        from prompt_toolkit.key_binding import KeyBindings
+        from backend.core.ouroboros.battle_test.transcript_hatches import (
+            install_transcript_search,
+        )
+        kb = KeyBindings()
+        assert install_transcript_search(kb) == 7
+        keys = {str(getattr(k, "value", k))
+                for b in kb.bindings for k in b.keys}
+        assert "/" in keys and "n" in keys and "N" in keys
+        # The wildcard query capture is NOT a registry action — `<any>` is not
+        # a chord an operator can rebind, so it binds directly while the six
+        # real keys stay remappable.
+        assert "<any>" in keys
+
+    def test_the_wildcard_is_not_offered_as_a_rebindable_action(self):
+        from backend.core.ouroboros.battle_test.keymap import (
+            effective_key_sequences,
+        )
+        assert effective_key_sequences(
+            "transcript:searchType", ("<any>",), context="Transcript",
+        ) == ()
+
+    def test_the_hatches_install_brings_the_search_with_them(self):
+        """One cluster, one install — a caller must not have to know that
+        search is a separate thing to remember to mount."""
+        from prompt_toolkit.key_binding import KeyBindings
+        from backend.core.ouroboros.battle_test.transcript_hatches import (
+            install_transcript_hatches,
+        )
+
+        class _UI:
+            def flash(self, *_a, **_k): pass
+
+        class _Client:
+            def send_input(self, *_a, **_k): pass
+
+        kb = KeyBindings()
+        assert install_transcript_hatches(kb, _UI(), _Client()) is True
+        keys = {str(getattr(k, "value", k))
+                for b in kb.bindings for k in b.keys}
+        assert "/" in keys, "the hatch install did not bring search"
+
+    def test_the_cockpit_receives_a_search_bar_renderer(self):
+        """Pinned at the seam: a renderer with no mount is the exact shape of
+        the bug this change exists to close."""
+        import inspect
+        from backend.core.ouroboros.cli.ov import _bipartite_attach_loop
+
+        src = inspect.getsource(_bipartite_attach_loop)
+        assert "search_rows=" in src
+
+    def test_the_bar_is_silent_until_it_is_opened(self):
+        """A search bar that always occupies a row spends it saying nothing,
+        every session, forever."""
+        from backend.core.ouroboros.battle_test import transcript_hatches as th
+        th.reset_search_for_tests()
+        assert th.search_status() == []
+
+    def test_the_bar_and_the_agent_view_share_one_container(self):
+        """Both are variable-height strips that must vanish when empty.
+        Two implementations would mean two answers to 'collapse when idle'."""
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            build_agent_row, build_dynamic_rows,
+        )
+        assert build_agent_row is build_dynamic_rows
+        row = build_dynamic_rows(lambda: ["/error  3/17"])
+        assert row.filter() is True
+        assert row.content.height().preferred == 1
+
+
+class TestNeverRaises:
+    @pytest.mark.parametrize("bad", [None, "x", -1, 10**12])
+    def test_resolve_survives_junk(self, bad):
+        assert resolve_ordinal(
+            bad, push_count=10, retained=5,  # type: ignore[arg-type]
+        ) in (None, 5) or True
+
+    def test_search_helpers_survive_a_dead_canvas(self):
+        """No cockpit mounted (fallback surface, headless run): every
+        accessor answers empty rather than raising into a key handler."""
+        from backend.core.ouroboros.battle_test import transcript_hatches as th
+        th.reset_search_for_tests()
+        assert th.transcript_lines() == []
+        assert th.viewport_top() is None
+        assert th.scroll_to_index(5) is False
+        assert th.search_is_armed() is False
+        assert th.search_status() == []


### PR DESCRIPTION
`transcript_hatches` has opened with *"a ring you can page but not search is a transcript in a locked box"* since it shipped — above four hatches and no search. `TranscriptSearch` was already written (smart case, wrapping `n`/`N`, Esc restoring your place, 21 tests) with **zero production callers**. Two complete halves that had never been introduced.

## The bug that mounting exposed

Its docstring claimed matches were *"re-resolved against the live buffer"*. They were not. Matches were **indices** into the searched snapshot, and the canvas is a bounded **ring**: once saturated, every push drops the oldest line and every stored index addresses something else. `n` would scroll somewhere real, showing plausible content, with nothing to indicate the cursor had left the match.

The existing suite searched a plain `list` — append-only — so the entire class was structurally invisible to it. Demonstrated against a real `RegionBuffer` after 50 evictions:

```
ordinal  12 -> evicted ✓        old index 12 -> 'line 62'
ordinal  40 -> evicted ✓        old index 40 -> 'line 90'
ordinal  88 -> index 38 ✓       old index 88 -> 'line 138'
```

A match is now an **ordinal** — how many lines the ring had ever seen when that one arrived, from the buffer's own monotonic `push_count`. Resolving accounts for everything pushed since; an aged-out line resolves to `None` and is *reported*, never approximated. A static list has base 0, so an ordinal is an index and all 21 existing tests pass untouched.

## The mount

Bound in `transcript_hatches`, not a new module: that file already owns the transcript key cluster — `[ v { }` bind under the same scrolled-back doorway, read the same ring through the same accessor, and move the view through the same `scroll_to_index` (extracted here, so block-jump and search share one piece of viewport arithmetic instead of two).

CC's grammar, each key filtered to the state where it is unambiguous:

| Key | Does | Why it can't be ambiguous |
|---|---|---|
| `/` | arms the bar | **while scrolled back** — no new mode, because reading history and issuing commands are already different states, and `/` at the live tail must stay the command palette |
| `<any>` | the query | binds **directly**, not through the keymap registry: `<any>` is a wildcard, not a chord an operator can rebind, and the registry is right to refuse it |
| `backspace` | edit | emptying it closes the bar |
| `enter` | keep the position, close | |
| `escape` | close **and** restore the pre-search offset | |
| `n` / `N` | walk matches | after the bar closes — the only place they're unambiguous, since while it's open `n` is a letter |

`n`/`N` step *past* evicted matches rather than wedging on them, and say so when every match has scrolled out.

Rendering reuses the agent view's container, generalised to `build_dynamic_rows` — one geometry primitive for every variable-height strip, so "collapse when empty" has one answer rather than one per strip.

## What it looks like

```
  ⎿ detail 60
  ⎿ ✗ BlockedPathError in test_scoped_paths     ← jumped here, in context
  ⎿ detail 61
  ...
  /BlockedPath  1/2▏
🐍 Watching…
────────────────────────────────────────
❯
```

## Verification

- 14 new tests on a real `RegionBuffer`, because that is the only thing that shows the eviction class
- The mount is pinned at three seams: the keys bind, the hatch install brings search with it, and the cockpit receives a `search_rows` renderer
- 170 green across transcript / search / hatches / agent-view / roster / bipartite / scrollback / region-mount / prompt-sizing / turn-spinner
- Live-verified in a 92×26 pty driving real keystrokes: `/BlockedPath` jumped the viewport ~280 lines back onto the match, with context above it, showing `1/2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `/` transcript search with an inline search bar and `n`/`N` navigation while scrolled back. Fixes search to track the bounded ring correctly by storing matches as ordinals and resolving them against the live buffer.

- **New Features**
  - Bind `/` (arm), `<any>` (type), `backspace` (edit/close when empty), `enter` (keep position), `escape` (restore), and `n`/`N` (after closing), gated to the scrolled-back state.
  - Renders a collapsible search bar above the prompt via `search_rows` using `build_dynamic_rows`; mounted in `ov` and plumbed through `build_bipartite_application`/`run_bipartite_repl`.
  - Adds `viewport_top()` and `scroll_to_index(context=…)` for precise jumps with context; shared by block-jump and search.
  - Installs with `install_transcript_hatches`; wildcard `<any>` capture binds directly (not a rebindable action).

- **Bug Fixes**
  - Stores matches as ordinals and resolves them with `push_count`/`retained`; evicted lines resolve to None instead of jumping to a wrong index.
  - `n`/`N` skip evicted matches and warn when all matches have scrolled out.
  - New tests on a real `RegionBuffer` cover ring eviction and the mount seams.

<sup>Written for commit 327a7a6ee347369b6e6d6e6669248892e3d49bbd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

