### PR TITLE
feat(ov): the demo shows the queue and the panic overlay too

### DIFF
--- a/backend/core/ouroboros/cli/ov_demo.py
+++ b/backend/core/ouroboros/cli/ov_demo.py
@@ -937,6 +937,83 @@ def _running_rows(elapsed: float, width: int) -> List[str]:
         return []
 
 
+#: When the operator is AHEAD of the organism — lines typed that it has
+#: not reached yet. Overlaps a busy window on purpose: a backlog only
+#: exists while something else is running.
+_BACKLOG = (11.0, 14.6)
+_BACKLOG_LINES = ("harden the vision floor", "then re-run the suite",
+                  "and open a PR")
+
+#: When a background task dies. Late, so the operator has watched a normal
+#: session first and sees the contrast.
+_PANIC_AT = (24.0, 30.0)
+
+
+def _queue_rows(elapsed: float, width: int) -> List[str]:
+    """The operator's own backlog, through the REAL renderer. NEVER raises.
+
+    Built from an actual queue snapshot shape rather than a drawn string,
+    so a regression in `render_queue` — the depth-0 silence rule, the
+    next-item preview, the refusal notice — shows up here.
+    """
+    try:
+        from backend.core.ouroboros.battle_test.operator_input_queue import (
+            render_queue,
+        )
+        lo, hi = _BACKLOG
+        if not (lo <= elapsed <= hi):
+            return []
+        # Drain one line at a time across the window.
+        done = int(((elapsed - lo) / max(0.01, hi - lo)) * (
+            len(_BACKLOG_LINES) + 1))
+        pending = list(_BACKLOG_LINES[done:])
+        if not pending:
+            return []
+        return render_queue({
+            "depth": len(pending),
+            "refused": 0,
+            "running": _BACKLOG_LINES[max(0, done - 1)],
+            "pending": pending,
+        }, width=width)
+    except Exception:  # noqa: BLE001
+        logger.debug("[OvDemo] queue strip unavailable", exc_info=True)
+        return []
+
+
+def _panic_rows(elapsed: float, width: int) -> List[str]:
+    """The FATAL_PANIC overlay, through the REAL renderer. NEVER raises.
+
+    The traceback is a genuine one — captured by actually raising — so the
+    demo exercises `render_panic`'s frame selection (it keeps the LAST
+    frames, because a traceback's head is framework scaffolding) rather
+    than a pre-formatted block that would keep looking right forever.
+    """
+    try:
+        import traceback as _tb
+
+        from backend.core.ouroboros.battle_test.panic_arbiter import (
+            render_panic,
+        )
+        lo, hi = _PANIC_AT
+        if not (lo <= elapsed <= hi):
+            return []
+        try:
+            raise RuntimeError(
+                "cannot import name 'get_active_harness' from harness")
+        except RuntimeError as exc:
+            tb = "".join(_tb.format_exception(type(exc), exc,
+                                              exc.__traceback__))
+        return render_panic({
+            "exc_type": "ImportError",
+            "message": "cannot import name 'get_active_harness' from harness",
+            "origin": "doc_staleness.sweep",
+            "traceback": tb,
+        }, width=width)
+    except Exception:  # noqa: BLE001
+        logger.debug("[OvDemo] panic overlay unavailable", exc_info=True)
+        return []
+
+
 def _stream_rows(elapsed: float, mux: Any = None) -> List[str]:
     """Strip rows for the demo, through the COCKPIT's renderer. NEVER raises.
 
@@ -1138,6 +1215,16 @@ def scene_live(console: Any, argv: Sequence[str] = ()) -> int:
         # else — the operator knew spend was happening and could not see what
         # for. Same words, revealed, then landing in the deck as the line
         # they became.
+        # The operator's backlog and the crash overlay, both through the
+        # cockpit's own renderers.
+        queue_rows=lambda: _queue_rows(
+            (clock() - start[0]) * speed,
+            __import__("shutil").get_terminal_size((80, 24)).columns,
+        ),
+        panic_rows=lambda: _panic_rows(
+            (clock() - start[0]) * speed,
+            __import__("shutil").get_terminal_size((80, 24)).columns,
+        ),
         stream_rows=lambda: _stream_rows(
             (clock() - start[0]) * speed, mux,
         ),

--- a/tests/battle_test/test_operator_input_queue.py
+++ b/tests/battle_test/test_operator_input_queue.py
@@ -281,3 +281,31 @@ class TestNeverRaises:
         )
         monkeypatch.setenv("JARVIS_OPERATOR_INPUT_QUEUE_ENABLED", "0")
         assert input_queue_enabled() is False
+
+
+class TestTheDemoShowsIt:
+    """`ov demo live` is where this gets WATCHED. A surface only the real
+    organism can drive is a surface nobody checks."""
+
+    def test_the_backlog_appears_and_drains(self):
+        from backend.core.ouroboros.cli import ov_demo as d
+        lo, hi = d._BACKLOG
+        assert d._queue_rows(lo + 0.2, 90), "no backlog during the window"
+        assert d._queue_rows(hi + 2.0, 90) == [], "it never drained"
+
+    def test_it_is_silent_outside_the_window(self):
+        from backend.core.ouroboros.cli import ov_demo as d
+        assert d._queue_rows(1.0, 90) == []
+
+    def test_it_uses_the_COCKPITS_renderer(self):
+        import inspect
+
+        from backend.core.ouroboros.cli import ov_demo as d
+        assert "render_queue" in inspect.getsource(d._queue_rows)
+
+    def test_the_demo_MOUNTS_it(self):
+        import inspect
+
+        from backend.core.ouroboros.cli import ov_demo as d
+        src = inspect.getsource(d.scene_live)
+        assert "queue_rows=" in src and "panic_rows=" in src

--- a/tests/battle_test/test_panic_arbiter.py
+++ b/tests/battle_test/test_panic_arbiter.py
@@ -234,3 +234,25 @@ class TestNeverRaises:
                                 "traceback": tb}, max_frames=5)
         assert any("f39.py" in r for r in rows)
         assert not any("f0.py" in r for r in rows)
+
+
+class TestTheDemoShowsIt:
+    def test_the_overlay_appears_in_the_demo(self):
+        from backend.core.ouroboros.cli import ov_demo as d
+        lo, _hi = d._PANIC_AT
+        rows = d._panic_rows(lo + 0.5, 90)
+        assert rows and "FATAL" in rows[0]
+
+    def test_it_is_absent_before_the_fault(self):
+        from backend.core.ouroboros.cli import ov_demo as d
+        assert d._panic_rows(1.0, 90) == []
+
+    def test_it_uses_a_REAL_traceback(self):
+        """A pre-formatted block would keep looking right through a
+        regression in `render_panic`'s frame selection."""
+        import inspect
+
+        from backend.core.ouroboros.cli import ov_demo as d
+        src = inspect.getsource(d._panic_rows)
+        assert "render_panic" in src
+        assert "format_exception" in src


