### PR TITLE
fix(ov): the transcript ring decodes a line by its own encoding

### DIFF
--- a/backend/core/ouroboros/battle_test/bipartite_layout.py
+++ b/backend/core/ouroboros/battle_test/bipartite_layout.py
@@ -191,6 +191,49 @@ def _overlay_style(role: str) -> str:
         return "bold bg:#0b0b0b"
 
 
+
+def _line_to_text(line: str) -> Any:
+    """One transcript line -> a Rich ``Text``, decoded by its OWN encoding.
+
+    The ring is a MARKUP ring: every producer pushes Rich markup and this seam
+    called `Text.from_markup` on all of it. That held while markup was the only
+    thing anyone pushed.
+
+    Then the masthead arrived. `render_cockpit_header` returns an ANSI string — it
+    was built for a prompt_toolkit ANSI window — and pushing it through a markup
+    decoder shredded it: `from_markup` consumed the ESC, then printed the numeric
+    payload of every truecolor SGR as literal text. On screen that is
+
+        2;192;144;166;48;2;199;150;170m   ;156;66;48;2;47;43;17m   [0m
+
+    smeared across the emblem. Two incompatible encodings meeting at one decoder.
+
+    So the decoder SNIFFS instead of assuming. A line carrying ESC is ANSI and goes
+    through `Text.from_ansi`, which is Rich's own decoder for exactly this; anything
+    else is markup and is unchanged. That fixes the CLASS rather than the masthead:
+    any producer may now push either encoding — a mirrored daemon line, a captured
+    subprocess tail, a syntax-highlighted diff — and the ring stops caring.
+
+    ANSI wins when a line somehow contains both, because a half-decoded escape is
+    unreadable garbage while a literal `[bold]` is merely ugly. Mixing the two in
+    one line is a producer bug either way, and this makes it look like one.
+
+    NEVER raises: an undecodable line renders as plain text rather than taking the
+    frame down with it.
+    """
+    try:
+        from rich.text import Text
+        if "\x1b" in line:
+            return Text.from_ansi(line)
+        return Text.from_markup(line)
+    except Exception:  # noqa: BLE001
+        try:
+            from rich.text import Text
+            return Text(str(line))
+        except Exception:  # noqa: BLE001
+            return str(line)
+
+
 def _canvas_dimension(mux: Any = None) -> Any:
     """How much room the live canvas takes — CONTENT-SIZED, recomputed per frame.
 
@@ -796,7 +839,7 @@ class BipartiteLayout:
                 except Exception:  # noqa: BLE001
                     body = Text("  O + V", style="bold #5EE06A", justify="center")
             elif lines:
-                body = Group(*[Text.from_markup(ln) for ln in lines])
+                body = Group(*[_line_to_text(ln) for ln in lines])
             else:
                 body = Text("  idle — waiting for the organism to act", style="bright_black")
             n = self._buffer.line_count if hasattr(self._buffer, "line_count") else len(lines)

--- a/tests/battle_test/test_canvas_allotment.py
+++ b/tests/battle_test/test_canvas_allotment.py
@@ -685,3 +685,62 @@ class TestTheMastheadIsSeededExactlyOnce:
                 assert isinstance(kw.value, ast.Call) and (
                     getattr(kw.value.func, "id", "") == "waived"), (
                     f"ov demo live mounts a real {kw.arg} region again")
+
+
+class TestTheRingDecodesByEncoding:
+    """The transcript ring holds two encodings now, and one decoder must serve both.
+
+    It was a MARKUP ring — every producer pushed Rich markup and the seam called
+    `Text.from_markup` on all of it. Then the masthead arrived as an ANSI string
+    (`render_cockpit_header` targets a prompt_toolkit ANSI window), `from_markup`
+    consumed the ESC, and the numeric payload of every truecolor SGR printed as
+    literal text across the emblem:
+
+        2;192;144;166;48;2;199;150;170m   ;156;66;48;2;47;43;17m   [0m
+    """
+
+    def test_an_ansi_line_is_decoded_not_shredded(self):
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            _line_to_text,
+        )
+        text = _line_to_text("\x1b[38;2;192;144;166mPIXEL\x1b[0m")
+        assert text.plain == "PIXEL", (
+            f"the SGR payload leaked into visible text: {text.plain!r}")
+        assert text.spans, "the colour was dropped along with the escape"
+
+    def test_a_markup_line_is_still_markup(self):
+        """The regression risk in the other direction: routing everything through
+        `from_ansi` would print every `[bold]` literally."""
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            _line_to_text,
+        )
+        text = _line_to_text("[bold]markup[/bold]")
+        assert text.plain == "markup"
+        assert text.spans
+
+    def test_a_seeded_masthead_leaks_no_escape_payload(self):
+        """End to end through the real render, which is where it actually showed."""
+        import re
+
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            BipartiteLayout,
+        )
+        mux = BipartiteLayout()
+        mux.seed_masthead(
+            lambda: "\x1b[38;2;94;224;106m██\x1b[0m EMBLEM\n"
+                    "\x1b[38;2;108;125;119mo+v\x1b[0m")
+        mux.push_raw("Signal(test_failure)")
+        rendered = mux.render_canvas_ansi()
+        visible = re.sub(r"\x1b\[[0-9;?]*[a-zA-Z]", "", rendered)
+        assert "EMBLEM" in visible
+        assert "38;2;" not in visible, (
+            f"escape payload printed as text: {visible!r}")
+        assert "[0m" not in visible
+
+    def test_an_undecodable_line_never_takes_the_frame_down(self):
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            _line_to_text,
+        )
+        # A truncated escape is exactly what a clipped producer emits.
+        assert _line_to_text("\x1b[38;2;1") is not None
+        assert _line_to_text("") is not None


### PR DESCRIPTION
## The masthead rendered as its own escape codes

From the screenshot, smeared across the emblem:

```
2;192;144;166;48;2;199;150;170m   ;156;66;48;2;47;43;17m   [0m
```

## Two encodings, one decoder

The ring is a **markup** ring. Every producer pushed Rich markup, so `render_canvas` called `Text.from_markup` on all of it — and that held for exactly as long as markup was the only thing anyone pushed.

Then #70289 seeded the masthead. `render_cockpit_header` returns an **ANSI** string (it was built for a prompt_toolkit ANSI window), and `from_markup` shredded it: the ESC was consumed as an unremarkable character and the numeric payload of every truecolor SGR printed as literal text.

My commit, my mismatch — I moved content across an encoding boundary without noticing there was one.

## The decoder sniffs

A line carrying ESC is ANSI and goes through `Text.from_ansi`, Rich's own decoder for exactly this. Anything else is markup, unchanged.

That fixes the **class** rather than the masthead. The ring stops caring which encoding a producer speaks, so a mirrored daemon line, a captured subprocess tail and a syntax-highlighted diff can all be pushed in whatever form they already have — no converter at each call site, no new contract for everyone to remember.

Deliberately **not** the alternatives:

| rejected | why |
|---|---|
| route everything through `from_ansi` | prints every `[bold]` literally — same bug, other direction. Pinned by a test. |
| strip ANSI before pushing | drops the emblem's colour, and the emblem **is** colour |
| convert at each producer | burdens every call site and leaves the ring's contract as fragile as it was |

ANSI wins when a line somehow contains both: a half-decoded escape is unreadable garbage while a literal `[bold]` is merely ugly. Mixing them in one line is a producer bug either way, and this makes it *look* like one rather than like a rendering fault.

Never raises — a truncated escape is what a clipped producer emits, so an undecodable line renders as plain text instead of taking the frame down.

## Tests

4 new, one of them **end-to-end through `render_canvas_ansi`**, because that is where it actually showed — the unit-level decode was never the broken part.

PTY-verified: **zero** leaked SGR fragments in visible text, every surface still rendering. 242 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes transcript ring rendering by decoding each line using its own encoding (ANSI vs Rich markup). This prevents ANSI payloads from printing as text and restores masthead colors.

- **Bug Fixes**
  - Added `_line_to_text` that inspects each line for ESC and decodes via `rich.Text.from_ansi` or `rich.Text.from_markup`.
  - Updated `render_canvas` to use `_line_to_text` for all transcript lines.
  - ANSI wins if both encodings appear in one line; falls back to plain text on bad/partial escapes to avoid crashes.
  - Added tests, including end-to-end through `render_canvas_ansi`, to ensure no leaked SGR sequences and markup still renders.

<sup>Written for commit a366fc8d4583ca8d6d94f54542f5d4526f040fc7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

