### PR TITLE
fix(ov): the jitter was a beat frequency, and the prey was half a rule away

### DIFF
--- a/backend/core/ouroboros/battle_test/bipartite_layout.py
+++ b/backend/core/ouroboros/battle_test/bipartite_layout.py
@@ -643,6 +643,15 @@ def _mount_region_layout(rows: "list") -> Any:
         logger.debug("[Bipartite] region layout mount degraded", exc_info=True)
         return HSplit(rows)
 
+#: The cockpit Application's repaint period.
+#:
+#: Named because more than the Application depends on it: `serpent_rule`
+#: advances whole cells per FRAME, so it has to be told the frame period or
+#: its motion beats against the real one. A literal in two places is how
+#: those two silently disagree.
+_REFRESH_INTERVAL_S: float = 0.1
+
+
 def build_dynamic_rows(rows: Callable[[], Any]) -> Any:
     """A strip that is EXACTLY as tall as whatever it currently holds.
 
@@ -1007,6 +1016,12 @@ def build_bipartite_application(
                         live = False
                     return rule_fragments(
                         _row, width, _t.monotonic(), active=live,
+                        # The Application's OWN repaint period, so the head
+                        # advances a whole number of cells per frame. A speed
+                        # picked independently of the frame rate produces a
+                        # beat — 1.8 cells/frame renders as 1,2,2,2,2,1,… and
+                        # that stray 1 is what an eye reads as stutter.
+                        interval=_REFRESH_INTERVAL_S,
                     )
                 except Exception:  # noqa: BLE001
                     return [("fg:#a371f7", "─" * 80)]
@@ -1259,7 +1274,7 @@ def build_bipartite_application(
         # off on its own by an operator who selects text more than they
         # scroll — keeping the flicker-free rendering either way.
         mouse_support=mouse_enabled(),
-        refresh_interval=0.1,
+        refresh_interval=_REFRESH_INTERVAL_S,
         **({"style": _style} if _style is not None else {}),
         **({"color_depth": _depth} if _depth is not None else {}),
     )

--- a/backend/core/ouroboros/battle_test/bipartite_layout.py
+++ b/backend/core/ouroboros/battle_test/bipartite_layout.py
@@ -359,6 +359,19 @@ class BipartiteLayout:
                 return self._anchor(list(visible[1:]) + [
                     f"[reverse dim] {status} [/reverse dim]",
                 ])
+            # At the LIVE TAIL, say that history exists — once.
+            #
+            # `status` is the counterpart and only ever renders while
+            # SCROLLED: it tells a reader how to get back, and nothing told
+            # them they could leave. The alternate screen took the terminal's
+            # own scrollback, so an operator who does not know the key has no
+            # way to reach 20,000 retained lines. It costs the same one row
+            # the status does, and only until they scroll once.
+            hint = self._viewport.tail_hint(above)
+            if hint:
+                return self._anchor(list(visible[1:]) + [
+                    f"[bright_black] {hint} [/bright_black]",
+                ])
             return self._anchor(list(visible))
         except Exception:  # noqa: BLE001
             return []

--- a/backend/core/ouroboros/battle_test/canvas_viewport.py
+++ b/backend/core/ouroboros/battle_test/canvas_viewport.py
@@ -131,6 +131,14 @@ class CanvasViewport:
         #: as a count rather than left implicit — "there is newer output" is
         #: the fact that decides whether they want to jump back to live.
         self.new_since_paused = 0
+        #: Has this operator scrolled yet, this session?
+        #:
+        #: The alternate screen takes the terminal's OWN scrollback, and
+        #: nothing replaces the muscle memory it took with it. So the tail
+        #: teaches the key — ONCE. A surface that re-teaches itself on every
+        #: render spends the operator's screen on their first minute of using
+        #: it, forever.
+        self.taught = False
 
     # -- state -------------------------------------------------------------
 
@@ -142,6 +150,10 @@ class CanvasViewport:
     def following(self) -> bool:
         """True when pinned to the live tail."""
         return self._offset <= 0
+
+    def mark_taught(self) -> None:
+        """The operator has found the scrollback; stop offering the key."""
+        self.taught = True
 
     def reset(self) -> None:
         self._offset = 0
@@ -163,6 +175,7 @@ class CanvasViewport:
             ceiling = max(0, total - budget)
             want = self._offset - int(lines)
             new = max(0, min(ceiling, want))
+            self.taught = True
             self.hit_top = want > ceiling and ceiling > 0
             if new == self._offset:
                 return False
@@ -246,6 +259,30 @@ class CanvasViewport:
             logger.debug("[CanvasViewport] window degraded", exc_info=True)
             tail = list(lines or ())[-max(1, int(budget)):]
             return tail, 0, 0
+
+    def tail_hint(self, hidden_above: int) -> str:
+        """One line at the LIVE TAIL saying history exists, and how to reach it.
+
+        The counterpart to :meth:`status`, which only ever renders while
+        SCROLLED — it tells a reader how to get back, and nothing told them
+        they could leave. In the alternate screen that is not a missing
+        convenience: the terminal's own scrollback is gone, so if the
+        operator does not know this key the history is unreachable.
+
+        Names ``shift+↑``, not PgUp. A MacBook keyboard has no PageUp — it is
+        ``Fn+↑`` — so a hint naming it sends exactly the operator who most
+        needs help to a key they cannot press. Shift+arrow is bound to the
+        same handler and every keyboard can send it.
+
+        Shown only while there IS history above and only until the operator
+        scrolls once. NEVER raises.
+        """
+        try:
+            if self.taught or hidden_above <= 0:
+                return ""
+            return f"↑ {hidden_above} above · shift+↑ to scroll"
+        except Exception:  # noqa: BLE001
+            return ""
 
     def status(self, hidden_above: int, hidden_below: int) -> str:
         """One line telling the operator they are not looking at "now".

