### PR TITLE
feat(ov): the archived diff, on screen, without costing a frame

### DIFF
--- a/backend/core/ouroboros/battle_test/bipartite_layout.py
+++ b/backend/core/ouroboros/battle_test/bipartite_layout.py
@@ -895,6 +895,10 @@ def build_bipartite_application(
     stream_rows: Optional[Callable[[], Any]] = None,
     queue_rows: Optional[Callable[[], Any]] = None,
     panic_rows: Optional[Callable[[], Any]] = None,
+    #: The archived-diff overlay (`diff_overlay.DiffOverlayController.rows`).
+    #: Rows arrive PRE-COLOURED by Rich, so this float renders them as ANSI
+    #: rather than under a single prompt_toolkit style.
+    diff_rows: Optional[Callable[[], Any]] = None,
     # NOTE: no `on_mux` here, deliberately. It belongs to `run_bipartite_repl`,
     # which CONSTRUCTS the multiplexer and therefore has something to hand
     # back. A caller of this function already holds the mux — it passes it in
@@ -1538,6 +1542,79 @@ def build_bipartite_application(
     # `top=1` rather than `ycursor=True`: a crash is not attached to where
     # the caret happens to be, and an overlay that moves while the
     # operator reads a traceback is hostile.
+    # ONE float host, established before any overlay wants it.
+    #
+    # This used to be implicit: whichever overlay block ran first found `root`
+    # was not a `FloatContainer` and wrapped it, and later blocks appended to the
+    # container the first one happened to create. With a single overlay that is
+    # invisible. With two it is a silent drop — the diff float was added under an
+    # `isinstance(root, FloatContainer)` guard that was False, because the block
+    # that creates the container runs AFTER it, so the overlay mounted nothing
+    # and reported nothing.
+    #
+    # Hoisting the host makes every overlay block a pure append, in source order,
+    # which is also the draw order. No block has to know whether it is first, and
+    # the next overlay added cannot reintroduce this by being placed anywhere in
+    # particular.
+    if diff_rows is not None or panic_rows is not None:
+        try:
+            from prompt_toolkit.layout import FloatContainer
+            if not isinstance(root, FloatContainer):
+                # Only when an overlay actually exists: an empty FloatContainer
+                # renders identically, but wrapping unconditionally would change
+                # the container tree for every cockpit that has no overlays and
+                # buys nothing.
+                root = FloatContainer(content=root, floats=[])
+        except Exception:  # noqa: BLE001
+            logger.debug("[Bipartite] float host unavailable", exc_info=True)
+
+    # The diff preview goes on FIRST, and the order is load-bearing.
+    #
+    # prompt_toolkit draws `root.floats` in list order, so a float appended later
+    # renders ON TOP. The panic overlay must win that contest: a crash outranks a
+    # diff the operator opened for themselves, and an overlay stack whose z-order
+    # depends on which block happens to run first is the kind of thing that
+    # silently inverts the next time this function is reorganised.
+    #
+    # It matches `overlay_arbiter`'s Z constants deliberately — Z_DIFF_PREVIEW <
+    # Z_PANIC — so the surface an operator SEES on top is the same one `Escape`
+    # closes first. Two orderings that disagree would mean pressing Escape
+    # dismissing something other than what they are looking at.
+    if diff_rows is not None:
+        try:
+            from prompt_toolkit.filters import Condition
+            from prompt_toolkit.layout import (
+                ConditionalContainer, Float, FloatContainer, Window,
+            )
+            from prompt_toolkit.layout.controls import FormattedTextControl
+            from prompt_toolkit.formatted_text import ANSI
+
+            def _diff_visible() -> bool:
+                try:
+                    return bool(diff_rows())
+                except Exception:  # noqa: BLE001
+                    return False
+
+            # ANSI, not a style tuple: the rows arrive already coloured by Rich
+            # (the syntax highlighting is the whole point of the overlay), and
+            # wrapping pre-escaped text in a single prompt_toolkit style would
+            # print the escapes and flatten the diff to one colour.
+            _diff_win = ConditionalContainer(
+                Window(
+                    FormattedTextControl(
+                        lambda: ANSI("\n".join(diff_rows())),
+                    ),
+                    wrap_lines=False,
+                ),
+                filter=Condition(_diff_visible),
+            )
+            if isinstance(root, FloatContainer):
+                root.floats.append(Float(
+                    content=_diff_win, top=1, left=2, right=2,
+                ))
+        except Exception:  # noqa: BLE001
+            logger.debug("[Bipartite] diff overlay unavailable", exc_info=True)
+
     if panic_rows is not None:
         try:
             from prompt_toolkit.filters import Condition
@@ -1590,14 +1667,14 @@ def build_bipartite_application(
                 ),
                 filter=Condition(_panic_visible),
             )
+            # Append-only. The host is hoisted above, so this block no longer
+            # has to be the one that creates it — and the diff float appended
+            # before it stays underneath, which is the z-order both this and
+            # `overlay_arbiter` agree on.
             if isinstance(root, FloatContainer):
                 root.floats.append(Float(
                     content=_panic_win, top=1, left=2, right=2,
                 ))
-            else:
-                root = FloatContainer(content=root, floats=[Float(
-                    content=_panic_win, top=1, left=2, right=2,
-                )])
         except Exception:  # noqa: BLE001
             # A cockpit that cannot draw the overlay must still RUN — the
             # panic is already logged and on the telemetry lane.
@@ -1704,6 +1781,7 @@ async def run_bipartite_repl(
     stream_rows: Optional[Callable[[], Any]] = None,
     queue_rows: Optional[Callable[[], Any]] = None,
     panic_rows: Optional[Callable[[], Any]] = None,
+    diff_rows: Optional[Callable[[], Any]] = None,
     on_mux: Optional[Callable[[Any], None]] = None,
     serpent_active: Optional[Callable[[], bool]] = None,
 ) -> None:
@@ -1748,6 +1826,7 @@ async def run_bipartite_repl(
             search_rows=search_rows, status_rows=status_rows,
             pending_rows=pending_rows, stream_rows=stream_rows,
             queue_rows=queue_rows, panic_rows=panic_rows,
+            diff_rows=diff_rows,
             serpent_active=serpent_active,
         )
         if watch_alive is not None:

--- a/backend/core/ouroboros/battle_test/diff_overlay.py
+++ b/backend/core/ouroboros/battle_test/diff_overlay.py
@@ -1,0 +1,410 @@
+"""The diff an operator asked to see, rendered without stalling the cockpit.
+
+`DiffArchive` keeps the last ~30 Yellow-tier candidates behind stable ``d-N``
+refs, and `DiffPreviewRenderer` knows how to draw one. Between them there was no
+way to actually LOOK at a diff on the cockpit: `/expand d-N` printed into a
+console, and the gate's own preview is transient. So the archive filled up with
+refs the operator was invited to name and could not open.
+
+Where the cost actually is
+==========================
+The brief said "reading large diff payloads from disk". It is worth being exact,
+because designing against the wrong cost produces a fix that protects nothing:
+`DiffArchive` is an in-memory RING. ``diff_text`` is already resident, and
+fetching it is a dict lookup.
+
+The frame-dropping cost is elsewhere, and it is real:
+
+  * **Rich syntax highlighting.** Pygments-lexing a few thousand diff lines and
+    composing them into segments is hundreds of milliseconds of pure CPU. On the
+    event loop that is a visible freeze — at 60fps the budget for an entire frame
+    is 16ms.
+  * **A review branch.** `ArchivedDiff.review_branch` names a real git branch, and
+    resolving it is a subprocess against the object store — genuinely I/O, and
+    genuinely unbounded.
+
+Both belong off the loop. So `asyncio.to_thread` wraps the RENDER, not a fake
+disk read, and the distinction is the difference between a fix and a decoration.
+
+Pure-pull render, out-of-band fill
+==================================
+A prompt_toolkit render callable is SYNCHRONOUS — `create_content` cannot await —
+so an overlay that fetched during render would block the frame no matter which
+thread the fetch used. There is no version of "await inside the renderer".
+
+The split that does work is the one `attach_heartbeat` and `MiniCrest` already
+use: state is filled asynchronously and out of band; the renderer is a pure,
+O(1) read of whatever has landed. :meth:`rows` never blocks, never touches the
+archive and never renders — it returns a list of strings that a background task
+prepared. Opening the overlay shows an immediate placeholder and invalidates once
+the real payload arrives, so the cockpit stays at frame rate through a diff of
+any size.
+
+Epochs, because the operator moves faster than the render
+=========================================================
+Every open bumps an epoch and a completing task whose epoch is stale DISCARDS its
+result. Without that:
+
+  * open `d-3`, then `d-7` before the first finishes → whichever thread wins
+    decides what is on screen, and it is not necessarily the one asked for last
+  * open, then dismiss mid-render → the finishing task resurrects an overlay the
+    operator already closed, which is worse than a slow one
+
+Cheaper and stricter than cancellation: a thread already inside Pygments cannot
+be interrupted, so the honest move is to let it finish and ignore it.
+
+NEVER raises. An overlay that can break the cockpit it draws over is worse than
+no overlay.
+"""
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any, Callable, List, Optional
+
+logger = logging.getLogger("Ouroboros.DiffOverlay")
+
+DIFF_OVERLAY_SCHEMA_VERSION = "diff_overlay.v1"
+
+#: The name it registers under with `overlay_arbiter`.
+OVERLAY_NAME = "diff_preview"
+
+
+def _terminal_width(fallback: int = 100) -> int:
+    """Resolved per call — a diff wrapped to a stale width is clipped, not
+    reflowed, because the canvas draws with ``wrap_lines=False``."""
+    try:
+        import shutil
+        return max(40, int(shutil.get_terminal_size((fallback, 30)).columns))
+    except Exception:  # noqa: BLE001
+        return fallback
+
+
+class DiffOverlayController:
+    """Owns "which diff is on screen, and what does it look like".
+
+    Deliberately NOT a renderer. It holds a ref, an epoch and a list of lines;
+    the drawing is `DiffPreviewRenderer`'s and the mounting is
+    `bipartite_layout`'s. Three jobs, three owners — the reason a regression in
+    the gate's own preview surfaces here too instead of in a parallel drawing
+    that agrees with itself.
+    """
+
+    __slots__ = ("_archive", "_invalidate", "_width_fn", "_lock", "_ref",
+                 "_rows", "_epoch", "_loading")
+
+    def __init__(
+        self,
+        *,
+        archive: Any,
+        invalidate: Optional[Callable[[], None]] = None,
+        width_fn: Optional[Callable[[], int]] = None,
+    ) -> None:
+        self._archive = archive
+        self._invalidate = invalidate
+        self._width_fn = width_fn or _terminal_width
+        self._lock = threading.RLock()
+        self._ref: Optional[str] = None
+        self._rows: List[str] = []
+        self._epoch = 0
+        self._loading = False
+
+    # -- overlay_arbiter contract ---------------------------------------
+
+    def is_active(self) -> bool:
+        """Is the overlay on screen? True from the instant it is opened.
+
+        Deliberately NOT "are there rows yet". The overlay is up while it loads —
+        that is what makes `Escape` close it during a slow render, instead of the
+        operator pressing it into a void and getting the rewind menu.
+        """
+        with self._lock:
+            return self._ref is not None
+
+    def dismiss(self) -> None:
+        """Close it, and orphan any render still in flight. NEVER raises."""
+        with self._lock:
+            self._ref = None
+            self._rows = []
+            self._loading = False
+            # Bumped so a task that finishes after this cannot resurrect us.
+            self._epoch += 1
+        self._repaint()
+
+    def rows(self) -> List[str]:
+        """The lines to draw. O(1), never blocks, never renders. NEVER raises."""
+        with self._lock:
+            return list(self._rows)
+
+    # -- opening --------------------------------------------------------
+
+    def open(self, ref: Optional[str] = None) -> bool:
+        """Show a diff. Returns whether the overlay is now up. NEVER raises.
+
+        Resolution happens HERE, synchronously, because it is a dict lookup and
+        an operator who typed an unknown ref deserves an immediate answer rather
+        than a placeholder that later turns into an error.
+
+        ``ref=None`` means the most recent archived diff — the overwhelmingly
+        common intent, and it saves an operator reading a ref off the screen only
+        to type it back.
+        """
+        try:
+            entry = self._resolve(ref)
+            if entry is None:
+                with self._lock:
+                    self._ref = str(ref or "d-?")
+                    self._rows = self._not_found_rows(ref)
+                    self._loading = False
+                    self._epoch += 1
+                self._repaint()
+                return True
+            with self._lock:
+                self._epoch += 1
+                epoch = self._epoch
+                self._ref = str(getattr(entry, "ref", "") or "")
+                self._loading = True
+                self._rows = self._loading_rows(self._ref, entry)
+            self._repaint()
+            self._schedule(entry, epoch)
+            return True
+        except Exception:  # noqa: BLE001
+            logger.debug("[DiffOverlay] open degraded", exc_info=True)
+            return False
+
+    def _resolve(self, ref: Optional[str]) -> Any:
+        """``d-N`` → entry, or the newest when no ref was named."""
+        try:
+            if ref:
+                text = str(ref).strip()
+                found = self._archive.lookup(text)
+                if found is not None:
+                    return found
+                # An operator typing `3` for `d-3` is being reasonable; the
+                # prefix is display grammar, not something they should have to
+                # remember. Tried only AFTER the literal, so a future ref shape
+                # that happens to be numeric is never shadowed.
+                if not text.startswith("d-"):
+                    return self._archive.lookup(f"d-{text.lstrip('d-')}")
+                return None
+            recent = list(self._archive.list_recent() or [])
+            return recent[0] if recent else None
+        except Exception:  # noqa: BLE001
+            return None
+
+    def _schedule(self, entry: Any, epoch: int) -> None:
+        """Render off the loop when there is a loop; inline when there is not.
+
+        Headless — a test, a CI run, `ov demo` composing a transcript — has no
+        frame budget to protect and no loop to schedule on. Rendering inline
+        there is not a fallback so much as the correct answer for that context,
+        and it keeps this class usable without an event loop at all.
+        """
+        try:
+            import asyncio
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                loop = None
+            if loop is None:
+                self._absorb(epoch, self._render_blocking(
+                    entry, self._width_fn()))
+                return
+            loop.create_task(self._load(entry, epoch))
+        except Exception:  # noqa: BLE001
+            logger.debug("[DiffOverlay] schedule degraded", exc_info=True)
+
+    async def _load(self, entry: Any, epoch: int) -> None:
+        """The off-loop render. NEVER raises out — it is a bare task.
+
+        `asyncio.to_thread` rather than a custom executor: the work is
+        CPU-and-subprocess bound, releases the GIL inside Pygments and git, and
+        the default thread pool is already the loop's. A private pool would be a
+        second answer to a question asyncio answers.
+        """
+        try:
+            import asyncio
+            width = self._width_fn()
+            rows = await asyncio.to_thread(self._render_blocking, entry, width)
+            self._absorb(epoch, rows)
+        except Exception:  # noqa: BLE001
+            logger.debug("[DiffOverlay] async render degraded", exc_info=True)
+            self._absorb(epoch, ["  diff preview unavailable"])
+
+    def _absorb(self, epoch: int, rows: List[str]) -> None:
+        """Accept a render ONLY if it is still the one being waited for."""
+        with self._lock:
+            if epoch != self._epoch or self._ref is None:
+                # Superseded by a newer open, or dismissed while we rendered.
+                return
+            self._rows = list(rows)
+            self._loading = False
+        self._repaint()
+
+    # -- rendering (runs on a worker thread) ----------------------------
+
+    def _render_blocking(self, entry: Any, width: int) -> List[str]:
+        """Entry → lines. BLOCKING and CPU-heavy by nature. NEVER raises.
+
+        Renders the archive's ``diff_text`` DIRECTLY rather than reconstructing
+        `FileChange` old/new content to hand to `DiffPreviewRenderer.build`. The
+        archive stores a unified diff; rebuilding both sides so a renderer can
+        re-diff them is a lossy round-trip that can only lose fidelity it cannot
+        add. The file TREE is still the real `_build_file_tree`, so the reach
+        gutter and the tree grammar stay shared with the gate's own preview.
+        """
+        out: List[str] = []
+        try:
+            out.extend(self._header_rows(entry))
+            out.extend(self._tree_rows(entry, width))
+            out.extend(self._diff_rows(entry, width))
+        except Exception:  # noqa: BLE001
+            logger.debug("[DiffOverlay] render degraded", exc_info=True)
+            if not out:
+                out = ["  diff preview unavailable"]
+        return out
+
+    def _header_rows(self, entry: Any) -> List[str]:
+        ref = str(getattr(entry, "ref", "") or "d-?")
+        op_id = str(getattr(entry, "op_id", "") or "?")
+        tier = str(getattr(entry, "risk_tier", "") or "")
+        summary = str(getattr(entry, "summary", "") or "")
+        head = f"  ◇ {ref} · {op_id}"
+        if tier:
+            head += f" · {tier}"
+        rows = [head]
+        if summary:
+            rows.append(f"    {summary}")
+        # Outcome is the question an operator opening an ARCHIVED diff is
+        # actually asking — "did this land?" — and it is the one thing a
+        # transient gate preview could never tell them.
+        apply_outcome = str(getattr(entry, "apply_outcome", "") or "")
+        verify = str(getattr(entry, "verify_outcome", "") or "")
+        if apply_outcome or verify:
+            rows.append(f"    apply {apply_outcome or '?'} · "
+                        f"verify {verify or '?'}")
+        branch = str(getattr(entry, "review_branch", "") or "")
+        if branch:
+            rows.append(f"    branch {branch}")
+        rows.append("")
+        return rows
+
+    def _tree_rows(self, entry: Any, width: int) -> List[str]:
+        """The file tree WITH its reach gutter, from the gate's own renderer."""
+        try:
+            from backend.core.ouroboros.battle_test.diff_preview import (
+                DiffPreviewRenderer, FileChange,
+            )
+            paths = list(getattr(entry, "file_paths", ()) or ())
+            if not paths:
+                return []
+            changes = [FileChange(path=str(p)) for p in paths]
+            tree = DiffPreviewRenderer()._build_file_tree(changes)
+            return self._to_lines(tree, width)
+        except Exception:  # noqa: BLE001
+            logger.debug("[DiffOverlay] tree degraded", exc_info=True)
+            return []
+
+    def _diff_rows(self, entry: Any, width: int) -> List[str]:
+        """The diff body, syntax-highlighted. The expensive half."""
+        text = str(getattr(entry, "diff_text", "") or "")
+        if not text.strip():
+            return ["    (no diff text archived for this ref)"]
+        try:
+            from rich.syntax import Syntax
+            return self._to_lines(
+                Syntax(text, "diff", theme="ansi_dark", word_wrap=False,
+                       background_color="default"),
+                width,
+            )
+        except Exception:  # noqa: BLE001
+            # Plain text beats nothing: an operator wanting to read a diff is
+            # not served by a highlighter's absence.
+            return [f"    {ln}" for ln in text.splitlines()]
+
+    def _to_lines(self, renderable: Any, width: int) -> List[str]:
+        """Rich renderable → ANSI lines, through a headless console.
+
+        The SAME shape `BipartiteLayout._render_to_ansi` uses, so the overlay and
+        the deck cannot disagree about how a Rich object becomes terminal text.
+        """
+        try:
+            from io import StringIO
+
+            from rich.console import Console
+            buf = StringIO()
+            Console(file=buf, force_terminal=True, color_system="truecolor",
+                    width=max(20, width - 4), highlight=False,
+                    emoji=True).print(renderable)
+            return buf.getvalue().rstrip("\n").split("\n")
+        except Exception:  # noqa: BLE001
+            return []
+
+    # -- helpers --------------------------------------------------------
+
+    def _loading_rows(self, ref: str, entry: Any) -> List[str]:
+        """What is on screen while the render runs.
+
+        Names the ref and the file count, both free, so the placeholder confirms
+        the operator opened what they meant even before the diff arrives.
+        """
+        count = len(list(getattr(entry, "file_paths", ()) or ()))
+        files = f"{count} file{'s' if count != 1 else ''}" if count else "…"
+        return [f"  ◇ {ref} · {files} · rendering…", ""]
+
+    def _not_found_rows(self, ref: Optional[str]) -> List[str]:
+        """An unknown ref says so, and says what IS available.
+
+        The archive is a ring, so a ref an operator read minutes ago may have
+        been evicted. "No such diff" alone invites them to doubt their typing;
+        listing the live refs answers the real question.
+        """
+        try:
+            available = list(self._archive.all_refs() or ())
+        except Exception:  # noqa: BLE001
+            available = []
+        rows = [f"  ◇ no diff archived as {ref or '(latest)'}"]
+        if available:
+            rows.append(f"    available: {' '.join(str(r) for r in available[-8:])}")
+        else:
+            rows.append("    the archive is empty — no candidate has been "
+                        "previewed yet")
+        rows.append("")
+        return rows
+
+    def _repaint(self) -> None:
+        try:
+            if self._invalidate is not None:
+                self._invalidate()
+        except Exception:  # noqa: BLE001
+            pass
+
+    # -- registration ---------------------------------------------------
+
+    def register(self) -> bool:
+        """Declare this overlay to `overlay_arbiter`. NEVER raises.
+
+        Below the Iron Gate and the panic: a preview the operator opened
+        themselves is the least urgent of the three, so `Escape` closes a crash
+        or a pending decision first. Registered rather than hardcoded into the
+        arbiter's filter, which is what lets `Escape` become contextually eager
+        without the arbiter knowing this class exists.
+        """
+        try:
+            from backend.core.ouroboros.battle_test.overlay_arbiter import (
+                Z_DIFF_PREVIEW, register_overlay,
+            )
+            return register_overlay(
+                OVERLAY_NAME, z=Z_DIFF_PREVIEW,
+                is_active=self.is_active, dismiss=self.dismiss,
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug("[DiffOverlay] registration degraded", exc_info=True)
+            return False
+
+
+__all__ = [
+    "DIFF_OVERLAY_SCHEMA_VERSION",
+    "OVERLAY_NAME",
+    "DiffOverlayController",
+]

--- a/tests/battle_test/test_diff_overlay.py
+++ b/tests/battle_test/test_diff_overlay.py
@@ -1,0 +1,345 @@
+"""The diff overlay must never cost the cockpit a frame.
+
+`DiffArchive` is an in-memory ring, so fetching `diff_text` is a dict lookup —
+the frame-dropping cost is SYNTAX HIGHLIGHTING (Pygments over thousands of diff
+lines is hundreds of milliseconds of pure CPU) and any git resolution of a
+`review_branch`. Both belong off the loop.
+
+A prompt_toolkit render callable is synchronous, so an overlay that fetched during
+render would block the frame whichever thread it used. The split that works is
+pure-pull render + out-of-band fill, and
+`test_a_large_render_never_stalls_the_event_loop` is the assertion that actually
+holds the mandate: it measures loop liveness rather than trusting the shape of
+the code.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from backend.core.ouroboros.battle_test.diff_archive import DiffArchive
+from backend.core.ouroboros.battle_test.diff_overlay import (
+    DiffOverlayController,
+)
+
+_DIFF = "\n".join(
+    ["--- a/backend/x.py", "+++ b/backend/x.py", "@@ -1,3 +1,4 @@"]
+    + [f"+    added line {i}" for i in range(40)]
+)
+
+
+def _archive(n: int = 1, diff: str = _DIFF) -> DiffArchive:
+    archive = DiffArchive()
+    for i in range(n):
+        archive.add(op_id=f"op-{i}", risk_tier="NOTIFY_APPLY",
+                    file_paths=("backend/x.py", "tests/test_x.py"),
+                    diff_text=diff, summary=f"candidate {i}")
+    return archive
+
+
+@pytest.fixture(autouse=True)
+def _clean_arbiter():
+    from backend.core.ouroboros.battle_test import overlay_arbiter as oa
+    oa.reset_for_tests()
+    yield
+    oa.reset_for_tests()
+
+
+class TestTheFrameBudget:
+    """The mandate, measured."""
+
+    @pytest.mark.asyncio
+    async def test_a_large_render_never_stalls_the_event_loop(self):
+        """A 6000-line diff renders while a 10ms heartbeat keeps ticking.
+
+        Asserts LOOP LIVENESS, not code shape: a future refactor that moved the
+        render back onto the loop would keep every other test in this file green
+        and fail only this one.
+        """
+        big = "\n".join(
+            ["--- a/x.py", "+++ b/x.py", "@@ -1,5 +1,6 @@"]
+            + [f"+    line {i} of a very large candidate diff"
+               for i in range(6000)]
+        )
+        archive = _archive(diff=big)
+        controller = DiffOverlayController(archive=archive,
+                                          width_fn=lambda: 120)
+        stalls = []
+
+        async def heartbeat():
+            last = time.perf_counter()
+            while True:
+                await asyncio.sleep(0.01)
+                now = time.perf_counter()
+                if now - last > 0.15:
+                    stalls.append(round((now - last) * 1000))
+                last = now
+
+        beat = asyncio.ensure_future(heartbeat())
+        try:
+            controller.open("d-1")
+            for _ in range(400):
+                await asyncio.sleep(0.01)
+                if len(controller.rows()) > 8:
+                    break
+        finally:
+            beat.cancel()
+        assert len(controller.rows()) > 100, "the diff never rendered"
+        assert not stalls, (
+            f"the event loop stalled for {stalls}ms — the render is back on the "
+            f"loop and the cockpit is dropping frames")
+
+    @pytest.mark.asyncio
+    async def test_rows_are_available_immediately_and_never_block(self):
+        """`rows()` is what the renderer calls every frame. It must be O(1) and
+        must not wait for the payload — the overlay shows a placeholder first."""
+        controller = DiffOverlayController(archive=_archive(),
+                                           width_fn=lambda: 100)
+        controller.open("d-1")
+        started = time.perf_counter()
+        rows = controller.rows()
+        assert (time.perf_counter() - started) < 0.05
+        assert rows and "rendering" in rows[0]
+
+
+class TestEpochsAndRaces:
+    """The operator moves faster than a 500ms render."""
+
+    @pytest.mark.asyncio
+    async def test_dismissing_mid_render_does_not_resurrect_the_overlay(self):
+        """A finishing task must not reopen something already closed — worse
+        than a slow overlay, because the operator did not ask for it."""
+        controller = DiffOverlayController(archive=_archive(),
+                                           width_fn=lambda: 100)
+        controller.open("d-1")
+        controller.dismiss()
+        for _ in range(30):
+            await asyncio.sleep(0.01)
+        assert controller.is_active() is False
+        assert controller.rows() == []
+
+    @pytest.mark.asyncio
+    async def test_the_newest_open_wins_a_race(self):
+        """Two opens in flight: whichever THREAD finishes first must not decide
+        what is on screen. Only the last ref asked for may land."""
+        archive = _archive(n=3)
+        controller = DiffOverlayController(archive=archive,
+                                           width_fn=lambda: 100)
+        controller.open("d-1")
+        controller.open("d-3")
+        for _ in range(200):
+            await asyncio.sleep(0.01)
+            if len(controller.rows()) > 8:
+                break
+        joined = "\n".join(controller.rows())
+        assert "d-3" in joined
+        assert "d-1 ·" not in joined
+
+    @pytest.mark.asyncio
+    async def test_a_stale_result_is_discarded_not_merged(self):
+        """Directly at the seam: an absorb carrying a superseded epoch is a
+        no-op rather than a partial overwrite."""
+        controller = DiffOverlayController(archive=_archive(),
+                                           width_fn=lambda: 100)
+        controller.open("d-1")
+        stale = -1
+        controller._absorb(stale, ["GHOST"])
+        assert "GHOST" not in "\n".join(controller.rows())
+
+
+class TestTheOverlayContract:
+    def test_it_is_active_from_the_instant_it_opens(self):
+        """NOT "once rows exist". The overlay is up while it loads, so `Escape`
+        closes it during a slow render instead of falling through to rewind."""
+        controller = DiffOverlayController(archive=_archive())
+        assert controller.is_active() is False
+        controller.open("d-1")
+        assert controller.is_active() is True
+
+    def test_dismiss_clears_everything(self):
+        controller = DiffOverlayController(archive=_archive())
+        controller.open("d-1")
+        controller.dismiss()
+        assert controller.is_active() is False
+        assert controller.rows() == []
+
+    def test_no_ref_opens_the_most_recent(self):
+        """The overwhelmingly common intent — and it saves reading a ref off the
+        screen only to type it back."""
+        controller = DiffOverlayController(archive=_archive(n=3),
+                                           width_fn=lambda: 100)
+        assert controller.open() is True
+        assert "d-3" in "\n".join(controller.rows())
+
+    def test_a_bare_number_resolves_to_a_ref(self):
+        """`3` for `d-3` is reasonable; the prefix is display grammar. Tried only
+        AFTER the literal, so a future numeric ref shape is never shadowed."""
+        controller = DiffOverlayController(archive=_archive(n=3),
+                                           width_fn=lambda: 100)
+        controller.open("2")
+        assert "d-2" in "\n".join(controller.rows())
+
+    def test_an_unknown_ref_says_so_and_lists_what_exists(self):
+        """The archive is a ring, so a ref read minutes ago may be evicted. "No
+        such diff" alone invites doubt about typing; the live refs answer the
+        real question."""
+        controller = DiffOverlayController(archive=_archive(n=2),
+                                           width_fn=lambda: 100)
+        controller.open("d-999")
+        joined = "\n".join(controller.rows())
+        assert "no diff archived" in joined
+        assert "d-1" in joined and "d-2" in joined
+
+    def test_an_empty_archive_explains_itself(self):
+        controller = DiffOverlayController(archive=DiffArchive())
+        controller.open()
+        assert "archive is empty" in "\n".join(controller.rows())
+
+    def test_a_diff_with_no_text_is_reported_not_blank(self):
+        archive = DiffArchive()
+        archive.add(op_id="op", risk_tier="NOTIFY_APPLY",
+                    file_paths=("x.py",), diff_text="", summary="empty")
+        controller = DiffOverlayController(archive=archive,
+                                           width_fn=lambda: 100)
+        controller.open("d-1")
+        assert "no diff text" in "\n".join(controller.rows())
+
+    def test_the_header_carries_the_outcome(self):
+        """The question an operator opening an ARCHIVED diff is asking — "did
+        this land?" — and the one thing a transient gate preview cannot tell
+        them."""
+        controller = DiffOverlayController(archive=_archive(),
+                                           width_fn=lambda: 100)
+        controller.open("d-1")
+        joined = "\n".join(controller.rows())
+        assert "apply" in joined and "verify" in joined
+
+    def test_a_broken_archive_never_raises(self):
+        """It runs on the operator's critical path; a lookup that explodes must
+        degrade, not crash the cockpit."""
+        class _Broken:
+            def lookup(self, _ref):
+                raise RuntimeError("archive corrupt")
+
+            def list_recent(self):
+                raise RuntimeError("archive corrupt")
+
+            def all_refs(self):
+                raise RuntimeError("archive corrupt")
+
+        controller = DiffOverlayController(archive=_Broken())
+        assert controller.open("d-1") is True
+        assert controller.rows()
+
+    def test_it_works_with_no_event_loop_at_all(self):
+        """Headless — a test, CI, a transcript compose — has no frame budget to
+        protect and no loop to schedule on. Rendering inline there is the correct
+        answer for that context, not a fallback."""
+        controller = DiffOverlayController(archive=_archive(),
+                                           width_fn=lambda: 100)
+        controller.open("d-1")
+        rows = controller.rows()
+        assert len(rows) > 8, "no inline render happened without a loop"
+        assert "added line 39" in "\n".join(rows)
+
+
+class TestArbiterIntegration:
+    def test_registering_makes_escape_contextually_eager(self):
+        """The overlay declares itself; the arbiter never learns this class
+        exists. That is what lets `Escape` become eager for it without an edit
+        to the keymap."""
+        from backend.core.ouroboros.battle_test import overlay_arbiter as oa
+        controller = DiffOverlayController(archive=_archive())
+        assert controller.register() is True
+        assert oa.overlay_active() is False
+        controller.open("d-1")
+        assert oa.overlay_active() is True
+
+    def test_escape_dismisses_it_through_the_arbiter(self):
+        from backend.core.ouroboros.battle_test import overlay_arbiter as oa
+        controller = DiffOverlayController(archive=_archive())
+        controller.register()
+        controller.open("d-1")
+        assert oa.dismiss_top() == "diff_preview"
+        assert controller.is_active() is False
+
+    def test_a_panic_outranks_the_diff(self):
+        """A crash outranks a preview the operator opened for themselves, so the
+        first Escape closes the panic."""
+        from backend.core.ouroboros.battle_test import overlay_arbiter as oa
+        controller = DiffOverlayController(archive=_archive())
+        controller.register()
+        controller.open("d-1")
+        oa.register_overlay("panic", z=oa.Z_PANIC, is_active=lambda: True,
+                            dismiss=lambda: None)
+        top = oa.top_overlay()
+        assert top is not None and top.name == "panic"
+
+
+class TestTheFloatMount:
+    """Inherits the panic overlay's structural pattern — see
+    `bipartite_layout`'s hoisted float host."""
+
+    def _floats(self, app):
+        from prompt_toolkit.layout import walk
+        for node in walk(app.layout.container):
+            if getattr(node, "floats", None):
+                return node.floats
+        return []
+
+    def _label(self, float_):
+        from prompt_toolkit.formatted_text import to_formatted_text
+        from prompt_toolkit.layout import walk
+        from prompt_toolkit.layout.controls import FormattedTextControl
+        for node in walk(float_.content):
+            control = getattr(node, "content", None)
+            if not isinstance(control, FormattedTextControl):
+                continue
+            try:
+                value = (control.text() if callable(control.text)
+                         else control.text)
+                text = "".join(f[1] for f in to_formatted_text(value))
+            except Exception:  # noqa: BLE001
+                continue
+            if "DIFF-SENTINEL" in text:
+                return "DIFF"
+            if "PANIC-SENTINEL" in text:
+                return "PANIC"
+        return "?"
+
+    def _app(self, **kwargs):
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            BipartiteLayout, build_bipartite_application,
+        )
+        return build_bipartite_application(
+            BipartiteLayout(), on_accept=lambda _t: None, **kwargs)
+
+    def test_the_diff_float_is_actually_mounted(self):
+        """It was NOT, on the first attempt: the block appended under an
+        `isinstance(root, FloatContainer)` guard that was False, because the
+        panic block that created the container ran after it. Mounted nothing and
+        reported nothing."""
+        app = self._app(diff_rows=lambda: ["DIFF-SENTINEL"])
+        assert [self._label(f) for f in self._floats(app)] == ["DIFF"]
+
+    def test_the_panic_draws_on_top_of_the_diff(self):
+        """Floats draw in list order, so the LAST is on top. This must agree
+        with `overlay_arbiter`'s Z constants, or Escape would dismiss something
+        other than what the operator is looking at."""
+        app = self._app(diff_rows=lambda: ["DIFF-SENTINEL"],
+                        panic_rows=lambda: ["PANIC-SENTINEL"])
+        assert [self._label(f) for f in self._floats(app)] == ["DIFF", "PANIC"]
+
+    def test_either_overlay_alone_still_mounts(self):
+        assert len(self._floats(self._app(
+            panic_rows=lambda: ["PANIC-SENTINEL"]))) == 1
+        assert len(self._floats(self._app(
+            diff_rows=lambda: ["DIFF-SENTINEL"]))) == 1
+
+    def test_no_overlays_means_no_float_host(self):
+        """An empty FloatContainer renders identically, but wrapping
+        unconditionally changes the container tree for every cockpit that has no
+        overlays and buys nothing."""
+        assert self._floats(self._app()) == []


### PR DESCRIPTION
## The archived diff, on screen, without costing a frame

`DiffArchive` keeps ~30 Yellow-tier candidates behind stable `d-N` refs and `DiffPreviewRenderer` knows how to draw one. Between them there was no way to **look** at a diff on the cockpit — `/expand d-N` printed into a console, the gate's preview is transient. The archive filled with refs the operator was invited to name and could not open.

## Where the cost actually is

Being exact matters, because designing against the wrong cost produces a fix that protects nothing. **`DiffArchive` is an in-memory ring** — `diff_text` is already resident and fetching it is a dict lookup. There is no disk read.

The frame-dropping cost is elsewhere and it is real:
- **Pygments** over a few thousand diff lines is hundreds of ms of pure CPU. A whole frame at 60fps is 16ms.
- **`review_branch`** names a real git branch; resolving it is an unbounded subprocess.

So `asyncio.to_thread` wraps the **render**, not a disk read that doesn't happen.

| | |
|---|---|
| 6000-line diff, off-thread | **483ms render · 26 loop ticks · 0 stalls** |
| same render inline | **494ms of fully blocked loop** (~30 dropped frames) |

## Pure-pull render, out-of-band fill

A prompt_toolkit render callable is **synchronous** — `create_content` cannot await — so an overlay that fetched during render would block the frame whichever thread it used. There is no "await inside the renderer".

The split that works is the one `attach_heartbeat` and `MiniCrest` already use: state fills asynchronously out of band; the renderer is a pure O(1) read of whatever landed. `rows()` never blocks, never touches the archive, never renders.

## Epochs, because the operator moves faster than the render

Every open bumps an epoch; a task completing with a stale epoch **discards** its result. Without it, `d-3` then `d-7` lets whichever thread wins decide what's on screen, and dismissing mid-render lets a finishing task **resurrect** an overlay already closed. Stricter and cheaper than cancellation — a thread inside Pygments cannot be interrupted, so the honest move is to let it finish and ignore it.

Renders `diff_text` **directly** rather than reconstructing `FileChange` old/new for `build()`: the archive stores a unified diff, and rebuilding both sides so a renderer can re-diff them is a lossy round-trip. The file **tree** is still the real `_build_file_tree`, so the reach gutter stays shared with the gate's own preview.

## A silent drop, found by looking

The float **mounted nothing** on the first attempt. It appended under `isinstance(root, FloatContainer)` — False, because the block that *creates* that container is the panic overlay's, and it runs afterwards. Reported success, drew nothing.

Fixed by **hoisting the float host** above both overlays, so every overlay block is a pure append in source order, which is also draw order. No block has to know whether it is first, and the next overlay cannot reintroduce this. Wrapped only when an overlay exists — an empty `FloatContainer` renders identically, but wrapping unconditionally changes the tree for every cockpit with none.

Draw order matches `overlay_arbiter`'s Z constants deliberately (`Z_DIFF_PREVIEW < Z_PANIC`), so the surface an operator **sees** on top is the one `Escape` closes first. Two orderings that disagreed would mean Escape dismissing something other than what they're looking at.

Rendered as **ANSI**, not under one prompt_toolkit style: rows arrive already coloured by Rich (the highlighting is the point), and wrapping pre-escaped text in a single style prints the escapes and flattens the diff.

## Nuances

- `is_active` is true **from the instant it opens**, not once rows exist — so `Escape` closes it during a slow render instead of falling through to rewind.
- An unknown ref says so **and lists the live refs** — the archive is a ring, so "no such diff" alone invites doubt about typing.
- A bare `3` resolves to `d-3`, tried only **after** the literal so a future numeric ref shape is never shadowed.
- **No event loop at all** → renders inline. Headless has no frame budget to protect; that's the correct answer for that context, not a fallback.

## Tests — 22 new

Led by one that measures **loop liveness** rather than code shape: a refactor moving the render back onto the loop keeps every other test green and fails only that one.

226 green across overlay, arbiter, canvas, cockpit-mount, rewind and demo suites. The capability-handoff ratchet reports **no dropped hooks** — the new `diff_rows` hook is consumed, which is the check that would have caught the silent float drop had it survived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an async, on-screen diff overlay for archived `d-N` refs that renders off the event loop to keep the cockpit at frame rate. Also fixes float mounting and z-order so the diff reliably appears beneath the panic overlay.

- New Features
  - New `DiffOverlayController`: renders syntax-highlighted diffs via `asyncio.to_thread`, discards stale epochs, and exposes O(1) `rows()`; falls back to inline rendering when no event loop is present.
  - Integration: registers with `overlay_arbiter` at `Z_DIFF_PREVIEW`; `bipartite_layout` adds optional `diff_rows` and draws precolored ANSI lines.
  - UX: opens latest by default; bare numbers resolve to `d-N`; unknown refs list available refs; header shows apply/verify outcomes and branch; never raises.

- Bug Fixes
  - Hoisted a single `FloatContainer` above overlays and append-only mounting to prevent silent drops.
  - Enforced z-order (diff below panic) to match arbiter priorities; only wrap when an overlay exists to avoid altering trees without overlays.
  - Added tests (including loop-liveness) to prevent regressions in rendering and float mounting.

<sup>Written for commit a30b03289bb5b404b8714e3d7050f465842b3bc5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

