### PR TITLE
feat(ov): one authority for "how much voice" — /narrate finally reaches the agora

### DIFF
--- a/backend/core/ouroboros/battle_test/narrative_channel.py
+++ b/backend/core/ouroboros/battle_test/narrative_channel.py
@@ -972,3 +972,73 @@ def register_shipped_invariants() -> list:
             validate=_validate_op_started_intent_prompt,
         ),
     ]
+
+
+# ---------------------------------------------------------------------------
+# Narrative-density voices — one per kind, derived from the enum
+# ---------------------------------------------------------------------------
+
+def _kind_density_table() -> Dict[str, tuple]:
+    """(min_density, legacy_flag) per kind value. NEVER raises.
+
+    Keyed by the ENUM member's value, not by a parallel list of literals,
+    so a renamed kind cannot silently lose its threshold — the same
+    discipline as `_validate_renderer_covers_all_kinds`, which exists
+    because a kind without a style renders as nothing at all.
+
+    A kind absent from this table resolves to ON rather than being dropped:
+    the failure mode of a forgotten entry must be "slightly too talkative",
+    never "invisible", because only one of those is noticeable.
+    """
+    return {
+        # The preamble IS the `preambles` level — it is what that rung of
+        # the ladder was named after.
+        NarrativeKind.TOOL_PREAMBLE.value: (
+            "preambles", "JARVIS_TOOL_PREAMBLE_FALLBACK_ENABLED"),
+        NarrativeKind.INTENT.value: ("on", "JARVIS_NARRATIVE_INTENT_ENABLED"),
+        NarrativeKind.PLAN_PROSE.value: ("on", ""),
+        NarrativeKind.L2_REPAIR_PROSE.value: ("on", ""),
+        NarrativeKind.DREAM.value: ("verbose", ""),
+        # Extended thinking is the only thing `verbose` ever promised, and
+        # the flag it wrote had no reader. This is that promise acquiring
+        # a consumer.
+        NarrativeKind.THINKING.value: (
+            "verbose", "JARVIS_NARRATIVE_THINKING_VERBOSE"),
+        # A failure report is audible at every level. Not `exempt`: an
+        # operator who explicitly silences postmortems has made a decision,
+        # and only alarms outrank an explicit decision.
+        NarrativeKind.POSTMORTEM_PROSE.value: ("off", ""),
+    }
+
+
+def register_voices(registry) -> int:
+    """Declare one voice per narrative kind. NEVER raises.
+
+    Iterating the enum rather than a hand-written list means a kind added
+    later gets a voice automatically — the property whose absence is the
+    whole defect: `/narrate` hardcoded four flags and was never updated
+    when the organism learned to speak in new ways.
+    """
+    try:
+        table = _kind_density_table()
+        count = 0
+        for kind in NarrativeKind:
+            min_density, legacy = table.get(kind.value, ("on", ""))
+            if registry.register(
+                f"narrative.{kind.value}", min_density,
+                legacy_flag=legacy, owner=__name__,
+                describe=f"NarrativeKind.{kind.name} frames",
+            ) is not None:
+                count += 1
+        return count
+    except Exception:  # noqa: BLE001
+        return 0
+
+
+try:  # Self-register at import — a voice must be known BEFORE it speaks.
+    from backend.core.ouroboros.ui.narrative_density import (  # noqa: E402
+        default_registry as _default_voice_registry,
+    )
+    register_voices(_default_voice_registry())
+except Exception:  # noqa: BLE001
+    pass

--- a/backend/core/ouroboros/battle_test/narrative_renderer.py
+++ b/backend/core/ouroboros/battle_test/narrative_renderer.py
@@ -334,6 +334,21 @@ def render_to_console(
 
     NEVER raises.
     """
+    # The SURFACING seam for the model's voice, and therefore where the
+    # operator's `/narrate` density applies. Deliberately not `start_frame`:
+    # the channel is a ring the operator can page back through with `n-N`,
+    # so gating admission would edit the record instead of the view, and a
+    # frame the dial hid at ON would be permanently missing after the dial
+    # went back to VERBOSE. Same reasoning as Moltbook's `_notify_subscribers`
+    # — the archive is not a display preference's to edit.
+    try:
+        from backend.core.ouroboros.ui.narrative_density import audible
+        kind = str(getattr(getattr(frame, "kind", ""), "value", "")
+                   or getattr(frame, "kind", "") or "").strip().lower()
+        if kind and not audible(f"narrative.{kind}"):
+            return False
+    except Exception:  # noqa: BLE001 — a dial that cannot answer must never
+        pass                                       # swallow the organism's voice
     rendered = compose(
         frame,
         op_active=op_active,

--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -1377,7 +1377,7 @@ class SerpentFlow:
         summary_lines = [
             f"[bold]Session[/bold]   {self._session_id}",
             f"[bold]Uptime[/bold]    {mins}m {secs:02d}s",
-            f"[bold]Evolved[/bold]   [{_SEM['success']}]{self._completed}[/]  "
+            f"[bold]Evolved[/bold]   [{_SEM['life']}]{self._completed}[/]  "
             f"[bold]Shed[/bold] [{_SEM['death']}]{self._failed}[/]",
             f"[bold]Cost[/bold]      ${self._cost_total:.4f} of ${self._cost_cap:.2f}",
         ]
@@ -1790,7 +1790,7 @@ class SerpentFlow:
         short = _short_id(op_id)
         w = self._block_w()
         stats = (
-            f"🐍 [{_SEM['success']}]✅ {self._completed}[/]  "
+            f"🐍 [{_SEM['life']}]✅ {self._completed}[/]  "
             f"[{_SEM['death']}]💀 {self._failed}[/] [dim]│[/dim] "
             f"💰 ${self._cost_total:.4f}/${self._cost_cap:.2f}"
         )
@@ -2505,7 +2505,7 @@ class SerpentFlow:
         # Risk badge
         risk = risk_tier.upper() if risk_tier else ""
         if risk in ("SAFE_AUTO", "LOW"):
-            risk_badge = f"[{_SEM['success']}]{risk}[/]"
+            risk_badge = f"[{_SEM['life']}]{risk}[/]"
         elif risk == "MEDIUM":
             risk_badge = f"[{_SEM['heal']}]{risk}[/{_SEM['heal']}]"
         elif risk:
@@ -2804,9 +2804,20 @@ class SerpentFlow:
         # ``/narrate off``.
         if not preamble:
             try:
-                _fallback_on = os.environ.get(
-                    "JARVIS_TOOL_PREAMBLE_FALLBACK_ENABLED", "true",
-                ).strip().lower() not in ("0", "false", "no", "off")
+                # Through the dial: an explicitly set
+                # JARVIS_TOOL_PREAMBLE_FALLBACK_ENABLED still wins,
+                # otherwise the operator's /narrate level decides. Default
+                # true is preserved — preambles are audible from the
+                # `preambles` rung up, and the default density is ON.
+                try:
+                    from backend.core.ouroboros.ui.narrative_density import (
+                        audible as _density_audible,
+                    )
+                    _fallback_on = _density_audible("narrative.tool_preamble")
+                except Exception:  # noqa: BLE001
+                    _fallback_on = os.environ.get(
+                        "JARVIS_TOOL_PREAMBLE_FALLBACK_ENABLED", "true",
+                    ).strip().lower() not in ("0", "false", "no", "off")
                 if _fallback_on:
                     from backend.core.ouroboros.governance.tool_preamble_synthesizer import (
                         synthesize_preamble,
@@ -3015,7 +3026,7 @@ class SerpentFlow:
             self._op_line(
                 op_id,
                 f"[{_SEM['life']}]🛡️ immune[/{_SEM['life']}]      "
-                f"[{_SEM['success']}]✅ {test_count}/{test_count} passing[/]",
+                f"[{_SEM['life']}]✅ {test_count}/{test_count} passing[/]",
             )
         else:
             self._op_line(
@@ -3086,7 +3097,7 @@ class SerpentFlow:
             )
             self._op_line(
                 op_id,
-                f"  [{_SEM['dim']}]⎿[/{_SEM['dim']}]  [{_SEM['success']}]✅ {test_total}/{test_total} passing[/]",
+                f"  [{_SEM['dim']}]⎿[/{_SEM['dim']}]  [{_SEM['life']}]✅ {test_total}/{test_total} passing[/]",
             )
         else:
             passing = test_total - test_failures
@@ -7203,7 +7214,7 @@ class SerpentREPL:
             f"  [bold]Session[/bold]      {f._session_id}"
         )
         f.console.print(
-            f"  [bold]Evolved[/bold]      [{_SEM['success']}]{f._completed}[/]"
+            f"  [bold]Evolved[/bold]      [{_SEM['life']}]{f._completed}[/]"
             f"  [dim]│[/dim]  [bold]Shed[/bold] [{_SEM['death']}]{f._failed}[/]"
             f"  [dim]│[/dim]  [bold]Active[/bold] {len(f._active_ops)}"
             f"  [dim]│[/dim]  [bold]Sensors[/bold] {f._sensors_active}"
@@ -7214,7 +7225,7 @@ class SerpentREPL:
             f"  [dim]│[/dim]  [bold]Lessons[/bold] {len(f._session_lessons)}"
             f"  [dim]│[/dim]  [bold]Plan Review[/bold] "
             # NOT migrated: this quoted string lives INSIDE an f-string
-            # expression, so `_SEM['success']` would reuse the delimiter
+            # expression, so `_SEM['life']` would reuse the delimiter
             # and terminate it. Hoisting the styles to locals is the fix,
             # but this sits inside an implicit string-concatenation block
             # where a statement cannot be inserted — ast.parse refused it.
@@ -8613,15 +8624,7 @@ class SerpentREPL:
         """
         parts = line.replace("/narrate", "narrate", 1).split(None, 1)
         if len(parts) < 2 or not parts[1].strip():
-            current = os.environ.get(
-                "JARVIS_NARRATIVE_DENSITY", "(unset — defaults to 'on')",
-            )
-            self._flow.console.print(
-                f"  [{_SEM['neural']}]Narrative density:[/{_SEM['neural']}] {current}\n"
-                f"  [{_SEM['dim']}]Usage: /narrate "
-                f"{' | '.join(self._NARRATE_DENSITIES)}[/{_SEM['dim']}]",
-                highlight=False,
-            )
+            self._print_narrate_roster()
             return
         density = parts[1].strip().lower()
         if density not in self._NARRATE_DENSITIES:
@@ -8631,30 +8634,66 @@ class SerpentREPL:
                 highlight=False,
             )
             return
