### PR TITLE
feat(ov): the rejection window is visible remotely — a deadline nobody sees

### DIFF
--- a/backend/core/ouroboros/battle_test/attach_heartbeat.py
+++ b/backend/core/ouroboros/battle_test/attach_heartbeat.py
@@ -53,6 +53,15 @@ def _context_pct(op_id: str) -> float:
         return 0.0
 
 
+def _pending_apply_payload() -> Optional[dict]:
+    """Open rejection windows, or None. NEVER raises."""
+    try:
+        from backend.core.ouroboros.battle_test.pending_apply import snapshot
+        return snapshot()
+    except Exception:  # noqa: BLE001
+        return None
+
+
 def _status_payload(snap: Any) -> Optional[dict]:
     """The status snapshot as a transport dict, or None. NEVER raises."""
     try:
@@ -309,6 +318,11 @@ def build_heartbeat_payload() -> Optional[Dict[str, Any]]:
             # builder, which is empty by construction and would draw an
             # eternally idle organism.
             "status": _status_payload(snap),
+            # An apply waiting out its rejection window. Carried here rather
+            # than mirrored as text because a countdown is STATE — the panel
+            # that draws it locally repaints eight times a second, and the
+            # bridge is a line stream.
+            "pending_apply": _pending_apply_payload(),
             "effort": effort,
             "provider": provider,
             "provider_label": provider_label,

--- a/backend/core/ouroboros/battle_test/bipartite_layout.py
+++ b/backend/core/ouroboros/battle_test/bipartite_layout.py
@@ -749,6 +749,7 @@ def build_bipartite_application(
     agent_rows: Optional[Callable[[], Any]] = None,
     search_rows: Optional[Callable[[], Any]] = None,
     status_rows: Optional[Callable[[], Any]] = None,
+    pending_rows: Optional[Callable[[], Any]] = None,
     serpent_active: Optional[Callable[[], bool]] = None,
 ) -> Any:
     """Construct the full-screen ``prompt_toolkit.Application``: Zone 1 an ANSI
@@ -1104,6 +1105,16 @@ def build_bipartite_application(
         except Exception:  # noqa: BLE001
             logger.debug("[Bipartite] %s row unavailable", label,
                          exc_info=True)
+    # The rejection window, above the search bar and the caret. It is the
+    # most time-critical row the cockpit ever draws — the operator has
+    # seconds — so it sits where the eye already is.
+    if pending_rows is not None:
+        try:
+            _pending_row = build_dynamic_rows(pending_rows)
+            if _pending_row is not None:
+                rows += [_pending_row]
+        except Exception:  # noqa: BLE001
+            logger.debug("[Bipartite] pending row unavailable", exc_info=True)
     # The search bar sits DIRECTLY above the prompt    # The palette is NOT a row. See the FloatContainer below: as an HSplit row
     # it shares the ambient grid with the canvas, so every asynchronous Deck or
     # Lane frame arriving underneath forces the palette's geometry to be
@@ -1369,6 +1380,7 @@ async def run_bipartite_repl(
     agent_rows: Optional[Callable[[], Any]] = None,
     search_rows: Optional[Callable[[], Any]] = None,
     status_rows: Optional[Callable[[], Any]] = None,
+    pending_rows: Optional[Callable[[], Any]] = None,
     serpent_active: Optional[Callable[[], bool]] = None,
 ) -> None:
     """Launch the full-screen Bipartite REPL: build the multiplexer, register it as
