### PR TITLE
fix(ov): an overlay that does not occlude is not an overlay

### DIFF
--- a/backend/core/ouroboros/battle_test/bipartite_layout.py
+++ b/backend/core/ouroboros/battle_test/bipartite_layout.py
@@ -142,6 +142,54 @@ def fullscreen_enabled() -> bool:
     return _real_tty()
 
 
+#: Where an overlay float sits, and how wide. ONE answer for every overlay.
+#:
+#: `top=1` rather than `ycursor=True`: an overlay is not attached to where the
+#: caret happens to be, and one that moves while the operator reads a traceback is
+#: hostile.
+#:
+#: `left=0, right=0` — FULL WIDTH — and that is a fix, not a preference. Inset at
+#: `left=2` the float began at column 2, so the deck's GLYPH GUTTER (columns 0-2,
+#: where `⏺`/`💭`/`●` live) stayed visible beside it. A FATAL traceback then read
+#: as interleaved with the transcript underneath: deck bullets running down the
+#: left margin of a crash report. Proven by rendering a float over a filled canvas
+#: and finding `CAFATAL LINE A` — two canvas columns, then the overlay.
+#:
+#: An overlay that does not occlude is not an overlay. Blank lines WITHIN a
+#: full-width float do paint over what is beneath them (verified), so opacity
+#: comes free once the inset is gone.
+_OVERLAY_FLOAT_POSITION = {"top": 1, "left": 0, "right": 0}
+
+
+def _overlay_style(role: str) -> str:
+    """Semantic role -> prompt_toolkit style, WITH a background. NEVER raises.
+
+    Extracted from the panic overlay's own `_panic_style`, which had the whole
+    translation argument right and only ever needed to be said once: Rich spells a
+    colour `bright_yellow`, prompt_toolkit spells it `ansibrightyellow`, and both
+    accept `#RRGGBB`. Assuming either dialect is how `class:panic` silently
+    rendered as the default in the first place.
+
+    The background is the half the panic version lacked. A foreground-only style
+    leaves prompt_toolkit painting the float's cells with the DEFAULT background,
+    which on a themed terminal is not necessarily the deck's — so the overlay read
+    as text floating on the transcript rather than as a surface on top of it.
+    """
+    try:
+        from backend.core.ouroboros.ui.semantic_tokens import style_for
+        raw = (style_for(role) or "").strip()
+        fg = ""
+        if raw.startswith("#"):
+            fg = raw
+        elif raw:
+            fg = "ansi" + raw.replace("_", "")
+        # `bg:default` is deliberately NOT used: it means "whatever was there",
+        # which is exactly the transparency being fixed.
+        return f"bold bg:#0b0b0b fg:{fg}" if fg else "bold bg:#0b0b0b"
+    except Exception:  # noqa: BLE001
+        return "bold bg:#0b0b0b"
+
+
 def _canvas_dimension() -> Any:
     """How much room the live canvas takes.
 
@@ -1605,12 +1653,16 @@ def build_bipartite_application(
                         lambda: ANSI("\n".join(diff_rows())),
                     ),
                     wrap_lines=False,
+                    # Opaque, so the deck does not show through a diff. The rows
+                    # carry their own Rich colours, so this contributes only the
+                    # background the float needs to occlude with.
+                    style="bg:#0b0b0b",
                 ),
                 filter=Condition(_diff_visible),
             )
             if isinstance(root, FloatContainer):
                 root.floats.append(Float(
-                    content=_diff_win, top=1, left=2, right=2,
+                    content=_diff_win, **_OVERLAY_FLOAT_POSITION,
                 ))
         except Exception:  # noqa: BLE001
             logger.debug("[Bipartite] diff overlay unavailable", exc_info=True)
@@ -1657,7 +1709,7 @@ def build_bipartite_application(
                 except Exception:  # noqa: BLE001
                     return "bold"
 
-            _p_style = _panic_style()
+            _p_style = _overlay_style("alert")
             _panic_win = ConditionalContainer(
                 Window(
                     FormattedTextControl(
@@ -1673,7 +1725,7 @@ def build_bipartite_application(
             # `overlay_arbiter` agree on.
             if isinstance(root, FloatContainer):
                 root.floats.append(Float(
-                    content=_panic_win, top=1, left=2, right=2,
+                    content=_panic_win, **_OVERLAY_FLOAT_POSITION,
                 ))
         except Exception:  # noqa: BLE001
             # A cockpit that cannot draw the overlay must still RUN — the

--- a/backend/core/ouroboros/battle_test/cockpit_mount.py
+++ b/backend/core/ouroboros/battle_test/cockpit_mount.py
@@ -376,6 +376,84 @@ def daemon_diff_rows() -> Any:
         return None
 
 
+def daemon_header() -> "tuple":
+    """``(render, height)`` for the crest above the deck, or ``(None, 0)``.
+
+    The daemon cockpit had no identity surface at all: the process that IS the
+    organism showed no emblem, while the attach client — a thin viewer of it — drew
+    one. Rendered by `crest_animator`'s own `render_cockpit_header`, so all three
+    surfaces draw the same emblem and none can drift into its own look.
+
+    `ensure_frames` is scheduled with `ensure_future` and that is safe HERE
+    specifically because the daemon builds its mount from inside an already-async
+    `SerpentREPL.start`. The identical line in `ov_demo` was a bug — it ran before
+    `asyncio.run`, so the coroutine was never awaited and the crest stayed on its
+    unbuilt fallback. The call is not portable; its context is what makes it
+    correct.
+    """
+    try:
+        from backend.core.ouroboros.ui.crest_animator import (
+            MiniCrest, render_cockpit_header,
+        )
+        mini = MiniCrest()
+        if not mini.available:
+            return (None, 0)
+        try:
+            import asyncio
+            asyncio.get_running_loop()
+            asyncio.ensure_future(mini.ensure_frames())
+        except RuntimeError:
+            # No loop: the emblem draws its static fallback rather than raising.
+            # Scheduling onto nothing is what produced the never-awaited warning.
+            pass
+
+        def _render() -> str:
+            try:
+                import time
+                return render_cockpit_header(
+                    mini, _daemon_header_lines(), _terminal_width(),
+                    now=time.monotonic(),
+                )
+            except Exception:  # noqa: BLE001
+                return ""
+
+        return (_render, max(3, int(getattr(mini, "rows", 3) or 3)))
+    except Exception:  # noqa: BLE001
+        logger.debug("[CockpitMount] crest header unavailable", exc_info=True)
+        return (None, 0)
+
+
+def _daemon_header_lines() -> List[Any]:
+    """Rich ``Text`` beside the emblem — never markup strings.
+
+    `render_cockpit_header` accepts "Rich renderable Texts (or plain strings)", so a
+    markup string is the PLAIN case and `[dim]…[/dim]` reaches the operator
+    verbatim. That shipped once already, in the demo's header.
+
+    Says DAEMON explicitly: this cockpit and the attach client's look alike, and an
+    operator who cannot tell which process they are typing at will eventually pause
+    autonomy on the wrong one.
+    """
+    try:
+        from rich.text import Text
+
+        from backend.core.ouroboros.ui.semantic_tokens import role_palette
+        palette = role_palette()
+        dim = palette.get("dim") or "dim"
+        first = Text()
+        first.append("◇ ", style=palette.get("neural") or "cyan")
+        first.append("O+V", style="bold")
+        first.append(" · daemon cockpit", style=dim)
+        return [
+            first,
+            Text("the organism itself · this process dispatches", style=dim),
+            Text("/ for verbs · esc-esc rewind · ctrl+r search", style=dim),
+        ]
+    except Exception:  # noqa: BLE001
+        return ["◇ O+V · daemon cockpit", "the organism itself",
+                "/ for verbs"]
+
+
 def build_daemon_mount(repl: Any = None) -> "dict":
     """Every in-process hook the daemon cockpit can fill, as a plain dict.
 
