### PR TITLE
feat(ov): one adapter, every producer — swarm and pool join the roster

### DIFF
--- a/backend/core/ouroboros/battle_test/agent_roster.py
+++ b/backend/core/ouroboros/battle_test/agent_roster.py
@@ -547,6 +547,108 @@ def _clip(text: Any, width: int) -> str:
 _CHROME_ROWS = 1
 
 
+#: Lifecycle verbs, DERIVED from the event name rather than listed per
+#: event type. The codebase already names its events consistently —
+#: `swarm_node_spawned` / `swarm_node_vaporized`, `worker_op_claimed`,
+#: `swarm_scatter` / `swarm_stitched` — so a suffix rule covers all 191
+#: types and, more importantly, covers the 192nd automatically. A
+#: hand-maintained table of event types is exactly the thing that drifted
+#: when this roster had one producer.
+_BEGIN_MARKERS = ("spawned", "claimed", "scatter", "started", "dispatched")
+_END_MARKERS = ("vaporized", "stitched", "committed", "quarantined",
+                "finished", "completed", "failed", "reaped", "cancelled")
+
+#: Payload keys that identify the WORKER, most specific first. A worker
+#: without its own id falls back to the op — one row per op is a truthful
+#: under-count; inventing a synthetic id would create phantom agents that
+#: never retire.
+_IDENTITY_KEYS = ("node_id", "unit_id", "worker_id", "agent_id", "chunk_id")
+
+
+def lifecycle_of(event_type: str) -> str:
+    """``begin`` / ``end`` / ``""`` for an event name. Pure. NEVER raises.
+
+    End is checked FIRST: `swarm_node_vaporized` contains neither begin
+    marker, but a future `worker_spawn_failed` contains both, and the
+    truthful reading of a name carrying both is that the thing ended.
+    """
+    try:
+        name = str(event_type or "").strip().lower()
+        if not name:
+            return ""
+        if any(m in name for m in _END_MARKERS):
+            return "end"
+        if any(m in name for m in _BEGIN_MARKERS):
+            return "begin"
+        return ""
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def observe_task_event(
+    event_type: str, op_id: str, payload: Optional[Dict[str, Any]] = None,
+) -> Optional[str]:
+    """Map ONE task event onto the roster. NEVER raises.
+
+    The single adapter that replaces N per-subsystem wirings. Every
+    producer that already publishes a task event — BackgroundAgentPool's
+    `worker_op_claimed`, chunk_swarm's `swarm_node_spawned`, and whatever
+    is written next — gains roster presence without an edit of its own.
+    Returns the agent id it touched, or None.
+    """
+    try:
+        verb = lifecycle_of(event_type)
+        if not verb:
+            return None
+        data = dict(payload or {})
+        op = str(op_id or "")
+        ident = ""
+        for key in _IDENTITY_KEYS:
+            if data.get(key) not in (None, ""):
+                ident = f"{key.split('_')[0]}-{data[key]}"
+                break
+        agent_id = ident or op
+        if not agent_id:
+            return None
+        roster = get_agent_roster()
+        if verb == "begin":
+            roster.spawn(
+                agent_id,
+                kind=str(event_type).split("_")[0][:12] or "agent",
+                goal=str(data.get("goal") or data.get("description") or "")[:120],
+                op_id=op,
+                # An identified worker hangs under its op; a row that IS
+                # the op has no parent, which keeps it at top level rather
+                # than making it its own child.
+                parent_id=op if ident else "",
+                worktree=str(data.get("worktree") or data.get("branch") or ""),
+            )
+        else:
+            roster.finish(
+                agent_id,
+                state="failed" if "fail" in str(event_type).lower()
+                or "quarantin" in str(event_type).lower() else "finished",
+                detail=str(data.get("reason") or data.get("error") or "")[:60],
+            )
+        return agent_id
+    except Exception:  # noqa: BLE001
+        logger.debug("[AgentRoster] task-event adapter degraded", exc_info=True)
+        return None
+
+
+def install_task_event_adapter() -> bool:
+    """Subscribe the roster to the in-process task-event tap. NEVER raises."""
+    try:
+        from backend.core.ouroboros.governance.ide_observability_stream import (
+            add_local_observer,
+        )
+        add_local_observer(observe_task_event)
+        return True
+    except Exception:  # noqa: BLE001
+        logger.debug("[AgentRoster] adapter install degraded", exc_info=True)
+        return False
+
+
 def order_by_lineage(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """Depth-first order with a ``depth`` stamped on each row. Pure.
 

--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -1313,6 +1313,17 @@ class BattleTestHarness:
                 install_task_factory(_running_loop)
             except Exception:  # noqa: BLE001
                 pass
+            # One adapter, every producer. Any subsystem that already
+            # publishes a task event gains roster presence without an edit
+            # of its own — which is how a registry with ONE producer stops
+            # being one permanently rather than three times.
+            try:
+                from backend.core.ouroboros.battle_test.agent_roster import (
+                    install_task_event_adapter,
+                )
+                install_task_event_adapter()
+            except Exception:  # noqa: BLE001
+                pass
         except Exception:
             logger.debug("Failed to install harness asyncio exception handler", exc_info=True)
 

--- a/backend/core/ouroboros/governance/ide_observability_stream.py
+++ b/backend/core/ouroboros/governance/ide_observability_stream.py
@@ -2414,6 +2414,40 @@ def reset_default_broker() -> None:
         _default_broker = None
 
 
+#: In-process consumers of task events. Distinct from SSE subscribers:
+#: synchronous, unbounded in count, and NOT gated on `stream_enabled()`.
+_LOCAL_OBSERVERS: List[Any] = []
+
+
+def add_local_observer(fn: Any) -> None:
+    """Register an in-process task-event consumer. NEVER raises."""
+    try:
+        if fn not in _LOCAL_OBSERVERS:
+            _LOCAL_OBSERVERS.append(fn)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def reset_local_observers() -> None:
+    _LOCAL_OBSERVERS.clear()
+
+
+def _notify_local_observers(
+    event_type: str, op_id: str, payload: Optional[Mapping[str, Any]],
+) -> None:
+    """Fan out to in-process observers. NEVER raises, never blocks.
+
+    An observer that throws is dropped from THIS call only — a broken
+    consumer must not stop the event reaching the others, and must never
+    stop the producer that published it.
+    """
+    for fn in list(_LOCAL_OBSERVERS):
+        try:
+            fn(event_type, op_id, dict(payload or {}))
+        except Exception:  # noqa: BLE001
+            logger.debug("[Stream] local observer failed", exc_info=True)
+
+
 def publish_task_event(
     event_type: str,
     op_id: str,
@@ -2424,6 +2458,15 @@ def publish_task_event(
     Returns the event_id on successful publish, None on any failure
     (stream disabled, invalid event_type, or broker exception).
     """
+    # LOCAL observers fire FIRST, and unconditionally.
+    #
+    # The obvious wiring was `subscribe()` — but that is the SSE path:
+    # bounded to 8 slots and gated on `stream_enabled()`. Feeding an
+    # in-process consumer through it would consume a slot meant for an
+    # HTTP client and, worse, make that consumer go dark whenever an
+    # unrelated observability flag is off. Agent visibility must not
+    # depend on whether anyone is watching over HTTP.
+    _notify_local_observers(event_type, op_id, payload)
     if not stream_enabled():
         return None
     try:

--- a/tests/battle_test/test_agentic_visibility.py
+++ b/tests/battle_test/test_agentic_visibility.py
@@ -142,3 +142,134 @@ class TestTheProducersActuallyJOIN:
         )
         src = inspect.getsource(subagent_scheduler._retire_from_roster)
         assert "except Exception" in src
