### PR TITLE
fix(voice): the mute now covers every speech path, not one

### DIFF
--- a/backend/core/cross_repo_voice_client.py
+++ b/backend/core/cross_repo_voice_client.py
@@ -276,6 +276,15 @@ class CrossRepoVoiceClient:
         Returns:
             (success: bool, reason: str) tuple
         """
+        # MASTER MUTE — see backend/core/voice_mute. Every speech path
+        # gets the same answer; a mute honoured by only some of them
+        # is not a mute.
+        try:
+            from backend.core.voice_mute import voice_muted
+            if voice_muted():
+                return False
+        except Exception:  # noqa: BLE001
+            pass
         if not self._initialized:
             await self.initialize()
 

--- a/backend/core/shared_voice_client.py
+++ b/backend/core/shared_voice_client.py
@@ -215,6 +215,15 @@ class VoiceClient:
         Returns:
             True if sent immediately, False if queued locally
         """
+        # MASTER MUTE — see backend/core/voice_mute. Every speech
+        # path gets the same answer; a mute honoured by only
+        # some of them is not a mute.
+        try:
+            from backend.core.voice_mute import voice_muted
+            if voice_muted():
+                return False
+        except Exception:  # noqa: BLE001
+            pass
         async with self._lock:
             if self._connected:
                 success = await self._send(text, priority, category, metadata)
@@ -399,6 +408,15 @@ async def announce(
     Returns:
         True if sent immediately, False if queued locally
     """
+    # MASTER MUTE — see backend/core/voice_mute. Every speech
+    # path gets the same answer; a mute honoured by only
+    # some of them is not a mute.
+    try:
+        from backend.core.voice_mute import voice_muted
+        if voice_muted():
+            return False
+    except Exception:  # noqa: BLE001
+        pass
     client = await get_or_create_client(source)
     return await client.announce(
         text=message,

--- a/backend/core/supervisor/unified_voice_orchestrator.py
+++ b/backend/core/supervisor/unified_voice_orchestrator.py
@@ -1380,10 +1380,8 @@ def _voice_muted() -> bool:
     reaching for silence is usually reaching for it NOW.
     """
     try:
-        import os as _os
-        return _os.environ.get(
-            "JARVIS_VOICE_MUTED", "0",
-        ).strip().lower() in ("1", "true", "yes", "on")
+        from backend.core.voice_mute import voice_muted
+        return voice_muted()
     except Exception:  # noqa: BLE001
         return False
 

--- a/backend/core/trinity_voice_coordinator.py
+++ b/backend/core/trinity_voice_coordinator.py
@@ -899,6 +899,14 @@ class TTSEngine(ABC):
         timeout: Optional[float] = None
     ) -> bool:
         """Speak message with circuit breaker protection."""
+        # MASTER MUTE — at the engine base class, which every TTS engine
+        # (pyttsx3, `say -o` + afplay) passes through. The first attempt
+        # put this only in `safe_say`, trusting that function's docstring
+        # calling itself canonical; it is one of at least five speech
+        # paths, and the operator still heard her.
+        from backend.core.voice_mute import voice_muted
+        if voice_muted():
+            return False
         timeout = timeout or self.config.engine_timeout
 
         # Check circuit breaker

--- a/backend/core/voice_mute.py
+++ b/backend/core/voice_mute.py
@@ -1,0 +1,46 @@
+"""One answer to "be quiet", for every speech path in the process.
+
+The first attempt put the mute in `unified_voice_orchestrator.safe_say`,
+on the strength of that function's own docstring calling itself "the
+canonical safe speech function for the entire JARVIS process".
+
+It is not. Verified after the operator reported still hearing her:
+
+    voice_orchestrator.speak / .announce
+    shared_voice_client.announce
+    cross_repo_voice_client.announce_*        (9 of them)
+    trinity_voice_coordinator engines         (pyttsx3, say -o + afplay)
+
+A docstring claiming canonicity is a claim, not a fact, and trusting one
+is how a mute shipped that did not mute. This module exists so the answer
+lives somewhere with NO dependencies — importable from any speech path
+without a cycle, and therefore actually reachable by all of them.
+
+Fails OPEN. An unreadable flag must never silence the organism, or a
+transient fault becomes permanent silence nobody can explain.
+"""
+from __future__ import annotations
+
+import os
+
+MASTER_MUTE_ENV_VAR = "JARVIS_VOICE_MUTED"
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+
+def voice_muted() -> bool:
+    """Has the operator asked for silence? NEVER raises.
+
+    Read fresh on every call rather than cached, so a mute takes effect on
+    the next sentence rather than the next restart — someone reaching for
+    silence is reaching for it now.
+    """
+    try:
+        return os.environ.get(
+            MASTER_MUTE_ENV_VAR, "0",
+        ).strip().lower() in _TRUTHY
+    except Exception:  # noqa: BLE001
+        return False
+
+
+__all__ = ["MASTER_MUTE_ENV_VAR", "voice_muted"]

