### PR TITLE
fix(ov): measure what was handed over, and what the canvas was given

### DIFF
--- a/backend/core/ouroboros/battle_test/bipartite_layout.py
+++ b/backend/core/ouroboros/battle_test/bipartite_layout.py
@@ -274,6 +274,13 @@ class BipartiteLayout:
         self._title = title
         self._resize_count = 0
         self._sprite: Any = None            # the DORMANT/WAKING hero animation
+        # The seed above is an ESTIMATE: the terminal's size stands in for the
+        # canvas's own allotment because nothing has measured the canvas yet.
+        # It is a fair guess and it is the best available before the first frame
+        # — a cockpit still has to draw something. `observe_allotment` replaces
+        # it with the framework's real number on that first render and flips
+        # this, so no reader ever mistakes the stand-in for the measurement.
+        self._allotment_measured = False
 
     # -- the Ouroboros hero animation -----------------------------------
 
@@ -374,8 +381,90 @@ class BipartiteLayout:
 
     # -- rendering ------------------------------------------------------
 
+    def observe_allotment(self, width: Optional[int],
+                          height: Optional[int]) -> bool:
+        """Record the rows and columns this canvas was ACTUALLY given.
+
+        The whole clipping defect in one sentence: the canvas was sizing itself
+        against the TERMINAL when what bounds it is the REGION its parent
+        `HSplit` hands it, and those are the same number only in a cockpit with
+        no header, no toolbar, no status row, no search bar, no pending strip,
+        no turn row and no agent view.
+
+        Measured, at 200x60 with a 12-row crest mounted: the mux believed it had
+        39 rows and produced 39 lines into a window that was given 8. Thirty-one
+        lines were dropped — and because a `Window` draws a content block from
+        its TOP, the rows it kept were the OLDEST of them. The operator was left
+        watching a window parked thirty-one lines behind the live tail, which is
+        the precise reason the last beats of a script "never rendered".
+
+        Predicting the answer is what failed, and every version of predicting
+        fails the same way. `_canvas_fragments` reserved exactly one row for
+        chrome (`size.rows - 1`), which was true when the cockpit was a canvas
+        and a prompt; each strip added since made it wronger, silently, because
+        nothing compared the prediction to reality. Deducting the strips instead
+        would mean this class re-deriving its parent's layout arithmetic — two
+        implementations of one truth, drifting the next time a row is added.
+
+        So it is OBSERVED, at the seam the framework already provides for it:
+        `UIControl.create_content(width, height)` is prompt_toolkit telling a
+        control exactly what it has. That is authoritative rather than inferred,
+        it needs no knowledge of what the siblings cost, and it stays correct
+        through a resize, a palette opening, a strip appearing mid-session, and
+        any row some future arc adds — none of which this method has to know
+        about.
+
+        Returns whether the allotment changed. NEVER raises.
+
+        A zero or ``None`` height is REFUSED rather than recorded. Those are
+        real states — a `ConditionalContainer` collapsed, a control asked to
+        measure rather than draw — and treating them as a budget would render an
+        empty deck and then invalidate on the emptiness. The last good
+        measurement is a better answer than a degenerate fresh one.
+        """
+        try:
+            changed = False
+            if width is not None and int(width) > 0:
+                new_width = max(10, int(width))
+                if new_width != self._width:
+                    self._width, changed = new_width, True
+            if height is not None and int(height) > 0:
+                new_height = max(3, int(height))
+                if new_height != self._height:
+                    self._height, changed = new_height, True
+                # Provenance is set even when the number is unchanged: an
+                # estimate that happens to equal the measurement is still an
+                # estimate until something measures it, and `allotment_measured`
+                # is what tells a reader which one they are looking at. Same
+                # rule the advisor follows about a cap that coincides with a
+                # real blast radius.
+                self._allotment_measured = True
+            return changed
+        except (TypeError, ValueError):
+            return False
+
+    @property
+    def allotment_measured(self) -> bool:
+        """Has a real render told us our size, or are we still guessing?
+
+        Exposed because "38 rows, measured" and "38 rows, assumed" are different
+        facts, and a surface that cannot tell them apart is how a hardcoded 24
+        survived long enough to be found by accident. The estimate is a
+        legitimate fallback before the first frame; it must simply never wear a
+        measurement's authority.
+        """
+        return bool(getattr(self, "_allotment_measured", False))
+
     def _line_budget(self) -> int:
-        """Rows the canvas may draw into, frame chrome deducted."""
+        """Rows the canvas may draw into, frame chrome deducted.
+
+        ``self._height`` is the canvas's OWN allotment — observed from the
+        framework once a frame has rendered (see :meth:`observe_allotment`),
+        estimated from the terminal before that. The chrome deduction is
+        unchanged and still means what it always meant: rows this canvas spends
+        on its own panel border and title. It was never wrong; it was being
+        subtracted from the wrong number.
+        """
         chrome = 4 if os.environ.get(
             "JARVIS_BIPARTITE_BORDER", "",
         ).strip().lower() in ("1", "true", "yes", "on") else 1
