### PR TITLE
feat(ov): blast-radius gutter + the demo learns what the cockpit learned

### DIFF
--- a/backend/core/ouroboros/battle_test/diff_preview.py
+++ b/backend/core/ouroboros/battle_test/diff_preview.py
@@ -270,6 +270,24 @@ class DiffPreviewRenderer:
             ),
             guide_style="muted",
         )
+        # Reach per file, from what is ALREADY known. `peek` cannot scan —
+        # a cold blast scan is a 39–43s burn, and paying it per file here
+        # would freeze the preview while the operator waits at a gate.
+        # Computed for the whole set at once because the bar's scale is a
+        # property of the SET: 12 dependents means nothing until you know
+        # whether it is the largest number on screen or the smallest.
+        gutter_rows = {}
+        gutter_summary = ""
+        try:
+            from backend.core.ouroboros.ui import blast_gutter as _bg
+            if _bg.gutter_enabled():
+                reaches = _bg.peek([c.path for c in changes])
+                gutter_rows = {
+                    row.reach.path: row for row in _bg.annotate_set(reaches)
+                }
+                gutter_summary = _bg.summary(reaches)
+        except Exception:  # noqa: BLE001 — a lost column, never a lost diff
+            gutter_rows = {}
         for c in changes:
             label = Text()
             label.append(c.path)
@@ -283,7 +301,19 @@ class DiffPreviewRenderer:
             elif c.is_binary:
                 label.append("  ")
                 label.append("[binary]", style="muted")
+            row = gutter_rows.get(c.path)
+            if row is not None:
+                label.append("  ")
+                label.append(row.bar, style=_reach_style(row.role))
+                label.append(f" {row.label}", style=_reach_style(row.role))
             tree.add(label)
+        if gutter_summary:
+            # The header carries the set-level finding — most importantly
+            # "unmeasured", because a column that is mostly `?` IS the
+            # finding: nothing here has been measured, so read the diff.
+            tree.label = Text.assemble(
+                tree.label, ("  ", ""), (gutter_summary, "muted"),
+            )
         return tree
 
     def _build_file_panel(self, change: FileChange) -> Any:
@@ -405,6 +435,24 @@ def _badge(status: str) -> "Text":  # type: ignore[name-defined]
     else:
         t.append(f"[? {status}]", style="muted")
     return t
+
+
+def _reach_style(role: str) -> str:
+    """Semantic role → a style this renderer can use. NEVER raises.
+
+    Asks `semantic_tokens` first so the gutter tracks the theme and its
+    tier, and falls back to the style vocabulary this module already uses
+    (``muted`` / ``warning``) when the palette is unavailable — the renderer
+    is documented to degrade to Rich defaults rather than fail.
+    """
+    try:
+        from backend.core.ouroboros.ui.semantic_tokens import sem
+        resolved = sem(role)
+        if resolved and resolved != "none":
+            return resolved
+    except Exception:  # noqa: BLE001
+        pass
+    return {"heal": "warning", "alert": "warning"}.get(role, "muted")
 
 
 def _status_color(status: str) -> str:

