### PR TITLE
feat(ov): measure which SURFACE can reach a module — the recurring blind spot

### DIFF
--- a/backend/core/ouroboros/battle_test/surface_reachability.py
+++ b/backend/core/ouroboros/battle_test/surface_reachability.py
@@ -1,0 +1,422 @@
+"""Which of `ov`'s surfaces can actually reach a module — the recurring blind spot.
+
+Five modules in a row have shipped complete, tested, and invisible on the
+surface the operator uses:
+
+    agent_roster        `render()` had zero production callers
+    transcript_search   complete, 21 tests, never bound to a key
+    live_status_line    wired into the daemon REPL only
+    rewind_menu         reached from `ov.py` only
+    op_fanout_tree      default-FALSE, reachable via one verb
+
+The progress board reports all of them LIVE, and it is right by its own
+measure: every one is imported by something. What it cannot see is WHICH
+SURFACE imports it, and `ov` has three that render:
+
+    serpent_flow        the daemon's flowing REPL
+    ov.AttachUI         the attach client's PromptSession fallback
+    bipartite_layout    the cockpit both of them mount
+
+A module reachable from exactly one of those is not a defect — but it is the
+shape every one of those five had, and nothing in the repo could see it. So
+this measures it: transitive import reachability from each surface's entry,
+over the same AST graph the board already builds.
+
+A signal, not a verdict
+-----------------------
+Asymmetry is evidence, never a conclusion, and the difference matters because
+acting on it blindly would be the same mistake in the other direction.
+`transcript_hatches` is reached from `ov.py` alone and is nonetheless LIVE on
+the cockpit, because `ov.py` installs its bindings into the `extra_key_bindings`
+the cockpit is built with. Reachability sees imports; it cannot see that a
+KeyBindings object was handed across.
+
+So this reports asymmetry and says what it means. The same stance the board
+takes on `dark`: a place to look, not a count of bugs.
+
+Lazy imports count
+------------------
+This codebase imports inside functions constantly — `try: from … import x`
+guarded per call site. `ast.walk` sees those, and it should: a lazy import IS
+a reachable edge, and treating only module-level imports as real would report
+most of the cockpit as unreachable from anything.
+
+Never raises, never imports the code it measures. Pure AST over source text —
+the audit must be safe to run against a module that would explode on import,
+because those are exactly the ones worth auditing.
+"""
+from __future__ import annotations
+
+import ast
+import logging
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, FrozenSet, List, Mapping, Optional, Set, Tuple
+
+logger = logging.getLogger("Ouroboros.SurfaceReachability")
+
+SURFACE_REACHABILITY_SCHEMA_VERSION = "surface_reachability.v1"
+
+MASTER_FLAG_ENV_VAR = "JARVIS_SURFACE_AUDIT_ENABLED"
+SURFACES_ENV_VAR = "JARVIS_SURFACE_AUDIT_SURFACES"
+ROOTS_ENV_VAR = "JARVIS_SURFACE_AUDIT_ROOTS"
+
+#: surface label → entry module. The three places `ov` draws from.
+#:
+#: Overridable via ``JARVIS_SURFACE_AUDIT_SURFACES`` as
+#: ``label=dotted.module,label=dotted.module`` — a fourth surface is a
+#: config change, not a code change, and this table has grown once already.
+_DEFAULT_SURFACES: Tuple[Tuple[str, str], ...] = (
+    ("daemon", "backend.core.ouroboros.battle_test.serpent_flow"),
+    ("attach", "backend.core.ouroboros.cli.ov"),
+    ("cockpit", "backend.core.ouroboros.battle_test.bipartite_layout"),
+)
+
+#: Where a module has to live to be worth auditing. Reachability into the
+#: governance core is a different question with a different answer.
+_DEFAULT_ROOTS: Tuple[str, ...] = (
+    "backend/core/ouroboros/battle_test",
+    "backend/core/ouroboros/ui",
+    "backend/core/ouroboros/cli",
+)
+
+
+def audit_enabled() -> bool:
+    """Default ON. This reads source; it never imports or executes it."""
+    return os.environ.get(
+        MASTER_FLAG_ENV_VAR, "1",
+    ).strip().lower() not in ("0", "false", "no", "off")
+
+
+def surfaces() -> Tuple[Tuple[str, str], ...]:
+    """``((label, entry_module), …)`` — the rendering surfaces to measure."""
+    raw = os.environ.get(SURFACES_ENV_VAR, "").strip()
+    if not raw:
+        return _DEFAULT_SURFACES
+    out: List[Tuple[str, str]] = []
+    for chunk in raw.split(","):
+        if "=" in chunk:
+            label, module = chunk.split("=", 1)
+            label, module = label.strip(), module.strip()
+            if label and module:
+                out.append((label, module))
+    return tuple(out) or _DEFAULT_SURFACES
+
+
+def audit_roots() -> Tuple[str, ...]:
+    raw = os.environ.get(ROOTS_ENV_VAR, "").strip()
+    if not raw:
+        return _DEFAULT_ROOTS
+    return tuple(p.strip() for p in raw.split(",") if p.strip()) or _DEFAULT_ROOTS
+
+
+# ---------------------------------------------------------------------------
+# The graph
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ModuleReach:
+    """One module and the surfaces that can reach it."""
+
+    module: str
+    path: str
+    reached_by: FrozenSet[str]
+
+    @property
+    def short(self) -> str:
+        return self.module.rsplit(".", 1)[-1]
+
+    @property
+    def orphan(self) -> bool:
+        """No surface reaches it. Either dead, or reached some way the import
+        graph cannot see — a plugin registry, a dynamic import, a verb table."""
+        return not self.reached_by
+
+    def asymmetric(self, total: int) -> bool:
+        """Reached by SOME surfaces but not all — the recurring shape."""
+        return 0 < len(self.reached_by) < total
+
+
+@dataclass
+class SurfaceReading:
+    """The whole audit, as data. Rendering is a separate concern."""
+
+    modules: List[ModuleReach] = field(default_factory=list)
+    surface_labels: Tuple[str, ...] = ()
+    scanned: int = 0
+    unresolved_entries: Tuple[str, ...] = ()
+    #: Modules that IMPORT a surface — boot paths, above the graph.
+    roots: FrozenSet[str] = frozenset()
+    schema_version: str = SURFACE_REACHABILITY_SCHEMA_VERSION
+
+    def asymmetric(self) -> List[ModuleReach]:
+        n = len(self.surface_labels)
+        return sorted(
+            (m for m in self.modules if m.asymmetric(n)),
+            key=lambda m: (len(m.reached_by), m.module),
+        )
+
+    def orphans(self) -> List[ModuleReach]:
+        """Unreached AND not a boot path. `harness` reaches every surface and
+        nothing reaches it; calling that an orphan would bury the real ones
+        under the entry points of the program."""
+        return sorted(
+            (m for m in self.modules
+             if m.orphan and m.module not in self.roots),
+            key=lambda m: m.module,
+        )
+
+    def reached_by(self, label: str) -> List[ModuleReach]:
+        return sorted((m for m in self.modules if label in m.reached_by),
+                      key=lambda m: m.module)
+
+
+def _repo_root() -> Path:
+    try:
+        from backend.core.ouroboros.battle_test.progress_board import (
+            _default_root,
+        )
+        return _default_root()
+    except Exception:  # noqa: BLE001
+        return Path(__file__).resolve().parents[4]
+
+
+def _index(roots: Tuple[str, ...]) -> Dict[str, Path]:
+    """``dotted module → source path`` for everything under ``roots``."""
+    out: Dict[str, Path] = {}
+    base = _repo_root()
+    for root in roots:
+        directory = base / root
+        if not directory.is_dir():
+            continue
+        for path in directory.rglob("*.py"):
+            try:
+                rel = path.relative_to(base).as_posix()
+            except ValueError:
+                continue
+            if "/tests/" in f"/{rel}" or rel.split("/")[-1].startswith("test_"):
+                continue
+            try:
+                from backend.core.ouroboros.battle_test.progress_board import (
+                    _module_name,
+                )
+                out[_module_name(rel)] = path
+            except Exception:  # noqa: BLE001
+                continue
+    return out
+
+
+def _edges(path: Path) -> Set[str]:
+    """Modules this file imports — module-level AND inside functions.
+
+    Reuses the board's extractor rather than writing a second one: two AST
+    walkers over the same syntax would eventually disagree about which
+    import shapes count, and the disagreement would be invisible.
+    """
+    try:
+        source = path.read_text(encoding="utf-8", errors="replace")
+        tree = ast.parse(source)
+    except Exception:  # noqa: BLE001 — a file that will not parse has no edges
+        return set()
+    try:
+        from backend.core.ouroboros.battle_test.progress_board import (
+            _imported_modules,
+        )
+        return set(_imported_modules(tree))
+    except Exception:  # noqa: BLE001
+        return set()
+
+
+def _reach(
+    entry: str,
+    index: Mapping[str, Path],
+    barriers: FrozenSet[str] = frozenset(),
+) -> Set[str]:
+    """Modules reachable from ``entry`` WITHOUT passing through a barrier.
+
+    The barriers are the other surfaces, and they are the whole reason this
+    function is not a plain transitive closure.
+
+    The first version was one, and it reported that every module is reachable
+    from every surface — which is true and useless. The three surfaces form a
+    CYCLE (`serpent_flow` imports `bipartite_layout`; `ov` imports both), so
+    closure from any one of them swallows the other two and everything they
+    touch. The asymmetry this exists to find collapsed to zero, and the
+    instrument would have confidently reported a clean bill of health for the
+    exact defect that motivated it.
+
+    Cutting at the boundary asks the question that actually matters: does THIS
+    surface reach the module on its own, or only by way of another surface? A
+    module the cockpit can only see through `ov.py` is precisely the shape of
+    `live_status_line` and `rewind_menu`.
+
+    Iterative with an explicit stack: the graph is cyclic even after the cuts,
+    and a recursive walk would blow the stack on the first loop.
+    """
+    seen: Set[str] = set()
+    stack: List[str] = [entry]
+    while stack:
+        current = stack.pop()
+        if current in seen:
+            continue
+        seen.add(current)
+        # A barrier is REACHED but never traversed: knowing the cockpit
+        # imports `ov` is true; inheriting everything `ov` imports is what
+        # destroyed the signal.
+        if current in barriers and current != entry:
+            continue
+        path = index.get(current)
+        if path is None:
+            continue
+        for target in _edges(path):
+            # Only follow edges that stay in scope. Third-party and
+            # governance-core imports are real, and out of this question.
+            if target in index and target not in seen:
+                stack.append(target)
+    return seen
+
+
+def _roots(index: Mapping[str, Path], entries: FrozenSet[str]) -> Set[str]:
+    """Modules that import a SURFACE — boot paths, not orphans.
+
+    `harness` reaches every surface; nothing reaches `harness`. Listing it as
+    unreachable would be technically true and would bury the real orphans
+    under the entry points of the program.
+    """
+    out: Set[str] = set()
+    for module, path in index.items():
+        if module in entries:
+            continue
+        if _edges(path) & entries:
+            out.add(module)
+    return out
+
+
+def audit(
+    *,
+    roots: Optional[Tuple[str, ...]] = None,
+    entries: Optional[Tuple[Tuple[str, str], ...]] = None,
+) -> SurfaceReading:
+    """Measure per-surface reachability. NEVER raises.
+
+    The entry modules themselves are excluded from the report — a surface
+    trivially reaches itself, and three rows saying so would be the loudest
+    thing in the output.
+    """
+    reading = SurfaceReading()
+    try:
+        if not audit_enabled():
+            return reading
+        scope = roots or audit_roots()
+        table = entries or surfaces()
+        index = _index(scope)
+        reading.scanned = len(index)
+        reading.surface_labels = tuple(label for label, _ in table)
+
+        missing: List[str] = []
+        reach: Dict[str, Set[str]] = {}
+        entry_set = frozenset(entry for _, entry in table)
+        for label, entry in table:
+            if entry not in index:
+                # An entry outside the scanned roots cannot be walked. Said
+                # out loud rather than silently contributing an empty set —
+                # which would mark every module unreachable from it and read
+                # as a catastrophic finding.
+                missing.append(f"{label}={entry}")
+                continue
+            reach[label] = _reach(entry, index, barriers=entry_set)
+        reading.unresolved_entries = tuple(missing)
+        reading.roots = frozenset(_roots(index, entry_set))
+
+        entry_modules = entry_set
+        for module in sorted(index):
+            if module in entry_modules:
+                continue
+            hit = frozenset(
+                label for label, reached in reach.items() if module in reached
+            )
+            reading.modules.append(ModuleReach(
+                module=module,
+                path=index[module].as_posix(),
+                reached_by=hit,
+            ))
+        return reading
+    except Exception:  # noqa: BLE001
+        logger.debug("[SurfaceReach] audit degraded", exc_info=True)
+        return reading
+
+
+# ---------------------------------------------------------------------------
+# Rendering — a separate concern, as the board keeps its own
+# ---------------------------------------------------------------------------
+
+
+def render(reading: SurfaceReading, *, limit: int = 20) -> List[str]:
+    """Operator-readable rows. NEVER raises.
+
+    Leads with the ASYMMETRIC modules because they are the finding; the
+    fully-reachable majority is the uninteresting background this exists to
+    filter out.
+    """
+    out: List[str] = []
+    try:
+        labels = reading.surface_labels
+        if not labels:
+            return ["  surface audit unavailable"]
+        for entry in reading.unresolved_entries:
+            out.append(f"  ⚠ entry outside the scanned roots: {entry}")
+
+        asym = reading.asymmetric()
+        out.append(
+            f"  {reading.scanned} modules · {len(labels)} surfaces "
+            f"({' · '.join(labels)})"
+        )
+        out.append("")
+        if not asym:
+            out.append("  every module is reachable from every surface")
+        else:
+            out.append(f"  reachable from SOME surfaces, not all "
+                       f"({len(asym)}):")
+            width = min(38, max((len(m.short) for m in asym), default=20))
+            for row in asym[:limit]:
+                marks = " ".join(
+                    ("✓" if label in row.reached_by else "·") for label in labels
+                )
+                out.append(f"    {row.short:<{width}}  {marks}")
+            if len(asym) > limit:
+                out.append(f"    … {len(asym) - limit} more")
+
+        orphans = reading.orphans()
+        if orphans:
+            out.append("")
+            out.append(f"  reached by NO surface ({len(orphans)}):")
+            for row in orphans[:limit]:
+                out.append(f"    ◇ {row.short}")
+            if len(orphans) > limit:
+                out.append(f"    … {len(orphans) - limit} more")
+
+        out.append("")
+        out.append("  asymmetry is a SIGNAL, not a defect count: bindings and")
+        out.append("  callables handed across a surface boundary are invisible")
+        out.append("  to an import graph. A place to look, not a verdict.")
+        return out
+    except Exception:  # noqa: BLE001
+        logger.debug("[SurfaceReach] render degraded", exc_info=True)
+        return out or ["  surface audit unavailable"]
+
+
+__all__ = [
+    "MASTER_FLAG_ENV_VAR",
+    "ROOTS_ENV_VAR",
+    "SURFACES_ENV_VAR",
+    "SURFACE_REACHABILITY_SCHEMA_VERSION",
+    "ModuleReach",
+    "SurfaceReading",
+    "audit",
+    "audit_enabled",
+    "audit_roots",
+    "render",
+    "surfaces",
+]

