### PR TITLE
fix(governance): stop quoting the code's own words as the operator's

### DIFF
--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -370,6 +370,93 @@ def _short_id(op_id: str) -> str:
     return hex_only[-6:] if len(hex_only) >= 6 else hex_only
 
 
+def _gate_decision(text: object) -> "OperatorDecision":
+    """Interpret a gate answer, keeping the operator's words. NEVER raises.
+
+    Enter means APPROVE here because the prompt is ``[Y/n]`` — a capital Y
+    is a promise, and the parser is told about it rather than guessing.
+    Everything after the verb survives as the reason:
+
+        ""                                  -> approve, unstated
+        "y"                                 -> approve, unstated
+        "n"                                 -> reject,  unstated
+        "n it loosens the permission gate"  -> reject,  STATED
+
+    Only the third and fourth differ from the old behaviour, and the
+    fourth is the whole point: it is the only shape that can produce a
+    reason a human actually gave.
+    """
+    try:
+        from backend.core.ouroboros.governance.inline_approval import (
+            InlineApprovalChoice, parse_gate_answer,
+        )
+        return parse_gate_answer(
+            text, empty_means=InlineApprovalChoice.APPROVE)
+    except Exception:  # noqa: BLE001
+        return _wordless_reject()
+
+
+def _reject_args(flow: Any, fallback: str) -> Tuple[str, str]:
+    """``(reason, provenance)`` for a rejection the operator just made.
+
+    This is the seam where three constants used to be born. It now RELAYS
+    rather than invents: if the operator typed a reason it is passed with
+    ``stated`` provenance; if they only said "n" the fallback still travels
+    (the audit log deserves to say which gate refused) but it goes as
+    ``unstated``, which makes it structurally ineligible to be stored and
+    replayed as something the human wanted.
+
+    Note what is NOT done here: the fallback is not suppressed. Losing the
+    audit line to protect the memory would be trading one blind spot for
+    another. The string is fine — the LIE was its provenance.
+
+    NEVER raises: a gate that fails to attribute a rejection must still
+    reject it.
+    """
+    try:
+        decision = getattr(flow, "_last_gate_decision", None)
+        if decision is not None and getattr(decision, "is_stated", False):
+            return (str(decision.reason), "stated")
+        prov = getattr(decision, "provenance", None)
+        return (fallback, getattr(prov, "value", None) or "unstated")
+    except Exception:  # noqa: BLE001
+        return (fallback, "unstated")
+
+
+def _synthetic_gate_decision(
+    *, approved: bool, detail: str,
+) -> "OperatorDecision":
+    """A decision no human made — headless bypass, dead surfaces, policy.
+
+    These are legitimate outcomes and must stay auditable (§7), so the
+    detail is carried. What they must never do is masquerade as the
+    operator: SYNTHETIC provenance makes them structurally ineligible to
+    become a preference, without needing anyone downstream to recognise
+    the particular sentence.
+    """
+    from backend.core.ouroboros.governance.inline_approval import (
+        InlineApprovalChoice, synthetic_decision,
+    )
+    return synthetic_decision(
+        InlineApprovalChoice.APPROVE if approved
+        else InlineApprovalChoice.REJECT,
+        detail,
+    )
+
+
+def _wordless_reject() -> "OperatorDecision":
+    """A rejection with nothing said — Ctrl-D, Ctrl-C, a degraded parse.
+
+    Explicitly constructed rather than defaulted into, so that "they said
+    nothing" is a decision the code MAKES and can be read back, instead of
+    an absence some later consumer fills in with a constant.
+    """
+    from backend.core.ouroboros.governance.inline_approval import (
+        InlineApprovalChoice, OperatorDecision,
+    )
+    return OperatorDecision(choice=InlineApprovalChoice.REJECT)
+
+
 def _headless_auto_approve_reason() -> Optional[str]:
     """Return a short reason string when the process is headless and
     should auto-approve, or ``None`` when the interactive prompt should
@@ -3899,9 +3986,18 @@ class SerpentFlow:
 
     async def _race_gate_answer(
         self, bridge_fut: Optional["asyncio.Future"],
-    ) -> Optional[bool]:
+    ) -> Optional["OperatorDecision"]:
         """Race the LOCAL [Y/n] prompt against the Operator Prompt Bridge
         (attached cockpits) — first answer wins, the loser is cancelled.
+
+        Returns the operator's DECISION, not a bool. The line they typed
+        used to be reduced here to ``ans in ("", "y", "yes")`` and dropped,
+        which left every rejection with no reason — so three call sites
+        substituted a constant, and those constants were then stored and
+        replayed to the model as "the user's explicit preferences". A
+        rejection that says WHY is the single most valuable signal this
+        gate can produce, and it was being thrown away one frame after it
+        arrived.
 
         Edge lattice (every surface can die independently):
         * local prompt raises (dead stdin — the Session-H OSError class)
@@ -3946,14 +4042,14 @@ class SerpentFlow:
                     race.discard(w)
                     if bridge_fut is not None and w is bridge_fut:
                         try:
-                            ans = str(w.result() or "").strip().lower()
+                            ans = str(w.result() or "")
                         except Exception:  # noqa: BLE001 — cancelled/superseded
                             continue
                         self._gate_answered_via_cockpit = True
-                        return ans in ("", "y", "yes")
+                        return _gate_decision(ans)
                     try:
-                        ans = str(w.result() or "").strip().lower()
-                        return ans in ("", "y", "yes")
+                        ans = str(w.result() or "")
+                        return _gate_decision(ans)
                     except (EOFError, KeyboardInterrupt):
                         # A REAL terminal's Ctrl-D/Ctrl-C is an explicit
                         # rejection. EOF from a fake/piped stdin (tests,
@@ -3968,7 +4064,10 @@ class SerpentFlow:
                         except Exception:  # noqa: BLE001
                             _tty = False
                         if _tty:
-                            return False
+                            # Explicit rejection, and explicitly wordless.
+                            # Ctrl-D is not an explanation, and recording
+                            # it as one is the bug this file just lost.
+                            return _wordless_reject()
                         deadline = _bridge_only_wait_s()
                         continue
                     except Exception:  # noqa: BLE001 — dead stdin: race on
@@ -4044,6 +4143,8 @@ class SerpentFlow:
                 # the log line is best-effort, the return value is what
                 # matters to the orchestrator.
                 pass
+            self._last_gate_decision = _synthetic_gate_decision(
+                approved=True, detail=f"headless: {_headless_reason}")
             return True
 
         # Step 1: Diff preview
@@ -4121,14 +4222,22 @@ class SerpentFlow:
         except Exception:  # noqa: BLE001
             bridge_fut = None
         try:
-            approved = await self._race_gate_answer(bridge_fut)
-            if approved is None:
-                approved = True        # every surface dead → Session-H parity
-            elif getattr(self, "_gate_answered_via_cockpit", False):
-                answered_via = "cockpit"
+            _decision = await self._race_gate_answer(bridge_fut)
+            if _decision is None:
+                # Every surface dead → Session-H parity. NOT a human
+                # approval, so it is stamped synthetic and can never be
+                # quoted back as something the operator wanted.
+                _decision = _synthetic_gate_decision(
+                    approved=True, detail="every approval surface dead")
+                approved = True
+            else:
+                approved = _decision.choice.name == "APPROVE"
+                if getattr(self, "_gate_answered_via_cockpit", False):
+                    answered_via = "cockpit"
         except asyncio.CancelledError:
             raise
         except Exception:  # noqa: BLE001
+            _decision = _wordless_reject()
             approved = False
         finally:
             try:
@@ -4138,6 +4247,16 @@ class SerpentFlow:
                 get_operator_prompt_bridge().end(bridge_fut)
             except Exception:  # noqa: BLE001
                 pass
+        # Held for the provider seam, which is the layer that actually calls
+        # reject(reason=...). Same instance-stash pattern as
+        # `_gate_answered_via_cockpit` above — the alternative is widening
+        # this method's return type through several bool-typed callers.
+        #
+        # Placed AFTER the whole try/except/finally rather than inside the
+        # `finally`: on CancelledError `_decision` is unbound, and a NameError
+        # raised from a finally block would replace the cancellation with a
+        # bug report about bookkeeping.
+        self._last_gate_decision = _decision
         # Mirror the decision + which surface answered (§7: every
         # human decision visible everywhere).
         try:
@@ -5092,8 +5211,8 @@ class SerpentApprovalProvider:
             if approved:
                 return await self._inner.approve(request_id, "operator")
             return await self._inner.reject(
-                request_id, "operator", "plan rejected via Plan Gate"
-            )
+                request_id, "operator", *_reject_args(
+                    self._flow, "plan rejected via Plan Gate"))
 
         # Generate proposed diff from candidate
         diff_text = ""
@@ -5141,7 +5260,9 @@ class SerpentApprovalProvider:
         if approved:
             return await self._inner.approve(request_id, "operator")
         else:
-            return await self._inner.reject(request_id, "operator", "rejected via Iron Gate")
+            return await self._inner.reject(
+                request_id, "operator", *_reject_args(
+                    self._flow, "rejected via Iron Gate"))
 
     async def list_pending(self) -> List[Dict[str, Any]]:
         """Delegate to inner provider."""

