### PR TITLE
feat(ov): one owner for what a colour MEANS, and a ratchet on the rest

### DIFF
--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -228,19 +228,58 @@ def is_repl_active() -> bool:
 # Color palette (organism theme)
 # ══════════════════════════════════════════════════════════════
 
-_C = {
-    "life": "bright_green",      # awakening, success, evolved
-    "neural": "cyan",            # thinking, processing, phases
-    "provider": "magenta",       # external brains (DW, Claude, J-Prime)
-    "file": "blue underline",    # file paths — clickable feel
-    "heal": "yellow",            # repair, immune response, caution
-    "death": "red",              # failure, rejection, shed
-    "dim": "dim",                # metadata (IDs, costs, timestamps)
-    "border": "dim",             # box-drawing borders
-    "code_add": "green",         # diff: added lines
-    "code_del": "red",           # diff: removed lines
-    "code_hunk": "cyan",         # diff: @@ hunk headers
-}
+# The cockpit's semantic roles:
+#   life      awakening, success, evolved      code_add   diff: added
+#   neural    thinking, phases                 code_del   diff: removed
+#   provider  external brains (DW/Claude)      code_hunk  diff: @@ headers
+#   file      paths — clickable feel           dim        metadata
+#   heal      repair, caution                  border     box-drawing
+#   death     failure, rejection, shed
+#
+# DERIVED from `ui.semantic_tokens`, not declared. This was a second,
+# independent palette of flat standard-ANSI names while `ui/theme.py`
+# owned a hex PALETTE and a ColorTier ladder — so on a truecolor terminal
+# theme-aware surfaces rendered hex and every `_C` line rendered plain
+# ANSI, at visibly different fidelity in the same session.
+#
+# A `dict` subclass rather than a snapshot: ColorTier is a property of the
+# TERMINAL, and a palette frozen at import outlives a resize, a
+# `--no-color` flip, or a client attaching from a different terminal than
+# the daemon booted on. Every `_C['death']` in this file keeps working
+# unchanged and now resolves live.
+class _SemanticPalette(dict):
+    """Role → resolved style, asked fresh. NEVER raises."""
+
+    def __missing__(self, key):
+        try:
+            from backend.core.ouroboros.ui.semantic_tokens import style_for
+            return style_for(key)
+        except Exception:  # noqa: BLE001
+            return ""
+
+    def __getitem__(self, key):
+        try:
+            from backend.core.ouroboros.ui.semantic_tokens import style_for
+            resolved = style_for(key)
+            if resolved:
+                return resolved
+        except Exception:  # noqa: BLE001
+            pass
+        return dict.get(self, key, "")
+
+    def get(self, key, default=""):
+        return self.__getitem__(key) or default
+
+
+_C = _SemanticPalette({
+    # Retained as the last-resort literals ONLY: if the theme cannot be
+    # consulted at all, rendering degrades to exactly what shipped before
+    # this projection existed — never to uncoloured, never to something new.
+    "life": "bright_green", "neural": "cyan", "provider": "magenta",
+    "file": "blue underline", "heal": "yellow", "death": "red",
+    "dim": "dim", "border": "dim", "code_add": "green",
+    "code_del": "red", "code_hunk": "cyan",
+})
 
 # Provider display names
 _PROV = {

--- a/backend/core/ouroboros/ui/semantic_tokens.py
+++ b/backend/core/ouroboros/ui/semantic_tokens.py
@@ -1,0 +1,171 @@
+"""What a colour MEANS, resolved once, for every surface.
+
+`ui/theme.py` owns colour: a hex `PALETTE`, a `_SEMANTIC_STD` map, and a
+`ColorTier` ladder (NONE / STANDARD / C256 / TRUECOLOR) that resolves a
+meaning to the best form a given terminal can actually show.
+
+`serpent_flow._C` was a second, independent palette — a flat dict of
+standard-ANSI names. So the two did not merely risk drifting apart: on a
+truecolor terminal the theme-aware surfaces rendered hex while every
+`_C`-coloured line rendered plain ANSI, at visibly different fidelity, in
+the same session.
+
+And 256 call sites bypassed both, writing bracketed colour names directly. The
+question "what colour is a failure" was answered independently 256 times,
+with nothing able to detect divergence.
+
+The vocabulary was never the problem
+====================================
+`_C`'s roles are good, and map almost exactly onto Claude Code's scheme —
+which is *semantic, not decorative*: the action verb is bold and
+uncoloured, paths are cyan, green appears only for additions and
+outcomes, yellow means "needs you", dim means metadata. The load-bearing
+rule is SCARCITY: when green is also chrome, a successful outcome stops
+being visible.
+
+So this module does not invent a vocabulary. It gives the existing one a
+single owner:
+
+    role  ("death", "life", "file", …)   what the cockpit calls it
+      ↓
+    semantic ("crit", "ok", "info", …)   what the theme calls it
+      ↓
+    tier-resolved style                  what THIS terminal can show
+
+`_C` becomes a projection of this, so no call site changes and nothing
+breaks — but there is exactly one answer to every colour question, and it
+is tier-aware everywhere instead of in half the codebase.
+
+NEVER raises. A surface that cannot resolve a colour must still render
+text; losing the colour is a cosmetic failure, losing the line is not.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Dict, Optional
+
+logger = logging.getLogger("Ouroboros.SemanticTokens")
+
+SEMANTIC_TOKENS_SCHEMA_VERSION = "semantic_tokens.v1"
+
+#: Cockpit ROLE → theme SEMANTIC. The only place the two vocabularies are
+#: connected. Roles are what the operator-facing code already says; the
+#: semantics are what `theme` already resolves. Neither side is rewritten
+#: to suit the other — a translation table between two existing, correct
+#: vocabularies is smaller and safer than a migration of either.
+_ROLE_TO_SEMANTIC: Dict[str, str] = {
+    # outcomes — the scarce ones. Green means "succeeded" or "added" and
+    # nothing else, which is what makes it readable at a glance.
+    "life": "ok_bold",
+    "code_add": "ok",
+    # failure
+    "death": "crit",
+    "code_del": "crit",
+    # needs-you
+    "heal": "warn",
+    # thinking / structure
+    "neural": "cyan",
+    "code_hunk": "cyan",
+    # external brains
+    "provider": "venom_purple",
+    # metadata — ids, costs, timings. The most common role, deliberately
+    # the quietest.
+    "dim": "muted",
+    "border": "faint",
+    "verbose": "verbose",
+    # paths get their own treatment below (underline is not a colour).
+    "file": "info",
+}
+
+#: Roles whose rendering carries a non-colour attribute. Kept separate
+#: because a tier that cannot do colour can still do underline, and
+#: conflating them loses the affordance on exactly the terminals that
+#: need it most.
+_ROLE_ATTRS: Dict[str, str] = {
+    "file": "underline",
+}
+
+def semantic_for(role: str) -> str:
+    """The theme semantic a cockpit role maps to. Pure. NEVER raises."""
+    try:
+        return _ROLE_TO_SEMANTIC.get(str(role or "").strip().lower(), "ink")
+    except Exception:  # noqa: BLE001
+        return "ink"
+
+
+def style_for(role: str, *, tier: Optional[object] = None) -> str:
+    """The resolved style string for ``role`` on this terminal.
+
+    Asks `theme` rather than restating it, so a palette change or a tier
+    downgrade reaches every surface at once. NEVER raises, and returns ""
+    when it cannot resolve — the caller's retained seed is the ONE place
+    the historical literals live, so this module never holds a second
+    copy of them. A missing colour is cosmetic; a missing line is not.
+    """
+    key = str(role or "").strip().lower()
+    try:
+        from backend.core.ouroboros.ui import theme as _theme
+        semantic = semantic_for(key)
+        resolved = ""
+        # `theme` is the authority. Its accessor has changed shape before,
+        # so ask in order of specificity rather than binding to one name.
+        for attr in ("semantic_style", "style_for_semantic", "resolve_style"):
+            fn = getattr(_theme, attr, None)
+            if callable(fn):
+                try:
+                    resolved = str(fn(semantic) or "")
+                except Exception:  # noqa: BLE001
+                    resolved = ""
+                if resolved:
+                    break
+        if not resolved:
+            table = getattr(_theme, "_SEMANTIC_STD", None)
+            if isinstance(table, dict):
+                resolved = str(table.get(semantic) or "")
+        attr_extra = _ROLE_ATTRS.get(key, "")
+        if attr_extra and attr_extra not in resolved:
+            resolved = f"{resolved} {attr_extra}".strip()
+        return resolved
+    except Exception:  # noqa: BLE001
+        logger.debug("[SemanticTokens] resolve degraded for %r", key,
+                     exc_info=True)
+        # "" on purpose: the caller's retained seed is the ONE place the
+        # historical literals live, and `_SemanticPalette` falls through
+        # to it. A copy here would be a second palette again — the exact
+        # defect this module exists to remove.
+        return ""
+
+
+def sem(role: str) -> str:
+    """Short alias — the call-site spelling.
+
+    Named for the QUESTION ("what does this mean") rather than the answer
+    ("red"), which is the whole point: a call site that says `sem("death")`
+    keeps meaning the right thing when the palette changes, and one that
+    says a literal colour does not.
+    """
+    return style_for(role)
+
+
+def role_palette() -> Dict[str, str]:
+    """Every role → its resolved style. The projection `_C` becomes.
+
+    Built fresh rather than cached: `ColorTier` is a property of the
+    terminal, and a cached palette computed during import would outlive a
+    resize, a `--no-color` flip, or a client attaching from a different
+    terminal than the daemon booted on. The cost is a dict comprehension
+    over a dozen keys.
+    """
+    try:
+        return {role: style_for(role) for role in _ROLE_TO_SEMANTIC}
+    except Exception:  # noqa: BLE001
+        return {}
+
+
+__all__ = [
+    "SEMANTIC_TOKENS_SCHEMA_VERSION",
+    "role_palette",
+    "sem",
+    "semantic_for",
+    "style_for",
+]

--- a/tests/battle_test/test_semantic_colour_tokens.py
+++ b/tests/battle_test/test_semantic_colour_tokens.py
@@ -1,0 +1,168 @@
+"""One answer to "what colour does this mean", and a ratchet on the rest.
+
+`ui/theme.py` owned a hex PALETTE and a ColorTier ladder. `serpent_flow._C`
+was a SECOND, independent palette of flat standard-ANSI names. They did not
+merely risk drifting: on a truecolor terminal the theme-aware surfaces
+rendered hex while every `_C` line rendered plain ANSI, at different
+fidelity, in the same session.
+
+And 365 call sites bypassed both with raw `[red]` / `[cyan]` literals — so
+"what colour is a failure" was answered independently 365 times, with
+nothing able to notice divergence.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+
+from backend.core.ouroboros.ui.semantic_tokens import (
+    role_palette,
+    sem,
+    semantic_for,
+    style_for,
+)
+
+
+class TestOneOwner:
+    def test_the_cockpit_palette_is_DERIVED_not_declared(self):
+        """`_C` was a second palette. It is now a projection — every
+        `_C['death']` in serpent_flow resolves through the theme."""
+        from backend.core.ouroboros.battle_test.serpent_flow import _C
+        assert _C["death"] == style_for("death")
+        assert _C["life"] == style_for("life")
+
+    def test_it_resolves_LIVE_not_at_import(self):
+        """ColorTier is a property of the terminal. A palette frozen at
+        import outlives a resize, a --no-color flip, or a client attaching
+        from a different terminal than the daemon booted on."""
+        from backend.core.ouroboros.battle_test import serpent_flow
+        assert type(serpent_flow._C).__name__ == "_SemanticPalette"
+
+    def test_every_role_maps_to_a_theme_semantic(self):
+        for role in role_palette():
+            assert semantic_for(role) != "ink", role
+
+    def test_a_theme_change_reaches_the_cockpit(self, monkeypatch):
+        """The point of one owner. Repaint the theme, and `_C` follows —
+        which a second literal dict could never do."""
+        from backend.core.ouroboros.ui import theme
+        from backend.core.ouroboros.battle_test.serpent_flow import _C
+        table = dict(getattr(theme, "_SEMANTIC_STD", {}))
+        table["crit"] = "bold magenta"
+        monkeypatch.setattr(theme, "_SEMANTIC_STD", table, raising=False)
+        assert "magenta" in _C["death"]
+
+
+class TestTheVocabularyMatchesClaudeCode:
+    def test_green_is_SCARCE(self):
+        """CC's load-bearing rule: green means "succeeded" or "added" and
+        nothing else. When green is also chrome, a successful outcome
+        stops being visible."""
+        greens = [r for r, s in role_palette().items() if "green" in s]
+        assert set(greens) <= {"life", "code_add"}, greens
+
+    def test_paths_are_cyan_and_underlined(self):
+        """CC renders paths as clickable-feeling. Underline is carried
+        separately from colour, so a terminal that cannot do colour keeps
+        the affordance."""
+        style = style_for("file")
+        assert "underline" in style
+
+    def test_failure_and_removal_share_one_colour(self):
+        assert style_for("death") == style_for("code_del")
+
+    def test_metadata_is_the_quietest_role(self):
+        assert style_for("dim") in ("dim", "bright_black", "grey50")
+
+
+class TestItNeverBreaksRendering:
+    @pytest.mark.parametrize("role", ["", None, "not_a_role", 42])
+    def test_an_unknown_role_still_returns_a_string(self, role):
+        assert isinstance(style_for(role), str)   # type: ignore[arg-type]
+
+    def test_a_dead_theme_yields_NO_second_copy_of_the_literals(
+            self, monkeypatch):
+        """It returns "" rather than its own fallback table.
+
+        The first draft kept a `_FALLBACK` dict here — which was a second
+        palette again, the exact defect this module removes, and it also
+        tripped `tests/ui/test_theme_guard.py`'s ban on literal styling in
+        `ui/`. One fix removed both: the historical literals live in
+        exactly one place (serpent_flow's retained seed) and the caller
+        falls through to them."""
+        import backend.core.ouroboros.ui.semantic_tokens as st
+
+        def _boom(*a, **k):
+            raise RuntimeError("theme unavailable")
+
+        monkeypatch.setattr(st, "semantic_for", _boom)
+        assert st.style_for("death") == ""
+        src = pathlib.Path(
+            "backend/core/ouroboros/ui/semantic_tokens.py").read_text()
+        assert "_FALLBACK" not in src, "a second palette grew back"
+
+    def test_the_cockpit_palette_survives_a_dead_theme(self, monkeypatch):
+        import backend.core.ouroboros.ui.semantic_tokens as st
+        from backend.core.ouroboros.battle_test.serpent_flow import _C
+        monkeypatch.setattr(
+            st, "style_for", lambda *a, **k: (_ for _ in ()).throw(
+                RuntimeError("down")))
+        assert _C["death"] == "red"      # the retained fallback literal
+
+
+# ---------------------------------------------------------------------------
+# The ratchet
+# ---------------------------------------------------------------------------
+
+#: Raw colour literals remaining, by package. A RATCHET: these numbers may
+#: only ever go DOWN. They are not a target and not a budget — they are the
+#: measured size of the migration, recorded so that the bleeding stops
+#: immediately while the existing sites are converted in batches.
+#:
+#: Touching 365 render sites in one sweep is exactly where a mistyped token
+#: silently produces plain text and no test notices, which is why the fix
+#: is "stop new ones now, migrate incrementally" rather than one change.
+_RAW_LITERAL_CEILING = {
+    "backend/core/ouroboros/battle_test": 244,
+    "backend/core/ouroboros/cli": 12,
+    "backend/core/ouroboros/ui": 3,
+    "backend/core/ouroboros/governance": 106,
+}
+
+_RAW = re.compile(
+    r"\[/?(?:bright_)?(?:red|green|yellow|blue|magenta|cyan|white|black)\b"
+    r"[^\]]*\]")
+
+
+def _count(root: str) -> int:
+    n = 0
+    for path in pathlib.Path(root).rglob("*.py"):
+        if "__pycache__" in str(path):
+            continue
+        n += len(_RAW.findall(path.read_text(errors="ignore")))
+    return n
+
+
+@pytest.mark.parametrize("root", sorted(_RAW_LITERAL_CEILING))
+def test_raw_colour_literals_only_ever_decrease(root):
+    """A call site that says `[red]` stops meaning the right thing the
+    moment the palette changes; one that says `sem("death")` does not.
+
+    This fails on a NEW raw literal, so the count cannot grow while the
+    migration is in progress. When it drops, lower the ceiling — a ratchet
+    that is never tightened is just a comment.
+    """
+    found = _count(root)
+    ceiling = _RAW_LITERAL_CEILING[root]
+    assert found <= ceiling, (
+        f"{root}: {found} raw colour literals, ceiling {ceiling}. "
+        f"Use sem('<role>') from ui.semantic_tokens instead of a literal "
+        f"colour — the role keeps meaning the right thing when the palette "
+        f"changes."
+    )
+    assert found >= ceiling - 40, (
+        f"{root}: down to {found} from {ceiling} — lower the ceiling in "
+        f"_RAW_LITERAL_CEILING so the ratchet keeps holding."
+    )


### PR DESCRIPTION
## What CC does, and what `ov` was doing

CC's colour is **semantic, not decorative** — the action verb bold and uncoloured, paths cyan, green **only** for additions and outcomes, yellow for "needs you", dim for metadata. The load-bearing rule is **scarcity**: when green is also chrome, a successful outcome stops being visible.

`ov` already had that vocabulary. It had it **twice**:

- `ui/theme.py` — hex `PALETTE` + a `ColorTier` ladder (NONE / STANDARD / C256 / TRUECOLOR)
- `serpent_flow._C` — a second, independent flat dict of standard-ANSI names

So on a truecolor terminal, theme-aware surfaces rendered hex while every `_C`-coloured line rendered plain ANSI — **different fidelity, same session**. And **365 call sites** bypassed both with literal bracketed colours, answering "what colour is a failure" independently 365 times with nothing able to notice divergence.

## One owner

```
role ("death")  →  theme semantic ("crit")  →  tier-resolved style
```

`_C` becomes a **live projection** via a dict subclass, so every existing `_C['death']` keeps working untouched and now resolves through the theme. Zero call-site churn.

A projection rather than a snapshot because **ColorTier is a property of the terminal**: a palette frozen at import outlives a resize, a `--no-color` flip, or a client attaching from a different terminal than the daemon booted on. Pinned by a test that repaints the theme and asserts `_C` follows — something a second literal dict could never do.

Only `file` changes visibly: **blue → cyan underline**, which is what CC uses for paths. Underline is carried separately from colour, so a terminal that cannot do colour keeps the affordance.

## The ratchet

Migrating 365 render sites in one sweep is exactly where a mistyped token silently produces plain text and no test notices. So the bleeding stops now and the migration proceeds in batches:

| package | ceiling |
|---|---|
| `battle_test` | 244 |
| `governance` | 106 |
| `cli` | 12 |
| `ui` | 3 |

These may only ever **decrease**. The test fails on a new literal, and tells you to lower the ceiling when the count drops — *a ratchet that is never tightened is just a comment.*

## Two defects found by running it

- The first draft carried its own `_FALLBACK` literal table — **a second palette again**, the exact defect being removed — and it tripped the *existing* `tests/ui/test_theme_guard.py` ban on literal styling in `ui/`. One fix removed both: the historical literals now live in exactly one place (serpent_flow's retained seed) and the caller falls through to them.
- My docstring's bracketed examples tripped the same guard, which cannot tell an example from an instruction — the second time this arc my own prose failed a structural test.

## Tests

**18 new; 142 green** across rendering, cockpit, panic, demo and presentation suites.

Pre-existing and untouched: `tests/ui/test_theme_guard.py` fails on `alt_screen.py`'s raw ANSI — verified red on clean `main`.

## Next

Steps 1–3 are this PR. Step 4 is the incremental migration of the 365, highest-traffic renderers first, each batch lowering its ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies color semantics under the theme and makes `_C` a live, tier‑aware projection for consistent styling across terminals. Adds a ratchet to block new raw color literals and begins incremental migration; paths now render as cyan with underline.

- **Refactors**
  - Added `ui/semantic_tokens.py`: role → semantic → tier‑resolved style; never raises.
  - Replaced `serpent_flow._C` with a projection backed by `semantic_tokens`; keeps previous literals as last‑resort fallback.
  - `file` role: cyan + underline; underline preserved even without color.
  - Green remains scarce (only `life` and `code_add`).
  - 18 new tests cover projection, tier changes, and semantics.

- **Migration**
  - No call‑site changes; existing `_C['role']` continues to work.
  - New test enforces ceilings for raw `[color]` literals; counts may only decrease: `battle_test` 244, `governance` 106, `cli` 12, `ui` 3.
  - When counts drop, lower the ceiling in the test.

<sup>Written for commit 07fd8ff1dfa8bf1527c3df21a21acb124a68ecd1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

