### PR TITLE
fix(ov): one diff style, on every tool round

### DIFF
--- a/backend/core/ouroboros/battle_test/diff_overlay.py
+++ b/backend/core/ouroboros/battle_test/diff_overlay.py
@@ -215,6 +215,28 @@ def reset_render_pool_for_tests() -> None:
             pass
 
 
+
+def _outcome_text(outcome: Any) -> str:
+    """A `DiffOutcome` / `VerifyOutcome` as the operator's word. NEVER raises.
+
+    `str()` on an enum MEMBER yields `DiffOutcome.PENDING` — the Python identity,
+    not the fact. That reached the overlay header verbatim
+    (`apply DiffOutcome.PENDING · verify VerifyOutcome.PENDING`), which reads as an
+    unfinished surface rather than as a status.
+
+    `.value` first because both are `(str, Enum)` and their values ARE the
+    operator-facing vocabulary (`pending`, `applied`, `failed`); falling back to
+    `str()` keeps a plain string or a future non-enum working rather than blanking
+    the field.
+    """
+    try:
+        if outcome is None:
+            return ""
+        return str(getattr(outcome, "value", outcome) or "")
+    except Exception:  # noqa: BLE001
+        return ""
+
+
 def _terminal_width(fallback: int = 100) -> int:
     """Resolved per call — a diff wrapped to a stale width is clipped, not
     reflowed, because the canvas draws with ``wrap_lines=False``."""
@@ -459,8 +481,8 @@ class DiffOverlayController:
         # Outcome is the question an operator opening an ARCHIVED diff is
         # actually asking — "did this land?" — and it is the one thing a
         # transient gate preview could never tell them.
-        apply_outcome = str(getattr(entry, "apply_outcome", "") or "")
-        verify = str(getattr(entry, "verify_outcome", "") or "")
+        apply_outcome = _outcome_text(getattr(entry, "apply_outcome", None))
+        verify = _outcome_text(getattr(entry, "verify_outcome", None))
         if apply_outcome or verify:
             rows.append(f"    apply {apply_outcome or '?'} · "
                         f"verify {verify or '?'}")

