### PR TITLE
fix(voice): a mute a RUNNING daemon can hear

### DIFF
--- a/backend/core/voice_mute.py
+++ b/backend/core/voice_mute.py
@@ -25,22 +25,99 @@ import os
 
 MASTER_MUTE_ENV_VAR = "JARVIS_VOICE_MUTED"
 
+#: Runtime mute. A FILE, because the process that is talking is usually a
+#: daemon that has been running for hours.
+#:
+#: The env var alone could not silence it, and that is not a bug in the
+#: flag — it is what an environment IS. `export` affects processes started
+#: AFTERWARDS, in that shell; a running process's environment was fixed at
+#: its launch. The operator exported the variable, the daemon (already up,
+#: headless, started from a different shell) never saw it, and kept
+#: talking. Correct behaviour, useless outcome.
+#:
+#: A sentinel file is observable by a process that is already running,
+#: needs no IPC, no port, no protocol, and survives the daemon outliving
+#: the terminal that started it — which is the specific condition under
+#: which someone actually wants silence.
+SENTINEL_NAME = "voice_muted"
+
 _TRUTHY = ("1", "true", "yes", "on")
+
+
+def sentinel_paths() -> tuple:
+    """Where a runtime mute may be declared. NEVER raises.
+
+    Repo-local first (per-checkout, what a soak reads), then the user's
+    home (machine-wide, what someone types once and forgets). Either
+    silences: an operator asking twice for quiet should not have to learn
+    which one this daemon happens to read.
+    """
+    try:
+        here = os.path.join(os.getcwd(), ".jarvis", SENTINEL_NAME)
+        home = os.path.join(
+            os.path.expanduser("~"), ".jarvis", SENTINEL_NAME)
+        return (here, home)
+    except Exception:  # noqa: BLE001
+        return ()
 
 
 def voice_muted() -> bool:
     """Has the operator asked for silence? NEVER raises.
 
-    Read fresh on every call rather than cached, so a mute takes effect on
-    the next sentence rather than the next restart — someone reaching for
-    silence is reaching for it now.
+    Read fresh on every call — env AND sentinel — so a mute takes effect
+    on the next sentence rather than the next restart. A `stat` costs
+    microseconds and sentences are seconds apart, so there is nothing to
+    cache and a cache would only delay the one thing being asked for.
     """
     try:
-        return os.environ.get(
-            MASTER_MUTE_ENV_VAR, "0",
-        ).strip().lower() in _TRUTHY
+        if os.environ.get(
+                MASTER_MUTE_ENV_VAR, "0").strip().lower() in _TRUTHY:
+            return True
     except Exception:  # noqa: BLE001
-        return False
+        pass
+    for path in sentinel_paths():
+        try:
+            if os.path.exists(path):
+                return True
+        except Exception:  # noqa: BLE001
+            continue
+    return False
 
 
-__all__ = ["MASTER_MUTE_ENV_VAR", "voice_muted"]
+def mute(scope: str = "repo") -> str:
+    """Create the sentinel. Returns the path written, or "". NEVER raises."""
+    try:
+        target = sentinel_paths()[0 if scope == "repo" else 1]
+        os.makedirs(os.path.dirname(target), exist_ok=True)
+        with open(target, "w", encoding="utf-8") as fh:
+            fh.write("silenced by the operator\n")
+        return target
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def unmute() -> int:
+    """Remove every sentinel. Returns how many were cleared. NEVER raises.
+
+    ALL of them, not the first found: a half-cleared mute that still
+    silences is exactly as confusing as a mute that does not.
+    """
+    cleared = 0
+    for path in sentinel_paths():
+        try:
+            if os.path.exists(path):
+                os.remove(path)
+                cleared += 1
+        except Exception:  # noqa: BLE001
+            continue
+    return cleared
+
+
+__all__ = [
+    "MASTER_MUTE_ENV_VAR",
+    "SENTINEL_NAME",
+    "mute",
+    "sentinel_paths",
+    "unmute",
+    "voice_muted",
+]

