### PR TITLE
feat(ov): one story, two projections — epistemics and reach land in the live cockpit

### DIFF
--- a/backend/core/ouroboros/cli/ov_demo.py
+++ b/backend/core/ouroboros/cli/ov_demo.py
@@ -31,7 +31,8 @@ from typing import Any, Callable, List, Optional, Sequence
 
 logger = logging.getLogger("Ouroboros.OvDemo")
 
-__all__ = ["run_demo", "demo_scenes", "DEMO_HELP"]
+__all__ = ["run_demo", "demo_scenes", "DEMO_HELP",
+           "transcript_lines"]
 
 DEMO_HELP = """ov demo -- watch the cockpit, no model calls
 
@@ -200,27 +201,41 @@ def _limit(argv: Sequence[str]) -> int:
 #: Deliberately a FAILING op: the deck's whole grammar — `⎿` results, an agora
 #: thread reacting to a failure — only shows itself when something goes wrong,
 #: and a demo of the happy path shows the least interesting third of it.
-_SCRIPT: List[Any] = [
-    ("act", ("Read", "backend/core/ouroboros/governance/risk_tier_floor.py")),
-    ("det", ("Read 847 lines",)),
-    ("act", ("Update", "risk_tier_floor.py")),
-    ("det", ("Updated risk_tier_floor.py with 18 additions and 3 removals",)),
-    ("diff", (412, "+", "    except RiskFloorConfigError:")),
-    ("diff", (413, "+", "        raise")),
-    ("diff", (414, "-", "    except Exception:  # noqa: BLE001")),
-    ("act", ("Validate", "7759-86")),
-    ("det", ("✗ 3 failed · test_scoped_paths, test_sandbox_dir", "crit")),
-    # Four claims that USED to render identically. The test result above is
-    # observed and stays clean; everything below is softer than it looks.
-    ("prov", ("modeled", "det",
-              ("the fixture is stale — the loader caches by path",))),
-    ("prov", ("synthetic", "det",
-              ("🗣 I'll read the file first",))),
-    ("prov", ("unknown", "det",
-              ("blast radius 50 files",))),
-    ("prov", ("stated", "det",
-              ('operator: "reject — that except clause is load-bearing"',))),
-]
+def transcript_lines() -> List[str]:
+    """The story, with the clock removed.
+
+    There used to be a SECOND hand-authored beat list here telling the same
+    op — 7759-86 on `risk_tier_floor.py` — in a different presentation. Two
+    scripts, one story, and they drifted exactly as you would expect: the
+    provenance beats added to the transcript never reached the live cockpit,
+    because nothing connected them.
+
+    So the transcript is now a PROJECTION of `_LIVE_BEATS` rather than a
+    rival of it. `compose_live_script` already renders every beat kind —
+    tools, agents, the agora, collapse, reach — so the only difference
+    between the two scenes is whether the timestamps are obeyed. A beat
+    added once now appears in both, and the transcript can never again show
+    something the cockpit does not.
+
+    NEVER raises.
+
+    The live script carries two kinds of beat: LINES to print, and CALLABLES
+    the driver invokes for their side effect — `_agent_beats` emits closures
+    that mutate the real `AgentRoster` so the cockpit's agent panel fills in
+    as the demo runs. A static transcript has no panel to mutate and no
+    clock to mutate it on, so callables are dropped rather than called.
+    Calling them here would leave a real roster populated by a scene that
+    never showed it.
+    """
+    try:
+        return [
+            line for _at, line in compose_live_script()
+            if isinstance(line, str)
+        ]
+    except Exception:  # noqa: BLE001
+        logger.debug("[OvDemo] transcript projection degraded", exc_info=True)
+        return []
+
 
 
 def _compose(kind: str, args: Sequence[Any]) -> str:
@@ -370,23 +385,11 @@ def scene_transcript(console: Any, argv: Sequence[str] = ()) -> int:
     # A blank line before each new action is the deck's only grouping cue.
     # Without it nine correct lines read as one paragraph, which is what
     # "it doesn't look like Claude Code" actually means most of the time.
-    for i, (kind, args) in enumerate(_SCRIPT):
-        if kind in ("act", "voice") and i:
-            _markup(console, "")
-        _markup(console, _compose(kind, args))
+    # `compose_live_script` already inserts the blank separators before each
+    # new action, so the projection carries the deck's grouping with it.
+    for line in transcript_lines():
+        _markup(console, line)
 
-    try:
-        from backend.core.ouroboros.battle_test.moltbook_inline import (
-            render_thread,
-        )
-        # `_markup`, not `_say`: the thread renderer tints its glyph and
-        # handle now, and printing that through a markup=False path shows the
-        # operator `[#58B0F8]💬[/#58B0F8]` — and then wraps the line, because
-        # the tags are counted as visible width.
-        for line in render_thread(_THREAD, width=76):
-            _markup(console, line)
-    except Exception as exc:  # noqa: BLE001
-        _say(console, f"  (agora unavailable: {exc})")
 
     _say(console)
     _rule(console, "palette")
@@ -591,7 +594,18 @@ _LIVE_BEATS: List[Any] = [
     # The agora reacting, rendered by the REAL renderer — see `_agora_beats`.
     (11.6, "agora", ()),
 
+    # Four claims the deck used to render identically. The pytest result at
+    # 9.2 is OBSERVED and stays clean; these are each softer than they look,
+    # and the operator deciding at the gate is the person who needs to know
+    # which is which.
+    (12.4, "prov", ("modeled", "det",
+                    ("the fixture is stale — the loader caches by path",))),
+    (12.9, "prov", ("unknown", "det", ("blast radius 50 files",))),
+    (13.4, "prov", ("stated", "det",
+                    ('operator: "that except clause is load-bearing"',))),
+
     (15.2, "act", ("Repair", "L2 · iteration 1/5", "warn")),
+    (15.7, "prov", ("synthetic", "det", ("🗣 I'll rebuild the fixture",))),
     (16.8, "det", ("fixture rebuilt from the live seam",)),
     (17.2, "voice", ("pinning the number it used to return would have made "
                      "the suite agree with the bug — the seam is the thing "
@@ -602,6 +616,9 @@ _LIVE_BEATS: List[Any] = [
                     _PYTEST_PASS, "success", 3980)),
 
     (20.4, "act", ("Gate", "7759-86 · NOTIFY_APPLY")),
+    # What the gate's own preview shows: which file in this change reaches
+    # furthest. Rendered by the REAL gutter — see `_reach_beats`.
+    (20.8, "reach", ()),
     (21.2, "det", ("applied · verified · committed 90706b8", "ok")),
     # The op FINISHES, and collapses to one line. Before #70250 nothing
     # rendered this: an unfocused op left no trace at all, and a focused
@@ -793,6 +810,49 @@ def _body_store() -> Any:
 _STORE: Any = None
 
 
+def _reach_beats(at: float) -> List[Any]:
+    """The reach gutter as deck lines. NEVER raises.
+
+    Through `blast_gutter.set_resolver`, never the advisor's own cache: that
+    cache is read by live GATE decisions, so a display surface writing to it
+    could let a demonstration change what the organism decides.
+
+    Not every file resolves, deliberately. Reach is cached per key, a
+    multi-file op leaves only its aggregate behind, and a cold scan is a
+    39-43s burn no display surface may trigger — so `?` is what an operator
+    will usually see, and a fully-resolved gutter would be a lie about the
+    common case.
+    """
+    try:
+        from backend.core.ouroboros.ui import blast_gutter as bg
+        seeded = {
+            "backend/core/ouroboros/governance/risk_tier_floor.py":
+                (47, "measured"),
+            "backend/core/ouroboros/governance/vision_floor.py":
+                (12, "localized_lower_bound"),
+            "tests/governance/test_risk_tier_floor.py": (0, "measured"),
+        }
+        paths = list(seeded) + ["docs/RISK_TIERS.md"]
+        bg.set_resolver(
+            lambda ps, root=None: seeded.get(list(ps)[0]) if ps else None)
+        try:
+            rows = bg.annotate_set(bg.peek(paths))
+            summary = bg.summary(bg.peek(paths))
+        finally:
+            bg.set_resolver(None)
+        # `summary` already opens with "reach"; prefixing it again produced
+        # "reach · reach 47 · 1 unmeasured".
+        out: List[Any] = [(at, _compose("det", (summary,)))]
+        for row in rows:
+            name = row.reach.path.rsplit("/", 1)[-1]
+            out.append((at, _compose(
+                "det", (f"  {row.bar} {row.label:>4}  {name}", "muted"))))
+        return out
+    except Exception:  # noqa: BLE001 — a demo must never be what breaks
+        logger.debug("[OvDemo] reach beat degraded", exc_info=True)
+        return []
+
+
 def compose_live_script() -> List[Any]:
     """`[(seconds, line), ...]` — the beats, composed and block-separated.
 
