### PR TITLE
fix(ov): a command is not a file — argument styling by what the argument IS

### DIFF
--- a/backend/core/ouroboros/battle_test/tool_render_registry.py
+++ b/backend/core/ouroboros/battle_test/tool_render_registry.py
@@ -165,6 +165,14 @@ class ToolRenderDescriptor:
     body_lexer: Optional[str]
     summarize_args: ArgsSummarizer
     summarize_result: ResultSummarizer
+    #: What the ARGUMENT is — "path", "command", "text" or "url".
+    #:
+    #: The header used to style every argument as a file path, because the
+    #: only descriptors reaching that branch WERE file tools. Once every tool
+    #: routed through it, `Bash(python3 -m pytest …)` and `Search("except
+    #: Exception")` rendered blue-underlined like clickable links. A command
+    #: is not a file, and a pattern is not a location.
+    arg_kind: str = "text"
     schema_version: str = TOOL_RENDER_REGISTRY_SCHEMA_VERSION
 
 
@@ -500,6 +508,7 @@ def _make(
     body_lexer: Optional[str],
     args_fn: ArgsSummarizer,
     result_fn: ResultSummarizer,
+    arg_kind: str = "text",
 ) -> ToolRenderDescriptor:
     return ToolRenderDescriptor(
         tool_kind=tool_kind,
@@ -509,6 +518,7 @@ def _make(
         body_lexer=body_lexer,
         summarize_args=_safe_args_summarizer(args_fn),
         summarize_result=_safe_result_summarizer(result_fn),
+        arg_kind=arg_kind,
     )
 
 
@@ -518,21 +528,25 @@ _DESCRIPTORS: Mapping[str, ToolRenderDescriptor] = {
         "read_file", "📄", "Read",
         BodyShape.NONE, None,
         _summarize_path_arg, _summarize_read,
+        arg_kind="path",
     ),
     "list_symbols": _make(
         "list_symbols", "📋", "Symbols",
         BodyShape.MULTI_LINE, "text",
         _summarize_path_arg, _summarize_list_symbols,
+        arg_kind="path",
     ),
     "list_dir": _make(
         "list_dir", "📂", "List",
         BodyShape.MULTI_LINE, "text",
         _summarize_path_arg, _summarize_list_dir,
+        arg_kind="path",
     ),
     "glob_files": _make(
         "glob_files", "📁", "Glob",
         BodyShape.MULTI_LINE, "text",
         _summarize_search_arg, _summarize_glob,
+        arg_kind="path",
     ),
     "search_code": _make(
         "search_code", "🔍", "Search",
@@ -543,38 +557,45 @@ _DESCRIPTORS: Mapping[str, ToolRenderDescriptor] = {
         "get_callers", "🔗", "Callers",
         BodyShape.MULTI_LINE, "text",
         _summarize_default_arg, _summarize_callers,
+        arg_kind="path",
     ),
     # ---- Write-shape (CC-style Update/Write headers) --------------------
     "edit_file": _make(
         "edit_file", "✏️", "Update",
         BodyShape.DIFF, "diff",
         _summarize_path_arg, _summarize_edit,
+        arg_kind="path",
     ),
     "write_file": _make(
         "write_file", "📝", "Write",
         BodyShape.SINGLE_LINE, None,
         _summarize_path_arg, _summarize_write,
+        arg_kind="path",
     ),
     "delete_file": _make(
         "delete_file", "🗑️", "Delete",
         BodyShape.SINGLE_LINE, None,
         _summarize_path_arg, _summarize_delete,
+        arg_kind="path",
     ),
     # ---- Execution-shape (LOG body) -------------------------------------
     "bash": _make(
         "bash", "💻", "Bash",
         BodyShape.LOG, "bash",
         _summarize_bash_arg, _summarize_bash,
+        arg_kind="command",
     ),
     "run_tests": _make(
         "run_tests", "🧪", "Test",
         BodyShape.LOG, "text",
         _summarize_default_arg, _summarize_tests,
+        arg_kind="path",
     ),
     "type_check": _make(
         "type_check", "🔬", "TypeCheck",
         BodyShape.LOG, "text",
         _summarize_default_arg, _summarize_type_check,
+        arg_kind="command",
     ),
     # ---- Git-shape ------------------------------------------------------
     "git_log": _make(
@@ -586,17 +607,20 @@ _DESCRIPTORS: Mapping[str, ToolRenderDescriptor] = {
         "git_diff", "📊", "GitDiff",
         BodyShape.DIFF, "diff",
         _summarize_default_arg, _summarize_git_diff,
+        arg_kind="path",
     ),
     "git_blame": _make(
         "git_blame", "🔎", "GitBlame",
         BodyShape.MULTI_LINE, "text",
         _summarize_path_arg, _summarize_git_blame,
+        arg_kind="path",
     ),
     # ---- Async-native (ToolManifest-only, not in _dispatch) -------------
     "web_fetch": _make(
         "web_fetch", "🌐", "Fetch",
         BodyShape.MULTI_LINE, "text",
         _summarize_default_arg, _summarize_web_fetch,
+        arg_kind="url",
     ),
     "web_search": _make(
         "web_search", "🌐", "WebSearch",

--- a/backend/core/ouroboros/battle_test/tool_render_view.py
+++ b/backend/core/ouroboros/battle_test/tool_render_view.py
@@ -463,6 +463,32 @@ def _escape(text: str) -> str:
 # ===========================================================================
 
 
+def _arg_colour(
+    arg_kind: str, palette: Optional[Mapping[str, str]],
+) -> str:
+    """Style for a tool's ARGUMENT, chosen by what the argument IS.
+
+    Every argument used to take the file style, because the only descriptors
+    reaching this branch were file tools. Once every tool routed through it,
+    `Bash(python3 -m pytest …)` and `Search("except Exception")` came out
+    blue-underlined — the convention this deck uses for a path you can open.
+    A command is not a location, and underlining one invites a click that
+    goes nowhere.
+
+    Falls back to the file style for an unknown kind, matching the behaviour
+    of every descriptor written before `arg_kind` existed.
+    """
+    try:
+        return {
+            "path": _palette_value(palette, "file"),
+            "command": _palette_value(palette, "dim"),
+            "text": _palette_value(palette, "dim"),
+            "url": _palette_value(palette, "file"),
+        }.get(str(arg_kind or ""), _palette_value(palette, "file"))
+    except Exception:  # noqa: BLE001
+        return _palette_value(palette, "file")
+
+
 def _compose_header(
     rendered_header: str,
     descriptor_cc_verb: Optional[str],
@@ -470,6 +496,7 @@ def _compose_header(
     status_enum: ToolStatus,
     palette: Optional[Mapping[str, str]],
     tool_name: str = "",
+    arg_kind: str = "text",
 ) -> str:
     """Build the Rich-markup header line.
 
@@ -500,7 +527,7 @@ def _compose_header(
         # rendered_header looks like "Read(foo.py)" — split into verb
         # + path-in-parens so we can colour each piece independently.
         verb_color = _palette_value(palette, "neural")
-        file_color = _palette_value(palette, "file")
+        arg_color = _arg_colour(arg_kind, palette)
         # Find the parens; if not present (defensive), fall back to dim.
         lparen = rendered_header.find("(")
         rparen = rendered_header.rfind(")")
@@ -509,7 +536,7 @@ def _compose_header(
             inner = rendered_header[lparen + 1 : rparen]
             return (
                 f"[{verb_color}]⏺ {verb}[/{verb_color}]"
-                f"([{file_color}]{_escape(inner)}[/{file_color}])"
+                f"([{arg_color}]{_escape(inner)}[/{arg_color}])"
                 f"{duration_part}{status_part}"
             )
         # Fall-through: emit as a plain neural-coloured header
@@ -523,7 +550,7 @@ def _compose_header(
     # and a distinct layout for it tells the operator about our descriptor
     # table rather than about their work.
     verb_color = _palette_value(palette, "neural")
-    file_color = _palette_value(palette, "file")
+    file_color = _arg_colour(arg_kind, palette)
     lparen = rendered_header.find("(")
     rparen = rendered_header.rfind(")")
     inner = rendered_header[lparen + 1 : rparen] if 0 < lparen < rparen else ""
@@ -753,6 +780,7 @@ def compose(
         # MCP-forwarded call rendered as `Default(#eng)`. This layer has
         # the real name and is the only one that does.
         tool_name=str(tool_name or ""),
+        arg_kind=getattr(descriptor, "arg_kind", "text"),
     )
 
     body_present = bool(rendered.body_lines)

--- a/tests/battle_test/test_deck_grammar_unification.py
+++ b/tests/battle_test/test_deck_grammar_unification.py
@@ -123,3 +123,45 @@ class TestTheGlyphIsCanonical:
     def test_status_failure_is_marked(self):
         out = compose("bash", "cmd", "boom", status=ToolStatus.ERROR)
         assert "✗" in _plain(out.header_markup)
+
+
+class TestArgumentsAreStyledByWhatTheyARE:
+    """A regression introduced by the unification itself.
+
+    Routing every tool through the CC-verb branch also routed every argument
+    through the FILE style, because the only descriptors that had ever
+    reached that branch were file tools. `Bash(python3 -m pytest …)` and
+    `Search("except Exception")` came out blue-underlined — this deck's
+    convention for a path you can open — inviting a click that goes nowhere.
+    """
+
+    def test_a_path_still_looks_like_a_path(self):
+        out = compose("read_file", "governance/risk_tier_floor.py", "x")
+        assert "underline" in out.header_markup
+
+    @pytest.mark.parametrize("kind,arg", [
+        ("bash", "python3 -m pytest -q"),
+        ("search_code", "except Exception"),
+        ("type_check", "mypy backend/"),
+    ])
+    def test_a_command_or_pattern_does_NOT(self, kind, arg):
+        out = compose(kind, arg, "x")
+        assert "underline" not in out.header_markup, (
+            f"{kind} argument styled as a clickable path"
+        )
+
+    def test_every_descriptor_declares_what_its_argument_is(self):
+        """Data, not a code path — the same shape as the verbs."""
+        for kind, desc in _DESCRIPTORS.items():
+            assert desc.arg_kind in ("path", "command", "text", "url"), (
+                f"{kind} has arg_kind={desc.arg_kind!r}"
+            )
+
+    def test_an_unknown_kind_degrades_to_the_old_behaviour(self):
+        """Every descriptor written before `arg_kind` existed behaved as a
+        file tool; an unrecognised value must keep doing that rather than
+        rendering unstyled."""
+        from backend.core.ouroboros.battle_test.tool_render_view import (
+            _arg_colour,
+        )
+        assert _arg_colour("nonsense", None) == _arg_colour("path", None)


### PR DESCRIPTION
A regression the grammar unification introduced, caught in the next screenshot.

Routing every tool through the CC-verb branch also routed every **argument** through the *file* style — because the only descriptors that had ever reached that branch were file tools:

```
⏺ Bash([blue underline]python3 -m pytest … -q[/])
⏺ Search([blue underline]"except Exception"[/])
```

Blue underline is this deck's convention for a path you can open. A command is not a location and a pattern is not a file; underlining them invites a click that goes nowhere.

## Fixed as data, same shape as the verbs

Descriptors declare `arg_kind` — `path` / `command` / `text` / `url` — and the header picks the style from it. 11 paths, 2 commands, 4 texts, 1 url. No code path branches on a tool name.

```
⏺ Read(governance/risk_tier_floor.py)      ← underlined, it IS a path
⏺ Bash(python3 -m pytest … -q)             ← dim, it is a command
⏺ Search("except Exception")               ← dim, it is a pattern
⏺ Fetch(https://x.dev)                     ← underlined, it IS a location
```

An unrecognised kind degrades to the **file** style rather than to none: every descriptor written before this field existed behaved as a file tool, so that is what an unknown value must keep doing.

## Repaired en route

`_make` accepted the new parameter and **silently dropped it** — a `.replace()` targeted a construction reading `summarize_args=args_fn` when the real code reads `summarize_args=_safe_args_summarizer(args_fn)`. Every descriptor reported `text` and the default looked entirely plausible. Asserting the match count catches this at the edit; the symptom does not.

## Verification

328 green across all five tool-render slices, plus 6 new tests: a path still underlines, commands and patterns do not, every descriptor declares a kind, and an unknown kind falls back to the pre-existing behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a regression where all tool arguments were styled as file paths. Arguments are now styled by what they are via a new `arg_kind`, so only paths/URLs are underlined and commands/patterns are dim.

- **Bug Fixes**
  - Added `arg_kind` (`path`/`command`/`text`/`url`) to `ToolRenderDescriptor` and use it in the header via `_arg_colour`; unknown kinds fall back to file style to preserve prior behavior.
  - Wired `arg_kind` through `_make` and `compose`; fixed `_make` dropping the param due to summarizer wrapping.
  - Updated descriptors to declare their argument kind and added tests: paths underline, commands/patterns do not, all descriptors declare a kind, and fallback works.

<sup>Written for commit 3738779fce4c6cd4e124f4e7dd97a7533c34fc85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

