### PR TITLE
feat(ov): implicit causality — the op DAG records itself

### DIFF
--- a/backend/core/ouroboros/battle_test/op_block_buffer.py
+++ b/backend/core/ouroboros/battle_test/op_block_buffer.py
@@ -68,6 +68,7 @@ What this module does NOT do
 """
 from __future__ import annotations
 
+import contextvars
 import enum
 import logging
 import os
@@ -318,6 +319,68 @@ def _safe_str(raw: object) -> str:
 # ===========================================================================
 
 
+#: Who is executing right now, per async task.
+#:
+#: A ContextVar rather than a parameter because that is exactly what an
+#: async parent/child relationship IS: a value scoped to the task that set
+#: it, inherited by everything that task spawns, and invisible to its
+#: siblings. Threading `parent_op_id` through signatures would have to be
+#: repeated at every new spawn pattern — and the fact that nobody did it
+#: even once is why `register_parent` had zero callers.
+_ACTIVE_PARENT_OP: contextvars.ContextVar = contextvars.ContextVar(
+    "ov_active_parent_op", default="",
+)
+
+
+class executing:
+    """Mark the op whose execution this frame belongs to.
+
+    Both a context manager and re-entrant by nesting. Uses the token
+    returned by `set()` and `reset()`s it, rather than restoring a saved
+    value — under concurrency those differ: `reset(token)` restores THIS
+    frame's predecessor, while assigning a saved value can clobber a
+    sibling task that ran in between.
+
+    NEVER raises. A failure to mark causality must not stop the op.
+    """
+
+    __slots__ = ("_op_id", "_token")
+
+    def __init__(self, op_id: object) -> None:
+        self._op_id = _safe_str(op_id)
+        self._token = None
+
+    def __enter__(self) -> "executing":
+        try:
+            if self._op_id:
+                self._token = _ACTIVE_PARENT_OP.set(self._op_id)
+        except Exception:  # noqa: BLE001
+            self._token = None
+        return self
+
+    def __exit__(self, *_exc: object) -> bool:
+        try:
+            if self._token is not None:
+                _ACTIVE_PARENT_OP.reset(self._token)
+        except Exception:  # noqa: BLE001
+            pass
+        return False          # never swallow the body's exception
+
+    async def __aenter__(self) -> "executing":
+        return self.__enter__()
+
+    async def __aexit__(self, *exc: object) -> bool:
+        return self.__exit__(*exc)
+
+
+def active_parent_op() -> str:
+    """The op executing in THIS async frame, or "". NEVER raises."""
+    try:
+        return _ACTIVE_PARENT_OP.get("")
+    except Exception:  # noqa: BLE001
+        return ""
+
+
 class OpBlockBuffer:
     """Thread-safe bounded FIFO of :class:`OpBlock` records.
 
@@ -455,6 +518,31 @@ class OpBlockBuffer:
 
     # ---- mutating API -------------------------------------------------
 
+    def _auto_link_from_context(self, child_op_id: str) -> None:
+        """Link a freshly-minted op to whoever is executing. NEVER raises.
+
+        The causality flows through the async CONTEXT rather than through
+        function signatures. `register_parent` had zero callers because
+        every candidate call site would have needed a `parent_op_id`
+        threaded down to it — so nobody threaded it, and a 777-line
+        renderer sat over a graph with no edges.
+
+        A ContextVar is the right shape because it is exactly what an
+        async parent/child relationship IS: a value scoped to the task
+        that set it, inherited by anything that task spawns, and invisible
+        to its siblings. Passing the id down would have to be repeated at
+        every new spawn pattern; the context is inherited by construction.
+        """
+        try:
+            parent = _ACTIVE_PARENT_OP.get("")
+            if not parent or parent == child_op_id:
+                return
+            self.register_parent(
+                child_op_id=child_op_id, parent_op_id=parent,
+            )
+        except Exception:  # noqa: BLE001
+            pass
+
     def start_op(self, op_id: object) -> Optional[OpBlock]:
         """Begin buffering for ``op_id``. Returns the newly-created
         :class:`OpBlock` (state=BUFFERING).
@@ -468,6 +556,7 @@ class OpBlockBuffer:
         op_id_safe = _safe_str(op_id)
         if not op_id_safe:
             return None
+        _newly_minted = op_id_safe not in self._active_op_ids
         with self._lock:
             existing_ref = self._active_op_ids.get(op_id_safe)
             if existing_ref is not None:
@@ -485,7 +574,14 @@ class OpBlockBuffer:
             self._items[ref] = block
             self._active_op_ids[op_id_safe] = ref
             self._evict_if_needed()
-            return block
+        # Linked OUTSIDE the lock: `register_parent` acquires it too, and
+        # re-entering a non-reentrant lock deadlocks. The block is already
+        # registered, so the only observable window is microseconds in
+        # which a reader sees an op with no parent — exactly what every
+        # reader saw before this existed.
+        if _newly_minted:
+            self._auto_link_from_context(op_id_safe)
+        return block
 
     def append(self, op_id: object, line: object) -> bool:
         """Append a rendered line to the active block for ``op_id``.
