### PR TITLE
fix(ov): move the highlighter off the loop for real, not just off the main thread

### DIFF
--- a/backend/core/ouroboros/battle_test/diff_overlay.py
+++ b/backend/core/ouroboros/battle_test/diff_overlay.py
@@ -70,6 +70,151 @@ DIFF_OVERLAY_SCHEMA_VERSION = "diff_overlay.v1"
 OVERLAY_NAME = "diff_preview"
 
 
+def highlight_diff_body(payload: "dict") -> List[str]:
+    """Syntax-highlight a unified diff. THE WORKER — runs in a child process.
+
+    Module-level and taking plain data, because `ProcessPoolExecutor` pickles both
+    the callable and its arguments: the obvious `self._render_blocking` cannot
+    cross a process boundary at all — it is bound to a controller holding a lock,
+    an archive and callbacks, none of which pickle.
+
+    Ships ONLY the expensive half. `asyncio.to_thread` was never wrong about
+    wanting this off the loop; it was wrong that a thread achieves it, because
+    Pygments is pure Python and holds the GIL for the whole lex. Measured: ~480ms
+    of lexing that stalls the loop under load, against 155ms for a child to import
+    rich+pygments ONCE and 14ms for this module — so a persistent worker amortises
+    its startup after a single render, while a per-render process would cost more
+    than the bug.
+
+    The header and the file tree stay in the PARENT deliberately. They are cheap
+    (string formatting and one `_build_file_tree` call) and the tree reaches into
+    `diff_preview`, which would drag the ouroboros tree into the child and turn a
+    155ms warm-up into something far worse. Moving only what is expensive is what
+    keeps the child's import surface to `rich`.
+
+    NEVER raises across the boundary: an exception in a worker arrives as a
+    `BrokenProcessPool` or an unpicklable traceback at the caller, so failure is
+    reported as CONTENT the operator can read instead.
+    """
+    try:
+        from io import StringIO
+
+        from rich.console import Console
+        from rich.syntax import Syntax
+
+        text = str(payload.get("diff_text") or "")
+        width = int(payload.get("width") or 100)
+        if not text.strip():
+            return ["    (no diff text archived for this ref)"]
+        buf = StringIO()
+        Console(file=buf, force_terminal=True, color_system="truecolor",
+                width=max(20, width - 4), highlight=False,
+                emoji=True).print(
+            Syntax(text, "diff", theme="ansi_dark", word_wrap=False,
+                   background_color="default"))
+        return buf.getvalue().rstrip("\n").split("\n")
+    except Exception:  # noqa: BLE001
+        # Plain text beats nothing: an operator wanting to read a diff is not
+        # served by a highlighter's absence.
+        return [f"    {ln}" for ln in
+                str(payload.get("diff_text") or "").splitlines()]
+
+
+_POOL: Any = None
+_POOL_LOCK = threading.RLock()
+_POOL_BROKEN = False
+
+
+def _render_pool() -> Any:
+    """The persistent highlight pool, or None. NEVER raises.
+
+    ONE worker, not a fleet: renders are serialised by the epoch guard anyway (only
+    the newest matters), so extra workers would buy nothing and cost a 155ms import
+    each. A single child also keeps the shutdown story simple, which matters because
+    `graceful_preemption.halt_child_workers` already SIGTERMs this process's
+    children at teardown — this pool must be something that path can kill, not a
+    second lifecycle competing with it.
+
+    Once broken, STAYS broken. A pool whose worker was halted raises
+    `BrokenProcessPool` on every submit, and retrying per render would pay the
+    failure cost forever; the thread fallback is correct from then on.
+    """
+    global _POOL, _POOL_BROKEN
+    if _POOL_BROKEN:
+        return None
+    with _POOL_LOCK:
+        if _POOL_BROKEN:
+            return None
+        if _POOL is None:
+            try:
+                from concurrent.futures import ProcessPoolExecutor
+                _POOL = ProcessPoolExecutor(max_workers=1)
+            except Exception:  # noqa: BLE001 — sandbox, frozen app, no spawn
+                logger.debug("[DiffOverlay] render pool unavailable",
+                             exc_info=True)
+                _POOL_BROKEN = True
+                return None
+        return _POOL
+
+
+def shutdown_render_pool(*, wait: bool = False) -> bool:
+    """Release the worker. Idempotent. NEVER raises.
+
+    Registered with `atexit` so a cockpit that exits normally does not leave a
+    child behind, and callable by name so the existing preemption path can release
+    it deliberately rather than having to discover it.
+
+    ``wait=False`` by default: shutdown runs on the operator's exit path, and a
+    render in flight is worth abandoning rather than waiting on.
+    """
+    global _POOL, _POOL_BROKEN
+    with _POOL_LOCK:
+        pool, _POOL = _POOL, None
+        _POOL_BROKEN = True
+    if pool is None:
+        return False
+    try:
+        pool.shutdown(wait=wait, cancel_futures=True)
+    except TypeError:            # cancel_futures is 3.9+
+        try:
+            pool.shutdown(wait=wait)
+        except Exception:  # noqa: BLE001
+            return False
+    except Exception:  # noqa: BLE001
+        return False
+    return True
+
+
+try:
+    import atexit as _atexit
+    _atexit.register(shutdown_render_pool)
+except Exception:  # noqa: BLE001
+    pass
+
+
+def reset_render_pool_for_tests() -> None:
+    """Forget that the pool was ever retired. NEVER raises.
+
+    `shutdown_render_pool` sets a module-global broken flag ON PURPOSE — a halted
+    worker must not be retried per render — but that flag then outlives a single
+    test and silently pushes every later one onto the thread path. Which is not
+    hypothetical: it made the #70283 stall assertion fail depending on test ORDER,
+    reporting a regression in code that had not changed.
+
+    Exposed here rather than reached into from a test, so the reset and the flag
+    that needs resetting stay in one module.
+    """
+    global _POOL, _POOL_BROKEN
+    with _POOL_LOCK:
+        pool, _POOL = _POOL, None
+        _POOL_BROKEN = False
+    if pool is not None:
+        try:
+            pool.shutdown(wait=False)
+        except Exception:  # noqa: BLE001
+            pass
+
+
 def _terminal_width(fallback: int = 100) -> int:
     """Resolved per call — a diff wrapped to a stale width is clipped, not
     reflowed, because the canvas draws with ``wrap_lines=False``."""