--- a/backend/core/ouroboros/cli/ov_demo.py
+++ b/backend/core/ouroboros/cli/ov_demo.py
@@ -38,7 +38,7 @@ DEMO_HELP = """ov demo -- watch the cockpit, no model calls
   ov demo             board + transcript
   ov demo board       what is LIVE vs DARK right now (derived from the tree)
   ov demo surfaces    which of the 3 surfaces can REACH each module
-  ov demo transcript  the CC-style deck: ops, diffs, agora threads
+  ov demo transcript  the CC-style deck: ops, diffs, agora threads\n  ov demo epistemics  reach gutter, provenance marks, voice roster
   ov demo live        the COCKPIT running, driven by synthetic events
                       (needs a real terminal; --speed=N to fast-forward)
   ov demo scenes      list available scenes
@@ -210,6 +210,16 @@ _SCRIPT: List[Any] = [
     ("diff", (414, "-", "    except Exception:  # noqa: BLE001")),
     ("act", ("Validate", "7759-86")),
     ("det", ("✗ 3 failed · test_scoped_paths, test_sandbox_dir", "crit")),
+    # Four claims that USED to render identically. The test result above is
+    # observed and stays clean; everything below is softer than it looks.
+    ("prov", ("modeled", "det",
+              ("the fixture is stale — the loader caches by path",))),
+    ("prov", ("synthetic", "det",
+              ("🗣 I'll read the file first",))),
+    ("prov", ("unknown", "det",
+              ("blast radius 50 files",))),
+    ("prov", ("stated", "det",
+              ('operator: "reject — that except clause is load-bearing"',))),
 ]
 
 
@@ -234,6 +244,19 @@ def _compose(kind: str, args: Sequence[Any]) -> str:
             return deck.diff(*args)
         if kind == "voice":
             return deck.voice(*args)
+        if kind == "prov":
+            # `(provenance, inner_kind, inner_args)`. Composed INSIDE a real
+            # `claiming(...)` and marked by the real `annotate`, which is how
+            # production does it at the `_op_line` chokepoint — declare the
+            # footing at a boundary, let everything rendered inside inherit.
+            # A demo that stamped the glyph itself would show a mark the
+            # cockpit might no longer produce.
+            from backend.core.ouroboros.ui.provenance import (
+                annotate, claiming,
+            )
+            with claiming(args[0]) as resolved:
+                inner = _compose(args[1], args[2])
+                return annotate(inner, resolved)
         return deck.blank()
     except Exception:  # noqa: BLE001 — a demo must never be what breaks
         logger.debug("[OvDemo] beat degraded: %s", kind, exc_info=True)
@@ -251,6 +274,94 @@ _THREAD: List[dict] = [
     {"handle": "@cassandra", "op_id": "op-7759-86", "kind": "conflict",
      "body": "REVIEW disagrees: that except clause still swallows I2"},
 ]
+
+
+def scene_epistemics(console: Any, argv: Sequence[str] = ()) -> int:
+    """What the cockpit knows, and how well — the three honesty surfaces.
+
+    Same rule as every other scene: the REAL renderers. The reach column is
+    produced by `DiffPreviewRenderer._build_file_tree` itself, so a
+    regression in the gate's own preview shows up here rather than in a
+    parallel drawing that agrees with itself.
+
+    The advisor cache is seeded for three of four files, deliberately. A
+    fully-resolved gutter would be a lie about the common case: reach is
+    cached per key, a multi-file op leaves only its aggregate behind, and a
+    cold scan is a 39-43s burn no display surface may trigger. `?` is what
+    an operator will usually see, so `?` is what the demo shows.
+    """
+    _rule(console, "what it knows, and how well")
+
+    _say(console, "  reach — which file in this change should you read hardest")
+    _say(console)
+    try:
+        from backend.core.ouroboros.battle_test.diff_preview import (
+            DiffPreviewRenderer, FileChange,
+        )
+        from backend.core.ouroboros.ui import blast_gutter as _bg
+        seeded = {
+            "backend/core/ouroboros/governance/orchestrator.py":
+                (47, "measured"),
+            "backend/core/ouroboros/ui/theme.py":
+                (12, "localized_lower_bound"),
+            "tests/battle_test/test_thing.py": (0, "measured"),
+        }
+        # Through the RESOLVER seam, never the advisor's own cache. That
+        # cache is read by live GATE decisions, so a display surface writing
+        # to it — even briefly, even with cleanup — could let a demo change
+        # what the organism decides. A demo may lie to itself; it may never
+        # lie to the gate.
+        _bg.set_resolver(
+            lambda paths, root=None: seeded.get(list(paths)[0])
+            if paths else None
+        )
+        try:
+            changes = [
+                FileChange(path=path, old_content="a\nb\n",
+                           new_content="a\nB\n")
+                for path in seeded
+            ] + [FileChange(path="docs/notes.md", old_content="",
+                            new_content="new\n")]
+            console.print(DiffPreviewRenderer()._build_file_tree(changes))
+        finally:
+            _bg.set_resolver(None)
+        _say(console)
+        _say(console, "  · 0 is a MEASURED zero. ? was never measured.")
+        _say(console, "  ≥ means a localized scan proved a lower bound.")
+    except Exception as exc:  # noqa: BLE001
+        _say(console, f"  reach gutter unavailable: {exc}")
+
+    _say(console)
+    _say(console, "  provenance — /provenance")
+    _say(console)
+    try:
+        from backend.core.ouroboros.ui.provenance import annotate, legend
+        _markup(console, "    unmarked  observed, or derived from observation")
+        for label, _glyph, meaning in legend():
+            _markup(console, f"    {annotate('', label).strip()}  {meaning}")
+    except Exception as exc:  # noqa: BLE001
+        _say(console, f"  legend unavailable: {exc}")
+
+    _say(console)
+    _say(console, "  voices — /narrate")
+    _say(console)
+    try:
+        from backend.core.ouroboros.ui.narrative_density import (
+            current_density, roster,
+        )
+        rows = roster()
+        heard = [r for r in rows if r.verdict.heard]
+        _say(console, f"    {current_density().label} · "
+                      f"{len(heard)}/{len(rows)} audible")
+        for r in rows:
+            glyph = "•" if r.verdict.heard else "◦"
+            why = "" if r.verdict.heard else f"  needs {r.voice.min_density.label}"
+            if r.voice.exempt:
+                why = "  alarm, never muted"
+            _say(console, f"    {glyph} {r.voice.name}{why}")
+    except Exception as exc:  # noqa: BLE001
+        _say(console, f"  roster unavailable: {exc}")
+    return 0
 
 
 def scene_transcript(console: Any, argv: Sequence[str] = ()) -> int:
@@ -1270,6 +1381,7 @@ _SCENES: "dict[str, Callable[[Any, Sequence[str]], int]]" = {
     "board": scene_board,
     "surfaces": scene_surfaces,
     "transcript": scene_transcript,
+    "epistemics": scene_epistemics,
     # NOT in the default all-scenes run: it takes over the screen and
     # waits for a keypress, so it must be asked for by name.
     "live": scene_live,

--- a/backend/core/ouroboros/governance/operation_advisor.py
+++ b/backend/core/ouroboros/governance/operation_advisor.py
@@ -2886,3 +2886,50 @@ __all__ = [
     "envelope_repo_root_status",
     "guard_envelope_repo_root",
 ]
+
+
+# ---------------------------------------------------------------------------
+# Read-only reach lookup — for surfaces, never for decisions
+# ---------------------------------------------------------------------------
+
+
+def peek_blast(
+    target_files: "Sequence[str]",
+    root: "Optional[str]" = None,
+) -> "Optional[Tuple[int, str]]":
+    """``(count, provenance)`` if this reach is ALREADY known, else None.
+
+    The read-only half of :meth:`_compute_blast_radius`. It reads the same
+    shared cache under the same lock with the same key and honours the same
+    TTL — and it will NEVER compute, scan, or populate anything.
+
+    That restriction is the entire point. A cold blast scan is a 39–43s
+    burn (soak bt-2026-07-21-205755, the failure that produced the whole
+    locality-bounding arc), and a display surface that triggered one per
+    file would turn a diff preview into a minutes-long freeze. Worse, it
+    would do so on the operator's critical path while they wait at a gate.
+
+    A miss is honestly a miss. It must NOT be reported as zero: the cache
+    deliberately stores only MEASURED-class results, so "absent" means
+    "never established", and the last time this system let an unestablished
+    reach wear a number, the fabricated cap was cached and poisoned every
+    op sharing the key for the TTL.
+
+    NEVER raises.
+    """
+    try:
+        if not target_files:
+            return None
+        scan_root = root if root is not None else str(Path.cwd())
+        cache_key = (frozenset(target_files), str(scan_root))
+        with _BLAST_RADIUS_CACHE_LOCK:
+            entry = _BLAST_RADIUS_CACHE_SHARED.get(cache_key)
+            if entry is None:
+                return None
+            computed_at, count = entry
+            if time.time() - computed_at >= _BLAST_RADIUS_CACHE_TTL_S:
+                return None            # stale is not known
+            provenance = _BLAST_PROVENANCE_SHARED.get(cache_key, "")
+        return (int(count), str(provenance or ""))
+    except Exception:  # noqa: BLE001
+        return None

--- a/backend/core/ouroboros/ui/blast_gutter.py
+++ b/backend/core/ouroboros/ui/blast_gutter.py
@@ -1,0 +1,326 @@
+"""What a diff does not tell you: what depends on the lines it changes.
+
+A diff answers "what changed". At a gate the operator is deciding something
+else — "what does this reach" — and two three-line edits render identically
+while differing fifty-fold in blast radius. The dangerous file in a
+multi-file change looks exactly like the safe one.
+
+The organism knows. `OperationAdvisor` computes reach with real care —
+`blast_radius`, an epistemic `blast_provenance`, a localized lower bound
+when a global scan cannot finish — and then `render_safety_plan()` writes
+it into the GENERATION PROMPT. The model is told. The human approving the
+change is not.
+
+Why this cannot simply resolve what it wants to show
+====================================================
+A cold blast scan is a 39–43 second burn. That is not a tuning detail; it
+is the failure that produced the entire Targeted Locality Bounding arc,
+where a timed-out scan fabricated `blast=50`, cached it, and let it satisfy
+a hard BLOCK.
+
+So a gutter that resolved reach per file would freeze a diff preview for
+minutes — on the operator's critical path, while they wait at a gate. This
+module therefore READS ONLY what is already known (`advisor.peek_blast`,
+which cannot scan) and is honest about the rest.
+
+A miss is a miss
+================
+An unresolved file renders `?`, never `0`. The advisor's cache stores only
+MEASURED-class results, so absent means "never established" — and the last
+time this system let an unestablished reach wear a number, that number was
+cached and poisoned every op sharing its key for the TTL.
+
+This is the `UNKNOWN` versus `UNSET` distinction from `provenance`, in the
+one place where it is most expensive to get wrong. Reach marked `?` is
+inert: it sorts last, contributes nothing to the scale, and is styled as a
+warning rather than as data.
+
+Relative, because that is the actual question
+=============================================
+The operator is not auditing an absolute dependency count; they are asking
+"which of THESE files should I look at hardest". So bars scale to the
+largest RESOLVED reach in the set. A single file with reach 3 fills its bar
+— relative to what it is being compared against, which is nothing. Absolute
+counts stay visible beside the bar for anyone who wants them.
+
+NEVER raises, and never blocks. A gutter that fails must cost the operator
+a column, not their diff.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Sequence
+
+logger = logging.getLogger("Ouroboros.BlastGutter")
+
+BLAST_GUTTER_SCHEMA_VERSION = "blast_gutter.v1"
+
+MASTER_FLAG_ENV_VAR = "JARVIS_BLAST_GUTTER_ENABLED"
+
+#: Bar width. Small on purpose — this is a gutter, not a chart. It sits
+#: beside a filename in a tree that already carries a status badge and a
+#: +/- count, and a wide bar would make the reach look like the headline
+#: rather than the annotation.
+_DEFAULT_WIDTH = 6
+
+#: Blocks, densest last. Unicode is degraded to ASCII when the terminal
+#: cannot carry it — the same discipline as `theme.ouroboros_frame`.
+_BLOCKS = "▁▂▃▄▅▆▇█"
+_ASCII_BLOCKS = ".:-=+*#@"
+
+
+def gutter_enabled() -> bool:
+    """Default ON. Off, the tree renders exactly as it did before."""
+    try:
+        return os.environ.get(
+            MASTER_FLAG_ENV_VAR, "1",
+        ).strip().lower() not in ("0", "false", "no", "off")
+    except Exception:  # noqa: BLE001
+        return True
+
+
+def _width() -> int:
+    try:
+        return max(1, min(24, int(os.environ.get(
+            "JARVIS_BLAST_GUTTER_WIDTH", _DEFAULT_WIDTH))))
+    except Exception:  # noqa: BLE001
+        return _DEFAULT_WIDTH
+
+
+@dataclass(frozen=True)
+class Reach:
+    """How far one file's change travels, and how well that is known."""
+
+    path: str
+    count: int = 0
+    #: The advisor's own vocabulary — "measured", "localized_lower_bound",
+    #: "synthetic_cap", "unknown" — kept verbatim rather than pre-digested,
+    #: so `provenance.project` stays the single place that vocabulary is
+    #: interpreted and this module never becomes a second opinion on it.
+    provenance: str = ""
+    resolved: bool = False
+
+    @property
+    def is_lower_bound(self) -> bool:
+        """A localized scan proves "at least this many", not "this many".
+
+        Rendering a lower bound as an exact count is the same class of lie
+        as rendering an unresolved one as zero, one decimal place quieter.
+        """
+        return self.provenance == "localized_lower_bound"
+
+
+#: Optional resolver override. Installed by the demo and by tests so neither
+#: has to seed the ADVISOR'S OWN shared cache to show a populated gutter.
+#: That matters more than it looks: the advisor's cache is read by live GATE
+#: decisions, so a display surface that wrote to it — even briefly, even with
+#: cleanup — could let a demonstration change what the organism decides. A
+#: demo may lie to itself; it may never lie to the gate.
+_RESOLVER = None
+
+
+def set_resolver(fn) -> None:
+    """Install (or clear, with None) the reach resolver. NEVER raises."""
+    global _RESOLVER
+    _RESOLVER = fn
+
+
+def peek(paths: Sequence[str], root: Optional[str] = None) -> List[Reach]:
+    """Reach for each path, WITHOUT computing anything. NEVER raises.
+
+    Each path is looked up alone — key ``frozenset({path})`` — because that
+    is the only key whose cached value describes that file rather than the
+    aggregate of the op it happened to travel with. A multi-file op leaves
+    only the aggregate behind, so most files in a large change will miss,
+    and will honestly say so.
+    """
+    out: List[Reach] = []
+    peek_blast = _RESOLVER
+    if peek_blast is None:
+        try:
+            from backend.core.ouroboros.governance.operation_advisor import (
+                peek_blast,
+            )
+        except Exception:  # noqa: BLE001
+            return [Reach(path=str(p)) for p in paths]
+    for raw in paths:
+        path = str(raw or "")
+        try:
+            hit = peek_blast([path], root)
+            if hit is None:
+                out.append(Reach(path=path))
+                continue
+            count, provenance = hit
+            out.append(Reach(path=path, count=int(count),
+                             provenance=str(provenance or ""),
+                             resolved=True))
+        except Exception:  # noqa: BLE001
+            out.append(Reach(path=path))
+    return out
+
+
+def _blocks(ascii_only: bool = False) -> str:
+    return _ASCII_BLOCKS if ascii_only else _BLOCKS
+
+
+def bar(reach: Reach, scale: int, *, width: Optional[int] = None,
+        ascii_only: bool = False) -> str:
+    """One file's bar, scaled against ``scale``. Pure. NEVER raises.
+
+    ``scale`` is the largest RESOLVED reach in the set, so the column
+    answers "which of these should I look at hardest" rather than posing an
+    absolute question nobody asked.
+    """
+    try:
+        cols = width if width and width > 0 else _width()
+        if not reach.resolved:
+            # Never a bar. An unresolved reach that rendered as an empty bar
+            # would be indistinguishable from a resolved reach of zero —
+            # the two facts this module exists to keep apart.
+            return "?".ljust(cols)
+        if scale <= 0 or reach.count <= 0:
+            return "·".ljust(cols)
+        blocks = _blocks(ascii_only)
+        filled = (reach.count / float(scale)) * cols
+        whole = int(filled)
+        out = blocks[-1] * min(whole, cols)
+        if whole < cols:
+            remainder = filled - whole
+            if remainder > 0:
+                idx = min(len(blocks) - 1,
+                          max(0, int(remainder * len(blocks))))
+                out += blocks[idx]
+        return out[:cols].ljust(cols)
+    except Exception:  # noqa: BLE001
+        return "?".ljust(width or _DEFAULT_WIDTH)
+
+
+def scale_of(reaches: Sequence[Reach]) -> int:
+    """The largest RESOLVED reach. Unresolved entries contribute nothing.
+
+    Letting a `?` participate would require inventing a value for it, which
+    is the fabrication this module refuses. NEVER raises.
+    """
+    try:
+        return max((r.count for r in reaches if r.resolved), default=0)
+    except Exception:  # noqa: BLE001
+        return 0
+
+
+def style_for(reach: Reach) -> str:
+    """Semantic ROLE for this reach — resolved by `semantic_tokens`.
+
+    Roles, never colours: a second palette here would drift from `theme`
+    exactly as `serpent_flow._C` did. Severity is RELATIVE to the set, so
+    thresholds live in :func:`annotate_set` where the scale is known.
+    """
+    if not reach.resolved:
+        return "heal"                  # a warning, not data
+    return "dim"
+
+
+@dataclass(frozen=True)
+class GutterRow:
+    """One rendered row: the bar, its label, and the style role."""
+
+    reach: Reach
+    bar: str
+    label: str
+    role: str
+
+
+def annotate_set(reaches: Sequence[Reach], *, width: Optional[int] = None,
+                 ascii_only: bool = False) -> List[GutterRow]:
+    """Render a whole set together. Pure. NEVER raises.
+
+    Together, because the scale — and therefore severity — is a property of
+    the SET, not of any one file. A per-file renderer could not know
+    whether 12 dependents is the largest number on screen or the smallest,
+    which is the only thing the operator actually wants to know.
+    """
+    rows: List[GutterRow] = []
+    try:
+        scale = scale_of(reaches)
+        for r in reaches:
+            if not r.resolved:
+                label = "?"
+                role = "heal"
+            else:
+                # "≥" is load-bearing: a localized scan proves a LOWER
+                # BOUND. `advisor_locality` keeps that distinction all the
+                # way through the gate; dropping it at the last inch would
+                # undo the arc that put it there.
+                label = f"{'≥' if r.is_lower_bound else ''}{r.count}"
+                role = "dim"
+                if scale > 0 and r.count >= scale and r.count > 0:
+                    role = "alert" if len(reaches) > 1 else "dim"
+            rows.append(GutterRow(
+                reach=r,
+                bar=bar(r, scale, width=width, ascii_only=ascii_only),
+                label=label,
+                role=role,
+            ))
+        return rows
+    except Exception:  # noqa: BLE001
+        logger.debug("[BlastGutter] annotate degraded", exc_info=True)
+        return []
+
+
+def summary(reaches: Sequence[Reach]) -> str:
+    """One line for a header, or "". Pure. NEVER raises.
+
+    Reports how much of the set is UNKNOWN, because a gutter that is mostly
+    `?` is itself the finding: it means nothing in this change has been
+    measured yet, and the operator should read the whole diff rather than
+    trusting a column that knows nothing.
+    """
+    try:
+        if not reaches:
+            return ""
+        resolved = [r for r in reaches if r.resolved]
+        if not resolved:
+            return "reach unmeasured"
+        top = max(resolved, key=lambda r: r.count)
+        parts = [f"reach ≤{top.count}" if top.is_lower_bound
+                 else f"reach {top.count}"]
+        unknown = len(reaches) - len(resolved)
+        if unknown:
+            parts.append(f"{unknown} unmeasured")
+        return " · ".join(parts)
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def as_dict(reaches: Sequence[Reach]) -> Dict[str, object]:
+    """Transport-safe projection for the cockpit. NEVER raises."""
+    try:
+        return {
+            "schema_version": BLAST_GUTTER_SCHEMA_VERSION,
+            "scale": scale_of(reaches),
+            "reaches": [
+                {"path": r.path, "count": r.count,
+                 "provenance": r.provenance, "resolved": r.resolved}
+                for r in reaches
+            ],
+        }
+    except Exception:  # noqa: BLE001
+        return {"scale": 0, "reaches": []}
+
+
+__all__ = [
+    "BLAST_GUTTER_SCHEMA_VERSION",
+    "GutterRow",
+    "MASTER_FLAG_ENV_VAR",
+    "Reach",
+    "annotate_set",
+    "as_dict",
+    "bar",
+    "gutter_enabled",
+    "peek",
+    "scale_of",
+    "set_resolver",
+    "style_for",
+    "summary",
+]

