### PR TITLE
feat(ov): the status line reaches the cockpit — and learns how wide it is

### DIFF
--- a/backend/core/ouroboros/battle_test/attach_heartbeat.py
+++ b/backend/core/ouroboros/battle_test/attach_heartbeat.py
@@ -53,6 +53,17 @@ def _context_pct(op_id: str) -> float:
         return 0.0
 
 
+def _status_payload(snap: Any) -> Optional[dict]:
+    """The status snapshot as a transport dict, or None. NEVER raises."""
+    try:
+        from backend.core.ouroboros.battle_test.status_line import (
+            snapshot_to_payload,
+        )
+        return snapshot_to_payload(snap) or None
+    except Exception:  # noqa: BLE001
+        return None
+
+
 def _context_reading(op_id: str, provider: str, snap: Any) -> Optional[dict]:
     """The context meter's payload for this op, or None.
 
@@ -240,6 +251,13 @@ def build_heartbeat_payload() -> Optional[Dict[str, Any]]:
             # with the binding wall named. `context_pct` stays for older
             # clients — additive, never a replacement.
             "context": _context_reading(op_id, provider, snap),
+            # The FULL status snapshot. `snap` is already in hand — this
+            # composer sampled it at the top for phase/route/provider — so
+            # the cockpit's status line costs a serialisation, not a second
+            # pull. Without it the attach client would render its own
+            # builder, which is empty by construction and would draw an
+            # eternally idle organism.
+            "status": _status_payload(snap),
             "effort": effort,
             "provider": provider,
             "provider_label": provider_label,

--- a/backend/core/ouroboros/battle_test/bipartite_layout.py
+++ b/backend/core/ouroboros/battle_test/bipartite_layout.py
@@ -726,6 +726,7 @@ def build_bipartite_application(
     turn_spinner: Any = None,
     agent_rows: Optional[Callable[[], Any]] = None,
     search_rows: Optional[Callable[[], Any]] = None,
+    status_rows: Optional[Callable[[], Any]] = None,
 ) -> Any:
     """Construct the full-screen ``prompt_toolkit.Application``: Zone 1 an ANSI
     window fed from ``mux.render_canvas_ansi()`` (re-rendered each frame, so
@@ -1014,6 +1015,16 @@ def build_bipartite_application(
                 rows += [_agent_row]
         except Exception:  # noqa: BLE001
             logger.debug("[Bipartite] agent row unavailable", exc_info=True)
+    # The status line sits between the agents and the search bar: it is
+    # ambient state rather than an event, so it belongs below the deck's
+    # flow and above the things the keyboard is currently talking to.
+    if status_rows is not None:
+        try:
+            _status_row = build_dynamic_rows(status_rows)
+            if _status_row is not None:
+                rows += [_status_row]
+        except Exception:  # noqa: BLE001
+            logger.debug("[Bipartite] status row unavailable", exc_info=True)
     # The search bar sits DIRECTLY above the prompt — closest to the caret,
     # because while it is open it is what the keyboard is talking to, and the
     # eye should not have to hunt for the thing currently receiving its keys.
@@ -1286,6 +1297,7 @@ async def run_bipartite_repl(
     turn_spinner: Any = None,
     agent_rows: Optional[Callable[[], Any]] = None,
     search_rows: Optional[Callable[[], Any]] = None,
+    status_rows: Optional[Callable[[], Any]] = None,
 ) -> None:
     """Launch the full-screen Bipartite REPL: build the multiplexer, register it as
     the live Zone-1 sink (so any producer — the daemon's event router OR the
@@ -1315,7 +1327,7 @@ async def run_bipartite_repl(
             toolbar=toolbar, header=header, header_height=header_height,
             completer=completer, history=history, auto_suggest=auto_suggest,
             turn_spinner=turn_spinner, agent_rows=agent_rows,
-            search_rows=search_rows,
+            search_rows=search_rows, status_rows=status_rows,
         )
         if watch_alive is not None:
             watcher = asyncio.ensure_future(

--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -736,6 +736,33 @@ def _extract_path_arg(args_summary: str) -> str:
     return text.split(" ", 1)[0].split("=", 1)[-1]
 
 
+def _local_status_rows() -> list:
+    """The status line from THIS process's builder, sized to this terminal.
+
+    The daemon owns the builder, so no bridge is involved — but it renders
+    through the same `render_snapshot` the remote cockpit calls, over the
+    same `StatusSnapshot`. Two sources, one renderer; the surfaces cannot
+    drift into different opinions about what a status line looks like.
+
+    NEVER raises.
+    """
+    try:
+        import shutil
+        from backend.core.ouroboros.battle_test.status_line import (
+            get_status_line_builder, render_snapshot,
+        )
+        builder = get_status_line_builder()
+        if builder is None:
+            return []
+        size = shutil.get_terminal_size(fallback=(100, 30))
+        line = render_snapshot(
+            builder.snapshot(), width=max(20, int(size.columns)),
+        )
+        return [f"  {line}"] if line else []
+    except Exception:  # noqa: BLE001
+        return []
+
+
 def _local_agent_rows() -> list:
     """Roster rows from THIS process's singleton, sized to this terminal.
 
@@ -6261,6 +6288,7 @@ class SerpentREPL:
                     # reason `render_roster` takes a snapshot rather than a
                     # roster: neither surface can drift into its own look.
                     agent_rows=_local_agent_rows,
+                    status_rows=_local_status_rows,
                 )
                 return
         except Exception:  # noqa: BLE001 — cockpit failure NEVER bricks the REPL

--- a/backend/core/ouroboros/battle_test/status_line.py
+++ b/backend/core/ouroboros/battle_test/status_line.py
@@ -49,6 +49,7 @@ import logging
 import os
 import sys
 import time
+import dataclasses
 from dataclasses import dataclass
 from typing import Any, List, Optional
 
@@ -962,3 +963,161 @@ def reset_status_line_builder() -> None:
     """Clear the singleton. Primarily for tests."""
     global _DEFAULT_BUILDER
     _DEFAULT_BUILDER = None
+
+
+# ===========================================================================
+# Transport + width adaptation — the cockpit mount (2026-07-28)
+# ===========================================================================
+#
+# `StatusLineBuilder` is a daemon singleton, and the surface that most needs
+# to draw it is `ov attach` — a DIFFERENT PROCESS whose builder is empty by
+# construction. Rendering the client's own would draw an eternally idle
+# organism, which looks exactly like a healthy quiet one.
+#
+# `StatusSnapshot` is already a frozen dataclass of plain fields, and
+# `_format_plain` is already a pure function over it. So the split costs a
+# serializer and a rehydrator, and BOTH processes keep calling the one
+# renderer — no second opinion about what a status line looks like.
+#
+# The other half of mounting it is width. `_format_plain` composes up to ten
+# `·`-joined segments and has never known how wide the terminal is: on the
+# daemon's `bottom_toolbar` prompt_toolkit clipped it, but a fixed-height
+# cockpit row with `wrap_lines=False` truncates mid-token, which reads as a
+# corrupted line rather than an abbreviated one.
+
+STATUS_LINE_SCHEMA_VERSION = "status_line.v1"
+
+#: Segment KEEP-priority. Higher survives longer.
+#:
+#: By meaning, not by position, and expressed as an allowlist of things worth
+#: keeping rather than a denylist of things to drop. The first draft guessed
+#: prefixes for the hotkey legend, guessed wrong, and at 120 columns shed
+#: `Phase:` while keeping `enter to submit` — the headline lost to a hint.
+#:
+#: An UNRECOGNISED segment scores lowest, which is the safe direction: a new
+#: token added by some future slice is decoration until someone says
+#: otherwise, and the alternative is that it silently outranks the phase.
+_KEEP_PRIORITY: tuple = (
+    ("Phase:", 100),        # what the organism is doing — the headline
+    ("⚠", 90),              # a warning is why the operator looked
+    ("dry", 90),            # a dry provider runway may BE the explanation
+    ("Cost:", 80),          # the budget is the other standing question
+    ("[", 60),              # [route·provider] badge
+    ("Op:", 50),
+    ("Idle:", 40),          # a countdown nobody watches while work runs
+)
+
+
+def _segment_priority(segment: str) -> int:
+    """Keep-priority for one `·`-joined segment. NEVER raises."""
+    try:
+        text = segment.strip()
+        for prefix, score in _KEEP_PRIORITY:
+            if text.startswith(prefix):
+                return score
+        return 0
+    except Exception:  # noqa: BLE001
+        return 0
+
+
+def snapshot_to_payload(snap: "StatusSnapshot") -> dict:
+    """A snapshot as a transport-safe dict. NEVER raises."""
+    try:
+        return {
+            "schema_version": STATUS_LINE_SCHEMA_VERSION,
+            "phase": snap.phase,
+            "phase_detail": snap.phase_detail,
+            "cost_spent_usd": round(float(snap.cost_spent_usd), 4),
+            "cost_budget_usd": round(float(snap.cost_budget_usd), 4),
+            "idle_elapsed_s": round(float(snap.idle_elapsed_s), 1),
+            "idle_timeout_s": round(float(snap.idle_timeout_s), 1),
+            "primary_op_id": snap.primary_op_id,
+            "extra_op_count": int(snap.extra_op_count),
+            "route": snap.route,
+            "provider": snap.provider,
+            "liquidity_exhausted": bool(snap.liquidity_exhausted),
+            "liquidity_provider": snap.liquidity_provider,
+            "liquidity_reset_s": snap.liquidity_reset_s,
+        }
+    except Exception:  # noqa: BLE001
+        return {}
+
+
+def payload_to_snapshot(payload: object) -> Optional["StatusSnapshot"]:
+    """Rehydrate a snapshot that arrived over the bridge, or None.
+
+    Unknown keys are IGNORED rather than passed through: a newer daemon may
+    add a field, and `StatusSnapshot(**payload)` would raise on the first
+    frame from it — turning an additive change into a client crash.
+    """
+    try:
+        if not isinstance(payload, dict) or not payload:
+            return None
+        fields = {f.name for f in dataclasses.fields(StatusSnapshot)}
+        return StatusSnapshot(**{
+            k: v for k, v in payload.items() if k in fields
+        })
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def fit_to_width(line: str, width: Optional[int]) -> str:
+    """Shed whole SEGMENTS, lowest keep-priority first, until the line fits.
+
+    Whole segments, never a slice: `Cost: $0.04 / $0.5` is a number the
+    operator will misread and `Phase: GENERAT` is a phase that does not
+    exist. An abbreviated line has to stay true.
+
+    NEVER raises.
+    """
+    try:
+        if not line or not width or int(width) <= 0:
+            return line
+        cols = int(width)
+        if len(line) <= cols:
+            return line
+        parts = line.split(" · ")
+        # Stable order among equals: drop the RIGHTMOST of the least
+        # important, so a line sheds from the end it was appended at.
+        while len(" · ".join(parts)) > cols and len(parts) > 1:
+            worst, worst_score = 0, None
+            for i, part in enumerate(parts):
+                score = _segment_priority(part)
+                if worst_score is None or score <= worst_score:
+                    worst, worst_score = i, score
+            parts.pop(worst)
+        out = " · ".join(parts)
+        # One segment left and still over: an honest clip WITH a marker, so
+        # the operator can see the line was cut rather than guess.
+        return out if len(out) <= cols else (out[: max(1, cols - 1)] + "…")
+    except Exception:  # noqa: BLE001
+        return line
+
+
+def render_snapshot(
+    snap: Optional["StatusSnapshot"],
+    *,
+    compact: Optional[bool] = None,
+    width: Optional[int] = None,
+) -> str:
+    """Render ANY snapshot — local or rehydrated — at a given width.
+
+    ``compact=None`` resolves from the terminal rather than from the env
+    alone. The env gate stays the explicit override, because an operator who
+    asked for compact means it at every width; what changes is that a narrow
+    terminal no longer needs to be told. NEVER raises.
+    """
+    try:
+        if snap is None or not status_line_enabled():
+            return ""
+        mode = compact_mode_enabled() if compact is None else bool(compact)
+        if compact is None and width and int(width) < _COMPACT_BELOW_COLS:
+            mode = True
+        return fit_to_width(_format_plain(snap, compact=mode), width)
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+#: Below this many columns the full line cannot hold its segments, so compact
+#: is the honest default. An env override still wins in both directions.
+_COMPACT_BELOW_COLS = 100

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -676,6 +676,8 @@ class AttachUI:
         #: not a local roster: this process dispatches nothing, so it has no
         #: business holding agent state of its own.
         self._agents: dict = {}
+        #: The daemon's `StatusSnapshot`, as of the last heartbeat.
+        self._status: dict = {}
         self._focus_lines: List[str] = []
         self._focus_note: str = ""
         self._flash_text: str = ""
@@ -990,6 +992,35 @@ class AttachUI:
         except Exception:  # noqa: BLE001
             return []
 
+    def _status_rows(self) -> List[str]:
+        """CC's status line, from the daemon's snapshot, at THIS terminal.
+
+        Retires on the same staleness window as the pulse and the roster —
+        one definition of "lost contact" across every surface fed by the
+        heartbeat, rather than three that drift apart and leave a dead
+        daemon's phase showing under an idle pulse.
+
+        NEVER raises: a status line is chrome.
+        """
+        try:
+            import time as _time
+            from backend.core.ouroboros.battle_test.attach_heartbeat import (
+                heartbeat_stale_after_s,
+            )
+            from backend.core.ouroboros.battle_test.status_line import (
+                payload_to_snapshot, render_snapshot,
+            )
+            age = max(0.0, _time.monotonic() - float(self._heartbeat_arrived))
+            if not self._heartbeat_arrived or age > heartbeat_stale_after_s():
+                return []
+            snap = payload_to_snapshot(self._status)
+            if snap is None:
+                return []
+            line = render_snapshot(snap, width=self._terminal_size()[0])
+            return [f"  {line}"] if line else []
+        except Exception:  # noqa: BLE001
+            return []
+
     def _terminal_size(self) -> tuple:
         """``(columns, rows)``, or ``(None, None)`` when it cannot be known.
 
@@ -1270,6 +1301,12 @@ class AttachUI:
                 agents = frame.get("agents")
                 if isinstance(agents, dict):
                     self._agents = agents
+                # The daemon's status snapshot. Same wholesale rule and the
+                # same reason: this process's own builder is empty, so a
+                # merge would blend real state with a blank.
+                status = frame.get("status")
+                if isinstance(status, dict):
+                    self._status = status
         except Exception:
             pass
 
@@ -3061,6 +3098,12 @@ async def _bipartite_attach_loop(client: Any, console: Any, ui: Any) -> None:
             # cluster that drives it, and a copy of its state on the UI would
             # be a second opinion about what the operator is typing.
             search_rows=_transcript_search_rows(),
+            # CC's status line — phase, cost, route, warnings — from the
+            # daemon's snapshot rather than this process's empty builder.
+            status_rows=(
+                ui._status_rows if ui is not None
+                and hasattr(ui, "_status_rows") else None
+            ),
             seed=[
                 "[bold]💭 Karen ▸[/bold] attached — I'm listening. verbs or "
                 "plain words both work · [cyan]wake[/cyan] arms my voice · "

--- a/tests/battle_test/test_status_line_cockpit_mount.py
+++ b/tests/battle_test/test_status_line_cockpit_mount.py
@@ -1,0 +1,206 @@
+"""The status line, mounted on the cockpit — and the width it never knew.
+
+`StatusLineBuilder` was fully built and `live_status_line` wired it into the
+daemon's PromptSession `bottom_toolbar`. The bipartite cockpit — the surface
+`ov` actually mounts, both locally and over attach — got only key hints. So
+the operator-load-bearing line (phase, cost, route, warnings) existed and was
+invisible on the surface they stare at.
+
+Two things had to be true to mount it, and each has a failure that reads as
+normal operation:
+
+  * it must cross a PROCESS boundary (the client's builder is empty by
+    construction, and an empty builder renders a perfectly plausible idle
+    organism);
+  * it must fit a WIDTH (`_format_plain` composes up to ten `·`-joined
+    segments and had never been told how wide the terminal is; a fixed-height
+    row with `wrap_lines=False` truncates mid-token).
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from backend.core.ouroboros.battle_test.status_line import (
+    StatusSnapshot,
+    fit_to_width,
+    payload_to_snapshot,
+    render_snapshot,
+    snapshot_to_payload,
+)
+
+
+@pytest.fixture
+def busy() -> StatusSnapshot:
+    return StatusSnapshot(
+        phase="GENERATE", phase_detail="47s",
+        cost_spent_usd=0.04, cost_budget_usd=0.50,
+        idle_elapsed_s=12, idle_timeout_s=600,
+        primary_op_id="7759-86ab-cdef", extra_op_count=2,
+        route="standard", provider="dw",
+        liquidity_exhausted=True, liquidity_provider="claude",
+        liquidity_reset_s=900,
+    )
+
+
+class TestItCrossesTheProcessBoundary:
+    def test_the_snapshot_survives_the_wire_unchanged(self, busy):
+        assert payload_to_snapshot(
+            json.loads(json.dumps(snapshot_to_payload(busy)))
+        ) == busy
+
+    def test_one_renderer_serves_both_sources(self, busy):
+        """A local builder and a rehydrated dict must produce the same line.
+        Two renderers would be edited months apart."""
+        rehydrated = payload_to_snapshot(snapshot_to_payload(busy))
+        assert render_snapshot(rehydrated, width=200) == render_snapshot(
+            busy, width=200)
+
+    def test_an_unknown_field_from_a_newer_daemon_does_not_crash_the_client(
+        self, busy,
+    ):
+        """THE forward-compat failure. `StatusSnapshot(**payload)` raises on
+        the first frame carrying a field this client has never heard of —
+        turning an additive daemon change into a client crash."""
+        payload = snapshot_to_payload(busy)
+        payload["some_future_field"] = "from a newer daemon"
+        assert payload_to_snapshot(payload) == busy
+
+    def test_junk_is_None_not_an_empty_snapshot(self):
+        """An empty StatusSnapshot renders a plausible IDLE organism. "We
+        received nothing" must not look like "nothing is happening"."""
+        assert payload_to_snapshot(None) is None
+        assert payload_to_snapshot({}) is None
+        assert payload_to_snapshot("nonsense") is None
+        assert render_snapshot(None) == ""
+
+
+class TestItFitsTheTerminal:
+    def test_the_headline_is_the_last_thing_standing(self, busy):
+        """At every width down to almost nothing, the phase survives."""
+        for width in (200, 140, 110, 80, 50, 28):
+            line = render_snapshot(busy, width=width)
+            assert "Phase:" in line, f"phase lost at {width} cols: {line!r}"
+
+    def test_a_warning_outlives_the_cost(self, busy):
+        """Priority is by MEANING. A dry provider runway may be the reason
+        the organism is doing nothing; the budget is a standing question."""
+        line = render_snapshot(busy, width=50)
+        assert "dry" in line and "Cost:" not in line
+
+    def test_the_hint_loses_to_the_headline(self, busy):
+        """The first draft guessed prefixes for the hotkey legend, guessed
+        wrong, and at 120 columns shed `Phase:` while keeping
+        `enter to submit`."""
+        line = render_snapshot(busy, width=120)
+        assert "Phase:" in line
+        assert "reverse-search" not in line
+
+    def test_an_unrecognised_segment_is_shed_before_the_essentials(self):
+        """A token some future slice appends is decoration until someone
+        says otherwise. The alternative is that it silently outranks the
+        phase."""
+        line = "Phase: GENERATE · Cost: $1.00 / $2.00 · brand new token here"
+        out = fit_to_width(line, 46)
+        assert "Phase:" in out and "brand new token" not in out
+
+    def test_it_sheds_whole_segments_never_a_slice(self, busy):
+        """`Cost: $0.04 / $0.5` is a number the operator will misread, and
+        `Phase: GENERAT` is a phase that does not exist."""
+        for width in range(30, 200, 7):
+            line = render_snapshot(busy, width=width)
+            if "Cost:" in line:
+                assert "$0.50" in line, f"cost clipped at {width}: {line!r}"
+
+    def test_everything_fits_or_is_marked(self, busy):
+        for width in range(20, 210, 3):
+            line = render_snapshot(busy, width=width)
+            assert len(line) <= width, f"{width}: {len(line)} — {line!r}"
+
+    def test_a_narrow_terminal_compacts_without_being_told(self):
+        """Compact was env-only. An operator on an 80-column terminal should
+        not have to know a flag exists."""
+        snap = StatusSnapshot(phase="GENERATE", cost_spent_usd=0.1,
+                              cost_budget_usd=0.5, primary_op_id="abc-1234")
+        assert len(render_snapshot(snap, width=60)) <= 60
+
+    def test_an_explicit_choice_still_wins(self, busy, monkeypatch):
+        """An operator who asked for compact means it at every width."""
+        monkeypatch.setenv("JARVIS_UI_STATUS_LINE_COMPACT", "1")
+        assert "Op:" not in render_snapshot(busy, width=400)
+
+    def test_no_width_means_no_shedding(self, busy):
+        """Callers that cannot know the terminal get today's behaviour."""
+        assert render_snapshot(busy, width=None) == render_snapshot(
+            busy, width=0)
+
+
+class TestTheMount:
+    def test_the_cockpit_accepts_a_status_provider(self):
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            build_bipartite_application,
+        )
+        import inspect
+        sig = inspect.signature(build_bipartite_application)
+        assert "status_rows" in sig.parameters
+
+    def test_the_row_collapses_when_there_is_nothing_to_say(self):
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            build_dynamic_rows,
+        )
+        assert build_dynamic_rows(lambda: []).filter() is False
+
+    def test_the_attach_client_is_wired_to_the_DAEMONS_snapshot(self):
+        """The bug this exists to avoid, pinned at the seam: the provider
+        must read the AttachUI, never this process's own builder."""
+        import inspect
+        from backend.core.ouroboros.cli.ov import _bipartite_attach_loop
+        src = inspect.getsource(_bipartite_attach_loop)
+        idx = src.find("status_rows=")
+        assert idx > 0
+        wiring = src[idx:idx + 200]
+        assert "_status_rows" in wiring
+        assert "get_status_line_builder" not in wiring
+
+    def test_the_daemon_cockpit_uses_its_LOCAL_builder(self):
+        import inspect
+        from backend.core.ouroboros.battle_test import serpent_flow as sf
+        src = inspect.getsource(sf._local_status_rows)
+        assert "get_status_line_builder" in src
+        assert "render_snapshot" in src
+
+    def test_a_stale_frame_retires_the_line(self):
+        """A dead daemon must not leave its last phase showing under an idle
+        pulse. Same window as the pulse and the roster — one definition of
+        lost contact, not three."""
+        import time
+        from backend.core.ouroboros.cli.ov import AttachUI
+        ui = AttachUI()
+        ui.on_telemetry({"kind": "heartbeat", "active": True,
+                         "status": snapshot_to_payload(StatusSnapshot(
+                             phase="GENERATE", cost_budget_usd=0.5))})
+        assert ui._status_rows()
+        ui._heartbeat_arrived = time.monotonic() - 10_000
+        assert ui._status_rows() == []
+
+    def test_the_heartbeat_carries_it(self):
+        import inspect
+        from backend.core.ouroboros.battle_test import attach_heartbeat as hb
+        assert '"status"' in inspect.getsource(hb.build_heartbeat_payload)
+
+
+class TestNeverRaises:
+    @pytest.mark.parametrize("call", [
+        lambda: snapshot_to_payload(None),
+        lambda: payload_to_snapshot(object()),
+        lambda: fit_to_width(None, 40),
+        lambda: fit_to_width("a · b", None),
+        lambda: render_snapshot(None, width=-5),
+    ])
+    def test_junk_degrades(self, call):
+        call()
+
+    def test_the_master_flag_silences_it(self, busy, monkeypatch):
+        monkeypatch.setenv("JARVIS_UI_STATUS_LINE_ENABLED", "0")
+        assert render_snapshot(busy, width=200) == ""


