### PR TITLE
fix(ov): bound the EXIT, not just the run — graceful shutdown had no deadline

### DIFF
--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -7196,6 +7196,101 @@ class BattleTestHarness:
         except NotImplementedError:
             logger.warning("Signal handlers not supported on this platform")
 
+    def _arm_shutdown_deadline(self, reason: str = "shutdown") -> None:
+        """Bound the EXIT, not just the run. NEVER raises. Idempotent.
+
+        Observed 2026-07-29: a soak ignored SIGTERM for 12+ seconds and
+        needed SIGKILL. The signal handler fired correctly — a 53KB
+        summary.json landed — and then graceful shutdown never finished.
+
+        Root cause: shutdown had no ceiling anywhere. `--max-wall-seconds`
+        bounds the RUN; every subsystem's cleanup is then awaited with no
+        deadline, so any single hanging await wedges the exit permanently
+        and an external SIGKILL is the only recourse. A process that
+        cannot be asked to stop is not shutting down, it is leaking.
+
+        Deliberately BLIND to shutdown progress, per the Watchdog
+        Isolation Invariant this file already documents for the wall-clock
+        cap: a watchdog that consults the inner state-ledger deadlocks
+        WITH the system it guards. Slice 47 rejected an "adaptive budget
+        waiver" for exactly this reason — a wedged VERIFY keeps the
+        extend-condition true forever. So this thread reads only
+        `time.monotonic()`, and the correct answer to "cleanup needs
+        longer" is a larger STATIC budget, never an activity-gated one.
+
+        Resource-zero, mirroring the wall-clock watchdog: a daemon thread,
+        a raw dup of fd 2 captured at ARM time (a poisoned logging lock
+        cannot wedge `os.write`), and `os.kill` rather than anything that
+        re-enters the interpreter's shutdown machinery — which is the very
+        thing suspected of being stuck.
+        """
+        try:
+            if getattr(self, "_shutdown_deadline_armed", False):
+                return                      # idempotent across signals
+            self._shutdown_deadline_armed = True
+
+            raw = os.environ.get("JARVIS_SHUTDOWN_GRACE_S", "").strip()
+            try:
+                grace_s = max(5.0, min(300.0, float(raw) if raw else 25.0))
+            except (TypeError, ValueError):
+                grace_s = 25.0
+
+            # Captured NOW, pre-wedge.
+            try:
+                panic_fd = os.dup(2)
+            except Exception:  # noqa: BLE001
+                panic_fd = 2
+            pid = os.getpid()
+            deadline = time.monotonic() + grace_s
+            done = threading.Event()
+            self._shutdown_deadline_done = done
+
+            def _reaper() -> None:
+                # A poll rather than one long wait, so a host suspend that
+                # pauses the process cannot skip the deadline entirely.
+                while not done.is_set():
+                    if time.monotonic() >= deadline:
+                        try:
+                            os.write(panic_fd, (
+                                f"\n[ShutdownWatchdog] graceful shutdown "
+                                f"({reason}) exceeded {grace_s:.0f}s — "
+                                f"SIGKILL {pid}. Cleanup was wedged; see "
+                                f"debug.log for the last phase reached.\n"
+                            ).encode("utf-8", "replace"))
+                        except Exception:  # noqa: BLE001
+                            pass
+                        try:
+                            os.kill(pid, signal.SIGKILL)
+                        except Exception:  # noqa: BLE001
+                            os._exit(75)     # last resort, never a return
+                        return
+                    done.wait(0.25)
+
+            threading.Thread(
+                target=_reaper, name="ov-shutdown-watchdog", daemon=True,
+            ).start()
+            logger.warning(
+                "[ShutdownWatchdog] armed: %s must complete within %.0fs "
+                "(JARVIS_SHUTDOWN_GRACE_S) or the process is killed.",
+                reason, grace_s,
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug("[ShutdownWatchdog] arm degraded", exc_info=True)
+
+    def _disarm_shutdown_deadline(self) -> None:
+        """Graceful shutdown finished in time. NEVER raises.
+
+        Called on the CLEAN completion path only. If it is never called,
+        the reaper fires — which is the correct default: an exit that
+        cannot confirm it finished should be forced, not trusted.
+        """
+        try:
+            done = getattr(self, "_shutdown_deadline_done", None)
+            if done is not None:
+                done.set()
+        except Exception:  # noqa: BLE001
+            pass
+
     def _handle_shutdown_signal(self, signal_name: Optional[str] = None) -> None:
         """Bound callback fired by asyncio on SIGHUP/SIGINT/SIGTERM.
 
@@ -7221,6 +7316,11 @@ class BattleTestHarness:
         contract that the ``register_signal_handlers`` production path
         always supplies the signal name.
         """
+        # Armed FIRST, before the partial-summary write and before the
+        # shutdown event. Everything after this line can wedge — the 2026
+        # -07-29 hang did exactly that, after the summary landed — and a
+        # deadline armed later would be armed by code that never runs.
+        self._arm_shutdown_deadline(str(signal_name or "signal"))
         # Harness Epic Slice 1 — arm the bounded-shutdown watchdog FIRST
         # (before any of the existing async / partial-summary work). If
         # the rest of this handler (or the downstream asyncio shutdown
@@ -9703,6 +9803,10 @@ class BattleTestHarness:
             reset_ops_digest_observer()
         except Exception:
             logger.debug("reset_ops_digest_observer(clear) failed", exc_info=True)
+        # The clean path completed, so the reaper is no longer needed. NOT
+        # disarmed anywhere else: an exit that cannot confirm it finished
+        # should be forced, not trusted.
+        self._disarm_shutdown_deadline()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/battle_test/test_shutdown_watchdog.py
+++ b/tests/battle_test/test_shutdown_watchdog.py
@@ -1,0 +1,219 @@
+"""The exit is bounded, not just the run.
+
+Observed 2026-07-29: a soak ignored SIGTERM for 12+ seconds and needed
+SIGKILL. The signal handler fired correctly — a 53KB summary.json landed —
+and then graceful shutdown never finished.
+
+`--max-wall-seconds` bounds the RUN. Nothing bounded the EXIT: every
+subsystem's cleanup was awaited with no ceiling, so one hanging await
+wedged the process permanently and an external SIGKILL was the only
+recourse. A process that cannot be asked to stop is not shutting down.
+"""
+from __future__ import annotations
+
+import ast
+import pathlib
+import subprocess
+import sys
+import textwrap
+import time
+
+import pytest
+
+_HARNESS = pathlib.Path("backend/core/ouroboros/battle_test/harness.py")
+
+
+def _src() -> str:
+    return _HARNESS.read_text()
+
+
+def _code_of(fn_name: str) -> str:
+    """A function's CODE, with its docstring removed.
+
+    Every structural check here must read code, not prose. The docstrings
+    deliberately NAME the things being avoided — "the partial-summary
+    write", "the last phase reached", "the extend-condition" — so a
+    substring match over the whole function flags the explanation as if it
+    were the offence. That mistake has now cost four tests this session;
+    stripping the docstring is the fix that generalises.
+    """
+    src = _src()
+    node = next(
+        n for n in ast.walk(ast.parse(src))
+        if isinstance(n, ast.FunctionDef) and n.name == fn_name
+    )
+    body = list(node.body)
+    if (body and isinstance(body[0], ast.Expr)
+            and isinstance(body[0].value, ast.Constant)
+            and isinstance(body[0].value.value, str)):
+        body = body[1:]
+    return "\n".join(
+        (ast.get_source_segment(src, stmt) or "") for stmt in body
+    )
+
+
+class TestItIsWiredAtBothEnds:
+    def test_armed_before_anything_that_can_wedge(self):
+        """Everything after the arm can hang — the 2026-07-29 failure did
+        exactly that, AFTER the summary landed. A deadline armed later
+        would be armed by code that never runs.
+
+        Asserted on STATEMENT ORDER via the AST rather than on string
+        offsets: the docstring names the very things being ordered against
+        ("the partial-summary write"), so a substring search finds the
+        explanation before the code every time.
+        """
+        src = _src()
+        node = next(
+            n for n in ast.walk(ast.parse(src))
+            if isinstance(n, ast.FunctionDef)
+            and n.name == "_handle_shutdown_signal"
+        )
+        stmts = [s for s in node.body
+                 if not (isinstance(s, ast.Expr)
+                         and isinstance(s.value, ast.Constant))]
+        arm_at = next(
+            i for i, st in enumerate(stmts)
+            if "_arm_shutdown_deadline" in (ast.dump(st))
+        )
+        assert arm_at == 0, (
+            "the deadline must be the FIRST executable statement; "
+            f"found at index {arm_at}"
+        )
+
+    def test_disarmed_ONLY_on_the_clean_path(self):
+        """An exit that cannot confirm it finished should be forced, not
+        trusted — so exactly one disarm site, on the full-summary path."""
+        assert _src().count("self._disarm_shutdown_deadline(") == 1
+
+    def test_it_is_idempotent_across_signals(self):
+        """SIGINT then SIGTERM must not start two reapers."""
+        src = _src()
+        node = next(
+            n for n in ast.walk(ast.parse(src))
+            if isinstance(n, ast.FunctionDef)
+            and n.name == "_arm_shutdown_deadline"
+        )
+        body = ast.get_source_segment(src, node) or ""
+        assert "_shutdown_deadline_armed" in body
+        assert "return" in body.split("_shutdown_deadline_armed")[1][:120]
+
+
+class TestTheWatchdogIsIsolated:
+    """The Watchdog Isolation Invariant this file already documents for the
+    wall-clock cap: a watchdog that consults the inner state-ledger
+    deadlocks WITH the system it guards."""
+
+    def test_it_reads_only_a_clock(self):
+        src = _src()
+        node = next(
+            n for n in ast.walk(ast.parse(src))
+            if isinstance(n, ast.FunctionDef)
+            and n.name == "_arm_shutdown_deadline"
+        )
+        body = ast.get_source_segment(src, node) or ""
+        body = _code_of("_arm_shutdown_deadline")
+        for forbidden in ("self._orchestrator", "_active_ops",
+                          "self._phase"):
+            assert forbidden not in body, forbidden
+        assert "time.monotonic()" in body
+
+    def test_it_captures_a_raw_fd_at_ARM_time(self):
+        """A poisoned logging lock cannot wedge `os.write`, and the fd must
+        be duped before the wedge, not during it."""
+        src = _src()
+        body = ast.get_source_segment(src, next(
+            n for n in ast.walk(ast.parse(src))
+            if isinstance(n, ast.FunctionDef)
+            and n.name == "_arm_shutdown_deadline")) or ""
+        assert "os.dup(2)" in body
+        assert "os.write(" in body
+
+    def test_it_kills_rather_than_re_entering_the_interpreter(self):
+        """`sys.exit` runs atexit handlers and interpreter teardown — the
+        very machinery suspected of being stuck."""
+        body = ast.get_source_segment(_src(), next(
+            n for n in ast.walk(ast.parse(_src()))
+            if isinstance(n, ast.FunctionDef)
+            and n.name == "_arm_shutdown_deadline")) or ""
+        assert "os.kill(" in body
+        assert "sys.exit(" not in body
+
+    def test_it_is_a_DAEMON_thread(self):
+        body = ast.get_source_segment(_src(), next(
+            n for n in ast.walk(ast.parse(_src()))
+            if isinstance(n, ast.FunctionDef)
+            and n.name == "_arm_shutdown_deadline")) or ""
+        assert "daemon=True" in body
+
+
+class TestTheGraceIsBounded:
+    def test_the_budget_is_a_knob_with_a_floor_and_a_ceiling(self):
+        body = ast.get_source_segment(_src(), next(
+            n for n in ast.walk(ast.parse(_src()))
+            if isinstance(n, ast.FunctionDef)
+            and n.name == "_arm_shutdown_deadline")) or ""
+        assert "JARVIS_SHUTDOWN_GRACE_S" in body
+        assert "max(5.0" in body and "min(300.0" in body
+
+    def test_no_activity_gated_extension(self):
+        """Slice 47 rejected an adaptive waiver: a wedged phase keeps the
+        extend-condition true forever, so the watchdog deadlocks WITH the
+        system. The answer to "cleanup needs longer" is a larger STATIC
+        budget."""
+        body = ast.get_source_segment(_src(), next(
+            n for n in ast.walk(ast.parse(_src()))
+            if isinstance(n, ast.FunctionDef)
+            and n.name == "_arm_shutdown_deadline")) or ""
+        code = _code_of("_arm_shutdown_deadline").lower()
+        for waiver in ("extend", "waiver", "refresh", "reset_deadline"):
+            assert waiver not in code, waiver
+
+
+@pytest.mark.timeout(60)
+class TestItActuallyKillsAWedge:
+    def test_a_hung_cleanup_is_terminated(self, tmp_path):
+        """The 2026-07-29 failure, reproduced in a real subprocess: the
+        handler fires, writes its summary, and then never returns."""
+        src = _src()
+        tree = ast.parse(src)
+        methods = "\n".join(
+            textwrap.dedent(ast.get_source_segment(src, n) or "")
+            for n in ast.walk(tree)
+            if isinstance(n, ast.FunctionDef)
+            and n.name in ("_arm_shutdown_deadline",
+                           "_disarm_shutdown_deadline")
+        )
+        probe = tmp_path / "probe.py"
+        probe.write_text(
+            "import os, signal, threading, time, logging\n"
+            "logger = logging.getLogger('p')\n"
+            "from typing import Optional\n"
+            "class H:\n"
+            + textwrap.indent(methods, "    ")
+            + "\nh = H()\n"
+            "os.environ['JARVIS_SHUTDOWN_GRACE_S'] = '5'\n"
+            "def on_term(*a):\n"
+            "    h._arm_shutdown_deadline('sigterm')\n"
+            "    while True: time.sleep(0.2)\n"
+            "signal.signal(signal.SIGTERM, on_term)\n"
+            "print('ready', flush=True)\n"
+            "time.sleep(120)\n"
+        )
+        proc = subprocess.Popen(
+            [sys.executable, str(probe)],
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
+        )
+        try:
+            assert proc.stdout is not None
+            assert "ready" in (proc.stdout.readline() or "")
+            proc.terminate()                  # SIGTERM into the wedge
+            t0 = time.monotonic()
+            rc = proc.wait(timeout=40)
+            elapsed = time.monotonic() - t0
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+        # Floor is 5s, so it must outlive a prompt exit and still die.
+        assert 4.0 < elapsed < 30.0, elapsed
+        assert rc != 0, "a SIGKILLed process should not report success"

--- a/tests/battle_test/test_shutdown_watchdog.py
+++ b/tests/battle_test/test_shutdown_watchdog.py
@@ -111,7 +111,6 @@ class TestTheWatchdogIsIsolated:
             if isinstance(n, ast.FunctionDef)
             and n.name == "_arm_shutdown_deadline"
         )