-        os.environ["JARVIS_NARRATIVE_DENSITY"] = density
-        # Compose the per-density env state. The downstream subsystems
-        # (intent_prompter / preamble synthesizer / channel) read these
-        # individual flags so the operator can tune via /narrate without
-        # touching env vars manually.
-        if density == "off":
-            os.environ["JARVIS_NARRATIVE_INTENT_ENABLED"] = "false"
-            os.environ["JARVIS_TOOL_PREAMBLE_FALLBACK_ENABLED"] = "false"
-        elif density == "preambles":
-            os.environ["JARVIS_NARRATIVE_INTENT_ENABLED"] = "false"
-            os.environ["JARVIS_TOOL_PREAMBLE_FALLBACK_ENABLED"] = "true"
-        elif density == "on":
-            os.environ["JARVIS_NARRATIVE_INTENT_ENABLED"] = "true"
-            os.environ["JARVIS_TOOL_PREAMBLE_FALLBACK_ENABLED"] = "true"
-        elif density == "verbose":
-            os.environ["JARVIS_NARRATIVE_INTENT_ENABLED"] = "true"
-            os.environ["JARVIS_TOOL_PREAMBLE_FALLBACK_ENABLED"] = "true"
-            # Verbose enables extended-thinking surfacing too (read by
-            # provider-side wiring when present)
-            os.environ["JARVIS_NARRATIVE_THINKING_VERBOSE"] = "true"
-        self._flow.console.print(
-            f"  [{_SEM['evolved']}]Narrative density set to {density}[/{_SEM['evolved']}]",
-            highlight=False,
-        )
+        # ONE write. The old body also set each producer's own master flag,
+        # which was wrong twice over: it reached a hardcoded three of the
+        # organism's voices (Moltbook's thirteen residents kept talking
+        # through `/narrate off`), and it made every later read of those
+        # flags look operator-set, so an explicit preference could never
+        # again be distinguished from the dial's own echo.
+        from backend.core.ouroboros.ui.narrative_density import set_density
+        set_density(density)
+        self._print_narrate_roster(header=f"Narrative density → {density}")
+
+    def _print_narrate_roster(self, *, header: str = "") -> None:
+        """Print the dial's reach: what speaks, what is silenced, and why.
+
+        The verb used to assert a density and stop. It could not have listed
+        its own effect, because it had none to list — the value it wrote had
+        no readers anywhere in the repo. Reading the roster means `/narrate`
+        can no longer claim a silence it did not deliver. NEVER raises.
+        """
+        try:
+            from backend.core.ouroboros.ui.narrative_density import (
+                current_density, roster,
+            )
+            level = current_density()
+            rows = roster()
+            heard = [r for r in rows if r.verdict.heard]
+            muted = [r for r in rows if not r.verdict.heard]
+            out = [
+                f"  [{_SEM['neural']}]"
+                f"{header or 'Narrative density'}[/{_SEM['neural']}] "
+                f"[{_SEM['dim']}]({level.label} · {len(heard)}/{len(rows)} "
+                f"voices audible)[/{_SEM['dim']}]"
+            ]
+            for r in heard:
+                why = ""
+                if r.voice.exempt:
+                    why = f" [{_SEM['dim']}]— alarm, never muted[/{_SEM['dim']}]"
+                elif r.verdict.reason.startswith("explicit:"):
+                    why = (f" [{_SEM['heal']}]— forced on by "
+                           f"{r.verdict.reason.split(':', 1)[1]}[/{_SEM['heal']}]")
+                out.append(f"    [{_SEM['life']}]•[/{_SEM['life']}] "
+                           f"{r.voice.name}{why}")
+            for r in muted:
+                why = ""
+                if r.verdict.reason.startswith("explicit:"):
+                    why = (f" [{_SEM['heal']}]— forced off by "
+                           f"{r.verdict.reason.split(':', 1)[1]}[/{_SEM['heal']}]")
+                else:
+                    why = (f" [{_SEM['dim']}]— needs "
+                           f"{r.voice.min_density.label}[/{_SEM['dim']}]")
+                out.append(f"    [{_SEM['dim']}]◦ {r.voice.name}[/{_SEM['dim']}]"
+                           f"{why}")
+            out.append(f"  [{_SEM['dim']}]Usage: /narrate "
+                       f"{' | '.join(self._NARRATE_DENSITIES)}[/{_SEM['dim']}]")
+            self._flow.console.print("\n".join(out), highlight=False)
+        except Exception:  # noqa: BLE001
+            self._flow.console.print(
+                f"  [{_SEM['dim']}]Usage: /narrate "
+                f"{' | '.join(self._NARRATE_DENSITIES)}[/{_SEM['dim']}]",
+                highlight=False,
+            )
 
     # ── Gap #4 Slice 4 — IDE-native review verbs ────────────────
 

--- a/backend/core/ouroboros/governance/intent_prompter.py
+++ b/backend/core/ouroboros/governance/intent_prompter.py
@@ -88,11 +88,28 @@ _MAX_MAX_TOKENS: int = 200
 
 
 def is_master_flag_enabled() -> bool:
-    """``JARVIS_NARRATIVE_INTENT_ENABLED``. **Default true** post Slice 5
-    graduation (2026-05-04). Operators set ``=false`` to suppress the
-    intent prompt's micro-LLM call at op_started. NEVER raises."""
-    raw = os.environ.get(MASTER_FLAG_ENV_VAR, "true")
-    return raw.strip().lower() not in ("0", "false", "no", "off")
+    """Should the intent prompt's micro-LLM call happen at op_started?
+
+    Resolved through `narrative_density`, which composes two answers this
+    function used to know only half of: an explicitly set
+    ``JARVIS_NARRATIVE_INTENT_ENABLED`` still wins (operator specificity
+    beats a global dial), and otherwise the operator's `/narrate` level
+    decides. Default true post Slice 5 graduation (2026-05-04) — preserved,
+    because the default density is ON and intent is audible at ON.
+
+    Checked here rather than at the renderer because this gate is a COST
+    gate: refusing later would mean the model call was already spent to
+    produce prose the operator asked not to see.
+
+    Falls back to the original read if the dial is unavailable, so this
+    module keeps working standalone. NEVER raises.
+    """
+    try:
+        from backend.core.ouroboros.ui.narrative_density import audible
+        return audible("narrative.intent")
+    except Exception:  # noqa: BLE001
+        raw = os.environ.get(MASTER_FLAG_ENV_VAR, "true")
+        return raw.strip().lower() not in ("0", "false", "no", "off")
 
 
 def read_timeout_s() -> float:

--- a/backend/core/ouroboros/governance/moltbook.py
+++ b/backend/core/ouroboros/governance/moltbook.py
@@ -558,6 +558,18 @@ async def _maybe_converse(stored: "MoltPost") -> None:
     try:
         if not converse_enabled() or stored.reply_to:
             return                     # recursion ban: replies are leaves
+        # Density is checked HERE, not at the renderer, for the reason
+        # `_reply_budget_ok` already states about posture: refusing at the
+        # surface means the reaction was still formulated — a model call
+        # spent and a resident's cooldown consumed — to produce something
+        # the operator asked not to see. The cheapest refusal is the one
+        # that happens before the dice are even rolled.
+        try:
+            from backend.core.ouroboros.ui.narrative_density import audible
+            if not audible("moltbook.banter"):
+                return
+        except Exception:  # noqa: BLE001 — fail open, never silence on a
+            pass                                        # lookup failure
         if stored.author_id == "operator":
             return                     # human posts summon via the semantic
                                        # router — never the ambient dice
@@ -696,12 +708,51 @@ def clear_molt_subscribers() -> None:
     _SUBSCRIBERS.clear()
 
 
