### PR TITLE
fix(ov): one width authority, and a hunk header that stops shouting

### DIFF
--- a/backend/core/ouroboros/battle_test/diff_overlay.py
+++ b/backend/core/ouroboros/battle_test/diff_overlay.py
@@ -241,10 +241,17 @@ def _terminal_width(fallback: int = 100) -> int:
     """Resolved per call — a diff wrapped to a stale width is clipped, not
     reflowed, because the canvas draws with ``wrap_lines=False``."""
     try:
-        import shutil
-        return max(40, int(shutil.get_terminal_size((fallback, 30)).columns))
+        # The SAME resolver the inline tool path uses. Two functions answering
+        # "how wide is the deck" is what banded one hunk to two different right
+        # edges, and it also meant a SIGWINCH moved one surface and not the other.
+        from backend.core.ouroboros.ui.deck_grammar import resolve_deck_width
+        return max(40, int(resolve_deck_width()))
     except Exception:  # noqa: BLE001
-        return fallback
+        try:
+            import shutil
+            return max(40, int(shutil.get_terminal_size((fallback, 30)).columns))
+        except Exception:  # noqa: BLE001
+            return fallback
 
 
 class DiffOverlayController:

--- a/backend/core/ouroboros/battle_test/tool_render_view.py
+++ b/backend/core/ouroboros/battle_test/tool_render_view.py
@@ -484,12 +484,11 @@ def _diff_wrapper_for(body_lines: Any,
             if stripped.startswith(("+++", "---")):
                 return _wrap_diff_line(text, palette)
             from backend.core.ouroboros.ui import deck_grammar as _deck
+            # None, deliberately: `deck.diff` asks `resolve_deck_width` itself, and
+            # that is the ONE authority both diff surfaces now use. Resolving a
+            # width here was the second opinion that gave the same hunk two right
+            # edges depending on which path drew it.
             width = None
-            try:
-                import shutil
-                width = shutil.get_terminal_size((100, 30)).columns
-            except Exception:  # noqa: BLE001
-                width = None
             if stripped.startswith("+"):
                 lineno = state["new"] or None
                 state["new"] += 1

--- a/backend/core/ouroboros/ui/deck_grammar.py
+++ b/backend/core/ouroboros/ui/deck_grammar.py
@@ -61,6 +61,9 @@ DETAIL_COLUMN: int = 5
 
 #: Width of the diff line-number gutter. Right-aligned, so the numbers form a
 #: column instead of drifting as the file passes 999 lines.
+#: A band narrower than this is not a band — a floor, not a guess.
+_MIN_DECK_WIDTH = 20
+
 GUTTER_WIDTH: int = 4
 
 
@@ -185,6 +188,66 @@ def voice(text: str) -> str:
     except Exception:  # noqa: BLE001
         return f"  {text}"
 
+
+
+
+def resolve_deck_width(explicit: Optional[int] = None) -> int:
+    """The column count a deck surface should fill RIGHT NOW. NEVER raises.
+
+    ONE answer for both diff surfaces. The inline tool renderer resolved its own
+    width from `shutil` while the overlay used a Console sized somewhere else, so
+    the same hunk banded to two different right edges depending on which path drew
+    it — the jagged edge was two functions disagreeing, not a padding bug.
+
+    Resolved PER CALL, never captured. A band whose width was measured once is
+    correct until the first SIGWINCH and then either falls short of the new edge or
+    overruns it and wraps — and the canvas draws with ``wrap_lines=False``, so an
+    overrun is clipped rather than reflowed. Asking every time is what makes the
+    band stretch and shrink elastically instead of shattering.
+
+    Prefers the LIVE prompt_toolkit application when one is mounted, because that is
+    the surface actually being drawn into and it knows about a resize before the
+    process environment does. Falls back to the terminal, then to a floor that keeps
+    a band visible rather than collapsing it to nothing.
+    """
+    try:
+        if explicit and int(explicit) > 0:
+            return max(_MIN_DECK_WIDTH, int(explicit))
+    except (TypeError, ValueError):
+        pass
+    try:
+        from prompt_toolkit.application.current import get_app_or_none
+        app = get_app_or_none()
+        if app is not None and app.output is not None:
+            columns = int(app.output.get_size().columns)
+            if columns > 0:
+                return max(_MIN_DECK_WIDTH, columns)
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        import shutil
+        return max(_MIN_DECK_WIDTH,
+                   int(shutil.get_terminal_size((100, 30)).columns))
+    except Exception:  # noqa: BLE001
+        return 100
+
+
+def band_fill(visible_len: int, width: Optional[int] = None,
+              *, indent: int = 0) -> int:
+    """Columns of background needed to carry a band to the right edge.
+
+    Takes the VISIBLE length — the plain text — never the markup string. Style tags
+    occupy no columns, so measuring markup over-pads by however many tags the
+    highlighter happened to emit, and a long line then wraps.
+
+    Clamped at zero: a line already wider than the terminal needs no fill, and a
+    negative repeat count would raise inside a render.
+    """
+    try:
+        total = resolve_deck_width(width)
+        return max(0, total - int(indent) - int(visible_len))
+    except Exception:  # noqa: BLE001
+        return 0
 
 
 def _legible_over_band(style: str, banded: bool) -> str:
@@ -349,10 +412,16 @@ def diff(lineno: Optional[int], sign: str, code: str,
         # markup carries style tags that occupy no columns, so measuring it would
         # over-pad by however many tags the highlighter happened to emit.
         pad = ""
-        if width:
-            visible = len(code) + 2          # the code plus "<sign> "
-            room = max(0, int(width) - DETAIL_COLUMN - GUTTER_WIDTH - 1 - visible)
-            if room and bg:
+        if bg:
+            # ONE padding authority, shared with the overlay. `band_fill` resolves
+            # the width per call, so a SIGWINCH between frames stretches or shrinks
+            # the band instead of leaving it at yesterday's edge.
+            room = band_fill(
+                len(code) + 2,               # the code plus "<sign> "
+                width,
+                indent=DETAIL_COLUMN + GUTTER_WIDTH + 1,
+            )
+            if room:
                 pad = _tint(" " * room, bg)
         sign_mark = _tint(f"{sign} ", bg) if bg else f"{sign} "
         return (" " * DETAIL_COLUMN

--- a/backend/core/ouroboros/ui/semantic_tokens.py
+++ b/backend/core/ouroboros/ui/semantic_tokens.py
@@ -74,7 +74,16 @@ _ROLE_TO_SEMANTIC: Dict[str, str] = {
     "heal": "warn",
     # thinking / structure
     "neural": "cyan",
-    "code_hunk": "cyan",
+    # Structural metadata RECEDES. A `@@ -410,7 +410,22 @@` header tells you where
+    # a hunk sits; it is not the change and must not compete with it for attention.
+    # It was `cyan` here and Pygments paints it magenta in the overlay — two loud
+    # colours for a coordinate. `structural_dim` is the role that says "this is
+    # scaffolding", so the code changes stay the focal point.
+    # Both point at the SEMANTIC, not at each other: `_ROLE_TO_SEMANTIC` is
+    # role -> semantic, and chaining `code_hunk -> structural_dim` made `style_for`
+    # resolve a role name it does not know and return "none" — an invisible header.
+    "code_hunk": "verbose",
+    "structural_dim": "verbose",
     # external brains
     "provider": "venom_purple",
     # goal lifecycle. Previously written as bare `blue` / `magenta` and

--- a/tests/ui/test_deck_diff_highlighting.py
+++ b/tests/ui/test_deck_diff_highlighting.py
@@ -90,12 +90,19 @@ class TestTheLexerIsInferredNeverDeclared:
 
 
 class TestTheBandIsSolid:
-    def test_width_pads_the_band_to_a_common_edge(self):
+    def test_a_wider_terminal_gives_a_wider_band(self):
         """Without padding an added block has a ragged right edge that stops at
-        each line's text instead of reading as one slab."""
-        narrow = dg.diff(1, "+", "raise", path=PATH)
-        padded = dg.diff(1, "+", "raise", path=PATH, width=90)
-        assert len(padded) > len(narrow)
+        each line's text instead of reading as one slab.
+
+        This used to compare "no width" against an explicit one, on the premise
+        that omitting the width meant no padding. That premise is gone by design:
+        `band_fill` RESOLVES a width when none is passed, so a band always reaches
+        the edge and the comparison has to be between two explicit widths. The old
+        form failed once the ambient terminal happened to be wider than the explicit
+        argument — a test measuring the wrong thing, passing by coincidence."""
+        narrow = dg.diff(1, "+", "raise", path=PATH, width=60)
+        wide = dg.diff(1, "+", "raise", path=PATH, width=110)
+        assert len(wide) > len(narrow)
 
     def test_padding_measures_the_CODE_not_the_markup(self):
         """Markup tags occupy no columns. Measuring the markup string would
@@ -257,3 +264,91 @@ class TestCommentsStayLegibleOnABand:
     def test_unbanded_styles_are_untouched(self):
         from backend.core.ouroboros.ui.deck_grammar import _legible_over_band
         assert _legible_over_band("dim italic", False) == "dim italic"
+
+
+class TestOneWidthAuthority:
+    """The jagged right edge was two functions disagreeing, not a padding bug.
+
+    The inline tool renderer resolved its own width from `shutil` while the overlay
+    used a Console sized somewhere else, so the same hunk banded to two different
+    edges depending on which path drew it — and a SIGWINCH moved one surface and not
+    the other.
+    """
+
+    def test_the_fill_scales_with_the_terminal(self):
+        """The mandated check: mocked 80 vs 120 columns must yield different fills,
+        and the difference must be exactly the column difference."""
+        from backend.core.ouroboros.ui.deck_grammar import band_fill
+        narrow = band_fill(30, 80, indent=12)
+        wide = band_fill(30, 120, indent=12)
+        assert wide > narrow
+        assert wide - narrow == 40, f"{wide} - {narrow} != 40"
+
+    def test_the_fill_is_never_negative(self):
+        """A line already wider than the terminal needs no fill, and a negative
+        repeat count would raise inside a render."""
+        from backend.core.ouroboros.ui.deck_grammar import band_fill
+        assert band_fill(500, 80, indent=12) == 0
+
+    def test_a_resize_between_calls_changes_the_answer(self):
+        """Resolved PER CALL, never captured. A band measured once is correct until
+        the first SIGWINCH and then clipped — the canvas draws with
+        `wrap_lines=False`, so an overrun is cut rather than reflowed."""
+        import shutil
+
+        from backend.core.ouroboros.ui import deck_grammar as dg
+        sizes = iter([shutil.os.terminal_size((120, 30)),
+                      shutil.os.terminal_size((80, 30))])
+        original = shutil.get_terminal_size
+        shutil.get_terminal_size = lambda *_a, **_k: next(sizes)
+        try:
+            first = dg.resolve_deck_width()
+            second = dg.resolve_deck_width()
+        finally:
+            shutil.get_terminal_size = original
+        assert (first, second) == (120, 80)
+
+    def test_a_degenerate_width_floors_rather_than_collapsing(self):
+        from backend.core.ouroboros.ui.deck_grammar import resolve_deck_width
+        assert resolve_deck_width(3) >= 20
+        assert resolve_deck_width(0) > 0
+
+    def test_both_surfaces_call_the_same_resolver(self):
+        """Structural, by AST — the comments name `shutil` in prose to explain what
+        was removed, so a substring search matches the explanation."""
+        import ast
+        import inspect
+
+        from backend.core.ouroboros.battle_test import diff_overlay as do
+        from backend.core.ouroboros.battle_test import tool_render_view as tv
+
+        for module, fn_name in ((do, "_terminal_width"),
+                                (tv, "_diff_wrapper_for")):
+            fn = getattr(module, fn_name)
+            names = {
+                n.name for node in ast.walk(ast.parse(
+                    inspect.getsource(fn).lstrip()))
+                if isinstance(node, ast.ImportFrom) for n in node.names
+            }
+            assert "resolve_deck_width" in names or "deck_grammar" in names, (
+                f"{fn_name} no longer routes through the shared width authority")
+
+
+class TestStructuralMetadataRecedes:
+    def test_the_hunk_header_is_subordinate(self):
+        """`@@ -410,7 +410,22 @@` tells you WHERE a hunk sits; it is not the change
+        and must not compete with it. It was cyan here and magenta in the overlay —
+        two loud colours for a coordinate."""
+        from backend.core.ouroboros.ui.semantic_tokens import role_palette
+        palette = role_palette()
+        assert palette["code_hunk"] == palette["structural_dim"]
+        assert palette["code_hunk"] not in ("cyan", "magenta")
+
+    def test_it_is_still_distinguishable_from_the_code(self):
+        """Subordinate, not invisible — a header the operator cannot find is a
+        different bug than one that shouts."""
+        from backend.core.ouroboros.ui.semantic_tokens import role_palette
+        palette = role_palette()
+        assert palette["code_hunk"]
+        assert palette["code_hunk"] not in ("none", "")
+        assert palette["code_hunk"] != palette["code_add"]


### PR DESCRIPTION
## Two visual defects, both structural rather than cosmetic

## The jagged edge was two functions disagreeing

The inline tool renderer resolved its own width from `shutil` while the overlay sized a Console somewhere else — so the **same hunk banded to two different right edges** depending on which path drew it, and a SIGWINCH moved one surface and not the other.

`resolve_deck_width` is now the single authority and both call it. It prefers the **live prompt_toolkit application** when one is mounted (that's the surface actually being drawn into, and it learns about a resize before the process environment does), falls back to the terminal, then to a floor that keeps a band visible rather than collapsing it.

**Resolved per call, never captured.** A band measured once is correct until the first resize and then either falls short of the new edge or overruns it — and the canvas draws with `wrap_lines=False`, so an overrun is **clipped, not reflowed**. Asking every time is what makes the band stretch and shrink elastically instead of shattering.

`band_fill` takes the **visible** length, never the markup string: style tags occupy no columns, so measuring markup over-pads by however many tags the highlighter emitted. Clamped at zero — a negative repeat count raises inside a render.

## Structural metadata recedes

`@@ -410,7 +410,22 @@` tells you *where* a hunk sits. It is not the change, and it was competing with it: `cyan` in the deck's palette and magenta from Pygments in the overlay — **two loud colours for a coordinate.**

`structural_dim` is the role that says "this is scaffolding," and `code_hunk` now resolves to the same semantic. **Subordinate, not invisible** — a header the operator cannot find is a different bug than one that shouts — and a test pins both ends.

## A mapping bug the palette caught

The first version mapped `code_hunk -> structural_dim`, chaining a role to another **role**. `_ROLE_TO_SEMANTIC` is role → semantic, so `style_for` resolved a name it didn't know and returned `"none"` — an *invisible* header instead of a subdued one. Both roles now point at the semantic directly.

## A test measuring the wrong thing

`test_width_pads_the_band_to_a_common_edge` compared "no width" against an explicit one, on the premise that omitting the width meant no padding. That premise is gone by design — `band_fill` **resolves** a width when none is passed — and the old form failed the moment the ambient terminal was wider than the explicit argument. **It had been passing by coincidence.** It now compares two explicit widths, which is the property it was always trying to assert.

## Tests — 7 new

The mandated **80-vs-120** check (fill difference must equal the column difference exactly) · a mocked **resize between successive calls** · an **AST pin** that both surfaces still route through the shared resolver · subordinate-but-not-invisible on the hunk role.

127 green across the highlighting, demo and overlay suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies deck width resolution across the overlay and inline tool to keep diff bands aligned and responsive to resize. Dims hunk headers so they’re clear but not loud, with tests that lock the behavior.

- **Bug Fixes**
  - One width authority for both diff surfaces; prefers live `prompt_toolkit` app size, falls back to `shutil`, then a safe minimum; resolved on each call for SIGWINCH-aware resizing.
  - Shared padding calculation uses visible text length (not markup) and clamps at zero to prevent over-padding and wrapping.
  - Removed duplicate width logic in the tool path; overlay width helper now defers to the shared resolver.
  - Hunk headers map directly to a subdued semantic, fixing the role-to-semantic bug that could make them invisible and aligning their style across views.

<sup>Written for commit c1f9b85693582b22fb616d17085fe9588e4533c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

