### PR TITLE
fix(battle_test): the notebook lands in its own session, atomically, and says so when it fails

### DIFF
--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -650,6 +650,44 @@ def _accepts_session(fn) -> bool:
         return False
 
 
+def _write_notebook_fault(session_dir: Any, exc: BaseException) -> bool:
+    """Record why the notebook is missing, in the session it is missing from.
+
+    NEVER raises: a tombstone that can take down the shutdown sequence is strictly
+    worse than no tombstone. Every failure mode here (an unwritable directory, a
+    disk that just filled, an interpreter mid-teardown) ends in a silent False.
+
+    Written with `os.replace` for the same reason the notebook is: teardown is
+    exactly when a write gets interrupted, and a truncated traceback reads as a
+    different bug than the one that actually happened.
+    """
+    try:
+        import os
+        import traceback
+        from datetime import datetime, timezone
+        from pathlib import Path
+
+        directory = Path(session_dir)
+        if not directory.is_dir():
+            return False
+        target = directory / ".notebook_fault.log"
+        tmp = directory / ".notebook_fault.log.tmp"
+        stamp = datetime.now(timezone.utc).isoformat()
+        body = (
+            f"notebook generation failed at {stamp}\n"
+            f"{type(exc).__name__}: {exc}\n\n"
+            + "".join(traceback.format_exception(type(exc), exc,
+                                                 exc.__traceback__))
+        )
+        with open(tmp, "w", encoding="utf-8") as fh:
+            fh.write(body)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp, target)
+        return True
+    except Exception:  # noqa: BLE001
+        return False
+
 class BattleTestHarness:
     """Orchestrates the full Ouroboros boot, event-driven session loop, and shutdown.
 
@@ -9760,16 +9798,39 @@ class BattleTestHarness:
                 logger.debug("[Harness] drift line render failed: %s", exc)
 
         # --- Notebook ---
+        #
+        # Written into THE SESSION DIRECTORY, beside the `summary.json` it is
+        # derived from. It used to go to a shared `notebooks/` with the fixed name
+        # `report.ipynb`, so every session overwrote the last: 764 sessions with a
+        # summary produced exactly ONE notebook, and that one was ten weeks stale
+        # because the failure below was swallowed. Session output belongs in the
+        # session's own directory; a timestamped filename in a global folder would
+        # be a workaround for the same mistake.
         try:
             from backend.core.ouroboros.battle_test.notebook_generator import NotebookGenerator
 
             summary_json_path = self._session_dir / "summary.json"
             if summary_json_path.exists():
                 nb_gen = NotebookGenerator(summary_path=summary_json_path)
-                nb_path = nb_gen.generate(output_dir=self._notebook_output_dir)
+                # The SAME `_session_dir` that resolved `summary.json` above —
+                # one path authority, not a second one to drift from it.
+                nb_path = nb_gen.generate(output_dir=self._session_dir)
                 logger.info("Notebook generated at %s", nb_path)
         except Exception as exc:
+            # A TOMBSTONE, not just a log line.
+            #
+            # This runs during teardown, when the prompt_toolkit UI may already be
+            # unmounted, so there is no reliable surface to show a panic on. A
+            # `logger.warning` alone is what let this fail silently for ten weeks —
+            # nobody reads a warning from a shutdown hook. The traceback goes into
+            # the session directory instead, next to the artifact that is missing,
+            # so the evidence is found by whoever goes looking for the notebook.
+            #
+            # Deliberately NOT re-raised: the notebook is a report, and losing the
+            # rest of the shutdown sequence (the summary write, the worktree reap)
+            # to a reporting failure would trade a nuisance for real damage.
             logger.warning("Notebook generation failed: %s", exc)
+            _write_notebook_fault(self._session_dir, exc)
 
         # --- Clear session id (Increment 3) ---
         # Release the strategic_direction module global so that a subsequent

--- a/backend/core/ouroboros/battle_test/notebook_generator.py
+++ b/backend/core/ouroboros/battle_test/notebook_generator.py
@@ -19,6 +19,62 @@ from typing import Any, Dict, List, Optional
 logger = logging.getLogger(__name__)
 
 
+def _atomic_write(path: "Path", render: "Callable[[Path], None]") -> "Path":
+    """Write via a temp sibling, fsync, then `os.replace`. NEVER leaves a partial.
+
+    This runs during SHUTDOWN, which is exactly when the process is least likely to
+    be allowed to finish: a SIGTERM from the harness's own deadline, a preemption on
+    a volatile cloud node, an operator's second Ctrl-C. A plain write interrupted
+    mid-stream leaves a truncated `.ipynb` — and a corrupt notebook is worse than an
+    absent one, because it looks like an artifact and fails only when someone tries
+    to open it months later.
+
+    Three steps, none of them optional:
+
+      * a TEMP SIBLING in the same directory, so the final `replace` is a rename
+        within one filesystem and therefore atomic. A temp file in `/tmp` would make
+        it a cross-device copy, which is not.
+      * `flush()` then `os.fsync()`, because a rename can otherwise be committed
+        while the DATA is still in the page cache — the metadata lands, the bytes do
+        not, and the file reads as zeros after a hard kill.
+      * `os.replace()`, which is atomic on POSIX and Windows alike: a reader either
+        sees the old file or the complete new one, never a half-written notebook.
+
+    The temp file is removed on ANY failure, so a crashed run does not leave
+    `.report.ipynb.tmp` litter behind for the next session to wonder about.
+    """
+    import os
+
+    path = Path(path)
+    tmp = path.with_name(f".{path.name}.tmp")
+    try:
+        render(tmp)
+        # `render` closed its own handle; reopen to force the bytes to disk. The
+        # fsync has to happen on the DATA file, before the rename, or the ordering
+        # guarantee this whole function exists for is not there.
+        with open(tmp, "rb+") as fh:
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp, path)
+        return path
+    except BaseException:
+        # BaseException, not Exception, and that distinction is the whole point.
+        # The interruption this function exists to survive is a SIGTERM or a
+        # Ctrl-C, which arrive as `KeyboardInterrupt` / `SystemExit` — neither of
+        # which is an `Exception`. Catching the narrower type left the half-written
+        # `.report.ipynb.tmp` on disk in precisely the scenario the atomicity was
+        # for, and a test that simulated a mid-write SIGTERM is what found it.
+        #
+        # Re-raised unchanged below: this cleans up, it does not decide that a
+        # shutdown signal should be ignored.
+        try:
+            if tmp.exists():
+                tmp.unlink()
+        except Exception:  # noqa: BLE001
+            pass
+        raise
+
+
 class NotebookGenerator:
     """Generate a Jupyter notebook or Markdown report from a battle test summary.
 
