### PR TITLE
feat(ov): the demo shows the last three things we built

### DIFF
--- a/backend/core/ouroboros/battle_test/stream_renderer.py
+++ b/backend/core/ouroboros/battle_test/stream_renderer.py
@@ -86,6 +86,7 @@ def render_inflight(
     text: str, *, width: Optional[int] = None,
     max_rows: int = INFLIGHT_MAX_ROWS,
     preserve_lines: bool = False,
+    keep_first: bool = False,
 ) -> List[str]:
     """Wrap an in-flight sentence into strip rows. Pure. NEVER raises.
 
@@ -129,7 +130,20 @@ def render_inflight(
             # Keep the NEWEST rows: the tail is where the writing is
             # happening, and an elided head reads as "there is more above",
             # which is true and about to be in the transcript anyway.
-            wrapped = ["…"] + wrapped[-(rows - 1):] if rows > 1 else ["…"]
+            #
+            # `keep_first` exempts row 0. A running command's first row is
+            # its HEADER — `$ bash · 11s` — which is context rather than
+            # content, and eliding it left a tail of test names with no
+            # indication of what was running or for how long. Caught by
+            # driving this from `ov demo live`, which is what the demo is
+            # for. The caller declares which shape it has, the same way it
+            # declares whether newlines are meaningful.
+            if keep_first and rows > 2:
+                wrapped = [wrapped[0], "…"] + wrapped[-(rows - 2):]
+            elif rows > 1:
+                wrapped = ["…"] + wrapped[-(rows - 1):]
+            else:
+                wrapped = ["…"]
         return [f"  {line}" for line in wrapped]
     except Exception:  # noqa: BLE001
         logger.debug("[StreamRender] inflight wrap degraded", exc_info=True)

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -1083,7 +1083,11 @@ class AttachUI:
                 self._stream_inflight, width=self._terminal_size()[0],
                 # Command output keeps its line structure; model prose does
                 # not. The producer is known from the frame that set it.
-                preserve_lines=self._stream_is_tool)
+                preserve_lines=self._stream_is_tool,
+                # Row 0 of a tool tail is `$ bash · 11s` — what is running
+                # and for how long. Eliding it leaves test names with no
+                # subject.
+                keep_first=self._stream_is_tool)
         except Exception:  # noqa: BLE001
             return []
 

--- a/backend/core/ouroboros/cli/ov_demo.py
+++ b/backend/core/ouroboros/cli/ov_demo.py
@@ -492,6 +492,11 @@ _LIVE_BEATS: List[Any] = [
 
     (20.4, "act", ("Gate", "7759-86 · NOTIFY_APPLY")),
     (21.2, "det", ("applied · verified · committed 90706b8", "ok")),
+    # The op FINISHES, and collapses to one line. Before #70250 nothing
+    # rendered this: an unfocused op left no trace at all, and a focused
+    # one stayed fully expanded forever.
+    (22.0, "collapse", ("⏺ risk_tier_floor.py evolved · ⏱ 21.6s · 💰 $0.0031",
+                        "o-1", 27)),
     (22.4, "act", ("Complete", "7759-86 · 22.4s · $0.011")),
 ]
 
@@ -519,6 +524,39 @@ def _agora_beats() -> List[Any]:
         lines = [f"  (agora unavailable: {exc})"]
     return [(_AGORA_AT[min(i, len(_AGORA_AT) - 1)], line)
             for i, line in enumerate(lines)]
+
+
+def _collapsed_beat(args: Sequence[Any]) -> str:
+    """A finished op, reduced to the one line the cockpit now emits.
+
+    The label comes from `task_panel_aggregator.derive_label` — the same
+    pure picker `serpent_flow._collapsed_label` and `op_fanout_tree` use —
+    so a regression in the label rule shows up here instead of silently
+    producing a plausible-looking demo. Hand-writing the string would
+    exercise none of it.
+    """
+    try:
+        from backend.core.ouroboros.governance.task_panel_aggregator import (
+            derive_label,
+        )
+        summary, ref, lines = (list(args) + ["", "", 0])[:3]
+        label = derive_label(summary_line=str(summary), fallback="op complete")
+        tail = f"{ref} · {lines} lines · /expand {ref}" if ref else ""
+        return (f"  [{_THEME('neural')}]{label}[/{_THEME('neural')}]"
+                f"  [{_THEME('dim')}]{tail}[/{_THEME('dim')}]"
+                if tail else f"  {label}")
+    except Exception:  # noqa: BLE001
+        logger.debug("[OvDemo] collapsed beat unavailable", exc_info=True)
+        return "  ⏺ op complete"
+
+
+def _THEME(slot: str) -> str:
+    """One colour slot, from the cockpit's own palette. NEVER raises."""
+    try:
+        from backend.core.ouroboros.battle_test.serpent_flow import _C
+        return _C.get(slot, "white")
+    except Exception:  # noqa: BLE001
+        return "white"
 
 
 def _tool_beats(at: float, args: Sequence[Any]) -> List[Any]:
@@ -657,6 +695,10 @@ def compose_live_script() -> List[Any]:
             continue
         if kind == "tool":
             out.extend(_tool_beats(at, args))