@@ -667,6 +763,34 @@ class OpBlockBuffer:
 
         NEVER raises.
         """
+        # ACYCLIC GUARANTEE. `op_fanout_tree` walks this graph to render
+        # it; a cycle would spin that walk forever, and the render happens
+        # on the operator's frame. Refuse the edge rather than defend
+        # inside every future reader.
+        #
+        # Walked from the PROPOSED PARENT upward: if the child already
+        # sits above it, this edge would close a loop. Depth-capped as
+        # well as visited-guarded, because a corrupt store could present a
+        # chain with no cycle and no end.
+        try:
+            _c = _safe_str(child_op_id)
+            _p = _safe_str(parent_op_id)
+            if _c and _c == _p:
+                return False          # self-parent is the shortest cycle
+            _seen, _cur, _hops = set(), _p, 0
+            while _cur and _hops < 64:
+                if _cur == _c:
+                    logger.debug(
+                        "[OpBlockBuffer] refused cyclic edge %s -> %s",
+                        _p, _c)
+                    return False
+                if _cur in _seen:
+                    break             # pre-existing cycle; do not add to it
+                _seen.add(_cur)
+                _cur = self.get_parent_op_id(_cur) or ""
+                _hops += 1
+        except Exception:  # noqa: BLE001
+            return False              # cannot prove acyclic -> refuse
         if not op_dependency_graph_enabled():
             return False
         child_safe = _safe_str(child_op_id)

--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -1967,6 +1967,26 @@ class SerpentFlow:
         except Exception:
             pass
 
+    def op_execution_scope(self, op_id: str) -> Any:
+        """Mark this frame as executing ``op_id``. NEVER raises.
+
+        The EXECUTION BOUNDARY. Any op minted inside this scope — by this
+        coroutine or anything it spawns — records itself as a child,
+        without a single call site passing a parent id down.
+
+        Exposed here rather than reaching into `op_block_buffer` from the
+        orchestrator, so the boundary lives beside the mint it pairs with
+        and a caller cannot enter one without the other being obvious.
+        """
+        try:
+            from backend.core.ouroboros.battle_test.op_block_buffer import (
+                executing,
+            )
+            return executing(op_id)
+        except Exception:  # noqa: BLE001
+            import contextlib
+            return contextlib.nullcontext()
+
     def _maybe_buffer_op_commit(self, op_id: str, summary: str) -> None:
         """Commit the block AND render its collapsed line. NEVER raises.
 