--- a/backend/core/ouroboros/cli/ov_demo.py
+++ b/backend/core/ouroboros/cli/ov_demo.py
@@ -37,6 +37,7 @@ DEMO_HELP = """ov demo -- watch the cockpit, no model calls
 
   ov demo             board + transcript
   ov demo board       what is LIVE vs DARK right now (derived from the tree)
+  ov demo surfaces    which of the 3 surfaces can REACH each module
   ov demo transcript  the CC-style deck: ops, diffs, agora threads
   ov demo live        the COCKPIT running, driven by synthetic events
                       (needs a real terminal; --speed=N to fast-forward)
@@ -153,6 +154,27 @@ def scene_board(console: Any, argv: Sequence[str] = ()) -> int:
     _say(console, "  dark = enabled, on disk, imported by nothing. A SIGNAL,")
     _say(console, "  not a defect count: plugin discovery and dynamic import")
     _say(console, "  remain invisible to a static graph.")
+    return 0
+
+
+def scene_surfaces(console: Any, argv: Sequence[str] = ()) -> int:
+    """Which of `ov`'s three surfaces can reach a module.
+
+    The board answers "is this imported by anything"; this answers "by
+    WHICH surface", which is the question five separate shipped-but-invisible
+    modules turned out to hinge on. Same discipline as the board: derived
+    from the tree, never cached, and stated as a signal rather than a verdict.
+    """
+    try:
+        from backend.core.ouroboros.battle_test.surface_reachability import (
+            audit, render,
+        )
+    except Exception as exc:  # noqa: BLE001
+        _say(console, f"  surface audit unavailable: {exc}")
+        return 1
+    _rule(console, "which surface can reach what")
+    for line in render(audit(), limit=_limit(argv)):
+        _say(console, line)
     return 0
 
 
@@ -861,6 +883,7 @@ def scene_live(console: Any, argv: Sequence[str] = ()) -> int:
 #: derived from what actually exists and cannot drift from it.
 _SCENES: "dict[str, Callable[[Any, Sequence[str]], int]]" = {
     "board": scene_board,
+    "surfaces": scene_surfaces,
     "transcript": scene_transcript,
     # NOT in the default all-scenes run: it takes over the screen and
     # waits for a keypress, so it must be asked for by name.

--- a/tests/battle_test/test_surface_reachability.py
+++ b/tests/battle_test/test_surface_reachability.py
@@ -1,0 +1,205 @@
+"""The per-surface audit — and the cycle that made its first version useless.
+
+Five modules in a row shipped complete and invisible on the surface the
+operator uses. The progress board called every one of them LIVE, correctly:
+each WAS imported. What nothing could see was *which surface* imported it.
+
+The load-bearing test here is the barrier walk. A plain transitive closure
+answers "every surface reaches everything" — true, because the surfaces
+import each other, and useless, because the asymmetry it exists to find
+collapses to zero. An instrument that reports a clean bill of health for the
+exact defect that motivated it is worse than no instrument.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.battle_test import surface_reachability as sr
+
+
+def _fake(tmp_path, files: dict):
+    """Write a tiny package and index it the way the audit does."""
+    for rel, body in files.items():
+        path = tmp_path / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body, encoding="utf-8")
+    return tmp_path
+
+
+class TestTheBarrierWalk:
+    def test_a_cycle_does_NOT_make_everything_reachable(self, tmp_path,
+                                                        monkeypatch):
+        """THE regression, found by running the first version.
+
+        `serpent_flow` imports `bipartite_layout`; `ov` imports both. Closure
+        from any one swallows the other two and everything they touch.
+        """
+        _fake(tmp_path, {
+            "pkg/__init__.py": "",
+            "pkg/daemon.py": "from pkg import cockpit\nfrom pkg import only_daemon\n",
+            "pkg/cockpit.py": "from pkg import daemon\nfrom pkg import only_cockpit\n",
+            "pkg/only_daemon.py": "",
+            "pkg/only_cockpit.py": "",
+        })
+        monkeypatch.setattr(sr, "_repo_root", lambda: tmp_path)
+        reading = sr.audit(
+            roots=("pkg",),
+            entries=(("daemon", "pkg.daemon"), ("cockpit", "pkg.cockpit")),
+        )
+        by = {m.short: m.reached_by for m in reading.modules}
+        assert by["only_daemon"] == frozenset({"daemon"}), (
+            "the cycle leaked: closure crossed into the other surface"
+        )
+        assert by["only_cockpit"] == frozenset({"cockpit"})
+
+    def test_a_barrier_is_REACHED_but_not_traversed(self, tmp_path,
+                                                    monkeypatch):
+        """Knowing the cockpit imports `ov` is true. Inheriting everything
+        `ov` imports is what destroyed the signal."""
+        _fake(tmp_path, {
+            "pkg/__init__.py": "",
+            "pkg/a.py": "from pkg import b\n",
+            "pkg/b.py": "from pkg import deep\n",
+            "pkg/deep.py": "",
+        })
+        monkeypatch.setattr(sr, "_repo_root", lambda: tmp_path)
+        reading = sr.audit(
+            roots=("pkg",), entries=(("a", "pkg.a"), ("b", "pkg.b")))
+        by = {m.short: m.reached_by for m in reading.modules}
+        assert by["deep"] == frozenset({"b"}), (
+            "`a` reached `deep` THROUGH the `b` surface — the cut failed"
+        )
+
+    def test_a_self_import_cycle_terminates(self, tmp_path, monkeypatch):
+        """The graph is cyclic even after the cuts; a recursive walk would
+        blow the stack on the first loop."""
+        _fake(tmp_path, {
+            "pkg/__init__.py": "",
+            "pkg/a.py": "from pkg import b\n",
+            "pkg/b.py": "from pkg import a\nfrom pkg import c\n",
+            "pkg/c.py": "from pkg import b\n",
+        })
+        monkeypatch.setattr(sr, "_repo_root", lambda: tmp_path)
+        reading = sr.audit(roots=("pkg",), entries=(("a", "pkg.a"),))
+        # `pkg` is the package `__init__`, correctly indexed as a module.
+        assert {m.short for m in reading.modules} == {"b", "c", "pkg"}
+
+
+class TestItSeesLazyImports:
+    def test_a_function_level_import_is_a_real_edge(self, tmp_path,
+                                                    monkeypatch):
+        """This codebase imports inside functions constantly. Counting only
+        module-level imports would report most of the cockpit unreachable."""
+        _fake(tmp_path, {
+            "pkg/__init__.py": "",
+            "pkg/a.py": "def go():\n    from pkg import lazy\n    return lazy\n",
+            "pkg/lazy.py": "",
+        })
+        monkeypatch.setattr(sr, "_repo_root", lambda: tmp_path)
+        reading = sr.audit(roots=("pkg",), entries=(("a", "pkg.a"),))
+        assert reading.modules[0].reached_by == frozenset({"a"})
+
+
+class TestHonestClassification:
+    def test_a_boot_path_is_not_an_orphan(self, tmp_path, monkeypatch):
+        """`harness` reaches every surface and nothing reaches it. Calling
+        that an orphan buries the real ones under the program's entry
+        points."""
+        _fake(tmp_path, {
+            "pkg/__init__.py": "",
+            "pkg/surface.py": "",
+            "pkg/harness.py": "from pkg import surface\n",
+            "pkg/truly_dead.py": "",
+        })
+        monkeypatch.setattr(sr, "_repo_root", lambda: tmp_path)
+        reading = sr.audit(
+            roots=("pkg",), entries=(("s", "pkg.surface"),))
+        orphans = {m.short for m in reading.orphans()}
+        assert "truly_dead" in orphans
+        assert "harness" not in orphans
+
+    def test_an_entry_outside_the_roots_is_said_OUT_LOUD(self, tmp_path,
+                                                         monkeypatch):
+        """Silently contributing an empty set would mark every module
+        unreachable from that surface and read as a catastrophic finding."""
+        _fake(tmp_path, {"pkg/__init__.py": "", "pkg/a.py": ""})
+        monkeypatch.setattr(sr, "_repo_root", lambda: tmp_path)
+        reading = sr.audit(
+            roots=("pkg",), entries=(("ghost", "pkg.does_not_exist"),))
+        assert reading.unresolved_entries
+        assert any("entry outside" in ln for ln in sr.render(reading))
+
+    def test_the_report_says_asymmetry_is_a_SIGNAL(self, tmp_path,
+                                                   monkeypatch):
+        """`transcript_hatches` is attach-only and LIVE on the cockpit, via a
+        KeyBindings object handed across. An import graph cannot see that, so
+        the output must not read as a defect count."""
+        _fake(tmp_path, {
+            "pkg/__init__.py": "", "pkg/a.py": "from pkg import x\n",
+            "pkg/b.py": "", "pkg/x.py": "",
+        })
+        monkeypatch.setattr(sr, "_repo_root", lambda: tmp_path)
+        text = "\n".join(sr.render(sr.audit(
+            roots=("pkg",), entries=(("a", "pkg.a"), ("b", "pkg.b")))))
+        assert "SIGNAL" in text and "not a verdict" in text
+
+
+class TestItIsSafeToRun:
+    def test_it_never_imports_what_it_measures(self):
+        """The modules worth auditing are exactly the ones that might explode
+        on import. Pure AST over source text, no execution."""
+        import ast
+        import pathlib
+        src = pathlib.Path(
+            "backend/core/ouroboros/battle_test/surface_reachability.py"
+        ).read_text(encoding="utf-8")
+        tree = ast.parse(src)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                name = getattr(node.func, "id", "") or getattr(
+                    node.func, "attr", "")
+                assert name not in ("import_module", "__import__", "exec",
+                                    "eval"), f"dynamic import/exec: {name}"
+
+    def test_an_unparseable_file_has_no_edges_and_does_not_raise(
+        self, tmp_path, monkeypatch,
+    ):
+        _fake(tmp_path, {
+            "pkg/__init__.py": "", "pkg/a.py": "from pkg import broken\n",
+            "pkg/broken.py": "def (((( this is not python\n",
+        })
+        monkeypatch.setattr(sr, "_repo_root", lambda: tmp_path)
+        reading = sr.audit(roots=("pkg",), entries=(("a", "pkg.a"),))
+        assert {m.short for m in reading.modules} == {"broken", "pkg"}
+
+    @pytest.mark.parametrize("call", [
+        lambda: sr.audit(roots=("nonexistent",)),
+        lambda: sr.render(sr.SurfaceReading()),
+        lambda: sr.audit(entries=()),
+    ])
+    def test_junk_degrades(self, call):
+        call()
+
+    def test_the_master_flag_silences_it(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_SURFACE_AUDIT_ENABLED", "0")
+        assert sr.audit().modules == []
+
+    def test_surfaces_are_configuration_not_code(self, monkeypatch):
+        """A fourth surface must not require an edit. This table grew once
+        already."""
+        monkeypatch.setenv("JARVIS_SURFACE_AUDIT_SURFACES", "x=pkg.x,y=pkg.y")
+        assert sr.surfaces() == (("x", "pkg.x"), ("y", "pkg.y"))
+
+
+class TestAgainstTheRealTree:
+    def test_it_finds_the_asymmetry_that_motivated_it(self):
+        """`rewind_menu` is reached from `ov.py` and from nothing else — the
+        shape that has now recurred five times."""
+        reading = sr.audit()
+        by = {m.short: m.reached_by for m in reading.modules}
+        assert by.get("rewind_menu") == frozenset({"attach"})
+
+    def test_the_three_surfaces_all_resolve(self):
+        reading = sr.audit()
+        assert reading.unresolved_entries == ()
+        assert set(reading.surface_labels) == {"daemon", "attach", "cockpit"}


### PR DESCRIPTION
Five modules in a row shipped complete, tested, and invisible on the surface the operator uses:

| module | how it was dark |
|---|---|
| `agent_roster` | `render()` had zero production callers |
| `transcript_search` | complete, 21 tests, never bound to a key |
| `live_status_line` | wired into the daemon REPL only |
| `rewind_menu` | reached from `ov.py` only |
| `op_fanout_tree` | default-FALSE, reachable via one verb |

The progress board called every one of them **LIVE**, and it was right by its own measure: each *was* imported. What nothing in the repo could see is **which surface** imports it — and `ov` has three that render (the daemon REPL, the attach client's PromptSession, the bipartite cockpit).

Mounting the sixth by hand would have been the workaround. The defect recurs because it is invisible.

## The cycle that made the first version useless

A plain transitive closure reported *"every module is reachable from every surface."* True, and useless: the surfaces **import each other** (`serpent_flow` imports `bipartite_layout`; `ov` imports both), so closure from any one swallows the other two and everything they touch. The instrument would have issued a clean bill of health for the exact defect that motivated it.

So the walk **cuts at surface boundaries** — a barrier is *reached* but never *traversed*. Knowing the cockpit imports `ov` is true; inheriting everything `ov` imports is what destroyed the signal.

That one change turned **0 findings into 68**:

```
  123 modules · 3 surfaces (daemon · attach · cockpit)

  reachable from SOME surfaces, not all (68):
    canvas_viewport         · · ✓
    diff_preview            ✓ · ·
    live_status_line        ✓ · ·
    op_block_buffer         ✓ · ·
    rewind_menu             · ✓ ·
    stream_renderer         ✓ · ·
    transcript_hatches      · ✓ ·
```

## Classification that doesn't cry wolf

- A module that **imports** a surface is a **root**, not an orphan. `harness` reaches every surface and nothing reaches it; listing it as unreachable would bury the real orphans under the program's own entry points.
- An entry outside the scanned roots is reported **out loud**. Silently contributing an empty set would mark every module unreachable from that surface and read as a catastrophe.
- Asymmetry is a **signal**, printed as one. `transcript_hatches` is attach-only and nonetheless live on the cockpit, because `ov.py` hands its `KeyBindings` into `extra_key_bindings`. An import graph cannot see an object passed across a boundary, and an output that read as a defect count would send the next reader to fix something that works.

## Composed, not duplicated

`_imported_modules`, `_module_name` and `_default_root` come from `progress_board`. Two AST walkers over the same syntax would eventually disagree about which import shapes count, and the disagreement would be invisible.

Never imports what it measures — pure AST over source text, AST-pinned against `import_module` / `exec` / `eval`. The modules worth auditing are exactly the ones that might explode on import.

Surfaces are **configuration** (`JARVIS_SURFACE_AUDIT_SURFACES`), so a fourth isn't a code change — that table has grown once already.

## Verification

- 16 tests, including the cycle regression against a synthetic package, lazy function-level imports counting as edges, a boot path not being called an orphan, and an unparseable file yielding no edges rather than raising
- A live assertion that `rewind_menu` still reads attach-only, so the instrument stays honest against the real tree
- Surfaced as `ov demo surfaces`, beside the board it complements
- 50 green across the audit and both demo suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-surface import reachability audit for `ov` to reveal modules only reachable from some surfaces, and exposes it via `ov demo surfaces`. The walk cuts at surface boundaries to avoid cycle-driven false positives.

- New Features
  - AST-based per-surface reachability audit in `backend/core/ouroboros/battle_test/surface_reachability.py` (never imports or executes code).
  - Traversal stops at other surfaces; reports asymmetric modules and true orphans while excluding boot-path roots.
  - New CLI: `ov demo surfaces` (supports `--limit`) rendering findings and unresolved entries.
  - Config via `JARVIS_SURFACE_AUDIT_ENABLED`, `JARVIS_SURFACE_AUDIT_SURFACES`, `JARVIS_SURFACE_AUDIT_ROOTS`; 16 tests added.

<sup>Written for commit 7bda6bcac973482ce840ae205dada0e856288761. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