--- a/backend/core/ouroboros/governance/approval_narrator.py
+++ b/backend/core/ouroboros/governance/approval_narrator.py
@@ -179,7 +179,9 @@ async def await_decision_with_operator(
                 if answer:
                     await provider.approve(request_id, "operator")
                 else:
-                    await provider.reject(request_id, "operator", "declined")
+                    await provider.reject(
+                        request_id, "operator", "declined", "unstated",
+                    )
             except Exception:  # noqa: BLE001
                 logger.debug("[ApprovalNarrator] decision relay failed",
                              exc_info=True)

--- a/backend/core/ouroboros/governance/approval_provider.py
+++ b/backend/core/ouroboros/governance/approval_provider.py
@@ -84,6 +84,25 @@ class ApprovalResult:
         Timestamp when the decision was made. ``None`` for PENDING.
     request_id:
         The request identifier (same as the operation's ``op_id``).
+    reason_provenance:
+        WHERE :attr:`reason` came from — ``"stated"`` (a human typed it),
+        ``"unstated"`` (a human decided and said nothing), or
+        ``"synthetic"`` (no human: headless, timeout, policy default).
+
+        It rides on this object rather than travelling as a parallel
+        argument for one reason: a reason and its provenance separated by
+        even one call frame WILL drift, and the consumer that ends up
+        holding a reason without its provenance has no way to ask. That
+        consumer is
+        :meth:`UserPreferenceStore.record_approval_rejection`, which turns
+        a reason into a FEEDBACK memory rendered to the model as "the
+        user's explicit preferences ... honour them without asking".
+
+        The default is ``"unstated"`` and not ``"stated"`` deliberately.
+        A construction site that has not thought about provenance has not
+        witnessed a human speak, and defaulting to the attributable value
+        is precisely how three code constants came to be quoted as the
+        operator's words in every generation prompt.
     """
 
     status: ApprovalStatus
@@ -91,6 +110,7 @@ class ApprovalResult:
     reason: Optional[str]
     decided_at: Optional[datetime]
     request_id: str
+    reason_provenance: str = "unstated"
 
 
 # ---------------------------------------------------------------------------
@@ -188,7 +208,8 @@ class ApprovalProvider(Protocol):
         ...  # pragma: no cover
 
     async def reject(
-        self, request_id: str, approver: str, reason: str
+        self, request_id: str, approver: str, reason: str,
+        provenance: str = "unstated",
     ) -> ApprovalResult:
         """Reject a pending request.
 
@@ -427,7 +448,8 @@ class CLIApprovalProvider:
     # -- reject --
 
     async def reject(
-        self, request_id: str, approver: str, reason: str
+        self, request_id: str, approver: str, reason: str,
+        provenance: str = "unstated",
     ) -> ApprovalResult:
         """Reject a pending request.
 
@@ -455,6 +477,7 @@ class CLIApprovalProvider:
             status=ApprovalStatus.REJECTED,
             approver=approver,
             reason=reason,
+            reason_provenance=provenance,
             decided_at=datetime.now(tz=timezone.utc),
             request_id=request_id,
         )

--- a/backend/core/ouroboros/governance/discord_gateway.py
+++ b/backend/core/ouroboros/governance/discord_gateway.py
@@ -112,7 +112,13 @@ class GatewayCommandRouter:
                 self._fire_decision(action="approve", op_id=op_id, user_id=str(user_id))
                 return {"ok": True, "action": "approve", "result": res}
             if act == "reject":
-                res = await self._provider.reject(op_id, approver, text or "rejected via Discord")
+                # `text` is what a human typed in Discord; the fallback is
+                # not. Same reason string either way — the provenance is
+                # what decides whether it may become a stored preference.
+                res = await self._provider.reject(
+                    op_id, approver, text or "rejected via Discord",
+                    "stated" if str(text or "").strip() else "unstated",
+                )
                 logger.info("[DiscordGateway] REJECTED_BY_OPERATOR op=%s by=%s", op_id, approver)
                 self._fire_decision(action="reject", op_id=op_id, user_id=str(user_id))
                 return {"ok": True, "action": "reject", "result": res}

--- a/backend/core/ouroboros/governance/inline_approval.py
+++ b/backend/core/ouroboros/governance/inline_approval.py
@@ -153,9 +153,249 @@ def parse_decision_input(text: str) -> InlineApprovalChoice:
     # Strip surrounding whitespace + take first token only (defends
     # against accidental "y\nsomething else").
     first_token = re.split(r"\s+", cleaned)[0]
-    if not first_token:
-        return InlineApprovalChoice.WAIT
-    return _CHOICE_TOKENS.get(first_token, InlineApprovalChoice.WAIT)
+    return _verb_of(first_token) or InlineApprovalChoice.WAIT
+
+
+def _verb_of(token: object) -> Optional[InlineApprovalChoice]:
+    """The choice a single token names, or None if it names none.
+
+    ``None`` rather than ``WAIT`` on purpose: the caller sometimes needs to
+    distinguish "they typed `wait`" from "that was not a verb at all", and
+    a function that answers WAIT to both makes the two indistinguishable.
+    That collapse silently dropped the reason from ``w defer to the PR``.
+
+    Edge punctuation is stripped because operators type the way they speak
+    — ``no, because it loosens the gate`` was scored WAIT purely on the
+    comma, turning an explicit rejection into a deferral. Only the EDGES
+    are stripped, so ``approve-but-wait`` stays the non-verb it is.
+    """
+    try:
+        tok = str(token or "").strip().lower().strip(
+            "\"'`.,;:!?()[]{}<>")
+        if not tok:
+            return None
+        return _CHOICE_TOKENS.get(tok)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+# ---------------------------------------------------------------------------
+# What the operator actually said
+# ---------------------------------------------------------------------------
+#
+# `parse_decision_input` above is a CLASSIFIER: it takes the first token and
+# discards the rest. That is correct for choosing a branch and catastrophic as
+# the only reading of the input, because every rejection then has to invent a
+# reason — and three call sites did exactly that, with the constants
+# "rejected via Iron Gate", "plan rejected via Plan Gate" and "inline reject".
+#
+# Those constants do not stay in the log. They flow:
+#
+#   reject(reason=<constant>)
+#     -> ApprovalResult.reason
+#     -> record_approval_rejection(reason=...)
+#     -> a FEEDBACK memory whose own text says it "encodes the user's stated
+#        reason ... and should be treated as a binding constraint"
+#     -> UserPreferenceMemory.format_for_prompt(), rendered under
+#        "They represent the user's explicit preferences ... Honour them
+#        without asking - contradicting a memory is a rejection cause."
+#
+# So a string the CODE wrote is presented to the model as something the HUMAN
+# said, as a binding constraint, in every subsequent generation prompt. That
+# is a fabricated attribution, the same defect class as a synthetic
+# blast-radius presented as measured — and it is worse than storing nothing,
+# because it is confident and content-free at once.
+#
+# The fix is not a better constant. It is to (a) stop discarding the words the
+# operator typed, and (b) make "they said nothing" a FIRST-CLASS, recordable
+# answer that is structurally ineligible to become a user preference.
+
+
+class ReasonProvenance(str, enum.Enum):
+    """Where a decision's reason came from — the epistemic ledger.
+
+    Mirrors ``Advisory.blast_provenance``: the question is never only "what
+    is the value" but "is this measured, or did we make it up". A consumer
+    that cannot tell a typed sentence from a code constant will eventually
+    present one as the other.
+    """
+
+    #: The operator's own words. The ONLY provenance eligible to become a
+    #: binding constraint attributed to the human.
+    STATED = "stated"
+    #: A human decided and gave no reason. A real, recordable event — and
+    #: emphatically not a preference. Silence is not a constraint.
+    UNSTATED = "unstated"
+    #: No human was involved: headless auto-approve, timeout, policy
+    #: default. Never a preference, and never presented as one.
+    SYNTHETIC = "synthetic"
+
+
+#: Longest reason retained. A reason is a sentence an operator types at a
+#: gate, not a document; past this it is a paste, and an unbounded string
+#: flows into every later generation prompt.
+MAX_REASON_CHARS = 400
+
+#: Leading connectives an operator naturally types after the verb
+#: ("n because the fixture is wrong"). Stripped so the stored reason reads
+#: as a statement rather than a fragment. Order matters: longest first, so
+#: "because of" is not left as "of".
+_REASON_LEAD_IN = (
+    "because of", "because", "since", "as", "due to", "reason:", "reason",
+    "-", "--", ":", ",",
+)
+
+
+def normalize_reason(text: object) -> str:
+    """The operator's words, or "" when they did not give any. NEVER raises.
+
+    "" is load-bearing: it is what makes :data:`ReasonProvenance.UNSTATED`
+    detectable rather than guessed. Punctuation-only input ("...", "!") is
+    normalized to "" for the same reason — it is not a statement, and
+    treating it as one recreates the fabrication in a smaller font.
+    """
+    try:
+        flat = " ".join(str(text or "").split())
+        if not flat:
+            return ""
+        # Strip a leading connective, case-insensitively, once.
+        low = flat.lower()
+        for lead in _REASON_LEAD_IN:
+            if low.startswith(lead) and len(flat) > len(lead):
+                nxt = flat[len(lead):]
+                if not nxt[:1].isalnum():          # "as" in "assert" is not
+                    flat = nxt.strip(" ,:-")       # a connective
+                    break
+        flat = flat.strip(" ,:-")
+        if not any(ch.isalnum() for ch in flat):
+            return ""                              # punctuation is not a why
+        return flat[:MAX_REASON_CHARS]
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+@dataclass(frozen=True)
+class OperatorDecision:
+    """A choice AND what the operator said about it, with provenance.
+
+    The pair is the point. A choice alone forces every downstream consumer
+    that wants a reason to invent one; a reason without provenance lets an
+    invented one pass as a stated one.
+    """
+
+    choice: "InlineApprovalChoice"
+    reason: str = ""
+    provenance: ReasonProvenance = ReasonProvenance.UNSTATED
+
+    @property
+    def is_stated(self) -> bool:
+        """May this become a constraint attributed to the human?"""
+        return (self.provenance is ReasonProvenance.STATED
+                and bool(self.reason))
+
+    def with_reason(self, text: object) -> "OperatorDecision":
+        """Attach words gathered later (a follow-up prompt). NEVER raises.
+
+        Empty input leaves the decision UNSTATED rather than marking it
+        stated-with-nothing — the follow-up being skipped is itself the
+        answer, and must not be laundered into a stated reason.
+        """
+        cleaned = normalize_reason(text)
+        if not cleaned:
+            return self
+        return OperatorDecision(
+            choice=self.choice, reason=cleaned,
+            provenance=ReasonProvenance.STATED,
+        )
+
+
+def parse_gate_answer(
+    text: object, *, empty_means: "InlineApprovalChoice",
+) -> OperatorDecision:
+    """Parse an answer where the PROMPT declared what a bare Enter means.
+
+    Two live prompts make opposite promises with the same parser behind
+    them: ``[Y/n]`` (capital Y) promises Enter = approve, while the inline
+    ``[y]es / [n]o / [s]how / [e]dit / [w]ait`` prompt promises Enter =
+    wait. Baking either into :func:`parse_decision` would silently break
+    the other, and baking BOTH in would mean the parser guessing which
+    surface called it.
+
+    So the default is an argument. The prompt that made the promise is the
+    only party that knows what it promised.
+
+    A bare Enter is always UNSTATED regardless of which choice it maps to —
+    accepting a default is a decision, never an explanation of one.
+    """
+    try:
+        if not str(text or "").strip():
+            return OperatorDecision(choice=empty_means)
+        return parse_decision(str(text))
+    except Exception:  # noqa: BLE001
+        return OperatorDecision(choice=InlineApprovalChoice.WAIT)
+
+
+def synthetic_decision(
+    choice: "InlineApprovalChoice", detail: object = "",
+) -> OperatorDecision:
+    """A decision no human made — headless, timeout, policy default.
+
+    Carries its detail so the event stays auditable (§7), and carries
+    SYNTHETIC so nothing downstream can quote it as the operator.
+    """
+    return OperatorDecision(
+        choice=choice,
+        reason=normalize_reason(detail),
+        provenance=ReasonProvenance.SYNTHETIC,
+    )
+
+
+def parse_decision(text: str) -> OperatorDecision:
+    """Parse operator input into a choice AND their reason. NEVER raises.
+
+    The choice half is delegated to :func:`parse_decision_input`, so the
+    safety-first contract it is pinned to (ambiguous never approves) has
+    exactly one implementation. What is new is that the REMAINDER of the
+    line survives:
+
+        "n"                            -> REJECT, unstated
+        "n the fixture is the wrong shape"
+                                       -> REJECT, STATED, "the fixture is..."
+        "no, because it loosens the gate"
+                                       -> REJECT, STATED, "it loosens the..."
+        "y"                            -> APPROVE, unstated
+
+    A reason on an UNPARSEABLE line is deliberately dropped: that input
+    returns WAIT, and attaching words to a choice the operator did not
+    make is how a typo becomes a stored preference.
+    """
+    try:
+        choice = parse_decision_input(text)
+        # The FIRST LINE only. `y\nrm -rf /` is the accidental-paste shape
+        # the classifier was hardened against; taking the remainder across
+        # the newline would quote a line the operator never meant to send
+        # as their stated reason — the same fabrication in a new costume.
+        raw = str(text or "").splitlines()[0] if str(text or "").strip() else ""
+        # Everything after the verb. `split(maxsplit=1)` rather than a
+        # regex over the whole line, so the reason keeps its own internal
+        # spacing decisions and we only ever remove the token we consumed.
+        parts = raw.strip().split(None, 1)
+        rest = parts[1] if len(parts) > 1 else ""
+        if _verb_of(parts[0] if parts else "") is None:
+            # Not a verb at all. The words are attached to nothing, and
+            # binding them to WAIT is how a typo becomes a stored reason.
+            # Asked as "is this a verb", never as "does it mean WAIT" —
+            # `w` and `defer` mean WAIT legitimately and keep their words.
+            return OperatorDecision(choice=choice)
+        reason = normalize_reason(rest)
+        if not reason:
+            return OperatorDecision(choice=choice)
+        return OperatorDecision(
+            choice=choice, reason=reason,
+            provenance=ReasonProvenance.STATED,
+        )
+    except Exception:  # noqa: BLE001
+        return OperatorDecision(choice=InlineApprovalChoice.WAIT)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/core/ouroboros/governance/inline_approval_provider.py
+++ b/backend/core/ouroboros/governance/inline_approval_provider.py
@@ -248,6 +248,7 @@ class InlineApprovalProvider:
 
     async def reject(
         self, request_id: str, approver: str, reason: str,
+        provenance: str = "unstated",
     ) -> ApprovalResult:
         pending = self._get_or_raise(request_id)
         if pending.result is not None:
@@ -259,6 +260,7 @@ class InlineApprovalProvider:
             status=ApprovalStatus.REJECTED,
             approver=approver,
             reason=reason,
+            reason_provenance=provenance,
             decided_at=datetime.now(tz=timezone.utc),
             request_id=request_id,
         )

--- a/backend/core/ouroboros/governance/inline_approval_renderer.py
+++ b/backend/core/ouroboros/governance/inline_approval_renderer.py
@@ -52,8 +52,11 @@ from backend.core.ouroboros.governance.approval_provider import (
 from backend.core.ouroboros.governance.inline_approval import (
     InlineApprovalChoice,
     InlineApprovalRequest,
+    OperatorDecision,
     decision_timeout_s,
     parse_decision_input,
+    parse_gate_answer,
+    synthetic_decision,
 )
 
 logger = logging.getLogger(__name__)
@@ -182,6 +185,21 @@ def prompt_decision(
     timeout_s: Optional[float] = None,
     now_fn=time.monotonic,
 ) -> InlineApprovalChoice:
+    """The CHOICE only — see :func:`prompt_decision_full` for the words.
+
+    Kept because callers and tests are pinned to a choice-returning
+    function; it is now a projection of the full decision rather than a
+    separate read, so the two can never disagree about the same line."""
+    return prompt_decision_full(
+        stream_in=stream_in, timeout_s=timeout_s, now_fn=now_fn,
+    ).choice
+
+
+def prompt_decision_full(
+    stream_in: Optional[IO[str]] = None,
+    timeout_s: Optional[float] = None,
+    now_fn=time.monotonic,
+) -> OperatorDecision:
     """Read one decision line from ``stream_in`` with a hard timeout.
 
     Returns:
@@ -214,16 +232,19 @@ def prompt_decision(
     while True:
         remaining = deadline - now_fn()
         if remaining <= 0:
-            return InlineApprovalChoice.TIMEOUT_DEFERRED
+            return synthetic_decision(
+                InlineApprovalChoice.TIMEOUT_DEFERRED, 'prompt timed out')
         try:
             ready, _, _ = select.select([fileno], [], [], remaining)
         except (OSError, ValueError) as exc:
             logger.warning(
                 "[InlineApprovalRenderer] select failed: %s", exc,
             )
-            return InlineApprovalChoice.WAIT
+            return synthetic_decision(
+                InlineApprovalChoice.WAIT, f'select failed: {exc}')
         if not ready:
-            return InlineApprovalChoice.TIMEOUT_DEFERRED
+            return synthetic_decision(
+                InlineApprovalChoice.TIMEOUT_DEFERRED, 'prompt timed out')
         return _read_one_line_or_safe(stream_in)
 
 
@@ -236,17 +257,27 @@ def _safe_fileno(stream: IO[str]) -> Optional[int]:
         return None
 
 
-def _read_one_line_or_safe(stream: IO[str]) -> InlineApprovalChoice:
-    """Read exactly one line; map empty/EOF/garbage → WAIT."""
+def _read_one_line_or_safe(stream: IO[str]) -> OperatorDecision:
+    """Read exactly one line; map empty/EOF/garbage → WAIT.
+
+    Returns the DECISION, not just the choice. The reason the operator
+    typed lived in this function for exactly one statement before
+    `parse_decision_input` reduced the line to a verb and dropped it, and
+    a placeholder was substituted three frames later.
+    """
     try:
         line = stream.readline()
     except (OSError, ValueError) as exc:
         logger.warning("[InlineApprovalRenderer] readline failed: %s", exc)
-        return InlineApprovalChoice.WAIT
+        return OperatorDecision(choice=InlineApprovalChoice.WAIT)
     if not line:
         # EOF — mirrors Slice 1 contract: no input ≠ approval.
-        return InlineApprovalChoice.WAIT
-    return parse_decision_input(line)
+        return OperatorDecision(choice=InlineApprovalChoice.WAIT)
+    # Enter means WAIT at THIS prompt (`[y]es / [n]o / ... / [w]ait` offers
+    # no default), which is the opposite of the Iron Gate's `[Y/n]`. The
+    # promise belongs to the prompt that made it, so it is declared here
+    # rather than assumed by the parser.
+    return parse_gate_answer(line, empty_means=InlineApprovalChoice.WAIT)
 
 
 # ---------------------------------------------------------------------------
@@ -383,19 +414,27 @@ def run_inline_approval_loop(
         block = render_request_block(request, diff_text=diff_text)
         _safe_print(stream_out, block)
 
-        choice = prompt_decision(
+        decision = prompt_decision_full(
             stream_in=stream_in,
             timeout_s=timeout_s,
         )
+        choice = decision.choice
 
         if choice is InlineApprovalChoice.APPROVE:
             return _await_now(
                 provider.approve(request.request_id, operator),
             )
         if choice is InlineApprovalChoice.REJECT:
+            # The operator's own words when they gave any. Slice 3 wrote
+            # the literal "inline reject" here and left a TODO for Slice 4
+            # to "add a one-line reason capture"; Slice 4 never came, and
+            # the placeholder was being stored downstream as the human's
+            # stated reason and replayed into every generation prompt.
             return _await_now(
                 provider.reject(
-                    request.request_id, operator, "inline reject",
+                    request.request_id, operator,
+                    decision.reason or "inline reject",
+                    "stated" if decision.is_stated else "unstated",
                 ),
             )
         if choice is InlineApprovalChoice.SHOW_STACK:

--- a/backend/core/ouroboros/governance/loop_cli.py
+++ b/backend/core/ouroboros/governance/loop_cli.py
@@ -179,7 +179,12 @@ async def handle_reject(
             "not_active: Governed loop is not active."
         )
 
-    result = await service._approval_provider.reject(op_id, approver, reason)
+    # An operator typed this on the command line. A blank one is still a
+    # rejection, just not an explanation of one.
+    result = await service._approval_provider.reject(
+        op_id, approver, reason,
+        "stated" if str(reason or "").strip() else "unstated",
+    )
 
     logger.info(
         "[CLI] reject: op_id=%s status=%s approver=%s reason=%r",

--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -5267,6 +5267,9 @@ class GovernedOrchestrator:
                                         description=f"[PLAN] {ctx.description}",
                                         target_files=list(ctx.target_files),
                                         reason=_reject_reason,
+                                        provenance=getattr(
+                                            _plan_decision,
+                                            "reason_provenance", "unstated"),
                                         approver=(
                                             getattr(_plan_decision, "approver", "human")
                                             or "human"
@@ -10420,6 +10423,8 @@ class GovernedOrchestrator:
                                 description=ctx.description,
                                 target_files=list(ctx.target_files),
                                 reason=_reject_reason,
+                                provenance=getattr(
+                                    decision, "reason_provenance", "unstated"),
                                 approver=getattr(decision, "approver", "human") or "human",
                             )
                         except Exception:

--- a/backend/core/ouroboros/governance/phase_runners/plan_runner.py
+++ b/backend/core/ouroboros/governance/phase_runners/plan_runner.py
@@ -636,6 +636,9 @@ class PLANRunner(PhaseRunner):
                                     description=f"[PLAN] {ctx.description}",
                                     target_files=list(ctx.target_files),
                                     reason=_reject_reason,
+                                    provenance=getattr(
+                                        _plan_decision,
+                                        "reason_provenance", "unstated"),
                                     approver=(
                                         getattr(_plan_decision, "approver", "human")
                                         or "human"

--- a/backend/core/ouroboros/governance/phase_runners/slice4b_runner.py
+++ b/backend/core/ouroboros/governance/phase_runners/slice4b_runner.py
@@ -413,6 +413,8 @@ class Slice4bRunner(PhaseRunner):
                             description=ctx.description,
                             target_files=list(ctx.target_files),
                             reason=_reject_reason,
+                            provenance=getattr(
+                                decision, "reason_provenance", "unstated"),
                             approver=getattr(decision, "approver", "human") or "human",
                         )
                     except Exception:

--- a/backend/core/ouroboros/governance/user_preference_memory.py
+++ b/backend/core/ouroboros/governance/user_preference_memory.py
@@ -800,6 +800,7 @@ class UserPreferenceStore:
         target_files: Sequence[str],
         reason: str,
         approver: str = "human",
+        provenance: str = "",
     ) -> Optional[UserMemory]:
         """Convert an approval rejection into a FEEDBACK memory.
 
@@ -808,9 +809,51 @@ class UserPreferenceStore:
         piling up identical entries. Returns the persisted memory, or
         ``None`` if the inputs were too sparse to build a meaningful
         entry.
+
+        Only a reason the human ACTUALLY STATED becomes a memory
+        --------------------------------------------------------
+        The content written here says the entry "encodes the user's stated
+        reason ... and should be treated as a binding constraint", and
+        :meth:`format_for_prompt` renders it under "the user's explicit
+        preferences ... Honour them without asking". Both sentences are
+        promises about provenance, and for a long time neither was true:
+        every interactive rejection arrived carrying a CONSTANT the code
+        had written — ``"rejected via Iron Gate"``, ``"plan rejected via
+        Plan Gate"``, ``"inline reject"`` — because the gate returned a
+        bool and the decision parser discarded everything after the verb.
+        So a string the code authored was injected into every later
+        generation prompt as a binding constraint the human had uttered.
+
+        That is fabricated attribution: the same defect class as a
+        synthetic blast radius presented as measured, and worse than
+        storing nothing, because it is confident and content-free at once.
+
+        ``provenance`` closes it, and closes it by CONTRACT rather than by
+        recognising the bad strings. A deny-list of the three known
+        literals would be hardcoding the symptom: it rots the moment a
+        fourth call site invents a fourth constant, and it cannot tell
+        ``"rejected via Iron Gate"`` (a constant) from ``"rejected because
+        the Iron Gate is right"`` (a sentence). So the question asked here
+        is never "does this string look invented" but "did the caller
+        witness a human say it".
+
+        A caller that does not declare provenance has not witnessed one,
+        and silence is refused. That is deliberately strict — the failure
+        mode it replaces was a silent, confident lie injected into every
+        subsequent prompt, and a lost memory is recoverable in a way a
+        fabricated constraint is not.
         """
         cleaned_reason = (reason or "").strip()
         if not cleaned_reason:
+            return None
+        prov = str(provenance or "").strip().lower()
+        if prov != "stated":
+            logger.debug(
+                "[UserPreferenceStore] op %s rejection not attributable to a "
+                "human (provenance=%r) — recorded as an event, never as a "
+                "preference",
+                op_id, prov or "undeclared",
+            )
             return None
         desc_short = (description or "unknown operation").strip()[:100]
         name = f"rejection_{_slug(desc_short, max_len=40)}"

--- a/tests/architecture/test_slice156_discord_gateway.py
+++ b/tests/architecture/test_slice156_discord_gateway.py
@@ -28,8 +28,12 @@ class _FakeApprovalProvider:
         self.rejected = []
     async def approve(self, request_id, approver):
         self.approved.append((request_id, approver)); return {"ok": True}
-    async def reject(self, request_id, approver, reason=""):
-        self.rejected.append((request_id, approver, reason)); return {"ok": True}
+    async def reject(self, request_id, approver, reason="",
+                     provenance="unstated"):
+        # Mirrors the real signature. A fake narrower than the contract
+        # makes the caller look correct while production would raise.
+        self.rejected.append(
+            (request_id, approver, reason, provenance)); return {"ok": True}
 
 
 class _FakeBridge:

--- a/tests/architecture/test_slice157_live_fire.py
+++ b/tests/architecture/test_slice157_live_fire.py
@@ -31,8 +31,10 @@ class _FakeProvider:
         self.approved = []
     async def approve(self, rid, approver):
         self.approved.append((rid, approver)); return {"ok": True}
-    async def reject(self, rid, approver, reason=""):
-        self.rejected.append((rid, approver, reason)); return {"ok": True}
+    async def reject(self, rid, approver, reason="",
+                     provenance="unstated"):
+        self.rejected.append(
+            (rid, approver, reason, provenance)); return {"ok": True}
 
 
 class TestLiveFirePayload(unittest.TestCase):

--- a/tests/governance/test_approval_narrator.py
+++ b/tests/governance/test_approval_narrator.py
@@ -67,7 +67,8 @@ class _Provider:
         self.decided = "APPROVED"
         self.event.set()
 
-    async def reject(self, _rid: str, who: str, why: str) -> None:
+    async def reject(self, _rid: str, who: str, why: str,
+                     provenance: str = "unstated") -> None:
         self.calls.append(f"reject:{who}:{why}")
         self.decided = "REJECTED"
         self.event.set()

--- a/tests/governance/test_inline_approval_renderer.py
+++ b/tests/governance/test_inline_approval_renderer.py
@@ -407,9 +407,13 @@ class _FakeProvider:
         self.calls.append(("approve", request_id, approver))
         return self._result(ApprovalStatus.APPROVED, request_id, approver)
 
-    def reject(self, request_id: str, approver: str, reason: str
-               ) -> ApprovalResult:
-        self.calls.append(("reject", request_id, approver, reason))
+    def reject(self, request_id: str, approver: str, reason: str,
+               provenance: str = "unstated") -> ApprovalResult:
+        # Mirrors the REAL signature including provenance. A fake that
+        # accepts less than the contract makes the caller look correct
+        # while the production provider would reject the same call.
+        self.calls.append(
+            ("reject", request_id, approver, reason, provenance))
         return self._result(
             ApprovalStatus.REJECTED, request_id, approver, reason,
         )
@@ -434,7 +438,10 @@ def test_loop_y_calls_approve():
     assert prov.calls[0][0] == "approve"
 
 
-def test_loop_n_calls_reject_with_inline_reason():
+def test_loop_n_alone_rejects_and_claims_no_reason():
+    """A bare `n` still carries the placeholder for the audit line — what
+    changed is that it travels as UNSTATED, so nothing downstream may
+    store it as something the operator said."""
     prov = _FakeProvider()
     req = _make_request(request_id="r1")
     result = run_inline_approval_loop(
@@ -444,7 +451,27 @@ def test_loop_n_calls_reject_with_inline_reason():
         timeout_s=1.0,
     )
     assert result.status is ApprovalStatus.REJECTED
-    assert prov.calls[0] == ("reject", "r1", "operator", "inline reject")
+    assert prov.calls[0] == (
+        "reject", "r1", "operator", "inline reject", "unstated")
+
+
+def test_loop_keeps_the_reason_the_operator_TYPED():
+    """The whole point. Slice 3 hardcoded "inline reject" and left a TODO
+    for Slice 4 to "add a one-line reason capture"; Slice 4 never came, so
+    the placeholder was stored and replayed as the human's stated reason
+    in every later generation prompt."""
+    prov = _FakeProvider()
+    req = _make_request(request_id="r1")
+    result = run_inline_approval_loop(
+        prov, req,
+        stream_in=io.StringIO("n this widens the permission gate\n"),
+        stream_out=io.StringIO(),
+        timeout_s=1.0,
+    )
+    assert result.status is ApprovalStatus.REJECTED
+    assert prov.calls[0] == (
+        "reject", "r1", "operator",
+        "this widens the permission gate", "stated")
 
 
 def test_loop_w_defers_via_await_decision_zero():

--- a/tests/governance/test_rejection_provenance.py
+++ b/tests/governance/test_rejection_provenance.py
@@ -1,0 +1,257 @@
+"""A reason nobody gave must never be quoted as something someone said.
+
+The Iron Gate returned a bool, and the decision parser took the first token
+and discarded the line. So a rejection arrived downstream with no reason, and
+three call sites supplied one:
+
+    serpent_flow.py           "rejected via Iron Gate"
+    serpent_flow.py           "plan rejected via Plan Gate"
+    inline_approval_renderer  "inline reject"     (+ a TODO for "Slice 4")
+
+Those strings did not stay in a log. Each became a FEEDBACK memory whose own
+content reads "It encodes the user's stated reason for blocking the operation
+and should be treated as a binding constraint", rendered into every later
+generation prompt under "They represent the user's explicit preferences ...
+Honour them without asking".
+
+So the organism was told to obey, as the operator's explicit wish, a sentence
+the codebase had written about itself. Confident and content-free at once —
+the same defect class as a synthetic blast radius presented as measured.
+"""
+from __future__ import annotations
+
+import pathlib
+import tempfile
+
+import pytest
+
+from backend.core.ouroboros.governance.inline_approval import (
+    InlineApprovalChoice,
+    OperatorDecision,
+    ReasonProvenance,
+    normalize_reason,
+    parse_decision,
+    parse_gate_answer,
+    synthetic_decision,
+)
+from backend.core.ouroboros.governance.user_preference_memory import (
+    MemoryType,
+    UserPreferenceStore,
+)
+
+
+@pytest.fixture
+def store():
+    with tempfile.TemporaryDirectory() as td:
+        yield UserPreferenceStore(pathlib.Path(td))
+
+
+def _reject(store, **kw):
+    base = dict(op_id="op-1", description="loosen the risk floor",
+                target_files=["gate.py"], reason="a reason")
+    base.update(kw)
+    return store.record_approval_rejection(**base)
+
+
+class TestOnlyWhatAHumanSaid:
+    def test_a_code_constant_never_becomes_a_constraint(self, store):
+        """THE regression, in the exact shape it shipped in."""
+        for constant in ("rejected via Iron Gate",
+                         "plan rejected via Plan Gate", "inline reject"):
+            assert _reject(store, reason=constant,
+                           provenance="unstated") is None
+        assert store.find_by_type(MemoryType.FEEDBACK) == []
+
+    def test_the_operators_own_words_DO(self, store):
+        mem = _reject(store, reason="it widens the permission gate",
+                      provenance="stated")
+        assert mem is not None
+        assert mem.why == "it widens the permission gate"
+
+    def test_no_human_present_is_never_a_preference(self, store):
+        assert _reject(store, reason="headless: no tty",
+                       provenance="synthetic") is None
+
+    def test_an_UNDECLARED_caller_is_refused(self, store):
+        """Strict on purpose. A caller that has not thought about
+        provenance has not witnessed a human speak, and defaulting to the
+        attributable value is exactly how this bug happened. A lost memory
+        is recoverable; a fabricated constraint injected into every prompt
+        is not."""
+        assert _reject(store) is None
+
+    def test_it_gates_on_PROVENANCE_not_on_recognising_strings(self, store):
+        """A deny-list of the three literals would rot on the fourth, and
+        cannot distinguish "rejected via Iron Gate" (a constant) from
+        "rejected because the Iron Gate is right" (a sentence)."""
+        assert _reject(store, reason="rejected via Iron Gate",
+                       provenance="stated") is not None
+        assert _reject(store, op_id="op-2", description="d2",
+                       reason="this reads exactly like a person wrote it",
+                       provenance="unstated") is None
+
+
+class TestTheWordsSurviveTheParser:
+    @pytest.mark.parametrize(("typed", "choice", "reason"), [
+        ("n", "REJECT", ""),
+        ("n it widens the permission gate", "REJECT",
+         "it widens the permission gate"),
+        ("no, because the fixture asserts the bug", "REJECT",
+         "the fixture asserts the bug"),
+        ("reject since this touches the audit file", "REJECT",
+         "this touches the audit file"),
+        ("y", "APPROVE", ""),
+    ])
+    def test_the_line_is_not_reduced_to_a_verb(self, typed, choice, reason):
+        d = parse_decision(typed)
+        assert d.choice.name == choice
+        assert d.reason == reason
+        assert d.is_stated is bool(reason)
+
+    def test_a_comma_no_longer_costs_the_rejection(self):
+        """`no, because ...` scored WAIT purely on the comma, silently
+        turning an explicit rejection into a deferral."""
+        assert parse_decision("no, because it is wrong").choice is (
+            InlineApprovalChoice.REJECT)
+
+    def test_a_legitimate_wait_keeps_its_words(self):
+        """`w` and `defer` MEAN wait. Asking "does this map to WAIT"
+        instead of "is this a verb" made them indistinguishable from
+        garbage, and dropped the reason."""
+        d = parse_decision("w defer to the PR path")
+        assert d.choice is InlineApprovalChoice.WAIT
+        assert d.reason == "defer to the PR path"
+
+    def test_garbage_attaches_its_words_to_NOTHING(self):
+        """Binding a reason to a choice the operator did not make is how a
+        typo becomes a stored preference."""
+        d = parse_decision("wat this is not a verb")
+        assert d.choice is InlineApprovalChoice.WAIT
+        assert d.reason == ""
+
+    def test_an_accidental_paste_is_not_a_stated_reason(self):
+        """`y\\nrm -rf /` is the shape the classifier was hardened against.
+        Quoting the second line as the operator's reason would be the same
+        fabrication wearing a different costume."""
+        assert parse_decision("y\nrm -rf /").reason == ""
+        assert parse_decision("n the real reason\nand a paste").reason == (
+            "the real reason")
+
+    def test_punctuation_is_not_an_explanation(self):
+        for junk in ("n ...", "n !!!", "n ---"):
+            assert parse_decision(junk).is_stated is False
+
+    def test_a_reason_is_bounded(self):
+        assert len(normalize_reason("word " * 5000)) <= 400
+
+
+class TestTheDefaultBelongsToThePrompt:
+    def test_enter_means_what_the_PROMPT_promised(self):
+        """`[Y/n]` promises Enter = approve; the inline prompt's
+        `[y]es/[n]o/.../[w]ait` promises Enter = wait. Baking either into
+        the parser silently breaks the other surface."""
+        assert parse_gate_answer(
+            "", empty_means=InlineApprovalChoice.APPROVE
+        ).choice is InlineApprovalChoice.APPROVE
+        assert parse_gate_answer(
+            "", empty_means=InlineApprovalChoice.WAIT
+        ).choice is InlineApprovalChoice.WAIT
+
+    def test_accepting_a_default_explains_nothing(self):
+        for default in (InlineApprovalChoice.APPROVE, InlineApprovalChoice.WAIT):
+            assert parse_gate_answer("", empty_means=default).is_stated is False
+
+
+class TestTheGateItself:
+    def test_the_iron_gate_relays_rather_than_invents(self):
+        from backend.core.ouroboros.battle_test.serpent_flow import (
+            _gate_decision, _reject_args,
+        )
+
+        class _Flow:
+            def __init__(self, d): self._last_gate_decision = d
+
+        spoke = _Flow(_gate_decision("n it widens the permission gate"))
+        assert _reject_args(spoke, "rejected via Iron Gate") == (
+            "it widens the permission gate", "stated")
+
+        silent = _Flow(_gate_decision("n"))
+        # The fallback still travels — the audit log deserves to say WHICH
+        # gate refused. What changed is that it cannot be attributed.
+        assert _reject_args(silent, "rejected via Iron Gate") == (
+            "rejected via Iron Gate", "unstated")
+
+    def test_ctrl_d_is_a_rejection_and_not_an_explanation(self):
+        from backend.core.ouroboros.battle_test.serpent_flow import (
+            _reject_args, _wordless_reject,
+        )
+
+        class _Flow:
+            _last_gate_decision = _wordless_reject()
+
+        assert _reject_args(_Flow(), "rejected via Iron Gate")[1] == "unstated"
+
+    def test_headless_auto_approve_is_synthetic(self):
+        from backend.core.ouroboros.battle_test.serpent_flow import (
+            _reject_args, _synthetic_gate_decision,
+        )
+
+        class _Flow:
+            _last_gate_decision = _synthetic_gate_decision(
+                approved=True, detail="headless: no tty")
+
+        assert _reject_args(_Flow(), "x")[1] == "synthetic"
+
+    def test_a_literal_reason_must_declare_its_provenance(self):
+        """Structural, so the class cannot come back through a fourth call
+        site. Any `reject(..., "<literal>")` is by definition a reason no
+        human typed, and must say so.
+
+        Checked as an AST rather than by grep: a regex over the source
+        both false-positives on the correct `*_reject_args(...)` spread
+        and cannot see a keyword argument on the following line."""
+        import ast
+        offenders = []
+        for path in pathlib.Path("backend/core/ouroboros").rglob("*.py"):
+            try:
+                tree = ast.parse(path.read_text())
+            except (SyntaxError, UnicodeDecodeError):
+                continue
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                if getattr(node.func, "attr", None) != "reject":
+                    continue
+                if len(node.args) < 3:
+                    continue
+                reason = node.args[2]
+                if not (isinstance(reason, ast.Constant)
+                        and isinstance(reason.value, str)):
+                    continue          # computed / relayed — fine
+                declared = (len(node.args) >= 4
+                            or any(k.arg == "provenance" for k in node.keywords))
+                if not declared:
+                    offenders.append(
+                        f"{path}:{node.lineno} reject(..., {reason.value!r})")
+        assert not offenders, (
+            "a hardcoded rejection reason with no provenance:\n"
+            + "\n".join(offenders))
+
+
+class TestNeverRaises:
+    @pytest.mark.parametrize("call", [
+        lambda: parse_decision(None),                  # type: ignore[arg-type]
+        lambda: parse_decision(12345),                 # type: ignore[arg-type]
+        lambda: normalize_reason(object()),
+        lambda: parse_gate_answer(None, empty_means=InlineApprovalChoice.WAIT),
+        lambda: synthetic_decision(InlineApprovalChoice.WAIT, None),
+    ])
+    def test_junk_degrades(self, call):
+        assert call() is not None
+
+    def test_with_reason_refuses_to_launder_emptiness(self):
+        """Skipping the follow-up prompt IS the answer, and must not be
+        upgraded to a stated reason."""
+        d = OperatorDecision(choice=InlineApprovalChoice.REJECT)
+        assert d.with_reason("   ").provenance is ReasonProvenance.UNSTATED
+        assert d.with_reason("it is wrong").is_stated is True

--- a/tests/test_ouroboros_governance/test_loop_cli.py
+++ b/tests/test_ouroboros_governance/test_loop_cli.py
@@ -138,8 +138,25 @@ class TestRejectCommand:
             approver="derek",
             reason="Too risky",
         )
+        # An operator typed "Too risky" at the CLI, so it travels as
+        # STATED and may become a durable constraint. The provenance is
+        # part of the call because a reason separated from where it came
+        # from is how three code constants ended up quoted as the human.
         service._approval_provider.reject.assert_called_once_with(
-            "op-test-001", "derek", "Too risky"
+            "op-test-001", "derek", "Too risky", "stated"
+        )
+
+    async def test_reject_with_blank_reason_is_not_attributed(self) -> None:
+        """A rejection with nothing typed is still a rejection — it is just
+        not an explanation, and must not be stored as one."""
+        from backend.core.ouroboros.governance.loop_cli import handle_reject
+
+        service = _mock_service()
+        await handle_reject(
+            service=service, op_id="op-test-002", approver="derek", reason="",
+        )
+        service._approval_provider.reject.assert_called_once_with(
+            "op-test-002", "derek", "", "unstated"
         )
 
     async def test_reject_with_no_service_raises(self) -> None:

--- a/tests/test_ouroboros_governance/test_user_preference_memory.py
+++ b/tests/test_ouroboros_governance/test_user_preference_memory.py
@@ -713,6 +713,7 @@ class TestPostmortemHooks:
             description="rewrite auth middleware",
             target_files=["src/auth/middleware.py"],
             reason="Legal hasn't signed off on storing session tokens this way",
+            provenance="stated",
         )
         assert mem is not None
         assert mem.type is MemoryType.FEEDBACK
@@ -742,12 +743,14 @@ class TestPostmortemHooks:
             description="rewrite auth middleware",
             target_files=[],
             reason="first reason",
+            provenance="stated",
         )
         mem2 = store.record_approval_rejection(
             op_id="op-2",
             description="rewrite auth middleware",
             target_files=[],
             reason="second reason",
+            provenance="stated",
         )
         assert mem1 is not None
         assert mem2 is not None
@@ -763,6 +766,7 @@ class TestPostmortemHooks:
             target_files=[],
             reason="reason",
             approver="derek",
+            provenance="stated",
         )
         assert mem is not None
         assert "derek" in mem.source
@@ -773,9 +777,43 @@ class TestPostmortemHooks:
             description="desc",
             target_files=[f"src/f{i}.py" for i in range(10)],
             reason="reason",
+            provenance="stated",
         )
         assert mem is not None
         assert len(mem.paths) == 4