--- a/tests/battle_test/test_blast_gutter.py
+++ b/tests/battle_test/test_blast_gutter.py
@@ -1,0 +1,224 @@
+"""A diff answers "what changed". A gate asks "what does this reach".
+
+`OperationAdvisor` computes reach with real care — a count, an epistemic
+provenance, a localized lower bound when a global scan cannot finish — and
+`render_safety_plan()` writes it into the GENERATION PROMPT. The model is
+told. The human approving the change is not.
+
+The constraint that shapes everything here: a cold blast scan is a 39–43
+second burn (the failure that produced the whole Targeted Locality Bounding
+arc, where a timed-out scan fabricated `blast=50`, cached it, and let it
+satisfy a hard BLOCK). So the gutter reads only what is already known, and
+says `?` for the rest.
+"""
+from __future__ import annotations
+
+import ast
+import pathlib
+import time
+
+import pytest
+
+from backend.core.ouroboros.governance import operation_advisor as oa
+from backend.core.ouroboros.ui import blast_gutter as bg
+
+
+@pytest.fixture(autouse=True)
+def _clean_cache():
+    oa._BLAST_RADIUS_CACHE_SHARED.clear()
+    oa._BLAST_PROVENANCE_SHARED.clear()
+    yield
+    oa._BLAST_RADIUS_CACHE_SHARED.clear()
+    oa._BLAST_PROVENANCE_SHARED.clear()
+
+
+def _warm(path: str, count: int, provenance: str = "measured") -> None:
+    key = (frozenset([path]), str(pathlib.Path.cwd()))
+    oa._BLAST_RADIUS_CACHE_SHARED[key] = (time.time(), count)
+    oa._BLAST_PROVENANCE_SHARED[key] = provenance
+
+
+class TestItCanNeverTriggerAScan:
+    """The load-bearing property. Everything else is presentation."""
+
+    def test_peek_blast_calls_nothing_that_computes(self):
+        """Structural: the read-only lookup must not reach any of the
+        advisor's computing entry points. Asserted on CALL NODES, not on a
+        substring search — the docstring names `_compute_blast_radius`
+        precisely to explain what it is the read-only half OF."""
+        src = pathlib.Path(oa.__file__).read_text()
+        fn = next(n for n in ast.walk(ast.parse(src))
+                  if isinstance(n, ast.FunctionDef) and n.name == "peek_blast")
+        called = {ast.unparse(n.func) for n in ast.walk(fn)
+                  if isinstance(n, ast.Call)}
+        forbidden = {"_compute_blast_radius", "_compute_blast_radius_async",
+                     "_oracle_blast_count", "compute_blast_radius",
+                     "get_blast_radius", "_cooperative_scan"}
+        assert not (called & forbidden), called & forbidden
+
+    def test_peek_blast_never_WRITES_the_cache(self):
+        """A display surface that populated the cache would let rendering
+        change what a later GATE decides."""
+        src = pathlib.Path(oa.__file__).read_text()
+        fn = next(n for n in ast.walk(ast.parse(src))
+                  if isinstance(n, ast.FunctionDef) and n.name == "peek_blast")
+        writes = [t for node in ast.walk(fn)
+                  if isinstance(node, ast.Assign)
+                  for t in node.targets if isinstance(t, ast.Subscript)]
+        assert not writes
+
+    def test_the_render_path_only_peeks(self):
+        src = pathlib.Path(bg.__file__).read_text()
+        called = {ast.unparse(n.func) for n in ast.walk(ast.parse(src))
+                  if isinstance(n, ast.Call)}
+        assert "peek_blast" in called
+        assert not (called & {"compute_blast_radius", "get_blast_radius"})
+
+    def test_a_cold_lookup_is_a_MISS_not_a_zero(self):
+        assert oa.peek_blast(["never/seen.py"]) is None
+        assert bg.peek(["never/seen.py"])[0].resolved is False
+
+
+class TestResolvedZeroIsNotUnknown:
+    """The distinction that costs the most to get wrong."""
+
+    def test_they_render_differently(self):
+        _warm("touched.py", 0)
+        rows = {r.reach.path: r for r in bg.annotate_set(
+            bg.peek(["touched.py", "cold.py"]))}
+        assert rows["touched.py"].label == "0"
+        assert rows["cold.py"].label == "?"
+        assert rows["touched.py"].bar != rows["cold.py"].bar
+
+    def test_an_unresolved_reach_never_gets_a_BAR(self):
+        """An empty bar would be indistinguishable from a resolved zero."""
+        assert bg.bar(bg.Reach("x"), 10).strip() == "?"
+
+    def test_unresolved_is_styled_as_a_WARNING_not_as_data(self):
+        assert bg.style_for(bg.Reach("x")) == "heal"
+        assert bg.style_for(bg.Reach("x", 3, "measured", True)) == "dim"
+
+
+class TestTheScaleIsRelativeToTheSet:
+    def test_scale_ignores_unresolved(self):
+        """Letting a `?` participate would require inventing a value."""
+        _warm("a.py", 30)
+        reaches = bg.peek(["a.py", "cold.py"])
+        assert bg.scale_of(reaches) == 30
+
+    def test_the_largest_file_fills_the_bar(self):
+        _warm("big.py", 40)
+        _warm("small.py", 4)
+        rows = {r.reach.path: r for r in bg.annotate_set(
+            bg.peek(["big.py", "small.py"]))}
+        assert rows["big.py"].bar.strip() == "█" * 6
+        assert len(rows["small.py"].bar.strip()) < 6
+
+    def test_the_largest_is_flagged_only_when_there_is_a_comparison(self):
+        """A lone file is not "the riskiest" — there is nothing it is
+        riskier than."""
+        _warm("solo.py", 99)
+        assert bg.annotate_set(bg.peek(["solo.py"]))[0].role == "dim"
+        _warm("other.py", 1)
+        rows = {r.reach.path: r for r in bg.annotate_set(
+            bg.peek(["solo.py", "other.py"]))}
+        assert rows["solo.py"].role == "alert"
+
+    def test_scale_of_an_all_unknown_set_is_zero_not_a_crash(self):
+        assert bg.scale_of(bg.peek(["a.py", "b.py"])) == 0
+
+
+class TestTheLowerBoundSurvivesToTheEye:
+    def test_a_localized_scan_renders_as_at_least(self):
+        """`advisor_locality` keeps "measured lower bound" distinct all the
+        way through the gate; dropping it at the last inch would undo the
+        arc that put it there."""
+        _warm("loc.py", 12, "localized_lower_bound")
+        assert bg.annotate_set(bg.peek(["loc.py"]))[0].label == "≥12"
+
+    def test_a_measured_scan_renders_exactly(self):
+        _warm("m.py", 12, "measured")
+        assert bg.annotate_set(bg.peek(["m.py"]))[0].label == "12"
+
+    def test_the_advisor_vocabulary_is_not_reinterpreted_here(self):
+        """`Reach` keeps the advisor's string verbatim so `provenance`
+        stays the single place that vocabulary is interpreted."""
+        _warm("v.py", 1, "localized_lower_bound")
+        assert bg.peek(["v.py"])[0].provenance == "localized_lower_bound"
+
+
+class TestTTLAndStaleness:
+    def test_a_stale_entry_is_a_MISS(self):
+        key = (frozenset(["old.py"]), str(pathlib.Path.cwd()))
+        oa._BLAST_RADIUS_CACHE_SHARED[key] = (
+            time.time() - (oa._BLAST_RADIUS_CACHE_TTL_S + 5), 99)
+        oa._BLAST_PROVENANCE_SHARED[key] = "measured"
+        assert oa.peek_blast(["old.py"]) is None
+
+    def test_a_fresh_entry_is_a_hit(self):
+        _warm("fresh.py", 7)
+        assert oa.peek_blast(["fresh.py"]) == (7, "measured")
+
+
+class TestTheSummaryReportsWhatIsNOTKnown:
+    def test_an_all_unknown_set_says_so(self):
+        """A gutter that is mostly `?` IS the finding."""
+        assert bg.summary(bg.peek(["a.py", "b.py"])) == "reach unmeasured"
+
+    def test_partial_knowledge_is_counted(self):
+        _warm("known.py", 5)
+        assert "1 unmeasured" in bg.summary(bg.peek(["known.py", "cold.py"]))
+
+    def test_empty_set_renders_nothing(self):
+        assert bg.summary([]) == ""
+
+
+class TestTheTreeDegradesSafely:
+    def test_master_flag_off_leaves_the_tree_untouched(self, monkeypatch):
+        from backend.core.ouroboros.battle_test.diff_preview import (
+            DiffPreviewRenderer, FileChange,
+        )
+        _warm("f.py", 9)
+        changes = [FileChange(path="f.py", old_content="a\n",
+                              new_content="b\n")]
+        monkeypatch.setenv(bg.MASTER_FLAG_ENV_VAR, "0")
+        off = DiffPreviewRenderer()._build_file_tree(changes)
+        monkeypatch.setenv(bg.MASTER_FLAG_ENV_VAR, "1")
+        on = DiffPreviewRenderer()._build_file_tree(changes)
+        assert str(off.children[0].label) != str(on.children[0].label)
+        assert "9" in str(on.children[0].label)
+
+    def test_a_broken_gutter_costs_a_column_not_the_diff(self, monkeypatch):
+        from backend.core.ouroboros.battle_test.diff_preview import (
+            DiffPreviewRenderer, FileChange,
+        )
+        monkeypatch.setattr(bg, "peek", lambda *_a, **_k: (
+            _ for _ in ()).throw(RuntimeError("boom")))
+        tree = DiffPreviewRenderer()._build_file_tree(
+            [FileChange(path="f.py", old_content="a\n", new_content="b\n")])
+        assert "f.py" in str(tree.children[0].label)
+
+
+class TestItNeverRaises:
+    @pytest.mark.parametrize("bad", [None, 0, object(), b"x", [], {}])
+    def test_peek_survives_anything(self, bad):
+        assert isinstance(bg.peek([bad]), list)  # type: ignore[list-item]
+
+    @pytest.mark.parametrize("bad", [None, 0, object(), "x"])
+    def test_peek_blast_survives_anything(self, bad):
+        assert oa.peek_blast(bad) is None  # type: ignore[arg-type]
+
+    def test_bar_survives_a_nonsense_scale(self):
+        r = bg.Reach("x", 5, "measured", True)
+        for scale in (0, -1, 1):
+            assert isinstance(bg.bar(r, scale), str)
+
+    def test_ascii_degradation(self):
+        r = bg.Reach("x", 10, "measured", True)
+        out = bg.bar(r, 10, ascii_only=True)
+        assert out.strip() and all(ord(c) < 128 for c in out)
+
+    def test_as_dict_is_transport_safe(self):
+        import json
+        _warm("j.py", 3)
+        json.dumps(bg.as_dict(bg.peek(["j.py", "cold.py"])))