@@ -806,7 +895,19 @@ def build_bipartite_application(
     stream_rows: Optional[Callable[[], Any]] = None,
     queue_rows: Optional[Callable[[], Any]] = None,
     panic_rows: Optional[Callable[[], Any]] = None,
-    on_mux: Optional[Callable[[Any], None]] = None,
+    # NOTE: no `on_mux` here, deliberately. It belongs to `run_bipartite_repl`,
+    # which CONSTRUCTS the multiplexer and therefore has something to hand
+    # back. A caller of this function already holds the mux — it passes it in
+    # as the first argument — so an `on_mux` callback here could only ever
+    # return the caller's own object to it.
+    #
+    # It was in this signature, read by nothing, passed by nobody: dead API
+    # surface that invited exactly one mistake, and duly caused it. Planning
+    # this work, I recommended "pass `on_mux` in the demo so in-transcript
+    # streaming demos its real mechanic" — which would have silently done
+    # nothing, because `ov demo live` calls THIS function directly. Removed
+    # rather than documented; a parameter that cannot be correct to pass should
+    # not be offered.
     serpent_active: Optional[Callable[[], bool]] = None,
 ) -> Any:
     """Construct the full-screen ``prompt_toolkit.Application``: Zone 1 an ANSI
@@ -824,19 +925,50 @@ def build_bipartite_application(
     from prompt_toolkit.key_binding import KeyBindings
 
     def _canvas_fragments():
-        # Re-sync dims to the live terminal each render → SIGWINCH handled for free.
-        try:
-            app = _APP_REF.get("app")
-            if app is not None and app.output is not None:
-                size = app.output.get_size()
-                if (size.columns, size.rows) != (mux.width, mux.height):
-                    mux.on_resize(size.columns, max(4, size.rows - 1))  # reserve deck row
-        except Exception:  # noqa: BLE001
-            pass
+        # NO terminal probe here any more, and no `size.rows - 1`.
+        #
+        # This used to re-sync the mux to `app.output.get_size()` minus one row
+        # "for the deck", which is a PREDICTION of what the surrounding HSplit
+        # would leave over. It was right while the cockpit was a canvas and a
+        # prompt, and every strip added since made it wronger by a row or twelve
+        # — silently, because nothing ever compared it to what the canvas was
+        # actually given. `_MeasuredCanvasControl` below now supplies the real
+        # number before this callable runs, so by here the budget is already
+        # correct for THIS frame.
         return ANSI(mux.render_canvas_ansi())
 
+    class _MeasuredCanvasControl(FormattedTextControl):
+        """A canvas control that tells the mux how big it really is.
+
+        `create_content(width, height)` is prompt_toolkit handing a control its
+        exact allotment for the frame about to be drawn. Recording it here — and
+        crucially, BEFORE delegating to ``super()``, which is what invokes the
+        text callable — means the very frame being measured is also the frame
+        that renders at the corrected size. There is no lag and no first-frame
+        flash of clipped content.
+
+        The alternative was to read ``window.render_info`` after a render, which
+        is the same measurement one frame late; every resize would then show a
+        single wrong frame, and a resize is exactly when an operator is looking.
+
+        A resize is published through the mux's existing invalidate so any
+        surface hanging off it repaints — the same hook `attach_sprite` and the
+        ReactiveTheme already use. Only on CHANGE: invalidating every frame from
+        inside a render is a repaint loop, and `observe_allotment` returning a
+        changed-flag is what keeps that honest.
+        """
+
+        def create_content(self, width, height=None):  # noqa: ANN001
+            try:
+                if mux.observe_allotment(width, height):
+                    mux._invalidate_now()
+            except Exception:  # noqa: BLE001 — never break a frame to measure it
+                logger.debug("[Bipartite] allotment observation degraded",
+                             exc_info=True)
+            return super().create_content(width, height)
+
     canvas = Window(
-        content=FormattedTextControl(_canvas_fragments, focusable=False),
+        content=_MeasuredCanvasControl(_canvas_fragments, focusable=False),
         wrap_lines=False, height=_canvas_dimension(),
     )
     # Ctrl+R history search rides the SAME completion menu the palette
@@ -1207,7 +1339,29 @@ def build_bipartite_application(
                 rows += [_pending_row]
         except Exception:  # noqa: BLE001
             logger.debug("[Bipartite] pending row unavailable", exc_info=True)
-    # The search bar sits DIRECTLY above the prompt    # The palette is NOT a row. See the FloatContainer below: as an HSplit row
+    # The search bar sits DIRECTLY above the prompt: while it is open it IS the
+    # next keystroke, which is the rule `_below_prompt` states for what goes
+    # above the caret versus what goes below it.
+    #
+    # This mount is a REPAIR. The comment above survived an edit that lost the
+    # code, leaving `search_rows` accepted by the signature, forwarded here by
+    # `run_bipartite_repl`, resolved by `ov.py::_transcript_search_rows` — and
+    # read by nothing. Transcript search was dark on the SHIPPING client, not
+    # merely in a demo, and the test guarding it asserted `"search_rows=" in
+    # src` so it passed for the entire period the feature did nothing.
+    #
+    # `build_dynamic_rows`' own docstring names this row — "the agent view, the
+    # search bar, and whatever comes next" — so the geometry primitive was
+    # built for it and then never handed it. Found by
+    # `ui/capability_handoff.py`, which exists because of this defect.
+    if search_rows is not None:
+        try:
+            _search_row = build_dynamic_rows(search_rows)
+            if _search_row is not None:
+                rows += [_search_row]
+        except Exception:  # noqa: BLE001
+            logger.debug("[Bipartite] search row unavailable", exc_info=True)
+    # The palette is NOT a row. See the FloatContainer below: as an HSplit row
     # it shares the ambient grid with the canvas, so every asynchronous Deck or
     # Lane frame arriving underneath forces the palette's geometry to be
     # recomputed along with everything else.

--- a/backend/core/ouroboros/cli/ov_demo.py
+++ b/backend/core/ouroboros/cli/ov_demo.py
@@ -31,6 +31,10 @@ from typing import Any, Callable, List, Optional, Sequence
 
 logger = logging.getLogger("Ouroboros.OvDemo")
 
+# A declared decline, readable by `ui/capability_handoff`'s audit. Returns None,
+# so passing `hook=waived(reason)` is identical at runtime to omitting the hook.
+from backend.core.ouroboros.ui.capability_handoff import waived
+
 __all__ = ["run_demo", "demo_scenes", "DEMO_HELP",
            "transcript_lines"]
 
@@ -1290,6 +1294,296 @@ async def _drive(mux: Any, app: Any, speed: float,
 
 
 
+# ---------------------------------------------------------------------------
+# The INPUT surface — the half of the cockpit the demo used to leave dark
+# ---------------------------------------------------------------------------
+#
+# `ov demo live` built the same Application `ov attach` builds and filled 8 of
+# its 19 hooks. Every unfilled one was an input-or-state surface, so an entire
+# merged arc — remappable keybindings, one verb registry, argument completion,
+# ghost text, Ctrl+R search — had no demo presence at all. The operator's
+# report was "there are features I never see", and they were right about the
+# cause more than the symptom: nothing bound the demo's coverage to the
+# cockpit's capability, so a hook could land and drift with nothing to notice.
+#
+# `ui/capability_handoff.py` is the structural answer (a builder's parameter
+# list IS the self-updating statement of what it can be given). These helpers
+# are the demo's side of it: every one resolves the REAL collaborator the
+# attach client uses, for the reason stated at the top of this module.
+
+
+def _demo_completer() -> Any:
+    """The `/` palette, from the LIVE verb registry. NEVER raises.
+
+    The same `_build_slash_completer` the attach client mounts, so the demo
+    shows the operator's actual verb set — 83 today, whatever it is tomorrow —
+    rather than a sample that would rot. `_demo_palette` already proved this
+    approach in the transcript scene; this puts it on the surface an operator
+    types into.
+    """
+    try:
+        from backend.core.ouroboros.cli.ov import _build_slash_completer
+        _ensure_primed()
+        return _build_slash_completer()
+    except Exception:  # noqa: BLE001
+        logger.debug("[OvDemo] completer unavailable", exc_info=True)
+        return None
+
+
+def _demo_history() -> Any:
+    """Recall for Ctrl+R and the Up arrow — IN MEMORY, never the real file.
+
+    `ov.py::_build_prompt_history` returns a `FileHistory` on the shared
+    `.jarvis/repl_history`, and mounting that here would make watching a demo
+    write into the operator's own recall. Same hazard the reach gutter refused
+    when it stopped seeding the advisor's live cache: a demo may lie to itself,
+    it may never leave a mark on the organism.
+
+    Seeded from the script's own operator lines so Ctrl+R has something true to
+    find — derived from `_BACKLOG_LINES` rather than invented, so the recall and
+    the queue strip cannot disagree about what was typed.
+    """
+    try:
+        from prompt_toolkit.history import InMemoryHistory
+        history = InMemoryHistory()
+        for line in _BACKLOG_LINES:
+            history.append_string(line)
+        return history
+    except Exception:  # noqa: BLE001
+        logger.debug("[OvDemo] history unavailable", exc_info=True)
+        return None
+
+
+def _demo_auto_suggest() -> Any:
+    """History ghost-text, through the cockpit's own factory. NEVER raises."""
+    try:
+        from backend.core.ouroboros.battle_test.repl_completion import (
+            build_auto_suggest,
+        )
+        return build_auto_suggest()
+    except Exception:  # noqa: BLE001
+        logger.debug("[OvDemo] auto-suggest unavailable", exc_info=True)
+        return None
+
+
+def _demo_status_rows() -> Any:
+    """The standing status line, from `serpent_flow`'s own provider.
+
+    Imported rather than rebuilt for the same reason `_agent_view_rows` is: a
+    second provider here would be a second opinion about what a status line
+    looks like, and the demo would keep agreeing with itself after the real one
+    regressed.
+    """
+    try:
+        from backend.core.ouroboros.battle_test.serpent_flow import (
+            _local_status_rows,
+        )
+        return _local_status_rows
+    except Exception:  # noqa: BLE001
+        logger.debug("[OvDemo] status rows unavailable", exc_info=True)
+        return None
+
+
+def _demo_search_rows() -> Any:
+    """The transcript search bar, from the module that owns it.
+
+    Worth stating why this row exists at all: `search_rows` was accepted by
+    `build_bipartite_application` and read by NOTHING, so this bar was dark on
+    the shipping attach client — not merely absent from the demo. Mounting it
+    here means a regression in the mount shows up in the one scene an operator
+    watches.
+    """
+    try:
+        from backend.core.ouroboros.battle_test.transcript_hatches import (
+            search_status,
+        )
+        return search_status
+    except Exception:  # noqa: BLE001
+        logger.debug("[OvDemo] search rows unavailable", exc_info=True)
+        return None
+
+
+#: When the Gate's rejection window is open. Straddles the GATE beat at 20.4 so
+#: the countdown and the `Gate · NOTIFY_APPLY` line describe one moment.
+_PENDING_AT = (20.4, 22.0)
+
+
+def _pending_rows(elapsed: float, width: int) -> List[str]:
+    """The NOTIFY_APPLY countdown, through the REAL renderer. NEVER raises.
+
+    `pending_apply.render` takes a transport snapshot, so the demo composes one
+    rather than drawing a strip — the countdown arithmetic, the width clipping
+    and the `applying…` end state are all the shipping renderer's, and a
+    regression in any of them surfaces here.
+
+    ``age_s`` advances the countdown DOWN between frames, which is what makes
+    the seconds tick rather than step. Derived from the demo clock so it obeys
+    ``--speed`` like everything else.
+    """
+    try:
+        from backend.core.ouroboros.battle_test.pending_apply import render
+        lo, hi = _PENDING_AT
+        if not (lo <= elapsed <= hi):
+            return []
+        total = max(0.01, hi - lo)
+        return render(
+            {
+                "schema_version": "pending_apply.v1",
+                "entries": [{
+                    "op_id": "7759-86",
+                    "summary": "risk_tier_floor.py · 1 file · NOTIFY_APPLY",
+                    "remaining_s": total,
+                }],
+            },
+            age_s=max(0.0, elapsed - lo), width=width,
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug("[OvDemo] pending strip unavailable", exc_info=True)
+        return []
+
+
+def _demo_turn_spinner(clock: Callable[[], float],
+                       started: Callable[[], float],
+                       speed: float) -> Any:
+    """The in-place turn spinner, bound to the demo's own clock. NEVER raises.
+
+    A real `TurnSpinner` reading a synthetic heartbeat: it renders the verb, the
+    elapsed and the token count for the question the operator just asked, in
+    place, between the deck and the prompt. The demo drives it from the same
+    `_GENERATING` windows the pulse and the serpent border use, so all three
+    agree about whether the organism is thinking — a spinner that runs while
+    the toolbar says idle teaches an operator to trust neither.
+    """
+    try:
+        from backend.core.ouroboros.battle_test.turn_spinner import TurnSpinner
+
+        def _heartbeat() -> Any:
+            script_t = max(0.0, clock() - started()) * max(0.01, speed)
+            if not _demo_generating(script_t):
+                return None
+            return {
+                "kind": "heartbeat",
+                "active": True,
+                "verb": "Synthesizing",
+                "elapsed_s": script_t,
+                "tokens_total": int(_generating_seconds(script_t) * 780),
+                "provider_label": "DEMO",
+            }
+
+        return TurnSpinner(heartbeat_fn=_heartbeat, now_fn=clock)
+    except Exception:  # noqa: BLE001
+        logger.debug("[OvDemo] turn spinner unavailable", exc_info=True)
+        return None
+
+
+def _header_lines() -> List[str]:
+    """The text beside the crest — what this cockpit IS, in three lines.
+
+    Says DEMO explicitly. A header identical to the attach client's would make a
+    screenshot of a synthetic session indistinguishable from a real one, and the
+    entire value of this scene is that an operator can trust what it shows.
+    """
+    dim = _THEME("dim")
+    return [
+        "◇ O+V · demo canvas",
+        f"[{dim}]synthetic events · no provider, no tokens[/{dim}]",
+        f"[{dim}]q to quit · / for verbs · ctrl+r to search[/{dim}]",
+    ]
+
+
+def _demo_header() -> "tuple[Any, int]":
+    """``(render, height)`` for the crest above the deck, or ``(None, 0)``.
+
+    Rendered by `crest_animator`'s own `render_cockpit_header`, so the demo
+    cannot show an emblem the cockpit no longer draws — the failure that
+    produced "the logos don't match" in the first place.
+
+    This was WAIVED for most of a session, and the reason is worth keeping: at
+    its natural 12 rows the crest made the last four beats of the script vanish.
+    Not a crest bug. The canvas was budgeting against the TERMINAL instead of
+    against the rows its parent actually gave it, so a header simply exposed an
+    arithmetic error that any strip would have exposed eventually. Capping the
+    height from here was tried and rejected as a workaround — it trades the
+    emblem for the transcript and leaves every other row unaccounted.
+
+    `BipartiteLayout.observe_allotment` fixed it at the root by measuring the
+    allotment at prompt_toolkit's own `create_content` seam, so the header costs
+    the deck nothing it has not accounted for and can be mounted honestly.
+    """
+    try:
+        from backend.core.ouroboros.ui.crest_animator import (
+            MiniCrest, render_cockpit_header,
+        )
+        mini = MiniCrest()
+        if not mini.available:
+            return (None, 0)
+        # Frames are built off-thread; the attach client kicks the same coroutine
+        # at mount. Without it the crest draws its static fallback rather than
+        # the animated emblem — correct, and not what the arc was about.
+        try:
+            import asyncio
+            asyncio.ensure_future(mini.ensure_frames())
+        except Exception:  # noqa: BLE001
+            pass
+
+        def _render() -> str:
+            try:
+                import shutil
+                import time
+                width = shutil.get_terminal_size(fallback=(100, 30)).columns
+                return render_cockpit_header(
+                    mini, _header_lines(), width, now=time.monotonic(),
+                )
+            except Exception:  # noqa: BLE001
+                return ""
+
+        return (_render, max(3, int(getattr(mini, "rows", 3) or 3)))
+    except Exception:  # noqa: BLE001
+        logger.debug("[OvDemo] crest header unavailable", exc_info=True)
+        return (None, 0)
+
+
+#: A defect found by WATCHING this scene — FIXED at the root, kept as the record.
+#:
+#: Mounting a 12-row crest header made the last four beats of the script — the
+#: Gate, the reach gutter, the collapse line and Complete — disappear from a
+#: 200x60 terminal. Proven not to be the driver: a headless run of `_drive`
+#: against a recording multiplexer delivers all 89 beats, Complete included.
+#: Proven to be the header: with `_demo_header` stubbed to `(None, 0)` and
+#: nothing else changed, `Gate(`, `reach` and `≥12` all render again.
+#:
+#: Root cause: `BipartiteLayout` seeds its canvas budget from the TERMINAL size
+#: (#70279 corrected it from a hardcoded 24 to the live terminal, which was the
+#: right fix for the bug it was chasing) and `_line_budget` deducts only the
+#: canvas's own chrome. It does not know what the surrounding `HSplit` spends on
+#: a header, a toolbar, a status row, a search bar, a pending strip, a turn row
+#: or the agent view. So the canvas renders more lines than its window can hold
+#: and prompt_toolkit clips the overflow — from the BOTTOM, which is where the
+#: newest and only interesting lines are.
+#:
+#: It was never a demo problem. `ov attach` mounts a 12-row crest through the
+#: same builder, so the shipping cockpit was clipping the tail of its own
+#: transcript too — simply harder to notice where lines arrive minutes apart
+#: rather than in a 22-second script.
+#:
+#: FIXED at the root in `BipartiteLayout.observe_allotment`: the canvas now takes
+#: its size from the allotment prompt_toolkit hands `create_content`, which is
+#: authoritative rather than inferred and needs no knowledge of what the siblings
+#: cost. Capping the header from this caller was tried and REJECTED as a
+#: workaround — it trades the emblem for the transcript and leaves every other
+#: row unaccounted, so the clipping returns the next time a strip is added. It
+#: did, immediately, from the status/search/pending strips added in the same
+#: session; the workaround would have hidden that too.
+#:
+#: Kept as the record because the shape recurs: a dimension nobody measured,
+#: standing in for one nobody could see. Regression spine:
+#: `tests/battle_test/test_canvas_allotment.py`.
+_LAYOUT_CLIPPING_NOTE = (
+    "FIXED — the canvas measures the region it is given (observe_allotment) "
+    "instead of predicting it from the terminal"
+)
+
+
 def _live_exit_bindings() -> Any:
     """Keys that end the demo. NEVER raises.
 
@@ -1360,9 +1654,14 @@ def scene_live(console: Any, argv: Sequence[str] = ()) -> int:
 
     mux = BipartiteLayout()
     script = compose_live_script()
+    _header, _header_height = _demo_header()
     app = build_bipartite_application(
         mux,
-        on_accept=lambda text: None,          # input is inert in a demo
+        # Typed input executes NOTHING — this scene has no organism to act on
+        # it. The palette, completion, ghost text and Ctrl+R below are all
+        # buffer-level, so they are fully live regardless; what stays inert is
+        # only the consequence of pressing Enter.
+        on_accept=lambda text: None,
         toolbar=_live_toolbar(
             lambda: start[0], clock,
             # The script's own end, derived rather than written: a beat added
@@ -1402,6 +1701,26 @@ def scene_live(console: Any, argv: Sequence[str] = ()) -> int:
         ),
         stream_rows=lambda: _stream_rows(
             (clock() - start[0]) * speed, mux,
+        ),
+        # ------------------------------------------------------------------
+        # The INPUT half. Unfilled until now, which is why a whole merged arc
+        # of keybinding and completion work had no demo presence — see the
+        # helpers above and `ui/capability_handoff.py` for why that drifted
+        # silently rather than being noticed.
+        # ------------------------------------------------------------------
+        completer=_demo_completer(),
+        history=_demo_history(),
+        auto_suggest=_demo_auto_suggest(),
+        turn_spinner=_demo_turn_spinner(clock, lambda: start[0], speed),
+        # The crest, mountable again now that the canvas measures its own
+        # allotment instead of predicting it (`_LAYOUT_CLIPPING_NOTE`).
+        header=_header,
+        header_height=_header_height,
+        status_rows=_demo_status_rows(),
+        search_rows=_demo_search_rows(),
+        pending_rows=lambda: _pending_rows(
+            (clock() - start[0]) * speed,
+            __import__("shutil").get_terminal_size((80, 24)).columns,
         ),
     )
     try:

--- a/backend/core/ouroboros/ui/capability_handoff.py
+++ b/backend/core/ouroboros/ui/capability_handoff.py
@@ -1,0 +1,1015 @@
+"""Did the value handed across that call boundary actually get USED?
+
+`surface_reachability` states this module's reason for existing, in its own
+docstring, as the limit of what it can see:
+
+    `transcript_hatches` is reached from `ov.py` alone and is nonetheless LIVE
+    on the cockpit, because `ov.py` installs its bindings into the
+    `extra_key_bindings` the cockpit is built with. **Reachability sees
+    imports; it cannot see that a KeyBindings object was handed across.**
+
+So there are two ways a finished feature goes dark, and the repo could only
+measure one of them:
+
+    IMPORT reachability   nothing imports the module          → the board sees it
+    HANDOFF consumption   a caller passes it and the callee    → NOTHING saw it
+                          drops the value on the floor
+
+The second is what happened to `search_rows`. `ov.py` resolves
+`transcript_hatches.search_status`, hands it to `run_bipartite_repl`, which
+forwards it to `build_bipartite_application`, whose signature accepts it and
+whose body never reads it. Three cooperating call sites, one dropped value, and
+transcript search was dark on the SHIPPING client — not merely in a demo. The
+board reported the module LIVE and was right: it is imported. The surface audit
+reported it reachable and was right too.
+
+The test that was supposed to hold it asserted ``"search_rows=" in src``. It
+passed for the entire period the feature did nothing, which is the third
+appearance of that antipattern in a week.
+
+Why a signature is the right source of truth
+============================================
+The alternative is a checklist of "capabilities the cockpit has", maintained by
+hand. That is `/narrate`'s hardcoded producer list in a new costume: correct the
+day it is written, wrong the moment a hook is added, with nothing to detect the
+drift. `narrative_density` inverted exactly this — producers REGISTER and the
+dial PULLS — and the same inversion applies here with an even better authority
+available, because a builder's parameter list already IS the complete,
+self-updating statement of what it can be given.
+
+Nothing here is hardcoded to `bipartite_layout`. Sinks are DISCOVERED by shape
+(:func:`discover_sinks`): a function carrying many keyword-only collaborators is
+a hook-shaped builder, whatever it is called and wherever it lives. Add a
+second cockpit builder and it is audited without editing this file.
+
+UNSET is not WAIVED
+===================
+A surface may legitimately decline a hook — `ov demo live` keeps input inert on
+purpose, so a completer would be furniture. But *silence* cannot be the way it
+says so, because silence is also what a forgotten hook looks like, and the whole
+class of defect here is a decision nobody made.
+
+:func:`waived` is the answer, and it is deliberately the same shape as
+`provenance`'s UNKNOWN-vs-UNSET distinction: it returns ``None``, so at runtime
+it is byte-for-byte identical to not passing the argument, and statically it is
+a declared decision with a reason attached, sitting AT the call site where the
+decision was actually made rather than in a registry that can drift from it.
+
+    completer=waived("input is inert in a demo — nothing to complete against")
+
+A forward is not a consumption
+==============================
+The analysis has to distinguish three things a body can do with a parameter,
+because collapsing them is how a pass-through wrapper looks like a defect and a
+real defect looks like a wrapper:
+
+    READ             the body does something with the value
+    FORWARDED_ONLY   every use is handing it to another sink, unexamined
+    UNREAD           the body never mentions it
+
+``FORWARDED_ONLY`` is not a finding by itself — `run_bipartite_repl` forwards
+almost everything and is correct to. It becomes a finding when the chain it
+forwards INTO does not consume it either, so consumption resolves transitively
+(:func:`effective_consumption`) with a cycle guard, and only a chain that
+terminates in ``UNREAD`` is reported.
+
+Honest about what it cannot see
+===============================
+Static analysis of a dynamic language has edges, and quietly guessing at them
+would make this instrument the thing it was built to catch. Each is reported as
+``OPAQUE`` rather than as a pass or a fail:
+
+  * a sink with ``**kwargs`` accepts names no signature enumerates
+  * a caller using ``**splat`` fills names no call site enumerates
+  * a body reaching a parameter through ``getattr``/``locals()`` reads it in a
+    way no AST walk can prove
+
+Pure AST over source text. Never imports the code it measures — a module that
+would explode on import is exactly the one worth auditing — and never raises.
+"""
+from __future__ import annotations
+
+import ast
+import enum
+import logging
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
+
+logger = logging.getLogger("Ouroboros.CapabilityHandoff")
+
+CAPABILITY_HANDOFF_SCHEMA_VERSION = "capability_handoff.v1"
+
+MASTER_FLAG_ENV_VAR = "JARVIS_CAPABILITY_HANDOFF_ENABLED"
+SINKS_ENV_VAR = "JARVIS_HANDOFF_SINKS"
+SURFACES_ENV_VAR = "JARVIS_HANDOFF_SURFACES"
+MIN_HOOKS_ENV_VAR = "JARVIS_HANDOFF_MIN_HOOKS"
+ROOTS_ENV_VAR = "JARVIS_HANDOFF_ROOTS"
+
+#: How many keyword-only collaborators make a function a hook-shaped builder.
+#: Tunable because "many" is a judgement and the right number is whatever
+#: separates builders from ordinary functions in a given tree — not a constant
+#: this module is entitled to fix forever.
+DEFAULT_MIN_HOOKS = 8
+
+#: Where to look for sinks and surfaces. Same roots the surface audit uses, for
+#: the same reason: handoff into the governance core is a different question.
+DEFAULT_ROOTS: Tuple[str, ...] = (
+    "backend/core/ouroboros/battle_test",
+    "backend/core/ouroboros/ui",
+    "backend/core/ouroboros/cli",
+)
+
+_FALSY = ("0", "false", "no", "off")
+
+
+def handoff_enabled() -> bool:
+    """Default ON. This reads source; it never imports or executes it."""
+    return os.environ.get(
+        MASTER_FLAG_ENV_VAR, "1",
+    ).strip().lower() not in _FALSY
+
+
+def min_hooks() -> int:
+    """The hook-count threshold that makes a function a sink."""
+    raw = os.environ.get(MIN_HOOKS_ENV_VAR, "").strip()
+    try:
+        return max(1, int(raw)) if raw else DEFAULT_MIN_HOOKS
+    except (TypeError, ValueError):
+        return DEFAULT_MIN_HOOKS
+
+
+def audit_roots() -> Tuple[str, ...]:
+    raw = os.environ.get(ROOTS_ENV_VAR, "").strip()
+    if not raw:
+        return DEFAULT_ROOTS
+    return tuple(p.strip() for p in raw.split(",") if p.strip()) or DEFAULT_ROOTS
+
+
+# ---------------------------------------------------------------------------
+# The waiver — runtime-inert, statically loud
+# ---------------------------------------------------------------------------
+
+
+def waived(reason: str) -> None:
+    """Declare that a hook is deliberately NOT filled here. Returns ``None``.
+
+    Passing ``hook=waived("...")`` is identical at runtime to omitting the
+    argument entirely — the callee's ``if hook is not None`` guard sees exactly
+    what it saw before, so adopting this can never change behaviour. The value
+    is that the omission stops being silent.
+
+    The reason is not decoration. An unfilled hook has two possible causes and
+    they need opposite responses: "this surface has no use for it" is a design
+    decision, and "nobody noticed it existed" is the defect this module exists
+    to find. Silence cannot distinguish them; a sentence can.
+
+    Deliberately mirrors `provenance`'s rule that UNKNOWN and UNSET are
+    different states. Nobody-asked and asked-and-declined are not the same
+    fact, and a surface that renders them identically is the bug.
+
+    The reason is consumed by the AST auditor reading this call site, never at
+    runtime — so this function declares its own discard with the same ``del``
+    statement :class:`Consumption.DECLARED_DROP` was taught to recognise. If
+    the convention is good enough to exempt other people's parameters it is
+    good enough for this one.
+    """
+    del reason
+    return None
+
+
+#: The call-site spelling the auditor looks for. Derived from the function's own
+#: name so a rename cannot desynchronise the analyser from the API.
+WAIVER_CALLABLE_NAME = waived.__name__
+
+
+class Consumption(enum.Enum):
+    """What a sink's body does with a parameter it accepts."""
+
+    READ = "read"
+    FORWARDED_ONLY = "forwarded_only"
+    UNREAD = "unread"
+    #: ``del param`` — the body accepts the name and deliberately discards it.
+    #:
+    #: Python already has the statement for "I take this and intentionally do
+    #: not use it", this codebase already uses it for exactly that
+    #: (`presentation_restraint.render_minimal_welcome` accepts ``session_id``
+    #: for caller compatibility and deletes it), and inventing a decorator or a
+    #: registry to say the same thing would be a second vocabulary for a
+    #: sentence the language can already form.
+    #:
+    #: This is the sink-side mirror of :func:`waived`, and it earns the same
+    #: treatment: a declared discard is accounted for, an undeclared one is a
+    #: finding. Silence is the only thing that is ever a defect.
+    DECLARED_DROP = "declared_drop"
+    #: The body could reach it in a way AST cannot prove (``**kwargs``,
+    #: ``getattr``, ``locals()``). Never counted as either a pass or a fail.
+    OPAQUE = "opaque"
+
+
+class FillState(enum.Enum):
+    """What a calling surface does about a hook the sink offers."""
+
+    FILLED = "filled"
+    WAIVED = "waived"
+    #: Neither passed nor declared — the state that is a finding.
+    UNSET = "unset"
+    #: The caller splats ``**kwargs``, so no call site enumerates the name.
+    OPAQUE = "opaque"
+
+
+@dataclass(frozen=True)
+class Hook:
+    """One collaborator a sink is willing to accept."""
+
+    name: str
+    sink: str
+    positional: bool
+    required: bool
+    consumption: Consumption
+    #: Sinks this parameter is handed onward to, unexamined.
+    forwards_to: Tuple[str, ...] = ()
+
+    @property
+    def short_sink(self) -> str:
+        return self.sink.rsplit(".", 1)[-1]
+
+
+@dataclass(frozen=True)
+class Fill:
+    """What one surface does about one hook."""
+
+    surface: str
+    sink: str
+    hook: str
+    state: FillState
+    reason: str = ""
+    line: int = 0
+
+
+@dataclass(frozen=True)
+class SinkSpec:
+    """A discovered hook-shaped builder: where it lives and what it is called."""
+
+    module: str
+    function: str
+    path: str
+    hook_count: int
+
+    @property
+    def qualname(self) -> str:
+        return f"{self.module}.{self.function}"
+
+
+@dataclass
+class HandoffReading:
+    """The whole audit, as data. Rendering is a separate concern."""
+
+    hooks: List[Hook] = field(default_factory=list)
+    fills: List[Fill] = field(default_factory=list)
+    sinks: List[SinkSpec] = field(default_factory=list)
+    surfaces: Tuple[str, ...] = ()
+    unparseable: Tuple[str, ...] = ()
+    schema_version: str = CAPABILITY_HANDOFF_SCHEMA_VERSION
+
+    # -- findings ----------------------------------------------------------
+
+    def dropped(self) -> List[Hook]:
+        """Hooks accepted by a sink and consumed by NOTHING it forwards to.
+
+        The `search_rows` class. This is the list that should always be empty,
+        and the only one of these accessors that describes a defect in the
+        cockpit itself rather than in a surface's coverage of it.
+        """
+        by_qual = {h.sink + "." + h.name: h for h in self.hooks}
+        out: List[Hook] = []
+        for hook in self.hooks:
+            if effective_consumption(hook, by_qual) is Consumption.UNREAD:
+                out.append(hook)
+        return sorted(out, key=lambda h: (h.sink, h.name))
+
+    def unset(self, surface: Optional[str] = None) -> List[Fill]:
+        """Hooks a surface neither fills nor declines. The coverage finding."""
+        return sorted(
+            (f for f in self.fills
+             if f.state is FillState.UNSET
+             and (surface is None or f.surface == surface)),
+            key=lambda f: (f.surface, f.sink, f.hook),
+        )
+
+    def divergence(self) -> List[Tuple[str, str, Tuple[str, ...],
+                                       Tuple[str, ...]]]:
+        """``(sink, hook, filled_by, unset_by)`` where surfaces DISAGREE.
+
+        This is the coverage finding, and scoping it to disagreement is what
+        makes it a signal instead of a wall. Every hook-shaped builder has
+        optional parameters most callers rightly ignore; reporting each of them
+        produced 102 rows of which four mattered, and an instrument nobody can
+        read is an instrument nobody runs.
+
+        Disagreement is the shape that actually indicates a gap: if one surface
+        passes a hook and another leaves it unset, the second is either missing
+        a capability the first proves is real, or making a decision it has not
+        declared. A hook NO caller fills is not a demo gap — it is an unused
+        option, which is a different and much weaker observation.
+
+        Precisely the doctrine `surface_reachability` arrived at for imports:
+        "Asymmetry is evidence, never a conclusion." Same reasoning, applied to
+        values handed across a boundary rather than to modules imported.
+        """
+        by_key: Dict[Tuple[str, str], Dict[str, List[FillState]]] = {}
+        for fill in self.fills:
+            key = (fill.sink, fill.hook)
+            by_key.setdefault(key, {}).setdefault(fill.surface, []).append(
+                fill.state)
+        out: List[Tuple[str, str, Tuple[str, ...], Tuple[str, ...]]] = []
+        for (sink, hook), per_surface in by_key.items():
+            filled, unset = [], []
+            for surface, states in per_surface.items():
+                # A surface with several call sites counts as filling the hook
+                # if ANY of them does: the capability is demonstrably reachable
+                # from there, which is the question.
+                if FillState.FILLED in states:
+                    filled.append(surface)
+                elif all(s is FillState.UNSET for s in states):
+                    unset.append(surface)
+            if filled and unset:
+                out.append((sink, hook, tuple(sorted(filled)),
+                            tuple(sorted(unset))))
+        return sorted(out, key=lambda row: (row[0], row[1]))
+
+    def waivers(self, surface: Optional[str] = None) -> List[Fill]:
+        return sorted(
+            (f for f in self.fills
+             if f.state is FillState.WAIVED
+             and (surface is None or f.surface == surface)),
+            key=lambda f: (f.surface, f.sink, f.hook),
+        )
+
+    def coverage(self, surface: str) -> Tuple[int, int]:
+        """``(accounted_for, offered)`` for one surface.
+
+        A WAIVED hook counts as accounted for. The number this exists to move
+        is not "hooks filled" — a surface that fills everything regardless of
+        whether it needs it is not better — it is "hooks nobody has thought
+        about", and that number should be zero.
+        """
+        rows = [f for f in self.fills if f.surface == surface]
+        if not rows:
+            return (0, 0)
+        ok = sum(1 for f in rows if f.state in (FillState.FILLED,
+                                                FillState.WAIVED,
+                                                FillState.OPAQUE))
+        return (ok, len(rows))
+
+
+# ---------------------------------------------------------------------------
+# AST helpers
+# ---------------------------------------------------------------------------
+
+#: Both function flavours. `run_bipartite_repl` is an `async def`, and a walker
+#: that only knew `FunctionDef` would silently skip every async sink — which is
+#: most of a cockpit.
+_FUNC_NODES = (ast.FunctionDef, ast.AsyncFunctionDef)
+
+
+def _repo_root() -> Path:
+    """Reuses the board's root resolution rather than inventing a second one."""
+    try:
+        from backend.core.ouroboros.battle_test.progress_board import (
+            _default_root,
+        )
+        return _default_root()
+    except Exception:  # noqa: BLE001
+        return Path(__file__).resolve().parents[4]
+
+
+def _parse(path: Path) -> Optional[ast.AST]:
+    try:
+        return ast.parse(path.read_text(encoding="utf-8", errors="replace"))
+    except Exception:  # noqa: BLE001 — a file that will not parse has no hooks
+        return None
+
+
+def _module_name_for(rel: str) -> str:
+    try:
+        from backend.core.ouroboros.battle_test.progress_board import (
+            _module_name,
+        )
+        return _module_name(rel)
+    except Exception:  # noqa: BLE001
+        return rel[:-3].replace("/", ".") if rel.endswith(".py") else rel
+
+
+def _source_files(roots: Sequence[str]) -> List[Tuple[str, Path]]:
+    """``(dotted_module, path)`` for every non-test source file under roots."""
+    base = _repo_root()
+    out: List[Tuple[str, Path]] = []
+    for root in roots:
+        directory = base / root
+        if not directory.is_dir():
+            continue
+        for path in sorted(directory.rglob("*.py")):
+            try:
+                rel = path.relative_to(base).as_posix()
+            except ValueError:
+                continue
+            leaf = rel.rsplit("/", 1)[-1]
+            if "/tests/" in f"/{rel}" or leaf.startswith("test_"):
+                continue
+            out.append((_module_name_for(rel), path))
+    return out
+
+
+def _functions(tree: ast.AST) -> Dict[str, Any]:
+    """Every function in a module by name, nested ones included.
+
+    Nested definitions matter in both directions: a sink can be defined inside
+    a factory, and a hook is frequently consumed inside a closure the builder
+    defines — `_toolbar_fragments` reads `toolbar` from the enclosing scope,
+    and a walker that stopped at the top level would call that hook UNREAD.
+    """
+    out: Dict[str, Any] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, _FUNC_NODES):
+            out.setdefault(node.name, node)
+    return out
+
+
+def _hook_names(fn: Any) -> Tuple[List[Tuple[str, bool, bool]], bool]:
+    """``([(name, positional, required)], opaque)`` for a function's params.
+
+    ``opaque`` is True when the signature carries ``**kwargs``: the sink then
+    accepts names no signature enumerates, and claiming a complete hook list
+    would be a lie of exactly the kind this module exists to stop.
+    """
+    args = fn.args
+    out: List[Tuple[str, bool, bool]] = []
+    # Positional params: required iff no default. Defaults bind to the TAIL of
+    # the positional list, so the offset matters.
+    pos = list(args.posonlyargs) + list(args.args)
+    n_defaults = len(args.defaults)
+    first_defaulted = len(pos) - n_defaults
+    for i, a in enumerate(pos):
+        if a.arg in ("self", "cls"):
+            continue
+        out.append((a.arg, True, i < first_defaulted))
+    for a, default in zip(args.kwonlyargs, args.kw_defaults):
+        out.append((a.arg, False, default is None))
+    return out, args.kwarg is not None
+
+
+def _callee_name(call: ast.Call) -> str:
+    """The bare function name a Call targets, through either spelling.
+
+    ``build_bipartite_application(...)`` and
+    ``bipartite_layout.build_bipartite_application(...)`` are the same handoff,
+    and an analyser that only recognised one of them would report the other as
+    a drop. Aliased imports resolve to the alias here and are reconciled by the
+    caller against the sink index.
+    """
+    func = call.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return ""
+
+
+def _reads_opaquely(fn: Any) -> bool:
+    """Does the body reach its own scope dynamically?
+
+    ``locals()``, ``vars()`` and ``getattr`` on a local can all consume a
+    parameter in a way no AST walk can prove. Rather than guess, the sink's
+    hooks become OPAQUE and are excluded from both the pass and the fail
+    columns.
+    """
+    for node in ast.walk(fn):
+        if isinstance(node, ast.Call):
+            name = _callee_name(node)
+            if name in ("locals", "vars", "eval", "exec"):
+                return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Sink discovery — by SHAPE, never by name
+# ---------------------------------------------------------------------------
+
+
+def discover_sinks(
+    *,
+    roots: Optional[Sequence[str]] = None,
+    threshold: Optional[int] = None,
+) -> List[SinkSpec]:
+    """Every hook-shaped builder in the tree. NEVER raises.
+
+    A sink is a function carrying at least ``threshold`` keyword-only
+    parameters. That is a structural property, not a naming convention, so it
+    holds for a builder this module has never heard of — which is the entire
+    point. Detecting them by name (``build_*``) or by annotation
+    (``Optional[Callable]``) would both have missed real hooks: `completer`,
+    `history`, `auto_suggest` and `turn_spinner` are all annotated ``Any``.
+
+    Explicit override via ``JARVIS_HANDOFF_SINKS`` as
+    ``dotted.module:function,dotted.module:function`` — an operator pinning the
+    audit to one sink should not have to satisfy a heuristic.
+    """
+    if not handoff_enabled():
+        return []
+    roots = tuple(roots) if roots is not None else audit_roots()
+    want = threshold if threshold is not None else min_hooks()
+    pinned = _pinned_sinks()
+    out: List[SinkSpec] = []
+    try:
+        for module, path in _source_files(roots):
+            tree = _parse(path)
+            if tree is None:
+                continue
+            rel = _relpath(path)
+            for name, fn in _functions(tree).items():
+                hooks = _hook_names(fn)[0]
+                kwonly = sum(1 for entry in hooks if not entry[1])
+                if pinned:
+                    if (module, name) not in pinned:
+                        continue
+                elif kwonly < want:
+                    continue
+                out.append(SinkSpec(module=module, function=name, path=rel,
+                                    hook_count=len(hooks)))
+    except Exception:  # noqa: BLE001
+        logger.debug("[CapabilityHandoff] sink discovery degraded",
+                     exc_info=True)
+    return sorted(out, key=lambda s: s.qualname)
+
+
+def _pinned_sinks() -> Set[Tuple[str, str]]:
+    raw = os.environ.get(SINKS_ENV_VAR, "").strip()
+    out: Set[Tuple[str, str]] = set()
+    for chunk in raw.split(","):
+        chunk = chunk.strip()
+        if ":" in chunk:
+            module, func = chunk.rsplit(":", 1)
+            if module.strip() and func.strip():
+                out.add((module.strip(), func.strip()))
+    return out
+
+
+def _relpath(path: Path) -> str:
+    try:
+        return path.relative_to(_repo_root()).as_posix()
+    except ValueError:
+        return str(path)
+
+
+# ---------------------------------------------------------------------------
+# Consumption — what the sink's body does with what it was given
+# ---------------------------------------------------------------------------
+
+
+def analyse_sink(spec: SinkSpec, *,
+                 sink_names: Optional[Set[str]] = None) -> List[Hook]:
+    """The hooks one sink offers, each with what its body does. NEVER raises.
+
+    ``sink_names`` is the set of bare function names that count as onward
+    sinks. A use of a parameter as an argument to one of those is a FORWARD,
+    not a consumption — the distinction that keeps a pass-through wrapper from
+    reading as a defect, and keeps `search_rows` from hiding behind one.
+    """
+    try:
+        base = _repo_root()
+        tree = _parse(base / spec.path)
+        if tree is None:
+            return []
+        fn = _functions(tree).get(spec.function)
+        if fn is None:
+            return []
+        names, kwargs_opaque = _hook_names(fn)
+        opaque_body = _reads_opaquely(fn)
+        onward = set(sink_names or ())
+        out: List[Hook] = []
+        for name, positional, required in names:
+            if kwargs_opaque or opaque_body:
+                consumption, forwards = Consumption.OPAQUE, ()
+            else:
+                consumption, forwards = _classify(fn, name, onward)
+            out.append(Hook(name=name, sink=spec.qualname,
+                            positional=positional, required=required,
+                            consumption=consumption, forwards_to=forwards))
+        return out
+    except Exception:  # noqa: BLE001
+        logger.debug("[CapabilityHandoff] sink analysis degraded: %s",
+                     spec.qualname, exc_info=True)
+        return []
+
+
+def _classify(fn: Any, param: str,
+              onward: Set[str]) -> Tuple[Consumption, Tuple[str, ...]]:
+    """READ / FORWARDED_ONLY / UNREAD for one parameter of one function.
+
+    Every LOAD of the name is examined. A load that is an argument to an onward
+    sink is a forward; anything else — a guard, a container, a call to a
+    renderer, a comparison — is a read. Stores are ignored: rebinding a
+    parameter is not consuming what the caller passed.
+    """
+    forwards: Set[str] = set()
+    loads = 0
+    forwarded = 0
+    deleted = False
+    for node in ast.walk(fn):
+        if isinstance(node, ast.Delete):
+            for target_node in node.targets:
+                if (isinstance(target_node, ast.Name)
+                        and target_node.id == param):
+                    deleted = True
+            continue
+        if not (isinstance(node, ast.Name) and node.id == param):
+            continue
+        if not isinstance(node.ctx, ast.Load):
+            continue
+        loads += 1
+        target = _forward_target(fn, node, onward)
+        if target:
+            forwarded += 1
+            forwards.add(target)
+    # Checked before the load count, because `del param` is a Del context and
+    # contributes no loads: a declared discard would otherwise be
+    # indistinguishable from the silent drop it exists to differentiate from.
+    if deleted and loads == 0:
+        return Consumption.DECLARED_DROP, ()
+    if loads == 0:
+        return Consumption.UNREAD, ()
+    if forwarded == loads:
+        return Consumption.FORWARDED_ONLY, tuple(sorted(forwards))
+    return Consumption.READ, tuple(sorted(forwards))
+
+
+def _forward_target(fn: Any, name_node: ast.Name,
+                    onward: Set[str]) -> str:
+    """The onward sink this load is being handed to, or "".
+
+    Matches the load against the argument lists of every Call in the function,
+    by identity, so a name appearing twice in one statement is judged per
+    occurrence rather than per spelling.
+    """
+    for node in ast.walk(fn):
+        if not isinstance(node, ast.Call):
+            continue
+        callee = _callee_name(node)
+        if not callee or callee not in onward:
+            continue
+        for arg in node.args:
+            if arg is name_node:
+                return callee
+        for kw in node.keywords:
+            if kw.value is name_node:
+                return callee
+    return ""
+
+
+def effective_consumption(hook: Hook,
+                          by_qual: Dict[str, Hook],
+                          _seen: Optional[Set[str]] = None) -> Consumption:
+    """Resolve a forward CHAIN to what actually happens at the end of it.
+
+    A parameter forwarded into a sink that reads it IS consumed — the wrapper
+    is doing its job. A parameter forwarded into a sink that drops it is
+    dropped, however many polite hops it took to get there. Reporting the hop
+    instead of the drop would point every investigation at the wrong file.
+
+    Cycle-guarded because mutual forwarding between overloads is legal and a
+    naive walk would not terminate. An unresolvable link (the target sink is
+    outside the audited roots) resolves to OPAQUE rather than to UNREAD:
+    "I cannot see the far end" and "the far end drops it" are different
+    findings and only one of them is a defect.
+    """
+    seen = set(_seen or ())
+    key = f"{hook.sink}.{hook.name}"
+    if key in seen:
+        return Consumption.OPAQUE
+    seen.add(key)
+    if hook.consumption is not Consumption.FORWARDED_ONLY:
+        return hook.consumption
+    verdicts: List[Consumption] = []
+    for target in hook.forwards_to:
+        # Same bare function name, any module: the forward was resolved by
+        # name, so the lookup has to be too.
+        matches = [h for qual, h in by_qual.items()
+                   if h.name == hook.name
+                   and qual.rsplit(".", 2)[-2] == target]
+        if not matches:
+            verdicts.append(Consumption.OPAQUE)
+            continue
+        for match in matches:
+            verdicts.append(effective_consumption(match, by_qual, seen))
+    if not verdicts:
+        return Consumption.OPAQUE
+    # ANY terminal read redeems the chain; a hook forwarded two ways where one
+    # end uses it is not dropped.
+    if Consumption.READ in verdicts:
+        return Consumption.READ
+    if Consumption.OPAQUE in verdicts:
+        return Consumption.OPAQUE
+    return Consumption.UNREAD
+
+
+# ---------------------------------------------------------------------------
+# Fills — what each calling surface does about each hook
+# ---------------------------------------------------------------------------
+
+
+def analyse_surface(module: str, path: Path, hooks: Sequence[Hook],
+                    *, sink_functions: Set[str]) -> List[Fill]:
+    """What ``module``'s call sites do about every hook. NEVER raises.
+
+    A module may call the same sink more than once for genuinely different
+    surfaces — `ov.py` builds a PromptSession fallback and a full cockpit — so
+    each call site is judged separately and labelled by line. Merging them
+    would let a fully-wired cockpit hide an unwired fallback.
+    """
+    out: List[Fill] = []
+    try:
+        tree = _parse(path)
+        if tree is None:
+            return []
+        by_sink: Dict[str, List[Hook]] = {}
+        for hook in hooks:
+            by_sink.setdefault(hook.sink.rsplit(".", 1)[0] + "|" +
+                               hook.sink.rsplit(".", 1)[-1], []).append(hook)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            callee = _callee_name(node)
+            if callee not in sink_functions:
+                continue
+            targets = [h for h in hooks
+                       if h.sink.rsplit(".", 1)[-1] == callee]
+            if not targets:
+                continue
+            out.extend(_fills_for_call(module, node, targets))
+    except Exception:  # noqa: BLE001
+        logger.debug("[CapabilityHandoff] surface analysis degraded: %s",
+                     module, exc_info=True)
+    return out
+
+
+def _fills_for_call(surface: str, call: ast.Call,
+                    hooks: Sequence[Hook]) -> List[Fill]:
+    """One call site → one Fill per hook the sink offers."""
+    line = getattr(call, "lineno", 0)
+    sink = hooks[0].sink if hooks else ""
+    splat = any(kw.arg is None for kw in call.keywords)
+    positional = [h for h in hooks if h.positional]
+    supplied_positionally = {
+        h.name for h in positional[:len(call.args)]
+    }
+    by_keyword: Dict[str, ast.AST] = {
+        kw.arg: kw.value for kw in call.keywords if kw.arg
+    }
+    out: List[Fill] = []
+    for hook in hooks:
+        if hook.name in supplied_positionally:
+            out.append(Fill(surface, sink, hook.name, FillState.FILLED,
+                            line=line))
+            continue
+        value = by_keyword.get(hook.name)
+        if value is None:
+            # A splatted caller may well be filling it; nothing at this call
+            # site enumerates the name, so neither pass nor fail is honest.
+            state = FillState.OPAQUE if splat else FillState.UNSET
+            out.append(Fill(surface, sink, hook.name, state, line=line))
+            continue
+        reason = _waiver_reason(value)
+        if reason is not None:
+            out.append(Fill(surface, sink, hook.name, FillState.WAIVED,
+                            reason=reason, line=line))
+        else:
+            out.append(Fill(surface, sink, hook.name, FillState.FILLED,
+                            line=line))
+    return out
+
+
+def _waiver_reason(value: ast.AST) -> Optional[str]:
+    """The reason string if this argument is a :func:`waived` call, else None.
+
+    Matched on the callable's own ``__name__`` so renaming the function cannot
+    leave the analyser matching a spelling that no longer exists. A waiver with
+    no reason is NOT a waiver — the reason is the entire difference between a
+    declared decision and a shrug — so an empty string falls through and the
+    hook reports UNSET.
+    """
+    if not isinstance(value, ast.Call):
+        return None
+    if _callee_name(value) != WAIVER_CALLABLE_NAME:
+        return None
+    for arg in list(value.args) + [kw.value for kw in value.keywords]:
+        if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+            text = arg.value.strip()
+            if text:
+                return text
+    return None
+
+
+def _pinned_surfaces() -> Tuple[str, ...]:
+    raw = os.environ.get(SURFACES_ENV_VAR, "").strip()
+    if not raw:
+        return ()
+    return tuple(s.strip() for s in raw.split(",") if s.strip())
+
+
+# ---------------------------------------------------------------------------
+# The audit
+# ---------------------------------------------------------------------------
+
+
+def audit(*, roots: Optional[Sequence[str]] = None,
+          threshold: Optional[int] = None) -> HandoffReading:
+    """Discover sinks, classify their hooks, and measure every caller.
+
+    NEVER raises: a degraded audit reports what it managed to establish. An
+    instrument that fails closed on a malformed tree is an instrument nobody
+    runs.
+    """
+    reading = HandoffReading()
+    if not handoff_enabled():
+        return reading
+    try:
+        roots = tuple(roots) if roots is not None else audit_roots()
+        sinks = discover_sinks(roots=roots, threshold=threshold)
+        reading.sinks = sinks
+        sink_functions = {s.function for s in sinks}
+        hooks: List[Hook] = []
+        for spec in sinks:
+            hooks.extend(analyse_sink(spec, sink_names=sink_functions))
+        reading.hooks = hooks
+
+        pinned = _pinned_surfaces()
+        labels: List[str] = []
+        unparseable: List[str] = []
+        for module, path in _source_files(roots):
+            if pinned and module not in pinned:
+                continue
+            if _parse(path) is None:
+                unparseable.append(module)
+                continue
+            fills = analyse_surface(module, path, hooks,
+                                    sink_functions=sink_functions)
+            if not fills:
+                continue
+            # A sink calling itself recursively is not a surface consuming it.
+            if any(s.module == module and s.function in sink_functions
+                   for s in sinks) and module not in pinned:
+                fills = [f for f in fills
+                         if f.sink.rsplit(".", 1)[0] != module]
+                if not fills:
+                    continue
+            reading.fills.extend(fills)
+            labels.append(module)
+        reading.surfaces = tuple(sorted(set(labels)))
+        reading.unparseable = tuple(sorted(unparseable))
+        # After every direct fill is known, never during: propagation reads the
+        # complete fill set, and folding it into the loop above would let a
+        # surface scanned early miss an edge a surface scanned later proved.
+        reading.fills.extend(propagate_fills(reading))
+    except Exception:  # noqa: BLE001
+        logger.debug("[CapabilityHandoff] audit degraded", exc_info=True)
+    return reading
+
+
+def propagate_fills(reading: HandoffReading) -> List[Fill]:
+    """Fills implied by a wrapper's forwarding. NEVER raises.
+
+    `ov.py` reaches the cockpit through `run_bipartite_repl`; `ov_demo` calls
+    `build_bipartite_application` directly. Both are filling the SAME
+    capability, and comparing them literally answers nothing — the two surfaces
+    never name the same sink, so the divergence that motivated this whole module
+    was invisible to the first version of it.
+
+    A wrapper that forwards a hook onward means anyone who filled the wrapper
+    has, in effect, filled the sink at the far end. That relationship is not
+    guessed: it is exactly the ``forwards_to`` edge already proven by
+    :func:`_classify`, so this reuses the forward graph rather than introducing
+    an "equivalent sinks" table — which would be the hardcoded checklist this
+    module exists to avoid, one level up.
+
+    Indirect fills never MASK a direct finding: they are additive, and a
+    surface that both calls the sink directly and leaves a hook unset there
+    keeps its UNSET row. The forward edge widens what counts as covered; it
+    cannot narrow it.
+    """
+    out: List[Fill] = []
+    try:
+        # hook name → sinks it is forwarded INTO, by the sink that forwards it.
+        forwards: Dict[Tuple[str, str], Tuple[str, ...]] = {
+            (h.sink, h.name): h.forwards_to for h in reading.hooks
+            if h.forwards_to
+        }
+        # bare function name → full qualnames, to resolve a forward target.
+        by_func: Dict[str, List[str]] = {}
+        for hook in reading.hooks:
+            by_func.setdefault(hook.sink.rsplit(".", 1)[-1], [])
+            if hook.sink not in by_func[hook.sink.rsplit(".", 1)[-1]]:
+                by_func[hook.sink.rsplit(".", 1)[-1]].append(hook.sink)
+        known = {(h.sink, h.name) for h in reading.hooks}
+        seen = {(f.surface, f.sink, f.hook) for f in reading.fills}
+        for fill in reading.fills:
+            for target_func in forwards.get((fill.sink, fill.hook), ()):
+                for target_sink in by_func.get(target_func, ()):
+                    if (target_sink, fill.hook) not in known:
+                        continue
+                    key = (fill.surface, target_sink, fill.hook)
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    out.append(Fill(fill.surface, target_sink, fill.hook,
+                                    fill.state, reason=fill.reason,
+                                    line=fill.line))
+    except Exception:  # noqa: BLE001
+        logger.debug("[CapabilityHandoff] fill propagation degraded",
+                     exc_info=True)
+    return out
+
+
+def render(reading: HandoffReading, *, limit: int = 20) -> List[str]:
+    """Operator-readable rows. NEVER raises.
+
+    Leads with DROPPED hooks because those are defects in the cockpit itself,
+    not gaps in a surface's coverage of it — a dropped hook means a feature is
+    dark for every caller, including the shipping one.
+    """
+    out: List[str] = []
+    try:
+        if not reading.sinks:
+            return ["  no hook-shaped sinks found (audit disabled or "
+                    "threshold too high)"]
+        out.append(f"  {len(reading.sinks)} sinks · {len(reading.hooks)} hooks "
+                   f"· {len(reading.surfaces)} calling surfaces")
+        for module in reading.unparseable:
+            out.append(f"  ⚠ unparseable, skipped: {module}")
+        out.append("")
+
+        dropped = reading.dropped()
+        if dropped:
+            out.append(f"  ✗ ACCEPTED AND DROPPED — dark for every caller "
+                       f"({len(dropped)}):")
+            for hook in dropped[:limit]:
+                out.append(f"      {hook.short_sink}({hook.name}) "
+                           f"— accepted, never read")
+            out.append("")
+        else:
+            out.append("  ✓ every hook a sink accepts is consumed, forwarded "
+                       "to a consumer, or declared discarded")
+            out.append("")
+
+        diverged = reading.divergence()
+        if diverged:
+            out.append(f"  · one surface proves it, another has not decided "
+                       f"({len(diverged)}):")
+            for sink, hook, filled, unset in diverged[:limit]:
+                fills = ", ".join(s.rsplit(".", 1)[-1] for s in filled)
+                gaps = ", ".join(s.rsplit(".", 1)[-1] for s in unset)
+                out.append(f"      {sink.rsplit('.', 1)[-1]}({hook})")
+                out.append(f"          filled by {fills} · unset in {gaps}")
+            if len(diverged) > limit:
+                out.append(f"      … {len(diverged) - limit} more")
+            out.append("")
+
+        for surface in reading.surfaces:
+            ok, total = reading.coverage(surface)
+            short = surface.rsplit(".", 1)[-1]
+            mark = "✓" if ok == total else "·"
+            out.append(f"  {mark} {short:<24} {ok}/{total} accounted for")
+
+        waivers = reading.waivers()
+        if waivers:
+            out.append("")
+            out.append(f"  declared waivers ({len(waivers)}):")
+            for fill in waivers[:limit]:
+                short = fill.surface.rsplit(".", 1)[-1]
+                out.append(f"      {short}·{fill.hook} — {fill.reason}")
+        out.append("")
+        out.append("  a WAIVED hook is accounted for. The number to drive to")
+        out.append("  zero is hooks nobody has decided about, not hooks unfilled.")
+    except Exception:  # noqa: BLE001
+        logger.debug("[CapabilityHandoff] render degraded", exc_info=True)
+    return out
+
+
+__all__ = [
+    "CAPABILITY_HANDOFF_SCHEMA_VERSION",
+    "Consumption",
+    "Fill",
+    "FillState",
+    "HandoffReading",
+    "Hook",
+    "SinkSpec",
+    "analyse_sink",
+    "analyse_surface",
+    "audit",
+    "discover_sinks",
+    "effective_consumption",
+    "handoff_enabled",
+    "render",
+    "waived",
+]