--- a/backend/core/voice_orchestrator.py
+++ b/backend/core/voice_orchestrator.py
@@ -334,6 +334,15 @@ class SerializedSpeaker:
         Returns:
             True if completed, False if timeout/interrupted
         """
+        # MASTER MUTE — see backend/core/voice_mute. Every speech path
+        # gets the same answer; a mute honoured by only some of them
+        # is not a mute.
+        try:
+            from backend.core.voice_mute import voice_muted
+            if voice_muted():
+                return False
+        except Exception:  # noqa: BLE001
+            pass
         timeout_s = timeout_s or float(os.environ.get("VOICE_PLAYBACK_TIMEOUT_S", "30"))
 
         async with self._playback_lock:
@@ -534,6 +543,15 @@ class VoiceOrchestrator:
 
         For kernel messages that originate within the same process.
         """
+        # MASTER MUTE — see backend/core/voice_mute. Every speech path
+        # gets the same answer; a mute honoured by only some of them
+        # is not a mute.
+        try:
+            from backend.core.voice_mute import voice_muted
+            if voice_muted():
+                return False
+        except Exception:  # noqa: BLE001
+            pass
         try:
             prio = VoicePriority[priority]
         except KeyError:

--- a/tests/battle_test/test_voice_mute_all_paths.py
+++ b/tests/battle_test/test_voice_mute_all_paths.py
@@ -1,0 +1,99 @@
+"""A mute honoured by only some speech paths is not a mute.
+
+The first attempt guarded `unified_voice_orchestrator.safe_say` alone, on
+the strength of its own docstring calling itself "the canonical safe
+speech function for the entire JARVIS process".
+
+It is not. The operator set the flag and still heard her. A docstring
+claiming canonicity is a claim, not a fact.
+"""
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+
+from backend.core.voice_mute import voice_muted
+
+#: Every function through which audio can leave this process. Derived by
+#: hunting the phrase the operator actually heard, not by trusting any
+#: module's self-description.
+SPEECH_ENTRY_POINTS = {
+    "backend/core/voice_orchestrator.py": ("speak", "announce"),
+    "backend/core/shared_voice_client.py": ("announce",),
+    "backend/core/cross_repo_voice_client.py": ("announce",),
+    "backend/core/trinity_voice_coordinator.py": ("speak",),
+    "backend/core/supervisor/unified_voice_orchestrator.py": ("safe_say",),
+}
+
+
+class TestEveryPathIsGuarded:
+    @pytest.mark.parametrize("rel", sorted(SPEECH_ENTRY_POINTS))
+    def test_the_mute_is_checked(self, rel):
+        """Structural, per file: a new speech path that forgets the check
+        is the exact bug this replaces."""
+        src = pathlib.Path(rel).read_text()
+        names = SPEECH_ENTRY_POINTS[rel]
+        found = 0
+        for node in ast.walk(ast.parse(src)):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if node.name not in names:
+                continue
+            body = ast.get_source_segment(src, node) or ""
+            assert "voice_muted" in body, f"{rel}:{node.lineno} {node.name}"
+            found += 1
+        assert found, f"{rel}: no entry point found — did it move?"
+
+    def test_the_answer_lives_in_a_LEAF_module(self):
+        """`voice_mute` must import nothing from the codebase, or some
+        speech path will hit a cycle and skip the check."""
+        src = pathlib.Path("backend/core/voice_mute.py").read_text()
+        for node in ast.walk(ast.parse(src)):
+            if isinstance(node, (ast.Import, ast.ImportFrom)):
+                mod = getattr(node, "module", "") or ""
+                assert not mod.startswith("backend"), mod
+
+
+class TestTheSwitch:
+    @pytest.mark.parametrize("val", ["1", "true", "TRUE", "yes", "on"])
+    def test_obvious_spellings_work(self, monkeypatch, val):
+        monkeypatch.setenv("JARVIS_VOICE_MUTED", val)
+        assert voice_muted() is True
+
+    @pytest.mark.parametrize("val", ["0", "false", "no", "off", ""])
+    def test_off_is_off(self, monkeypatch, val):
+        monkeypatch.setenv("JARVIS_VOICE_MUTED", val)
+        assert voice_muted() is False
+
+    def test_read_fresh_every_call(self, monkeypatch):
+        monkeypatch.delenv("JARVIS_VOICE_MUTED", raising=False)
+        assert voice_muted() is False
+        monkeypatch.setenv("JARVIS_VOICE_MUTED", "1")
+        assert voice_muted() is True
+
+    def test_it_fails_OPEN(self, monkeypatch):
+        """A transient env fault must not become permanent silence nobody
+        can explain."""
+        import backend.core.voice_mute as vm
+        monkeypatch.setattr(
+            vm.os.environ, "get",
+            lambda *a, **k: (_ for _ in ()).throw(RuntimeError("env down")))
+        assert vm.voice_muted() is False
+
+
+class TestItActuallySilences:
+    @pytest.mark.asyncio
+    async def test_safe_say_is_silent(self, monkeypatch):
+        from backend.core.supervisor.unified_voice_orchestrator import safe_say
+        monkeypatch.setenv("JARVIS_VOICE_MUTED", "1")
+        assert await safe_say("hello", source="test") is False
+
+    @pytest.mark.asyncio
+    async def test_even_the_emergency_carve_out_is_silent(self, monkeypatch):
+        """`skip_gate` speaks whether or not the room is ready. An operator
+        who asked for silence IS the room."""
+        from backend.core.supervisor.unified_voice_orchestrator import safe_say
+        monkeypatch.setenv("JARVIS_VOICE_MUTED", "1")
+        assert await safe_say("urgent", skip_gate=True, source="test") is False


