### PR TITLE
feat(ov): rewind at the daemon's own terminal, through the same lock

### DIFF
--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -4322,6 +4322,52 @@ class BattleTestHarness:
             logger.debug("[Attach] input queue unavailable", exc_info=True)
             return None
 
+    def _repl_cmd_rewind(self) -> None:
+        """Show restore points under the viewport lock. NEVER raises.
+
+        Reuses the daemon's EXISTING `/undo` planner as the snapshot source
+        and the cockpit's own `RewindController` for the lock, so there is
+        no second snapshot system and no second lock. What differs is only
+        the transport — local calls instead of bridge frames — and the
+        surface: numbered rows, because the daemon REPL is a PromptSession
+        with no palette Float to host a menu.
+        """
+        try:
+            from pathlib import Path as _Path
+
+            from backend.core.ouroboros.battle_test.rewind_menu import (
+                local_rewind_rows,
+            )
+
+            def _provider(limit: int) -> list:
+                from backend.core.ouroboros.battle_test.undo_command import (
+                    UndoPlanner,
+                )
+                plan = UndoPlanner(
+                    _Path(self._config.repo_path),
+                    governed_loop_service=self._governed_loop_service,
+                ).plan(limit, mode="preview")
+                return [
+                    {
+                        "sha": str(getattr(t, "sha", "") or ""),
+                        "subject": str(getattr(t, "subject", "") or ""),
+                    }
+                    for t in (getattr(plan, "targets", None) or ())
+                ]
+
+            for line in local_rewind_rows(
+                pause=self._repl_cmd_pause,
+                resume=self._repl_cmd_resume,
+                provider=_provider,
+            ):
+                self._repl_print(line)
+        except Exception:  # noqa: BLE001
+            logger.debug("[Rewind] daemon-side rewind degraded", exc_info=True)
+            try:
+                self._repl_print("  (rewind unavailable — see debug.log)")
+            except Exception:  # noqa: BLE001
+                pass
+
     async def _handle_repl_command_for(
         self, command: str, session: Optional[str],
     ) -> None:
@@ -4400,6 +4446,13 @@ class BattleTestHarness:
             self._repl_cmd_remember(command.strip())
         elif cmd.startswith("/forget") or cmd.startswith("forget "):
             self._repl_cmd_forget(command.strip())
+        elif cmd.startswith("/rewind") or cmd == "rewind":
+            # Esc-Esc rewind, for the DAEMON's own terminal. The menu was
+            # client-only because the cockpit is a separate process and had
+            # to ask over the bridge; here the same three calls are local,
+            # through the same controller and the same lock. One
+            # implementation, two entrances.
+            self._repl_cmd_rewind()
         elif cmd.startswith("/undo") or cmd.startswith("undo ") or cmd == "undo":
             # /undo N (revert last N O+V commits); /undo preview [N];
             # /undo --hard N. Async because executor awaits comm emits.

--- a/backend/core/ouroboros/battle_test/rewind_menu.py
+++ b/backend/core/ouroboros/battle_test/rewind_menu.py
@@ -58,6 +58,95 @@ def _reply_timeout_s() -> float:
         return 5.0
 
 