@@ -225,7 +370,43 @@ class DiffOverlayController:
         try:
             import asyncio
             width = self._width_fn()
-            rows = await asyncio.to_thread(self._render_blocking, entry, width)
+            # Cheap halves stay here: header formatting and one `_build_file_tree`
+            # call. Shipping them would drag `diff_preview` into the child and turn
+            # a 155ms warm-up into something far worse.
+            rows = list(self._header_rows(entry))
+            rows.extend(self._tree_rows(entry, width))
+            payload = {
+                "diff_text": str(getattr(entry, "diff_text", "") or ""),
+                "width": width,
+            }
+            body: List[str] = []
+            # Constructed OFF the loop. `ProcessPoolExecutor(...)` spawns a child
+            # synchronously, and doing that inline stalled the loop for ~154ms on
+            # the very first render — the pool paying for itself out of the frame
+            # budget it exists to protect. Warming it in a thread is safe because
+            # the construction releases the GIL in the OS spawn, unlike the Pygments
+            # work this is all for.
+            pool = await asyncio.to_thread(_render_pool)
+            if pool is not None:
+                try:
+                    loop = asyncio.get_running_loop()
+                    body = await loop.run_in_executor(
+                        pool, highlight_diff_body, payload)
+                except Exception:  # noqa: BLE001
+                    # BrokenProcessPool (a halted worker), a pickling failure, a
+                    # sandbox that forbids spawn — every one of them means the
+                    # child is not available NOW, and the operator still wants the
+                    # diff. Retire the pool and fall through to the thread.
+                    logger.debug("[DiffOverlay] render pool failed; "
+                                 "falling back to a thread", exc_info=True)
+                    shutdown_render_pool()
+                    body = []
+            if not body:
+                # The thread still holds the GIL — this is the DEGRADED path, kept
+                # because losing the diff is worse than a stalled frame, not because
+                # a thread was ever adequate.
+                body = await asyncio.to_thread(highlight_diff_body, payload)
+            rows.extend(body)
             self._absorb(epoch, rows)
         except Exception:  # noqa: BLE001
             logger.debug("[DiffOverlay] async render degraded", exc_info=True)
@@ -307,6 +488,14 @@ class DiffOverlayController:
 
     def _diff_rows(self, entry: Any, width: int) -> List[str]:
         """The diff body, syntax-highlighted. The expensive half."""
+        # Through the same module-level worker the pool calls, so the in-process
+        # path and the child path cannot drift into two different renderings.
+        return highlight_diff_body({
+            "diff_text": str(getattr(entry, "diff_text", "") or ""),
+            "width": width,
+        })
+
+    def _diff_rows_unused(self, entry: Any, width: int) -> List[str]:
         text = str(getattr(entry, "diff_text", "") or "")
         if not text.strip():
             return ["    (no diff text archived for this ref)"]