--- a/tests/battle_test/test_voice_master_mute.py
+++ b/tests/battle_test/test_voice_master_mute.py
@@ -16,8 +16,17 @@ from backend.core.supervisor.unified_voice_orchestrator import (
 
 
 @pytest.fixture(autouse=True)
-def _unmuted(monkeypatch):
+def _isolated(monkeypatch):
+    """No env, and NO real sentinel files.
+
+    These tests read the actual filesystem otherwise — and the moment an
+    operator legitimately mutes their own machine, the suite starts
+    failing for a reason that has nothing to do with the code. Tests that
+    exercise sentinels re-patch `sentinel_paths` themselves.
+    """
+    import backend.core.voice_mute as vm
     monkeypatch.delenv("JARVIS_VOICE_MUTED", raising=False)
+    monkeypatch.setattr(vm, "sentinel_paths", lambda: ())
     yield
 
 
@@ -70,8 +79,13 @@ class TestOneSwitch:
     def test_a_broken_env_read_never_silences_by_accident(self, monkeypatch):
         """Fail OPEN: an unreadable flag must not mute the organism, or a
         transient fault becomes permanent silence nobody can explain."""
+        import backend.core.voice_mute as vm
         import backend.core.supervisor.unified_voice_orchestrator as u
-        monkeypatch.setattr(
-            u.os.environ, "get",
-            lambda *a, **k: (_ for _ in ()).throw(RuntimeError("env down")))
+
+        def _boom():
+            raise RuntimeError("env down")
+
+        # Patch the LEAF the orchestrator delegates to — patching the
+        # shared `os` module would break every later test in the session.
+        monkeypatch.setattr(vm, "voice_muted", _boom)
         assert u._voice_muted() is False

--- a/tests/battle_test/test_voice_mute_all_paths.py
+++ b/tests/battle_test/test_voice_mute_all_paths.py
@@ -28,6 +28,21 @@ SPEECH_ENTRY_POINTS = {
 }
 
 
+@pytest.fixture(autouse=True)
+def _isolated(monkeypatch):
+    """No env, and NO real sentinel files.
+
+    These tests read the actual filesystem otherwise — and the moment an
+    operator legitimately mutes their own machine, the suite starts
+    failing for a reason that has nothing to do with the code. Tests that
+    exercise sentinels re-patch `sentinel_paths` themselves.
+    """
+    import backend.core.voice_mute as vm
+    monkeypatch.delenv("JARVIS_VOICE_MUTED", raising=False)
+    monkeypatch.setattr(vm, "sentinel_paths", lambda: ())
+    yield
+
+
 class TestEveryPathIsGuarded:
     @pytest.mark.parametrize("rel", sorted(SPEECH_ENTRY_POINTS))
     def test_the_mute_is_checked(self, rel):
@@ -77,9 +92,24 @@ class TestTheSwitch:
         """A transient env fault must not become permanent silence nobody
         can explain."""
         import backend.core.voice_mute as vm
-        monkeypatch.setattr(
-            vm.os.environ, "get",
-            lambda *a, **k: (_ for _ in ()).throw(RuntimeError("env down")))
+
+        class _Hostile:
+            """Only THIS module's view of os is broken.
+
+            The first version patched `vm.os.environ.get` — and `vm.os` IS
+            the global `os` module, so it broke `os.environ.get` for pytest
+            itself and every test that ran after. A monkeypatch that reaches
+            outside the unit under test is not a test, it is sabotage with a
+            fixture.
+            """
+
+            class environ:
+                @staticmethod
+                def get(*_a, **_k):
+                    raise RuntimeError("env down")
+
+        monkeypatch.setattr(vm, "os", _Hostile)
+        monkeypatch.setattr(vm, "sentinel_paths", lambda: ())
         assert vm.voice_muted() is False
 
 

--- a/tests/battle_test/test_voice_mute_all_paths.py
+++ b/tests/battle_test/test_voice_mute_all_paths.py
@@ -97,3 +97,66 @@ class TestItActuallySilences:
         from backend.core.supervisor.unified_voice_orchestrator import safe_say
         monkeypatch.setenv("JARVIS_VOICE_MUTED", "1")
         assert await safe_say("urgent", skip_gate=True, source="test") is False
+
+
+class TestARunningDaemonCanBeSilenced:
+    """`export` cannot reach a process that is already running.
+
+    The operator exported the flag and still heard her. That was not a bug
+    in the flag — it is what an environment IS: `export` affects processes
+    started AFTERWARDS in that shell, and a running process's environment
+    was fixed at its launch. The daemon (up for 23 hours, headless,
+    started from a different shell) never saw it. Correct behaviour,
+    useless outcome.
+    """
+
+    def test_a_sentinel_FILE_silences_without_a_restart(self, tmp_path,
+                                                        monkeypatch):
+        import backend.core.voice_mute as vm
+        monkeypatch.delenv("JARVIS_VOICE_MUTED", raising=False)
+        target = tmp_path / ".jarvis" / "voice_muted"
+        monkeypatch.setattr(vm, "sentinel_paths", lambda: (str(target),))
+        assert vm.voice_muted() is False
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("x")
+        # No restart, no re-import, no IPC.
+        assert vm.voice_muted() is True
+
+    def test_either_scope_silences(self, tmp_path, monkeypatch):
+        """Repo-local for a soak, home for "I typed it once". An operator
+        asking twice for quiet should not have to learn which one this
+        daemon happens to read."""
+        import backend.core.voice_mute as vm
+        monkeypatch.delenv("JARVIS_VOICE_MUTED", raising=False)
+        a, b = tmp_path / "a", tmp_path / "b"
+        monkeypatch.setattr(vm, "sentinel_paths", lambda: (str(a), str(b)))
+        for which in (a, b):
+            which.write_text("x")
+            assert vm.voice_muted() is True
+            which.unlink()
+            assert vm.voice_muted() is False
+
+    def test_unmute_clears_EVERY_sentinel(self, tmp_path, monkeypatch):
+        """Not the first found: a half-cleared mute that still silences is
+        exactly as confusing as a mute that does not."""
+        import backend.core.voice_mute as vm
+        monkeypatch.delenv("JARVIS_VOICE_MUTED", raising=False)
+        a, b = tmp_path / "a", tmp_path / "b"
+        a.write_text("x"); b.write_text("x")
+        monkeypatch.setattr(vm, "sentinel_paths", lambda: (str(a), str(b)))
+        assert vm.unmute() == 2
+        assert vm.voice_muted() is False
+
+    def test_the_env_var_still_works(self, monkeypatch):
+        """Both, not either: env for a fresh launch, sentinel for a live
+        one."""
+        import backend.core.voice_mute as vm
+        monkeypatch.setattr(vm, "sentinel_paths", lambda: ())
+        monkeypatch.setenv("JARVIS_VOICE_MUTED", "1")
+        assert vm.voice_muted() is True
+
+    def test_an_unreadable_sentinel_path_never_silences(self, monkeypatch):
+        import backend.core.voice_mute as vm
+        monkeypatch.delenv("JARVIS_VOICE_MUTED", raising=False)
+        monkeypatch.setattr(vm, "sentinel_paths", lambda: (None, 42))
+        assert vm.voice_muted() is False


### PR DESCRIPTION
> Stacked on #70267 — merge that first.

You exported `JARVIS_VOICE_MUTED=1` and still heard her. I checked the process table instead of guessing again:

```
PID 5255   ouroboros_battle_test.py --headless   up 23h
PID 19222  audio_plane_host.py                   up 1d 2h
```

That is not a bug in the flag. **It is what an environment IS**: `export` affects processes started *afterwards* in that shell, and a running process's environment was fixed at its launch. The daemon — headless, started a day earlier from a different shell — never saw the variable and never could. Correct behaviour, useless outcome.

**An env var is a launch-time instrument. Silence is a runtime request** — and the moment someone wants it is precisely the moment the thing talking has been running for hours.

## The sentinel

`.jarvis/voice_muted` in the repo, or `~/.jarvis/voice_muted`. Observable by a process already running, with no IPC, no port and no protocol — and it survives the daemon outliving the terminal that started it, which is the specific condition under which anyone actually wants quiet.

| behaviour | why |
|---|---|
| either scope silences | repo-local is what a soak reads, home is what someone types once — an operator asking twice for quiet shouldn't have to learn which one this daemon reads |
| `unmute()` clears **every** sentinel | a half-cleared mute that still silences is as confusing as one that doesn't |
| env still honoured | for a fresh launch; both checked, fresh, per call |
| fails **open** | an unreadable path must never become permanent silence nobody can explain |

## What this does NOT fix

**PID 5255 loaded its modules before any of this code existed.** No flag and no file can reach it. That process has to be restarted — and saying otherwise would be the third wrong answer to the same question.

#70268 is the reason that was invisible in the first place.

## Two test defects fixed along the way

- `test_it_fails_OPEN` patched `vm.os.environ.get` — and `vm.os` **is** the global `os` module, so it broke `os.environ.get` for pytest itself and six unrelated tests. A monkeypatch that reaches outside the unit under test is not a test.
- The suite read the **real filesystem** for sentinels, so it went red the moment an operator legitimately muted their own machine. An autouse fixture now clears both env and sentinel paths.

## Tests

**25 green** on the mute spine; **55 green** with the master-mute and voice-follows-attachment spines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a runtime master mute and wires it into every speech path so a running daemon can be silenced immediately. Supports `JARVIS_VOICE_MUTED` and `.jarvis/voice_muted` sentinels, checks both per call, and fails open on errors.

- **New Features**
  - Leaf module `backend/core/voice_mute.py` now exports `SENTINEL_NAME`, `sentinel_paths()`, `voice_muted()`, `mute()`, and `unmute()`; still a no-internal-imports leaf to avoid cycles.
  - Runtime sentinel support for `.jarvis/voice_muted` and `~/.jarvis/voice_muted`; `mute(scope)` creates one and returns its path, `unmute()` clears all and returns a count.
  - Master mute check is applied across all speech entry points (orchestrators, clients, and TTS engines).

- **Bug Fixes**
  - `_voice_muted` in the unified orchestrator delegates to `voice_muted()` for consistent, fail-open behavior.
  - Tests isolated from real env and filesystem via autouse fixtures; fail-open tests patch the leaf module (not the global `os`) to avoid session-wide side effects.

<sup>Written for commit b9b3cca73f0715203ca425ccda320b46e3d1ff56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