@@ -391,7 +469,7 @@ def build_daemon_mount(repl: Any = None) -> "dict":
     local action sink (`daemon_key_bindings`). Every other provider reads
     process-global state.
     """
-    return {
+    mount: dict = {
         "pending_rows": daemon_pending_rows,
         "panic_rows": daemon_panic_rows,
         "queue_rows": daemon_queue_rows,
@@ -409,6 +487,21 @@ def build_daemon_mount(repl: Any = None) -> "dict":
         # open it is a row that can never appear.
         "extra_key_bindings": daemon_key_bindings(repl),
     }
+    # The crest and its height travel TOGETHER — `header_height` sizes the region
+    # `header` draws into, so a mount carrying one without the other either
+    # reserves rows nothing fills or draws an emblem into zero rows. Unpacked from
+    # one call rather than resolved twice, so they cannot disagree.
+    mount["header"], mount["header_height"] = daemon_header()
+    # `stream_rows` is deliberately absent, and this is the reason rather than an
+    # oversight: there is NO process-global in-flight text to read.
+    # `live_tool_stream.make_tool_observer` creates a stream per tool CALL and
+    # nothing publishes a current frame, so a provider here would have to invent
+    # one — and an in-flight strip that shows the wrong sentence is worse than no
+    # strip. The correct fix is a `set_active_stream` registry mirroring the
+    # `set_active_canvas` / `set_active_queue` pattern this codebase already uses
+    # twice, which needs a producer-side audit of every stream construction site.
+    # Left UNSET rather than waived so `capability_handoff` keeps reporting it.
+    return mount
 
 
 __all__ = [

--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -6693,6 +6693,10 @@ class SerpentREPL:
                     # `/expand d-N` opens this. The daemon owns the archive, so
                     # this is the only surface that can render a diff locally.
                     diff_rows=_mount.get("diff_rows"),
+                    # The crest. The process that IS the organism showed no
+                    # emblem while a thin viewer of it drew one.
+                    header=_mount.get("header"),
+                    header_height=_mount.get("header_height") or 0,
                 )
                 return
         except Exception:  # noqa: BLE001 — cockpit failure NEVER bricks the REPL

--- a/tests/battle_test/test_diff_overlay.py
+++ b/tests/battle_test/test_diff_overlay.py
@@ -450,3 +450,91 @@ class TestTheWiring:
         assert calls
         passed = {kw.arg for c in calls for kw in c.keywords if kw.arg}
         assert "diff_rows" in passed
+
+
+class TestOverlaysOcclude:
+    """An overlay that does not cover what is beneath it is not an overlay.
+
+    Reproduced from a screenshot: the FATAL traceback had deck bullets (`⏺`, `💭`,
+    `●`) running down its left margin. The float was inset at `left=2`, so the
+    deck's GLYPH GUTTER — columns 0-2 — stayed visible beside it, and a crash
+    report read as interleaved with the transcript underneath.
+    """
+
+    def _render(self, **kwargs):
+        """One real frame, floats included. Call from an ASYNC test.
+
+        The Application's input buffer schedules a history load on the running
+        loop, so a synchronous caller dies with "no running event loop" — the same
+        constraint the arbiter's KeyProcessor tests hit.
+
+        `write_to_screen` DEFERS float drawing; `Screen.draw_all_floats()` is what
+        actually paints them. Without that call the first version of this test
+        reported no overlay at all and would have "passed" for a float that never
+        rendered.
+        """
+        from prompt_toolkit.layout.containers import to_container
+        from prompt_toolkit.layout.mouse_handlers import MouseHandlers
+        from prompt_toolkit.layout.screen import Screen, WritePosition
+
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            BipartiteLayout, build_bipartite_application,
+        )
+        mux = BipartiteLayout()
+        for i in range(40):
+            mux.push_raw(f"CANVAS-LINE-{i}")
+        app = build_bipartite_application(
+            mux, on_accept=lambda _t: None, **kwargs)
+        width, height = 60, 20
+        screen = Screen(default_char=None, initial_width=width,
+                        initial_height=height)
+        to_container(app.layout.container).write_to_screen(
+            screen, MouseHandlers(), WritePosition(0, 0, width, height),
+            "", False, None)
+        screen.draw_all_floats()
+        return [
+            "".join(screen.data_buffer[y][x].char for x in range(width))
+            for y in range(height)
+        ]
+
+    @pytest.mark.asyncio
+    async def test_the_panic_overlay_hides_the_deck_beneath_it(self):
+        rows = self._render(
+            panic_rows=lambda: ["FATAL LINE A", "", "", "FATAL LINE D"])
+        overlay = rows[1:5]
+        assert any("FATAL LINE A" in r for r in overlay)
+        for r in overlay:
+            assert "CANVAS-" not in r, (
+                f"deck bled through the overlay: {r.rstrip()!r} — the float is "
+                f"inset again and the glyph gutter shows beside it")
+
+    @pytest.mark.asyncio
+    async def test_a_blank_overlay_line_still_occludes(self):
+        """The subtle half. Rows 2 and 3 of the payload are EMPTY, and an empty
+        line that paints nothing lets the transcript show through the middle of a
+        traceback."""
+        rows = self._render(
+            panic_rows=lambda: ["HEADER", "", "", "FOOTER"])
+        assert "CANVAS-" not in rows[2]
+        assert "CANVAS-" not in rows[3]
+
+    @pytest.mark.asyncio
+    async def test_the_diff_overlay_occludes_too(self):
+        """Same contract, same helpers — it would be pointless to fix one."""
+        rows = self._render(diff_rows=lambda: ["DIFF HEADER", "", "+ added"])
+        for r in rows[1:4]:
+            assert "CANVAS-" not in r
+
+    def test_both_overlays_share_one_position_contract(self):
+        """Two spellings of "where does an overlay sit" is how one of them gets
+        inset again."""
+        from backend.core.ouroboros.battle_test import bipartite_layout as bl
+        assert bl._OVERLAY_FLOAT_POSITION["left"] == 0
+        assert bl._OVERLAY_FLOAT_POSITION["right"] == 0
+
+    def test_the_overlay_style_carries_a_background(self):
+        """A foreground-only style leaves prompt_toolkit painting the float's
+        cells with the DEFAULT background, which on a themed terminal is not the
+        deck's — so the overlay reads as text floating on the transcript."""
+        from backend.core.ouroboros.battle_test import bipartite_layout as bl
+        assert "bg:" in bl._overlay_style("alert")