@@ -1400,7 +1412,7 @@ async def run_bipartite_repl(
             completer=completer, history=history, auto_suggest=auto_suggest,
             turn_spinner=turn_spinner, agent_rows=agent_rows,
             search_rows=search_rows, status_rows=status_rows,
-            serpent_active=serpent_active,
+            pending_rows=pending_rows, serpent_active=serpent_active,
         )
         if watch_alive is not None:
             watcher = asyncio.ensure_future(

--- a/backend/core/ouroboros/battle_test/pending_apply.py
+++ b/backend/core/ouroboros/battle_test/pending_apply.py
@@ -1,0 +1,191 @@
+"""The rejection window, made visible on the surface the operator is watching.
+
+A NOTIFY_APPLY op announces itself and then waits — five seconds in which
+`/reject` will stop it. Locally that wait is a Rich `Live` panel counting
+down. Remotely it was `_notify_apply_plain_fallback`: a silent sleep that
+polls the cancel flag and emits nothing.
+
+So an attached operator saw
+
+    ⎿  /reject 7759-86 to cancel — diff follows as ⏺ Update
+
+and then five seconds of nothing. The window was open and the only sign of it
+was a sentence that had already scrolled. A deadline nobody can see is not a
+choice, it is a delay.
+
+Why not simply mirror the panel
+--------------------------------
+`Live` is a screen-REWRITING widget: it repaints the same region eight times
+a second. The bridge is a line-oriented stream, so forwarding it would put
+forty panels a second into the deck — worse than silence, and it would bury
+the very diff the panel exists to show.
+
+The remote representation of live state on this cockpit is not a mirrored
+widget, it is state carried on the heartbeat and drawn by a strip that
+re-renders each frame — the shape the agent roster and the status line
+already use. This is that, for a countdown.
+
+Remaining, never a deadline
+---------------------------
+The snapshot carries SECONDS LEFT, computed where the clock lives.
+`time.monotonic()` is a per-process origin, so shipping a deadline and
+subtracting the reader's clock yields a countdown wrong by however long the
+two processes have been alive — and plausibly wrong, which is worse. The
+reader counts DOWN by the frame's own age between heartbeats, exactly as the
+pulse counts elapsed UP.
+
+NEVER raises. A countdown that can break a repaint is not worth having, and
+the apply proceeds on its own timer regardless of whether anything drew it.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger("Ouroboros.PendingApply")
+
+PENDING_APPLY_SCHEMA_VERSION = "pending_apply.v1"
+
+MASTER_FLAG_ENV_VAR = "JARVIS_PENDING_APPLY_STRIP_ENABLED"
+
+_LOCK = threading.Lock()
+#: op_id → (deadline_monotonic, reason). At most a handful are ever open.
+_PENDING: Dict[str, Any] = {}
+
+
+def strip_enabled() -> bool:
+    """Default ON. Off, the window is invisible again — which is the state
+    this module exists to end, so it is off only by explicit choice."""
+    return os.environ.get(
+        MASTER_FLAG_ENV_VAR, "1",
+    ).strip().lower() not in ("0", "false", "no", "off")
+
+
+def note_pending(
+    op_id: str, *, delay_s: float, reason: str = "",
+    clock: Optional[Any] = None,
+) -> None:
+    """An apply is waiting out its rejection window. NEVER raises."""
+    try:
+        key = str(op_id or "").strip()
+        if not key or float(delay_s) <= 0:
+            return
+        now = (clock or time.monotonic)()
+        with _LOCK:
+            _PENDING[key] = (now + float(delay_s), str(reason or ""))
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def clear_pending(op_id: str) -> None:
+    """The window closed — applied, rejected, or failed. NEVER raises.
+
+    Called from the SAME `finally` that ends the wait, so a rejection and a
+    completion retire the strip by the identical path. A cleared-on-success
+    -only design leaves a rejected op counting down forever.
+    """
+    try:
+        with _LOCK:
+            _PENDING.pop(str(op_id or "").strip(), None)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def reset_for_tests() -> None:
+    with _LOCK:
+        _PENDING.clear()
+
+
+def snapshot(clock: Optional[Any] = None) -> Optional[dict]:
+    """Open windows as a transport-safe dict, or None when none are.
+
+    None rather than an empty list: "no apply is pending" and "the daemon
+    never told us" are different facts, and a reader that cannot tell them
+    apart will draw the first when it means the second.
+
+    Expired entries are dropped HERE, where the clock that set them lives.
+    A reader deciding an op had expired would be guessing from a frame that
+    is already a second old.
+    """
+    try:
+        if not strip_enabled():
+            return None
+        now = (clock or time.monotonic)()
+        rows: List[dict] = []
+        with _LOCK:
+            for op_id, (deadline, reason) in list(_PENDING.items()):
+                remaining = deadline - now
+                if remaining <= 0:
+                    _PENDING.pop(op_id, None)
+                    continue
+                rows.append({
+                    "op_id": op_id,
+                    # SECONDS LEFT, never the deadline — see the docstring.
+                    "remaining_s": round(float(remaining), 2),
+                    "reason": reason,
+                })
+        if not rows:
+            return None
+        rows.sort(key=lambda r: r["remaining_s"])
+        return {
+            "schema_version": PENDING_APPLY_SCHEMA_VERSION,
+            "rows": rows,
+        }
+    except Exception:  # noqa: BLE001
+        logger.debug("[PendingApply] snapshot degraded", exc_info=True)
+        return None
+
+
+def render(
+    payload: Optional[dict], *, age_s: float = 0.0, width: Optional[int] = None,
+) -> List[str]:
+    """Rows for the countdown strip, or [] when nothing is pending.
+
+    ``age_s`` is how long ago the snapshot was taken; the countdown advances
+    DOWN by it, so the seconds tick between 1 Hz heartbeats instead of
+    stepping. The mirror of how the pulse advances elapsed UP.
+
+    An entry whose remaining time has run out between frames renders as
+    `applying…` rather than vanishing: the operator's last impression should
+    be that the window closed, not that the op disappeared.
+    """
+    try:
+        if not strip_enabled() or not isinstance(payload, dict):
+            return []
+        rows = [r for r in (payload.get("rows") or ()) if isinstance(r, dict)]
+        if not rows:
+            return []
+        age = max(0.0, float(age_s or 0.0))
+        cols = int(width) if width and int(width) > 0 else 80
+        out: List[str] = []
+        for row in rows:
+            left = float(row.get("remaining_s") or 0.0) - age
+            op = str(row.get("op_id") or "")[:16]
+            if left <= 0.0:
+                out.append(f"  ⏵ applying {op}…")
+                continue
+            reason = " ".join(str(row.get("reason") or "").split())
+            head = f"  ⏵ {op} applies in {left:0.1f}s · /reject {op} to stop"
+            room = cols - len(head) - 3
+            if reason and room > 12:
+                head = f"{head} · {reason[:room]}"
+            out.append(head[:cols])
+        return out
+    except Exception:  # noqa: BLE001
+        logger.debug("[PendingApply] render degraded", exc_info=True)
+        return []
+
+
+__all__ = [
+    "MASTER_FLAG_ENV_VAR",
+    "PENDING_APPLY_SCHEMA_VERSION",
+    "clear_pending",
+    "note_pending",
+    "render",
+    "reset_for_tests",
+    "snapshot",
+    "strip_enabled",
+]

--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -3127,6 +3127,7 @@ class SerpentFlow:
             )
             return await self._notify_apply_plain_fallback(
                 delay_s=delay_s, cancel_check=cancel_check,
+                op_id=op_id, reason=reason,
             )
 
         # Optional on-disk dump — never fails loudly.
@@ -3140,12 +3141,14 @@ class SerpentFlow:
         if not should_render(self.console):
             return await self._notify_apply_plain_fallback(
                 delay_s=delay_s, cancel_check=cancel_check,
+                op_id=op_id, reason=reason,
             )
 
         if not changes:
             # Degenerate — still honor the delay so behavior is unchanged.
             return await self._notify_apply_plain_fallback(
                 delay_s=delay_s, cancel_check=cancel_check,
+                op_id=op_id, reason=reason,
             )
 
         try:
@@ -3153,6 +3156,7 @@ class SerpentFlow:
         except Exception:
             return await self._notify_apply_plain_fallback(
                 delay_s=delay_s, cancel_check=cancel_check,
+                op_id=op_id, reason=reason,
             )
 
         renderer = DiffPreviewRenderer()
@@ -3177,6 +3181,7 @@ class SerpentFlow:
             )
             return await self._notify_apply_plain_fallback(
                 delay_s=delay_s, cancel_check=cancel_check,
+                op_id=op_id, reason=reason,
             )
 
         try:
@@ -3226,6 +3231,8 @@ class SerpentFlow:
         *,
         delay_s: float,
         cancel_check: Optional[Any] = None,
+        op_id: str = "",
+        reason: str = "",
     ) -> bool:
         """Legacy plain-sleep path — used when the rich preview is off
         or fails. Polls the cancel flag on the same 250ms cadence so
@@ -3233,25 +3240,59 @@ class SerpentFlow:
         """
         import asyncio
         import time as _time
-        deadline = _time.monotonic() + max(0.0, delay_s)
-        while True:
-            remaining = deadline - _time.monotonic()
-            if remaining <= 0:
-                break
+
+        # PUBLISH THE WINDOW.
+        #
+        # This path is taken whenever the rich preview cannot draw — which,
+        # on a detached daemon, is ALWAYS: `should_render` asks whether this
+        # process's console is a terminal, and a daemon's is not. So the
+        # attached operator was told `/reject <op> to cancel` and then given
+        # five seconds of silence to act in.
+        #
+        # The panel itself cannot be mirrored — `Live` repaints a region
+        # eight times a second and the bridge is a line stream. What crosses
+        # is the STATE, on the heartbeat, drawn by a strip that re-renders
+        # each frame; the shape the roster and status line already use.
+        _pending_op = str(op_id or "").strip()
+        try:
+            from backend.core.ouroboros.battle_test.pending_apply import (
+                note_pending,
+            )
+            note_pending(_pending_op, delay_s=delay_s, reason=reason or "")
+        except Exception:  # noqa: BLE001 — a strip must not gate an apply
+            pass
+
+        try:
+            deadline = _time.monotonic() + max(0.0, delay_s)
+            while True:
+                remaining = deadline - _time.monotonic()
+                if remaining <= 0:
+                    break
+                if cancel_check is not None:
+                    try:
+                        if cancel_check():
+                            return True
+                    except Exception:
+                        pass
+                await asyncio.sleep(min(0.25, max(0.05, remaining)))
             if cancel_check is not None:
                 try:
                     if cancel_check():
                         return True
                 except Exception:
                     pass
-            await asyncio.sleep(min(0.25, max(0.05, remaining)))
-        if cancel_check is not None:
+            return False
+        finally:
+            # ONE exit for the strip. Rejection returns early from inside the
+            # loop, so clearing on the success path alone would leave a
+            # rejected op counting down forever on every attached cockpit.
             try:
-                if cancel_check():
-                    return True
-            except Exception:
+                from backend.core.ouroboros.battle_test.pending_apply import (
+                    clear_pending,
+                )
+                clear_pending(_pending_op)
+            except Exception:  # noqa: BLE001
                 pass
-        return False
 
     # ── Operation completion ──────────────────────────────────
 

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -678,6 +678,8 @@ class AttachUI:
         self._agents: dict = {}
         #: The daemon's `StatusSnapshot`, as of the last heartbeat.
         self._status: dict = {}
+        #: Applies waiting out their rejection window, as of the last frame.
+        self._pending_apply: dict = {}
         self._focus_lines: List[str] = []
         self._focus_note: str = ""
         self._flash_text: str = ""
@@ -1021,6 +1023,27 @@ class AttachUI:
         except Exception:  # noqa: BLE001
             return []
 
+    def _pending_apply_rows(self) -> List[str]:
+        """The rejection window, counting down. NEVER raises.
+
+        Retires on the same staleness window as the pulse, the roster and
+        the status line — a dead daemon must not leave a countdown ticking
+        toward an apply that will never happen.
+        """
+        try:
+            import time as _time
+            from backend.core.ouroboros.battle_test.attach_heartbeat import (
+                heartbeat_stale_after_s,
+            )
+            from backend.core.ouroboros.battle_test.pending_apply import render
+            age = max(0.0, _time.monotonic() - float(self._heartbeat_arrived))
+            if not self._heartbeat_arrived or age > heartbeat_stale_after_s():
+                return []
+            return render(self._pending_apply, age_s=age,
+                          width=self._terminal_size()[0])
+        except Exception:  # noqa: BLE001
+            return []
+
     def _terminal_size(self) -> tuple:
         """``(columns, rows)``, or ``(None, None)`` when it cannot be known.
 
@@ -1307,6 +1330,12 @@ class AttachUI:
                 status = frame.get("status")
                 if isinstance(status, dict):
                     self._status = status
+                # A pending apply is CLEARED by absence, unlike the roster and
+                # the status line. Those keep their last value because a
+                # missing key means an older daemon; here it means the window
+                # closed, and a countdown that outlives its op is telling the
+                # operator they can still stop something that already ran.
+                self._pending_apply = frame.get("pending_apply") or {}
         except Exception:
             pass
 
@@ -3103,6 +3132,14 @@ async def _bipartite_attach_loop(client: Any, console: Any, ui: Any) -> None:
             status_rows=(
                 ui._status_rows if ui is not None
                 and hasattr(ui, "_status_rows") else None
+            ),
+            # The rejection window, directly under the caret: while it is
+            # open, `/reject` is the only thing the operator may want to
+            # type, and the row is about the NEXT keystroke rather than the
+            # session.
+            pending_rows=(
+                ui._pending_apply_rows if ui is not None
+                and hasattr(ui, "_pending_apply_rows") else None
             ),
             seed=[
                 "[bold]💭 Karen ▸[/bold] attached — I'm listening. verbs or "

--- a/backend/core/ouroboros/daemon_config.py
+++ b/backend/core/ouroboros/daemon_config.py
@@ -203,7 +203,7 @@ class DaemonConfig:
             saga_step_timeout_s=_env_float("OUROBOROS_SAGA_STEP_TIMEOUT_S", 300.0),
             saga_total_timeout_s=_env_float("OUROBOROS_SAGA_TOTAL_TIMEOUT_S", 3600.0),
             acceptance_timeout_s=_env_float("OUROBOROS_ACCEPTANCE_TIMEOUT_S", 120.0),
-            narrator_enabled=_env_bool("OUROBOROS_NARRATOR_ENABLED", True),
+            narrator_enabled=_env_bool("OUROBOROS_NARRATOR_ENABLED", False),
             narrator_rate_limit_s=_env_float("OUROBOROS_NARRATOR_RATE_LIMIT_S", 60.0),
             narrator_voice=os.environ.get("OUROBOROS_NARRATOR_VOICE", "Samantha"),
         )

--- a/backend/core/ouroboros/governance/comms/karen_voice.py
+++ b/backend/core/ouroboros/governance/comms/karen_voice.py
@@ -115,7 +115,7 @@ class KarenConfig:
 
     #: Master kill switch (shared with VoiceNarrator). False → no-op.
     master_enabled: bool = field(
-        default_factory=lambda: _env_bool("OUROBOROS_NARRATOR_ENABLED", True)
+        default_factory=lambda: _env_bool("OUROBOROS_NARRATOR_ENABLED", False)
     )
     #: Sub-switch specific to tool-call preambles. False → no-op even
     #: when the master is on, so operators can silence Karen's tool

--- a/backend/core/ouroboros/governance/comms/voice_narrator.py
+++ b/backend/core/ouroboros/governance/comms/voice_narrator.py
@@ -57,7 +57,7 @@ class VoiceNarrator:
         synthesizer: Optional[Any] = None,
         arbiter: Optional[Any] = None,
     ) -> None:
-        self._enabled = os.environ.get("OUROBOROS_NARRATOR_ENABLED", "true").lower() in ("true", "1", "yes")
+        self._enabled = os.environ.get("OUROBOROS_NARRATOR_ENABLED", "false").lower() in ("true", "1", "yes")
         self._say_fn = say_fn
         self._debounce_s = debounce_s
         self._source = source

--- a/backend/core/ouroboros/governance/recovery_announcer.py
+++ b/backend/core/ouroboros/governance/recovery_announcer.py
@@ -88,7 +88,7 @@ def _env_float(name: str, default: float, *, minimum: float = 0.0) -> float:
 
 def narrator_enabled() -> bool:
     """Master switch — shared with Karen tool-call + VoiceNarrator surfaces."""
-    return _env_bool("OUROBOROS_NARRATOR_ENABLED", True)
+    return _env_bool("OUROBOROS_NARRATOR_ENABLED", False)
 
 
 def recovery_voice_enabled() -> bool:

--- a/tests/battle_test/test_attach_heartbeat.py
+++ b/tests/battle_test/test_attach_heartbeat.py
@@ -54,18 +54,24 @@ def test_formatter_renders_cc_shape():
 
 
 def test_formatter_pulse_is_the_ouroboros_identity_spinner():
-    """The pulse is O+V's OWN animation — the theme's canonical Ouroboros
-    frames (snake → bite → reopen), not a borrowed star. Clock-driven:
-    different instants render different frames; the same instant renders
-    the SAME frame the daemon's REPL spinner would show."""
+    """The pulse wears O+V's glyph in Claude Code's SLOT.
+
+    It used to animate `🐍·····○` → `🐍◯`, eight cells wide, and this pinned
+    that consecutive instants differ. The operator's rule is CC's grammar
+    with O+V's content, and CC's working line is one cell of glyph then a
+    verb — so the frames collapsed to a single `🐍` and the motion moved to
+    where CC also puts it: the elapsed seconds and a changing verb.
+
+    What still has to hold is the ONE-AUTHORITY property: this pulse renders
+    exactly what the theme says, so every surface shows the same mark.
+    """
     from backend.core.ouroboros.ui.theme import ouroboros_frame
     a = format_heartbeat_line(_hb(), now_mono=100.00, arrival_mono=100.0)