--- a/backend/core/ouroboros/battle_test/tool_render_view.py
+++ b/backend/core/ouroboros/battle_test/tool_render_view.py
@@ -415,6 +415,108 @@ def _wrap_diff_line(
     return _escape(line)
 
 
+def _diff_wrapper_for(body_lines: Any,
+                      fallback_path: Optional[str] = None) -> Any:
+    """A per-line diff styler that KNOWS the file and the line numbers.
+
+    `_wrap_diff_line` colours by prefix and nothing else, so an `Update(f.py)`
+    block rendered a flat red/green wall while `deck_grammar.diff` — used by one
+    scripted beat — rendered the same change with a gutter, syntax highlighting and
+    a dark band. Two visual languages for one fact, in one session.
+
+    The fix is not to thread a path down from the caller. A unified diff ALREADY
+    carries both things:
+
+        +++ b/backend/.../risk_tier_floor.py     <- the path, so the lexer
+        @@ -410,7 +410,22 @@                     <- the numbering origin
+
+    So this walks the body ONCE, derives them, and returns a closure with the same
+    ``(line, palette)`` signature every other wrapper has. No new parameter, no
+    caller changes, and nothing hardcoded — a diff for a `.toml` highlights as toml
+    because the diff says so.
+
+    Numbering follows the two files separately: a removed line belongs to the OLD
+    side and a context or added line to the NEW one. Conflating them makes the
+    gutter confidently wrong, which is worse than absent.
+
+    Degrades in place: a body with no `@@` (a `git log`, a truncated fragment) gets
+    no numbers, and a body with no `+++` gets no highlighting, both landing exactly
+    on the previous flat rendering rather than on an error.
+    """
+    # The diff's own `+++` header is authoritative when present, but the density
+    # policy STRIPS the `---`/`+++` pair before a wrapper ever sees the body — it
+    # elides them as noise, correctly, since the header line duplicates the block's
+    # own `Update(path)` title. So the tool's ARGUMENT is the fallback, and for
+    # `edit_file` that argument IS the file. Header first, argument second: a diff
+    # that carries its own path should win, because a multi-file patch's argument
+    # names only one of them.
+    path: Optional[str] = fallback_path or None
+    try:
+        for raw in list(body_lines or ()):
+            text = str(raw)
+            if text.startswith("+++"):
+                # `+++ b/path` — strip the diff's own `b/` prefix, which is not
+                # part of the filename and would defeat extension inference.
+                candidate = text[3:].strip().split("\t")[0].strip()
+                if candidate.startswith(("a/", "b/")):
+                    candidate = candidate[2:]
+                if candidate and candidate != "/dev/null":
+                    path = candidate
+                break
+    except Exception:  # noqa: BLE001
+        path = None
+
+    state = {"old": 0, "new": 0}
+
+    def _wrap(line: str, palette: Optional[Mapping[str, str]]) -> str:
+        try:
+            text = str(line)
+            stripped = text.lstrip()
+            if stripped.startswith("@@"):
+                # Reset both counters from the hunk header. `-a,b +c,d` — the two
+                # origins are independent and both are needed.
+                import re as _re
+                m = _re.search(r"-(\d+)(?:,\d+)?\s+\+(\d+)", stripped)
+                if m:
+                    state["old"] = int(m.group(1))
+                    state["new"] = int(m.group(2))
+                return _wrap_diff_line(text, palette)
+            if stripped.startswith(("+++", "---")):
+                return _wrap_diff_line(text, palette)
+            from backend.core.ouroboros.ui import deck_grammar as _deck
+            width = None
+            try:
+                import shutil
+                width = shutil.get_terminal_size((100, 30)).columns
+            except Exception:  # noqa: BLE001
+                width = None
+            if stripped.startswith("+"):
+                lineno = state["new"] or None
+                state["new"] += 1
+                return _deck.diff(lineno, "+", stripped[1:], path=path,
+                                  width=width)
+            if stripped.startswith("-"):
+                lineno = state["old"] or None
+                state["old"] += 1
+                return _deck.diff(lineno, "-", stripped[1:], path=path,
+                                  width=width)
+            # Context: advances BOTH sides, and is shown against the new file
+            # because that is the one the operator is about to be living with.
+            lineno = state["new"] or None
+            if state["new"]:
+                state["new"] += 1
+            if state["old"]:
+                state["old"] += 1
+            body = stripped[1:] if stripped.startswith(" ") else stripped
+            return _deck.diff(lineno, " ", body, path=path, width=width)
+        except Exception:  # noqa: BLE001
+            # The previous rendering is a perfectly good fallback; losing the diff
+            # to a styling failure is not.
+            return _wrap_diff_line(str(line), palette)
+
+    return _wrap
+
+
 def _wrap_log_line(
     line: str, palette: Optional[Mapping[str, str]],
 ) -> str:
@@ -803,6 +905,12 @@ def compose(
         wrapper = _BODY_WRAPPERS.get(
             descriptor.body_shape, _wrap_text_line,
         )
+        # A diff body is the one shape whose styling needs CONTEXT — the file it
+        # belongs to and where its hunks start — and both are carried in the body
+        # itself. Built per compose, so the numbering cannot leak between blocks.
+        if wrapper is _wrap_diff_line:
+            wrapper = _diff_wrapper_for(rendered.body_lines,
+                                        fallback_path=str(args_str or "") or None)
     # ONE seam for the indent, not four wrappers each remembering to.
     #
     # Every body line lands in the deck's body column, so a pytest traceback

--- a/backend/core/ouroboros/cli/ov_demo.py
+++ b/backend/core/ouroboros/cli/ov_demo.py
@@ -633,34 +633,11 @@ _LIVE_BEATS: List[Any] = [
     (18.0, "tool", ("run_tests", "tests/governance/test_risk_tier_floor.py",
                     _PYTEST_PASS, "success", 3980)),
 
-    # The hunk, syntax-highlighted with a dark add/del band — the `Update(file)`
-    # block Claude Code draws.
-    #
-    # Placed in the script's LARGEST empty window (13.8-15.2), and that is a
-    # measurement rather than a guess. A tool beat's body is dealt out over ~1.5s,
-    # so the first version — at 7.9, beside the `edit_file` beat at 7.2 — landed
-    # INSIDE that spread and the operator saw two renderings of one hunk
-    # alternating line by line. Moving it to 19.0 hit `run_tests`' body for the
-    # same reason. The gap is found by sorting the composed timestamps, so a beat
-    # added later cannot silently reintroduce the overlap without the window
-    # shrinking visibly.
-    #
-    # The 4th beat arg is the PATH, which is what lets the language be inferred.
-    #
-    # Long term this belongs INSIDE `tool_render_view`, so every tool round is
-    # highlighted rather than this one scripted block — see the note in the PR.
-    (13.9, "act", ("Update", "risk_tier_floor.py", "ok")),
-    (14.0, "det", ("+4 −2 · reviewed before the gate",)),
-    (14.1, "diff", (410, " ", "    try:", _EDIT_PATH)),
-    (14.2, "diff", (411, " ", "        return _resolve_floor(raw)", _EDIT_PATH)),
-    (14.3, "diff", (412, "-", "    except Exception:  # noqa: BLE001",
-                    _EDIT_PATH)),
-    (14.4, "diff", (413, "-", "        return SAFE_AUTO", _EDIT_PATH)),
-    (14.5, "diff", (412, "+", "    except RiskFloorConfigError:", _EDIT_PATH)),
-    (14.6, "diff", (413, "+", "        # A malformed floor must not degrade "
-                              "quietly", _EDIT_PATH)),
-    (14.7, "diff", (414, "+", "        raise", _EDIT_PATH)),
-
+    # NO scripted Update block. The `edit_file` tool beat at 7.2 now renders its
+    # hunk through `deck_grammar.diff` (see `tool_render_view._diff_wrapper_for`),
+    # so the gutter, the syntax and the dark band arrive on EVERY tool round rather
+    # than on one hand-built block beside them. Keeping this would narrate the same
+    # edit twice in two places — which is what the operator saw.
     (20.4, "act", ("Gate", "7759-86 · NOTIFY_APPLY")),
     # What the gate's own preview shows: which file in this change reaches
     # furthest. Rendered by the REAL gutter — see `_reach_beats`.

--- a/tests/ui/test_deck_diff_highlighting.py
+++ b/tests/ui/test_deck_diff_highlighting.py
@@ -127,21 +127,66 @@ class TestItNeverBreaksTheDeck:
 
 
 class TestTheDemoShowsIt:
-    def test_the_script_carries_a_banded_update_block(self):
+    """The demo's hunk is highlighted by the TOOL RENDERER, not by a scripted beat.
+
+    It used to be both, and that was the defect the operator photographed: the
+    `edit_file` tool block rendered a flat red/green wall while a hand-built
+    `Update` beat rendered the same change with a gutter, syntax and a band — two
+    visual languages for one fact. Routing `tool_render_view`'s diff bodies through
+    `deck_grammar.diff` made the scripted block redundant, so it is gone.
+
+    These assert the ROUTE as well as the result: a future change that re-adds a
+    parallel scripted block should fail here rather than quietly reintroduce two
+    styles.
+    """
+
+    def test_the_composed_script_carries_a_banded_hunk(self):
         from backend.core.ouroboros.cli import ov_demo as d
-        script = d.compose_live_script()
         from backend.core.ouroboros.ui.semantic_tokens import role_palette
         palette = role_palette()
         marks = (f"on {palette['code_add_bg']}", f"on {palette['code_del_bg']}")
-        banded = [l for _at, l in script
+        banded = [l for _at, l in d.compose_live_script()
                   if isinstance(l, str) and any(m in l for m in marks)]
-        assert banded, "ov demo live shows no syntax-highlighted hunk"
+        assert banded, "ov demo live shows no banded hunk"
         assert any("bright_blue" in l or "blue" in l for l in banded), (
-            "the demo's hunk has a band but no syntax colour")
+            "the hunk has a band but no syntax colour")
 
-    def test_the_hunk_beats_name_a_path(self):
-        """The 4th beat arg is what lets the language be inferred."""
+    def test_the_highlighting_comes_from_the_tool_renderer(self):
+        """Not from a scripted `diff` beat. The whole point of the change is that
+        EVERY tool round is highlighted, not one curated block."""
         from backend.core.ouroboros.cli import ov_demo as d
-        hunks = [args for _at, kind, args in d._LIVE_BEATS if kind == "diff"]
-        assert hunks, "no diff beats in the script"
-        assert all(len(a) > 3 and str(a[3]).endswith(".py") for a in hunks)
+        assert not [a for _at, kind, a in d._LIVE_BEATS if kind == "diff"], (
+            "a scripted diff beat is back — the tool renderer already highlights, "
+            "so this would narrate the same edit twice")
+        assert any(kind == "tool" and args and args[0] == "edit_file"
+                   for _at, kind, args in d._LIVE_BEATS), (
+            "no edit_file beat left to carry the hunk")
+
+    def test_the_tool_wrapper_infers_path_and_numbers_from_the_diff(self):
+        """No parameter threading: a unified diff carries `+++ b/path` and `@@`,
+        so the styler derives both from the body it is given."""
+        from backend.core.ouroboros.battle_test.tool_render_view import (
+            _diff_wrapper_for,
+        )
+        wrap = _diff_wrapper_for([
+            "--- a/x/risk_tier_floor.py", "+++ b/x/risk_tier_floor.py",
+            "@@ -410,7 +410,22 @@", "     try:", "+        raise",
+        ])
+        wrap("--- a/x/risk_tier_floor.py", None)
+        wrap("+++ b/x/risk_tier_floor.py", None)
+        wrap("@@ -410,7 +410,22 @@", None)
+        ctx = wrap("     try:", None)
+        added = wrap("+        raise", None)
+        assert "410" in ctx, "the hunk origin was not read from @@"
+        assert "bright_blue" in added or "blue" in added, (
+            "the path was not read from +++, so no language was inferred")
+
+    def test_a_body_without_a_diff_header_degrades_in_place(self):
+        """A `git log` or a truncated fragment has no `@@` and no `+++`. It must
+        land on the previous flat rendering, not on an error."""
+        from backend.core.ouroboros.battle_test.tool_render_view import (
+            _diff_wrapper_for,
+        )
+        wrap = _diff_wrapper_for(["some log output", "more output"])
+        assert wrap("some log output", None) is not None
+        assert wrap("+ not really a diff", None) is not None


### PR DESCRIPTION
## Two visual languages for one fact

From your screenshots: the `edit_file` block rendered a **flat red/green wall** with no gutter and no syntax, while a hand-built `Update` beat rendered the **same change** with numbers, highlighting and a dark band.

#70292's own source comment had already named the cause — the highlighting went into `deck_grammar.diff`, which only the scripted beat used.

## The renderer, not a beat beside it

`tool_render_view._wrap_diff_line` coloured by prefix and nothing else. It now routes through `deck_grammar.diff`, so the gutter, inferred language and add/del band arrive on **every tool round**.

That needs context a per-line wrapper doesn't have — and the diff already carries it:

```
+++ b/backend/.../risk_tier_floor.py     the path, so the lexer
@@ -410,7 +410,22 @@                     the numbering origin
```

`_diff_wrapper_for` walks the body once, derives both, and returns a closure with the same `(line, palette)` signature every other wrapper has. **No new parameter, no caller changes, nothing hardcoded** — a `.toml` diff highlights as toml because the diff says so.

Numbering follows the two files **separately**: a removed line belongs to the old side, a context or added line to the new. Conflating them makes the gutter confidently wrong, which is worse than absent.

## The header is stripped before a wrapper sees it

Found by running it: the density policy elides the `---`/`+++` pair as noise — correctly, since it duplicates the block's own `Update(path)` title — so the path scan came back empty and every line rendered **banded but unhighlighted**.

The tool's **argument** is the fallback, and for `edit_file` that argument *is* the file. Header first, argument second: a diff carrying its own path should win, because a multi-file patch's argument names only one of them.

## The duplicate is gone, not silenced

With the tool block highlighted, the scripted `Update` beat became redundant — removed, which also removes the *"same edit narrated twice"* you saw. Two tests asserted those beats existed; they now assert the **route** (no scripted diff beat, and an `edit_file` beat still present to carry the hunk), so a future change that re-adds a parallel block fails rather than quietly reintroducing two styles.

## Also: `DiffOutcome.PENDING`

The overlay header printed `apply DiffOutcome.PENDING · verify VerifyOutcome.PENDING` — `str()` on an enum **member** yields the Python identity, not the fact. `_outcome_text` prefers `.value` (both are `(str, Enum)` and their values *are* the operator-facing vocabulary) and falls back to `str()` so a plain string still renders rather than blanking the field.

Degrades in place: no `@@` → no numbers; no path → no highlighting; a styling failure → the previous flat line. Each lands where the old rendering was, not on an error.

6 tests rewritten or added; **179 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make diff rendering consistent across all tool rounds with a single guttered, syntax‑highlighted style, and remove the duplicate scripted diff in the demo. Also show user‑friendly status text in the overlay header.

- **Bug Fixes**
  - Route tool diff bodies through `deck_grammar.diff` via `_diff_wrapper_for`, so every `edit_file` shows gutter, syntax, and add/del band.
  - `_diff_wrapper_for` infers the file from `+++` (falls back to the tool argument), reads hunk origins from `@@`, keeps old/new line numbers separately, and degrades to the previous flat rendering if headers are missing or styling fails.
  - Remove scripted `Update`/`diff` beats from `ov_demo`; the `edit_file` beat now carries the hunk. Tests assert no scripted diff and that the tool beat remains.
  - Use `_outcome_text` in the overlay to render enum `.value` (e.g., `pending`), with a safe fallback for non‑enums.

<sup>Written for commit dbe5fa4b64528b7ec0e3f53244aec323afdddf54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

