### PR TITLE
fix(ov): a frame is rendered twice, and the passes must not disagree

### DIFF
--- a/backend/core/ouroboros/battle_test/bipartite_layout.py
+++ b/backend/core/ouroboros/battle_test/bipartite_layout.py
@@ -1107,6 +1107,32 @@ def build_bipartite_application(
         def create_content(self, width, height=None):  # noqa: ANN001
             try:
                 if mux.observe_allotment(width, height):
+                    # The text this control produces DEPENDS on the allotment we
+                    # just learned, so the cached text is now stale. Clearing it is
+                    # the whole reason a changed allotment is worth detecting.
+                    #
+                    # prompt_toolkit renders a frame in TWO passes: a measurement
+                    # pass with `height=None`, then the draw pass with the real
+                    # height. `create_content` pulls its text through
+                    # `_get_formatted_text_cached`, so without this the draw pass
+                    # REUSES the measurement pass's text — computed against
+                    # whatever budget was in effect before anything was measured.
+                    #
+                    # Measured, greedy canvas, 400 lines in a 30-row terminal:
+                    #
+                    #   asked_h=None  mux.h=24 (stale seed)  ->  24 lines
+                    #   asked_h=12    mux.h=12 (correct)     ->  24 lines  <-- stale
+                    #
+                    # Twenty-four lines painted into twelve rows, clipped from the
+                    # BOTTOM: the newest output lost. Recording the right height was
+                    # never enough — #70280's claim of a "zero-lag, same-frame"
+                    # observation held only while the two passes happened to agree,
+                    # which is why content-sizing hid this and greedy exposed it.
+                    for attr in ("_fragment_cache", "_content_cache"):
+                        cache = getattr(self, attr, None)
+                        clear = getattr(cache, "clear", None)
+                        if callable(clear):
+                            clear()
                     mux._invalidate_now()
             except Exception:  # noqa: BLE001 — never break a frame to measure it
                 logger.debug("[Bipartite] allotment observation degraded",

--- a/tests/battle_test/test_canvas_allotment.py
+++ b/tests/battle_test/test_canvas_allotment.py
@@ -431,3 +431,103 @@ class TestTheCanvasIsContentSized:
         assert dimension.max == dimension.preferred, (
             "max must equal preferred or the child absorbs slack and the void "
             "returns")
+
+
+class TestTheTwoPassRender:
+    """A frame is rendered TWICE, and the passes must not disagree.
+
+    prompt_toolkit measures with `height=None`, then draws with the real height.
+    `create_content` pulls its text through `_get_formatted_text_cached`, so
+    without invalidation the DRAW pass reuses the MEASUREMENT pass's text —
+    computed against whatever budget was in effect before anything was measured.
+
+    Measured before the fix (greedy canvas, 400 lines, 30-row terminal):
+
+        asked_h=None  mux.h=24 (stale seed)  ->  24 lines
+        asked_h=12    mux.h=12 (correct)     ->  24 lines   <-- stale
+
+    Twenty-four lines painted into twelve rows, clipped from the BOTTOM: the
+    newest output lost. #70280's claim of a "zero-lag, same-frame" observation
+    held only while the two passes happened to agree, which is why content-sizing
+    hid this and a greedy canvas exposed it.
+    """
+
+    def _paint(self, *, greedy, header_rows, screen_rows, lines=1000):
+        from prompt_toolkit.layout.containers import to_container
+        from prompt_toolkit.layout.dimension import Dimension
+        from prompt_toolkit.layout.mouse_handlers import MouseHandlers
+        from prompt_toolkit.layout.screen import Screen, WritePosition
+
+        from backend.core.ouroboros.battle_test import bipartite_layout as bl
+
+        original = bl._canvas_dimension
+        if greedy:
+            bl._canvas_dimension = lambda mux=None: Dimension(weight=1)
+        try:
+            mux = bl.BipartiteLayout()
+            for i in range(lines):
+                mux.push_raw(f"DECK-{i}")
+            extra = ({} if not header_rows else dict(
+                header=lambda: "\n".join(f"C{i}" for i in range(header_rows)),
+                header_height=header_rows))
+            app = bl.build_bipartite_application(
+                mux, on_accept=lambda _t: None, toolbar=lambda: "tb",
+                status_rows=lambda: ["status"],
+                pending_rows=lambda: ["pending"],
+                agent_rows=lambda: ["agent"], **extra)
+            width = 60
+            screen = Screen(default_char=None, initial_width=width,
+                            initial_height=screen_rows)
+            to_container(app.layout.container).write_to_screen(
+                screen, MouseHandlers(),
+                WritePosition(0, 0, width, screen_rows), "", False, None)
+            return ["".join(screen.data_buffer[y][x].char
+                            for x in range(width)).rstrip()
+                    for y in range(screen_rows)]
+        finally:
+            bl._canvas_dimension = original
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("screen_rows", [24, 30, 40, 60, 80])
+    @pytest.mark.parametrize("header_rows", [0, 12])
+    async def test_a_thousand_line_deck_never_loses_its_tail(
+        self, fullscreen, screen_rows, header_rows,
+    ):
+        """THE mandate. Parameterised over HEIGHT because the defect is
+        height-dependent: it passed at 40 rows and failed at 30, which is exactly
+        how a single-height test let it through the first time."""
+        rows = self._paint(greedy=True, header_rows=header_rows,
+                           screen_rows=screen_rows)
+        assert any("DECK-999" in r for r in rows), (
+            f"the newest line is not painted at {screen_rows} rows with a "
+            f"{header_rows}-row header — content was rendered for a budget the "
+            f"window does not have and clipped from the bottom")
+        assert any(r.startswith("❯") for r in rows), "the prompt was squeezed out"
+
+    def test_a_changed_allotment_invalidates_the_cached_text(self):
+        """The mechanism, directly. Recording the height is not enough — the text
+        cache has to be dropped, or the draw pass reuses the measurement pass's
+        render."""
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            BipartiteLayout,
+        )
+        mux = BipartiteLayout()
+        for i in range(400):
+            mux.push_raw(f"x{i}")
+        mux.observe_allotment(80, 30)
+        first = len(mux.render_canvas_ansi().rstrip("\n").split("\n"))
+        assert mux.observe_allotment(80, 12) is True
+        second = len(mux.render_canvas_ansi().rstrip("\n").split("\n"))
+        assert second < first, (
+            f"the canvas produced {second} lines after shrinking to 12 rows, "
+            f"having produced {first} at 30 — the budget did not take effect")
+
+    def test_an_unchanged_allotment_does_not_thrash_the_cache(self):
+        """Clearing on every pass would recompute the whole deck twice per frame
+        for no reason. The changed-flag is what keeps the invalidation honest."""
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            BipartiteLayout,
+        )
+        mux = BipartiteLayout()
+        mux.observe_allotment(80, 24)
+        assert mux.observe_allotment(80, 24) is False


