### PR TITLE
feat(ov): the masthead joins the transcript, the prompt returns to the bottom

### DIFF
--- a/backend/core/ouroboros/battle_test/bipartite_layout.py
+++ b/backend/core/ouroboros/battle_test/bipartite_layout.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import logging
 import os
+import threading
 from typing import Any, Callable, List, Optional, Tuple
 
 from backend.core.ouroboros.ui.semantic_tokens import (  # noqa: E402
@@ -248,10 +249,28 @@ def _canvas_dimension(mux: Any = None) -> Any:
 
     def _dimension() -> Any:
         try:
-            want = int(mux.content_height())
-            if not fullscreen_enabled():
-                want = min(want, rows)
-            want = max(1, want)
+            # IN THE ALTERNATE SCREEN THE CANVAS IS GREEDY, and that is Claude
+            # Code's geometry: the input is pinned to the BOTTOM and the transcript
+            # flows UPWARD into it, so the newest line is always the one directly
+            # above where you type and the eye never travels.
+            #
+            # Safe as of the two-pass cache invalidation (#70288). Before it, a
+            # greedy region lost its tail at small terminal heights because the
+            # measurement pass's text was reused by the draw pass — content
+            # rendered for a budget the window did not have, clipped from the
+            # bottom. Content-sizing hid that by making the two passes agree; it
+            # also collapsed the whole stack to the top of the screen, which is the
+            # thing an operator actually complained about.
+            #
+            # The blank band content-sizing was reaching for was never the canvas's
+            # fault — it came from mounting the crest as a FIXED region. That now
+            # lives in the transcript (`seed_masthead`).
+            if fullscreen_enabled():
+                return Dimension(weight=1)
+            # Inline, the app does not own the screen: a greedy canvas would reserve
+            # its height every repaint and turn the restored scrollback into a wall
+            # of blanks. There it stays a content-sized bounded region.
+            want = max(1, min(int(mux.content_height()), rows))
             return Dimension(min=0, max=want, preferred=want)
         except Exception:  # noqa: BLE001
             # Degrade to the greedy region rather than to nothing: a canvas that
@@ -375,6 +394,11 @@ class BipartiteLayout:
         # it with the framework's real number on that first render and flips
         # this, so no reader ever mistakes the stand-in for the measurement.
         self._allotment_measured = False
+        # Masthead claims, and the lock that makes the claim atomic with the push.
+        # A plain bool plus a later `if not seeded` is check-then-act: two boot
+        # threads both read False before either writes and both seed.
+        self._masthead_lock = threading.RLock()
+        self._masthead_seeded: set = set()
 
     # -- the Ouroboros hero animation -----------------------------------
 
@@ -548,6 +572,78 @@ class BipartiteLayout:
         measurement's authority.
         """
         return bool(getattr(self, "_allotment_measured", False))
+
+    def seed_masthead(self, render: Any, *, key: str = "masthead") -> int:
+        """Push the identity block into the TRANSCRIPT, exactly once. NEVER raises.
+
+        Claude Code's banner is not a fixed region — it is the top of the
+        scrollback. It sits directly above the first thing that happens and scrolls
+        away as work arrives, because a masthead is only interesting until there is
+        something better in its place.
+
+        Mounting it as `header`/`header_height` instead is what stranded the emblem
+        at row 0 while a bottom-anchored deck hugged the prompt, with a band between
+        that belonged to neither. As transcript content it needs no reserved rows,
+        cannot strand itself, and participates in the scrollback the operator pages
+        back through.
+
+        IDEMPOTENT, and that is the load-bearing part
+        --------------------------------------------
+        Boot is exactly when a terminal emits a flurry of SIGWINCH: the app mounts,
+        the alternate screen is claimed, the crest warms off-thread, and any of
+        those can drive a layout rebuild. A masthead pushed per rebuild would stack
+        three emblems into the ring, and the ring is append-only — nothing would
+        take them back out.
+
+        Guarded by a claim under the SAME lock that guards the push, not by a
+        check-then-act: two threads that both read "not yet seeded" before either
+        writes would both proceed, which is the classic double-seed. The flag is
+        keyed, so a surface with a genuinely different banner can seed its own
+        without either being able to suppress the other.
+
+        Returns the number of lines seeded — 0 when it was already done, which lets
+        a caller tell "I seeded" from "someone beat me to it" without inspecting the
+        ring.
+        """
+        try:
+            with self._masthead_lock:
+                if key in self._masthead_seeded:
+                    return 0
+                # Claimed BEFORE rendering. Rendering the crest is slow enough to
+                # be preempted, and a claim taken afterwards would leave the whole
+                # render inside the race it exists to close.
+                self._masthead_seeded.add(key)
+                text = render() if callable(render) else render
+                lines = str(text or "").split("\n")
+                # Trailing blanks from a renderer that ends with a newline would
+                # open a gap between the emblem and the first event — the very
+                # thing this exists to close.
+                while lines and not lines[-1].strip():
+                    lines.pop()
+                if not lines:
+                    # Nothing to show: release the claim so a later call with a
+                    # warmed renderer can still seed. An empty masthead is not a
+                    # seeded masthead, and holding the claim would make a cold
+                    # boot permanently emblem-less.
+                    self._masthead_seeded.discard(key)
+                    return 0
+                for line in lines:
+                    self._buffer.push(line)
+                # One blank BETWEEN the masthead and the feed — the deck's only
+                # grouping cue, the same separator `compose_live_script` puts
+                # before each action.
+                self._buffer.push("")
+            self._invalidate_now()
+            return len(lines) + 1
+        except Exception:  # noqa: BLE001
+            logger.debug("[Bipartite] masthead seed degraded", exc_info=True)
+            return 0
+
+    def masthead_seeded(self, key: str = "masthead") -> bool:
+        """Has this banner already been laid down? For tests and for a caller
+        that wants to skip an expensive render it does not need."""
+        with self._masthead_lock:
+            return key in self._masthead_seeded
 
     def content_height(self) -> int:
         """Rows the canvas WANTS — its content plus its own chrome. NEVER raises.

--- a/backend/core/ouroboros/battle_test/cockpit_mount.py
+++ b/backend/core/ouroboros/battle_test/cockpit_mount.py
@@ -376,6 +376,29 @@ def daemon_diff_rows() -> Any:
         return None
 
 
+def seed_daemon_masthead(mux: Any) -> int:
+    """Lay the daemon's identity block into its transcript. NEVER raises.
+
+    The orphan from unmounting the header: the identity line had nowhere else to
+    live, and an operator who cannot tell WHICH process they are typing at will
+    eventually pause autonomy on the wrong one.
+
+    Idempotent via `seed_masthead`'s own claim, so the resize storm a terminal emits
+    during boot cannot stack emblems into an append-only ring. Safe to call from
+    every mount path for exactly that reason.
+    """
+    try:
+        if mux is None:
+            return 0
+        render, _height = daemon_header()
+        if render is None:
+            return 0
+        return int(mux.seed_masthead(render, key="daemon"))
+    except Exception:  # noqa: BLE001
+        logger.debug("[CockpitMount] masthead seed degraded", exc_info=True)
+        return 0
+
+
 def daemon_header() -> "tuple":
     """``(render, height)`` for the crest above the deck, or ``(None, 0)``.
 
@@ -487,11 +510,14 @@ def build_daemon_mount(repl: Any = None) -> "dict":
         # open it is a row that can never appear.
         "extra_key_bindings": daemon_key_bindings(repl),
     }
-    # The crest and its height travel TOGETHER — `header_height` sizes the region
-    # `header` draws into, so a mount carrying one without the other either
-    # reserves rows nothing fills or draws an emblem into zero rows. Unpacked from
-    # one call rather than resolved twice, so they cannot disagree.
-    mount["header"], mount["header_height"] = daemon_header()
+    # NO header region. The crest is TRANSCRIPT content now — see
+    # `seed_daemon_masthead`, called once at cockpit mount. A fixed top region
+    # stranded the emblem at row 0 while the bottom-anchored deck hugged the
+    # prompt, and the band between belonged to neither.
+    #
+    # `header`/`header_height` are left ABSENT rather than waived here because the
+    # mount is a dict of values, not a call site — `capability_handoff` reads the
+    # waiver at the place the argument is passed, which is `serpent_flow`.
     # `stream_rows` is deliberately absent, and this is the reason rather than an
     # oversight: there is NO process-global in-flight text to read.
     # `live_tool_stream.make_tool_observer` creates a stream per tool CALL and

--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -6662,9 +6662,13 @@ class SerpentREPL:
                 _mount = {}
                 try:
                     from backend.core.ouroboros.battle_test.cockpit_mount import (  # noqa: E501
-                        build_daemon_mount,
+                        build_daemon_mount, seed_daemon_masthead,
                     )
                     _mount = build_daemon_mount(self)
+                    # The identity block, as the first lines of the transcript
+                    # rather than a fixed top region. Idempotent, so a boot-time
+                    # resize storm cannot stack emblems into an append-only ring.
+                    seed_daemon_masthead(get_active_canvas())
                 except Exception:  # noqa: BLE001 — strips never gate the cockpit
                     _mount = {}
                 await run_bipartite_repl(
@@ -6693,10 +6697,6 @@ class SerpentREPL:
                     # `/expand d-N` opens this. The daemon owns the archive, so
                     # this is the only surface that can render a diff locally.
                     diff_rows=_mount.get("diff_rows"),
-                    # The crest. The process that IS the organism showed no
-                    # emblem while a thin viewer of it drew one.
-                    header=_mount.get("header"),
-                    header_height=_mount.get("header_height") or 0,
                 )
                 return
         except Exception:  # noqa: BLE001 — cockpit failure NEVER bricks the REPL

--- a/backend/core/ouroboros/cli/ov_demo.py
+++ b/backend/core/ouroboros/cli/ov_demo.py
@@ -1926,10 +1926,15 @@ def scene_live(console: Any, argv: Sequence[str] = ()) -> int:
         history=_demo_history(),
         auto_suggest=_demo_auto_suggest(),
         turn_spinner=_demo_turn_spinner(clock, lambda: start[0], speed),
-        # The crest, mountable again now that the canvas measures its own
-        # allotment instead of predicting it (`_LAYOUT_CLIPPING_NOTE`).
-        header=_header,
-        header_height=_header_height,
+        # NO fixed masthead. The crest is seeded INTO the transcript (below), so
+        # it sits directly on top of the deck and scrolls away as work arrives —
+        # Claude Code's own banner behaviour. Mounted as a region it was nailed to
+        # row 0 while the bottom-anchored deck hugged the prompt.
+        header=waived(
+            "the crest is transcript content, not a region — seeded once via "
+            "seed_masthead so it flows upward with the deck"
+        ),
+        header_height=waived("no fixed header region is mounted"),
         status_rows=_demo_status_rows(),
         search_rows=_demo_search_rows(),
         pending_rows=lambda: _pending_rows(
@@ -1946,6 +1951,12 @@ def scene_live(console: Any, argv: Sequence[str] = ()) -> int:
         # The emblem's frames, built now that a loop exists. Scheduling this at
         # header-construction time created a coroutine nobody awaited.
         await _warm_crest(_crest)
+        # AFTER the warmup: seeded before it, `render_cockpit_header` has no frames
+        # and returns nothing, so the emblem was silently absent from the deck.
+        # `seed_masthead` is idempotent, so a resize storm during boot cannot stack
+        # a second copy into an append-only ring.
+        if _header is not None:
+            mux.seed_masthead(_header)
         start[0] = clock()
         driver = asyncio.ensure_future(
             _drive(mux, app, speed, lambda: start[0], clock, script))

--- a/tests/battle_test/test_canvas_allotment.py
+++ b/tests/battle_test/test_canvas_allotment.py
@@ -132,9 +132,8 @@ class TestTheOperatorVisibleSymptom:
         actually loses, so that is what is asserted per header size.
         """
         from backend.core.ouroboros.battle_test.bipartite_layout import (
-            BipartiteLayout, _terminal_size,
+            BipartiteLayout,
         )
-        ceiling = max(3, _terminal_size()[1])
         for header_rows in (3, 12, 20):
             mux = BipartiteLayout()
             for i in range(200):
@@ -142,8 +141,15 @@ class TestTheOperatorVisibleSymptom:
             _render_once(_heavy_app(mux, header_rows=header_rows))
             assert any("row199" in ln for ln in _visible(mux)), (
                 f"tail lost with a {header_rows}-row header")
-            assert mux.height <= ceiling, (
-                f"allotment {mux.height} exceeds the terminal with a "
+            # The allotment is whatever region the layout GAVE the canvas, which
+            # under a greedy dimension is the leftover after chrome. It is NOT
+            # bounded by `_terminal_size()` here: this harness renders into a
+            # synthetic screen larger than the real terminal, and an earlier
+            # version of this assertion conflated the two and failed a correct
+            # render. What must hold is that the canvas never claims MORE than the
+            # screen it was handed.
+            assert mux.height <= 60, (
+                f"allotment {mux.height} exceeds the rendered screen with a "
                 f"{header_rows}-row header")
 
 
@@ -323,23 +329,25 @@ class TestTheCanvasIsContentSized:
         return ["".join(screen.data_buffer[y][x].char for x in range(width)
                         ).rstrip() for y in range(screen_rows)]
 
-    @pytest.mark.asyncio
-    async def test_no_blank_band_between_the_crest_and_a_short_deck(self, fullscreen):
-        """THE regression. Measured as a GAP rather than as a dimension, so it
-        fails for any future cause of the void, not only this one."""
+    def test_the_masthead_is_contiguous_with_the_deck(self):
+        """This used to mount a header REGION and assert a zero-row gap to the
+        deck. No surface mounts one any more — the masthead is transcript content,
+        so adjacency is now structural rather than something to measure: both live
+        in the same ring, separated by exactly the one blank the deck grammar puts
+        before every action.
+
+        Rewritten rather than deleted, because the guarantee it protected (the
+        emblem must not be stranded away from the feed) still matters — it is just
+        enforced by construction now instead of by geometry.
+        """
         from backend.core.ouroboros.battle_test.bipartite_layout import (
             BipartiteLayout,
         )
         mux = BipartiteLayout()
-        for line in ("Signal(test_failure)", "  2 source loci",
-                     "Read(risk_tier_floor.py)", "  847 lines read"):
-            mux.push_raw(line)
-        rows = self._rows(mux)
-        last_crest = max(y for y, r in enumerate(rows) if "CREST-" in r)
-        first_deck = next(y for y, r in enumerate(rows) if "Signal(" in r)
-        assert first_deck - last_crest - 1 == 0, (
-            f"{first_deck - last_crest - 1} blank rows between the crest and the "
-            f"deck — the canvas is greedy again")
+        mux.seed_masthead(lambda: "CREST-A\nCREST-B")
+        mux.push_raw("Signal(test_failure)")
+        ring = list(mux._buffer.snapshot())
+        assert ring == ["CREST-A", "CREST-B", "", "Signal(test_failure)"], ring
 
     @pytest.mark.asyncio
     async def test_a_deck_longer_than_the_screen_still_shows_its_tail(self, fullscreen):
@@ -531,3 +539,149 @@ class TestTheTwoPassRender:
         mux = BipartiteLayout()
         mux.observe_allotment(80, 24)
         assert mux.observe_allotment(80, 24) is False
+
+
+class TestTheMastheadIsSeededExactlyOnce:
+    """Boot is exactly when a terminal emits a flurry of SIGWINCH.
+
+    The app mounts, the alternate screen is claimed, the crest warms off-thread —
+    any of those can drive a layout rebuild. The ring is APPEND-ONLY, so a masthead
+    pushed per rebuild stacks emblems that nothing can take back out.
+    """
+
+    MARK = "MASTHEAD-IDENTITY"
+
+    def _mux(self):
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            BipartiteLayout,
+        )
+        return BipartiteLayout()
+
+    def test_a_second_seed_is_a_no_op(self):
+        mux = self._mux()
+        assert mux.seed_masthead(lambda: f"{self.MARK}\nb") == 3
+        assert mux.seed_masthead(lambda: f"{self.MARK}\nb") == 0
+        assert sum(1 for l in mux._buffer.snapshot() if self.MARK in l) == 1
+
+    def test_an_empty_render_releases_the_claim(self):
+        """A cold crest renders nothing. Holding the claim would make that boot
+        permanently emblem-less — an empty masthead is not a seeded masthead."""
+        mux = self._mux()
+        assert mux.seed_masthead(lambda: "") == 0
+        assert mux.masthead_seeded() is False
+        assert mux.seed_masthead(lambda: f"{self.MARK}") == 2
+
+    def test_distinct_keys_do_not_suppress_each_other(self):
+        mux = self._mux()
+        assert mux.seed_masthead(lambda: "A", key="demo") == 2
+        assert mux.seed_masthead(lambda: "B", key="daemon") == 2
+
+    @pytest.mark.asyncio
+    async def test_a_resize_storm_concurrent_with_warmup_seeds_once(self):
+        """THE mandated race. 24 seeders against 200 dimension mutations.
+
+        A check-then-act guard passes this most runs and fails under load, which is
+        the worst possible failure mode — so the claim is taken under the SAME lock
+        as the push, and taken BEFORE the render, because rendering a crest is slow
+        enough to be preempted.
+        """
+        import threading
+
+        mux = self._mux()
+        stop = threading.Event()
+        errors = []
+
+        def resizer():
+            try:
+                n = 0
+                while not stop.is_set() and n < 200:
+                    mux.observe_allotment(60 + (n % 40), 20 + (n % 25))
+                    n += 1
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        def seeder():
+            try:
+                mux.seed_masthead(lambda: f"{self.MARK}\nsecond\nthird")
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        resizers = [threading.Thread(target=resizer) for _ in range(4)]
+        seeders = [threading.Thread(target=seeder) for _ in range(24)]
+        for t in resizers + seeders:
+            t.start()
+        for t in seeders:
+            t.join(timeout=10)
+        stop.set()
+        for t in resizers:
+            t.join(timeout=10)
+
+        assert not errors, f"the race raised: {errors[:3]}"
+        snapshot = list(mux._buffer.snapshot())
+        assert sum(1 for l in snapshot if self.MARK in l) == 1, (
+            f"masthead seeded {sum(1 for l in snapshot if self.MARK in l)} times "
+            f"under concurrent resizes — the claim is check-then-act")
+        assert len(snapshot) == 4, f"ring holds {len(snapshot)} lines, expected 4"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("screen_rows", [24, 30, 40, 60])
+    async def test_the_tail_survives_a_seeded_masthead_at_a_thousand_lines(
+        self, fullscreen, screen_rows,
+    ):
+        """The two mandates together: the masthead is in the transcript AND the
+        newest line is still painted, with the prompt pinned near the bottom."""
+        from prompt_toolkit.layout.containers import to_container
+        from prompt_toolkit.layout.mouse_handlers import MouseHandlers
+        from prompt_toolkit.layout.screen import Screen, WritePosition
+
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            build_bipartite_application,
+        )
+        mux = self._mux()
+        mux.seed_masthead(lambda: f"{self.MARK}\nline2\nline3")
+        for i in range(1000):
+            mux.push_raw(f"DECK-{i}")
+        app = build_bipartite_application(
+            mux, on_accept=lambda _t: None, toolbar=lambda: "tb",
+            status_rows=lambda: ["status"], pending_rows=lambda: ["pending"])
+        width = 60
+        screen = Screen(default_char=None, initial_width=width,
+                        initial_height=screen_rows)
+        to_container(app.layout.container).write_to_screen(
+            screen, MouseHandlers(), WritePosition(0, 0, width, screen_rows),
+            "", False, None)
+        rows = ["".join(screen.data_buffer[y][x].char for x in range(width)
+                        ).rstrip() for y in range(screen_rows)]
+        assert any("DECK-999" in r for r in rows), (
+            f"tail lost at {screen_rows} rows with a seeded masthead")
+        prompt = next((y for y, r in enumerate(rows) if r.startswith("❯")), None)
+        assert prompt is not None and prompt >= screen_rows - 5, (
+            f"the prompt is at row {prompt} of {screen_rows} — it must be pinned "
+            f"near the bottom with the transcript flowing up into it")
+
+    def test_no_surface_mounts_a_top_header_region_any_more(self):
+        """A fixed region stranded the emblem at row 0 while a bottom-anchored deck
+        hugged the prompt. Pinned by AST rather than substring: the comments around
+        these call sites name `header` in prose to explain why it is gone."""
+        import ast
+        import inspect
+
+        from backend.core.ouroboros.battle_test import cockpit_mount as cm
+
+        assert "header" not in cm.build_daemon_mount(None), (
+            "the daemon mount carries a header region again")
+
+        from backend.core.ouroboros.cli import ov_demo as d
+
+        call = [
+            n for n in ast.walk(ast.parse(inspect.getsource(d.scene_live)
+                                          .lstrip()))
+            if isinstance(n, ast.Call)
+            and (getattr(n.func, "id", "") or getattr(n.func, "attr", ""))
+            == "build_bipartite_application"
+        ][0]
+        for kw in call.keywords:
+            if kw.arg in ("header", "header_height"):
+                assert isinstance(kw.value, ast.Call) and (
+                    getattr(kw.value.func, "id", "") == "waived"), (
+                    f"ov demo live mounts a real {kw.arg} region again")


