### PR TITLE
fix(ov): Karen is silent unless asked — narrator default OFF

### DIFF
--- a/backend/core/ouroboros/daemon_config.py
+++ b/backend/core/ouroboros/daemon_config.py
@@ -203,7 +203,7 @@ class DaemonConfig:
             saga_step_timeout_s=_env_float("OUROBOROS_SAGA_STEP_TIMEOUT_S", 300.0),
             saga_total_timeout_s=_env_float("OUROBOROS_SAGA_TOTAL_TIMEOUT_S", 3600.0),
             acceptance_timeout_s=_env_float("OUROBOROS_ACCEPTANCE_TIMEOUT_S", 120.0),
-            narrator_enabled=_env_bool("OUROBOROS_NARRATOR_ENABLED", True),
+            narrator_enabled=_env_bool("OUROBOROS_NARRATOR_ENABLED", False),
             narrator_rate_limit_s=_env_float("OUROBOROS_NARRATOR_RATE_LIMIT_S", 60.0),
             narrator_voice=os.environ.get("OUROBOROS_NARRATOR_VOICE", "Samantha"),
         )

--- a/backend/core/ouroboros/governance/comms/karen_voice.py
+++ b/backend/core/ouroboros/governance/comms/karen_voice.py
@@ -115,7 +115,7 @@ class KarenConfig:
 
     #: Master kill switch (shared with VoiceNarrator). False → no-op.
     master_enabled: bool = field(
-        default_factory=lambda: _env_bool("OUROBOROS_NARRATOR_ENABLED", True)
+        default_factory=lambda: _env_bool("OUROBOROS_NARRATOR_ENABLED", False)
     )
     #: Sub-switch specific to tool-call preambles. False → no-op even
     #: when the master is on, so operators can silence Karen's tool

--- a/backend/core/ouroboros/governance/comms/voice_narrator.py
+++ b/backend/core/ouroboros/governance/comms/voice_narrator.py
@@ -57,7 +57,7 @@ class VoiceNarrator:
         synthesizer: Optional[Any] = None,
         arbiter: Optional[Any] = None,
     ) -> None:
-        self._enabled = os.environ.get("OUROBOROS_NARRATOR_ENABLED", "true").lower() in ("true", "1", "yes")
+        self._enabled = os.environ.get("OUROBOROS_NARRATOR_ENABLED", "false").lower() in ("true", "1", "yes")
         self._say_fn = say_fn
         self._debounce_s = debounce_s
         self._source = source

--- a/backend/core/ouroboros/governance/recovery_announcer.py
+++ b/backend/core/ouroboros/governance/recovery_announcer.py
@@ -88,7 +88,7 @@ def _env_float(name: str, default: float, *, minimum: float = 0.0) -> float:
 
 def narrator_enabled() -> bool:
     """Master switch — shared with Karen tool-call + VoiceNarrator surfaces."""
-    return _env_bool("OUROBOROS_NARRATOR_ENABLED", True)
+    return _env_bool("OUROBOROS_NARRATOR_ENABLED", False)
 
 
 def recovery_voice_enabled() -> bool:


### PR DESCRIPTION
The operator asked twice to turn Karen's voice off. The first answer was a pair of exports to run, which is homework, not a fix.

## Why their existing setting did nothing

`.env` line 430 already reads `OUROBOROS_NARRATOR_ENABLED=false`.

**Nothing in `backend/core/ouroboros/` calls `load_dotenv`** — there is no dotenv loader anywhere in the package — so the flag was never read and the default (`true`) won. They had turned her off and the file was never opened. Another control with no consumer.

## Which switch, and why not the other one

`JARVIS_VOICE_ENABLED` is read by the vision handler, the display handler, the kernel config and the unified voice orchestrator. Flipping it would disable voice **input** and features well beyond Karen — more than was asked for.

`OUROBOROS_NARRATOR_ENABLED` is precisely the narrator master switch, shared by `VoiceNarrator`, `RecoveryAnnouncer`, `KarenVoice` and `DaemonNarrator`. All four defaulted `True`; all four now default `False`, so speech is opt-**in** across every surface that produces it.

Voice input, the wake word and `/voice` are untouched.

```
default                        : False
OUROBOROS_NARRATOR_ENABLED=true: True
```

Reversible in one variable, verified both directions.

## Not done, deliberately

Teaching `ov` to load `.env`. That file is 556 lines of keys and flags, much of it written for the supervisor and daemon rather than the cockpit, and loading all of it at boot would change behaviour neither of us predicted. A default flip is the small legible change; a dotenv loader is a separate decision with its own blast radius — happy to do it behind a flag with a declared key allowlist if wanted.

## Verification

98 tests green across daemon-config, karen-voice control plane, §38 karen-voice, narrator wiring and boot briefing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the narrator OFF by default so Karen stays silent unless explicitly enabled. Flips the `OUROBOROS_NARRATOR_ENABLED` default to false in `DaemonConfig`, `VoiceNarrator`, `KarenVoice`, and `RecoveryAnnouncer`; voice input and the wake word are unchanged.

- **Migration**
  - To enable narration, set `OUROBOROS_NARRATOR_ENABLED=true`. Avoid `JARVIS_VOICE_ENABLED` (it controls voice input).

<sup>Written for commit 64a2f58cac375e1e9c6c01a5c5e8b0cb0f9148ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