--- a/tests/cli/test_ov_demo.py
+++ b/tests/cli/test_ov_demo.py
@@ -10,6 +10,8 @@ silently blesses regressions.
 """
 from __future__ import annotations
 
+import ast
+import pathlib
 import pytest
 
 from backend.core.ouroboros.cli.ov import resolve
@@ -250,3 +252,93 @@ class TestLiveScene:
         render = _live_toolbar(lambda: 0.0, lambda: 7.5)
         text = render()
         assert "q to quit" in text and "tokens" in text
+
+
+class TestEpistemicsScene:
+    """The three surfaces that say how well the organism knows a thing."""
+
+    def test_it_is_a_derived_scene(self):
+        from backend.core.ouroboros.cli.ov_demo import demo_scenes
+        assert "epistemics" in demo_scenes()
+
+    def test_it_NEVER_writes_the_advisors_live_cache(self):
+        """The load-bearing invariant.
+
+        That cache is read by live GATE decisions, so a display surface
+        writing to it — even briefly, even with cleanup — could let a
+        demonstration change what the organism decides. A demo may lie to
+        itself; it may never lie to the gate.
+        """
+        from rich.console import Console
+        from backend.core.ouroboros.cli.ov_demo import scene_epistemics
+        from backend.core.ouroboros.governance import operation_advisor as oa
+        oa._BLAST_RADIUS_CACHE_SHARED.clear()
+        oa._BLAST_PROVENANCE_SHARED.clear()
+        scene_epistemics(Console(force_terminal=True, width=80))
+        assert oa._BLAST_RADIUS_CACHE_SHARED == {}
+        assert oa._BLAST_PROVENANCE_SHARED == {}
+
+    def test_the_source_never_names_the_advisor_cache(self):
+        """Structural backstop: the runtime check above also passes for a
+        scene that writes and then cleans up perfectly, and the hazard is
+        the WINDOW, not the residue."""
+        import backend.core.ouroboros.cli.ov_demo as mod
+        src = pathlib.Path(mod.__file__).read_text()
+        assert "_BLAST_RADIUS_CACHE_SHARED" not in src
+        assert "_BLAST_PROVENANCE_SHARED" not in src
+
+    def test_the_resolver_override_is_always_released(self):
+        """Left installed, every later gutter in the process would show the
+        demo's numbers."""
+        from rich.console import Console
+        from backend.core.ouroboros.cli.ov_demo import scene_epistemics
+        from backend.core.ouroboros.ui import blast_gutter as bg
+        scene_epistemics(Console(force_terminal=True, width=80))
+        assert bg._RESOLVER is None
+
+    def test_it_renders_the_REAL_diff_tree(self):
+        """Not a parallel drawing that agrees with itself while the gate's
+        own preview is broken."""
+        import backend.core.ouroboros.cli.ov_demo as mod
+        src = pathlib.Path(mod.__file__).read_text()
+        fn = next(n for n in ast.walk(ast.parse(src))
+                  if isinstance(n, ast.FunctionDef)
+                  and n.name == "scene_epistemics")
+        called = {ast.unparse(n.func) for n in ast.walk(fn)
+                  if isinstance(n, ast.Call)}
+        assert "DiffPreviewRenderer()._build_file_tree" in called
+        assert "legend" in called and "roster" in called
+
+    def test_a_broken_surface_degrades_instead_of_crashing(self, monkeypatch):
+        from rich.console import Console
+        from backend.core.ouroboros.cli import ov_demo as mod
+        from backend.core.ouroboros.ui import blast_gutter as bg
+        monkeypatch.setattr(bg, "set_resolver", lambda *_a: (
+            _ for _ in ()).throw(RuntimeError("boom")))
+        assert mod.scene_epistemics(Console(force_terminal=True)) == 0
+
+
+class TestProvenanceBeats:
+    def test_the_marks_come_from_the_REAL_annotator(self):
+        """A demo that stamped the glyph itself would keep showing a mark
+        the cockpit no longer produces."""
+        import backend.core.ouroboros.cli.ov_demo as mod
+        src = pathlib.Path(mod.__file__).read_text()
+        fn = next(n for n in ast.walk(ast.parse(src))
+                  if isinstance(n, ast.FunctionDef) and n.name == "_compose")
+        called = {ast.unparse(n.func) for n in ast.walk(fn)
+                  if isinstance(n, ast.Call)}
+        assert {"annotate", "claiming"} <= called
+
+    def test_every_marked_rung_appears_in_the_transcript(self):
+        from backend.core.ouroboros.cli.ov_demo import _SCRIPT, _compose
+        rendered = " ".join(_compose(k, a) for k, a in _SCRIPT)
+        for glyph in ("‹model›", "‹synthetic›",
+                      "‹unverified›", "‹stated›"):
+            assert glyph in rendered, glyph
+
+    def test_observed_beats_stay_CLEAN(self):
+        """Scarcity: a demo that marked every line would be showing a
+        transcript the cockpit does not produce."""
+        from backend.core.ouroboros.cli.ov_demo import _compose
+        assert "‹" not in _compose("det", ("Read 847 lines",))


