### PR TITLE
feat(ov): tokens land IN the transcript — the blocker was my analysis

### DIFF
--- a/backend/core/ouroboros/battle_test/bipartite_layout.py
+++ b/backend/core/ouroboros/battle_test/bipartite_layout.py
@@ -318,6 +318,23 @@ class BipartiteLayout:
         await asyncio.sleep(0)   # cooperative yield — the decoupling proof
         self.emit(event_type, payload)
 
+    def set_streaming_tail(self, text: object) -> None:
+        """The line currently being WRITTEN, rendered inside the deck.
+
+        Not a push: this is a view of something still happening, and a
+        pending line that entered the ring would be evicted by maxlen
+        mid-sentence and survive as history if the stream died. `as_text`
+        composes it last on every frame, so it lands at the end of the
+        transcript exactly where it will come to rest — which is CC's
+        actual mechanic, rather than a strip below the deck approximating
+        it. NEVER raises.
+        """
+        try:
+            self._buffer.set_pending(text)
+        except Exception:  # noqa: BLE001
+            return
+        self._invalidate_now()
+
     def push_raw(self, markup_line: str) -> None:
         """Push a pre-formatted Rich-markup line (e.g. piped Sentinel stdout).
         Never raises."""
@@ -761,6 +778,7 @@ def build_bipartite_application(
     stream_rows: Optional[Callable[[], Any]] = None,
     queue_rows: Optional[Callable[[], Any]] = None,
     panic_rows: Optional[Callable[[], Any]] = None,
+    on_mux: Optional[Callable[[Any], None]] = None,
     serpent_active: Optional[Callable[[], bool]] = None,
 ) -> Any:
     """Construct the full-screen ``prompt_toolkit.Application``: Zone 1 an ANSI
@@ -1490,6 +1508,7 @@ async def run_bipartite_repl(
     stream_rows: Optional[Callable[[], Any]] = None,
     queue_rows: Optional[Callable[[], Any]] = None,
     panic_rows: Optional[Callable[[], Any]] = None,
+    on_mux: Optional[Callable[[Any], None]] = None,
     serpent_active: Optional[Callable[[], bool]] = None,
 ) -> None:
     """Launch the full-screen Bipartite REPL: build the multiplexer, register it as
@@ -1510,6 +1529,16 @@ async def run_bipartite_repl(
         height=max(6, size.lines - max(0, header_height) - 2),
         title=title,
     )
+    # Hand the multiplexer to the caller. Without it the client holds no
+    # reference to the deck, so a seam like `set_streaming_tail` is
+    # reachable in principle and inert in practice — the trap this
+    # codebase has produced five times, most recently inside the fix for
+    # it.
+    if on_mux is not None:
+        try:
+            on_mux(mux)
+        except Exception:  # noqa: BLE001
+            logger.debug("[Bipartite] on_mux hook failed", exc_info=True)
     set_active_canvas(mux)
     for ln in (seed or []):
         mux.push_raw(ln)

--- a/backend/core/ouroboros/battle_test/split_layout.py
+++ b/backend/core/ouroboros/battle_test/split_layout.py
@@ -92,11 +92,31 @@ def _region_title() -> Dict[str, str]:
 
 @dataclass
 class RegionBuffer:
-    """Bounded append-only text buffer for one region."""
+    """Bounded append-only HISTORY, plus one uncommitted tail.
+
+    The ring stays append-only — that is correct and load-bearing, because
+    it holds the session's history and nothing should be able to rewrite
+    it. What was missing is that `as_text` COMPOSES on every read, so an
+    in-flight line does not need the ring to mutate: it only needs to be
+    joined on at render time.
+
+    That distinction was the whole blocker. Believing the tail had to be
+    written INTO the ring implied per-stream anchors, a rule for a
+    competing producer appending mid-sentence, and a re-wrap on every
+    delta. Composition needs none of them: the pending tail is one string,
+    always last, and a push simply lands in front of it.
+
+    The result is CC's actual mechanic — tokens appearing at the END of
+    the transcript, in place — rather than a separate strip below it.
+    """
     name: str
     maxlen: int
     _lines: Deque[str] = field(default_factory=deque)
     _push_count: int = 0
+    #: The line currently being written. NOT history: it is unbounded by
+    #: maxlen, never evicted, and replaced wholesale rather than appended
+    #: to, because the producer always sends the whole tail it has.
+    _pending: str = ""
 
     def push(self, line: str) -> None:
         # Bound maxlen once the buffer crosses threshold.
@@ -105,14 +125,39 @@ class RegionBuffer:
         while len(self._lines) > self.maxlen:
             self._lines.popleft()
 