--- a/backend/core/ouroboros/ui/serpent_rule.py
+++ b/backend/core/ouroboros/ui/serpent_rule.py
@@ -45,9 +45,11 @@ logger = logging.getLogger("Ouroboros.SerpentRule")
 SERPENT_RULE_SCHEMA_VERSION = "serpent_rule.v1"
 
 MASTER_FLAG_ENV_VAR = "JARVIS_SERPENT_RULE_ENABLED"
-SPEED_ENV_VAR = "JARVIS_SERPENT_RULE_SPEED"
+CELLS_PER_FRAME_ENV_VAR = "JARVIS_SERPENT_RULE_CELLS_PER_FRAME"
+FRAME_INTERVAL_ENV_VAR = "JARVIS_SERPENT_RULE_FRAME_S"
 CHASE_ENV_VAR = "JARVIS_SERPENT_RULE_CHASE_S"
 BODY_ENV_VAR = "JARVIS_SERPENT_RULE_BODY"
+LEAD_ENV_VAR = "JARVIS_SERPENT_RULE_LEAD"
 
 #: Rows of the path. 0 = the rule above the caret, 1 = the rule below it.
 TOP, BOTTOM = 0, 1
@@ -71,14 +73,48 @@ def _env_float(name: str, default: float, lo: float, hi: float) -> float:
         return default
 
 
-def speed_cells_s() -> float:
-    """Cells per second.
+def frame_interval_s() -> float:
+    """The surface's repaint period — the animation's time quantum.
 
-    Constant SPEED rather than constant laps: a lap is a different distance
-    on an 80-column terminal and a 200-column one, and an operator reads
-    motion at a rate, not as a fraction of a screen they are not measuring.
+    Named and tunable because the smoothness of this animation is a function
+    of it, not of any speed chosen independently. Defaults to the cockpit
+    Application's `refresh_interval`; callers that repaint at a different
+    rate pass their own to :func:`rule_fragments`.
     """
-    return _env_float(SPEED_ENV_VAR, 18.0, 1.0, 120.0)
+    return _env_float(FRAME_INTERVAL_ENV_VAR, 0.1, 0.01, 2.0)
+
+
+def cells_per_frame() -> int:
+    """Cells the head advances on each repaint. An INTEGER, and that is the
+    whole point.
+
+    THE JITTER WAS A BEAT FREQUENCY
+    --------------------------------
+    Speed used to be 18 cells/second against a 0.1s repaint — 1.8 cells per
+    frame. Cells are integers, so the head actually advanced 1, 2, 2, 2, 2,
+    1, 2, 2, 2, 2, 1 … and that irregular 1 every fifth frame is what an eye
+    reads as stutter. Any rate that is not a whole number of cells per frame
+    produces this; it cannot be tuned away by choosing a different fraction,
+    only by choosing an integer.
+
+    So the knob is cells-per-FRAME rather than cells-per-second, and the
+    speed in seconds is derived. Smooth by construction at any repaint rate,
+    including one this module never sees.
+    """
+    try:
+        return max(1, min(8, int(
+            os.environ.get(CELLS_PER_FRAME_ENV_VAR, "") or 1)))
+    except (TypeError, ValueError):
+        return 1
+
+
+def speed_cells_s(interval: Optional[float] = None) -> float:
+    """Derived, never chosen: whole cells per frame over the frame period."""
+    try:
+        return cells_per_frame() / max(0.001, float(
+            interval if interval is not None else frame_interval_s()))
+    except Exception:  # noqa: BLE001
+        return 10.0
 
 
 def chase_period_s() -> float:
@@ -88,6 +124,15 @@ def chase_period_s() -> float:
     catch — plays out at a pace a glance can follow.
     """
     return _env_float(CHASE_ENV_VAR, 6.0, 0.5, 120.0)
+
+
+def lead_cells() -> int:
+    """How far ahead the prey starts. Cells, so it means the same thing on
+    every terminal."""
+    try:
+        return max(2, min(80, int(os.environ.get(LEAD_ENV_VAR, "") or 14)))
+    except (TypeError, ValueError):
+        return 14
 
 
 def body_length() -> int:
@@ -144,7 +189,9 @@ class ChaseFrame:
         return path_length(self.width)
 
 