-        body = ast.get_source_segment(src, node) or ""
         body = _code_of("_arm_shutdown_deadline")
         for forbidden in ("self._orchestrator", "_active_ops",
                           "self._phase"):
@@ -161,10 +160,6 @@ class TestTheGraceIsBounded:
         extend-condition true forever, so the watchdog deadlocks WITH the
         system. The answer to "cleanup needs longer" is a larger STATIC
         budget."""
-        body = ast.get_source_segment(_src(), next(
-            n for n in ast.walk(ast.parse(_src()))
-            if isinstance(n, ast.FunctionDef)
-            and n.name == "_arm_shutdown_deadline")) or ""
         code = _code_of("_arm_shutdown_deadline").lower()
         for waiver in ("extend", "waiver", "refresh", "reset_deadline"):
             assert waiver not in code, waiver


### PR DESCRIPTION
## The failure

The daemon this session terminated ignored SIGTERM for 12+ seconds and needed SIGKILL. The signal handler fired **correctly** — a 53KB `summary.json` landed. Then graceful shutdown never finished.

## Root cause

`grep -n 'SHUTDOWN_DEADLINE|shutdown_deadline|SHUTDOWN_TIMEOUT' harness.py` → **nothing**.

`--max-wall-seconds` bounds the **run**. Every subsystem's cleanup is then awaited with no ceiling, so a single hanging await wedges the exit permanently and an external SIGKILL is the only recourse. A process that cannot be asked to stop is not shutting down, it is leaking.

## Built on this file's own pattern

`_start_wall_clock_hard_deadline_thread` already solves the shape, so `_arm_shutdown_deadline` mirrors it rather than inventing a second mechanism:

| | why |
|---|---|
| daemon thread | survives a wedged event loop |
| `os.dup(2)` **at arm time** | a poisoned logging lock cannot wedge `os.write`; the fd must be duped before the wedge, not during it |
| `os.kill` not `sys.exit` | `sys.exit` runs atexit handlers and interpreter teardown — the machinery suspected of being stuck |

Armed as the **first executable statement** of `_handle_shutdown_signal`. Everything after that line can wedge, and the observed failure proved it by wedging *after* the summary write. A deadline armed later is armed by code that never runs.

## Blind, per the invariant already documented here

> a watchdog that shares a resource — signal path, logging lock, **or state-ledger** — with the system it guards is not a watchdog

Slice 47 rejected an "adaptive budget waiver" for exactly this reason: a wedged phase keeps the extend-condition true forever, so the watchdog deadlocks *with* the system. This thread reads only `time.monotonic()`. The answer to "cleanup needs longer" is a larger **static** `JARVIS_SHUTDOWN_GRACE_S` (default 25s, floor 5, ceiling 300) — a malformed knob clamps rather than disarming, because "no deadline" is the state being fixed.

Disarmed on exactly **one** path, after the full summary is stamped. Idempotent, so SIGINT-then-SIGTERM starts one reaper.

## Proof

A real subprocess whose SIGTERM handler writes its summary and then never returns:

```
[ShutdownWatchdog] armed: sigterm must complete within 5s or the process is killed.
handler fired, summary written
[ShutdownWatchdog] graceful shutdown (sigterm) exceeded 5s — SIGKILL 26750.
```

10 new tests · **85 green** across shutdown-watchdog, partial-shutdown, rewind, causality, ctrl-c and supervisor-exit.

## Two self-inflicted lessons, both now structural

1. **Four tests failed by matching my own prose.** The docstrings name "the partial-summary write" and "the extend-condition" precisely to explain the design, so a substring search over a whole function flags the explanation as the offence. Structural checks now strip docstrings via AST, and the ordering assertion compares **statement positions**, not string offsets.
2. **A cleanup regex ate six tests.** A non-greedy span matched first-to-last occurrence; the suite went 10 → 4 while the substitution count reported 1. Redone line-anchored with paren balancing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a hard-deadline shutdown watchdog so exits can’t hang. It arms first in the signal handler and kills the process if graceful shutdown exceeds the configured grace period.

- **Bug Fixes**
  - Added a watchdog thread that SIGKILLs the process if shutdown exceeds `JARVIS_SHUTDOWN_GRACE_S` (default 25s, clamped 5–300s); idempotent across signals and disarmed only on the clean completion path.
  - Armed as the first executable statement in `_handle_shutdown_signal`; verified with a real subprocess test that a wedged handler is terminated.
  - Uses `os.dup(2)` and `os.kill` to avoid logging locks and interpreter teardown; polls the deadline to handle host suspend.
  - Tests tightened with AST-based order checks and docstring-stripped source reads; removed redundant source-segment reads.

<sup>Written for commit 59591a8547e512932f04e4bdd9476c24351461fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

