### PR TITLE
refactor(ov): migrate governance colours to semantic roles — 106 to 25

### DIFF
--- a/backend/core/ouroboros/governance/claude_style_transport.py
+++ b/backend/core/ouroboros/governance/claude_style_transport.py
@@ -80,6 +80,14 @@ import time
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
+from backend.core.ouroboros.ui.semantic_tokens import (  # noqa: E402
+    role_palette as _role_palette,
+)
+
+#: Semantic colour roles — the SAME name and access pattern as every
+#: other module. One vocabulary, one spelling, one owner.
+_SEM = _role_palette()
+
 logger = logging.getLogger(__name__)
 
 
@@ -407,7 +415,7 @@ class ClaudeStyleTransport:
                 if len(files) > 1:
                     files_repr += f" [dim]+{len(files) - 1}[/dim]"
             self._safe_print(
-                f"[green]{OpStatusGlyph.DONE.value}[/green] "
+                f"[{_SEM['success']}]{OpStatusGlyph.DONE.value}[/] "
                 f"[bold]{state.sensor}[/bold]([dim]{state.short_id}[/dim])"
                 f" done [dim]({elapsed})[/dim]{files_repr}"
             )
@@ -418,9 +426,9 @@ class ClaudeStyleTransport:
         if outcome in ("failed", "postmortem"):
             reason = str(payload.get("reason_code", "") or "")[:60]
             self._safe_print(
-                f"[red]{OpStatusGlyph.FAILED.value}[/red] "
+                f"[{_SEM['death']}]{OpStatusGlyph.FAILED.value}[/] "
                 f"[bold]{state.sensor}[/bold]([dim]{state.short_id}[/dim])"
-                f" shed: [red]{reason}[/red] [dim]({elapsed})[/dim]"
+                f" shed: [{_SEM['death']}]{reason}[/] [dim]({elapsed})[/dim]"
             )
             self._failed_count += 1
             self._feed_composer()
@@ -441,13 +449,13 @@ class ClaudeStyleTransport:
             files_repr = ""
             if files:
                 first = str(files[0])[:40]
-                files_repr = f" [yellow]{first}[/yellow]"
+                files_repr = f" [{_SEM['heal']}]{first}[/]"
                 if len(files) > 1:
                     files_repr += f" [dim]+{len(files) - 1}[/dim]"
             self._safe_print(
-                f"[yellow]{OpStatusGlyph.RUNNING.value}[/yellow] "
+                f"[{_SEM['heal']}]{OpStatusGlyph.RUNNING.value}[/] "
                 f"[bold]{state.sensor}[/bold]([dim]{state.short_id}[/dim])"
-                f" [yellow]NOTIFY[/yellow] auto-applying"
+                f" [{_SEM['heal']}]NOTIFY[/] auto-applying"
                 f"{files_repr} [dim]({elapsed})[/dim]"
             )
             return
@@ -455,9 +463,9 @@ class ClaudeStyleTransport:
         if outcome == "escalated":
             reason = str(payload.get("reason_code", "") or "")[:50]
             self._safe_print(
-                f"[yellow]{OpStatusGlyph.RUNNING.value}[/yellow] "
+                f"[{_SEM['heal']}]{OpStatusGlyph.RUNNING.value}[/] "
                 f"[bold]{state.sensor}[/bold]([dim]{state.short_id}[/dim])"
-                f" [yellow]escalated[/yellow] [dim]{reason}"
+                f" [{_SEM['heal']}]escalated[/] [dim]{reason}"
                 f" ({elapsed})[/dim]"
             )
             return
@@ -481,9 +489,9 @@ class ClaudeStyleTransport:
         short = state.short_id if state else _short_id(op_id)
         reason = str(payload.get("root_cause", "unknown") or "unknown")[:60]
         self._safe_print(
-            f"[red]{OpStatusGlyph.FAILED.value}[/red] "
+            f"[{_SEM['death']}]{OpStatusGlyph.FAILED.value}[/] "
             f"[bold]{sensor}[/bold]([dim]{short}[/dim])"
-            f" postmortem: [red]{reason}[/red] [dim]({elapsed})[/dim]"
+            f" postmortem: [{_SEM['death']}]{reason}[/] [dim]({elapsed})[/dim]"
         )
 
     # -- helpers -----------------------------------------------------
