### PR TITLE
feat(ov): the agent roster shows the GRAPH, and L3 finally appears in it

### DIFF
--- a/backend/core/ouroboros/battle_test/agent_roster.py
+++ b/backend/core/ouroboros/battle_test/agent_roster.py
@@ -231,10 +231,11 @@ class AgentEntry:
     """One dispatched agent, and what is known about it."""
 
     __slots__ = ("agent_id", "kind", "goal", "state", "started", "finished",
-                 "detail")
+                 "detail", "op_id", "parent_id", "worktree")
 
     def __init__(self, agent_id: str, kind: str = "", goal: str = "",
-                 started: float = 0.0) -> None:
+                 started: float = 0.0, op_id: str = "",
+                 parent_id: str = "", worktree: str = "") -> None:
         self.agent_id = str(agent_id or "")
         self.kind = str(kind or "agent")
         self.goal = str(goal or "")
@@ -243,6 +244,18 @@ class AgentEntry:
         self.started = float(started)
         self.finished: Optional[float] = None
         self.detail = ""
+        # The organism's agents form a GRAPH — an op fans out to units,
+        # a unit spawns subagents, each may hold its own worktree. The
+        # roster modelled a flat list, so it could show WHO was working
+        # and never what they were working ON, under whom, or in which
+        # isolated tree. Those three facts are the difference between a
+        # list of names and a picture of the work.
+        self.op_id = str(op_id or "")
+        self.parent_id = str(parent_id or "")
+        #: The isolated tree this agent mutates, when it has one. L3
+        #: promises isolation; an operator cannot verify a promise they
+        #: cannot see.
+        self.worktree = str(worktree or "")
 
     @property
     def running(self) -> bool:
@@ -273,13 +286,24 @@ class AgentEntry:
         is carried UNCLIPPED: how much of it fits is the reader's question,
         because the reader is the one who knows how wide its terminal is.
         """
-        return {
+        row = {
             "id": self.agent_id,
             "kind": self.kind,
             "goal": self.goal,
             "state": self.state,
             "elapsed_s": round(self.elapsed(now), 1),
         }
+        # Structural fields ride only when they are KNOWN. An absent key
+        # is "this producer did not say", which a reader can render as
+        # flat; a present-but-empty one would claim the agent has no
+        # parent, and a false claim about the graph is worse than none.
+        if self.op_id:
+            row["op_id"] = self.op_id
+        if self.parent_id:
+            row["parent_id"] = self.parent_id
+        if self.worktree:
+            row["worktree"] = self.worktree
+        return row
 
     def __repr__(self) -> str:  # pragma: no cover — diagnostics only
         return f"<AgentEntry {self.agent_id!r} {self.kind} {self.state}>"
@@ -314,8 +338,17 @@ class AgentRoster:
 
     # -- the feed ----------------------------------------------------------
 
-    def spawn(self, agent_id: str, kind: str = "", goal: str = "") -> None:
-        """An agent was dispatched. NEVER raises."""
+    def spawn(self, agent_id: str, kind: str = "", goal: str = "",
+              op_id: str = "", parent_id: str = "",
+              worktree: str = "") -> None:
+        """An agent was dispatched. NEVER raises.
+
+        The structural arguments are OPTIONAL and default to empty, so
+        every existing caller keeps working unchanged and a producer that
+        knows more can say more. That is deliberate: this roster had
+        exactly ONE producer for a long time, and the way to fix that is
+        to make joining cheap, not to demand every caller learn a schema.
+        """
         try:
             key = str(agent_id or "").strip()
             if not key:
@@ -327,7 +360,9 @@ class AgentRoster:
                 self._entries[key].started = self._clock()
                 self._entries[key].state = "running"
                 return
-            self._entries[key] = AgentEntry(key, kind, goal, self._clock())
+            self._entries[key] = AgentEntry(
+                key, kind, goal, self._clock(),
+                op_id=op_id, parent_id=parent_id, worktree=worktree)
             self._order.append(key)
             self._evict()
         except Exception:  # noqa: BLE001
@@ -512,6 +547,62 @@ def _clip(text: Any, width: int) -> str:
 _CHROME_ROWS = 1
 
 
+def order_by_lineage(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Depth-first order with a ``depth`` stamped on each row. Pure.
+
+    The organism's agents form a graph — an op fans out to units, a unit
+    spawns subagents. Rendered flat, twelve agents are twelve names; ordered
+    by lineage they are three ops with their work underneath, which is the
+    question an operator actually has.
+
+    Roots are anything whose parent is absent or unknown, so an orphan (a
+    child whose parent already finished and was reaped) still renders at
+    top level rather than vanishing. A cycle — which should be impossible
+    and therefore will happen — is broken by a visited set, not by trusting
+    the data. NEVER raises: a roster that cannot be sorted still lists.
+    """
+    try:
+        by_id = {str(r.get("id") or ""): r for r in rows if r.get("id")}
+        kids: Dict[str, List[Dict[str, Any]]] = {}
+        roots: List[Dict[str, Any]] = []
+        for r in rows:
+            parent = str(r.get("parent_id") or "")
+            if parent and parent in by_id:
+                kids.setdefault(parent, []).append(r)
+            else:
+                roots.append(r)
+        out: List[Dict[str, Any]] = []
+        seen = set()
+
+        def _walk(row: Dict[str, Any], depth: int) -> None:
+            rid = str(row.get("id") or "")
+            if rid in seen or depth > 6:
+                return
+            seen.add(rid)
+            row = dict(row)
+            row["depth"] = depth
+            out.append(row)
+            for child in kids.get(rid, ()):
+                _walk(child, depth + 1)
+
+        for root in roots:
+            _walk(root, 0)
+        # Anything unreachable from a root (a cycle) still gets listed —
+        # losing an agent from the view is worse than losing its indent.
+        for r in rows:
+            if str(r.get("id") or "") not in seen:
+                r = dict(r)
+                r["depth"] = 0
+                out.append(r)
+        return out
+    except Exception:  # noqa: BLE001
+        logger.debug("[AgentRoster] lineage ordering degraded", exc_info=True)
+        try:
+            return list(rows or ())
+        except Exception:  # noqa: BLE001
+            return []
+
+
 def render_roster(
     snapshot: Optional[Dict[str, Any]],
     *,
@@ -549,6 +640,11 @@ def render_roster(
         rows = [r for r in (snapshot.get("rows") or ()) if isinstance(r, dict)]
         if not rows:
             return []
+        # ORDERED BY LINEAGE before anything is measured or drawn: a flat
+        # list of twelve agents is twelve names; the same twelve ordered by
+        # who spawned whom is three ops with their work underneath. The
+        # indent is the only thing that turns a roster into a picture.
+        rows = order_by_lineage(rows)
         age = max(0.0, float(age_s or 0.0))
         # Fold to fit BEFORE anything is formatted: the count line has to
         # include what the height budget dropped, and it cannot if the drop
@@ -592,8 +688,19 @@ def render_roster(
             if state == "running":
                 elapsed += age
             took = f"  {format_duration(elapsed)}"
-            label = _clip(row.get("goal"), label_w) if label_w else ""
-            body = f"{row.get('kind') or 'agent'}  {label}".rstrip()
+            # Depth eats into the GOAL column, not the terminal width: an
+            # indent that pushed the line wider would wrap on exactly the
+            # deep rows it is meant to clarify.
+            depth = max(0, min(4, int(row.get("depth") or 0)))
+            indent = "  " * depth
+            label = (_clip(row.get("goal"), max(8, label_w - len(indent)))
+                     if label_w else "")
+            body = f"{indent}{row.get('kind') or 'agent'}  {label}".rstrip()
+            # The isolated tree this agent mutates. L3 PROMISES isolation;
+            # an operator cannot verify a promise they cannot see.
+            wt = str(row.get("worktree") or "")
+            if wt:
+                body = f"{body}  ⧉{_clip(wt, 18)}"
             lines.append(f"{mark} {glyph} {body}{took}".rstrip())
         # What the PRODUCER withheld plus what the height budget folded. Two
         # separate elisions, one honest number — reporting either alone would

--- a/backend/core/ouroboros/governance/autonomy/subagent_scheduler.py
+++ b/backend/core/ouroboros/governance/autonomy/subagent_scheduler.py
@@ -72,6 +72,36 @@ def _fmt_opt_float(value: Optional[float]) -> str:
     return repr(float(value))
 
 
+def _retire_from_roster(result: "WorkUnitResult", branch: str = "") -> None:
+    """Mark the unit finished, and record the worktree it actually held.
+
+    Called from the same telemetry seam that already fires on every exit
+    path, so a unit cannot finish without leaving the roster — an agent
+    stuck at "running" forever is worse than one never shown, because it
+    reports work that is not happening. NEVER raises.
+    """
+    try:
+        from backend.core.ouroboros.battle_test.agent_roster import (
+            get_agent_roster,
+        )
+        uid = str(getattr(result, "unit_id", "") or getattr(result, "id", ""))
+        if not uid:
+            return
+        roster = get_agent_roster()
+        entry = roster._entries.get(uid) if hasattr(roster, "_entries") else None
+        if entry is not None and branch:
+            entry.worktree = str(branch)[:80]
+        status = str(getattr(getattr(result, "status", ""), "name", "")
+                     or getattr(result, "status", ""))
+        roster.finish(
+            uid,
+            state="failed" if "FAIL" in status.upper() else "finished",
+            detail=str(getattr(result, "failure_class", "") or "")[:60],
+        )
+    except Exception:  # noqa: BLE001
+        pass
+
+
 def _emit_unit_telemetry(result: "WorkUnitResult", branch: str) -> None:
     """Emit the per-unit [L3Telemetry] breadcrumb. Fail-soft + gated."""
     if not _l3_telemetry_enabled():
@@ -154,6 +184,31 @@ class GenerationSubagentExecutor:
         """
         started_at_ns = time.monotonic_ns()
         causal_parent_id = graph.causal_trace_id
+        # ROSTER. An L3 unit was invisible: the roster had exactly one
+        # producer (the Phase B subagent path), so parallel worktree units
+        # ran with no operator-facing trace at all — the isolation L3
+        # PROMISES could not be verified by the person it protects.
+        #
+        # Joined here rather than in a new registry: one model, many
+        # producers. The structural fields are optional, so this costs a
+        # call and teaches the roster the graph it could not previously
+        # express.
+        try:
+            from backend.core.ouroboros.battle_test.agent_roster import (
+                get_agent_roster,
+            )
+            get_agent_roster().spawn(
+                str(getattr(unit, "unit_id", "") or getattr(unit, "id", "")),
+                kind="L3-unit",
+                goal=str(getattr(unit, "goal", "")
+                         or getattr(unit, "description", ""))[:120],
+                op_id=str(getattr(graph, "op_id", "")
+                          or getattr(graph, "graph_id", "")),
+                parent_id=str(getattr(graph, "op_id", "")
+                              or getattr(graph, "graph_id", "")),
+            )
+        except Exception:  # noqa: BLE001
+            pass          # a roster fault must never stop a work unit
         _worktree_path: Optional[Path] = None
         _sandbox: Optional[Any] = self._build_sandbox_for_unit(unit)
         # --- L3 telemetry locals (fail-soft; never affect control flow) ---
@@ -402,6 +457,9 @@ class GenerationSubagentExecutor:
                     )
                 try:
                     _emit_unit_telemetry(_result, _branch_label)
+                    # Same seam, so the roster cannot disagree with
+                    # telemetry about whether this unit finished.
+                    _retire_from_roster(_result, _branch_label)
                 except Exception:  # noqa: BLE001 — telemetry never breaks the unit
                     logger.debug(
                         "[L3Telemetry] per-unit emit raised (non-fatal)",

--- a/tests/battle_test/test_agentic_visibility.py
+++ b/tests/battle_test/test_agentic_visibility.py
@@ -1,0 +1,144 @@
+"""The roster showed WHO, never what they worked on, under whom, or where.
+
+`AgentEntry` was flat — id, kind, goal, state, times — and had exactly ONE
+producer (`serpent_flow`'s Phase B subagent path). So L3 worktree units,
+which are the organism's most parallel work, ran with no operator-facing
+trace at all: the isolation L3 *promises* could not be verified by the
+person it protects.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.battle_test.agent_roster import (
+    AgentRoster,
+    order_by_lineage,
+    render_roster,
+)
+
+
+def _peopled():
+    r = AgentRoster()
+    r.spawn("op-1", kind="op", goal="harden the vision floor")
+    r.spawn("unit-a", kind="L3-unit", goal="patch the floor",
+            op_id="op-1", parent_id="op-1", worktree="unit-a-wt")
+    r.spawn("sub-1", kind="Explore", goal="map callers", parent_id="unit-a")
+    r.spawn("unit-b", kind="L3-unit", goal="rebuild fixture",
+            op_id="op-1", parent_id="op-1", worktree="unit-b-wt")
+    return r
+
+
+class TestTheGraphIsExpressible:
+    def test_an_entry_carries_op_parent_and_worktree(self):
+        rows = _peopled().snapshot()["rows"]
+        unit = next(r for r in rows if r["id"] == "unit-a")
+        assert unit["op_id"] == "op-1"
+        assert unit["parent_id"] == "op-1"
+        assert unit["worktree"] == "unit-a-wt"
+
+    def test_absent_structure_is_ABSENT_not_empty(self):
+        """A present-but-empty parent claims the agent has no parent. A
+        false claim about the graph is worse than no claim."""
+        r = AgentRoster()
+        r.spawn("plain", kind="agent", goal="g")
+        row = r.snapshot()["rows"][0]
+        assert "parent_id" not in row
+        assert "worktree" not in row
+
+    def test_existing_callers_keep_working(self):
+        """The structural args are optional on purpose: this roster had
+        one producer for a long time, and the way to fix that is to make
+        joining cheap, not to demand every caller learn a schema."""
+        r = AgentRoster()
+        r.spawn("legacy", "Explore", "a goal")      # positional, as before
+        assert r.snapshot()["rows"][0]["id"] == "legacy"
+
+
+class TestLineage:
+    def test_children_follow_their_parent(self):
+        rows = order_by_lineage(_peopled().snapshot()["rows"])
+        order = [r["id"] for r in rows]
+        assert order.index("unit-a") < order.index("sub-1") < order.index("unit-b")
+
+    def test_depth_is_stamped(self):
+        depths = {r["id"]: r["depth"]
+                  for r in order_by_lineage(_peopled().snapshot()["rows"])}
+        assert depths == {"op-1": 0, "unit-a": 1, "sub-1": 2, "unit-b": 1}
+
+    def test_an_ORPHAN_still_renders(self):
+        """A child whose parent already finished and was reaped must not
+        vanish — losing an agent from the view is the failure this fixes."""
+        rows = order_by_lineage([{"id": "x", "parent_id": "long-gone"}])
+        assert len(rows) == 1 and rows[0]["depth"] == 0
+
+    def test_a_CYCLE_cannot_hang_the_render(self):
+        """Should be impossible, and therefore will happen."""
+        rows = order_by_lineage([{"id": "a", "parent_id": "b"},
+                                 {"id": "b", "parent_id": "a"}])
+        assert len(rows) == 2
+
+    def test_no_agent_is_ever_lost(self):
+        rows = [{"id": f"n{i}", "parent_id": "nope"} for i in range(30)]
+        assert len(order_by_lineage(rows)) == 30
+
+    @pytest.mark.parametrize("junk", [None, [], [{}], [{"id": None}], "x"])
+    def test_junk_degrades(self, junk):
+        assert isinstance(order_by_lineage(junk), list)  # type: ignore[arg-type]
+
+
+class TestItRenders:
+    def test_the_indent_shows_the_graph(self):
+        out = render_roster(_peopled().snapshot(), width=100)
+        body = "\n".join(out)
+        assert "  L3-unit" in body       # depth 1
+        assert "    Explore" in body     # depth 2
+
+    def test_the_worktree_is_VISIBLE(self):
+        """L3 promises isolation. An operator cannot verify a promise they
+        cannot see."""
+        body = "\n".join(render_roster(_peopled().snapshot(), width=100))
+        assert "unit-a-wt" in body and "unit-b-wt" in body
+
+    def test_indent_eats_the_goal_column_not_the_width(self):
+        """An indent that pushed the line wider would wrap on exactly the
+        deep rows it exists to clarify."""
+        for w in (60, 80, 120):
+            out = render_roster(_peopled().snapshot(), width=w)
+            assert all(len(line) <= w for line in out), w
+
+
+class TestTheProducersActuallyJOIN:
+    def test_L3_units_enter_the_roster(self):
+        """THE gap: L3 was the organism's most parallel work and had no
+        roster presence at all."""
+        import inspect
+
+        from backend.core.ouroboros.governance.autonomy import (
+            subagent_scheduler,
+        )
+        src = inspect.getsource(subagent_scheduler)
+        assert "get_agent_roster" in src
+        assert "L3-unit" in src
+
+    def test_L3_units_also_LEAVE_it(self):
+        """An agent stuck at "running" forever is worse than one never
+        shown: it reports work that is not happening."""
+        import inspect
+
+        from backend.core.ouroboros.governance.autonomy import (
+            subagent_scheduler,
+        )
+        assert hasattr(subagent_scheduler, "_retire_from_roster")
+        src = inspect.getsource(subagent_scheduler)
+        # Retired at the SAME seam telemetry already fires on, so the two
+        # cannot disagree about whether a unit finished.
+        assert "_retire_from_roster(_result" in src
+
+    def test_a_roster_fault_never_stops_a_work_unit(self):
+        import inspect
+
+        from backend.core.ouroboros.governance.autonomy import (
+            subagent_scheduler,
+        )
+        src = inspect.getsource(subagent_scheduler._retire_from_roster)
+        assert "except Exception" in src


### PR DESCRIPTION
Two root causes, both structural.

## The model was flat

`AgentEntry` carried id, kind, goal, state and times — and nothing about **relationships**. So the roster could say *who* was working and never what they were working **on**, under **whom**, or in which isolated **tree**. Twelve agents rendered as twelve names.

It now carries `op_id`, `parent_id` and `worktree`:

```
◯ op  harden the vision floor
◯   L3-unit  patch risk_tier_floor  ⧉unit-a-wt
◯     Explore  map every caller of the floor
◯   L3-unit  rebuild the fixture  ⧉unit-b-wt
```

The worktree is on screen because **L3 promises isolation, and an operator cannot verify a promise they cannot see.**

## There was exactly one producer

`serpent_flow`'s Phase B subagent path. **L3 worktree units — the organism's most parallel work — had no roster presence at all**, so a three-worker graph showed as nothing.

They now join at `execute()` and **retire at the same telemetry seam** that already fires on every exit path, so the roster and telemetry cannot disagree about whether a unit finished. An agent stuck at `running` forever is worse than one never shown: it reports work that is not happening.

Joined to the **existing** roster rather than given a registry of their own — one model, many producers. The structural arguments are **optional**, so every existing caller keeps working unchanged and a producer that knows more can say more. Making joining cheap is how a one-producer registry stops being one.

## Edge cases the ordering must survive

| case | behaviour |
|---|---|
| **orphan** — parent finished and was reaped | renders at top level, never vanishes |
| **cycle** — impossible, therefore will happen | broken by a visited set, not by trusting the data |
| deep nesting | capped at 4 levels of indent |
| 30 unrelated agents | all 30 listed — losing one from the view is the failure being fixed |
| narrow terminal | the indent eats the **goal column**, not the width — an indent that widened the line would wrap on precisely the deep rows it exists to clarify |

## Two defects found by running it

- The lineage call was inserted **before `rows` was extracted**, so it raised `NameError` into the renderer's own `except` and returned an **empty roster**. Visible only because I rendered it instead of trusting the diff.
- `order_by_lineage`'s fallback did `list(rows)` on the junk that had just raised — so **the fallback could raise from its own fallback**. That is not fail-soft, it is fail-later.

## Tests

**19 new; 152 green** across roster, agentic visibility, heartbeat, panic, attach and demo suites.

## Not proven

Still not verified against a live organism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The roster now shows the agent graph with indentation and worktree labels. L3 worktree units appear and retire correctly, keeping the roster and telemetry in sync.

- **New Features**
  - Roster entries now include `op_id`, `parent_id`, and `worktree` (all optional to keep existing producers working).
  - Depth-first `order_by_lineage` stamps `depth` and renders indents; orphans render at top level, cycles are guarded, and depth is capped; indent trims the goal column, not width.
  - L3 units join in `execute()` as `L3-unit` and retire at the same telemetry seam; `worktree` is shown in the label (⧉worktree).

- **Bug Fixes**
  - Ensure lineage ordering runs after `rows` are extracted to avoid an empty roster from a `NameError`.
  - Fallbacks in `order_by_lineage` are now fail-soft and never raise; roster hooks never block unit execution.

<sup>Written for commit 0a5f8ed54847d7aa42e50105ea92770c92fab738. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