+class LocalRewindClient:
+    """The daemon terminal's half of the Transactional Viewport Lock.
+
+    `RewindController` needs exactly three things from a "client":
+    ``send_autonomy("pause")``, ``send_rewind_request()`` and
+    ``send_autonomy("resume")``. Nothing about the lock is bridge-specific
+    — the bridge existed because the cockpit is a SEPARATE PROCESS and had
+    to ask the daemon to pause. At the daemon's own terminal there is no
+    second process, so the same three calls are local.
+
+    So the lock is not reimplemented here. This is the second entrance to
+    one implementation — the pattern `_on_autonomy` already states in its
+    own comment ("the SAME intake pause the pause/resume verbs flip: one
+    implementation, two entrances").
+
+    The snapshot arrives SYNCHRONOUSLY, which the bridge path cannot do.
+    `deliver()` is therefore called from inside `send_rewind_request()`,
+    before it returns — the controller tolerates this because it only ever
+    required delivery to happen once, not later.
+
+    NEVER raises: a rewind menu that can break the REPL it opens in is
+    worse than no menu.
+    """
+
+    __slots__ = ("_pause", "_resume", "_provider", "_deliver", "_limit",
+                 "_held")
+
+    def __init__(
+        self,
+        *,
+        pause: Callable[[], Any],
+        resume: Callable[[], Any],
+        provider: Callable[[int], Any],
+        deliver: Optional[Callable[[Any], Any]] = None,
+        limit: int = 10,
+    ) -> None:
+        self._pause = pause
+        self._resume = resume
+        self._provider = provider
+        self._deliver = deliver
+        self._limit = max(1, int(limit))
+        #: Whether WE acquired the hold. A resume we did not pause for
+        #: would release someone else's lock — the refcount upstream is
+        #: what makes concurrent holders safe, and lying to it defeats it.
+        self._held = False
+
+    def bind_deliver(self, deliver: Callable[[Any], Any]) -> None:
+        self._deliver = deliver
+
+    def send_autonomy(self, action: str) -> bool:
+        try:
+            if str(action) == "pause":
+                self._pause()
+                self._held = True
+                return True
+            if str(action) == "resume":
+                if not self._held:
+                    return True      # nothing of ours to release
+                self._resume()
+                self._held = False
+                return True
+            return False
+        except Exception:  # noqa: BLE001
+            logger.debug("[Rewind] local autonomy %s failed", action,
+                         exc_info=True)
+            return False
+
+    def send_rewind_request(self) -> bool:
+        """Fetch and deliver the snapshot in one step. NEVER raises.
+
+        Returns False when the planner yields nothing — the controller
+        treats that as an empty list and releases the hold, which is the
+        correct outcome: an empty menu must not leave intake paused.
+        """
+        try:
+            rows = list(self._provider(self._limit) or ())
+        except Exception:  # noqa: BLE001
+            logger.debug("[Rewind] local provider failed", exc_info=True)
+            return False
+        if self._deliver is None:
+            return False
+        try:
+            self._deliver({"candidates": rows})
+            return True
+        except Exception:  # noqa: BLE001
+            logger.debug("[Rewind] local deliver failed", exc_info=True)
+            return False
+
+
 class RewindController:
     """The lock's client half + the menu's state machine.
 
@@ -251,6 +340,87 @@ class RewindCompleter(_completer_base()):  # type: ignore[misc]
             return
 
 
+def render_restore_points(
+    candidates: Any, *, width: Optional[int] = None,
+) -> List[str]:
+    """The restore points as plain rows. Pure. NEVER raises.
+
+    A plain list rather than a Float, because the DAEMON's own REPL is a
+    `PromptSession` and has no palette overlay — the Float belongs to the
+    cockpit's `FloatContainer`. Rendering rows means the same snapshot is
+    usable on a surface that cannot host a menu, instead of the daemon
+    terminal having no rewind at all.
+
+    Numbered to match `/undo N` exactly, so the reading and the command
+    cannot disagree — and NOT auto-executed: a rollback should never be
+    one accidental keystroke, which is the same reason the cockpit menu
+    only INSERTS the command.
+    """
+    try:
+        rows = [c for c in (candidates or ()) if isinstance(c, dict)]
+        if not rows:
+            return ["  (no restore points — nothing committed to undo)"]
+        cols = int(width) if width and int(width) > 0 else 80
+        # The HEADER is clipped too. Clipping only the data rows left the
+        # one line that names the command running past a narrow terminal —
+        # and that line is the affordance.
+        out = [
+            "  ⏪ restore points — `/undo N` to revert (Enter confirms)"[:cols]
+        ]
+        for i, c in enumerate(rows, start=1):
+            sha = str(c.get("sha") or c.get("commit") or "")[:9]
+            subject = " ".join(str(
+                c.get("subject") or c.get("summary") or "").split())
+            when = str(c.get("age") or c.get("when") or "")
+            line = f"    {i:>2}. {sha}  {subject}"
+            if when:
+                line = f"{line}  ({when})"
+            out.append(line[:cols])
+        return out
+    except Exception:  # noqa: BLE001
+        logger.debug("[Rewind] render degraded", exc_info=True)
+        return ["  (restore points unavailable)"]
+
+
+def local_rewind_rows(
+    *,
+    pause: Callable[[], Any],
+    resume: Callable[[], Any],
+    provider: Callable[[int], Any],
+    limit: int = 10,
+    width: Optional[int] = None,
+) -> List[str]:
+    """Take the lock, snapshot, render, RELEASE. NEVER raises.
+
+    The whole daemon-side sequence in one call, through the same
+    controller the cockpit uses. The release is in a `finally`: a snapshot
+    that leaves intake paused because rendering raised would be strictly
+    worse than no rewind — the organism would sit idle and nothing would
+    say why.
+    """
+    client = LocalRewindClient(
+        pause=pause, resume=resume, provider=provider, limit=limit,
+    )
+    captured: List[Any] = []
+    client.bind_deliver(lambda payload: captured.append(payload))
+    controller = RewindController(client)
+    try:
+        controller.open()
+        rows = (captured[-1].get("candidates") if captured else ()) or ()
+        return render_restore_points(rows, width=width)
+    except Exception:  # noqa: BLE001
+        logger.debug("[Rewind] local sequence degraded", exc_info=True)
+        return ["  (rewind unavailable)"]
+    finally:
+        try:
+            controller.close()
+        except Exception:  # noqa: BLE001
+            # Belt and braces — the controller releases exactly once, but a
+            # paused organism with no explanation is the one outcome worth
+            # a second guard.
+            client.send_autonomy("resume")
+
+
 def merge_rewind_completer(
     base_completer: Any, controller: Optional[RewindController],
 ) -> Any:
@@ -301,6 +471,9 @@ def install_rewind_binding(kb: Any, controller: RewindController) -> bool:
 
 
 __all__ = [
+    "LocalRewindClient",
+    "local_rewind_rows",
+    "render_restore_points",
     "MASTER_FLAG_ENV_VAR",
     "REWIND_ACTION",
     "REWIND_DEFAULT_KEYS",

--- a/tests/battle_test/test_rewind_daemon_side.py
+++ b/tests/battle_test/test_rewind_daemon_side.py
@@ -1,0 +1,169 @@
+"""Rewind at the daemon's own terminal, through the same lock.
+
+The Esc-Esc menu was client-only. Not arbitrarily: the cockpit is a
+SEPARATE PROCESS and had to ask the daemon to pause over the bridge. At the
+daemon's own terminal there is no second process, so the same three calls
+are local — which means the Transactional Viewport Lock did not need
+reimplementing, only a second entrance.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.battle_test.rewind_menu import (
+    LocalRewindClient,
+    RewindController,
+    local_rewind_rows,
+    render_restore_points,
+)
+
+_POINTS = [
+    {"sha": "90706b8cd", "subject": "harden the vision floor", "age": "12m"},
+    {"sha": "a1b2c3d4e", "subject": "rebuild the fixture", "age": "1h"},
+]
+
+
+def _spy():
+    return {"paused": 0, "resumed": 0}
+
+
+class TestTheLockIsNotReimplemented:
+    def test_the_controller_needs_only_three_methods(self):
+        """That is why no lock logic had to be copied: nothing about it was
+        bridge-specific."""
+        import inspect
+        src = inspect.getsource(RewindController)
+        for call in ("send_autonomy", "send_rewind_request"):
+            assert call in src
+        assert LocalRewindClient(
+            pause=lambda: None, resume=lambda: None, provider=lambda n: [],
+        ).send_autonomy("pause") is True
+
+    def test_the_daemon_path_uses_the_SAME_controller(self):
+        import inspect
+        src = inspect.getsource(local_rewind_rows)
+        assert "RewindController(" in src
+
+    def test_the_hold_is_taken_and_released_exactly_once(self):
+        s = _spy()
+        local_rewind_rows(
+            pause=lambda: s.__setitem__("paused", s["paused"] + 1),
+            resume=lambda: s.__setitem__("resumed", s["resumed"] + 1),
+            provider=lambda n: _POINTS,
+        )
+        assert s == {"paused": 1, "resumed": 1}
+
+    def test_a_resume_we_did_not_pause_for_is_refused(self):
+        """Releasing a hold we never took would drop someone else's lock —
+        the upstream refcount is what makes concurrent holders safe, and
+        lying to it defeats it."""
+        s = _spy()
+        c = LocalRewindClient(
+            pause=lambda: s.__setitem__("paused", s["paused"] + 1),
+            resume=lambda: s.__setitem__("resumed", s["resumed"] + 1),
+            provider=lambda n: [],
+        )
+        assert c.send_autonomy("resume") is True     # no-op, not an error
+        assert s["resumed"] == 0
+
+
+class TestItNeverLeavesTheOrganismPaused:
+    def test_an_exploding_provider_still_releases(self):
+        """A snapshot that leaves intake paused because the planner raised
+        is worse than no rewind: the organism sits idle and nothing says
+        why."""
+        s = _spy()
+        rows = local_rewind_rows(
+            pause=lambda: s.__setitem__("paused", s["paused"] + 1),
+            resume=lambda: s.__setitem__("resumed", s["resumed"] + 1),
+            provider=lambda n: (_ for _ in ()).throw(RuntimeError("git down")),
+        )
+        assert s["resumed"] == 1
+        assert rows and "no restore points" in rows[0] or rows
+
+    def test_an_exploding_renderer_still_releases(self, monkeypatch):
+        import backend.core.ouroboros.battle_test.rewind_menu as rm
+        s = _spy()
+        monkeypatch.setattr(
+            rm, "render_restore_points",
+            lambda *a, **k: (_ for _ in ()).throw(RuntimeError("render down")))
+        rm.local_rewind_rows(
+            pause=lambda: s.__setitem__("paused", s["paused"] + 1),
+            resume=lambda: s.__setitem__("resumed", s["resumed"] + 1),
+            provider=lambda n: _POINTS,
+        )
+        assert s["resumed"] == 1
+
+    def test_an_empty_snapshot_releases_too(self):
+        s = _spy()
+        local_rewind_rows(
+            pause=lambda: s.__setitem__("paused", s["paused"] + 1),
+            resume=lambda: s.__setitem__("resumed", s["resumed"] + 1),
+            provider=lambda n: [],
+        )
+        assert s["resumed"] == 1
+
+
+class TestTheSurfaceSuitsTheTerminal:
+    def test_rows_not_a_float(self):
+        """The daemon REPL is a PromptSession with no palette overlay; the
+        Float belongs to the cockpit's FloatContainer. Rows mean the same
+        snapshot is usable on a surface that cannot host a menu."""
+        rows = render_restore_points(_POINTS, width=90)
+        assert all(isinstance(r, str) for r in rows)
+        assert any("90706b8cd" in r for r in rows)
+
+    def test_numbering_matches_the_undo_command(self):
+        """The reading and the command must not disagree."""
+        rows = render_restore_points(_POINTS, width=90)
+        assert " 1. " in rows[1] and " 2. " in rows[2]
+        assert "/undo" in rows[0]
+
+    def test_nothing_is_auto_executed(self):
+        """A rollback should never be one accidental keystroke — the same
+        reason the cockpit menu only INSERTS the command."""
+        rows = render_restore_points(_POINTS)
+        assert "Enter confirms" in rows[0]
+
+    def test_an_empty_list_says_so_rather_than_showing_nothing(self):
+        assert "no restore points" in render_restore_points([])[0]
+
+    @pytest.mark.parametrize("junk", [None, "x", [None], [{}], 42])
+    def test_junk_degrades(self, junk):
+        assert isinstance(render_restore_points(junk), list)  # type: ignore
+
+    def test_rows_respect_the_width(self):
+        wide = [{"sha": "a" * 40, "subject": "s" * 200}]
+        for w in (40, 80, 120):
+            assert all(len(r) <= w for r in render_restore_points(wide, width=w))
+
+
+class TestItIsREACHABLE:
+    def test_the_daemon_offers_a_verb(self):
+        import inspect
+
+        # Checked in the SOURCE, not via a guessed class name — this
+        # module's REPL class is not `SerpentREPL`, and asserting on a name
+        # I assumed would have failed while the wiring was correct.
+        from backend.core.ouroboros.battle_test import harness
+        src = inspect.getsource(harness)
+        assert "def _repl_cmd_rewind" in src
+        assert 'cmd.startswith("/rewind")' in src
+
+    def test_the_verb_is_DISCOVERABLE(self):
+        """It became findable with no registration, because verb discovery
+        reads the chain structurally."""
+        from backend.core.ouroboros.battle_test.repl_dispatch_registry import (
+            list_verbs, prime_registry,
+        )
+        prime_registry(force=True)
+        assert "rewind" in list_verbs()
+
+    def test_it_reuses_the_undo_planner(self):
+        """No second snapshot system."""
+        import inspect
+
+        from backend.core.ouroboros.battle_test import harness
+        src = inspect.getsource(harness)
+        i = src.index("_repl_cmd_rewind")
+        assert "UndoPlanner" in src[i:i + 2000]