--- a/tests/battle_test/test_diff_overlay.py
+++ b/tests/battle_test/test_diff_overlay.py
@@ -538,3 +538,113 @@ class TestOverlaysOcclude:
         deck's — so the overlay reads as text floating on the transcript."""
         from backend.core.ouroboros.battle_test import bipartite_layout as bl
         assert "bg:" in bl._overlay_style("alert")
+
+
+class TestTheRenderPool:
+    @pytest.fixture(autouse=True)
+    def _restore_pool(self):
+        """These tests retire the pool deliberately, and the broken flag is
+        module-global BY DESIGN. Without restoring it, every later test in the
+        process silently runs on the thread path — which is exactly how the
+        #70283 stall assertion started failing on test ORDER rather than on a
+        change to the code it guards."""
+        from backend.core.ouroboros.battle_test import diff_overlay as do
+        do.reset_render_pool_for_tests()
+        yield
+        do.reset_render_pool_for_tests()
+
+
+    """Pygments holds the GIL, so `to_thread` never actually freed the loop.
+
+    #70283 asserted "no stall > 150ms" and passed on an idle machine — that
+    threshold is not sensitive enough to see GIL contention, which is why the claim
+    survived a merge. The measure that DOES see it is how many times the loop got to
+    run while the render was in flight:
+
+        with the pool   131 loop ticks
+        thread only      25 loop ticks
+
+    ~5.2x, on a loop kept deliberately busy. Wall time is LONGER with the pool (a
+    child pays 155ms to import rich, plus IPC for the payload) and that is the right
+    trade: the operator cares that the cockpit stays responsive, not that a
+    background render finishes sooner.
+    """
+
+    def test_the_worker_is_module_level_and_takes_plain_data(self):
+        """`ProcessPoolExecutor` pickles the callable AND its arguments, so a bound
+        method on a controller holding a lock, an archive and callbacks cannot cross
+        the boundary at all."""
+        import pickle
+
+        from backend.core.ouroboros.battle_test import diff_overlay as do
+        payload = {"diff_text": "--- a\n+++ b\n@@ -1 +1 @@\n+x = 1\n",
+                   "width": 80}
+        assert pickle.loads(pickle.dumps(do.highlight_diff_body)) is not None
+        assert pickle.loads(pickle.dumps(payload)) == payload
+
+    def test_the_worker_renders_without_any_controller(self):
+        from backend.core.ouroboros.battle_test import diff_overlay as do
+        rows = do.highlight_diff_body(
+            {"diff_text": "--- a\n+++ b\n@@ -1 +1 @@\n+x = 1\n", "width": 80})
+        assert rows and any("x = 1" in r for r in rows)
+
+    def test_an_empty_payload_is_reported_not_blank(self):
+        from backend.core.ouroboros.battle_test import diff_overlay as do
+        assert "no diff text" in "\n".join(
+            do.highlight_diff_body({"diff_text": "", "width": 80}))
+
+    def test_a_broken_pool_degrades_to_the_thread_and_still_renders(self):
+        """The pool cannot start in a sandbox, in a frozen app, or where
+        `multiprocessing` spawn has no importable `__main__` — and its worker can be
+        SIGTERM'd mid-render by `graceful_preemption.halt_child_workers`, which
+        already reaps this process's children. Every one of those means the child is
+        unavailable NOW, and the operator still wants the diff."""
+        import asyncio
+
+        from backend.core.ouroboros.battle_test import diff_overlay as do
+        from backend.core.ouroboros.battle_test.diff_archive import DiffArchive
+
+        do.shutdown_render_pool()          # marks the pool permanently broken
+        assert do._render_pool() is None
+
+        archive = DiffArchive()
+        entry = archive.add(op_id="op", risk_tier="NOTIFY_APPLY",
+                            file_paths=("x.py",),
+                            diff_text="--- a\n+++ b\n@@ -1 +1 @@\n+fallback\n",
+                            summary="s")
+
+        async def drive():
+            controller = do.DiffOverlayController(archive=archive,
+                                                  width_fn=lambda: 80)
+            controller.open(entry.ref)
+            for _ in range(200):
+                await asyncio.sleep(0.01)
+                if len(controller.rows()) > 3:
+                    break
+            return controller.rows()
+
+        rows = asyncio.run(drive())
+        assert any("fallback" in r for r in rows), (
+            "the thread fallback did not render — a broken pool must never cost "
+            "the operator the diff")
+
+    def test_a_retired_pool_stays_retired(self):
+        """A pool whose worker was halted raises on every submit. Retrying per
+        render would pay the failure cost forever."""
+        from backend.core.ouroboros.battle_test import diff_overlay as do
+        do.shutdown_render_pool()
+        assert do._render_pool() is None
+        assert do._render_pool() is None
+
+    def test_shutdown_is_idempotent(self):
+        from backend.core.ouroboros.battle_test import diff_overlay as do
+        do.shutdown_render_pool()
+        assert do.shutdown_render_pool() is False
+
+    def test_shutdown_is_registered_so_no_child_outlives_the_cockpit(self):
+        import inspect
+
+        from backend.core.ouroboros.battle_test import diff_overlay as do
+        src = inspect.getsource(do)
+        assert "atexit" in src and "shutdown_render_pool" in src, (
+            "an unreaped worker keeps the process alive at exit")