### PR DESCRIPTION
## Answering the question directly: it did not

`ov demo live` drove `stream_rows` and the collapse beat. Nothing drove `queue_rows` (#70254) or `panic_rows` — the two most recent surfaces were watchable only by provoking a real backlog or a real crash.

## What it shows now

The operator ahead of the organism:

```
  ⋯ 3 queued · next: harden the vision floor
  ⋯ 1 queued · next: and open a PR
```

A background task dying:

```
  ☠  FATAL — a background task died
     ImportError: cannot import name 'get_active_harness' from harness
     origin: doc_staleness.sweep

     Traceback (most recent call last):
       File ".../ov_demo.py", line 921, in _panic_rows
     RuntimeError: cannot import name 'get_active_harness' from harness
```

(That message is the real one from this arc — the third swallowed ImportError.)

## Through the real renderers

Per this module's own rule — *"a demo with its own draw path is worse than no demo"*:

- the backlog builds an actual **queue-snapshot shape** and calls `render_queue`, so the depth-0 silence rule, the next-item preview and the refusal notice are exercised rather than drawn
- the panic captures a **genuine traceback by raising**, then calls `render_panic`. A pre-formatted block would keep looking correct through a regression in its frame selection — it keeps the *last* frames, because a traceback's head is framework scaffolding

## Timed to mean something

The backlog overlaps a busy window, because an operator is only ever ahead of the organism while something else is running. The panic lands late, so a normal session is watched first and the contrast is visible.

## Tests

**7 new** pinning that both appear, both are silent outside their window, both call the real renderer, and the demo actually mounts them. **120 green** across queue, panic, demo, stream and attach suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The live demo now shows the operator input queue and the fatal panic overlay through the cockpit’s real renderers. This makes both surfaces watchable and verifiable without triggering real backlogs or crashes.

- **New Features**
  - `queue_rows`: builds a real queue snapshot and calls `render_queue`; appears only during `_BACKLOG` (11.0–14.6s) and drains line by line.
  - `panic_rows`: captures a genuine traceback by raising and calls `render_panic`; appears only during `_PANIC_AT` (24.0–30.0s).
  - Wired both into `scene_live` (via `queue_rows=` and `panic_rows=`) with terminal width detection so they render correctly alongside `stream_rows`.

<sup>Written for commit 0574b40568f99e78d93ad45c3691ff00e5015f0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