--- a/tests/battle_test/test_canvas_allotment.py
+++ b/tests/battle_test/test_canvas_allotment.py
@@ -1,0 +1,280 @@
+"""The canvas must size itself against the region it is GIVEN.
+
+The defect these tests hold shut: `BipartiteLayout` budgeted its deck against
+the TERMINAL, while what bounds it is the leftover its parent `HSplit` hands it.
+Measured at 200x60 with a 12-row crest mounted, the mux believed it had 39 rows,
+produced 39 lines, and was given 8 — and because a `Window` draws a content block
+from its TOP, the 8 it kept were the OLDEST. The operator watched a window parked
+thirty-one lines behind the live tail, and the last beats of a script appeared
+never to render at all.
+
+`test_the_newest_line_is_visible_under_heavy_chrome` is the one that matters: it
+asserts the operator-visible symptom rather than the arithmetic, so it fails for
+any future reason the tail stops being reachable — a new strip, a taller header,
+a changed dimension — not only for the cause fixed here.
+"""
+from __future__ import annotations
+
+import re
+
+import pytest
+
+
+def _render_once(app, rows=60, cols=200):
+    """Drive ONE real frame through prompt_toolkit's own render path.
+
+    Not a simulation: `write_to_screen` is what the renderer calls, so the
+    heights the controls receive here are the heights they receive in a cockpit.
+    The input `BufferControl` wants a running loop and raises without one; the
+    canvas is measured long before that, so the exception is caught and the
+    partial frame is exactly what we need.
+    """
+    from prompt_toolkit.layout.containers import to_container
+    from prompt_toolkit.layout.mouse_handlers import MouseHandlers
+    from prompt_toolkit.layout.screen import Screen, WritePosition
+
+    screen = Screen(default_char=None, initial_width=cols, initial_height=rows)
+    try:
+        to_container(app.layout.container).write_to_screen(
+            screen, MouseHandlers(), WritePosition(0, 0, cols, rows),
+            "", False, None,
+        )
+    except Exception:  # noqa: BLE001 — the input buffer needs an event loop
+        pass
+    return screen
+
+
+def _heavy_app(mux, header_rows=12):
+    """A cockpit wearing every strip it supports.
+
+    The defect scaled with sibling cost, so a bare canvas-and-prompt layout
+    would not have shown it — which is precisely why it survived.
+    """
+    from backend.core.ouroboros.battle_test.bipartite_layout import (
+        build_bipartite_application,
+    )
+    return build_bipartite_application(
+        mux,
+        on_accept=lambda _t: None,
+        toolbar=lambda: "toolbar",
+        header=lambda: "\n".join(["crest"] * header_rows),
+        header_height=header_rows,
+        status_rows=lambda: ["status"],
+        search_rows=lambda: ["search"],
+        pending_rows=lambda: ["pending"],
+        queue_rows=lambda: ["queued"],
+        agent_rows=lambda: ["agent"],
+    )
+
+
+def _visible(mux):
+    """The deck lines an operator would actually see, ANSI stripped."""
+    plain = re.sub(r"\x1b\[[0-9;]*m", "", mux.render_canvas_ansi())
+    return [ln for ln in plain.split("\n") if ln.strip()]
+
+
+@pytest.fixture()
+def fullscreen(monkeypatch):
+    """The cockpit mode. Outside it the canvas is a bounded 8-row region, which
+    is a different (and also previously broken) arithmetic."""
+    monkeypatch.setenv("JARVIS_BIPARTITE_FULLSCREEN", "1")
+
+
+class TestTheOperatorVisibleSymptom:
+    def test_the_newest_line_is_visible_under_heavy_chrome(self, fullscreen):
+        """THE regression. A deck whose newest line cannot be seen is not a
+        transcript, and this is what "the last beats never rendered" was."""
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            BipartiteLayout,
+        )
+        mux = BipartiteLayout()
+        for i in range(200):
+            mux.push_raw(f"deckline{i}")
+        _render_once(_heavy_app(mux))
+        lines = _visible(mux)
+        assert any("deckline199" in ln for ln in lines), (
+            "the NEWEST deck line is not visible — the canvas is rendering more "
+            "lines than its window holds and the overflow is clipped from the "
+            "bottom.\nvisible tail was: "
+            + repr([ln.strip()[:40] for ln in lines[-3:]])
+        )
+
+    def test_the_deck_never_produces_more_lines_than_it_was_given(self, fullscreen):
+        """The mechanism behind the symptom. Producing more rows than the window
+        holds is silent — prompt_toolkit simply drops them — so nothing but an
+        explicit comparison catches it."""
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            BipartiteLayout,
+        )
+        mux = BipartiteLayout()
+        for i in range(200):
+            mux.push_raw(f"line{i}")
+        _render_once(_heavy_app(mux))
+        assert len(_visible(mux)) <= mux.height, (
+            f"produced {len(_visible(mux))} lines into {mux.height} rows"
+        )
+
+    def test_a_taller_header_costs_the_deck_rows_not_its_tail(self, fullscreen):
+        """A bigger header should make the deck SHORTER, never make it lose the
+        end. Before the fix a 12-row crest cost the deck its last four beats
+        while the deck went on believing it had the whole terminal."""
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            BipartiteLayout,
+        )
+        heights = {}
+        for header_rows in (3, 12, 20):
+            mux = BipartiteLayout()
+            for i in range(200):
+                mux.push_raw(f"row{i}")
+            _render_once(_heavy_app(mux, header_rows=header_rows))
+            heights[header_rows] = mux.height
+            assert any("row199" in ln for ln in _visible(mux)), (
+                f"tail lost with a {header_rows}-row header")
+        assert heights[3] > heights[12] > heights[20], (
+            f"the deck did not shrink as the header grew: {heights}")
+
+
+class TestObservationReplacesPrediction:
+    def test_the_allotment_is_a_guess_until_a_frame_measures_it(self):
+        """An estimate is a legitimate fallback before the first render. It must
+        simply never claim to be a measurement — the rule that would have made
+        the hardcoded 24 visible instead of load-bearing."""
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            BipartiteLayout,
+        )
+        assert BipartiteLayout().allotment_measured is False
+
+    def test_a_render_turns_the_guess_into_a_measurement(self, fullscreen):
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            BipartiteLayout,
+        )
+        mux = BipartiteLayout()
+        _render_once(_heavy_app(mux))
+        assert mux.allotment_measured is True
+
+    def test_the_measured_height_is_the_region_not_the_terminal(self, fullscreen):
+        """The whole point. With 12 rows of crest plus six one-row strips, a
+        60-row terminal cannot be leaving the canvas 60 — or 59."""
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            BipartiteLayout,
+        )
+        mux = BipartiteLayout()
+        _render_once(_heavy_app(mux), rows=60)
+        assert 3 <= mux.height <= 60 - 12, (
+            f"height {mux.height} does not account for the mounted chrome")
+
+    def test_scroll_metrics_clamp_against_the_measured_budget(self, fullscreen):
+        """#70279's lesson: the scroll keys move against this number, so a stale
+        budget means a deck that can neither show its tail nor be scrolled to
+        it. One source, both readers."""
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            BipartiteLayout,
+        )
+        mux = BipartiteLayout()
+        for i in range(200):
+            mux.push_raw(f"x{i}")
+        _render_once(_heavy_app(mux))
+        total, budget = mux.scroll_metrics()
+        assert budget == mux._line_budget()
+        assert total == 200
+
+
+class TestObserveAllotmentContract:
+    """Every degenerate shape the framework can hand a control."""
+
+    def _mux(self):
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            BipartiteLayout,
+        )
+        return BipartiteLayout()
+
+    @pytest.mark.parametrize("height", [None, 0, -5])
+    def test_a_degenerate_height_is_refused_not_recorded(self, height):
+        """`None` means "measure, do not draw"; 0 means a collapsed conditional
+        container. Recording either as a budget renders an empty deck — the last
+        good measurement is a better answer than a degenerate fresh one."""
+        mux = self._mux()
+        mux.observe_allotment(200, 40)
+        before = mux.height
+        mux.observe_allotment(200, height)
+        assert mux.height == before
+
+    def test_a_none_height_does_not_forge_a_measurement(self):
+        """A control asked to measure has told us nothing about our size, so
+        provenance must not flip. Otherwise the very first `create_content(w,
+        None)` would brand the terminal estimate as measured."""
+        mux = self._mux()
+        mux.observe_allotment(200, None)
+        assert mux.allotment_measured is False
+
+    def test_width_is_taken_independently_of_height(self):
+        """They arrive together and can fail separately; a valid width should
+        not be discarded because the height was a measuring pass."""
+        mux = self._mux()
+        mux.observe_allotment(137, None)
+        assert mux.width == 137
+
+    def test_an_unchanged_allotment_reports_no_change(self):
+        """The return value gates a repaint. Invalidating on every frame from
+        inside a render is a repaint loop, so "same size" must be falsy."""
+        mux = self._mux()
+        mux.observe_allotment(200, 40)
+        assert mux.observe_allotment(200, 40) is False
+
+    def test_a_changed_allotment_reports_the_change(self):
+        mux = self._mux()
+        mux.observe_allotment(200, 40)
+        assert mux.observe_allotment(200, 25) is True
+
+    def test_an_unchanged_height_still_counts_as_measured(self):
+        """An estimate that happens to equal the measurement is still an
+        estimate until something measures it — the advisor's rule about a cap
+        that coincides with a real blast radius."""
+        mux = self._mux()
+        seeded = mux.height
+        mux.observe_allotment(None, seeded)
+        assert mux.allotment_measured is True
+
+    def test_garbage_never_raises_into_a_frame(self):
+        """This runs inside `create_content`. An exception here is a dead
+        cockpit, so the contract is total."""
+        mux = self._mux()
+        for bad in ("tall", object(), [], {}):
+            assert mux.observe_allotment(bad, bad) is False
+
+
+class TestNoPredictionRemains:
+    def test_the_canvas_no_longer_guesses_from_the_terminal(self):
+        """`size.rows - 1` was the prediction: one row reserved for chrome, true
+        while the cockpit was a canvas and a prompt, wronger with every strip
+        added since. A structural pin, because a well-meaning re-add would
+        restore the defect and every behavioural test above would still pass —
+        the prediction only loses to the measurement when both are present."""
+        import ast
+        import inspect
+
+        from backend.core.ouroboros.battle_test import bipartite_layout as bl
+
+        src = inspect.getsource(bl.build_bipartite_application)
+        tree = ast.parse(src.lstrip())
+        fragments = [
+            n for n in ast.walk(tree)
+            if isinstance(n, ast.FunctionDef) and n.name == "_canvas_fragments"
+        ]
+        assert fragments, "_canvas_fragments not found"
+        body = ast.dump(fragments[0])
+        assert "on_resize" not in body, (
+            "the canvas is predicting its size from the terminal again; it must "
+            "observe the allotment prompt_toolkit hands create_content")
+
+    def test_observation_is_wired_into_the_control(self):
+        """Behaviour, not spelling: build an app, render, and require that the
+        mux was told a height it could not have guessed."""
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            BipartiteLayout,
+        )
+        mux = BipartiteLayout(height=999)
+        _render_once(_heavy_app(mux))
+        assert mux.height != 999, (
+            "a render did not reach observe_allotment — the measuring control "
+            "is not mounted on the canvas window")

