### PR TITLE
fix(ov): the daemon cockpit can see the state it produces

### DIFF
--- a/backend/core/ouroboros/battle_test/cockpit_mount.py
+++ b/backend/core/ouroboros/battle_test/cockpit_mount.py
@@ -1,0 +1,397 @@
+"""What a cockpit mount CONSISTS of — assembled once, for the surface asking.
+
+`ov` has three surfaces that render, and all three hand-assemble their own
+argument list for `build_bipartite_application`. So they drift, and the drift is
+invisible: nothing compares them, so a hook added for one surface is simply
+absent on the others until an operator notices a feature they were promised.
+
+`serpent_flow` already says this out loud, about the last time it happened:
+
+    The daemon-side cockpit is a surface the operator TYPES into, and it ran
+    with zero completion, zero persistent history and zero ghost-text while the
+    attach cockpit had all three wired at ov.py — the two-surfaces split, again.
+
+That was fixed for three hooks by `repl_completion.build_completion_wiring` — one
+factory, both surfaces, "so the vocabularies cannot diverge". Eleven more hooks
+were still in the same state, and this module is that same fix generalised rather
+than a second mechanism beside it.
+
+The daemon was blind to state it PRODUCES
+=========================================
+The worst of it is not that the daemon cockpit was missing decoration. It is the
+direction of the blindness:
+
+    `pending_apply`   the daemon calls `note_pending` / `clear_pending`. It is
+                      the source of the NOTIFY_APPLY countdown, and it never
+                      mounted the strip that draws it.
+    `panic_arbiter`   the daemon calls `arbitrate` from its own event-loop
+                      exception handler. It is where the crash HAPPENS, and the
+                      FATAL overlay only ever rendered on a remote client.
+
+An operator sitting at the daemon's own terminal could not see a gate the daemon
+was running or a task the daemon had just lost. The state was produced locally
+and legible only from somewhere else.
+
+Same renderer, different source
+===============================
+The rule this module is built on is already stated at `_local_agent_rows`:
+
+    Same renderer as the remote cockpit, different source, which is the entire
+    reason `render_roster` takes a snapshot rather than a roster: neither
+    surface can drift into its own look.
+
+So every provider here resolves an IN-PROCESS snapshot and hands it to the SHARED
+renderer the attach client already calls. Nothing is drawn twice, and a
+regression in a strip shows up on both surfaces at once instead of on whichever
+one happened to keep its own copy.
+
+The asymmetry that stays
+------------------------
+The attach client gates its strips on heartbeat STALENESS — a dead daemon must
+not leave a countdown ticking toward an apply that will never happen. The daemon
+has no such concept and must not grow one: it IS the source, so there is no
+transport to go stale and no last-arrival to measure. Staleness is a property of
+a bridge, not of the state, and importing that check here would mean the daemon
+retiring its own live truth on a timer.
+
+No new flags
+------------
+Every strip already owns its own master switch (`pending_apply.strip_enabled`,
+`panic_arbiter.panic_arbiter_enabled`, `operator_input_queue.input_queue_enabled`,
+and so on) and each returns an empty list when off. Mounting a provider therefore
+cannot force a surface on, and adding a gate here would be a second answer to a
+question those modules already answer — the mistake `narrative_density` refused
+when it declined to absorb posture.
+
+Width is resolved PER FRAME, never captured
+-------------------------------------------
+Every renderer takes a width and the canvas draws with ``wrap_lines=False``, so a
+row wrapped to a stale width is clipped at the right edge rather than reflowed.
+A provider closing over the width it saw at mount would be correct until the
+first resize.
+
+NEVER raises. A strip that cannot resolve returns no rows; a cockpit that cannot
+draw a strip still draws the cockpit.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, List, Optional
+
+logger = logging.getLogger("Ouroboros.CockpitMount")
+
+COCKPIT_MOUNT_SCHEMA_VERSION = "cockpit_mount.v1"
+
+
+def _terminal_width(fallback: int = 100) -> int:
+    """This frame's width. Resolved on every call, deliberately — see module doc."""
+    try:
+        import shutil
+        return max(20, int(shutil.get_terminal_size((fallback, 30)).columns))
+    except Exception:  # noqa: BLE001
+        return fallback
+
+
+# ---------------------------------------------------------------------------
+# In-process providers — local snapshot → the SHARED renderer
+# ---------------------------------------------------------------------------
+
+
+def daemon_pending_rows() -> List[str]:
+    """The NOTIFY_APPLY countdown, for the process that owns the gate.
+
+    `snapshot()` drops expired entries where the clock that set them lives, so
+    this reader never decides whether an op has run out — it would be guessing
+    from a frame that is already a second old.
+
+    ``age_s=0.0`` and not a measured age: in-process there is no transport
+    between the snapshot and the render, so the age IS zero. The attach client
+    passes a real age because its snapshot crossed a bridge and the countdown has
+    to keep ticking between 1 Hz heartbeats.
+    """
+    try:
+        from backend.core.ouroboros.battle_test.pending_apply import (
+            render, snapshot,
+        )
+        return render(snapshot(), age_s=0.0, width=_terminal_width())
+    except Exception:  # noqa: BLE001
+        logger.debug("[CockpitMount] pending rows unavailable", exc_info=True)
+        return []
+
+
+def daemon_panic_rows() -> List[str]:
+    """The FATAL overlay, on the process where the task actually died.
+
+    `recent_panics()` is the arbiter's own deduplicated record — the daemon's
+    loop exception handler calls `arbitrate`, which is what fills it. Rendering
+    the most recent one mirrors the client, which holds a single `self._panic`.
+
+    The overlay is the loudest thing a cockpit draws, so it must not be summoned
+    by an EMPTY record: `render_panic(None)` already answers `[]`, and passing a
+    falsy payload through unchanged keeps that one decision in one place.
+
+    The field names do NOT line up, and the mismatch is silent. `Panic` stores
+    ``traceback_text``; `render_panic` reads ``"traceback"`` — the wire spelling
+    the attach client receives over the bridge. Handing the dataclass's own
+    ``__dict__`` straight over therefore produces a FATAL overlay with an empty
+    traceback: the alarm fires, correctly, and drops the only part of it anybody
+    needs. So the adapter is explicit and `_panic_payload` is pinned by a test
+    that derives the expected keys from `render_panic` itself, rather than
+    restating them here where they could rot apart again.
+    """
+    try:
+        from backend.core.ouroboros.battle_test.panic_arbiter import (
+            recent_panics, render_panic,
+        )
+        panics = recent_panics() or []
+        if not panics:
+            return []
+        return render_panic(_panic_payload(panics[-1]),
+                            width=_terminal_width())
+    except Exception:  # noqa: BLE001
+        logger.debug("[CockpitMount] panic rows unavailable", exc_info=True)
+        return []
+
+
+def _panic_payload(panic: Any) -> Optional[dict]:
+    """A `Panic` in the shape `render_panic` reads. NEVER raises.
+
+    A dict is passed through untouched — that is already the wire shape, and
+    re-mapping it would corrupt the client's own payload if this were ever reused
+    on that side.
+    """
+    if panic is None:
+        return None
+    if isinstance(panic, dict):
+        return panic
+    try:
+        return {
+            "exc_type": getattr(panic, "exc_type", "") or "",
+            "message": getattr(panic, "message", "") or "",
+            "origin": getattr(panic, "origin", "") or "",
+            # The rename that would otherwise have shipped an empty overlay.
+            "traceback": getattr(panic, "traceback_text", "") or "",
+        }
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def daemon_queue_rows() -> List[str]:
+    """The operator's own backlog — lines typed ahead of the organism."""
+    try:
+        from backend.core.ouroboros.battle_test.operator_input_queue import (
+            active_queue_snapshot, render_queue,
+        )
+        return render_queue(active_queue_snapshot(), width=_terminal_width())
+    except Exception:  # noqa: BLE001
+        logger.debug("[CockpitMount] queue rows unavailable", exc_info=True)
+        return []
+
+
+def daemon_search_rows() -> Any:
+    """The `/` transcript search bar, or None when the hatches are absent.
+
+    None rather than a lambda yielding nothing: a strip whose provider can never
+    produce anything should not be in the layout at all, which is the contract
+    `ov.py::_transcript_search_rows` already states.
+    """
+    try:
+        from backend.core.ouroboros.battle_test.transcript_hatches import (
+            search_status,
+        )
+        return search_status
+    except Exception:  # noqa: BLE001
+        logger.debug("[CockpitMount] search rows unavailable", exc_info=True)
+        return None
+
+
+def daemon_serpent_active() -> bool:
+    """Is the organism THINKING right now?
+
+    Drives the serpent hairline border. Read from `build_heartbeat_payload` — the
+    same pure-pull payload the turn spinner and the toolbar pulse consume — so the
+    border, the verb and the token counter cannot disagree about whether work is
+    happening. A border that moves while the toolbar says idle teaches an operator
+    to stop believing both.
+
+    This hook was filled by NEITHER shipping surface: the animation existed and
+    only ever ran in `ov demo live`.
+    """
+    try:
+        from backend.core.ouroboros.battle_test.attach_heartbeat import (
+            build_heartbeat_payload,
+        )
+        payload = build_heartbeat_payload() or {}
+        return bool(payload.get("active"))
+    except Exception:  # noqa: BLE001
+        return False
+
+
+class LocalCockpitClient:
+    """The daemon terminal's stand-in for the attach client's `ui`/`client`.
+
+    `install_transcript_hatches(kb, ui, client)` needs exactly three things:
+    ``ui.flash(...)``, a mutable ``ui._narrate_verbose`` and
+    ``client.send_input(...)``. None of that is bridge-specific — the bridge
+    exists because the cockpit is a SEPARATE PROCESS and had to ask the daemon to
+    act. At the daemon's own terminal there is no second process, so the same
+    three calls are local.
+
+    This is `LocalRewindClient`'s argument applied to the hatches: the second
+    ENTRANCE to one implementation, never a second implementation. It is why the
+    keys are not reimplemented here — the daemon gets the identical remappable
+    action set, so `keybindings.json` cannot mean two different things depending
+    on which terminal an operator is sitting at.
+
+    Serves as BOTH `ui` and `client`: the installer only ever asks for those
+    three members, and splitting them into two shims would invent a distinction
+    the callee does not make.
+
+    NEVER raises. A keybinding that can break the REPL it is bound in is worse
+    than an unbound key.
+    """
+
+    __slots__ = ("_send", "_flash", "_narrate_verbose")
+
+    def __init__(self, *, send_input: Any, flash: Any = None) -> None:
+        self._send = send_input
+        self._flash = flash
+        #: Read AND written by the hatch action, so it has to be a real
+        #: attribute rather than a property — the installer toggles it.
+        self._narrate_verbose = False
+
+    def send_input(self, text: str) -> None:
+        try:
+            if self._send is not None:
+                self._send(str(text))
+        except Exception:  # noqa: BLE001
+            logger.debug("[CockpitMount] local send_input degraded",
+                         exc_info=True)
+
+    def flash(self, message: str, *_args: Any, **_kwargs: Any) -> None:
+        """Surface a transient notice. Falls back to the canvas.
+
+        The attach client owns a flash region; the daemon cockpit does not, and
+        the canvas is the surface an operator is already reading. Swallowing the
+        message instead would make a bound key look broken.
+        """
+        try:
+            if self._flash is not None:
+                self._flash(str(message))
+                return
+            from backend.core.ouroboros.battle_test.bipartite_layout import (
+                get_active_canvas,
+            )
+            canvas = get_active_canvas()
+            if canvas is not None:
+                canvas.push_raw(str(message))
+        except Exception:  # noqa: BLE001
+            logger.debug("[CockpitMount] local flash degraded", exc_info=True)
+
+
+def daemon_key_bindings(repl: Any = None) -> Any:
+    """The hatch/search action set, bound locally. None when nothing bound.
+
+    Mounted for a reason that is easy to miss: the search BAR without the search
+    KEY is decoration. `search_rows` gives the daemon cockpit a strip that
+    renders when a search is open, and on this surface nothing could open one —
+    `extra_key_bindings` was unset, so `/` was never bound. Shipping the strip
+    alone would have added a row that could never appear and called the gap
+    closed.
+
+    Returns a `KeyBindings` the caller merges through the layout's existing
+    `extra_key_bindings` seam, so there is no layout surgery and the daemon and
+    attach surfaces stay one code path.
+    """
+    try:
+        from prompt_toolkit.key_binding import KeyBindings
+
+        from backend.core.ouroboros.battle_test.transcript_hatches import (
+            install_transcript_hatches,
+        )
+        send = getattr(repl, "_dispatch_verb", None) or getattr(
+            repl, "handle_input", None)
+        shim = LocalCockpitClient(send_input=send)
+        kb = KeyBindings()
+        if not install_transcript_hatches(kb, shim, shim):
+            return None
+        return kb
+    except Exception:  # noqa: BLE001
+        logger.debug("[CockpitMount] daemon key bindings unavailable",
+                     exc_info=True)
+        return None
+
+
+def daemon_toolbar() -> Any:
+    """The pulse line, or None. NEVER raises.
+
+    `format_heartbeat_line` is what every attached cockpit draws, fed by the same
+    pure-pull `build_heartbeat_payload` the turn spinner and `serpent_active`
+    read. The daemon had no toolbar at all: the process that knows the provider,
+    the elapsed and the token count showed none of it at its own terminal.
+
+    ``now_mono``/``arrival_mono`` are the same instant here. The client passes a
+    real arrival because its payload crossed a bridge and the elapsed has to
+    advance between 1 Hz frames; in-process there is no transport, so claiming an
+    age would be inventing one.
+    """
+    try:
+        from backend.core.ouroboros.battle_test.attach_heartbeat import (
+            build_heartbeat_payload, format_heartbeat_line,
+        )
+
+        def _render() -> str:
+            try:
+                import time
+                now = time.monotonic()
+                return format_heartbeat_line(
+                    build_heartbeat_payload(), now_mono=now, arrival_mono=now,
+                ) or ""
+            except Exception:  # noqa: BLE001
+                return ""
+
+        return _render
+    except Exception:  # noqa: BLE001
+        logger.debug("[CockpitMount] toolbar unavailable", exc_info=True)
+        return None
+
+
+def build_daemon_mount(repl: Any = None) -> "dict":
+    """Every in-process hook the daemon cockpit can fill, as a plain dict.
+
+    Returned as VALUES for the caller to pass explicitly, and deliberately not
+    splatted at the call site. `ui/capability_handoff` reads a `**kwargs` splat as
+    OPAQUE — it cannot see which names a splat covers, and rightly refuses to
+    guess — so a mount that spread itself would blind the very audit that found
+    these eleven gaps. The composition removes the duplicated LOGIC; the call
+    sites stay named so coverage remains measurable, and `divergence()` still
+    flags any surface that forgets one.
+
+    ``repl`` is the daemon REPL, consulted only for the one provider that needs a
+    local action sink (`daemon_key_bindings`). Every other provider reads
+    process-global state.
+    """
+    return {
+        "pending_rows": daemon_pending_rows,
+        "panic_rows": daemon_panic_rows,
+        "queue_rows": daemon_queue_rows,
+        # Resolved (not a factory): a strip whose provider can never yield should
+        # not be in the layout at all.
+        "search_rows": daemon_search_rows(),
+        "serpent_active": daemon_serpent_active,
+        "toolbar": daemon_toolbar(),
+        # Bound here so the search bar above is REACHABLE. A strip with no key to
+        # open it is a row that can never appear.
+        "extra_key_bindings": daemon_key_bindings(repl),
+    }
+
+
+__all__ = [
+    "COCKPIT_MOUNT_SCHEMA_VERSION",
+    "build_daemon_mount",
+    "daemon_panic_rows",
+    "daemon_pending_rows",
+    "daemon_queue_rows",
+    "daemon_search_rows",
+    "daemon_serpent_active",
+]