+def voice_for(post: Any) -> str:
+    """Which registered voice this post speaks with.
+
+    Derived from distinctions the agora ALREADY makes — a `⚔`, a `reply_to`
+    — rather than a new field on the post. A taxonomy that has to be stamped
+    at write time is a taxonomy that will be wrong for every post already in
+    the table. NEVER raises.
+    """
+    try:
+        from backend.core.ouroboros.battle_test.moltbook_inline import (
+            is_conflict,
+        )
+        if is_conflict(post):
+            return "moltbook.conflict"
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        if getattr(post, "reply_to", None) or (
+                isinstance(post, dict) and post.get("reply_to")):
+            return "moltbook.banter"
+    except Exception:  # noqa: BLE001
+        pass
+    return "moltbook.post"
+
+
 def _notify_subscribers(post: Any) -> None:
     """Fan one post out to the live feed.
 
     Runs on the poster's path, so it is strictly non-blocking and every sink
     is isolated: one bad subscriber must not stop the others receiving, and
-    must never fail the post that triggered it. NEVER raises."""
+    must never fail the post that triggered it. NEVER raises.
+
+    Gated on the operator's narrative density — the SURFACING seam, not the
+    storage one. A muted post is still written to `moltbook_posts`, so
+    `/moltbook` shows an unbroken history and turning the dial back up does
+    not reveal a gap where the society went quiet. Silence here means "not in
+    my transcript", never "did not happen": the archive is the society's
+    memory and a display preference has no business editing it.
+    """
+    try:
+        from backend.core.ouroboros.ui.narrative_density import audible
+        if not audible(voice_for(post)):
+            return
+    except Exception:  # noqa: BLE001 — a dial that cannot answer must not
+        pass                                    # silence the room. Fail open.
     for sink in list(_SUBSCRIBERS):
         try:
             sink(post)
@@ -721,3 +772,61 @@ def post_molt_nowait(
         loop.create_task(post_molt(author_id, kind, body, **kw))
     except Exception:  # noqa: BLE001
         pass
+
+
+# ---------------------------------------------------------------------------
+# Narrative-density voices — declared HERE, beside the code that speaks
+# ---------------------------------------------------------------------------
+
+
+def register_voices(registry: Any) -> int:
+    """Declare the agora's voices. Discovered by `narrative_density`.
+
+    Co-located with the poster for the same reason `register_flags` is
+    co-located with its consumer: a taxonomy maintained in the dial's own
+    file is a taxonomy that drifts from the thing it describes, which is
+    precisely how `/narrate` came to push four flags at a subsystem that
+    reads none of them.
+
+    The three voices are not new categories. They are the distinctions the
+    agora already draws — a conflict, a reply, a first-party post — given
+    the thresholds an operator would expect:
+
+      * ``off``       — nothing but conflicts
+      * ``preambles`` — nothing but conflicts (the room is not a preamble)
+      * ``on``        — the organism's own reports
+      * ``verbose``   — the full society, banter included
+
+    Returns the number registered. NEVER raises.
+    """
+    try:
+        from backend.core.ouroboros.ui.narrative_density import Density
+        specs = (
+            ("moltbook.conflict", Density.OFF, True,
+             "⚔ REVIEW contesting GENERATE — an alarm, never banter"),
+            ("moltbook.post", Density.ON, False,
+             "first-party posts: what the organism reports about itself"),
+            ("moltbook.banter", Density.VERBOSE, False,
+             "resident reactions and replies — the agora's social layer"),
+        )
+        count = 0
+        for name, min_density, exempt, describe in specs:
+            if registry.register(
+                name, min_density, exempt=exempt, describe=describe,
+                legacy_flag=("JARVIS_MOLTBOOK_CONVERSE_ENABLED"
+                             if name == "moltbook.banter" else ""),
+                owner=__name__,
+            ) is not None:
+                count += 1
+        return count
+    except Exception:  # noqa: BLE001
+        return 0
+
+
+try:  # Self-register at import: a voice must be known BEFORE it speaks.
+    from backend.core.ouroboros.ui.narrative_density import (  # noqa: E402
+        default_registry as _default_voice_registry,
+    )
+    register_voices(_default_voice_registry())
+except Exception:  # noqa: BLE001 — the agora works without the dial
+    pass

--- a/backend/core/ouroboros/ui/narrative_density.py
+++ b/backend/core/ouroboros/ui/narrative_density.py
@@ -1,0 +1,452 @@
+"""How much voice the operator wants — asked once, by everyone who speaks.
+
+`/narrate {off|preambles|on|verbose}` reads as the dial for the organism's
+voice. It is not one. It is four `os.environ` writes to a list of producer
+flags hardcoded in the verb, and the list is wrong in three separate ways:
+
+    JARVIS_NARRATIVE_DENSITY            0 readers, anywhere in the repo
+    JARVIS_NARRATIVE_THINKING_VERBOSE   0 readers, anywhere in the repo
+    JARVIS_TOOL_PREAMBLE_FALLBACK_ENABLED   1
+    JARVIS_NARRATIVE_INTENT_ENABLED         1
+
+So the density value the verb reports back — the one its docstring says it
+sets "so subsystem readers see consistent state" — is consumed by nobody,
+and `/narrate verbose`'s promise of extended-thinking streams is a write to
+a flag no code has ever read.
+
+Meanwhile the Moltbook agora — 13 personas with an autonomous reaction
+engine — reads none of them. `/narrate off` silences two voices and leaves
+the loudest one talking.
+
+The bug is not the missing Moltbook entry
+=========================================
+Adding `JARVIS_MOLTBOOK_ENABLED` to the verb's list would fix Moltbook and
+leave the class untouched: the next voice added to the organism is silent to
+the dial again, and nothing detects it. The verb PUSHES to a list of
+producers, so it must be edited every time the organism learns to speak —
+and it was not edited even once.
+
+Invert it. This module owns the ladder; producers REGISTER a voice and PULL.
+Adding a voice requires no edit here and no edit to the verb, and `/narrate`
+can finally answer "what will I actually hear" by reading the roster instead
+of asserting it.
+
+    OFF(0) < PREAMBLES(1) < ON(2) < VERBOSE(3)
+
+Ordinal, so a voice declares a threshold and the comparison is total. This is
+the same shape as `risk_tier_floor`'s composing knobs, for the same reason:
+"strictest wins" needs an order, not a set of booleans.
+
+Four rules, in order
+====================
+1. **Unknown voices are HEARD.** A dial that mutes what it does not
+   recognise silently deletes the output of any subsystem that forgot to
+   register — the exact failure this module exists to end, reintroduced
+   from the other side. `posture_allows` already resolves an unknown posture
+   to SPEAK for the same reason.
+2. **Exempt voices bypass the dial.** A `⚔` conflict is REVIEW contesting
+   GENERATE: the system reporting that its own components disagree. That is
+   not banter and no verbosity preference should be able to suppress it.
+   Reuses Moltbook's existing `is_conflict` notion rather than inventing a
+   second one.
+3. **An explicitly set legacy flag WINS.** Operator specificity beats a
+   global dial. Detected by KEY PRESENCE in `os.environ`, never by
+   truthiness — `FLAG=false` is an operator decision and `FLAG` unset is
+   the absence of one, and a truthiness test cannot tell them apart.
+   This is why the verb must stop writing those flags: once the dial writes
+   them, every later read looks operator-set and the dial freezes itself at
+   whatever it wrote first.
+4. Otherwise: audible iff `current_density() >= voice.min_density`.
+
+What this does NOT own
+======================
+POSTURE. Moltbook already refuses banter under HARDEN, and duplicating that
+here would give the same question two answers. Density is the operator's
+stated preference; posture is the organism's situational read; both gates
+must pass, so "strictest wins" falls out of the AND without a combinator.
+
+NEVER raises. A surface that cannot resolve a preference must still speak:
+losing narration is a nuisance, losing the ability to reason about whether
+narration happened is the bug being fixed.
+"""
+from __future__ import annotations
+
+import enum
+import logging
+import os
+import threading
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+
+logger = logging.getLogger("Ouroboros.NarrativeDensity")
+
+NARRATIVE_DENSITY_SCHEMA_VERSION = "narrative_density.v1"
+
+#: The one key the dial writes. Everything else is derived or explicit.
+DENSITY_ENV_VAR = "JARVIS_NARRATIVE_DENSITY"
+
+_TRUTHY = ("1", "true", "yes", "on")
+_FALSY = ("0", "false", "no", "off")
+
+
+class Density(enum.IntEnum):
+    """How much of the organism's voice reaches the transcript.
+
+    ``IntEnum`` because the whole point is that thresholds compare. A voice
+    says "I need at least ON" and the dial answers with ``>=``; an
+    unordered enum would push that comparison back into every producer,
+    which is how the four-flag shotgun happened in the first place.
+    """
+
+    OFF = 0
+    PREAMBLES = 1
+    ON = 2
+    VERBOSE = 3
+
+    @property
+    def label(self) -> str:
+        return self.name.lower()
+
+
+#: Matches the verb's existing vocabulary exactly. The vocabulary was never
+#: the problem — `/narrate`'s four levels are good and operators know them.
+DENSITY_NAMES: Tuple[str, ...] = tuple(d.label for d in Density)
+
+#: Unset resolves here, matching the verb's own "(unset — defaults to 'on')".
+DEFAULT_DENSITY = Density.ON
+
+
+def coerce_density(raw: object, default: Density = DEFAULT_DENSITY) -> Density:
+    """Parse a density from anything. NEVER raises.
+
+    Accepts the label, the int, or a `Density`. An unparseable value returns
+    ``default`` rather than OFF: a typo in a config must not silence the
+    organism, because silence is indistinguishable from a healthy quiet
+    system and the operator would have no signal that their value was junk.
+    """
+    try:
+        if isinstance(raw, Density):
+            return raw
+        if isinstance(raw, bool):          # bool is an int — check first
+            return Density.ON if raw else Density.OFF
+        if isinstance(raw, int):
+            return Density(max(0, min(3, int(raw))))
+        text = str(raw or "").strip().lower()
+        if not text:
+            return default
+        for d in Density:
+            if text == d.label:
+                return d
+        if text.isdigit():
+            return Density(max(0, min(3, int(text))))
+        return default
+    except Exception:  # noqa: BLE001
+        return default
+
+
+def current_density() -> Density:
+    """The operator's stated preference right now. NEVER raises."""
+    try:
+        return coerce_density(os.environ.get(DENSITY_ENV_VAR))
+    except Exception:  # noqa: BLE001
+        return DEFAULT_DENSITY
+
+
+def set_density(raw: object) -> Density:
+    """Set the dial and return what it resolved to. NEVER raises.
+
+    Writes ONE key. The verb's old behaviour — also writing each producer's
+    own master flag — is what made rule 3 unusable, because after the first
+    `/narrate` every producer flag looked operator-set forever.
+    """
+    resolved = coerce_density(raw)
+    try:
+        os.environ[DENSITY_ENV_VAR] = resolved.label
+    except Exception:  # noqa: BLE001
+        logger.debug("[NarrativeDensity] set degraded", exc_info=True)
+    return resolved
+
+
+@dataclass(frozen=True)
+class Voice:
+    """One thing that speaks, and the level at which it becomes audible."""
+
+    name: str
+    min_density: Density
+    #: Pre-existing master flag for this producer. Honoured when EXPLICITLY
+    #: present in the environment, so operators and launch scripts that set
+    #: it keep working and keep winning over the dial.
+    legacy_flag: str = ""
+    #: Alarms. Not subject to the dial at any level — see rule 2.
+    exempt: bool = False
+    describe: str = ""
+    owner: str = ""
+
+
+@dataclass(frozen=True)
+class Verdict:
+    """Whether a voice is audible, and WHY.
+
+    Never a bare bool, for the same reason `SubmitResult` is not: the whole
+    defect being fixed is a dial that could not explain itself. A caller
+    that only ever learns "no" cannot tell the operator whether the cause
+    was the dial, an explicit flag, or an unregistered producer.
+    """
+
+    heard: bool
+    reason: str = ""
+    voice: Optional[Voice] = None
+
+    def __bool__(self) -> bool:
+        return bool(self.heard)
+
+
+class VoiceRegistry:
+    """Every voice that has declared itself. Thread-safe. NEVER raises."""
+
+    def __init__(self) -> None:
+        self._voices: Dict[str, Voice] = {}
+        self._lock = threading.Lock()
+
+    def register(
+        self,
+        name: str,
+        min_density: object = DEFAULT_DENSITY,
+        *,
+        legacy_flag: str = "",
+        exempt: bool = False,
+        describe: str = "",
+        owner: str = "",
+    ) -> Optional[Voice]:
+        """Declare a voice. Idempotent — re-registration overrides in place,
+        matching `FlagRegistry.bulk_register(override=True)` so a reloaded
+        module does not fork the roster."""
+        try:
+            key = str(name or "").strip().lower()
+            if not key:
+                return None
+            voice = Voice(
+                name=key,
+                min_density=coerce_density(min_density),
+                legacy_flag=str(legacy_flag or "").strip(),
+                exempt=bool(exempt),
+                describe=str(describe or "").strip(),
+                owner=str(owner or "").strip(),
+            )
+            with self._lock:
+                self._voices[key] = voice
+            return voice
+        except Exception:  # noqa: BLE001
+            logger.debug("[NarrativeDensity] register degraded for %r",
+                         name, exc_info=True)
+            return None
+
+    def get(self, name: str) -> Optional[Voice]:
+        try:
+            with self._lock:
+                return self._voices.get(str(name or "").strip().lower())
+        except Exception:  # noqa: BLE001
+            return None
+
+    def all(self) -> Tuple[Voice, ...]:
+        try:
+            with self._lock:
+                return tuple(sorted(
+                    self._voices.values(),
+                    key=lambda v: (int(v.min_density), v.name),
+                ))
+        except Exception:  # noqa: BLE001
+            return ()
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._voices)
+
+
+_REGISTRY = VoiceRegistry()
+_REGISTRY_LOCK = threading.Lock()
+
+
+def default_registry() -> VoiceRegistry:
+    return _REGISTRY
+
+
+def register_voice(name: str, min_density: object = DEFAULT_DENSITY,
+                   **kw: object) -> Optional[Voice]:
+    """Module-level convenience — the spelling producers use."""
+    return _REGISTRY.register(name, min_density, **kw)  # type: ignore[arg-type]
+
+
+def reset_for_tests() -> None:
+    """Drop every voice and the discovery latch."""
+    global _discovered
+    with _REGISTRY_LOCK:
+        _discovered = False
+    _REGISTRY._voices.clear()  # noqa: SLF001 — test seam, same module
+
+
+# ---------------------------------------------------------------------------
+# The question every producer asks
+# ---------------------------------------------------------------------------
+
+
+def permits(name: str, *, density: Optional[Density] = None) -> Verdict:
+    """May ``name`` speak right now, and why. NEVER raises.
+
+    Cheap by construction: a dict lookup, an ordinal compare, and at most one
+    `os.environ` read. It is called on posting paths, so it must never import,
+    never walk packages, and never touch a database.
+    """
+    try:
+        key = str(name or "").strip().lower()
+        voice = _REGISTRY.get(key)
+        if voice is None:
+            # Rule 1 — fail OPEN. Muting the unrecognised would recreate the
+            # very silent-drop this module exists to end.
+            return Verdict(True, "unregistered")
+        if voice.exempt:
+            return Verdict(True, "exempt", voice)          # rule 2
+        if voice.legacy_flag and voice.legacy_flag in os.environ:
+            raw = os.environ.get(voice.legacy_flag, "").strip().lower()
+            if raw in _FALSY:
+                return Verdict(False, f"explicit:{voice.legacy_flag}", voice)
+            if raw in _TRUTHY:
+                return Verdict(True, f"explicit:{voice.legacy_flag}", voice)
+            # Present but unparseable: fall through to the dial rather than
+            # guessing. An operator typo should not pin a voice on or off.
+        level = current_density() if density is None else density
+        if level >= voice.min_density:
+            return Verdict(True, f"density:{level.label}", voice)
+        return Verdict(False, f"density:{level.label}", voice)
+    except Exception:  # noqa: BLE001
+        logger.debug("[NarrativeDensity] permits degraded for %r",
+                     name, exc_info=True)
+        return Verdict(True, "degraded")
+
+
+def audible(name: str) -> bool:
+    """`permits(...)` as a bare bool, for hot seams that only branch."""
+    return bool(permits(name))
+
+
+# ---------------------------------------------------------------------------
+# The honesty surface
+# ---------------------------------------------------------------------------
+
+#: Packages whose direct submodules may own voices. Metadata about WHERE
+#: voices live, not the voices themselves — adding a voice inside an
+#: existing module needs zero edits here. Mirrors
+#: `flag_registry_seed._FLAG_PROVIDER_PACKAGES`, deliberately: two walkers
+#: with two conventions would be the duplication this module is arguing
+#: against.
+_VOICE_PROVIDER_PACKAGES: Tuple[str, ...] = (
+    "backend.core.ouroboros.governance",
+    "backend.core.ouroboros.battle_test",
+)
+
+_discovered = False
+
+
+def ensure_discovered(*, force: bool = False) -> int:
+    """Import-walk for voices declared by modules not yet loaded.
+
+    Only the ROSTER needs this. Correctness does not: a producer registers
+    its voices at its own import, so by the time it can speak it is in the
+    registry. The walk exists so `/narrate` can list a voice belonging to a
+    subsystem this session has not exercised yet — otherwise the surface
+    would under-report exactly like the verb it replaces.
+
+    Delegates to the existing AST-pinned discovery primitive rather than
+    hand-rolling a second `pkgutil` walk. Idempotent. NEVER raises.
+    """
+    global _discovered
+    try:
+        with _REGISTRY_LOCK:
+            if _discovered and not force:
+                return len(_REGISTRY)
+            _discovered = True
+        from backend.core.ouroboros.governance.meta.module_discovery import (
+            discover_module_provided_callable,
+            make_registry_handler,
+        )
+        discover_module_provided_callable(
+            packages=_VOICE_PROVIDER_PACKAGES,
+            attr_name="register_voices",
+            handler=make_registry_handler(registry=_REGISTRY),
+            excluded_modules=(__name__,),
+            log_prefix="NarrativeDensity",
+        )
+        return len(_REGISTRY)
+    except Exception:  # noqa: BLE001
+        logger.debug("[NarrativeDensity] discovery degraded", exc_info=True)
+        return len(_REGISTRY)
+
+
+@dataclass(frozen=True)
+class RosterRow:
+    voice: Voice
+    verdict: Verdict
+
+
+def roster(*, density: Optional[Density] = None,
+           discover: bool = True) -> List[RosterRow]:
+    """Every known voice and whether it is audible. NEVER raises.
+
+    This is what `/narrate` should have been able to print from the start:
+    the dial reporting what it actually reaches, rather than asserting a
+    density nothing reads.
+    """
+    try:
+        if discover:
+            ensure_discovered()
+        return [
+            RosterRow(voice=v, verdict=permits(v.name, density=density))
+            for v in _REGISTRY.all()
+        ]
+    except Exception:  # noqa: BLE001
+        return []
+
+
+def snapshot(*, discover: bool = True) -> dict:
+    """Transport-safe projection for the cockpit / observability."""
+    try:
+        level = current_density()
+        rows = roster(discover=discover)
+        return {
+            "schema_version": NARRATIVE_DENSITY_SCHEMA_VERSION,
+            "density": level.label,
+            "audible": [r.voice.name for r in rows if r.verdict.heard],
+            "silenced": [r.voice.name for r in rows if not r.verdict.heard],
+            "exempt": [r.voice.name for r in rows if r.voice.exempt],
+            "overridden": [
+                r.voice.name for r in rows
+                if r.verdict.reason.startswith("explicit:")
+            ],
+        }
+    except Exception:  # noqa: BLE001
+        return {"density": DEFAULT_DENSITY.label, "audible": [],
+                "silenced": [], "exempt": [], "overridden": []}
+
+
+__all__ = [
+    "DEFAULT_DENSITY",
+    "DENSITY_ENV_VAR",
+    "DENSITY_NAMES",
+    "Density",
+    "NARRATIVE_DENSITY_SCHEMA_VERSION",
+    "RosterRow",
+    "Verdict",
+    "Voice",
+    "VoiceRegistry",
+    "audible",
+    "coerce_density",
+    "current_density",
+    "default_registry",
+    "ensure_discovered",
+    "permits",
+    "register_voice",
+    "reset_for_tests",
+    "roster",
+    "set_density",
+    "snapshot",
+]