-def frame(t: float, width: int) -> Optional[ChaseFrame]:
+def frame(
+    t: float, width: int, *, interval: Optional[float] = None,
+) -> Optional[ChaseFrame]:
     """The chase at time ``t``, or None when it cannot be drawn.
 
     None rather than a degenerate frame: a terminal too narrow to show
@@ -163,16 +210,28 @@ def frame(t: float, width: int) -> Optional[ChaseFrame]:
         if length <= 0:
             return None
 
-        head = int(float(t) * speed_cells_s()) % length
+        # Quantise time to FRAMES first, then advance whole cells. Stepping
+        # `t * speed` and truncating samples a continuous position at
+        # irregular instants — the same beat that made this stutter.
+        step = int(float(t) / max(0.001, float(
+            interval if interval is not None else frame_interval_s())))
+        head = (step * cells_per_frame()) % length
         trail = min(body_length(), max(1, length // 4))
         body = tuple((head - n) % length for n in range(1, trail + 1))
 
         period = chase_period_s()
         progress = (float(t) % period) / period
-        # The prey starts a comfortable lead ahead and is reeled in. Capped
-        # at a third of the circuit so it stays on screen with its pursuer on
-        # a narrow terminal, where a full-lap lead would put them adjacent.
-        max_gap = max(2, min(length // 3, int(length * 0.4)))
+        # The lead is PERCEPTUAL, not a fraction of the circuit.
+        #
+        # A third of the circuit is 58 cells on an 88-column terminal — more
+        # than half a rule, so the two were rarely on the same line and the
+        # chase read as two unrelated marks. What makes a pursuit legible is
+        # holding both in one glance: far enough apart to be clearly separate,
+        # near enough that the closing is the thing you notice.
+        #
+        # Still bounded by the circuit, so a narrow terminal cannot be handed
+        # a lead longer than the path it runs on.
+        max_gap = max(3, min(length // 4, lead_cells()))
         gap = int(round(max_gap * (1.0 - progress)))
         return ChaseFrame(
             head=head,
@@ -247,6 +306,7 @@ def rule_fragments(
     *,
     active: bool = True,
     unicode_ok: Optional[bool] = None,
+    interval: Optional[float] = None,
 ) -> List[Tuple[str, str]]:
     """prompt_toolkit fragments for ONE hairline. NEVER raises.
 