--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -6638,6 +6638,35 @@ class SerpentREPL:
                     _bp_wiring = build_completion_wiring(self)
                 except Exception:  # noqa: BLE001
                     _bp_wiring = None
+                # The strips this process PRODUCES and could not see.
+                #
+                # `capability_handoff` measured this surface at 7 of 18 hooks
+                # while `ov attach` filled nearly all of them, and the direction
+                # of the gap was the finding: the daemon calls `note_pending` /
+                # `clear_pending`, so it is the source of the NOTIFY_APPLY
+                # countdown and never mounted the strip that draws it; it calls
+                # `panic_arbiter.arbitrate` from its own loop exception handler,
+                # so it is where a task actually dies and the FATAL overlay only
+                # ever rendered on a remote client. An operator at the daemon's
+                # own terminal could not see a gate this process was running or a
+                # task it had just lost.
+                #
+                # Assembled by `cockpit_mount.build_daemon_mount` rather than
+                # listed here, so the next hook is taught in one place — the same
+                # move `build_completion_wiring` already made for the three hooks
+                # above, and for the same stated reason: one factory, both
+                # surfaces, so the vocabularies cannot diverge. Passed by NAME
+                # rather than splatted, because `capability_handoff` reads a
+                # `**kwargs` splat as OPAQUE and a mount that spread itself would
+                # blind the audit that found these gaps.
+                _mount = {}
+                try:
+                    from backend.core.ouroboros.battle_test.cockpit_mount import (  # noqa: E501
+                        build_daemon_mount,
+                    )
+                    _mount = build_daemon_mount(self)
+                except Exception:  # noqa: BLE001 — strips never gate the cockpit
+                    _mount = {}
                 await run_bipartite_repl(
                     on_accept=_on_accept,
                     completer=getattr(_bp_wiring, "completer", None),
@@ -6651,6 +6680,16 @@ class SerpentREPL:
                     # roster: neither surface can drift into its own look.
                     agent_rows=_local_agent_rows,
                     status_rows=_local_status_rows,
+                    # Same rule, extended to the strips that were missing it.
+                    pending_rows=_mount.get("pending_rows"),
+                    panic_rows=_mount.get("panic_rows"),
+                    queue_rows=_mount.get("queue_rows"),
+                    search_rows=_mount.get("search_rows"),
+                    serpent_active=_mount.get("serpent_active"),
+                    toolbar=_mount.get("toolbar"),
+                    # The KEY for the search bar above. Mounting the strip alone
+                    # would have added a row nothing could ever open.
+                    extra_key_bindings=_mount.get("extra_key_bindings"),
                 )
                 return
         except Exception:  # noqa: BLE001 — cockpit failure NEVER bricks the REPL

