### PR TITLE
feat(ov): the generation reaches the cockpit — a line at a time

### DIFF
--- a/backend/core/ouroboros/battle_test/cockpit_attach.py
+++ b/backend/core/ouroboros/battle_test/cockpit_attach.py
@@ -198,6 +198,28 @@ def operator_present() -> bool:
         return False
 
 
+def publish_markup_global(text: str, *, session: Optional[str] = None) -> bool:
+    """Emit one composed line to every attached cockpit. Returns whether it went.
+
+    For producers with no handle to the bridge — the token stream runs three
+    packages away from the harness that owns it. Same registry the presence
+    check uses, so "is anyone listening" and "send it to them" cannot
+    disagree about which bridge is live.
+
+    The caller owns ESCAPING. This channel is styled chrome around inert
+    data; untrusted text must be escaped before it arrives, per
+    `publish_markup`. NEVER raises.
+    """
+    try:
+        bridge = _ACTIVE_BRIDGE
+        if bridge is None or attached_cockpits() <= 0:
+            return False
+        bridge.publish_markup(str(text), session=session)
+        return True
+    except Exception:  # noqa: BLE001
+        return False
+
+
 def attach_enabled() -> bool:
     """Master gate — default ON. NEVER raises."""
     return os.environ.get(

--- a/backend/core/ouroboros/battle_test/stream_renderer.py
+++ b/backend/core/ouroboros/battle_test/stream_renderer.py
@@ -67,6 +67,19 @@ def flow_mode_enabled() -> bool:
     return os.environ.get(_FLOW_MODE_ENV_VAR, "0").strip().lower() in _TRUTHY
 
 
+#: Longest single line the deck will carry from a generation. A model can
+#: emit a 40k-character line; the deck is a ring of terminal rows.
+_MIRROR_MAX_LINE_CHARS = 2000
+
+
+def mirror_stream_enabled() -> bool:
+    """Default ON. Off, the generation is invisible on an attached cockpit
+    again — which is the state this exists to end. NEVER raises."""
+    return os.environ.get(
+        "JARVIS_STREAM_MIRROR_ENABLED", "1",
+    ).strip().lower() not in ("0", "false", "no", "off")
+
+
 def find_commit_boundary(text: str, start: int = 0) -> int:
     """Return the index up to which ``text`` can be safely committed to
     scrollback: just past the LAST complete blank line that sits OUTSIDE
@@ -184,6 +197,15 @@ class StreamRenderer:
         # the env gate at start() so one op never splits across modes.
         self._flow_mode: bool = False
         self._committed_offset: int = 0
+        #: How much of the buffer has been MIRRORED to attached cockpits.
+        #:
+        #: Separate from `_committed_offset`, which belongs to the local Live
+        #: widget's scrollback commits. They advance on different triggers and
+        #: for different audiences; sharing one cursor would make a local
+        #: terminal's rendering decisions silently truncate a remote deck.
+        self._mirrored_offset: int = 0
+        #: Has this stream announced itself to the deck yet?
+        self._mirror_opened: bool = False
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -329,6 +351,11 @@ class StreamRenderer:
         # synchronous drain opportunity.
         self._drain_remaining_sync()
 
+        # FINAL mirror flush — the tail after the last newline would
+        # otherwise never reach an attached cockpit, so every generation
+        # would lose its closing sentence.
+        self._mirror_completed_lines(final=True)
+
         if self._live is not None:
             try:
                 from rich.markdown import Markdown
@@ -375,6 +402,8 @@ class StreamRenderer:
         self._queue = None
         self._buffer = ""
         self._committed_offset = 0
+        self._mirrored_offset = 0
+        self._mirror_opened = False
         self._flow_mode = False
         self._op_id = ""
         self._provider = ""
@@ -518,6 +547,9 @@ class StreamRenderer:
                     self._buffer += "".join(pending)
                     pending.clear()
                     self._render_buffer_safe()
+                    # Same batch tick as the local widget, so the remote deck
+                    # and a local terminal see the generation at one cadence.
+                    self._mirror_completed_lines()
                     last_render = now
         except asyncio.CancelledError:
             # Final flush on cancellation (end() path). Any pending
@@ -528,6 +560,79 @@ class StreamRenderer:
                 pending.clear()
                 self._render_buffer_safe()
             raise
+
+    def _mirror_completed_lines(self, *, final: bool = False) -> None:
+        """Send completed LINES of the generation to attached cockpits.
+
+        WHY THIS EXISTS
+        ---------------
+        The Rich `Live` widget is skipped whenever a SerpentREPL is active —
+        it "writes via direct cursor manipulation that bypasses
+        `patch_stdout` and clobbers the input prompt". In `ov` the REPL is
+        always active, so the visible stream has never rendered there, and
+        enabling it would corrupt the line the operator is typing on. The
+        widget cannot be the answer; it is the thing that does not fit.
+
+        What DOES fit is the channel the cockpit already has: a mirrored,
+        line-oriented deck. So the generation arrives as it is written,
+        a line at a time, next to the ⏺ blocks it belongs with.
+
+        WHY NOT `find_commit_boundary`
+        -------------------------------
+        That helper commits at blank lines OUTSIDE fenced code blocks, so
+        Rich can re-parse a complete Markdown block in scrollback. The deck
+        does not re-parse — it draws escaped text. Borrowing that rule here
+        would make a long paragraph or an open code fence show NOTHING until
+        the stream ended, which is the silence this exists to fix. Different
+        medium, different boundary: the last newline.
+
+        NEVER raises, and never blocks — the bridge publish is a queue put.
+        """
+        try:
+            if not mirror_stream_enabled():
+                return
+            end = len(self._buffer)
+            if not final:
+                nl = self._buffer.rfind("\n", self._mirrored_offset)
+                if nl < 0:
+                    return
+                end = nl + 1
+            chunk = self._buffer[self._mirrored_offset:end]
+            if not chunk.strip():
+                self._mirrored_offset = end
+                return
+
+            from backend.core.ouroboros.battle_test.cockpit_attach import (
+                publish_markup_global,
+            )
+            from rich.markup import escape
+
+            lines = chunk.splitlines()
+            sent_any = False
+            for raw in lines:
+                text = raw.rstrip()
+                if not text and not sent_any:
+                    continue
+                # Model output is UNTRUSTED — escaped before it touches a
+                # channel documented as styled chrome around inert data.
+                body = escape(text[:_MIRROR_MAX_LINE_CHARS])
+                if len(text) > _MIRROR_MAX_LINE_CHARS:
+                    body += "…"
+                if not self._mirror_opened:
+                    # One ⏺ opens the block, as assistant prose does in the
+                    # deck's grammar; continuations indent under it.
+                    lead = f"⏺ {body}"
+                    self._mirror_opened = True
+                else:
+                    lead = f"  {body}"
+                if publish_markup_global(lead):
+                    sent_any = True
+            self._mirrored_offset = end
+        except Exception:  # noqa: BLE001 — a mirror must not break a stream
+            logger.debug(
+                "[StreamRender] op=%s mirror degraded", self._op_id,
+                exc_info=True,
+            )
 
     def _render_buffer_safe(self) -> None:
         """Swap the Markdown renderable on Live. Rich handles the

--- a/tests/battle_test/test_stream_mirror.py
+++ b/tests/battle_test/test_stream_mirror.py
@@ -1,280 +1,156 @@
-"""Model output reaches an attached cockpit.
+"""The generation reaches an attached cockpit, a line at a time.
 
-`StreamRenderer` shows tokens arriving as the model thinks — the difference
-between watching work happen and reading a report of it. It draws with Rich
-`Live`, an animated in-place widget, so it needs a real TTY and CANNOT be
-mirrored: `Live` repaints by moving the cursor, and replaying those escapes on
-a remote surface corrupts it rather than animating it.
+`stream_renderer` skips its Rich `Live` widget whenever a SerpentREPL is
+active, because Live "writes via direct cursor manipulation that bypasses
+`patch_stdout` and clobbers the input prompt". In `ov` the REPL is ALWAYS
+active, so the visible token stream has never rendered there — and enabling
+it would corrupt the line the operator is typing on. The widget is not the
+answer; it is the thing that does not fit.
 
-The local widget is therefore untouched, and a SECOND consumer of the same
-token feed emits committed text frames. Two renderings of one stream; neither
-a degraded copy of the other.
+What fits is the channel the cockpit already has: a mirrored, line-oriented
+deck. These tests pin that the generation arrives there, that untrusted model
+text is escaped before it does, and that nothing about the stream itself can
+be broken by the mirror failing.
 """
 from __future__ import annotations
 
-import ast
-from pathlib import Path
-from typing import Any, List
-
 import pytest
 
-from backend.core.ouroboros.battle_test.stream_mirror import (
-    StreamMirror,
-    fan_out_tokens,
-    stream_mirror_enabled,
-)
-
-_REPO = Path(__file__).resolve().parents[2]
-_SRC = _REPO / "backend/core/ouroboros/battle_test/serpent_flow.py"
+from backend.core.ouroboros.battle_test import cockpit_attach as ca
+from backend.core.ouroboros.battle_test.stream_renderer import StreamRenderer
 
 
-def _mirror(frames: List[str], t: Any = None) -> StreamMirror:
-    clock = t if t is not None else (lambda: 0.0)
-    return StreamMirror(frames.append, clock=clock)
+class _Bridge:
+    def __init__(self) -> None:
+        self._clients = {"c": object()}
+        self.sent: list = []
+
+    def publish_markup(self, text, session=None):
+        self.sent.append(str(text))
 
 
-# --------------------------------------------------------------------------
-# 1. tokens become frames, not a flood
-# --------------------------------------------------------------------------
-
-def test_tokens_are_batched_into_frames() -> None:
-    """One bridge write per token would put thousands of frames on the socket
-    for a single reply, and the client would parse JSON instead of drawing."""
-    frames: List[str] = []
-    m = _mirror(frames)
-    for _ in range(200):
-        m.on_token("word ")
-    m.end()
-    assert frames, "nothing was emitted"
-    assert len(frames) < 30, f"{len(frames)} frames for 200 tokens — a flood"
+@pytest.fixture
+def bridge():
+    b = _Bridge()
+    ca.set_active_bridge(b)
+    yield b
+    ca.set_active_bridge(None)
 
 
-def test_the_whole_text_survives_batching() -> None:
-    """Batching must not lose prose."""
-    frames: List[str] = []
-    m = _mirror(frames)
-    words = [f"w{i} " for i in range(120)]
-    for w in words:
-        m.on_token(w)
-    m.end()
-    joined = "".join(frames)
-    assert "w0 " in joined and "w119 " in joined
+def _renderer() -> StreamRenderer:
+    r = StreamRenderer.__new__(StreamRenderer)
+    r._buffer = ""
+    r._mirrored_offset = 0
+    r._mirror_opened = False
+    r._op_id = "7759-86"
+    return r
 
 
-def test_a_slow_stream_still_flushes_on_TIME() -> None:
-    """Char count alone would hold text indefinitely when the model is slow —
-    the operator would watch a still screen while tokens trickled in."""
-    frames: List[str] = []
-    clock = {"t": 0.0}
-    m = _mirror(frames, lambda: clock["t"])
-    m.on_token("a short sentence that ends here. ")
-    clock["t"] = 10.0
-    m.on_token("more ")
-    assert frames, "a slow stream never flushed"
+def _feed(r, *chunks, final=False):
+    for c in chunks:
+        r._buffer += c
+        r._mirror_completed_lines()
+    if final:
+        r._mirror_completed_lines(final=True)
 
 
-def test_end_emits_the_remainder_boundary_or_not() -> None:
-    """A tail with no clean cut must not be silently swallowed."""
-    frames: List[str] = []
-    m = _mirror(frames)
-    m.on_token("no terminator here")
-    m.end()
-    assert "".join(frames).strip() == "no terminator here"
+class TestItReachesTheDeck:
+    def test_completed_lines_are_mirrored(self, bridge):
+        _feed(_renderer(), "the vision floor raises\n")
+        assert bridge.sent == ["⏺ the vision floor raises"]
+
+    def test_the_block_opens_ONCE(self, bridge):
+        """One ⏺ opens the block, as assistant prose does in the deck's
+        grammar; continuations indent under it."""
+        _feed(_renderer(), "first\n", "second\n", "third\n")
+        assert bridge.sent[0].startswith("⏺ ")
+        assert all(s.startswith("  ") for s in bridge.sent[1:])
+
+    def test_a_partial_line_WAITS_for_its_newline(self, bridge):
+        """Emitting a half-written sentence would make the deck stutter
+        words rather than deliver lines."""
+        _feed(_renderer(), "the vision floor ")
+        assert bridge.sent == []
+
+    def test_the_final_tail_is_not_LOST(self, bridge):
+        """Content after the last newline would otherwise never be sent, so
+        every generation would lose its closing sentence."""
+        r = _renderer()
+        _feed(r, "line one\n", "no trailing newline", final=True)
+        assert bridge.sent[-1].strip() == "no trailing newline"
+
+    def test_a_code_fence_survives(self, bridge):
+        """`find_commit_boundary` refuses to split a fence because Rich
+        re-parses Markdown in scrollback. The deck draws escaped text and
+        does not re-parse, so borrowing that rule would show NOTHING until
+        the fence closed — the silence this exists to fix."""
+        _feed(_renderer(), "```python\n", "def f():\n", "    raise\n")
+        assert any("def f():" in s for s in bridge.sent)
 
 
-def test_end_on_an_empty_stream_emits_nothing() -> None:
-    frames: List[str] = []
-    _mirror(frames).end()
-    assert frames == []
+class TestModelTextIsInert:
+    def test_markup_in_the_generation_is_ESCAPED(self, bridge):
+        """The channel is documented as styled chrome around inert data.
+        A model that emits `[bold red]` must not restyle the operator's
+        deck."""
+        _feed(_renderer(), "consider [bold red]this[/bold red] case\n")
+        assert "\\[bold red]" in bridge.sent[0]
+
+    def test_an_enormous_line_is_bounded(self, bridge):
+        """A model can emit a 40k-character line; the deck is a ring of
+        terminal rows."""
+        _feed(_renderer(), "x" * 40000 + "\n")
+        assert len(bridge.sent[0]) < 2200
+        assert bridge.sent[0].endswith("…")
 
 
-def test_whitespace_only_is_not_a_frame() -> None:
-    frames: List[str] = []
-    m = _mirror(frames)
-    m.on_token("   \n  ")
-    m.end()
-    assert frames == []
+class TestItNeverBreaksTheStream:
+    def test_no_cockpit_attached_sends_nothing_and_does_not_raise(self):
+        ca.set_active_bridge(None)
+        r = _renderer()
+        _feed(r, "some output\n", final=True)
+        assert r._mirrored_offset > 0   # it still advanced; nothing hung
+
+    def test_a_raising_bridge_is_swallowed(self):
+        class _Broken:
+            _clients = {"c": 1}
+            def publish_markup(self, *a, **k):
+                raise RuntimeError("bridge down")
+        ca.set_active_bridge(_Broken())
+        try:
+            _feed(_renderer(), "output\n", final=True)
+        finally:
+            ca.set_active_bridge(None)
+
+    def test_the_master_flag_silences_it(self, bridge, monkeypatch):
+        monkeypatch.setenv("JARVIS_STREAM_MIRROR_ENABLED", "0")
+        _feed(_renderer(), "output\n", final=True)
+        assert bridge.sent == []
+
+    def test_the_mirror_owns_its_OWN_cursor(self):
+        """`_committed_offset` belongs to the local Live widget's scrollback
+        commits. Sharing one cursor would let a local terminal's rendering
+        decisions silently truncate a remote deck."""
+        import inspect
+        src = inspect.getsource(StreamRenderer._mirror_completed_lines)
+        assert "_mirrored_offset" in src
+        assert "_committed_offset" not in src
 
 
-# --------------------------------------------------------------------------
-# 2. it cuts where the local renderer cuts
-# --------------------------------------------------------------------------
+class TestItIsWiredToTheDrainLoop:
+    def test_the_consumer_mirrors_on_every_batch(self):
+        import inspect
+        src = inspect.getsource(StreamRenderer._consume)
+        assert "_mirror_completed_lines()" in src
 
-def test_it_uses_the_renderers_own_boundary_rule() -> None:
-    """Reusing `find_commit_boundary` means both surfaces break text at the
-    same places, so they never disagree about what has been "said" — and
-    markdown spanning a boundary is not severed mid-structure."""
-    src = (_REPO / "backend/core/ouroboros/battle_test/"
-           "stream_mirror.py").read_text()
-    imported = {
-        alias.name
-        for node in ast.walk(ast.parse(src))
-        if isinstance(node, ast.ImportFrom) for alias in node.names
-    }
-    assert "find_commit_boundary" in imported
+    def test_end_of_stream_flushes_the_tail(self):
+        import inspect
+        src = inspect.getsource(StreamRenderer.end)
+        assert "_mirror_completed_lines(final=True)" in src
 
-
-def test_a_long_unbroken_paragraph_is_not_held_hostage() -> None:
-    """Holding text for a boundary that never arrives is worse than one
-    awkward break."""
-    frames: List[str] = []
-    m = _mirror(frames)
-    m.on_token("x" * 500)
-    assert frames, "a boundaryless paragraph was never sent"
-
-
-# --------------------------------------------------------------------------
-# 3. a stalled cockpit cannot grow the daemon
-# --------------------------------------------------------------------------
-
-def test_the_buffer_is_bounded() -> None:
-    """An attached cockpit that stops reading must never become a memory leak
-    in the organism."""
-    # flush_chars huge so the char trigger never fires, and a frozen clock so
-    # the timer never fires — the only way text genuinely accumulates.
-    m = StreamMirror(None, flush_chars=10 ** 9, clock=lambda: 0.0)
-    for _ in range(5000):
-        m.on_token("0123456789")
-    assert m.pending_chars <= 8192
-    assert m.chars_dropped > 0
-
-
-def test_dropping_keeps_the_RECENT_text() -> None:
-    """When a cockpit falls behind, the recent text is what the operator is
-    waiting for — the same rule as the console spooler."""
-    frames: List[str] = []
-    m = StreamMirror(frames.append, flush_chars=10 ** 9, clock=lambda: 0.0)
-    for i in range(3000):
-        m.on_token(f"{i:06d} ")
-    m.end()
-    assert "2999" in "".join(frames)
-
-
-@pytest.mark.parametrize("junk", [None, 42, object(), b"bytes"])
-def test_a_hostile_token_never_raises(junk: Any) -> None:
-    frames: List[str] = []
-    _mirror(frames).on_token(junk)
-
-
-def test_a_failing_sink_cannot_break_the_stream() -> None:
-    def _boom(_text: str) -> None:
-        raise RuntimeError("cockpit gone")
-
-    m = StreamMirror(_boom, clock=lambda: 0.0)
-    for _ in range(50):
-        m.on_token("word ")
-    m.end()          # must not raise
-
-
-# --------------------------------------------------------------------------
-# 4. the local renderer is untouched
-# --------------------------------------------------------------------------
-
-def test_the_local_renderer_still_receives_every_token() -> None:
-    """`Live` is correct where it runs. This ADDS a consumer; it does not
-    redirect one."""
-    seen: List[str] = []
-
-    class _Renderer:
-        def on_token(self, text: str) -> None:
-            seen.append(text)
-
-        def end(self) -> None:
-            seen.append("END")
-
-    frames: List[str] = []
-    w = fan_out_tokens(_Renderer(), _mirror(frames))
-    w.on_token("a ")
-    w.on_token("b ")
-    w.end()
-    assert seen == ["a ", "b ", "END"]
-
-
-def test_the_local_renderer_is_fed_FIRST() -> None:
-    """The terminal that has always worked must not be starved by a mirror
-    fault."""
-    seen: List[str] = []
-
-    class _Renderer:
-        def on_token(self, text: str) -> None:
-            seen.append(text)
-
-        def end(self) -> None: ...
-
-    def _boom(_t: str) -> None:
-        raise RuntimeError("bridge down")
-
-    w = fan_out_tokens(_Renderer(), StreamMirror(_boom, clock=lambda: 0.0))
-    for _ in range(50):
-        w.on_token("word ")
-    assert len(seen) == 50
-
-
-def test_an_inner_fault_cannot_blank_the_cockpit() -> None:
-    class _Broken:
-        def on_token(self, _t: str) -> None:
-            raise RuntimeError("Live crashed")
-
-        def end(self) -> None:
-            raise RuntimeError("Live crashed")
-
-    frames: List[str] = []
-    w = fan_out_tokens(_Broken(), _mirror(frames))
-    w.on_token("still visible remotely. ")
-    w.end()
-    assert frames
-
-
-def test_everything_else_passes_through() -> None:
-    """`start()`, `notify()`, the counters — reimplementing the renderer's
-    surface would silently drop whatever it grows next."""
-    class _Renderer:
-        def on_token(self, _t: str) -> None: ...
-        def end(self) -> None: ...
-        def start(self, op_id: str, provider: str = "") -> str:
-            return f"started:{op_id}"
-
-        @property
-        def token_count(self) -> int:
-            return 7
-
-    w = fan_out_tokens(_Renderer(), _mirror([]))
-    assert w.start("op-1") == "started:op-1"
-    assert w.token_count == 7
-
-
-def test_a_missing_renderer_is_returned_untouched() -> None:
-    assert fan_out_tokens(None, _mirror([])) is None
-
-
-# --------------------------------------------------------------------------
-# 5. wiring
-# --------------------------------------------------------------------------
-
-def test_the_switch_defaults_on() -> None:
-    assert stream_mirror_enabled() is True
-
-
-def test_the_switch_leaves_local_streaming_alone(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setenv("JARVIS_STREAM_MIRROR_ENABLED", "0")
-    assert stream_mirror_enabled() is False
-    src = _SRC.read_text()
-    assert "if stream_mirror_enabled():" in src
-    assert "register_stream_renderer(self._stream_renderer)" in src
-
-
-def test_the_fan_out_is_registered_not_a_replacement() -> None:
-    """Providers keep calling `get_stream_renderer().on_token` and are never
-    told there are now two consumers."""
-    src = _SRC.read_text()
-    assert "fan_out_tokens(" in src
-    assert "register_stream_renderer(self._stream_renderer)" in src
-
-
-def test_the_mirror_is_resolved_PER_FRAME() -> None:
-    """SerpentFlow is constructed before the bridge attaches, so a handle
-    captured at build time would be None forever."""
-    src = _SRC.read_text()
-    assert "lambda text: self._mirror_markup(text)" in src
+    def test_it_publishes_through_the_registry_the_presence_check_uses(self):
+        """"Is anyone listening" and "send it to them" must not disagree
+        about which bridge is live."""
+        import inspect
+        src = inspect.getsource(ca.publish_markup_global)
+        assert "_ACTIVE_BRIDGE" in src and "attached_cockpits" in src


### PR DESCRIPTION
The last of the four reachability findings — and like the others, it wasn't a reachability problem.

## The widget is not the answer; it's the thing that doesn't fit

`stream_renderer` skips its Rich `Live` widget when stdout isn't a TTY **or when a SerpentREPL is active**, and the second reason is load-bearing. Its own comment says why:

> Live writes via direct cursor manipulation that bypasses `patch_stdout` and clobbers the input prompt under concurrent output.

In `ov` the REPL is **always** active. So the visible token stream has never rendered there — and relaxing the gate, or mirroring the widget, would corrupt the line you're typing on. Same shape as the NOTIFY_APPLY panel: a screen-rewriting widget can't be carried by a line-oriented bridge.

## What fits is the channel the cockpit already has

The generation now arrives on the deck as it's written, one line at a time, beside the `⏺` blocks it belongs with:

```
⏺ The vision floor raises, and the caller
  swallows it.
  ```python
  def f():
      raise
  ```
```

One `⏺` opens the block and continuations indent under it — the deck's own grammar for assistant prose.

## Why not `find_commit_boundary`

That helper is right there, and it's the **wrong abstraction here**. It commits at blank lines *outside fenced code blocks* so Rich can re-parse a complete Markdown block in scrollback. The deck doesn't re-parse — it draws escaped text. Borrowing that rule would show **nothing** until a long paragraph ended or a code fence closed, which is precisely the silence this fixes.

Different medium, different boundary: the last newline.

The final flush is separate and necessary — content after the last newline would otherwise never be sent, so every generation would lose its closing sentence.

## Model text is inert

`publish_markup` is documented as styled chrome around inert data, and model output is untrusted, so every line is **escaped** before it travels: a generation containing `[bold red]` must not restyle the operator's deck. Lines are bounded at 2000 chars — a model can emit 40k on one line and the deck is a ring of terminal rows.

The mirror owns its **own cursor**. `_committed_offset` belongs to the local Live widget's scrollback commits; sharing it would let a local terminal's rendering decisions silently truncate a remote deck.

Published through the same registry the voice-presence check uses, so *"is anyone listening"* and *"send it to them"* can't disagree about which bridge is live.

## Verification

14 new tests; 84 green across the three pre-existing stream suites and cockpit-attach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send model generation to the cockpit in real time, one line at a time, instead of relying on `Rich` `Live` which can’t run under the SerpentREPL. Lines are escaped and bounded, and a final flush ensures the tail is delivered.

- **New Features**
  - Added a line-oriented mirror in `StreamRenderer` that sends completed lines on each drain tick via `publish_markup_global`.
  - Opens a single `⏺` block; subsequent lines indent under it to match the deck’s grammar.
  - Escapes untrusted model text (`rich.markup.escape`) and caps each line at 2000 chars with an ellipsis when truncated.
  - Finalizes with `_mirror_completed_lines(final=True)` so content after the last newline is not lost.
  - Controlled by `JARVIS_STREAM_MIRROR_ENABLED` (default on); uses its own `_mirrored_offset` cursor, separate from `_committed_offset`, and publishes through the same registry as the presence check.

<sup>Written for commit aee523022049032d3a1aef7211a968736a518e8c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