### PR DESCRIPTION
The Esc-Esc menu was cockpit-only — and not arbitrarily. The cockpit is a **separate process**, so it had to ask the daemon to pause over the bridge. That transport is why the feature looked client-shaped.

## The lock was never bridge-specific

`RewindController` needs exactly **three** things from a "client":

```
send_autonomy("pause")   send_rewind_request()   send_autonomy("resume")
```

So the Transactional Viewport Lock is not reimplemented — it gets a **second entrance**, which is the pattern `_on_autonomy` already states in its own comment:

> *"the SAME intake pause the pause/resume verbs flip — one implementation, two entrances."*

`LocalRewindClient` satisfies those three calls locally: the daemon's own `_repl_cmd_pause` / `_repl_cmd_resume`, and its **existing** `/undo` planner as the snapshot source. No second lock, no second snapshot system.

The snapshot arrives **synchronously**, which the bridge path cannot do, so `deliver()` is called from inside `send_rewind_request()` — the controller tolerates that because it only ever required delivery to happen *once*, not *later*.

## Rows, not a Float

```
  ⏪ restore points — `/undo N` to revert (Enter confirms)
     1. 90706b8cd  harden the vision floor  (12m)
     2. a1b2c3d4e  rebuild the fixture  (1h)
```

The daemon REPL is a `PromptSession` with no palette overlay — the Float belongs to the cockpit's `FloatContainer`. Rows mean the same snapshot is usable on a surface that **cannot host a menu**, instead of the daemon terminal having no rewind at all.