--- a/tests/battle_test/test_narrative_density.py
+++ b/tests/battle_test/test_narrative_density.py
@@ -1,0 +1,287 @@
+"""One authority for "how much voice", and the ways it must not fail.
+
+`/narrate` pushed four `os.environ` writes at a hardcoded list of producers.
+Two of the four keys had zero readers anywhere in the repository, and the
+Moltbook agora — thirteen personas with an autonomous reaction engine — read
+none of them, so `/narrate off` silenced two voices and left the loudest one
+talking.
+
+These tests pin the inverted design: producers register and PULL, and the
+failure modes of a dial (muting the unknown, freezing itself, editing the
+archive) are each held shut.
+"""
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+
+from backend.core.ouroboros.ui import narrative_density as nd
+
+_LEGACY_FLAGS = (
+    "JARVIS_NARRATIVE_INTENT_ENABLED",
+    "JARVIS_TOOL_PREAMBLE_FALLBACK_ENABLED",
+    "JARVIS_NARRATIVE_THINKING_VERBOSE",
+    "JARVIS_MOLTBOOK_CONVERSE_ENABLED",
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch):
+    """No test may read the developer's real environment.
+
+    A dial whose resolution depends on ambient env is exactly the thing
+    under test; letting it leak in would make these assertions describe
+    the machine rather than the code.
+    """
+    import os
+    for flag in (*_LEGACY_FLAGS, nd.DENSITY_ENV_VAR):
+        monkeypatch.delenv(flag, raising=False)
+    yield
+    # `monkeypatch.delenv` on a key that was ABSENT records nothing to
+    # restore, and `set_density` then writes the key directly — so without
+    # this the dial leaks out of the suite. It did: it left density=off in
+    # the process and a later file's `intent_master_flag_default_on`
+    # failed, correctly, on a value this file had set.
+    for flag in (*_LEGACY_FLAGS, nd.DENSITY_ENV_VAR):
+        os.environ.pop(flag, None)
+    for name in ("t.alarm", "t.legacy", "t.presence", "t.typo",
+                 "t.thresh", "t.reason"):
+        nd.default_registry()._voices.pop(name, None)  # noqa: SLF001
+
+
+class TestTheLadder:
+    def test_it_is_ordinal(self):
+        """Thresholds must compare. An unordered enum would push the
+        comparison back into every producer — how four hardcoded flags
+        happened."""
+        assert nd.Density.OFF < nd.Density.PREAMBLES < nd.Density.ON \
+            < nd.Density.VERBOSE
+
+    @pytest.mark.parametrize("raw,expect", [
+        ("off", nd.Density.OFF), ("VERBOSE", nd.Density.VERBOSE),
+        (2, nd.Density.ON), ("3", nd.Density.VERBOSE),
+        (nd.Density.OFF, nd.Density.OFF),
+    ])
+    def test_it_parses_what_operators_actually_type(self, raw, expect):
+        assert nd.coerce_density(raw) is expect
+
+    def test_junk_resolves_to_the_DEFAULT_not_to_silence(self):
+        """A typo in a config must not mute the organism. Silence is
+        indistinguishable from a healthy quiet system, so the operator
+        would get no signal that their value was junk."""
+        assert nd.coerce_density("lowd") is nd.DEFAULT_DENSITY
+        assert nd.coerce_density(None) is nd.DEFAULT_DENSITY
+        assert nd.coerce_density("") is nd.DEFAULT_DENSITY
+        assert nd.DEFAULT_DENSITY is not nd.Density.OFF
+
+    def test_out_of_range_ints_clamp(self):
+        assert nd.coerce_density(99) is nd.Density.VERBOSE
+        assert nd.coerce_density(-5) is nd.Density.OFF
+
+
+class TestTheFourRules:
+    def test_1_an_UNREGISTERED_voice_is_heard(self):
+        """Fail OPEN. A dial that mutes what it does not recognise silently
+        deletes the output of any subsystem that forgot to register — the
+        very failure being fixed, reintroduced from the other side."""
+        nd.set_density("off")
+        v = nd.permits("some.voice.nobody.declared")
+        assert v.heard is True
+        assert v.reason == "unregistered"
+
+    def test_2_an_EXEMPT_voice_outranks_even_an_explicit_flag(self, monkeypatch):
+        """A ⚔ is REVIEW contesting GENERATE: the system reporting that its
+        own components disagree. No verbosity preference outranks that."""
+        reg = nd.default_registry()
+        reg.register("t.alarm", nd.Density.VERBOSE, exempt=True,
+                     legacy_flag="JARVIS_T_ALARM")
+        monkeypatch.setenv("JARVIS_T_ALARM", "false")
+        nd.set_density("off")
+        assert nd.permits("t.alarm").heard is True
+
+    def test_3_explicit_presence_beats_the_dial_BOTH_ways(self, monkeypatch):
+        reg = nd.default_registry()
+        reg.register("t.legacy", nd.Density.ON, legacy_flag="JARVIS_T_LEGACY")
+        nd.set_density("off")
+        monkeypatch.setenv("JARVIS_T_LEGACY", "true")
+        assert nd.permits("t.legacy").heard is True
+        nd.set_density("verbose")
+        monkeypatch.setenv("JARVIS_T_LEGACY", "false")
+        assert nd.permits("t.legacy").heard is False
+
+    def test_3_PRESENCE_is_the_test_not_truthiness(self, monkeypatch):
+        """`FLAG=false` is an operator decision; `FLAG` unset is the absence
+        of one. A truthiness test cannot tell them apart, which is why the
+        old verb's own writes made every producer look operator-set."""
+        reg = nd.default_registry()
+        reg.register("t.presence", nd.Density.ON,
+                     legacy_flag="JARVIS_T_PRESENCE")
+        nd.set_density("verbose")
+        assert nd.permits("t.presence").reason.startswith("density:")
+        monkeypatch.setenv("JARVIS_T_PRESENCE", "false")
+        assert nd.permits("t.presence").reason.startswith("explicit:")
+
+    def test_3_an_unparseable_explicit_falls_through_to_the_dial(
+            self, monkeypatch):
+        """An operator typo should not pin a voice on or off forever."""
+        reg = nd.default_registry()
+        reg.register("t.typo", nd.Density.ON, legacy_flag="JARVIS_T_TYPO")
+        monkeypatch.setenv("JARVIS_T_TYPO", "yes-please")
+        nd.set_density("off")
+        assert nd.permits("t.typo").heard is False
+        nd.set_density("on")
+        assert nd.permits("t.typo").heard is True
+
+    def test_4_threshold(self):
+        reg = nd.default_registry()
+        reg.register("t.thresh", nd.Density.ON)
+        nd.set_density("preambles")
+        assert nd.permits("t.thresh").heard is False
+        nd.set_density("on")
+        assert nd.permits("t.thresh").heard is True
+
+    def test_a_verdict_always_carries_a_reason(self):
+        """Never a bare bool. The defect being fixed is a dial that could
+        not explain itself."""
+        reg = nd.default_registry()
+        reg.register("t.reason", nd.Density.VERBOSE)
+        nd.set_density("off")
+        assert nd.permits("t.reason").reason
+
+
+class TestTheDialWritesExactlyOneKey:
+    def test_set_density_touches_only_its_own_key(self, monkeypatch):
+        nd.set_density("off")
+        import os
+        assert os.environ[nd.DENSITY_ENV_VAR] == "off"
+        for flag in _LEGACY_FLAGS:
+            assert flag not in os.environ, (
+                f"{flag} written by the dial — this is the self-shadowing "
+                "bug: once written, every later read looks operator-set"
+            )
+
+    def test_the_verb_no_longer_shotguns_producer_flags(self):
+        """Structural, AST-based: no `os.environ[...] = ...` inside
+        `_handle_narrate`.
+
+        Checked as an ASSIGNMENT node rather than by searching the source
+        for flag names — the docstring legitimately names those flags while
+        explaining why it must not write them, and a substring search cannot
+        tell an explanation from the offence.
+        """
+        src = pathlib.Path(
+            "backend/core/ouroboros/battle_test/serpent_flow.py").read_text()
+        fn = next(n for n in ast.walk(ast.parse(src))
+                  if isinstance(n, ast.FunctionDef)
+                  and n.name == "_handle_narrate")
+        writes = [
+            t for node in ast.walk(fn)
+            if isinstance(node, ast.Assign)
+            for t in node.targets
+            if isinstance(t, ast.Subscript)
+            and isinstance(t.value, ast.Attribute)
+            and t.value.attr == "environ"
+        ]
+        assert not writes, f"{len(writes)} os.environ writes in _handle_narrate"
+
+
+class TestTheRoster:
+    def test_it_reports_every_registered_voice(self):
+        nd.ensure_discovered()
+        names = {r.voice.name for r in nd.roster()}
+        assert "moltbook.banter" in names
+        assert "narrative.intent" in names
+
+    def test_the_two_voice_families_share_one_ladder(self):
+        """The point of the exercise: Moltbook and the narrative channel
+        answer to the SAME dial."""
+        nd.ensure_discovered()
+        nd.set_density("off")
+        heard = {r.voice.name for r in nd.roster() if r.verdict.heard}
+        assert "moltbook.banter" not in heard
+        assert "narrative.intent" not in heard
+        assert "moltbook.conflict" in heard      # alarm survives
+
+        nd.set_density("verbose")
+        heard = {r.voice.name for r in nd.roster() if r.verdict.heard}
+        assert {"moltbook.banter", "narrative.thinking"} <= heard
+
+    def test_snapshot_is_transport_safe(self):
+        nd.set_density("on")
+        snap = nd.snapshot()
+        assert snap["density"] == "on"
+        assert isinstance(snap["audible"], list)
+        import json
+        json.dumps(snap)                      # must survive the bridge
+
+    def test_discovery_is_idempotent(self):
+        first = nd.ensure_discovered()
+        assert nd.ensure_discovered() == first
+
+
+class TestMoltbookIsGatedAtBothSeams:
+    def test_surfacing_is_gated_but_the_ARCHIVE_IS_NOT(self):
+        """A display preference has no business editing the society's
+        memory. `_notify_subscribers` gates the feed; the row is still
+        written, so `/moltbook` shows an unbroken history and turning the
+        dial back up does not reveal a gap."""
+        from backend.core.ouroboros.governance import moltbook
+        src = pathlib.Path(moltbook.__file__).read_text()
+        tree = ast.parse(src)
+        notify = next(n for n in ast.walk(tree)
+                      if isinstance(n, ast.FunctionDef)
+                      and n.name == "_notify_subscribers")
+        assert any(
+            isinstance(n, ast.Call) and getattr(n.func, "id", "") == "audible"
+            for n in ast.walk(notify)
+        ), "the surfacing seam does not consult the dial"
+        # ...and the storage path must NOT.
+        store = next(n for n in ast.walk(tree)
+                     if isinstance(n, ast.ClassDef)
+                     and n.name == "MoltbookStore")
+        assert not any(
+            isinstance(n, ast.Call) and getattr(n.func, "id", "") == "audible"
+            for n in ast.walk(store)
+        ), "the STORE consults the dial — density is editing the archive"
+
+    def test_banter_generation_refuses_before_the_dice(self):
+        """Refusing at the renderer would mean the reaction was already
+        formulated — a model call spent and a resident's cooldown consumed
+        — to produce something the operator asked not to see. The existing
+        posture gate is checked first for exactly this reason."""
+        from backend.core.ouroboros.governance import moltbook
+        fn = next(n for n in ast.walk(ast.parse(
+            pathlib.Path(moltbook.__file__).read_text()))
+            if isinstance(n, ast.AsyncFunctionDef)
+            and n.name == "_maybe_converse")
+        body = ast.unparse(fn)
+        gate = body.index("moltbook.banter")
+        dice = body.index("sha256")
+        assert gate < dice, "density is checked after the dice are rolled"
+
+    def test_voice_is_derived_from_what_a_post_already_is(self):
+        from backend.core.ouroboros.governance.moltbook import voice_for
+        assert voice_for({"kind": "musing", "body": "⚔ contested"}) \
+            == "moltbook.conflict"
+        assert voice_for({"kind": "musing", "reply_to": "p1"}) \
+            == "moltbook.banter"
+        assert voice_for({"kind": "status", "body": "all green"}) \
+            == "moltbook.post"
+
+
+class TestItNeverRaises:
+    @pytest.mark.parametrize("bad", [None, 0, object(), b"x", [], {}])
+    def test_permits_survives_anything(self, bad):
+        assert isinstance(nd.permits(bad), nd.Verdict)  # type: ignore[arg-type]
+
+    def test_a_broken_registry_degrades_to_audible(self, monkeypatch):
+        """A dial that cannot answer must never swallow the organism's
+        voice."""
+        def _boom(*_a, **_k):
+            raise RuntimeError("registry gone")
+        monkeypatch.setattr(nd._REGISTRY, "get", _boom)
+        v = nd.permits("anything")
+        assert v.heard is True
+        assert v.reason == "degraded"