### PR DESCRIPTION
`StatusLineBuilder` was fully built and `live_status_line` wired it into the daemon's PromptSession `bottom_toolbar`. The bipartite cockpit — the surface `ov` actually mounts, locally **and** over attach — got only key hints. The operator-load-bearing line (phase, cost, route, warnings) existed and was invisible on the surface they stare at.

Two things had to be true to mount it, and each fails in a way that reads as normal operation.

## It had to cross a process boundary

Under `ov attach` the cockpit is a different process whose `get_status_line_builder()` is empty by construction — and an empty builder renders a perfectly plausible **IDLE** organism. Rendering the client's own would have shown a healthy quiet system that was in fact mid-GENERATE.

The split cost almost nothing: `StatusSnapshot` is already a frozen dataclass of plain fields and `_format_plain` is already a pure function over it. So — a serializer, a rehydrator, and **both processes keep calling the one renderer**. `attach_heartbeat` already sampled `builder.snapshot()` for phase/route/provider, so carrying the whole thing costs a serialisation, not a second pull.

`payload_to_snapshot` filters unknown keys rather than splatting them: `StatusSnapshot(**payload)` raises on the first frame from a newer daemon that added a field, turning an additive change into a client crash.

## It had to fit a terminal

`_format_plain` composes up to ten `·`-joined segments and had **never been told how wide the terminal is**. On the daemon's `bottom_toolbar` prompt_toolkit clipped it; in a fixed-height cockpit row with `wrap_lines=False` it truncates mid-token — `Cost: $0.04 / $0.5` is a number the operator will misread, and `Phase: GENERAT` is a phase that does not exist.