+            continue
+        if kind == "collapse":
+            out.append((at, ""))
+            out.append((at, _collapsed_beat(args)))
             continue
         if kind == "agent":
             out.extend(_agent_beats(at, args))
@@ -816,6 +858,85 @@ def _inflight_text(elapsed: float) -> str:
         return ""
 
 
+#: Windows during which a shell command is RUNNING, and the output it
+#: produces. Deliberately overlapping the tool beats they belong to, so the
+#: live tail and the `⏺ Bash(…)` block describe the same command.
+_RUNNING = {
+    (9.2, 12.4): (
+        "bash",
+        "python3 -m pytest tests/governance/test_risk_tier_floor.py -q",
+        [
+            "collecting ...",
+            "test_risk_tier_floor.py::test_quiet_hours_wraps PASSED",
+            "test_risk_tier_floor.py::test_paranoia_shortcut PASSED",
+            "test_risk_tier_floor.py::test_vision_floor_clamped FAILED",
+            "stderr:E   AssertionError: expected notify_apply, got safe_auto",
+            "1 failed, 42 passed in 3.9s",
+        ],
+    ),
+    (18.0, 20.6): (
+        "bash",
+        "python3 -m pytest tests/governance/test_risk_tier_floor.py -q",
+        [
+            "collecting ...",
+            "test_risk_tier_floor.py::test_vision_floor_clamped PASSED",
+            "43 passed in 4.1s",
+        ],
+    ),
+}
+
+
+def _running_rows(elapsed: float, width: int) -> List[str]:
+    """A shell command's live tail, through the REAL LiveToolStream.
+
+    Not a formatted string: the synthetic bytes go through the same
+    coalescing, `\r` collapsing, ANSI stripping and credential redaction
+    a real container's output does, and come back out of the same
+    `render_inflight(preserve_lines=True)` the cockpit uses. A hand-drawn
+    tail would keep looking right through a regression in any of them.
+
+    NEVER raises.
+    """
+    try:
+        from backend.core.ouroboros.battle_test.live_tool_stream import (
+            LiveToolStream,
+        )
+        from backend.core.ouroboros.battle_test.stream_renderer import (
+            render_inflight,
+        )
+        for (lo, hi), (tool, _cmd, lines) in _RUNNING.items():
+            if not (lo <= elapsed <= hi):
+                continue
+            frames: List[Any] = []
+            clock = [lo]
+            stream = LiveToolStream(
+                tool=tool, op_id="demo", publish=frames.append,
+                clock=lambda: clock[0],
+            )
+            # Deal the lines out over the window, then ask the stream what
+            # it would be showing NOW.
+            shown = int(((elapsed - lo) / max(0.01, hi - lo)) * len(lines))
+            for line in lines[:max(1, shown)]:
+                clock[0] += 0.2
+                if line.startswith("stderr:"):
+                    stream("stderr", line[7:] + "\n")
+                else:
+                    stream("stdout", line + "\n")
+            if not frames:
+                return []
+            frame = frames[-1]
+            head = f"$ {tool} · {elapsed - lo:.0f}s"
+            body = str(frame.get("text") or "")
+            return render_inflight(
+                f"{head}\n{body}" if body else head,
+                width=width, preserve_lines=True, keep_first=True,
+            )
+        return []
+    except Exception:  # noqa: BLE001
+        logger.debug("[OvDemo] running-command tail unavailable", exc_info=True)
+        return []
+
+
 def _stream_rows(elapsed: float, mux: Any = None) -> List[str]:
     """Strip rows for the demo, through the COCKPIT's renderer. NEVER raises.
 
@@ -828,9 +949,6 @@ def _stream_rows(elapsed: float, mux: Any = None) -> List[str]:
         from backend.core.ouroboros.battle_test.stream_renderer import (
             render_inflight,
         )
-        text = _inflight_text(elapsed)
-        if not text:
-            return []
         width = None
         try:
             width = getattr(mux, "width", None) if mux is not None else None
@@ -839,6 +957,15 @@ def _stream_rows(elapsed: float, mux: Any = None) -> List[str]:
         if not width:
             import shutil
             width = shutil.get_terminal_size((80, 24)).columns
+        # A running command outranks model prose in the same strip: they
+        # never overlap in a real op either, and the command is the thing
+        # the operator cannot otherwise see.
+        running = _running_rows(elapsed, width)
+        if running:
+            return running
+        text = _inflight_text(elapsed)
+        if not text:
+            return []
         return render_inflight(text, width=width)
     except Exception:  # noqa: BLE001
         logger.debug("[OvDemo] inflight strip unavailable", exc_info=True)

--- a/tests/battle_test/test_stream_inflight.py
+++ b/tests/battle_test/test_stream_inflight.py
@@ -249,9 +249,36 @@ class TestTheDemoShowsIt:
         assert d._stream_rows(lands - 0.1) != []
 
     def test_it_is_quiet_when_nothing_is_generating(self):
+        """Idle means idle. Times chosen from the windows themselves, not
+        written down — t=12.0 used to be idle and is now inside a running
+        command, and a hardcoded moment silently stops testing what it
+        was named for."""
         from backend.core.ouroboros.cli import ov_demo as d
-        assert d._stream_rows(0.5) == []
-        assert d._stream_rows(12.0) == []
+        busy = list(d._GENERATING) + list(d._RUNNING)
+        idle = [t for t in (0.5, 13.5, 14.5, 21.5)
+                if not any(lo <= t <= hi for lo, hi in busy)]
+        assert idle, "the script has no idle moment left to test"
+        for t in idle:
+            assert d._stream_rows(t) == [], t
+
+    def test_a_RUNNING_command_shows_its_tail(self):
+        """The 40-second black box, made watchable. Driven through the
+        real LiveToolStream, so the demo exercises its coalescing,
+        redaction and stderr tagging rather than a drawn picture."""
+        from backend.core.ouroboros.cli import ov_demo as d
+        (lo, hi) = list(d._RUNNING)[0]
+        rows = d._stream_rows(lo + (hi - lo) * 0.8)
+        assert rows, "a running command showed nothing"
+        assert rows[0].strip().startswith("$"), rows[0]
+
+    def test_the_running_header_survives_elision(self):
+        """Row 0 says WHAT is running and for how long. The elision keeps
+        newest rows, so without an exemption a long tail left test names
+        with no subject."""
+        from backend.core.ouroboros.cli import ov_demo as d
+        (lo, hi) = list(d._RUNNING)[0]
+        rows = d._stream_rows(hi - 0.2)
+        assert rows and rows[0].strip().startswith("$"), rows
 
     def test_the_demo_calls_the_COCKPITS_renderer(self):
         """A second wrap here would keep agreeing with itself while the real