--- a/tests/battle_test/test_narrative_repl_slice4.py
+++ b/tests/battle_test/test_narrative_repl_slice4.py
@@ -51,20 +51,17 @@ def test_handle_narrate_method_defined():
 
 
 def test_handle_narrate_supports_four_densities():
-    src = _src()
-    tree = ast.parse(src)
-    handler_src = ""
-    for node in ast.walk(tree):
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            if node.name == "_handle_narrate":
-                handler_src = ast.unparse(node)
-                break
-    assert handler_src
-    for density in ("off", "preambles", "on", "verbose"):
-        assert (
-            f"'{density}'" in handler_src
-            or f'"{density}"' in handler_src
-        ), f"_handle_narrate missing density {density!r}"
+    """Behavioural: each level RESOLVES, rather than merely appearing as a
+    literal in the handler's source.
+
+    The previous form asserted `"off" in ast.unparse(handler)` — satisfied
+    by a docstring, a comment, or a dead branch. It passed throughout the
+    period when `/narrate off` left thirteen Moltbook residents talking.
+    """
+    from backend.core.ouroboros.ui import narrative_density as nd
+    for name in ("off", "preambles", "on", "verbose"):
+        assert nd.set_density(name).label == name
+        assert nd.current_density().label == name
 
 
 # ===========================================================================
