### PR TITLE
feat(ov): the sentence, visible while it is being written

### DIFF
--- a/backend/core/ouroboros/battle_test/bipartite_layout.py
+++ b/backend/core/ouroboros/battle_test/bipartite_layout.py
@@ -750,6 +750,7 @@ def build_bipartite_application(
     search_rows: Optional[Callable[[], Any]] = None,
     status_rows: Optional[Callable[[], Any]] = None,
     pending_rows: Optional[Callable[[], Any]] = None,
+    stream_rows: Optional[Callable[[], Any]] = None,
     serpent_active: Optional[Callable[[], bool]] = None,
 ) -> Any:
     """Construct the full-screen ``prompt_toolkit.Application``: Zone 1 an ANSI
@@ -1105,6 +1106,18 @@ def build_bipartite_application(
         except Exception:  # noqa: BLE001
             logger.debug("[Bipartite] %s row unavailable", label,
                          exc_info=True)
+    # The sentence being WRITTEN, directly under the deck it is about to
+    # become part of. The deck is bottom-anchored, so its newest entry sits
+    # immediately above this — the in-flight text appears exactly where it
+    # will land, which is what makes it read as inline rather than as a
+    # separate widget.
+    if stream_rows is not None:
+        try:
+            _stream_row = build_dynamic_rows(stream_rows)
+            if _stream_row is not None:
+                rows += [_stream_row]
+        except Exception:  # noqa: BLE001
+            logger.debug("[Bipartite] stream row unavailable", exc_info=True)
     # The rejection window, above the search bar and the caret. It is the
     # most time-critical row the cockpit ever draws — the operator has
     # seconds — so it sits where the eye already is.
@@ -1381,6 +1394,7 @@ async def run_bipartite_repl(
     search_rows: Optional[Callable[[], Any]] = None,
     status_rows: Optional[Callable[[], Any]] = None,
     pending_rows: Optional[Callable[[], Any]] = None,
+    stream_rows: Optional[Callable[[], Any]] = None,
     serpent_active: Optional[Callable[[], bool]] = None,
 ) -> None:
     """Launch the full-screen Bipartite REPL: build the multiplexer, register it as