### PR DESCRIPTION
Two commits: the reach gutter, then `ov demo` catching up to it and to this week's four merged PRs.

## 1. Show what a change REACHES

A diff answers "what changed". At a gate the operator is deciding something else — *what does this reach* — and two three-line edits render identically while differing fiftyfold in blast radius.

`OperationAdvisor` computes reach with real care (`blast_radius`, an epistemic `blast_provenance`, a localized lower bound). Then `render_safety_plan()` writes it into the **generation prompt**. The model is told. The human approving the change is not.

### The constraint that shaped everything

This cannot simply resolve what it wants to show. A cold blast scan is a **39–43 second burn** — the failure that produced the whole Targeted Locality Bounding arc, where a timed-out scan fabricated `blast=50`, cached it, and let it satisfy a hard BLOCK.

So `peek_blast` is the **read-only half** of `_compute_blast_radius`: same cache, lock, key and TTL, structurally incapable of computing or writing. Pinned by AST tests on call nodes and assignment targets — not substring searches, since the docstring *names* `_compute_blast_radius` to say what it is the read-only half of.

### A miss is a miss

Most files in a multi-file change **will** miss — the advisor caches by `frozenset(target_files)`, the aggregate, not per file. Those render `?`, never `0`.

```
Changed files (4)  reach 47 · 1 unmeasured
├── …/governance/orchestrator.py    [~ modified]  +1/-1  ██████ 47
├── …/ui/theme.py                   [~ modified]  +1/-1  █▅     ≥12
├── tests/battle_test/test_thing.py [~ modified]  +1/-1  ·      0
└── docs/notes.md                   [+ new]       +1/-0  ?      ?
```