--- a/tests/battle_test/test_implicit_causality.py
+++ b/tests/battle_test/test_implicit_causality.py
@@ -1,0 +1,190 @@
+"""Causality flows through the async context, not through signatures.
+
+`op_fanout_tree` (777L) renders a parent/child op graph from
+`OpBlockBuffer`. The store had the fields, the renderer had the walk, both
+had master flags — and `register_parent`, the one method that records an
+edge, had **zero call sites**. Every hit in the tree was a docstring.
+
+The reason nobody called it is structural: every candidate call site would
+have needed a `parent_op_id` threaded down to it. So a ContextVar carries
+it instead — which is exactly what an async parent/child relationship IS:
+a value scoped to the task that set it, inherited by what that task
+spawns, invisible to its siblings.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from backend.core.ouroboros.battle_test.op_block_buffer import (
+    OpBlockBuffer,
+    active_parent_op,
+    executing,
+)
+
+
+@pytest.fixture(autouse=True)
+def _graph_on(monkeypatch):
+    monkeypatch.setenv("JARVIS_OP_DEPENDENCY_GRAPH_ENABLED", "1")
+    yield
+
+
+class TestTheEdgeRecordsItself:
+    def test_an_op_minted_inside_another_is_its_child(self):
+        b = OpBlockBuffer()
+        with executing("root"):
+            b.start_op("root")
+            b.start_op("child")
+        assert b.get_parent_op_id("child") == "root"
+        assert "child" in b.get_child_op_ids("root")
+
+    def test_no_context_means_no_parent(self):
+        """A root op is a root. Inventing a parent would be worse than
+        the flat tree this replaces."""
+        b = OpBlockBuffer()
+        b.start_op("lonely")
+        assert b.get_parent_op_id("lonely") in ("", None)
+
+    def test_nothing_is_threaded_through_a_signature(self):
+        """The DRY mandate: `start_op` must not have grown a
+        `parent_op_id` parameter."""
+        import inspect
+        params = inspect.signature(OpBlockBuffer.start_op).parameters
+        assert set(params) == {"self", "op_id"}
+
+    def test_re_starting_an_op_does_not_re_link(self):
+        """`start_op` is idempotent for an active op; a retry must not
+        append a duplicate child edge."""
+        b = OpBlockBuffer()
+        with executing("root"):
+            b.start_op("root")
+            b.start_op("child")
+            b.start_op("child")
+        assert b.get_child_op_ids("root").count("child") == 1
+
+
+class TestAsyncIsolation:
+    @pytest.mark.asyncio
+    async def test_parallel_parents_do_not_leak_into_each_other(self):
+        """THE mandated proof. Two parents running concurrently must not
+        adopt each other's children."""
+        b = OpBlockBuffer()
+
+        async def branch(parent: str, child: str, delay: float):
+            with executing(parent):
+                b.start_op(parent)
+                await asyncio.sleep(delay)      # interleave deliberately
+                b.start_op(child)
+
+        await asyncio.gather(
+            branch("A", "a1", 0.02),
+            branch("B", "b1", 0.01),
+        )
+        assert b.get_parent_op_id("a1") == "A"
+        assert b.get_parent_op_id("b1") == "B"
+        assert b.get_child_op_ids("A") == ("a1",)
+        assert b.get_child_op_ids("B") == ("b1",)
+
+    @pytest.mark.asyncio
+    async def test_a_spawned_task_INHERITS_the_context(self):
+        """Inheritance is the whole reason this is a ContextVar and not a
+        thread-local or a global."""
+        b = OpBlockBuffer()
+
+        async def grandchild():
+            b.start_op("gc")
+
+        with executing("root"):
+            b.start_op("root")
+            await asyncio.create_task(grandchild())
+        assert b.get_parent_op_id("gc") == "root"
+
+    @pytest.mark.asyncio
+    async def test_a_sibling_started_after_does_NOT_inherit(self):
+        b = OpBlockBuffer()
+        with executing("root"):
+            b.start_op("root")
+        b.start_op("after")          # outside the frame
+        assert b.get_parent_op_id("after") in ("", None)
+
+    def test_nesting_restores_the_predecessor(self):
+        assert active_parent_op() == ""
+        with executing("outer"):
+            with executing("inner"):
+                assert active_parent_op() == "inner"
+            assert active_parent_op() == "outer", "reset() lost the frame"
+        assert active_parent_op() == ""
+
+    def test_the_token_is_reset_not_reassigned(self):
+        """Under concurrency these differ: `reset(token)` restores THIS
+        frame's predecessor, while assigning a saved value can clobber a
+        sibling task that ran in between."""
+        import inspect
+        src = inspect.getsource(executing)
+        assert ".reset(" in src and ".set(" in src
+
+
+class TestTheDAGStaysAcyclic:
+    def test_a_direct_cycle_is_refused(self):
+        b = OpBlockBuffer()
+        with executing("root"):
+            b.start_op("root")
+            b.start_op("child")
+        assert b.register_parent(
+            child_op_id="root", parent_op_id="child") is False
+
+    def test_self_parent_is_refused(self):
+        b = OpBlockBuffer()
+        b.start_op("solo")
+        assert b.register_parent(
+            child_op_id="solo", parent_op_id="solo") is False
+
+    def test_a_deep_cycle_is_refused(self):
+        b = OpBlockBuffer()
+        # `b` must be minted under `a`'s frame, not its own: starting an op
+        # inside `executing(<itself>)` is a self-parent, which is correctly
+        # REFUSED — so the first draft of this test built a two-node chain
+        # and then asserted a three-node cycle was caught.
+        with executing("a"):
+            b.start_op("a")
+            b.start_op("b")
+        with executing("b"):
+            b.start_op("c")
+        assert b.get_parent_op_id("b") == "a"
+        assert b.get_parent_op_id("c") == "b"
+        # a -> b -> c already; making `a` a child of `c` closes the loop.
+        assert b.register_parent(child_op_id="a", parent_op_id="c") is False
+
+    def test_a_legitimate_deep_chain_is_allowed(self):
+        b = OpBlockBuffer()
+        b.start_op("x"); b.start_op("y")
+        assert b.register_parent(child_op_id="y", parent_op_id="x") is True
+
+    def test_the_walk_is_depth_capped(self):
+        """A corrupt store could present a chain with no cycle and no end;
+        the render happens on the operator's frame."""
+        import inspect
+        src = inspect.getsource(OpBlockBuffer.register_parent)
+        assert "_hops" in src and "64" in src
+
+
+class TestNeverRaises:
+    @pytest.mark.parametrize("bad", [None, "", 42, object()])
+    def test_junk_op_ids_degrade(self, bad):
+        b = OpBlockBuffer()
+        with executing(bad):          # type: ignore[arg-type]
+            b.start_op(bad)           # type: ignore[arg-type]
+
+    def test_a_failing_link_never_breaks_start_op(self, monkeypatch):
+        b = OpBlockBuffer()
+        monkeypatch.setattr(
+            b, "register_parent",
+            lambda **k: (_ for _ in ()).throw(RuntimeError("boom")))
+        with executing("root"):
+            assert b.start_op("child") is not None
+
+    def test_the_body_exception_is_not_swallowed(self):
+        with pytest.raises(ValueError):
+            with executing("root"):
+                raise ValueError("must propagate")


