### PR TITLE
fix(ov): the demo obeys the width authority instead of holding five opinions

### DIFF
--- a/backend/core/ouroboros/cli/ov_demo.py
+++ b/backend/core/ouroboros/cli/ov_demo.py
@@ -260,17 +260,13 @@ def _compose(kind: str, args: Sequence[Any]) -> str:
             return deck.detail(args[0], tone=(args[1] if len(args) > 1
                                               else "muted"))
         if kind == "diff":
-            # `(lineno, sign, code)` positionally, plus the PATH the hunk belongs
-            # to so `deck.diff` can infer the language, and the terminal WIDTH so
-            # the add/del band reaches a common right edge instead of stopping at
-            # each line's text. Both keyword-only, so the three-tuple call shape
-            # every other beat uses is unchanged.
-            import shutil
-            return deck.diff(
-                *args[:3],
-                path=(args[3] if len(args) > 3 else None),
-                width=shutil.get_terminal_size((100, 30)).columns,
-            )
+            # Kept for the beat KIND, not for a caller: the script carries no
+            # `diff` beats since the tool renderer began highlighting its own
+            # hunks. It no longer resolves a width — `deck.diff` asks
+            # `resolve_deck_width`, the one authority both diff surfaces use, and
+            # a third opinion here is exactly what #70298 removed elsewhere.
+            return deck.diff(*args[:3],
+                             path=(args[3] if len(args) > 3 else None))
         if kind == "voice":
             return deck.voice(*args)
         if kind == "prov":
@@ -1341,6 +1337,30 @@ def _open_demo_diff() -> Optional[str]:
     return None
 
 
+
+def _deck_width() -> int:
+    """This frame's width, from the ONE authority. NEVER raises.
+
+    The strips used to call `shutil.get_terminal_size((80, 24))` each, three times,
+    with a fallback that disagreed with the deck's own (100x30) and with no
+    knowledge of the live prompt_toolkit application. So on a resize the queue, the
+    panic overlay and the in-flight strip could each be measuring a different
+    terminal than the diff bands beside them.
+
+    `resolve_deck_width` prefers the mounted application, which learns about a
+    SIGWINCH before the process environment does — the reason it exists.
+    """
+    try:
+        from backend.core.ouroboros.ui.deck_grammar import resolve_deck_width
+        return int(resolve_deck_width())
+    except Exception:  # noqa: BLE001
+        try:
+            import shutil
+            return int(shutil.get_terminal_size((100, 30)).columns)
+        except Exception:  # noqa: BLE001
+            return 100
+
+
 def _panic_rows(elapsed: float, width: int) -> List[str]:
     """The FATAL_PANIC overlay, through the REAL renderer. NEVER raises.
 
@@ -1398,8 +1418,10 @@ def _stream_rows(elapsed: float, mux: Any = None) -> List[str]:
         except Exception:  # noqa: BLE001
             width = None
         if not width:
-            import shutil
-            width = shutil.get_terminal_size((80, 24)).columns
+            # The mux's own width when it has one, else the shared authority —
+            # never a private `shutil` call with a fallback that disagrees with
+            # the deck's.
+            width = _deck_width()
         # A running command outranks model prose in the same strip: they
         # never overlap in a real op either, and the command is the thing
         # the operator cannot otherwise see.
@@ -1729,11 +1751,13 @@ def _demo_header() -> "tuple[Any, int, Any]":
 
         def _render() -> str:
             try:
-                import shutil
                 import time
-                width = shutil.get_terminal_size(fallback=(100, 30)).columns
+                # Same authority as every other surface: the masthead is seeded
+                # INTO the transcript, so it must wrap to the width the deck
+                # believes in, not to one it measured for itself.
                 return render_cockpit_header(
-                    mini, _header_lines(), width, now=time.monotonic(),
+                    mini, _header_lines(), _deck_width(),
+                    now=time.monotonic(),
                 )
             except Exception:  # noqa: BLE001
                 return ""
@@ -1960,11 +1984,11 @@ def scene_live(console: Any, argv: Sequence[str] = ()) -> int:
         # cockpit's own renderers.
         queue_rows=lambda: _queue_rows(
             (clock() - start[0]) * speed,
-            __import__("shutil").get_terminal_size((80, 24)).columns,
+            _deck_width(),
         ),
         panic_rows=lambda: _panic_rows(
             (clock() - start[0]) * speed,
-            __import__("shutil").get_terminal_size((80, 24)).columns,
+            _deck_width(),
         ),
         stream_rows=lambda: _stream_rows(
             (clock() - start[0]) * speed, mux,
@@ -1996,7 +2020,7 @@ def scene_live(console: Any, argv: Sequence[str] = ()) -> int:
         search_rows=_demo_search_rows(),
         pending_rows=lambda: _pending_rows(
             (clock() - start[0]) * speed,
-            __import__("shutil").get_terminal_size((80, 24)).columns,
+            _deck_width(),
         ),
     )
     try:


### PR DESCRIPTION
## Follow-up to #70298 — the demo was holding five width opinions of its own

#70298 made `resolve_deck_width` the one authority for how wide a deck surface is, preferring the **live prompt_toolkit application** because it learns about a SIGWINCH before the process environment does.

The demo wasn't consulted, and it had five independent answers:

| site | its own answer |
|---|---|
| `_compose("diff", …)` | a private `shutil` call — a **third** opinion, in exactly the place #70298 was consolidating |
| `_queue_rows` | `get_terminal_size((80, 24))` |
| `_panic_rows` | `get_terminal_size((80, 24))` |
| `_stream_rows` | `get_terminal_size((80, 24))` |
| masthead render | `get_terminal_size(fallback=(100, 30))` |

**Two different fallbacks**, none aware of the mounted application. So on a resize the queue strip, the crash overlay, the in-flight strip and the diff bands beside them could each be measuring a different terminal — the same divergence #70298 fixed between the tool path and the overlay, reproduced one layer up.

All five now route through `_deck_width`, a thin seam over `resolve_deck_width` that keeps a degraded fallback for when the authority itself can't answer. That fallback is the **only** `get_terminal_size` left in the module, and it's the resolver's own fallback rather than a rival to it.

## Dead code removed with it

The `diff` beat kind has carried no beats since #70294 gave the tool renderer its own highlighting, so `_compose`'s `diff` branch was unreachable — and it was the loudest of the five. The branch stays (the *kind* is still part of the grammar) but no longer resolves a width.

The **masthead** is the subtle one: it's seeded *into* the transcript, so it must wrap to the width the deck believes in rather than one it measured for itself — otherwise the emblem and the first event disagree about where the right edge is.

No behaviour added, no beat changed — **97 beats before and after.** 86 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies the demo to use a single width source so all surfaces stay aligned on resize. Replaces five conflicting terminal width checks with `_deck_width()` over `resolve_deck_width()`.

- Bug Fixes
  - Route queue, panic, stream, and masthead renders through `_deck_width()` (shared authority with safe fallback).
  - Remove local `shutil.get_terminal_size` calls and mixed fallbacks (80x24 vs 100x30).
  - Keep the `diff` beat kind but stop resolving width in `_compose`; `deck.diff` now queries the authority.

<sup>Written for commit 819020910408b062383113dda95d3955ced4bfab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