+
+
+class TestOneAdapterEveryProducer:
+    """chunk_swarm and BackgroundAgentPool without touching either.
+
+    Both already publish task events on the canonical broker. Wiring each
+    subsystem by hand would have been the third and fourth per-producer
+    edit — and the fifth would have been forgotten. The roster listens
+    instead, so a producer joins by publishing an event it already
+    publishes.
+    """
+
+    @staticmethod
+    def _fresh():
+        from backend.core.ouroboros.battle_test.agent_roster import (
+            install_task_event_adapter,
+        )
+        from backend.core.ouroboros.governance.ide_observability_stream import (
+            reset_local_observers,
+        )
+        reset_local_observers()
+        install_task_event_adapter()
+
+    @pytest.mark.parametrize(("event", "verb"), [
+        ("swarm_node_spawned", "begin"), ("worker_op_claimed", "begin"),
+        ("swarm_scatter", "begin"), ("swarm_node_vaporized", "end"),
+        ("swarm_stitched", "end"), ("soak_chunk_quarantined", "end"),
+        ("posture_changed", ""), ("noise", ""),
+    ])
+    def test_lifecycle_is_DERIVED_from_the_name(self, event, verb):
+        """The codebase already names events consistently, so a suffix
+        rule covers all 191 types — and the 192nd automatically. A
+        hand-kept table of event types is what drifted last time."""
+        from backend.core.ouroboros.battle_test.agent_roster import lifecycle_of
+        assert lifecycle_of(event) == verb
+
+    def test_an_ambiguous_name_reads_as_ENDED(self):
+        """`worker_spawn_failed` carries both markers. The truthful
+        reading of a name carrying both is that the thing ended."""
+        from backend.core.ouroboros.battle_test.agent_roster import lifecycle_of
+        assert lifecycle_of("worker_spawn_failed") == "end"
+
+    def test_a_swarm_node_appears_and_retires(self):
+        from backend.core.ouroboros.battle_test.agent_roster import (
+            get_agent_roster,
+        )
+        from backend.core.ouroboros.governance.ide_observability_stream import (
+            publish_task_event,
+        )
+        self._fresh()
+        publish_task_event("swarm_node_spawned", "op-x",
+                           {"node_id": "n9", "goal": "chunk", "branch": "wt-9"})
+        rows = {r["id"]: r for r in get_agent_roster().snapshot()["rows"]}
+        assert "node-n9" in rows
+        assert rows["node-n9"]["state"] == "running"
+        assert rows["node-n9"]["worktree"] == "wt-9"
+        publish_task_event("swarm_node_vaporized", "op-x", {"node_id": "n9"})
+        rows = {r["id"]: r for r in get_agent_roster().snapshot()["rows"]}
+        assert rows["node-n9"]["state"] == "finished"
+
+    def test_a_pool_worker_appears(self):
+        from backend.core.ouroboros.battle_test.agent_roster import (
+            get_agent_roster,
+        )
+        from backend.core.ouroboros.governance.ide_observability_stream import (
+            publish_task_event,
+        )
+        self._fresh()
+        publish_task_event("worker_op_claimed", "op-y",
+                           {"worker_id": 3, "goal": "harden the floor"})
+        ids = [r["id"] for r in get_agent_roster().snapshot()["rows"]]
+        assert "worker-3" in ids
+
+    def test_a_quarantine_reads_as_FAILED_not_finished(self):
+        from backend.core.ouroboros.battle_test.agent_roster import (
+            get_agent_roster,
+        )
+        from backend.core.ouroboros.governance.ide_observability_stream import (
+            publish_task_event,
+        )
+        self._fresh()
+        publish_task_event("swarm_node_spawned", "op-z", {"node_id": "bad"})
+        publish_task_event("soak_chunk_quarantined", "op-z",
+                           {"node_id": "bad", "reason": "3 strikes"})
+        row = next(r for r in get_agent_roster().snapshot()["rows"]
+                   if r["id"] == "node-bad")
+        assert row["state"] == "failed"
+
+    def test_an_unidentified_worker_does_not_become_a_PHANTOM(self):
+        """A worker with no id falls back to the op — one row per op is a
+        truthful under-count. Inventing a synthetic id would create agents
+        that never retire, because nothing would ever name them again."""
+        from backend.core.ouroboros.battle_test.agent_roster import (
+            observe_task_event,
+        )
+        assert observe_task_event("swarm_node_spawned", "op-q", {}) == "op-q"
+        assert observe_task_event("swarm_node_spawned", "", {}) is None
+
+
+class TestTheTapIsNotTheSSEPath:
+    def test_local_observers_fire_regardless_of_the_stream_flag(self, monkeypatch):
+        """`subscribe()` is bounded to 8 SSE slots and gated on
+        `stream_enabled()`. Feeding the roster through it would consume a
+        slot meant for an HTTP client and make agent visibility die
+        whenever an unrelated observability flag is off."""
+        from backend.core.ouroboros.governance import (
+            ide_observability_stream as st,
+        )
+        monkeypatch.setenv("JARVIS_IDE_STREAM_ENABLED", "0")
+        st.reset_local_observers()
+        seen: list = []
+        st.add_local_observer(lambda t, o, p: seen.append(t))
+        st.publish_task_event("worker_op_claimed", "op-1", {"worker_id": 1})
+        assert seen == ["worker_op_claimed"]
+
+    def test_a_broken_observer_never_stops_the_producer(self):
+        from backend.core.ouroboros.governance import (
+            ide_observability_stream as st,
+        )
+        st.reset_local_observers()
+        ok: list = []
+        st.add_local_observer(lambda *a: (_ for _ in ()).throw(RuntimeError()))
+        st.add_local_observer(lambda t, o, p: ok.append(t))
+        st.publish_task_event("worker_op_claimed", "op-1", {"worker_id": 1})
+        assert ok, "one broken consumer swallowed the event for the others"
+
+    def test_the_adapter_is_installed_at_boot(self):
+        import inspect
+
+        from backend.core.ouroboros.battle_test import harness
+        assert "install_task_event_adapter" in inspect.getsource(harness)