### PR DESCRIPTION
`op_fanout_tree` (777L) renders a parent/child op graph. The store had the fields, the renderer had the walk, both had master flags — and **`register_parent`, the one method that records an edge, had zero call sites**. Every hit in the tree was a docstring.

A five-layer feature over a graph that had never held a single edge.

## A correction to my own finding

I reported this under the name **`link_parent_child`, which does not exist** — it appears only in prose. The real method is `register_parent`, and it too has no callers, so the finding stands under the right name.

I had grepped the documentation and believed I had grepped the code.

## Why nobody ever called it

Structural, not negligent. Every candidate call site would have needed a `parent_op_id` threaded down to it, so the first person to try would have had to change signatures across the whole spawn path. Nobody did it once, which is why it was never done at all.

**So the id is not passed. It is inherited.**

```python
with executing("op-7759"):
    b.start_op("op-7759")
    b.start_op("cand-0")        # ← records itself as a child. No argument.
```

`_ACTIVE_PARENT_OP` is a `contextvars.ContextVar`, and **`start_op` — the minting seam** (not `OpBlockBuffer.__init__`, which runs once per buffer) — consults it and links transparently.

A ContextVar is the correct shape because it is precisely what an async parent/child relationship *is*: a value scoped to the task that set it, inherited by everything that task spawns, invisible to its siblings. `start_op`'s signature is unchanged, and a test pins that it **stayed** unchanged.

`executing(op_id)` uses the token from `set()` and `reset()`s it rather than restoring a saved value — under concurrency those differ: `reset` restores *this* frame's predecessor, while assignment can clobber a sibling task that ran in between.

## Acyclic by refusal, not by defence

The renderer walks this graph **on the operator's frame**, so a cycle would spin their terminal. `register_parent` walks up from the *proposed parent* and refuses any edge that would close a loop — self-parent, direct, or deep — depth-capped at 64 as well as visited-guarded, because a corrupt store could present a chain with no cycle and no end.

Refusing once beats defending in every future reader.

Linking happens **outside** the buffer lock: `register_parent` takes it too, and re-entering a non-reentrant lock deadlocks.

## Two defects found by running it

- My deep-cycle test built a **two**-node chain and asserted a three-node cycle was caught. `start_op("b")` inside `executing("b")` is a self-parent and correctly refused, so `b` had no parent and there was no loop to detect. **The code was right; the fixture was wrong.**
- The first auto-linker called `link_parent_child` — the name from the docstrings. It would have raised `AttributeError` on every mint, into an `except` that swallows it, leaving the graph exactly as empty as before **while looking wired**.

## Tests

**20 new**, including the mandated async proof: two parents running concurrently do not adopt each other's children, and a spawned task inherits its creator's frame. **112 green** across causality, collapse, streaming, op-block and attach suites.

## Flags stay default-off

Turning them on is a graduation decision, and these edges have never been seen on a live op. The plumbing is proven; the behaviour is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically record parent-child edges in the op DAG using async context, so ops minted inside `executing(op_id)` link to their parent without passing ids. Adds cycle refusal and an execution-scope helper; flags remain default-off.

- **New Features**
  - Implicit causality via ContextVar `_ACTIVE_PARENT_OP` and `executing` (sync/async); `start_op` auto-links child to current parent.
  - Acyclic guarantee in `register_parent`: refuses self/direct/deep cycles, with a 64-depth cap.
  - Linking occurs outside the buffer lock to avoid deadlocks.
  - `serpent_flow.op_execution_scope(op_id)` exposes the execution boundary; no changes to `start_op` signature; feature gated and default-off.

- **Bug Fixes**
  - Replaced nonexistent `link_parent_child` call with `register_parent`.
  - Fixed deep-cycle test setup; added 20 tests covering async isolation and context inheritance.

<sup>Written for commit eb3aff0d9ec3f25180fc77011e0f0a8208a7c1a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

