### PR TITLE
fix(ov): typing into a cockpit had different rules than typing at the daemon

### DIFF
--- a/backend/core/ouroboros/battle_test/attach_heartbeat.py
+++ b/backend/core/ouroboros/battle_test/attach_heartbeat.py
@@ -62,6 +62,17 @@ def _pending_apply_payload() -> Optional[dict]:
         return None
 
 
+def _input_queue_payload() -> dict:
+    """The attached-input queue's depth, or {}. NEVER raises."""
+    try:
+        from backend.core.ouroboros.battle_test.operator_input_queue import (
+            active_queue_snapshot,
+        )
+        return active_queue_snapshot()
+    except Exception:  # noqa: BLE001
+        return {}
+
+
 def _status_payload(snap: Any) -> Optional[dict]:
     """The status snapshot as a transport dict, or None. NEVER raises."""
     try:
@@ -318,6 +329,11 @@ def build_heartbeat_payload() -> Optional[Dict[str, Any]]:
             # builder, which is empty by construction and would draw an
             # eternally idle organism.
             "status": _status_payload(snap),
+            # Submitted-but-unprocessed operator lines. Carried here
+            # rather than pushed, for the reason every other live state
+            # is: it is a picture of NOW, and a dropped frame costs a
+            # tick of accuracy rather than a queued line.
+            "input_queue": _input_queue_payload(),
             # An apply waiting out its rejection window. Carried here rather
             # than mirrored as text because a countdown is STATE — the panel
             # that draws it locally repaints eight times a second, and the

--- a/backend/core/ouroboros/battle_test/bipartite_layout.py
+++ b/backend/core/ouroboros/battle_test/bipartite_layout.py
@@ -751,6 +751,7 @@ def build_bipartite_application(
     status_rows: Optional[Callable[[], Any]] = None,
     pending_rows: Optional[Callable[[], Any]] = None,
     stream_rows: Optional[Callable[[], Any]] = None,
+    queue_rows: Optional[Callable[[], Any]] = None,
     serpent_active: Optional[Callable[[], bool]] = None,
 ) -> Any:
     """Construct the full-screen ``prompt_toolkit.Application``: Zone 1 an ANSI
@@ -1111,6 +1112,15 @@ def build_bipartite_application(
     # immediately above this — the in-flight text appears exactly where it
     # will land, which is what makes it read as inline rather than as a
     # separate widget.
+    # The operator's own backlog, nearest the caret — it is about what
+    # THEY did, so it belongs closest to where they are typing.
+    if queue_rows is not None:
+        try:
+            _q_row = build_dynamic_rows(queue_rows)
+            if _q_row is not None:
+                rows += [_q_row]
+        except Exception:  # noqa: BLE001
+            logger.debug("[Bipartite] queue row unavailable", exc_info=True)
     if stream_rows is not None:
         try:
             _stream_row = build_dynamic_rows(stream_rows)
@@ -1395,6 +1405,7 @@ async def run_bipartite_repl(
     status_rows: Optional[Callable[[], Any]] = None,
     pending_rows: Optional[Callable[[], Any]] = None,
     stream_rows: Optional[Callable[[], Any]] = None,
+    queue_rows: Optional[Callable[[], Any]] = None,
     serpent_active: Optional[Callable[[], bool]] = None,
 ) -> None:
     """Launch the full-screen Bipartite REPL: build the multiplexer, register it as
