### PR TITLE
fix(ov): one grammar in the deck — three shapes and two column disciplines

### DIFF
--- a/backend/core/ouroboros/battle_test/tool_render_registry.py
+++ b/backend/core/ouroboros/battle_test/tool_render_registry.py
@@ -233,13 +233,19 @@ def _summarize_path_arg(args: str) -> str:
 
 
 def _summarize_bash_arg(args: str) -> str:
-    """Bash command — show with leading ``$``."""
+    """The command itself.
+
+    The leading ``$`` was a shell cue for a header that read
+    ``💻 bash $ pytest -q``. Inside ``Bash(…)`` the verb already says which
+    interpreter this is, so the sigil is a second announcement of the same
+    fact — and it reads as part of the command, which it is not.
+    """
     s = _safe_str(args).strip()
     if not s:
-        return "$"
+        return ""
     # Collapse internal whitespace for one-line display
     s = re.sub(r"\s+", " ", s)
-    return _truncate(f"$ {s}", 80)
+    return _truncate(s, 80)
 
 
 def _summarize_search_arg(args: str) -> str:
@@ -470,6 +476,22 @@ def _safe_result_summarizer(fn: ResultSummarizer) -> ResultSummarizer:
 # ===========================================================================
 
 
+def _titlecase_kind(tool_kind: str) -> str:
+    """``mcp_slack_post_message`` → ``McpSlackPostMessage``.
+
+    A last-resort verb for a tool with no descriptor. Derived rather than
+    tabled, because the whole point of the fallback is that nobody wrote an
+    entry for this one — an MCP server names its own tools and no table here
+    can enumerate them in advance.
+    """
+    try:
+        parts = [p for p in str(tool_kind or "tool").replace("-", "_").split("_")
+                 if p]
+        return "".join(p[:1].upper() + p[1:] for p in parts) or "Tool"
+    except Exception:  # noqa: BLE001
+        return "Tool"
+
+
 def _make(
     tool_kind: str,
     icon: str,
@@ -498,27 +520,27 @@ _DESCRIPTORS: Mapping[str, ToolRenderDescriptor] = {
         _summarize_path_arg, _summarize_read,
     ),
     "list_symbols": _make(
-        "list_symbols", "📋", None,
+        "list_symbols", "📋", "Symbols",
         BodyShape.MULTI_LINE, "text",
         _summarize_path_arg, _summarize_list_symbols,
     ),
     "list_dir": _make(
-        "list_dir", "📂", None,
+        "list_dir", "📂", "List",
         BodyShape.MULTI_LINE, "text",
         _summarize_path_arg, _summarize_list_dir,
     ),
     "glob_files": _make(
-        "glob_files", "📁", None,
+        "glob_files", "📁", "Glob",
         BodyShape.MULTI_LINE, "text",
         _summarize_search_arg, _summarize_glob,
     ),
     "search_code": _make(
-        "search_code", "🔍", None,
+        "search_code", "🔍", "Search",
         BodyShape.MULTI_LINE, "text",
         _summarize_search_arg, _summarize_search,
     ),
     "get_callers": _make(
-        "get_callers", "🔗", None,
+        "get_callers", "🔗", "Callers",
         BodyShape.MULTI_LINE, "text",
         _summarize_default_arg, _summarize_callers,
     ),
@@ -534,55 +556,55 @@ _DESCRIPTORS: Mapping[str, ToolRenderDescriptor] = {
         _summarize_path_arg, _summarize_write,
     ),
     "delete_file": _make(
-        "delete_file", "🗑️", None,
+        "delete_file", "🗑️", "Delete",
         BodyShape.SINGLE_LINE, None,
         _summarize_path_arg, _summarize_delete,
     ),
     # ---- Execution-shape (LOG body) -------------------------------------
     "bash": _make(
-        "bash", "💻", None,
+        "bash", "💻", "Bash",
         BodyShape.LOG, "bash",
         _summarize_bash_arg, _summarize_bash,
     ),
     "run_tests": _make(
-        "run_tests", "🧪", None,
+        "run_tests", "🧪", "Test",
         BodyShape.LOG, "text",
         _summarize_default_arg, _summarize_tests,
     ),
     "type_check": _make(
-        "type_check", "🔬", None,
+        "type_check", "🔬", "TypeCheck",
         BodyShape.LOG, "text",
         _summarize_default_arg, _summarize_type_check,
     ),
     # ---- Git-shape ------------------------------------------------------
     "git_log": _make(
-        "git_log", "📜", None,
+        "git_log", "📜", "GitLog",
         BodyShape.MULTI_LINE, "text",
         _summarize_default_arg, _summarize_git_log,
     ),
     "git_diff": _make(
-        "git_diff", "📊", None,
+        "git_diff", "📊", "GitDiff",
         BodyShape.DIFF, "diff",
         _summarize_default_arg, _summarize_git_diff,
     ),
     "git_blame": _make(
-        "git_blame", "🔎", None,
+        "git_blame", "🔎", "GitBlame",
         BodyShape.MULTI_LINE, "text",
         _summarize_path_arg, _summarize_git_blame,
     ),
     # ---- Async-native (ToolManifest-only, not in _dispatch) -------------
     "web_fetch": _make(
-        "web_fetch", "🌐", None,
+        "web_fetch", "🌐", "Fetch",
         BodyShape.MULTI_LINE, "text",
         _summarize_default_arg, _summarize_web_fetch,
     ),
     "web_search": _make(
-        "web_search", "🌐", None,
+        "web_search", "🌐", "WebSearch",
         BodyShape.MULTI_LINE, "text",
         _summarize_search_arg, _summarize_web_search,
     ),
     "ask_human": _make(
-        "ask_human", "🗣️", None,
+        "ask_human", "🗣️", "Ask",
         BodyShape.SINGLE_LINE, None,
         _summarize_default_arg, _summarize_ask_human,
     ),
@@ -689,14 +711,23 @@ def render(
     args_summary = descriptor.summarize_args(args_safe)
     body_summary = descriptor.summarize_result(result_safe, status_enum)
 
-    # Header line: CC verb (Read/Update/Write/...) takes precedence;
-    # otherwise icon-prefixed kind for the legacy-style one-liner path.
+    # Header line: ``Verb(args)``, uniformly.
+    #
+    # Every descriptor now carries a `cc_verb`, so the icon path below is
+    # reached only by an UNKNOWN tool — an MCP-forwarded one, typically.
+    # It used to be reached by fifteen of the eighteen built-ins, which is
+    # why one deck showed `⏺ Read(foo.py)` beside `🔍 search_code "x"` and
+    # `💻 bash $ pytest`: three shapes, three naming conventions, one screen.
+    #
+    # The unknown case gets the same shape rather than a different one. A
+    # tool this registry has never heard of is still a tool call, and giving
+    # it its own layout tells the operator about our descriptor table instead
+    # of about their work. The icon is kept in the DESCRIPTOR — it is useful
+    # in a picker or a legend — it is simply not part of the deck line.
     if descriptor.cc_verb:
         header_line = f"{descriptor.cc_verb}({args_summary})"
     else:
-        header_line = (
-            f"{descriptor.icon} {descriptor.tool_kind} {args_summary}".rstrip()
-        )
+        header_line = f"{_titlecase_kind(descriptor.tool_kind)}({args_summary})"
 
     # Body lines: only when shape allows AND budget > 0 AND result has content.
     body_lines: Tuple[str, ...] = ()

--- a/backend/core/ouroboros/battle_test/tool_render_view.py
+++ b/backend/core/ouroboros/battle_test/tool_render_view.py
@@ -469,6 +469,7 @@ def _compose_header(
     duration_ms: float,
     status_enum: ToolStatus,
     palette: Optional[Mapping[str, str]],
+    tool_name: str = "",
 ) -> str:
     """Build the Rich-markup header line.
 
@@ -517,12 +518,58 @@ def _compose_header(
             f"{duration_part}{status_part}"
         )
 
-    # Icon path
-    c = _palette_value(palette, "neural")
+    # Unknown tool — MCP-forwarded, typically. SAME shape as everything
+    # else: a tool this registry has never heard of is still a tool call,
+    # and a distinct layout for it tells the operator about our descriptor
+    # table rather than about their work.
+    verb_color = _palette_value(palette, "neural")
+    file_color = _palette_value(palette, "file")
+    lparen = rendered_header.find("(")
+    rparen = rendered_header.rfind(")")
+    inner = rendered_header[lparen + 1 : rparen] if 0 < lparen < rparen else ""
+    try:
+        from backend.core.ouroboros.battle_test.tool_render_registry import (
+            _titlecase_kind,
+        )
+        verb = _titlecase_kind(tool_name) if tool_name else rendered_header
+    except Exception:  # noqa: BLE001
+        verb = rendered_header
     return (
-        f"[{c}]{_escape(rendered_header)}[/{c}]"
+        f"[{verb_color}]⏺ {_escape(verb)}[/{verb_color}]"
+        f"([{file_color}]{_escape(inner)}[/{file_color}])"
         f"{duration_part}{status_part}"
     )
+
+
+def _detail_prefix() -> str:
+    """``  ⎿  `` — the deck's continuation lead, from the ONE definition.
+
+    Composed rather than written so the glyph, the indent and the gap all
+    come from `deck_grammar`; a literal here is how this line drifted to
+    column 0 in the first place. NEVER raises — an unstyled fallback still
+    indents, because the indent is the part that carries meaning.
+    """
+    try:
+        from backend.core.ouroboros.ui.deck_grammar import detail
+        from rich.text import Text
+        # `detail("")` is the prefix and nothing else.
+        return Text.from_markup(detail("")).plain
+    except Exception:  # noqa: BLE001
+        return "  ⎿  "
+
+
+def _body_indent() -> str:
+    """Leading spaces that put a body line under the summary's text.
+
+    Body lines rendered at column 0, so a pytest traceback under a failing
+    `Bash(…)` looked like console output that had escaped the block rather
+    than the result OF it.
+    """
+    try:
+        from backend.core.ouroboros.ui.deck_grammar import DETAIL_COLUMN
+        return " " * int(DETAIL_COLUMN)
+    except Exception:  # noqa: BLE001
+        return "     "
 
 
 def _compose_summary(
@@ -555,13 +602,17 @@ def _compose_summary(
         return ("", "")
 
     c_dim = _palette_value(palette, "dim")
-    try:
-        from backend.core.ouroboros.ui.theme import mark
-        glyph = mark("detail") or "⎿"
-    except Exception:  # noqa: BLE001 — a themeless render still continues
-        glyph = "⎿"
+    # INDENTED under the action, through the module that owns the deck's
+    # column discipline.
+    #
+    # This line sat at column 0 while `deck_grammar` put every other
+    # continuation at column 2 with its body at column 5 — so one deck
+    # showed `⏺ Repair(L2)` / `  ⎿ fixture rebuilt` directly above
+    # `⏺ Update(f.py)` / `⎿ +5 / -2` with the diff flat beneath it. Two
+    # column disciplines, and the block structure is the indentation: remove
+    # it and a transcript is a log.
     summary_markup = (
-        f"[{c_dim}]{glyph}  {_escape(summary_text)}[/{c_dim}]"
+        f"[{c_dim}]{_detail_prefix()}{_escape(summary_text)}[/{c_dim}]"
     )
 
     expansion_hint = ""
@@ -696,6 +747,12 @@ def compose(
         duration_ms,
         status_enum,
         palette,
+        # The tool the CALLER asked for. An unknown tool resolves to the
+        # default descriptor, whose own `tool_kind` is the string
+        # "default" — so the registry layer cannot name it and an
+        # MCP-forwarded call rendered as `Default(#eng)`. This layer has
+        # the real name and is the only one that does.
+        tool_name=str(tool_name or ""),
     )
 
     body_present = bool(rendered.body_lines)
@@ -718,9 +775,19 @@ def compose(
         wrapper = _BODY_WRAPPERS.get(
             descriptor.body_shape, _wrap_text_line,
         )
+    # ONE seam for the indent, not four wrappers each remembering to.
+    #
+    # Every body line lands in the deck's body column, so a pytest traceback
+    # under a failing `Bash(…)` reads as the result OF that call rather than
+    # as console output that escaped the block. The wrappers keep owning
+    # COLOUR; this owns POSITION, and neither has to know the other's rules.
+    _indent = _body_indent()
     body_lines_markup: Tuple[str, ...] = tuple(
-        _wrap_marker_line(ln, palette) if "elided" in ln and ln.lstrip().startswith("…")
-        else wrapper(ln, palette)
+        _indent + (
+            _wrap_marker_line(ln, palette)
+            if "elided" in ln and ln.lstrip().startswith("…")
+            else wrapper(ln, palette)
+        )
         for ln in rendered.body_lines
     )
 

--- a/tests/battle_test/test_deck_grammar_unification.py
+++ b/tests/battle_test/test_deck_grammar_unification.py
@@ -1,0 +1,125 @@
+"""ONE grammar in the deck — the structural defect an operator spotted.
+
+`deck_grammar` owns the deck's column discipline: `⏺` at column 0, `⎿` at 2,
+body at 5. `tool_render_view` emitted its own — summary and body both flat at
+column 0 — and its headers came in two shapes, because fifteen of eighteen
+descriptors had `cc_verb=None` and fell to an icon path.
+
+So one screen showed:
+
+    ⏺ Repair(L2 · iteration 1/5)
+      ⎿  fixture rebuilt from the live seam     ← deck_grammar
+    ⏺ Update(risk_tier_floor.py)  90ms
+    ⎿  +5 / -2 lines                            ← tool_render_view, flat
+    --- a/backend/core/ouroboros/governance/…    ← body at column 0
+    🔍 search_code "except Exception"           ← icon path, snake_case
+    💻 bash $ python3 -m pytest -q
+
+Three shapes, three naming conventions, two column disciplines. These tests
+pin the single grammar that replaced them.
+"""
+from __future__ import annotations
+
+import pytest
+from rich.text import Text
+
+from backend.core.ouroboros.battle_test.tool_render_registry import (
+    _DESCRIPTORS, ToolStatus, get_descriptor,
+)
+from backend.core.ouroboros.battle_test.tool_render_view import compose
+from backend.core.ouroboros.ui import deck_grammar as deck
+
+
+def _plain(markup: str) -> str:
+    return Text.from_markup(markup).plain
+
+
+def _col(markup: str) -> int:
+    p = _plain(markup)
+    return len(p) - len(p.lstrip())
+
+
+@pytest.fixture(autouse=True)
+def _no_colour(monkeypatch):
+    from backend.core.ouroboros.ui import theme
+    monkeypatch.setattr(theme, "_active_tier_cache", theme.ColorTier.NONE)
+    yield
+
+
+class TestOneHeaderShape:
+    @pytest.mark.parametrize("kind", sorted(_DESCRIPTORS))
+    def test_every_builtin_renders_the_action_shape(self, kind):
+        out = compose(kind, "arg", "result", duration_ms=10)
+        assert _plain(out.header_markup).startswith("⏺ "), kind
+
+    @pytest.mark.parametrize("kind", sorted(_DESCRIPTORS))
+    def test_no_builtin_leaks_its_internal_id(self, kind):
+        """`search_code` and `run_tests` are tool ids. `Search` and `Test`
+        are what the operator is watching happen."""
+        assert get_descriptor(kind).cc_verb
+        assert kind not in _plain(compose(kind, "a", "r").header_markup)
+
+    def test_an_unknown_tool_gets_the_same_shape_and_its_own_name(self):
+        """An MCP-forwarded tool is still a tool call. A distinct layout for
+        it would tell the operator about our descriptor table."""
+        out = compose("mcp_slack_post_message", "#eng", "ok")
+        plain = _plain(out.header_markup)
+        assert plain.startswith("⏺ McpSlackPostMessage(")
+        assert "_default" not in plain
+
+
+class TestOneColumnDiscipline:
+    def test_the_summary_sits_in_the_decks_continuation_column(self):
+        out = compose("read_file", "foo.py", "a\nb\nc")
+        assert _col(out.summary_markup) == 2
+
+    def test_body_lines_sit_in_the_decks_body_column(self):
+        out = compose("bash", "pytest -q", "FAILED a\nFAILED b\n2 failed")
+        assert out.body_lines_markup
+        for line in out.body_lines_markup:
+            assert _col(line) == deck.DETAIL_COLUMN
+
+    def test_a_tool_block_and_a_grammar_block_agree(self):
+        """The two must be indistinguishable in structure — that is the
+        whole point. A reader should not be able to tell which module drew
+        which line."""
+        tool = compose("read_file", "foo.py", "x\ny")
+        assert _col(tool.header_markup) == _col(deck.action("Repair", "L2"))
+        assert _col(tool.summary_markup) == _col(deck.detail("rebuilt"))
+
+    @pytest.mark.parametrize("kind,result", [
+        ("edit_file", "--- a/x.py\n+++ b/x.py\n@@ -1 +1 @@\n-old\n+new"),
+        ("bash", "line one\nline two"),
+        ("search_code", "a.py:1: hit\nb.py:2: hit"),
+    ])
+    def test_every_body_SHAPE_indents(self, kind, result):
+        """Diff, log and match bodies each have their own colour wrapper.
+        Position is owned once, at the seam where they are applied — not
+        four times, once per wrapper."""
+        out = compose(kind, "arg", result)
+        assert out.body_lines_markup
+        assert all(_col(ln) == deck.DETAIL_COLUMN
+                   for ln in out.body_lines_markup)
+
+    def test_the_elision_marker_indents_with_its_body(self):
+        """It described lines at column 5 from column 3."""
+        from backend.core.ouroboros.battle_test.tool_render_store import (
+            BoundedBodyStore,
+        )
+        big = "\n".join(f"line {i}" for i in range(200))
+        out = compose("bash", "cmd", big, store=BoundedBodyStore())
+        markers = [ln for ln in out.body_lines_markup if "elided" in ln]
+        assert markers and _col(markers[0]) == deck.DETAIL_COLUMN
+
+
+class TestTheGlyphIsCanonical:
+    def test_the_continuation_mark_comes_from_the_theme(self):
+        """It was `⏎` (U+23CE) here and `⎿` (U+23BF) everywhere else, while
+        four docstrings claimed otherwise."""
+        from backend.core.ouroboros.ui.theme import mark
+        out = compose("read_file", "foo.py", "x")
+        assert mark("detail") in _plain(out.summary_markup)
+
+    def test_status_failure_is_marked(self):
+        out = compose("bash", "cmd", "boom", status=ToolStatus.ERROR)
+        assert "✗" in _plain(out.header_markup)

--- a/tests/battle_test/test_tool_render_registry_slice1.py
+++ b/tests/battle_test/test_tool_render_registry_slice1.py
@@ -151,7 +151,17 @@ def test_cc_verb_assignments(kind: str, expected_verb: str):
     "delete_file", "type_check", "web_fetch", "web_search", "ask_human",
 ])
 def test_non_cc_tools_use_icon_path(kind: str):
-    assert get_descriptor(kind).cc_verb is None
+    """INVERTED: every built-in now carries a CC verb.
+
+    Fifteen of eighteen descriptors had `cc_verb=None`, so they fell to the
+    icon path and one deck showed `⏺ Read(foo.py)` beside `🔍 search_code
+    "x"` and `💻 bash $ pytest` — three shapes and three naming conventions
+    on one screen. The icon path is now reached only by a tool this registry
+    has never heard of.
+    """
+    assert get_descriptor(kind).cc_verb, (
+        f"{kind} has no CC verb and would fall back to the unknown-tool path"
+    )
 
 
 # ===========================================================================
@@ -193,13 +203,16 @@ def test_path_args_truncate_to_80_chars():
 
 
 def test_bash_args_show_dollar_prefix():
+    """The `$` was a shell cue for `💻 bash $ pytest -x`. Inside `Bash(…)`
+    the verb already says which interpreter this is, and the sigil reads as
+    part of the command — which it is not."""
     desc = get_descriptor("bash")
-    assert desc.summarize_args("pytest -x") == "$ pytest -x"
+    assert desc.summarize_args("pytest -x") == "pytest -x"
 
 
 def test_bash_args_collapse_whitespace():
     desc = get_descriptor("bash")
-    assert desc.summarize_args("  pytest   -x  ") == "$ pytest -x"
+    assert desc.summarize_args("  pytest   -x  ") == "pytest -x"
 
 
 def test_search_args_quoted():
@@ -340,9 +353,10 @@ def test_render_cc_verb_header_format():
 
 
 def test_render_icon_header_format():
+    """One header shape for every tool: `Verb(args)`."""
     desc = get_descriptor("bash")
     out = render(desc, "ls", "x", ToolStatus.SUCCESS)
-    assert out.header_line.startswith("💻 bash $ ls")
+    assert out.header_line == "Bash(ls)"
 
 
 def test_render_default_descriptor_for_unknown():
@@ -350,8 +364,11 @@ def test_render_default_descriptor_for_unknown():
         get_descriptor("mcp_unknown_tool"), "args", "result",
         ToolStatus.SUCCESS,
     )
-    # Default descriptor uses icon path; header begins with the wrench icon.
-    assert out.header_line.startswith("🔧 _default")
+    # An unknown tool is still a tool call. Giving it its own layout would
+    # tell the operator about our descriptor table rather than their work.
+    # (The registry layer cannot name it — `_default` is the descriptor's own
+    # kind; `tool_render_view` substitutes the real name, covered there.)
+    assert out.header_line.startswith("Default(")
 
 
 def test_render_zero_budget_yields_no_body():
@@ -429,7 +446,7 @@ def test_render_invalid_descriptor_falls_back_to_default():
         "not-a-descriptor",  # type: ignore[arg-type]
         "args", "result", ToolStatus.SUCCESS,
     )
-    assert out.header_line.startswith("🔧 _default")
+    assert out.header_line.startswith("Default(")
 
 
 def test_render_handles_none_inputs():

--- a/tests/battle_test/test_tool_render_view_slice4.py
+++ b/tests/battle_test/test_tool_render_view_slice4.py
@@ -149,21 +149,29 @@ def test_compose_icon_header_for_search():
         "search_code", "pattern", "hit1\nhit2",
         explicit_density=_density(),
     )
-    # Icon-prefixed rendered_header, NOT a CC verb.
-    assert "⏺" not in out.header_markup
-    assert "search_code" in out.header_markup
-    assert "🔍" in out.header_markup
+    # INVERTED: one grammar. `⏺ Search("pattern")`, not `🔍 search_code`.
+    assert "⏺" in out.header_markup
+    assert "Search" in out.header_markup
+    assert "🔍" not in out.header_markup
+    assert "search_code" not in out.header_markup
 
 
 def test_compose_default_descriptor_for_unknown_tool():
-    """MCP-forwarded tools land here; default descriptor renders the
-    icon path with the wrench glyph."""
+    """MCP-forwarded tools land here — and get the SAME shape.
+
+    The registry resolves them to the default descriptor, whose own
+    `tool_kind` is the literal string `_default`, so this layer substitutes
+    the name the caller actually asked for. Without it an MCP call rendered
+    as `Default(#eng)`, naming our fallback instead of their tool.
+    """
     out = compose(
         "mcp_unknown", "args", "result",
         explicit_density=_density(),
     )
-    assert "🔧" in out.header_markup
-    assert "_default" in out.header_markup
+    assert "⏺" in out.header_markup
+    assert "McpUnknown" in out.header_markup
+    assert "🔧" not in out.header_markup
+    assert "_default" not in out.header_markup
 
 
 def test_compose_includes_duration_ms():
@@ -499,8 +507,14 @@ def test_console_renders_full_pipeline():
     if out.expansion_hint:
         console.print(out.expansion_hint)
     text = console.export_text()
-    assert "search_code" in text
+    assert "Search" in text
     assert "matches" in text
+    # The deck's column discipline, end to end: the summary indents under
+    # the action and the body indents under the summary.
+    lines = [ln for ln in text.splitlines() if ln.strip()]
+    assert lines[0].startswith("⏺ ")
+    assert lines[1].startswith("  ⎿  ")
+    assert lines[2].startswith("     ")
     assert "elided" in text
     assert "/expand t-" in text
 


### PR DESCRIPTION
The operator saw it before any test did:

```
⏺ Repair(L2 · iteration 1/5)
  ⎿  fixture rebuilt from the live seam     ← deck_grammar
⏺ Update(risk_tier_floor.py)  90ms
⎿  +5 / -2 lines                            ← tool_render_view, FLAT
--- a/backend/core/ouroboros/governance/…    ← body at column 0
🔍 search_code "except Exception"           ← icon path, snake_case
💻 bash $ python3 -m pytest -q
```

Three header shapes, three naming conventions, two column disciplines — on one screen. `deck_grammar` owns the deck's columns (`⏺` at 0, `⎿` at 2, body at 5); `tool_render_view` predates it and emitted its own.

## Verbs are data, not a code path

Fifteen of eighteen descriptors carried `cc_verb=None`, so they fell to an icon path that existed only to serve them. **Filling the table is the whole fix** — `search_code` → `Search`, `bash` → `Bash`, `run_tests` → `Test` — and the icon path is now reached only by a tool this registry has never heard of.

That fallback gets the **same shape** rather than its own. An MCP-forwarded tool is still a tool call, and a distinct layout for it tells the operator about our descriptor table instead of about their work. It also gets its own **name**: the registry resolves unknowns to a default descriptor whose `tool_kind` is the literal string `_default`, so an MCP call rendered as `Default(#eng)`. Only the view layer knows what the caller asked for, so the substitution happens there.

```
before                          after
🔍 search_code "except …"       ⏺ Search("except Exception")
💻 bash $ python3 -m pytest     ⏺ Bash(python3 -m pytest -q)
🧪 run_tests tests/…            ⏺ Test(tests/governance/)
🔧 _default(#eng)               ⏺ McpSlackPostMessage(#eng)
```

The icon stays in the descriptor — useful in a picker or a legend, simply not part of a deck line. `bash` loses its `$` sigil: it was a shell cue for `💻 bash $ …`, and inside `Bash(…)` the verb already says which interpreter this is.

## Position is owned once

The summary composes its lead through `deck_grammar.detail`, and body lines take `DETAIL_COLUMN` at the **one seam** where the four colour wrappers are applied — not four times, once per wrapper. Diff, log, match and code bodies each keep owning *colour*; none has to remember *position*.

```
⏺ Bash(python3 -m pytest -q)  4.1s  ✗
  ⎿  command failed (error)
     FAILED test_scoped_paths
     FAILED test_sandbox_dir
```

A pytest traceback under a failing `Bash(…)` now reads as the result *of* that call rather than as console output that escaped the block.

## Test pins

**23 pins encoded the two-grammar behaviour.** Each was *inverted* to the stronger contract rather than deleted, with the reason recorded — `test_non_cc_tools_use_icon_path` now asserts every built-in **has** a verb; the console-pipeline test asserts the 0/2/5 columns end to end.

46 new tests parametrised over every descriptor and every body shape, including the one that matters most: **a tool block and a `deck_grammar` block must be structurally indistinguishable** — a reader should not be able to tell which module drew which line.

309 green across all five tool-render slices, both demo suites and the deck grammar. Live-verified at 100×40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies the deck to a single grammar and column discipline: all tool headers now render as ⏺ Verb(args) and bodies align to `deck_grammar` columns. Removes mixed icon/snake_case headers and flat bodies, so logs read as results of the call.

- **Refactors**
  - Added `cc_verb` for all built‑in descriptors; header format is `Verb(args)`.
  - Unknown/MCP tools use the same shape with a titlecased name (e.g., `McpSlackPostMessage`) via `_titlecase_kind`; icons stay in descriptors, not deck lines.
  - Removed `$` from Bash args summaries.
  - Centralized indentation: summary uses `deck_grammar.detail`, bodies use `DETAIL_COLUMN`; wrappers keep color only.

- **Bug Fixes**
  - Fixed mixed header shapes/naming and misaligned bodies.
  - Tracebacks/logs now sit under the triggering call, not at column 0.
  - Inverted and added tests to pin the single‑grammar behavior across all body shapes.

<sup>Written for commit 57dd32df5b13c21a6a9dc416e8f419cdbc95b2ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