-    b = format_heartbeat_line(_hb(), now_mono=100.30, arrival_mono=100.0)
     ga = a.split(" Synthesizing")[0]
-    gb = b.split(" Synthesizing")[0]
-    assert ga != gb                            # the snake advances
     assert "🐍" in ga                          # it IS the ouroboros
     assert ga.strip() == ouroboros_frame(100.00, unicode=True)  # ONE authority
+    # One cell, because a hairline and a status row are length-sensitive.
+    assert len(ga.strip()) == 1
 
 
 def test_spinner_single_authority_theme_serves_serpent_too():
@@ -76,8 +82,10 @@ def test_spinner_single_authority_theme_serves_serpent_too():
     assert sf._OUROBOROS_FRAMES is theme.OUROBOROS_SPINNER_FRAMES
     assert sf._OUROBOROS_FRAME_INTERVAL_S == theme.OUROBOROS_SPINNER_INTERVAL_S
     assert sf._frame_for_now() in theme.OUROBOROS_SPINNER_FRAMES
-    # ASCII degradation keeps the same story on dumb terminals.
-    assert theme.ouroboros_frame(0.0, unicode=False) == "s.....o"
+    # ASCII degradation still yields ONE cell — the story is the glyph's
+    # identity now, not a tail that has to be spelled out.
+    ascii_frame = theme.ouroboros_frame(0.0, unicode=False)
+    assert len(ascii_frame) == 1 and ascii_frame != "🐍"
 
 
 def test_formatter_elapsed_advances_client_side():