### PR DESCRIPTION
## Why

`ov demo live` is where this cockpit gets **watched**, and three merged features were invisible in it: a running command's live tail (#70249), the collapsed op block (#70250), and the widened verb count (#70252). A feature the demo cannot show is a feature nobody checks.

## What it looks like now

A command running, mid-op:

```
  $ bash · 3s
  …
  test_risk_tier_floor.py::test_vision_floor_clamped FAILED
  stderr │ E   AssertionError: expected notify_apply, got safe_auto
```

The op finishing:

```
  ⏺ risk_tier_floor.py evolved · ⏱ 21.6s · 💰 $0.0031   o-1 · 27 lines · /expand o-1
```

## Driven through the real renderers

Per this module's own stated rule — *"a demo with its own draw path is worse than no demo: it agrees with itself while the cockpit is broken"*:

- the running tail feeds synthetic bytes through an **actual `LiveToolStream`**, so the demo exercises its coalescing, `\r` collapsing, ANSI stripping, credential redaction and stderr tagging, and renders through the same `render_inflight(preserve_lines=True)` the cockpit calls
- the collapsed line's label comes from **`task_panel_aggregator.derive_label`** — the same pure picker `serpent_flow._collapsed_label` and `op_fanout_tree` use

Hand-written strings would have exercised none of it, and kept looking correct through a regression in every one.

## A shipped defect, found by building the demo

`render_inflight` elides to the **newest** rows — right for prose, wrong for a command. Row 0 is `$ bash · 11s`: what is running and for how long. A long tail elided it away and left a list of test names with no subject.

That is a real defect in #70249 **as merged**, visible the moment the demo drew it:

```
  …                                          ← header gone
  test_risk_tier_floor.py::test_paranoia_shortcut PASSED
  test_risk_tier_floor.py::test_vision_floor_clamped FAILED
```

Fixed with `keep_first`, declared by the caller the same way `preserve_lines` is — the strip's owner knows whether row 0 is a header. Both the cockpit and the demo declare it.

## Nuances

- A running command **outranks** model prose in the shared strip: they never overlap in a real op, and the command is the thing the operator could not otherwise see.
- The running windows deliberately overlap the `⏺ Bash(…)` tool beats they belong to, so the live tail and the block describe the same command.
- One test premise had gone **stale rather than wrong**: `t=12.0` was an idle moment when written and is now inside a running command. It now *derives* its idle moments from the windows themselves — a hardcoded timestamp silently stops testing what it was named for.

## Tests

**126 green** across demo, stream, live-tool-stream and attach suites; 119 more across verb-discovery, collapse and progress-board.

The demo board now reports **82 discoverable (62 routed here)**, reflecting #70252.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `ov demo live` to stream a running command’s tail, show the collapsed op summary, and reflect the widened verb count using the real renderers. Also fix elision so the running command header stays visible.

- New Features
  - Streams synthetic command output through `LiveToolStream` and renders via `render_inflight(preserve_lines=True)`.
  - Adds the collapsed-op line using `task_panel_aggregator.derive_label` with cockpit theming.
  - Running command output outranks model prose in the shared strip; the demo intentionally overlaps the related tool block.

- Bug Fixes
  - Adds `keep_first` to `render_inflight` to preserve row 0 (e.g., "$ bash · Ns") when eliding; used in the cockpit and demo for tool output.
  - Tests derive idle moments from the script windows and assert the running tail and header behavior.

<sup>Written for commit 791e647626193a7204d1b54b2dfe95266b256dac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