### PR DESCRIPTION
## An overlay that does not occlude is not an overlay

From the screenshot: the FATAL traceback had deck bullets — `⏺`, `💭`, `●` — running down its left margin, so a crash report read as **interleaved** with the transcript underneath.

### Root cause, reproduced

The float was positioned `left=2, right=2`. The deck's **glyph gutter is columns 0–2**. So the overlay began at column 2 and the transcript's two leftmost columns stayed visible beside it, for its whole height:

```
'CAFATAL LINE A'      <- two canvas columns, then the overlay
```

Both overlays now share one `_OVERLAY_FLOAT_POSITION` — full width, `left=0, right=0`. Two spellings of "where does an overlay sit" is how one of them gets inset again.

`_panic_style` had the whole Rich→prompt_toolkit translation argument right and only ever needed saying once, so it is now the shared `_overlay_style`. **The background is the half it lacked**: a foreground-only style leaves prompt_toolkit painting the float's cells with the *default* background, which on a themed terminal is not the deck's. `bg:default` is deliberately not used — it means "whatever was there", which is the transparency being fixed.

Blank lines *within* a full-width float do paint over what's beneath them (verified), so opacity comes free once the inset is gone.

## The last two daemon hooks

`header` + `header_height`, unpacked from **one** `daemon_header()` call because they travel together — a mount carrying one without the other either reserves rows nothing fills or draws an emblem into zero rows.