The line now sheds **whole segments** by keep-priority, and compact resolves from the terminal when not asked for explicitly (an operator who set the env flag still means it at every width).

The first draft got this wrong instructively: it listed prefixes to *drop*, guessed the hotkey legend's, guessed wrong, and at 120 columns shed `Phase:` while keeping `enter to submit` — the headline lost to a hint. It's now an allowlist of what's worth **keeping**, so an unrecognised segment scores lowest. A token some future slice appends is decoration until someone says otherwise; the alternative is that it silently outranks the phase.

Priority is by **meaning**, so the dry-provider warning outlives the cost — a dry runway may be *why* the organism is doing nothing, while the budget is a standing question:

```
200 cols  Phase · Cost · Idle · ⚠ dry · Op · [std·dw] · legend
 80 cols  Phase · Cost · Idle · ⚠ dry
 50 cols  Phase · ⚠ dry
 28 cols  Phase
```

## Mounted the same way as its neighbours

Both surfaces go through the **same `build_dynamic_rows` container** the agent view and search bar already use, and retire on the **same staleness window** as the pulse and the roster — one definition of "lost contact" across every heartbeat-fed surface, not three that drift apart and leave a dead daemon's phase showing under an idle pulse.

## Verification

- 25 new tests, weighted to the failures that look like success: an empty snapshot rendering a plausible idle organism, a mid-token clip, a newer daemon's field crashing the client
- Both mounts pinned at their seams — the attach client must read `_status_rows` and never `get_status_line_builder`; the daemon cockpit must read its local builder
- **90 pre-existing status-line tests still green** — every byte-identical render guarantee preserved (all additions are new functions)
- 107 green across status-line / heartbeat / agent-view / bipartite / context-meter
- Live-verified on the real cockpit at 130 and 74 columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mounts the status line (phase, cost, route, warnings) in the cockpit (local and `ov attach`) and makes it width‑aware by dropping whole segments to fit. Both processes now use one renderer, so the line looks the same everywhere.

- **New Features**
  - Transport: heartbeat includes a serialized `StatusSnapshot`; client rehydrates with `payload_to_snapshot`; unknown keys are ignored for forward‑compat; both sides render via `render_snapshot`.
  - Cockpit integration: `bipartite_layout` now accepts `status_rows`; attach client reads the daemon’s snapshot; daemon cockpit reads its local builder; the row collapses when empty and uses the same staleness window as pulse/roster.
  - Width adaptation: `fit_to_width` sheds whole segments by keep‑priority (Phase > warnings > Cost > badges > Op > Idle); never mid‑token truncation; ellipsis only if a single segment still overflows; compact auto‑enables below 100 cols (env override still wins).
  - Tests: new suite verifies transport, forward‑compat, width rules, and mounting; existing status‑line tests remain green.

<sup>Written for commit 4749d6ea450664d89bc837a17c2d9683dbae5ccd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

