### PR TITLE
fix(ov): a daemon can now say what it is without being watched

### DIFF
--- a/backend/core/ouroboros/battle_test/daemon_provenance.py
+++ b/backend/core/ouroboros/battle_test/daemon_provenance.py
@@ -26,12 +26,12 @@ import os
 import subprocess
 import time
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger("Ouroboros.Provenance")
 
 __all__ = ["client_binary_warning", "read_provenance", "staleness_line",
-           "write_provenance"]
+           "write_provenance", "env_drift", "env_drift_line"]
 
 _STAMP = ".jarvis/daemon_provenance.json"
 
@@ -52,6 +52,61 @@ def _git(*args: str, root: Optional[Path] = None) -> str:
         return ""
 
 
+def _jarvis_env() -> Dict[str, str]:
+    """The JARVIS_* environment, for staleness comparison. NEVER raises.
+
+    VALUES are kept, not just keys: "the daemon has JARVIS_VOICE_MUTED=0
+    and you have =1" is actionable, while "the daemon has different env"
+    is another thing to go and check.
+    """
+    try:
+        import os as _os
+        return {
+            k: str(v)[:80] for k, v in _os.environ.items()
+            if k.startswith("JARVIS_")
+        }
+    except Exception:  # noqa: BLE001
+        return {}
+
+
+def env_drift(provenance: Optional[Dict[str, Any]] = None) -> List[str]:
+    """JARVIS_* settings that differ between this shell and that daemon.
+
+    Returns human-readable differences, most actionable first. Empty when
+    they agree — or when the daemon predates this field, which is stated
+    rather than guessed at: an older daemon has no `env` key, and claiming
+    agreement we cannot verify is how the last three answers went wrong.
+
+    NEVER raises.
+    """
+    try:
+        data = provenance if provenance is not None else read_provenance()
+        if not isinstance(data, dict) or "env" not in data:
+            return []
+        theirs = data.get("env")
+        # `env: null` means the daemon recorded NOTHING, not that it ran
+        # with an empty environment. Treating the two alike reported every
+        # local setting as "absent in the daemon" — a confident answer
+        # built on a field that was never written.
+        if not isinstance(theirs, dict) or not theirs:
+            return []
+        mine = _jarvis_env()
+        out: List[str] = []
+        for key in sorted(set(mine) | set(theirs)):
+            a, b = theirs.get(key), mine.get(key)
+            if a == b:
+                continue
+            if a is None:
+                out.append(f"{key}={b} is set here, ABSENT in the daemon")
+            elif b is None:
+                out.append(f"{key}={a} in the daemon, unset here")
+            else:
+                out.append(f"{key}: daemon={a}, here={b}")
+        return out
+    except Exception:  # noqa: BLE001
+        return []
+
+
 def write_provenance(path: Optional[Path] = None) -> Optional[Path]:
     """Stamp what this daemon booted from. Called once, at boot."""
     target = path or (_repo_root() / _STAMP)
@@ -61,6 +116,19 @@ def write_provenance(path: Optional[Path] = None) -> Optional[Path]:
             "pid": os.getpid(),
             "booted_at": time.time(),
             "commit": _git("rev-parse", "HEAD"),
+            # The daemon's ENVIRONMENT, as it was at launch.
+            #
+            # Code staleness was already covered; this is the other half,
+            # and it is the half that actually bit: an operator exported
+            # JARVIS_VOICE_MUTED=1 and the daemon kept talking, because
+            # `export` reaches processes started AFTERWARDS and this one
+            # was a day old. Same commit, so no warning fired — the code
+            # was current and the environment was not.
+            #
+            # Only JARVIS_* is captured: everything else is the machine's
+            # business, and a full environ dump on disk is a credential
+            # leak waiting for a postmortem to read it.
+            "env": _jarvis_env(),
             "branch": _git("rev-parse", "--abbrev-ref", "HEAD"),
         }), encoding="utf-8")
         return target
