### PR TITLE
feat(ov): CC's grammar, O+V's serpent — the snake runs the hairlines

### DIFF
--- a/backend/core/ouroboros/battle_test/attach_heartbeat.py
+++ b/backend/core/ouroboros/battle_test/attach_heartbeat.py
@@ -110,6 +110,57 @@ _PHASE_VERBS = {
 }
 
 
+def flavour_rotate_s() -> float:
+    """How long a flavour verb holds before the next one.
+
+    Slow enough to read, fast enough to feel alive. CC changes its word on a
+    similar cadence for the same reason: the glyph cannot carry motion on its
+    own once it is an emoji.
+    """
+    try:
+        return max(1.0, min(60.0, float(os.environ.get(
+            "JARVIS_ATTACH_VERB_ROTATE_S", "") or 4.0)))
+    except (TypeError, ValueError):
+        return 4.0
+
+
+def _flavour_verb(op_id: str, now: Optional[float] = None) -> str:
+    """A verb for work with no phase to name — O+V's own register.
+
+    WHY NOT A SECOND WORD LIST
+    ---------------------------
+    `turn_spinner.turn_verbs()` already is one: `Coiling`, `Digesting`,
+    `Unwinding`, `Sensing`, `Reckoning` — the organism's voice, extendable by
+    the operator through `JARVIS_TURN_VERBS` without touching a renderer.
+    Writing a second table here would be two vocabularies drifting apart, and
+    the operator's extras would only reach one of them.
+
+    PHASE TRUTH OUTRANKS FLAVOUR
+    -----------------------------
+    This is the FALLBACK. When the pipeline knows it is in GENERATE, the line
+    says `Synthesizing` because that is what is happening — CC picks a whimsical
+    gerund because it has nothing more specific to say, and trading a true
+    label for a charming one would be a downgrade. Flavour fills the silence;
+    it does not replace the signal.
+
+    Stable within a rotation window and seeded by the op, so two ops working
+    at once do not chant the same word and one op does not flicker between
+    words on consecutive repaints.
+    """
+    try:
+        import time as _time
+        from backend.core.ouroboros.battle_test.turn_spinner import turn_verbs
+        verbs = turn_verbs()
+        if not verbs:
+            return ""
+        t = _time.monotonic() if now is None else float(now)
+        bucket = int(t / flavour_rotate_s())
+        seed = sum(ord(c) for c in str(op_id or "")) + bucket
+        return verbs[seed % len(verbs)]
+    except Exception:  # noqa: BLE001
+        return ""
+
+
 def heartbeat_interval_s() -> float:
     """Publisher cadence; ``0`` disables. Re-read at call time."""
     try:
@@ -175,7 +226,7 @@ def build_heartbeat_payload() -> Optional[Dict[str, Any]]:
             except Exception:  # noqa: BLE001
                 pass
 
-        phase_verb = _PHASE_VERBS.get(phase, "")
+        phase_verb = _PHASE_VERBS.get(phase, "") or _flavour_verb(op_id)
         active = bool(thinking_active or phase_verb)
         if not verb or not thinking_active:
             verb = phase_verb or verb