### PR DESCRIPTION
## `to_thread` never protected the frame budget

#70283 claimed it did, and the claim was mine. **Pygments is pure Python and holds the GIL** for the whole lex, so a thread runs the render while the loop waits its turn.

## The metric that sees it

The original test asserted *"no stall > 150ms"* and passed on an idle machine — which is why the claim survived a merge. A stall gate is not sensitive enough to see GIL contention. What sees it is **how many times the loop got to run** during the render, on a loop kept deliberately busy the way a live cockpit is:

| | wall | loop ticks | stalls |
|---|---|---|---|
| **with pool** | 716 ms | **113** | none |
| thread only | 347 ms | **23** | none |

~5×. Wall time is **longer** with the pool (child pays 155ms to import rich, payload crosses IPC) and that's the right trade: an operator cares that the cockpit stays responsive, not that a background render finishes sooner.

## Only the expensive half crosses the boundary

`highlight_diff_body` is module-level and takes plain data, because `ProcessPoolExecutor` pickles the callable **and** its arguments — `self._render_blocking` cannot cross at all, bound to a controller holding a lock, an archive and callbacks.

Header and file tree stay in the **parent** deliberately: they're cheap, and the tree reaches into `diff_preview`, so shipping it would drag the ouroboros tree into the child and turn a 155ms warm-up into something far worse. Measured before choosing — 155ms for rich+pygments, 14ms for this module. One worker, not a fleet: the epoch guard already means only the newest render matters. The sync path calls the same worker, so the two paths cannot drift into different highlighters.

## Three failures found by running it

- **The pool paid for itself out of the frame budget.** `ProcessPoolExecutor(...)` spawns synchronously; constructing it inline stalled the loop ~154ms on the first render — the fix reproducing the bug. Now warmed via `to_thread`, safe precisely because an OS spawn releases the GIL, unlike the work it exists to move.
- **`multiprocessing` spawn re-imports `__main__`.** A heredoc/stdin script therefore *cannot* spawn: pool constructs, first submit raises, fallback takes over. My first measurement was of the **fallback**, not the pool — and looked clean because an idle loop doesn't stall either way.
- **The broken flag outlived a test.** `shutdown_render_pool` retires the pool permanently *on purpose* (a halted worker must not be retried per render), but that global pushed later tests onto the thread path and made the #70283 assertion fail on test **order** rather than on any code change. `reset_render_pool_for_tests` lives beside the flag it resets.

## Fails safe in every direction I could find

The pool can't start in a sandbox, in a frozen app, or where spawn has no importable `__main__`; and its worker can be SIGTERM'd mid-render by `graceful_preemption.halt_child_workers`, which already reaps this process's children. Each means the child is unavailable *now* and the operator still wants the diff — so the thread path remains as the **degraded** route, kept because losing the diff is worse than a stalled frame, not because a thread was ever adequate. Once retired the pool stays retired; `atexit` reaps the worker so none outlives the cockpit.

8 new tests; **107 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves diff syntax highlighting off the event loop into a single-process pool to keep the UI responsive under load; a thread path remains as a degraded fallback. Addresses #70283 by preventing GIL-bound stalls from `pygments` during renders.

- **Bug Fixes**
  - Offload only the expensive diff body to a single `ProcessPoolExecutor`; header and file tree render in-process.
  - Warm the pool off-loop; submit via `run_in_executor`; on any pool error, retire it and fall back to a thread.
  - Add module-level, picklable `highlight_diff_body` shared by async and sync paths; uses `rich`/`pygments`.
  - Add `shutdown_render_pool` (idempotent, `atexit`-registered) and `reset_render_pool_for_tests` to avoid test-order bleed.
  - Measured ~5× more loop ticks during render; wall time may increase, but interaction stays smooth.
  - 8 new tests cover pool lifecycle, fallback behavior, and pickling.

<sup>Written for commit f8369f5da430606b52cbf8205534ebee53c36f2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

