### PR TITLE
fix(ov): voice follows attachment — Karen stops when the room empties

### DIFF
--- a/backend/core/ouroboros/battle_test/cockpit_attach.py
+++ b/backend/core/ouroboros/battle_test/cockpit_attach.py
@@ -135,6 +135,69 @@ def _accepts_two_positional(fn: Any) -> bool:
         return False
 
 
+#: The live bridge, for code that cannot be handed one.
+#:
+#: Same pattern as `bipartite_layout.set_active_canvas`: the producer
+#: (the harness, which builds the bridge) and the consumer (the speech
+#: primitive, three packages away) have no handle to each other.
+_ACTIVE_BRIDGE: Any = None
+
+
+def set_active_bridge(bridge: Any) -> None:
+    """Register the live bridge, or clear it with None. NEVER raises."""
+    global _ACTIVE_BRIDGE
+    try:
+        _ACTIVE_BRIDGE = bridge
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def attached_cockpits() -> int:
+    """How many cockpits are listening right now. NEVER raises."""
+    try:
+        clients = getattr(_ACTIVE_BRIDGE, "_clients", None)
+        return len(clients) if clients else 0
+    except Exception:  # noqa: BLE001
+        return 0
+
+
+def operator_present() -> bool:
+    """Is there a human who can perceive output right now?
+
+    THE PROBLEM THIS ANSWERS
+    -------------------------
+    `ov` detaches: closing the terminal leaves the organism running, which is
+    the intended behaviour and a good one. But Karen kept NARRATING to a
+    machine whose operator had gone home — audio out of the speakers with no
+    cockpit anywhere to hear it. Text already behaves correctly:
+    `publish_markup` returns early when `_clients` is empty. Speech had no
+    equivalent, so it addressed an empty room.
+
+    Two ways a human can be present, and both count:
+
+      * a cockpit is ATTACHED over the bridge (`ov attach`), or
+      * this process owns a real terminal (a foreground run with its own
+        REPL, where the operator is looking straight at it).
+
+    The TTY arm is also the honest degradation: if the bridge cannot be
+    consulted at all, a detached daemon has no terminal and falls silent
+    while a foreground run keeps its voice — which is the correct answer in
+    both cases, reached without guessing.
+    """
+    try:
+        if attached_cockpits() > 0:
+            return True
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        from backend.core.ouroboros.battle_test.presentation_restraint import (
+            real_stdout_isatty,
+        )
+        return bool(real_stdout_isatty())
+    except Exception:  # noqa: BLE001
+        return False
+
+
 def attach_enabled() -> bool:
     """Master gate — default ON. NEVER raises."""
     return os.environ.get(

--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -4659,6 +4659,16 @@ class BattleTestHarness:
             )
             if await bridge.start():
                 self._cockpit_attach_bridge = bridge
+                # Publish it for code that cannot be handed one — the speech
+                # primitive lives three packages away and needs to know
+                # whether anybody is listening before it talks.
+                try:
+                    from backend.core.ouroboros.battle_test.cockpit_attach import (
+                        set_active_bridge,
+                    )
+                    set_active_bridge(bridge)
+                except Exception:  # noqa: BLE001
+                    pass
                 # Tool-activity mirror (2026-07-23): wire SerpentFlow's
                 # op-scoped render chokepoint to the bridge's typed
                 # markup channel — attached `ov` cockpits see the SAME
@@ -4821,9 +4831,23 @@ class BattleTestHarness:
                                  exc_info=True)
             else:
                 self._cockpit_attach_bridge = None
+            try:
+                from backend.core.ouroboros.battle_test.cockpit_attach import (
+                    set_active_bridge,
+                )
+                set_active_bridge(None)
+            except Exception:  # noqa: BLE001
+                pass
         except Exception:  # noqa: BLE001
             logger.debug("[CockpitAttach] mount degraded", exc_info=True)
             self._cockpit_attach_bridge = None