--- a/backend/core/ouroboros/battle_test/bipartite_layout.py
+++ b/backend/core/ouroboros/battle_test/bipartite_layout.py
@@ -727,6 +727,7 @@ def build_bipartite_application(
     agent_rows: Optional[Callable[[], Any]] = None,
     search_rows: Optional[Callable[[], Any]] = None,
     status_rows: Optional[Callable[[], Any]] = None,
+    serpent_active: Optional[Callable[[], bool]] = None,
 ) -> Any:
     """Construct the full-screen ``prompt_toolkit.Application``: Zone 1 an ANSI
     window fed from ``mux.render_canvas_ansi()`` (re-rendered each frame, so
@@ -970,9 +971,53 @@ def build_bipartite_application(
             height=header_height, wrap_lines=False,
         ))
     # The CC input framing: a dim hairline above AND below the ❯ row.
-    def _rule() -> Any:
-        # Bright venom-purple hairlines (Style Guide brand) — visible framing.
-        return Window(height=1, char="─", style="fg:#a371f7")
+    def _rule(row: int = 0) -> Any:
+        """A venom-purple hairline — with the serpent running it while the
+        organism works.
+
+        The boot crest already tells this story: a snake travelling a closed
+        path after a `+`, catching it, going round again. Two hairlines ARE a
+        closed path (left→right along the top, right→left along the bottom),
+        so the same creature lives here on the same laws — `serpent_rule`
+        takes the crest's own prey palette.
+
+        Falls back to the plain `char="─"` Window when no activity source was
+        supplied: a border that moves forever is a distraction that teaches
+        the operator to stop seeing the border, and framing the caret is the
+        one thing this line has to do.
+        """
+        if serpent_active is None:
+            return Window(height=1, char="─", style="fg:#a371f7")
+        try:
+            from prompt_toolkit.layout.controls import FormattedTextControl
+
+            def _fragments(_row: int = row) -> Any:
+                try:
+                    import time as _t
+                    from backend.core.ouroboros.ui.serpent_rule import (
+                        rule_fragments,
+                    )
+                    width = 80
+                    app = _APP_REF.get("app")
+                    if app is not None and app.output is not None:
+                        width = max(1, int(app.output.get_size().columns))
+                    try:
+                        live = bool(serpent_active())
+                    except Exception:  # noqa: BLE001
+                        live = False
+                    return rule_fragments(
+                        _row, width, _t.monotonic(), active=live,
+                    )
+                except Exception:  # noqa: BLE001
+                    return [("fg:#a371f7", "─" * 80)]
+
+            return Window(
+                content=FormattedTextControl(_fragments, focusable=False),
+                height=1, wrap_lines=False,
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug("[Bipartite] serpent rule unavailable", exc_info=True)
+            return Window(height=1, char="─", style="fg:#a371f7")
 
     # The palette sits ABOVE the input, full width, and pushes the prompt down
     # as it opens — the same relationship Claude Code has. A Float would
@@ -1075,9 +1120,9 @@ def build_bipartite_application(
     # newest event lands against the prompt, and a row wedged underneath meant
     # the LAST thing before the input was a status bar the deck did not own.
     if _toolbar_row is not None and toolbar_above_prompt():
-        rows += [_toolbar_row, _rule(), prompt, _rule()]
+        rows += [_toolbar_row, _rule(0), prompt, _rule(1)]
     else:
-        rows += [_rule(), prompt, _rule()]
+        rows += [_rule(0), prompt, _rule(1)]
         if _toolbar_row is not None:
             rows.append(_toolbar_row)
     # The standing state, under the box the operator types into.
@@ -1296,6 +1341,7 @@ async def run_bipartite_repl(
     agent_rows: Optional[Callable[[], Any]] = None,
     search_rows: Optional[Callable[[], Any]] = None,
     status_rows: Optional[Callable[[], Any]] = None,
+    serpent_active: Optional[Callable[[], bool]] = None,
 ) -> None:
     """Launch the full-screen Bipartite REPL: build the multiplexer, register it as
     the live Zone-1 sink (so any producer — the daemon's event router OR the
@@ -1326,6 +1372,7 @@ async def run_bipartite_repl(
             completer=completer, history=history, auto_suggest=auto_suggest,
             turn_spinner=turn_spinner, agent_rows=agent_rows,
             search_rows=search_rows, status_rows=status_rows,
+            serpent_active=serpent_active,
         )
         if watch_alive is not None:
             watcher = asyncio.ensure_future(

--- a/backend/core/ouroboros/cli/ov_demo.py
+++ b/backend/core/ouroboros/cli/ov_demo.py
@@ -755,6 +755,14 @@ def _live_toolbar(
     return _render
 
 
+def _demo_generating(elapsed: float) -> bool:
+    """Is the scripted organism thinking right now? NEVER raises."""
+    try:
+        return any(lo <= elapsed <= hi for lo, hi in _GENERATING)
+    except Exception:  # noqa: BLE001
+        return False
+
+
 def _generating_seconds(elapsed: float) -> float:
     """Seconds spent INSIDE a generating window, up to ``elapsed``.
 
@@ -909,6 +917,13 @@ def scene_live(console: Any, argv: Sequence[str] = ()) -> int:
         # scene exists to make visible. Reused rather than reimplemented, so
         # the demo and the daemon cockpit render it identically.
         agent_rows=_agent_view_rows(),
+        # The serpent runs the hairlines while the organism is THINKING —
+        # gated on the same `_GENERATING` windows the pulse uses, so the
+        # border and the verb agree about whether work is happening. A
+        # border that moves forever teaches the operator to stop seeing it.
+        serpent_active=lambda: _demo_generating(
+            (clock() - start[0]) * speed
+        ),
     )
     try:
         mux.set_invalidate(app.invalidate)

--- a/backend/core/ouroboros/ui/serpent_rule.py
+++ b/backend/core/ouroboros/ui/serpent_rule.py
@@ -1,0 +1,349 @@
+"""The serpent runs the prompt's hairlines, chasing the prey.
+
+The boot crest already tells this story: a snake travelling a closed path
+after a `+`, catching it, and going round again. `crest_animator` owns the
+laws — `_prey_plus_hit` for the prey's shape, `_prey_rgb` for its pale-core
+-to-venom-purple gradient — and renders them into a raster.
+
+This is the same story on a different geometry. The cockpit frames its input
+with two hairlines rather than a box, and two hairlines are a closed path:
+left→right along the top, right→left along the bottom, and round. A cycle of
+``2 × width`` cells, which is all a chase needs.
+
+Clock-stateless, like `ouroboros_frame`
+----------------------------------------
+Every frame is a pure function of ``(t, width)``. No tick task, no state, no
+coordination: any number of readers at any instant derive the same frame, and
+a dropped repaint costs one frame rather than desynchronising an animation
+from its own clock. That property is why the spinner could be consumed by
+three surfaces without any of them owning it, and it is worth more here —
+this one is redrawn on every keystroke.
+
+Resize is free for the same reason. The path length is derived from the width
+handed in at render time, so a SIGWINCH mid-chase simply produces a frame for
+the new geometry; there is no cached path to invalidate.
+
+Decoration that knows it is decoration
+---------------------------------------
+It animates only while the organism is WORKING. A border that moves forever
+is a distraction that teaches the operator to stop seeing the border, and the
+one thing this line has to do is frame the place they type. Idle renders the
+plain hairline, byte-identical to what shipped before this existed.
+
+NEVER raises. A chase that cannot be computed renders as the hairline it
+decorates.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, List, Optional, Tuple
+
+logger = logging.getLogger("Ouroboros.SerpentRule")
+
+SERPENT_RULE_SCHEMA_VERSION = "serpent_rule.v1"
+
+MASTER_FLAG_ENV_VAR = "JARVIS_SERPENT_RULE_ENABLED"
+SPEED_ENV_VAR = "JARVIS_SERPENT_RULE_SPEED"
+CHASE_ENV_VAR = "JARVIS_SERPENT_RULE_CHASE_S"
+BODY_ENV_VAR = "JARVIS_SERPENT_RULE_BODY"
+
+#: Rows of the path. 0 = the rule above the caret, 1 = the rule below it.
+TOP, BOTTOM = 0, 1
+
+#: Narrower than this and the path is too short to read as motion — the
+#: serpent would appear to teleport rather than travel.
+_MIN_WIDTH = 12
+
+
+def serpent_enabled() -> bool:
+    """Default ON. Off renders the plain hairline. NEVER raises."""
+    return os.environ.get(
+        MASTER_FLAG_ENV_VAR, "1",
+    ).strip().lower() not in ("0", "false", "no", "off")
+
+
+def _env_float(name: str, default: float, lo: float, hi: float) -> float:
+    try:
+        return max(lo, min(hi, float(os.environ.get(name, "") or default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def speed_cells_s() -> float:
+    """Cells per second.
+
+    Constant SPEED rather than constant laps: a lap is a different distance
+    on an 80-column terminal and a 200-column one, and an operator reads
+    motion at a rate, not as a fraction of a screen they are not measuring.
+    """
+    return _env_float(SPEED_ENV_VAR, 18.0, 1.0, 120.0)
+
+
+def chase_period_s() -> float:
+    """Seconds from a fresh prey to the bite.
+
+    The gap closes across this window, so the whole arc — pursuit, closing,
+    catch — plays out at a pace a glance can follow.
+    """
+    return _env_float(CHASE_ENV_VAR, 6.0, 0.5, 120.0)
+
+
+def body_length() -> int:
+    """Cells of serpent behind the head, fading."""
+    try:
+        return max(1, min(24, int(os.environ.get(BODY_ENV_VAR, "") or 5)))
+    except (TypeError, ValueError):
+        return 5
+
+
+# ---------------------------------------------------------------------------
+# The path
+# ---------------------------------------------------------------------------
+
+
+def path_length(width: int) -> int:
+    """Cells in one full circuit of the two hairlines."""
+    try:
+        return max(0, 2 * int(width))
+    except (TypeError, ValueError):
+        return 0
+
+
+def cell_at(index: int, width: int) -> Tuple[int, int]:
+    """``(row, x)`` for a position along the circuit.
+
+    The top runs left→right and the bottom runs right→left, so the path is a
+    closed loop rather than two strips scanned the same way — a serpent that
+    reappeared at the left edge each time would read as two animations, not
+    one creature going round.
+    """
+    try:
+        w = max(1, int(width))
+        i = int(index) % (2 * w)
+        if i < w:
+            return TOP, i
+        return BOTTOM, (2 * w - 1 - i)
+    except (TypeError, ValueError):
+        return TOP, 0
+
+
+@dataclass(frozen=True)
+class ChaseFrame:
+    """One instant of the chase, as positions along the circuit."""
+
+    head: int
+    body: Tuple[int, ...]
+    prey: int
+    biting: bool
+    width: int
+
+    @property
+    def length(self) -> int:
+        return path_length(self.width)
+
+
+def frame(t: float, width: int) -> Optional[ChaseFrame]:
+    """The chase at time ``t``, or None when it cannot be drawn.
+
+    None rather than a degenerate frame: a terminal too narrow to show
+    travel should render its hairline plainly, not a serpent that jumps a
+    third of the screen per repaint.
+
+    The gap closes linearly across :func:`chase_period_s` and reaches zero at
+    the bite, then the prey is ahead again — the ouroboros arc the crest
+    tells, in one dimension.
+    """
+    try:
+        w = int(width)
+        if w < _MIN_WIDTH or not serpent_enabled():
+            return None
+        length = path_length(w)
+        if length <= 0:
+            return None
+
+        head = int(float(t) * speed_cells_s()) % length
+        trail = min(body_length(), max(1, length // 4))
+        body = tuple((head - n) % length for n in range(1, trail + 1))
+
+        period = chase_period_s()
+        progress = (float(t) % period) / period
+        # The prey starts a comfortable lead ahead and is reeled in. Capped
+        # at a third of the circuit so it stays on screen with its pursuer on
+        # a narrow terminal, where a full-lap lead would put them adjacent.
+        max_gap = max(2, min(length // 3, int(length * 0.4)))
+        gap = int(round(max_gap * (1.0 - progress)))
+        return ChaseFrame(
+            head=head,
+            body=body,
+            prey=(head + gap) % length,
+            biting=gap <= 0,
+            width=w,
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug("[SerpentRule] frame degraded", exc_info=True)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Rendering — prompt_toolkit fragments for one row
+# ---------------------------------------------------------------------------
+
+
+def _hex(rgb: Any) -> str:
+    """``(r, g, b)`` → ``#rrggbb``. Accepts any 3-sequence. NEVER raises."""
+    try:
+        r, g, b = (max(0, min(255, int(c))) for c in tuple(rgb)[:3])
+        return f"#{r:02x}{g:02x}{b:02x}"
+    except Exception:  # noqa: BLE001
+        return "#a371f7"
+
+
+def _palette() -> Tuple[str, str, Tuple[int, int, int], Tuple[int, int, int]]:
+    """``(rule, serpent, prey_core, prey_edge)`` from the ONE brand source.
+
+    The prey's colours are the crest's own — pale eye-colour core fading to
+    the V's venom purple — so the creature on the hairline and the creature
+    on the boot screen are visibly the same animal. Falls back to the Style
+    Guide hexes if the crest cannot be imported, which keeps this module
+    usable in a headless test without dragging in the rasteriser.
+    """
+    try:
+        from backend.core.ouroboros.ui.theme import PALETTE
+        rule = PALETTE.get("venom_purple", "#a371f7")
+        serpent = PALETTE.get("venom_green", "#5EE06A")
+    except Exception:  # noqa: BLE001
+        rule, serpent = "#a371f7", "#5EE06A"
+    try:
+        from backend.core.ouroboros.ui.crest import _EYE_RGB, _V_TOP_RGB
+        return rule, serpent, _EYE_RGB, _V_TOP_RGB
+    except Exception:  # noqa: BLE001
+        return rule, serpent, (234, 255, 208), (192, 132, 252)
+
+
+def _glyphs(unicode_ok: Optional[bool] = None) -> Tuple[str, str, str, str]:
+    """``(rule, head, body, prey)``.
+
+    Every mark is ONE cell. The identity emoji is deliberately absent: `🐍`
+    is double-width on most terminals and single on some, so a hairline
+    carrying it would be the wrong length on half the machines that draw it —
+    and the length of this line is the frame around the operator's caret.
+    """
+    try:
+        from backend.core.ouroboros.ui.theme import supports_unicode
+        ok = supports_unicode() if unicode_ok is None else bool(unicode_ok)
+    except Exception:  # noqa: BLE001
+        ok = bool(unicode_ok)
+    if ok:
+        return "─", "◉", "●", "+"
+    return "-", "O", "o", "+"
+
+
+def rule_fragments(
+    row: int,
+    width: int,
+    t: float,
+    *,
+    active: bool = True,
+    unicode_ok: Optional[bool] = None,
+) -> List[Tuple[str, str]]:
+    """prompt_toolkit fragments for ONE hairline. NEVER raises.
+
+    Idle (``active=False``) returns the plain rule — byte-identical to the
+    line that shipped before this module existed, so the feature costs
+    nothing when the organism is doing nothing.
+    """
+    # Resolved INSIDE the guard, and the width parsed exactly once.
+    #
+    # Both were outside it, and both were "NEVER raises" violations the
+    # tests caught: a theme that could not be imported propagated out of a
+    # repaint, and the except clause re-ran `int(width)` on the very value
+    # that had just failed to parse — so a bad width raised FROM the
+    # handler meant to absorb it.
+    rule_c, g_rule, cells = "#a371f7", "─", 0
+    try:
+        rule_c, serpent_c, prey_core, prey_edge = _palette()
+        g_rule, g_head, g_body, g_prey = _glyphs(unicode_ok)
+        w = max(0, int(width))
+        cells = w
+        if w <= 0:
+            return []
+        plain = [(f"fg:{rule_c}", g_rule * w)]
+        if not active:
+            return plain
+        f = frame(t, w)
+        if f is None:
+            return plain
+
+        # cell → (glyph, style). Built for THIS row only; the other row's
+        # cells are simply absent, so one pass over the body serves both.
+        marks = {}
+        for n, pos in enumerate(reversed(f.body)):
+            r, x = cell_at(pos, w)
+            if r == row:
+                # Older segments dim toward the rule they are crossing.
+                fade = 0.35 + 0.5 * (n / max(1, len(f.body)))
+                marks[x] = (g_body, f"fg:{_scale(serpent_c, fade)}")
+        r, x = cell_at(f.head, w)
+        if r == row:
+            marks[x] = (g_head, f"fg:{serpent_c} bold")
+        r, x = cell_at(f.prey, w)
+        if r == row:
+            # The bite flashes the prey to its core colour — the one moment
+            # the crest's story resolves, and the only place this line is
+            # allowed to be the brightest thing on screen.
+            rgb = prey_core if f.biting else prey_edge
+            marks[x] = (g_prey, f"fg:{_hex(rgb)}" + (" bold" if f.biting else ""))
+
+        if not marks:
+            return plain
+        out: List[Tuple[str, str]] = []
+        run: List[str] = []
+        for x in range(w):
+            if x in marks:
+                if run:
+                    out.append((f"fg:{rule_c}", "".join(run)))
+                    run = []
+                glyph, style = marks[x]
+                out.append((style, glyph))
+            else:
+                run.append(g_rule)
+        if run:
+            out.append((f"fg:{rule_c}", "".join(run)))
+        return out
+    except Exception:  # noqa: BLE001
+        logger.debug("[SerpentRule] render degraded", exc_info=True)
+        # `cells` is whatever was successfully parsed before the failure —
+        # never re-derived from the argument that caused it.
+        return [(f"fg:{rule_c}", g_rule * cells)] if cells else []
+
+
+def _scale(hex_colour: str, factor: float) -> str:
+    """Dim a hex colour toward black. NEVER raises."""
+    try:
+        h = hex_colour.lstrip("#")
+        rgb = tuple(int(h[i:i + 2], 16) for i in (0, 2, 4))
+        return _hex(tuple(int(c * max(0.0, min(1.0, factor))) for c in rgb))
+    except Exception:  # noqa: BLE001
+        return hex_colour
+
+
+__all__ = [
+    "BODY_ENV_VAR",
+    "BOTTOM",
+    "CHASE_ENV_VAR",
+    "ChaseFrame",
+    "MASTER_FLAG_ENV_VAR",
+    "SERPENT_RULE_SCHEMA_VERSION",
+    "SPEED_ENV_VAR",
+    "TOP",
+    "body_length",
+    "cell_at",
+    "chase_period_s",
+    "frame",
+    "path_length",
+    "rule_fragments",
+    "serpent_enabled",
+    "speed_cells_s",
+]

--- a/backend/core/ouroboros/ui/theme.py
+++ b/backend/core/ouroboros/ui/theme.py
@@ -286,24 +286,26 @@ def mark(name: str, *, unicode: Optional[bool] = None) -> str:
 # number of readers agree with zero coordination and zero tick tasks.
 
 OUROBOROS_SPINNER_INTERVAL_S: float = 0.10
-OUROBOROS_SPINNER_FRAMES: tuple = (
-    "🐍·····○",
-    "🐍····○",
-    "🐍···○",
-    "🐍··○",
-    "🐍·○",
-    "🐍◯",       # bite — eating own tail
-    "🐍·○",       # cycle resumes
-    "🐍··○",
-    "🐍···○",
-    "🐍····○",
-    "🐍·····○",
-)
+#: The organism's glyph, in Claude Code's SLOT.
+#:
+#: CC's working line is `✽ Synthesizing…` — one cell of glyph, then a verb.
+#: This used to be `🐍·····○` closing to `🐍◯`: the snake eating its own tail,
+#: eight cells wide, animating the tail rather than the word.
+#:
+#: The operator's rule is CC's grammar with O+V's content, and here that
+#: resolves cleanly — the SHAPE is CC's one-glyph slot, the GLYPH is ours.
+#: An emoji cannot morph the way `✻✽✳✶` does, so the motion moved to where CC
+#: also puts it: the elapsed seconds, and a verb that changes as the organism
+#: works. A spinner that animates a decoration while the words stand still is
+#: telling the operator about a timer, not about the work.
+#:
+#: Kept as a tuple with a single entry rather than collapsing to a constant,
+#: so `ouroboros_frame()` keeps its signature and every consumer — the daemon
+#: toolbar, the attach pulse, the demo — inherits this with no edit. A second
+#: glyph could be added here and animate again with no change to a renderer.
+OUROBOROS_SPINNER_FRAMES: tuple = ("🐍",)
 #: ASCII degradation (same geometry, same story) for non-unicode terminals.
-_OUROBOROS_ASCII_FRAMES: tuple = (
-    "s.....o", "s....o", "s...o", "s..o", "s.o", "sO",
-    "s.o", "s..o", "s...o", "s....o", "s.....o",
-)
+_OUROBOROS_ASCII_FRAMES: tuple = ("~",)
 
 
 def ouroboros_frame(

--- a/tests/ui/test_serpent_rule.py
+++ b/tests/ui/test_serpent_rule.py
@@ -1,0 +1,168 @@
+"""The serpent runs the hairlines, chasing the prey.
+
+The boot crest already tells this story on a raster. Two hairlines are also a
+closed path — left→right along the top, right→left along the bottom — so the
+same creature lives here on the same laws.
+
+These tests pin the properties that make it safe to redraw on every
+keystroke: it is a pure function of (t, width), it costs nothing when idle,
+and it degrades to the hairline it decorates rather than raising into a
+repaint.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.ui import serpent_rule as sr
+
+
+def _text(row, width, t, **kw):
+    return "".join(txt for _s, txt in sr.rule_fragments(row, width, t, **kw))
+
+
+class TestThePathIsAClosedLoop:
+    def test_the_top_runs_left_to_right(self):
+        assert sr.cell_at(0, 64) == (sr.TOP, 0)
+        assert sr.cell_at(63, 64) == (sr.TOP, 63)
+
+    def test_the_bottom_runs_RIGHT_TO_LEFT(self):
+        """A serpent that reappeared at the left edge each time would read as
+        two animations, not one creature going round."""
+        assert sr.cell_at(64, 64) == (sr.BOTTOM, 63)
+        assert sr.cell_at(127, 64) == (sr.BOTTOM, 0)
+
+    def test_it_wraps(self):
+        assert sr.cell_at(128, 64) == sr.cell_at(0, 64)
+        assert sr.cell_at(-1, 64) == sr.cell_at(127, 64)
+
+    def test_the_circuit_is_both_rules(self):
+        assert sr.path_length(64) == 128
+
+    def test_every_cell_is_reachable_exactly_once(self):
+        seen = [sr.cell_at(i, 40) for i in range(sr.path_length(40))]
+        assert len(set(seen)) == len(seen) == 80
+
+
+class TestTheChase:
+    def test_the_gap_closes_to_a_bite(self):
+        """The ouroboros arc the crest tells, in one dimension."""
+        period = sr.chase_period_s()
+        gaps = []
+        for frac in (0.0, 0.25, 0.5, 0.75, 0.98):
+            f = sr.frame(frac * period, 64)
+            gaps.append((f.prey - f.head) % f.length)
+        assert gaps == sorted(gaps, reverse=True), gaps
+        assert sr.frame(period * 0.999, 64).biting
+
+    def test_the_prey_stays_on_screen_with_its_pursuer(self):
+        """A full-lap lead on a narrow terminal would put them adjacent —
+        indistinguishable from a bite that never happened."""
+        for width in (12, 24, 80, 200):
+            f = sr.frame(0.0, width)
+            gap = (f.prey - f.head) % f.length
+            assert gap <= f.length // 3 + 1, (width, gap)
+
+    def test_the_body_trails_BEHIND_the_head(self):
+        f = sr.frame(1.0, 64)
+        assert f.body[0] == (f.head - 1) % f.length
+        assert len(set(f.body)) == len(f.body)
+
+    def test_the_head_advances_with_time(self):
+        a, b = sr.frame(0.0, 64), sr.frame(1.0, 64)
+        assert a.head != b.head
+
+
+class TestItIsAPureFunctionOfTimeAndWidth:
+    def test_two_readers_at_one_instant_agree(self):
+        """Why the spinner could be consumed by three surfaces with none of
+        them owning it — and it matters more here, redrawn per keystroke."""
+        assert sr.frame(3.7, 64) == sr.frame(3.7, 64)
+        assert _text(sr.TOP, 64, 3.7) == _text(sr.TOP, 64, 3.7)
+
+    def test_resize_needs_no_invalidation(self):
+        """The path length is derived at render time, so a SIGWINCH
+        mid-chase simply produces a frame for the new geometry."""
+        assert sr.frame(2.0, 40).width == 40
+        assert sr.frame(2.0, 200).width == 200
+        assert len(_text(sr.TOP, 40, 2.0)) == 40
+        assert len(_text(sr.TOP, 200, 2.0)) == 200
+
+    def test_no_state_leaks_between_calls(self):
+        first = _text(sr.TOP, 64, 1.0)
+        _ = [_text(sr.BOTTOM, 99, t) for t in range(20)]
+        assert _text(sr.TOP, 64, 1.0) == first
+
+
+class TestItKnowsItIsDecoration:
+    def test_idle_renders_the_PLAIN_hairline(self):
+        """A border that moves forever teaches the operator to stop seeing
+        the border, and framing the caret is the one thing it has to do."""
+        plain = _text(sr.TOP, 64, 3.0, active=False)
+        assert plain == "─" * 64
+
+    def test_idle_costs_exactly_one_fragment(self):
+        assert len(sr.rule_fragments(sr.TOP, 64, 3.0, active=False)) == 1
+
+    def test_a_narrow_terminal_does_not_animate(self):
+        """Too short to read as motion — the serpent would appear to
+        teleport rather than travel."""
+        assert sr.frame(1.0, 8) is None
+        assert _text(sr.TOP, 8, 1.0) == "─" * 8
+
+    def test_the_master_flag_silences_it(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_SERPENT_RULE_ENABLED", "0")
+        assert sr.frame(1.0, 64) is None
+        assert _text(sr.TOP, 64, 1.0) == "─" * 64
+
+
+class TestTheLineKeepsItsLength:
+    @pytest.mark.parametrize("width", [12, 13, 40, 79, 80, 81, 200])
+    @pytest.mark.parametrize("t", [0.0, 1.3, 5.9, 60.0])
+    def test_the_rule_is_always_exactly_width(self, width, t):
+        """The length of this line is the frame around the operator's caret.
+        Every mark is one cell for exactly this reason — the identity emoji
+        is double-width on most terminals and single on some."""
+        for row in (sr.TOP, sr.BOTTOM):
+            assert len(_text(row, width, t)) == width
+
+    def test_no_multi_cell_glyphs(self):
+        rule, head, body, prey = sr._glyphs(unicode_ok=True)
+        for g in (rule, head, body, prey):
+            assert len(g) == 1
+
+
+class TestDegradation:
+    def test_ascii_keeps_the_geometry(self):
+        assert len(_text(sr.TOP, 64, 1.0, unicode_ok=False)) == 64
+        assert "─" not in _text(sr.TOP, 64, 1.0, unicode_ok=False)
+
+    @pytest.mark.parametrize("bad", [None, -5, "wide", 0])
+    def test_junk_width_never_raises(self, bad):
+        assert isinstance(sr.rule_fragments(sr.TOP, bad, 1.0), list)
+        assert sr.frame(1.0, bad) is None
+
+    def test_junk_time_never_raises(self):
+        for t in (None, "now", float("nan")):
+            assert isinstance(sr.rule_fragments(sr.TOP, 64, t), list)
+
+    def test_a_dead_palette_still_draws_the_rule(self, monkeypatch):
+        monkeypatch.setattr(sr, "_palette", lambda: (_ for _ in ()).throw(
+            RuntimeError("theme down")))
+        assert isinstance(sr.rule_fragments(sr.TOP, 64, 1.0), list)
+
+
+class TestItSharesTheCrestsPalette:
+    def test_the_prey_wears_the_crests_colours(self):
+        """The creature on the hairline and the creature on the boot screen
+        must be visibly the same animal."""
+        from backend.core.ouroboros.ui.crest import _EYE_RGB, _V_TOP_RGB
+        _rule, _serpent, core, edge = sr._palette()
+        assert core == _EYE_RGB and edge == _V_TOP_RGB
+
+    def test_the_bite_flashes_the_prey_to_its_CORE(self):
+        period = sr.chase_period_s()
+        biting = sr.frame(period * 0.999, 64)
+        assert biting.biting
+        row, _x = sr.cell_at(biting.prey, 64)
+        styles = [st for st, _t in sr.rule_fragments(row, 64, period * 0.999)]
+        assert any("bold" in st for st in styles)


### PR DESCRIPTION
Operator rule: **Claude Code's grammar, O+V's content.** Three pieces of that, all in the same register.

## The glyph goes in CC's slot

CC's working line is `✽ Synthesizing…` — one cell of glyph, then a verb. Ours was `🐍·····○` closing to `🐍◯`: eight cells wide, animating the *tail* rather than the word.

```
before   🐍··○ Watching… (74m 18s · ↓ 3477.4k tokens)
after    🐍 Synthesizing… (5s · ↓ 613 tokens · DEMO)
```

An emoji can't morph the way `✻✽✳✶` does, so the motion moved to where CC also puts it — the elapsed seconds and a verb that changes as work proceeds. `OUROBOROS_SPINNER_FRAMES` stays a tuple (one entry) and `ouroboros_frame()` keeps its signature, so all three consumers inherit this with no edit, and a second glyph could animate again without touching a renderer.

## The vocabulary was already written

`turn_spinner.TURN_VERBS` is O+V's own register — *Coiling, Digesting, Unwinding, Sensing, Reckoning* — extendable via `JARVIS_TURN_VERBS` without touching a renderer. It had never been wired to the heartbeat, which carried its own `_PHASE_VERBS` table. A second word list would have been two vocabularies drifting apart, with the operator's extras reaching only one.

**Phase truth outranks flavour.** When the pipeline knows it's in GENERATE the line says `Synthesizing`, because that is what is happening. CC picks a whimsical gerund because it has nothing more specific to say — flavour fills the silence, it doesn't replace the signal. Stable within a rotation window and seeded by the op, so two ops don't chant the same word and one op doesn't flicker between words on consecutive repaints.

## The serpent runs the hairlines

The boot crest already tells this story: a snake travelling a closed path after a `+`, catching it, going round again. **Two hairlines are a closed path** — left→right along the top, right→left along the bottom — so the same creature lives there on the same laws. `serpent_rule` takes the crest's own prey palette (`_EYE_RGB` core → `_V_TOP_RGB` venom purple), so the animal on the border and the animal on the boot screen are visibly the same one.

```
🐍 Synthesizing… (5s · ↓ 613 tokens · DEMO) — q to quit
───────────────────────────────────────────────────────
❯
─────────────────────────────+─◉●●●●●──────────────────
```

**Clock-stateless**, like `ouroboros_frame`: every frame is a pure function of `(t, width)`. No tick task, no state — a dropped repaint costs one frame rather than desynchronising the animation from its own clock, which matters more here because this redraws on every keystroke. Resize is free: the path length is derived at render time, so a SIGWINCH mid-chase just produces a frame for the new geometry.

**Decoration that knows it is decoration.** It animates only while the organism is *working*, gated on the same windows the pulse uses. Idle renders the plain hairline, byte-identical to what shipped before. A border that moves forever teaches the operator to stop seeing the border, and framing the caret is the one thing this line has to do.

Every mark is **one cell** — the identity emoji is deliberately absent from the rule, because `🐍` is double-width on most terminals and single on some, and the length of this line is the frame around the caret.

## Verification

54 tests — the closed loop, the chase closing to a bite, purity under repeated calls, resize without invalidation, exact width at every terminal size, ASCII degradation, and the master flag.

**Two of them found real "NEVER raises" violations in the first draft:** a palette resolved outside the guard propagated a dead theme out of a repaint, and the `except` clause re-parsed the very width that had just failed to parse — so a bad width raised *from* the handler meant to absorb it.

Live-verified in an 88×30 pty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a snake animation that runs along the prompt hairlines and only animates while work is in progress. Also switches the working-line spinner to a single `🐍` glyph with phase-aware verbs and a flavor-verb fallback.

- **New Features**
  - New `serpent_rule` renderer: clock-stateless, resize-safe, and degrades to a plain hairline when idle or disabled; uses crest prey palette so the border matches the boot crest. Controlled by `JARVIS_SERPENT_RULE_ENABLED`, `JARVIS_SERPENT_RULE_SPEED`, `JARVIS_SERPENT_RULE_CHASE_S`, and `JARVIS_SERPENT_RULE_BODY`.
  - Integrated into `bipartite_layout` hairlines via a `serpent_active` callback; the demo wires this to generating windows so the border and verb agree.
  - Heartbeat now prefers phase verbs; when none, it rotates through `turn_spinner.turn_verbs()` via `_flavour_verb`, seeded by op id and paced by `JARVIS_ATTACH_VERB_ROTATE_S`.

- **Refactors**
  - Spinner frames reduced to `("🐍",)` (ASCII `"~"`) while keeping `ouroboros_frame()` API; motion is conveyed by elapsed time and the changing verb.
  - Hardened error handling in the renderer (palette resolution and width parsing) and added tests for purity, width guarantees, ASCII fallback, and non-raising behavior.

<sup>Written for commit 0e0905d6da16d76d3a50590dfef279d3a549b128. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

