### PR TITLE
fix(ov): Escape decides what it means per keystroke, not at bind time

### DIFF
--- a/backend/core/ouroboros/battle_test/overlay_arbiter.py
+++ b/backend/core/ouroboros/battle_test/overlay_arbiter.py
@@ -1,0 +1,276 @@
+"""Who owns `Escape` right now — decided per keystroke, not at bind time.
+
+Two bindings want the same key and both are right:
+
+    Escape        dismiss the overlay covering the cockpit
+    Escape Escape open the rewind menu
+
+`prompt_toolkit` resolves that ambiguity by BUFFERING: on the first `Escape` it
+waits to see whether a second arrives. `eager=True` opts out of the wait. So the
+key is over-subscribed in a way no static flag can settle:
+
+    eager=False   the panic overlay needs a timeout or a second key to close —
+                  the overlay SAYS "esc dismisses" and appears not to listen
+    eager=True    the `esc esc` sequence can never complete, because the first
+                  Escape always fires — rewind becomes unreachable
+
+Both are the same mistake: deciding at BIND time a question that only has an
+answer at KEYSTROKE time. Whether `Escape` means "close this" depends entirely on
+whether there is something to close.
+
+Contextual eagerness
+====================
+`eager` accepts a FILTER, not only a bool. That is the whole fix, and it is
+`prompt_toolkit`'s own mechanism rather than a way around it:
+
+    eager = Condition(overlay_active)
+
+With an overlay up, `Escape` is eager and closes it on the first press. With the
+cockpit clear the condition is False, the binding is inactive, and the input
+processor buffers `esc esc` exactly as it always did — the sequence works because
+nothing is competing for the prefix, not because a timer was tuned. No custom
+timeout loop, no second input processor, no polling.
+
+Overlays REGISTER; the arbiter PULLS
+====================================
+The condition could have asked `ui._panic` directly, which is what the existing
+`app:dismissPanic` filter does. That is right for one overlay and wrong the
+moment there are three: the Iron Gate prompt and the diff preview are equally
+dismissable, and a hardcoded list of them here would need editing every time the
+cockpit grows a surface — `/narrate`'s producer list, again, in the one place
+where being wrong means a key silently stops working.
+
+So an overlay declares itself, with a Z so the ARBITER can answer "which one is
+on top" rather than each overlay guessing. Adding an overlay needs no edit here
+and none to the keymap.
+
+Fail-open, deliberately
+=======================
+An `is_active` that raises is treated as NOT active. The consequence of guessing
+wrong in that direction is a rewind menu opening when an overlay was up — a
+visible, recoverable surprise. Guessing the other way makes `Escape` eager
+forever, which silently deletes `esc esc` for the rest of the session and looks
+exactly like the bug this module exists to end. When the state cannot be read,
+the sequence keeps working.
+
+NEVER raises. A keybinding that can break the REPL it is bound in is worse than
+an unbound key.
+"""
+from __future__ import annotations
+
+import logging
+import threading
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional
+
+logger = logging.getLogger("Ouroboros.OverlayArbiter")
+
+OVERLAY_ARBITER_SCHEMA_VERSION = "overlay_arbiter.v1"
+
+#: Z-order constants for the overlays that exist today. Named rather than
+#: numeric at the call sites, and ORDERED by how much the operator needs to deal
+#: with the thing before anything else: a crash outranks a decision, which
+#: outranks a preview they opened themselves.
+Z_DIFF_PREVIEW = 100
+Z_IRON_GATE = 200
+Z_PANIC = 300
+
+
+@dataclass(frozen=True)
+class Overlay:
+    """One dismissable surface, and how to ask about it.
+
+    ``is_active`` is a CALLABLE rather than a flag because overlay state lives
+    where the overlay lives — `AttachUI._panic`, a pending-gate table, a diff
+    archive cursor. Copying it in here would mean a second source of truth that
+    goes stale between frames.
+    """
+
+    name: str
+    z: int
+    is_active: Callable[[], bool]
+    dismiss: Callable[[], None]
+
+
+_LOCK = threading.RLock()
+_OVERLAYS: Dict[str, Overlay] = {}
+
+
+def register_overlay(
+    name: str,
+    *,
+    z: int,
+    is_active: Callable[[], bool],
+    dismiss: Callable[[], None],
+) -> bool:
+    """Declare a dismissable overlay. Idempotent by name. NEVER raises.
+
+    Re-registering a name REPLACES it, so a surface rebuilt on reconnect does not
+    leave a stale predicate behind that reports an overlay nobody can see — which
+    would hold `Escape` eager forever, the exact failure this module prevents.
+    """
+    try:
+        if not name or not callable(is_active) or not callable(dismiss):
+            return False
+        with _LOCK:
+            _OVERLAYS[str(name)] = Overlay(
+                name=str(name), z=int(z), is_active=is_active, dismiss=dismiss,
+            )
+        return True
+    except Exception:  # noqa: BLE001
+        logger.debug("[OverlayArbiter] register degraded: %s", name,
+                     exc_info=True)
+        return False
+
+
+def unregister_overlay(name: str) -> bool:
+    try:
+        with _LOCK:
+            return _OVERLAYS.pop(str(name), None) is not None
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def reset_for_tests() -> None:
+    with _LOCK:
+        _OVERLAYS.clear()
+
+
+def _is_active(overlay: Overlay) -> bool:
+    """Ask one overlay whether it is up. NEVER raises — see fail-open, above."""
+    try:
+        return bool(overlay.is_active())
+    except Exception:  # noqa: BLE001
+        logger.debug("[OverlayArbiter] %s could not report state",
+                     overlay.name, exc_info=True)
+        return False
+
+
+def active_overlays() -> List[Overlay]:
+    """Every overlay currently up, TOPMOST FIRST.
+
+    Ties broken by name so the order is deterministic: two overlays at one Z
+    would otherwise be dismissed in dict order, and "which one did Escape
+    close" must not depend on registration sequence.
+    """
+    with _LOCK:
+        snapshot = list(_OVERLAYS.values())
+    return sorted(
+        (o for o in snapshot if _is_active(o)),
+        key=lambda o: (-o.z, o.name),
+    )
+
+
+def overlay_active() -> bool:
+    """Is anything dismissable on screen? The filter the whole design turns on."""
+    return bool(active_overlays())
+
+
+def top_overlay() -> Optional[Overlay]:
+    overlays = active_overlays()
+    return overlays[0] if overlays else None
+
+
+def dismiss_top() -> Optional[str]:
+    """Close the topmost overlay. Returns its name, or None. NEVER raises.
+
+    Exactly ONE per press, never a cascade: with a panic over a gate over a
+    preview, an operator pressing Escape means "close the thing I am looking at",
+    and clearing all three would discard two decisions they never saw. The next
+    press takes the next one.
+
+    A `dismiss` that raises reports None rather than claiming success — the
+    overlay is still up, so saying otherwise would make the key look answered
+    when the screen has not changed.
+    """
+    overlay = top_overlay()
+    if overlay is None:
+        return None
+    try:
+        overlay.dismiss()
+        return overlay.name
+    except Exception:  # noqa: BLE001
+        logger.debug("[OverlayArbiter] %s refused to dismiss", overlay.name,
+                     exc_info=True)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# The binding
+# ---------------------------------------------------------------------------
+
+
+def install_escape_arbiter(
+    kb: Any,
+    *,
+    rewind: Optional[Callable[[Any], None]] = None,
+    context: str = "Chat",
+) -> bool:
+    """Bind contextual `Escape` and the `Esc-Esc` fallback. NEVER raises.
+
+    Both go through `keymap.bind_action`, so each stays remappable in
+    `keybindings.json` and shows up in `/keys` — the paradigm established when the
+    panic overlay's advertised key was first made real. Nothing here reimplements
+    a binding.
+
+    The two filters are COMPLEMENTS on purpose. `Escape` is active and eager only
+    while an overlay is up; the sequence is active only while none is. They can
+    never both be live for the same keystroke, so the input processor is never
+    asked to choose between a prefix and a completion — the ambiguity is removed
+    rather than arbitrated.
+    """
+    try:
+        from prompt_toolkit.filters import Condition
+
+        from backend.core.ouroboros.battle_test.keymap import bind_action
+
+        _showing = Condition(overlay_active)
+        _clear = Condition(lambda: not overlay_active())
+
+        def _dismiss(_event: Any) -> None:
+            dismiss_top()
+
+        bound = bind_action(
+            kb, "app:dismissOverlay", ("escape",), _dismiss,
+            context=context,
+            filter=_showing,
+            # The fix. A Filter, evaluated per keystroke — so `Escape` skips the
+            # sequence wait only when there is something for it to close.
+            eager=_showing,
+            description="dismiss the overlay on top (panic, gate, diff)",
+        )
+
+        if rewind is not None:
+            from backend.core.ouroboros.battle_test.rewind_menu import (
+                REWIND_DEFAULT_KEYS,
+            )
+            bound = bind_action(
+                kb, "app:rewind", REWIND_DEFAULT_KEYS, rewind,
+                context=context,
+                # Inactive while an overlay is up, so the eager Escape above has
+                # no competing prefix to buffer against.
+                filter=_clear,
+                description="open the rewind menu (Esc-Esc)",
+            ) or bound
+        return bool(bound)
+    except Exception:  # noqa: BLE001
+        logger.debug("[OverlayArbiter] escape arbiter unavailable",
+                     exc_info=True)
+        return False
+
+
+__all__ = [
+    "OVERLAY_ARBITER_SCHEMA_VERSION",
+    "Overlay",
+    "Z_DIFF_PREVIEW",
+    "Z_IRON_GATE",
+    "Z_PANIC",
+    "active_overlays",
+    "dismiss_top",
+    "install_escape_arbiter",
+    "overlay_active",
+    "register_overlay",
+    "reset_for_tests",
+    "top_overlay",
+    "unregister_overlay",
+]