### PR DESCRIPTION
`chunk_swarm` and `BackgroundAgentPool` are now in the roster **without either file being edited**.

## Why not wire them the way L3 was

Per-producer wiring was right for L3 (its lifecycle has no event) and **wrong as a pattern**: swarm and pool would have been the third and fourth hand-edit, and the fifth would have been forgotten — which is exactly how this roster came to have one producer in the first place.

Both already publish on the canonical broker, so **the roster listens**. A producer joins by publishing an event it already publishes.

## Not through `subscribe()`

The obvious wiring was the existing `subscribe()`. It's the **SSE path** — bounded to 8 slots and gated on `stream_enabled()`. Feeding an in-process consumer through it would spend a slot meant for an HTTP client and, far worse, **make agent visibility vanish whenever an unrelated observability flag is off**.

So `publish_task_event` gained a local-observer fan-out that fires **first and unconditionally**, ahead of the `stream_enabled()` gate. An observer that throws is dropped for that call only — a broken consumer must not stop the event reaching the others, and must never stop the producer.

## The mapping is derived, not tabulated

191 event types, and the codebase already names them consistently:

```
swarm_node_spawned   → begin      swarm_node_vaporized    → end
worker_op_claimed    → begin      swarm_stitched          → end
swarm_scatter        → begin      soak_chunk_quarantined  → end (failed)
posture_changed      → ignored
```