--- a/tests/battle_test/test_capability_handoff.py
+++ b/tests/battle_test/test_capability_handoff.py
@@ -1,0 +1,348 @@
+"""The handoff auditor, and the ratchet that keeps the cockpit honest.
+
+Two kinds of test live here and they are doing different jobs.
+
+The RATCHET (:class:`TestNoHookIsDropped`) runs the real audit over the real
+tree and demands that every hook a sink accepts is consumed, forwarded to a
+consumer, or explicitly discarded. It is the regression that `search_rows`
+never had: a defect that stayed invisible for as long as its own test asserted
+a substring of the caller's source.
+
+The ANALYSER tests are pure AST over inline snippets — no filesystem, no
+imports of the code under measurement. They exist because an instrument that
+is confidently wrong is worse than no instrument, and every one of them is a
+scenario the first draft of this module got wrong or would have.
+"""
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+from backend.core.ouroboros.ui import capability_handoff as ch
+
+
+def _fn(source: str, name: str):
+    """Parse a snippet and hand back one function node."""
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if node.name == name:
+                return node
+    raise AssertionError(f"no function {name!r} in snippet")
+
+
+class TestConsumptionClassification:
+    """READ / FORWARDED_ONLY / UNREAD / DECLARED_DROP / OPAQUE."""
+
+    def test_a_body_that_uses_the_value_reads_it(self):
+        fn = _fn("def sink(*, hook=None):\n"
+                 "    if hook is not None:\n"
+                 "        render(hook)\n", "sink")
+        assert ch._classify(fn, "hook", set())[0] is ch.Consumption.READ
+
+    def test_a_body_that_never_mentions_it_is_the_search_rows_defect(self):
+        fn = _fn("def sink(*, hook=None):\n"
+                 "    return build()\n", "sink")
+        assert ch._classify(fn, "hook", set())[0] is ch.Consumption.UNREAD
+
+    def test_handing_it_straight_to_another_sink_is_a_forward_not_a_read(self):
+        """The distinction that keeps a pass-through wrapper off the defect
+        list — and keeps a dropped hook from hiding behind one."""
+        fn = _fn("def wrapper(*, hook=None):\n"
+                 "    return inner(hook=hook)\n", "wrapper")
+        kind, forwards = ch._classify(fn, "hook", {"inner"})
+        assert kind is ch.Consumption.FORWARDED_ONLY
+        assert forwards == ("inner",)
+
+    def test_forwarding_to_something_that_is_not_a_sink_is_a_read(self):
+        """`build_dynamic_rows(status_rows)` is consumption. Treating every
+        call as a forward would report the whole cockpit as dropped."""
+        fn = _fn("def sink(*, hook=None):\n"
+                 "    return build_dynamic_rows(hook)\n", "sink")
+        assert ch._classify(fn, "hook", {"inner"})[0] is ch.Consumption.READ
+
+    def test_one_real_use_beats_any_number_of_forwards(self):
+        fn = _fn("def sink(*, hook=None):\n"
+                 "    inner(hook=hook)\n"
+                 "    if hook:\n"
+                 "        log(hook)\n", "sink")
+        assert ch._classify(fn, "hook", {"inner"})[0] is ch.Consumption.READ
+
+    def test_del_is_a_declared_discard_not_a_silent_drop(self):
+        """`presentation_restraint.render_minimal_welcome` accepts
+        ``session_id`` for caller compatibility and deletes it. Python already
+        has this sentence; a decorator would be a second vocabulary for it."""
+        fn = _fn("def sink(*, session_id=''):\n"
+                 "    del session_id\n"
+                 "    return 1\n", "sink")
+        assert (ch._classify(fn, "session_id", set())[0]
+                is ch.Consumption.DECLARED_DROP)
+
+    def test_rebinding_a_parameter_is_not_consuming_it(self):
+        """A Store is not a Load. A body that overwrites what it was handed
+        has used the NAME, never the caller's value."""
+        fn = _fn("def sink(*, hook=None):\n"
+                 "    hook = 3\n", "sink")
+        assert ch._classify(fn, "hook", set())[0] is ch.Consumption.UNREAD
+
+    def test_a_closure_reading_the_enclosing_scope_counts(self):
+        """`_toolbar_fragments` reads `toolbar` from the enclosing frame. A
+        walker that stopped at the top level would call it UNREAD and report
+        the toolbar — visibly working — as a dropped hook."""
+        fn = _fn("def sink(*, toolbar=None):\n"
+                 "    def frags():\n"
+                 "        return toolbar()\n"
+                 "    return frags\n", "sink")
+        assert ch._classify(fn, "toolbar", set())[0] is ch.Consumption.READ
+
+
+class TestSignatureShapes:
+    """What counts as a hook, across every parameter spelling."""
+
+    def test_keyword_only_with_default_is_an_optional_hook(self):
+        hooks, opaque = ch._hook_names(
+            _fn("def sink(mux, *, a=None, b=None):\n    pass\n", "sink"))
+        assert opaque is False
+        assert [(n, pos, req) for n, pos, req in hooks] == [
+            ("mux", True, True), ("a", False, False), ("b", False, False)]
+
+    def test_defaults_bind_to_the_tail_of_the_positional_list(self):
+        """Off-by-one here would mark required params optional and invert
+        every downstream judgement about what a caller must supply."""
+        hooks, _ = ch._hook_names(
+            _fn("def sink(a, b, c=1, d=2):\n    pass\n", "sink"))
+        assert hooks == [("a", True, True), ("b", True, True),
+                         ("c", True, False), ("d", True, False)]
+
+    def test_a_kwargs_sink_is_opaque_rather_than_complete(self):
+        """A signature with ``**kwargs`` accepts names it does not enumerate.
+        Claiming a complete hook list there would be the exact species of
+        confident wrongness this module exists to end."""
+        _hooks, opaque = ch._hook_names(
+            _fn("def sink(*, a=None, **rest):\n    pass\n", "sink"))
+        assert opaque is True
+
+    def test_async_sinks_are_found(self):
+        """`run_bipartite_repl` is an `async def`. A walker that only knew
+        `FunctionDef` would silently skip most of a cockpit."""
+        fn = _fn("async def sink(*, a=None):\n    return a\n", "sink")
+        assert ch._classify(fn, "a", set())[0] is ch.Consumption.READ
+
+    def test_self_and_cls_are_not_hooks(self):
+        hooks, _ = ch._hook_names(
+            _fn("def method(self, *, a=None):\n    pass\n", "method"))
+        assert [n for n, _p, _r in hooks] == ["a"]
+
+    @pytest.mark.parametrize("dyn", ["locals()", "vars()", "eval('x')"])
+    def test_dynamic_scope_access_makes_the_whole_sink_opaque(self, dyn):
+        """A body reaching its own frame dynamically could consume anything.
+        OPAQUE is the honest verdict; guessing either way would be a lie."""
+        fn = _fn(f"def sink(*, a=None):\n    return {dyn}\n", "sink")
+        assert ch._reads_opaquely(fn) is True
+
+
+class TestCalleeResolution:
+    def test_both_call_spellings_resolve_to_the_same_handoff(self):
+        """``build(...)`` and ``module.build(...)`` are one relationship. An
+        analyser recognising only one would report the other as a drop."""
+        bare = ast.parse("build(x)").body[0].value
+        dotted = ast.parse("mod.build(x)").body[0].value
+        assert ch._callee_name(bare) == ch._callee_name(dotted) == "build"
+
+    def test_an_unresolvable_callee_is_empty_not_a_guess(self):
+        call = ast.parse("funcs['build'](x)").body[0].value
+        assert ch._callee_name(call) == ""
+
+
+class TestWaivers:
+    """UNSET is not WAIVED — the provenance rule, applied to call sites."""
+
+    def test_a_waiver_carries_its_reason(self):
+        value = ast.parse("waived('input is inert in a demo')"
+                          ).body[0].value
+        assert ch._waiver_reason(value) == "input is inert in a demo"
+
+    def test_an_empty_reason_is_not_a_waiver(self):
+        """The reason IS the waiver. Without it the call says only "I typed
+        something here", which is what silence already said."""
+        assert ch._waiver_reason(ast.parse("waived('')").body[0].value) is None
+        assert ch._waiver_reason(ast.parse("waived('  ')").body[0].value) is None
+
+    def test_an_ordinary_value_is_a_fill_not_a_waiver(self):
+        value = ast.parse("lambda: rows").body[0].value
+        assert ch._waiver_reason(value) is None
+
+    def test_the_analyser_matches_the_functions_real_name(self):
+        """Matched via ``waived.__name__`` so a rename cannot leave the
+        analyser hunting a spelling that no longer exists."""
+        assert ch.WAIVER_CALLABLE_NAME == ch.waived.__name__
+
+    def test_waived_returns_none_so_adopting_it_changes_nothing(self):
+        """The whole safety argument: at runtime it is identical to omitting
+        the argument, so a callee's ``is not None`` guard cannot tell."""
+        assert ch.waived("any reason at all") is None
+
+
+class TestForwardChains:
+    """A hop is not a drop, and a drop behind a hop is still a drop."""
+
+    def _hook(self, sink, name, kind, forwards=()):
+        return ch.Hook(name=name, sink=sink, positional=False, required=False,
+                       consumption=kind, forwards_to=tuple(forwards))
+
+    def test_a_forward_into_a_consumer_is_consumed(self):
+        wrapper = self._hook("m.wrapper", "h",
+                             ch.Consumption.FORWARDED_ONLY, ["builder"])
+        builder = self._hook("m.builder", "h", ch.Consumption.READ)
+        by_qual = {"m.wrapper.h": wrapper, "m.builder.h": builder}
+        assert ch.effective_consumption(wrapper, by_qual) is ch.Consumption.READ
+
+    def test_a_forward_into_a_dropper_reports_the_drop(self):
+        """The `search_rows` chain exactly: ov → wrapper → builder → floor."""
+        wrapper = self._hook("m.wrapper", "h",
+                             ch.Consumption.FORWARDED_ONLY, ["builder"])
+        builder = self._hook("m.builder", "h", ch.Consumption.UNREAD)
+        by_qual = {"m.wrapper.h": wrapper, "m.builder.h": builder}
+        assert (ch.effective_consumption(wrapper, by_qual)
+                is ch.Consumption.UNREAD)
+
+    def test_an_unresolvable_far_end_is_opaque_not_a_defect(self):
+        """"I cannot see the far end" and "the far end drops it" are
+        different findings, and only one of them is a bug."""
+        wrapper = self._hook("m.wrapper", "h",
+                             ch.Consumption.FORWARDED_ONLY, ["elsewhere"])
+        assert (ch.effective_consumption(wrapper, {"m.wrapper.h": wrapper})
+                is ch.Consumption.OPAQUE)
+
+    def test_mutual_forwarding_terminates(self):
+        """Two overloads forwarding to each other is legal. A naive walk
+        would not return."""
+        a = self._hook("m.a", "h", ch.Consumption.FORWARDED_ONLY, ["b"])
+        b = self._hook("m.b", "h", ch.Consumption.FORWARDED_ONLY, ["a"])
+        assert ch.effective_consumption(a, {"m.a.h": a, "m.b.h": b}) \
+            is ch.Consumption.OPAQUE
+
+    def test_any_consuming_branch_redeems_a_two_way_forward(self):
+        w = self._hook("m.w", "h", ch.Consumption.FORWARDED_ONLY,
+                       ["good", "bad"])
+        good = self._hook("m.good", "h", ch.Consumption.READ)
+        bad = self._hook("m.bad", "h", ch.Consumption.UNREAD)
+        by_qual = {"m.w.h": w, "m.good.h": good, "m.bad.h": bad}
+        assert ch.effective_consumption(w, by_qual) is ch.Consumption.READ
+
+
+class TestFillStates:
+    """What a call site says about each hook it was offered."""
+
+    def _hooks(self, *names, positional=()):
+        return [ch.Hook(name=n, sink="m.sink", positional=(n in positional),
+                        required=False, consumption=ch.Consumption.READ)
+                for n in names]
+
+    def _call(self, source):
+        return ast.parse(source).body[0].value
+
+    def test_a_keyword_argument_is_a_fill(self):
+        fills = ch._fills_for_call("surf", self._call("sink(a=1)"),
+                                   self._hooks("a"))
+        assert fills[0].state is ch.FillState.FILLED
+
+    def test_an_omitted_hook_is_unset(self):
+        fills = ch._fills_for_call("surf", self._call("sink()"),
+                                   self._hooks("a"))
+        assert fills[0].state is ch.FillState.UNSET
+
+    def test_a_positional_argument_still_counts(self):
+        """`ov demo live` passes its mux positionally. Keyword-only matching
+        would report the cockpit's own multiplexer as unset."""
+        fills = ch._fills_for_call("surf", self._call("sink(mux)"),
+                                   self._hooks("mux", positional=("mux",)))
+        assert fills[0].state is ch.FillState.FILLED
+
+    def test_a_splatting_caller_is_opaque_never_a_failure(self):
+        """``sink(**opts)`` may well fill it; no call site enumerates the
+        name, so neither pass nor fail would be honest."""
+        fills = ch._fills_for_call("surf", self._call("sink(**opts)"),
+                                   self._hooks("a"))
+        assert fills[0].state is ch.FillState.OPAQUE
+
+    def test_a_waiver_is_accounted_for_and_keeps_its_reason(self):
+        fills = ch._fills_for_call(
+            "surf", self._call("sink(a=waived('nothing to complete against'))"),
+            self._hooks("a"))
+        assert fills[0].state is ch.FillState.WAIVED
+        assert fills[0].reason == "nothing to complete against"
+
+
+class TestDivergenceIsTheSignal:
+    def test_only_disagreement_between_surfaces_is_reported(self):
+        """A hook NOBODY fills is an unused option, not a demo gap. Reporting
+        every unfilled optional produced 102 rows of which four mattered."""
+        reading = ch.HandoffReading(fills=[
+            ch.Fill("client", "m.sink", "used", ch.FillState.FILLED),
+            ch.Fill("demo", "m.sink", "used", ch.FillState.UNSET),
+            ch.Fill("client", "m.sink", "ignored", ch.FillState.UNSET),
+            ch.Fill("demo", "m.sink", "ignored", ch.FillState.UNSET),
+        ])
+        assert [(h, f, u) for _s, h, f, u in reading.divergence()] == [
+            ("used", ("client",), ("demo",))]
+
+    def test_a_declared_waiver_is_not_a_divergence(self):
+        """The point of waiving: a surface that has decided is no longer a
+        finding, so the list shrinks to things nobody has thought about."""
+        reading = ch.HandoffReading(fills=[
+            ch.Fill("client", "m.sink", "h", ch.FillState.FILLED),
+            ch.Fill("demo", "m.sink", "h", ch.FillState.WAIVED,
+                    reason="input is inert here"),
+        ])
+        assert reading.divergence() == []
+
+    def test_coverage_counts_waivers_as_accounted_for(self):
+        reading = ch.HandoffReading(fills=[
+            ch.Fill("demo", "m.sink", "a", ch.FillState.FILLED),
+            ch.Fill("demo", "m.sink", "b", ch.FillState.WAIVED, reason="why"),
+            ch.Fill("demo", "m.sink", "c", ch.FillState.UNSET),
+        ])
+        assert reading.coverage("demo") == (2, 3)
+
+
+class TestNoHookIsDropped:
+    """THE RATCHET. The regression `search_rows` never had.
+
+    Runs the real analyser over the real tree. A new hook that is accepted and
+    never read fails here, at authoring time, instead of shipping dark and
+    being found by an operator months later asking why a feature they paid for
+    is invisible.
+    """
+
+    def test_every_hook_a_sink_accepts_is_accounted_for(self):
+        reading = ch.audit()
+        assert reading.sinks, "no sinks discovered — the audit found nothing"
+        dropped = reading.dropped()
+        assert not dropped, (
+            "these hooks are accepted by a sink and consumed by nothing it "
+            "forwards to, so the capability is dark for EVERY caller:\n"
+            + "\n".join(f"  {h.sink}({h.name})" for h in dropped)
+            + "\n\nEither consume the value, forward it to something that "
+              "does, or `del` the parameter to declare the discard."
+        )
+
+    def test_the_cockpit_builder_is_among_the_discovered_sinks(self):
+        """Guards the ratchet itself. Discovery is by SHAPE, so a refactor
+        that drops the hook count below the threshold would empty the audit
+        and turn the test above green by measuring nothing."""
+        quals = {s.qualname for s in ch.audit().sinks}
+        assert any(q.endswith("bipartite_layout.build_bipartite_application")
+                   for q in quals), (
+            f"the cockpit builder is no longer being audited: {sorted(quals)}")
+
+    def test_a_disabled_audit_reports_nothing_rather_than_passing(self, monkeypatch):
+        """Master-off must yield an EMPTY reading, so a suite that silently
+        ran with the flag unset cannot look like a clean bill of health."""
+        monkeypatch.setenv(ch.MASTER_FLAG_ENV_VAR, "0")
+        reading = ch.audit()
+        assert reading.sinks == [] and reading.hooks == []
+
+    def test_render_never_raises_on_an_empty_reading(self):
+        assert ch.render(ch.HandoffReading())