### PR DESCRIPTION
You set `JARVIS_VOICE_MUTED=1` and still heard her. The mute was real — it was in the wrong place.

## What I got wrong

I put it in `unified_voice_orchestrator.safe_say` on the strength of **that function's own docstring**: *"the canonical safe speech function for the entire JARVIS process."*

It is not canonical. Verified only after your report:

| module | entry points |
|---|---|
| `voice_orchestrator` | `speak`, `announce` |
| `shared_voice_client` | `announce` (method **and** module-level) |
| `cross_repo_voice_client` | `announce` |
| `trinity_voice_coordinator` | engine `speak` — pyttsx3, `say -o` + afplay |
| `unified_voice_orchestrator` | `safe_say` |

**Five modules, seven entry points.** A docstring claiming canonicity is a claim, not a fact — and I trusted one instead of checking callers, which is the exact failure mode this session has been finding all day, committed by me in the fix for it.

## The fix

`backend/core/voice_mute.py` holds the answer and **nothing else**: a leaf with no codebase imports, so every speech path can reach it without a cycle. A test asserts that emptiness — the moment it imports something real, some path hits a cycle and silently skips the check.

All seven entry points now ask it. The engine-level guard in `trinity_voice_coordinator.speak` is the load-bearing one: it's the base class every TTS engine passes through, so it catches paths that never touched an orchestrator at all.

## Two things the sweep caught before writing

- `shared_voice_client` has a **method and a module-level function both named `announce`**. A fixed indent was correct for one and a `SyntaxError` for the other; the indent is now read from each function's own `col_offset`. `ast.parse` refused the bad version.
- The guard is inserted **after** the docstring, not before — a guard above it turns the docstring into dead code and the function into one with no documentation.

Still fails **open**, still read fresh per call, still outranks `skip_gate`.

## Tests

**20 new; 50 green** across the mute, master-mute and voice-follows-attachment spines.

The structural test enumerates every entry point per file, so a new speech path that forgets the check fails rather than shipping silent-except-not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes master mute so `JARVIS_VOICE_MUTED=1` silences all TTS paths. Centralizes mute logic and guards every speech entry point, including the engine base.

- **Bug Fixes**
  - Added `backend/core/voice_mute.py` with `voice_muted()` as the single source of truth; reads `JARVIS_VOICE_MUTED` on each call and fails open.
  - Applied the mute check to all entry points: `voice_orchestrator.speak/announce`, `shared_voice_client.announce` (method and module), `cross_repo_voice_client.announce`, and `trinity_voice_coordinator.speak` (engine base).
  - Kept guards after function docstrings to preserve docs.
  - Added structural tests to enforce guard coverage and ensure `voice_mute` has no codebase imports.

<sup>Written for commit 282a147514d45c96e94f0ad67ea708d79b3e2be7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70267?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