@@ -1412,7 +1426,8 @@ async def run_bipartite_repl(
             completer=completer, history=history, auto_suggest=auto_suggest,
             turn_spinner=turn_spinner, agent_rows=agent_rows,
             search_rows=search_rows, status_rows=status_rows,
-            pending_rows=pending_rows, serpent_active=serpent_active,
+            pending_rows=pending_rows, stream_rows=stream_rows,
+            serpent_active=serpent_active,
         )
         if watch_alive is not None:
             watcher = asyncio.ensure_future(

--- a/backend/core/ouroboros/battle_test/cockpit_attach.py
+++ b/backend/core/ouroboros/battle_test/cockpit_attach.py
@@ -220,6 +220,23 @@ def publish_markup_global(text: str, *, session: Optional[str] = None) -> bool:
         return False
 
 
+def publish_telemetry_global(payload: dict) -> bool:
+    """Emit one typed telemetry frame to attached cockpits. NEVER raises.
+
+    The control-plane sibling of :func:`publish_markup_global`, for producers
+    with no handle to the bridge. Used by live STATE — a frame dropped here
+    costs one frame of smoothness, never a transcript line.
+    """
+    try:
+        bridge = _ACTIVE_BRIDGE
+        if bridge is None or attached_cockpits() <= 0:
+            return False
+        bridge.publish_telemetry(payload)
+        return True
+    except Exception:  # noqa: BLE001
+        return False
+
+
 def attach_enabled() -> bool:
     """Master gate — default ON. NEVER raises."""
     return os.environ.get(

--- a/backend/core/ouroboros/battle_test/stream_renderer.py
+++ b/backend/core/ouroboros/battle_test/stream_renderer.py
@@ -40,7 +40,7 @@ import logging
 import os
 import sys
 import time
-from typing import Any, Optional
+from typing import Any, List, Optional
 
 logger = logging.getLogger("Ouroboros.StreamRenderer")
 
@@ -70,6 +70,55 @@ def flow_mode_enabled() -> bool:
 #: Longest single line the deck will carry from a generation. A model can
 #: emit a 40k-character line; the deck is a ring of terminal rows.
 _MIRROR_MAX_LINE_CHARS = 2000
+
+#: Longest in-flight tail carried per frame. Past this the model
+#: has stopped writing a sentence and started writing a document.
+_INFLIGHT_MAX_CHARS = 800
+
+
+#: Rows an in-flight sentence may occupy before it is elided. It is one
+#: thought, not a document; past this the strip would push the deck off
+#: screen to show text that is about to become deck content.
+INFLIGHT_MAX_ROWS = 4
+
+
+def render_inflight(
+    text: str, *, width: Optional[int] = None,
+    max_rows: int = INFLIGHT_MAX_ROWS,
+) -> List[str]:
+    """Wrap an in-flight sentence into strip rows. Pure. NEVER raises.
+
+    Lives HERE, beside the producer, and is called by every surface that
+    draws in-flight text — the attach cockpit and the demo. The daemon
+    cannot do this wrap itself (it may serve two cockpits of different
+    widths, and only each client knows its own), so the wrap is necessarily
+    client-side; what must NOT be client-side is a second opinion about what
+    the shape is. That is the same split the roster and the status line use:
+    state crosses the bridge, one renderer draws it.
+
+    Indented as a continuation, because that is what it is — the line the
+    deck is about to receive. A bottom-anchored deck puts its newest entry
+    directly above this strip, so the sentence appears exactly where it will
+    land, which is what makes it read as inline rather than as a widget.
+    """
+    try:
+        import textwrap
+        flat = " ".join(str(text or "").split())
+        if not flat:
+            return []
+        cols = int(width) if width and int(width) > 0 else 80
+        room = max(20, cols - 4)
+        rows = max(1, int(max_rows))
+        wrapped = textwrap.wrap(flat, width=room) or [flat[:room]]
+        if len(wrapped) > rows:
+            # Keep the NEWEST rows: the tail is where the writing is
+            # happening, and an elided head reads as "there is more above",
+            # which is true and about to be in the transcript anyway.
+            wrapped = ["…"] + wrapped[-(rows - 1):] if rows > 1 else ["…"]
+        return [f"  {line}" for line in wrapped]
+    except Exception:  # noqa: BLE001
+        logger.debug("[StreamRender] inflight wrap degraded", exc_info=True)
+        return []
 
 
 def mirror_stream_enabled() -> bool:
@@ -206,6 +255,8 @@ class StreamRenderer:
         self._mirrored_offset: int = 0
         #: Has this stream announced itself to the deck yet?
         self._mirror_opened: bool = False
+        #: Last tail published, so an idle frame costs nothing.
+        self._last_inflight: str = ""
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -355,6 +406,8 @@ class StreamRenderer:
         # otherwise never reach an attached cockpit, so every generation
         # would lose its closing sentence.
         self._mirror_completed_lines(final=True)
+        # Clear the strip: everything is in the transcript now.
+        self._publish_inflight_tail(done=True)
 
         if self._live is not None:
             try:
@@ -404,6 +457,7 @@ class StreamRenderer:
         self._committed_offset = 0
         self._mirrored_offset = 0
         self._mirror_opened = False
+        self._last_inflight = ""
         self._flow_mode = False
         self._op_id = ""
         self._provider = ""
@@ -550,6 +604,9 @@ class StreamRenderer:
                     # Same batch tick as the local widget, so the remote deck
                     # and a local terminal see the generation at one cadence.
                     self._mirror_completed_lines()
+                    # The in-flight sentence, on the same tick — so the strip
+                    # and the deck never disagree about where the boundary is.
+                    self._publish_inflight_tail()
                     last_render = now
         except asyncio.CancelledError:
             # Final flush on cancellation (end() path). Any pending
@@ -560,6 +617,63 @@ class StreamRenderer:
                 pending.clear()
                 self._render_buffer_safe()
             raise
+
+    def _publish_inflight_tail(self, *, done: bool = False) -> None:
+        """Send the sentence currently being WRITTEN to attached cockpits.
+
+        WHAT THIS IS AND IS NOT
+        ------------------------
+        `_mirror_completed_lines` sends finished lines into the deck, where
+        they stay. This sends the UNCOMMITTED remainder — the text after the
+        last newline, which is the sentence the model is in the middle of.
+        The two never overlap: everything before `_mirrored_offset` has
+        already landed in the transcript, everything after it is in flight.
+
+        WHY NOT MUTATE THE DECK'S TAIL
+        -------------------------------
+        The obvious shape is "replace the last line as it grows", and the
+        deck's ring is APPEND-ONLY (`RegionBuffer.push`). Adding tail
+        mutation would need an anchor per stream, a rule for what happens
+        when another producer appends mid-sentence, and a re-wrap on every
+        delta — a lot of new failure modes in the structure that holds the
+        session's history.
+
+        The cockpit already has a primitive for live, self-re-rendering
+        state: the dynamic strip the agent view, status line and countdown
+        all use. A strip sits directly under a bottom-anchored deck, so an
+        in-flight sentence appears exactly where the next line will land —
+        it reads as inline, and nothing has to mutate history to do it.
+
+        Carried on the telemetry lane rather than the markup lane because it
+        is STATE, not a transcript entry: the last frame wins, and a dropped
+        one costs a frame of smoothness rather than a lost line.
+
+        NEVER raises, and never blocks.
+        """
+        try:
+            if not mirror_stream_enabled():
+                return
+            tail = "" if done else self._buffer[self._mirrored_offset:]
+            if tail == self._last_inflight and not done:
+                return          # nothing new — do not spend a frame
+            self._last_inflight = tail
+            from backend.core.ouroboros.battle_test.cockpit_attach import (
+                publish_telemetry_global,
+            )
+            publish_telemetry_global({
+                "kind": "stream_inflight",
+                "op_id": str(self._op_id or ""),
+                # Bounded: the wrap happens on the client, which knows its
+                # width, but an unbounded tail would still cross the bridge
+                # every frame. A sentence that long has stopped being one.
+                "text": tail[-_INFLIGHT_MAX_CHARS:],
+                "done": bool(done),
+            })
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "[StreamRender] op=%s inflight degraded", self._op_id,
+                exc_info=True,
+            )
 
     def _mirror_completed_lines(self, *, final: bool = False) -> None:
         """Send completed LINES of the generation to attached cockpits.

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -680,6 +680,9 @@ class AttachUI:
         self._status: dict = {}
         #: Applies waiting out their rejection window, as of the last frame.
         self._pending_apply: dict = {}
+        #: The sentence currently being written, if a generation is live.
+        self._stream_inflight: str = ""
+        self._stream_arrived: float = 0.0
         self._focus_lines: List[str] = []
         self._focus_note: str = ""
         self._flash_text: str = ""
@@ -1044,6 +1047,40 @@ class AttachUI:
         except Exception:  # noqa: BLE001
             return []
 
+    def _stream_rows(self) -> List[str]:
+        """The in-flight sentence, wrapped to THIS terminal. NEVER raises.
+
+        This half is STATE — what was last received, and when. The SHAPE is
+        `stream_renderer.render_inflight`, shared with every other surface
+        that draws in-flight text, so no two of them can disagree about it.
+        The wrap is necessarily client-side (the daemon may serve two
+        cockpits of different widths, and the canvas draws with
+        `wrap_lines=False`, so an unwrapped sentence is clipped at the right
+        edge and appears to stop growing) — but a second OPINION about the
+        shape is exactly what the roster and status line already paid for.
+
+        Retires on the same staleness window as every other heartbeat-fed
+        surface: a dead daemon must not leave half a sentence hanging on
+        screen as though it were still being written.
+        """
+        try:
+            import time as _time
+            from backend.core.ouroboros.battle_test.attach_heartbeat import (
+                heartbeat_stale_after_s,
+            )
+            from backend.core.ouroboros.battle_test.stream_renderer import (
+                render_inflight,
+            )
+            if not self._stream_inflight or not self._stream_arrived:
+                return []
+            age = max(0.0, _time.monotonic() - float(self._stream_arrived))
+            if age > heartbeat_stale_after_s():
+                return []
+            return render_inflight(
+                self._stream_inflight, width=self._terminal_size()[0])
+        except Exception:  # noqa: BLE001
+            return []
+
     def _terminal_size(self) -> tuple:
         """``(columns, rows)``, or ``(None, None)`` when it cannot be known.
 
@@ -1336,6 +1373,18 @@ class AttachUI:
                 # closed, and a countdown that outlives its op is telling the
                 # operator they can still stop something that already ran.
                 self._pending_apply = frame.get("pending_apply") or {}
+            elif isinstance(frame, dict) and frame.get(
+                "kind",
+            ) == "stream_inflight":
+                # The sentence the model is in the middle of. STATE, so the
+                # last frame wins outright — no accumulation to drift, and a
+                # dropped frame costs one tick of smoothness rather than a
+                # word. `done` clears it: everything is in the deck by then.
+                self._stream_inflight = (
+                    "" if frame.get("done") else str(frame.get("text") or "")
+                )
+                import time as _time
+                self._stream_arrived = _time.monotonic()
         except Exception:
             pass
 
@@ -3140,6 +3189,12 @@ async def _bipartite_attach_loop(client: Any, console: Any, ui: Any) -> None:
             pending_rows=(
                 ui._pending_apply_rows if ui is not None
                 and hasattr(ui, "_pending_apply_rows") else None
+            ),
+            # The sentence being written — directly under the deck it is
+            # about to become part of.
+            stream_rows=(
+                ui._stream_rows if ui is not None
+                and hasattr(ui, "_stream_rows") else None
             ),
             seed=[
                 "[bold]💭 Karen ▸[/bold] attached — I'm listening. verbs or "

--- a/backend/core/ouroboros/cli/ov_demo.py
+++ b/backend/core/ouroboros/cli/ov_demo.py
@@ -452,7 +452,12 @@ _LIVE_BEATS: List[Any] = [
     (3.4, "tool", ("search_code", "except Exception",
                    _SEARCH_RESULT, "success", 180)),
 
-    (5.0, "voice", ("the vision floor raises, and the caller swallows it",)),
+    # Lands when its reveal COMPLETES (5.0 + _REVEAL_S), not when the
+    # organism starts composing it — the strip shows the sentence being
+    # written, and this is the moment it becomes transcript.
+    (7.0, "voice", ("the vision floor raises, and the caller swallows it — "
+                    "every guard downstream is reading a tier that was "
+                    "never applied",)),
 
     # WHO is working — the roster the cockpit now mounts. Driven through the
     # real `AgentRoster`, so the agent view fills in as the demo runs instead
@@ -477,6 +482,9 @@ _LIVE_BEATS: List[Any] = [
 
     (15.2, "act", ("Repair", "L2 · iteration 1/5", "warn")),
     (16.8, "det", ("fixture rebuilt from the live seam",)),
+    (17.2, "voice", ("pinning the number it used to return would have made "
+                     "the suite agree with the bug — the seam is the thing "
+                     "to assert on",)),
     (17.4, "agent", ("finish", "sub-9c11", "finished",
                      "no counterexample · 12 tools")),
     (18.0, "tool", ("run_tests", "tests/governance/test_risk_tier_floor.py",
@@ -763,6 +771,80 @@ def _demo_generating(elapsed: float) -> bool:
         return False
 
 
+#: What the organism is WRITING inside each generating window, keyed by the
+#: window's start. The text is the prose that lands in the deck when the
+#: window closes — the strip shows the sentence being composed, and then the
+#: same words become the transcript line, which is precisely the effect.
+_INFLIGHT_TEXT = {
+    5.0: "the vision floor raises, and the caller swallows it — every "
+         "guard downstream is reading a tier that was never applied",
+    15.2: "pinning the number it used to return would have made the "
+          "suite agree with the bug — the seam is the thing to assert on",
+}
+
+#: Seconds a sentence takes to appear. Not the window's full length: the
+#: model finishes writing before the phase ends, and a reveal stretched to
+#: fill the window would crawl in a way no real stream does.
+_REVEAL_S = 2.0
+
+
+def _inflight_text(elapsed: float) -> str:
+    """The partially-written sentence at ``elapsed``, or "". NEVER raises.
+
+    Revealed on WORD boundaries. A character-by-character reveal looks like
+    a typewriter effect, which is a different thing pretending to be this
+    one — a real token stream arrives in word-ish pieces, and mid-word
+    truncation reads as corruption rather than as composition.
+    """
+    try:
+        for lo, hi in _GENERATING:
+            if not (lo <= elapsed <= hi):
+                continue
+            text = _INFLIGHT_TEXT.get(lo)
+            if not text:
+                return ""
+            words = text.split()
+            frac = min(1.0, max(0.0, (elapsed - lo) / max(0.01, _REVEAL_S)))
+            shown = int(round(frac * len(words)))
+            if shown >= len(words):
+                # Written. It belongs to the deck now, and leaving it in the
+                # strip would show the same sentence twice.
+                return ""
+            return " ".join(words[:max(1, shown)])
+        return ""
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def _stream_rows(elapsed: float, mux: Any = None) -> List[str]:
+    """Strip rows for the demo, through the COCKPIT's renderer. NEVER raises.
+
+    `stream_renderer.render_inflight` is the same function the attach
+    cockpit calls — imported, never reimplemented, for the reason stated at
+    the top of this module. A demo with its own wrap would keep agreeing
+    with itself while the real one regressed.
+    """
+    try:
+        from backend.core.ouroboros.battle_test.stream_renderer import (
+            render_inflight,
+        )
+        text = _inflight_text(elapsed)
+        if not text:
+            return []
+        width = None
+        try:
+            width = getattr(mux, "width", None) if mux is not None else None
+        except Exception:  # noqa: BLE001
+            width = None
+        if not width:
+            import shutil
+            width = shutil.get_terminal_size((80, 24)).columns
+        return render_inflight(text, width=width)
+    except Exception:  # noqa: BLE001
+        logger.debug("[OvDemo] inflight strip unavailable", exc_info=True)
+        return []
+
+
 def _generating_seconds(elapsed: float) -> float:
     """Seconds spent INSIDE a generating window, up to ``elapsed``.
 
@@ -923,6 +1005,14 @@ def scene_live(console: Any, argv: Sequence[str] = ()) -> int:
         # border that moves forever teaches the operator to stop seeing it.
         serpent_active=lambda: _demo_generating(
             (clock() - start[0]) * speed
+        ),
+        # The sentence being WRITTEN, through the cockpit's own wrapper. The
+        # generating windows used to show a climbing token count and nothing
+        # else — the operator knew spend was happening and could not see what
+        # for. Same words, revealed, then landing in the deck as the line
+        # they became.
+        stream_rows=lambda: _stream_rows(
+            (clock() - start[0]) * speed, mux,
         ),
     )
     try:

--- a/tests/battle_test/test_stream_inflight.py
+++ b/tests/battle_test/test_stream_inflight.py
@@ -1,0 +1,301 @@
+"""The sentence being written, visible as it is written.
+
+#70245 sent COMPLETED lines to the deck, which fixed the silence but not the
+smoothness: an operator waited for a newline before anything appeared. CC
+streams tokens into its transcript; this is the same effect through a
+line-oriented bridge — completed lines land in the deck, and the uncommitted
+remainder shows in a live strip directly beneath it.
+
+The two never overlap. Everything before `_mirrored_offset` is transcript;
+everything after it is in flight.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.battle_test import cockpit_attach as ca
+from backend.core.ouroboros.battle_test.stream_renderer import StreamRenderer
+from backend.core.ouroboros.cli.ov import AttachUI
+
+
+class _Bridge:
+    def __init__(self) -> None:
+        self._clients = {"c": object()}
+        self.deck: list = []
+        self.telemetry: list = []
+
+    def publish_markup(self, text, session=None):
+        self.deck.append(str(text))
+
+    def publish_telemetry(self, payload):
+        self.telemetry.append(payload)
+
+
+@pytest.fixture
+def bridge():
+    b = _Bridge()
+    ca.set_active_bridge(b)
+    yield b
+    ca.set_active_bridge(None)
+
+
+def _renderer():
+    r = StreamRenderer.__new__(StreamRenderer)
+    r._buffer = ""
+    r._mirrored_offset = 0
+    r._mirror_opened = False
+    r._op_id = "7759-86"
+    r._last_inflight = ""
+    return r
+
+
+def _feed(r, ui, bridge, *chunks, done=False):
+    for c in chunks:
+        r._buffer += c
+        r._mirror_completed_lines()
+        r._publish_inflight_tail()
+        if bridge.telemetry:
+            ui.on_telemetry(bridge.telemetry[-1])
+    if done:
+        r._mirror_completed_lines(final=True)
+        r._publish_inflight_tail(done=True)
+        ui.on_telemetry(bridge.telemetry[-1])
+
+
+class TestTheSentenceGrows:
+    def test_text_appears_before_its_newline(self, bridge):
+        """THE gap #70245 left. An operator waited for a newline before
+        anything appeared at all."""
+        ui = AttachUI()
+        _feed(_renderer(), ui, bridge, "The vision floor ")
+        assert bridge.deck == []            # nothing complete yet
+        assert "The vision floor" in " ".join(ui._stream_rows())
+
+    def test_it_grows_word_by_word(self, bridge):
+        ui, r = AttachUI(), _renderer()
+        seen = []
+        for chunk in ("The vision ", "floor ", "raises"):
+            _feed(r, ui, bridge, chunk)
+            seen.append(" ".join(ui._stream_rows()).strip())
+        assert seen[0] != seen[1] != seen[2]
+        assert all(seen[i] in seen[i + 1] for i in range(2))
+
+    def test_a_completed_line_MOVES_to_the_deck(self, bridge):
+        ui, r = AttachUI(), _renderer()
+        _feed(r, ui, bridge, "the caller swallows it.\n")
+        assert any("swallows it." in d for d in bridge.deck)
+        assert ui._stream_rows() == [], "it stayed in the strip too"
+
+    def test_transcript_and_strip_never_overlap(self, bridge):
+        """Everything before the commit offset is transcript; everything
+        after is in flight. Showing a line in both would double it."""
+        ui, r = AttachUI(), _renderer()
+        _feed(r, ui, bridge, "first line\n", "second in progress")
+        assert any("first line" in d for d in bridge.deck)
+        strip = " ".join(ui._stream_rows())
+        assert "first line" not in strip
+        assert "second in progress" in strip
+
+    def test_done_clears_the_strip(self, bridge):
+        ui, r = AttachUI(), _renderer()
+        _feed(r, ui, bridge, "trailing text", done=True)
+        assert ui._stream_rows() == []
+        assert any("trailing text" in d for d in bridge.deck)
+
+
+class TestTheClientOwnsTheWrap:
+    def test_it_wraps_to_THIS_terminal(self, bridge, monkeypatch):
+        """The daemon serving two cockpits of different widths cannot
+        pre-wrap for both, and the canvas draws with `wrap_lines=False` — an
+        unwrapped sentence is clipped and appears to stop growing."""
+        ui, r = AttachUI(), _renderer()
+        monkeypatch.setattr(ui, "_terminal_size", lambda: (40, 30))
+        _feed(r, ui, bridge, "word " * 30)
+        rows = ui._stream_rows()
+        assert len(rows) > 1
+        assert all(len(x) <= 40 for x in rows)
+
+    def test_a_wider_terminal_uses_fewer_rows(self, bridge, monkeypatch):
+        ui, r = AttachUI(), _renderer()
+        monkeypatch.setattr(ui, "_terminal_size", lambda: (40, 30))
+        _feed(r, ui, bridge, "word " * 30)
+        narrow = len(ui._stream_rows())
+        monkeypatch.setattr(ui, "_terminal_size", lambda: (160, 30))
+        assert len(ui._stream_rows()) < narrow
+
+    def test_a_runaway_sentence_is_bounded(self, bridge):
+        """An in-flight sentence is one thought, not a document. Past a few
+        rows the strip would push the deck off screen to show text that is
+        about to become deck content."""
+        ui, r = AttachUI(), _renderer()
+        _feed(r, ui, bridge, "word " * 800)
+        rows = ui._stream_rows()
+        assert len(rows) <= 4
+        assert rows[0].strip() == "…"
+
+
+class TestItIsStateNotTranscript:
+    def test_the_LAST_frame_wins(self, bridge):
+        """Carried on the telemetry lane because it is state. No
+        accumulation to drift, and a dropped frame costs a tick of
+        smoothness rather than a word."""
+        ui = AttachUI()
+        ui.on_telemetry({"kind": "stream_inflight", "text": "aaa"})
+        ui.on_telemetry({"kind": "stream_inflight", "text": "bbb"})
+        assert "bbb" in " ".join(ui._stream_rows())
+        assert "aaa" not in " ".join(ui._stream_rows())
+
+    def test_an_unchanged_tail_spends_no_frame(self, bridge):
+        r = _renderer()
+        r._buffer = "steady"
+        r._publish_inflight_tail()
+        n = len(bridge.telemetry)
+        r._publish_inflight_tail()
+        assert len(bridge.telemetry) == n
+
+    def test_a_stale_frame_retires_the_strip(self, bridge):
+        """A dead daemon must not leave half a sentence hanging."""
+        import time
+        ui = AttachUI()
+        ui.on_telemetry({"kind": "stream_inflight", "text": "half a sentence"})
+        assert ui._stream_rows()
+        ui._stream_arrived = time.monotonic() - 10_000
+        assert ui._stream_rows() == []
+
+    def test_the_deck_is_never_mutated(self):
+        """The obvious shape is "replace the last line as it grows", and the
+        ring is APPEND-ONLY. Tail mutation would need an anchor per stream, a
+        rule for a competing producer mid-sentence, and a re-wrap per delta —
+        new failure modes in the structure holding the session's history."""
+        import ast
+        import inspect
+        import textwrap
+        # Checked as CALLS, not as text: the docstring names `push_raw` and
+        # `replace` precisely to explain why they are not used, and a string
+        # match cannot tell an explanation from an invocation.
+        tree = ast.parse(textwrap.dedent(
+            inspect.getsource(StreamRenderer._publish_inflight_tail)))
+        called = {
+            getattr(n.func, "attr", getattr(n.func, "id", ""))
+            for n in ast.walk(tree) if isinstance(n, ast.Call)
+        }
+        assert "push_raw" not in called
+        assert not any("replace" in c for c in called)
+
+
+class TestNeverBreaksTheStream:
+    def test_no_cockpit_attached_is_silent_and_safe(self):
+        ca.set_active_bridge(None)
+        r = _renderer()
+        r._buffer = "text"
+        r._publish_inflight_tail()
+        r._publish_inflight_tail(done=True)
+
+    def test_a_raising_bridge_is_swallowed(self):
+        class _Broken:
+            _clients = {"c": 1}
+            def publish_telemetry(self, *a, **k):
+                raise RuntimeError("down")
+        ca.set_active_bridge(_Broken())
+        try:
+            r = _renderer()
+            r._buffer = "text"
+            r._publish_inflight_tail()
+        finally:
+            ca.set_active_bridge(None)
+
+    def test_the_master_flag_silences_it(self, bridge, monkeypatch):
+        monkeypatch.setenv("JARVIS_STREAM_MIRROR_ENABLED", "0")
+        r = _renderer()
+        r._buffer = "text"
+        r._publish_inflight_tail()
+        assert bridge.telemetry == []
+
+    def test_junk_frames_degrade(self):
+        ui = AttachUI()
+        for junk in (None, "x", {"kind": "stream_inflight"},
+                     {"kind": "stream_inflight", "text": None}):
+            ui.on_telemetry(junk)
+            assert isinstance(ui._stream_rows(), list)
+
+
+class TestTheDemoShowsIt:
+    """`ov demo live` is where this gets WATCHED. A strip only the real
+    organism can drive would be another surface built and never seen — the
+    exact pattern that has cost this cockpit five modules."""
+
+    def test_the_demo_reveals_a_sentence_progressively(self):
+        from backend.core.ouroboros.cli import ov_demo as d
+        seen = [" ".join(d._stream_rows(t)).strip()
+                for t in (5.0, 5.6, 6.2, 6.8)]
+        assert all(seen), "the generating window shows nothing"
+        assert all(seen[i] in seen[i + 1] for i in range(3)), seen
+
+    def test_it_vacates_when_the_line_becomes_transcript(self):
+        """Showing it in both places would print the sentence twice."""
+        from backend.core.ouroboros.cli import ov_demo as d
+        lands = [t for t, line in d.compose_live_script()
+                 if "vision floor" in str(line)]
+        assert lands, "the voice beat vanished"
+        assert d._stream_rows(lands[0]) == []
+        assert d._stream_rows(lands[0] + 0.5) == []
+
+    def test_the_reveal_finishes_BEFORE_the_line_lands(self):
+        """Reasoning that arrives after the edit it justifies is not
+        reasoning, it is a caption."""
+        from backend.core.ouroboros.cli import ov_demo as d
+        lands = min(t for t, line in d.compose_live_script()
+                    if "vision floor" in str(line))
+        assert d._stream_rows(lands - 0.1) != []
+
+    def test_it_is_quiet_when_nothing_is_generating(self):
+        from backend.core.ouroboros.cli import ov_demo as d
+        assert d._stream_rows(0.5) == []
+        assert d._stream_rows(12.0) == []
+
+    def test_the_demo_calls_the_COCKPITS_renderer(self):
+        """A second wrap here would keep agreeing with itself while the real
+        one regressed — the rule stated at the top of `ov_demo`."""
+        import inspect
+        from backend.core.ouroboros.cli import ov_demo as d
+        src = inspect.getsource(d._stream_rows)
+        assert "render_inflight" in src
+        assert "textwrap" not in src
+
+    def test_the_strip_is_actually_MOUNTED(self):
+        import inspect
+        from backend.core.ouroboros.cli import ov_demo as d
+        assert "stream_rows=" in inspect.getsource(d.scene_live)
+
+
+class TestOneRendererTwoSurfaces:
+    def test_the_cockpit_does_not_own_a_private_wrap(self):
+        import inspect
+        from backend.core.ouroboros.cli.ov import AttachUI
+        src = inspect.getsource(AttachUI._stream_rows)
+        assert "render_inflight" in src
+        assert "textwrap" not in src
+
+    def test_both_surfaces_render_identically(self):
+        from backend.core.ouroboros.battle_test.stream_renderer import (
+            render_inflight,
+        )
+        text = "the vision floor raises, and the caller swallows it entirely"
+        ui = AttachUI()
+        ui.on_telemetry({"kind": "stream_inflight", "text": text})
+        ui._terminal_size = lambda: (72, 30)   # type: ignore[method-assign]
+        assert ui._stream_rows() == render_inflight(text, width=72)
+
+    def test_the_shape_survives_junk(self):
+        from backend.core.ouroboros.battle_test.stream_renderer import (
+            render_inflight,
+        )
+        # Nothing to say renders nothing. A non-string is a CALLER bug, and
+        # stringifying it is the harmless degradation — type-checking here
+        # would buy no safety the `except` does not already give.
+        for empty in (None, "", "   ", "\n\t "):
+            assert render_inflight(empty) == []        # type: ignore[arg-type]
+        assert render_inflight(5) == ["  5"]           # type: ignore[arg-type]
+        assert render_inflight("x", width=0) != []
+        assert render_inflight("x", width=-40) != []
+        assert render_inflight("x " * 400, max_rows=1) == ["  …"]


### PR DESCRIPTION
## What an operator sees

Before — the generating window, with only a token counter moving:

```
⏺ Signal(test_failure · risk_tier_floor.py)
  ⎿  2 source loci · 1 test locus
                                          🐍 Synthesizing… (12s · ↓ 4.1k · DW-397B)
```

After:

```
⏺ Signal(test_failure · risk_tier_floor.py)
  ⎿  2 source loci · 1 test locus

  the vision floor raises, and the caller swallows it — every guard
  downstream is reading a tier that was
                                          🐍 Synthesizing… (12s · ↓ 4.1k · DW-397B)
```

…and then it becomes the transcript line it was always going to be.

## The gap

#70245 mirrored completed **lines** to the cockpit. That fixed the silence but not the smoothness: an operator waited for a newline before anything appeared at all. They could see spend happening and not what for.

Completed lines still land in the deck. The **uncommitted remainder** — the text after the last newline, the sentence the model is in the middle of — now shows in a live strip directly beneath. The two never overlap: everything before `_mirrored_offset` is transcript, everything after is in flight.

## Why not mutate the deck's tail

The obvious shape is *"replace the last line as it grows"*, and the ring is **append-only** (`RegionBuffer.push`). Tail mutation would need an anchor per stream, a rule for what happens when another producer appends mid-sentence, and a re-wrap on every delta — a lot of new failure modes in the structure that holds the session's history.

The cockpit already has a primitive for live, self-re-rendering state: the dynamic strip the roster, status line and countdown all use. A strip under a bottom-anchored deck puts the sentence exactly where it will land, so it reads as inline without anything mutating history to achieve it.

Carried on the **telemetry** lane rather than markup because it is state, not a transcript entry — the last frame wins outright, identical tails spend no frame, and a dropped one costs a tick of smoothness rather than a line.

## One renderer, two surfaces

`stream_renderer.render_inflight` is pure and shared. The wrap *must* be client-side — the daemon may serve two cockpits of different widths, and the canvas draws with `wrap_lines=False`, so an unwrapped sentence is clipped at the right edge and appears to stop growing. What must **not** be client-side is a second opinion about the shape; that is what the roster and the status line already paid for. The attach cockpit and `ov demo live` both call it, neither owns a copy, and a test pins that neither grows a private `textwrap`.

## Visible in the demo

`ov demo live` reveals the sentence across its generating windows on **word** boundaries — character-by-character is a typewriter effect impersonating a token stream, and mid-word truncation reads as corruption rather than composition. The same words then land as the deck line they became.

The voice beats moved to where their reveal completes: reasoning that arrives *after* the edit it justifies is a caption, not reasoning.

Without this the strip would be another surface built and never watched — the pattern that has already cost this cockpit five modules.

## Bounds

| | |
|---|---|
| wire | 800 chars per frame |
| screen | 4 rows, newest kept, head elided to `…` |
| retirement | shared heartbeat staleness window |
| master | `JARVIS_STREAM_MIRROR_ENABLED` (default on) |

A dead daemon cannot leave half a sentence hanging as though it were still being written.

## Tests

25 new in `tests/battle_test/test_stream_inflight.py`; **208 green** across the stream, cockpit, bipartite and demo suites.

The ones that matter are where being wrong looks like being right: transcript and strip never overlapping, the reveal finishing *before* its line lands, both surfaces rendering identically, and the deck never being mutated (asserted as **calls** via AST — the docstring names `push_raw` precisely to explain why it is not used, and a string match cannot tell an explanation from an invocation).

## What is not proven

Not verified against a live organism — every check here is unit tests and synthetic events. Granularity is **line-and-in-flight-sentence**, not CC's true per-token render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows the sentence being written beneath the deck during generation, revealing words live and moving the finished line into the transcript. Removes the empty wait for a newline so operators see what the spend is producing.

- **New Features**
  - Streams the uncommitted tail via telemetry to cockpits; last frame wins and unchanged tails don’t send.
  - Shared client-side renderer `render_inflight(text, width)` wraps to the terminal; bounded to 800 chars and 4 rows; clears on completion or heartbeat staleness.
  - Attach cockpit mounts a live “stream strip” under the bottom-anchored deck; no tail mutation; gated by `JARVIS_STREAM_MIRROR_ENABLED` (default on).
  - `ov demo live` reveals sentences on word boundaries and lands the line when the reveal completes.

- **Refactors**
  - Added `publish_telemetry_global`; plumbed `stream_rows` through `bipartite_layout` and `AttachUI`.
  - Stream renderer publishes in-flight updates on the same tick as completed-line mirroring and clears state on end.
  - 25 new tests validate no transcript/strip overlap, bounds, shared renderer use, demo wiring, and robustness.

<sup>Written for commit 5be20dc9618901c3a5d67db95a5323c3a932eb63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