`· 0` is a **measured** zero. `? ?` was never measured — it contributes nothing to the scale and is styled as a warning, not data. `≥12` preserves the lower bound `advisor_locality` carries all the way through the gate.

Bars scale to the largest **resolved** reach, because "which should I read hardest" is the actual question. A lone file is never flagged riskiest — there's nothing it's riskier than.

## 2. The demo learns what the cockpit learned

`board` and `surfaces` needed **nothing** — they derive from the tree by `ast.parse`, uncached on purpose. That's the half built right, and it's why the hand-authored half being stale was invisible.

The transcript now carries the distinction, composed inside a real `claiming(...)` and marked by the real `annotate`:

```
⎿  ✗ 3 failed · test_scoped_paths, test_sandbox_dir
⎿  the fixture is stale — the loader caches by path  ‹model›
⎿  🗣 I'll read the file first                       ‹synthetic›
⎿  blast radius 50 files                             ‹unverified›
⎿  operator: "reject — that clause is load-bearing"  ‹stated›
```

The observed line stays clean — a demo that marked everything would show a transcript the cockpit doesn't draw.

`ov demo epistemics` adds the gutter, the `/provenance` legend and the `/narrate` roster, with the gutter rendered by `DiffPreviewRenderer._build_file_tree` **itself**.