@@ -120,6 +188,26 @@ def staleness_line(
         # transcribed pid, and a `kill`.
         return (f"⚠ daemon booted {_age(age_s)} ago on {commit[:7]} · "
                 f"{detail} · run `ov restart` to load current code")
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def env_drift_line(max_shown: int = 3) -> str:
+    """One line naming the settings this daemon cannot see. NEVER raises.
+
+    Separate from `staleness_line` because the remedies differ: stale CODE
+    wants a restart, a stale ENVIRONMENT wants a restart too — but only
+    after the operator knows WHICH setting is being ignored, or they will
+    restart and set it in the wrong shell again.
+    """
+    try:
+        drift = env_drift()
+        if not drift:
+            return ""
+        shown = " · ".join(drift[:max_shown])
+        more = f" (+{len(drift) - max_shown} more)" if len(drift) > max_shown else ""
+        return (f"⚠ this daemon's environment predates your shell — {shown}"
+                f"{more} · `export` cannot reach a running process; restart it")
     except Exception:  # noqa: BLE001
         return ""
 

--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -1294,6 +1294,29 @@ class BattleTestHarness:
 
         try:
             _running_loop.set_exception_handler(_harness_loop_exception_handler)
+            # IDENTITY, at boot, unconditionally.
+            #
+            # This stamp already existed — inside
+            # `_start_cockpit_attach_bridge`, so a daemon only recorded what
+            # it was made of IF someone attached a cockpit to it. Its own
+            # comment states the intent exactly ("it outlives the terminal
+            # that started it"), and the placement defeated it: a headless
+            # daemon, which is precisely the one an operator cannot see,
+            # never stamped itself at all.
+            #
+            # A process's identity is a property of the PROCESS, not of
+            # whether anyone is watching it. Written here, before any
+            # surface exists, so `ov attach` can always answer "how old is
+            # this thing and what code is it running" — the question whose
+            # absence sent an operator chasing environment variables at a
+            # daemon that had been up for 23 hours.
+            try:
+                from backend.core.ouroboros.battle_test.daemon_provenance import (  # noqa: E501
+                    write_provenance,
+                )
+                write_provenance()
+            except Exception:  # noqa: BLE001
+                pass
             # Panic broadcast: a traceback in a log file is invisible to
             # someone watching a cockpit.
             try:

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -1781,9 +1781,17 @@ async def _split_plane_loop(
     # verb with old behaviour while looking perfectly healthy.
     try:
         from backend.core.ouroboros.battle_test.daemon_provenance import (
+            env_drift_line,
             staleness_line,
         )
         _stale = staleness_line()
+        # The OTHER half of "why isn't this daemon doing what I asked".
+        # Stale code and a stale environment are different failures with
+        # the same symptom, and showing only one sent an operator chasing
+        # a flag at a process that could never have seen it.
+        _drift = env_drift_line()
+        if _drift:
+            _stale = f"{_stale}\n{_drift}" if _stale else _drift
         if _stale:
             console.print(_stale, markup=False, highlight=False)
     except Exception:  # noqa: BLE001 — provenance must never block an attach

--- a/tests/battle_test/test_daemon_identity.py
+++ b/tests/battle_test/test_daemon_identity.py
@@ -1,0 +1,133 @@
+"""A daemon must be able to say what it is, without being watched.
+
+The whole chase — export a flag, still hear the voice, export again, add
+guards, add a sentinel — happened because nothing told the operator (or
+me) that the process talking had been running for 23 hours on code from
+the previous day. The instrument existed. It was stamped inside
+`_start_cockpit_attach_bridge`, so a daemon only recorded what it was made
+of IF someone attached a cockpit to it.
+
+A process's identity is a property of the PROCESS, not of whether anyone
+is watching it.
+"""
+from __future__ import annotations
+
+import ast
+import json
+import pathlib
+import time
+
+import pytest
+
+from backend.core.ouroboros.battle_test import daemon_provenance as dp
+
+
+class TestIdentityIsStampedAtBoot:
+    def test_the_stamp_is_NOT_gated_on_a_cockpit(self):
+        """It was written inside the attach-bridge setup, so the headless
+        daemon — the one an operator cannot see — never stamped itself."""
+        src = pathlib.Path(
+            "backend/core/ouroboros/battle_test/harness.py").read_text()
+        tree = ast.parse(src)
+        gated = boot = False
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            body = ast.get_source_segment(src, node) or ""
+            if "write_provenance()" not in body:
+                continue
+            if node.name == "_start_cockpit_attach_bridge":
+                gated = True
+            else:
+                boot = True
+        assert boot, "provenance is written nowhere outside the attach path"
+
+    def test_it_records_what_the_operator_needs(self, tmp_path):
+        path = dp.write_provenance(tmp_path / "p.json")
+        assert path is not None
+        data = dp.read_provenance(tmp_path / "p.json")
+        for key in ("commit", "branch", "booted_at", "pid", "env"):
+            assert key in data, key
+
+
+class TestTheIncidentIsNowVISIBLE:
+    def test_a_stale_daemon_says_so(self, tmp_path):
+        """The exact shape: 23 hours old, behind HEAD."""
+        p = tmp_path / "p.json"
+        dp.write_provenance(p)
+        d = dp.read_provenance(p)
+        d["booted_at"] = time.time() - 23 * 3600
+        d["commit"] = "0" * 40
+        p.write_text(json.dumps(d))
+        line = dp.staleness_line(p)
+        assert "23h" in line and "behind HEAD" in line
+
+    def test_a_stale_ENVIRONMENT_says_so_even_on_the_same_commit(
+            self, tmp_path, monkeypatch):
+        """The half that actually bit. Code current, environment a day
+        old — no code warning fires, and `export` still cannot reach it."""
+        monkeypatch.delenv("JARVIS_VOICE_MUTED", raising=False)
+        p = tmp_path / "p.json"
+        dp.write_provenance(p)
+        monkeypatch.setenv("JARVIS_VOICE_MUTED", "1")
+        drift = dp.env_drift(dp.read_provenance(p))
+        assert any("JARVIS_VOICE_MUTED" in d for d in drift), drift
+        assert "ABSENT in the daemon" in " ".join(drift)
+
+    def test_the_line_names_the_SETTING_not_just_the_fact(self, tmp_path,
+                                                          monkeypatch):
+        """"different env" is another thing to go and check. The whole
+        point is that the operator should not have to."""
+        monkeypatch.delenv("JARVIS_VOICE_MUTED", raising=False)
+        p = tmp_path / "p.json"
+        dp.write_provenance(p)
+        monkeypatch.setenv("JARVIS_VOICE_MUTED", "1")
+        monkeypatch.setattr(dp, "read_provenance",
+                            lambda *_a, **_k: dp.read_provenance.__wrapped__(p)
+                            if hasattr(dp.read_provenance, "__wrapped__")
+                            else json.loads(p.read_text()))
+        line = dp.env_drift_line()
+        assert "JARVIS_VOICE_MUTED" in line
+        assert "export" in line and "restart" in line
+
+    def test_agreement_is_silent(self, tmp_path):
+        dp.write_provenance(tmp_path / "p.json")
+        assert dp.env_drift(dp.read_provenance(tmp_path / "p.json")) == []
+
+
+class TestItRefusesToGuess:
+    def test_a_daemon_predating_the_field_claims_NOTHING(self):
+        """An older daemon has no `env` key. Claiming agreement we cannot
+        verify is how the last three answers went wrong."""
+        assert dp.env_drift({"commit": "abc"}) == []
+
+    @pytest.mark.parametrize("junk", [{}, {"env": "x"}, {"env": None},
+                                      {"env": {}}, 42])
+    def test_junk_degrades(self, junk):
+        """`env: null` and `env: {}` mean the daemon recorded NOTHING, not
+        that it ran with an empty environment. Treating them alike
+        reported every local setting as "absent in the daemon" — a
+        confident answer built on a field that was never written.
+
+        `None` is deliberately NOT in this list: it means "use the
+        default provenance", which is a legitimate call, not junk."""
+        assert dp.env_drift(junk) == []          # type: ignore[arg-type]
+
+    def test_only_JARVIS_vars_are_captured(self, tmp_path, monkeypatch):
+        """A full environ dump on disk is a credential leak waiting for a
+        postmortem to read it."""
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "should-never-land")
+        dp.write_provenance(tmp_path / "p.json")
+        blob = (tmp_path / "p.json").read_text()
+        assert "should-never-land" not in blob
+        assert "AWS_SECRET" not in blob
+
+
+class TestTheOperatorSeesIt:
+    def test_attach_shows_BOTH_halves(self):
+        """Stale code and a stale environment are different failures with
+        the same symptom; showing only one sent an operator chasing a flag
+        at a process that could never have seen it."""
+        src = pathlib.Path("backend/core/ouroboros/cli/ov.py").read_text()
+        assert "env_drift_line" in src
+        assert "staleness_line" in src


### PR DESCRIPTION
**The root cause of the whole voice chase.**

`write_provenance()` — the stamp recording a daemon's commit, branch and boot time — lived inside `_start_cockpit_attach_bridge`. Its own comment states the intent exactly:

> *"Stamp what this daemon is MADE of. It outlives the terminal that started it, so an operator cannot otherwise tell a minute-old process from a two-day one carrying none of today's fixes."*

**The placement defeated it.** A daemon only recorded what it was made of *if someone attached a cockpit*. So the headless one — precisely the process an operator cannot see — never stamped itself at all.

A process's identity is a property of the **process**, not of whether anyone is watching it. It is stamped at boot now, before any surface exists.

## What that would have prevented

```
PID 5255  ouroboros_battle_test.py --headless  up 23h
```

You exported `JARVIS_VOICE_MUTED=1` and kept hearing her. Three answers followed — a mute at `safe_say` (trusting a docstring calling itself canonical), guards on all seven speech paths, then a sentinel file — **before anyone checked the process table**.

With the stamp at boot, `ov attach` says on the first line:

```
⚠ daemon booted 23h ago on 0000000 · behind HEAD · run `ov restart` to load current code
```

## The other half, which nothing covered

Code staleness was already computed. A daemon on the **current commit** with a **day-old environment** was invisible — and that is the failure that actually bit, because `export` reaches processes started *afterwards* and says nothing about one already running.

Provenance now fingerprints the `JARVIS_*` environment at boot, and the client reports the difference **by name**:

```
⚠ this daemon's environment predates your shell —
  JARVIS_VOICE_MUTED=1 is set here, ABSENT in the daemon ·
  `export` cannot reach a running process; restart it
```

Values are kept, not just keys: *"the daemon has =0 and you have =1"* is actionable; *"different env"* is another thing to go and check.

## Nuances

- **Only `JARVIS_*` is captured.** A full environ dump on disk is a credential leak waiting for a postmortem to read it — pinned by a test that plants an `AWS_SECRET_ACCESS_KEY` and asserts it never lands.
- **A daemon predating the field claims nothing.** No `env` key → no comparison, rather than a guess.
- **`env: null` and `env: {}` mean "recorded nothing", not "ran with an empty environment."** Conflating them reported every local setting as absent — a confident answer built on a field that was never written. Found by running it.

## Tests

**14 new; 112 green** across identity, attach, cockpit and panic suites.

## Related

The mute work itself (7 speech paths + runtime sentinel) is on `fix/voice-mute-true-egress` and `fix/voice-mute-runtime-sentinel`. This PR is the reason none of that was discoverable in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Daemons now stamp their identity at boot so headless processes always record commit/branch/boot time, and `ov attach` now shows `JARVIS_*` env drift between your shell and the running daemon.

- **Bug Fixes**
  - Write provenance at startup instead of inside the cockpit attach path, so every daemon (headless or not) records commit, branch, boot time, and pid.
  - Prevents misdiagnosis when a long‑running daemon ignores new shell exports by surfacing its age and code state immediately.

- **New Features**
  - Capture `JARVIS_*` environment at boot and compare to the current shell; `ov attach` prints a one‑liner naming specific differences (e.g., “JARVIS_VOICE_MUTED: daemon=0, here=1”) and advises restart.
  - Add `env_drift()` and `env_drift_line()` helpers; keep values (truncated), only record `JARVIS_*` to avoid credential leaks, and treat older stamps without `env` as “unknown,” not “empty.”

<sup>Written for commit 09c97c8b1774007b7a4b632ca5226f612094ab8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