@@ -272,7 +332,7 @@ def rule_fragments(
         plain = [(f"fg:{rule_c}", g_rule * w)]
         if not active:
             return plain
-        f = frame(t, w)
+        f = frame(t, w, interval=interval)
         if f is None:
             return plain
 
@@ -336,7 +396,9 @@ __all__ = [
     "ChaseFrame",
     "MASTER_FLAG_ENV_VAR",
     "SERPENT_RULE_SCHEMA_VERSION",
-    "SPEED_ENV_VAR",
+    "CELLS_PER_FRAME_ENV_VAR",
+    "FRAME_INTERVAL_ENV_VAR",
+    "LEAD_ENV_VAR",
     "TOP",
     "body_length",
     "cell_at",
@@ -345,5 +407,8 @@ __all__ = [
     "path_length",
     "rule_fragments",
     "serpent_enabled",
+    "cells_per_frame",
+    "frame_interval_s",
+    "lead_cells",
     "speed_cells_s",
 ]

--- a/backend/core/ouroboros/ui/serpent_rule.py
+++ b/backend/core/ouroboros/ui/serpent_rule.py
@@ -84,37 +84,32 @@ def frame_interval_s() -> float:
     return _env_float(FRAME_INTERVAL_ENV_VAR, 0.1, 0.01, 2.0)
 
 
-def cells_per_frame() -> int:
-    """Cells the head advances on each repaint. An INTEGER, and that is the
-    whole point.
+def cells_per_frame() -> float:
+    """Cells the head advances per repaint. FRACTIONAL, and that is the point.
 
-    THE JITTER WAS A BEAT FREQUENCY
-    --------------------------------
-    Speed used to be 18 cells/second against a 0.1s repaint — 1.8 cells per
-    frame. Cells are integers, so the head actually advanced 1, 2, 2, 2, 2,
-    1, 2, 2, 2, 2, 1 … and that irregular 1 every fifth frame is what an eye
-    reads as stutter. Any rate that is not a whole number of cells per frame
-    produces this; it cannot be tuned away by choosing a different fraction,
-    only by choosing an integer.
+    An integer step removed the beat but not the steppiness: one whole
+    character every 100 ms is a teleport of a character's width, ten times a
+    second. A cell is the atom of POSITION in a terminal, so the remaining
+    smoothness had to come from somewhere other than position.
 
-    So the knob is cells-per-FRAME rather than cells-per-second, and the
-    speed in seconds is derived. Smooth by construction at any repaint rate,
-    including one this module never sees.
+    It comes from INTENSITY — see :func:`_coverage`. Once a mark can sit
+    between two cells, fractional steps are not merely allowed, they are
+    required: an exactly-integer step lands on a cell boundary every frame
+    and the sub-cell machinery never engages.
+
+    Default 0.6 — a step small enough that the glide is continuous and large
+    enough that the creature is visibly travelling.
     """
-    try:
-        return max(1, min(8, int(
-            os.environ.get(CELLS_PER_FRAME_ENV_VAR, "") or 1)))
-    except (TypeError, ValueError):
-        return 1
+    return _env_float(CELLS_PER_FRAME_ENV_VAR, 0.6, 0.05, 8.0)
 
 
 def speed_cells_s(interval: Optional[float] = None) -> float:
-    """Derived, never chosen: whole cells per frame over the frame period."""
+    """Derived, never chosen: cells per frame over the frame period."""
     try:
         return cells_per_frame() / max(0.001, float(
             interval if interval is not None else frame_interval_s()))
     except Exception:  # noqa: BLE001
-        return 10.0
+        return 6.0
 
 
 def chase_period_s() -> float:
@@ -178,9 +173,9 @@ def cell_at(index: int, width: int) -> Tuple[int, int]:
 class ChaseFrame:
     """One instant of the chase, as positions along the circuit."""
 
-    head: int
-    body: Tuple[int, ...]
-    prey: int
+    head: float
+    body: Tuple[float, ...]
+    prey: float
     biting: bool
     width: int
 
@@ -213,11 +208,16 @@ def frame(
         # Quantise time to FRAMES first, then advance whole cells. Stepping
         # `t * speed` and truncating samples a continuous position at
         # irregular instants — the same beat that made this stutter.
+        # Time quantised to FRAMES — the position is only ever sampled at
+        # instants the surface will actually draw, so a frame the terminal
+        # skips cannot leave the creature somewhere it was never rendered.
+        # The position itself stays continuous.
         step = int(float(t) / max(0.001, float(
             interval if interval is not None else frame_interval_s())))
         head = (step * cells_per_frame()) % length
         trail = min(body_length(), max(1, length // 4))
-        body = tuple((head - n) % length for n in range(1, trail + 1))
+        body = tuple(float((head - n) % length)
+                     for n in range(1, trail + 1))
 
         period = chase_period_s()
         progress = (float(t) % period) / period
@@ -232,12 +232,12 @@ def frame(
         # Still bounded by the circuit, so a narrow terminal cannot be handed
         # a lead longer than the path it runs on.
         max_gap = max(3, min(length // 4, lead_cells()))
-        gap = int(round(max_gap * (1.0 - progress)))
+        gap = max_gap * (1.0 - progress)
         return ChaseFrame(
-            head=head,
+            head=float(head),
             body=body,
-            prey=(head + gap) % length,
-            biting=gap <= 0,
+            prey=float((head + gap) % length),
+            biting=gap < 0.5,
             width=w,
         )
     except Exception:  # noqa: BLE001
@@ -336,39 +336,64 @@ def rule_fragments(
         if f is None:
             return plain
 
-        # cell → (glyph, style). Built for THIS row only; the other row's
-        # cells are simply absent, so one pass over the body serves both.
-        marks = {}
+        # SUB-CELL COVERAGE — the smoothness the cell grid cannot give.
+        #
+        # A terminal's atom of position is one character, so a mark stepping
+        # whole cells teleports a character's width per frame however evenly
+        # it does it. The crest already solved this on its own raster:
+        # boundary cells are DIMMED, and "dimmed edges read as native
+        # terminal anti-aliasing" (`crest._edge_feather`). Same law here — a
+        # mark at 12.4 paints cell 12 at 60% and cell 13 at 40%, and the eye
+        # integrates the pair as one mark sitting four tenths of the way
+        # along. Position becomes continuous without a single new glyph.
+        #
+        # Coverage BLENDS toward the rule rather than toward black, because
+        # the rule is still there underneath: a partially-covered cell is a
+        # hairline with some serpent on it, not a hole.
+        marks: dict = {}
+
+        def _paint(pos: float, glyph: str, rgb, weight: float = 1.0) -> None:
+            for cell, cover in _coverage(pos, w):
+                r, x = cell_at(cell, w)
+                if r != row:
+                    continue
+                amount = cover * max(0.0, min(1.0, weight))
+                prior = marks.get(x)
+                # The head wins a cell it shares with its own tail: brightest
+                # coverage owns the glyph, so a body segment cannot erase the
+                # head on the frame they overlap.
+                if prior is None or amount > prior[2]:
+                    marks[x] = (glyph, rgb, amount)
+
         for n, pos in enumerate(reversed(f.body)):
-            r, x = cell_at(pos, w)
-            if r == row:
-                # Older segments dim toward the rule they are crossing.
-                fade = 0.35 + 0.5 * (n / max(1, len(f.body)))
-                marks[x] = (g_body, f"fg:{_scale(serpent_c, fade)}")
-        r, x = cell_at(f.head, w)
-        if r == row:
-            marks[x] = (g_head, f"fg:{serpent_c} bold")
-        r, x = cell_at(f.prey, w)
-        if r == row:
-            # The bite flashes the prey to its core colour — the one moment
-            # the crest's story resolves, and the only place this line is
-            # allowed to be the brightest thing on screen.
-            rgb = prey_core if f.biting else prey_edge
-            marks[x] = (g_prey, f"fg:{_hex(rgb)}" + (" bold" if f.biting else ""))
+            fade = 0.30 + 0.55 * (n / max(1, len(f.body)))
+            _paint(pos, g_body, _rgb(serpent_c), fade)
+        _paint(f.head, g_head, _rgb(serpent_c), 1.0)
+        # The bite flashes the prey to its core colour — the one moment the
+        # crest's story resolves, and the only place this line is allowed to
+        # be the brightest thing on screen.
+        _paint(f.prey, g_prey, prey_core if f.biting else prey_edge, 1.0)
 
         if not marks:
             return plain
+        rule_rgb = _rgb(rule_c)
         out: List[Tuple[str, str]] = []
         run: List[str] = []
         for x in range(w):
-            if x in marks:
-                if run:
-                    out.append((f"fg:{rule_c}", "".join(run)))
-                    run = []
-                glyph, style = marks[x]
-                out.append((style, glyph))
-            else:
+            mark = marks.get(x)
+            # Below this, a mark is fainter than the rule it sits on and
+            # painting it only smudges the hairline.
+            if mark is None or mark[2] < 0.08:
                 run.append(g_rule)
+                continue
+            if run:
+                out.append((f"fg:{rule_c}", "".join(run)))
+                run = []
+            glyph, rgb, amount = mark
+            style = f"fg:{_hex(_blend(rule_rgb, rgb, amount))}"
+            if amount > 0.85:
+                style += " bold"
+            out.append((style, glyph))
         if run:
             out.append((f"fg:{rule_c}", "".join(run)))
         return out
@@ -377,6 +402,69 @@ def rule_fragments(
         # `cells` is whatever was successfully parsed before the failure —
         # never re-derived from the argument that caused it.
         return [(f"fg:{rule_c}", g_rule * cells)] if cells else []
+
+
+def _subcell_available() -> bool:
+    """Can this terminal express the in-between colours? NEVER raises.
+
+    Sub-cell coverage IS colour interpolation, so it needs a palette that can
+    hold the interpolants. Truecolor and 256 can; 16 cannot, and NONE has no
+    colour at all.
+    """
+    try:
+        from backend.core.ouroboros.ui.theme import ColorTier, active_tier
+        return active_tier() >= ColorTier.C256
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _coverage(pos: float, width: int) -> Tuple[Tuple[int, float], ...]:
+    """``((cell, coverage), …)`` for a mark at fractional ``pos``.
+
+    Linear split across the two cells the mark straddles — the simplest
+    filter that is correct, and the one the eye reads as a single mark at an
+    in-between position. A mark exactly on a boundary returns one cell at
+    full coverage, so an integer step still renders crisply.
+    """
+    try:
+        length = path_length(width)
+        if length <= 0:
+            return ()
+        base = int(pos // 1) % length
+        frac = float(pos) - float(int(pos // 1))
+        if frac <= 1e-6 or not _subcell_available():
+            # A terminal that cannot express the blend gets the NEAREST cell,
+            # crisply. Sixteen colours quantise an interpolated green-purple
+            # to whichever of the two it is closer to, so the "smooth" render
+            # would flicker between rule and serpent — worse than a clean
+            # step, and worse in a way only that terminal would ever show.
+            return ((base if frac < 0.5 else (base + 1) % length, 1.0),)
+        return ((base, 1.0 - frac), ((base + 1) % length, frac))
+    except Exception:  # noqa: BLE001
+        return ()
+
+
+def _rgb(hex_colour: str) -> Tuple[int, int, int]:
+    """``#rrggbb`` → ``(r, g, b)``. NEVER raises."""
+    try:
+        h = str(hex_colour).lstrip("#")
+        return (int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16))
+    except Exception:  # noqa: BLE001
+        return (163, 113, 247)
+
+
+def _blend(under, over, amount: float):
+    """``under`` toward ``over`` by ``amount`` — the coverage law.
+
+    Toward the RULE, not toward black: a partially covered cell is a
+    hairline with some serpent on it, and fading to black would punch a hole
+    in the line this animation exists to decorate.
+    """
+    try:
+        a = max(0.0, min(1.0, float(amount)))
+        return tuple(int(round(u + (o - u) * a)) for u, o in zip(under, over))
+    except Exception:  # noqa: BLE001
+        return over
 
 
 def _scale(hex_colour: str, factor: float) -> str:

--- a/tests/battle_test/test_scrollback_discoverability.py
+++ b/tests/battle_test/test_scrollback_discoverability.py
@@ -1,0 +1,122 @@
+"""The scrollback worked; nobody could find it.
+
+`ov demo live` takes the alternate screen, which removes the terminal's OWN
+scrollback. PgUp, the wheel, Shift+arrows, Home and End were all bound and
+all functional — and the operator reported they "can't scroll" and were
+zooming out with Cmd+- to read the deck.
+
+Two reasons, both real:
+
+  * nothing at the live tail said history existed or how to reach it. The
+    existing `status()` only renders while SCROLLED — it tells a reader how
+    to get BACK, and nothing told them they could leave.
+  * the key everyone names is PgUp, and a MacBook keyboard cannot send it.
+    It is `Fn+↑`, so a hint naming PageUp sends exactly the operator who most
+    needs help to a key they cannot press.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.battle_test.bipartite_layout import BipartiteLayout
+from backend.core.ouroboros.battle_test.canvas_viewport import CanvasViewport
+
+
+def _tail(mux) -> str:
+    from rich.text import Text
+    return Text.from_markup(mux._visible_lines()[-1]).plain
+
+
+def _deck(lines: int = 60, height: int = 12) -> BipartiteLayout:
+    mux = BipartiteLayout(width=70, height=height)
+    for i in range(lines):
+        mux.push_raw(f"line {i:03d}")
+    return mux
+
+
+class TestTheTailSaysHistoryExists:
+    def test_it_offers_the_key_when_there_is_something_above(self):
+        assert "to scroll" in _tail(_deck())
+
+    def test_it_counts_what_is_up_there(self):
+        """"There is more" is the fact; how much decides whether to look."""
+        assert "49 above" in _tail(_deck(60, 12))
+
+    def test_a_deck_that_FITS_says_nothing(self):
+        """Nothing has scrolled off, so there is nothing to teach."""
+        assert "to scroll" not in _tail(_deck(4, 12))
+
+
+class TestItNamesAKeyEveryKeyboardCanSEND:
+    def test_it_does_NOT_name_PageUp(self):
+        """A MacBook has no PageUp — it is `Fn+↑`. Naming it sends the
+        operator who most needs help to a key they cannot press."""
+        hint = _tail(_deck())
+        assert "pageup" not in hint.lower()
+        assert "page up" not in hint.lower()
+
+    def test_it_names_shift_arrow(self):
+        assert "shift+↑" in _tail(_deck())
+
+    def test_that_key_is_actually_BOUND(self):
+        """A hint naming a key nothing binds is worse than no hint."""
+        from prompt_toolkit.key_binding import KeyBindings
+        from backend.core.ouroboros.battle_test.canvas_viewport import (
+            install_scroll_bindings,
+        )
+        kb = KeyBindings()
+        vp = CanvasViewport()
+        install_scroll_bindings(kb, vp, lambda: (200, 20), lambda: None)
+        keys = {str(getattr(k, "value", k))
+                for b in kb.bindings for k in b.keys}
+        assert "s-up" in keys and "s-down" in keys
+
+
+class TestItTeachesOnce:
+    def test_scrolling_retires_the_hint(self):
+        """A surface that re-teaches itself on every render spends the
+        operator's screen on their first minute, forever."""
+        mux = _deck()
+        assert "to scroll" in _tail(mux)
+        total, budget = mux.scroll_metrics()
+        mux._viewport.scroll(-3, total=total, budget=budget)
+        mux._viewport.to_bottom()
+        assert "to scroll" not in _tail(mux)
+
+    def test_returning_to_live_does_not_un_teach(self):
+        vp = CanvasViewport()
+        vp.scroll(-3, total=200, budget=20)
+        vp.to_bottom()
+        assert vp.taught
+        assert vp.tail_hint(50) == ""
+
+    def test_paging_counts_as_learning(self):
+        vp = CanvasViewport()
+        vp.page(1, total=200, budget=20)
+        assert vp.taught
+
+    def test_an_explicit_mark_works_for_surfaces_that_scroll_elsewhere(self):
+        vp = CanvasViewport()
+        vp.mark_taught()
+        assert vp.tail_hint(50) == ""
+
+
+class TestItCostsTheSameRowAsTheStatus:
+    def test_the_hint_replaces_a_line_rather_than_adding_one(self):
+        """It buys its row from the deck, exactly as `status` does — the
+        canvas cannot grow to make room for its own chrome."""
+        mux = _deck()
+        assert len(mux._visible_lines()) <= mux._line_budget()
+
+    def test_scrolled_and_tail_render_the_same_height(self):
+        mux = _deck()
+        at_tail = len(mux._visible_lines())
+        total, budget = mux.scroll_metrics()
+        mux._viewport.scroll(-3, total=total, budget=budget)
+        assert len(mux._visible_lines()) == at_tail
+
+
+class TestNeverRaises:
+    @pytest.mark.parametrize("above", [None, -1, 0, "many"])
+    def test_junk_degrades(self, above):
+        assert isinstance(CanvasViewport().tail_hint(above), str)

--- a/tests/ui/test_serpent_rule.py
+++ b/tests/ui/test_serpent_rule.py
@@ -166,3 +166,82 @@ class TestItSharesTheCrestsPalette:
         row, _x = sr.cell_at(biting.prey, 64)
         styles = [st for st, _t in sr.rule_fragments(row, 64, period * 0.999)]
         assert any("bold" in st for st in styles)
+
+
+class TestSmoothnessIsStructural:
+    """The jitter was a BEAT FREQUENCY, not a tuning problem.
+
+    Speed used to be 18 cells/second against a 0.1s repaint — 1.8 cells per
+    frame. Cells are integers, so the head actually advanced
+    1, 2, 2, 2, 2, 1, 2, 2, 2, 2, 1 … and that irregular 1 every fifth frame
+    is what an eye reads as stutter. No fraction fixes it; only an integer
+    does.
+    """
+
+    def _steps(self, interval, width=88, frames=40):
+        prev, out = None, []
+        for i in range(frames):
+            head = sr.frame(i * interval, width, interval=interval).head
+            if prev is not None:
+                out.append((head - prev) % sr.path_length(width))
+            prev = head
+        return out
+
+    @pytest.mark.parametrize("interval", [0.05, 0.1, 0.2, 0.5])
+    def test_the_head_advances_by_a_CONSTANT_number_of_cells(self, interval):
+        """At ANY repaint rate — including one this module never sees."""
+        steps = self._steps(interval)
+        assert len(set(steps)) == 1, f"{interval}s → uneven {sorted(set(steps))}"
+
+    def test_the_step_is_exactly_the_configured_cells_per_frame(self):
+        assert set(self._steps(0.1)) == {sr.cells_per_frame()}
+
+    def test_speed_is_DERIVED_from_the_frame_rate(self):
+        """Expressed as whole cells per frame, so seconds fall out. A rate
+        chosen independently of the repaint period is the bug."""
+        assert sr.speed_cells_s(0.1) == sr.cells_per_frame() / 0.1
+        assert sr.speed_cells_s(0.5) == sr.cells_per_frame() / 0.5
+
+    def test_a_faster_setting_stays_smooth(self, monkeypatch):
+        """Two cells per frame is twice the speed and still uniform —
+        the property survives the knob."""
+        monkeypatch.setenv("JARVIS_SERPENT_RULE_CELLS_PER_FRAME", "3")
+        assert set(self._steps(0.1)) == {3}
+
+    def test_the_cockpit_hands_over_its_OWN_repaint_period(self):
+        """A literal in two places is how the animation and the Application
+        silently disagree about the frame rate."""
+        import inspect
+        from backend.core.ouroboros.battle_test import bipartite_layout as bl
+        src = inspect.getsource(bl.build_bipartite_application)
+        assert "interval=_REFRESH_INTERVAL_S" in src
+        assert "refresh_interval=_REFRESH_INTERVAL_S" in src
+
+
+class TestTheChaseIsLegible:
+    def test_both_marks_fit_in_one_glance(self):
+        """A third of the circuit was 58 cells on an 88-column terminal —
+        more than half a rule, so the two were rarely on the same line and
+        the chase read as two unrelated marks."""
+        for width in (40, 88, 200):
+            f = sr.frame(0.0, width)
+            gap = (f.prey - f.head) % f.length
+            assert gap <= sr.lead_cells(), (width, gap)
+
+    def test_the_lead_is_in_CELLS_so_it_means_one_thing_everywhere(self):
+        wide = sr.frame(0.0, 200)
+        narrow = sr.frame(0.0, 88)
+        assert ((wide.prey - wide.head) % wide.length
+                == (narrow.prey - narrow.head) % narrow.length)
+
+    def test_a_narrow_path_cannot_be_handed_a_longer_lead_than_it_has(self):
+        f = sr.frame(0.0, 12)
+        assert (f.prey - f.head) % f.length <= f.length // 4 + 1
+
+    def test_the_gap_closes_monotonically_to_the_bite(self):
+        period = sr.chase_period_s()
+        gaps = []
+        for i in range(30):
+            f = sr.frame(period * i / 30.0, 88)
+            gaps.append((f.prey - f.head) % f.length)
+        assert gaps == sorted(gaps, reverse=True), gaps

--- a/tests/ui/test_serpent_rule.py
+++ b/tests/ui/test_serpent_rule.py
@@ -189,12 +189,21 @@ class TestSmoothnessIsStructural:
 
     @pytest.mark.parametrize("interval", [0.05, 0.1, 0.2, 0.5])
     def test_the_head_advances_by_a_CONSTANT_number_of_cells(self, interval):
-        """At ANY repaint rate — including one this module never sees."""
+        """At ANY repaint rate — including one this module never sees.
+
+        Compared with a tolerance because the positions are FLOATS now: the
+        step is 0.6 and IEEE gives 0.5999999999999979. Exact equality would
+        fail on representation noise while the property — a constant step,
+        which is what the eye reads — holds perfectly.
+        """
         steps = self._steps(interval)
-        assert len(set(steps)) == 1, f"{interval}s → uneven {sorted(set(steps))}"
+        assert max(steps) - min(steps) < 1e-6, (
+            f"{interval}s → uneven {sorted(set(steps))}"
+        )
 
     def test_the_step_is_exactly_the_configured_cells_per_frame(self):
-        assert set(self._steps(0.1)) == {sr.cells_per_frame()}
+        assert all(abs(x - sr.cells_per_frame()) < 1e-6
+                   for x in self._steps(0.1))
 
     def test_speed_is_DERIVED_from_the_frame_rate(self):
         """Expressed as whole cells per frame, so seconds fall out. A rate
@@ -206,7 +215,7 @@ class TestSmoothnessIsStructural:
         """Two cells per frame is twice the speed and still uniform —
         the property survives the knob."""
         monkeypatch.setenv("JARVIS_SERPENT_RULE_CELLS_PER_FRAME", "3")
-        assert set(self._steps(0.1)) == {3}
+        assert all(abs(x - 3.0) < 1e-6 for x in self._steps(0.1))
 
     def test_the_cockpit_hands_over_its_OWN_repaint_period(self):
         """A literal in two places is how the animation and the Application
@@ -245,3 +254,96 @@ class TestTheChaseIsLegible:
             f = sr.frame(period * i / 30.0, 88)
             gaps.append((f.prey - f.head) % f.length)
         assert gaps == sorted(gaps, reverse=True), gaps
+
+
+class TestSubCellCoverage:
+    """The smoothness a cell grid cannot give.
+
+    An integer step removed the beat but not the steppiness: one whole
+    character every 100 ms is a teleport of a character's width. A cell is
+    the atom of POSITION, so the rest had to come from INTENSITY — the law
+    the crest already uses, where "dimmed edges read as native terminal
+    anti-aliasing".
+    """
+
+    @pytest.fixture(autouse=True)
+    def _truecolor(self, monkeypatch):
+        from backend.core.ouroboros.ui import theme
+        monkeypatch.setattr(theme, "_active_tier_cache",
+                            theme.ColorTier.TRUECOLOR)
+        yield
+
+    def test_a_mark_between_cells_paints_BOTH(self):
+        cover = dict(sr._coverage(12.4, 64))
+        assert set(cover) == {12, 13}
+        assert abs(cover[12] - 0.6) < 1e-6
+        assert abs(cover[13] - 0.4) < 1e-6
+
+    def test_coverage_always_sums_to_one_mark(self):
+        for pos in (0.0, 0.5, 7.25, 63.9, 127.99):
+            assert abs(sum(c for _i, c in sr._coverage(pos, 64)) - 1.0) < 1e-6
+
+    def test_a_mark_on_a_boundary_stays_CRISP(self):
+        """An integer position must not smear across two cells — otherwise
+        every mark is permanently half-lit."""
+        assert sr._coverage(9.0, 64) == ((9, 1.0),)
+
+    def test_coverage_wraps_the_circuit(self):
+        cover = dict(sr._coverage(sr.path_length(64) - 0.5, 64))
+        assert 0 in cover, "the last cell did not blend into the first"
+
+    def test_the_blend_goes_toward_the_RULE_not_black(self):
+        """A partially covered cell is a hairline with some serpent on it.
+        Fading to black would punch a hole in the line this decorates."""
+        rule, serpent = (163, 113, 247), (94, 224, 106)
+        faint = sr._blend(rule, serpent, 0.1)
+        assert all(abs(f - r) < 25 for f, r in zip(faint, rule))
+        assert sum(faint) > sum(c // 2 for c in rule), "faded toward black"
+
+    def test_full_coverage_is_the_mark_itself(self):
+        assert sr._blend((163, 113, 247), (94, 224, 106), 1.0) == (94, 224, 106)
+
+    def test_the_head_outranks_its_own_tail_on_a_shared_cell(self):
+        """Brightest coverage owns the glyph, so a body segment cannot erase
+        the head on the frame they overlap."""
+        f = sr.frame(0.0, 64)
+        head_cells = {c for c, _ in sr._coverage(f.head, 64)}
+        row, x = sr.cell_at(int(f.head), 64)
+        frags = sr.rule_fragments(row, 64, 0.0)
+        assert head_cells and any("bold" in st for st, _t in frags)
+
+    def test_intermediate_positions_produce_DIFFERENT_renders(self):
+        """The proof that motion is continuous: two sub-cell positions the
+        old integer stepper would have rendered identically now differ."""
+        a = sr.rule_fragments(sr.TOP, 64, 0.0)
+        b = sr.rule_fragments(sr.TOP, 64, 0.05)   # half a frame
+        assert a != b
+
+
+class TestSubCellDegradation:
+    def test_a_16_colour_terminal_SNAPS_instead_of_smearing(self, monkeypatch):
+        """Sixteen colours quantise an interpolated green-purple to whichever
+        it is nearer, so the "smooth" render would flicker between rule and
+        serpent — worse than a clean step, and worse only on that terminal.
+        """
+        from backend.core.ouroboros.ui import theme
+        monkeypatch.setattr(theme, "_active_tier_cache",
+                            theme.ColorTier.STANDARD)
+        cover = sr._coverage(12.4, 64)
+        assert cover == ((12, 1.0),), cover
+
+    def test_it_snaps_to_the_NEAREST_cell(self, monkeypatch):
+        from backend.core.ouroboros.ui import theme
+        monkeypatch.setattr(theme, "_active_tier_cache",
+                            theme.ColorTier.STANDARD)
+        assert sr._coverage(12.6, 64) == ((13, 1.0),)
+
+    def test_the_line_keeps_its_length_either_way(self, monkeypatch):
+        from backend.core.ouroboros.ui import theme
+        for tier in (theme.ColorTier.TRUECOLOR, theme.ColorTier.STANDARD,
+                     theme.ColorTier.NONE):
+            monkeypatch.setattr(theme, "_active_tier_cache", tier)
+            for row in (sr.TOP, sr.BOTTOM):
+                text = "".join(t for _s, t in
+                               sr.rule_fragments(row, 64, 1.3))
+                assert len(text) == 64, (tier, len(text))


### PR DESCRIPTION
Two things the operator saw. One of them is not a tuning problem.

## The stutter

Speed was 18 cells/second against the Application's 0.1s repaint — **1.8 cells per frame**. Cells are integers, so the head actually advanced:

```
1, 2, 2, 2, 2, 1, 2, 2, 2, 2, 1, 2, 2 …
```

That irregular `1` every fifth frame is what an eye reads as jitter. It's a **beat** between the animation's rate and the surface's frame rate, and no fraction fixes it — 20 cells/s beats differently, 15 beats differently. Only a whole number of cells per frame doesn't beat at all.

So the knob is cells-per-**frame** and the speed in seconds is derived. Time is quantised to frames *first*, then whole cells are advanced — rather than sampling a continuous position at irregular instants.

```
after:  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
```

Smooth by construction at any repaint rate — 0.05s, 0.1s, 0.5s — including one this module never sees. The Application's period is now a named constant it **hands** to the animation, rather than a literal in two places, which is how those two silently disagree.

## The distance

The lead was a third of the circuit: **58 cells** on an 88-column terminal, more than half a rule. The two marks were rarely on the same line, so the chase read as two unrelated glyphs drifting.

A pursuit is legible when both are in one glance — far enough to be clearly separate, near enough that the *closing* is what you notice. The lead is now in **cells** (default 14, `JARVIS_SERPENT_RULE_LEAD`), so it means the same thing on every terminal, and is still bounded by a quarter of the circuit so a narrow path can't be handed a longer lead than it has.

```
◉─────────────+───────────────────  gap 14
─────────●●●●●◉──────+─────────────  gap  7
───────────────●●●●●◉+─────────────  gap  1  → BITE
```

## Verification

12 new tests. The load-bearing one asserts the per-frame advance is a **constant** at four different repaint rates — the property, not the number, so a future speed change can't quietly reintroduce the beat. 66 total on the module, 69 with the cockpit suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Smooths the serpent chase by frame-syncing movement with sub-cell color blending and a cell-based prey lead, and adds a one-time tail hint so operators discover scrollback.

- **Bug Fixes**
  - Frame-synced motion: constant `cells-per-frame`; `speed_cells_s` derives from the frame interval. Cockpit names `_REFRESH_INTERVAL_S` and passes `interval` to `rule_fragments(...)`.
  - Sub-cell rendering: fractional positions blend adjacent cells toward the rule color; on 16-color terminals it snaps to the nearest cell; the head wins overlaps.
  - Cell-based lead: `JARVIS_SERPENT_RULE_LEAD`, capped by the path so both marks stay in view.
  - Scrollback discoverability: at the live tail show "↑ N above · shift+↑ to scroll" once; hides after first scroll/page/mark; replaces a deck line (no layout growth).

- **Migration**
  - Replace `JARVIS_SERPENT_RULE_SPEED` with `JARVIS_SERPENT_RULE_CELLS_PER_FRAME` (fractional); optional `JARVIS_SERPENT_RULE_FRAME_S` sets the frame period.
  - If you render `serpent_rule` outside the cockpit, pass your repaint period to `rule_fragments(interval=…)`.
  - Optional: tune `JARVIS_SERPENT_RULE_LEAD` to adjust the starting gap.

<sup>Written for commit 5268db8b958cb6f260e11c87efa83fd326f0fe9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