+
+    def test_a_reason_no_human_stated_is_NOT_a_preference(self, store):
+        """THE regression. Three call sites passed a code constant here —
+        "rejected via Iron Gate", "plan rejected via Plan Gate", "inline
+        reject" — because the gate returned a bool and the decision parser
+        discarded everything after the verb. Each became a FEEDBACK memory
+        whose content claims to encode "the user's stated reason", rendered
+        to the model under "the user's explicit preferences ... Honour them
+        without asking". A string the CODE wrote, quoted as the human."""
+        for prov in ("unstated", "synthetic", ""):
+            assert store.record_approval_rejection(
+                op_id="op-fab",
+                description="rewrite the permission gate",
+                target_files=["src/gate.py"],
+                reason="rejected via Iron Gate",
+                provenance=prov,
+            ) is None, f"provenance={prov!r} became a binding constraint"
+        assert store.find_by_type(MemoryType.FEEDBACK) == []
+
+    def test_the_gate_is_provenance_not_a_denylist_of_strings(self, store):
+        """A deny-list of the three known constants would rot on the fourth
+        and cannot tell "rejected via Iron Gate" (a constant) from
+        "rejected because the Iron Gate is right" (a sentence). The
+        question asked is whether a human was WITNESSED saying it."""
+        assert store.record_approval_rejection(
+            op_id="op-a", description="d", target_files=[],
+            reason="rejected via Iron Gate", provenance="stated",
+        ) is not None          # same string, witnessed → legitimate
+        assert store.record_approval_rejection(
+            op_id="op-b", description="d2", target_files=[],
+            reason="this genuinely reads like a human sentence",
+            provenance="unstated",
+        ) is None              # human-shaped, unwitnessed → refused
 
     def test_record_rollback_creates_feedback(self, store):
         mem = store.record_rollback(


### PR DESCRIPTION
## The defect

The Iron Gate returned a `bool`, and the decision parser took the first token and discarded the rest of the line. A rejection therefore reached the provider with **no reason** — so three call sites supplied one:

| site | constant |
|---|---|
| `serpent_flow.py` | `"rejected via Iron Gate"` |
| `serpent_flow.py` | `"plan rejected via Plan Gate"` |
| `inline_approval_renderer.py` | `"inline reject"` — with a TODO for a "Slice 4" that never came |

Those strings did not stay in a log:

```
reject(reason=<constant>)
  → ApprovalResult.reason
  → record_approval_rejection(reason=…)
  → a FEEDBACK memory whose own content reads
      "It encodes the user's stated reason for blocking the operation
       and should be treated as a binding constraint"
  → UserPreferenceStore.format_for_prompt()   ← live on the shipping CLASSIFY path
      "They represent the user's explicit preferences …
       Honour them without asking — contradicting a memory is a rejection cause."
```

So a sentence **the codebase wrote about itself** was injected into every subsequent generation prompt as a binding constraint the human had uttered — and deduped by op-shape, so it persisted and accumulated.

This is fabricated attribution: structurally the same defect as a synthetic blast radius presented as measured. It is worse than storing nothing, because it is confident and content-free at once.

## The fix is not a better constant

**1 · The parser keeps the words.** `parse_decision` delegates the *choice* to the existing safety-pinned classifier (so "ambiguous never approves" has one implementation) and preserves the remainder as the reason.

```
"n"                                   → REJECT,  unstated
"n it widens the permission gate"     → REJECT,  STATED
"no, because the fixture asserts …"   → REJECT,  STATED
""            (the [Y/n] default)     → APPROVE, unstated
```

**2 · Provenance is first-class** — `stated` / `unstated` / `synthetic` — and rides **on `ApprovalResult` beside the reason**, not as a parallel argument. Separated by even one call frame the two drift, and the consumer left holding a reason without its provenance has no way to ask.

**3 · The memory gate asks the right question.** Not *"does this string look invented"* — a deny-list of the three literals rots on the fourth and cannot distinguish `"rejected via Iron Gate"` (a constant) from `"rejected because the Iron Gate is right"` (a sentence) — but *"did the caller witness a human say it"*. **Undeclared is refused**: a caller that has not thought about provenance has not witnessed one, and defaulting to the attributable value is precisely how this happened.

## Edge cases

Two parser defects surfaced by exercising it, both pre-existing:

- `no, because it loosens the gate` scored **WAIT** on the comma alone — silently demoting an explicit rejection to a deferral.
- Asking *"does this token mean WAIT"* rather than *"is this a verb"* made a legitimate `w` / `defer` indistinguishable from garbage and dropped its reason.

`y\nrm -rf /` keeps its hardening: the reason stops at the first line, because quoting a pasted second line as the operator's words is the same fabrication in a new costume. Punctuation-only input (`n ...`) is not an explanation. Reasons are bounded at 400 chars.

The `[Y/n]` gate promises Enter = approve; the inline prompt's `[y]es/[n]o/…/[w]ait` promises Enter = wait. **The default is an argument**, because the prompt that made the promise is the only party that knows what it promised.

## What is now honest rather than dark

| path | before | after |
|---|---|---|
| Discord typed text | constant-or-text, indistinguishable | `stated` when a human typed it |
| `loop_cli --reason` | dropped on the floor | `stated` / `unstated` |
| inline renderer | `"inline reject"` | the operator's line |
| headless auto-approve | looked like an approval | `synthetic` |
| Ctrl-D / dead surfaces | looked like a stated rejection | `unstated` |

The fallback string still travels in every case — the audit log deserves to say *which* gate refused. The lie was its provenance, never its text.

## Tests

Three test fakes had a **narrower `reject()` than the contract** — which is exactly what fakes exist to catch. Found by AST sweep rather than one failure at a time.

A structural AST test now fails any `reject(..., "<literal>")` that does not declare provenance, so a fourth call site cannot reintroduce the class. It is an AST check and not a grep because a regex both false-positives on the correct `*_reject_args(...)` spread and cannot see a keyword on the next line.

**28 new tests; 560 green** across approval, plan-approval, inline-gate, discord, loop-cli and preference-memory.

## Not proven

Not verified against a live organism — unit tests only. And the operator still has no numbered dialog *inviting* a reason; this change makes one possible, and makes its absence honest in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes fabricated attribution by preserving the operator’s typed reason and attaching provenance to every rejection. Stops hardcoded placeholders from being stored and replayed as the user’s words.

- **Bug Fixes**
  - Parser now returns an `OperatorDecision` with choice, reason, and provenance; keeps words after the verb and fixes comma/verb edge cases.
  - Gates relay decisions instead of inventing reasons: blanks are `unstated`, headless/timeouts are `synthetic`, and only typed text is `stated`.
  - `ApprovalResult` adds `reason_provenance`; provider `reject()` now accepts `provenance` (default `unstated`).
  - `UserPreferenceStore.record_approval_rejection` only persists when `provenance="stated"`; undeclared or non-human input is refused.
  - Discord and CLI pass `stated` when a user typed a reason; empty input stays `unstated`.

- **Migration**
  - Update all `reject(request_id, approver, reason)` calls to include `provenance`: use `stated` for user-typed reasons, `unstated` for placeholders/fallbacks, and `synthetic` when no human was involved.
  - Ensure test fakes/stubs accept the new `reject(..., provenance="unstated")` signature; a new AST test fails any `reject(..., "<literal>")` without explicit provenance.
  - For prompts with defaults, use `parse_gate_answer(..., empty_means=...)` to declare what Enter means on that surface.

<sup>Written for commit 38be3a4c97b200cce941ef81c74d5b846c3affc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