### PR DESCRIPTION
## Step 1 of the geometry plan — and it unblocks the rest

A greedy canvas can now be bottom-anchored **without losing the newest output.**

## What I got wrong, and the measurement that showed it

I reverted the last attempt saying *"greedy plus a mounted header loses the tail."* The revert was right; **the attribution was not.** At 400 lines in a 30-row terminal:

| config | tail |
|---|---|
| greedy, 12-row header | **lost** |
| greedy, **no header** | **lost** |
| content-sized, 12-row header | survives |

Greedy loses the tail with no header anywhere near it. The header was never the cause.

## The real cause

prompt_toolkit renders a frame in **two passes** — a measurement pass with `height=None`, then the draw pass with the real height — and `FormattedTextControl.create_content` pulls its text through `_get_formatted_text_cached`. Instrumented, one frame:

```
asked_h=None  mux.h=24 (stale seed)  ->  24 lines, first DECK-378
asked_h=12    mux.h=12 (correct)     ->  24 lines, first DECK-378   <-- stale
```

The measurement pass renders at whatever budget was in effect *before anything was measured*. `observe_allotment` then records the correct 12 on the draw pass — and it is **too late**, because the text is already cached. Twenty-four lines painted into twelve rows, clipped from the bottom.

So #70280's *"zero-lag, same-frame observation"* was only ever true while the two passes happened to **agree** on the height. Content-sizing made them agree — which is why it hid this — and greedy made them disagree, which is why it exposed it. The observation was never the whole contract.

## The fix is the invalidation the detection was always for

A changed allotment now drops the control's `_fragment_cache` and `_content_cache` before delegating, so the draw pass recomputes at the budget it was actually given.

Not a workaround: the text this control produces **depends on a dimension prompt_toolkit just changed**, and telling a cache its input moved is what a cache invalidation *is*.

Gated on the changed-flag, which is now load-bearing twice over — clearing on every pass would recompute the whole deck twice per frame, forever.

**Verified: 1000 lines, greedy + bottom-anchor, tail intact at 24/30/40/60/80 rows, with and without a 12-row header. Ten of ten.**

## Tests

The mandated assertion, **parameterised over height** — because the defect is height-dependent: it passed at 40 rows and failed at 30, which is exactly how a single-height test let it through the first time. Plus a direct check that a shrunk allotment produces fewer lines (the mechanism), and one that an unchanged allotment does not thrash the cache.

37 in the file; **243 green** across canvas, viewport, bipartite, overlay, cockpit-mount, handoff, arbiter, streaming and demo suites.

## Still to come

Seed the crest into the transcript, unmount the top header region, switch the fullscreen canvas to greedy. **That last step is now safe, which it was not before this commit.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a two-pass render mismatch in `prompt_toolkit` that reused stale cached text, causing the newest lines to be clipped in greedy, bottom-anchored canvases. We now invalidate caches on allotment changes so the draw pass recomputes at the correct height.

- **Bug Fixes**
  - In `_MeasuredCanvasControl.create_content`, clear `_fragment_cache` and `_content_cache` when `observe_allotment` reports a change, then invalidate; this aligns the measurement (`height=None`) and draw passes.
  - Verified with height-parameterized tests: a 1000-line deck keeps its tail at 24/30/40/60/80 rows; shrinking height reduces lines, and unchanged height does not thrash the cache.

<sup>Written for commit 5c6227f6a37c2ee0f2872390db5df69d4f682e43. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