+            try:
+                from backend.core.ouroboros.battle_test.cockpit_attach import (
+                    set_active_bridge,
+                )
+                set_active_bridge(None)
+            except Exception:  # noqa: BLE001
+                pass
 
     def _qos_emit_signal(self, envelope: Any) -> None:
         """Route a UX_DEGRADATION_EVENT into O+V's intake — the SAME

--- a/backend/core/supervisor/unified_voice_orchestrator.py
+++ b/backend/core/supervisor/unified_voice_orchestrator.py
@@ -1408,6 +1408,35 @@ async def safe_say(
     if not text or not text.strip():
         return False
 
+    # 0. IS ANYBODY THERE?
+    #
+    # `ov` detaches: closing the terminal leaves the organism running, which
+    # is intended and good. But speech kept coming out of the machine's
+    # speakers after the operator had gone — audio addressed to an empty
+    # room, and no way to stop it short of killing the daemon.
+    #
+    # Text already behaves correctly: `publish_markup` returns early when no
+    # cockpit is attached. Speech had no equivalent, so this is that — at the
+    # ONE primitive the whole process speaks through, rather than in each of
+    # the thirteen narrators that call it.
+    #
+    # `skip_gate` is the deliberate carve-out and it already existed for
+    # exactly this class of message: something urgent enough to say whether
+    # or not the room is ready for it. Emergencies still speak.
+    if not skip_gate:
+        try:
+            from backend.core.ouroboros.battle_test.cockpit_attach import (
+                operator_present,
+            )
+            if not operator_present():
+                logger.debug(
+                    "[safe_say:%s] no operator present — not speaking: %s",
+                    source, text[:60],
+                )
+                return False
+        except Exception:  # noqa: BLE001 — presence is a courtesy, not a gate
+            pass
+
     # 1. Dedup check (broker-level, across all subsystems)
     if not skip_dedup:
         if global_speech_dedup_check(text):

--- a/tests/battle_test/test_voice_follows_attachment.py
+++ b/tests/battle_test/test_voice_follows_attachment.py
@@ -1,0 +1,140 @@
+"""Karen speaks to a room, and stops when the room empties.
+
+`ov` detaches: closing the terminal leaves the organism running, which is
+intended and good. But speech kept coming out of the machine's speakers after
+the operator had gone home — audio addressed to nobody, with no way to stop
+it short of killing the daemon.
+
+Text already behaved correctly: `publish_markup` returns early when no
+cockpit is attached. Speech had no equivalent.
+
+The first attempt at this was to flip the narrator's default to OFF. That
+treats the symptom and costs Karen the times she IS useful; the operator
+diagnosed the real cause — the voice outliving the terminal — and this is
+that fix.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from backend.core.ouroboros.battle_test import cockpit_attach as ca
+
+
+class _Bridge:
+    def __init__(self, n: int) -> None:
+        self._clients = {f"c{i}": object() for i in range(n)}
+
+
+@pytest.fixture(autouse=True)
+def _detached(monkeypatch):
+    """No bridge and no terminal — the state a daemonised `ov` is in."""
+    ca.set_active_bridge(None)
+    monkeypatch.setattr(
+        "backend.core.ouroboros.battle_test.presentation_restraint"
+        ".real_stdout_isatty", lambda: False,
+    )
+    yield
+    ca.set_active_bridge(None)
+
+
+class TestPresence:
+    def test_a_detached_daemon_has_no_operator(self):
+        assert ca.attached_cockpits() == 0
+        assert ca.operator_present() is False
+
+    def test_an_attached_cockpit_is_an_operator(self):
+        ca.set_active_bridge(_Bridge(1))
+        assert ca.operator_present() is True
+
+    def test_several_cockpits_are_counted(self):
+        ca.set_active_bridge(_Bridge(3))
+        assert ca.attached_cockpits() == 3
+
+    def test_detaching_empties_the_room(self):
+        ca.set_active_bridge(_Bridge(1))
+        assert ca.operator_present()
+        ca.set_active_bridge(None)
+        assert ca.operator_present() is False
+
+    def test_a_FOREGROUND_run_counts_even_with_no_bridge(self, monkeypatch):
+        """The operator is looking straight at the daemon's own terminal.
+        Requiring an attached cockpit would silence Karen for someone in the
+        room with her."""
+        monkeypatch.setattr(
+            "backend.core.ouroboros.battle_test.presentation_restraint"
+            ".real_stdout_isatty", lambda: True,
+        )
+        assert ca.operator_present() is True
+
+    def test_an_unreadable_bridge_falls_back_to_the_TERMINAL(self, monkeypatch):
+        """The honest degradation: if the bridge cannot be consulted, a
+        detached daemon has no terminal and falls silent while a foreground
+        run keeps its voice — the right answer in both cases, reached
+        without guessing."""
+        class _Broken:
+            @property
+            def _clients(self):
+                raise RuntimeError("bridge down")
+        ca.set_active_bridge(_Broken())
+        assert ca.operator_present() is False
+        monkeypatch.setattr(
+            "backend.core.ouroboros.battle_test.presentation_restraint"
+            ".real_stdout_isatty", lambda: True,
+        )
+        assert ca.operator_present() is True
+
+
+class TestTheSpeechPrimitiveHonoursIt:
+    def _say(self, **kw):
+        from backend.core.supervisor.unified_voice_orchestrator import safe_say
+        return asyncio.get_event_loop().run_until_complete(
+            safe_say("the vision floor raises", source="test", **kw))
+
+    def test_an_empty_room_gets_no_speech(self):
+        assert self._say() is False
+
+    def test_urgent_speech_still_gets_through(self):
+        """`skip_gate` already existed for exactly this class of message —
+        something urgent enough to say whether or not the room is ready. An
+        emergency must not be silenced by an absent audience."""
+        import inspect
+        from backend.core.supervisor import unified_voice_orchestrator as uvo
+        src = inspect.getsource(uvo.safe_say)
+        gate = src[src.index("IS ANYBODY THERE"):src.index("1. Dedup")]
+        assert "if not skip_gate:" in gate
+
+    def test_the_gate_is_at_the_ONE_primitive(self):
+        """Thirteen modules call `safe_say`. Gating each would be thirteen
+        chances to miss one, and the fourteenth would ship ungated."""
+        import inspect
+        from backend.core.supervisor import unified_voice_orchestrator as uvo
+        assert "operator_present" in inspect.getsource(uvo.safe_say)
+
+    def test_presence_is_a_courtesy_not_a_hard_gate(self):
+        """If the check itself fails, speech proceeds. A broken import must
+        not mute the assistant."""
+        import inspect
+        from backend.core.supervisor import unified_voice_orchestrator as uvo
+        src = inspect.getsource(uvo.safe_say)
+        gate = src[src.index("IS ANYBODY THERE"):src.index("1. Dedup")]
+        assert "except Exception" in gate and "pass" in gate
+
+
+class TestTheHarnessPublishesTheBridge:
+    def test_it_registers_on_mount_and_clears_on_teardown(self):
+        import pathlib
+        src = pathlib.Path(
+            "backend/core/ouroboros/battle_test/harness.py"
+        ).read_text(encoding="utf-8")
+        assert "set_active_bridge(bridge)" in src
+        assert "set_active_bridge(None)" in src
+
+
+class TestNeverRaises:
+    @pytest.mark.parametrize("junk", [None, object(), 42, "bridge"])
+    def test_junk_bridges_degrade(self, junk):
+        ca.set_active_bridge(junk)
+        assert isinstance(ca.attached_cockpits(), int)
+        assert isinstance(ca.operator_present(), bool)