@@ -813,6 +873,10 @@ def compose_live_script() -> List[Any]:
             continue
         if kind == "agent":
             out.extend(_agent_beats(at, args))
+            continue
+        if kind == "reach":
+            out.append((at, ""))
+            out.extend(_reach_beats(at))
             continue
         # The separator rides the SAME timestamp as the line it precedes, so
         # the block opens as one visual event instead of a gap that appears a

--- a/tests/cli/test_ov_demo.py
+++ b/tests/cli/test_ov_demo.py
@@ -331,8 +331,8 @@ class TestProvenanceBeats:
         assert {"annotate", "claiming"} <= called
 
     def test_every_marked_rung_appears_in_the_transcript(self):
-        from backend.core.ouroboros.cli.ov_demo import _SCRIPT, _compose
-        rendered = " ".join(_compose(k, a) for k, a in _SCRIPT)
+        from backend.core.ouroboros.cli.ov_demo import transcript_lines
+        rendered = " ".join(transcript_lines())
         for glyph in ("‹model›", "‹synthetic›",
                       "‹unverified›", "‹stated›"):
             assert glyph in rendered, glyph
@@ -342,3 +342,53 @@ class TestProvenanceBeats:
         transcript the cockpit does not produce."""
         from backend.core.ouroboros.cli.ov_demo import _compose
         assert "‹" not in _compose("det", ("Read 847 lines",))
+
+
+class TestOneStoryTwoProjections:
+    """There used to be two hand-authored beat lists telling the same op in
+    two presentations, and they drifted: provenance beats added to the
+    transcript never reached the live cockpit."""
+
+    def test_the_transcript_is_DERIVED_from_the_live_beats(self):
+        import backend.core.ouroboros.cli.ov_demo as mod
+        src = pathlib.Path(mod.__file__).read_text()
+        fn = next(n for n in ast.walk(ast.parse(src))
+                  if isinstance(n, ast.FunctionDef)
+                  and n.name == "transcript_lines")
+        called = {ast.unparse(n.func) for n in ast.walk(fn)
+                  if isinstance(n, ast.Call)}
+        assert "compose_live_script" in called
+
+    def test_there_is_no_second_beat_list(self):
+        import backend.core.ouroboros.cli.ov_demo as mod
+        src = pathlib.Path(mod.__file__).read_text()
+        assigns = [t.id for n in ast.walk(ast.parse(src))
+                   if isinstance(n, ast.AnnAssign) and isinstance(n.target,
+                                                                  ast.Name)
+                   for t in (n.target,)
+                   if t.id.endswith("BEATS") or t.id == "_SCRIPT"]
+        assert assigns == ["_LIVE_BEATS"], assigns
+
+    def test_callable_beats_are_dropped_not_CALLED(self):
+        """`_agent_beats` emits closures that mutate the real AgentRoster.
+        A static transcript has no panel to mutate; calling them would leave
+        a real roster populated by a scene that never showed it."""
+        from backend.core.ouroboros.cli.ov_demo import transcript_lines
+        assert all(isinstance(x, str) for x in transcript_lines())
+
+    def test_the_agora_renders_exactly_once(self):
+        """The scene used to call the thread renderer itself AND inherit it
+        from the projection."""
+        from backend.core.ouroboros.cli.ov_demo import transcript_lines
+        joined = "\n".join(transcript_lines())
+        assert joined.count("@cassandra") == 1
+
+    def test_the_reach_gutter_reaches_BOTH_scenes(self):
+        from backend.core.ouroboros.cli.ov_demo import (
+            compose_live_script, transcript_lines,
+        )
+        live = " ".join(l for _a, l in compose_live_script()
+                        if isinstance(l, str))
+        for token in ("≥12", "unmeasured"):
+            assert token in live, token
+            assert token in " ".join(transcript_lines()), token


### PR DESCRIPTION
`ov demo transcript` and `ov demo live` were **two hand-authored beat lists narrating the same operation** — 7759-86 on `risk_tier_floor.py` — in two presentations, with nothing connecting them.

They had already drifted, and I caused it: the provenance beats I added last commit went into `_SCRIPT`, so `ov demo transcript` showed the epistemic marks and the live cockpit did not.

## Why copying the beats across was the wrong fix

It would have deepened the duplication rather than removed it. The second list would still exist, and the next beat added to either would drift again — the same shape as `/narrate`'s hardcoded producer list.

## The transcript is now a projection

`compose_live_script` already renders every beat kind — tools, agents, agora, collapse — so the only real difference between the scenes was whether the timestamps are obeyed.

`_SCRIPT` is **deleted**. `transcript_lines()` is the live script with the clock removed. A beat added once appears in both, pinned by a structural test that `_LIVE_BEATS` is the only beat list in the module.

**The payoff was bigger than the fix.** The transcript had been showing a thin nine-beat version while the live scene carried tool blocks with parked lines, real diffs, `/expand t-N` refs and the 💭 intent line. Unifying handed the static scene all of it for free.

## Two things unification exposed

**Callable beats.** The live script carries lines to print *and* closures the driver invokes for side effect — `_agent_beats` mutates the real `AgentRoster` so the cockpit's agent panel fills in as the demo runs. A static transcript has no panel to mutate and no clock to mutate it on, so callables are dropped rather than called. Calling them would leave a real roster populated by a scene that never showed it.

**The agora rendered twice** — once from the projection's `agora` beat, once from `scene_transcript`'s own leftover call. Invisible while the two scripts were separate; a failing test the moment they weren't.

## Epistemics folded into the story, not bolted beside it

The four provenance beats now sit where the narrative actually produces them — the model's claim after the failing pytest, the unverified blast beside it, the operator's stated reason, the synthetic preamble at L2. The pytest result above them stays clean, because it is **observed**:

```
⎿  the fixture is stale — the loader caches by path  ‹model›
⎿  blast radius 50 files                            ‹unverified›
⎿  operator: "that except clause is load-bearing"   ‹stated›
⎿  🗣 I'll rebuild the fixture                       ‹synthetic›
```

The reach gutter lands at the **GATE** beat — the moment a NOTIFY_APPLY preview really would show one:

```
⎿  reach 47 · 1 unmeasured
⎿    ██████   47  risk_tier_floor.py
⎿    █▅      ≥12  vision_floor.py
⎿    ·         0  test_risk_tier_floor.py
⎿    ?         ?  RISK_TIERS.md
```

Rendered by the real gutter through `blast_gutter.set_resolver`, never the advisor's own cache. Not every file resolves, deliberately: reach is cached per key, a multi-file op leaves only its aggregate behind, and a cold scan is a 39–43s burn no display surface may trigger. `?` is what an operator will usually see.

**5 new tests · 38 green** in the demo suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies the demo into one story with two projections: the transcript now derives from the live script to eliminate drift. Epistemic marks and the reach gutter appear in both scenes at the right moments.

- **New Features**
  - Epistemic marks are folded into the story at their production points; the observed pytest result stays clean.
  - Reach gutter renders at `Gate` via `blast_gutter.set_resolver`; unresolved files show `?` by design.
  - The transcript inherits full live details (tool blocks, diffs, intent lines).

- **Refactors**
  - Deleted duplicate `_SCRIPT`; transcript is `transcript_lines()` from `compose_live_script`; `_LIVE_BEATS` is the only beat list (pinned by a structural test).
  - Transcript drops callable beats to avoid mutating live state; the agora now renders exactly once.
  - Added 5 tests; demo suite stays green.

<sup>Written for commit 4549178cd30df47e024f757e050c28b6089d60a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