@@ -597,7 +605,7 @@ class ClaudeStyleTransport:
             diff_text = str(metadata.get("diff_text", "") or "")
             self._safe_print(
                 f"  [bold]Update[/bold]("
-                f"[cyan]{path}{line_repr}[/cyan])"
+                f"[{_SEM['neural']}]{path}{line_repr}[/])"
             )
             if added is not None or removed is not None:
                 stats = []

--- a/backend/core/ouroboros/governance/organism_status.py
+++ b/backend/core/ouroboros/governance/organism_status.py
@@ -60,6 +60,14 @@ import time
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional, Tuple
 
+from backend.core.ouroboros.ui.semantic_tokens import (  # noqa: E402
+    role_palette as _role_palette,
+)
+
+#: Semantic colour roles — the SAME name and access pattern as every
+#: other module. One vocabulary, one spelling, one owner.
+_SEM = _role_palette()
+
 logger = logging.getLogger(__name__)
 
 
@@ -225,7 +233,7 @@ def format_risk_tier_badge(
     token. NEVER raises.
 
     ``plain=True`` — returns plain text ``"● GREEN"``.
-    ``plain=False`` — returns Rich-markup ``"[green]● GREEN[/green]"``.
+    ``plain=False`` — returns Rich-markup ``f"[{_SEM['success']}]● GREEN[/]"``.
 
     When light is None, composes :func:`read_current_risk_light_safe`."""
     try:

--- a/backend/core/ouroboros/governance/plan_approval_repl.py
+++ b/backend/core/ouroboros/governance/plan_approval_repl.py
@@ -61,6 +61,14 @@ from backend.core.ouroboros.governance.plan_approval import (
     get_default_controller,
 )
 
+from backend.core.ouroboros.ui.semantic_tokens import (  # noqa: E402
+    role_palette as _role_palette,
+)
+
+#: Semantic colour roles — the SAME name and access pattern as every
+#: other module. One vocabulary, one spelling, one owner.
+_SEM = _role_palette()
+
 
 # --- Result dataclass ------------------------------------------------------
 
@@ -112,7 +120,7 @@ def dispatch_plan_command(
         parts = shlex.split(stripped)
     except ValueError as exc:
         return PlanDispatchResult(
-            ok=False, text="[red]Malformed /plan line: %s[/red]" % exc,
+            ok=False, text=f"[{_SEM['death']}]Malformed /plan line: %s[/]" % exc,
         )
     assert parts[0] == "/plan"
     args = parts[1:]
@@ -128,7 +136,7 @@ def dispatch_plan_command(
         return PlanDispatchResult(
             ok=False,
             text=(
-                "[red]Unknown /plan subcommand: %s[/red]  "
+                f"[{_SEM['death']}]Unknown /plan subcommand: %s[/]  "
                 "([dim]try [bold]/plan help[/bold][/dim])"
             ) % sub,
         )
@@ -147,7 +155,7 @@ def _cmd_mode(
     env = os.environ.get("JARVIS_PLAN_APPROVAL_MODE", "false")
     current = env.strip().lower() == "true"
     if not args:
-        state = "[green]ON[/green]" if current else "[dim]OFF[/dim]"
+        state = f"[{_SEM['success']}]ON[/]" if current else "[dim]OFF[/dim]"
         pending = controller.pending_count
         return PlanDispatchResult(
             ok=True,
@@ -163,20 +171,20 @@ def _cmd_mode(
         os.environ["JARVIS_PLAN_APPROVAL_MODE"] = "true"
         return PlanDispatchResult(
             ok=True,
-            text="[green]Plan approval mode ENABLED[/green]  "
+            text=f"[{_SEM['success']}]Plan approval mode ENABLED[/]  "
             "[dim](next op with a plan will halt for review)[/dim]",
         )
     if toggle == "off":
         os.environ["JARVIS_PLAN_APPROVAL_MODE"] = "false"
         return PlanDispatchResult(
             ok=True,
-            text="[yellow]Plan approval mode DISABLED[/yellow]  "
+            text=f"[{_SEM['heal']}]Plan approval mode DISABLED[/]  "
             "[dim](complex ops still gated via the complexity "
             "heuristic)[/dim]",
         )
     return PlanDispatchResult(
         ok=False,
-        text="[red]/plan mode takes 'on' or 'off'[/red]",
+        text=f"[{_SEM['death']}]/plan mode takes 'on' or 'off'[/]",
     )
 
 
@@ -208,7 +216,7 @@ def _cmd_pending(
         )
         preview = (approach or "(no approach)")[:60]
         lines.append(
-            "  [cyan]%s[/cyan]  [dim]expires in %ds[/dim]  %s" % (
+            f"  [{_SEM['neural']}]%s[/]  [dim]expires in %ds[/dim]  %s" % (
                 s["op_id"], int(remaining), preview,
             )
         )
@@ -228,14 +236,14 @@ def _cmd_show(
     if not args:
         return PlanDispatchResult(
             ok=False,
-            text="[red]/plan show requires an op-id[/red]",
+            text=f"[{_SEM['death']}]/plan show requires an op-id[/]",
         )
     op_id = args[0]
     snap = controller.snapshot(op_id)
     if snap is None:
         return PlanDispatchResult(
             ok=False,
-            text="[red]No plan registered for op=%s[/red]" % op_id,
+            text=f"[{_SEM['death']}]No plan registered for op=%s[/]" % op_id,
         )
     return PlanDispatchResult(ok=True, text=render_plan_detail(snap))
 
@@ -249,7 +257,7 @@ def _cmd_approve(
     if not args:
         return PlanDispatchResult(
             ok=False,
-            text="[red]/plan approve requires an op-id[/red]",
+            text=f"[{_SEM['death']}]/plan approve requires an op-id[/]",
         )
     op_id = args[0]
     try:
@@ -257,12 +265,12 @@ def _cmd_approve(
     except PlanApprovalStateError as exc:
         return PlanDispatchResult(
             ok=False,
-            text="[red]Cannot approve %s: %s[/red]" % (op_id, exc),
+            text=f"[{_SEM['death']}]Cannot approve %s: %s[/]" % (op_id, exc),
         )
     return PlanDispatchResult(
         ok=True,
         text=(
-            "[green]✓ Plan APPROVED for %s[/green]  "
+            f"[{_SEM['success']}]✓ Plan APPROVED for %s[/]  "
             "[dim](reviewer=%s, elapsed=%.1fs)[/dim]"
         ) % (op_id, outcome.reviewer, outcome.elapsed_s),
     )
@@ -278,7 +286,7 @@ def _cmd_reject(
         return PlanDispatchResult(
             ok=False,
             text=(
-                "[red]/plan reject requires <op-id> and a reason[/red]  "
+                f"[{_SEM['death']}]/plan reject requires <op-id> and a reason[/]  "
                 "[dim](rejection reason is mandatory — it feeds back "
                 "into future PLAN attempts)[/dim]"
             ),
@@ -290,12 +298,12 @@ def _cmd_reject(
     except PlanApprovalStateError as exc:
         return PlanDispatchResult(
             ok=False,
-            text="[red]Cannot reject %s: %s[/red]" % (op_id, exc),
+            text=f"[{_SEM['death']}]Cannot reject %s: %s[/]" % (op_id, exc),
         )
     return PlanDispatchResult(
         ok=True,
         text=(
-            "[yellow]✗ Plan REJECTED for %s[/yellow]  "
+            f"[{_SEM['heal']}]✗ Plan REJECTED for %s[/]  "
             "[dim](reviewer=%s, reason=%s)[/dim]"
         ) % (op_id, outcome.reviewer, outcome.reason),
     )
@@ -312,7 +320,7 @@ def _cmd_history(
     except ValueError:
         return PlanDispatchResult(
             ok=False,
-            text="[red]/plan history takes an integer limit[/red]",
+            text=f"[{_SEM['death']}]/plan history takes an integer limit[/]",
         )
     limit = max(1, min(limit, 500))
     history = controller.history()
@@ -363,14 +371,14 @@ _HANDLERS = {
 def _render_help() -> str:
     return (
         "[bold]/plan[/bold] commands:\n"
-        "  [cyan]/plan mode[/cyan]               show current plan-mode state\n"
-        "  [cyan]/plan mode on|off[/cyan]        toggle session-wide plan mode\n"
-        "  [cyan]/plan pending[/cyan]            list pending plans\n"
-        "  [cyan]/plan show <op-id>[/cyan]       render full plan detail\n"
-        "  [cyan]/plan approve <op-id>[/cyan]    approve a pending plan\n"
-        "  [cyan]/plan reject <op-id> <reason>[/cyan] reject with reason\n"
-        "  [cyan]/plan history [N][/cyan]        last N resolved plans (default 10)\n"
-        "  [cyan]/plan help[/cyan]               this message"
+        f"  [{_SEM['neural']}]/plan mode[/]               show current plan-mode state\n"
+        f"  [{_SEM['neural']}]/plan mode on|off[/]        toggle session-wide plan mode\n"
+        f"  [{_SEM['neural']}]/plan pending[/]            list pending plans\n"
+        f"  [{_SEM['neural']}]/plan show <op-id>[/]       render full plan detail\n"
+        f"  [{_SEM['neural']}]/plan approve <op-id>[/]    approve a pending plan\n"
+        f"  [{_SEM['neural']}]/plan reject <op-id> <reason>[/] reject with reason\n"
+        f"  [{_SEM['neural']}]/plan history [N][/]        last N resolved plans (default 10)\n"
+        f"  [{_SEM['neural']}]/plan help[/]               this message"
     )
 
 
@@ -427,19 +435,19 @@ def render_plan_detail(snap: dict) -> str:
                 fp = ch.get("file_path", "") or ch.get("file", "")
                 action = ch.get("action", "modify")
                 reason = ch.get("reason", "") or ch.get("rationale", "")
-                head = "  [cyan]%d.[/cyan] %s  [dim]%s[/dim]" % (i, fp, action)
+                head = f"  [{_SEM['neural']}]%d.[/] %s  [dim]%s[/dim]" % (i, fp, action)
                 parts.append(head)
                 if reason:
                     for line in textwrap.wrap(reason, width=70):
                         parts.append("     [dim]%s[/dim]" % line)
             else:
-                parts.append("  [cyan]%d.[/cyan] %s" % (i, ch))
+                parts.append(f"  [{_SEM['neural']}]%d.[/] %s" % (i, ch))
         parts.append("")
 
     if risks:
         parts.append("[bold]Risks[/bold]")
         for r in risks:
-            parts.append("  [yellow]▸[/yellow] %s" % r)
+            parts.append(f"  [{_SEM['heal']}]▸[/] %s" % r)
         parts.append("")
 
     if tests:

--- a/backend/core/ouroboros/governance/posture_palette.py
+++ b/backend/core/ouroboros/governance/posture_palette.py
@@ -53,6 +53,14 @@ import logging
 import os
 from typing import Any, Dict, Optional
 
+from backend.core.ouroboros.ui.semantic_tokens import (  # noqa: E402
+    role_palette as _role_palette,
+)
+
+#: Semantic colour roles — the SAME name and access pattern as every
+#: other module. One vocabulary, one spelling, one owner.
+_SEM = _role_palette()
+
 logger = logging.getLogger(__name__)
 
 
@@ -224,7 +232,7 @@ def format_posture_badge(
     Rich pipeline.
 
     ``plain=False`` — returns Rich-markup-wrapped form like
-    ``"[green]🐍 EXPLORE[/green]"`` ready for direct emit into
+    ``f"[{_SEM['success']}]🐍 EXPLORE[/]"`` ready for direct emit into
     a Rich console.
     """
     try:

--- a/backend/core/ouroboros/governance/risk_command_preview.py
+++ b/backend/core/ouroboros/governance/risk_command_preview.py
@@ -35,6 +35,14 @@ import os
 from dataclasses import dataclass, field
 from typing import Any, Optional, Tuple
 
+from backend.core.ouroboros.ui.semantic_tokens import (  # noqa: E402
+    role_palette as _role_palette,
+)
+
+#: Semantic colour roles — the SAME name and access pattern as every
+#: other module. One vocabulary, one spelling, one owner.
+_SEM = _role_palette()
+
 logger = logging.getLogger(__name__)
 
 
@@ -449,7 +457,7 @@ def format_command_preview(
         )
     if preview.governor_emergency:
         parts.append(
-            "  [red]⚠ governor emergency brake active[/]"
+            f"  [{_SEM['death']}]⚠ governor emergency brake active[/]"
         )
     if preview.diagnostic:
         parts.append(

--- a/tests/battle_test/test_semantic_colour_tokens.py
+++ b/tests/battle_test/test_semantic_colour_tokens.py
@@ -207,7 +207,7 @@ _RAW_LITERAL_CEILING = {
     "backend/core/ouroboros/battle_test": 42,
     "backend/core/ouroboros/cli": 12,
     "backend/core/ouroboros/ui": 3,
-    "backend/core/ouroboros/governance": 106,
+    "backend/core/ouroboros/governance": 25,
 }
 
 _RAW = re.compile(


### PR DESCRIPTION
Step 4, batch 3. **`governance` raw colour literals: 106 → 25.** 41 string literals rewritten across 6 files.

## Only what is provably identical

`red → death`, `green → success`, `yellow → heal`, `cyan → neural` — each asserted to resolve to exactly the literal it replaces *before a byte moved*. `[/red]` → `[/]`, already verified identical under Rich including the nested case.

## The 21 `bright_*` are untouched, by construction

The pattern requires `[` immediately before the colour name, so `[bright_yellow]` **cannot match**. No role resolves to a bright variant, and widening the regex to catch them would be inventing a mapping rather than proving one.

They need a judgment pass — `bright_yellow` (17 sites) most likely wants an emphatic-warning role that doesn't exist yet, and that's a vocabulary decision, not a sweep.

## The bug the guard caught

`plan_approval_repl.py` — **54 literals, half the package** — aborted with a `SyntaxError` at line 56 and was never written.

Cause: the `_SEM` injector placed its import after a line matched by `^from ...`, and that file's last top-level import is **parenthesized across several lines**. The insertion landed *inside* the statement and split it:

```python
from backend.core.ouroboros.governance.plan_approval import (
from backend.core.ouroboros.ui.semantic_tokens import (   # ← inserted here
    role_palette as _role_palette,
)
    PlanApprovalController,      # ← orphaned
)
```

Fixed structurally: the anchor is now `ast` `end_lineno` of the last top-level `Import`/`ImportFrom` node — correct for single-line, parenthesized and aliased forms alike. *A regex that matches the first line of a multi-line statement will always be wrong about where that statement ends.*

This is the third time in this migration that `ast.parse` refused a write and the refusal was correct. The staged approach is doing exactly what it was built for.

## Tests

**271 green** across colour, plan-approval, inline-approval, provenance, gate-choices, panic and demo suites.

## Remaining

| package | left | why |
|---|---|---|
| `battle_test` | 42 | serpent_flow 38 (needs a hand pass), bipartite_layout 4 (brace-bearing strings) |
| `governance` | 25 | 21 `bright_*` (judgment), 4 brace-bearing |
| `cli` | 12 | |
| `ui` | 3 | pre-existing `alt_screen` raw ANSI |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates `governance` console colours from raw literals to semantic roles to standardize theming and cut raw usages from 106 to 25. Also fixes the import-injection bug that broke `plan_approval_repl.py` with parenthesized imports.

- **Refactors**
  - Replace raw colours with roles: red→`death`, green→`success`, yellow→`heal`, cyan→`neural` (output unchanged).
  - Updated 6 files (41 literals) including status lines, badges, and help text.
  - Leave 21 `bright_*` sites as-is for a later vocabulary decision.
  - All suites green (271).

- **Bug Fixes**
  - Correct `_SEM` import injection: now inserts after the last top-level import using `ast` `end_lineno`, preventing `SyntaxError` on multi-line imports.

<sup>Written for commit c870665336ddfe8d9e9926e5de30797d797dd308. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