--- a/tests/battle_test/test_transcript_search_mount.py
+++ b/tests/battle_test/test_transcript_search_mount.py
@@ -146,14 +146,87 @@ class TestTheMount:
                 for b in kb.bindings for k in b.keys}
         assert "/" in keys, "the hatch install did not bring search"
 
-    def test_the_cockpit_receives_a_search_bar_renderer(self):
-        """Pinned at the seam: a renderer with no mount is the exact shape of
-        the bug this change exists to close."""
-        import inspect
-        from backend.core.ouroboros.cli.ov import _bipartite_attach_loop
+    def test_the_cockpit_actually_draws_the_search_bar_it_was_given(self):
+        """The bar must reach the LAYOUT, not merely reach the signature.
 
-        src = inspect.getsource(_bipartite_attach_loop)
-        assert "search_rows=" in src
+        This test used to read ``assert "search_rows=" in src`` against
+        `_bipartite_attach_loop` — proving only that the CALLER passes the
+        argument, which it always did. `build_bipartite_application` accepted
+        the parameter and never read it, so transcript search was dark on the
+        shipping client, and this test passed throughout. It asserted the half
+        of the handoff that was never broken.
+
+        So it now builds the real Application and looks for the provider's
+        output in the container tree. That fails if the mount is removed, which
+        is the whole job.
+        """
+        from prompt_toolkit.formatted_text import to_formatted_text
+        from prompt_toolkit.layout import walk
+        from prompt_toolkit.layout.controls import FormattedTextControl
+
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            BipartiteLayout, build_bipartite_application,
+        )
+
+        def drawn(app):
+            """Every string the layout's text controls would render.
+
+            Fragments are JOINED per control, never inspected individually:
+            `to_formatted_text` on an ``ANSI`` value yields ONE FRAGMENT PER
+            CHARACTER, so a substring search over the fragment list can never
+            match a multi-character sentinel. The first version of this helper
+            did exactly that and reported the mount missing while it was
+            working — an assertion that fails for a reason unrelated to the
+            behaviour is worse than none.
+            """
+            out = []
+            for node in walk(app.layout.container):
+                control = getattr(node, "content", None)
+                if not isinstance(control, FormattedTextControl):
+                    continue
+                try:
+                    value = (control.text() if callable(control.text)
+                             else control.text)
+                    out.append("".join(f[1] for f in to_formatted_text(value)))
+                except Exception:  # noqa: BLE001
+                    continue
+            return out
+
+        mark = "SEARCH-BAR-SENTINEL 3/17"
+        with_bar = build_bipartite_application(
+            BipartiteLayout(), on_accept=lambda _t: None,
+            search_rows=lambda: [mark],
+        )
+        assert any(mark in line for line in drawn(with_bar)), (
+            "search_rows was accepted and never mounted — the search bar is "
+            "dark on every surface that passes it"
+        )
+
+    def test_the_bar_costs_nothing_when_no_provider_is_given(self):
+        """The complement, and not a formality: a mount that draws the row
+        unconditionally would pass the test above while stealing a line from
+        every cockpit that has no search bar."""
+        from prompt_toolkit.formatted_text import to_formatted_text
+        from prompt_toolkit.layout import walk
+        from prompt_toolkit.layout.controls import FormattedTextControl
+
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            BipartiteLayout, build_bipartite_application,
+        )
+
+        app = build_bipartite_application(
+            BipartiteLayout(), on_accept=lambda _t: None)
+        for node in walk(app.layout.container):
+            control = getattr(node, "content", None)
+            if not isinstance(control, FormattedTextControl):
+                continue
+            try:
+                value = (control.text() if callable(control.text)
+                         else control.text)
+                text = "".join(f[1] for f in to_formatted_text(value))
+            except Exception:  # noqa: BLE001
+                continue
+            assert "SEARCH-BAR-SENTINEL" not in text
 
     def test_the_bar_is_silent_until_it_is_opened(self):
         """A search bar that always occupies a row spends it saying nothing,


### PR DESCRIPTION
## Two defects, one shape

A value passed across a boundary that nobody checked the far side of.

The operator's report was *"there are `ov` features I never see in `ov demo live`"*. True — but the cause was not a list of omissions. **Nothing in the repo could measure whether a value handed to a callee is actually used.**

## The blind spot was already written down

`surface_reachability` states it as its own limit: *"Reachability sees imports; it cannot see that a KeyBindings object was handed across."* A finished feature can go dark two ways and only one was measurable.

`ui/capability_handoff.py` measures the other. A builder's parameter list already **is** the complete, self-updating statement of what it can be given, so that is the authority — a hand-kept capability checklist would be `/narrate`'s hardcoded producer list in a new costume.

- **Sinks discovered by shape**, not name or annotation — `completer`, `history`, `auto_suggest`, `turn_spinner` are all annotated `Any`.
- **A forward is not a consumption**, resolved transitively with a cycle guard: a pass-through wrapper is not a defect, a drop behind one still is.
- **`divergence()` is the signal, not "unfilled"** — every-unfilled-optional gave 102 rows of which 4 mattered. `surface_reachability`'s "asymmetry is evidence, never a conclusion", applied to values.
- **Fills propagate along proven forward edges** — without it `ov.py` (wrapper) and `ov_demo` (builder) never name the same sink.
- **`waived("reason")` returns None** — byte-identical at runtime to omitting the argument, statically a declared decision at the site where it was made. `del param` is the sink-side equivalent, because Python already has that sentence and this codebase already used it.

## What it found

| defect | consequence |
|---|---|
| `search_rows` accepted, forwarded, resolved by `ov.py`, read by **nothing** | transcript search dark on the **shipping** attach client |
| `on_mux` dead on the builder (zero loads) | removed; caught my own plan being wrong |

## The canvas was budgeting against the wrong number

Found by *watching* the scene. `BipartiteLayout` sized its deck against the **terminal**, while what bounds it is the leftover its parent `HSplit` hands it.

At 200×60 with a 12-row crest: the mux believed **39 rows**, produced **39 lines**, was given **8** — and a `Window` draws from the **top**, so the eight it kept were the *oldest*. The operator watched a window parked 31 lines behind the live tail.

**Not a demo problem** — `ov attach` mounts the same crest through the same builder, so the shipping cockpit was clipping the tail of its own transcript.

Predicting failed: `_canvas_fragments` reserved exactly one row for chrome (`size.rows - 1`), true when the cockpit was a canvas and a prompt, wronger with every strip since. Deducting the strips instead would mean re-deriving the parent's layout arithmetic — two implementations of one truth.

So it is **observed**, at the seam the framework already provides: `create_content(width, height)` is prompt_toolkit telling a control what it has. Recorded *before* delegating to `super()` (which invokes the text callable), so the frame being measured is the frame that renders corrected — **zero lag**. `render_info` after a render is the same measurement one frame late, and a resize would flash one wrong frame, which is exactly when an operator is looking.

`self._height` already drove `_line_budget()`, the Rich console height **and** the Panel height, so the observed number corrects all three with no new plumbing.

Degenerate heights are **refused, not recorded** — `None` means measure-not-draw, `0` a collapsed `ConditionalContainer`; the last good measurement beats a degenerate fresh one, and `None` must not forge provenance. `allotment_measured` keeps the estimate from wearing a measurement's authority.

Capping the header from the caller was tried and **rejected** as a workaround: it trades the emblem for the transcript and leaves every other row unaccounted, so the clipping returns the next time a strip is added. It did, immediately, from the strips added in this same change.

## The demo fills the half it left dark

8 of 19 hooks → every input-or-state surface now mounted through the **real** collaborator: `/` palette from the live verb registry, ghost text, turn spinner, status line, search bar, NOTIFY_APPLY countdown via `pending_apply.render`. History is **in-memory** — `_build_prompt_history` returns a FileHistory on the operator's shared recall, and a demo writing there is the hazard the reach gutter already refused.

## Tests — 58 new, 158 green

- `test_the_newest_line_is_visible_under_heavy_chrome` asserts the operator-visible **symptom**, so it fails for any future cause.
- A structural pin forbids the terminal prediction returning — behavioural tests would still pass with it restored, since a prediction only loses to a measurement when both are present.
- The handoff **ratchet** requires every accepted hook to be consumed, forwarded, or declared discarded — guarded by a second test that the cockpit builder is still among the discovered sinks, or a refactor could empty the audit and turn the ratchet green by measuring nothing.
- `test_transcript_search_mount` no longer reads `"search_rows=" in src`. That assertion held the half of the handoff that was never broken and passed for the entire period the feature did nothing — the fourth appearance of that antipattern in a week.

Verified under a PTY at 200×60 and at a pathological 80×24 where the crest is half the screen: the deck reaches its tail in both, and the reach gutter legitimately scrolls into the retained ring with the tail hint rather than being clipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a capability-handoff auditor and makes the canvas size itself to the space it’s actually given. This fixes dropped hooks like `search_rows` and stops the transcript tail from being clipped.

- **Bug Fixes**
  - Added `ui/capability_handoff.py` to audit builder params by shape, propagate forwards, and allow explicit drops via `waived("reason")`.
  - Mounted `search_rows` so the search bar actually renders; removed dead `on_mux`.
  - `BipartiteLayout` now observes real height via `create_content(width, height)`, tracks `_allotment_measured`, rejects degenerate values, and uses the measured height for line budgeting.
  - Tests: assert newest line stays visible under heavy chrome, pin against terminal-size prediction, add a handoff ratchet, and verify the search bar reaches the layout.

- **New Features**
  - `ov_demo` now mounts real input/state collaborators: `/` palette from the live verb registry, ghost text, turn spinner, status line, search bar, and NOTIFY_APPLY countdown; uses in-memory history.

<sup>Written for commit 3bfbb4ff0ea6f3f9e97bbe77ff4a258215a8494b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

