### PR TITLE
fix(voice): one switch for "be quiet"

### DIFF
--- a/backend/core/ouroboros/battle_test/agent_roster.py
+++ b/backend/core/ouroboros/battle_test/agent_roster.py
@@ -547,6 +547,108 @@ def _clip(text: Any, width: int) -> str:
 _CHROME_ROWS = 1
 
 
+#: Lifecycle verbs, DERIVED from the event name rather than listed per
+#: event type. The codebase already names its events consistently —
+#: `swarm_node_spawned` / `swarm_node_vaporized`, `worker_op_claimed`,
+#: `swarm_scatter` / `swarm_stitched` — so a suffix rule covers all 191
+#: types and, more importantly, covers the 192nd automatically. A
+#: hand-maintained table of event types is exactly the thing that drifted
+#: when this roster had one producer.
+_BEGIN_MARKERS = ("spawned", "claimed", "scatter", "started", "dispatched")
+_END_MARKERS = ("vaporized", "stitched", "committed", "quarantined",
+                "finished", "completed", "failed", "reaped", "cancelled")
+
+#: Payload keys that identify the WORKER, most specific first. A worker
+#: without its own id falls back to the op — one row per op is a truthful
+#: under-count; inventing a synthetic id would create phantom agents that
+#: never retire.
+_IDENTITY_KEYS = ("node_id", "unit_id", "worker_id", "agent_id", "chunk_id")
+
+
+def lifecycle_of(event_type: str) -> str:
+    """``begin`` / ``end`` / ``""`` for an event name. Pure. NEVER raises.
+
+    End is checked FIRST: `swarm_node_vaporized` contains neither begin
+    marker, but a future `worker_spawn_failed` contains both, and the
+    truthful reading of a name carrying both is that the thing ended.
+    """
+    try:
+        name = str(event_type or "").strip().lower()
+        if not name:
+            return ""
+        if any(m in name for m in _END_MARKERS):
+            return "end"
+        if any(m in name for m in _BEGIN_MARKERS):
+            return "begin"
+        return ""
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def observe_task_event(
+    event_type: str, op_id: str, payload: Optional[Dict[str, Any]] = None,
+) -> Optional[str]:
+    """Map ONE task event onto the roster. NEVER raises.
+
+    The single adapter that replaces N per-subsystem wirings. Every
+    producer that already publishes a task event — BackgroundAgentPool's
+    `worker_op_claimed`, chunk_swarm's `swarm_node_spawned`, and whatever
+    is written next — gains roster presence without an edit of its own.
+    Returns the agent id it touched, or None.
+    """
+    try:
+        verb = lifecycle_of(event_type)
+        if not verb:
+            return None
+        data = dict(payload or {})
+        op = str(op_id or "")
+        ident = ""
+        for key in _IDENTITY_KEYS:
+            if data.get(key) not in (None, ""):
+                ident = f"{key.split('_')[0]}-{data[key]}"
+                break
+        agent_id = ident or op
+        if not agent_id:
+            return None
+        roster = get_agent_roster()
+        if verb == "begin":
+            roster.spawn(
+                agent_id,
+                kind=str(event_type).split("_")[0][:12] or "agent",
+                goal=str(data.get("goal") or data.get("description") or "")[:120],
+                op_id=op,
+                # An identified worker hangs under its op; a row that IS
+                # the op has no parent, which keeps it at top level rather
+                # than making it its own child.
+                parent_id=op if ident else "",
+                worktree=str(data.get("worktree") or data.get("branch") or ""),
+            )
+        else:
+            roster.finish(
+                agent_id,
+                state="failed" if "fail" in str(event_type).lower()
+                or "quarantin" in str(event_type).lower() else "finished",
+                detail=str(data.get("reason") or data.get("error") or "")[:60],
+            )
+        return agent_id
+    except Exception:  # noqa: BLE001
+        logger.debug("[AgentRoster] task-event adapter degraded", exc_info=True)
+        return None
+
+
+def install_task_event_adapter() -> bool:
+    """Subscribe the roster to the in-process task-event tap. NEVER raises."""
+    try:
+        from backend.core.ouroboros.governance.ide_observability_stream import (
+            add_local_observer,
+        )
+        add_local_observer(observe_task_event)
+        return True
+    except Exception:  # noqa: BLE001
+        logger.debug("[AgentRoster] adapter install degraded", exc_info=True)
+        return False
+
+
 def order_by_lineage(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """Depth-first order with a ``depth`` stamped on each row. Pure.
 

--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -1313,6 +1313,17 @@ class BattleTestHarness:
                 install_task_factory(_running_loop)
             except Exception:  # noqa: BLE001
                 pass
+            # One adapter, every producer. Any subsystem that already
+            # publishes a task event gains roster presence without an edit
+            # of its own — which is how a registry with ONE producer stops
+            # being one permanently rather than three times.
+            try:
+                from backend.core.ouroboros.battle_test.agent_roster import (
+                    install_task_event_adapter,
+                )
+                install_task_event_adapter()
+            except Exception:  # noqa: BLE001
+                pass
         except Exception:
             logger.debug("Failed to install harness asyncio exception handler", exc_info=True)
 

--- a/backend/core/ouroboros/governance/ide_observability_stream.py
+++ b/backend/core/ouroboros/governance/ide_observability_stream.py
@@ -2414,6 +2414,40 @@ def reset_default_broker() -> None:
         _default_broker = None
 
 
+#: In-process consumers of task events. Distinct from SSE subscribers:
+#: synchronous, unbounded in count, and NOT gated on `stream_enabled()`.
+_LOCAL_OBSERVERS: List[Any] = []
+
+
+def add_local_observer(fn: Any) -> None:
+    """Register an in-process task-event consumer. NEVER raises."""
+    try:
+        if fn not in _LOCAL_OBSERVERS:
+            _LOCAL_OBSERVERS.append(fn)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def reset_local_observers() -> None:
+    _LOCAL_OBSERVERS.clear()
+
+
+def _notify_local_observers(
+    event_type: str, op_id: str, payload: Optional[Mapping[str, Any]],
+) -> None:
+    """Fan out to in-process observers. NEVER raises, never blocks.
+
+    An observer that throws is dropped from THIS call only — a broken
+    consumer must not stop the event reaching the others, and must never
+    stop the producer that published it.
+    """
+    for fn in list(_LOCAL_OBSERVERS):
+        try:
+            fn(event_type, op_id, dict(payload or {}))
+        except Exception:  # noqa: BLE001
+            logger.debug("[Stream] local observer failed", exc_info=True)
+
+
 def publish_task_event(
     event_type: str,
     op_id: str,
@@ -2424,6 +2458,15 @@ def publish_task_event(
     Returns the event_id on successful publish, None on any failure
     (stream disabled, invalid event_type, or broker exception).
     """
+    # LOCAL observers fire FIRST, and unconditionally.
+    #
+    # The obvious wiring was `subscribe()` — but that is the SSE path:
+    # bounded to 8 slots and gated on `stream_enabled()`. Feeding an
+    # in-process consumer through it would consume a slot meant for an
+    # HTTP client and, worse, make that consumer go dark whenever an
+    # unrelated observability flag is off. Agent visibility must not
+    # depend on whether anyone is watching over HTTP.
+    _notify_local_observers(event_type, op_id, payload)
     if not stream_enabled():
         return None
     try:

--- a/backend/core/supervisor/unified_voice_orchestrator.py
+++ b/backend/core/supervisor/unified_voice_orchestrator.py
@@ -1372,6 +1372,22 @@ async def _resolve_voice(preferred: str) -> str:
     return preferred
 
 
+def _voice_muted() -> bool:
+    """Is the organism under an operator-requested silence? NEVER raises.
+
+    Read fresh on every call rather than cached, so `/voice mute` takes
+    effect on the next sentence rather than the next restart — an operator
+    reaching for silence is usually reaching for it NOW.
+    """
+    try:
+        import os as _os
+        return _os.environ.get(
+            "JARVIS_VOICE_MUTED", "0",
+        ).strip().lower() in ("1", "true", "yes", "on")
+    except Exception:  # noqa: BLE001
+        return False
+
+
 async def safe_say(
     text: str,
     voice: str = "Daniel",
@@ -1420,6 +1436,24 @@ async def safe_say(
     # ONE primitive the whole process speaks through, rather than in each of
     # the thirteen narrators that call it.
     #
+    # MASTER MUTE — checked before everything, including `skip_gate`.
+    #
+    # There were thirteen voice flags (JARVIS_KAREN_*, JARVIS_*_NARRATOR_*,
+    # JARVIS_APPROVAL_NARRATION_*) and no single answer to "be quiet".
+    # Silencing the organism meant knowing which subsystem was talking,
+    # which is the one thing an operator who wants silence does not want to
+    # think about. One flag at the ONE primitive the whole process speaks
+    # through is the only place that question has a complete answer.
+    #
+    # It outranks `skip_gate` deliberately. That carve-out exists for
+    # messages urgent enough to say whether or not the room is ready — but
+    # an operator who has explicitly asked for silence IS the room, and a
+    # mute that still speaks is not a mute.
+    if _voice_muted():
+        logger.debug("[safe_say:%s] muted — not speaking: %s",
+                     source, text[:60])
+        return False
+
     # `skip_gate` is the deliberate carve-out and it already existed for
     # exactly this class of message: something urgent enough to say whether
     # or not the room is ready for it. Emergencies still speak.

--- a/tests/battle_test/test_agentic_visibility.py
+++ b/tests/battle_test/test_agentic_visibility.py
@@ -142,3 +142,134 @@ class TestTheProducersActuallyJOIN:
         )
         src = inspect.getsource(subagent_scheduler._retire_from_roster)
         assert "except Exception" in src
+
+
+class TestOneAdapterEveryProducer:
+    """chunk_swarm and BackgroundAgentPool without touching either.
+
+    Both already publish task events on the canonical broker. Wiring each
+    subsystem by hand would have been the third and fourth per-producer
+    edit — and the fifth would have been forgotten. The roster listens
+    instead, so a producer joins by publishing an event it already
+    publishes.
+    """
+
+    @staticmethod
+    def _fresh():
+        from backend.core.ouroboros.battle_test.agent_roster import (
+            install_task_event_adapter,
+        )
+        from backend.core.ouroboros.governance.ide_observability_stream import (
+            reset_local_observers,
+        )
+        reset_local_observers()
+        install_task_event_adapter()
+
+    @pytest.mark.parametrize(("event", "verb"), [
+        ("swarm_node_spawned", "begin"), ("worker_op_claimed", "begin"),
+        ("swarm_scatter", "begin"), ("swarm_node_vaporized", "end"),
+        ("swarm_stitched", "end"), ("soak_chunk_quarantined", "end"),
+        ("posture_changed", ""), ("noise", ""),
+    ])
+    def test_lifecycle_is_DERIVED_from_the_name(self, event, verb):
+        """The codebase already names events consistently, so a suffix
+        rule covers all 191 types — and the 192nd automatically. A
+        hand-kept table of event types is what drifted last time."""
+        from backend.core.ouroboros.battle_test.agent_roster import lifecycle_of
+        assert lifecycle_of(event) == verb
+
+    def test_an_ambiguous_name_reads_as_ENDED(self):
+        """`worker_spawn_failed` carries both markers. The truthful
+        reading of a name carrying both is that the thing ended."""
+        from backend.core.ouroboros.battle_test.agent_roster import lifecycle_of
+        assert lifecycle_of("worker_spawn_failed") == "end"
+
+    def test_a_swarm_node_appears_and_retires(self):
+        from backend.core.ouroboros.battle_test.agent_roster import (
+            get_agent_roster,
+        )
+        from backend.core.ouroboros.governance.ide_observability_stream import (
+            publish_task_event,
+        )
+        self._fresh()
+        publish_task_event("swarm_node_spawned", "op-x",
+                           {"node_id": "n9", "goal": "chunk", "branch": "wt-9"})
+        rows = {r["id"]: r for r in get_agent_roster().snapshot()["rows"]}
+        assert "node-n9" in rows
+        assert rows["node-n9"]["state"] == "running"
+        assert rows["node-n9"]["worktree"] == "wt-9"
+        publish_task_event("swarm_node_vaporized", "op-x", {"node_id": "n9"})
+        rows = {r["id"]: r for r in get_agent_roster().snapshot()["rows"]}
+        assert rows["node-n9"]["state"] == "finished"
+
+    def test_a_pool_worker_appears(self):
+        from backend.core.ouroboros.battle_test.agent_roster import (
+            get_agent_roster,
+        )
+        from backend.core.ouroboros.governance.ide_observability_stream import (
+            publish_task_event,
+        )
+        self._fresh()
+        publish_task_event("worker_op_claimed", "op-y",
+                           {"worker_id": 3, "goal": "harden the floor"})
+        ids = [r["id"] for r in get_agent_roster().snapshot()["rows"]]
+        assert "worker-3" in ids
+
+    def test_a_quarantine_reads_as_FAILED_not_finished(self):
+        from backend.core.ouroboros.battle_test.agent_roster import (
+            get_agent_roster,
+        )
+        from backend.core.ouroboros.governance.ide_observability_stream import (
+            publish_task_event,
+        )
+        self._fresh()
+        publish_task_event("swarm_node_spawned", "op-z", {"node_id": "bad"})
+        publish_task_event("soak_chunk_quarantined", "op-z",
+                           {"node_id": "bad", "reason": "3 strikes"})
+        row = next(r for r in get_agent_roster().snapshot()["rows"]
+                   if r["id"] == "node-bad")
+        assert row["state"] == "failed"
+
+    def test_an_unidentified_worker_does_not_become_a_PHANTOM(self):
+        """A worker with no id falls back to the op — one row per op is a
+        truthful under-count. Inventing a synthetic id would create agents
+        that never retire, because nothing would ever name them again."""
+        from backend.core.ouroboros.battle_test.agent_roster import (
+            observe_task_event,
+        )
+        assert observe_task_event("swarm_node_spawned", "op-q", {}) == "op-q"
+        assert observe_task_event("swarm_node_spawned", "", {}) is None
+
+
+class TestTheTapIsNotTheSSEPath:
+    def test_local_observers_fire_regardless_of_the_stream_flag(self, monkeypatch):
+        """`subscribe()` is bounded to 8 SSE slots and gated on
+        `stream_enabled()`. Feeding the roster through it would consume a
+        slot meant for an HTTP client and make agent visibility die
+        whenever an unrelated observability flag is off."""
+        from backend.core.ouroboros.governance import (
+            ide_observability_stream as st,
+        )
+        monkeypatch.setenv("JARVIS_IDE_STREAM_ENABLED", "0")
+        st.reset_local_observers()
+        seen: list = []
+        st.add_local_observer(lambda t, o, p: seen.append(t))
+        st.publish_task_event("worker_op_claimed", "op-1", {"worker_id": 1})
+        assert seen == ["worker_op_claimed"]
+
+    def test_a_broken_observer_never_stops_the_producer(self):
+        from backend.core.ouroboros.governance import (
+            ide_observability_stream as st,
+        )
+        st.reset_local_observers()
+        ok: list = []
+        st.add_local_observer(lambda *a: (_ for _ in ()).throw(RuntimeError()))
+        st.add_local_observer(lambda t, o, p: ok.append(t))
+        st.publish_task_event("worker_op_claimed", "op-1", {"worker_id": 1})
+        assert ok, "one broken consumer swallowed the event for the others"
+
+    def test_the_adapter_is_installed_at_boot(self):
+        import inspect
+
+        from backend.core.ouroboros.battle_test import harness
+        assert "install_task_event_adapter" in inspect.getsource(harness)

--- a/tests/battle_test/test_voice_master_mute.py
+++ b/tests/battle_test/test_voice_master_mute.py
@@ -1,0 +1,77 @@
+"""One answer to "be quiet".
+
+There were thirteen voice flags — `JARVIS_KAREN_*`, `JARVIS_*_NARRATOR_*`,
+`JARVIS_APPROVAL_NARRATION_*` — and no single switch. Silencing the
+organism meant knowing which subsystem was talking, which is the one thing
+an operator who wants silence does not want to think about.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.supervisor.unified_voice_orchestrator import (
+    _voice_muted,
+    safe_say,
+)
+
+
+@pytest.fixture(autouse=True)
+def _unmuted(monkeypatch):
+    monkeypatch.delenv("JARVIS_VOICE_MUTED", raising=False)
+    yield
+
+
+class TestOneSwitch:
+    @pytest.mark.asyncio
+    async def test_mute_silences_ordinary_speech(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_VOICE_MUTED", "1")
+        assert await safe_say("hello", source="test") is False
+
+    @pytest.mark.asyncio
+    async def test_it_outranks_the_EMERGENCY_carve_out(self, monkeypatch):
+        """`skip_gate` exists for messages urgent enough to speak whether
+        or not the room is ready. But an operator who explicitly asked for
+        silence IS the room — and a mute that still speaks is not a mute."""
+        monkeypatch.setenv("JARVIS_VOICE_MUTED", "1")
+        assert await safe_say("urgent", skip_gate=True, source="test") is False
+
+    @pytest.mark.parametrize("val", ["1", "true", "TRUE", "yes", "on"])
+    def test_the_obvious_spellings_all_work(self, monkeypatch, val):
+        """Someone reaching for silence should not have to guess the
+        truthy spelling."""
+        monkeypatch.setenv("JARVIS_VOICE_MUTED", val)
+        assert _voice_muted() is True
+
+    @pytest.mark.parametrize("val", ["0", "false", "no", "off", ""])
+    def test_off_really_is_off(self, monkeypatch, val):
+        monkeypatch.setenv("JARVIS_VOICE_MUTED", val)
+        assert _voice_muted() is False
+
+    def test_it_is_read_FRESH_every_call(self, monkeypatch):
+        """`/voice mute` should take effect on the next sentence, not the
+        next restart — an operator reaching for silence wants it now."""
+        assert _voice_muted() is False
+        monkeypatch.setenv("JARVIS_VOICE_MUTED", "1")
+        assert _voice_muted() is True
+        monkeypatch.setenv("JARVIS_VOICE_MUTED", "0")
+        assert _voice_muted() is False
+
+    def test_it_sits_at_the_ONE_chokepoint(self):
+        """Thirteen narrators call `safe_say`; muting there is the only
+        place the question has a complete answer."""
+        import inspect
+
+        from backend.core.supervisor import unified_voice_orchestrator as u
+        src = inspect.getsource(u.safe_say)
+        assert "_voice_muted()" in src
+        # Before the gate AND before skip_gate's carve-out.
+        assert src.index("_voice_muted()") < src.index("if not skip_gate")
+
+    def test_a_broken_env_read_never_silences_by_accident(self, monkeypatch):
+        """Fail OPEN: an unreadable flag must not mute the organism, or a
+        transient fault becomes permanent silence nobody can explain."""
+        import backend.core.supervisor.unified_voice_orchestrator as u
+        monkeypatch.setattr(
+            u.os.environ, "get",
+            lambda *a, **k: (_ for _ in ()).throw(RuntimeError("env down")))
+        assert u._voice_muted() is False


### PR DESCRIPTION
There were **thirteen** voice flags and no single answer to *"be quiet"*:

```
JARVIS_KAREN_VOICE_ENABLED        JARVIS_APPROVAL_NARRATION_ENABLED
JARVIS_KAREN_PROACTIVE_ENABLED    JARVIS_LIFECYCLE_NARRATOR_ENABLED
JARVIS_KAREN_TOOL_VOICE_ENABLED   JARVIS_INTAKE_A_NARRATOR_ENABLED
JARVIS_KAREN_SYNTH_ENABLED        JARVIS_INTROSPECTIVE_VOICE_ENABLED
JARVIS_KAREN_BARGE_IN_ENABLED     JARVIS_ADAPTIVE_VOICE_ROUTER_ENABLED
JARVIS_KAREN_VOICE_COMMAND_ENABLED …
```

Silencing the organism meant first knowing **which subsystem was talking** — the one thing an operator who wants silence does not want to think about.

## One flag, one chokepoint

`JARVIS_VOICE_MUTED=1`, honoured at `safe_say` — documented as *"the canonical safe speech function for the entire JARVIS process"*, and therefore the only place that question has a complete answer. Thirteen narrators, one primitive.

## It outranks `skip_gate`

That carve-out exists for messages urgent enough to speak whether or not the room is ready. But **an operator who has explicitly asked for silence *is* the room**, and a mute that still speaks is not a mute. Pinned by a test.

## Two details that matter

- **Read fresh every call**, not cached — it takes effect on the next sentence rather than the next restart. Someone reaching for silence is reaching for it *now*.
- **Fails open.** An unreadable flag must never mute the organism, or a transient fault becomes permanent silence nobody can explain.

## Tests

**15 new; 30 green** with the existing voice-follows-attachment spine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a single master mute for all voice output and auto-wire agent visibility to task events. This gives operators one switch to silence speech and makes swarm/pool workers appear in the roster without per-producer edits.

- New Features
  - Voice: `JARVIS_VOICE_MUTED` is checked first in `safe_say`, outranks `skip_gate`, applies immediately (read per call), and fails open if the env read errors.
  - Agent visibility: `publish_task_event` now fans out to in-process observers before `stream_enabled()`, and `install_task_event_adapter` maps events to the roster (lifecycle derived from event name; identity from payload). Broken observers don’t block others; installed at boot.

- Migration
  - To mute speech: set `JARVIS_VOICE_MUTED=1`.

<sup>Written for commit 00a229c369ca7962ca8b4d4850c1c73b5227781e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