Lifecycle comes from a marker rule over the **name**, which covers all 191 and — the actual point — **the 192nd automatically**. A hand-kept table of event types is precisely what drifts.

**End is tested before begin:** `worker_spawn_failed` carries both markers, and the truthful reading of a name carrying both is that it ended.

Identity comes from the payload, most specific first (`node_id`, `unit_id`, `worker_id`, `agent_id`, `chunk_id`). A worker with **no** id falls back to the op — one row per op is a truthful under-count, while inventing a synthetic id would create **phantom agents that never retire**, because nothing would ever name them again.

## What it looks like

```
◯ worker  harden the vision floor
⏺ swarm   chunk 1/7  ⧉swarm-n1        ← vaporized
◯ swarm   chunk 2/7  ⧉swarm-n2        ← running
```

## Tests

**16 new; 193 green** across agentic visibility, roster, heartbeat, observability-stream, panic and attach suites.

## Not proven

Still not verified against a live organism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a single task-event adapter so the roster auto-tracks agents from `chunk_swarm` and `BackgroundAgentPool` without touching their code. Agent visibility is now independent of SSE settings and avoids phantom agents.

- **New Features**
  - Added local in-process observers for `publish_task_event`; fire first, not gated by `stream_enabled()`, and don’t use `subscribe()` SSE slots.
  - Derived lifecycle from event names with end checked first; no per-type table needed.
  - Agent identity selected from payload keys (`node_id`, `unit_id`, `worker_id`, `agent_id`, `chunk_id`), falling back to `op_id` when missing.
  - Adapter installs at boot via the harness; producers join the roster by publishing the events they already emit.
  - Tests: 16 new; 193 passing.

<sup>Written for commit 6818a74b7384afe1748da9bddf6a3dd759e49177. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