@@ -182,32 +179,57 @@ def test_intent_prompt_uses_create_task():
 # ===========================================================================
 
 
-def test_narrate_off_disables_intent_and_preambles():
-    src = _src()
-    tree = ast.parse(src)
-    handler = ""
-    for node in ast.walk(tree):
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            if node.name == "_handle_narrate":
-                handler = ast.unparse(node)
-                break
-    assert handler
-    # density=off must explicitly turn off both flags
-    assert "JARVIS_NARRATIVE_INTENT_ENABLED" in handler
-    assert "JARVIS_TOOL_PREAMBLE_FALLBACK_ENABLED" in handler
+def test_narrate_off_silences_intent_and_preambles(monkeypatch):
+    """Behavioural, and checked at the REAL consumer.
+
+    `intent_prompter.is_master_flag_enabled` is the function that decides
+    whether the micro-LLM call happens. Asserting a flag name appears in the
+    verb's source never established that anything downstream agreed.
+    """
+    from backend.core.ouroboros.ui import narrative_density as nd
+    from backend.core.ouroboros.governance import intent_prompter
+    monkeypatch.delenv("JARVIS_NARRATIVE_INTENT_ENABLED", raising=False)
+    monkeypatch.delenv("JARVIS_TOOL_PREAMBLE_FALLBACK_ENABLED", raising=False)
+    nd.ensure_discovered()
+
+    nd.set_density("on")
+    assert intent_prompter.is_master_flag_enabled() is True
+    assert nd.audible("narrative.tool_preamble") is True
+
+    nd.set_density("off")
+    assert intent_prompter.is_master_flag_enabled() is False
+    assert nd.audible("narrative.tool_preamble") is False
 
 
-def test_narrate_verbose_enables_thinking_surfacing():
-    src = _src()
-    tree = ast.parse(src)
-    handler = ""
-    for node in ast.walk(tree):
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            if node.name == "_handle_narrate":
-                handler = ast.unparse(node)
-                break
-    assert handler
-    assert "JARVIS_NARRATIVE_THINKING_VERBOSE" in handler
+def test_an_explicit_flag_outranks_the_dial(monkeypatch):
+    """Operator specificity beats a global dial — and this is why the verb
+    had to stop writing those flags. While it did, every read after the
+    first `/narrate` saw a flag that looked operator-set, so the dial
+    permanently shadowed itself."""
+    from backend.core.ouroboros.ui import narrative_density as nd
+    from backend.core.ouroboros.governance import intent_prompter
+    nd.ensure_discovered()
+    nd.set_density("off")
+    monkeypatch.setenv("JARVIS_NARRATIVE_INTENT_ENABLED", "true")
+    assert intent_prompter.is_master_flag_enabled() is True
+    verdict = nd.permits("narrative.intent")
+    assert verdict.reason == "explicit:JARVIS_NARRATIVE_INTENT_ENABLED"
+
+
+def test_narrate_verbose_enables_thinking_surfacing(monkeypatch):
+    """`verbose`'s one promise, finally with a consumer.
+
+    The previous form asserted the handler mentioned
+    JARVIS_NARRATIVE_THINKING_VERBOSE. That flag had ZERO readers in the
+    repository, so the test passed while the feature did not exist.
+    """
+    from backend.core.ouroboros.ui import narrative_density as nd
+    monkeypatch.delenv("JARVIS_NARRATIVE_THINKING_VERBOSE", raising=False)
+    nd.ensure_discovered()
+    nd.set_density("on")
+    assert nd.audible("narrative.thinking") is False
+    nd.set_density("verbose")
+    assert nd.audible("narrative.thinking") is True
 
 
 # ===========================================================================


