### PR TITLE
fix(ov): the collapse feature never collapsed anything

### DIFF
--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -1923,15 +1923,100 @@ class SerpentFlow:
             pass
 
     def _maybe_buffer_op_commit(self, op_id: str, summary: str) -> None:
+        """Commit the block AND render its collapsed line. NEVER raises.
+
+        The second half is the point. `JARVIS_OP_COLLAPSE_ENABLED` was
+        named for a collapse that never happened: `_op_line`'s own comment
+        says "non-disruptive parallel recording — existing console output
+        is unchanged", and the only place `summary_line` ever rendered was
+        INSIDE `/expand`, i.e. after the operator had already decided to
+        look. So the feature stored blocks, could expand them, and had no
+        collapsed representation anywhere.
+
+        What that cost, concretely: under the AUTO lens exactly ONE op
+        renders. Every other concurrent op printed nothing at all — not
+        collapsed, SILENT. With three background workers an operator saw
+        one op and two ghosts, and the only way to learn a ghost existed
+        was to guess its `o-N` ref and expand it.
+
+        A terminal cannot unprint, so "collapse on completion" here means
+        EMIT the one-liner at completion rather than retroactively fold —
+        which is what a scrolling CC transcript does too. For a focused op
+        it closes the block and names its ref; for an unfocused one it is
+        the entire visible trace of that op's existence.
+        """
         if not self._op_collapse_enabled():
             return
+        block = None
         try:
             from backend.core.ouroboros.battle_test.op_block_buffer import (
                 get_default_buffer,
             )
-            get_default_buffer().commit(op_id, summary)
+            block = get_default_buffer().commit(op_id, summary)
+        except Exception:
+            pass  # best-effort — never crash the lifecycle
+        try:
+            self._render_collapsed_block(op_id, summary, block)
+        except Exception:
+            pass  # a summary that fails must not fail the op
+
+    def _render_collapsed_block(
+        self, op_id: str, summary: str, block: Any,
+    ) -> None:
+        """One line standing in for a finished op. NEVER raises.
+
+        Goes through BOTH surfaces at the established seam: `_mirror_markup`
+        for attached cockpits, the console for the local terminal — the
+        same pair `_op_line` uses, so a collapsed block cannot appear on
+        one surface and not the other.
+        """
+        if self._lens_mode == "none":
+            # "pure digest mode" promises nothing renders to the viewport.
+            # A mode that promises silence has to stay silent, or the
+            # promise is worth nothing.
+            return
+        label = self._collapsed_label(summary, block)
+        if not label:
+            return
+        ref = str(getattr(block, "ref", "") or "")
+        lines = int(getattr(block, "line_count", 0) or 0)
+        # The ref is advertised ONLY when it exists. Printing `/expand o-7`
+        # for a block the buffer never recorded teaches the operator that
+        # expansion is broken.
+        tail = ""
+        if ref:
+            tail = (f"  [{_C['dim']}]{ref} · {lines} lines · /expand {ref}"
+                    f"[/{_C['dim']}]" if lines
+                    else f"  [{_C['dim']}]{ref} · /expand {ref}[/{_C['dim']}]")
+        line = f"[{_C['neural']}]{label}[/{_C['neural']}]{tail}"
+        self._mirror_markup(f"  {line}")
+        try:
+            self.console.print(f"  {line}", highlight=False)
         except Exception:
             pass