--- a/tests/battle_test/test_cockpit_mount.py
+++ b/tests/battle_test/test_cockpit_mount.py
@@ -1,0 +1,246 @@
+"""The daemon cockpit must be able to see the state it produces.
+
+`capability_handoff` measured `serpent_flow` at 7 of 18 cockpit hooks while
+`ov attach` filled nearly all of them, and the DIRECTION of the gap was the
+finding rather than the count:
+
+    pending_apply   the daemon calls `note_pending` / `clear_pending`, so it is
+                    the source of the NOTIFY_APPLY countdown — and never mounted
+                    the strip that draws it.
+    panic_arbiter   the daemon calls `arbitrate` from its own loop exception
+                    handler, so it is where a task dies — and the FATAL overlay
+                    only ever rendered on a remote client.
+
+An operator at the daemon's own terminal could not see a gate this process was
+running or a task it had just lost.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.battle_test import cockpit_mount as cm
+
+
+@pytest.fixture(autouse=True)
+def _clean_state():
+    """Both sources are process-global; a leaked panic or pending op would make
+    these tests pass or fail depending on their order."""
+    from backend.core.ouroboros.battle_test import panic_arbiter as pa
+    try:
+        pa.reset_for_tests()
+    except Exception:  # noqa: BLE001
+        pass
+    yield
+    try:
+        pa.reset_for_tests()
+    except Exception:  # noqa: BLE001
+        pass
+
+
+class TestTheDaemonSeesWhatItProduces:
+    def test_a_pending_apply_reaches_the_daemons_own_strip(self):
+        """The countdown for a gate THIS process is running."""
+        from backend.core.ouroboros.battle_test import pending_apply as pd
+        pd.note_pending("7759-86", delay_s=5.0, reason="NOTIFY_APPLY")
+        try:
+            rows = cm.daemon_pending_rows()
+        finally:
+            pd.clear_pending("7759-86")
+        assert any("7759-86" in r for r in rows), (
+            f"the daemon cannot see its own pending apply: {rows!r}")
+
+    def test_a_panic_reaches_the_daemons_own_overlay(self):
+        """The crash overlay on the process where the task actually died."""
+        from backend.core.ouroboros.battle_test import panic_arbiter as pa
+        try:
+            raise RuntimeError("cannot import name 'get_active_harness'")
+        except RuntimeError as exc:
+            pa.report(exc, origin="doc_staleness.sweep")
+        rows = cm.daemon_panic_rows()
+        assert rows, "the daemon cannot see its own panic"
+        assert any("get_active_harness" in r for r in rows)
+
+    def test_the_panic_overlay_carries_its_traceback(self):
+        """The bug this nearly shipped. `Panic` stores ``traceback_text``;
+        `render_panic` reads ``"traceback"``. Passing the dataclass's own
+        ``__dict__`` renders the alarm and silently drops the only part of it
+        anybody needs."""
+        from backend.core.ouroboros.battle_test import panic_arbiter as pa
+        try:
+            raise ValueError("boom in the sweep")
+        except ValueError as exc:
+            pa.report(exc, origin="unit")
+        joined = "\n".join(cm.daemon_panic_rows())
+        assert "Traceback" in joined or "ValueError" in joined, (
+            "the overlay rendered without its traceback — the "
+            "traceback_text/traceback rename was not adapted")
+
+    def test_the_payload_keys_are_the_ones_the_renderer_reads(self):
+        """Derived from `render_panic`'s own source rather than restated, so a
+        rename on either side breaks this instead of quietly emptying a field."""
+        import inspect
+        import re
+
+        from backend.core.ouroboros.battle_test import panic_arbiter as pa
+
+        wanted = set(re.findall(r'\.get\(\s*"([a-z_]+)"',
+                                inspect.getsource(pa.render_panic)))
+
+        class _P:
+            exc_type, message, origin = "E", "m", "o"
+            traceback_text = "tb"
+
+        payload = cm._panic_payload(_P())
+        assert wanted <= set(payload), (
+            f"render_panic reads {sorted(wanted)}; payload supplies "
+            f"{sorted(payload)}")
+        assert payload["traceback"] == "tb"
+
+    def test_a_dict_payload_passes_through_untouched(self):
+        """Already the wire shape. Re-mapping it would corrupt the client's own
+        payload if this were ever reused on that side."""
+        wire = {"exc_type": "E", "message": "m", "origin": "o",
+                "traceback": "tb"}
+        assert cm._panic_payload(wire) is wire
+
+    def test_nothing_pending_and_nothing_crashed_draws_nothing(self):
+        """A cockpit must cost zero rows when there is nothing to say. The panic
+        overlay is the loudest thing it draws and must never be summoned by an
+        empty record."""
+        assert cm.daemon_pending_rows() == []
+        assert cm.daemon_panic_rows() == []
+        assert cm._panic_payload(None) is None
+
+
+class TestTheSearchBarIsReachable:
+    def test_the_mount_binds_the_key_that_opens_the_strip(self):
+        """A strip with no key to open it is a row that can never appear.
+        `search_rows` was mounted on the daemon while `extra_key_bindings` stayed
+        unset, so `/` was bound nowhere and the bar was decoration."""
+        mount = cm.build_daemon_mount(None)
+        kb = mount.get("extra_key_bindings")
+        assert kb is not None, "no key bindings — the search bar cannot be opened"
+        keys = {str(getattr(k, "value", k)) for b in kb.bindings for k in b.keys}
+        assert "/" in keys, f"the search key is not bound: {sorted(keys)}"
+
+    def test_the_mount_supplies_the_strip_as_well_as_the_key(self):
+        assert cm.build_daemon_mount(None).get("search_rows") is not None
+
+    def test_the_bar_is_silent_until_it_is_opened(self):
+        from backend.core.ouroboros.battle_test import transcript_hatches as th
+        th.reset_search_for_tests()
+        provider = cm.build_daemon_mount(None)["search_rows"]
+        assert provider() == []
+
+
+class TestTheLocalEntrance:
+    """`LocalRewindClient`'s argument, applied to the hatches: one
+    implementation, two entrances — never a second implementation."""
+
+    def test_it_serves_as_both_ui_and_client(self):
+        """The installer only ever asks for `flash`, `_narrate_verbose` and
+        `send_input`; splitting them into two shims would invent a distinction
+        the callee does not make."""
+        shim = cm.LocalCockpitClient(send_input=lambda _t: None)
+        assert hasattr(shim, "flash") and hasattr(shim, "send_input")
+        assert shim._narrate_verbose is False
+
+    def test_send_input_reaches_the_local_sink(self):
+        seen = []
+        cm.LocalCockpitClient(send_input=seen.append).send_input("/narrate on")
+        assert seen == ["/narrate on"]
+
+    def test_narrate_verbose_is_writable(self):
+        """The hatch action toggles it, so a read-only property would break the
+        binding rather than the binding breaking."""
+        shim = cm.LocalCockpitClient(send_input=lambda _t: None)
+        shim._narrate_verbose = True
+        assert shim._narrate_verbose is True
+
+    def test_a_missing_sink_never_raises(self):
+        """A keybinding that can break the REPL it is bound in is worse than an
+        unbound key."""
+        cm.LocalCockpitClient(send_input=None).send_input("anything")
+        cm.LocalCockpitClient(send_input=None).flash("a notice")
+
+    def test_a_raising_sink_never_escapes(self):
+        def _boom(_t):
+            raise RuntimeError("dispatch died")
+        cm.LocalCockpitClient(send_input=_boom).send_input("/verb")
+
+    def test_flash_prefers_an_explicit_sink(self):
+        seen = []
+        cm.LocalCockpitClient(send_input=None, flash=seen.append).flash("hi")
+        assert seen == ["hi"]
+
+
+class TestTheMountContract:
+    def test_every_hook_it_claims_is_a_real_cockpit_hook(self):
+        """The mount would otherwise be free to invent names the builder does not
+        accept, and the caller's `.get()` would silently pass None for a hook
+        that never existed."""
+        import ast
+        import inspect
+
+        from backend.core.ouroboros.battle_test import bipartite_layout as bl
+
+        fn = [
+            n for n in ast.walk(ast.parse(inspect.getsource(bl).lstrip()))
+            if isinstance(n, ast.FunctionDef)
+            and n.name == "build_bipartite_application"
+        ][0]
+        accepted = {a.arg for a in fn.args.args} | {
+            a.arg for a in fn.args.kwonlyargs}
+        assert set(cm.build_daemon_mount(None)) <= accepted, (
+            f"mount claims hooks the builder does not accept: "
+            f"{sorted(set(cm.build_daemon_mount(None)) - accepted)}")
+
+    def test_the_mount_never_raises_without_a_repl(self):
+        assert isinstance(cm.build_daemon_mount(None), dict)
+
+    def test_width_is_resolved_per_call_not_captured(self, monkeypatch):
+        """Every renderer takes a width and the canvas draws with
+        `wrap_lines=False`, so a row wrapped to a stale width is clipped rather
+        than reflowed. A provider closing over its mount-time width would be
+        correct until the first resize."""
+        import shutil
+        sizes = iter([shutil.os.terminal_size((200, 60)),
+                      shutil.os.terminal_size((80, 24))])
+        monkeypatch.setattr(shutil, "get_terminal_size",
+                            lambda *_a, **_k: next(sizes))
+        assert cm._terminal_width() == 200
+        assert cm._terminal_width() == 80
+
+    def test_a_degenerate_terminal_still_yields_a_usable_width(self, monkeypatch):
+        import shutil
+        monkeypatch.setattr(
+            shutil, "get_terminal_size",
+            lambda *_a, **_k: (_ for _ in ()).throw(OSError("no tty")))
+        assert cm._terminal_width() >= 20
+
+
+class TestTheDaemonIsWiredToTheMount:
+    def test_serpent_flow_passes_the_mounted_hooks(self):
+        """Behaviour would need a live daemon cockpit, so this pins the wiring
+        structurally — and pins it by AST rather than substring, because the
+        docstrings around this call site name these hooks in prose to explain the
+        defect and a text search matches the explanation."""
+        import ast
+        import inspect
+
+        from backend.core.ouroboros.battle_test import serpent_flow as sf
+
+        tree = ast.parse(inspect.getsource(sf))
+        calls = [
+            n for n in ast.walk(tree)
+            if isinstance(n, ast.Call)
+            and (getattr(n.func, "id", "") or getattr(n.func, "attr", ""))
+            == "run_bipartite_repl"
+        ]
+        assert calls, "the daemon no longer mounts the bipartite cockpit"
+        passed = {kw.arg for c in calls for kw in c.keywords if kw.arg}
+        for hook in ("pending_rows", "panic_rows", "queue_rows", "search_rows",
+                     "serpent_active", "toolbar", "extra_key_bindings"):
+            assert hook in passed, (
+                f"the daemon cockpit stopped mounting {hook} — it produces this "
+                f"state and would be blind to it again")


### PR DESCRIPTION
## The daemon was blind to state it produces

`ui/capability_handoff` — merged an hour ago in #70280 to find exactly this class — measured `serpent_flow` at **7 of 18** cockpit hooks while `ov attach` filled nearly all of them. The count wasn't the finding. The **direction** was:

| producer | consequence |
|---|---|
| daemon calls `note_pending` / `clear_pending` | it is the **source** of the NOTIFY_APPLY countdown and never mounted the strip that draws it |
| daemon calls `panic_arbiter.arbitrate` from its own loop handler | it is where a task **dies**, and the FATAL overlay only ever rendered on a remote client |

An operator at the daemon's own terminal could not see a gate this process was running, or a task it had just lost. `serpent_active` was filled by *neither* shipping surface — the serpent hairline animation had only ever run in a demo.

## Not eleven forgotten arguments

Three surfaces hand-assemble their own argument list for the same builder, so they drift and nothing compares them. `serpent_flow` already says this out loud about the last occurrence — *"the daemon-side cockpit ran with zero completion, zero persistent history and zero ghost-text while the attach cockpit had all three wired at ov.py — the two-surfaces split, again"* — fixed then for three hooks by `repl_completion.build_completion_wiring`: one factory, both surfaces, *"so the vocabularies cannot diverge."*

`cockpit_mount.py` is that same fix generalised, **not a second mechanism beside it.**

## Same renderer, different source

Already stated at `_local_agent_rows`: *"Same renderer as the remote cockpit, different source... neither surface can drift into its own look."* Every provider resolves an in-process snapshot and hands it to the **shared** renderer the client already calls. Nothing is drawn twice.

**The asymmetry that stays:** the client gates strips on heartbeat staleness, because a dead daemon must not leave a countdown ticking toward an apply that will never happen. The daemon must not grow that check — it *is* the source, so there is no transport to go stale. Staleness is a property of a bridge, not of the state. Same reason `age_s=0.0` and `now_mono == arrival_mono`.

**No new flags** — every strip owns its master switch and returns no rows when off, so mounting a provider cannot force a surface on. A gate here would be a second answer to a question those modules already answer.

## Two things found by building it

**A silent field rename.** `Panic` stores `traceback_text`; `render_panic` reads `"traceback"` — the wire spelling. Passing the dataclass's `__dict__` renders a FATAL overlay with an **empty traceback**: the alarm fires correctly and drops the only part anybody needs. `_panic_payload` adapts explicitly, pinned by a test that derives the expected keys from `render_panic` itself.

**A strip with no key to open it.** Mounting `search_rows` while `extra_key_bindings` stayed unset gives the daemon a search bar nothing can open — a row that can never appear, shipped as a closed gap. `daemon_key_bindings` binds the real hatch set via `LocalCockpitClient`: `LocalRewindClient`'s argument applied to the hatches, since the installer needs exactly `ui.flash`, a mutable `ui._narrate_verbose` and `client.send_input`, none of it bridge-specific. One implementation, two entrances — so `keybindings.json` cannot mean two things depending on which terminal you sit at.

Width is resolved **per frame**, never captured: the canvas draws with `wrap_lines=False`, so a row wrapped to a stale width is clipped rather than reflowed.

## Passed by name, not splatted

`**mount` would have been shorter and wrong. `capability_handoff` reads a `**kwargs` splat as OPAQUE — it cannot see which names a splat covers and rightly refuses to guess — so a mount that spread itself would **blind the very audit that found these gaps.** The composition removes the duplicated logic; call sites stay named so coverage stays measurable.

## Result

`serpent_flow` now fills **12 of 18**, up from 7. The remaining five (`header`/`header_height`, `stream_rows`, plus `title`/`seed`/`watch_alive` on the wrapper) are **honest gaps, not waived** — each needs a local source that does not exist yet, and the audit will keep reporting them until it does.

20 tests; 198 green across the cockpit, canvas, demo and rewind suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the daemon-side cockpit show the state it produces by introducing a single mount that feeds shared renderers from local snapshots. This wires pending apply, crash overlay, queue, search, serpent activity, and toolbar into the daemon REPL.

- **New Features**
  - Added `backend/core/ouroboros/battle_test/cockpit_mount.py` with `build_daemon_mount` to assemble daemon hooks once and pass them by name.
  - Local providers render via shared functions: pending apply, panic overlay, input queue, search bar, `serpent_active`, and toolbar (zero transport age, width resolved per frame).
  - Introduced `LocalCockpitClient` and `daemon_key_bindings` so the search bar is reachable (`/`) on the daemon terminal.
  - Integrated the mount in `serpent_flow` by passing `pending_rows`, `panic_rows`, `queue_rows`, `search_rows`, `serpent_active`, `toolbar`, and `extra_key_bindings`.

- **Bug Fixes**
  - Fixed panic overlay payload: adapt `traceback_text` to `"traceback"` so the traceback renders.
  - Ensured strips never break the REPL: providers fail safe and return empty output when unavailable.
  - Increased cockpit coverage: daemon now fills 12/18 hooks (was 7); remaining gaps are tracked.
  - Added tests in `tests/battle_test/test_cockpit_mount.py` for payload mapping, key bindings, width handling, and wiring.

<sup>Written for commit 0c22cf2d6d17b0aa6c5f2093d39c78aacb4d3f4c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