### PR DESCRIPTION
The operator's diagnosis, which was better than mine: **the voice kept going after they closed the terminal.** I had proposed flipping the narrator default to OFF — that treats the symptom and costs Karen every time she *is* useful. #70242 is closed.

## The actual cause

`ov` **detaches**. Closing the terminal leaves the organism running — intended, documented, and a good property. But speech kept coming out of the machine's speakers with no cockpit anywhere to hear it, and no way to stop it short of killing the daemon.

Text already got this right: `publish_markup` returns early when `_clients` is empty, so an unattended daemon writes to nobody. **Speech had no equivalent** and addressed an empty room.

## One primitive, not thirteen narrators

`safe_say` is documented as *"the canonical safe speech function for the entire JARVIS process"* and thirteen modules call it. The gate goes there. Gating each narrator would be thirteen chances to miss one, and the fourteenth would ship ungated — which is how this class of defect has recurred all session.

`skip_gate` is the carve-out, and it **already existed** for exactly this class of message: something urgent enough to say whether or not the room is ready for it. Emergencies still speak.

## What counts as present

Two ways, and both count:

- a cockpit **attached** over the bridge, or
- this process owning a **real terminal** — a foreground run where the operator is looking straight at it

Requiring an attached cockpit would silence Karen for someone sitting in the room with her.

The TTY arm doubles as the honest degradation. If the bridge can't be consulted at all, a detached daemon has no terminal and falls silent while a foreground run keeps its voice — the correct answer in both cases, reached without a fail-open/fail-closed guess. And if the presence *check* raises, speech proceeds: a broken import must not mute the assistant.

```
detached daemon, no tty   → silent
cockpit attached          → speaks
foreground run, has tty   → speaks
bridge unreadable         → falls back to the terminal
skip_gate=True            → always speaks
```

The bridge is published through a module-level registry — the same pattern `bipartite_layout.set_active_canvas` already uses for the same reason: the producer (the harness) and the consumer (a speech primitive three packages away) have no handle to each other. Registered on mount, cleared on teardown.

## Verification

15 new tests; 81 green across attach, daemon-config, karen-voice control plane, narrator wiring and boot briefing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop Karen from speaking after the room empties. Speech now plays only when a cockpit is attached or the process has a real TTY; urgent messages still speak.

- **Bug Fixes**
  - Added a presence gate in `safe_say` that checks `operator_present()` unless `skip_gate=True`.
  - Introduced a bridge registry in `cockpit_attach` with `set_active_bridge`, `attached_cockpits`, and `operator_present()` (counts attached cockpits or TTY; never raises; degrades to TTY when bridge is unreadable).
  - Updated the harness to publish the active bridge on mount and clear it on teardown.
  - Added tests for presence and speech gating (15 new tests).

<sup>Written for commit 1cb91e677af4863cf2e5e1d2f24888a4c301200e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

