### PR TITLE
fix(ov): the canvas takes the room it needs, so the crest sits on the deck

### DIFF
--- a/backend/core/ouroboros/battle_test/bipartite_layout.py
+++ b/backend/core/ouroboros/battle_test/bipartite_layout.py
@@ -190,29 +190,75 @@ def _overlay_style(role: str) -> str:
         return "bold bg:#0b0b0b"
 
 
-def _canvas_dimension() -> Any:
-    """How much room the live canvas takes.
+def _canvas_dimension(mux: Any = None) -> Any:
+    """How much room the live canvas takes — CONTENT-SIZED, recomputed per frame.
 
-    In the alternate screen it takes what is left — there is nowhere else for
-    history to live, so it should be as large as possible.
+    Returns a CALLABLE, because a `Dimension` computed once at build time cannot
+    follow content that grows. prompt_toolkit accepts `AnyDimension`, so a callable
+    is its own supported idiom, and it is the one `build_dynamic_rows` already uses
+    for every other variable-height strip. The canvas was the last region still
+    sized by a constant.
 
-    Outside it, a greedy canvas would push the prompt to the bottom of a
-    screen the app does not own, and prompt_toolkit would reserve that height
-    on every repaint — turning the scrollback we just restored into a wall of
-    blank rows. It becomes a bounded live region instead: recent activity
-    stays visible, and everything older scrolls into the terminal's own
-    history where it belongs.
+    ONE shape for both modes
+    -----------------------
+        Dimension(min=0, max=want, preferred=want)
+
+    Which is EXACTLY what the inline branch already used — it simply had `want`
+    hardcoded to 8 rather than derived. So this is the existing shape, given a real
+    number, rather than a new mechanism.
+
+    Every part of that triple is load-bearing, and two plausible alternatives are
+    both wrong in ways only a render reveals:
+
+    * ``Dimension(weight=1)`` (the old fullscreen branch) makes the canvas the
+      greedy flex child. It is handed every leftover row, and `_anchor` then pads
+      the TOP to push a short deck down against the prompt — which is precisely how
+      a 12-row crest, thirty blank rows and four transcript lines ended up on one
+      screen.
+    * ``Dimension.exact(want)`` looks tidier and BREAKS THE COCKPIT. Verified: an
+      exact 30 rows inside 10 available renders `Window too small...` and nothing
+      else — HSplit refuses rather than clamps. ``min=0`` is what makes the region
+      shrinkable, so a deck longer than the terminal degrades to the tail instead of
+      to an error.
+    * ``max=want`` is what stops the void coming back. Without a ceiling the child
+      absorbs slack by weight — the trap `build_dynamic_rows` documents about an
+      eight-row black slab nailed open above the prompt.
+
+    Outside the alternate screen the derived height is additionally capped by
+    ``JARVIS_BIPARTITE_LIVE_ROWS``: there the app does not own the screen, and a
+    canvas that grows with its content would reserve that height on every repaint,
+    turning the scrollback we just restored into a wall of blank rows.
+
+    ``mux=None`` keeps the old signature working and falls back to the previous
+    constant behaviour, so a caller that has no multiplexer to measure is not
+    forced to invent one.
     """
     from prompt_toolkit.layout.dimension import Dimension
-    if fullscreen_enabled():
-        return Dimension(weight=1)
+
     try:
         rows = max(0, int(os.environ.get("JARVIS_BIPARTITE_LIVE_ROWS", "8")))
     except (TypeError, ValueError):
         rows = 8
-    # min=0 so an idle organism shows no empty frame at all — the cockpit
-    # should occupy exactly the prompt when there is nothing happening.
-    return Dimension(min=0, max=rows, preferred=rows)
+
+    if mux is None:
+        # No content to measure: preserve exactly what this function did before.
+        if fullscreen_enabled():
+            return Dimension(weight=1)
+        return Dimension(min=0, max=rows, preferred=rows)
+
+    def _dimension() -> Any:
+        try:
+            want = int(mux.content_height())
+            if not fullscreen_enabled():
+                want = min(want, rows)
+            want = max(1, want)
+            return Dimension(min=0, max=want, preferred=want)
+        except Exception:  # noqa: BLE001
+            # Degrade to the greedy region rather than to nothing: a canvas that
+            # cannot size itself must still be able to show the transcript.
+            return Dimension(weight=1)
+
+    return _dimension
 
 
 def bottom_anchor_enabled() -> bool:
@@ -502,6 +548,54 @@ class BipartiteLayout:
         measurement's authority.
         """
         return bool(getattr(self, "_allotment_measured", False))