### PR DESCRIPTION
## Steps 2 and 3 of the geometry plan — unblocked by #70288

## Claude Code's geometry, finally

The canvas is greedy again in the alternate screen, so **the input is pinned to the bottom and the transcript flows upward into it.** Safe now only because #70288 fixed the two-pass cache — before it, a greedy region silently clipped its newest lines at small terminal heights.

The blank band that made content-sizing look necessary was never the canvas's fault. It came from mounting the crest as a **fixed top region**, which stranded the emblem at row 0 while a bottom-anchored deck hugged the prompt forty rows below.

So the header region is **gone from every surface** — demo, daemon, and the mount that feeds it — and the emblem is transcript content, sitting directly on the feed and scrolling away as work arrives.

The orphaned identity line went with it, into the same payload, via the existing `_SEM` roles. **No new layout component**: your audit call was right — `pending_rows` / `_below_prompt` already carry the telemetry, and a Bottom-Anchored Telemetry Bar would have duplicated three already-bottom-anchored hooks.

## Idempotent by claim, not check-then-act

Boot is exactly when a terminal emits a flurry of SIGWINCH — app mount, alt-screen claim, off-thread crest warmup — and the ring is **append-only**, so a masthead pushed per rebuild stacks emblems nothing can remove.

The claim is taken **under the same lock as the push**, and **before the render**: two threads that both read "not yet seeded" before either writes would both proceed, and rendering a crest is slow enough to be preempted in exactly that window. Keyed, so demo and daemon each seed their own banner without suppressing the other.