@@ -1427,7 +1438,7 @@ async def run_bipartite_repl(
             turn_spinner=turn_spinner, agent_rows=agent_rows,
             search_rows=search_rows, status_rows=status_rows,
             pending_rows=pending_rows, stream_rows=stream_rows,
-            serpent_active=serpent_active,
+            queue_rows=queue_rows, serpent_active=serpent_active,
         )
         if watch_alive is not None:
             watcher = asyncio.ensure_future(

--- a/backend/core/ouroboros/battle_test/bipartite_layout.py
+++ b/backend/core/ouroboros/battle_test/bipartite_layout.py
@@ -752,6 +752,7 @@ def build_bipartite_application(
     pending_rows: Optional[Callable[[], Any]] = None,
     stream_rows: Optional[Callable[[], Any]] = None,
     queue_rows: Optional[Callable[[], Any]] = None,
+    panic_rows: Optional[Callable[[], Any]] = None,
     serpent_active: Optional[Callable[[], bool]] = None,
 ) -> Any:
     """Construct the full-screen ``prompt_toolkit.Application``: Zone 1 an ANSI
@@ -1306,6 +1307,51 @@ def build_bipartite_application(
     except Exception:  # noqa: BLE001
         _editing_mode = None
 
+    # ── FATAL_PANIC overlay ────────────────────────────────────────────
+    # The SAME FloatContainer architecture the `/` palette established —
+    # one Z-index story, not a second overlay mechanism. Mounted last, so
+    # it draws ABOVE the palette: a completion menu must never occlude the
+    # notice that the organism has died in the background.
+    #
+    # `top=1` rather than `ycursor=True`: a crash is not attached to where
+    # the caret happens to be, and an overlay that moves while the
+    # operator reads a traceback is hostile.
+    if panic_rows is not None:
+        try:
+            from prompt_toolkit.filters import Condition
+            from prompt_toolkit.layout import (
+                ConditionalContainer, Float, FloatContainer, Window,
+            )
+            from prompt_toolkit.layout.controls import FormattedTextControl
+
+            def _panic_visible() -> bool:
+                try:
+                    return bool(panic_rows())
+                except Exception:  # noqa: BLE001
+                    return False
+
+            _panic_win = ConditionalContainer(
+                Window(
+                    FormattedTextControl(
+                        lambda: [("class:panic", "\n".join(panic_rows()))],
+                    ),
+                    wrap_lines=False, style="class:panic",
+                ),
+                filter=Condition(_panic_visible),
+            )
+            if isinstance(root, FloatContainer):
+                root.floats.append(Float(
+                    content=_panic_win, top=1, left=2, right=2,
+                ))
+            else:
+                root = FloatContainer(content=root, floats=[Float(
+                    content=_panic_win, top=1, left=2, right=2,
+                )])
+        except Exception:  # noqa: BLE001
+            # A cockpit that cannot draw the overlay must still RUN — the
+            # panic is already logged and on the telemetry lane.
+            logger.debug("[Bipartite] panic overlay unavailable", exc_info=True)
+
     app = Application(
         layout=PTLayout(root, focused_element=prompt),
         **({"editing_mode": _editing_mode}
@@ -1406,6 +1452,7 @@ async def run_bipartite_repl(
     pending_rows: Optional[Callable[[], Any]] = None,
     stream_rows: Optional[Callable[[], Any]] = None,
     queue_rows: Optional[Callable[[], Any]] = None,
+    panic_rows: Optional[Callable[[], Any]] = None,
     serpent_active: Optional[Callable[[], bool]] = None,
 ) -> None:
     """Launch the full-screen Bipartite REPL: build the multiplexer, register it as
@@ -1438,7 +1485,8 @@ async def run_bipartite_repl(
             turn_spinner=turn_spinner, agent_rows=agent_rows,
             search_rows=search_rows, status_rows=status_rows,
             pending_rows=pending_rows, stream_rows=stream_rows,
-            queue_rows=queue_rows, serpent_active=serpent_active,
+            queue_rows=queue_rows, panic_rows=panic_rows,
+            serpent_active=serpent_active,
         )
         if watch_alive is not None:
             watcher = asyncio.ensure_future(

--- a/backend/core/ouroboros/battle_test/cockpit_attach.py
+++ b/backend/core/ouroboros/battle_test/cockpit_attach.py
@@ -237,6 +237,25 @@ def publish_telemetry_global(payload: dict) -> bool:
         return False
 
 
+def install_panic_broadcast() -> bool:
+    """Route FATAL_PANIC frames onto the UDS telemetry lane. NEVER raises.
+
+    Registered once; the arbiter dedups, so a cascade is one frame. Uses
+    `publish_telemetry_global` — the same lane and envelope the heartbeat,
+    the in-flight stream and the tool tail already ride, so no new
+    transport, no new frame convention, and clients that predate this
+    ignore an unknown `kind` exactly as they always have.
+    """
+    try:
+        from backend.core.ouroboros.battle_test.panic_arbiter import (
+            register_sink,
+        )
+        register_sink(publish_telemetry_global)
+        return True
+    except Exception:  # noqa: BLE001
+        return False
+
+
 def attach_enabled() -> bool:
     """Master gate — default ON. NEVER raises."""
     return os.environ.get(

--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -1242,6 +1242,17 @@ class BattleTestHarness:
         _running_loop = asyncio.get_event_loop()
 
         def _harness_loop_exception_handler(loop_, ctx_):
+            # Panic Arbiter (backstop detector). Delegation rather than a
+            # third `set_exception_handler`: this handler's curated
+            # suppression stays authoritative, and the arbiter adds the
+            # thing a log file cannot — a broadcast the operator sees.
+            try:
+                from backend.core.ouroboros.battle_test.panic_arbiter import (
+                    arbitrate as _arbitrate,
+                )
+                _arbitrate(loop_, ctx_)
+            except Exception:  # noqa: BLE001
+                pass
             # Interpreter finalization guard (operator paste 2026-07-18):
             # during shutdown the QueueHandler's copy.copy(record) dies
             # with "ImportError: sys.meta_path is None" and logging
@@ -1273,6 +1284,15 @@ class BattleTestHarness:
 
         try:
             _running_loop.set_exception_handler(_harness_loop_exception_handler)
+            # Panic broadcast: a traceback in a log file is invisible to
+            # someone watching a cockpit.
+            try:
+                from backend.core.ouroboros.battle_test.cockpit_attach import (
+                    install_panic_broadcast,
+                )
+                install_panic_broadcast()
+            except Exception:  # noqa: BLE001
+                pass
         except Exception:
             logger.debug("Failed to install harness asyncio exception handler", exc_info=True)
 

--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -4211,6 +4211,43 @@ class BattleTestHarness:
         except Exception:  # noqa: BLE001
             return ""
 
+    def _operator_input_queue(self, loop: Any) -> Any:
+        """The ordered input queue for attached cockpits, or None.
+
+        None means "fall back to the legacy fire-and-forget task", which
+        is what the master flag off selects and what a construction
+        failure degrades to. Losing ORDER is bad; losing the operator's
+        line entirely would be worse, so the fallback stays.
+        """
+        try:
+            from backend.core.ouroboros.battle_test.operator_input_queue import (  # noqa: E501
+                OperatorInputQueue, input_queue_enabled,
+            )
+            if not input_queue_enabled():
+                return None
+            q = getattr(self, "_op_input_q", None)
+            if q is None:
+                q = OperatorInputQueue(
+                    lambda text, session: self._handle_repl_command_for(
+                        text, session),
+                )
+                self._op_input_q = q
+                q.start()
+                # Publish for read-only observers (the heartbeat), so the
+                # operator can SEE a backlog rather than infer one from
+                # silence.
+                try:
+                    from backend.core.ouroboros.battle_test.operator_input_queue import (  # noqa: E501
+                        set_active_queue,
+                    )
+                    set_active_queue(q)
+                except Exception:  # noqa: BLE001
+                    pass
+            return q
+        except Exception:  # noqa: BLE001
+            logger.debug("[Attach] input queue unavailable", exc_info=True)
+            return None
+
     async def _handle_repl_command_for(
         self, command: str, session: Optional[str],
     ) -> None:
@@ -4572,6 +4609,28 @@ class BattleTestHarness:
                 try:
                     loop = asyncio.get_running_loop()
                 except RuntimeError:
+                    return
+                # ORDERED, matching the local terminal. `create_task` per
+                # line gave the same action two concurrency semantics
+                # depending on which surface it was typed into: `/pause`
+                # then `/status` could report the pre-pause state, and a
+                # pasted block became one racing task per line.
+                #
+                # The queue serializes HANDLERS, not ops — a handler
+                # schedules work and returns, so a long op never delays
+                # the next line the operator types.
+                q = self._operator_input_queue(loop)
+                if q is not None:
+                    res = q.submit(text, session)
+                    if not res.accepted and res.reason not in ("empty",):
+                        # Refused, never dropped: an operator who believes
+                        # a goal landed is worse off than one told it did
+                        # not.
+                        try:
+                            self._flow._mirror_markup(
+                                f"  [yellow]⚠ {res.reason}[/yellow]")
+                        except Exception:  # noqa: BLE001
+                            pass
                     return
                 loop.create_task(self._handle_repl_command_for(text, session))
 

--- a/backend/core/ouroboros/battle_test/operator_input_queue.py
+++ b/backend/core/ouroboros/battle_test/operator_input_queue.py
@@ -178,7 +178,19 @@ class OperatorInputQueue:
                 return self._consumer
             self._waiter = asyncio.Event()
             self._closed = False
-            self._consumer = asyncio.ensure_future(self._drain())
+            # SUPERVISED. This object holds a reference to its own
+            # consumer, which is exactly the case the loop handler never
+            # sees: asyncio only surfaces an unretrieved task exception at
+            # garbage collection, and a live reference defers that
+            # forever. The done-callback fires immediately instead.
+            try:
+                from backend.core.ouroboros.battle_test.panic_arbiter import (
+                    spawn_supervised,
+                )
+                self._consumer = spawn_supervised(
+                    self._drain(), origin="operator_input_queue.drain")
+            except Exception:  # noqa: BLE001
+                self._consumer = asyncio.ensure_future(self._drain())
             return self._consumer
         except Exception:  # noqa: BLE001
             logger.debug("[OperatorInput] consumer start degraded",

--- a/backend/core/ouroboros/battle_test/operator_input_queue.py
+++ b/backend/core/ouroboros/battle_test/operator_input_queue.py
@@ -1,0 +1,326 @@
+"""One meaning for "the operator submitted a line", whichever surface it came from.
+
+The same action had two concurrency semantics:
+
+    serpent_flow.py:6322   result = self._on_command(line)
+                           await result                    <- serialized
+    harness.py:4576        loop.create_task(
+                               self._handle_repl_command_for(text, session))
+
+Typing at the daemon terminal was ordered and backpressured. Typing the
+identical line into an attached cockpit spawned a task per line, with no
+ordering and no bound. That is not only a UX difference:
+
+  * ``/pause`` then ``/status`` could report the PRE-pause state, because
+    the second handler was free to finish first.
+  * a pasted block of N lines became N concurrent handlers, all racing.
+  * nothing showed that a submitted line had not been acted on yet, so a
+    busy organism was indistinguishable from a dropped keystroke.
+
+Why a queue rather than an await
+--------------------------------
+Awaiting inline in ``_on_input`` was never an option — that callback runs
+on the bridge's read loop, and blocking it would stall every attached
+cockpit's input, heartbeat and telemetry behind one slow handler. Which is
+precisely why it was made fire-and-forget.
+
+So: enqueue on the read loop (non-blocking, order preserved), and let ONE
+consumer await handlers in turn. The local surface's semantics, without
+the local surface's blocking.
+
+What this does NOT serialize
+-----------------------------
+The OPS. ``_handle_repl_command`` schedules work and returns; the op it
+starts runs in its own task and outlives the handler. So the queue makes
+handlers ordered and cheap, and a long-running op never delays the next
+command an operator types. Serializing ops would be a different — and
+wrong — change: the organism is concurrent by design.
+
+Bounded, and never silently
+---------------------------
+A full queue REFUSES with a visible reason rather than dropping. Operator
+intent is not telemetry: a silently discarded goal is worse than a
+rejected one, because the operator believes it landed.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from dataclasses import dataclass
+from typing import Any, Callable, List, Optional
+
+logger = logging.getLogger("Ouroboros.OperatorInputQueue")
+
+OPERATOR_INPUT_QUEUE_SCHEMA_VERSION = "operator_input_queue.v1"
+
+MASTER_FLAG_ENV_VAR = "JARVIS_OPERATOR_INPUT_QUEUE_ENABLED"
+
+#: Submitted-but-unprocessed lines held before refusing. Generous enough
+#: for a pasted block, small enough that a runaway producer cannot hide a
+#: thousand pending intents behind a busy organism.
+_DEFAULT_MAX_DEPTH = 32
+
+
+def input_queue_enabled() -> bool:
+    """Default ON. Off, attached input is fire-and-forget again — the
+    unordered, unbounded behaviour this module exists to end."""
+    try:
+        return os.environ.get(
+            MASTER_FLAG_ENV_VAR, "1",
+        ).strip().lower() not in ("0", "false", "no", "off")
+    except Exception:  # noqa: BLE001
+        return True
+
+
+def _max_depth() -> int:
+    try:
+        return max(1, min(512, int(os.environ.get(
+            "JARVIS_OPERATOR_INPUT_QUEUE_DEPTH", _DEFAULT_MAX_DEPTH))))
+    except Exception:  # noqa: BLE001
+        return _DEFAULT_MAX_DEPTH
+
+
+@dataclass(frozen=True)
+class QueuedInput:
+    """One submitted line, waiting its turn."""
+
+    text: str
+    session: Optional[str] = None
+    submitted_monotonic: float = 0.0
+
+    def preview(self, width: int = 48) -> str:
+        flat = " ".join(str(self.text or "").split())
+        return flat if len(flat) <= width else flat[: width - 1] + "…"
+
+
+@dataclass(frozen=True)
+class SubmitResult:
+    """What happened to a submitted line. Never a bare bool.
+
+    ``accepted=False`` always carries a reason, because the one outcome
+    this module must never produce is an operator believing their line
+    landed when it did not.
+    """
+
+    accepted: bool
+    depth: int = 0
+    reason: str = ""
+
+
+class OperatorInputQueue:
+    """FIFO for operator lines, drained by one consumer.
+
+    Thread-confined to the event loop it is created on; ``submit`` is
+    non-blocking and safe to call from a bridge read callback.
+    """
+
+    def __init__(
+        self,
+        handler: Callable[[str, Optional[str]], Any],
+        *,
+        max_depth: Optional[int] = None,
+        clock: Optional[Callable[[], float]] = None,
+    ) -> None:
+        self._handler = handler
+        self._clock = clock or time.monotonic
+        self._max_depth = int(max_depth or _max_depth())
+        self._pending: List[QueuedInput] = []
+        self._waiter: Optional[asyncio.Event] = None
+        self._consumer: Optional[Any] = None
+        self._running: Optional[QueuedInput] = None
+        self._closed = False
+        #: Lines refused for want of room. Surfaced, never silent.
+        self.refused = 0
+
+    # -- producer side (bridge read loop) ------------------------------
+
+    def submit(self, text: object, session: Optional[str] = None) -> SubmitResult:
+        """Enqueue one line. Non-blocking. NEVER raises.
+
+        Order is established HERE, on the read loop, which is the only
+        place submission order is knowable. Anything downstream that
+        re-derives it from timestamps would be guessing.
+        """
+        try:
+            flat = str(text or "")
+            if not flat.strip():
+                return SubmitResult(accepted=False, reason="empty")
+            if self._closed:
+                return SubmitResult(accepted=False, reason="shutting down")
+            if len(self._pending) >= self._max_depth:
+                self.refused += 1
+                # REFUSE, never drop. A discarded goal the operator
+                # believes landed is worse than a rejected one.
+                return SubmitResult(
+                    accepted=False, depth=len(self._pending),
+                    reason=f"queue full ({self._max_depth}) — "
+                           f"wait or /cancel",
+                )
+            self._pending.append(QueuedInput(
+                text=flat, session=session,
+                submitted_monotonic=self._clock(),
+            ))
+            if self._waiter is not None:
+                self._waiter.set()
+            return SubmitResult(accepted=True, depth=len(self._pending))
+        except Exception:  # noqa: BLE001
+            logger.debug("[OperatorInput] submit degraded", exc_info=True)
+            return SubmitResult(accepted=False, reason="submit failed")
+
+    # -- consumer side --------------------------------------------------
+
+    def start(self) -> Optional[Any]:
+        """Begin draining. Idempotent. Returns the consumer task or None."""
+        try:
+            if self._consumer is not None and not self._consumer.done():
+                return self._consumer
+            self._waiter = asyncio.Event()
+            self._closed = False
+            self._consumer = asyncio.ensure_future(self._drain())
+            return self._consumer
+        except Exception:  # noqa: BLE001
+            logger.debug("[OperatorInput] consumer start degraded",
+                         exc_info=True)
+            return None
+
+    async def _drain(self) -> None:
+        """Await each handler in turn, forever. NEVER exits on error.
+
+        A consumer that dies on one bad handler wedges every later line
+        the operator types — the queue would then be strictly worse than
+        the unordered path it replaced.
+        """
+        while True:
+            try:
+                if not self._pending:
+                    if self._closed:
+                        return
+                    if self._waiter is not None:
+                        self._waiter.clear()
+                        await self._waiter.wait()
+                    else:                      # pragma: no cover
+                        await asyncio.sleep(0.05)
+                    continue
+                item = self._pending.pop(0)
+                self._running = item
+                try:
+                    result = self._handler(item.text, item.session)
+                    if asyncio.iscoroutine(result) or isinstance(
+                            result, asyncio.Future):
+                        await result
+                except asyncio.CancelledError:
+                    raise
+                except Exception:  # noqa: BLE001
+                    logger.debug(
+                        "[OperatorInput] handler failed for %r",
+                        item.preview(), exc_info=True)
+                finally:
+                    self._running = None
+            except asyncio.CancelledError:
+                return
+            except Exception:  # noqa: BLE001
+                logger.debug("[OperatorInput] drain degraded", exc_info=True)
+                await asyncio.sleep(0.05)
+
+    async def aclose(self) -> None:
+        """Stop accepting, let the consumer finish, report what was lost."""
+        self._closed = True
+        try:
+            if self._waiter is not None:
+                self._waiter.set()
+            if self._consumer is not None:
+                self._consumer.cancel()
+        except Exception:  # noqa: BLE001
+            pass
+
+    # -- observation ----------------------------------------------------
+
+    @property
+    def depth(self) -> int:
+        return len(self._pending)
+
+    def snapshot(self) -> dict:
+        """Transport-safe view for the cockpit. NEVER raises.
+
+        Depth alone is not enough: an operator who typed three lines wants
+        to see WHICH three are still waiting, or the queue is just another
+        opaque delay.
+        """
+        try:
+            return {
+                "schema_version": OPERATOR_INPUT_QUEUE_SCHEMA_VERSION,
+                "depth": len(self._pending),
+                "refused": int(self.refused),
+                "running": (self._running.preview()
+                            if self._running is not None else ""),
+                "pending": [q.preview() for q in self._pending[:5]],
+            }
+        except Exception:  # noqa: BLE001
+            return {"depth": 0, "refused": 0, "running": "", "pending": []}
+
+
+#: The live queue, for read-only observers (the heartbeat). Mirrors
+#: `cockpit_attach._ACTIVE_BRIDGE`: a producer publishes itself rather
+#: than every consumer hunting for a harness singleton — the version of
+#: this that reached for `harness.get_active_harness()` failed silently,
+#: because no such function exists and the import error was swallowed.
+_ACTIVE_QUEUE: Optional["OperatorInputQueue"] = None
+
+
+def set_active_queue(queue: Optional["OperatorInputQueue"]) -> None:
+    """Publish (or retire) the live queue. NEVER raises."""
+    global _ACTIVE_QUEUE
+    _ACTIVE_QUEUE = queue
+
+
+def active_queue_snapshot() -> dict:
+    """The live queue's state, or {} when there is none. NEVER raises."""
+    try:
+        q = _ACTIVE_QUEUE
+        return q.snapshot() if q is not None else {}
+    except Exception:  # noqa: BLE001
+        return {}
+
+
+def render_queue(payload: Optional[dict], *, width: Optional[int] = None) -> List[str]:
+    """Rows for the queued-input strip, or []. Pure. NEVER raises.
+
+    Renders nothing at depth 0 — a queue that is keeping up should be
+    invisible. It earns a row only when the operator is ahead of the
+    organism, which is exactly when they need to know.
+    """
+    try:
+        if not isinstance(payload, dict):
+            return []
+        depth = int(payload.get("depth") or 0)
+        refused = int(payload.get("refused") or 0)
+        if depth <= 0 and refused <= 0:
+            return []
+        cols = int(width) if width and int(width) > 0 else 80
+        rows: List[str] = []
+        if depth > 0:
+            head = f"  ⋯ {depth} queued"
+            first = [p for p in (payload.get("pending") or ()) if p]
+            if first:
+                head = f"{head} · next: {first[0]}"
+            rows.append(head[:cols])
+        if refused > 0:
+            rows.append(f"  ⚠ {refused} refused — queue was full"[:cols])
+        return rows
+    except Exception:  # noqa: BLE001
+        return []
+
+
+__all__ = [
+    "MASTER_FLAG_ENV_VAR",
+    "OPERATOR_INPUT_QUEUE_SCHEMA_VERSION",
+    "OperatorInputQueue",
+    "QueuedInput",
+    "SubmitResult",
+    "input_queue_enabled",
+    "active_queue_snapshot",
+    "render_queue",
+    "set_active_queue",
+]

--- a/backend/core/ouroboros/battle_test/panic_arbiter.py
+++ b/backend/core/ouroboros/battle_test/panic_arbiter.py
@@ -1,0 +1,377 @@
+"""A background death the operator can see, within milliseconds of it happening.
+
+Three times in one arc a missing symbol was swallowed by a broad ``except``
+and the system carried on describing a world that had stopped existing.
+The failure mode is not the ``except`` blocks — hunting those is endless
+and each one is individually defensible. It is that **a detached task can
+die and nothing tells anyone**.
+
+Two detectors, because one is not enough
+========================================
+The obvious design is ``loop.set_exception_handler()``. It is necessary
+and, alone, insufficient — and the gap is not theoretical:
+
+    async def boom(): raise RuntimeError("silent death")
+    t = asyncio.create_task(boom())
+    await asyncio.sleep(0.05)        # handler has NOT fired
+    keep = t                         # any registry holding a reference
+    await asyncio.sleep(0.05)        # still has NOT fired
+    del t, keep; gc.collect()        # ... only now does it fire
+
+asyncio surfaces a task's unretrieved exception when the Task object is
+**garbage collected**. Anything that keeps a reference — a task registry,
+``self._tasks``, a list comprehension that outlives the await — defers
+that indefinitely. A long-lived daemon holding its own tasks is exactly
+the case where the loop handler never fires at all.
+
+So:
+
+  1. :func:`spawn_supervised` — a ``create_task`` that attaches a
+     done-callback. Fires the instant the task completes with an
+     exception, regardless of who holds a reference. This is the one that
+     catches the case we actually have.
+  2. :func:`arbitrate` — the loop-level handler, as a BACKSTOP for
+     everything the first cannot see: callback errors, transport faults,
+     tasks spawned by libraries, and GC-time leaks from code that never
+     adopted (1).
+
+Neither replaces the other, and a panic reported by both is reported once
+(deduplicated by signature).
+
+Not every exception is a panic
+==============================
+``serpent_flow`` already carries ``_EXPECTED_BACKGROUND_EXC_PATTERNS`` for
+known-benign shutdown noise, and ``CancelledError`` is control flow rather
+than failure. Both are honoured — an alarm that cries wolf during every
+clean shutdown trains the operator to ignore the one that matters. What is
+NOT honoured is silence: anything not provably benign is a panic.
+
+Broadcast, not just logged
+==========================
+A traceback in a log file is invisible to someone watching a cockpit. The
+panic is serialized onto the SAME UDS telemetry lane every other live
+state uses, and the client raises the overlay that the ``/`` palette's
+``FloatContainer`` architecture already provides. One Z-index story, one
+envelope, one lane.
+
+NEVER raises. An arbiter that can throw is a second silent death.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+import traceback
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional
+
+logger = logging.getLogger("Ouroboros.PanicArbiter")
+
+PANIC_SCHEMA_VERSION = "fatal_panic.v1"
+
+#: The frame kind. Matches the existing UDS envelope convention
+#: (``{"type": ..., ...}`` downstream frames) rather than inventing one.
+PANIC_KIND = "fatal_panic"
+
+MASTER_FLAG_ENV_VAR = "JARVIS_PANIC_ARBITER_ENABLED"
+
+#: Distinct panics retained. A cascade (one fault triggering ten) must not
+#: become ten overlays, and an operator only ever acts on the first.
+_MAX_RETAINED = 8
+
+_LOCK = threading.Lock()
+_PANICS: List["Panic"] = []
+_SEEN: Dict[str, float] = {}
+_SINKS: List[Callable[[dict], None]] = []
+
+
+def panic_arbiter_enabled() -> bool:
+    """Default ON. Off, a background death is invisible again."""
+    try:
+        return os.environ.get(
+            MASTER_FLAG_ENV_VAR, "1",
+        ).strip().lower() not in ("0", "false", "no", "off")
+    except Exception:  # noqa: BLE001
+        return True
+
+
+@dataclass(frozen=True)
+class Panic:
+    """One unhandled background failure."""
+
+    kind: str
+    message: str
+    exc_type: str
+    traceback_text: str
+    origin: str
+    signature: str
+    at_unix: float
+
+    def as_payload(self) -> dict:
+        return {
+            "type": PANIC_KIND,
+            "kind": PANIC_KIND,
+            "schema_version": PANIC_SCHEMA_VERSION,
+            "message": self.message,
+            "exc_type": self.exc_type,
+            "traceback": self.traceback_text,
+            "origin": self.origin,
+            "signature": self.signature,
+            "at_unix": self.at_unix,
+        }
+
+
+def _is_benign(exc: BaseException, message: str) -> bool:
+    """Known-benign background noise? NEVER raises.
+
+    Deliberately narrow. Cancellation is control flow, and the shutdown
+    patterns `serpent_flow` already curates are real noise — but anything
+    not provably benign is a panic. The failure this module exists to end
+    is silence, so the default answer is "report it".
+    """
+    try:
+        import asyncio
+        if isinstance(exc, asyncio.CancelledError):
+            return True
+        if isinstance(exc, (KeyboardInterrupt, SystemExit)):
+            return True
+        import sys
+        if sys.is_finalizing() or sys.meta_path is None:
+            # Interpreter teardown: logging itself dies here. Reported
+            # panics during finalization are noise from a dying process.
+            return True
+        try:
+            from backend.core.ouroboros.battle_test.serpent_flow import (
+                _EXPECTED_BACKGROUND_EXC_PATTERNS,
+            )
+        except Exception:  # noqa: BLE001
+            _EXPECTED_BACKGROUND_EXC_PATTERNS = ()   # type: ignore[assignment]
+        blob = f"{message} {exc}"
+        return any(p in blob for p in _EXPECTED_BACKGROUND_EXC_PATTERNS or ())
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _signature(exc_type: str, tb_text: str) -> str:
+    """Identity of a panic, for dedup. Pure.
+
+    The exception type plus the LAST frame — a cascade of ten failures
+    from one root produces one overlay, and a task that dies every second
+    does not produce sixty.
+    """
+    try:
+        last = ""
+        for line in reversed((tb_text or "").splitlines()):
+            if line.strip().startswith("File "):
+                last = line.strip()
+                break
+        return f"{exc_type}|{last}"[:200]
+    except Exception:  # noqa: BLE001
+        return str(exc_type)[:200]
+
+
+def register_sink(sink: Callable[[dict], None]) -> None:
+    """Add a panic consumer (the UDS broadcaster, a test spy). NEVER raises."""
+    try:
+        with _LOCK:
+            if sink not in _SINKS:
+                _SINKS.append(sink)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def reset_for_tests() -> None:
+    with _LOCK:
+        _PANICS.clear()
+        _SEEN.clear()
+        _SINKS.clear()
+
+
+def recent_panics() -> List[Panic]:
+    with _LOCK:
+        return list(_PANICS)
+
+
+def report(
+    exc: Optional[BaseException], *, message: str = "", origin: str = "",
+    clock: Optional[Callable[[], float]] = None,
+) -> Optional[Panic]:
+    """Record and BROADCAST one background failure. NEVER raises.
+
+    Returns the Panic, or None when suppressed (benign, duplicate, or the
+    master flag is off).
+    """
+    try:
+        if not panic_arbiter_enabled():
+            return None
+        now = (clock or time.time)()
+        if exc is None:
+            exc_type, tb_text = "UnknownError", ""
+        else:
+            if _is_benign(exc, message):
+                return None
+            exc_type = type(exc).__name__
+            tb_text = "".join(traceback.format_exception(
+                type(exc), exc, exc.__traceback__))[-4000:]
+        sig = _signature(exc_type, tb_text)
+        with _LOCK:
+            if sig in _SEEN:
+                return None                # a cascade is still one panic
+            _SEEN[sig] = now
+            panic = Panic(
+                kind=PANIC_KIND,
+                message=str(message or (str(exc) if exc else "unknown"))[:400],
+                exc_type=exc_type, traceback_text=tb_text,
+                origin=str(origin or "unknown")[:80],
+                signature=sig, at_unix=float(now),
+            )
+            _PANICS.append(panic)
+            del _PANICS[:-_MAX_RETAINED]
+            sinks = list(_SINKS)
+        # Logged FIRST, so a dead bridge cannot cost us the record.
+        logger.error("[PANIC] %s: %s (origin=%s)\n%s",
+                     exc_type, panic.message, panic.origin, tb_text)
+        payload = panic.as_payload()
+        for sink in sinks:
+            try:
+                sink(payload)
+            except Exception:  # noqa: BLE001
+                logger.debug("[PanicArbiter] sink failed", exc_info=True)
+        return panic
+    except Exception:  # noqa: BLE001
+        # An arbiter that raises is a second silent death.
+        try:
+            logger.debug("[PanicArbiter] report degraded", exc_info=True)
+        except Exception:  # noqa: BLE001
+            pass
+        return None
+
+
+def arbitrate(loop: Any, context: dict) -> None:
+    """``loop.set_exception_handler`` target — the BACKSTOP detector.
+
+    Catches what :func:`spawn_supervised` cannot see: callback errors,
+    transport faults, library-spawned tasks, and GC-time leaks from code
+    that never adopted supervision. NEVER raises.
+    """
+    try:
+        ctx = context if isinstance(context, dict) else {}
+        message = str(ctx.get("message") or "unhandled exception in event loop")
+        exc = ctx.get("exception")
+        extras = " | ".join(
+            f"{k}={ctx[k]!r}" for k in sorted(ctx)
+            if k not in ("message", "exception")
+        )
+        report(exc if isinstance(exc, BaseException) else None,
+               message=f"{message}{(' | ' + extras) if extras else ''}",
+               origin="loop_handler")
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def install(loop: Any = None) -> bool:
+    """Install the backstop on ``loop``. Idempotent. NEVER raises."""
+    try:
+        import asyncio
+        target = loop or asyncio.get_event_loop()
+        target.set_exception_handler(arbitrate)
+        return True
+    except Exception:  # noqa: BLE001
+        logger.debug("[PanicArbiter] install degraded", exc_info=True)
+        return False
+
+
+def supervise(task: Any, *, origin: str = "") -> Any:
+    """Attach the IMMEDIATE detector to an existing task. NEVER raises.
+
+    A done-callback fires the moment the task completes with an
+    exception — no GC required, no reference-lifetime dependency. This is
+    the detector that catches a long-lived daemon's own tasks, which the
+    loop handler never sees because the daemon holds them.
+    """
+    try:
+        def _on_done(t: Any) -> None:
+            try:
+                if t.cancelled():
+                    return
+                exc = t.exception()
+                if exc is not None:
+                    # The exception's OWN text first: "detached task
+                    # died: operator_input_queue.drain" tells the operator
+                    # where and not what, and what is the actionable half.
+                    report(exc, message=f"{exc} (detached task: "
+                                        f"{origin or 'unknown'})",
+                           origin=origin or "detached_task")
+            except Exception:  # noqa: BLE001
+                pass
+        task.add_done_callback(_on_done)
+    except Exception:  # noqa: BLE001
+        pass
+    return task
+
+
+def spawn_supervised(coro: Any, *, origin: str = "") -> Any:
+    """``create_task`` that cannot die silently. NEVER raises the spawn.
+
+    The drop-in for every ``loop.create_task(...)`` whose failure would
+    otherwise be invisible.
+    """
+    import asyncio
+    task = asyncio.ensure_future(coro)
+    return supervise(task, origin=origin)
+
+
+# ---------------------------------------------------------------------------
+# Rendering — shared by the overlay and any plain-text surface
+# ---------------------------------------------------------------------------
+
+
+def render_panic(payload: Optional[dict], *, width: Optional[int] = None,
+                 max_frames: int = 12) -> List[str]:
+    """The operator-facing crash block. Pure. NEVER raises.
+
+    The LAST frames are kept, not the first: the root of a traceback is
+    usually framework scaffolding and the tail is where the organism
+    actually died.
+    """
+    try:
+        if not isinstance(payload, dict):
+            return []
+        cols = int(width) if width and int(width) > 0 else 80
+        rows = [
+            "☠  FATAL — a background task died",
+            f"   {payload.get('exc_type', '?')}: "
+            f"{str(payload.get('message') or '')[:200]}",
+            f"   origin: {payload.get('origin', '?')}",
+            "",
+        ]
+        tb = str(payload.get("traceback") or "").splitlines()
+        if tb:
+            kept = tb[-max_frames:]
+            if len(tb) > max_frames:
+                rows.append(f"   … {len(tb) - max_frames} earlier frames")
+            rows.extend(f"   {ln}" for ln in kept)
+        rows.append("")
+        rows.append("   the organism may be degraded — /status  ·  esc dismisses")
+        return [r[:cols] for r in rows]
+    except Exception:  # noqa: BLE001
+        return ["☠  FATAL — a background task died (render degraded)"]
+
+
+__all__ = [
+    "MASTER_FLAG_ENV_VAR",
+    "PANIC_KIND",
+    "PANIC_SCHEMA_VERSION",
+    "Panic",
+    "arbitrate",
+    "install",
+    "panic_arbiter_enabled",
+    "recent_panics",
+    "register_sink",
+    "render_panic",
+    "report",
+    "reset_for_tests",
+    "spawn_supervised",
+    "supervise",
+]

--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -6947,6 +6947,17 @@ class SerpentREPL:
         _previous_exc_handler = _running_loop.get_exception_handler()
 
         def _repl_loop_exception_handler(loop_, ctx_):
+            # Panic Arbiter (backstop detector). Delegation rather than a
+            # third `set_exception_handler`: this handler's curated
+            # suppression stays authoritative, and the arbiter adds the
+            # thing a log file cannot — a broadcast the operator sees.
+            try:
+                from backend.core.ouroboros.battle_test.panic_arbiter import (
+                    arbitrate as _arbitrate,
+                )
+                _arbitrate(loop_, ctx_)
+            except Exception:  # noqa: BLE001
+                pass
             msg = ctx_.get("message", "Unhandled exception in event loop")
             exc = ctx_.get("exception")
             extras = " | ".join(

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -680,6 +680,8 @@ class AttachUI:
         self._status: dict = {}
         #: Applies waiting out their rejection window, as of the last frame.
         self._pending_apply: dict = {}
+        #: Submitted-but-unprocessed operator lines, as of the last frame.
+        self._input_queue: dict = {}
         #: The sentence currently being written, if a generation is live.
         self._stream_inflight: str = ""
         self._stream_arrived: float = 0.0
@@ -1050,6 +1052,23 @@ class AttachUI:
         except Exception:  # noqa: BLE001
             return []
 
+    def _input_queue_rows(self) -> List[str]:
+        """Lines typed but not yet reached. NEVER raises.
+
+        Silent at depth 0 — a queue keeping up should be invisible. It
+        earns a row only when the operator is ahead of the organism,
+        which is exactly when a busy system is otherwise indistinguishable
+        from a dropped keystroke.
+        """
+        try:
+            from backend.core.ouroboros.battle_test.operator_input_queue import (  # noqa: E501
+                render_queue,
+            )
+            return render_queue(
+                self._input_queue, width=self._terminal_size()[0])
+        except Exception:  # noqa: BLE001
+            return []
+
     def _stream_rows(self) -> List[str]:
         """The in-flight sentence, wrapped to THIS terminal. NEVER raises.
 
@@ -1383,6 +1402,11 @@ class AttachUI:
                 # closed, and a countdown that outlives its op is telling the
                 # operator they can still stop something that already ran.
                 self._pending_apply = frame.get("pending_apply") or {}
+                # Lines the operator submitted that the organism has not
+                # reached yet. Cleared by absence for the same reason the
+                # countdown is: a stale backlog tells them work is
+                # pending that already ran.
+                self._input_queue = frame.get("input_queue") or {}
             elif isinstance(frame, dict) and frame.get(
                 "kind",
             ) == "stream_inflight":
@@ -3231,6 +3255,12 @@ async def _bipartite_attach_loop(client: Any, console: Any, ui: Any) -> None:
             stream_rows=(
                 ui._stream_rows if ui is not None
                 and hasattr(ui, "_stream_rows") else None
+            ),
+            # The operator's own backlog, directly above the caret where
+            # they are still typing.
+            queue_rows=(
+                ui._input_queue_rows if ui is not None
+                and hasattr(ui, "_input_queue_rows") else None
             ),
             seed=[
                 "[bold]💭 Karen ▸[/bold] attached — I'm listening. verbs or "

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -682,6 +682,9 @@ class AttachUI:
         self._pending_apply: dict = {}
         #: Submitted-but-unprocessed operator lines, as of the last frame.
         self._input_queue: dict = {}
+        #: The last FATAL_PANIC, until the operator dismisses it. Sticky
+        #: on purpose: a crash notice that scrolls away was never seen.
+        self._panic: dict = {}
         #: The sentence currently being written, if a generation is live.
         self._stream_inflight: str = ""
         self._stream_arrived: float = 0.0
@@ -1052,6 +1055,21 @@ class AttachUI:
         except Exception:  # noqa: BLE001
             return []
 
+    def _panic_rows(self) -> List[str]:
+        """The crash overlay's content, or []. NEVER raises."""
+        try:
+            from backend.core.ouroboros.battle_test.panic_arbiter import (
+                render_panic,
+            )
+            return render_panic(
+                self._panic, width=self._terminal_size()[0])
+        except Exception:  # noqa: BLE001
+            return []
+
+    def dismiss_panic(self) -> None:
+        """Operator acknowledged the crash. NEVER raises."""
+        self._panic = {}
+
     def _input_queue_rows(self) -> List[str]:
         """Lines typed but not yet reached. NEVER raises.
 
@@ -1420,6 +1438,14 @@ class AttachUI:
                 self._stream_is_tool = False
                 import time as _time
                 self._stream_arrived = _time.monotonic()
+            elif isinstance(frame, dict) and frame.get(
+                    "kind") == "fatal_panic":
+                # A background task died. STICKY — unlike every other live
+                # state here, this is NOT cleared by absence: the organism
+                # may be degraded, and a notice that vanishes on the next
+                # heartbeat is a notice nobody read. `/dismiss` or esc
+                # clears it.
+                self._panic = dict(frame)
             elif isinstance(frame, dict) and frame.get("kind") == "tool_stream":
                 # A running command's live tail. It shares the in-flight
                 # strip with the model's sentence rather than owning a
@@ -3261,6 +3287,12 @@ async def _bipartite_attach_loop(client: Any, console: Any, ui: Any) -> None:
             queue_rows=(
                 ui._input_queue_rows if ui is not None
                 and hasattr(ui, "_input_queue_rows") else None
+            ),
+            # The crash overlay — above everything, cleared only by the
+            # operator.
+            panic_rows=(
+                ui._panic_rows if ui is not None
+                and hasattr(ui, "_panic_rows") else None
             ),
             seed=[
                 "[bold]💭 Karen ▸[/bold] attached — I'm listening. verbs or "

--- a/tests/battle_test/test_cockpit_attach.py
+++ b/tests/battle_test/test_cockpit_attach.py
@@ -13,6 +13,8 @@ CLI item #6 mandates:
 """
 from __future__ import annotations
 
+import ast
+
 import asyncio
 import json
 import os
@@ -380,8 +382,19 @@ def test_harness_mounts_bridge_and_mirrors_chokepoint():
     assert "_start_cockpit_attach_bridge" in src
     body = src[src.index("def _repl_print"):][:2000]
     assert "publish_line" in body                  # chokepoint mirror
-    assert "_handle_repl_command" in src[
-        src.index("def _start_cockpit_attach_bridge"):][:4000]
+    # Structural, not positional. This previously asserted the name
+    # appeared within an arbitrary 4000-character window after the `def`,
+    # so adding a comment block to the function broke it while the wiring
+    # was intact. The claim is "attached input reaches the REPL handler" —
+    # which is a fact about the FUNCTION, not about byte offsets.
+    tree = ast.parse(src)
+    fn = next(
+        n for n in ast.walk(tree)
+        if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and n.name == "_start_cockpit_attach_bridge"
+    )
+    assert "_handle_repl_command" in ast.dump(fn), (
+        "attached operator input no longer reaches the REPL handler")
 
 
 def test_ov_attach_is_real_not_stub():

--- a/tests/battle_test/test_operator_input_queue.py
+++ b/tests/battle_test/test_operator_input_queue.py
@@ -1,0 +1,283 @@
+"""One meaning for "the operator submitted a line", whichever surface it came from.
+
+    serpent_flow.py:6322   result = self._on_command(line); await result
+    harness.py:4576        loop.create_task(self._handle_repl_command_for(...))
+
+Typing at the daemon terminal was ordered and backpressured. Typing the
+identical line into an attached cockpit spawned a task per line, with no
+ordering and no bound — so `/pause` then `/status` could report the
+PRE-pause state, and a pasted block became N racing handlers.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from backend.core.ouroboros.battle_test.operator_input_queue import (
+    OperatorInputQueue,
+    active_queue_snapshot,
+    render_queue,
+    set_active_queue,
+)
+
+
+async def _collector(delay: float = 0.005):
+    seen: list = []
+
+    async def handler(text, session=None):
+        await asyncio.sleep(delay)
+        seen.append(text)
+
+    q = OperatorInputQueue(handler)
+    q.start()
+    return q, seen
+
+
+class TestOrderIsPreserved:
+    @pytest.mark.asyncio
+    async def test_a_fast_paste_stays_in_submission_order(self):
+        """THE defect. N concurrent handlers finish in whatever order the
+        loop pleases."""
+        q, seen = await _collector()
+        for i in range(8):
+            q.submit(f"line {i}")
+        await asyncio.sleep(0.25)
+        assert seen == [f"line {i}" for i in range(8)]
+
+    @pytest.mark.asyncio
+    async def test_a_slow_handler_does_not_let_the_next_overtake_it(self):
+        seen: list = []
+
+        async def handler(text, session=None):
+            await asyncio.sleep(0.08 if text == "slow" else 0.0)
+            seen.append(text)
+
+        q = OperatorInputQueue(handler)
+        q.start()
+        q.submit("slow")
+        q.submit("fast")
+        await asyncio.sleep(0.3)
+        assert seen == ["slow", "fast"]
+
+    @pytest.mark.asyncio
+    async def test_submitting_never_blocks_the_caller(self):
+        """`submit` runs on the bridge's READ loop. Blocking it would
+        stall every cockpit's input, heartbeat and telemetry behind one
+        slow handler — which is why the original was fire-and-forget."""
+        q, _ = await _collector(delay=0.5)
+        loop = asyncio.get_running_loop()
+        t0 = loop.time()
+        for i in range(20):
+            q.submit(f"x{i}")
+        assert loop.time() - t0 < 0.05
+
+
+class TestItRefusesRatherThanDrops:
+    @pytest.mark.asyncio
+    async def test_nothing_submitted_is_ever_lost_silently(self):
+        """Operator intent is not telemetry. Every line is either
+        PROCESSED or REFUSED-with-a-reason; the one outcome forbidden is
+        vanishing while the operator believes it landed."""
+        processed: list = []
+
+        async def handler(text, session=None):
+            await asyncio.sleep(0.002)
+            processed.append(text)
+
+        q = OperatorInputQueue(handler, max_depth=4)
+        q.start()
+        results = [q.submit(f"x{i}") for i in range(12)]
+        await asyncio.sleep(0.4)
+        accepted = [f"x{i}" for i, r in enumerate(results) if r.accepted]
+        refused = [r for r in results if not r.accepted]
+        assert sorted(processed) == sorted(accepted)
+        assert len(accepted) + len(refused) == 12
+        assert all(r.reason for r in refused), "a line vanished without a why"
+
+    @pytest.mark.asyncio
+    async def test_refusal_carries_a_reason_and_a_count(self):
+        async def handler(text, session=None):
+            await asyncio.sleep(1.0)
+
+        q = OperatorInputQueue(handler, max_depth=2)
+        q.start()
+        results = [q.submit(f"x{i}") for i in range(5)]
+        refused = [r for r in results if not r.accepted]
+        assert refused, "a bounded queue accepted everything"
+        assert all(r.reason for r in refused)
+        assert q.refused == len(refused)
+
+    @pytest.mark.asyncio
+    async def test_empty_input_is_ignored_not_refused(self):
+        q, _ = await _collector()
+        for junk in ("", "   ", "\n", None):
+            res = q.submit(junk)
+            assert res.accepted is False
+            assert res.reason == "empty"
+
+
+class TestItCannotWedge:
+    @pytest.mark.asyncio
+    async def test_a_raising_handler_does_not_stop_the_queue(self):
+        """A consumer that dies on one bad handler wedges every later
+        line — strictly worse than the unordered path it replaced."""
+        seen: list = []
+
+        async def handler(text, session=None):
+            if text == "boom":
+                raise RuntimeError("handler died")
+            seen.append(text)
+
+        q = OperatorInputQueue(handler)
+        q.start()
+        for t in ("a", "boom", "b", "c"):
+            q.submit(t)
+        await asyncio.sleep(0.15)
+        assert seen == ["a", "b", "c"]
+
+    @pytest.mark.asyncio
+    async def test_a_sync_handler_works_too(self):
+        seen: list = []
+        q = OperatorInputQueue(lambda t, s=None: seen.append(t))
+        q.start()
+        q.submit("plain")
+        await asyncio.sleep(0.05)
+        assert seen == ["plain"]
+
+    @pytest.mark.asyncio
+    async def test_start_is_idempotent(self):
+        q, seen = await _collector()
+        first = q.start()
+        assert q.start() is first
+
+    @pytest.mark.asyncio
+    async def test_close_stops_accepting(self):
+        q, _ = await _collector()
+        await q.aclose()
+        assert q.submit("late").accepted is False
+
+
+class TestTheOperatorCanSEEIt:
+    @pytest.mark.asyncio
+    async def test_depth_zero_renders_NOTHING(self):
+        """A queue keeping up should be invisible. It earns a row only
+        when the operator is ahead of the organism."""
+        q, _ = await _collector()
+        assert render_queue(q.snapshot()) == []
+
+    @pytest.mark.asyncio
+    async def test_a_backlog_shows_depth_and_what_is_next(self):
+        """Depth alone is not enough — someone who typed three lines wants
+        to know WHICH are still waiting, or the queue is just another
+        opaque delay."""
+        async def handler(text, session=None):
+            await asyncio.sleep(0.6)
+
+        q = OperatorInputQueue(handler)
+        q.start()
+        for t in ("first goal", "second goal", "third goal"):
+            q.submit(t)
+        await asyncio.sleep(0.01)
+        rows = render_queue(q.snapshot(), width=100)
+        assert rows and "queued" in rows[0]
+        assert "second goal" in rows[0]
+
+    @pytest.mark.asyncio
+    async def test_refusals_are_surfaced(self):
+        async def handler(text, session=None):
+            await asyncio.sleep(1.0)
+
+        q = OperatorInputQueue(handler, max_depth=1)
+        q.start()
+        for i in range(4):
+            q.submit(f"x{i}")
+        rows = render_queue(q.snapshot(), width=100)
+        assert any("refused" in r for r in rows)
+
+    @pytest.mark.asyncio
+    async def test_it_rides_the_heartbeat(self):
+        """The cockpit is a different process; the depth crosses on the
+        same lane every other live state does."""
+        from backend.core.ouroboros.battle_test.attach_heartbeat import (
+            _input_queue_payload,
+        )
+
+        async def handler(text, session=None):
+            await asyncio.sleep(0.6)
+
+        q = OperatorInputQueue(handler)
+        q.start()
+        set_active_queue(q)
+        try:
+            q.submit("a")
+            q.submit("b")
+            await asyncio.sleep(0.01)
+            payload = _input_queue_payload()
+            assert payload.get("depth", 0) >= 1
+            assert payload.get("running") or payload.get("pending")
+        finally:
+            set_active_queue(None)
+
+    def test_no_live_queue_is_an_empty_payload_not_a_crash(self):
+        set_active_queue(None)
+        assert active_queue_snapshot() == {}
+
+
+class TestTheWiring:
+    def test_the_attach_path_uses_the_queue(self):
+        import inspect
+
+        from backend.core.ouroboros.battle_test import harness
+        src = inspect.getsource(harness)
+        assert "_operator_input_queue" in src
+
+    def test_the_legacy_path_survives_as_a_fallback(self):
+        """Losing ORDER is bad; losing the line entirely is worse. With
+        the master flag off — or if the queue cannot be built — the
+        original `create_task` path must still deliver the line."""
+        import ast as _ast
+        import pathlib as _p
+
+        src = _p.Path(
+            "backend/core/ouroboros/battle_test/harness.py").read_text()
+        tree = _ast.parse(src)
+        # The fallback must remain REACHABLE: a `create_task(...)` call on
+        # the same handler, outside the queue branch.
+        fallbacks = [
+            n for n in _ast.walk(tree)
+            if isinstance(n, _ast.Call)
+            and getattr(n.func, "attr", "") == "create_task"
+            and "_handle_repl_command_for" in _ast.dump(n)
+        ]
+        assert fallbacks, "the legacy delivery path was removed entirely"
+
+    def test_ops_are_NOT_serialized_only_handlers(self):
+        """`_handle_repl_command` schedules work and returns. Serializing
+        the OPS would be a different and wrong change — the organism is
+        concurrent by design."""
+        import inspect
+
+        from backend.core.ouroboros.battle_test import operator_input_queue
+        doc = inspect.getdoc(operator_input_queue) or ""
+        assert "does NOT serialize" in doc.replace("\n", " ") or \
+            "NOT serialize" in doc
+
+
+class TestNeverRaises:
+    @pytest.mark.parametrize("call", [
+        lambda: render_queue(None),
+        lambda: render_queue("junk"),
+        lambda: render_queue({"depth": "x"}),
+        lambda: active_queue_snapshot(),
+    ])
+    def test_junk_degrades(self, call):
+        assert call() is not None
+
+    @pytest.mark.asyncio
+    async def test_master_flag_off_falls_back(self, monkeypatch):
+        from backend.core.ouroboros.battle_test.operator_input_queue import (
+            input_queue_enabled,
+        )
+        monkeypatch.setenv("JARVIS_OPERATOR_INPUT_QUEUE_ENABLED", "0")
+        assert input_queue_enabled() is False

--- a/tests/battle_test/test_panic_arbiter.py
+++ b/tests/battle_test/test_panic_arbiter.py
@@ -1,0 +1,236 @@
+"""A background death the operator can see, within milliseconds.
+
+Three times in one arc a missing symbol was swallowed by a broad `except`
+and the system carried on describing a world that had stopped existing.
+The failure is not the `except` blocks — it is that a detached task can die
+and nothing tells anyone.
+"""
+from __future__ import annotations
+
+import asyncio
+import gc
+
+import pytest
+
+from backend.core.ouroboros.battle_test import panic_arbiter as pa
+
+
+@pytest.fixture(autouse=True)
+def _clean():
+    pa.reset_for_tests()
+    yield
+    pa.reset_for_tests()
+
+
+class TestTheMandateEndToEnd:
+    @pytest.mark.asyncio
+    async def test_a_raising_detached_task_trips_the_arbiter_and_the_UI(self):
+        """THE required proof: a mocked detached task raising RuntimeError
+        trips the handler, routes FATAL_PANIC through a mocked UDS
+        dispatcher, and triggers the UI overlay callback."""
+        uds_frames: list = []
+        pa.register_sink(uds_frames.append)
+        pa.install()
+
+        async def deliberate():
+            raise RuntimeError("deliberate background fault")
+
+        pa.spawn_supervised(deliberate(), origin="test.detached")
+        await asyncio.sleep(0.05)
+
+        assert uds_frames, "nothing reached the UDS dispatcher"
+        frame = uds_frames[0]
+        assert frame["type"] == pa.PANIC_KIND
+        assert frame["exc_type"] == "RuntimeError"
+        assert "deliberate background fault" in frame["message"]
+        assert "RuntimeError" in frame["traceback"]
+
+        # …and the UI overlay callback renders it.
+        from backend.core.ouroboros.cli.ov import AttachUI
+        ui = AttachUI()
+        ui._terminal_size = lambda: (100, 30)   # type: ignore[method-assign]
+        ui.on_telemetry({**frame, "kind": pa.PANIC_KIND})
+        rows = ui._panic_rows()
+        assert rows, "the overlay drew nothing"
+        assert "FATAL" in rows[0]
+        assert any("RuntimeError" in r for r in rows)
+
+
+class TestTwoDetectorsBecauseOneIsNotEnough:
+    @pytest.mark.asyncio
+    async def test_the_loop_handler_alone_MISSES_a_referenced_task(self):
+        """The load-bearing nuance. asyncio surfaces an unretrieved task
+        exception at GARBAGE COLLECTION; anything holding a reference — a
+        task registry, `self._tasks` — defers that indefinitely. A daemon
+        holding its own tasks is exactly the case that never fires."""
+        fired: list = []
+        asyncio.get_running_loop().set_exception_handler(
+            lambda loop, ctx: fired.append(ctx))
+
+        async def boom():
+            raise RuntimeError("silent death")
+
+        task = asyncio.ensure_future(boom())     # deliberately UNsupervised
+        await asyncio.sleep(0.05)
+        assert not fired, "if this passes, the GC gap closed upstream"
+        keep = task                              # a live reference
+        await asyncio.sleep(0.05)
+        assert not fired
+        del task, keep
+        gc.collect()
+        await asyncio.sleep(0.05)
+        assert fired, "the backstop should eventually fire, at GC"
+
+    @pytest.mark.asyncio
+    async def test_supervision_fires_WITHOUT_gc(self):
+        """Which is why the immediate detector exists."""
+        seen: list = []
+        pa.register_sink(seen.append)
+
+        async def boom():
+            raise RuntimeError("caught immediately")
+
+        t = pa.spawn_supervised(boom(), origin="held")
+        held = t                                  # reference kept ON PURPOSE
+        await asyncio.sleep(0.05)
+        assert seen, "the immediate detector did not fire"
+        assert held is not None
+
+    @pytest.mark.asyncio
+    async def test_the_backstop_catches_what_supervision_cannot(self):
+        """Callback errors and transport faults have no task to supervise."""
+        seen: list = []
+        pa.register_sink(seen.append)
+        pa.install()
+        asyncio.get_running_loop().call_exception_handler(
+            {"message": "transport failed", "exception": ValueError("bad frame")})
+        await asyncio.sleep(0.01)
+        assert seen and seen[0]["exc_type"] == "ValueError"
+
+
+class TestItDoesNotCryWolf:
+    def test_a_cascade_is_ONE_panic(self):
+        """Ten failures from one root must not be ten overlays."""
+        seen: list = []
+        pa.register_sink(seen.append)
+        for _ in range(10):
+            try:
+                raise RuntimeError("same root")
+            except RuntimeError as exc:
+                pa.report(exc, origin="x")
+        assert len(seen) == 1
+
+    def test_distinct_fault_SITES_are_distinct_panics(self):
+        seen: list = []
+        pa.register_sink(seen.append)
+
+        def _site_a():
+            raise ValueError("from a")
+
+        def _site_b():
+            raise TypeError("from b")
+
+        for fn in (_site_a, _site_b):
+            try:
+                fn()
+            except Exception as exc:  # noqa: BLE001
+                pa.report(exc, origin="x")
+        assert len(seen) == 2
+
+    def test_the_SAME_site_dedups_even_with_a_new_message(self):
+        """Dedup is by fault SITE on purpose. A task dying every second at
+        one line must not produce sixty overlays — and keying on the
+        message would defeat dedup entirely the moment a message contained
+        an op-id or a timestamp."""
+        seen: list = []
+        pa.register_sink(seen.append)
+        for i in range(5):
+            try:
+                raise ValueError(f"attempt {i} at op-{i}")
+            except ValueError as exc:
+                pa.report(exc, origin="x")
+        assert len(seen) == 1
+
+    @pytest.mark.parametrize("exc", [
+        asyncio.CancelledError(), KeyboardInterrupt(), SystemExit(),
+    ])
+    def test_control_flow_is_not_a_panic(self, exc):
+        """An alarm that fires on every clean shutdown trains the operator
+        to ignore the one that matters."""
+        seen: list = []
+        pa.register_sink(seen.append)
+        pa.report(exc, origin="shutdown")
+        assert seen == []
+
+    def test_anything_not_provably_benign_IS_a_panic(self):
+        """The failure this module ends is silence, so the default answer
+        is 'report it'."""
+        seen: list = []
+        pa.register_sink(seen.append)
+        pa.report(ImportError("cannot import name 'get_active_harness'"),
+                  origin="the exact shape that bit us three times")
+        assert len(seen) == 1
+
+
+class TestItReusesWhatExists:
+    def test_it_rides_the_EXISTING_uds_envelope(self):
+        """No new transport, no new frame convention: clients that predate
+        this ignore an unknown kind exactly as they always have."""
+        import inspect
+
+        from backend.core.ouroboros.battle_test import cockpit_attach
+        src = inspect.getsource(cockpit_attach.install_panic_broadcast)
+        assert "publish_telemetry_global" in src
+
+    def test_it_reuses_the_palette_FloatContainer(self):
+        import inspect
+
+        from backend.core.ouroboros.battle_test import bipartite_layout
+        src = inspect.getsource(bipartite_layout.build_bipartite_application)
+        assert "panic_rows" in src
+        assert "FloatContainer" in src
+
+    def test_both_existing_handlers_DELEGATE_rather_than_multiply(self):
+        """A third `set_exception_handler` would be the duplication we
+        were told to avoid; the two curated handlers stay authoritative."""
+        import pathlib
+        for rel in ("battle_test/serpent_flow.py", "battle_test/harness.py"):
+            src = pathlib.Path(
+                f"backend/core/ouroboros/{rel}").read_text()
+            assert "panic_arbiter" in src, rel
+
+
+class TestNeverRaises:
+    def test_the_arbiter_cannot_become_a_second_silent_death(self):
+        def _bad_sink(_p):
+            raise RuntimeError("sink exploded")
+        pa.register_sink(_bad_sink)
+        assert pa.report(ValueError("real"), origin="x") is not None
+
+    @pytest.mark.parametrize("call", [
+        lambda: pa.report(None),
+        lambda: pa.arbitrate(None, None),          # type: ignore[arg-type]
+        lambda: pa.arbitrate(None, {"junk": 1}),
+        lambda: pa.render_panic(None),
+        lambda: pa.render_panic({"traceback": None}),
+        lambda: pa.supervise(None),
+        lambda: pa.install(object()),
+    ])
+    def test_junk_degrades(self, call):
+        call()
+
+    def test_the_master_flag_silences_it(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_PANIC_ARBITER_ENABLED", "0")
+        seen: list = []
+        pa.register_sink(seen.append)
+        pa.report(RuntimeError("x"), origin="y")
+        assert seen == []
+
+    def test_the_overlay_keeps_the_LAST_frames(self):
+        """A traceback's head is framework scaffolding; the tail is where
+        the organism actually died."""
+        tb = "\n".join(f"  File \"f{i}.py\", line {i}" for i in range(40))
+        rows = pa.render_panic({"exc_type": "E", "message": "m",
+                                "traceback": tb}, max_frames=5)
+        assert any("f39.py" in r for r in rows)
+        assert not any("f0.py" in r for r in rows)


### PR DESCRIPTION
## The divergence

The same action carried **two concurrency semantics**:

| surface | dispatch | ordering |
|---|---|---|
| daemon terminal — `serpent_flow.py:6322` | `result = self._on_command(line)` → `await result` | serialized, backpressured |
| attached cockpit — `harness.py:4576` | `loop.create_task(self._handle_repl_command_for(...))` | **unordered, unbounded** |

That is not only a UX difference:

- `/pause` then `/status` could report the **pre-pause state**, because the second handler was free to finish first.
- a pasted block of N lines became **N concurrent handlers**, all racing.
- nothing showed that a submitted line had not been acted on, so a busy organism was indistinguishable from a dropped keystroke.

## A queue, not an await

Awaiting inline was never available: `_on_input` runs on the bridge's **read loop**, and blocking it would stall every attached cockpit's input, heartbeat and telemetry behind one slow handler — which is precisely why it was fire-and-forget.

So the line is enqueued on the read loop (non-blocking, order established where it is knowable) and **one consumer** awaits handlers in turn. The local surface's semantics without its blocking, and one meaning for *"the operator submitted a line"* instead of two.

**What is not serialized is the ops.** `_handle_repl_command` schedules work and returns, so a long-running op never delays the next line typed. Serializing ops would be a different — and wrong — change: the organism is concurrent by design.

## Refuses, never drops

A full queue returns a **reason**. Operator intent is not telemetry: a silently discarded goal is worse than a rejected one, because the operator believes it landed.

```
  ⋯ 3 queued · next: second goal
  ⚠ 3 refused — queue was full
```

A test pins that every submitted line is either processed or refused-with-a-why, and that the counts add up.

The consumer **survives a raising handler** — one that died on a bad line would wedge every later line, making the queue strictly worse than the unordered path it replaced. The legacy `create_task` delivery stays reachable as the master-flag-off fallback, pinned by an AST test: losing *order* is bad, losing the line entirely is worse.

## Visible

Depth rides the heartbeat like every other live cockpit state, and renders directly above the caret — nearest where the operator is typing, because it is about what **they** did. Silent at depth 0: a queue keeping up should be invisible, and earns a row only when the operator is ahead of the organism.

## Two defects found while building it

- The first heartbeat payload reached for `harness.get_active_harness()` — **which does not exist**. The ImportError was swallowed and the depth would have read `{}` forever. Replaced with the module-level publisher pattern `cockpit_attach` already uses for its active bridge. (Third time this arc that a broad `except` hid a missing symbol.)
- `test_harness_mounts_bridge_and_mirrors_chokepoint` asserted a name appeared within an **arbitrary 4000-character window** after a `def`, so adding a comment broke it while the wiring was intact. Now structural — the claim is a fact about the function, not about byte offsets.

Two of my own new tests were weak (one trivially true, one literally `assert True`) and are replaced with claims that can fail.

## Tests

**23 new; 202 green** across queue, attach, heartbeat, bipartite, multiplex, thin-client, stream and demo suites.

## Not proven

Unit tests only — not verified against a live organism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized operator input and added a panic arbiter: cockpit commands now run in submission order via an ordered, bounded queue with visible feedback, and any background task crash is broadcast and shown as a sticky overlay. This removes race conditions, prevents silent drops, and makes failures visible within milliseconds.

- **New Features**
  - `OperatorInputQueue` (default ON; toggle with `JARVIS_OPERATOR_INPUT_QUEUE_ENABLED`) serializes attached-cockpit command handlers; bounded (default 32), refuses with a reason; heartbeat carries a snapshot; `ov` renders a short strip above the caret; `bipartite_layout` plumbs `queue_rows`.
  - Panic Arbiter (default ON; toggle with `JARVIS_PANIC_ARBITER_ENABLED`): immediate detector via supervised tasks plus loop backstop; deduped by fault site; broadcasts `fatal_panic` on the existing UDS lane via `publish_telemetry_global`; `ov` shows a sticky crash overlay; `bipartite_layout` plumbs `panic_rows`; `harness` and `serpent_flow` delegate to the arbiter.

- **Bug Fixes**
  - Unified semantics across surfaces: `/pause` then `/status` is consistent; pasted blocks no longer race.
  - Queue consumer survives handler errors; legacy `create_task` path remains as a fallback when disabled or on construction failure.
  - Fixed first-heartbeat publisher bug (replaced missing harness getter with a module-level publisher); tightened a brittle test to a structural assertion.

<sup>Written for commit c899c6de3aacb16ed11e755e02ac76990e5384c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

