### PR TITLE
fix(ov): 16 verbs were handled and impossible to find

### DIFF
--- a/backend/core/ouroboros/battle_test/repl_dispatch_registry.py
+++ b/backend/core/ouroboros/battle_test/repl_dispatch_registry.py
@@ -74,13 +74,14 @@ sub-package name (``m10``).
 """
 from __future__ import annotations
 
+import ast
 import inspect
 import logging
 import os
 import threading
 import time
 from dataclasses import dataclass, field
-from typing import Any, Callable, Optional, Sequence, Tuple
+from typing import Any, Callable, Dict, Optional, Sequence, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -109,6 +110,12 @@ _DEFAULT_PROVIDER_PACKAGES: Tuple[str, ...] = (
 # cooperative cancellation; ``/postmortems`` takes argv-style).
 # These retain their legacy custom handlers in
 # :mod:`serpent_flow`.
+#: Verbs that EXIST but are routed by someone else → a provenance note.
+#: Populated at prime time by derivation, never by hand: a hand-written
+#: list is exactly what drifted here before, and a verb added to the
+#: harness chain tomorrow must not need a second edit to be findable.
+_EXTERNAL_VERBS: Dict[str, str] = {}
+
 _CUSTOM_HANDLER_EXCLUSIONS: Tuple[str, ...] = (
     "budget",
     "risk",
@@ -199,13 +206,212 @@ def reset_registry_for_tests() -> None:
     global _REGISTRY_PRIMED
     with _REGISTRY_LOCK:
         _VERB_TO_DISPATCHER.clear()
+        # Both maps, or `list_verbs()` stays non-empty after a reset and
+        # "discovery has not run" becomes indistinguishable from
+        # "discovery found nothing" — a distinction the progress board
+        # reports on and therefore must be able to make.
+        _EXTERNAL_VERBS.clear()
         _REGISTRY_PRIMED = False
 
 
+#: Modules whose if/elif command chains are scanned for verbs that exist
+#: but are dispatched there. A curated LIST OF FILES, not of verbs — the
+#: verbs are derived, so adding one needs no edit here.
+_CHAIN_SOURCES: Tuple[str, ...] = (
+    "backend/core/ouroboros/battle_test/harness.py",
+    "backend/core/ouroboros/battle_test/serpent_flow.py",
+)
+
+#: Names a REPL command chain binds its input to. Structural rather than
+#: positional: the scan finds branches by what they TEST, so the chain can
+#: be reordered, renamed or split without breaking discovery.
+_CHAIN_SUBJECTS = frozenset({"cmd", "command"})
+
+
+def discover_chain_verbs(
+    sources: Optional[Sequence[str]] = None, root: Optional[str] = None,
+) -> Dict[str, str]:
+    """Verbs handled by an if/elif command chain → where. NEVER raises.
+
+    Derived by reading the chain itself, because every hand-maintained
+    alternative drifts. That is not hypothetical here: `/help` lost
+    sixteen verbs precisely because a list said what existed and the code
+    said something else, and nothing compared them.
+
+    The scan is structural — it looks for branches whose test inspects a
+    command-shaped variable (``cmd == "x"``, ``cmd.startswith("/x")``) —
+    so the chain can be reordered, renamed or split and discovery follows.
+    It runs once at prime time on two files and is bounded by that.
+
+    Only literals that look like verbs are admitted, and only from
+    top-level branch TESTS, never from bodies — a string inside a branch
+    is an argument or a message, not a verb.
+    """
+    out: Dict[str, str] = {}
+    try:
+        import os as _os
+        base = root or _os.getcwd()
+        for rel in (sources if sources is not None else _CHAIN_SOURCES):
+            path = _os.path.join(base, rel)
+            try:
+                tree = ast.parse(open(path, "r", encoding="utf-8").read())
+            except Exception:  # noqa: BLE001
+                continue
+            name = _os.path.basename(rel)
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.If):
+                    continue
+                if not _branch_routes_somewhere(node):
+                    continue
+                for verb in _verbs_in_test(node.test):
+                    out.setdefault(verb, f"{name}:{node.lineno}")
+    except Exception:  # noqa: BLE001
+        logger.debug("[ReplRegistry] chain discovery degraded", exc_info=True)
+    return out
+
+
+#: Call-name shapes a verb branch routes to. Prefixes rather than exact
+#: names, so a new handler needs no edit here.
+_HANDLER_SHAPES: Tuple[str, ...] = (
+    "_repl_cmd_", "_handle_", "_cmd_", "dispatch_",
+)
+
+
+def _branch_routes_somewhere(node: Any) -> bool:
+    """Does this branch's BODY hand off to a command handler?
+
+    The discriminator between a verb and a coincidence. ``cmd == "ops"``
+    and ``raw == "true"`` are the same shape as tests; they differ in what
+    they do next — one calls ``self._repl_cmd_ops()``, the other assigns a
+    boolean. Asking the body keeps this derived: a denylist of words that
+    merely LOOK like verbs would need an entry every time someone wrote a
+    new env parse.
+
+    Only the branch's own body is inspected, never nested ``If`` bodies,
+    so a sub-command handler inside a verb branch is not mistaken for a
+    second verb. NEVER raises.
+    """
+    try:
+        for stmt in getattr(node, "body", ()) or ():
+            for sub in ast.walk(stmt):
+                if isinstance(sub, ast.If):
+                    continue
+                if not isinstance(sub, ast.Call):
+                    continue
+                fn = sub.func
+                fname = getattr(fn, "attr", None) or getattr(fn, "id", "")
+                if any(str(fname).startswith(p) for p in _HANDLER_SHAPES):
+                    return True
+        return False
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _verbs_in_test(test: Any) -> Tuple[str, ...]:
+    """Verb literals a branch test compares against. Pure. NEVER raises."""
+    found = []
+    try:
+        for node in ast.walk(test):
+            subject = None
+            literals = []
+            if isinstance(node, ast.Compare):
+                subject = node.left
+                literals = [c for c in node.comparators]
+            elif isinstance(node, ast.Call):
+                fn = node.func
+                if (isinstance(fn, ast.Attribute)
+                        and fn.attr in ("startswith", "endswith")):
+                    subject = fn.value
+                    literals = list(node.args)
+            if subject is None:
+                continue
+            # Unwrap `cmd.strip()` / `cmd.lower()` to reach the name.
+            while isinstance(subject, ast.Call) and isinstance(
+                    subject.func, ast.Attribute):
+                subject = subject.func.value
+            if isinstance(subject, ast.Attribute):
+                subject = subject.value
+            if not (isinstance(subject, ast.Name)
+                    and subject.id in _CHAIN_SUBJECTS):
+                continue
+            for lit in literals:
+                if isinstance(lit, (ast.Tuple, ast.List, ast.Set)):
+                    lit_iter = lit.elts
+                else:
+                    lit_iter = [lit]
+                for item in lit_iter:
+                    if not (isinstance(item, ast.Constant)
+                            and isinstance(item.value, str)):
+                        continue
+                    token = item.value.strip().lstrip("/").split()[0] \
+                        if item.value.strip() else ""
+                    token = token.lower()
+                    if (token and len(token) <= 24
+                            and token.replace("_", "").replace(
+                                "-", "").isalnum()
+                            and not token.isdigit()):
+                        found.append(token)
+    except Exception:  # noqa: BLE001
+        return tuple()
+    return tuple(found)
+
+
 def list_verbs() -> Tuple[str, ...]:
-    """Snapshot of registered verb names. Read-only."""
+    """Every verb that EXISTS, however it is dispatched. Read-only.
+
+    Discovery and dispatch are different questions, and fusing them cost
+    16 verbs their visibility. `_CUSTOM_HANDLER_EXCLUSIONS` says it out
+    loud — those verbs "retain their legacy custom handlers" — so the
+    exclusion was a routing decision ("do not auto-dispatch this"), and
+    reading it as an existence claim erased `/goal`, `/budget`, `/risk`,
+    `/plan`, `/undo` and eleven others from `/help`, tab completion, the
+    slash palette and the progress board's count.
+
+    An operator cannot use a verb they cannot find. This returns the
+    union; :func:`try_dispatch` still consults only the dispatcher map,
+    so ROUTING is byte-for-byte unchanged.
+    """
+    with _REGISTRY_LOCK:
+        return tuple(sorted(
+            set(_VERB_TO_DISPATCHER.keys()) | set(_EXTERNAL_VERBS.keys())))
+
+
+def list_dispatchable_verbs() -> Tuple[str, ...]:
+    """Only verbs THIS registry routes. The dispatch half of the split."""
     with _REGISTRY_LOCK:
         return tuple(sorted(_VERB_TO_DISPATCHER.keys()))
+
+
+def external_verbs() -> Dict[str, str]:
+    """Verbs handled elsewhere → where. Read-only snapshot.
+
+    The value is a provenance string (``harness.py:4292``, ``custom
+    handler``) so `/help` can tell an operator where a verb lives rather
+    than implying this registry owns it.
+    """
+    with _REGISTRY_LOCK:
+        return dict(_EXTERNAL_VERBS)
+
+
+def register_external_verb(verb: object, where: object = "") -> bool:
+    """Record that ``verb`` exists and is dispatched somewhere else.
+
+    Discovery only — this NEVER makes the verb routable here, so a
+    mis-registration cannot hijack a line. NEVER raises.
+    """
+    try:
+        name = str(verb or "").strip().lstrip("/").lower()
+        if not name or not name.replace("_", "").replace("-", "").isalnum():
+            return False
+        with _REGISTRY_LOCK:
+            if name in _VERB_TO_DISPATCHER:
+                # Already routable here. Claiming it is also external
+                # would make `/help` ambiguous about who owns it.
+                return False
+            _EXTERNAL_VERBS[name] = str(where or "external handler")[:80]
+        return True
+    except Exception:  # noqa: BLE001
+        return False
 
 
 def registry_primed() -> bool:
@@ -349,14 +555,20 @@ def prime_registry(
 
     with _REGISTRY_LOCK:
         if _REGISTRY_PRIMED and not force:
+            _known = tuple(sorted(
+                set(_VERB_TO_DISPATCHER.keys()) | set(_EXTERNAL_VERBS.keys())))
             return RegistryReport(
-                verb_count=len(_VERB_TO_DISPATCHER),
-                verbs=tuple(sorted(_VERB_TO_DISPATCHER.keys())),
+                verb_count=len(_known),
+                verbs=_known,
                 excluded=tuple(_CUSTOM_HANDLER_EXCLUSIONS),
                 elapsed_s=time.monotonic() - t0,
             )
         if force:
             _VERB_TO_DISPATCHER.clear()
+            # Rediscovered below from the same two derived sources. Leaving
+            # them would make a forced re-prime cumulative rather than a
+            # fresh read.
+            _EXTERNAL_VERBS.clear()
 
     pkg_list = (
         tuple(packages) if packages is not None
@@ -480,9 +692,30 @@ def prime_registry(
         log_prefix="ReplRegistry",
     )
 
+    # Verbs that EXIST but are routed elsewhere, from two DERIVED sources
+    # so neither can drift into a stale hand-written list:
+    #
+    #  1. the exclusion list itself. Its own comment says these "retain
+    #     their legacy custom handlers" — that is a statement that they
+    #     exist, and reading it as "these do not exist" is what erased
+    #     /goal, /budget, /risk and /plan from every discovery surface.
+    #  2. the if/elif command chains, read structurally.
+    #
+    # Discovery only. `try_dispatch` still consults `_VERB_TO_DISPATCHER`
+    # alone, so routing is byte-for-byte what it was.
+    try:
+        for _verb in exclusions:
+            register_external_verb(_verb, "custom handler")
+        for _verb, _where in discover_chain_verbs().items():
+            register_external_verb(_verb, _where)
+    except Exception:  # noqa: BLE001
+        logger.debug("[ReplRegistry] external verb discovery degraded",
+                     exc_info=True)
+
     with _REGISTRY_LOCK:
         _REGISTRY_PRIMED = True
-        verbs = tuple(sorted(_VERB_TO_DISPATCHER.keys()))
+        verbs = tuple(sorted(
+            set(_VERB_TO_DISPATCHER.keys()) | set(_EXTERNAL_VERBS.keys())))
 
     return RegistryReport(
         verb_count=len(verbs),

--- a/tests/battle_test/test_verb_discovery.py
+++ b/tests/battle_test/test_verb_discovery.py
@@ -1,0 +1,177 @@
+"""A verb an operator cannot find is a verb they do not have.
+
+The registry answered two different questions with one dictionary: "how do
+I route this line" and "does this verb exist". `_CUSTOM_HANDLER_EXCLUSIONS`
+says out loud that its entries "retain their legacy custom handlers" — a
+statement that they EXIST — and excluding them from the map erased them
+from `/help`, tab completion, the slash palette and the progress board's
+count. Sixteen top-level verbs, `/undo` and `/goal` and `/budget` among
+them, were handled and undiscoverable.
+"""
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+
+from backend.core.ouroboros.battle_test.repl_dispatch_registry import (
+    _CHAIN_SOURCES,
+    _CUSTOM_HANDLER_EXCLUSIONS,
+    discover_chain_verbs,
+    external_verbs,
+    list_dispatchable_verbs,
+    list_verbs,
+    prime_registry,
+    register_external_verb,
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _primed():
+    prime_registry()
+
+
+class TestTheSixteen:
+    @pytest.mark.parametrize("verb", [
+        "undo", "goal", "budget", "risk", "plan", "remember", "forget",
+        "tdd", "plugins", "status", "ops", "pause", "resume", "infer",
+        "liquidity", "doctor",
+    ])
+    def test_every_handled_verb_is_findable(self, verb):
+        assert verb in list_verbs(), f"/{verb} is handled and invisible"
+
+    def test_each_one_says_WHERE_it_lives(self):
+        """`/help` should be able to tell an operator where a verb is
+        handled rather than implying this registry owns it."""
+        ext = external_verbs()
+        assert ext.get("undo", "").startswith("harness.py:")
+        assert ext.get("risk") == "custom handler"
+
+
+class TestRoutingIsUnCHANGED:
+    def test_discovery_grew_and_dispatch_did_not(self):
+        """The whole point: making a verb findable must not make this
+        registry start routing it. A verb routed twice is worse than one
+        routed nowhere."""
+        assert len(list_verbs()) > len(list_dispatchable_verbs())
+
+    def test_no_external_verb_is_dispatchable_here(self):
+        overlap = set(external_verbs()) & set(list_dispatchable_verbs())
+        assert not overlap, f"{overlap} would be routed twice"
+
+    def test_registering_an_existing_dispatcher_is_REFUSED(self):
+        """Ambiguity about who owns a verb is worse than an unlisted one."""
+        known = list_dispatchable_verbs()[0]
+        assert register_external_verb(known, "somewhere") is False
+
+    @pytest.mark.asyncio
+    async def test_an_external_verb_still_falls_THROUGH(self):
+        """`/undo` must reach the harness chain exactly as before."""
+        from backend.core.ouroboros.battle_test.repl_dispatch_registry import (
+            try_dispatch,
+        )
+        outcome = await try_dispatch("/undo 2")
+        assert outcome.matched is False
+
+
+class TestDerivedNeverWritten:
+    def test_the_chain_scan_finds_verbs_by_what_they_DO(self):
+        """`cmd == "ops"` and `raw == "true"` are identical as tests. The
+        discriminator is the body: one routes to a handler, the other
+        assigns a boolean. A denylist of non-verb words would need an
+        entry every time someone wrote a new env parse."""
+        derived = discover_chain_verbs()
+        assert "undo" in derived
+        for noise in ("true", "yes", "on", "false", "unknown"):
+            assert noise not in derived, noise
+
+    def test_it_is_structural_not_positional(self):
+        """Line numbers and function names change; the scan must survive
+        the chain being reordered, renamed or split."""
+        src = "\n".join([
+            "def anything(self, command):",
+            "    cmd = command.strip()",
+            "    if cmd == 'zzztest':",
+            "        self._repl_cmd_zzztest(cmd)",
+        ])
+        tmp = pathlib.Path("build_tmp_chain_probe.py")
+        tmp.write_text(src)
+        try:
+            found = discover_chain_verbs(sources=[tmp.name])
+        finally:
+            tmp.unlink(missing_ok=True)
+        assert "zzztest" in found
+
+    def test_a_sub_command_is_not_mistaken_for_a_verb(self):
+        """`/memory add` must not register `add`. Only the branch's own
+        body is inspected, never nested If bodies."""
+        derived = discover_chain_verbs()
+        for sub in ("add", "rm", "list", "all"):
+            assert sub not in derived, sub
+
+    def test_no_hand_written_verb_list_exists(self):
+        """The defect was a list saying what existed while the code said
+        otherwise, with nothing comparing them."""
+        import inspect
+
+        from backend.core.ouroboros.battle_test import (
+            repl_dispatch_registry as r,
+        )
+        src = inspect.getsource(r.discover_chain_verbs)
+        for verb in ("undo", "goal", "budget", "tdd"):
+            assert f'"{verb}"' not in src
+
+
+class TestItCannotRegress:
+    def test_EVERY_routing_branch_in_the_chain_is_discoverable(self):
+        """The invariant that stops verb #17 from going dark. Reads the
+        chains directly, so it fails the moment a handled verb is not
+        findable — which is precisely what nothing checked before."""
+        known = set(list_verbs())
+        missing = []
+        for rel in _CHAIN_SOURCES:
+            path = pathlib.Path(rel)
+            if not path.exists():
+                continue
+            tree = ast.parse(path.read_text())
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.If):
+                    continue
+                from backend.core.ouroboros.battle_test import (
+                    repl_dispatch_registry as r,
+                )
+                if not r._branch_routes_somewhere(node):
+                    continue
+                for verb in r._verbs_in_test(node.test):
+                    if verb not in known:
+                        missing.append(f"/{verb} ({path.name}:{node.lineno})")
+        assert not missing, (
+            "handled but undiscoverable — no /help, no completion, no "
+            "palette:\n  " + "\n  ".join(sorted(set(missing))))
+
+    def test_every_EXCLUDED_verb_is_discoverable(self):
+        """Excluding a verb from auto-dispatch is a routing decision. It
+        must never again be read as an existence claim."""
+        known = set(list_verbs())
+        for verb in _CUSTOM_HANDLER_EXCLUSIONS:
+            assert verb in known, verb
+
+
+class TestNeverRaises:
+    @pytest.mark.parametrize("call", [
+        lambda: discover_chain_verbs(sources=["does/not/exist.py"]),
+        lambda: discover_chain_verbs(sources=[]),
+        lambda: register_external_verb(None),
+        lambda: register_external_verb("  "),
+        lambda: register_external_verb("has spaces"),
+        lambda: external_verbs(),
+    ])
+    def test_junk_degrades(self, call):
+        assert call() is not None or True
+
+    def test_a_syntactically_broken_source_is_skipped(self, tmp_path):
+        bad = tmp_path / "broken.py"
+        bad.write_text("def (((:\n")
+        assert discover_chain_verbs(
+            sources=[bad.name], root=str(tmp_path)) == {}

--- a/tests/governance/test_repl_dispatch_registry.py
+++ b/tests/governance/test_repl_dispatch_registry.py
@@ -115,17 +115,31 @@ def test_discovers_newly_unlocked_verbs():
         )
 
 
-def test_excluded_verbs_not_in_registry():
+def test_excluded_verbs_are_not_DISPATCHED_here():
+    """Excluding a verb is a ROUTING decision, never an existence claim.
+
+    This test previously asserted the excluded verbs were absent from
+    `report.verbs` — i.e. that they did not exist. They do: the exclusion
+    list's own comment says they "retain their legacy custom handlers".
+    Reading a routing decision as an existence claim is what erased
+    /budget, /risk, /goal and /plan from `/help`, tab completion and the
+    slash palette, so the assertion now pins the two halves separately.
+    """
     from backend.core.ouroboros.battle_test.repl_dispatch_registry import (  # noqa: E501
+        list_dispatchable_verbs,
         prime_registry,
     )
     report = prime_registry(force=True)
+    routable = set(list_dispatchable_verbs())
     for excluded in (
         "budget", "risk", "goal", "cancel", "plan",
         "postmortems", "inline",
     ):
-        assert excluded not in report.verbs, (
-            f"excluded verb {excluded!r} leaked into registry"
+        assert excluded not in routable, (
+            f"excluded verb {excluded!r} became routable here"
+        )
+        assert excluded in report.verbs, (
+            f"excluded verb {excluded!r} is handled but undiscoverable"
         )
 
 


### PR DESCRIPTION
Replaces #70251, which GitHub auto-closed when its stacked base branch was deleted on merge. Same commit, rebased onto main.

## The finding

**62 verbs were findable. 78 were handled.**

The registry answered two different questions with one dictionary: *"how do I route this line"* and *"does this verb exist"*. `list_verbs()` and `try_dispatch()` both read `_VERB_TO_DISPATCHER`, so anything absent from the dispatch map did not exist as far as `/help`, tab completion, the slash palette and the progress board were concerned.

`_CUSTOM_HANDLER_EXCLUSIONS` says the quiet part out loud:

> *"These retain their legacy custom handlers in `serpent_flow`."*

That is a statement that they **exist** and are deliberately routed elsewhere. Reading it as *"these do not exist"* erased `/budget`, `/risk`, `/goal`, `/plan`, `/cancel`, `/postmortems`, `/inline`.

Twelve more live in the harness if/elif chain — `/undo`, `/remember`, `/forget`, `/tdd`, `/plugins`, `/status`, `/ops`, `/pause`, `/resume`, `/infer`, `/liquidity`, `/doctor` — invisible **by construction**, because discovery only ever looked for module-level `dispatch_<verb>_command` callables.

## Discovery and dispatch are now separate questions

| | before | after |
|---|---|---|
| discoverable | 62 | **82** |
| dispatchable | 62 | **62** — byte-for-byte unchanged |

`try_dispatch` still consults `_VERB_TO_DISPATCHER` **alone**, so `/undo` still falls through to the harness chain exactly as before (pinned by a test). `_EXTERNAL_VERBS` records verbs that exist and are handled elsewhere, with provenance — so `/help` can say `/undo → harness.py:4292` rather than implying this registry owns it. A verb already routable here is **refused** external registration: ambiguity about ownership is worse than an unlisted verb.

## Derived from two sources, never a hand list

A hand-written list is exactly what drifted, so both sources are read from the code:

1. **the exclusion list itself** — it already names verbs known to exist
2. **the if/elif chains**, read structurally

The scan finds branches testing a command-shaped variable, then asks what the branch **does**. `cmd == "ops"` and `raw == "true"` are indistinguishable as *tests*; they differ in that one calls `self._repl_cmd_ops()` and the other assigns a boolean. That discriminator is why no denylist of non-verb words is needed — otherwise every new env parse would need an entry. Sub-commands are excluded by never descending into nested `If` bodies, so `/memory add` does not register `add`.

Structural rather than positional, so the chain can be reordered, renamed or split and discovery follows.

## An invariant that stops verb #17

A test reads the chains directly and fails if any routing branch is not discoverable. **Nothing compared the two before** — that absence is the defect, not the sixteen verbs.

## Three defects found by running it

- `reset_registry_for_tests` cleared only the dispatch map, leaving `list_verbs()` non-empty after a reset — making *"discovery has not run"* indistinguishable from *"discovery found nothing"*, a distinction the progress board reports on.
- The idempotent short-circuit built its report from the dispatch map alone, so a second `prime_registry()` described a different registry than the first.
- **This module never imported `ast`.** The new scan's `NameError` was swallowed by its own broad `except` and returned zero verbs *silently*. Found by removing the swallow, not by reading the code — my own defensive handler hid my own bug.

## Tests

**34 new; 383 green** across registry, completion, help, palette, progress-board, demo and collapse suites.

The test asserting excluded verbs were *absent from the registry* now pins routing and existence separately — it was encoding the conflation.

## Not proven

Unit tests only — not verified against a live organism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split verb discovery from dispatch so `/help`, completion, and the slash palette list every handled verb without changing routing. Findable verbs: 62 → 82; dispatchable remains 62.

- **New Features**
  - `list_verbs()` now returns the union of local and external verbs; added `list_dispatchable_verbs()` and `external_verbs()`.
  - Added `_EXTERNAL_VERBS` with provenance; `register_external_verb()` refuses verbs already routed here to avoid ownership ambiguity.
  - External verbs are derived at prime time from two sources: `_CUSTOM_HANDLER_EXCLUSIONS` and a structural `ast` scan of command chains in `harness.py` and `serpent_flow.py` (`discover_chain_verbs()`), ignoring sub-commands.
  - `try_dispatch` still consults `_VERB_TO_DISPATCHER` only; routing is unchanged.

- **Bug Fixes**
  - `reset_registry_for_tests()` now clears both dispatch and external maps; `prime_registry()` short-circuit/report uses the union and forced re-prime clears externals.
  - Imported `ast`; previously a swallowed `NameError` caused silent zero-verbs discovery.
  - Tests: 34 new cases enforce that every routing branch is discoverable and excluded verbs are discoverable but not dispatched.

<sup>Written for commit 75eb0cd8f11121260eddbff12b49684c2155b13d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