Its `ensure_future(mini.ensure_frames())` is guarded by `get_running_loop()`, because **the identical line was a bug in `ov_demo`**: there it ran before `asyncio.run`, was never awaited, and the crest stayed on its unbuilt fallback. The daemon builds its mount from inside an already-async `start`, so the call is correct there. The call is not portable; its context is what makes it work, and the guard says so.

Header lines are Rich `Text`, never markup strings — that shipped once already.

### `stream_rows` is left UNSET, with a reason

There is **no process-global in-flight text to read**. `live_tool_stream.make_tool_observer` creates a stream per tool *call* and nothing publishes a current frame, so a provider would have to invent one — and an in-flight strip showing the wrong sentence is worse than no strip.

The correct fix is a `set_active_stream` registry mirroring the `set_active_canvas` / `set_active_queue` pattern this codebase already uses twice, which needs a producer-side audit of every construction site. **Left unset rather than waived, so the audit keeps reporting it.**

`serpent_flow`: **15 → 17 of 18.**

## NOT changed: the blank band above a short deck

Also in the screenshot, and it is **by design**. `_anchor` pads the top so the newest line lands against the prompt, and `bottom_anchor_enabled` states the tradeoff and rejects the alternative in its own docstring:

> A top-aligned canvas puts the conversation at row 0 and leaves a void between it and the prompt — which is what an operator reads as "it does not flow like Claude".

The design chose *which* void to have and kept the newest line adjacent to the caret. It is transient — a full deck has none — and `JARVIS_BIPARTITE_BOTTOM_ANCHOR=0` is the operator's switch. Changing a deliberate geometry decision is the operator's call, not a fix.

## Tests — 6 new

The load-bearing pair asserts no `CANVAS-` text survives inside the float's rows, **including on its blank lines** — the subtle half, where an unpainted empty line lets the transcript show through the middle of a traceback.

They're async because the helper builds a real Application whose input buffer schedules a history load on the running loop. Two earlier versions were wrong in instructive ways: one died synchronously on that, and one silently rendered **no float at all** because `write_to_screen` defers floats until `Screen.draw_all_floats()`.

175 green. Handoff ratchet: no dropped hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes overlays so they fully occlude the deck and standardizes their position and style. Adds a daemon cockpit crest header and wires it safely through the mount.

- **Bug Fixes**
  - Overlays are now full-width and opaque via a shared `_OVERLAY_FLOAT_POSITION` (left/right 0).
  - New `_overlay_style` adds a background; applied to panic and diff overlays so no deck text shows through.
  - Tests verify overlays occlude completely, including on blank lines.

- **New Features**
  - Daemon cockpit now exposes a crest `header` and `header_height` via `daemon_header()` and passes them through `serpent_flow`.
  - `mini.ensure_frames()` is scheduled only when a running loop exists to avoid never-awaited coroutines.
  - Header lines use Rich `Text` and label “daemon cockpit”; `stream_rows` is intentionally unset pending a proper `set_active_stream` registry.

<sup>Written for commit 9b3524d796be2ddb1586317e2662cfea0b6c6239. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