+    def set_pending(self, text: object) -> None:
+        """The in-flight tail. "" clears it. NEVER raises.
+
+        Deliberately NOT a push: a pending line that entered the ring
+        would be evicted by maxlen mid-sentence, and would survive as
+        history if the stream died before completing. It is a view of
+        something still happening, not a record of something that did.
+        """
+        try:
+            self._pending = str(text or "")
+        except Exception:  # noqa: BLE001
+            self._pending = ""
+
+    @property
+    def pending(self) -> str:
+        return self._pending
+
     def snapshot(self) -> Tuple[str, ...]:
         return tuple(self._lines)
 
     def as_text(self) -> str:
+        # Composed, so the tail is always LAST regardless of what any
+        # other producer pushed while the stream was open. No anchor, no
+        # ordering rule, no re-wrap — the frame is rebuilt anyway.
+        if self._pending:
+            if self._lines:
+                return "\n".join(self._lines) + "\n" + self._pending
+            return self._pending
         return "\n".join(self._lines)
 
     def clear(self) -> None:
         self._lines.clear()
+        self._pending = ""
 
     @property
     def push_count(self) -> int:

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -1063,6 +1063,34 @@ class AttachUI:
         except Exception:  # noqa: BLE001
             return []
 
+    def _push_tail_to_deck(self) -> None:
+        """Compose the in-flight text into the transcript. NEVER raises.
+
+        Wrapped by the deck's own renderer at its own width, so nothing
+        here needs to know the terminal size — which is why this can live
+        on the producer side at all.
+        """
+        try:
+            mux = getattr(self, "_mux", None)
+            if mux is None or not hasattr(mux, "set_streaming_tail"):
+                return
+            mux.set_streaming_tail(self._stream_inflight or "")
+        except Exception:  # noqa: BLE001
+            pass
+
+    def _deck_carries_tail(self) -> bool:
+        """Is the in-flight text already inside the transcript? NEVER raises.
+
+        The strip predates the deck being able to hold it. Both exist so
+        the fallback survives — a cockpit whose mux lacks the seam still
+        streams, below the deck, exactly as before.
+        """
+        try:
+            mux = getattr(self, "_mux", None)
+            return mux is not None and hasattr(mux, "set_streaming_tail")
+        except Exception:  # noqa: BLE001
+            return False
+
     def _panic_rows(self) -> List[str]:
         """The crash overlay's content, or []. NEVER raises."""
         try:
@@ -1123,6 +1151,12 @@ class AttachUI:
                 return []
             age = max(0.0, _time.monotonic() - float(self._stream_arrived))
             if age > heartbeat_stale_after_s():
+                return []
+            # When the deck can carry the tail itself, the strip stands
+            # down: rendering the same text twice is worse than either
+            # placement alone. The deck is the better home — the words
+            # appear where they will come to rest.
+            if self._deck_carries_tail():
                 return []
             return render_inflight(
                 self._stream_inflight, width=self._terminal_size()[0],
@@ -1446,6 +1480,7 @@ class AttachUI:
                 self._stream_is_tool = False
                 import time as _time
                 self._stream_arrived = _time.monotonic()
+                self._push_tail_to_deck()
             elif isinstance(frame, dict) and frame.get(
                     "kind") == "fatal_panic":
                 # A background task died. STICKY — unlike every other live
@@ -1479,6 +1514,7 @@ class AttachUI:
                         f"{_head}\n{_body}" if _body else _head)
                 self._stream_is_tool = True
                 self._stream_arrived = _time.monotonic()
+                self._push_tail_to_deck()
         except Exception:
             pass
 
@@ -3272,8 +3308,18 @@ async def _bipartite_attach_loop(client: Any, console: Any, ui: Any) -> None:
         pass
 
     try:
+        def _capture_mux(m: Any) -> None:
+            # The deck's own buffer, so in-flight text can be composed
+            # INTO the transcript rather than approximated by a strip
+            # beneath it.
+            try:
+                setattr(ui, "_mux", m)
+            except Exception:  # noqa: BLE001
+                pass
+
         await run_bipartite_repl(
             on_accept=_on_accept,
+            on_mux=_capture_mux,
             title="◇ O+V · proactive canvas",
             toolbar=_toolbar_with_mode if ui is not None else None,
             watch_alive=_alive,

--- a/backend/core/ouroboros/governance/voice_repl.py
+++ b/backend/core/ouroboros/governance/voice_repl.py
@@ -217,11 +217,56 @@ def _render_status() -> VoiceReplDispatchResult:
 
 
 def _set_mute(on: bool) -> VoiceReplDispatchResult:
-    a = _announcer()
-    a.set_mute(on=on)
-    state = "muted" if on else "unmuted"
+    """Silence, at the scope the operator actually meant. NEVER raises.
+
+    This used to flip ONE announcer's in-process flag and reply "Karen
+    muted." It did not touch the other six speech paths
+    (`voice_orchestrator`, `shared_voice_client`, `cross_repo_voice_client`,
+    the TTS engine base class), did not survive a restart, and could not
+    reach any other process. So an operator typed `/voice mute`, was told
+    it worked, and kept hearing her — a false confirmation, which is worse
+    than having no verb at all.
+
+    Now it does both: the announcer flag AND the durable sentinel that
+    every speech path consults. The reply states what was actually
+    achieved rather than asserting a result it cannot verify.
+    """
+    announcer_ok = False
+    try:
+        _announcer().set_mute(on=on)
+        announcer_ok = True
+    except Exception:  # noqa: BLE001
+        pass
+
+    sentinel = ""
+    cleared = 0
+    try:
+        from backend.core.voice_mute import mute as _mute, unmute as _unmute
+        if on:
+            sentinel = _mute()
+        else:
+            cleared = _unmute()
+    except Exception:  # noqa: BLE001
+        pass
+
+    if on:
+        # The sentinel is what makes this durable and process-wide, so its
+        # absence is the part worth reporting — an operator told "muted"
+        # who is still hearing her needs to know which half failed.
+        if sentinel:
+            text = ("  /voice: muted — every speech path, and it survives "
+                    "a restart.")
+        elif announcer_ok:
+            text = ("  /voice: Karen's announcer muted, but the durable "
+                    "sentinel could NOT be written — other speech paths "
+                    "may still talk, and this will not survive a restart.")
+        else:
+            text = "  /voice: could not mute — nothing changed."
+        return VoiceReplDispatchResult(ok=bool(sentinel), text=text)
+
+    freed = f" ({cleared} sentinel{'s' if cleared != 1 else ''} cleared)" if cleared else ""
     return VoiceReplDispatchResult(
-        ok=True, text=f"  /voice: Karen {state}.",
+        ok=True, text=f"  /voice: unmuted{freed}.",
     )
 
 

--- a/tests/battle_test/test_in_transcript_streaming.py
+++ b/tests/battle_test/test_in_transcript_streaming.py
@@ -1,0 +1,120 @@
+"""Tokens land IN the transcript, not in a strip beneath it.
+
+I reported for three status reports running that per-token streaming was
+blocked by `RegionBuffer` being append-only, and that closing it would
+need per-stream anchors, interleaving rules and a re-wrap per delta.
+
+That was wrong. `as_text()` is `"\\n".join(self._lines)` — it COMPOSES on
+every read. The ring is append-only for HISTORY, which is correct and
+load-bearing, but nothing ever required the in-flight line to enter it.
+Every complication I cited came from assuming mutation.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.battle_test.split_layout import RegionBuffer
+
+
+class TestTheTailIsComposedNotMutated:
+    def test_it_renders_at_the_end_of_the_transcript(self):
+        b = RegionBuffer(name="deck", maxlen=10)
+        b.push("⏺ Signal(test_failure)")
+        b.set_pending("  the vision floor raises")
+        assert b.as_text().splitlines()[-1] == "  the vision floor raises"
+
+    def test_a_competing_producer_cannot_displace_it(self):
+        """The reason no anchor or ordering rule is needed: composition
+        puts the tail last on every frame, whatever else arrived."""
+        b = RegionBuffer(name="deck", maxlen=10)
+        b.set_pending("  mid-sentence")
+        b.push("⏺ Bash(pytest -q)")
+        assert b.as_text().splitlines()[-1] == "  mid-sentence"
+
+    def test_the_tail_is_NOT_history(self):
+        """A pending line inside the ring would be evicted by maxlen
+        mid-sentence, and would survive as history if the stream died
+        before completing. It is a view of something happening, not a
+        record of something that did."""
+        b = RegionBuffer(name="deck", maxlen=2)
+        b.set_pending("  in flight")
+        for i in range(5):
+            b.push(f"line {i}")
+        assert b.snapshot() == ("line 3", "line 4")   # ring bounded
+        assert b.as_text().splitlines()[-1] == "  in flight"  # survives
+
+    def test_completing_a_line_leaves_no_duplicate(self):
+        b = RegionBuffer(name="deck", maxlen=10)
+        b.set_pending("  half a sen")
+        b.set_pending("  half a sentence done")
+        b.push("  half a sentence done")
+        b.set_pending("")
+        assert b.as_text().count("half a sentence done") == 1
+
+    def test_an_empty_tail_changes_nothing(self):
+        b = RegionBuffer(name="deck", maxlen=10)
+        b.push("only line")
+        before = b.as_text()
+        b.set_pending("")
+        assert b.as_text() == before
+
+    def test_a_tail_with_no_history_still_renders(self):
+        b = RegionBuffer(name="deck", maxlen=10)
+        b.set_pending("  first words of the session")
+        assert "first words" in b.as_text()
+
+    def test_clear_takes_the_tail_with_it(self):
+        b = RegionBuffer(name="deck", maxlen=10)
+        b.push("x"); b.set_pending("  pending")
+        b.clear()
+        assert b.as_text() == ""
+
+    @pytest.mark.parametrize("junk", [None, 42, object()])
+    def test_junk_degrades(self, junk):
+        b = RegionBuffer(name="deck", maxlen=10)
+        b.set_pending(junk)          # type: ignore[arg-type]
+        assert isinstance(b.as_text(), str)
+
+
+class TestItIsActuallyREACHABLE:
+    """The seam existing is not the property that matters — five inert
+    features this session proved that."""
+
+    def test_the_mux_exposes_the_seam(self):
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            BipartiteLayout,
+        )
+        assert hasattr(BipartiteLayout, "set_streaming_tail")
+
+    def test_the_repl_hands_its_mux_to_the_caller(self):
+        """Without this the client holds no reference to the deck, and the
+        seam is reachable in principle and inert in practice."""
+        import inspect
+
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            run_bipartite_repl,
+        )
+        assert "on_mux" in inspect.signature(run_bipartite_repl).parameters
+
+    def test_the_client_captures_it_and_feeds_it(self):
+        import inspect
+
+        from backend.core.ouroboros.cli import ov
+        src = inspect.getsource(ov)
+        assert "on_mux=_capture_mux" in src
+        assert "_push_tail_to_deck" in src
+
+    def test_the_strip_stands_down_when_the_deck_carries_it(self):
+        """Rendering the same text twice is worse than either placement
+        alone."""
+        from backend.core.ouroboros.cli.ov import AttachUI
+        ui = AttachUI()
+        ui._terminal_size = lambda: (80, 30)   # type: ignore[method-assign]
+        ui.on_telemetry({"kind": "stream_inflight", "text": "hello there"})
+        assert ui._stream_rows(), "no deck -> the strip must still stream"
+
+        class _Mux:
+            def set_streaming_tail(self, _t): pass
+
+        ui._mux = _Mux()
+        assert ui._stream_rows() == [], "both surfaces drew the same text"

--- a/tests/battle_test/test_voice_verb_engages_real_mute.py
+++ b/tests/battle_test/test_voice_verb_engages_real_mute.py
@@ -1,0 +1,81 @@
+"""`/voice mute` must silence what it says it silenced.
+
+It flipped ONE announcer's in-process flag and replied "Karen muted." It
+did not touch the other six speech paths, did not survive a restart, and
+could not reach any other process. An operator typed it, was told it
+worked, and kept hearing her — a false confirmation, which is worse than
+having no verb at all.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance.voice_repl import (
+    dispatch_voice_command,
+)
+from backend.core.voice_mute import unmute, voice_muted
+
+
+@pytest.fixture(autouse=True)
+def _clean(monkeypatch):
+    monkeypatch.delenv("JARVIS_VOICE_MUTED", raising=False)
+    unmute()
+    yield
+    unmute()
+
+
+class TestTheVerbDoesWhatItClaims:
+    def test_mute_actually_mutes_every_path(self):
+        assert voice_muted() is False
+        res = dispatch_voice_command("/voice mute")
+        assert res.ok is True
+        assert voice_muted() is True, "the verb reported success and did nothing"
+
+    def test_unmute_clears_it(self):
+        dispatch_voice_command("/voice mute")
+        assert voice_muted() is True
+        res = dispatch_voice_command("/voice unmute")
+        assert res.ok is True
+        assert voice_muted() is False
+
+    @pytest.mark.parametrize("spelling", ["/voice mute", "/voice off"])
+    def test_both_spellings_engage_the_real_mute(self, spelling):
+        unmute()
+        dispatch_voice_command(spelling)
+        assert voice_muted() is True
+
+    def test_it_says_the_mute_is_DURABLE(self):
+        """The sentinel is what makes it survive a restart and reach other
+        processes; the reply should say so, because that is the property
+        the operator is relying on."""
+        res = dispatch_voice_command("/voice mute")
+        assert "restart" in res.text.lower()
+
+    def test_unmute_reports_what_it_CLEARED(self):
+        dispatch_voice_command("/voice mute")
+        res = dispatch_voice_command("/voice unmute")
+        assert "sentinel" in res.text.lower()
+
+
+class TestItRefusesToOVERCLAIM:
+    def test_a_failed_sentinel_is_REPORTED_not_swallowed(self, monkeypatch):
+        """An operator told "muted" who is still hearing her needs to know
+        which half failed. Reporting success on a partial mute is the
+        original defect, restated."""
+        import backend.core.ouroboros.governance.voice_repl as vr
+        monkeypatch.setattr(
+            "backend.core.voice_mute.mute", lambda *a, **k: "")
+        res = vr.dispatch_voice_command("/voice mute")
+        assert res.ok is False, "claimed success with no durable mute"
+        assert "could NOT" in res.text or "not survive" in res.text
+
+    def test_a_dead_announcer_does_not_stop_the_real_mute(self, monkeypatch):
+        """The durable half is the one that matters; a broken announcer
+        must not prevent silence."""
+        import backend.core.ouroboros.governance.voice_repl as vr
+        monkeypatch.setattr(
+            vr, "_announcer",
+            lambda: (_ for _ in ()).throw(RuntimeError("no announcer")))
+        res = vr.dispatch_voice_command("/voice mute")
+        assert voice_muted() is True
+        assert res.ok is True


### PR DESCRIPTION
For three status reports I told you per-token streaming was blocked by `RegionBuffer` being append-only, and that closing it would need per-stream anchors, a rule for a competing producer appending mid-sentence, and a re-wrap on every delta.

**That was wrong.**

```python
def as_text(self) -> str:
    return "\n".join(self._lines)
```

It **composes on every read**. The ring is append-only for *history* — correct and load-bearing — but nothing ever required the in-flight line to enter it. Every complication I cited came from assuming mutation.

## Composition dissolves them

`set_pending(text)` holds one uncommitted string; `as_text()` joins it last.

The tail is therefore **always last**, regardless of what any other producer pushed while the stream was open — that's the anchor problem and the ordering rule, both *dissolved* rather than solved. The frame is rebuilt anyway, so there's no re-wrap to do.

```
⏺ Signal(test_failure)
  the vision floor raises, and the caller      ← in flight, inside the deck

⏺ Signal(test_failure)
  the vision floor raises, and the caller swallows it.   ← now history
⏺ Bash(pytest -q)                                        ← pushed mid-stream
  next sentence forming                                  ← still last
```

It is deliberately **not a push**. A pending line inside the ring would be evicted by `maxlen` mid-sentence, and would survive as history if the stream died before completing. It is a view of something still happening, not a record of something that did.

The result is CC's actual mechanic — text appearing at the end of the transcript, in place — rather than a strip beneath it approximating one. The strip **stands down** when the deck can carry the tail, and remains as the fallback for a cockpit whose mux lacks the seam: rendering the same words twice is worse than either placement alone.

## Reachable, and that took a second pass

`AttachUI` had no reference to the deck, so `set_streaming_tail` was reachable in principle and **inert in practice** — the trap this codebase has produced five times, this time inside the fix for it.

`run_bipartite_repl` now hands its multiplexer to the caller via `on_mux`, the client captures it, and a test asserts **the capture**, not the seam's existence.

## One self-inflicted wound worth recording

While inserting that hook I wrote before parsing and corrupted the file — the insertion landed inside the multi-line `BipartiteLayout(...)` call. Repaired by re-inserting at the AST's own `end_lineno` for the assignment **statement**.

A line-offset guess is always wrong about where a multi-line statement ends. That is the identical lesson the import-injector learned during the colour migration, relearned because I reached for a regex under time pressure.

## Tests

**14 new; 98 green** across streaming, bipartite, attach, mux and demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Per-token streaming now renders directly inside the transcript; the tail is composed on each frame instead of using a separate strip. Also, /voice mute now silences all speech paths and persists across restarts.

- **New Features**
  - In-transcript token streaming via a composed tail: `RegionBuffer.set_pending` holds the in-flight line; `as_text` joins it last on every render.
  - UI wiring for the tail: `BipartiteLayout.set_streaming_tail` and `run_bipartite_repl(on_mux)` let the client capture the mux and feed the tail; the legacy strip hides when the deck carries it.

- **Bug Fixes**
  - `/voice mute` engages the durable sentinel used by every speech path and the announcer flag; replies report partial failures; `/voice unmute` clears and reports sentinel count. Tests cover both mute and streaming paths.

<sup>Written for commit ae866ec2b9ade8f04022e69a08a3b09399584105. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

