### PR TITLE
fix(ov): the demo stops teaching a keybinding the cockpit does not have

### DIFF
--- a/backend/core/ouroboros/cli/ov_demo.py
+++ b/backend/core/ouroboros/cli/ov_demo.py
@@ -623,6 +623,9 @@ _LIVE_BEATS: List[Any] = [
     # What the gate's own preview shows: which file in this change reaches
     # furthest. Rendered by the REAL gutter — see `_reach_beats`.
     (20.8, "reach", ()),
+    # The archived diff, opened on the surface that owns it. A CALLABLE beat:
+    # the overlay IS the output, so there is no line to push.
+    (21.0, "diffopen", ()),
     (21.2, "det", ("applied · verified · committed 90706b8", "ok")),
     # The op FINISHES, and collapses to one line. Before #70250 nothing
     # rendered this: an unfocused op left no trace at all, and a focused
@@ -893,6 +896,14 @@ def compose_live_script() -> List[Any]:
             continue
         if kind == "agent":
             out.extend(_agent_beats(at, args))
+            continue
+        if kind == "diffopen":
+            # A lambda, not the function object: `_LIVE_SCRIPT` is composed at
+            # IMPORT time and `_open_demo_diff` is defined further down the
+            # module, so binding the name here would raise NameError before the
+            # module finishes loading. Deferring the lookup to playback also
+            # means a test that swaps the opener gets the swapped one.
+            out.append((at, lambda: _open_demo_diff()))
             continue
         if kind == "reach":
             out.append((at, ""))
@@ -1175,6 +1186,104 @@ def _queue_rows(elapsed: float, width: int) -> List[str]:
         return []
 
 
+#: Overlays the operator has closed in THIS scene. Reset per run, because a
+#: module-level flag surviving into the next `ov demo live` would open the scene
+#: with the FATAL already dismissed and no way to see it.
+_DISMISSED: "dict[str, bool]" = {}
+
+
+def _register_demo_overlays(elapsed_fn: Callable[[], float]) -> None:
+    """Declare the scene's overlays to the real arbiter. NEVER raises.
+
+    The demo's panic is scripted, so "is it up" is a function of the CLOCK rather
+    than of a stored crash — but the arbiter never asked for a stored anything, it
+    asked for a predicate. That is why registration takes callables: a surface
+    knows its own liveness, and the arbiter only orders them by Z.
+
+    Registered through the SAME `register_overlay` the client and the daemon use,
+    so `Escape` behaves identically here. A demo with its own dismissal rule would
+    be teaching a keybinding the cockpit does not have.
+    """
+    try:
+        from backend.core.ouroboros.battle_test.overlay_arbiter import (
+            Z_PANIC, register_overlay, reset_for_tests,
+        )
+        # A previous run's registrations would otherwise keep answering with a
+        # dead clock — an overlay reporting "up" forever holds Escape eager and
+        # silently deletes every other meaning of the key.
+        reset_for_tests()
+        _DISMISSED.clear()
+
+        def _panic_up() -> bool:
+            if _DISMISSED.get("panic"):
+                return False
+            lo, hi = _PANIC_AT
+            return lo <= elapsed_fn() <= hi
+
+        register_overlay(
+            "demo_panic", z=Z_PANIC, is_active=_panic_up,
+            dismiss=lambda: _DISMISSED.__setitem__("panic", True),
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug("[OvDemo] overlay registration degraded", exc_info=True)
+
+
+def _demo_diff_rows() -> Any:
+    """The archived-diff overlay, over a DEMO-LOCAL archive. NEVER raises.
+
+    Deliberately NOT `diff_overlay.get_default_controller()`. That singleton reads
+    `get_default_archive()` — the process-wide archive a real daemon files
+    candidates into — and a demo must never touch the organism's own state. Same
+    refusal the reach gutter makes when it goes through `blast_gutter.set_resolver`
+    instead of seeding the advisor's live cache: a demo may lie to itself, never to
+    the organism.
+
+    So the controller is constructed over a private `DiffArchive` seeded with the
+    scene's own candidate. Everything else is the REAL machinery — the same
+    controller class, the same off-thread render, the same `d-N` refs, the same
+    arbiter registration — so a regression in any of it shows up here.
+    """
+    try:
+        from backend.core.ouroboros.battle_test.diff_archive import DiffArchive
+        from backend.core.ouroboros.battle_test.diff_overlay import (
+            DiffOverlayController,
+        )
+        archive = DiffArchive()
+        archive.add(
+            op_id="7759-86", risk_tier="NOTIFY_APPLY",
+            file_paths=("backend/core/ouroboros/governance/risk_tier_floor.py",
+                        "tests/governance/test_risk_tier_floor.py"),
+            diff_text=_EDIT_RESULT,
+            summary="raise the vision floor, stop the caller swallowing it",
+        )
+        controller = DiffOverlayController(archive=archive,
+                                           width_fn=lambda: 100)
+        controller.register()
+        global _DIFF_CONTROLLER
+        _DIFF_CONTROLLER = controller
+        return controller.rows
+    except Exception:  # noqa: BLE001
+        logger.debug("[OvDemo] diff overlay unavailable", exc_info=True)
+        return None
+
+
+_DIFF_CONTROLLER: Any = None
+
+
+def _open_demo_diff() -> Optional[str]:
+    """Script beat: open the archived diff. Returns nothing to print.
+
+    The overlay IS the output — pushing a line as well would describe a surface
+    the operator can already see.
+    """
+    try:
+        if _DIFF_CONTROLLER is not None:
+            _DIFF_CONTROLLER.open()
+    except Exception:  # noqa: BLE001
+        logger.debug("[OvDemo] diff open degraded", exc_info=True)
+    return None
+
+
 def _panic_rows(elapsed: float, width: int) -> List[str]:
     """The FATAL_PANIC overlay, through the REAL renderer. NEVER raises.
 
@@ -1191,6 +1300,11 @@ def _panic_rows(elapsed: float, width: int) -> List[str]:
         )
         lo, hi = _PANIC_AT
         if not (lo <= elapsed <= hi):
+            return []
+        # Closed by Escape, through the real arbiter. Without this the overlay
+        # advertises "esc dismisses" and then ignores the key — the defect the
+        # arbiter exists to end, reproduced inside its own demonstration.
+        if _DISMISSED.get("panic"):
             return []
         try:
             raise RuntimeError(
@@ -1671,7 +1785,42 @@ def _live_exit_bindings() -> Any:
         event.app.exit()
 
     kb.add("q", filter=_buffer_empty)(_quit)
-    kb.add("escape", filter=_buffer_empty, eager=True)(_quit)
+
+    # `escape` used to be `eager=True` here, bound straight to QUIT — and this
+    # scene MOUNTS a FATAL overlay whose own text reads "esc dismisses". So the
+    # one surface built to demonstrate the cockpit taught the exact opposite of
+    # what the cockpit does: Escape closed the demo instead of the overlay.
+    #
+    # The hook audit could not see it. `extra_key_bindings` was FILLED, so
+    # `capability_handoff` reported coverage — it measures whether a hook is
+    # given a value, not whether the value is current. A stale filler is
+    # invisible to it, which is worth knowing about the instrument.
+    #
+    # Routed through the real arbiter instead: one `Escape` whose eagerness is a
+    # per-keystroke FILTER, active only while something dismissable is up. With
+    # the deck clear the arbiter's binding is inactive and the quit below fires;
+    # with the panic up, Escape dismisses it and the demo stays open.
+    try:
+        from backend.core.ouroboros.battle_test.overlay_arbiter import (
+            install_escape_arbiter, overlay_active,
+        )
+        install_escape_arbiter(kb)
+
+        @Condition
+        def _nothing_to_dismiss() -> bool:
+            try:
+                return not overlay_active()
+            except Exception:  # noqa: BLE001
+                return True
+
+        # The COMPLEMENT of the arbiter's filter, so the two can never both fire
+        # for one keystroke. Not eager: with an overlay up this must lose to the
+        # arbiter, and with none up there is no sequence competing for the prefix.
+        kb.add("escape", filter=_buffer_empty & _nothing_to_dismiss)(_quit)
+    except Exception:  # noqa: BLE001
+        # A demo must still be closable if the arbiter is unavailable.
+        kb.add("escape", filter=_buffer_empty, eager=True)(_quit)
+
     kb.add("c-c")(_quit)
     kb.add("c-d")(_quit)
     return kb
@@ -1713,6 +1862,9 @@ def scene_live(console: Any, argv: Sequence[str] = ()) -> int:
     mux = BipartiteLayout()
     script = compose_live_script()
     _header, _header_height, _crest = _demo_header()
+    # Declared before the Application is built, so the Escape arbiter's filter has
+    # something to ask about on the very first keystroke.
+    _register_demo_overlays(lambda: (clock() - start[0]) * speed)
     app = build_bipartite_application(
         mux,
         # Typed input executes NOTHING — this scene has no organism to act on
@@ -1760,6 +1912,10 @@ def scene_live(console: Any, argv: Sequence[str] = ()) -> int:
         stream_rows=lambda: _stream_rows(
             (clock() - start[0]) * speed, mux,
         ),
+        # The archived-diff overlay — the last hook the demo left dark, and the
+        # only one `capability_handoff` still reported as diverging from the
+        # daemon. Over a DEMO-LOCAL archive: see `_demo_diff_rows`.
+        diff_rows=_demo_diff_rows(),
         # ------------------------------------------------------------------
         # The INPUT half. Unfilled until now, which is why a whole merged arc
         # of keybinding and completion work had no demo presence — see the

--- a/tests/cli/test_ov_demo.py
+++ b/tests/cli/test_ov_demo.py
@@ -392,3 +392,129 @@ class TestOneStoryTwoProjections:
         for token in ("≥12", "unmeasured"):
             assert token in live, token
             assert token in " ".join(transcript_lines()), token
+
+
+class TestTheDemoShowsTheLatestFeatures:
+    """The demo must not teach a keybinding the cockpit does not have.
+
+    `capability_handoff` reported `extra_key_bindings` as FILLED and was right —
+    it measures whether a hook is GIVEN a value, not whether the value is current.
+    A stale filler is invisible to it, which is the instrument's own limit and the
+    reason these are behavioural tests rather than another coverage check.
+    """
+
+    def _fresh(self):
+        from backend.core.ouroboros.battle_test import overlay_arbiter as oa
+        oa.reset_for_tests()
+        return oa
+
+    def test_escape_is_no_longer_bound_eagerly_to_quit(self):
+        """It was `kb.add("escape", eager=True)(_quit)` while this same scene
+        mounts a FATAL overlay whose text reads "esc dismisses" — so Escape closed
+        the DEMO instead of the overlay, teaching the exact inverse of #70282."""
+        from prompt_toolkit.filters import Filter
+
+        from backend.core.ouroboros.cli import ov_demo as d
+        self._fresh()
+        kb = d._live_exit_bindings()
+        escapes = [b for b in kb.bindings
+                   if len(b.keys) == 1
+                   and str(getattr(b.keys[0], "value", b.keys[0])) == "escape"]
+        assert escapes, "escape is not bound at all"
+        assert not any(b.eager is True for b in escapes), (
+            "escape is eager unconditionally again — `esc` can no longer reach an "
+            "overlay and the demo quits instead of dismissing")
+        assert any(isinstance(b.eager, Filter) for b in escapes), (
+            "no per-keystroke eager filter — the arbiter is not mounted")
+
+    def test_escape_dismisses_the_scripted_panic(self):
+        """Through the REAL arbiter, so the demo and the cockpit answer the key
+        identically. The demo's panic is clock-driven rather than stored, which is
+        why `register_overlay` takes a predicate instead of a flag."""
+        from backend.core.ouroboros.cli import ov_demo as d
+        oa = self._fresh()
+        clock = [26.0]                      # inside _PANIC_AT
+        d._register_demo_overlays(lambda: clock[0])
+        assert oa.overlay_active() is True
+        assert d._panic_rows(26.0, 100), "the panic strip drew nothing"
+        assert oa.dismiss_top() == "demo_panic"
+        assert d._panic_rows(26.0, 100) == [], (
+            "the overlay advertises 'esc dismisses' and ignored it")
+
+    def test_nothing_is_dismissable_before_the_panic_window(self):
+        """So Escape still quits during the ordinary run — the complement filter
+        has to actually be a complement."""
+        from backend.core.ouroboros.cli import ov_demo as d
+        oa = self._fresh()
+        d._register_demo_overlays(lambda: 10.0)
+        assert oa.overlay_active() is False
+
+    def test_a_previous_run_cannot_leave_an_overlay_up(self):
+        """A stale registration answering with a dead clock would hold Escape
+        eager forever and silently delete every other meaning of the key."""
+        from backend.core.ouroboros.cli import ov_demo as d
+        oa = self._fresh()
+        d._register_demo_overlays(lambda: 26.0)
+        assert oa.overlay_active() is True
+        d._register_demo_overlays(lambda: 5.0)      # a new run, clock reset
+        assert oa.overlay_active() is False
+
+    def test_the_diff_overlay_is_mounted_and_openable(self):
+        from backend.core.ouroboros.cli import ov_demo as d
+        oa = self._fresh()
+        provider = d._demo_diff_rows()
+        assert callable(provider)
+        assert provider() == []
+        d._open_demo_diff()
+        assert oa.overlay_active() is True
+        assert oa.dismiss_top() == "diff_preview"
+
+    def test_the_diff_overlay_never_touches_the_process_archive(self):
+        """The singleton reads `get_default_archive()` — the archive a real daemon
+        files candidates into. Same refusal the reach gutter makes by going through
+        `set_resolver` instead of seeding the advisor's live cache: a demo may lie
+        to itself, never to the organism.
+
+        Checked against the CODE with docstrings stripped via AST. The docstring
+        names both singletons precisely to explain why they are refused, so a
+        substring search over the source matches the explanation and fails a
+        correct implementation — the fifth prose false-positive this session, and
+        the same fix the shutdown watchdog's structural tests generalised to.
+        """
+        import ast
+        import inspect
+
+        from backend.core.ouroboros.cli import ov_demo as d
+
+        tree = ast.parse(inspect.getsource(d._demo_diff_rows).lstrip())
+        for node in ast.walk(tree):
+            # Drop the docstring node, leaving only executable statements.
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                if (node.body and isinstance(node.body[0], ast.Expr)
+                        and isinstance(node.body[0].value, ast.Constant)
+                        and isinstance(node.body[0].value.value, str)):
+                    node.body = node.body[1:]
+        code = ast.dump(tree)
+        assert "get_default_controller" not in code, (
+            "the demo reaches for the process-wide controller, which reads the "
+            "archive a real daemon files candidates into")
+        assert "get_default_archive" not in code
+        assert "DiffArchive" in code, "the demo must own its archive"
+
+    def test_the_script_carries_a_beat_that_opens_the_diff(self):
+        """A mounted overlay nothing opens is a float that can never appear."""
+        from backend.core.ouroboros.cli import ov_demo as d
+        assert any(kind == "diffopen" for _at, kind, _args in d._LIVE_BEATS)
+        script = d.compose_live_script()
+        assert sum(1 for _at, line in script if callable(line)) >= 1
+
+    def test_the_demo_fills_every_hook_the_cockpit_offers(self):
+        """The ratchet for THIS surface. A new Application hook now fails here
+        until the demo either fills it or declares a waiver."""
+        from backend.core.ouroboros.ui.capability_handoff import audit
+        fills = [f for f in audit().fills
+                 if f.surface.endswith("ov_demo")
+                 and "build_bipartite_application" in f.sink]
+        unset = sorted(f.hook for f in fills if f.state.name == "UNSET")
+        assert not unset, (
+            f"ov demo live leaves these cockpit hooks dark: {unset}")


### PR DESCRIPTION
## Asked whether the latest features reached `ov demo live`

The handoff ledger answered **18 of 19** hooks — `diff_rows` alone unset. It was right, and it was **not the whole answer.**

## The instrument's own limit

`extra_key_bindings` was reported **FILLED**, because `capability_handoff` measures whether a hook is *given* a value — not whether the value is **current**. A stale filler is invisible to it.

And this filler was worse than stale:

```python
kb.add("escape", filter=_buffer_empty, eager=True)(_quit)
```

…while the same scene **mounts a FATAL overlay** at 24–30s whose own text reads *"esc dismisses"*. So pressing Escape during the demo's panic **quit the demo** — the one surface built to show operators how the cockpit behaves was teaching the exact inverse of #70282, in the scene that demonstrates the overlay the arbiter exists to close.

Now routed through the real `install_escape_arbiter`, with the quit binding carrying the **complement** filter (`not overlay_active()`) so the two can never both fire for one keystroke.

The panic is **registered**, not special-cased. It is clock-driven rather than stored — the scene has no crash object, only a window — which is exactly why `register_overlay` takes a **predicate**: a surface knows its own liveness and the arbiter only orders them by Z. Registration resets per run, because a stale predicate answering with a dead clock would report an overlay nobody can see and hold Escape eager for the rest of the session.

## `diff_rows`, over a demo-local archive

Deliberately **not** `get_default_controller()`. That singleton reads `get_default_archive()` — the process-wide archive a real daemon files candidates into — and a demo must never touch the organism's own state. Same refusal the reach gutter makes by going through `blast_gutter.set_resolver` rather than seeding the advisor's live cache: **a demo may lie to itself, never to the organism.**

Everything else is the real machinery — same controller, same off-thread render, same `d-N` refs, same arbiter registration — so a regression in any of it surfaces here. A `diffopen` beat opens it at 21.0s, between the GATE and the collapse, where an operator reviewing a Yellow-tier candidate would actually look.

The beat is a **lambda**, not the function object: `_LIVE_SCRIPT` is composed at *import* time and the opener is defined further down the module, so binding the name directly raised `NameError` before the module finished loading.

**`ov demo live` is now 19 of 19.**

## Tests — 9 new

The load-bearing ones are **behavioural**, for the reason above: a coverage check cannot see a stale filler. They assert Escape actually dismisses, and that no unconditional `eager=True` survives. One is a **ratchet** — a new Application hook now fails in the demo's own suite until it is filled or waived.

One had to be written twice. It first searched the source text for `get_default_archive`, which the docstring **names** in order to explain why it is refused — so it failed a correct implementation. Now stripped via AST, the same generalising fix the shutdown watchdog's structural tests arrived at. Fifth prose false-positive this session.

177 green across demo, arbiter, overlay, canvas, cockpit-mount and handoff suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `ov demo live` so Escape dismisses overlays instead of quitting, matching the cockpit. Adds a demo‑local archived diff overlay and a script beat to open it, filling the last unset `diff_rows` hook.

- Bug Fixes
  - Route Escape through `install_escape_arbiter`; bind quit with the complement filter (`not overlay_active()`), removing the unconditional eager quit.
  - Register the scripted panic with `register_overlay` using a clock-based predicate and reset state per run, so Escape dismisses it and keys stay responsive.

- New Features
  - Provide `diff_rows` via a demo‑local `DiffArchive` and `DiffOverlayController` (no `get_default_archive()`), with the real renderer and arbiter.
  - Add a `diffopen` beat (lambda) at 21.0s to open the overlay; `ov demo live` now fills 19/19 hooks.

<sup>Written for commit f3248d45927dcd072f251dcd0a7aa577f431404d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