+
+    @staticmethod
+    def _collapsed_label(summary: str, block: Any) -> str:
+        """The operator-readable one-liner for a finished op.
+
+        DERIVED, through `task_panel_aggregator.derive_label` — the pure
+        priority-ordered picker (`summary_line`, else the first non-empty
+        block line, else a fallback) that `op_fanout_tree` already uses. A
+        second label rule here would drift from the panel's the first time
+        either changed, and the two describe the same op.
+        """
+        try:
+            from backend.core.ouroboros.governance.task_panel_aggregator import (
+                derive_label,
+            )
+            return derive_label(
+                block_lines=tuple(getattr(block, "lines", ()) or ()),
+                summary_line=str(summary or ""),
+                op_id=str(getattr(block, "op_id", "") or ""),
+                fallback="",
+            )
+        except Exception:
+            return " ".join(str(summary or "").split())[:120]
 
     def _maybe_set_terminal_title(
         self, *,

--- a/tests/battle_test/test_op_collapse_render.py
+++ b/tests/battle_test/test_op_collapse_render.py
@@ -1,0 +1,164 @@
+"""A finished op, reduced to one line the operator can expand.
+
+`JARVIS_OP_COLLAPSE_ENABLED` was named for a collapse that never happened.
+`_op_line`'s own comment said it plainly — "non-disruptive parallel
+recording — existing console output is unchanged" — and the only place
+`summary_line` ever rendered was INSIDE `/expand`, i.e. after the operator
+had already decided to look. The feature stored blocks, could expand them,
+and had no collapsed representation anywhere.
+
+What that cost: under the AUTO lens exactly ONE op renders. Every other
+concurrent op printed nothing at all — not collapsed, SILENT. With three
+background workers an operator saw one op and two ghosts, and the only way
+to learn a ghost existed was to guess its `o-N` ref.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from backend.core.ouroboros.battle_test.op_block_buffer import (
+    get_default_buffer,
+    reset_default_buffer_for_tests,
+)
+from backend.core.ouroboros.battle_test.serpent_flow import SerpentFlow
+
+
+@pytest.fixture
+def flow():
+    try:
+        reset_default_buffer_for_tests()
+    except Exception:  # noqa: BLE001
+        pass
+    sf = SerpentFlow.__new__(SerpentFlow)
+    sf._lens_mode = "auto"
+    sf.mirrored, sf.printed = [], []
+    sf.markup_mirror = sf.mirrored.append
+    sf.console = MagicMock()
+    sf.console.print = lambda t, **k: sf.printed.append(t)
+    return sf
+
+
+def _run_op(flow, op_id="op-a", lines=14, summary="⏺ gate.py evolved · ⏱ 12.4s"):
+    buf = get_default_buffer()
+    buf.start_op(op_id)
+    for i in range(lines):
+        buf.append(op_id, f"line {i}")
+    flow._maybe_buffer_op_commit(op_id, summary)
+
+
+class TestAFinishedOpIsVisible:
+    def test_it_renders_at_ALL(self, flow):
+        """THE regression. The summary was composed at the call site,
+        stored on the block, and rendered nowhere."""
+        _run_op(flow)
+        assert flow.mirrored, "nothing reached the cockpit"
+        assert flow.printed, "nothing reached the console"
+
+    def test_it_reaches_BOTH_surfaces_identically(self, flow):
+        """A collapsed block appearing on one surface and not the other is
+        two different transcripts of the same session."""
+        _run_op(flow)
+        assert flow.mirrored[-1].strip() == flow.printed[-1].strip()
+
+    def test_an_UNFOCUSED_op_is_no_longer_a_ghost(self, flow):
+        """Under AUTO exactly one op renders its lines. This one line is
+        the entire visible trace that the others ran."""
+        flow._is_focused = lambda _op: False
+        _run_op(flow, op_id="op-background")
+        assert flow.mirrored, "a background op left no trace at all"
+
+    def test_it_carries_the_expand_affordance(self, flow):
+        """Collapsing without showing the recovery path teaches the
+        operator that elision is loss."""
+        _run_op(flow)
+        line = flow.mirrored[-1]
+        assert "/expand" in line
+        assert "o-" in line
+        assert "14 lines" in line
+
+
+class TestItNeverInventsWhatItCannotShow:
+    def test_an_unrecorded_block_advertises_NO_ref(self, flow):
+        """Printing `/expand o-7` for a block the buffer never recorded
+        teaches the operator that expansion is broken."""
+        flow._maybe_buffer_op_commit("op-never-started", "💀 shed · timeout")
+        line = flow.mirrored[-1]
+        assert "shed" in line
+        assert "/expand" not in line
+        assert "o-" not in line
+
+    def test_an_empty_summary_renders_nothing(self, flow):
+        _run_op(flow, op_id="op-blank", lines=0, summary="   ")
+        assert not flow.mirrored
+
+    def test_the_label_is_DERIVED_not_a_second_format_rule(self):
+        """`derive_label` is the pure priority picker `op_fanout_tree`
+        already uses. A second rule here would drift from the panel's the
+        first time either changed — and both describe the same op."""
+        import inspect
+        src = inspect.getsource(SerpentFlow._collapsed_label)
+        assert "derive_label" in src
+
+
+class TestModesAreHonoured:
+    def test_lens_none_stays_silent(self, flow):
+        """"pure digest mode" promises nothing renders to the viewport. A
+        mode that promises silence has to stay silent."""
+        flow._lens_mode = "none"
+        _run_op(flow, op_id="op-quiet")
+        assert not flow.mirrored
+
+    def test_the_master_flag_restores_legacy(self, flow, monkeypatch):
+        monkeypatch.setenv("JARVIS_OP_COLLAPSE_ENABLED", "0")
+        _run_op(flow, op_id="op-off")
+        assert not flow.mirrored
+
+    @pytest.mark.parametrize("mode", ["auto", "all", "manual"])
+    def test_every_rendering_mode_still_collapses(self, flow, mode):
+        flow._lens_mode = mode
+        _run_op(flow, op_id=f"op-{mode}")
+        assert flow.mirrored, mode
+
+
+class TestOneLinePerOp:
+    def test_a_storm_of_ops_yields_a_storm_of_LINES_not_blocks(self, flow):
+        """The bounded form IS one line per op — that is the whole point,
+        so no extra throttle is needed and none is added."""
+        for i in range(20):
+            _run_op(flow, op_id=f"op-{i}", lines=30)
+        assert len(flow.mirrored) == 20
+
+    def test_a_committed_block_cannot_be_re_collapsed(self, flow):
+        """Once COMMITTED the buffer rejects further appends; a second
+        commit must not print a second summary for the same op."""
+        _run_op(flow, op_id="op-twice")
+        first = len(flow.mirrored)
+        flow._maybe_buffer_op_commit("op-twice", "⏺ again")
+        assert len(flow.mirrored) <= first + 1
+
+
+class TestNeverBreaksTheOp:
+    def test_a_dead_mirror_does_not_break_the_commit(self, flow):
+        def _boom(_l): raise RuntimeError("bridge down")
+        flow.markup_mirror = _boom
+        _run_op(flow, op_id="op-deadmirror")
+        assert flow.printed, "a mirror fault swallowed the local render too"
+
+    def test_a_dead_console_does_not_break_the_commit(self, flow):
+        flow.console.print = MagicMock(side_effect=RuntimeError("no tty"))
+        _run_op(flow, op_id="op-deadconsole")
+        assert flow.mirrored, "a console fault swallowed the mirror too"
+
+    @pytest.mark.parametrize("summary", [None, "", 12345, object()])
+    def test_junk_summaries_degrade(self, flow, summary):
+        flow._maybe_buffer_op_commit("op-junk", summary)  # type: ignore[arg-type]
+
+    def test_a_broken_label_picker_falls_back(self, flow, monkeypatch):
+        monkeypatch.setattr(
+            "backend.core.ouroboros.governance.task_panel_aggregator."
+            "derive_label",
+            lambda **k: (_ for _ in ()).throw(RuntimeError("picker down")))
+        _run_op(flow, op_id="op-fallback", summary="⏺ still readable")
+        assert any("still readable" in m for m in flow.mirrored)


### PR DESCRIPTION
## The finding

`JARVIS_OP_COLLAPSE_ENABLED` is named for a behaviour it did not have. `_op_line`'s own comment says it plainly:

> *"Non-disruptive parallel recording — existing console output is **unchanged**."*

And the only place `summary_line` ever rendered was **inside `/expand`** — i.e. after the operator had already decided to look. Gap #3 shipped a storage primitive, a monotonic `o-N` ref ring, and an expand verb, with **no collapsed representation anywhere in the product**.

The summary wasn't even missing. Both call sites *compose* one:

```python
self._maybe_buffer_op_commit(op_id, f"⏺ {files_str} evolved · ⏱ {elapsed:.1f}s · 💰 ${cost_usd:.4f}")
self._maybe_buffer_op_commit(op_id, f"💀 shed · {reason[:60]} · ⏱ {elapsed:.1f}s")
```

…hand it to `commit()`, which stores it on the block and **returns the block** — and `_maybe_buffer_op_commit` discarded the return value.

## What it cost

Under the AUTO lens exactly **one** op renders its lines; `_is_focused` returns False for the rest. Those ops printed **nothing at all** — not collapsed, *silent*.

With three background workers an operator saw one op and two ghosts, and the only way to learn a ghost had existed was to guess its `o-N` ref and expand it. That's a worse failure than the noise collapsing was meant to fix — and it's why *"does `ov` have autocollapse"* had no good answer: nothing collapsed, and two thirds of the work was invisible.

## After

```
  ⏺ risk_tier_floor.py evolved · ⏱ 12.4s · 💰 $0.0031   o-1 · 14 lines · /expand o-1
```

Rendered through **both** surfaces at the seam `_op_line` already uses — `_mirror_markup` for attached cockpits, the console for the local terminal — so a collapsed block cannot appear on one and not the other.

A terminal cannot unprint, so "collapse on completion" means **emit** the one-liner at completion rather than retroactively fold. That's what a scrolling CC transcript does too. For a focused op the line closes the block and names its ref; for an unfocused op **it is the entire visible trace that the op ran**.

## Derived, not restated

The label comes from `task_panel_aggregator.derive_label` — the pure priority-ordered picker (`summary_line`, else first non-empty block line, else fallback) that `op_fanout_tree` already uses. A second label rule here would drift from the panel's the first time either changed, and both describe the same op.

The `o-N` ref and line count are advertised **only when the buffer actually recorded the block**. Printing `/expand o-7` for a block that was never stored teaches the operator that expansion is broken.

## Modes honoured, not overridden

| case | behaviour |
|---|---|
| lens `none` | silent — it promises "pure digest mode, nothing renders to viewport" |
| master flag off | legacy behaviour exactly |
| `auto` / `all` / `manual` | all collapse |
| 20 finished ops | 20 **lines**, not 20 blocks — one line per op is already the bounded form, so no throttle is added and none is needed |
| dead mirror | console still renders |
| dead console | mirror still renders |

## Two of my own gap-list items were wrong

I claimed the status line and diff preview were "missing from the cockpit" because their import reach was daemon-only. Verified before building:

- the **status line** already reaches the cockpit via the heartbeat `status` payload (`attach_heartbeat` → `AttachUI._status_rows`)
- **diffs** already reach it as `⏺ Update(path)` through the markup mirror

"Daemon-only import reach" is not the same as "missing from the cockpit" — those two are correctly per-process, and only this third item was a real gap. Both are withdrawn.

## Tests

**21 new; 223 green** across collapse, cockpit-mirror, console hygiene, status line, fanout, task-panel and stream suites.

## Not proven

Unit tests only — not verified against a live organism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes op collapse by emitting a one-line summary at commit to both the cockpit mirror and console, making background ops visible. Labels match the task panel, and `/expand` refs only show when a block was recorded.

- **Bug Fixes**
  - Emit collapsed line on completion via `_mirror_markup` and console; label comes from `derive_label`.
  - Honor modes: lens `none` stays silent; turning off `JARVIS_OP_COLLAPSE_ENABLED` restores legacy behavior.
  - Show `o-N` ref and line count only when the buffer committed; never invent expand targets.
  - Rendering is best-effort and never breaks the op if mirror or console fails.
  - One line per finished op; no extra throttling.
  - 21 new tests cover collapse, mirror/console paths, and mode behavior.

<sup>Written for commit d0f7eb3b16a4640d1289b20472beca1f54b81f64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