### PR DESCRIPTION
`/narrate off` left thirteen Moltbook residents talking.

## The dial was never a dial

`_handle_narrate` wrote four env vars. Their actual reach:

| flag | readers in the repo |
|---|---|
| `JARVIS_NARRATIVE_DENSITY` | **0** |
| `JARVIS_NARRATIVE_THINKING_VERBOSE` | **0** |
| `JARVIS_TOOL_PREAMBLE_FALLBACK_ENABLED` | 1 |
| `JARVIS_NARRATIVE_INTENT_ENABLED` | 1 |

The density it reported back — the value its docstring said it set *"so subsystem readers see consistent state"* — is consumed by nobody. `/narrate verbose`'s promise of extended-thinking streams was a write to a flag no code has ever read.

Adding a Moltbook entry to that list fixes the instance and leaves the class untouched: **the verb PUSHES to a hardcoded list of producers**, so it must be edited every time the organism learns to speak — and it was never edited once. Moltbook is just the loudest voice to prove it.

## Inverted: producers register and PULL

`ui/narrative_density.py` owns an ordinal ladder and a registry. Modules declare voices *beside the code that speaks*, discovered through the **existing** AST-pinned `module_discovery` primitive rather than a second `pkgutil` walk. Adding a voice needs no edit to the dial and none to the verb.

Four rules, each a failure mode held shut:

1. **Unregistered → HEARD.** A dial that mutes what it doesn't recognise silently deletes the output of any subsystem that forgot to register — this bug from the other side. `posture_allows` already resolves unknown → SPEAK.
2. **Exempt bypasses the dial.** A `⚔` is REVIEW contesting GENERATE — components disagreeing. Reuses Moltbook's `is_conflict`, not a second notion.
3. **An explicitly set legacy flag wins** — by KEY PRESENCE, never truthiness (`FLAG=false` is a decision; unset is the absence of one). This is *why* the verb had to stop writing those flags: while it did, every later read looked operator-set and the dial shadowed itself.
4. Otherwise `current_density() >= voice.min_density`.

**Posture is deliberately not absorbed.** Moltbook already refuses banter under HARDEN; duplicating it would give one question two answers. Both gates must pass, so "strictest wins" falls out of the AND with no combinator.

## Gated where it costs, surfaced where it shows

Moltbook gates at **both** real seams, for the reason `_reply_budget_ok` already states about posture: `_maybe_converse` refuses *before the dice*, so a muted reaction is never formulated — no model call, no cooldown burned. `_notify_subscribers` gates the feed, but **the row is still written**. A display preference has no business editing the society's memory. Same split on the narrative side: `render_to_console`, never `start_frame`, because the channel is a ring the operator pages back through with `n-N`.

Proven end to end — at `off`, 1 of 2 posts surfaces (the `⚔`) while all 7 rows remain stored:

```
verbose   surfaced=2  stored_total=2
on        surfaced=2  stored_total=5
off       surfaced=1  stored_total=7
```

`/narrate` now prints its reach and can no longer claim a silence it didn't deliver:

```
Narrative density → preambles (preambles · 3/10 voices audible)
  • moltbook.conflict — alarm, never muted
  • narrative.postmortem_prose
  • narrative.tool_preamble
  ◦ moltbook.post — needs on
  ◦ moltbook.banter — forced off by JARVIS_MOLTBOOK_CONVERSE_ENABLED
  ◦ narrative.thinking — needs verbose
```

## The suite was guarding the bug

Three tests asserted the verb's **source** contained specific flag literals. They never called anything, so they passed throughout the period the feature didn't work — `test_narrate_verbose_enables_thinking_surfacing` "proved" verbose worked by checking the handler mentioned a flag with zero readers. Rewritten as behaviour, checked at the real consumer.

And my own isolation bug, caught by the suite: `monkeypatch.delenv` on an **absent** key records nothing to restore, so `set_density`'s direct write leaked out of the file and a later `intent_master_flag_default_on` failed on a value this file had set.

**31 new tests · 644 passed** across every touched subsystem. The 6 remaining failures are pre-existing provider/RT-gate reds — confirmed by an A/B with `intent_prompter` reverted to HEAD (5 failed either way), since the editable install makes source-reading tests resolve to the live tree and a worktree baseline is unreliable for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `/narrate` a real dial that controls all voices (including Moltbook) and shows what’s audible. Adds one authority for narrative verbosity with clear, cost-aware gating.

- **New Features**
  - Added `ui/narrative_density.py`: ordinal ladder (off < preambles < on < verbose), a voice registry, and `audible()/permits()` APIs.
  - Producers self-register voices via `register_voices` beside the code that speaks; discovered with existing `module_discovery`.
  - `/narrate` now sets only `JARVIS_NARRATIVE_DENSITY` and prints a roster of voices with reasons (density, explicit flag, exempt).
  - `moltbook`: registers `moltbook.conflict` (exempt), `moltbook.post` (on), `moltbook.banter` (verbose); gates banter before model calls and gates feed surfacing while still storing rows.
  - Narrative channel: each `NarrativeKind` registers as `narrative.*`; renderer gates at `render_to_console`.
  - Rules: unknown voices are heard; exempt bypasses dial; explicit legacy flags win by presence; else `current_density >= min_density`.

- **Bug Fixes**
  - `/narrate off` no longer leaves Moltbook talking; banter is muted unless `verbose`.
  - `narrative.thinking` now surfaces only at `verbose`; `intent_prompter` follows the dial to avoid unnecessary calls.
  - Removed shotgun writes of `JARVIS_NARRATIVE_INTENT_ENABLED`/`JARVIS_TOOL_PREAMBLE_FALLBACK_ENABLED`/`JARVIS_NARRATIVE_THINKING_VERBOSE`; explicit env overrides still respected.
  - Tests rewritten to assert behavior at real consumers; added 31 tests.

<sup>Written for commit 47753bd95594d78f2e53cdc9126fffd29b8646de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