An **empty render releases the claim** — a cold crest renders nothing, and holding it there would make that boot permanently emblem-less. Seeding must also happen *after* the warmup, for the same reason: before it, `render_cockpit_header` has no frames.

**Proven:** 24 concurrent seeders against 200 dimension mutations leave **exactly one** masthead in a 4-line ring — still one after 1000 further pushes. Tail intact at 24/30/40/60 rows with the masthead seeded, prompt pinned near the bottom at every height.

## Two tests rewritten, not deleted

Both were #70286 assertions about the content-sized regime this replaces:

- `test_no_blank_band_between_the_crest_and_a_short_deck` mounted a header **region** and measured the gap. No surface mounts one now, so adjacency is *structural* — both live in one ring separated by exactly the blank the deck grammar puts before every action. It asserts the ring instead.
- The other bounded the allotment by `_terminal_size()`, conflating the real terminal with the larger synthetic screen this harness renders into, and failed a correct render.

## One mandate I did NOT implement as specified

> *"Inject the masthead as dynamic FormattedText that reflows on aggressive resize."*

The transcript ring stores **strings** — seeded content is static by construction, and that is what makes it a *record* rather than a live region. Every deck line already re-wraps at render time through the Rich console's current width, so the identity **text** reflows like any other transcript line.

What cannot reflow is the **emblem**, and it should not: it is a fixed-cell halfblock sprite whose geometry is the entire point of the anisotropic-sampling work behind it. Resampling per resize would distort it — the exact defect that arc closed. Reported rather than faked.

46 in the file; **252 green**. PTY-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move the masthead into the transcript and make the canvas greedy in the alternate screen so the prompt sits at the bottom and the feed scrolls up into it. The fixed header region is removed; the masthead now scrolls away like normal transcript content.

- **New Features**
  - Greedy canvas in the alternate screen; inline mode remains content-sized and bounded.
  - `seed_masthead`: seeds the masthead into the ring once (keyed, lock-guarded, releases on empty render) and returns the number of lines added.
  - Daemon and demo seed after crest warmup (`seed_daemon_masthead`); transcript text reflows on resize, emblem stays fixed-cell.

- **Refactors**
  - Removed `header`/`header_height` wiring from the daemon mount and `serpent_flow`; `ov_demo` waives the header and seeds instead.
  - Tests rewritten to assert masthead/deck contiguity, idempotent seeding under resize storms, and correct screen-bound allotment.

<sup>Written for commit f44b6b5216f5c0dcbcaf5db38f7a87b9aab0f0bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