### A hazard I introduced, then removed

My first version **seeded the advisor's live shared cache** and popped the entries after. Wrong even with perfect cleanup: that cache is read by live GATE decisions, so `ov demo epistemics` on a running daemon could change what the organism decides for the width of the scene. **The hazard is the window, not the residue.** Now behind `blast_gutter.set_resolver`, held by two tests — runtime (cache untouched) *and* structural (the source never names it), because the runtime check alone also passes for a scene that writes and cleans up flawlessly.

## Verification

**43 new tests** (34 gutter + 9 demo); 33 green in the demo suite.

The 8 failures + 31 errors in the 126-file advisor/diff-preview run are **pre-existing** — identical with both modified sources reverted to HEAD (8 failed either way; 854 vs 820 passed is exactly the 34 excluded new tests), and every failing file passes in isolation. The `slice12ae` ones are `EnumX is EnumX` identity mismatches, the signature of a module imported twice in a large run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a blast‑radius gutter to the diff preview so operators can see which files a change reaches, not just what it edits. The `ov demo` now shows the same epistemics as the cockpit (gutter, provenance marks, voice roster) without touching live caches.

- **New Features**
  - Diff preview: per-file reach gutter with bar + count, plus a header summary, rendered by `DiffPreviewRenderer._build_file_tree`.
  - Read-only reach lookup: `operation_advisor.peek_blast()` reads the shared cache (same key/lock/TTL), never computes or writes. Misses show `?`, a measured zero shows `0`, and lower bounds render as `≥N`.
  - Gutter module: `backend/core/ouroboros/ui/blast_gutter.py` scales bars to the largest resolved reach, excludes unknowns from scale, and maps roles to theme tokens. Degrades safely and never blocks rendering.
  - Controls: `JARVIS_BLAST_GUTTER_ENABLED` (default on) toggles the column; `JARVIS_BLAST_GUTTER_WIDTH` adjusts bar width.
  - Demo: `ov demo epistemics` renders the real diff tree gutter, the `/provenance` legend, and the `/narrate` voice roster. Uses `blast_gutter.set_resolver` to seed values without writing the advisor’s cache. New tests cover the gutter, demo scene, and safety invariants.

<sup>Written for commit 21a362c15706fa401bcfd0a677d060d8b9be8954. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

