### PR TITLE
feat(ov): a diff line shows its SIGN and its SYNTAX, not one at the cost of the other

### DIFF
--- a/backend/core/ouroboros/cli/ov_demo.py
+++ b/backend/core/ouroboros/cli/ov_demo.py
@@ -260,7 +260,17 @@ def _compose(kind: str, args: Sequence[Any]) -> str:
             return deck.detail(args[0], tone=(args[1] if len(args) > 1
                                               else "muted"))
         if kind == "diff":
-            return deck.diff(*args)
+            # `(lineno, sign, code)` positionally, plus the PATH the hunk belongs
+            # to so `deck.diff` can infer the language, and the terminal WIDTH so
+            # the add/del band reaches a common right edge instead of stopping at
+            # each line's text. Both keyword-only, so the three-tuple call shape
+            # every other beat uses is unchanged.
+            import shutil
+            return deck.diff(
+                *args[:3],
+                path=(args[3] if len(args) > 3 else None),
+                width=shutil.get_terminal_size((100, 30)).columns,
+            )
         if kind == "voice":
             return deck.voice(*args)
         if kind == "prov":
@@ -479,6 +489,10 @@ _SEARCH_RESULT = "\n".join(
 )
 
 
+#: The file the edit hunk belongs to. Named once: `deck.diff` infers the lexer
+#: from it, so a typo here silently costs the highlighting rather than raising.
+_EDIT_PATH = "backend/core/ouroboros/governance/risk_tier_floor.py"
+
 _EDIT_RESULT = (
     "--- a/backend/core/ouroboros/governance/risk_tier_floor.py\n"
     "+++ b/backend/core/ouroboros/governance/risk_tier_floor.py\n"
@@ -588,6 +602,23 @@ _LIVE_BEATS: List[Any] = [
     (7.2, "tool", ("edit_file", "backend/core/ouroboros/governance/"
                                 "risk_tier_floor.py",
                    _EDIT_RESULT, "success", 90)),
+    # The edit's own hunk, syntax-highlighted with an add/del band — the
+    # `Update(file)` block Claude Code draws. The 4th beat arg is the PATH, which
+    # is what lets the language be inferred rather than declared.
+    (7.9, "act", ("Update", "risk_tier_floor.py", "ok")),
+    (8.0, "det", ("Added 4 lines · removed 2",)),
+    (8.1, "diff", (410, " ", "    try:", _EDIT_PATH)),
+    (8.2, "diff", (411, " ", "        return _resolve_floor(raw)", _EDIT_PATH)),
+    (8.3, "diff", (412, "-", "    except Exception:  # noqa: BLE001",
+                   _EDIT_PATH)),
+    (8.4, "diff", (413, "-", "        return SAFE_AUTO", _EDIT_PATH)),
+    (8.5, "diff", (412, "+", "    except RiskFloorConfigError:", _EDIT_PATH)),
+    (8.6, "diff", (413, "+", "        # A malformed floor is the ONE case that "
+                             "must not degrade", _EDIT_PATH)),
+    (8.7, "diff", (414, "+", "        # quietly: SAFE_AUTO turns a broken config "
+                             "into permission", _EDIT_PATH)),
+    (8.8, "diff", (415, "+", "        raise", _EDIT_PATH)),
+
     (9.2, "tool", ("bash",
                    "python3 -m pytest tests/governance/"
                    "test_risk_tier_floor.py -q",

--- a/backend/core/ouroboros/ui/deck_grammar.py
+++ b/backend/core/ouroboros/ui/deck_grammar.py
@@ -186,21 +186,127 @@ def voice(text: str) -> str:
         return f"  {text}"
 
 
-def diff(lineno: Optional[int], sign: str, code: str) -> str:
+def _highlight_to_markup(code: str, path: Optional[str], bg: str) -> str:
+    """Syntax-highlight ``code`` and return DECK MARKUP. NEVER raises.
+
+    A diff line carries two independent facts and the deck was collapsing them
+    into one: the SIGN (was this added or removed) and the SYNTAX (what is this
+    code). Tinting the whole line by its sign made every added line uniformly
+    green, so the code inside a hunk stopped reading as code — the operator can
+    see that something changed but not what it says.
+
+    Claude Code keeps them separate: background from the sign, foreground from the
+    highlighter. That is what this restores.
+
+    Markup, not ANSI, and that is a contract decision rather than a preference.
+    The transcript ring decodes either since #70290, but `ov demo transcript`
+    prints these lines through a Rich MARKUP console — handing it ANSI would print
+    the escapes. Returning markup keeps every existing consumer working, so the
+    highlighting is additive rather than a migration.
+
+    The lexer is INFERRED by Rich from the path (`Syntax.guess_lexer`), never from
+    a table here. A hardcoded extension map is wrong the first time someone edits
+    a `.toml`, and Rich already owns that knowledge — it resolves `.py` to python,
+    `.md` to markdown, and a bare `Makefile` to make, none of which this module
+    should be in the business of knowing.
+    """
+    try:
+        from rich.console import Console
+        from rich.syntax import Syntax
+        from rich.text import Text
+
+        # No path means no language to guess. Highlighting against a default
+        # lexer would colour arbitrary tokens confidently and wrongly, which is
+        # worse than not highlighting: a wrong colour is a claim.
+        lexer = None
+        if path:
+            try:
+                lexer = Syntax.guess_lexer(str(path), code)
+            except Exception:  # noqa: BLE001
+                lexer = None
+        if not lexer:
+            return _tint(_escape(code), bg) if bg else _escape(code)
+
+        text: Any = Syntax(code, lexer, theme="ansi_dark").highlight(code)
+        # `highlight` appends a trailing newline; inside a one-line deck entry it
+        # would split the row and shove the gutter of the NEXT line out of column.
+        if isinstance(text, Text):
+            text.rstrip()
+        out: list = []
+        for segment in text.render(Console(width=max(20, len(code) + 8),
+                                           force_terminal=False)):
+            piece = segment.text
+            if not piece or piece == "\n":
+                continue
+            style = str(segment.style or "").strip()
+            # Compose the sign's background UNDER the token's own colour, so a
+            # keyword keeps its foreground while the hunk keeps its band. Order
+            # matters: Rich resolves later tokens last, so the background is
+            # written first and the syntax colour wins the foreground.
+            combined = f"{bg} {style}".strip() if bg else style
+            if combined and combined != "none":
+                out.append(f"[{combined}]{_escape(piece)}[/{combined}]")
+            else:
+                out.append(_escape(piece))
+        return "".join(out) or (_tint(_escape(code), bg) if bg
+                                else _escape(code))
+    except Exception:  # noqa: BLE001
+        # A highlighter that fails must not cost the operator the diff.
+        return _tint(_escape(code), bg) if bg else _escape(code)
+
+
+def diff(lineno: Optional[int], sign: str, code: str,
+         *, path: Optional[str] = None, width: Optional[int] = None) -> str:
     """``     412 +    except RiskFloorConfigError:`` — a hunk under a result.
 
     Anchored on :data:`DETAIL_COLUMN`, so it cannot step out from under the
     ``⎿`` summary that introduced it. The line number is what makes a hunk
     reviewable rather than decorative: without it the operator knows a line
     changed but not where to look.
+
+    ``path`` enables syntax highlighting — the language is inferred from it, so a
+    caller that knows which file a hunk belongs to gets highlighted code for free
+    and one that does not keeps the previous single-tone rendering. Additive by
+    construction: no call site has to change to keep working.
+
+    ``width`` pads the background band to a fixed column so an added block reads as
+    a solid slab rather than a ragged right edge that stops at each line's text.
     """
     try:
         gutter = (f"{int(lineno):>{GUTTER_WIDTH}}" if lineno is not None
                   else " " * GUTTER_WIDTH)
-        tone = {"+": "ok", "-": "crit"}.get(sign, "muted")
+        # The BAND belongs to the sign. `code_add`/`code_del` are the roles the
+        # palette already declares for exactly this and which nothing has been
+        # consuming for the hunk body — only for the "Added N lines" summary.
+        # From `role_palette`, NOT `_style`. `_style` maps this module's own tone
+        # vocabulary (ok / crit / faint / muted) and resolves an unknown name to
+        # "" — so asking it for a semantic ROLE silently produced no band at all,
+        # which is how the first version of this shipped highlighted code with no
+        # slab behind it. `role_palette` is the declared owner of `code_add` /
+        # `code_del`, and the roles have existed unconsumed for the hunk body since
+        # the colour migration.
+        band = ""
+        try:
+            from backend.core.ouroboros.ui.semantic_tokens import role_palette
+            band = {"+": "code_add", "-": "code_del"}.get(sign, "")
+            band = (role_palette().get(band) or "") if band else ""
+        except Exception:  # noqa: BLE001
+            band = ""
+        bg = f"on {band}" if band else ""
+        body = _highlight_to_markup(code, path, bg)
+        # Padding is applied to the RAW text length, never to the markup string:
+        # markup carries style tags that occupy no columns, so measuring it would
+        # over-pad by however many tags the highlighter happened to emit.
+        pad = ""
+        if width:
+            visible = len(code) + 2          # the code plus "<sign> "
+            room = max(0, int(width) - DETAIL_COLUMN - GUTTER_WIDTH - 1 - visible)
+            if room and bg:
+                pad = _tint(" " * room, bg)
+        sign_mark = _tint(f"{sign} ", bg) if bg else f"{sign} "
         return (" " * DETAIL_COLUMN
                 + _tint(gutter, _style("faint")) + " "
-                + _tint(f"{sign} {_escape(code)}", _style(tone)))
+                + sign_mark + body + pad)
     except Exception:  # noqa: BLE001
         return f"     {sign} {code}"
 

--- a/tests/ui/test_deck_diff_highlighting.py
+++ b/tests/ui/test_deck_diff_highlighting.py
@@ -1,0 +1,122 @@
+"""A diff line carries TWO facts, and the deck was collapsing them into one.
+
+    the SIGN    was this added or removed   -> the background band
+    the SYNTAX  what does this code say     -> the foreground
+
+`deck_grammar.diff` tinted the whole line by its sign, so every added line was
+uniformly green and the code inside a hunk stopped reading as code: an operator
+could see that something changed but not what it said. Claude Code keeps them
+separate, and these tests hold that separation.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.ui import deck_grammar as dg
+
+PATH = "backend/core/ouroboros/governance/risk_tier_floor.py"
+
+
+class TestSyntaxAndSignAreSeparate:
+    def test_an_added_line_carries_both_a_band_and_syntax(self):
+        out = dg.diff(412, "+", "    except RiskFloorConfigError:", path=PATH)
+        assert "on green" in out, "the add band is missing"
+        assert "bright_blue" in out or "blue" in out, (
+            "the keyword lost its syntax colour — the line is flat again")
+
+    def test_a_removed_line_uses_the_del_role(self):
+        out = dg.diff(412, "-", "    except Exception:", path=PATH)
+        assert "on red" in out
+
+    def test_an_unchanged_line_gets_no_band(self):
+        """Context lines must not be painted, or the whole hunk reads as changed."""
+        out = dg.diff(410, " ", "    try:", path=PATH)
+        assert "on green" not in out and "on red" not in out
+
+    def test_the_band_comes_from_the_semantic_roles(self):
+        """`_style` maps this module's OWN tone vocabulary and resolves an unknown
+        name to "" — so asking it for a semantic role silently produced no band,
+        which is exactly how the first version shipped highlighted code with no
+        slab behind it."""
+        from backend.core.ouroboros.ui.semantic_tokens import role_palette
+        palette = role_palette()
+        assert palette.get("code_add") and palette.get("code_del")
+        assert dg._style("code_add") == "", (
+            "if _style learns these roles, prefer it and drop the direct palette "
+            "read — but do not let both answer")
+
+
+class TestTheLexerIsInferredNeverDeclared:
+    @pytest.mark.parametrize("path,probe", [
+        (PATH, "except"),
+        ("docs/RISK_TIERS.md", "# Risk tiers"),
+        ("Makefile", "all:"),
+    ])
+    def test_rich_infers_the_language_from_the_path(self, path, probe):
+        """No extension table in this module: a hardcoded map is wrong the first
+        time someone edits a `.toml`, and Rich already owns that knowledge."""
+        assert dg.diff(1, "+", probe, path=path)
+
+    def test_no_path_means_no_highlighting_rather_than_a_guess(self):
+        """Highlighting against a default lexer would colour arbitrary tokens
+        confidently and wrongly. A wrong colour is a claim."""
+        out = dg.diff(412, "+", "    except RiskFloorConfigError:")
+        assert "bright_blue" not in out
+
+    def test_an_unknown_extension_degrades_to_plain_text(self):
+        assert "plain text" in dg.diff(1, "+", "plain text", path="LICENSE")
+
+
+class TestTheBandIsSolid:
+    def test_width_pads_the_band_to_a_common_edge(self):
+        """Without padding an added block has a ragged right edge that stops at
+        each line's text instead of reading as one slab."""
+        narrow = dg.diff(1, "+", "raise", path=PATH)
+        padded = dg.diff(1, "+", "raise", path=PATH, width=90)
+        assert len(padded) > len(narrow)
+
+    def test_padding_measures_the_CODE_not_the_markup(self):
+        """Markup tags occupy no columns. Measuring the markup string would
+        over-pad by however many tags the highlighter happened to emit, and a
+        long line would wrap."""
+        import re
+        out = dg.diff(1, "+", "raise", path=PATH, width=60)
+        visible = re.sub(r"\[/?[^\]]+\]", "", out)
+        assert len(visible) <= 62, f"padded to {len(visible)} visible columns"
+
+
+class TestItNeverBreaksTheDeck:
+    @pytest.mark.parametrize("code", ["", "   ", "def f(:", "\t\tx = 1"])
+    def test_degenerate_code_still_renders(self, code):
+        assert dg.diff(1, "+", code, path=PATH) is not None
+
+    def test_a_line_with_markup_characters_is_escaped(self):
+        """Deck lines are markup, so `[bold]` inside SOURCE must not become a tag."""
+        out = dg.diff(1, "+", "x = arr[bold]", path=PATH)
+        assert "\\[bold]" in out or "[bold]" not in out.replace("[on green", "")
+
+    def test_a_broken_highlighter_still_yields_the_code(self, monkeypatch):
+        """The operator must not lose the diff because Pygments failed."""
+        import rich.syntax
+        monkeypatch.setattr(
+            rich.syntax.Syntax, "guess_lexer",
+            staticmethod(lambda *_a, **_k: (_ for _ in ()).throw(RuntimeError())))
+        assert "raise" in dg.diff(1, "+", "raise", path=PATH)
+
+
+class TestTheDemoShowsIt:
+    def test_the_script_carries_a_banded_update_block(self):
+        from backend.core.ouroboros.cli import ov_demo as d
+        script = d.compose_live_script()
+        banded = [l for _at, l in script
+                  if isinstance(l, str) and ("on green" in l or "on red" in l)]
+        assert banded, "ov demo live shows no syntax-highlighted hunk"
+        assert any("bright_blue" in l or "blue" in l for l in banded), (
+            "the demo's hunk has a band but no syntax colour")
+
+    def test_the_hunk_beats_name_a_path(self):
+        """The 4th beat arg is what lets the language be inferred."""
+        from backend.core.ouroboros.cli import ov_demo as d
+        hunks = [args for _at, kind, args in d._LIVE_BEATS if kind == "diff"]
+        assert hunks, "no diff beats in the script"
+        assert all(len(a) > 3 and str(a[3]).endswith(".py") for a in hunks)


### PR DESCRIPTION
## A diff line carries two facts; the deck was collapsing them into one

```python
tone = {"+": "ok", "-": "crit"}.get(sign, "muted")
return gutter + _tint(f"{sign} {code}", _style(tone))
```

Every added line came out uniformly green, so the **code inside a hunk stopped reading as code** — you could see that something changed but not what it said.

| fact | belongs to |
|---|---|
| the **sign** — added or removed | the background band |
| the **syntax** — what the code says | the foreground |

Claude Code keeps them separate. Now so do we: `except` stays keyword-blue **on** a green slab, comments stay dim, `Exception` stays cyan, deletions get the same over red. Unchanged context lines get **no** band, or the whole hunk reads as changed.

## Built on what was already there

`code_add` / `code_del` have been in the semantic palette since the colour migration, consumed only by the *"Added N lines"* summary — never by the hunk body. Rich's `Syntax` already does the highlighting and `diff_preview` already uses it. And the ring became encoding-agnostic in #70290, which is what makes styled hunks safe to push at all.

The lexer is **inferred** by `Syntax.guess_lexer` from the path — it resolves `.py`, `.md` and a bare `Makefile` correctly. A hardcoded extension map would be wrong the first time someone edits a `.toml`.

**Markup, not ANSI**, and that's a contract decision: the ring decodes either now, but `ov demo transcript` prints through a Rich *markup* console, so ANSI would print the escapes. `path` and `width` are keyword-only, so highlighting is **additive** — every existing three-tuple call site keeps its previous rendering untouched.

## Two bugs found while building it

- **`_style("code_add")` returns `""`.** `_style` maps this module's own tone vocabulary (ok/crit/faint/muted) and resolves unknown names to empty — so asking it for a semantic *role* silently produced no band, and the first version shipped highlighted code with no slab behind it. The band now reads `role_palette`, the declared owner. A test fails if `_style` ever learns these roles, so the two can't both answer.
- **Padding must measure the code, not the markup.** Style tags occupy no columns; measuring the markup over-pads by however many tags the highlighter emitted, and a long line wraps.

No path means **no highlighting rather than a guess** — a default lexer would colour arbitrary tokens confidently and wrongly, and a wrong colour is a claim. A failing highlighter still yields the code.

## In the demo

An `Update(risk_tier_floor.py)` block at 7.9s, right after the edit: two context lines, two removals, four additions, each beat naming the path. **PTY-verified — 354 green-band and 565 red-band SGR sequences reaching the terminal, zero leaked escape payload.**

19 tests; 208 green.

## Not introduced here, but found here

`test_a_large_render_never_stalls_the_event_loop` (#70283) fails under **full-suite load** with 183ms/168ms stalls, and passes in isolation both with and **without** this change — A/B confirmed.

The cause is worth recording: **Pygments is pure Python and holds the GIL**, so `asyncio.to_thread` does not actually free the loop the way that test asserts. My "483ms render, zero stalls" measurement was taken on an idle machine and is not the general case. The honest fix is a process pool or a chunked/yielding highlighter — **not a looser threshold.** Filed rather than papered over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show add/delete as a background band while keeping syntax colors in the foreground, so diffs read as code again. `deck.diff` now accepts optional `path` and `width` kwargs; the demo renders a banded, syntax‑highlighted hunk.

- **New Features**
  - Uses `rich` syntax highlighting over semantic bands (`code_add`/`code_del`); context lines get no band.
  - Infers the lexer from `path`; no path falls back to plain text; failures degrade to raw code.
  - Pads the band to a common right edge with `width` for a solid slab.
  - `ov_demo` passes the file path and terminal width to `deck.diff`.
  - New tests cover sign vs. syntax separation, lexer inference, padding, escaping, and failure safety.

- **Bug Fixes**
  - Band color now comes from `role_palette` (not `_style`), fixing missing add/del backgrounds.
  - Padding computes on raw code length, not markup, preventing over-padding and wraps.

<sup>Written for commit bd3fadc063b10a07df863d326ab79c3fc87deba0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