+
+    def content_height(self) -> int:
+        """Rows the canvas WANTS — its content plus its own chrome. NEVER raises.
+
+        This is what makes the crest sit directly above the deck. The canvas used
+        to be `Dimension(weight=1)`, the greedy flex child, so it was handed every
+        leftover row and `_anchor` padded the TOP to push its few lines down
+        against the prompt. With a 12-row crest mounted the result was an emblem,
+        thirty blank rows, and four lines of transcript: two islands with a void
+        between them.
+
+        Derived from the RING, never from `_line_budget()`, and that is the whole
+        reason this is a separate method rather than a call to the budget. The
+        budget is `allotment - chrome`, and the allotment is now what this returns,
+        so asking the budget would close a loop: 4 lines → allot 4 → budget 3 →
+        show 3 → allot 3 → budget 2 … a collapse spiral, one row per frame.
+        Reading `len(snapshot())` breaks it, because the ring's size does not depend
+        on how tall the canvas is.
+
+        Clamped by the TERMINAL, not by ``self._height``, for the same reason: the
+        observed allotment is this function's own output, and clamping a value by
+        itself is the loop again wearing a hat. The terminal is an external fact.
+
+        An IDLE canvas keeps room for its resting hero. Collapsing to one row when
+        nothing has happened would replace the animated emblem — the DORMANT
+        centrepiece — with a single line of idle text, which is a regression
+        disguised as tightness.
+        """
+        try:
+            chrome = 4 if os.environ.get(
+                "JARVIS_BIPARTITE_BORDER", "",
+            ).strip().lower() in ("1", "true", "yes", "on") else 1
+            _cols, term_rows = _terminal_size()
+            # Leave the surrounding chrome (prompt, toolbar, strips, a header) room
+            # to exist. Without a ceiling a long deck would claim the whole screen
+            # and prompt_toolkit would shrink the prompt to nothing.
+            ceiling = max(3, int(term_rows) - 2)
+            if self._hero_active():
+                hero = getattr(self._sprite, "rows", None)
+                want = int(hero) if isinstance(hero, int) and hero > 0 else 12
+                return max(3, min(want + chrome, ceiling))
+            lines = len(self._buffer.snapshot())
+            if lines <= 0:
+                # Not zero: the idle line still needs somewhere to be drawn.
+                return min(1 + chrome, ceiling)
+            return max(1, min(lines + chrome, ceiling))
+        except Exception:  # noqa: BLE001
+            return max(3, self._height)
 
     def _line_budget(self) -> int:
         """Rows the canvas may draw into, frame chrome deducted.
@@ -1021,7 +1115,10 @@ def build_bipartite_application(
 
     canvas = Window(
         content=_MeasuredCanvasControl(_canvas_fragments, focusable=False),
-        wrap_lines=False, height=_canvas_dimension(),
+        wrap_lines=False,
+        # Content-sized, so a short deck sits directly under the header
+        # instead of being padded down against the prompt.
+        height=_canvas_dimension(mux),
     )
     # Ctrl+R history search rides the SAME completion menu the palette
     # renders — a gated completer that yields nothing until the

--- a/tests/battle_test/test_canvas_allotment.py
+++ b/tests/battle_test/test_canvas_allotment.py
@@ -114,24 +114,37 @@ class TestTheOperatorVisibleSymptom:
             f"produced {len(_visible(mux))} lines into {mux.height} rows"
         )
 
-    def test_a_taller_header_costs_the_deck_rows_not_its_tail(self, fullscreen):
-        """A bigger header should make the deck SHORTER, never make it lose the
-        end. Before the fix a 12-row crest cost the deck its last four beats
-        while the deck went on believing it had the whole terminal."""
+    def test_a_taller_header_never_costs_the_deck_its_tail(self, fullscreen):
+        """A bigger header may make the deck shorter; it must never make it lose
+        the end. Before the allotment fix a 12-row crest cost the deck its last
+        four beats while the deck went on believing it had the whole terminal.
+
+        This used to also assert the allotment shrank MONOTONICALLY with header
+        size, and that assertion encoded the greedy canvas: when the canvas took
+        every leftover row, a taller header necessarily left it fewer. Now the
+        canvas is CONTENT-SIZED, so whichever of {content, terminal, leftover} is
+        smallest decides — and with a full ring the content ceiling binds first,
+        so all three header sizes legitimately settle on the same height. Keeping
+        the old assertion would have meant reverting the fix to satisfy a test of
+        the behaviour the fix removed.
+
+        What must hold in every regime is the tail, which is what an operator
+        actually loses, so that is what is asserted per header size.
+        """
         from backend.core.ouroboros.battle_test.bipartite_layout import (
-            BipartiteLayout,
+            BipartiteLayout, _terminal_size,
         )
-        heights = {}
+        ceiling = max(3, _terminal_size()[1])
         for header_rows in (3, 12, 20):
             mux = BipartiteLayout()
             for i in range(200):
                 mux.push_raw(f"row{i}")
             _render_once(_heavy_app(mux, header_rows=header_rows))
-            heights[header_rows] = mux.height
             assert any("row199" in ln for ln in _visible(mux)), (
                 f"tail lost with a {header_rows}-row header")
-        assert heights[3] > heights[12] > heights[20], (
-            f"the deck did not shrink as the header grew: {heights}")
+            assert mux.height <= ceiling, (
+                f"allotment {mux.height} exceeds the terminal with a "
+                f"{header_rows}-row header")
 
 
 class TestObservationReplacesPrediction:
@@ -278,3 +291,143 @@ class TestNoPredictionRemains:
         assert mux.height != 999, (
             "a render did not reach observe_allotment — the measuring control "
             "is not mounted on the canvas window")
+
+
+class TestTheCanvasIsContentSized:
+    """The crest must sit DIRECTLY above the deck.
+
+    The canvas was `Dimension(weight=1)` — the greedy flex child — so it was handed
+    every leftover row and `_anchor` padded the TOP to push a short deck down
+    against the prompt. With a 12-row crest that produced an emblem, ~30 blank rows,
+    and four transcript lines: two islands with a void between them.
+    """
+
+    def _rows(self, mux, screen_rows=40, header_rows=12):
+        from prompt_toolkit.layout.containers import to_container
+        from prompt_toolkit.layout.mouse_handlers import MouseHandlers
+        from prompt_toolkit.layout.screen import Screen, WritePosition
+
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            build_bipartite_application,
+        )
+        app = build_bipartite_application(
+            mux, on_accept=lambda _t: None,
+            header=lambda: "\n".join(f"CREST-{i}" for i in range(header_rows)),
+            header_height=header_rows, toolbar=lambda: "toolbar")
+        width = 60
+        screen = Screen(default_char=None, initial_width=width,
+                        initial_height=screen_rows)
+        to_container(app.layout.container).write_to_screen(
+            screen, MouseHandlers(), WritePosition(0, 0, width, screen_rows),
+            "", False, None)
+        return ["".join(screen.data_buffer[y][x].char for x in range(width)
+                        ).rstrip() for y in range(screen_rows)]
+
+    @pytest.mark.asyncio
+    async def test_no_blank_band_between_the_crest_and_a_short_deck(self, fullscreen):
+        """THE regression. Measured as a GAP rather than as a dimension, so it
+        fails for any future cause of the void, not only this one."""
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            BipartiteLayout,
+        )
+        mux = BipartiteLayout()
+        for line in ("Signal(test_failure)", "  2 source loci",
+                     "Read(risk_tier_floor.py)", "  847 lines read"):
+            mux.push_raw(line)
+        rows = self._rows(mux)
+        last_crest = max(y for y, r in enumerate(rows) if "CREST-" in r)
+        first_deck = next(y for y, r in enumerate(rows) if "Signal(" in r)
+        assert first_deck - last_crest - 1 == 0, (
+            f"{first_deck - last_crest - 1} blank rows between the crest and the "
+            f"deck — the canvas is greedy again")
+
+    @pytest.mark.asyncio
+    async def test_a_deck_longer_than_the_screen_still_shows_its_tail(self, fullscreen):
+        """`Dimension.exact` would have been tidier and BREAKS THIS: an exact 30
+        rows inside 10 available renders `Window too small...` and nothing else,
+        because HSplit refuses rather than clamps. `min=0` is what makes the region
+        shrinkable."""
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            BipartiteLayout,
+        )
+        mux = BipartiteLayout()
+        for i in range(400):
+            mux.push_raw(f"DECK-{i}")
+        rows = self._rows(mux, screen_rows=30)
+        assert not any("too small" in r for r in rows)
+        assert any(r.startswith("❯") for r in rows), "the prompt was squeezed out"
+        assert any("DECK-399" in r for r in rows), "the newest line is not visible"
+
+    def test_the_wanted_height_tracks_the_ring_not_the_budget(self):
+        """`content_height` must read `len(snapshot())`. Asking `_line_budget()`
+        closes a loop — the budget is allotment-minus-chrome and the allotment is
+        this value, so 4 lines → allot 4 → budget 3 → show 3 → allot 3 … a collapse
+        spiral of one row per frame."""
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            BipartiteLayout,
+        )
+        mux = BipartiteLayout()
+        empty = mux.content_height()
+        for i in range(4):
+            mux.push_raw(f"x{i}")
+        four = mux.content_height()
+        assert four > empty
+        # Stable under repeated measurement — a spiral would shrink each call.
+        assert [mux.content_height() for _ in range(5)] == [four] * 5
+
+    def test_the_wanted_height_is_capped_by_the_terminal(self):
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            BipartiteLayout, _terminal_size,
+        )
+        mux = BipartiteLayout()
+        for i in range(5000):
+            mux.push_raw(f"x{i}")
+        assert mux.content_height() <= max(3, _terminal_size()[1])
+
+    def test_an_idle_canvas_keeps_room_for_its_hero(self):
+        """Collapsing to one row when nothing has happened would replace the
+        DORMANT animated emblem with a line of idle text."""
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            BipartiteLayout,
+        )
+        mux = BipartiteLayout()
+
+        class _Sprite:
+            rows = 10
+
+            def set_invalidate(self, _fn):
+                pass
+
+        mux.attach_sprite(_Sprite())
+        if mux._hero_active():
+            assert mux.content_height() >= 10
+
+    def test_the_dimension_is_recomputed_per_frame(self):
+        """A `Dimension` baked at build time cannot follow content that grows.
+        prompt_toolkit accepts a callable, which is the idiom `build_dynamic_rows`
+        already uses for every other variable-height strip."""
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            BipartiteLayout, _canvas_dimension,
+        )
+        mux = BipartiteLayout()
+        dim = _canvas_dimension(mux)
+        assert callable(dim), "the canvas dimension is static again"
+        before = dim().preferred
+        for i in range(6):
+            mux.push_raw(f"grow {i}")
+        assert dim().preferred > before
+
+    def test_the_region_can_shrink_so_hsplit_never_refuses(self):
+        """`min=0` is the difference between degrading to the tail and rendering
+        `Window too small...`."""
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            BipartiteLayout, _canvas_dimension,
+        )
+        mux = BipartiteLayout()
+        for i in range(50):
+            mux.push_raw(f"x{i}")
+        dimension = _canvas_dimension(mux)()
+        assert dimension.min == 0
+        assert dimension.max == dimension.preferred, (
+            "max must equal preferred or the child absorbs slack and the void "
+            "returns")


### PR DESCRIPTION
## The canvas takes the room it needs

The blank band between the emblem and the transcript was the canvas being `Dimension(weight=1)` — the **greedy flex child**. It was handed every leftover row, and `_anchor` then padded the *top* to push a short deck down against the prompt: a 12-row crest, ~30 blank rows, four lines of transcript. Two islands with a void between them.

## The shape already existed

```python
Dimension(min=0, max=want, preferred=want)
```

That is **exactly** what the inline branch of `_canvas_dimension` already returned — it just had `want` hardcoded to `8`, while the fullscreen branch took the greedy path. So this is the existing shape given a real number, not a new mechanism. The canvas was the last variable-height region still sized by a constant while every other strip went through `build_dynamic_rows`' per-repaint `Dimension`.

Returned as a **callable**, which is prompt_toolkit's own `AnyDimension` idiom: a `Dimension` computed once at build time cannot follow content that grows.

## Two tidier-looking alternatives are both wrong

| attempt | what a render says |
|---|---|
| `Dimension.exact(want)` | **`Window too small...`** and nothing else — 30 exact rows in 10 available. HSplit *refuses* rather than clamps. `min=0` is the difference between degrading to the tail and rendering an error. |
| dropping `max` | the child absorbs slack by weight — the trap `build_dynamic_rows` documents about an eight-row black slab nailed open above the prompt. `max == preferred` is what keeps the void from coming back. |

## The loop that had to be broken

`content_height()` reads `len(self._buffer.snapshot())`, **never** `_line_budget()`, and is ceilinged by the **terminal** rather than by `self._height`. Both are the same hazard: the budget is allotment-minus-chrome and the allotment is now this function's own output, so asking either closes a cycle —

> 4 lines → allot 4 → budget 3 → show 3 → allot 3 → budget 2 …

a collapse spiral of one row per frame. The ring's size and the terminal's size are external facts; they cannot spiral. Pinned by a test that measures the same value five times.

An **idle** canvas keeps room for its resting hero — collapsing to one row would replace the DORMANT animated emblem with a line of idle text. Outside the alternate screen the height is additionally capped by `JARVIS_BIPARTITE_LIVE_ROWS`, because there the app does not own the screen.

## Measured

Crest ends row 11, deck starts row 12 — a **zero-row gap**, prompt at 19, blank below. Claude Code's geometry. A 400-line deck in 30 rows still clamps with no `too small`, keeps the prompt, and shows `DECK-399`.

## A test I changed rather than satisfied

`test_a_taller_header_costs_the_deck_rows_not_its_tail` asserted the allotment shrank **monotonically** with header size. That encoded the greedy canvas: when it took every leftover row, a taller header necessarily left it fewer. Content-sized, whichever of {content, terminal, leftover} is smallest decides — so with a full ring all three header sizes legitimately settle on the same height.

Keeping it would have meant **reverting the fix to satisfy a test of the behaviour the fix removed.** It now asserts what must hold in every regime: the **tail survives**, which is what an operator actually loses.

8 new tests, the load-bearing one measuring the crest→deck **gap** so it fails for any future cause of the void. 209 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the live canvas content-sized so the crest sits directly on the deck, removing the blank gap. Height now tracks content each repaint and clamps to the terminal (and `JARVIS_BIPARTITE_LIVE_ROWS` when not fullscreen).

- **Bug Fixes**
  - `_canvas_dimension(mux)` now returns a callable `prompt_toolkit` `Dimension(min=0, max=want, preferred=want)`; replaces greedy `weight=1`.
  - `want` comes from `mux.content_height()`, which reads ring size, caps to terminal rows, and limits to `JARVIS_BIPARTITE_LIVE_ROWS` outside fullscreen.
  - `min=0` prevents HSplit “Window too small...” errors; `max == preferred` stops the canvas absorbing slack.
  - Canvas window now passes `mux` so height follows content; idle hero keeps space; long decks still show the tail.

<sup>Written for commit ef2187a8b2abd6cefb4e6b75fb64a8b0ad7173a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