@@ -288,7 +344,8 @@ class NotebookGenerator:
             "version": "3.9",
         }
 
-        nbformat.write(nb, str(output_path))
+        _atomic_write(output_path,
+                      lambda tmp: nbformat.write(nb, str(tmp)))
         logger.info("NotebookGenerator: notebook written to %s", output_path)
         return output_path.resolve()
 
@@ -445,6 +502,9 @@ class NotebookGenerator:
             "",
         ]
 
-        output_path.write_text("\n".join(lines))
+        _atomic_write(
+            output_path,
+            lambda tmp: tmp.write_text("\n".join(lines)),
+        )
         logger.info("NotebookGenerator: markdown report written to %s", output_path)
         return output_path.resolve()

--- a/tests/battle_test/test_notebook_session_isolation.py
+++ b/tests/battle_test/test_notebook_session_isolation.py
@@ -1,0 +1,161 @@
+"""764 sessions with a summary produced exactly ONE notebook, ten weeks stale.
+
+Two defects stacked, and neither was visible:
+
+  * `report.ipynb` was written to a shared `notebooks/` directory under a FIXED
+    name, so every session overwrote the previous one.
+  * the failure was swallowed by a bare `except` on the shutdown hook, so the
+    overwriting stopped working entirely and nobody heard about it.
+
+A report is worth little; evidence that it is missing is worth a lot. These hold
+both halves.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+def _summary(tmp_path: Path) -> Path:
+    path = tmp_path / "summary.json"
+    path.write_text(json.dumps({
+        "session_id": "bt-test", "schema_version": 2,
+        "session_outcome": "complete", "ops": [],
+    }))
+    return path
+
+
+class TestSessionIsolation:
+    def test_the_notebook_lands_in_the_session_directory(self, tmp_path):
+        """Beside the `summary.json` it is derived from. A global folder is what
+        let 764 sessions collapse into one file."""
+        from backend.core.ouroboros.battle_test.notebook_generator import (
+            NotebookGenerator,
+        )
+        out = NotebookGenerator(summary_path=_summary(tmp_path)).generate(
+            output_dir=tmp_path)
+        assert Path(out).parent == tmp_path
+        assert Path(out).exists()
+
+    def test_two_sessions_do_not_overwrite_each_other(self, tmp_path):
+        """The actual data loss, reproduced: same filename, different sessions."""
+        from backend.core.ouroboros.battle_test.notebook_generator import (
+            NotebookGenerator,
+        )
+        first, second = tmp_path / "s1", tmp_path / "s2"
+        for d in (first, second):
+            d.mkdir()
+        a = NotebookGenerator(summary_path=_summary(first)).generate(
+            output_dir=first)
+        b = NotebookGenerator(summary_path=_summary(second)).generate(
+            output_dir=second)
+        assert Path(a) != Path(b)
+        assert Path(a).exists() and Path(b).exists()
+
+    def test_the_harness_passes_its_own_session_dir(self):
+        """Structural, by AST: the comments here name `notebooks/` in prose to
+        explain what was wrong, so a substring search matches the explanation."""
+        import ast
+        import inspect
+
+        from backend.core.ouroboros.battle_test import harness as h
+
+        src = inspect.getsource(h)
+        tree = ast.parse(src)
+        calls = [
+            n for n in ast.walk(tree)
+            if isinstance(n, ast.Call)
+            and getattr(n.func, "attr", "") == "generate"
+        ]
+        assert calls, "the harness no longer generates a notebook"
+        for call in calls:
+            for kw in call.keywords:
+                if kw.arg == "output_dir":
+                    assert "_session_dir" in ast.dump(kw.value), (
+                        "the notebook is being written outside the session "
+                        "directory again")
+
+
+class TestAtomicWrites:
+    def test_a_completed_write_leaves_no_temp_file(self, tmp_path):
+        from backend.core.ouroboros.battle_test.notebook_generator import (
+            _atomic_write,
+        )
+        _atomic_write(tmp_path / "report.ipynb",
+                      lambda tmp: tmp.write_text("{}"))
+        assert not list(tmp_path.glob(".*tmp")), "temp litter left behind"
+
+    def test_an_interrupted_write_leaves_NO_partial_artifact(self, tmp_path):
+        """A truncated `.ipynb` is worse than an absent one: it looks like an
+        artifact and fails only when someone opens it months later."""
+        from backend.core.ouroboros.battle_test.notebook_generator import (
+            _atomic_write,
+        )
+        target = tmp_path / "report.ipynb"
+
+        def _die(tmp: Path) -> None:
+            tmp.write_text('{"cells": [')      # a half-written notebook
+            raise KeyboardInterrupt("SIGTERM mid-write")
+
+        with pytest.raises(KeyboardInterrupt):
+            _atomic_write(target, _die)
+        assert not target.exists(), "a partial notebook was committed"
+        assert not list(tmp_path.glob(".*tmp"))
+
+    def test_an_existing_notebook_survives_a_failed_rewrite(self, tmp_path):
+        """`os.replace` is atomic: a reader sees the OLD file or the complete new
+        one, never a half-written one."""
+        from backend.core.ouroboros.battle_test.notebook_generator import (
+            _atomic_write,
+        )
+        target = tmp_path / "report.ipynb"
+        target.write_text("ORIGINAL")
+        with pytest.raises(RuntimeError):
+            _atomic_write(target,
+                          lambda tmp: (_ for _ in ()).throw(RuntimeError("x")))
+        assert target.read_text() == "ORIGINAL"
+
+
+class TestTheFaultTombstone:
+    def test_a_failure_writes_a_tombstone_in_that_session(self, tmp_path):
+        """Teardown may have unmounted the UI, so there is no reliable surface for
+        a panic. The traceback goes next to the artifact that is missing."""
+        from backend.core.ouroboros.battle_test.harness import (
+            _write_notebook_fault,
+        )
+        try:
+            raise RuntimeError("no space left on device")
+        except RuntimeError as exc:
+            assert _write_notebook_fault(tmp_path, exc) is True
+        tomb = tmp_path / ".notebook_fault.log"
+        assert tomb.exists()
+        body = tomb.read_text()
+        assert "no space left on device" in body
+        assert "RuntimeError" in body and "Traceback" in body
+
+    def test_the_tombstone_never_raises_into_the_shutdown_sequence(self):
+        """A tombstone that can take down teardown is worse than no tombstone."""
+        from backend.core.ouroboros.battle_test.harness import (
+            _write_notebook_fault,
+        )
+        assert _write_notebook_fault(Path("/definitely/not/here"),
+                                     RuntimeError("x")) is False
+        assert _write_notebook_fault(None, RuntimeError("x")) is False
+
+    def test_the_harness_no_longer_swallows_the_failure_silently(self):
+        """The bare `except` logged a warning nobody reads from a shutdown hook —
+        which is precisely how ten weeks passed. It must now leave an artifact."""
+        import ast
+        import inspect
+
+        from backend.core.ouroboros.battle_test import harness as h
+
+        src = inspect.getsource(h)
+        idx = src.find("Notebook generation failed")
+        assert idx != -1, "the notebook failure handler is gone"
+        window = src[idx:idx + 400]
+        assert "_write_notebook_fault" in window, (
+            "the failure is logged but leaves no tombstone — the exact silence "
+            "this fix exists to end")


### PR DESCRIPTION
## 764 sessions wrote a `summary.json`. There is **one** notebook, and it is ten weeks stale.

Two defects stacked, neither visible from inside the system.

## Session isolation, not a unique filename

`generate(output_dir=self._notebook_output_dir)` wrote `report.ipynb` into a shared `notebooks/` directory under a **fixed name**, so every session overwrote the previous one. It now goes to `self._session_dir` — the **same attribute** that resolved `summary.json` two lines above, so there is one path authority rather than a second to drift from it.

A timestamped filename in a global folder is a workaround for the same mistake: session output belongs in the session's directory, where `summary.json` and `debug.log` already live and where anyone investigating a run is already looking.

## Atomic, because this runs at teardown

Shutdown is exactly when a process is least likely to be allowed to finish — the harness's wall-clock deadline, a preemption, a second Ctrl-C. A truncated `.ipynb` is **worse than an absent one**: it looks like an artifact and fails only when someone opens it months later.

`_atomic_write` does three things, none optional:

- a **temp sibling** in the same directory, so the commit is a same-filesystem rename and therefore atomic (a temp in `/tmp` would make it a cross-device copy)
- `flush()` then `os.fsync()` on the **data file before the rename**, or the metadata lands while the bytes are still in the page cache and the file reads as zeros after a hard kill
- `os.replace()` — atomic on POSIX and Windows, so a reader sees the old file or the complete new one

Both write sites go through it — the `nbformat` path **and** the Markdown fallback.

## A bug the test found, in the fix itself

Cleanup was `except Exception`, and `KeyboardInterrupt` is a `BaseException`. So a simulated SIGTERM mid-write left `.report.ipynb.tmp` on disk in **precisely the scenario the atomicity exists for**. Now `except BaseException`, re-raised unchanged: this cleans up, it does not decide a shutdown signal should be ignored.

## A tombstone, because a log line *was* the silence

The bare `except` logged a warning and moved on. Nobody reads a warning from a shutdown hook — which is how ten weeks passed with no notebook and no complaint.

`_write_notebook_fault` writes the serialized traceback to `.notebook_fault.log` **in that session's directory**, next to the artifact that is missing. Same fsync-and-replace discipline, because a truncated traceback reads as a different bug than the one that happened.

Deliberately **not** re-raised: the notebook is a report, and losing the rest of shutdown — the summary write, the worktree reap — to a reporting failure trades a nuisance for real damage. The tombstone writer itself never raises; one that can take down teardown is worse than none.

## Tests — 9 new

Session isolation · two sessions not overwriting each other · an **AST pin** that the harness passes its own `_session_dir` · an interrupted write leaving no partial · an existing notebook surviving a failed rewrite · the tombstone carrying its traceback · a structural pin that the failure path can no longer be silent.

34 green with the existing generator and partial-shutdown suites.

**Not touched:** the 764 existing session directories. This stops the loss; it cannot recover what the overwrites already took.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Writes the battle test notebook to each session’s directory and saves it atomically; on failure, leaves a tombstone file so the issue is discoverable.

- **Bug Fixes**
  - Write `report.ipynb` to `_session_dir` instead of a shared `notebooks/` folder to stop cross-session overwrites.
  - Add `_atomic_write` (temp sibling + `fsync` + `os.replace`) and use it for both nbformat and Markdown outputs to prevent partial files during teardown; cleanup now catches `BaseException`.
  - On generation failure, write `.notebook_fault.log` in the session directory and keep shutdown moving; the harness no longer swallows the error silently.

<sup>Written for commit 90e76282a4666cfa376f1de00a2211c3c2ace333. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

