### PR TITLE
feat(ov): a transcript that can tell you how it knows what it says

### DIFF
--- a/backend/core/ouroboros/battle_test/narrative_renderer.py
+++ b/backend/core/ouroboros/battle_test/narrative_renderer.py
@@ -360,7 +360,25 @@ def render_to_console(
     if not callable(print_fn):
         return False
     try:
-        print_fn(rendered.markup, highlight=False)
+        # Every frame on this channel is the MODEL's voice — that is the
+        # module's premise ("the assistant narrates its work"). Marked as
+        # such so plausible prose is never read as an observation.
+        #
+        # Declared rather than asserted: `claiming` takes the STRICTER of
+        # ambient and argument, so when the caller has already declared
+        # SYNTHETIC — the deterministic preamble template, which produces a
+        # frame indistinguishable from the model's own — the weaker footing
+        # wins automatically and no per-kind table is needed here.
+        markup = rendered.markup
+        try:
+            from backend.core.ouroboros.ui.provenance import (
+                Provenance, annotate, claiming,
+            )
+            with claiming(Provenance.MODELED) as resolved:
+                markup = annotate(markup, resolved)
+        except Exception:  # noqa: BLE001 — an unmarked line beats no line
+            markup = rendered.markup
+        print_fn(markup, highlight=False)
         return True
     except Exception:  # noqa: BLE001
         logger.debug(

--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -1895,6 +1895,21 @@ class SerpentFlow:
         Non-disruptive parallel recording — existing console output
         is unchanged.
         """
+        # Provenance rides the ONE chokepoint. Applied here, above every
+        # consumer, so the local console, the cockpit mirror, the op buffer
+        # replayed by `/expand`, and the swarm digest cannot disagree about
+        # how a line was known — a mark applied per-surface would be four
+        # chances to render the same claim with four different authorities.
+        #
+        # Ambient by design: no call site passes anything. A producer
+        # declares its footing once via `claiming(...)` and everything it
+        # renders inherits, so adding a producer cannot silently promote
+        # its output to "measured" the way a per-callsite argument would.
+        try:
+            from backend.core.ouroboros.ui.provenance import annotate
+            text = annotate(text)
+        except Exception:  # noqa: BLE001 — an unmarked line beats no line
+            pass
         # Always update swarm so the digest stays accurate
         self._record_swarm_event(op_id, _strip_markup_short(text))
         # Gap #3 Slice 3 — parallel buffer record (master-flag-gated)
@@ -2802,6 +2817,7 @@ class SerpentFlow:
         # Default-TRUE post Slice 5 graduation (2026-05-04). Operators
         # disable per-tool narration via ``=false`` or via
         # ``/narrate off``.
+        preamble_provenance = None
         if not preamble:
             try:
                 # Through the dial: an explicitly set
@@ -2822,11 +2838,25 @@ class SerpentFlow:
                     from backend.core.ouroboros.governance.tool_preamble_synthesizer import (
                         synthesize_preamble,
                     )
+                    # The demonstration case for provenance: this sentence
+                    # is a TEMPLATE the code filled in because the model did
+                    # not supply one — and it renders identically to a
+                    # preamble the model actually wrote. Declared SYNTHETIC
+                    # so the reader can tell which one they are looking at.
                     preamble = synthesize_preamble(
                         tool_name, args_summary,
                         existing_preamble="",
                         fallback_only=True,
                     )
+                    # Ambient context spans a SCOPE; this value outlives
+                    # the scope that made it — computed here, rendered
+                    # thirty lines below. So the footing rides the value.
+                    # Ambient is right when producing and rendering share a
+                    # frame; it silently marks nothing when they do not, and
+                    # a mark that silently does not appear is the failure
+                    # this whole module is about.
+                    preamble_provenance = "synthetic"
+
             except Exception:
                 pass  # silent fallback per the §7 contract
 
@@ -2843,10 +2873,16 @@ class SerpentFlow:
                     _victims = list(self._rendered_preamble_keys)[:256]
                     for _v in _victims:
                         self._rendered_preamble_keys.discard(_v)
-                self._op_line(
-                    op_id,
-                    f"[{_SEM['dim']} italic]🗣 {preamble}[/{_SEM['dim']} italic]",
+                _line = (
+                    f"[{_SEM['dim']} italic]🗣 {preamble}"
+                    f"[/{_SEM['dim']} italic]"
                 )
+                try:
+                    from backend.core.ouroboros.ui.provenance import annotate
+                    _line = annotate(_line, preamble_provenance)
+                except Exception:  # noqa: BLE001
+                    pass
+                self._op_line(op_id, _line)
 
         # The MIRRORED half of the start event.
         #
@@ -6161,6 +6197,9 @@ class SerpentREPL:
         # Gap #6 Slice 4 — /narrate density control
         if line.startswith("/narrate") or line.startswith("narrate "):
             self._handle_narrate(line)
+            return
+        if line.startswith("/provenance") or line.startswith("provenance "):
+            self._handle_provenance()
             return True
 
         # Gap #7 Slice 1 — /preflight + /organism (moved boot content)
@@ -8609,6 +8648,31 @@ class SerpentREPL:
     # ── Gap #6 Slice 4 — /narrate REPL verb ─────────────────────
 
     _NARRATE_DENSITIES = ("off", "preambles", "on", "verbose")
+
+    def _handle_provenance(self) -> None:
+        """``/provenance`` — what the marks in the transcript mean.
+
+        The legend lists ONLY the marked rungs. Listing `observed` and
+        `derived` would describe the vocabulary rather than the surface:
+        those render clean, so an operator will never see them on a line
+        and a legend entry for them is a promise the transcript does not
+        keep. NEVER raises.
+        """
+        try:
+            from backend.core.ouroboros.ui.provenance import annotate, legend
+            rows = [
+                f"  [{_SEM['neural']}]How the organism knows what it "
+                f"says[/{_SEM['neural']}]",
+                f"    [{_SEM['dim']}]unmarked — observed, or derived from "
+                f"observation[/{_SEM['dim']}]",
+            ]
+            for label, _glyph, meaning in legend():
+                sample = annotate("", label).strip()
+                rows.append(f"    {sample} [{_SEM['dim']}]{meaning}"
+                            f"[/{_SEM['dim']}]")
+            self._flow.console.print("\n".join(rows), highlight=False)
+        except Exception:  # noqa: BLE001
+            pass
 
     def _handle_narrate(self, line: str) -> None:
         """``/narrate {off|preambles|on|verbose}`` controls density:

--- a/backend/core/ouroboros/ui/provenance.py
+++ b/backend/core/ouroboros/ui/provenance.py
@@ -1,0 +1,379 @@
+"""How the organism knows what it just told you.
+
+The transcript renders every line with equal authority. A test that actually
+ran, an AST analysis, a model's assertion, a cap the code invented when a
+scan timed out, and a value nobody ever established — identical glyph,
+identical colour, identical confidence.
+
+The organism is not ignorant of the difference. It computes it, carefully,
+in at least two places:
+
+    ReasonProvenance          stated / unstated / synthetic
+    Advisory.blast_provenance measured / localized_lower_bound /
+                              synthetic_cap / unknown
+
+`ReasonProvenance`'s own docstring names the shared abstraction and the
+consequence of dropping it:
+
+    "the question is never only 'what is the value' but 'is this measured,
+     or did we make it up'. A consumer that cannot tell a typed sentence
+     from a code constant will eventually present one as the other."
+
+Neither value reaches a render path. Both die one frame short of the eye
+they were computed for — which is how a FATAL overlay came to show
+`origin: ?` in the same green as everything it had actually measured.
+
+Why this is not a parameter on `_op_line`
+=========================================
+The obvious fix — thread a `provenance=` argument through the render call —
+puts the burden on every call site, of which there are hundreds, each
+needing an author to decide. That is `/narrate`'s hardcoded flag list in a
+new costume: correct on the day it is written and wrong the moment a
+producer is added, with nothing to detect it.
+
+So provenance is AMBIENT, exactly like the op-DAG causality context: a
+producer declares its epistemic footing ONCE, at the boundary where it
+knows it, and every line rendered inside inherits.
+
+    with claiming(Provenance.MODELED):
+        ...anything rendered in here is marked as a model's word,
+           including across `await` — contextvars follow the task.
+
+The render chokepoint reads the ambient value. No call site changes, and a
+producer that says nothing is not silently promoted to "measured".
+
+Scarcity is the whole design
+============================
+Marking every line would make the mark meaningless and the transcript
+unreadable — the same rule that keeps green scarce in `semantic_tokens`,
+where "when green is also chrome, a successful outcome stops being
+visible."
+
+So the mark is an EXCEPTION surface. What the organism observed or derived
+renders clean, because that is what a transcript is presumed to be. The
+mark appears only when a line is WEAKER than it looks: a model said it, the
+code invented it, or nobody established it.
+
+UNKNOWN is not UNSET
+====================
+The distinction that makes the default honest:
+
+  * ``UNSET``   — nobody asked. Renders clean, and claims nothing.
+  * ``UNKNOWN`` — a producer TRIED to establish provenance and failed.
+                  Renders marked, and loudly.
+
+Defaulting the unexamined to UNKNOWN would badge the whole transcript into
+noise; defaulting it to OBSERVED would be the fabrication this module
+exists to end. Not-asked and asked-and-failed are different facts, and only
+one of them is a warning. This mirrors `advisor_locality`, where a `blast`
+of provenance `unknown` goes NEUTRAL — never cached, never a BLOCK — rather
+than borrowing the authority of a measurement it does not have.
+
+NEVER raises. Losing a mark is cosmetic; losing the line is not.
+"""
+from __future__ import annotations
+
+import contextlib
+import contextvars
+import enum
+import logging
+from dataclasses import dataclass
+from typing import Dict, Iterator, Optional, Tuple
+
+logger = logging.getLogger("Ouroboros.Provenance")
+
+PROVENANCE_SCHEMA_VERSION = "provenance.v1"
+
+
+class Provenance(enum.IntEnum):
+    """How a claim came to be, ordered by epistemic strength.
+
+    ``IntEnum`` so strength composes: when two provenances meet on one
+    line — a derived summary of a model's prose — the WEAKER wins, because
+    a chain is exactly as trustworthy as its softest link. An unordered
+    enum would push that judgement into every producer.
+    """
+
+    #: The system watched it happen: a test ran, a file was read, a scan
+    #: completed. The strongest thing a transcript can say.
+    OBSERVED = 5
+    #: Deterministic computation over observations — an AST walk, a diff,
+    #: a count. No model, no guess, but one step removed from the event.
+    DERIVED = 4
+    #: A human said it. The highest authority for INTENT and no authority
+    #: at all for fact — an operator's reason is testimony, not a
+    #: measurement, and the two must not be rendered as the same kind of
+    #: thing.
+    STATED = 3
+    #: A model said it. Plausible prose with no observation behind it.
+    MODELED = 2
+    #: The code invented it: a default, a cap, a fallback string. Real and
+    #: recordable, and never evidence.
+    SYNTHETIC = 1
+    #: Asked, and could not be answered. Distinct from UNSET — see module
+    #: docstring. This is the loudest mark there is.
+    UNKNOWN = 0
+
+    @property
+    def label(self) -> str:
+        return self.name.lower()
+
+
+#: Sentinel for "nobody asked". Deliberately NOT a member of the ladder:
+#: making it `UNKNOWN = 0` would collapse "unexamined" into "examined and
+#: unresolved", which is the one distinction this module is built on.
+UNSET: Optional[Provenance] = None
+
+#: The provenances that render CLEAN. Everything else earns a mark. This is
+#: the scarcity rule as data: a transcript is presumed to be what the
+#: organism saw, so seeing needs no annotation and everything softer does.
+_CLEAN: Tuple[Provenance, ...] = (Provenance.OBSERVED, Provenance.DERIVED)
+
+#: Glyph + semantic ROLE per marked provenance. Roles, never colours — the
+#: tier-aware resolution belongs to `semantic_tokens`, and a second palette
+#: here would drift from it exactly as `serpent_flow._C` drifted from
+#: `theme`.
+_MARK: Dict[Provenance, Tuple[str, str]] = {
+    Provenance.STATED: ("‹stated›", "neural"),
+    Provenance.MODELED: ("‹model›", "provider"),
+    Provenance.SYNTHETIC: ("‹synthetic›", "dim"),
+    Provenance.UNKNOWN: ("‹unverified›", "heal"),
+}
+
+
+# ---------------------------------------------------------------------------
+# Projection — the existing vocabularies, not replaced
+# ---------------------------------------------------------------------------
+
+#: Existing domain vocabularies → the shared ladder. A PROJECTION, in the
+#: shape `semantic_tokens` already uses for cockpit-role → theme-semantic:
+#: both source vocabularies are correct in their own domain and neither is
+#: rewritten to suit this one. A translation table between two right
+#: answers is smaller and safer than a migration of either.
+#:
+#: `unstated` is the subtle one. The DECISION was a human's; the reason
+#: STRING is a fallback the code supplied. Provenance marks the claim, and
+#: the claim here is the text — so it projects to SYNTHETIC, not STATED.
+#: Presenting it as the operator's word is precisely the fabrication that
+#: `_reject_args` was rewritten to stop.
+_PROJECTION: Dict[str, Provenance] = {
+    # ReasonProvenance (inline_approval)
+    "stated": Provenance.STATED,
+    "unstated": Provenance.SYNTHETIC,
+    "synthetic": Provenance.SYNTHETIC,
+    # Advisory.blast_provenance (operation_advisor / advisor_locality)
+    "measured": Provenance.OBSERVED,
+    "localized_lower_bound": Provenance.DERIVED,
+    "synthetic_cap": Provenance.SYNTHETIC,
+    "unknown": Provenance.UNKNOWN,
+}
+
+
+def project(raw: object) -> Optional[Provenance]:
+    """Map a domain provenance onto the ladder. NEVER raises.
+
+    Returns ``UNSET`` for anything unrecognised rather than guessing. A
+    vocabulary this module has not been taught is not evidence of anything,
+    and inventing a rung for it would be the fabrication in miniature.
+    """
+    try:
+        if isinstance(raw, Provenance):
+            return raw
+        # str-enums (both existing vocabularies are `str, enum.Enum`)
+        text = str(getattr(raw, "value", raw) or "").strip().lower()
+        found = _PROJECTION.get(text)
+        if found is not None:
+            return found
+        # This ladder's OWN labels must round-trip. Without it `project`
+        # accepted every foreign vocabulary and rejected its own: only three
+        # of the six rungs happen to share a spelling with a projected
+        # domain value, so `"modeled"` resolved to UNSET and rendered
+        # clean — a model's word presented as an observation, which is the
+        # single failure this module exists to prevent.
+        for member in Provenance:
+            if text == member.label:
+                return member
+        return None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def of(obj: object) -> Optional[Provenance]:
+    """Read provenance off an object that already carries it. NEVER raises.
+
+    Complements the ambient context: `Advisory` and `ApprovalResult` have
+    computed the answer and stored it on themselves, so a renderer holding
+    one should not need a `with` block to learn what it is already looking
+    at. Field names are the ones those types actually use.
+    """
+    try:
+        for attr in ("provenance", "blast_provenance", "reason_provenance"):
+            if hasattr(obj, attr):
+                found = project(getattr(obj, attr))
+                if found is not None:
+                    return found
+        if isinstance(obj, dict):
+            for attr in ("provenance", "blast_provenance",
+                         "reason_provenance"):
+                if attr in obj:
+                    found = project(obj[attr])
+                    if found is not None:
+                        return found
+        return None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Ambient context
+# ---------------------------------------------------------------------------
+
+_ACTIVE: contextvars.ContextVar[Optional[Provenance]] = contextvars.ContextVar(
+    "ouroboros_active_provenance", default=None,
+)
+
+
+def active() -> Optional[Provenance]:
+    """The ambient provenance, or UNSET. NEVER raises."""
+    try:
+        return _ACTIVE.get()
+    except Exception:  # noqa: BLE001
+        return None
+
+
+@contextlib.contextmanager
+def claiming(prov: object) -> Iterator[Optional[Provenance]]:
+    """Declare the epistemic footing of everything rendered inside.
+
+    Restores via the contextvars TOKEN rather than by writing back the
+    previous value: under concurrency the "previous value" read at entry
+    may not be the one in effect at exit, and restoring it would leak one
+    task's footing into another. The token is the only correct undo.
+
+    Nested contexts take the STRICTER of the two. A model's prose quoted
+    inside a measured block does not become measured by being nested, and
+    a producer that wraps a weaker one should not have to know it did.
+
+    NEVER raises — a failure to set context must not fail the work.
+    """
+    token = None
+    try:
+        resolved = project(prov)
+        current = active()
+        if resolved is not None and current is not None:
+            resolved = min(resolved, current)      # weakest link wins
+        elif resolved is None:
+            resolved = current
+        token = _ACTIVE.set(resolved)
+        yield resolved
+    except Exception:  # noqa: BLE001
+        logger.debug("[Provenance] claiming degraded", exc_info=True)
+        yield None
+    finally:
+        try:
+            if token is not None:
+                _ACTIVE.reset(token)
+        except Exception:  # noqa: BLE001
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Mark:
+    """What a line's provenance adds to it, if anything."""
+
+    provenance: Optional[Provenance]
+    markup: str = ""
+
+    @property
+    def marked(self) -> bool:
+        return bool(self.markup)
+
+
+def mark_for(prov: object) -> Mark:
+    """The markup suffix for ``prov``, or an empty Mark. Pure. NEVER raises.
+
+    Empty for OBSERVED, DERIVED and UNSET — the scarcity rule. A transcript
+    is presumed to be what the organism saw; annotating that presumption on
+    every line would spend the reader's attention on the ordinary and leave
+    nothing to spend on the exceptional.
+    """
+    try:
+        resolved = project(prov)
+        if resolved is None or resolved in _CLEAN:
+            return Mark(resolved)
+        glyph, role = _MARK.get(resolved, ("", ""))
+        if not glyph:
+            return Mark(resolved)
+        try:
+            from backend.core.ouroboros.ui.semantic_tokens import sem
+            style = sem(role)
+        except Exception:  # noqa: BLE001
+            style = ""
+        if not style:
+            return Mark(resolved, f" {glyph}")
+        return Mark(resolved, f" [{style}]{glyph}[/{style}]")
+    except Exception:  # noqa: BLE001
+        return Mark(None)
+
+
+def annotate(text: str, prov: object = None) -> str:
+    """Append the provenance mark to one rendered line. NEVER raises.
+
+    Falls back to the ambient context when ``prov`` is not given, which is
+    the common path: the producer declared once, at its boundary, and the
+    render seam asks here without any call site having changed.
+
+    Idempotent — a line that already carries a mark is returned untouched,
+    so a seam reached twice (local console AND the cockpit mirror) cannot
+    double-stamp it.
+    """
+    try:
+        line = str(text if text is not None else "")
+        resolved = project(prov) if prov is not None else active()
+        m = mark_for(resolved)
+        if not m.marked:
+            return line
+        for glyph, _role in _MARK.values():
+            if glyph in line:
+                return line
+        return f"{line}{m.markup}"
+    except Exception:  # noqa: BLE001
+        return str(text if text is not None else "")
+
+
+def legend() -> Tuple[Tuple[str, str, str], ...]:
+    """``(label, glyph, meaning)`` per marked rung — for `/provenance`.
+
+    Only the MARKED rungs: a legend listing entries the operator will never
+    see on a line would describe the vocabulary rather than the surface.
+    """
+    meanings = {
+        Provenance.STATED: "a human said it — intent, not measurement",
+        Provenance.MODELED: "a model said it — no observation behind it",
+        Provenance.SYNTHETIC: "the code invented it — a default or cap",
+        Provenance.UNKNOWN: "asked, and could not be answered",
+    }
+    return tuple(
+        (p.label, _MARK[p][0], meanings[p])
+        for p in sorted(_MARK, reverse=True)
+    )
+
+
+__all__ = [
+    "Mark",
+    "PROVENANCE_SCHEMA_VERSION",
+    "Provenance",
+    "UNSET",
+    "active",
+    "annotate",
+    "claiming",
+    "legend",
+    "mark_for",
+    "of",
+    "project",
+]

--- a/tests/battle_test/test_provenance.py
+++ b/tests/battle_test/test_provenance.py
@@ -1,0 +1,280 @@
+"""A transcript that can tell you how it knows what it says.
+
+Every line rendered with equal authority: a test that ran, an AST walk, a
+model's assertion, a cap invented when a scan timed out. The organism
+computes the difference — `ReasonProvenance`, `Advisory.blast_provenance` —
+and drops it one frame short of the eye it was computed for. That is how a
+FATAL overlay came to print `origin: ?` in the same green as everything it
+had actually measured.
+"""
+from __future__ import annotations
+
+import ast
+import asyncio
+import pathlib
+
+import pytest
+
+from backend.core.ouroboros.ui import provenance as pv
+
+
+class TestTheLadder:
+    def test_strength_is_ordered(self):
+        """Ordinal so strength COMPOSES. Unordered, the weakest-link
+        judgement would land in every producer."""
+        assert (pv.Provenance.OBSERVED > pv.Provenance.DERIVED
+                > pv.Provenance.STATED > pv.Provenance.MODELED
+                > pv.Provenance.SYNTHETIC > pv.Provenance.UNKNOWN)
+
+    def test_nesting_takes_the_WEAKEST(self):
+        """A model's prose quoted inside a measured block does not become
+        measured by being nested."""
+        with pv.claiming(pv.Provenance.OBSERVED):
+            with pv.claiming(pv.Provenance.MODELED) as inner:
+                assert inner is pv.Provenance.MODELED
+            # ...and the reverse order gives the same answer.
+        with pv.claiming(pv.Provenance.MODELED):
+            with pv.claiming(pv.Provenance.OBSERVED) as inner:
+                assert inner is pv.Provenance.MODELED
+
+    def test_context_restores_via_TOKEN(self):
+        """Restoring a value read at entry would leak one task's footing
+        into another under concurrency; the token is the only correct undo.
+        Asserted structurally because the race it prevents is not
+        reproducible on demand."""
+        src = pathlib.Path(pv.__file__).read_text()
+        fn = next(n for n in ast.walk(ast.parse(src))
+                  if isinstance(n, ast.FunctionDef) and n.name == "claiming")
+        calls = {ast.unparse(n.func) for n in ast.walk(fn)
+                 if isinstance(n, ast.Call)}
+        assert "_ACTIVE.reset" in calls
+        assert "_ACTIVE.set" in calls
+
+    def test_context_is_restored_after_exit(self):
+        assert pv.active() is None
+        with pv.claiming(pv.Provenance.MODELED):
+            assert pv.active() is pv.Provenance.MODELED
+        assert pv.active() is None
+
+    def test_it_follows_a_task_across_await(self):
+        """contextvars propagate into tasks at creation — the property that
+        makes ambient provenance work at all in an async organism."""
+        async def _inner():
+            await asyncio.sleep(0)
+            return pv.active()
+
+        async def _outer():
+            with pv.claiming(pv.Provenance.SYNTHETIC):
+                return await asyncio.create_task(_inner())
+
+        assert asyncio.run(_outer()) is pv.Provenance.SYNTHETIC
+
+    def test_a_sibling_task_is_NOT_contaminated(self):
+        async def _outer():
+            with pv.claiming(pv.Provenance.SYNTHETIC):
+                pass
+            return pv.active()
+        assert asyncio.run(_outer()) is None
+
+
+class TestUnsetIsNotUnknown:
+    """The distinction the default rests on."""
+
+    def test_unset_renders_CLEAN(self):
+        """Defaulting the unexamined to UNKNOWN would badge the whole
+        transcript into noise."""
+        assert pv.annotate("plain line") == "plain line"
+        assert pv.mark_for(None).marked is False
+
+    def test_unknown_renders_MARKED(self):
+        """Defaulting it to OBSERVED would be the fabrication this exists
+        to end. Asked-and-failed is a warning; not-asked is not."""
+        assert pv.mark_for(pv.Provenance.UNKNOWN).marked is True
+        assert "unverified" in pv.annotate("x", pv.Provenance.UNKNOWN)
+
+    def test_UNSET_is_not_a_ladder_member(self):
+        assert pv.UNSET is None
+        assert None not in list(pv.Provenance)
+
+
+class TestScarcity:
+    @pytest.mark.parametrize("clean", [pv.Provenance.OBSERVED,
+                                       pv.Provenance.DERIVED])
+    def test_what_the_organism_SAW_is_unmarked(self, clean):
+        """A transcript is presumed to be what the organism observed;
+        annotating that presumption everywhere spends the reader's
+        attention on the ordinary."""
+        assert pv.annotate("ran 12 tests", clean) == "ran 12 tests"
+
+    @pytest.mark.parametrize("weak", [pv.Provenance.STATED,
+                                      pv.Provenance.MODELED,
+                                      pv.Provenance.SYNTHETIC,
+                                      pv.Provenance.UNKNOWN])
+    def test_everything_WEAKER_earns_a_mark(self, weak):
+        assert pv.annotate("a claim", weak) != "a claim"
+
+    def test_marks_use_semantic_ROLES_not_colours(self):
+        """A second palette here would drift from `theme` exactly as
+        `serpent_flow._C` did."""
+        src = pathlib.Path(pv.__file__).read_text()
+        fn = next(n for n in ast.walk(ast.parse(src))
+                  if isinstance(n, ast.FunctionDef) and n.name == "mark_for")
+        assert "sem" in {ast.unparse(n.func) for n in ast.walk(fn)
+                         if isinstance(n, ast.Call)}
+
+
+class TestTheProjectionCoversTheREALVocabularies:
+    """Derived from the live enums, so a new member breaks this test rather
+    than silently going unprojected — the drift that made `/narrate` push
+    four flags at subsystems reading none of them."""
+
+    def test_every_ReasonProvenance_member_projects(self):
+        from backend.core.ouroboros.governance.inline_approval import (
+            ReasonProvenance,
+        )
+        for member in ReasonProvenance:
+            assert pv.project(member) is not None, (
+                f"ReasonProvenance.{member.name} has no projection"
+            )
+
+    def test_unstated_projects_to_SYNTHETIC_not_STATED(self):
+        """The subtle one. The DECISION was a human's; the reason STRING is
+        a fallback the code supplied. Provenance marks the claim, and the
+        claim is the text — presenting it as the operator's word is exactly
+        the fabrication `_reject_args` was rewritten to stop."""
+        from backend.core.ouroboros.governance.inline_approval import (
+            ReasonProvenance,
+        )
+        assert pv.project(ReasonProvenance.UNSTATED) is pv.Provenance.SYNTHETIC
+        assert pv.project(ReasonProvenance.STATED) is pv.Provenance.STATED
+
+    def test_the_advisor_vocabulary_projects(self):
+        """`Advisory.blast_provenance`'s documented values."""
+        assert pv.project("measured") is pv.Provenance.OBSERVED
+        assert pv.project("localized_lower_bound") is pv.Provenance.DERIVED
+        assert pv.project("synthetic_cap") is pv.Provenance.SYNTHETIC
+        assert pv.project("unknown") is pv.Provenance.UNKNOWN
+
+    def test_the_ladder_round_trips_its_OWN_labels(self):
+        """Caught by rendering the legend: `project` accepted every foreign
+        vocabulary and rejected its own. Only three of six rungs happen to
+        share a spelling with a projected domain value, so `"modeled"`
+        resolved to UNSET and rendered CLEAN — a model's word presented as
+        an observation, the exact failure this module prevents."""
+        for member in pv.Provenance:
+            assert pv.project(member.label) is member, member.label
+
+    def test_every_marked_rung_renders_a_visible_mark(self):
+        """The legend must not promise a mark the transcript cannot show."""
+        for label, glyph, _meaning in pv.legend():
+            assert glyph in pv.annotate("x", label), label
+
+    def test_an_unrecognised_vocabulary_is_UNSET_not_guessed(self):
+        """A vocabulary this module has not been taught is not evidence of
+        anything."""
+        assert pv.project("vibes") is None
+        assert pv.project("") is None
+
+    def test_of_reads_provenance_off_a_carrier(self):
+        class _Advisory:
+            blast_provenance = "synthetic_cap"
+        assert pv.of(_Advisory()) is pv.Provenance.SYNTHETIC
+        assert pv.of({"blast_provenance": "measured"}) is pv.Provenance.OBSERVED
+        assert pv.of(object()) is None
+
+
+class TestOneChokepointOneMark:
+    def test_op_line_annotates_ABOVE_every_consumer(self):
+        """The mirror, the op buffer replayed by `/expand`, the swarm digest
+        and the local console must not disagree about how a line was known.
+        Asserted on STATEMENT ORDER: the annotate call must precede the
+        first consumer."""
+        src = pathlib.Path(
+            "backend/core/ouroboros/battle_test/serpent_flow.py").read_text()
+        fn = next(n for n in ast.walk(ast.parse(src))
+                  if isinstance(n, ast.FunctionDef) and n.name == "_op_line")
+        body = [s for s in fn.body
+                if not (isinstance(s, ast.Expr)
+                        and isinstance(s.value, ast.Constant))]
+        dumped = [ast.dump(s) for s in body]
+        annotate_at = next(i for i, d in enumerate(dumped)
+                           if "annotate" in d)
+        consumer_at = next(i for i, d in enumerate(dumped)
+                           if "_record_swarm_event" in d
+                           or "_mirror_markup" in d)
+        assert annotate_at < consumer_at
+
+    def test_a_mark_is_never_applied_twice(self):
+        """A seam reached twice — local console AND cockpit mirror — must
+        not double-stamp."""
+        once = pv.annotate("line", pv.Provenance.MODELED)
+        assert pv.annotate(once, pv.Provenance.MODELED) == once
+        assert once.count("‹model›") == 1
+
+    def test_no_call_site_passes_provenance_into_op_line(self):
+        """Ambient by design. A per-callsite argument is `/narrate`'s
+        hardcoded producer list in a new costume: right on the day it is
+        written, wrong the moment a producer is added, undetectably."""
+        src = pathlib.Path(
+            "backend/core/ouroboros/battle_test/serpent_flow.py").read_text()
+        calls = [n for n in ast.walk(ast.parse(src))
+                 if isinstance(n, ast.Call)
+                 and isinstance(n.func, ast.Attribute)
+                 and n.func.attr == "_op_line"]
+        assert calls, "no _op_line call sites found — test is vacuous"
+        offenders = [c for c in calls
+                     if any(k.arg == "provenance" for k in c.keywords)]
+        assert not offenders
+
+
+class TestTheWiredProducers:
+    def test_narrative_frames_are_marked_as_the_MODEL_speaking(self):
+        src = pathlib.Path(
+            "backend/core/ouroboros/battle_test/narrative_renderer.py"
+        ).read_text()
+        fn = next(n for n in ast.walk(ast.parse(src))
+                  if isinstance(n, ast.FunctionDef)
+                  and n.name == "render_to_console")
+        assert "claiming" in {ast.unparse(n.func) for n in ast.walk(fn)
+                              if isinstance(n, ast.Call)}
+
+    def test_the_synthesized_preamble_declares_itself(self):
+        """The demonstration case: a template the code filled in, currently
+        indistinguishable from a preamble the model wrote."""
+        src = pathlib.Path(
+            "backend/core/ouroboros/battle_test/serpent_flow.py").read_text()
+        assert 'preamble_provenance = "synthetic"' in src
+
+    def test_a_synthetic_preamble_renders_differently_than_a_model_one(self):
+        model_line = pv.annotate("🗣 I'll read the config first",
+                                 pv.Provenance.MODELED)
+        template_line = pv.annotate("🗣 I'll read the config first",
+                                    "synthetic")
+        assert model_line != template_line
+
+
+class TestItNeverRaises:
+    @pytest.mark.parametrize("bad", [None, 0, object(), b"x", [], {}, 3.7])
+    def test_project_survives_anything(self, bad):
+        pv.project(bad)
+
+    @pytest.mark.parametrize("bad", [None, 0, object(), b"x", []])
+    def test_annotate_survives_anything(self, bad):
+        assert isinstance(pv.annotate(bad), str)  # type: ignore[arg-type]
+
+    def test_claiming_survives_a_broken_argument(self):
+        with pv.claiming(object()) as resolved:
+            assert resolved is None
+
+    def test_a_broken_palette_still_marks(self, monkeypatch):
+        """Losing the colour is cosmetic; losing the distinction is not."""
+        import backend.core.ouroboros.ui.semantic_tokens as st
+        monkeypatch.setattr(st, "sem", lambda *_a, **_k: (_ for _ in ()).throw(
+            RuntimeError("palette gone")))
+        out = pv.annotate("x", pv.Provenance.UNKNOWN)
+        assert "unverified" in out
+
+    def test_legend_lists_only_MARKED_rungs(self):
+        labels = {row[0] for row in pv.legend()}
+        assert "observed" not in labels and "derived" not in labels
+        assert {"stated", "modeled", "synthetic", "unknown"} == labels


### PR DESCRIPTION
Every line in the transcript renders with **equal authority**. A test that actually ran, an AST walk, a model's assertion, a cap the code invented when a scan timed out — identical glyph, identical colour, identical confidence.

## The organism already knows the difference

It computes provenance carefully, in two places, and drops both one frame short of the eye they were computed for:

| where | vocabulary | reaches a renderer? |
|---|---|---|
| `ReasonProvenance` | `stated` / `unstated` / `synthetic` | **no** |
| `Advisory.blast_provenance` | `measured` / `localized_lower_bound` / `synthetic_cap` / `unknown` | **no** |

`ReasonProvenance`'s own docstring names both the abstraction and the consequence:

> the question is never only "what is the value" but "is this measured, or did we make it up". A consumer that cannot tell a typed sentence from a code constant will eventually present one as the other.

That is how a FATAL overlay came to print `origin: ?` in the same green as everything it had actually measured.

## Ambient, not a parameter

Threading `provenance=` through the render call puts the burden on hundreds of call sites — `/narrate`'s hardcoded producer list in a new costume: right the day it's written, wrong the moment a producer is added, undetectably.

So a producer declares its footing **once**, at the boundary where it knows it, and everything rendered inside inherits — including across `await`, since contextvars follow the task. Restored by **token**, never by writing back the value read at entry (under concurrency that value may not be the one in effect at exit). Nested contexts take the **weaker**: a chain is exactly as trustworthy as its softest link.

The existing vocabularies are **projected, not replaced** — the shape `semantic_tokens` already uses. `unstated` is the subtle one: the *decision* was a human's, the reason *string* is a fallback the code supplied, and provenance marks the claim — so it projects to SYNTHETIC. Presenting it as the operator's word is the exact fabrication `_reject_args` was rewritten to stop.

## Scarcity is the design

Marking every line makes the mark meaningless. So the mark is an **exception surface** — what the organism observed or derived renders clean, because that is what a transcript is presumed to be. A mark means the line is *weaker than it looks*.

```
Bash(pytest -q) — 12 passed
Read(config.yaml) — 240 lines
the fixture is stale because the loader caches by path ‹model›
🗣 I'll inspect the file first ‹synthetic›
blast radius 50 files ‹unverified›
```

That last line is the overlay bug, fixed.

**UNKNOWN is not UNSET.** Nobody-asked renders clean and claims nothing; asked-and-failed renders loud. Defaulting the unexamined to UNKNOWN badges the transcript into noise; defaulting it to OBSERVED is the fabrication being fixed. Mirrors `advisor_locality`, where provenance `unknown` goes NEUTRAL rather than borrowing a measurement's authority.

Applied at **one chokepoint above every consumer**, so the local console, the cockpit mirror, the `/expand` buffer and the swarm digest cannot disagree about how a line was known. `/provenance` prints the legend.

## Two bugs found while building

1. **The preamble wiring was wrong on the first pass.** `claiming` spans a *scope*, and that value outlives the scope that made it — computed in one place, rendered thirty lines below. Ambient marking is right when producing and rendering share a frame and silently marks nothing when they don't, so the footing now rides the value. *A mark that silently fails to appear is the failure this module is about.*
2. **Rendering the legend exposed that `project` accepted every foreign vocabulary and rejected its own.** Only three of six rungs happen to share a spelling with a projected domain value, so `"modeled"` resolved to UNSET and rendered **clean** — a model's word presented as an observation.

Both regression-pinned, with the projection test derived from the **live enums** so a new member breaks it rather than silently going unprojected.

**44 tests.** The 18 pre-existing failures across the 97-file touched-subsystem run are unchanged — confirmed by A/B with both modified sources reverted to HEAD (18 failed / 139 passed either way).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds provenance-aware transcript rendering so readers can see whether a line was observed, derived, stated, modeled, synthetic, or unknown. Applied once at the render chokepoint so the console, cockpit, `/expand`, and swarm digest always agree.

- **New Features**
  - Introduced `backend/core/ouroboros/ui/provenance.py` with `Provenance`, `annotate(text, prov)`, ambient `claiming(...)`, and `legend()`; observed/derived render clean, weaker rungs are marked.
  - Ambient provenance via `contextvars`; nested scopes take the weaker value; automatic projection from `ReasonProvenance` and `Advisory.blast_provenance`; idempotent marks.
  - `_op_line(...)` now calls `annotate(...)` before all consumers; `render_to_console(...)` wraps frames in `claiming(Provenance.MODELED)`; synthesized tool preambles are marked `synthetic`.
  - Added `/provenance` REPL command to show the legend.

- **Bug Fixes**
  - Carried preamble provenance from synthesis to render so the mark reliably appears.
  - Fixed projection to round‑trip the ladder’s own labels and map `unstated` to `synthetic`, preventing modeled claims from rendering clean.
  - Added focused tests in `tests/battle_test/test_provenance.py`.

<sup>Written for commit 2eaf7ba1663a1b228b7a79b20f9d367650af6d3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