Numbering matches `/undo N` exactly so the reading and the command cannot disagree, and nothing is auto-executed — a rollback should never be one accidental keystroke, the same reason the cockpit menu only *inserts* the command.

## Never leaves the organism paused

The release is in a `finally`, with a belt-and-braces resume after it. **A snapshot that leaves intake paused because the planner or renderer raised is strictly worse than no rewind** — the organism sits idle and nothing says why. Tested for both.

A `resume` we did not `pause` for is **refused** rather than passed through: releasing a hold we never took would drop someone else's, and the upstream refcount is what makes concurrent holders safe.

## Two defects found by running it

- The **header** line naming the command was not clipped to the terminal width — only the data rows were. On a narrow terminal, the one line carrying the affordance ran off the edge.
- My own test asserted `harness.SerpentREPL` exists. **It does not** — the class has another name. The assertion would have failed while the wiring was correct, so it now reads the source rather than a guessed attribute.

## Composition

`/rewind` became discoverable with **no registration** — 82 verbs → 83 — because verb discovery reads the chain structurally. Two earlier pieces of this session composing without being asked to.

## Tests

**20 new; 128 green** across rewind, undo, verb-discovery, causality and attach suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add daemon-side rewind to the REPL using the same Transactional Viewport Lock as the cockpit, with no new lock or snapshot system. Restore points render as numbered rows that map directly to `/undo N`, so rewind works without a Float menu.

- **New Features**
  - Added `LocalRewindClient` that implements `send_autonomy("pause"|"resume")` and `send_rewind_request()` for `RewindController`.
  - Added `/rewind` verb to the daemon REPL (`_repl_cmd_rewind`), auto-discovered by the verb registry.
  - Reuses the existing `/undo` `UndoPlanner` as the snapshot source; delivers synchronously and always releases the lock.
  - Refuses `resume` if this client didn’t `pause`, preserving upstream refcounts.
  - New helpers: `local_rewind_rows` and `render_restore_points`. 20 new tests; 128 green.

- **Bug Fixes**
  - Clip the header line to terminal width (not just data rows).
  - Fix test by reading the REPL source instead of asserting a guessed class name.

<sup>Written for commit 5e75d2f7758152eb52780bffc5a6169750d9a2c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