--- a/backend/core/ouroboros/battle_test/rewind_menu.py
+++ b/backend/core/ouroboros/battle_test/rewind_menu.py
@@ -452,7 +452,27 @@ def install_rewind_binding(kb: Any, controller: RewindController) -> bool:
                     get_app_or_none,
                 )
                 app = get_app_or_none()
-                return app is not None and not app.current_buffer.text
+                if app is None or app.current_buffer.text:
+                    return False
+                # ...and nothing dismissable is on screen.
+                #
+                # `overlay_arbiter` binds a single `Escape` whose eagerness is a
+                # per-keystroke FILTER, active only while an overlay is up. This
+                # is the COMPLEMENT of that filter, and the pair is what removes
+                # the collision rather than arbitrating it: with a panic showing,
+                # the first Escape closes it eagerly and this sequence must not
+                # also be live, or two presses would dismiss AND rewind. With the
+                # cockpit clear the eager binding is inactive, so the input
+                # processor buffers `esc esc` naturally — no timer, no custom
+                # processor, no polling.
+                #
+                # Asked here rather than in the arbiter because this filter
+                # already owns "when does a double-Esc mean rewind", and that
+                # question has exactly one right place to be answered.
+                from backend.core.ouroboros.battle_test.overlay_arbiter import (
+                    overlay_active,
+                )
+                return not overlay_active()
             except Exception:  # noqa: BLE001
                 return False
 

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -2285,7 +2285,13 @@ def _client_extra_bindings(ui: Any, client: Any) -> Any:
             except Exception:  # noqa: BLE001
                 return False
 