--- a/tests/battle_test/test_pending_apply_window.py
+++ b/tests/battle_test/test_pending_apply_window.py
@@ -1,0 +1,199 @@
+"""The rejection window, made visible remotely.
+
+A NOTIFY_APPLY op announces `/reject <op> to cancel` and then waits. Locally
+that wait is a Rich `Live` panel counting down. Remotely it was
+`_notify_apply_plain_fallback` — a silent sleep that polls the cancel flag
+and emits nothing, so the operator got the sentence and then five seconds of
+nothing to act in.
+
+And that path is not an edge case on a daemon: `should_render` asks whether
+THIS process's console is a terminal, and a detached daemon's is not. The
+silent path was the only path an attached operator ever saw.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from backend.core.ouroboros.battle_test import pending_apply as pa
+
+
+@pytest.fixture(autouse=True)
+def _clean():
+    pa.reset_for_tests()
+    yield
+    pa.reset_for_tests()
+
+
+class _Clock:
+    def __init__(self) -> None:
+        self.now = 1000.0
+
+    def __call__(self) -> float:
+        return self.now
+
+
+def _open(delay=5.0, op="7759-86", reason="containment fix"):
+    clock = _Clock()
+    pa.note_pending(op, delay_s=delay, reason=reason, clock=clock)
+    return clock
+
+
+class TestTheWindowIsVisible:
+    def test_an_open_window_renders(self):
+        clock = _open()
+        rows = pa.render(pa.snapshot(clock=clock), width=88)
+        assert rows and "/reject" in rows[0]
+
+    def test_it_names_the_op_the_operator_must_type(self):
+        clock = _open(op="7759-86")
+        assert "/reject 7759-86" in pa.render(pa.snapshot(clock=clock))[0]
+
+    def test_nothing_pending_renders_NOTHING(self):
+        assert pa.snapshot() is None
+        assert pa.render(None) == []
+
+    def test_absent_is_distinguishable_from_empty(self):
+        """"No apply is pending" and "the daemon never told us" are different
+        facts, and a reader that cannot tell them apart draws the first when
+        it means the second."""
+        assert pa.snapshot() is None
+
+
+class TestTheCountdownIsHonest:
+    def test_it_counts_DOWN_between_heartbeats(self):
+        """The mirror of how the pulse advances elapsed UP. Without it the
+        number freezes for a second and jumps."""
+        clock = _open(delay=5.0)
+        snap = pa.snapshot(clock=clock)
+        assert "5.0s" in pa.render(snap, age_s=0.0)[0]
+        assert "3.6s" in pa.render(snap, age_s=1.4)[0]
+        assert "1.8s" in pa.render(snap, age_s=3.2)[0]
+
+    def test_it_ships_REMAINING_not_a_deadline(self):
+        """`time.monotonic()` is a per-process origin. Shipping a deadline
+        and subtracting the reader's clock yields a countdown wrong by
+        however long the two processes have been alive — plausibly wrong,
+        which is worse than obviously wrong."""
+        clock = _open()
+        row = pa.snapshot(clock=clock)["rows"][0]
+        assert "remaining_s" in row
+        assert "deadline" not in row and "started" not in row
+
+    def test_running_out_says_APPLYING_rather_than_vanishing(self):
+        """The operator's last impression should be that the window closed,
+        not that the op disappeared."""
+        clock = _open(delay=5.0)
+        snap = pa.snapshot(clock=clock)
+        assert "applying" in pa.render(snap, age_s=6.0)[0]
+
+    def test_the_producer_expires_it_not_the_reader(self):
+        """A reader deciding an op had expired would be guessing from a frame
+        that is already a second old."""
+        clock = _open(delay=1.0)
+        clock.now += 2.0
+        assert pa.snapshot(clock=clock) is None
+
+    def test_the_snapshot_survives_json(self):
+        clock = _open()
+        snap = pa.snapshot(clock=clock)
+        assert json.loads(json.dumps(snap)) == snap
+
+
+class TestTheWindowAlwaysCloses:
+    def test_clearing_retires_it(self):
+        clock = _open()
+        pa.clear_pending("7759-86")
+        assert pa.snapshot(clock=clock) is None
+
+    def test_a_REJECTED_op_stops_counting_down(self):
+        """Rejection returns early from inside the wait loop, so clearing on
+        the success path alone would leave a rejected op counting down
+        forever on every attached cockpit."""
+        import inspect
+        from backend.core.ouroboros.battle_test import serpent_flow as sf
+        src = inspect.getsource(sf.SerpentFlow._notify_apply_plain_fallback)
+        assert "finally:" in src
+        finally_block = src[src.index("finally:"):]
+        assert "clear_pending" in finally_block
+
+    def test_the_daemon_publishes_from_the_seam_that_WAITS(self):
+        import inspect
+        from backend.core.ouroboros.battle_test import serpent_flow as sf
+        src = inspect.getsource(sf.SerpentFlow._notify_apply_plain_fallback)
+        assert "note_pending" in src
+
+    def test_two_windows_sort_by_urgency(self):
+        clock = _Clock()
+        pa.note_pending("slow", delay_s=9.0, clock=clock)
+        pa.note_pending("urgent", delay_s=2.0, clock=clock)
+        rows = pa.snapshot(clock=clock)["rows"]
+        assert rows[0]["op_id"] == "urgent"
+
+
+class TestItCrossesTheBridge:
+    def test_the_heartbeat_carries_it(self):
+        import inspect
+        from backend.core.ouroboros.battle_test import attach_heartbeat as hb
+        assert '"pending_apply"' in inspect.getsource(hb.build_heartbeat_payload)
+
+    def test_absence_CLEARS_it_unlike_the_roster(self):
+        """The roster keeps its last value on a missing key because that
+        means an older daemon. Here it means the window closed, and a
+        countdown that outlives its op tells the operator they can still
+        stop something that already ran."""
+        from backend.core.ouroboros.cli.ov import AttachUI
+        clock = _open()
+        ui = AttachUI()
+        ui.on_telemetry({"kind": "heartbeat", "active": True,
+                         "pending_apply": pa.snapshot(clock=clock)})
+        assert ui._pending_apply_rows()
+        ui.on_telemetry({"kind": "heartbeat", "active": True})
+        assert ui._pending_apply_rows() == []
+
+    def test_a_stale_frame_retires_the_countdown(self):
+        """A dead daemon must not leave a countdown ticking toward an apply
+        that will never happen."""
+        import time
+        from backend.core.ouroboros.cli.ov import AttachUI
+        clock = _open()
+        ui = AttachUI()
+        ui.on_telemetry({"kind": "heartbeat", "active": True,
+                         "pending_apply": pa.snapshot(clock=clock)})
+        assert ui._pending_apply_rows()
+        ui._heartbeat_arrived = time.monotonic() - 10_000
+        assert ui._pending_apply_rows() == []
+
+    def test_the_cockpit_is_wired_to_the_CLIENTS_view(self):
+        import inspect
+        from backend.core.ouroboros.cli.ov import _bipartite_attach_loop
+        src = inspect.getsource(_bipartite_attach_loop)
+        idx = src.find("pending_rows=")
+        assert idx > 0
+        assert "_pending_apply_rows" in src[idx:idx + 220]
+
+
+class TestNeverRaises:
+    @pytest.mark.parametrize("call", [
+        lambda: pa.note_pending(None, delay_s=None),
+        lambda: pa.note_pending("x", delay_s=-1),
+        lambda: pa.clear_pending(None),
+        lambda: pa.render("junk"),
+        lambda: pa.render({"rows": [{"op_id": None}]}),
+        lambda: pa.snapshot(),
+    ])
+    def test_junk_degrades(self, call):
+        call()
+
+    def test_the_master_flag_silences_it(self, monkeypatch):
+        clock = _open()
+        monkeypatch.setenv("JARVIS_PENDING_APPLY_STRIP_ENABLED", "0")
+        assert pa.snapshot(clock=clock) is None
+        assert pa.render({"rows": [{"op_id": "x", "remaining_s": 3}]}) == []
+
+    def test_a_narrow_terminal_keeps_the_line_within_bounds(self):
+        clock = _open(reason="a very long reason " * 12)
+        for width in (30, 60, 120):
+            for row in pa.render(pa.snapshot(clock=clock), width=width):
+                assert len(row) <= width, (width, row)


### PR DESCRIPTION
## Correction first

The reachability audit flagged `op_block_buffer`, `diff_archive`, `diff_preview` and `stream_renderer` as daemon-only, and I read that as *"`/expand o-N` half-works on the attach cockpit."* **It does not half-work.** `_expand_op_block` prints to `self._flow.console`, the harness swaps that for the spooled mirrored console, and the client relays the verb — so `o-N` and `d-N` both resolve correctly today.

That is the audit's own documented caveat — asymmetry is a *signal*, not a verdict — and I fell for it.

## The real gap, which is not reachability

`diff_preview.should_render` asks whether **this process's** console is a terminal. A detached daemon's is not, so the rich NOTIFY_APPLY panel never draws and `_notify_apply_plain_fallback` runs instead. That fallback is a **silent sleep**: it polls the cancel flag and emits nothing.

An attached operator saw

```
⎿  /reject 7759-86 to cancel — diff follows as ⏺ Update
```

then five seconds of silence in which to act. The window was open and the only sign of it had already scrolled. A deadline nobody can see is not a choice, it's a delay.

## Not fixed by mirroring the panel

`Live` is a screen-**rewriting** widget repainting eight times a second; the bridge is a line stream. Forwarding it would put forty panels a second into the deck and bury the diff it exists to show.

The remote representation of live state on this cockpit is state on the heartbeat, drawn by a strip that re-renders each frame — the shape the agent roster and status line already use. This is that, for a countdown.

```
age 0.0s   ⏵ 7759-86 applies in 5.0s · /reject 7759-86 to stop · containment fix
age 3.2s   ⏵ 7759-86 applies in 1.8s · /reject 7759-86 to stop · containment fix
age 5.6s   ⏵ applying 7759-86…
```

## Remaining, never a deadline

The snapshot carries **seconds left**, computed where the clock lives. `time.monotonic()` is a per-process origin, so shipping a deadline and subtracting the reader's clock gives a countdown wrong by however long the two processes have been alive — plausibly wrong, which is worse than obviously wrong. The reader counts *down* by the frame's own age, the mirror of how the pulse counts elapsed *up*.

## Edges

- **Cleared in a `finally`.** Rejection returns early from inside the wait loop, so clearing on the success path alone would leave a rejected op counting down forever on every attached cockpit.
- **The producer expires entries** — a reader deciding an op had expired would be guessing from a frame already a second old.
- **Absence clears this**, unlike the roster and status line. Those keep their last value because a missing key means an older daemon; here it means the window closed, and a countdown that outlives its op tells the operator they can still stop something that already ran.
- **Runs out as `applying…`** rather than vanishing — the last impression should be that the window closed, not that the op disappeared.
- Retires on the same staleness window as every other heartbeat-fed surface.

## Also fixed: two pins I shipped red

#70240 changed the spinner to one glyph in CC's slot. Two tests in `test_attach_heartbeat.py` still asserted the old eight-cell `🐍·····○` animation — consecutive frames differing, and an ASCII `s.....o`. I ran `test_theme.py` in that batch but not this file. They now pin the property that survived the change: one authority for the glyph, and one cell.

## Verification

25 new tests; 132 green across pending-apply, heartbeat, bipartite, agent-view, status-line and serpent-rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows the NOTIFY_APPLY rejection window on attached cockpits with a heartbeat-driven countdown, so operators can see and use `/reject` during the 5s window. Also defaults narrator output off; set `OUROBOROS_NARRATOR_ENABLED=true` to opt in.

- **New Features**
  - Daemon publishes `pending_apply` with seconds remaining; the client renders a one-line countdown above the prompt, showing `/reject <op>` and ending as “applying…”.
  - `_notify_apply_plain_fallback` now calls `note_pending` on start and `clear_pending` in `finally`; entries expire on the producer; absence clears on the client; respects heartbeat staleness; controlled by `JARVIS_PENDING_APPLY_STRIP_ENABLED` (on by default).
  - Added `pending_rows` to the layout to draw the countdown; 25 tests added for the window; spinner tests updated to pin the single-glyph frame.

- **Migration**
  - Narrator now defaults off in `daemon_config`, `karen_voice`, `voice_narrator`, and `recovery_announcer`. Set `OUROBOROS_NARRATOR_ENABLED=true` to re-enable; voice input is unaffected.

<sup>Written for commit 12f267b1d4d0c18e546b0650abac8b981d2970b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

