### PR TITLE
fix(ov): the cockpit measures the terminal it is actually in

### DIFF
--- a/backend/core/ouroboros/battle_test/bipartite_layout.py
+++ b/backend/core/ouroboros/battle_test/bipartite_layout.py
@@ -213,6 +213,22 @@ def _canvas_max_lines() -> int:
         return _DEFAULT_MAX_LINES
 
 
+def _terminal_size() -> "tuple":
+    """``(columns, lines)`` from the live terminal. NEVER raises.
+
+    The fallback is only for a genuinely sizeless stdout (a pipe, a CI
+    runner). It is deliberately NOT the old 100x24 default: a value that
+    silently stands in for a real measurement is how a hardcoded 24 survived
+    long enough to clip the deck.
+    """
+    try:
+        import shutil
+        sz = shutil.get_terminal_size(fallback=(100, 24))
+        return (int(sz.columns), int(sz.lines))
+    except Exception:  # noqa: BLE001
+        return (100, 24)
+
+
 class BipartiteLayout:
     """The TUI multiplexer: a bounded Zone-1 telemetry ring + Rich composition of
     the two zones + resize recompute. Pure/headless-testable — the live
@@ -224,8 +240,8 @@ class BipartiteLayout:
         *,
         registry: Any = None,
         max_lines: Optional[int] = None,
-        width: int = 100,
-        height: int = 24,
+        width: Optional[int] = None,
+        height: Optional[int] = None,
         invalidate: Optional[Callable[[], None]] = None,
         title: str = "◇ O+V · proactive canvas",
     ) -> None:
@@ -240,8 +256,20 @@ class BipartiteLayout:
         )
         self._viewport = CanvasViewport()
         self._registry = registry
-        self._width = max(10, int(width))
-        self._height = max(3, int(height))
+        # Seeded from the LIVE terminal, not from a constant. `height=24`
+        # was a hardcoded dimension every caller that omitted it inherited
+        # forever: `_line_budget` deducts chrome from `self._height`, so a
+        # frozen 24 clipped the deck identically at LINES=30 and LINES=120,
+        # and `scroll_metrics` handed the scroll keys that same stale budget
+        # — the deck could neither show its tail nor be scrolled to it.
+        #
+        # SIGWINCH keeps it true afterwards (see `handle_sigwinch`, wired at
+        # application build). Seeding matters independently: SIGWINCH fires
+        # on CHANGE, so a cockpit booted into an 80x50 terminal that is never
+        # resized would otherwise run its whole life believing it had 24 rows.
+        seed_w, seed_h = _terminal_size()
+        self._width = max(10, int(seed_w if width is None else width))
+        self._height = max(3, int(seed_h if height is None else height))
         self._invalidate = invalidate
         self._title = title
         self._resize_count = 0
@@ -957,6 +985,20 @@ def build_bipartite_application(
         pass
     # Scrollback keys. In the alternate screen the terminal no longer offers
     # its own, so these ARE the scrollback — not a convenience layered on it.
+    # SIGWINCH → the layout. `handle_sigwinch` existed, read the live
+    # terminal, and had NO CALLER: a resize never reached `_line_budget`, so
+    # the deck kept clipping to whatever height the constructor was given.
+    # Registered here rather than in each caller so every surface that builds
+    # this Application inherits it — the demo and the daemon cockpit alike.
+    #
+    # Best-effort by design: signal handlers may only be installed on the
+    # main thread, and a cockpit hosted on a worker must still render. It
+    # degrades to the constructor seed, which is now the live size anyway.
+    try:
+        import signal as _signal
+        _signal.signal(_signal.SIGWINCH, mux.handle_sigwinch)
+    except (ValueError, OSError, AttributeError):
+        pass
     try:
         install_scroll_bindings(
             kb, mux._viewport, mux.scroll_metrics, mux._invalidate_now,


### PR DESCRIPTION
Two dimensional defects, found while chasing a scrolling report.

## `height: int = 24`

A hardcoded dimension every caller that omitted it inherited permanently. `ov demo live` constructs `BipartiteLayout()` with no arguments, so its deck believed it had 24 rows in a 50-row terminal for the whole session.

That number is load-bearing twice: `_line_budget` deducts chrome from `self._height` to size the window, and `scroll_metrics` hands the scroll keys **that same number** as the clamp they move against. A stale height mis-sizes the view and the scrolling clamp together.

## `handle_sigwinch` had zero callers

It already read the live terminal and recomputed both zones. Nothing registered it — the wired-but-inert shape this codebase keeps hitting, and the reason the constructor default was load-bearing at all.

## Both halves are needed

Neither substitutes for the other. SIGWINCH fires on **change**, so a cockpit booted into an 80×50 terminal that is never resized would run its whole life on the seed. And a correct seed goes stale the first time the operator drags a window edge.

So: the seed comes from the live terminal through one shared `_terminal_size()` probe, and SIGWINCH is registered at **application build** — once, where every surface that builds this Application inherits it, rather than in each caller.

Registration is best-effort by design: signal handlers may only be installed on the main thread, and a cockpit hosted on a worker must still render. It degrades to the seed, which is now the live size anyway.

The probe's fallback is deliberately **not** the old 100×24 — a value that silently stands in for a real measurement is exactly how a hardcoded 24 survived long enough to be found by accident.

## Verification

Under a PTY, a 50-row terminal now seeds `height 50 / budget 49` where it previously read 24 regardless. **32 green** across the bipartite and canvas-viewport suites.

## Honest scope

This does **not** change scrolling. `CanvasViewport` already holds position across appends and invalidate storms (proven separately), and Zone-1 already renders through it — the layout reports `↑ 46 above · shift+↑ to scroll` with the tail correctly visible. These are real dimensional bugs found on the way, not the cause of any scroll complaint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the real terminal size at startup and update on resize so the cockpit renders and scrolls with correct dimensions. This removes the 24-row default and wires up resize handling.

- **Bug Fixes**
  - Seed `BipartiteLayout` from a new `_terminal_size()` probe; optional `width`/`height` still override.
  - Register `SIGWINCH` at application build to call `handle_sigwinch`; best-effort if signal install isn’t allowed.
  - Fix clipped views and wrong scroll clamps by basing `_line_budget` and `scroll_metrics` on the live `self._height`.

<sup>Written for commit 733ca20049c884be8a813b67404bda233ad5f2f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