-        def _dismiss_panic(event: Any) -> None:
+        def _dismiss_panic_now() -> None:
+            """The dismissal itself, with no key event attached.
+
+            The arbiter calls this; the legacy `bind_action` fallback wraps it.
+            Split so the behaviour is written once — an overlay's dismiss is a
+            fact about the overlay, not about the keystroke that asked for it.
+            """
             try:
                 ui.dismiss_panic()
                 ui.flash("☠ panic dismissed — /status to check the organism",
@@ -2293,15 +2299,42 @@ def _client_extra_bindings(ui: Any, client: Any) -> Any:
             except Exception:  # noqa: BLE001
                 pass
 
-        # The overlay SAYS "esc dismisses". Nothing was bound to it, so a
-        # FATAL notice covered the cockpit permanently — advertising a key
-        # that does nothing is worse than advertising none. Filtered on the
-        # overlay being up, so esc keeps its existing meaning otherwise.
-        bind_action(
-            kb, "app:dismissPanic", ("escape",), _dismiss_panic,
-            context="Chat", filter=_panic_showing,
-            description="dismiss the FATAL panic overlay",
-        )
+        def _dismiss_panic(event: Any) -> None:
+            _dismiss_panic_now()
+
+        # The overlay SAYS "esc dismisses", and this is what makes the key mean
+        # it. Routed through `overlay_arbiter` rather than bound here, because
+        # `Escape` is over-subscribed: rewind owns `esc esc`, so a plain
+        # (non-eager) binding needed the sequence to TIME OUT before the panic
+        # would close — the overlay advertised a key that answered late — while
+        # `eager=True` would have made `esc esc` unreachable forever.
+        #
+        # The arbiter binds ONE Escape whose `eager` is a FILTER, so eagerness is
+        # decided per keystroke by whether anything is actually on screen. The
+        # panic is REGISTERED rather than hardcoded into that filter: the Iron
+        # Gate prompt and the diff preview are equally dismissable, and a list of
+        # them inside the arbiter would need editing every time the cockpit grows
+        # a surface.
+        try:
+            from backend.core.ouroboros.battle_test.overlay_arbiter import (
+                Z_PANIC, install_escape_arbiter, register_overlay,
+            )
+            register_overlay(
+                "panic", z=Z_PANIC,
+                is_active=lambda: bool(getattr(ui, "_panic", None)),
+                dismiss=_dismiss_panic_now,
+            )
+            # `rewind` is deliberately NOT passed: `install_rewind_binding` below
+            # already owns the sequence together with its empty-prompt filter,
+            # and re-binding it here would be a second opinion about when a
+            # draft's double-Esc means "clear" instead of "rewind".
+            install_escape_arbiter(kb)
+        except Exception:  # noqa: BLE001 — a cockpit must boot without the arbiter
+            bind_action(
+                kb, "app:dismissPanic", ("escape",), _dismiss_panic,
+                context="Chat", filter=_panic_showing,
+                description="dismiss the FATAL panic overlay",
+            )
 
         def _show_help(event: Any) -> None:
             _render_client_keys(ui, "/keys")

--- a/backend/core/ouroboros/cli/ov_demo.py
+++ b/backend/core/ouroboros/cli/ov_demo.py
@@ -683,10 +683,26 @@ def _collapsed_beat(args: Sequence[Any]) -> str:
 
 
 def _THEME(slot: str) -> str:
-    """One colour slot, from the cockpit's own palette. NEVER raises."""
+    """One colour slot, from the semantic-role owner. NEVER raises.
+
+    This read `serpent_flow._C`, which does not exist — the import raised
+    ImportError on every call and the `except` handed back the fallback, so every
+    slot in this module resolved to plain `"white"` and had done since it was
+    written. Visible in the demo as a flat white collapse line, and in the crest
+    header as a literal `[white]…[/white]` where a dim style should have been.
+
+    A total `except` around a hardcoded fallback is what let it hide: the module
+    kept working, in one colour, and nothing said the palette was never reached.
+
+    `ui.semantic_tokens.role_palette()` is the one owner of what a colour MEANS
+    (#70256-#70260 migrated 365 raw literals into it) and is the same accessor,
+    spelled the same way, that `bipartite_layout._SEM` uses. One vocabulary, one
+    spelling, one owner — so a role renamed there cannot leave this module
+    quietly monochrome again.
+    """
     try:
-        from backend.core.ouroboros.battle_test.serpent_flow import _C
-        return _C.get(slot, "white")
+        from backend.core.ouroboros.ui.semantic_tokens import role_palette
+        return role_palette().get(slot) or "white"
     except Exception:  # noqa: BLE001
         return "white"
 
@@ -1476,22 +1492,41 @@ def _demo_turn_spinner(clock: Callable[[], float],
         return None
 
 
-def _header_lines() -> List[str]:
+def _header_lines() -> List[Any]:
     """The text beside the crest — what this cockpit IS, in three lines.
 
     Says DEMO explicitly. A header identical to the attach client's would make a
     screenshot of a synthetic session indistinguishable from a real one, and the
     entire value of this scene is that an operator can trust what it shows.
+
+    Returned as Rich ``Text``, not markup strings. `render_cockpit_header`
+    composes its lines beside the emblem and takes "Rich renderable Texts (or
+    plain strings)" — a markup string is the PLAIN case, so `[dim]…[/dim]` was
+    printed to the operator verbatim rather than interpreted. Building `Text`
+    with explicit styles is what `ov.py::_header_lines` already does, so both
+    surfaces hand this function the same type.
     """
-    dim = _THEME("dim")
-    return [
-        "◇ O+V · demo canvas",
-        f"[{dim}]synthetic events · no provider, no tokens[/{dim}]",
-        f"[{dim}]q to quit · / for verbs · ctrl+r to search[/{dim}]",
-    ]
+    try:
+        from rich.text import Text
+        dim = _THEME("dim")
+        first = Text()
+        first.append("◇ ", style=_THEME("neural"))
+        first.append("O+V", style="bold")
+        first.append(" · demo canvas", style=dim)
+        return [
+            first,
+            Text("synthetic events · no provider, no tokens", style=dim),
+            Text("q to quit · / for verbs · ctrl+r to search", style=dim),
+        ]
+    except Exception:  # noqa: BLE001 — plain strings are the documented fallback
+        return [
+            "◇ O+V · demo canvas",
+            "synthetic events · no provider, no tokens",
+            "q to quit · / for verbs · ctrl+r to search",
+        ]
 
 
-def _demo_header() -> "tuple[Any, int]":
+def _demo_header() -> "tuple[Any, int, Any]":
     """``(render, height)`` for the crest above the deck, or ``(None, 0)``.
 
     Rendered by `crest_animator`'s own `render_cockpit_header`, so the demo
@@ -1516,15 +1551,10 @@ def _demo_header() -> "tuple[Any, int]":
         )
         mini = MiniCrest()
         if not mini.available:
-            return (None, 0)
-        # Frames are built off-thread; the attach client kicks the same coroutine
-        # at mount. Without it the crest draws its static fallback rather than
-        # the animated emblem — correct, and not what the arc was about.
-        try:
-            import asyncio
-            asyncio.ensure_future(mini.ensure_frames())
-        except Exception:  # noqa: BLE001
-            pass
+            # Three elements, like every other exit. A 2-tuple here would raise
+            # ValueError at the caller's unpack on exactly the terminals that
+            # cannot draw an emblem — the ones least able to show the traceback.
+            return (None, 0, None)
 
         def _render() -> str:
             try:
@@ -1537,10 +1567,38 @@ def _demo_header() -> "tuple[Any, int]":
             except Exception:  # noqa: BLE001
                 return ""
 
-        return (_render, max(3, int(getattr(mini, "rows", 3) or 3)))
+        return (_render, max(3, int(getattr(mini, "rows", 3) or 3)), mini)
     except Exception:  # noqa: BLE001
         logger.debug("[OvDemo] crest header unavailable", exc_info=True)
-        return (None, 0)
+        return (None, 0, None)
+
+
+async def _warm_crest(mini: Any) -> None:
+    """Build the emblem's frames, INSIDE a running loop. NEVER raises.
+
+    This was `asyncio.ensure_future(mini.ensure_frames())` at header-construction
+    time, which is before `asyncio.run` — so there was no running loop, the
+    coroutine was created and never scheduled, and Python said so:
+
+        RuntimeWarning: coroutine 'MiniCrest.ensure_frames' was never awaited
+
+    The visible result was a crest stuck on its unbuilt fallback: a partial
+    emblem in the corner, which is exactly what the screenshot showed. `ov.py`
+    gets away with the same call because it makes it from inside an already-async
+    `_bipartite_attach_loop`; copying the line without its context dropped the
+    only thing making it work.
+
+    Awaited rather than fire-and-forget: the frames are what the first painted
+    header draws from, and a task racing the first frame is the difference
+    between an emblem and a placeholder. `MiniCrest` caches, so the cost is paid
+    once per session and the loop is not blocked — `ensure_frames` is a
+    coroutine that hands off while the rings are built.
+    """
+    try:
+        if mini is not None:
+            await mini.ensure_frames()
+    except Exception:  # noqa: BLE001 — a cockpit without an emblem still flies
+        logger.debug("[OvDemo] crest warmup degraded", exc_info=True)
 
 
 #: A defect found by WATCHING this scene — FIXED at the root, kept as the record.
@@ -1654,7 +1712,7 @@ def scene_live(console: Any, argv: Sequence[str] = ()) -> int:
 
     mux = BipartiteLayout()
     script = compose_live_script()
-    _header, _header_height = _demo_header()
+    _header, _header_height, _crest = _demo_header()
     app = build_bipartite_application(
         mux,
         # Typed input executes NOTHING — this scene has no organism to act on
@@ -1729,6 +1787,9 @@ def scene_live(console: Any, argv: Sequence[str] = ()) -> int:
         pass
 
     async def _main() -> None:
+        # The emblem's frames, built now that a loop exists. Scheduling this at
+        # header-construction time created a coroutine nobody awaited.
+        await _warm_crest(_crest)
         start[0] = clock()
         driver = asyncio.ensure_future(
             _drive(mux, app, speed, lambda: start[0], clock, script))

--- a/tests/battle_test/test_overlay_arbiter.py
+++ b/tests/battle_test/test_overlay_arbiter.py
@@ -1,0 +1,250 @@
+"""`Escape` must mean two things, and the input processor must never guess.
+
+    Escape         dismiss the overlay covering the cockpit
+    Escape Escape  open the rewind menu
+
+`prompt_toolkit` disambiguates by BUFFERING the first `Escape` to see whether a
+second follows, and `eager=True` opts out of that wait. Neither static choice
+works: without eager the panic overlay needs a timeout to close while advertising
+"esc dismisses"; with eager the `esc esc` sequence can never complete and rewind
+becomes unreachable.
+
+The state machine is asserted against the REAL `KeyProcessor`, driven
+asynchronously because `process_keys` schedules its own buffering timer on the
+running loop — the very mechanism under test. A synchronous test cannot exercise
+the wait at all, which is precisely why the collision survived: it is invisible
+until keys are actually fed through the processor.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from backend.core.ouroboros.battle_test import overlay_arbiter as oa
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """The registry is process-global; a leaked overlay holds `Escape` eager and
+    would silently delete `esc esc` for every later test."""
+    oa.reset_for_tests()
+    yield
+    oa.reset_for_tests()
+
+
+class _Harness:
+    """Feeds real key presses through a real processor inside a real app session."""
+
+    def __init__(self):
+        self.fired = []
+        self.overlay_up = False
+        oa.register_overlay(
+            "panic", z=oa.Z_PANIC,
+            is_active=lambda: self.overlay_up,
+            dismiss=lambda: self.fired.append("dismiss"),
+        )
+        from prompt_toolkit.key_binding import KeyBindings
+        self.kb = KeyBindings()
+        assert oa.install_escape_arbiter(
+            self.kb, rewind=lambda _e: self.fired.append("rewind"))
+
+    async def press(self, count: int):
+        """Feed ``count`` Escapes and return what fired."""
+        from prompt_toolkit.application import Application
+        from prompt_toolkit.application.current import set_app
+        from prompt_toolkit.input import create_pipe_input
+        from prompt_toolkit.key_binding.key_processor import (
+            KeyPress, KeyProcessor,
+        )
+        from prompt_toolkit.keys import Keys
+        from prompt_toolkit.output import DummyOutput
+
+        self.fired.clear()
+        with create_pipe_input() as pipe:
+            app = Application(key_bindings=self.kb, input=pipe,
+                              output=DummyOutput())
+            with set_app(app):
+                proc = KeyProcessor(self.kb)
+                for _ in range(count):
+                    proc.feed(KeyPress(Keys.Escape, ""))
+                proc.process_keys()
+                # Let the buffering timer settle, so a binding that is waiting
+                # for a longer match gets its chance to time out. Without this a
+                # non-eager Escape looks identical to one that never matched.
+                await asyncio.sleep(0.05)
+                proc.process_keys()
+        return list(self.fired)
+
+
+class TestTheThreeTransitions:
+    """The mandated state machine."""
+
+    @pytest.mark.asyncio
+    async def test_an_overlay_makes_escape_eager(self):
+        """(1) Overlay up: ONE Escape closes it, with no wait for a second."""
+        h = _Harness()
+        h.overlay_up = True
+        assert await h.press(1) == ["dismiss"]
+
+    @pytest.mark.asyncio
+    async def test_a_clear_cockpit_ignores_a_single_escape(self):
+        """(2) Nothing to close: a lone Escape must NOT reach the dismiss
+        callback. If it does, the binding is eager unconditionally and `esc esc`
+        is already dead."""
+        h = _Harness()
+        h.overlay_up = False
+        assert await h.press(1) == []
+
+    @pytest.mark.asyncio
+    async def test_escape_escape_opens_rewind_when_clear(self):
+        """(3) The sequence completes because nothing is competing for the
+        prefix — buffered naturally by the processor, not by a tuned timer."""
+        h = _Harness()
+        h.overlay_up = False
+        assert await h.press(2) == ["rewind"]
+
+    @pytest.mark.asyncio
+    async def test_the_two_meanings_never_fire_together(self):
+        """The filters are complements, so no keystroke can satisfy both. An
+        overlay dismissal that ALSO opened the rewind menu would be the
+        collision wearing a different costume."""
+        h = _Harness()
+        h.overlay_up = True
+        assert "rewind" not in await h.press(2)
+
+    @pytest.mark.asyncio
+    async def test_one_press_closes_exactly_one_overlay(self):
+        """A panic over a gate: Escape means "close what I am looking at".
+        Cascading would discard a decision the operator never saw."""
+        h = _Harness()
+        h.overlay_up = True
+        gate = {"up": True}
+        oa.register_overlay("gate", z=oa.Z_IRON_GATE,
+                            is_active=lambda: gate["up"],
+                            dismiss=lambda: h.fired.append("gate"))
+        assert await h.press(1) == ["dismiss"]      # panic outranks the gate
+        h.overlay_up = False
+        assert await h.press(1) == ["gate"]
+
+
+class TestTheBindingItself:
+    def test_escape_is_bound_eagerly_by_a_FILTER_not_a_bool(self):
+        """The root fix, pinned. `eager=True` breaks the sequence and
+        `eager=False` breaks the dismiss; only a per-keystroke filter can be
+        right in both states, and a well-meaning simplification to a bool would
+        pass every behavioural test in one of the two states."""
+        from prompt_toolkit.filters import Filter
+        from prompt_toolkit.key_binding import KeyBindings
+
+        kb = KeyBindings()
+        oa.register_overlay("x", z=1, is_active=lambda: False,
+                            dismiss=lambda: None)
+        oa.install_escape_arbiter(kb, rewind=lambda _e: None)
+        single = [b for b in kb.bindings if len(b.keys) == 1]
+        assert single, "no single-Escape binding was installed"
+        assert isinstance(single[0].eager, Filter), (
+            f"eager must be a Filter evaluated per keystroke, got "
+            f"{single[0].eager!r}")
+
+    def test_both_the_key_and_the_sequence_are_bound(self):
+        from prompt_toolkit.key_binding import KeyBindings
+        kb = KeyBindings()
+        oa.install_escape_arbiter(kb, rewind=lambda _e: None)
+        lengths = sorted(len(b.keys) for b in kb.bindings)
+        assert lengths == [1, 2], f"expected Esc and Esc-Esc, got {lengths}"
+
+    def test_the_sequence_uses_rewinds_own_default_keys(self):
+        """Spelled once, in `rewind_menu`. Re-typing "esc esc" here is how two
+        modules end up disagreeing about a key."""
+        from backend.core.ouroboros.battle_test.rewind_menu import (
+            REWIND_DEFAULT_KEYS,
+        )
+        import inspect
+        src = inspect.getsource(oa.install_escape_arbiter)
+        assert "REWIND_DEFAULT_KEYS" in src
+        assert REWIND_DEFAULT_KEYS
+
+    def test_no_rewind_handler_still_binds_the_dismiss(self):
+        """A surface with no rewind (there is no `/undo` planner on every
+        cockpit) must still be able to close its overlays."""
+        from prompt_toolkit.key_binding import KeyBindings
+        kb = KeyBindings()
+        assert oa.install_escape_arbiter(kb, rewind=None)
+        assert [len(b.keys) for b in kb.bindings] == [1]
+
+
+class TestTheRegistry:
+    def test_nothing_registered_means_escape_is_not_eager(self):
+        """The DEFAULT must be the safe one: with no overlays the sequence has
+        to keep working, because that is the state a cockpit is in almost all of
+        the time."""
+        assert oa.overlay_active() is False
+        assert oa.dismiss_top() is None
+
+    def test_topmost_wins_by_z(self):
+        oa.register_overlay("diff", z=oa.Z_DIFF_PREVIEW,
+                            is_active=lambda: True, dismiss=lambda: None)
+        oa.register_overlay("panic", z=oa.Z_PANIC,
+                            is_active=lambda: True, dismiss=lambda: None)
+        top = oa.top_overlay()
+        assert top is not None and top.name == "panic"
+
+    def test_a_tie_is_broken_deterministically(self):
+        """Two overlays at one Z must not be dismissed in dict order — "which
+        one did Escape close" cannot depend on registration sequence."""
+        for name in ("zebra", "alpha"):
+            oa.register_overlay(name, z=50, is_active=lambda: True,
+                                dismiss=lambda: None)
+        assert [o.name for o in oa.active_overlays()] == ["alpha", "zebra"]
+
+    def test_an_inactive_overlay_is_not_counted(self):
+        oa.register_overlay("panic", z=oa.Z_PANIC, is_active=lambda: False,
+                            dismiss=lambda: None)
+        assert oa.overlay_active() is False
+
+    def test_an_is_active_that_raises_FAILS_OPEN(self):
+        """Guessing "active" would hold Escape eager forever and silently delete
+        `esc esc` for the session — indistinguishable from the bug this module
+        exists to end. Guessing "clear" opens a rewind menu unexpectedly, which
+        is visible and recoverable."""
+        def _boom():
+            raise RuntimeError("state unreadable")
+        oa.register_overlay("broken", z=1, is_active=_boom,
+                            dismiss=lambda: None)
+        assert oa.overlay_active() is False
+
+    def test_a_dismiss_that_raises_does_not_claim_success(self):
+        """The overlay is still up. Reporting a name would make the key look
+        answered while the screen has not changed."""
+        def _boom():
+            raise RuntimeError("cannot close")
+        oa.register_overlay("stuck", z=1, is_active=lambda: True,
+                            dismiss=_boom)
+        assert oa.dismiss_top() is None
+
+    def test_reregistering_a_name_replaces_it(self):
+        """A surface rebuilt on reconnect must not leave a stale predicate
+        reporting an overlay nobody can see."""
+        oa.register_overlay("panic", z=1, is_active=lambda: True,
+                            dismiss=lambda: None)
+        oa.register_overlay("panic", z=1, is_active=lambda: False,
+                            dismiss=lambda: None)
+        assert oa.overlay_active() is False
+        assert len(oa.active_overlays()) == 0
+
+    def test_unregister_removes_it(self):
+        oa.register_overlay("panic", z=1, is_active=lambda: True,
+                            dismiss=lambda: None)
+        assert oa.unregister_overlay("panic") is True
+        assert oa.overlay_active() is False
+        assert oa.unregister_overlay("panic") is False
+
+    @pytest.mark.parametrize("bad", [
+        {"name": "", "is_active": lambda: True, "dismiss": lambda: None},
+        {"name": "x", "is_active": None, "dismiss": lambda: None},
+        {"name": "x", "is_active": lambda: True, "dismiss": None},
+    ])
+    def test_a_malformed_registration_is_refused(self, bad):
+        assert oa.register_overlay(z=1, **bad) is False
+        assert oa.overlay_active() is False


### PR DESCRIPTION
## `Escape` was over-subscribed, and no static flag can settle it

| binding | wants |
|---|---|
| `Escape` | dismiss the overlay covering the cockpit |
| `Escape Escape` | open the rewind menu |

prompt_toolkit disambiguates by **buffering** the first `Escape`; `eager=True` opts out of that wait. Neither static choice works:

- `eager=False` → the panic overlay needs the sequence to **time out** before closing. It says *"esc dismisses"* and answers late.
- `eager=True` → the `esc esc` sequence can **never complete**. Rewind becomes unreachable.

Both are the same mistake: deciding at **bind** time a question that only has an answer at **keystroke** time.

## Contextual eagerness — prompt_toolkit's own mechanism

`eager` accepts a **Filter**, not only a bool:

```python
eager = Condition(overlay_active)
```

Overlay up → `Escape` is eager, closes on the first press. Cockpit clear → the condition is False, the binding is inactive, and the processor buffers `esc esc` exactly as it always did. **The sequence works because nothing competes for the prefix, not because a timer was tuned.** No custom timeout loop, no second input processor, no polling.

`install_rewind_binding`'s existing empty-prompt filter gains the **complement** (`not overlay_active()`) — asked there because that filter already owns *"when does a double-Esc mean rewind"*. The pair can never both be live for one keystroke, so the ambiguity is **removed** rather than arbitrated.

## Overlays register; the arbiter pulls

The condition could have read `ui._panic` directly — what the binding it replaces did. Right for one overlay, wrong the moment there are three. A hardcoded list inside the arbiter would need editing every time the cockpit grows a surface: `/narrate`'s producer list again, in the one place where being wrong means a key silently stops working.

- **One dismissal per press, never a cascade** — with a panic over a gate, "close the thing I am looking at" must not discard a decision never seen.
- **Fail-open**: an `is_active` that raises counts as *not* active. Guessing the other way holds `Escape` eager forever and silently deletes `esc esc` — indistinguishable from the bug being fixed. Guessing this way opens a menu unexpectedly: visible, recoverable.
- A `dismiss` that raises reports `None` rather than claiming success — the overlay is still up.

## Three regressions from the last change, all mine

Found by running `ov demo live` and screenshotting it, which is the only way any of these surface:

1. **`_THEME` read `serpent_flow._C`, which does not exist.** The import raised `ImportError` on *every* call and the bare `except` returned its `"white"` fallback — so every colour in the module had always resolved to plain white. Visible as a flat collapse line and a literal `[white]…[/white]` in the header. A total `except` around a hardcoded default is what let it hide. Now `ui.semantic_tokens.role_palette()`.
2. **`_header_lines` returned markup strings.** `render_cockpit_header` takes Rich `Text` *or plain strings* — and a markup string is the plain case, so the operator saw `[dim]…[/dim]` verbatim. Now `rich.text.Text`, the type `ov.py` already hands it.
3. **`ensure_frames` was never awaited.** `asyncio.ensure_future(...)` ran *before* `asyncio.run`, so no loop existed and Python said exactly that. The crest stayed on its unbuilt fallback — the partial emblem. `ov.py` gets away with the same line from inside an async function; copying it without its context dropped the only thing making it work.

Plus a fourth caught by the type checker: `_demo_header`'s `mini.available` early return still handed back a **2-tuple** after the signature grew to three — a `ValueError` at the caller's unpack on exactly the terminals that cannot draw an emblem.

## Tests — 20 new, async, real `KeyProcessor`

It **has** to be async: `process_keys` schedules its buffering timer on the running loop, so a synchronous test cannot exercise the wait at all. That is precisely why this collision survived.

The three mandated transitions are asserted directly:

1. overlay active → `Escape` fires the dismiss eagerly
2. cockpit clear → a lone `Escape` does **not** reach the dismiss
3. cockpit clear → `Esc-Esc` opens rewind

Plus a pin that `eager` is a `Filter` and not a bool — a well-meaning simplification would pass every behavioural test in one of the two states.

98 green across arbiter, rewind, demo and cockpit-mount suites. PTY-verified at 200×60 that the markup leak, the RuntimeWarning and the partial crest are gone.

**Not in this PR:** the async Diff-Preview overlay. `Z_DIFF_PREVIEW` and the registry are in place for it, but the overlay itself is unbuilt — flagged rather than half-landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Escape decide per keystroke: when an overlay is visible, a single Escape dismisses it; when clear, Esc-Esc opens rewind. This removes the timing conflict in `prompt_toolkit` by using a contextual `eager` filter instead of a static choice.

- New Features
  - Added `overlay_arbiter` with an overlay registry and Z-order (`Z_PANIC`, `Z_IRON_GATE`, `Z_DIFF_PREVIEW`), plus `overlay_active`, `top_overlay`, and `dismiss_top`.
  - Bound `Escape` with `eager=Condition(overlay_active)` and bound rewind on `Esc-Esc` with the complementary filter; panic overlay registers itself in `ov.py`.
  - Guarantees one dismissal per press, deterministic topmost selection (by Z then name), and fail-open behavior if state/dismiss raises.

- Bug Fixes
  - Demo colors now read from `ui.semantic_tokens.role_palette()`; header lines use `rich.text.Text` instead of markup strings.
  - Crest frames are built inside a running loop (fixes RuntimeWarning and partial emblem) and `_demo_header` now always returns a 3-tuple.
  - Added 20 async tests using the real `KeyProcessor` to assert the three required transitions and pin `eager` as a `Filter`.

<sup>Written for commit 51430097a4be3a7bec7e652d20dead71268b1c87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

