### PR TITLE
feat(ov): Claude Code interactive-mode parity, Tiers 1-5

### DIFF
--- a/backend/core/ouroboros/battle_test/agent_roster.py
+++ b/backend/core/ouroboros/battle_test/agent_roster.py
@@ -72,6 +72,7 @@ from __future__ import annotations
 
 import logging
 import os
+import threading
 import time
 from typing import Any, Callable, Dict, List, Optional
 
@@ -80,6 +81,7 @@ logger = logging.getLogger("Ouroboros.AgentRoster")
 __all__ = [
     "ROSTER_SCHEMA_VERSION", "AgentEntry", "AgentRoster", "agent_view_enabled",
     "format_duration", "render_roster", "roster_hint",
+    "roster_visible", "set_roster_visible", "toggle_roster",
 ]
 
 #: Additive schema. A reader that does not know a field ignores it; a reader
@@ -110,6 +112,67 @@ def agent_view_enabled() -> bool:
     return os.environ.get(
         "JARVIS_AGENT_VIEW_ENABLED", "1",
     ).strip().lower() not in ("0", "false", "no", "off")
+
+
+#: Whether the roster OCCUPIES ROWS, as distinct from whether it EXISTS.
+#:
+#: Claude Code draws exactly this distinction and states it in its own docs:
+#: the `Ctrl+T` checklist "is separate from the background-task view. To see
+#: running shells and subagents, use `/tasks` instead." The checklist is
+#: ambient; the running-subagent view is asked for. Under fullscreen "the
+#: input box stays fixed at the bottom of the screen" — nothing standing sits
+#: beneath the caret.
+#:
+#: This cockpit had the roster mounted permanently below the prompt, so three
+#: workers and a sentinel cost five rows under the caret on an IDLE session,
+#: forever. `agent_view_enabled` could not fix that: it is the KILL SWITCH,
+#: and turning the feature off to reclaim the rows also throws away the
+#: snapshot, the bridge and `/tasks` itself. Visibility is the separate,
+#: cheaper question — the data keeps flowing either way.
+#:
+#: Process-local by design. Two cockpits attached to one daemon are two
+#: operators with two screens and two opinions about what is worth five rows;
+#: a shared flag would let one of them redraw the other's terminal.
+_VISIBLE: Optional[bool] = None
+_VISIBLE_LOCK = threading.Lock()
+
+
+def roster_visible() -> bool:
+    """Whether the roster may draw right now. NEVER raises.
+
+    Resolved from ``JARVIS_AGENT_VIEW_ROSTER_VISIBLE`` on first read (default
+    OFF) and thereafter from whatever `/tasks` last set, so the env var seeds
+    the session and the verb owns it. Lazy rather than at import: the flag is
+    read from a render path, and an import-time snapshot would miss an env
+    change made by a harness that imports this module before it configures.
+    """
+    global _VISIBLE
+    with _VISIBLE_LOCK:
+        if _VISIBLE is None:
+            _VISIBLE = os.environ.get(
+                "JARVIS_AGENT_VIEW_ROSTER_VISIBLE", "0",
+            ).strip().lower() in ("1", "true", "yes", "on")
+        return bool(_VISIBLE)
+
+
+def set_roster_visible(value: object) -> bool:
+    """Show or hide the roster; returns the new state. NEVER raises."""
+    global _VISIBLE
+    with _VISIBLE_LOCK:
+        _VISIBLE = bool(value)
+        return _VISIBLE
+
+
+def toggle_roster() -> bool:
+    """Flip visibility; returns the new state. NEVER raises."""
+    return set_roster_visible(not roster_visible())
+
+
+def reset_roster_visibility_for_tests() -> None:
+    """Drop back to the unresolved state so the next read re-reads the env."""
+    global _VISIBLE
+    with _VISIBLE_LOCK:
+        _VISIBLE = None
 
 
 def _stale_after_s() -> float:
@@ -735,6 +798,14 @@ def render_roster(
     beyond the budget are folded into the "… N more" count rather than
     silently dropped, because a roster that quietly shows six of forty is
     worse than one that says so.
+
+    This function does NOT consult :func:`roster_visible`, and that is a
+    decision rather than an omission. Visibility is a question about a
+    SURFACE — does this cockpit spend rows on the roster right now — and this
+    is the renderer, which answers "what does a roster look like". Gating
+    here made every caller that wanted the picture opt out of a mode question
+    it had not asked, `/tasks` included; the providers own the mode. See
+    :func:`roster_visible` for where the gate actually lives.
     """
     try:
         if not agent_view_enabled() or not isinstance(snapshot, dict):

--- a/backend/core/ouroboros/battle_test/attach_heartbeat.py
+++ b/backend/core/ouroboros/battle_test/attach_heartbeat.py
@@ -298,6 +298,28 @@ def build_heartbeat_payload() -> Optional[Dict[str, Any]]:
         except Exception:  # noqa: BLE001 — a rosterless heartbeat still beats
             agents = None
 
+        # The diff CATALOG — refs, file counts, summaries, risk tiers, and
+        # deliberately no diff text. Small enough to ride 1 Hz, and it is what
+        # makes two things on a remote overlay CORRECT rather than guessed:
+        # an unknown ref can list what IS available (the archive is a ring, so
+        # a ref read minutes ago may have been evicted), and the loading
+        # placeholder can name the real file count before the body arrives.
+        #
+        # The TEXT is fetched only when a diff is opened. Diffs are the one
+        # payload on this lane with no natural bound, and putting them here
+        # would ship megabytes per second to draw nothing.
+        try:
+            from backend.core.ouroboros.battle_test.diff_archive import (
+                get_default_archive,
+            )
+            from backend.core.ouroboros.battle_test.diff_bridge import (
+                build_diff_catalog, diff_bridge_enabled,
+            )
+            diffs = (build_diff_catalog(get_default_archive())
+                     if diff_bridge_enabled() else None)
+        except Exception:  # noqa: BLE001 — a catalogue-less heartbeat beats
+            diffs = None
+
         return {
             "kind": "heartbeat",
             "schema_version": HEARTBEAT_SCHEMA_VERSION,
@@ -306,6 +328,11 @@ def build_heartbeat_payload() -> Optional[Dict[str, Any]]:
             # heard of `agents` ignores the key, and a newer client that does
             # not receive one renders no roster. Neither is a version error.
             "agents": agents,
+            # Additive under heartbeat.v1, exactly as `agents` was: a client
+            # that has never heard of it ignores the key, and a daemon that
+            # sends none leaves the client with an empty catalog rather than
+            # a version error.
+            "diffs": diffs,
             "active": active,
             "verb": verb,
             "phase": phase,

--- a/backend/core/ouroboros/battle_test/bipartite_layout.py
+++ b/backend/core/ouroboros/battle_test/bipartite_layout.py
@@ -1474,6 +1474,33 @@ def build_bipartite_application(
         install_stash_binding(kb, lambda: prompt.buffer)
     except Exception:  # noqa: BLE001
         pass
+    # Ctrl+_ / Ctrl+Shift+- — undo the last input edit. CC binds `chat:undo`
+    # to exactly these, and prompt_toolkit already ships the command; it was
+    # simply never bound, so the prompt accepted paragraphs with no way back
+    # from a mis-typed `Ctrl+W` or `Ctrl+U`.
+    #
+    # Delegated to pt's own `undo` rather than tracking edits here: the buffer
+    # owns its undo stack, and a second history of the same text would
+    # disagree with it the first time a completion inserted anything.
+    try:
+        from backend.core.ouroboros.battle_test.keymap import bind_action
+        from prompt_toolkit.key_binding.bindings.named_commands import (
+            get_by_name,
+        )
+        _undo = get_by_name("undo")
+
+        def _do_undo(event: Any) -> None:
+            try:
+                _undo.handler(event)
+            except Exception:  # noqa: BLE001
+                pass
+
+        bind_action(
+            kb, "chat:undo", ("ctrl+_", "ctrl+shift+-"), _do_undo,
+            context="Chat", description="undo the last input edit",
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug("[Bipartite] undo binding unavailable", exc_info=True)
     # Ctrl+Z — suspend to the shell, `fg` to come back. CC binds it and this
     # cockpit did not, which is a gap the alternate screen CREATES rather than
     # inherits: a normal terminal turns Ctrl+Z into SIGTSTP itself, but a

--- a/backend/core/ouroboros/battle_test/bipartite_layout.py
+++ b/backend/core/ouroboros/battle_test/bipartite_layout.py
@@ -1429,6 +1429,38 @@ def build_bipartite_application(
         install_stash_binding(kb, lambda: prompt.buffer)
     except Exception:  # noqa: BLE001
         pass
+    # Ctrl+Z — suspend to the shell, `fg` to come back. CC binds it and this
+    # cockpit did not, which is a gap the alternate screen CREATES rather than
+    # inherits: a normal terminal turns Ctrl+Z into SIGTSTP itself, but a
+    # full-screen app holds the terminal in raw mode, so the keystroke arrives
+    # as an ordinary key and the shell never sees it. The operator's habit
+    # silently stopped working the day the cockpit went full-screen.
+    #
+    # `suspend_to_background` is prompt_toolkit's own: it leaves the alternate
+    # screen, restores cooked mode, raises SIGTSTP, and repaints on SIGCONT.
+    # Doing this by hand means owning terminal-state restoration across a
+    # signal, and getting it wrong leaves the operator at a shell with no echo.
+    #
+    # Bound HERE so every surface that builds this Application inherits it —
+    # the daemon cockpit and the attach client alike — which is the same
+    # reasoning the SIGWINCH handler below is registered on.
+    try:
+        import signal as _sig
+        if hasattr(_sig, "SIGTSTP"):        # Unix only, as CC documents
+            from backend.core.ouroboros.battle_test.keymap import bind_action
+
+            def _suspend(event: Any) -> None:
+                try:
+                    event.app.suspend_to_background()
+                except Exception:  # noqa: BLE001
+                    logger.debug("[Bipartite] suspend degraded", exc_info=True)
+
+            bind_action(
+                kb, "app:suspend", ("ctrl+z",), _suspend, context="Global",
+                description="suspend to the shell (`fg` to resume)",
+            )
+    except Exception:  # noqa: BLE001
+        logger.debug("[Bipartite] suspend binding unavailable", exc_info=True)
     # Scrollback keys. In the alternate screen the terminal no longer offers
     # its own, so these ARE the scrollback — not a convenience layered on it.
     # SIGWINCH → the layout. `handle_sigwinch` existed, read the live

--- a/backend/core/ouroboros/battle_test/bipartite_layout.py
+++ b/backend/core/ouroboros/battle_test/bipartite_layout.py
@@ -1474,6 +1474,31 @@ def build_bipartite_application(
         install_stash_binding(kb, lambda: prompt.buffer)
     except Exception:  # noqa: BLE001
         pass
+    # The completion menu and the gate, made remappable. Both WORKED and
+    # neither could be rebound — `/keys` could not list them and
+    # keybindings.json could not move them.
+    #
+    # Registered AFTER prompt_toolkit's own bindings and gated on
+    # `has_completions` / a pending gate, so they win exactly while those
+    # states hold and are absent otherwise. Nothing is unbound and nothing is
+    # monkeypatched.
+    try:
+        from backend.core.ouroboros.battle_test.menu_bindings import (
+            install_completion_actions, install_confirm_actions,
+        )
+        install_completion_actions(kb)
+        # Through `on_accept` — the same callable a typed `/accept` goes
+        # through — so the risk tier, the audit trail and the countdown clear
+        # exactly as they do for the verb. A key that bypassed the verb would
+        # be a second approval path, and here that is a governance problem
+        # rather than a UI one.
+        install_confirm_actions(
+            kb,
+            submit=(lambda line: on_accept(line)
+                    if callable(on_accept) else None),
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug("[Bipartite] menu bindings unavailable", exc_info=True)
     # Ctrl+_ / Ctrl+Shift+- — undo the last input edit. CC binds `chat:undo`
     # to exactly these, and prompt_toolkit already ships the command; it was
     # simply never bound, so the prompt accepted paragraphs with no way back

--- a/backend/core/ouroboros/battle_test/bipartite_layout.py
+++ b/backend/core/ouroboros/battle_test/bipartite_layout.py
@@ -1318,7 +1318,7 @@ def build_bipartite_application(
             # from a mouse handler inside a full-screen Application draws
             # over the frame. Which clipboard path was used matters — they
             # fail differently — so this is not decoration.
-            notify=lambda msg: mux.emit("line", {"text": f"  {msg}"}),
+            notify=lambda msg: mux.push_raw(f"  [dim]{msg}[/dim]"),
         )
     except Exception:  # noqa: BLE001
         logger.debug("[Bipartite] canvas mouse unavailable", exc_info=True)

--- a/backend/core/ouroboros/battle_test/bipartite_layout.py
+++ b/backend/core/ouroboros/battle_test/bipartite_layout.py
@@ -1278,8 +1278,32 @@ def build_bipartite_application(
                              exc_info=True)
             return super().create_content(width, height)
 
+    _canvas_control = _MeasuredCanvasControl(_canvas_fragments,
+                                             focusable=False)
+    # Click-to-expand. `mouse_support` was already on — the wheel scrolled —
+    # but there were no MouseEventType handlers anywhere, so every click fell
+    # on the floor. Installed on THIS control because it is the one that draws
+    # the transcript; the rows it resolves against are the rendered ANSI, so
+    # the panel border and the anchor padding need no arithmetic.
+    #
+    # A click SUBMITS `/expand <ref>` through `on_accept` — the same callable
+    # a typed line goes through — so every surface routes a click exactly the
+    # way it already routes typing, and the whole `/expand` ref family works
+    # without any of it being reimplemented for the mouse.
+    try:
+        from backend.core.ouroboros.battle_test.canvas_mouse import (
+            install_canvas_mouse,
+        )
+        install_canvas_mouse(
+            _canvas_control,
+            lambda: mux.render_canvas_ansi().splitlines(),
+            lambda line: (on_accept(line) if callable(on_accept) else None),
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug("[Bipartite] canvas mouse unavailable", exc_info=True)
+
     canvas = Window(
-        content=_MeasuredCanvasControl(_canvas_fragments, focusable=False),
+        content=_canvas_control,
         wrap_lines=False,
         # Content-sized, so a short deck sits directly under the header
         # instead of being padded down against the prompt.

--- a/backend/core/ouroboros/battle_test/bipartite_layout.py
+++ b/backend/core/ouroboros/battle_test/bipartite_layout.py
@@ -1220,7 +1220,23 @@ def build_bipartite_application(
         # actually given. `_MeasuredCanvasControl` below now supplies the real
         # number before this callable runs, so by here the budget is already
         # correct for THIS frame.
-        return ANSI(mux.render_canvas_ansi())
+        base = ANSI(mux.render_canvas_ansi())
+        # The selection highlight. Applied HERE, over the fragments the
+        # canvas already produced, so there is no second render path and no
+        # widget — and it costs nothing when nothing is selected, because
+        # `apply_selection` returns its input untouched and the ANSI object
+        # is handed straight through without ever being expanded to a list.
+        try:
+            from backend.core.ouroboros.battle_test.canvas_selection import (
+                apply_selection, current_selection,
+            )
+            selection = current_selection()
+            if selection is None or selection.empty:
+                return base
+            from prompt_toolkit.formatted_text import to_formatted_text
+            return apply_selection(to_formatted_text(base), selection)
+        except Exception:  # noqa: BLE001 — a highlight never breaks a frame
+            return base
 
     class _MeasuredCanvasControl(FormattedTextControl):
         """A canvas control that tells the mux how big it really is.
@@ -1298,6 +1314,11 @@ def build_bipartite_application(
             _canvas_control,
             lambda: mux.render_canvas_ansi().splitlines(),
             lambda line: (on_accept(line) if callable(on_accept) else None),
+            # Copy notices land in the deck rather than a print: printing
+            # from a mouse handler inside a full-screen Application draws
+            # over the frame. Which clipboard path was used matters — they
+            # fail differently — so this is not decoration.
+            notify=lambda msg: mux.emit("line", {"text": f"  {msg}"}),
         )
     except Exception:  # noqa: BLE001
         logger.debug("[Bipartite] canvas mouse unavailable", exc_info=True)

--- a/backend/core/ouroboros/battle_test/canvas_mouse.py
+++ b/backend/core/ouroboros/battle_test/canvas_mouse.py
@@ -1,0 +1,220 @@
+"""Clicking a transcript line that says it has more to show.
+
+Claude Code: "Click a collapsed tool result to expand it and see the full
+output. Click again to collapse. **Only messages that have more to show are
+clickable.**"
+
+`mouse_support` was already on — the wheel scrolls — but the cockpit had ZERO
+`MouseEventType` handlers, so every click fell on the floor. That was the
+largest single parity gap measured against CC's documented surface: 1 of 13.
+
+The affordance is already on the screen
+---------------------------------------
+This needed no new addressing scheme and no line→ref index to keep in sync,
+because the transcript already PRINTS the ref on any line that has more
+behind it:
+
+    ⎿ 41 lines parked · /expand t-3
+
+That text exists so an operator can read the ref and type the verb. A click
+is doing that for them. Which means "has more to show" is not a property this
+module has to be told — it is a property it can SEE, and it is exactly the
+same property CC uses to decide what is clickable.
+
+The consequence worth stating: a producer that starts emitting a new ref
+family becomes clickable for free, and one that stops printing refs becomes
+un-clickable for free. Neither needs an edit here. An index would have had to
+be updated by every producer, and the day one forgot, a line would look
+clickable and do nothing — which is worse than not being clickable at all.
+
+Rows are indexed against RENDERED output
+----------------------------------------
+`mouse_event.position.y` is relative to the control's own content, and that
+content is the canvas Panel — border rows, padding and all. So the row is
+resolved against the rendered ANSI lines rather than against the mux's
+logical line list. That is exact by construction: row Y is whatever is on
+row Y. Deriving it instead — logical lines, plus the anchor padding, plus the
+panel's top border, minus the scroll offset — is four assumptions that must
+all stay true, and a click landing one line off is the kind of defect an
+operator reports as "it expanded the wrong thing".
+
+Border rows carry no ref, so they are simply not clickable. The arithmetic
+never has to be right because it is never done.
+
+A click IS the verb
+-------------------
+Resolution ends by submitting `/expand <ref>` through the surface's own
+`on_accept` — the same callable a typed line goes through. So the daemon
+cockpit, the attach client and the demo each route a click exactly the way
+they already route typing, with no second dispatch path to drift, and
+`/expand`'s whole ref family (`t-` `d-` `o-` `n-` `p-` `q-` `b-`) works on
+day one because none of it is reimplemented here.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import re
+from typing import Any, Callable, List, Optional, Sequence
+
+logger = logging.getLogger("Ouroboros.CanvasMouse")
+
+CANVAS_MOUSE_SCHEMA_VERSION: str = "canvas_mouse.1"
+
+__all__ = [
+    "CANVAS_MOUSE_SCHEMA_VERSION",
+    "canvas_mouse_enabled",
+    "clickable_rows",
+    "install_canvas_mouse",
+    "ref_at_row",
+    "ref_in_line",
+]
+
+#: The explicit affordance: a line that TELLS the operator how to expand it.
+#: Preferred over a bare ref because it is unambiguous — the line is offering
+#: the action, not merely mentioning an artifact.
+_EXPAND_RE = re.compile(r"/expand\s+([a-z]-\d+)")
+
+#: A bare ref, for surfaces that print one without the verb (the moltbook
+#: feed appends `n-4` alone). Second, so a line carrying both is resolved by
+#: the offer rather than by whatever ref happens to appear first in it.
+#:
+#: The `\d` is deliberate and load-bearing: refs are `letter-digits`, and a
+#: looser pattern matches ordinary prose — "a well-known b-tree" would become
+#: a clickable line that expands nothing.
+_BARE_REF_RE = re.compile(r"(?:^|[\s·|(\[])([a-z]-\d+)(?=$|[\s·|)\].,])")
+
+
+def canvas_mouse_enabled() -> bool:
+    """``JARVIS_CANVAS_MOUSE_ENABLED`` (default true). NEVER raises.
+
+    Separate from `JARVIS_DISABLE_MOUSE`, which turns CAPTURE off entirely
+    and costs the operator wheel scrolling too. This switch keeps the wheel
+    and stands down only the click handling — the same split CC draws with
+    `CLAUDE_CODE_DISABLE_MOUSE_CLICKS` versus `CLAUDE_CODE_DISABLE_MOUSE`.
+    """
+    return os.environ.get(
+        "JARVIS_CANVAS_MOUSE_ENABLED", "1",
+    ).strip().lower() not in ("0", "false", "no", "off")
+
+
+def ref_in_line(line: Any) -> Optional[str]:
+    """The ref a line OFFERS, or None. Pure. NEVER raises.
+
+    ANSI is stripped through `append_only.strip_ansi` rather than a third
+    regex in this file — the canvas is drawn as ANSI, and two strippers that
+    disagree about an escape sequence would disagree about what a line says.
+    """
+    try:
+        text = str(line or "")
+        try:
+            from backend.core.ouroboros.battle_test.append_only import (
+                strip_ansi,
+            )
+            text = strip_ansi(text)
+        except Exception:  # noqa: BLE001
+            pass
+        offered = _EXPAND_RE.search(text)
+        if offered:
+            return offered.group(1)
+        bare = _BARE_REF_RE.search(text)
+        return bare.group(1) if bare else None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def ref_at_row(rows: Sequence[Any], row: Any) -> Optional[str]:
+    """The ref on a rendered row, or None. Pure. NEVER raises.
+
+    Out-of-range is None rather than an error: a click can land on the frame
+    during a resize, between the render that sized it and the one that filled
+    it, and a cockpit must not fault on a mis-timed click.
+    """
+    try:
+        index = int(row)
+        if index < 0 or index >= len(rows):
+            return None
+        return ref_in_line(rows[index])
+    except (TypeError, ValueError):
+        return None
+    except Exception:  # NEVER let a click break a frame  # noqa: BLE001
+        return None
+
+
+def clickable_rows(rows: Sequence[Any]) -> List[int]:
+    """Every row index that offers a ref. NEVER raises.
+
+    Exposed for a future hover highlight — CC highlights the row under the
+    cursor — and because it makes "which lines are clickable" answerable in a
+    test without a terminal.
+    """
+    try:
+        return [i for i, line in enumerate(rows) if ref_in_line(line)]
+    except Exception:  # noqa: BLE001
+        return []
+
+
+def resolve_click(rows: Sequence[Any], row: Any) -> Optional[str]:
+    """The line to SUBMIT for a click, or None. Pure. NEVER raises."""
+    ref = ref_at_row(rows, row)
+    return f"/expand {ref}" if ref else None
+
+
+def install_canvas_mouse(
+    control: Any,
+    rows_fn: Callable[[], Sequence[Any]],
+    submit: Callable[[str], Any],
+) -> bool:
+    """Give a control click-to-expand. NEVER raises; True when installed.
+
+    Wraps rather than replaces the existing `mouse_handler`, and returns
+    ``NotImplemented`` for everything it does not consume. That return value
+    is load-bearing: prompt_toolkit reads it as "not handled" and applies its
+    own default, which is what turns wheel events into scrolling. A handler
+    that returned None for unhandled events would silently take the wheel
+    away — trading the one mouse capability the cockpit already had for the
+    one it was adding.
+    """
+    try:
+        if control is None or not canvas_mouse_enabled():
+            return False
+        from prompt_toolkit.mouse_events import MouseEventType
+
+        previous = getattr(control, "mouse_handler", None)
+
+        def _handler(mouse_event: Any) -> Any:
+            try:
+                # MOUSE_UP, not DOWN: a click is a press AND a release in the
+                # same place, and acting on the press would fire while the
+                # operator is still deciding — including at the start of a
+                # drag they meant as a selection.
+                if getattr(mouse_event, "event_type", None) is not (
+                    MouseEventType.MOUSE_UP
+                ):
+                    raise _Unhandled
+                row = getattr(getattr(mouse_event, "position", None), "y", None)
+                line = resolve_click(list(rows_fn() or ()), row)
+                if not line:
+                    raise _Unhandled
+                submit(line)
+                return None
+            except _Unhandled:
+                pass
+            except Exception:  # noqa: BLE001 — a click must never break a frame
+                logger.debug("[CanvasMouse] click degraded", exc_info=True)
+            if callable(previous):
+                try:
+                    return previous(mouse_event)
+                except Exception:  # noqa: BLE001
+                    return NotImplemented
+            return NotImplemented
+
+        control.mouse_handler = _handler
+        return True
+    except Exception:  # noqa: BLE001
+        logger.debug("[CanvasMouse] install degraded", exc_info=True)
+        return False
+
+
+class _Unhandled(Exception):
+    """Internal: this event is not ours. Never escapes the handler."""

--- a/backend/core/ouroboros/battle_test/canvas_mouse.py
+++ b/backend/core/ouroboros/battle_test/canvas_mouse.py
@@ -302,6 +302,7 @@ def install_canvas_mouse(
     control: Any,
     rows_fn: Callable[[], Sequence[Any]],
     submit: Callable[[str], Any],
+    notify: Optional[Callable[[str], Any]] = None,
 ) -> bool:
     """Give a control click-to-expand. NEVER raises; True when installed.
 
@@ -322,14 +323,33 @@ def install_canvas_mouse(
 
         def _handler(mouse_event: Any) -> Any:
             try:
+                kind = getattr(mouse_event, "event_type", None)
+                point = getattr(mouse_event, "position", None)
+                at = (getattr(point, "y", None), getattr(point, "x", None))
+
+                # --- selection: press anchors, drag extends ---------------
+                if kind is MouseEventType.MOUSE_DOWN:
+                    _drag_start(at)
+                    raise _Unhandled     # pt still gets its own default
+                if kind is MouseEventType.MOUSE_MOVE:
+                    if _drag_extend(at):
+                        return None      # consumed: this IS the drag
+                    raise _Unhandled
+
                 # MOUSE_UP, not DOWN: a click is a press AND a release in the
                 # same place, and acting on the press would fire while the
                 # operator is still deciding — including at the start of a
                 # drag they meant as a selection.
-                if getattr(mouse_event, "event_type", None) is not (
-                    MouseEventType.MOUSE_UP
-                ):
+                if kind is not MouseEventType.MOUSE_UP:
                     raise _Unhandled
+
+                # A release that ENDED A DRAG is a selection, not a click.
+                # Checked before every other gesture: the press that began it
+                # was over some line, and treating the release as a click
+                # would expand whatever the drag happened to start on.
+                copied = _drag_finish(at, rows_fn, notify)
+                if copied:
+                    return None
                 row = getattr(getattr(mouse_event, "position", None), "y", None)
                 rows = list(rows_fn() or ())
                 # A MODIFIED click asks to open, and is checked FIRST because
@@ -368,3 +388,92 @@ def install_canvas_mouse(
 
 class _Unhandled(Exception):
     """Internal: this event is not ours. Never escapes the handler."""
+
+
+# ---------------------------------------------------------------------------
+# drag-to-select
+# ---------------------------------------------------------------------------
+
+
+def _valid(at: Any) -> bool:
+    return (isinstance(at, tuple) and len(at) == 2
+            and isinstance(at[0], int) and isinstance(at[1], int))
+
+
+def _drag_start(at: Any) -> None:
+    """Anchor a possible selection. NEVER raises.
+
+    Every press anchors, because a press cannot yet be distinguished from
+    the start of a drag. An anchor with no movement stays `empty`, which is
+    exactly what lets the release fall through to click-to-expand.
+    """
+    try:
+        from backend.core.ouroboros.battle_test.canvas_selection import (
+            Selection, selection_enabled, set_current_selection,
+        )
+        if not selection_enabled() or not _valid(at):
+            return
+        set_current_selection(Selection((at[0], at[1])))
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _drag_extend(at: Any) -> bool:
+    """Grow the selection under a held button. True when consumed."""
+    try:
+        from backend.core.ouroboros.battle_test.canvas_selection import (
+            current_selection, set_current_selection,
+        )
+        sel = current_selection()
+        if sel is None or not sel.active or not _valid(at):
+            return False
+        set_current_selection(sel.extend_to(at[0], at[1]))
+        return True
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _drag_finish(at: Any, rows_fn: Any, notify: Any) -> bool:
+    """End a drag, copying what it covered. True when it WAS a drag.
+
+    False for a press-and-release in one place, which is the whole reason
+    the anchor is kept even for a plain click: the release has to be able to
+    tell a selection from a click, and only the anchor knows.
+
+    The selection is CLEARED once copied. A highlight that outlives the
+    gesture is a cockpit asserting the operator still has something selected
+    when they have moved on — and the next click would extend it.
+    """
+    try:
+        from backend.core.ouroboros.battle_test.canvas_selection import (
+            copy_on_release, current_selection, extract_text,
+            set_current_selection,
+        )
+        sel = current_selection()
+        if sel is None:
+            return False
+        if _valid(at):
+            sel = sel.extend_to(at[0], at[1])
+        if sel.empty:
+            set_current_selection(None)
+            return False           # a click, not a drag
+        text = extract_text(list(rows_fn() or ()), sel)
+        set_current_selection(None)
+        if not text or not copy_on_release():
+            return True            # it WAS a drag; there was nothing to copy
+        from backend.core.ouroboros.battle_test.clipboard_write import (
+            copy_text, describe_path,
+        )
+        path = copy_text(text)
+        if notify is not None:
+            lines = text.count("\n") + 1
+            where = describe_path(path or "") if path else (
+                "no clipboard tool available — nothing copied")
+            try:
+                notify(f"{where} · {lines} line{'s' if lines != 1 else ''}")
+            except Exception:  # noqa: BLE001
+                pass
+        return True
+    except Exception:  # noqa: BLE001
+        logger.debug("[CanvasMouse] drag finish degraded", exc_info=True)
+        return False

--- a/backend/core/ouroboros/battle_test/canvas_mouse.py
+++ b/backend/core/ouroboros/battle_test/canvas_mouse.py
@@ -85,6 +85,22 @@ _EXPAND_RE = re.compile(r"/expand\s+([a-z]-\d+)")
 _BARE_REF_RE = re.compile(r"(?:^|[\s·|(\[])([a-z]-\d+)(?=$|[\s·|)\].,])")
 
 
+#: A URL worth offering to open. HTTP(S) ONLY, and that restriction is the
+#: security boundary rather than a convenience: the transcript carries
+#: MODEL-AUTHORED text, so this is the one surface that takes something the
+#: organism wrote and hands it to the operating system. `file://` would open
+#: arbitrary local paths, and the `javascript:` / `data:` family is a
+#: browser-side execution vector. Neither is worth a convenience.
+_URL_RE = re.compile(r"\bhttps?://[^\s<>\"'`)\]]+")
+
+#: A path-shaped token. Deliberately loose, because the containment check —
+#: not the pattern — is what makes opening safe. A pattern strict enough to
+#: be a security control would also miss half the paths the transcript
+#: prints; a permissive pattern plus "must resolve INSIDE the repo and must
+#: already exist" is both safer and more useful.
+_PATH_RE = re.compile(r"[\w./\-]*[\w\-]+\.[A-Za-z][\w]{0,9}\b")
+
+
 def canvas_mouse_enabled() -> bool:
     """``JARVIS_CANVAS_MOUSE_ENABLED`` (default true). NEVER raises.
 
@@ -160,6 +176,128 @@ def resolve_click(rows: Sequence[Any], row: Any) -> Optional[str]:
     return f"/expand {ref}" if ref else None
 
 
+# ---------------------------------------------------------------------------
+# Cmd/Ctrl+click — the one surface that hands model text to the OS
+# ---------------------------------------------------------------------------
+
+
+def _repo_root() -> Any:
+    from pathlib import Path
+    return Path(__file__).resolve().parents[4]
+
+
+def target_in_line(line: Any, *, root: Any = None) -> Optional[tuple]:
+    """``("url"|"path", value)`` a line offers to open, or None. NEVER raises.
+
+    Containment, not pattern-matching, is what makes this safe. The
+    transcript is MODEL-AUTHORED, so a path is offered only when it resolves
+    INSIDE the repository and already EXISTS on disk — which rules out
+    `/etc/passwd`, `~/.ssh/id_rsa` and `../../` traversal without needing a
+    regex clever enough to enumerate them. A file that does not exist is not
+    openable anyway, so the check costs nothing an operator would miss.
+
+    URLs are restricted to http(s) at the pattern, because there the scheme
+    IS the capability: `file://` reaches the local disk and `javascript:` is
+    execution.
+    """
+    try:
+        from pathlib import Path
+
+        text = str(line or "")
+        try:
+            from backend.core.ouroboros.battle_test.append_only import (
+                strip_ansi,
+            )
+            text = strip_ansi(text)
+        except Exception:  # noqa: BLE001
+            pass
+
+        found = _URL_RE.search(text)
+        if found:
+            # Trailing punctuation belongs to the sentence, not the URL.
+            return ("url", found.group(0).rstrip(".,;:!?"))
+
+        base = Path(root) if root is not None else _repo_root()
+        try:
+            base = base.resolve()
+        except Exception:  # noqa: BLE001
+            return None
+        for match in _PATH_RE.finditer(text):
+            raw = match.group(0).strip()
+            if not raw or raw.startswith("-"):
+                continue
+            try:
+                candidate = (base / raw).resolve()
+            except Exception:  # noqa: BLE001
+                continue
+            # `is_relative_to` on the RESOLVED path, so `..` segments and
+            # symlinks are both answered by the same check rather than by a
+            # string prefix whose shape an attacker chooses. Available since
+            # 3.9, which is this repo's floor.
+            if candidate.is_relative_to(base) and candidate.is_file():
+                return ("path", str(candidate))
+        return None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def open_target(kind: Any, value: Any) -> bool:
+    """Hand one target to the platform opener. NEVER raises; True if launched.
+
+    `subprocess` with an ARGV LIST and never a shell string: the value came
+    from the transcript, and a shell would make every metacharacter in it
+    executable. The opener is chosen from `sys.platform` rather than hardcoded
+    so this is not macOS-only.
+
+    Fire-and-forget: the operator asked to open something, not to wait for it,
+    and a browser cold-start must not stall the render loop that dispatched
+    the click.
+    """
+    try:
+        import subprocess
+        import sys
+
+        target = str(value or "")
+        if not target:
+            return False
+        if str(kind) == "url" and not target.startswith(("http://", "https://")):
+            return False        # belt and braces — the pattern already forbids it
+        if sys.platform == "darwin":
+            argv = ["open", target]
+        elif sys.platform.startswith("win"):
+            argv = ["cmd", "/c", "start", "", target]
+        else:
+            argv = ["xdg-open", target]
+        subprocess.Popen(
+            argv, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        return True
+    except Exception:  # noqa: BLE001
+        logger.debug("[CanvasMouse] open degraded", exc_info=True)
+        return False
+
+
+def _is_open_gesture(mouse_event: Any) -> bool:
+    """Did the operator ask to OPEN rather than to expand? NEVER raises.
+
+    Claude Code documents the awkward truth here: "the terminal mouse
+    protocol has no way to encode the Cmd key, so Claude Code receives it as
+    a plain click." So this asks for any modifier the protocol CAN carry —
+    Control or Alt — and does not pretend Cmd is available. An operator on a
+    terminal that sends neither still has `/expand` and the path in the line
+    to copy; what they must never get is a plain click silently launching
+    something.
+    """
+    try:
+        from prompt_toolkit.mouse_events import MouseModifier
+
+        mods = getattr(mouse_event, "modifiers", None) or frozenset()
+        return bool(mods & {MouseModifier.CONTROL, MouseModifier.ALT})
+    except Exception:  # noqa: BLE001
+        return False
+
+
 def install_canvas_mouse(
     control: Any,
     rows_fn: Callable[[], Sequence[Any]],
@@ -193,7 +331,19 @@ def install_canvas_mouse(
                 ):
                     raise _Unhandled
                 row = getattr(getattr(mouse_event, "position", None), "y", None)
-                line = resolve_click(list(rows_fn() or ()), row)
+                rows = list(rows_fn() or ())
+                # A MODIFIED click asks to open, and is checked FIRST because
+                # a line can offer both — `⏺ Read(backend/x.py) · /expand t-3`
+                # is a path and an expansion, and the modifier is the operator
+                # saying which one they meant.
+                if _is_open_gesture(mouse_event):
+                    target = target_in_line(
+                        rows[row] if isinstance(row, int)
+                        and 0 <= row < len(rows) else "")
+                    if target and open_target(*target):
+                        return None
+                    raise _Unhandled
+                line = resolve_click(rows, row)
                 if not line:
                     raise _Unhandled
                 submit(line)

--- a/backend/core/ouroboros/battle_test/canvas_selection.py
+++ b/backend/core/ouroboros/battle_test/canvas_selection.py
@@ -1,0 +1,299 @@
+"""Selecting text in the transcript, which has no selection model to borrow.
+
+Claude Code: "Click and drag to select text anywhere in the conversation …
+Selected text copies to your clipboard automatically on mouse release."
+
+prompt_toolkit gives selection to BUFFERS — `BufferControl.mouse_handler`
+already tracks an anchor, extends on drag and highlights, which is why
+selecting inside the ov prompt has always worked and needed no code. The
+canvas is a `FormattedTextControl`: a list of styled runs with no cursor, no
+anchor and no notion that two of its characters might be "between" each
+other. Everything a buffer gets for free has to exist here.
+
+Coordinates are RENDERED cells
+------------------------------
+A selection is (row, col) over the canvas as drawn — panel border, anchor
+padding and all — for the same reason click-to-expand resolves rows that way:
+it is what the mouse reports, and it is exact by construction. Mapping back
+to logical transcript lines would mean carrying an offset that is right only
+while four other things stay true, and a selection that highlights one row
+off is worse than none.
+
+The consequence is honest rather than clever: dragging across the panel's
+left edge selects the panel's left edge. That is also what a terminal's own
+selection does, and what CC documents its selection as capturing — "the
+hard-wrapped terminal rendering rather than the source text".
+
+Highlighting is a pure transform
+--------------------------------
+`apply_selection` takes the fragment list the canvas already produces and
+returns a new one with the selected cells restyled. No widget, no second
+render path, and — because it is pure over (fragments, selection) — the
+geometry is testable at every edge without a terminal: backwards drags,
+zero-width drags, selections running off the end of a short row, and the
+single-row case that is not the multi-row case with the middle removed.
+
+It costs nothing when nothing is selected: the transform returns the input
+list unchanged, so an idle canvas walks no characters at all.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from typing import Any, Iterable, List, Optional, Sequence, Tuple
+
+logger = logging.getLogger("Ouroboros.CanvasSelection")
+
+CANVAS_SELECTION_SCHEMA_VERSION: str = "canvas_selection.1"
+
+__all__ = [
+    "CANVAS_SELECTION_SCHEMA_VERSION",
+    "Selection",
+    "apply_selection",
+    "copy_on_release",
+    "current_selection",
+    "extract_text",
+    "reset_selection_for_tests",
+    "selection_enabled",
+    "selection_style",
+    "set_current_selection",
+]
+
+
+def selection_enabled() -> bool:
+    """``JARVIS_CANVAS_SELECTION_ENABLED`` (default true). NEVER raises."""
+    return os.environ.get(
+        "JARVIS_CANVAS_SELECTION_ENABLED", "1",
+    ).strip().lower() not in ("0", "false", "no", "off")
+
+
+def copy_on_release() -> bool:
+    """Copy automatically when the button comes up (CC's default).
+
+    ``JARVIS_CANVAS_COPY_ON_SELECT=0`` turns it off, mirroring CC's own
+    "Copy on select" toggle — an operator who selects to READ rather than to
+    copy does not want their clipboard replaced every time.
+    """
+    return os.environ.get(
+        "JARVIS_CANVAS_COPY_ON_SELECT", "1",
+    ).strip().lower() not in ("0", "false", "no", "off")
+
+
+def selection_style() -> str:
+    """The style appended to selected cells. NEVER raises.
+
+    ``reverse`` rather than a colour: the cockpit's theme is operator-chosen
+    and reactive, and a hardcoded highlight colour is the one thing certain
+    to collide with some theme. Reversing whatever the cell already is
+    inherits the theme instead of arguing with it.
+    """
+    return os.environ.get("JARVIS_SELECTION_STYLE", "reverse").strip() or "reverse"
+
+
+class Selection:
+    """An anchor and a cursor over rendered cells.
+
+    Stored UNNORMALISED — the anchor is where the drag began, which may be
+    after the cursor — because normalising on store would lose the direction,
+    and extending a backwards drag needs to know which end is moving.
+    """
+
+    __slots__ = ("anchor", "cursor", "active")
+
+    def __init__(self, anchor: Tuple[int, int],
+                 cursor: Optional[Tuple[int, int]] = None,
+                 active: bool = True) -> None:
+        self.anchor: Tuple[int, int] = (int(anchor[0]), int(anchor[1]))
+        src = cursor if cursor is not None else anchor
+        self.cursor: Tuple[int, int] = (int(src[0]), int(src[1]))
+        self.active = bool(active)
+
+    # -- geometry -------------------------------------------------------
+
+    def ordered(self) -> Tuple[Tuple[int, int], Tuple[int, int]]:
+        """``(start, end)`` in reading order, whichever way it was dragged."""
+        a, c = self.anchor, self.cursor
+        return (a, c) if (a[0], a[1]) <= (c[0], c[1]) else (c, a)
+
+    @property
+    def empty(self) -> bool:
+        """A press with no drag. Not a selection — and the distinction is
+        load-bearing, because a plain click must still reach click-to-expand
+        rather than being swallowed as a zero-width selection."""
+        return self.anchor == self.cursor
+
+    def contains(self, row: int, col: int) -> bool:
+        """Is this rendered cell inside the selection? Pure. NEVER raises.
+
+        Half-open at the END so the cell under the release point is not
+        included — the same convention every editor uses, and what makes a
+        one-cell drag select one cell rather than two.
+        """
+        try:
+            if not self.active or self.empty:
+                return False
+            (sr, sc), (er, ec) = self.ordered()
+            if row < sr or row > er:
+                return False
+            if sr == er:
+                return sc <= col < ec
+            if row == sr:
+                return col >= sc
+            if row == er:
+                return col < ec
+            return True
+        except Exception:  # noqa: BLE001
+            return False
+
+    def extend_to(self, row: int, col: int) -> "Selection":
+        return Selection(self.anchor, (row, col), active=True)
+
+    def __repr__(self) -> str:  # pragma: no cover — diagnostics
+        return f"Selection({self.anchor} -> {self.cursor}, active={self.active})"
+
+
+_LOCK = threading.Lock()
+_CURRENT: Optional[Selection] = None
+
+
+def current_selection() -> Optional[Selection]:
+    """The live selection, or None. NEVER raises.
+
+    A module-level current, matching `set_active_canvas` / `set_active_queue`
+    — the canvas fragments are produced deep inside a render callable that
+    has no handle to whatever is tracking the mouse.
+    """
+    with _LOCK:
+        return _CURRENT
+
+
+def set_current_selection(selection: Optional[Selection]) -> None:
+    """Publish or clear the live selection. NEVER raises."""
+    global _CURRENT
+    with _LOCK:
+        _CURRENT = selection
+
+
+def reset_selection_for_tests() -> None:
+    set_current_selection(None)
+
+
+# ---------------------------------------------------------------------------
+# text
+# ---------------------------------------------------------------------------
+
+
+def extract_text(rows: Sequence[Any], selection: Optional[Selection]) -> str:
+    """The selected text, as it appears on screen. Pure. NEVER raises.
+
+    Trailing whitespace is trimmed per line because the canvas pads every row
+    out to the panel's width — without it, every copied line would carry a
+    tail of spaces to the right border, and a multi-line paste would arrive
+    ragged for a reason the operator cannot see.
+
+    The single-row case is handled first and separately: it is NOT the
+    multi-row case with the middle removed, and writing it that way slices
+    the first row from `start` to end-of-line and the last from
+    start-of-line to `end`, which for one row is the whole row twice.
+    """
+    try:
+        if selection is None or selection.empty:
+            return ""
+        lines = _plain_rows(rows)
+        (sr, sc), (er, ec) = selection.ordered()
+        if sr < 0:
+            sr, sc = 0, 0
+        if er >= len(lines):
+            er, ec = max(0, len(lines) - 1), len(lines[-1]) if lines else 0
+        if not lines or sr > er:
+            return ""
+        if sr == er:
+            return lines[sr][sc:ec].rstrip()
+        out = [lines[sr][sc:].rstrip()]
+        out.extend(line.rstrip() for line in lines[sr + 1:er])
+        out.append(lines[er][:ec].rstrip())
+        return "\n".join(out)
+    except Exception:  # noqa: BLE001
+        logger.debug("[CanvasSelection] extract degraded", exc_info=True)
+        return ""
+
+
+def _plain_rows(rows: Sequence[Any]) -> List[str]:
+    try:
+        from backend.core.ouroboros.battle_test.append_only import strip_ansi
+        return [strip_ansi(str(r)) for r in (rows or ())]
+    except Exception:  # noqa: BLE001
+        return [str(r) for r in (rows or ())]
+
+
+# ---------------------------------------------------------------------------
+# highlight
+# ---------------------------------------------------------------------------
+
+
+def apply_selection(
+    fragments: Iterable[Any],
+    selection: Optional[Selection] = None,
+) -> List[Any]:
+    """Restyle the selected cells. Pure. NEVER raises.
+
+    Walks the fragment stream tracking (row, col) — newlines advance the row
+    and reset the column — and splits a run wherever it crosses a selection
+    boundary. Runs are accumulated and flushed on a state CHANGE rather than
+    emitted per character: a screenful of one-character fragments is a
+    pathological input for every downstream renderer, and the whole point of
+    a fragment list is that it is runs.
+
+    Returns the input unchanged when nothing is selected, so an idle canvas
+    pays nothing for this existing.
+    """
+    try:
+        source = list(fragments or ())
+        sel = selection if selection is not None else current_selection()
+        if sel is None or not sel.active or sel.empty or not selection_enabled():
+            return source
+        style_suffix = " " + selection_style()
+        out: List[Any] = []
+        row = col = 0
+
+        for fragment in source:
+            if not isinstance(fragment, (tuple, list)) or len(fragment) < 2:
+                out.append(fragment)
+                continue
+            style, text = fragment[0], str(fragment[1])
+            extra = tuple(fragment[2:])          # mouse handlers etc. survive
+            run: List[str] = []
+            run_selected: Optional[bool] = None
+
+            def _flush() -> None:
+                if not run:
+                    return
+                styled = (str(style) + style_suffix) if run_selected else style
+                out.append((styled, "".join(run)) + extra)
+                run.clear()
+
+            for ch in text:
+                if ch == "\n":
+                    _flush()
+                    run_selected = None
+                    out.append((style, "\n") + extra)
+                    row += 1
+                    col = 0
+                    continue
+                is_sel = sel.contains(row, col)
+                if run_selected is None:
+                    run_selected = is_sel
+                elif is_sel != run_selected:
+                    _flush()
+                    run_selected = is_sel
+                run.append(ch)
+                col += 1
+            _flush()
+        return out
+    except Exception:  # noqa: BLE001 — a highlight must never break a frame
+        logger.debug("[CanvasSelection] highlight degraded", exc_info=True)
+        try:
+            return list(fragments or ())
+        except Exception:  # noqa: BLE001
+            return []

--- a/backend/core/ouroboros/battle_test/canvas_viewport.py
+++ b/backend/core/ouroboros/battle_test/canvas_viewport.py
@@ -108,6 +108,20 @@ def canvas_history_lines() -> int:
     return _DEFAULT_HISTORY_LINES
 
 
+def auto_scroll_enabled() -> bool:
+    """``JARVIS_AUTO_SCROLL`` (default true). NEVER raises.
+
+    Claude Code's own escape hatch: "To turn auto-follow off entirely so the
+    view stays where you leave it, open `/config` and set Auto-scroll to
+    off." Off, the view never moves on its own and every arriving line is
+    held — which is what an operator reading a long trace while the organism
+    keeps working actually wants.
+    """
+    return os.environ.get(
+        "JARVIS_AUTO_SCROLL", "1",
+    ).strip().lower() not in ("0", "false", "no", "off")
+
+
 class CanvasViewport:
     """Which slice of the history is on screen, and how the operator moves it.
 
@@ -131,6 +145,22 @@ class CanvasViewport:
         #: as a count rather than left implicit — "there is newer output" is
         #: the fact that decides whether they want to jump back to live.
         self.new_since_paused = 0
+        #: Auto-follow held OFF explicitly, independent of the offset.
+        #:
+        #: Until this existed, "pinned to the tail" and "showing the newest
+        #: line" were ONE state with one variable — `following` was derived
+        #: from `_offset <= 0` — so there was no honest way to stop following
+        #: without also moving the view. The transcript viewer documented
+        #: that limitation rather than faking a pin, and this is the field
+        #: that removes it: a reader can freeze the page they are on at the
+        #: live tail, and arriving output holds still instead of scrolling
+        #: the sentence they are mid-way through off the screen.
+        #:
+        #: Claude Code states the same property — "scrolling up pauses
+        #: auto-follow so new output doesn't pull you back to the bottom" —
+        #: and separately allows turning follow off entirely. Scrolling still
+        #: pauses implicitly via the offset; this is the explicit half.
+        self._paused = False
         #: Has this operator scrolled yet, this session?
         #:
         #: The alternate screen takes the terminal's OWN scrollback, and
@@ -148,8 +178,41 @@ class CanvasViewport:
 
     @property
     def following(self) -> bool:
-        """True when pinned to the live tail."""
-        return self._offset <= 0
+        """True when new output will pull the view along.
+
+        BOTH conditions, because they are genuinely different reasons not to
+        follow: an operator who scrolled up (`_offset > 0`) and one who froze
+        the page they are on (`_paused`). Deriving this from the offset alone
+        is what made a pin-without-moving impossible.
+        """
+        return self._offset <= 0 and not self._paused
+
+    @property
+    def paused(self) -> bool:
+        """Auto-follow explicitly held, regardless of position."""
+        return self._paused
+
+    def pause(self) -> bool:
+        """Freeze the view where it is. True if this changed anything.
+
+        Deliberately does NOT move the offset. Freezing by scrolling would
+        discard the line the operator was reading when they asked — which is
+        the whole reason the derived version could not do this.
+        """
+        changed = not self._paused
+        self._paused = True
+        return changed
+
+    def resume(self) -> bool:
+        """Follow again. True if this changed anything.
+
+        Does not move either: a caller that wants the tail calls
+        `to_bottom`, and one that wants to keep reading where it is while
+        letting output resume behind it gets exactly that.
+        """
+        changed = self._paused
+        self._paused = False
+        return changed
 
     def mark_taught(self) -> None:
         """The operator has found the scrollback; stop offering the key."""
@@ -159,6 +222,11 @@ class CanvasViewport:
         self._offset = 0
         self.hit_top = False
         self.new_since_paused = 0
+        # Returning to live means FOLLOWING again. Leaving the flag set would
+        # give an operator who jumped to the bottom a view pinned at the
+        # bottom that never updates — the most confusing possible state,
+        # because it looks exactly like a working tail on a dead organism.
+        self._paused = False
 
     # -- movement ----------------------------------------------------------
 
@@ -207,8 +275,16 @@ class CanvasViewport:
         return self.scroll(-max(0, int(total)), total=total, budget=budget)
 
     def to_bottom(self) -> bool:
-        """Return to live. The one move that is always available."""
-        if self._offset == 0:
+        """Return to live. The one move that is always available.
+
+        "Already at offset 0" is NOT "already following" now that a pause can
+        hold the tail without moving it. The early return used to be correct
+        because the two were the same fact; with an explicit flag it left a
+        reader who paused AT the tail permanently un-following — and every
+        surface gated on `is_scrolled_back` then behaved as though they were
+        still in history after they had left the viewer.
+        """
+        if self._offset == 0 and not self._paused:
             return False
         self.reset()
         return True
@@ -240,13 +316,18 @@ class CanvasViewport:
             # plain list in tests.
             marker = total if appended is None else int(appended)
             previous, self._last_appended = self._last_appended, marker
-            if self._offset > 0 and previous is not None and marker > previous:
+            held = self._offset > 0 or self._paused or not auto_scroll_enabled()
+            if held and previous is not None and marker > previous:
                 arrived = marker - previous
                 self._offset += arrived
                 self.new_since_paused += arrived
 
             if total <= budget:
                 # Everything fits; there is no history to be inside of.
+                # `_paused` is NOT cleared here: a short transcript that grows
+                # past the budget while the operator is reading must stay
+                # held, and clearing the flag on a frame that happened to fit
+                # would silently resume follow underneath them.
                 self._offset = 0
                 return snap, 0, 0
             ceiling = total - budget

--- a/backend/core/ouroboros/battle_test/clipboard_write.py
+++ b/backend/core/ouroboros/battle_test/clipboard_write.py
@@ -1,0 +1,298 @@
+"""Putting text on the operator's clipboard, and saying which way it went.
+
+Nothing in this repo could write the clipboard. `clipboard_image` reads one
+(and only on macOS, via `osascript`), and prompt_toolkit's own clipboard is
+in-memory unless `pyperclip` is installed, which it is not. So the cockpit
+could offer a selection and then have nowhere to put it.
+
+Claude Code documents the cascade this implements, and the reason it is a
+cascade rather than one call is that the answer genuinely differs by
+environment:
+
+    macOS: pbcopy. Linux: wl-copy on Wayland, or xclip or xsel on X11,
+    whichever is installed … Windows and WSL: PowerShell Set-Clipboard.
+    Inside tmux it also writes to the tmux paste buffer. Over SSH it falls
+    back to OSC 52 escape sequences.
+
+Why it reports the path it used
+-------------------------------
+CC "prints a toast after each copy telling you which path it used", and that
+is not decoration. These paths fail differently and visibly: OSC 52 is
+silently swallowed by terminals that block it, the tmux buffer is not the
+system clipboard, and X11's PRIMARY selection pastes with middle-click rather
+than with Cmd+V. An operator who is told "copied via OSC 52" can reason about
+why their paste did not arrive. One told only "copied" cannot.
+
+Why every writer is tried, not just the first that exists
+---------------------------------------------------------
+A tool being INSTALLED is not the same as it WORKING — `xclip` on a machine
+with no `DISPLAY` exits non-zero, and `wl-copy` outside a Wayland session
+does too. So a writer counts only when it exits cleanly, and the cascade
+continues past one that claims to exist and then fails. Reporting success
+because a binary was on PATH is how an operator ends up with an empty
+clipboard and no idea why.
+
+Never a shell
+-------------
+Every writer takes the text on STDIN and an argv LIST. The text is a
+selection from a transcript that contains model-authored output; a shell
+string would make every metacharacter in it executable, and this is the one
+module whose whole job is to handle text somebody else wrote.
+"""
+from __future__ import annotations
+
+import base64
+import logging
+import os
+import shutil
+import subprocess
+import sys
+from typing import List, Optional, Tuple
+
+logger = logging.getLogger("Ouroboros.ClipboardWrite")
+
+CLIPBOARD_WRITE_SCHEMA_VERSION: str = "clipboard_write.1"
+
+__all__ = [
+    "CLIPBOARD_WRITE_SCHEMA_VERSION",
+    "clipboard_write_enabled",
+    "copy_text",
+    "describe_path",
+    "max_copy_chars",
+    "osc52_limit",
+]
+
+#: Terminals commonly cap an OSC 52 payload; xterm's historical limit is the
+#: one most others copied. Exceeded, the sequence is dropped SILENTLY — which
+#: is why this is checked rather than attempted and hoped for.
+_OSC52_DEFAULT_LIMIT = 74_994
+
+
+def clipboard_write_enabled() -> bool:
+    """``JARVIS_CLIPBOARD_WRITE_ENABLED`` (default true). NEVER raises."""
+    return os.environ.get(
+        "JARVIS_CLIPBOARD_WRITE_ENABLED", "1",
+    ).strip().lower() not in ("0", "false", "no", "off")
+
+
+def max_copy_chars() -> int:
+    """Cap on one copy. NEVER raises.
+
+    A selection is operator-driven, but "select all" over a 20 000-line
+    canvas is one gesture, and piping megabytes through a subprocess on the
+    render thread's behalf is how a copy becomes a freeze.
+    """
+    try:
+        return max(1_000, min(20_000_000, int(
+            os.environ.get("JARVIS_CLIPBOARD_MAX_CHARS", "") or 2_000_000)))
+    except (TypeError, ValueError):
+        return 2_000_000
+
+
+def osc52_limit() -> int:
+    """Largest OSC 52 payload worth attempting. NEVER raises."""
+    try:
+        return max(1_000, min(10_000_000, int(
+            os.environ.get("JARVIS_OSC52_LIMIT", "") or _OSC52_DEFAULT_LIMIT)))
+    except (TypeError, ValueError):
+        return _OSC52_DEFAULT_LIMIT
+
+
+def _in_tmux() -> bool:
+    return bool(os.environ.get("TMUX"))
+
+
+def _over_ssh() -> bool:
+    return bool(os.environ.get("SSH_CONNECTION")
+                or os.environ.get("SSH_TTY")
+                or os.environ.get("SSH_CLIENT"))
+
+
+def _wayland() -> bool:
+    return bool(os.environ.get("WAYLAND_DISPLAY"))
+
+
+def _x11() -> bool:
+    return bool(os.environ.get("DISPLAY"))
+
+
+def _run(argv: List[str], text: str, timeout: float = 3.0) -> bool:
+    """One writer. True only on a CLEAN exit. NEVER raises.
+
+    A non-zero exit is the whole point of checking: `xclip` with no DISPLAY
+    and `wl-copy` outside a Wayland session both exist and both fail, and a
+    cascade that stopped at "the binary is on PATH" would report success and
+    leave the clipboard empty.
+    """
+    try:
+        proc = subprocess.run(
+            argv, input=text.encode("utf-8", "replace"),
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            timeout=timeout, check=False,
+        )
+        return proc.returncode == 0
+    except (OSError, subprocess.SubprocessError):
+        return False
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _native_writers() -> List[Tuple[str, List[str]]]:
+    """Platform writers, in the order CC documents. NEVER raises.
+
+    On X11 both the CLIPBOARD and the PRIMARY selection are written, because
+    they are two different buffers and an operator who middle-clicks is
+    reaching for PRIMARY. Writing only one makes the copy work with Ctrl+V
+    and not with the middle button, which reads as an intermittent bug.
+    """
+    out: List[Tuple[str, List[str]]] = []
+    try:
+        if sys.platform == "darwin":
+            if shutil.which("pbcopy"):
+                out.append(("pbcopy", ["pbcopy"]))
+            return out
+        if sys.platform.startswith("win"):
+            if shutil.which("powershell"):
+                out.append(("Set-Clipboard",
+                            ["powershell", "-NoProfile", "-Command",
+                             "$input | Set-Clipboard"]))
+            return out
+        # Linux / BSD
+        if _wayland() and shutil.which("wl-copy"):
+            out.append(("wl-copy", ["wl-copy"]))
+        if _x11():
+            if shutil.which("xclip"):
+                out.append(("xclip", ["xclip", "-selection", "clipboard"]))
+                out.append(("xclip:primary",
+                            ["xclip", "-selection", "primary"]))
+            elif shutil.which("xsel"):
+                out.append(("xsel", ["xsel", "--clipboard", "--input"]))
+                out.append(("xsel:primary", ["xsel", "--primary", "--input"]))
+        # WSL: a Linux userland with a Windows clipboard behind it.
+        if shutil.which("clip.exe"):
+            out.append(("clip.exe", ["clip.exe"]))
+    except Exception:  # noqa: BLE001
+        pass
+    return out
+
+
+def _write_osc52(text: str, out_stream: object = None) -> bool:
+    """The escape-sequence path — the only one that works over SSH.
+
+    Written to the REAL stdout by descriptor, for the same reason the
+    alternate screen's restore is: `sys.stdout` may be a `patch_stdout` proxy
+    or a Rich capture, and a control sequence delivered into a proxy never
+    reaches the terminal.
+
+    Oversized payloads are refused rather than attempted: past the terminal's
+    limit the sequence is dropped SILENTLY, and a copy that reports success
+    and did nothing is worse than one that says it could not.
+    """
+    try:
+        # A TERMINAL, or nothing. An escape sequence written into a pipe, a
+        # log or a captured test stream is not a copy — it is corruption of
+        # whatever is reading that stream, and it is invisible until someone
+        # greps the output and finds `]52;c;` glued to a line. Probed through
+        # `real_stdout_isatty` because `sys.stdout.isatty()` is False under
+        # the active `patch_stdout` proxy, which is the same trap the
+        # presentation layer already documents.
+        if out_stream is None:
+            try:
+                from backend.core.ouroboros.battle_test.presentation_restraint import (  # noqa: E501
+                    real_stdout_isatty,
+                )
+                if not real_stdout_isatty():
+                    return False
+            except Exception:  # noqa: BLE001
+                return False
+        payload = text.encode("utf-8", "replace")
+        if len(base64.b64encode(payload)) > osc52_limit():
+            return False
+        encoded = base64.b64encode(payload).decode("ascii")
+        seq = f"\x1b]52;c;{encoded}\x07"
+        if _in_tmux():
+            # tmux swallows an unknown OSC unless it is wrapped for
+            # passthrough, and `allow-passthrough` must be on for even this
+            # to reach the outer terminal.
+            seq = f"\x1bPtmux;\x1b{seq}\x1b\\"
+        stream = out_stream if out_stream is not None else (
+            sys.__stdout__ or sys.stdout)
+        if stream is None:
+            return False
+        fd = stream.fileno()
+        data = seq.encode("ascii", "ignore")
+        view = memoryview(data)
+        while view:
+            written = os.write(fd, view)
+            if written <= 0:
+                return False
+            view = view[written:]
+        return True
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def describe_path(path: str) -> str:
+    """One operator-readable sentence about how a copy travelled.
+
+    These paths fail differently, and naming the one used is what lets an
+    operator reason about a paste that did not arrive.
+    """
+    return {
+        "pbcopy": "copied",
+        "Set-Clipboard": "copied",
+        "clip.exe": "copied (Windows clipboard)",
+        "wl-copy": "copied",
+        "xclip": "copied",
+        "xsel": "copied",
+        "xclip:primary": "copied to the primary selection (middle-click)",
+        "xsel:primary": "copied to the primary selection (middle-click)",
+        "tmux": "copied to the tmux buffer (not the system clipboard)",
+        "osc52": "copied via OSC 52 — some terminals block this",
+    }.get(str(path), "copied")
+
+
+def copy_text(text: object, *, out_stream: object = None) -> Optional[str]:
+    """Put text on the clipboard. Returns the path used, or None.
+
+    Tries every applicable writer and reports the FIRST that exited cleanly.
+    Inside tmux the paste buffer is written as well as the system clipboard,
+    because they are different buffers and an operator inside tmux reaches
+    for both. NEVER raises: a failed copy is reported, never thrown at a
+    render thread.
+    """
+    if not clipboard_write_enabled():
+        return None
+    try:
+        payload = str(text or "")
+        if not payload:
+            return None
+        cap = max_copy_chars()
+        if len(payload) > cap:
+            payload = payload[:cap]
+            logger.debug("[Clipboard] truncated to %d chars", cap)
+
+        used: Optional[str] = None
+        for name, argv in _native_writers():
+            if _run(argv, payload):
+                # PRIMARY is written IN ADDITION to the clipboard, so it must
+                # not be reported as the path when the real clipboard already
+                # took it — the operator would be told to middle-click when
+                # Ctrl+V works.
+                if used is None or not name.endswith(":primary"):
+                    used = used or name
+                continue
+
+        if _in_tmux() and shutil.which("tmux"):
+            if _run(["tmux", "load-buffer", "-"], payload):
+                used = used or "tmux"
+
+        # OSC 52 last, and ALWAYS attempted over SSH: there is no local tool
+        # that can reach the operator's actual machine from the far end.
+        if used is None or _over_ssh():
+            if _write_osc52(payload, out_stream=out_stream):
+                used = used or "osc52"
+        return used
+    except Exception:  # noqa: BLE001
+        logger.debug("[Clipboard] copy degraded", exc_info=True)
+        return None

--- a/backend/core/ouroboros/battle_test/cockpit_mount.py
+++ b/backend/core/ouroboros/battle_test/cockpit_mount.py
@@ -306,6 +306,9 @@ def daemon_key_bindings(repl: Any = None) -> Any:
     try:
         from prompt_toolkit.key_binding import KeyBindings
 
+        from backend.core.ouroboros.battle_test.subagent_control import (
+            install_stop_all_binding,
+        )
         from backend.core.ouroboros.battle_test.transcript_hatches import (
             install_transcript_hatches,
         )
@@ -313,13 +316,59 @@ def daemon_key_bindings(repl: Any = None) -> Any:
             repl, "handle_input", None)
         shim = LocalCockpitClient(send_input=send)
         kb = KeyBindings()
-        if not install_transcript_hatches(kb, shim, shim):
+        hatches = install_transcript_hatches(kb, shim, shim)
+        # Ctrl+X Ctrl+K, through the SAME shim: the chord sends `/stop-all`
+        # and `_dispatch_repl_command` does the rest, so the daemon and the
+        # attach client reach one authority by one route.
+        stop_all = install_stop_all_binding(
+            kb, shim,
+            notify=lambda msg: _daemon_notice(repl, msg),
+            running=_local_running_agents,
+        )
+        # Bound if EITHER cluster took. Returning None when only the hatches
+        # failed would silently drop the stop-all chord along with them.
+        if not (hatches or stop_all):
             return None
         return kb
     except Exception:  # noqa: BLE001
         logger.debug("[CockpitMount] daemon key bindings unavailable",
                      exc_info=True)
         return None
+
+
+def _daemon_notice(repl: Any, message: str) -> None:
+    """One transient line on the daemon's own console. NEVER raises.
+
+    The client answers this with `ui.flash`, which the daemon cockpit has no
+    equivalent of — its transient surface IS the console. Kept to a plain
+    dim line rather than reaching for the deck: an arming prompt that has
+    three seconds to live must not join a scrollback the operator will read
+    later.
+    """
+    try:
+        flow = getattr(repl, "_flow", None)
+        console = getattr(flow, "console", None)
+        if console is None:
+            return
+        console.print(f"  [dim]{message}[/dim]", highlight=False)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _local_running_agents() -> int:
+    """Agents running in THIS process's roster. NEVER raises.
+
+    The daemon dispatches them, so its own singleton is the truth here — no
+    snapshot age, no bridge. The attach client asks its `AttachUI` instead,
+    which holds the daemon's last frame.
+    """
+    try:
+        from backend.core.ouroboros.battle_test.agent_roster import (
+            get_agent_roster,
+        )
+        return int(get_agent_roster().running_count)   # a property
+    except Exception:  # noqa: BLE001
+        return 0
 
 
 def daemon_toolbar() -> Any:

--- a/backend/core/ouroboros/battle_test/cockpit_mount.py
+++ b/backend/core/ouroboros/battle_test/cockpit_mount.py
@@ -312,11 +312,22 @@ def daemon_key_bindings(repl: Any = None) -> Any:
         from backend.core.ouroboros.battle_test.transcript_hatches import (
             install_transcript_hatches,
         )
+        from backend.core.ouroboros.battle_test.transcript_mode import (
+            install_transcript_mode_bindings,
+        )
         send = getattr(repl, "_dispatch_verb", None) or getattr(
             repl, "handle_input", None)
         shim = LocalCockpitClient(send_input=send)
         kb = KeyBindings()
         hatches = install_transcript_hatches(kb, shim, shim)
+        # Ctrl+O and the less-style viewer table. Mounted beside the hatches
+        # because they are two halves of one surface: the hatches are the
+        # keys, this is the state that makes them unambiguous.
+        install_transcript_mode_bindings(
+            kb, notify=lambda out: _daemon_notice(
+                repl, out if isinstance(out, str) else "\n".join(out),
+            ),
+        )
         # Ctrl+X Ctrl+K, through the SAME shim: the chord sends `/stop-all`
         # and `_dispatch_repl_command` does the rest, so the daemon and the
         # attach client reach one authority by one route.

--- a/backend/core/ouroboros/battle_test/cockpit_mount.py
+++ b/backend/core/ouroboros/battle_test/cockpit_mount.py
@@ -382,6 +382,50 @@ def _local_running_agents() -> int:
         return 0
 
 
+def daemon_stream_rows() -> Any:
+    """The sentence being written, at the daemon's own terminal. NEVER raises.
+
+    This hook was UNSET, and the reason was recorded honestly rather than
+    waived: there was no process-global in-flight text to read, because
+    every stream published its frames and kept none. The daemon composed the
+    words, shipped them across the bridge, and could not draw them.
+
+    `inflight_registry` closes that by recording each frame where it is
+    COMPOSED — before `publish_telemetry_global`, which returns early with no
+    cockpit attached and would otherwise leave this strip working only while
+    somebody else was watching.
+
+    Renders through `stream_renderer.render_inflight`, the same function the
+    attach client calls, so the two surfaces cannot disagree about the shape.
+    Only the WIDTH is local, which is the one thing the daemon genuinely
+    cannot know for a remote client and genuinely does know for itself.
+    """
+    def _rows() -> Any:
+        try:
+            import shutil
+            from backend.core.ouroboros.battle_test.inflight_registry import (
+                current_inflight,
+            )
+            from backend.core.ouroboros.battle_test.stream_renderer import (
+                render_inflight,
+            )
+            entry = current_inflight()
+            if entry is None or not entry.text:
+                return []
+            size = shutil.get_terminal_size(fallback=(100, 30))
+            return render_inflight(
+                entry.text, width=max(20, int(size.columns)),
+                # Command output keeps its line structure; model prose does
+                # not. Carried on the entry rather than guessed, because the
+                # frame's `kind` is the only place that is known for certain.
+                preserve_lines=entry.is_tool,
+                keep_first=entry.is_tool,
+            )
+        except Exception:  # noqa: BLE001
+            return []
+    return _rows
+
+
 def daemon_toolbar() -> Any:
     """The pulse line, or None. NEVER raises.
 
@@ -578,15 +622,15 @@ def build_daemon_mount(repl: Any = None) -> "dict":
     # `header`/`header_height` are left ABSENT rather than waived here because the
     # mount is a dict of values, not a call site — `capability_handoff` reads the
     # waiver at the place the argument is passed, which is `serpent_flow`.
-    # `stream_rows` is deliberately absent, and this is the reason rather than an
-    # oversight: there is NO process-global in-flight text to read.
-    # `live_tool_stream.make_tool_observer` creates a stream per tool CALL and
-    # nothing publishes a current frame, so a provider here would have to invent
-    # one — and an in-flight strip that shows the wrong sentence is worse than no
-    # strip. The correct fix is a `set_active_stream` registry mirroring the
-    # `set_active_canvas` / `set_active_queue` pattern this codebase already uses
-    # twice, which needs a producer-side audit of every stream construction site.
-    # Left UNSET rather than waived so `capability_handoff` keeps reporting it.
+    # `stream_rows` is now FILLED. It was UNSET because there was no
+    # process-global in-flight text to read — every stream published its
+    # frames and kept none, so the daemon composed the words and could not
+    # draw them. `inflight_registry` records each frame at its composition
+    # site, which is strictly better than the `set_active_stream` registry
+    # this comment used to call for: that would have needed every stream
+    # CONSTRUCTION site to remember to register, and a producer that forgets
+    # is silently dark. Emission is the seam no producer can skip.
+    mount["stream_rows"] = daemon_stream_rows()
     return mount
 
 
@@ -598,4 +642,5 @@ __all__ = [
     "daemon_queue_rows",
     "daemon_search_rows",
     "daemon_serpent_active",
+    "daemon_stream_rows",
 ]

--- a/backend/core/ouroboros/battle_test/confirm_chord.py
+++ b/backend/core/ouroboros/battle_test/confirm_chord.py
@@ -1,0 +1,127 @@
+"""Destructive keystrokes that ask, in the keystroke itself.
+
+Claude Code binds two actions this way and the shape is the same both times:
+``Ctrl+X Ctrl+K`` stops every running background subagent — "press twice
+within 3 seconds to confirm" — and in fullscreen ``Ctrl+L`` redraws once and
+runs ``/clear`` if pressed again inside two seconds.
+
+Why a latch and not a dialog
+-----------------------------
+The alternative to this is a modal "are you sure? [y/N]", and for a key an
+operator reaches for while something is going wrong that is the wrong trade:
+it steals focus, it has to be dismissed, and it turns a reflex into a
+conversation. A repeat of the same chord costs nothing to learn — the
+operator's fingers are already there — and it cannot be triggered by a single
+mis-hit, which is the only failure this guard exists to prevent.
+
+Why the window is short
+-----------------------
+The arm has to expire, or the second half of the confirmation can arrive
+minutes later attached to a completely different intention. Three seconds is
+long enough to be a deliberate repeat and short enough that no unrelated
+keystroke lands inside it.
+
+Why the clock is injected
+-------------------------
+So the expiry is TESTABLE without sleeping. A guard whose only test is
+"press twice fast and hope" is a guard nobody re-verifies after they change
+it, and this one stands between a mis-hit and every running agent.
+"""
+from __future__ import annotations
+
+import os
+import threading
+import time
+from typing import Callable, Optional
+
+__all__ = ["ConfirmLatch", "confirm_window_s"]
+
+
+#: Claude Code's own window for `Ctrl+X Ctrl+K`.
+_DEFAULT_WINDOW_S = 3.0
+
+
+def confirm_window_s(env_var: str = "JARVIS_CONFIRM_CHORD_WINDOW_S") -> float:
+    """Seconds a first press stays armed. NEVER raises.
+
+    Clamped rather than trusted: zero would make the chord fire on the first
+    press (the guard removed by configuration, silently), and a very long
+    window would let an unrelated keystroke complete a confirmation the
+    operator has long forgotten starting.
+    """
+    try:
+        return max(0.5, min(30.0, float(
+            os.environ.get(env_var, "") or _DEFAULT_WINDOW_S,
+        )))
+    except (TypeError, ValueError):
+        return _DEFAULT_WINDOW_S
+
+
+class ConfirmLatch:
+    """One destructive action's arm/confirm state.
+
+    ``press()`` returns True only on a repeat inside the window — that return
+    value IS the decision, so a caller cannot accidentally act on the arming
+    press by reading the wrong attribute.
+    """
+
+    def __init__(
+        self,
+        window_s: Optional[float] = None,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._window = float(window_s) if window_s is not None else None
+        self._clock = clock
+        self._armed_at: Optional[float] = None
+        self._lock = threading.Lock()
+
+    @property
+    def window_s(self) -> float:
+        """Re-read per call when not pinned, so an env change lands without a
+        restart — the same discipline the roster's row budget follows."""
+        return self._window if self._window is not None else confirm_window_s()
+
+    def press(self) -> bool:
+        """Record a press; True means CONFIRMED. NEVER raises.
+
+        A confirmation consumes the arm, so a third press starts over rather
+        than firing again. Holding the chord down must not repeat a
+        destructive action once per key-repeat interval.
+        """
+        try:
+            now = float(self._clock())
+        except Exception:  # noqa: BLE001
+            now = 0.0
+        with self._lock:
+            armed_at = self._armed_at
+            if armed_at is not None and (now - armed_at) <= self.window_s:
+                self._armed_at = None
+                return True
+            self._armed_at = now
+            return False
+
+    def armed(self) -> bool:
+        """Whether a press is waiting for its repeat, expiry included.
+
+        Checked rather than stored: an arm that expired while nothing was
+        pressed must READ as disarmed, or a toolbar hint would go on
+        advertising a confirmation the next press will not give.
+        """
+        try:
+            now = float(self._clock())
+        except Exception:  # noqa: BLE001
+            return False
+        with self._lock:
+            armed_at = self._armed_at
+            if armed_at is None:
+                return False
+            if (now - armed_at) > self.window_s:
+                self._armed_at = None
+                return False
+            return True
+
+    def disarm(self) -> None:
+        """Drop a pending arm — for when the operator does something else
+        that plainly means they moved on. NEVER raises."""
+        with self._lock:
+            self._armed_at = None

--- a/backend/core/ouroboros/battle_test/diff_archive.py
+++ b/backend/core/ouroboros/battle_test/diff_archive.py
@@ -236,6 +236,61 @@ class ArchivedDiff:
             d["diff_text"] = self.diff_text
         return d
 
+    @classmethod
+    def from_dict(cls, payload: Any) -> Optional["ArchivedDiff"]:
+        """The inverse of :meth:`to_dict`. NEVER raises; None if unusable.
+
+        Exists so a process that did not ARCHIVE a diff can still hold the
+        real record rather than a look-alike. An attach client renders diffs
+        through the same `DiffOverlayController` the daemon uses, and that
+        controller reads a dozen fields off the entry — handing it a duck-typed
+        stand-in would mean every field it learns to read next has to be
+        remembered here too, and the day one is forgotten the remote overlay
+        silently renders a blank where the local one shows a risk tier.
+
+        Reconstructing the frozen dataclass makes that class of drift
+        impossible: a field added to `ArchivedDiff` travels or fails loudly.
+
+        Tolerant on INPUT because the sender may be older: a missing field
+        takes the same default the archive would have used, and an unknown one
+        is ignored. That is the same additive contract `to_dict`'s consumers
+        already rely on.
+        """
+        try:
+            if not isinstance(payload, dict):
+                return None
+            ref = _safe_str(payload.get("ref"))
+            if not ref:
+                return None
+            return cls(
+                ref=ref,
+                op_id=_safe_str(payload.get("op_id")),
+                risk_tier=_safe_str(payload.get("risk_tier")),
+                file_paths=_safe_path_tuple(payload.get("file_paths")),
+                # Absent means "not shipped", which is not the same as empty —
+                # but the record cannot represent the difference, and the
+                # catalog projection deliberately omits it. Callers that need
+                # the text ask whether `diff_text` is truthy.
+                diff_text=_safe_str(payload.get("diff_text")),
+                summary=_safe_str(payload.get("summary")),
+                review_branch=(
+                    _safe_str(payload.get("review_branch")) or None
+                ),
+                apply_outcome=DiffOutcome.coerce(payload.get("apply_outcome")),
+                verify_outcome=VerifyOutcome.coerce(
+                    payload.get("verify_outcome")),
+                apply_error=_safe_str(payload.get("apply_error")),
+                # Monotonic clocks are per-process origins, so a timestamp
+                # from the daemon means nothing here. Zero is the honest
+                # value: this reader does not know when it was archived, and
+                # inventing a local `monotonic()` would be a plausible lie.
+                archived_at=0.0,
+                terminal_at=0.0,
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug("[DiffArchive] from_dict degraded", exc_info=True)
+            return None
+
 
 @dataclass(frozen=True)
 class ArchiveSnapshot:

--- a/backend/core/ouroboros/battle_test/diff_bridge.py
+++ b/backend/core/ouroboros/battle_test/diff_bridge.py
@@ -1,0 +1,351 @@
+"""A diff archive that lives in another process.
+
+The gap
+-------
+`capability_handoff` measured `diff_rows` UNSET on `ov`. The daemon owns the
+`DiffArchive`, so `/expand d-3` typed at an attached cockpit travelled to the
+daemon, opened the diff on the DAEMON's overlay, and mirrored back one line
+saying `⏺ d-3 — esc closes`. The operator was told a diff had opened and was
+shown nothing. On the surface an operator reviews changes from, the review
+surface was the one thing that did not cross.
+
+Why this is not a second overlay
+--------------------------------
+`DiffOverlayController` takes its archive as a constructor argument. It was
+built transport-agnostic and nobody had used that: it needs only `lookup`,
+`list_recent` and `all_refs`. So the client does not need a second controller,
+a second renderer, a second epoch guard or a second off-thread Pygments pass —
+it needs something archive-SHAPED. This is that.
+
+Everything downstream is then literally the same code: the same syntax
+highlighting, the same `Escape` arbitration, the same 483 ms off-thread render
+that keeps the loop unstalled. A regression in the daemon's diff surfaces on
+the client too, which is the property this codebase keeps buying deliberately.
+
+Two payloads, because they have different costs
+-----------------------------------------------
+A CATALOG — refs, file counts, summaries, risk tiers, no diff text — is small
+enough to ride the 1 Hz heartbeat, and it is what makes two things CORRECT
+rather than approximate:
+
+  * `all_refs()` — so an unknown ref lists what IS available. The archive is a
+    ring, so a ref an operator read minutes ago may have been evicted, and
+    "no such diff" alone invites them to doubt their typing.
+  * the loading placeholder's file count — so the overlay confirms they opened
+    what they meant before the diff itself arrives.
+
+The TEXT is fetched only when a diff is actually opened. Diffs are unbounded
+in a way nothing else on this lane is; putting them on the heartbeat would
+mean shipping megabytes per second to draw nothing.
+
+Pending is not absent
+---------------------
+The controller resolves synchronously and treats `None` as "no such diff" —
+correct for a local dict, wrong across a socket, where "not here yet" and "not
+a thing" are different answers and only one of them is an error. So `lookup`
+returns a PENDING record built from the catalog: the overlay opens, shows the
+right ref and file count, and re-renders when the text lands. An operator
+never sees "no such diff" for a diff that exists and is in flight.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+logger = logging.getLogger("Ouroboros.DiffBridge")
+
+DIFF_BRIDGE_SCHEMA_VERSION: str = "diff_bridge.1"
+
+#: The frame the daemon publishes in reply to a fetch. Addressed to the
+#: cockpit that asked, never broadcast — two attached operators reviewing
+#: different diffs must not overwrite each other's overlay.
+DIFF_PAYLOAD_KIND: str = "diff_payload"
+
+#: The key the catalog rides under on the heartbeat. Additive under
+#: `heartbeat.v1`, exactly as `agents` was: a client that has never heard of
+#: it ignores the key, and a daemon that does not send one leaves the client
+#: with an empty catalog rather than a version error.
+CATALOG_KEY: str = "diffs"
+
+__all__ = [
+    "CATALOG_KEY",
+    "DIFF_BRIDGE_SCHEMA_VERSION",
+    "DIFF_PAYLOAD_KIND",
+    "RemoteDiffArchive",
+    "build_diff_catalog",
+    "catalog_rows",
+    "diff_bridge_enabled",
+    "fetch_timeout_s",
+    "max_diff_chars",
+]
+
+
+def diff_bridge_enabled() -> bool:
+    """``JARVIS_DIFF_BRIDGE_ENABLED`` (default true). NEVER raises."""
+    return os.environ.get(
+        "JARVIS_DIFF_BRIDGE_ENABLED", "1",
+    ).strip().lower() not in ("0", "false", "no", "off")
+
+
+def catalog_rows() -> int:
+    """Refs advertised on the heartbeat. NEVER raises.
+
+    Bounded because this rides a 1 Hz frame. The number only has to cover
+    what an operator might plausibly still refer to by ref; the archive's own
+    ring is the real limit and `/diffs` can list it in full.
+    """
+    try:
+        return max(1, min(64, int(
+            os.environ.get("JARVIS_DIFF_CATALOG_ROWS", "") or 12)))
+    except (TypeError, ValueError):
+        return 12
+
+
+def max_diff_chars() -> int:
+    """Cap on a fetched diff's text. NEVER raises.
+
+    A diff is the one payload on this lane with no natural bound — a
+    generated migration can be megabytes, and a bridge frame that large
+    stalls every other frame queued behind it, including the heartbeat that
+    tells the operator anything is happening at all.
+
+    Truncation is announced in the text rather than silent, because a diff
+    that simply stops is indistinguishable from one that ended.
+    """
+    try:
+        return max(4_000, min(4_000_000, int(
+            os.environ.get("JARVIS_DIFF_MAX_CHARS", "") or 400_000)))
+    except (TypeError, ValueError):
+        return 400_000
+
+
+def fetch_timeout_s() -> float:
+    """How long a fetch may be outstanding before it is called lost.
+
+    Not cosmetic: without it a daemon that dies mid-fetch leaves the overlay
+    saying "rendering…" forever, which is the same lie every other
+    heartbeat-fed surface in this cockpit is careful not to tell.
+    """
+    try:
+        return max(1.0, min(120.0, float(
+            os.environ.get("JARVIS_DIFF_FETCH_TIMEOUT_S", "") or 10.0)))
+    except (TypeError, ValueError):
+        return 10.0
+
+
+def build_diff_catalog(archive: Any, *, limit: Optional[int] = None) -> List[Dict[str, Any]]:
+    """The daemon's side: a bounded, text-free projection of the archive.
+
+    Built from `ArchivedDiff.to_dict(include_diff_text=False)` — the
+    projection that already exists for "keep SSE / observability payloads
+    bounded" — rather than a hand-assembled dict, so a field added to the
+    record travels without a second edit here. NEVER raises.
+    """
+    try:
+        if archive is None:
+            return []
+        rows = list(archive.list_recent() or ())
+        cap = catalog_rows() if limit is None else max(1, int(limit))
+        out: List[Dict[str, Any]] = []
+        for entry in rows[:cap]:
+            try:
+                out.append(entry.to_dict(include_diff_text=False))
+            except Exception:  # noqa: BLE001
+                continue
+        return out
+    except Exception:  # noqa: BLE001
+        logger.debug("[DiffBridge] catalog degraded", exc_info=True)
+        return []
+
+
+class RemoteDiffArchive:
+    """The daemon's archive, as seen from a cockpit that is not the daemon.
+
+    Satisfies the duck-type `DiffOverlayController` already requires —
+    ``lookup``, ``list_recent``, ``all_refs`` — so the controller mounts
+    against it with no change at all.
+    """
+
+    __slots__ = ("_lock", "_catalog", "_full", "_pending", "_request",
+                 "_clock", "_missing")
+
+    def __init__(
+        self,
+        request: Optional[Callable[[str], None]] = None,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._lock = threading.RLock()
+        #: ref -> catalog dict (no diff text). Replaced wholesale per frame.
+        self._catalog: Dict[str, Dict[str, Any]] = {}
+        #: ref -> fully-hydrated ArchivedDiff.
+        self._full: Dict[str, Any] = {}
+        #: ref -> monotonic time the fetch was issued.
+        self._pending: Dict[str, float] = {}
+        #: refs the daemon has explicitly said it does not have.
+        self._missing: set = set()
+        self._request = request
+        self._clock = clock
+
+    # -- ingest ---------------------------------------------------------
+
+    def ingest_catalog(self, rows: Any) -> int:
+        """Absorb the heartbeat's catalog. NEVER raises; returns the count.
+
+        Replaced wholesale rather than merged: the archive is a RING, so an
+        absent ref means evicted. Merging would let a ref the daemon dropped
+        live forever in a client that happened to see it once.
+        """
+        try:
+            fresh: Dict[str, Dict[str, Any]] = {}
+            for row in list(rows or ()):
+                if isinstance(row, dict) and row.get("ref"):
+                    fresh[str(row["ref"])] = row
+            with self._lock:
+                self._catalog = fresh
+                # A hydrated diff for a ref that has since been evicted is
+                # dropped with it — otherwise `all_refs` and `lookup` would
+                # disagree about what exists.
+                for ref in [r for r in self._full if r not in fresh]:
+                    self._full.pop(ref, None)
+                self._missing.intersection_update(set())
+            return len(fresh)
+        except Exception:  # noqa: BLE001
+            return 0
+
+    def ingest_payload(self, frame: Any) -> Optional[str]:
+        """Absorb a fetched diff. NEVER raises; returns the ref it filled.
+
+        A frame marked `missing` records the negative rather than dropping it:
+        without that, `lookup` would re-issue the fetch on the next render and
+        the overlay would sit in a request loop against a ref that will never
+        arrive.
+        """
+        try:
+            if not isinstance(frame, dict):
+                return None
+            ref = str(frame.get("ref") or "")
+            if not ref:
+                return None
+            with self._lock:
+                self._pending.pop(ref, None)
+                if frame.get("missing"):
+                    self._missing.add(ref)
+                    self._full.pop(ref, None)
+                    return ref
+                from backend.core.ouroboros.battle_test.diff_archive import (
+                    ArchivedDiff,
+                )
+                entry = ArchivedDiff.from_dict(frame)
+                if entry is None:
+                    return None
+                self._full[ref] = entry
+                self._missing.discard(ref)
+            return ref
+        except Exception:  # noqa: BLE001
+            logger.debug("[DiffBridge] payload ingest degraded", exc_info=True)
+            return None
+
+    # -- the archive duck-type ------------------------------------------
+
+    def lookup(self, ref: object) -> Any:
+        """``d-N`` -> entry, a PENDING entry, or None. NEVER raises.
+
+        Three answers where a local archive has two, because across a socket
+        "not here yet" is not "not a thing". Returning None for an in-flight
+        fetch would render "no such diff" over a diff that exists.
+        """
+        try:
+            text = str(ref or "").strip()
+            if not text:
+                return None
+            with self._lock:
+                if text in self._missing:
+                    return None
+                hydrated = self._full.get(text)
+                if hydrated is not None:
+                    return hydrated
+                known = self._catalog.get(text)
+            if known is None:
+                return None
+            self._ensure_fetch(text)
+            # A record with no diff text. The controller renders its header
+            # and file tree from the catalog fields, so the overlay is
+            # immediately correct about WHAT is opening while the body loads.
+            from backend.core.ouroboros.battle_test.diff_archive import (
+                ArchivedDiff,
+            )
+            return ArchivedDiff.from_dict(known)
+        except Exception:  # noqa: BLE001
+            return None
+
+    def list_recent(self, limit: Optional[int] = None) -> List[Any]:
+        """Newest first, hydrated where possible. NEVER raises."""
+        try:
+            with self._lock:
+                rows = list(self._catalog.values())
+                full = dict(self._full)
+            from backend.core.ouroboros.battle_test.diff_archive import (
+                ArchivedDiff,
+            )
+            out = []
+            for row in rows:
+                ref = str(row.get("ref") or "")
+                out.append(full.get(ref) or ArchivedDiff.from_dict(row))
+            out = [e for e in out if e is not None]
+            return out[:limit] if limit else out
+        except Exception:  # noqa: BLE001
+            return []
+
+    def all_refs(self) -> Tuple[str, ...]:
+        """Every ref the daemon currently holds. NEVER raises."""
+        with self._lock:
+            return tuple(self._catalog)
+
+    # -- fetching -------------------------------------------------------
+
+    def _ensure_fetch(self, ref: str) -> None:
+        """Issue a fetch unless one is already outstanding. NEVER raises.
+
+        Deduplicated on the ref, because `lookup` runs from a RENDER path and
+        a repainting overlay would otherwise ask the daemon for the same diff
+        at the frame rate.
+        """
+        try:
+            now = float(self._clock())
+            with self._lock:
+                issued = self._pending.get(ref)
+                if issued is not None and (now - issued) < fetch_timeout_s():
+                    return          # already in flight
+                self._pending[ref] = now
+            if self._request is not None:
+                self._request(ref)
+        except Exception:  # noqa: BLE001
+            logger.debug("[DiffBridge] fetch degraded", exc_info=True)
+
+    def pending_refs(self) -> Tuple[str, ...]:
+        """Fetches still within their timeout. NEVER raises."""
+        try:
+            now = float(self._clock())
+            timeout = fetch_timeout_s()
+            with self._lock:
+                live = [r for r, at in self._pending.items()
+                        if (now - at) < timeout]
+                for ref in [r for r in self._pending if r not in live]:
+                    self._pending.pop(ref, None)
+            return tuple(live)
+        except Exception:  # noqa: BLE001
+            return ()
+
+    def is_hydrated(self, ref: object) -> bool:
+        with self._lock:
+            return str(ref or "") in self._full
+
+    def clear(self) -> None:
+        with self._lock:
+            self._catalog.clear()
+            self._full.clear()
+            self._pending.clear()
+            self._missing.clear()

--- a/backend/core/ouroboros/battle_test/epistemic_filter.py
+++ b/backend/core/ouroboros/battle_test/epistemic_filter.py
@@ -1,0 +1,200 @@
+"""Navigating the transcript by how the organism KNOWS what it said.
+
+Claude Code's transcript viewer jumps between search matches and between
+prompts. It cannot jump between claims, because nothing in it records which
+sentences were observed and which were asserted. O+V already does: every
+`_op_line` passes through `ui/provenance`, and a line the organism could not
+stand behind carries a mark saying so.
+
+That marking has been feeding the EYE since it shipped and nothing has ever
+navigated by it. This is the consumer.
+
+    c / C   jump to the next / previous CLAIM
+
+A claim is any line the organism marked — `‹stated›`, `‹model›`,
+`‹synthetic›`, `‹unverified›`. Pressing `c` through a session is asking the
+one question no other tool can answer: *show me every place this thing
+asserted something it did not observe.*
+
+Clean is two things, and it says so
+-----------------------------------
+`provenance` renders OBSERVED and DERIVED with no mark at all — marks are the
+EXCEPTION surface, which is what keeps a busy transcript readable. The
+consequence for a reader of rendered text is that "clean" means
+observed-or-derived and the two are genuinely indistinguishable from the
+line alone.
+
+So `provenance_of_line` returns None for a clean line rather than guessing
+OBSERVED. Reporting the stronger of the two would be exactly the kind of
+confident-and-wrong the mark vocabulary exists to prevent, and `UNKNOWN` is
+already taken by a different fact — asked and unanswerable. Three states,
+kept distinct.
+
+Read from the RENDERED line
+---------------------------
+The marks are visible text, because they were built to be read by a human.
+That means classification needs no index, no producer change and no second
+record to drift: a line that starts carrying a new mark becomes navigable for
+free. The same property that made click-to-expand cheap.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import re
+from typing import Any, List, Optional, Sequence
+
+logger = logging.getLogger("Ouroboros.EpistemicFilter")
+
+EPISTEMIC_FILTER_SCHEMA_VERSION: str = "epistemic_filter.1"
+
+__all__ = [
+    "EPISTEMIC_FILTER_SCHEMA_VERSION",
+    "claim_rows",
+    "epistemic_filter_enabled",
+    "next_claim_row",
+    "provenance_of_line",
+    "summarise",
+]
+
+#: Derived from the mark vocabulary at import rather than transcribed, so a
+#: new rung — or a re-worded mark — travels without an edit here. A hardcoded
+#: glyph list is how a filter silently stops seeing a category.
+_MARKS: "list" = []
+
+
+def _marks() -> "list":
+    """``[(pattern, Provenance), ...]`` weakest first. NEVER raises.
+
+    Weakest first because a line can carry more than one mark — a derived
+    summary of a model's prose — and `provenance` already rules that the
+    WEAKER wins: a chain is exactly as trustworthy as its softest link.
+    Scanning in strength order means the first hit is the right answer
+    without comparing them.
+    """
+    global _MARKS
+    if _MARKS:
+        return _MARKS
+    try:
+        from backend.core.ouroboros.ui.provenance import Provenance, mark_for
+
+        built = []
+        for prov in sorted(Provenance, key=lambda p: int(p)):
+            markup = getattr(mark_for(prov), "markup", "") or ""
+            # `‹model›` out of ` [magenta]‹model›[/magenta]` — the visible
+            # text, which is what survives into a rendered line.
+            found = re.search(r"‹[^›]+›", markup)
+            if found:
+                built.append((re.compile(re.escape(found.group(0))), prov))
+        _MARKS = built
+    except Exception:  # noqa: BLE001
+        logger.debug("[Epistemic] mark table degraded", exc_info=True)
+        _MARKS = []
+    return _MARKS
+
+
+def epistemic_filter_enabled() -> bool:
+    """``JARVIS_EPISTEMIC_NAV_ENABLED`` (default true). NEVER raises."""
+    return os.environ.get(
+        "JARVIS_EPISTEMIC_NAV_ENABLED", "1",
+    ).strip().lower() not in ("0", "false", "no", "off")
+
+
+def provenance_of_line(line: Any) -> Optional[Any]:
+    """The rung a rendered line declares, or None if it declares none.
+
+    None is NOT "observed". A clean line is observed-or-derived and the two
+    cannot be told apart from the text — reporting the stronger would be the
+    confident-and-wrong this vocabulary exists to prevent. Pure. NEVER raises.
+    """
+    try:
+        text = str(line or "")
+        try:
+            from backend.core.ouroboros.battle_test.append_only import (
+                strip_ansi,
+            )
+            text = strip_ansi(text)
+        except Exception:  # noqa: BLE001
+            pass
+        # Rich markup may still be present when a line is read before
+        # rendering; the mark's visible text is inside it either way.
+        for pattern, prov in _marks():
+            if pattern.search(text):
+                return prov
+        return None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def claim_rows(rows: Sequence[Any]) -> List[int]:
+    """Indices of every row the organism MARKED. Pure. NEVER raises.
+
+    "Marked" rather than "weak": the set is exactly the lines that carry an
+    exception, which is the set an operator auditing a session wants to walk.
+    """
+    try:
+        return [i for i, line in enumerate(rows or ())
+                if provenance_of_line(line) is not None]
+    except Exception:  # noqa: BLE001
+        return []
+
+
+def next_claim_row(
+    rows: Sequence[Any],
+    current: Any,
+    direction: int = 1,
+    *,
+    wrap: bool = True,
+) -> Optional[int]:
+    """The next marked row from ``current``, or None. Pure. NEVER raises.
+
+    Wraps by default, like every `n`/`N` an operator has used. Returns None
+    only when there is nothing to go to at all — a reader who presses `c` in
+    a session with no claims should be told that, not moved somewhere
+    arbitrary and left to wonder.
+    """
+    try:
+        marks = claim_rows(rows)
+        if not marks:
+            return None
+        try:
+            here = int(current)
+        except (TypeError, ValueError):
+            here = -1 if direction >= 0 else len(list(rows or ()))
+        if direction >= 0:
+            after = [i for i in marks if i > here]
+            if after:
+                return after[0]
+            return marks[0] if wrap else None
+        before = [i for i in marks if i < here]
+        if before:
+            return before[-1]
+        return marks[-1] if wrap else None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def summarise(rows: Sequence[Any]) -> str:
+    """``3 modeled · 1 unverified`` — what this screenful is standing on.
+
+    Counted rather than listed, and ordered weakest-first so the least
+    defensible category is read first. An empty result renders nothing: a
+    transcript with no claims is the good case and does not need a badge
+    saying so. NEVER raises.
+    """
+    try:
+        from collections import Counter
+
+        counts: Any = Counter()
+        for line in rows or ():
+            prov = provenance_of_line(line)
+            if prov is not None:
+                counts[prov] += 1
+        if not counts:
+            return ""
+        parts = [f"{n} {prov.label}"
+                 for prov, n in sorted(counts.items(),
+                                       key=lambda kv: int(kv[0]))]
+        return " · ".join(parts)
+    except Exception:  # noqa: BLE001
+        return ""

--- a/backend/core/ouroboros/battle_test/inflight_registry.py
+++ b/backend/core/ouroboros/battle_test/inflight_registry.py
@@ -1,0 +1,259 @@
+"""What the organism is writing RIGHT NOW, readable in the producing process.
+
+The gap this closes
+-------------------
+`capability_handoff` measured `stream_rows` UNSET on the daemon cockpit, and
+`cockpit_mount` recorded why in its own comment rather than papering over it:
+
+    there is NO process-global in-flight text to read.
+    `live_tool_stream.make_tool_observer` creates a stream per tool CALL and
+    nothing publishes a current frame, so a provider here would have to
+    invent one.
+
+So the daemon composed every in-flight frame, shipped it across the bridge,
+and could not draw it at its own terminal. Attached clients saw the sentence
+being written; the process writing it did not.
+
+Why not tap the publish seam
+----------------------------
+The obvious single chokepoint is `publish_telemetry_global`, which every
+frame already crosses. It is the wrong one, and specifically wrong for this
+consumer: it returns early when `attached_cockpits() <= 0`. A daemon with
+nobody attached publishes nothing — which is exactly the case where the
+daemon's OWN cockpit is the surface being looked at. Tapping there would
+have produced a strip that works only while a second cockpit is watching.
+
+So the registry is fed where frames are COMPOSED, before any transport
+decision: `stream_renderer` for model prose, `live_tool_stream` for command
+tails. Two sites, because there are genuinely two producers — but one sink,
+and both hand it the payload they were already building, so the sink cannot
+drift from what crosses the wire.
+
+Why a map rather than a single slot
+-----------------------------------
+"The" in-flight text is not a single thing. L3 dispatches subagents in
+parallel and the Venom loop can have several tools open at once, so at any
+instant there may be four sentences being written. A single slot would
+flicker between them at whatever rate they happen to emit — the surface
+would be busy and unreadable, and worse, it would look like one stream
+behaving erratically rather than four behaving normally.
+
+The map is keyed by stream identity and the reader takes the most recently
+updated LIVE entry: "what is happening right now" answered literally. Bounded
+and TTL'd, because a producer that dies mid-command never sends `done`, and a
+strip that hangs on a sentence nobody is writing is the specific lie every
+other heartbeat-fed surface in this cockpit is careful not to tell.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger("Ouroboros.InflightRegistry")
+
+INFLIGHT_REGISTRY_SCHEMA_VERSION: str = "inflight_registry.1"
+
+__all__ = [
+    "INFLIGHT_REGISTRY_SCHEMA_VERSION",
+    "InflightEntry",
+    "current_inflight",
+    "inflight_registry_enabled",
+    "inflight_ttl_s",
+    "live_inflight",
+    "note_inflight_frame",
+    "reset_inflight_for_tests",
+]
+
+#: Slots kept before the oldest is evicted. A ceiling, not a target: the
+#: reader draws ONE, and this only has to be wide enough that a burst of
+#: parallel subagents cannot push the live entry out before it is read.
+_MAX_SLOTS = 32
+
+
+def inflight_registry_enabled() -> bool:
+    """``JARVIS_INFLIGHT_REGISTRY_ENABLED`` (default true). NEVER raises."""
+    return os.environ.get(
+        "JARVIS_INFLIGHT_REGISTRY_ENABLED", "1",
+    ).strip().lower() not in ("0", "false", "no", "off")
+
+
+def inflight_ttl_s() -> float:
+    """How long a frame stays current without an update. NEVER raises.
+
+    Not a display preference — a correctness bound. A producer killed
+    mid-command never sends ``done``, and without this the strip would show
+    that command's last output for the rest of the session as though it were
+    still running.
+
+    Clamped rather than trusted: too small and a genuinely slow command
+    (a 90-second test run emitting nothing) flickers out between frames; too
+    large and a dead one lingers. The default is generous relative to
+    `live_tool_stream`'s own emit interval so a quiet-but-alive command
+    survives, and short enough that a dead one clears within a breath.
+    """
+    try:
+        return max(1.0, min(120.0, float(
+            os.environ.get("JARVIS_INFLIGHT_TTL_S", "") or 8.0,
+        )))
+    except (TypeError, ValueError):
+        return 8.0
+
+
+class InflightEntry:
+    """One producer's current sentence, and what shape it is.
+
+    ``is_tool`` is carried rather than re-derived because the two producers
+    need different wrapping — command output keeps its line structure, model
+    prose does not — and the frame's own ``kind`` is the only place that
+    distinction is known for certain.
+    """
+
+    __slots__ = ("key", "text", "is_tool", "at", "op_id")
+
+    def __init__(self, key: str, text: str, is_tool: bool, at: float,
+                 op_id: str = "") -> None:
+        self.key = key
+        self.text = text
+        self.is_tool = is_tool
+        self.at = at
+        self.op_id = op_id
+
+    def age_s(self, now: Optional[float] = None) -> float:
+        return max(0.0, (now if now is not None else time.monotonic()) - self.at)
+
+    def __repr__(self) -> str:  # pragma: no cover — diagnostics only
+        return (f"InflightEntry(key={self.key!r}, is_tool={self.is_tool}, "
+                f"chars={len(self.text)})")
+
+
+_LOCK = threading.Lock()
+_SLOTS: "Dict[str, InflightEntry]" = {}
+
+
+def _key_for(payload: Any) -> str:
+    """Stream identity: the op AND the tool.
+
+    Not the op alone. The Venom loop can hold several tools open inside one
+    operation, and keying on `op_id` would make them overwrite each other —
+    which reads as a single stream flickering rather than as the several that
+    are actually running.
+    """
+    try:
+        op = str(payload.get("op_id") or "")
+        tool = str(payload.get("tool") or payload.get("kind") or "")
+        label = str(payload.get("label") or "")
+        return f"{op}::{tool}::{label}"
+    except Exception:  # noqa: BLE001
+        return "::"
+
+
+def note_inflight_frame(payload: Any) -> bool:
+    """Record one composed frame. NEVER raises; True when it was kept.
+
+    Takes the payload the producer was ALREADY building rather than a
+    hand-assembled copy, which is what stops this from becoming a second
+    opinion about what is in flight.
+
+    ``done`` retires the slot instead of storing an empty one: by then the
+    text has landed in the deck, and an empty slot that is merely "not live"
+    still has to be reasoned about by every reader.
+    """
+    if not inflight_registry_enabled():
+        return False
+    try:
+        if not isinstance(payload, dict):
+            return False
+        kind = str(payload.get("kind") or "")
+        if kind not in ("stream_inflight", "tool_stream"):
+            return False
+        key = _key_for(payload)
+        now = time.monotonic()
+        with _LOCK:
+            if payload.get("done"):
+                _SLOTS.pop(key, None)
+                return True
+            text = compose_inflight_text(payload)
+            if not text:
+                _SLOTS.pop(key, None)
+                return False
+            _SLOTS[key] = InflightEntry(
+                key=key, text=text, is_tool=(kind == "tool_stream"),
+                at=now, op_id=str(payload.get("op_id") or ""),
+            )
+            # Evict by AGE, not insertion order: the oldest slot is the one
+            # least likely to still be alive, and a dict's insertion order
+            # would evict a long-running command that simply started first.
+            if len(_SLOTS) > _MAX_SLOTS:
+                oldest = min(_SLOTS.values(), key=lambda e: e.at)
+                _SLOTS.pop(oldest.key, None)
+        return True
+    except Exception:  # noqa: BLE001
+        logger.debug("[Inflight] note degraded", exc_info=True)
+        return False
+
+
+def compose_inflight_text(payload: Any) -> str:
+    """The frame's text, headered exactly as every surface headers it.
+
+    ONE composition. The attach client built ``$ bash · 11s`` inline while
+    handling the frame; a second copy here would be a second opinion about
+    what an in-flight tool tail looks like, which is the precise defect the
+    roster and the status line each already paid for once.
+
+    The header is what makes a long command read as WORKING rather than
+    stalled — which is the entire complaint a black box produces.
+    """
+    try:
+        if not isinstance(payload, dict):
+            return ""
+        body = str(payload.get("text") or "")
+        if str(payload.get("kind") or "") != "tool_stream":
+            return body
+        tool = str(payload.get("tool") or "tool")
+        try:
+            head = f"$ {tool} · {float(payload.get('elapsed_s') or 0.0):.0f}s"
+        except (TypeError, ValueError):
+            head = f"$ {tool}"
+        return f"{head}\n{body}" if body else head
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def live_inflight(now: Optional[float] = None) -> List[InflightEntry]:
+    """Every entry still within its TTL, newest first. NEVER raises.
+
+    Expiry is evaluated on READ rather than swept on a timer: there is no
+    thread to own a sweep here, and a registry that needs one has invented a
+    lifecycle for what is otherwise pure state. Stale entries are dropped as
+    they are noticed, so the map cannot accumulate them either.
+    """
+    try:
+        moment = now if now is not None else time.monotonic()
+        ttl = inflight_ttl_s()
+        with _LOCK:
+            dead = [k for k, e in _SLOTS.items() if e.age_s(moment) > ttl]
+            for k in dead:
+                _SLOTS.pop(k, None)
+            entries = list(_SLOTS.values())
+        return sorted(entries, key=lambda e: e.at, reverse=True)
+    except Exception:  # noqa: BLE001
+        return []
+
+
+def current_inflight(now: Optional[float] = None) -> Optional[InflightEntry]:
+    """The one sentence to draw, or None. NEVER raises.
+
+    Most-recently-updated wins. With four subagents writing at once that is
+    the honest answer to "what is happening right now", and it is stable in
+    practice because a producer mid-burst keeps refreshing its own slot.
+    """
+    entries = live_inflight(now)
+    return entries[0] if entries else None
+
+
+def reset_inflight_for_tests() -> None:
+    with _LOCK:
+        _SLOTS.clear()

--- a/backend/core/ouroboros/battle_test/keymap.py
+++ b/backend/core/ouroboros/battle_test/keymap.py
@@ -85,6 +85,51 @@ RESERVED_KEYSTROKES: Dict[str, str] = {
     "ctrl+m": "identical to Enter in terminals (both send CR)",
 }
 
+#: Claude Code's name for an action ov already has under its own.
+#:
+#: ALIASES, not renames. `agents:stopAll` and `chat:killAgents` are the same
+#: capability on the same chord, and both must resolve — an operator arriving
+#: from CC writes CC's name in `keybindings.json` and expects it to work,
+#: while anyone who already bound ov's name must not have their config
+#: silently stop applying. Renaming would fix the first at the cost of the
+#: second, and a config key that maps to nothing fails SILENTLY: the binding
+#: simply never appears.
+#:
+#: Read left-to-right: CC's spelling -> ov's canonical id.
+ACTION_ALIASES: Dict[str, str] = {
+    "chat:killAgents": "agents:stopAll",
+    "app:toggleTranscript": "transcript:toggle",
+    "app:toggleTodos": "app:toggleChecklist",
+    "app:interrupt": "chat:interrupt",
+    "chat:cycleMode": "app:cycleTrust",
+    # CC's `scroll:*` family is ov's `transcript:*` viewer table — same
+    # movements, same defaults, different namespace because ov's arrived
+    # with the viewer rather than with a scroll region.
+    "scroll:lineUp": "transcript:lineUp",
+    "scroll:lineDown": "transcript:lineDown",
+    "scroll:halfPageUp": "transcript:halfUp",
+    "scroll:halfPageDown": "transcript:halfDown",
+    "scroll:fullPageUp": "transcript:pageUp",
+    "scroll:fullPageDown": "transcript:pageDown",
+    "scroll:top": "transcript:top",
+    "scroll:bottom": "transcript:bottom",
+}
+
+
+def aliases_for(action: str) -> Tuple[str, ...]:
+    """Every spelling that means *action*, itself included. NEVER raises."""
+    try:
+        target = str(action or "")
+        names = {target}
+        names.update(a for a, canon in ACTION_ALIASES.items()
+                     if canon == target)
+        if target in ACTION_ALIASES:
+            names.add(ACTION_ALIASES[target])
+        return tuple(sorted(names))
+    except Exception:  # noqa: BLE001
+        return (str(action or ""),)
+
+
 #: Rebindable, but the operator deserves a heads-up.
 TERMINAL_CONFLICTS: Dict[str, str] = {
     "ctrl+b": "tmux prefix (tmux swallows it unless pressed twice)",
@@ -597,13 +642,16 @@ def effective_key_sequences(
         overrides: Dict[str, Optional[str]] = {}
         for ctx in ("Global", context):
             overrides.update(cfg.blocks.get(ctx, {}))
+        # Any spelling of this action counts. A config written against CC's
+        # name must bind ov's action, and vice versa — see `ACTION_ALIASES`.
+        names = set(aliases_for(action))
         kept = [
             canon for canon, _ in defaults
-            if canon not in overrides or overrides[canon] == action
+            if canon not in overrides or overrides[canon] in names
         ]
         added = [
             canon for canon, mapped in overrides.items()
-            if mapped == action and canon not in kept
+            if mapped in names and canon not in kept
         ]
         seen: set = set()
         out: List[Tuple[str, ...]] = []
@@ -876,6 +924,8 @@ def write_config_template() -> Optional[str]:
 
 
 __all__ = [
+    "ACTION_ALIASES",
+    "aliases_for",
     "ActionSpec",
     "CONFIG_PATH_ENV_VAR",
     "CONFIG_TEMPLATE",

--- a/backend/core/ouroboros/battle_test/live_tool_stream.py
+++ b/backend/core/ouroboros/battle_test/live_tool_stream.py
@@ -293,6 +293,24 @@ class LiveToolStream:
         self._send(payload)
 
     def _send(self, payload: dict) -> None:
+        # THE seam, and deliberately here rather than at the construction
+        # site. `cockpit_mount` recorded the correct fix as "a
+        # `set_active_stream` registry ... which needs a producer-side audit
+        # of every stream construction site" — but construction sites can
+        # multiply, and a producer that forgets to register is silently dark.
+        # Every frame a stream ever emits passes through this one method
+        # regardless of how the stream was made, so recording here cannot be
+        # forgotten by a future caller.
+        #
+        # Before the `self._publish` branch, so an injected publisher (the
+        # demo, the tests) records identically to the real bridge.
+        try:
+            from backend.core.ouroboros.battle_test.inflight_registry import (
+                note_inflight_frame,
+            )
+            note_inflight_frame(payload)
+        except Exception:  # noqa: BLE001
+            pass
         try:
             if self._publish is not None:
                 self._publish(payload)

--- a/backend/core/ouroboros/battle_test/menu_bindings.py
+++ b/backend/core/ouroboros/battle_test/menu_bindings.py
@@ -1,0 +1,226 @@
+"""The completion menu and the gate, made remappable.
+
+Both surfaces WORKED and neither could be rebound. `/keys` could not list
+them, `keybindings.json` could not move them, and an operator who had
+remapped everything else found these four keys immovable for no reason they
+could see. Claude Code declares both as first-class contexts —
+`autocomplete:accept|dismiss|previous|next` and `confirm:yes|no` — so this is
+the last of its interactive-action catalog ov had no answer for.
+
+Overriding, not declaring
+-------------------------
+Every other action in this cockpit was NEW: nothing was bound, so declaring
+it was the whole job. These keys are already bound, inside prompt_toolkit's
+own `basic`/`emacs` bindings, and that makes the work a different shape.
+
+The lever is the FILTER. prompt_toolkit resolves a keystroke to the last
+matching binding whose filter passes, so a binding registered after pt's and
+gated on `has_completions` wins exactly while the menu is open and is absent
+otherwise. Nothing is unbound, nothing is monkeypatched, and with the menu
+closed `Tab` and the arrows behave precisely as they did.
+
+Why the gate is not simply CC's dialog
+--------------------------------------
+CC's `Confirmation` context is a MODAL — while it is up, nothing else can
+receive a key, so binding bare `y` and `n` there is free. ov's NOTIFY_APPLY
+gate is a STRIP drawn over a live prompt the operator can still type into.
+Binding `y` unconditionally would mean an operator writing "yes, rerun the
+suite" accepted a patch on the first character.
+
+So the confirm keys additionally require an EMPTY BUFFER. With anything
+typed they are ordinary characters; on an empty prompt with a gate pending
+they are the answer to it. That restriction is not in CC because CC does not
+have this problem.
+
+`Escape` is deliberately NOT bound to `confirm:no`. It already means
+interrupt-or-dismiss and the overlay arbiter owns it; a third meaning that
+appears only while a gate is up is how an operator learns to distrust the
+key. `n` says no, and `/reject` always works.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Callable, Optional
+
+logger = logging.getLogger("Ouroboros.MenuBindings")
+
+MENU_BINDINGS_SCHEMA_VERSION: str = "menu_bindings.1"
+
+__all__ = [
+    "MENU_BINDINGS_SCHEMA_VERSION",
+    "gate_is_pending",
+    "install_completion_actions",
+    "install_confirm_actions",
+    "menu_bindings_enabled",
+]
+
+
+def menu_bindings_enabled() -> bool:
+    """``JARVIS_MENU_BINDINGS_ENABLED`` (default true). NEVER raises.
+
+    Off, prompt_toolkit's own bindings are left entirely alone — which is
+    what the surface did before, so the rollback is exact.
+    """
+    return os.environ.get(
+        "JARVIS_MENU_BINDINGS_ENABLED", "1",
+    ).strip().lower() not in ("0", "false", "no", "off")
+
+
+def gate_is_pending() -> bool:
+    """Is a NOTIFY_APPLY window open right now? NEVER raises.
+
+    Read from `pending_apply.snapshot`, which returns None when idle and
+    drops expired rows where the clock that set them lives — so this reader
+    never decides whether a window has closed. A confirm key that answered a
+    gate which had already auto-applied would be worse than one that did
+    nothing.
+    """
+    try:
+        from backend.core.ouroboros.battle_test.pending_apply import snapshot
+        snap = snapshot()
+        return bool(snap and snap.get("rows"))
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _buffer_empty() -> bool:
+    """NEVER raises. False when it cannot tell — the safe direction, because
+    a confirm key must not fire on a prompt that might have text in it."""
+    try:
+        from prompt_toolkit.application.current import get_app_or_none
+        app = get_app_or_none()
+        if app is None or app.current_buffer is None:
+            return False
+        return not app.current_buffer.text.strip()
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def install_completion_actions(kb: Any) -> int:
+    """Make the completion menu's four keys remappable. NEVER raises.
+
+    Returns the number bound. Each is gated on `has_completions`, so with the
+    menu closed prompt_toolkit's own handling is untouched — `Tab` still
+    indents or completes, and the arrows still walk history.
+    """
+    if kb is None or not menu_bindings_enabled():
+        return 0
+    try:
+        from prompt_toolkit.filters import has_completions
+
+        from backend.core.ouroboros.battle_test.keymap import bind_action
+
+        def _buf(event: Any) -> Any:
+            return getattr(event, "current_buffer", None) or (
+                event.app.current_buffer if getattr(event, "app", None) else None)
+
+        def _accept(event: Any) -> None:
+            try:
+                buf = _buf(event)
+                state = getattr(buf, "complete_state", None)
+                current = getattr(state, "current_completion", None)
+                if current is not None:
+                    buf.apply_completion(current)
+                else:
+                    # Nothing HIGHLIGHTED yet — the menu is open but the
+                    # operator has not walked it. Selecting the first entry is
+                    # what every shell does and what makes one Tab enough.
+                    buf.complete_next()
+            except Exception:  # noqa: BLE001
+                pass
+
+        def _dismiss(event: Any) -> None:
+            try:
+                buf = _buf(event)
+                if buf is not None:
+                    buf.cancel_completion()
+            except Exception:  # noqa: BLE001
+                pass
+
+        def _walk(step: int) -> Callable[[Any], None]:
+            def _handler(event: Any) -> None:
+                try:
+                    buf = _buf(event)
+                    if buf is None:
+                        return
+                    if step > 0:
+                        buf.complete_next()
+                    else:
+                        buf.complete_previous()
+                except Exception:  # noqa: BLE001
+                    pass
+            return _handler
+
+        bound = 0
+        for action, keys, handler, desc in (
+            ("autocomplete:accept", ("tab",), _accept, "accept the suggestion"),
+            ("autocomplete:dismiss", ("escape",), _dismiss, "close the menu"),
+            ("autocomplete:next", ("down",), _walk(+1), "next suggestion"),
+            ("autocomplete:previous", ("up",), _walk(-1), "previous suggestion"),
+        ):
+            bound += bind_action(
+                kb, action, keys, handler, context="Autocomplete",
+                filter=has_completions, description=desc,
+            )
+        return bound
+    except Exception:  # noqa: BLE001
+        logger.debug("[MenuBindings] completion actions unavailable",
+                     exc_info=True)
+        return 0
+
+
+def install_confirm_actions(
+    kb: Any,
+    submit: Optional[Callable[[str], Any]] = None,
+) -> int:
+    """Answer a pending gate with one key. NEVER raises; returns the count.
+
+    `y` accepts and `n` rejects, but ONLY on an empty prompt with a gate
+    actually open — see the module docstring for why that guard does not
+    exist in CC. `Enter` joins `y` for the same reason CC binds it there: on
+    an empty prompt it submits nothing, so the only thing it can mean while a
+    gate is up is "the obvious answer".
+
+    Both route through `submit` — the same callable a typed `/accept` goes
+    through — so the risk tier, the audit trail and the countdown clear
+    exactly as they do for the verb. A key that bypassed the verb would be a
+    second approval path, and this is the one surface where two paths that
+    disagree is a governance problem rather than a UI one.
+    """
+    if kb is None or submit is None or not menu_bindings_enabled():
+        return 0
+    try:
+        from prompt_toolkit.filters import Condition
+
+        from backend.core.ouroboros.battle_test.keymap import bind_action
+
+        @Condition
+        def _answerable() -> bool:
+            return gate_is_pending() and _buffer_empty()
+
+        def _answer(verb: str) -> Callable[[Any], None]:
+            def _handler(event: Any) -> None:
+                try:
+                    submit(verb)
+                except Exception:  # noqa: BLE001
+                    logger.debug("[MenuBindings] %s degraded", verb,
+                                 exc_info=True)
+            return _handler
+
+        bound = 0
+        bound += bind_action(
+            kb, "confirm:yes", ("y", "enter"), _answer("/accept"),
+            context="Confirmation", filter=_answerable,
+            description="accept the pending apply (empty prompt only)",
+        )
+        bound += bind_action(
+            kb, "confirm:no", ("n",), _answer("/reject"),
+            context="Confirmation", filter=_answerable,
+            description="reject the pending apply (empty prompt only)",
+        )
+        return bound
+    except Exception:  # noqa: BLE001
+        logger.debug("[MenuBindings] confirm actions unavailable",
+                     exc_info=True)
+        return 0

--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -29,11 +29,19 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import logging
 import os
 import re
 import subprocess
 import sys
 import time
+
+#: Module logger. SIX `except` handlers in this file called `logger.debug`
+#: and nothing defined it, so each raised `NameError` FROM THE HANDLER —
+#: turning a swallowed degradation into a crash and making every
+#: "NEVER raises" docstring above them false. Found by Pyright while a
+#: seventh was being added.
+logger = logging.getLogger("Ouroboros.SerpentFlow")
 from collections import deque
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
@@ -6587,6 +6595,13 @@ class SerpentREPL:
                 run_bipartite_repl,
                 should_run_bipartite,
             )
+            # Imported UNALIASED: `capability_handoff` matches the
+            # call-site spelling derived from the function's own
+            # name, so `as _waived` would make the waiver invisible
+            # to the auditor it exists for.
+            from backend.core.ouroboros.ui.capability_handoff import (
+                waived,
+            )
             if should_run_bipartite():
                 import asyncio as _aio
 
@@ -6739,6 +6754,25 @@ class SerpentREPL:
                     # spot in the other direction: it COMPOSED every in-flight
                     # frame, shipped it over the bridge, and could not draw it.
                     stream_rows=_mount.get("stream_rows"),
+                    # DECLINED, not overlooked — and said here because a
+                    # waiver is read at the call site, which is why
+                    # `cockpit_mount` could not declare it from inside a dict
+                    # of values.
+                    #
+                    # An identity header would strand the emblem at row 0
+                    # while the bottom-anchored deck hugs the prompt, leaving
+                    # a band that belongs to neither. The daemon puts its
+                    # identity in the TRANSCRIPT instead (`seed_daemon_
+                    # masthead`), where it scrolls with the work it names.
+                    # `waived()` returns None, so this is byte-identical at
+                    # runtime to omitting the argument; what changes is that
+                    # the omission stops being silent, and the audit stops
+                    # reporting a design decision as an unfilled hook.
+                    header=waived(
+                        "the daemon's identity lives in the transcript "
+                        "masthead, not in a header row"),
+                    header_height=waived(
+                        "no header row to size — see `header`"),
                 )
                 return
         except Exception:  # noqa: BLE001 — cockpit failure NEVER bricks the REPL

--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -6727,6 +6727,11 @@ class SerpentREPL:
                     # `/expand d-N` opens this. The daemon owns the archive, so
                     # this is the only surface that can render a diff locally.
                     diff_rows=_mount.get("diff_rows"),
+                    # The sentence being written, at the terminal of the
+                    # process writing it. This was the daemon's oldest blind
+                    # spot in the other direction: it COMPOSED every in-flight
+                    # frame, shipped it over the bridge, and could not draw it.
+                    stream_rows=_mount.get("stream_rows"),
                 )
                 return
         except Exception:  # noqa: BLE001 — cockpit failure NEVER bricks the REPL

--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -903,6 +903,17 @@ def _local_agent_rows() -> list:
     takes the snapshot, so the local and remote surfaces run identical code
     over identical data and cannot diverge in appearance.
 
+    Gated on `roster_visible` — the roster mounts BELOW the caret, and Claude
+    Code puts nothing standing there ("the input box stays fixed at the bottom
+    of the screen"; running subagents are what `/tasks` is for). Hidden by
+    default, so an idle cockpit does not spend five rows under the cursor
+    listing workers nobody asked about. The snapshot keeps updating either
+    way, so `/tasks` answers instantly rather than warming up.
+
+    The gate is HERE rather than in `render_roster` because this is the
+    function that decides whether a cockpit row exists; the renderer only
+    decides what one looks like.
+
     NEVER raises: the agent view is chrome, and chrome does not get to take
     down the REPL.
     """
@@ -910,7 +921,10 @@ def _local_agent_rows() -> list:
         import shutil
         from backend.core.ouroboros.battle_test.agent_roster import (
             get_agent_roster, render_roster, roster_line_budget,
+            roster_visible,
         )
+        if not roster_visible():
+            return []
         size = shutil.get_terminal_size(fallback=(100, 30))
         return render_roster(
             get_agent_roster().snapshot(),
@@ -6201,6 +6215,16 @@ class SerpentREPL:
         if line.startswith("/provenance") or line.startswith("provenance "):
             self._handle_provenance()
             return True
+        # CC's background-task view, which its docs keep deliberately separate
+        # from the Ctrl+T checklist. On THIS surface the roster is local, so
+        # the verb toggles this process's own visibility flag; an attached
+        # cockpit intercepts `/tasks` in `ov._route_operator_line` and never
+        # sends it here, because that terminal's rows are that client's.
+        if line in ("/tasks", "tasks") or line.startswith(
+            ("/tasks ", "tasks "),
+        ):
+            self._handle_tasks(line)
+            return True
 
         # Gap #7 Slice 1 — /preflight + /organism (moved boot content)
         if line in ("/preflight", "preflight"):
@@ -8742,6 +8766,75 @@ class SerpentREPL:
     # ── Gap #6 Slice 4 — /narrate REPL verb ─────────────────────
 
     _NARRATE_DENSITIES = ("off", "preambles", "on", "verbose")
+
+    def _handle_tasks(self, line: str) -> None:
+        """``/tasks [on|off]`` — the running-subagent roster, on demand.
+
+        Claude Code separates the ambient checklist from the background-task
+        view and says so plainly: the `Ctrl+T` checklist "is separate from the
+        background-task view. To see running shells and subagents, use
+        `/tasks` instead." Under fullscreen, "the input box stays fixed at the
+        bottom of the screen" — nothing standing lives beneath the caret.
+
+        This cockpit had the roster mounted permanently below the prompt, so
+        an idle session spent five rows under the operator's cursor listing
+        workers they had not asked about. The rows are now asked for.
+
+        The verb prints the roster whenever it turns it ON, so the operator
+        gets the answer in the same keystroke rather than turning a surface on
+        and then waiting a frame to read it. NEVER raises.
+        """
+        try:
+            import shutil
+            from backend.core.ouroboros.battle_test.agent_roster import (
+                get_agent_roster, render_roster, roster_line_budget,
+                roster_visible, set_roster_visible, toggle_roster,
+            )
+            arg = (line.split(None, 1)[1].strip().lower()
+                   if " " in line.strip() else "")
+            if arg in ("on", "show"):
+                shown = set_roster_visible(True)
+            elif arg in ("off", "hide"):
+                shown = set_roster_visible(False)
+            elif arg:
+                state = "shown" if roster_visible() else "hidden"
+                self._flow.console.print(
+                    f"  [{_SEM['dim']}]tasks: {state} "
+                    f"(on | off)[/{_SEM['dim']}]", highlight=False,
+                )
+                return
+            else:
+                shown = toggle_roster()
+            if not shown:
+                self._flow.console.print(
+                    f"  [{_SEM['dim']}]tasks: hidden[/{_SEM['dim']}]",
+                    highlight=False,
+                )
+                return
+            size = shutil.get_terminal_size(fallback=(100, 30))
+            # Straight to the renderer, which holds no opinion about
+            # visibility — the gate lives in the row PROVIDERS. A verb that
+            # consulted the flag it had just flipped would have to be careful
+            # about ordering; this one cannot get that wrong.
+            rows = render_roster(
+                get_agent_roster().snapshot(),
+                width=max(20, int(size.columns)),
+                max_lines=roster_line_budget(max(4, int(size.lines))),
+            )
+            if not rows:
+                # Claude Code's own edge, stated in its docs: "when Claude
+                # hasn't created any checklist items yet, the toggle has no
+                # visible effect because there's nothing to display." An
+                # empty roster and a broken verb look identical unless one
+                # of them says which it is.
+                self._flow.console.print(
+                    f"  [{_SEM['dim']}]tasks: shown · nothing running"
+                    f"[/{_SEM['dim']}]", highlight=False,
+                )
+                return
+            self._flow.console.print("\n".join(rows), highlight=False)
+        except Exception:  # noqa: BLE001
+            pass
 
     def _handle_provenance(self) -> None:
         """``/provenance`` — what the marks in the transcript mean.

--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -6231,6 +6231,13 @@ class SerpentREPL:
         if line in ("/stop-all", "stop-all"):
             self._handle_stop_all()
             return True
+        # A cockpit asking for a diff's BYTES. Not an operator verb — it is
+        # issued by `RemoteDiffArchive` when an overlay opens — so it is
+        # deliberately absent from the palette and answers on the telemetry
+        # lane rather than the transcript.
+        if line.startswith("/diff-fetch "):
+            self._serve_diff_fetch(line.split(None, 1)[1])
+            return True
 
         # Gap #7 Slice 1 — /preflight + /organism (moved boot content)
         if line in ("/preflight", "preflight"):
@@ -8777,6 +8784,68 @@ class SerpentREPL:
     # ── Gap #6 Slice 4 — /narrate REPL verb ─────────────────────
 
     _NARRATE_DENSITIES = ("off", "preambles", "on", "verbose")
+
+    def _serve_diff_fetch(self, ref: str) -> bool:
+        """Ship one archived diff to the cockpit that asked. NEVER raises.
+
+        The daemon owns the `DiffArchive`, so before this an `/expand d-3`
+        typed at an attached cockpit opened the diff on the DAEMON's overlay
+        and mirrored back one line saying it had opened. The operator was told
+        a diff was on screen and shown nothing — on the surface they review
+        changes from, the review surface was the one thing that did not cross.
+
+        Published ADDRESSED, not broadcast. The bridge reads the requesting
+        session from a ContextVar set at dispatch, and an addressed frame
+        whose cockpit has since detached is dropped rather than sprayed at
+        everyone — so two operators reviewing different diffs cannot overwrite
+        each other's overlay.
+
+        A ref the archive does not hold is answered with an explicit
+        `missing`, never with silence: the client records the negative and
+        stops asking, where silence would leave it re-issuing the fetch at the
+        frame rate against a ref that will never arrive.
+        """
+        try:
+            from backend.core.ouroboros.battle_test.cockpit_attach import (
+                publish_telemetry_global,
+            )
+            from backend.core.ouroboros.battle_test.diff_archive import (
+                get_default_archive,
+            )
+            from backend.core.ouroboros.battle_test.diff_bridge import (
+                DIFF_PAYLOAD_KIND, diff_bridge_enabled, max_diff_chars,
+            )
+            if not diff_bridge_enabled():
+                return False
+            entry = get_default_archive().lookup(str(ref or "").strip())
+            if entry is None:
+                publish_telemetry_global({
+                    "kind": DIFF_PAYLOAD_KIND,
+                    "ref": str(ref or ""),
+                    "missing": True,
+                })
+                return True
+            payload = entry.to_dict(include_diff_text=True)
+            text = str(payload.get("diff_text") or "")
+            cap = max_diff_chars()
+            if len(text) > cap:
+                # ANNOUNCED, not silent. A diff that simply stops is
+                # indistinguishable from one that ended, and an operator
+                # reviewing a truncated patch as though it were whole is the
+                # worst outcome this surface can produce.
+                dropped = len(text) - cap
+                payload["diff_text"] = (
+                    text[:cap]
+                    + f"\n… {dropped} more characters not shown "
+                      f"(JARVIS_DIFF_MAX_CHARS={cap})\n"
+                )
+                payload["truncated"] = True
+            payload["kind"] = DIFF_PAYLOAD_KIND
+            publish_telemetry_global(payload)
+            return True
+        except Exception:  # noqa: BLE001
+            logger.debug("[SerpentFlow] diff fetch degraded", exc_info=True)
+            return False
 
     def _handle_stop_all(self) -> None:
         """``/stop-all`` — ask every running op to stop at its next boundary.

--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -6225,6 +6225,12 @@ class SerpentREPL:
         ):
             self._handle_tasks(line)
             return True
+        # The verb behind CC's Ctrl+X Ctrl+K. A verb as well as a chord
+        # because the attach client cannot cancel anything itself — it holds
+        # no governed loop — so its keystroke has to arrive here as a line.
+        if line in ("/stop-all", "stop-all"):
+            self._handle_stop_all()
+            return True
 
         # Gap #7 Slice 1 — /preflight + /organism (moved boot content)
         if line in ("/preflight", "preflight"):
@@ -8766,6 +8772,55 @@ class SerpentREPL:
     # ── Gap #6 Slice 4 — /narrate REPL verb ─────────────────────
 
     _NARRATE_DENSITIES = ("off", "preambles", "on", "verbose")
+
+    def _handle_stop_all(self) -> None:
+        """``/stop-all`` — ask every running op to stop at its next boundary.
+
+        Claude Code's `Ctrl+X Ctrl+K`: "stop all running background subagents
+        in this session". ov ran L3 subagents with no keyboard control over
+        them at all — the largest functional gap against CC's interactive
+        surface, because the one thing an operator watching work go wrong
+        wants is a way to stop it.
+
+        Broad where `Esc` is narrow. Bare `Esc` cancels the operator's OWN
+        most recent op precisely so a reflex cannot kill a soak; this reaches
+        autonomous work too, and pays for that reach with the chord and its
+        repeat rather than with a warning nobody reads.
+
+        Cooperative: ops stop at their next phase transition. Saying so
+        matters — an operator told "stopped" who then watches a VERIFY finish
+        concludes the verb is broken, when it is the phase model working.
+        NEVER raises.
+        """
+        try:
+            if self._gls is None or not hasattr(
+                self._gls, "request_cancel_all",
+            ):
+                self._flow.console.print(
+                    f"  [{_SEM['death']}]stop-all unavailable (no governed "
+                    f"loop on this surface)[/{_SEM['death']}]",
+                    highlight=False,
+                )
+                return
+            stopped = self._gls.request_cancel_all() or []
+            if not stopped:
+                self._flow.console.print(
+                    f"  [{_SEM['dim']}]nothing running[/{_SEM['dim']}]",
+                    highlight=False,
+                )
+                return
+            noun = "op" if len(stopped) == 1 else "ops"
+            self._flow.console.print(
+                f"  [{_SEM['evolved']}]stopping {len(stopped)} {noun} — "
+                f"each halts at its next phase boundary[/{_SEM['evolved']}]\n"
+                + "\n".join(
+                    f"    [{_SEM['dim']}]{op}[/{_SEM['dim']}]"
+                    for op in stopped
+                ),
+                highlight=False,
+            )
+        except Exception:  # noqa: BLE001
+            pass
 
     def _handle_tasks(self, line: str) -> None:
         """``/tasks [on|off]`` — the running-subagent roster, on demand.

--- a/backend/core/ouroboros/battle_test/status_line.py
+++ b/backend/core/ouroboros/battle_test/status_line.py
@@ -51,7 +51,7 @@ import sys
 import time
 import dataclasses
 from dataclasses import dataclass
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger("Ouroboros.StatusLine")
 
@@ -159,6 +159,17 @@ def _custom_segment() -> str:
         import subprocess
         proc = subprocess.run(
             cmd, shell=True, capture_output=True, text=True, timeout=1.0,
+            # THE contract, not just a pipe. Claude Code's status line
+            # "receives JSON session data on stdin and displays whatever your
+            # script prints", and scripts written against it parse that
+            # object — so a runner that offered stdout-only would run
+            # somebody's existing statusline and hand it nothing to read.
+            #
+            # Shaped like CC's payload rather than like our internals for the
+            # same reason: the whole value of a status-line contract is that
+            # a script written once works in both, and inventing a private
+            # schema would make every such script ov-specific.
+            input=_statusline_payload(),
         )
         line = (proc.stdout or "").strip().splitlines()
         text = line[0][:80] if line else ""
@@ -166,6 +177,67 @@ def _custom_segment() -> str:
         return text
     except Exception:  # noqa: BLE001
         return _CUSTOM_SEGMENT_CACHE.get("text", "")
+
+
+def _statusline_payload(snapshot: Any = None) -> str:
+    """The JSON a status-line script reads on stdin. NEVER raises.
+
+    Mirrors Claude Code's documented shape — `model`, `workspace`, `cost`,
+    `context_window`, `session_id` — so a script written for CC runs here
+    unchanged. Keys ov cannot answer are OMITTED rather than faked: a script
+    reading `.cost.total_cost_usd` gets a real number or nothing, never a
+    zero that looks like a free session.
+
+    Additive by the same rule the heartbeat follows: a consumer that has
+    never heard of a key ignores it, and one expecting a key we do not send
+    falls back the way it would against an older CC.
+    """
+    import json
+
+    payload: Dict[str, Any] = {"schema_version": STATUS_LINE_SCHEMA_VERSION}
+    try:
+        import os as _os
+        cwd = _os.getcwd()
+        payload["cwd"] = cwd
+        payload["workspace"] = {"current_dir": cwd, "project_dir": cwd}
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        snap = snapshot if snapshot is not None else _current_snapshot()
+        if snap is not None:
+            # `phase` and `route` have no CC counterpart and are the two
+            # things an O+V operator most wants on a status line, so they
+            # ride alongside rather than being contorted into CC's shape.
+            payload["phase"] = getattr(snap, "phase", "") or "IDLE"
+            if getattr(snap, "route", ""):
+                payload["route"] = snap.route
+            if getattr(snap, "provider", ""):
+                payload["model"] = {"id": snap.provider,
+                                    "display_name": snap.provider}
+            spent = getattr(snap, "cost_spent_usd", None)
+            if spent is not None:
+                cost: Dict[str, Any] = {"total_cost_usd": round(float(spent), 6)}
+                budget = getattr(snap, "cost_budget_usd", None)
+                if budget:
+                    cost["budget_usd"] = round(float(budget), 6)
+                payload["cost"] = cost
+            if getattr(snap, "primary_op_id", ""):
+                payload["session_id"] = snap.primary_op_id
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        return json.dumps(payload)
+    except Exception:  # noqa: BLE001
+        return "{}"
+
+
+def _current_snapshot() -> Any:
+    """The live snapshot, or None. NEVER raises."""
+    try:
+        builder = get_status_line_builder()
+        return builder.snapshot() if builder is not None else None
+    except Exception:  # noqa: BLE001
+        return None
 
 
 class StatusLineBuilder:

--- a/backend/core/ouroboros/battle_test/stream_renderer.py
+++ b/backend/core/ouroboros/battle_test/stream_renderer.py
@@ -689,7 +689,7 @@ class StreamRenderer:
             from backend.core.ouroboros.battle_test.cockpit_attach import (
                 publish_telemetry_global,
             )
-            publish_telemetry_global({
+            frame = {
                 "kind": "stream_inflight",
                 "op_id": str(self._op_id or ""),
                 # Bounded: the wrap happens on the client, which knows its
@@ -697,7 +697,23 @@ class StreamRenderer:
                 # every frame. A sentence that long has stopped being one.
                 "text": tail[-_INFLIGHT_MAX_CHARS:],
                 "done": bool(done),
-            })
+            }
+            # Recorded HERE, before the transport decision, and handed the
+            # very dict that is about to cross the wire.
+            #
+            # `publish_telemetry_global` returns early when no cockpit is
+            # attached, so a daemon with nobody watching publishes nothing —
+            # which is exactly when its OWN cockpit is the surface being
+            # looked at. Feeding the registry after that call would give the
+            # daemon a strip that works only while someone else is watching.
+            try:
+                from backend.core.ouroboros.battle_test.inflight_registry import (  # noqa: E501
+                    note_inflight_frame,
+                )
+                note_inflight_frame(frame)
+            except Exception:  # noqa: BLE001
+                pass
+            publish_telemetry_global(frame)
         except Exception:  # noqa: BLE001
             logger.debug(
                 "[StreamRender] op=%s inflight degraded", self._op_id,

--- a/backend/core/ouroboros/battle_test/subagent_control.py
+++ b/backend/core/ouroboros/battle_test/subagent_control.py
@@ -1,0 +1,130 @@
+"""Keyboard control over running subagents — Claude Code's `Ctrl+X Ctrl+K`.
+
+The gap this closes
+-------------------
+ov dispatches L3 subagents into isolated worktrees and shows them in the
+roster, and an operator watching that go wrong had no key to stop it. `Esc`
+cancels the operator's OWN most recent op and is narrow on purpose — one
+reflex that reached autonomous work could kill a soak — so there was nothing
+between "cancel the thing I asked for" and "kill the process".
+
+Claude Code binds exactly this: "Stop all running background subagents in this
+session. Press twice within 3 seconds to confirm." The chord and its repeat
+ARE the safety argument. A single key with this reach would be a mis-hit
+waiting to happen; four deliberate presses cannot be.
+
+One installer, two transports
+-----------------------------
+Both cockpits send the same LINE. On the attach client `send_input` crosses
+the socket to the daemon; on the daemon `LocalCockpitClient` routes it
+straight into `_dispatch_verb`. So the authority — `request_cancel_all` on the
+governed loop — has exactly one caller reachable from exactly one verb, and
+the two surfaces cannot drift into different ideas of what the chord does.
+
+That asymmetry is not incidental. The attach client holds no governed loop and
+can cancel nothing itself; a client-side implementation would have had to grow
+its own opinion about what "all" means, on a process that cannot see the ops.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Optional
+
+logger = logging.getLogger("Ouroboros.SubagentControl")
+
+__all__ = ["STOP_ALL_ACTION", "STOP_ALL_KEYS", "STOP_ALL_VERB",
+           "install_stop_all_binding"]
+
+#: The remappable action id, so `/keys` lists it and keybindings.json can
+#: move it. Named for what it does to the ORGANISM, not for the keys.
+STOP_ALL_ACTION: str = "agents:stopAll"
+
+#: Claude Code's own chord. A chord rather than a single key because the
+#: reach is broad; `keymap.parse_keystroke` turns the space-separated form
+#: into prompt_toolkit's two-step sequence.
+STOP_ALL_KEYS = ("ctrl+x ctrl+k",)
+
+#: The verb both surfaces send. The chord is a shortcut FOR this, never a
+#: second path to the same authority.
+STOP_ALL_VERB: str = "/stop-all"
+
+
+def install_stop_all_binding(
+    kb: Any,
+    client: Any,
+    notify: Optional[Callable[[str], None]] = None,
+    running: Optional[Callable[[], int]] = None,
+) -> bool:
+    """Bind the stop-all chord into *kb*. NEVER raises; True when bound.
+
+    ``client`` needs only ``send_input``. ``notify`` shows the arming
+    message — a flash on the client, a console line on the daemon — and
+    ``running`` reports how many agents are live so the prompt can say what
+    is about to be stopped rather than asking the operator to confirm a
+    number they cannot see.
+    """
+    try:
+        from backend.core.ouroboros.battle_test.confirm_chord import (
+            ConfirmLatch, confirm_window_s,
+        )
+        from backend.core.ouroboros.battle_test.keymap import bind_action
+
+        if kb is None or client is None or not hasattr(client, "send_input"):
+            return False
+
+        latch = ConfirmLatch()
+
+        def _say(message: str) -> None:
+            if notify is None:
+                return
+            try:
+                notify(message)
+            except Exception:  # noqa: BLE001
+                pass
+
+        def _count() -> Optional[int]:
+            if running is None:
+                return None
+            try:
+                return int(running())
+            except Exception:  # noqa: BLE001
+                return None
+
+        def _stop_all(event: Any = None) -> None:
+            if not latch.press():
+                # The ARMING press. It reports what the confirmation would
+                # actually do, because "press again to confirm" on an idle
+                # organism asks the operator to weigh a consequence that does
+                # not exist — and they learn to confirm without reading.
+                n = _count()
+                if n == 0:
+                    _say("nothing running")
+                    latch.disarm()
+                    return
+                subject = (
+                    f"{n} agent{'s' if n != 1 else ''}"
+                    if n is not None else "all running work"
+                )
+                _say(
+                    f"press again within {confirm_window_s():.0f}s to stop "
+                    f"{subject}"
+                )
+                return
+            # CONFIRMED. The verb carries it from here — on either surface.
+            try:
+                client.send_input(STOP_ALL_VERB)
+                _say("stopping — each op halts at its next phase boundary")
+            except Exception:  # noqa: BLE001
+                logger.debug("[SubagentControl] stop-all send failed",
+                             exc_info=True)
+                _say("stop-all could not reach the organism")
+
+        return bind_action(
+            kb, STOP_ALL_ACTION, STOP_ALL_KEYS, _stop_all,
+            context="Global",
+            description="stop every running agent (press twice to confirm)",
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug("[SubagentControl] stop-all binding unavailable",
+                     exc_info=True)
+        return False

--- a/backend/core/ouroboros/battle_test/transcript_hatches.py
+++ b/backend/core/ouroboros/battle_test/transcript_hatches.py
@@ -570,7 +570,15 @@ def install_transcript_hatches(kb: Any, ui: Any, client: Any) -> bool:
 
         from backend.core.ouroboros.battle_test.keymap import bind_action
 
-        scrolled = Condition(is_scrolled_back)
+        # The viewer, OR a scrolled-back canvas. Widened rather than
+        # replaced: scrolled-back was the ONLY way these keys ever became
+        # live, and an operator with that habit must not lose it because a
+        # mode arrived. `transcript_surface_active` is the one predicate both
+        # states resolve through, so the two cannot drift.
+        from backend.core.ouroboros.battle_test.transcript_mode import (
+            transcript_surface_active,
+        )
+        scrolled = Condition(transcript_surface_active)
         bound = 0
 
         bound += bind_action(
@@ -617,7 +625,13 @@ def install_transcript_hatches(kb: Any, ui: Any, client: Any) -> bool:
                 pass
 
         bound += bind_action(
-            kb, "narrate:toggle", ("ctrl+o",), _toggle_narrate,
+            # MOVED off Ctrl+O, which Claude Code owns for the transcript
+            # viewer. Three actions claimed that one key here — this, the
+            # deck's `lanes`, and the legacy TUI's expand — which is one more
+            # than a key can serve. Narration loses the least by moving: it
+            # is the only one of the three with a typed verb (`/narrate`)
+            # that does exactly the same thing.
+            kb, "narrate:toggle", ("ctrl+x ctrl+n",), _toggle_narrate,
             context="Global",
             description="toggle live narration normal ↔ verbose (/narrate)",
         )

--- a/backend/core/ouroboros/battle_test/transcript_hatches.py
+++ b/backend/core/ouroboros/battle_test/transcript_hatches.py
@@ -235,13 +235,112 @@ def jump_block(event: Any, direction: int) -> None:
         logger.debug("[Hatches] jump degraded", exc_info=True)
 
 
+#: `Ctrl+L` pressed twice CLEARS. One latch, module-level, because the two
+#: presses are two separate key events and the state between them has to
+#: outlive the first handler.
+_CLEAR_LATCH: Any = None
+
+
+def _clear_latch() -> Any:
+    """The double-press latch, built once. NEVER raises; None if unavailable."""
+    global _CLEAR_LATCH
+    if _CLEAR_LATCH is None:
+        try:
+            from backend.core.ouroboros.battle_test.confirm_chord import (
+                ConfirmLatch,
+            )
+            # CC's window for this gesture is TWO seconds, not the three its
+            # `Ctrl+X Ctrl+K` uses — and the difference is the point. Killing
+            # every agent deserves a longer think than redrawing a screen, so
+            # the window is pinned here rather than inherited from the shared
+            # default.
+            _CLEAR_LATCH = ConfirmLatch(window_s=_clear_window_s())
+        except Exception:  # noqa: BLE001
+            return None
+    return _CLEAR_LATCH
+
+
+def _clear_window_s() -> float:
+    """``JARVIS_CLEAR_DOUBLE_PRESS_S`` (default 2.0, CC's). NEVER raises."""
+    try:
+        return max(0.5, min(10.0, float(
+            os.environ.get("JARVIS_CLEAR_DOUBLE_PRESS_S", "") or 2.0)))
+    except (TypeError, ValueError):
+        return 2.0
+
+
 def force_redraw(event: Any) -> None:
-    """``Ctrl+L`` — recover a garbled screen. NEVER raises."""
+    """``Ctrl+L`` — recover a garbled screen; twice in 2s clears. NEVER raises.
+
+    Claude Code: "if you press `Ctrl+L` once, Claude Code redraws the screen
+    and also shows a hint that pressing it again runs `/clear`. If you press
+    it twice within two seconds, Claude Code runs `/clear`."
+
+    The redraw happens on BOTH presses, and that ordering is the whole design:
+    the first press must do its own job completely, because an operator
+    reaching for Ctrl+L is usually recovering a garbled screen and has no
+    intention of clearing anything. Arming is a side effect of a key that
+    already worked, never a mode it puts them into.
+
+    Reuses `ConfirmLatch` — the primitive built for `Ctrl+X Ctrl+K`, whose
+    docstring already named this as CC's second use of the shape. A second
+    timer here would be two answers to "did they press it twice".
+    """
     try:
         event.app.renderer.clear()
         event.app.invalidate()
     except Exception:  # noqa: BLE001
         pass
+    try:
+        latch = _clear_latch()
+        if latch is None:
+            return
+        if not latch.press():
+            _flash_clear_hint(event)
+            return
+        _submit_clear(event)
+    except Exception:  # noqa: BLE001
+        logger.debug("[Hatches] clear latch degraded", exc_info=True)
+
+
+def _flash_clear_hint(event: Any) -> None:
+    """Say that a second press clears. NEVER raises.
+
+    Without this the gesture is undiscoverable AND dangerous: an operator who
+    happens to hit Ctrl+L twice while fixing a garbled screen would lose their
+    transcript with no warning that it was about to happen.
+    """
+    try:
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            get_active_canvas,
+        )
+        canvas = get_active_canvas()
+        if canvas is not None:
+            canvas.emit("line", {
+                "text": f"  press ctrl+l again within "
+                        f"{_clear_window_s():.0f}s to clear the transcript",
+            })
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _submit_clear(event: Any) -> None:
+    """Run `/clear` the way a typed line would. NEVER raises.
+
+    Through the prompt buffer's own accept handler rather than by calling a
+    clear function directly: `/clear` is a verb every surface already routes,
+    and reaching past that router would mean this key clears on some surfaces
+    and not others.
+    """
+    try:
+        buf = event.app.current_buffer
+        if buf is None:
+            return
+        buf.text = "/clear"
+        buf.cursor_position = len("/clear")
+        buf.validate_and_handle()
+    except Exception:  # noqa: BLE001
+        logger.debug("[Hatches] clear submit degraded", exc_info=True)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/core/ouroboros/battle_test/transcript_hatches.py
+++ b/backend/core/ouroboros/battle_test/transcript_hatches.py
@@ -316,10 +316,13 @@ def _flash_clear_hint(event: Any) -> None:
         )
         canvas = get_active_canvas()
         if canvas is not None:
-            canvas.emit("line", {
-                "text": f"  press ctrl+l again within "
-                        f"{_clear_window_s():.0f}s to clear the transcript",
-            })
+            # `push_raw`, not `emit`: `emit` renders through the typed
+            # event registry, and an unregistered type falls to the null
+            # renderer, which prints the TYPE NAME. This surfaced as a
+            # transcript line reading `· line`.
+            canvas.push_raw(
+                f"  [dim]press ctrl+l again within "
+                f"{_clear_window_s():.0f}s to clear the transcript[/dim]")
     except Exception:  # noqa: BLE001
         pass
 

--- a/backend/core/ouroboros/battle_test/transcript_mode.py
+++ b/backend/core/ouroboros/battle_test/transcript_mode.py
@@ -19,29 +19,26 @@ An explicit mode answers all of that at once: inside it every key is
 unambiguous, so the whole `less`-style table becomes bindable, and there is
 somewhere honest to put `?`.
 
-What this mode does NOT do
---------------------------
-It does not pause auto-follow on entry, and that is a property of the
-viewport rather than an omission here. `CanvasViewport.following` is
-DERIVED — `self._offset <= 0` — so "pinned to the tail" and "showing the
-newest line" are one state with one variable. There is no honest way to
-stop following without also moving the view, and moving it would throw away
-the line the operator pressed the key while reading, which is the only line
-they certainly care about.
+Entering PINS the page
+----------------------
+It does now, and that is a change from how this shipped. `CanvasViewport`
+originally derived `following` from `_offset <= 0`, so "pinned to the tail"
+and "showing the newest line" were one state with one variable and there was
+no honest way to stop following without also moving the view — which would
+have thrown away the line the operator pressed the key while reading. This
+module documented that limitation rather than faking a pin.
 
-So entering at the live tail gives a keyboard mode, not a frozen page: new
-output still arrives and the view still follows until the operator scrolls.
-One press of `k` pauses it, because any non-zero offset is what "paused"
-MEANS here. CC does better — "scrolling up pauses auto-follow so new output
-doesn't pull you back to the bottom" is a real independent flag there — and
-matching it needs a `paused` field on the viewport plus an audit of every
-consumer of `following` (the status line, the tail hint, the emit path).
-That is its own change; claiming it in this one would be a pin that does
-not pin.
+The viewport now carries a real `paused` flag, so entering freezes the page
+WITHOUT moving it: arriving output is held, `new_since_paused` counts what
+landed, and the sentence the operator was reading stays where it was. That
+is CC's stated property — "scrolling up pauses auto-follow so new output
+doesn't pull you back to the bottom" — with the explicit half now available
+as well as the scroll-implied one.
 
-Leaving DOES return to the tail, which works and matters: the organism keeps
-running while the operator reads, and an exit that left the view in history
-would hand back a cockpit that looks live and is showing minutes-old output.
+Leaving returns to the tail AND resumes, which works and matters: the
+organism keeps running while the operator reads, and an exit that left the
+view in history would hand back a cockpit that looks live while showing
+minutes-old output.
 
 Scrolled-back is still a way IN (unchanged, so nobody's habit breaks) but no
 longer the only one, and the mode is the way the operator is TOLD they are
@@ -115,19 +112,32 @@ def transcript_surface_active() -> bool:
 
 
 def enter_transcript_mode() -> bool:
-    """Enter the viewer. NEVER raises; True if it changed.
+    """Enter the viewer and PIN the page. NEVER raises; True if it changed.
 
-    Deliberately does NOT move the view. Entering where the operator was
-    reading is the whole contract — a viewer that jumped on entry would
-    discard the line they pressed the key while looking at. See the module
-    docstring for why it cannot pause auto-follow either.
+    Deliberately does not MOVE the view — entering where the operator was
+    reading is the whole contract, and a viewer that jumped on entry would
+    discard the line they pressed the key while looking at. It does now
+    freeze it: `CanvasViewport.pause` holds arriving output without touching
+    the offset, which is the distinction the derived `following` could not
+    express.
     """
     with _LOCK:
         changed = not _ACTIVE[0]
         _ACTIVE[0] = True
     if changed:
+        _pause_viewport()
         _repaint()
     return changed
+
+
+def _pause_viewport() -> None:
+    """Hold auto-follow without moving the view. NEVER raises."""
+    try:
+        vp = _viewport()
+        if vp is not None and hasattr(vp, "pause"):
+            vp.pause()
+    except Exception:  # noqa: BLE001
+        logger.debug("[TranscriptMode] pause degraded", exc_info=True)
 
 
 def exit_transcript_mode() -> bool:

--- a/backend/core/ouroboros/battle_test/transcript_mode.py
+++ b/backend/core/ouroboros/battle_test/transcript_mode.py
@@ -80,6 +80,15 @@ _VIEWER_ACTIONS: Tuple[Tuple[str, Tuple[str, ...], str], ...] = (
 )
 
 _ACTIVE = [False]
+#: Where the claim walk is standing, in RING coordinates.
+#:
+#: Without it, each press re-derives its starting point from the newest
+#: VISIBLE line — and after landing on a claim that line is below the claim,
+#: so searching backward finds the same one again and `C` sticks. Every
+#: `n`/`N` an operator has used carries a cursor for exactly this reason.
+#:
+#: None means "not walking": the next press starts from where the eye is.
+_CLAIM_CURSOR: List[Optional[int]] = [None]
 _LOCK = threading.Lock()
 
 
@@ -124,6 +133,7 @@ def enter_transcript_mode() -> bool:
     with _LOCK:
         changed = not _ACTIVE[0]
         _ACTIVE[0] = True
+        _CLAIM_CURSOR[0] = None
     if changed:
         _pause_viewport()
         _repaint()
@@ -150,6 +160,7 @@ def exit_transcript_mode() -> bool:
     with _LOCK:
         changed = bool(_ACTIVE[0])
         _ACTIVE[0] = False
+        _CLAIM_CURSOR[0] = None
     if changed:
         _resume_viewport()
     return changed
@@ -167,6 +178,7 @@ def toggle_transcript_mode() -> bool:
 def reset_transcript_mode_for_tests() -> None:
     with _LOCK:
         _ACTIVE[0] = False
+        _CLAIM_CURSOR[0] = None
 
 
 # ---------------------------------------------------------------------------
@@ -198,6 +210,89 @@ def _metrics() -> Tuple[int, int]:
         return int(total), int(budget)
     except Exception:  # noqa: BLE001
         return 0, 0
+
+
+def _all_lines() -> list:
+    """Every RETAINED line, oldest first. NEVER raises.
+
+    The full ring, not the rendered window — and that distinction is the
+    whole feature. Classifying only what is drawn finds claims that are
+    already on screen, so `c` would move nowhere and look broken. The point
+    of walking claims is reaching the ones twenty thousand lines back.
+    """
+    try:
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            get_active_canvas,
+        )
+        canvas = get_active_canvas()
+        if canvas is None:
+            return []
+        return list(canvas._buffer.snapshot() or ())
+    except Exception:  # noqa: BLE001
+        return []
+
+
+def _visible_index(total: int, budget: int, offset: int) -> int:
+    """Buffer index of the NEWEST visible line. NEVER raises.
+
+    The one place the two coordinate systems meet: the viewport counts back
+    from the tail, the ring counts forward from the oldest. Everything else
+    stays in ring coordinates so there is only ever this one conversion to
+    get wrong.
+    """
+    try:
+        return max(0, int(total) - max(0, int(offset)) - 1)
+    except Exception:  # noqa: BLE001
+        return 0
+
+
+def _seek_to_index(vp: Any, index: int, total: int, budget: int) -> None:
+    """Scroll so buffer line ``index`` is on screen. NEVER raises.
+
+    Placed a third of a screen down rather than at an edge: a claim pinned to
+    the top row has no context above it, and one pinned to the bottom is
+    about to be pushed off by the next arriving line.
+
+    Expressed as a RELATIVE scroll because the viewport owns its clamping —
+    an absolute offset computed here would be stale against a ring that drops
+    lines as it rotates.
+    """
+    try:
+        if vp is None or total <= 0:
+            return
+        lead = max(1, int(budget) // 3)
+        end = min(int(total), max(1, int(index) + 1 + lead))
+        want = max(0, int(total) - end)
+        delta = int(getattr(vp, "offset", 0) or 0) - want
+        # `scroll` takes NEGATIVE for older. `want > offset` means going
+        # BACK, so the difference is negated exactly once, here — the same
+        # sign trap `CanvasViewport.page` records having been got backwards.
+        if delta:
+            vp.scroll(delta, total=total, budget=budget)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _say_no_claims(summary: str) -> None:
+    """Tell the operator the search found nothing, and what IS there.
+
+    A jump key that silently does nothing is indistinguishable from a broken
+    one — the same reason an unknown `/expand` ref lists what is available.
+    """
+    try:
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            get_active_canvas,
+        )
+        canvas = get_active_canvas()
+        if canvas is None:
+            return
+        # `push_raw`, not `emit` — see `transcript_hatches._flash_clear_hint`.
+        canvas.push_raw(
+            f"  [dim]no unobserved claims · {summary}[/dim]" if summary else
+            "  [dim]no unobserved claims retained — everything on record "
+            "was observed or derived[/dim]")
+    except Exception:  # noqa: BLE001
+        pass
 
 
 def _repaint() -> None:
@@ -403,6 +498,59 @@ def install_transcript_mode_bindings(
                     logger.debug("[TranscriptMode] move degraded",
                                  exc_info=True)
             return _handler
+
+        # --- beyond CC: jump by EPISTEMIC STATE -------------------------
+        #
+        # CC's viewer jumps between search matches and prompts. It cannot
+        # jump between claims, because nothing in it records which sentences
+        # were observed and which were asserted. O+V marks every one at the
+        # `_op_line` chokepoint and has never navigated by it.
+        #
+        # Pressing `c` through a session asks the question no other tool can
+        # answer: show me every place this thing asserted something it did
+        # not observe.
+        def _claim(direction: int) -> Any:
+            def _handler(event: Any) -> None:
+                try:
+                    from backend.core.ouroboros.battle_test.epistemic_filter import (  # noqa: E501
+                        epistemic_filter_enabled, next_claim_row, summarise,
+                    )
+                    if not epistemic_filter_enabled():
+                        return
+                    lines = _all_lines()
+                    if not lines:
+                        return
+                    vp = _viewport()
+                    total, budget = _metrics()
+                    with _LOCK:
+                        cursor = _CLAIM_CURSOR[0]
+                    here = cursor if cursor is not None else _visible_index(
+                        total or len(lines), budget,
+                        int(getattr(vp, "offset", 0) or 0),
+                    )
+                    target = next_claim_row(lines, here, direction)
+                    if target is None:
+                        _say_no_claims(summarise(lines))
+                        return
+                    with _LOCK:
+                        _CLAIM_CURSOR[0] = target
+                    _seek_to_index(vp, target, total or len(lines), budget)
+                    _repaint()
+                except Exception:  # noqa: BLE001
+                    logger.debug("[TranscriptMode] claim jump degraded",
+                                 exc_info=True)
+            return _handler
+
+        for action, keys, direction, desc in (
+            ("transcript:nextClaim", ("c",), +1,
+             "jump to the next unobserved claim"),
+            ("transcript:prevClaim", ("C",), -1,
+             "jump to the previous unobserved claim"),
+        ):
+            bound += bind_action(
+                kb, action, keys, _claim(direction),
+                context="Transcript", filter=inside, description=desc,
+            )
 
         _KINDS = {
             "transcript:lineUp": ("line", -1),

--- a/backend/core/ouroboros/battle_test/transcript_mode.py
+++ b/backend/core/ouroboros/battle_test/transcript_mode.py
@@ -1,0 +1,417 @@
+"""The transcript viewer as a MODE — Claude Code's `Ctrl+O`.
+
+What was already here, and what was missing
+-------------------------------------------
+`transcript_hatches` already binds most of CC's viewer keys — `/` search,
+`n`/`N`, `{`/`}`, `[` to native scrollback, `v` to `$EDITOR`. What it did not
+have is the thing that makes them a VIEWER rather than a set of shortcuts:
+a state you are in.
+
+It stood in a mode's place with a proxy — "printable hatch keys are live
+while the operator is scrolled back" — and that proxy is load-bearing,
+because `[`, `v`, `{` and `}` are characters someone might genuinely type.
+It is also silent. Nothing tells the operator the keys changed meaning, the
+doorway (PgUp) is not the doorway CC teaches, and `j`/`k`/`g`/`G`/`Space`
+were never bound at all because at the live tail they would type as
+themselves.
+
+An explicit mode answers all of that at once: inside it every key is
+unambiguous, so the whole `less`-style table becomes bindable, and there is
+somewhere honest to put `?`.
+
+What this mode does NOT do
+--------------------------
+It does not pause auto-follow on entry, and that is a property of the
+viewport rather than an omission here. `CanvasViewport.following` is
+DERIVED — `self._offset <= 0` — so "pinned to the tail" and "showing the
+newest line" are one state with one variable. There is no honest way to
+stop following without also moving the view, and moving it would throw away
+the line the operator pressed the key while reading, which is the only line
+they certainly care about.
+
+So entering at the live tail gives a keyboard mode, not a frozen page: new
+output still arrives and the view still follows until the operator scrolls.
+One press of `k` pauses it, because any non-zero offset is what "paused"
+MEANS here. CC does better — "scrolling up pauses auto-follow so new output
+doesn't pull you back to the bottom" is a real independent flag there — and
+matching it needs a `paused` field on the viewport plus an audit of every
+consumer of `following` (the status line, the tail hint, the emit path).
+That is its own change; claiming it in this one would be a pin that does
+not pin.
+
+Leaving DOES return to the tail, which works and matters: the organism keeps
+running while the operator reads, and an exit that left the view in history
+would hand back a cockpit that looks live and is showing minutes-old output.
+
+Scrolled-back is still a way IN (unchanged, so nobody's habit breaks) but no
+longer the only one, and the mode is the way the operator is TOLD they are
+in a viewer.
+"""
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any, List, Optional, Tuple
+
+logger = logging.getLogger("Ouroboros.TranscriptMode")
+
+__all__ = [
+    "TRANSCRIPT_MODE_SCHEMA_VERSION",
+    "enter_transcript_mode",
+    "exit_transcript_mode",
+    "install_transcript_mode_bindings",
+    "is_transcript_mode",
+    "shortcut_panel",
+    "toggle_transcript_mode",
+    "transcript_surface_active",
+]
+
+TRANSCRIPT_MODE_SCHEMA_VERSION: str = "transcript_mode.1"
+
+#: CC's own viewer table, as (keys, what it does). Declared ONCE and read
+#: back by both the binder and `?`, so the panel cannot advertise a key
+#: nothing binds — the defect `roster_hint` already exists to prevent.
+_VIEWER_ACTIONS: Tuple[Tuple[str, Tuple[str, ...], str], ...] = (
+    ("transcript:lineUp", ("k", "up"), "scroll one line up"),
+    ("transcript:lineDown", ("j", "down"), "scroll one line down"),
+    ("transcript:halfUp", ("ctrl+u",), "scroll half a page up"),
+    ("transcript:halfDown", ("ctrl+d",), "scroll half a page down"),
+    ("transcript:pageUp", ("ctrl+b", "b"), "scroll a full page up"),
+    ("transcript:pageDown", ("ctrl+f", "space"), "scroll a full page down"),
+    ("transcript:top", ("g",), "jump to the top"),
+    ("transcript:bottom", ("G",), "jump to the bottom"),
+)
+
+_ACTIVE = [False]
+_LOCK = threading.Lock()
+
+
+# ---------------------------------------------------------------------------
+# state
+# ---------------------------------------------------------------------------
+
+
+def is_transcript_mode() -> bool:
+    """Whether the viewer owns the keyboard right now. NEVER raises."""
+    with _LOCK:
+        return bool(_ACTIVE[0])
+
+
+def transcript_surface_active() -> bool:
+    """The viewer OR a scrolled-back canvas. NEVER raises.
+
+    The filter the printable hatch keys use. Both are states in which `[`,
+    `v`, `{` and `}` cannot be something the operator meant to type, and
+    widening rather than replacing means the pre-existing scroll-back habit
+    keeps working exactly as it did.
+    """
+    try:
+        from backend.core.ouroboros.battle_test.transcript_hatches import (
+            is_scrolled_back,
+        )
+        return is_transcript_mode() or is_scrolled_back()
+    except Exception:  # noqa: BLE001
+        return is_transcript_mode()
+
+
+def enter_transcript_mode() -> bool:
+    """Enter the viewer. NEVER raises; True if it changed.
+
+    Deliberately does NOT move the view. Entering where the operator was
+    reading is the whole contract — a viewer that jumped on entry would
+    discard the line they pressed the key while looking at. See the module
+    docstring for why it cannot pause auto-follow either.
+    """
+    with _LOCK:
+        changed = not _ACTIVE[0]
+        _ACTIVE[0] = True
+    if changed:
+        _repaint()
+    return changed
+
+
+def exit_transcript_mode() -> bool:
+    """Leave the viewer, return to the tail and resume following.
+
+    Returning to the tail is not optional. The organism keeps working while
+    the operator reads; an exit that left the view in history would hand
+    back a cockpit that looks live and is showing minutes-old output.
+    """
+    with _LOCK:
+        changed = bool(_ACTIVE[0])
+        _ACTIVE[0] = False
+    if changed:
+        _resume_viewport()
+    return changed
+
+
+def toggle_transcript_mode() -> bool:
+    """Flip the mode; returns the new state. NEVER raises."""
+    if is_transcript_mode():
+        exit_transcript_mode()
+        return False
+    enter_transcript_mode()
+    return True
+
+
+def reset_transcript_mode_for_tests() -> None:
+    with _LOCK:
+        _ACTIVE[0] = False
+
+
+# ---------------------------------------------------------------------------
+# the viewport, reached the way the hatches already reach it
+# ---------------------------------------------------------------------------
+
+
+def _viewport() -> Optional[Any]:
+    try:
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            get_active_canvas,
+        )
+        canvas = get_active_canvas()
+        return getattr(canvas, "_viewport", None) if canvas else None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _metrics() -> Tuple[int, int]:
+    """(total lines, visible budget) for the live canvas, or (0, 0)."""
+    try:
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            get_active_canvas,
+        )
+        canvas = get_active_canvas()
+        if canvas is None:
+            return 0, 0
+        total, budget = canvas.scroll_metrics()
+        return int(total), int(budget)
+    except Exception:  # noqa: BLE001
+        return 0, 0
+
+
+def _repaint() -> None:
+    try:
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            get_active_canvas,
+        )
+        canvas = get_active_canvas()
+        if canvas is not None:
+            canvas._invalidate_now()
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _resume_viewport() -> None:
+    try:
+        vp = _viewport()
+        if vp is not None:
+            vp.to_bottom()
+        _repaint()
+    except Exception:  # noqa: BLE001
+        logger.debug("[TranscriptMode] resume degraded", exc_info=True)
+
+
+# ---------------------------------------------------------------------------
+# `?`
+# ---------------------------------------------------------------------------
+
+
+def shortcut_panel() -> List[str]:
+    """The viewer's own key reference — CC's `?` inside the viewer.
+
+    Composed from the declarations rather than written beside them, and from
+    the EFFECTIVE keys rather than the defaults, so an operator who remapped
+    a key in keybindings.json is shown the key they actually have. A panel
+    that confidently lists someone else's bindings is worse than no panel.
+
+    NEVER raises: the panel degrades to the declared defaults.
+    """
+    rows: List[str] = ["  transcript viewer"]
+    try:
+        from backend.core.ouroboros.battle_test.keymap import (
+            effective_key_sequences,
+        )
+    except Exception:  # noqa: BLE001
+        effective_key_sequences = None  # type: ignore[assignment]
+
+    def _keys(action: str, defaults: Tuple[str, ...]) -> str:
+        if effective_key_sequences is None:
+            return " / ".join(defaults)
+        try:
+            seqs = effective_key_sequences(
+                action, defaults, context="Transcript",
+            )
+            shown = [
+                " ".join(_pretty(k) for k in seq) for seq in seqs
+            ]
+            return " / ".join(shown) if shown else " / ".join(defaults)
+        except Exception:  # noqa: BLE001
+            return " / ".join(defaults)
+
+    try:
+        for action, defaults, meaning in _VIEWER_ACTIONS:
+            rows.append(f"    {_keys(action, defaults):<18} {meaning}")
+        for action, defaults, meaning in (
+            ("transcript:search", ("/",), "search"),
+            ("transcript:nextMatch", ("n",), "next match"),
+            ("transcript:prevMatch", ("N",), "previous match"),
+            ("transcript:prevBlock", ("{",), "previous ⏺/❯ block"),
+            ("transcript:nextBlock", ("}",), "next ⏺/❯ block"),
+            ("transcript:dump", ("[",), "write to native scrollback"),
+            ("transcript:editor", ("v",), "open in $EDITOR"),
+            ("transcript:exit", ("q", "escape"), "leave the viewer"),
+        ):
+            rows.append(f"    {_keys(action, defaults):<18} {meaning}")
+    except Exception:  # noqa: BLE001
+        logger.debug("[TranscriptMode] panel degraded", exc_info=True)
+    return rows
+
+
+def _pretty(key: Any) -> str:
+    """One key, as an operator would say it aloud.
+
+    Handles BOTH spellings, because both reach here: `effective_key_sequences`
+    returns prompt_toolkit's wire form (``"c-u"``, ``" "``) while a raw
+    ``Keys`` member stringifies as ``"Keys.ControlU"``. The first cut only
+    knew the second, so the panel printed ``c-u`` and rendered the space key
+    as nothing at all — a shortcut reference with a blank in it.
+    """
+    try:
+        name = str(getattr(key, "name", None) or key).rsplit(".", 1)[-1]
+        if name == " " or name == "space":
+            return "space"
+        if name.startswith("c-") and len(name) > 2:
+            return f"ctrl+{name[2:]}"
+        if name.startswith("Control") and len(name) > 7:
+            return f"ctrl+{name[7:].lower()}"
+        return {
+            "Up": "↑", "Down": "↓", "up": "↑", "down": "↓",
+            "Escape": "esc", "escape": "esc",
+        }.get(name, name)
+    except Exception:  # noqa: BLE001
+        return str(key)
+
+
+# ---------------------------------------------------------------------------
+# the bindings
+# ---------------------------------------------------------------------------
+
+
+def install_transcript_mode_bindings(
+    kb: Any,
+    notify: Optional[Any] = None,
+) -> bool:
+    """Mount Ctrl+O and the viewer's key table. NEVER raises.
+
+    Returns True when ≥1 key bound. ``notify`` renders the `?` panel and the
+    mode's own messages — a flash on the attach client, a console line on
+    the daemon — because this module owns no surface and must not grow one.
+    """
+    try:
+        from prompt_toolkit.filters import Condition
+
+        from backend.core.ouroboros.battle_test.keymap import bind_action
+
+        if kb is None:
+            return False
+        inside = Condition(is_transcript_mode)
+        bound = 0
+
+        def _say(lines: Any) -> None:
+            if notify is None:
+                return
+            try:
+                notify(lines)
+            except Exception:  # noqa: BLE001
+                pass
+
+        # --- the doorway -------------------------------------------------
+        def _toggle(event: Any) -> None:
+            if toggle_transcript_mode():
+                _say("transcript — ? for keys, q to leave")
+            else:
+                _say("live")
+
+        bound += bind_action(
+            kb, "transcript:toggle", ("ctrl+o",), _toggle, context="Global",
+            description="enter/leave the transcript viewer",
+        )
+
+        def _exit(event: Any) -> None:
+            exit_transcript_mode()
+            _say("live")
+
+        # `eager`, so `q` and `Escape` leave the viewer rather than waiting
+        # to see whether they begin a longer sequence — an exit key that
+        # hesitates reads as a cockpit that has hung.
+        bound += bind_action(
+            kb, "transcript:exit", ("q", "escape"), _exit,
+            context="Transcript", filter=inside, eager=inside,
+            description="leave the transcript viewer",
+        )
+
+        def _help(event: Any) -> None:
+            _say(shortcut_panel())
+
+        bound += bind_action(
+            kb, "transcript:help", ("?",), _help,
+            context="Transcript", filter=inside,
+            description="show the viewer's keys",
+        )
+
+        # --- the less-style table ---------------------------------------
+        def _mover(kind: str, direction: int) -> Any:
+            def _handler(event: Any) -> None:
+                try:
+                    vp = _viewport()
+                    if vp is None:
+                        return
+                    total, budget = _metrics()
+                    if kind == "line":
+                        vp.scroll(direction, total=total, budget=budget)
+                    elif kind == "half":
+                        vp.scroll(
+                            direction * max(1, budget // 2),
+                            total=total, budget=budget,
+                        )
+                    elif kind == "page":
+                        # SIGN FLIP. `CanvasViewport.page` takes +1 for PgUp
+                        # (older) while `scroll` takes NEGATIVE for older —
+                        # the two disagree, and its own docstring records the
+                        # first cut of the PgUp binding getting this wrong and
+                        # reading as a dead key. `direction` is negative-for-
+                        # older here to match `scroll`, so it inverts once,
+                        # here, rather than each caller remembering.
+                        vp.page(-direction, total=total, budget=budget)
+                    elif kind == "top":
+                        vp.to_top(total=total, budget=budget)
+                    else:
+                        vp.to_bottom()
+                    _repaint()
+                except Exception:  # noqa: BLE001
+                    logger.debug("[TranscriptMode] move degraded",
+                                 exc_info=True)
+            return _handler
+
+        _KINDS = {
+            "transcript:lineUp": ("line", -1),
+            "transcript:lineDown": ("line", +1),
+            "transcript:halfUp": ("half", -1),
+            "transcript:halfDown": ("half", +1),
+            "transcript:pageUp": ("page", -1),
+            "transcript:pageDown": ("page", +1),
+            "transcript:top": ("top", -1),
+            "transcript:bottom": ("bottom", +1),
+        }
+        for action, defaults, _meaning in _VIEWER_ACTIONS:
+            kind, direction = _KINDS[action]
+            bound += bind_action(
+                kb, action, defaults, _mover(kind, direction),
+                context="Transcript", filter=inside,
+                description=_meaning,
+            )
+        return bound > 0
+    except Exception:  # noqa: BLE001
+        logger.debug("[TranscriptMode] bindings unavailable", exc_info=True)
+        return False

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -1141,6 +1141,91 @@ class AttachUI:
         except Exception:  # noqa: BLE001
             return None
 
+    def diff_controller(self, client: Any = None) -> Any:
+        """This cockpit's diff overlay, backed by the daemon's archive.
+
+        NOT a second overlay. `DiffOverlayController` takes its archive as a
+        constructor argument — it was built transport-agnostic and nobody had
+        used that — so the client gets the same renderer, the same epoch
+        guard, the same `Escape` arbitration and the same off-thread Pygments
+        pass that keeps the loop unstalled. A regression in the daemon's diff
+        surfaces here too, instead of in a parallel drawing that agrees with
+        itself.
+
+        Built lazily and once: the controller that the `/expand d-N` verb
+        OPENS and the `diff_rows` hook that DRAWS must be the same object, or
+        the verb fills a surface nothing renders.
+        """
+        existing = getattr(self, "_diff_controller", None)
+        if existing is not None:
+            return existing
+        try:
+            from backend.core.ouroboros.battle_test.diff_bridge import (
+                RemoteDiffArchive,
+            )
+            from backend.core.ouroboros.battle_test.diff_overlay import (
+                DiffOverlayController,
+            )
+
+            def _request(ref: str) -> None:
+                # Issued from a RENDER path, so it must never block. The verb
+                # travels on the ordinary input lane and the answer comes back
+                # addressed on the telemetry lane.
+                try:
+                    if client is not None:
+                        client.send_input(f"/diff-fetch {ref}")
+                except Exception:  # noqa: BLE001
+                    pass
+
+            archive = RemoteDiffArchive(request=_request)
+            controller = DiffOverlayController(
+                archive=archive,
+                invalidate=self._invalidate,
+                width_fn=lambda: self._terminal_size()[0] or 100,
+            )
+            self._diff_archive = archive
+            self._diff_controller = controller
+            try:
+                controller.register()
+            except Exception:  # noqa: BLE001
+                pass
+            return controller
+        except Exception:  # noqa: BLE001
+            return None
+
+    def _ingest_diff_catalog(self, rows: Any) -> None:
+        """Absorb the heartbeat's diff catalog. NEVER raises."""
+        try:
+            archive = getattr(self, "_diff_archive", None)
+            if archive is not None:
+                archive.ingest_catalog(rows)
+        except Exception:  # noqa: BLE001
+            pass
+
+    def _ingest_diff_payload(self, frame: Any) -> None:
+        """Absorb a fetched diff and re-render if it is the one on screen.
+
+        Re-OPENING is what turns a late arrival into a repaint: the
+        controller's epoch guard already makes a stale render harmless, so
+        asking it to open the same ref again is the whole mechanism — no
+        second code path for "the body finally landed". NEVER raises.
+        """
+        try:
+            archive = getattr(self, "_diff_archive", None)
+            controller = getattr(self, "_diff_controller", None)
+            if archive is None:
+                return
+            ref = archive.ingest_payload(frame)
+            if not ref or controller is None:
+                return
+            # Only if THIS ref is the one the operator is looking at. A fetch
+            # that lands after they moved on must not yank the overlay back.
+            if controller.is_active() and getattr(
+                    controller, "_ref", None) == ref:
+                controller.open(ref)
+        except Exception:  # noqa: BLE001
+            pass
+
     def _serpent_active(self) -> bool:
         """Is the organism THINKING right now, as far as THIS terminal knows?
 
@@ -1589,6 +1674,15 @@ class AttachUI:
                 # countdown is: a stale backlog tells them work is
                 # pending that already ran.
                 self._input_queue = frame.get("input_queue") or {}
+                # The diff CATALOG — refs and metadata, no bytes. Replaced
+                # wholesale by the archive itself for the same reason the
+                # countdown is cleared by absence: the archive is a RING, so
+                # a ref that stopped being advertised was evicted, and a
+                # merge would let it live forever in a client that saw it
+                # once. `all_refs()` feeding "no such diff — available: …"
+                # is only honest if this is current.
+                if frame.get(_DIFF_CATALOG_KEY) is not None:
+                    self._ingest_diff_catalog(frame.get(_DIFF_CATALOG_KEY))
             elif isinstance(frame, dict) and frame.get(
                 "kind",
             ) == "stream_inflight":
@@ -1603,6 +1697,10 @@ class AttachUI:
                 import time as _time
                 self._stream_arrived = _time.monotonic()
                 self._push_tail_to_deck()
+            elif isinstance(frame, dict) and frame.get(
+                    "kind") == _DIFF_PAYLOAD_KIND:
+                # The bytes of a diff we asked for, addressed to this cockpit.
+                self._ingest_diff_payload(frame)
             elif isinstance(frame, dict) and frame.get(
                     "kind") == "fatal_panic":
                 # A background task died. STICKY — unlike every other live
@@ -1733,6 +1831,20 @@ def _short_path(path: str) -> str:
     return "/".join(parts[-2:]) if len(parts) >= 2 else (parts[-1] if parts else "")
 
 
+#: The reply frame `RemoteDiffArchive` waits for. Read from the bridge module
+#: rather than spelled again here — a kind string that disagrees between
+#: producer and consumer is a frame silently dropped, which is exactly how
+#: `_VALID_EVENT_TYPES` bit this codebase before.
+try:
+    from backend.core.ouroboros.battle_test.diff_bridge import (
+        CATALOG_KEY as _DIFF_CATALOG_KEY,
+        DIFF_PAYLOAD_KIND as _DIFF_PAYLOAD_KIND,
+    )
+except Exception:  # noqa: BLE001
+    _DIFF_PAYLOAD_KIND = "diff_payload"
+    _DIFF_CATALOG_KEY = "diffs"
+
+
 def _route_operator_line(client: Any, ui: Any, line: Any) -> str:
     """THE one operator-line router — shared by the legacy split-plane loop AND
     the Bipartite cockpit (DRY: verbs behave identically on both surfaces).
@@ -1787,6 +1899,24 @@ def _route_operator_line(client: Any, ui: Any, line: Any) -> str:
                 ui.flash(ui.set_task_view(arg))
             _report_local_history(client, text)
             return "handled"
+
+        # `/expand d-N` is a CLIENT concern for a reason the other refs are
+        # not: the diff OVERLAY is drawn on this terminal. Relayed, it opened
+        # the diff on the daemon's own cockpit and mirrored back a line saying
+        # it had opened — the operator was told a diff was on screen and shown
+        # nothing. Only `d-` is intercepted; `t-`/`o-`/`n-` refs keep
+        # round-tripping and mirroring as markup, which already works.
+        if low.startswith(("/expand d-", "expand d-")):
+            arg = text.split(None, 1)[1].strip() if " " in text else ""
+            controller = (ui.diff_controller(client)
+                          if ui is not None and hasattr(ui, "diff_controller")
+                          else None)
+            if controller is not None and controller.open(arg):
+                _report_local_history(client, text)
+                return "handled"
+            # No controller (no prompt_toolkit, degraded mount): fall through
+            # and let the daemon answer in the transcript rather than
+            # swallowing the operator's request.
 
         # /keys is likewise a CLIENT concern when attached: the bindings
         # that govern THIS terminal (deck selection, Esc-interrupt,
@@ -3569,6 +3699,15 @@ async def _bipartite_attach_loop(client: Any, console: Any, ui: Any) -> None:
             agent_rows=(
                 ui._agent_lines if ui is not None
                 and hasattr(ui, "_agent_lines") else None
+            ),
+            # The archived-diff overlay, backed by the daemon's archive over
+            # the bridge. Measured UNSET here: the daemon owns the archive, so
+            # this was the surface that could not draw the one thing it exists
+            # to review.
+            diff_rows=(
+                (lambda: ui.diff_controller(client).rows())
+                if ui is not None and hasattr(ui, "diff_controller")
+                else None
             ),
             # The serpent runs the hairlines while the organism is THINKING.
             # Measured UNSET here by `capability_handoff`, which meant the

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -2698,6 +2698,23 @@ def _build_selection_bindings(ui: Any, client: Any) -> Any:
             description="interrupt your own in-flight work (/cancel)",
         )
 
+        # Ctrl+X Ctrl+K — CC's stop-all, the one keyboard control ov lacked
+        # over the L3 subagents it actually runs. Bound through the shared
+        # installer so this surface and the daemon's cannot disagree about
+        # what the chord means; both just send `/stop-all`.
+        try:
+            from backend.core.ouroboros.battle_test.subagent_control import (
+                install_stop_all_binding,
+            )
+            install_stop_all_binding(
+                kb, client,
+                notify=lambda msg: ui.flash(msg, seconds=3.5),
+                running=(ui._agent_count if hasattr(ui, "_agent_count")
+                         else None),
+            )
+        except Exception:  # noqa: BLE001
+            pass
+
         def _esc(event: Any) -> None:
             fsm.escape()
             ui.refresh()

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -1062,17 +1062,13 @@ class AttachUI:
         NEVER raises — an unrenderable roster costs its rows, not the cockpit.
         """
         try:
-            import time as _time
             from backend.core.ouroboros.battle_test.agent_roster import (
                 render_roster, roster_line_budget, roster_visible,
             )
-            from backend.core.ouroboros.battle_test.attach_heartbeat import (
-                heartbeat_stale_after_s,
-            )
             if not roster_visible():
                 return []
-            age = max(0.0, _time.monotonic() - float(self._heartbeat_arrived))
-            if not self._heartbeat_arrived or age > heartbeat_stale_after_s():
+            age = self._heartbeat_age()
+            if age is None:
                 return []
             size = self._terminal_size()
             return render_roster(
@@ -1093,15 +1089,10 @@ class AttachUI:
         NEVER raises: a status line is chrome.
         """
         try:
-            import time as _time
-            from backend.core.ouroboros.battle_test.attach_heartbeat import (
-                heartbeat_stale_after_s,
-            )
             from backend.core.ouroboros.battle_test.status_line import (
                 payload_to_snapshot, render_snapshot,
             )
-            age = max(0.0, _time.monotonic() - float(self._heartbeat_arrived))
-            if not self._heartbeat_arrived or age > heartbeat_stale_after_s():
+            if self._heartbeat_age() is None:
                 return []
             snap = payload_to_snapshot(self._status)
             if snap is None:
@@ -1111,6 +1102,72 @@ class AttachUI:
         except Exception:  # noqa: BLE001
             return []
 
+    def _heartbeat_age(self) -> Optional[float]:
+        """Seconds since the daemon's last frame, or None when contact is lost.
+
+        ONE definition of "lost contact", which is what three separate
+        docstrings on this class were already asking for in prose — the
+        roster's ("the roster expires on the SAME window the pulse uses — one
+        clock, one definition"), the status line's ("rather than three that
+        drift apart and leave a dead daemon's phase showing under an idle
+        pulse") and the countdown's. All three then implemented it inline, and
+        the serpent border was about to make it four.
+
+        The failure that discipline prevents is specific and reads as normal
+        operation: if the daemon dies mid-dispatch, the last frame this
+        process holds says three agents are running, phase is GENERATE and the
+        border should be moving — and it will say that forever. Every surface
+        fed by this heartbeat has to retire on the same clock or the cockpit
+        shows a confident, coherent, wrong picture of a dead organism.
+
+        Returns the AGE rather than a bool because callers need it: running
+        agents advance by it so seconds tick smoothly between 1 Hz frames, and
+        the apply countdown subtracts it. A bool would force every caller to
+        recompute the number the predicate already had.
+
+        NEVER raises — a surface that cannot ask degrades to "lost", which is
+        the safe direction: it stops drawing rather than inventing them.
+        """
+        try:
+            import time as _time
+            from backend.core.ouroboros.battle_test.attach_heartbeat import (
+                heartbeat_stale_after_s,
+            )
+            arrived = float(self._heartbeat_arrived or 0.0)
+            if not arrived:
+                return None
+            age = max(0.0, _time.monotonic() - arrived)
+            return None if age > heartbeat_stale_after_s() else age
+        except Exception:  # noqa: BLE001
+            return None
+
+    def _serpent_active(self) -> bool:
+        """Is the organism THINKING right now, as far as THIS terminal knows?
+
+        Drives the serpent hairline that frames the caret. The daemon answers
+        this from `build_heartbeat_payload` in-process; an attach client has
+        no organism to ask, so it reads the `active` flag off the last frame
+        that crossed the bridge. Same question, same field, two sources —
+        which is the property that keeps the border, the toolbar verb and the
+        token counter from disagreeing about whether work is happening.
+
+        `capability_handoff` measured this hook UNSET on `ov`, so the
+        animation ran in `ov demo live` and on the daemon's own terminal and
+        was dead on the surface an operator actually attaches with. The border
+        simply never moved, which is indistinguishable from an organism that
+        is never busy.
+
+        Staleness retires it, and that is the load-bearing half: a border that
+        keeps animating after the daemon dies is the cockpit asserting work is
+        in flight when nothing is running at all.
+        """
+        try:
+            if self._heartbeat_age() is None:
+                return False
+            return bool((self._heartbeat or {}).get("active"))
+        except Exception:  # noqa: BLE001
+            return False
+
     def _pending_apply_rows(self) -> List[str]:
         """The rejection window, counting down. NEVER raises.
 
@@ -1119,13 +1176,9 @@ class AttachUI:
         toward an apply that will never happen.
         """
         try:
-            import time as _time
-            from backend.core.ouroboros.battle_test.attach_heartbeat import (
-                heartbeat_stale_after_s,
-            )
             from backend.core.ouroboros.battle_test.pending_apply import render
-            age = max(0.0, _time.monotonic() - float(self._heartbeat_arrived))
-            if not self._heartbeat_arrived or age > heartbeat_stale_after_s():
+            age = self._heartbeat_age()
+            if age is None:
                 return []
             return render(self._pending_apply, age_s=age,
                           width=self._terminal_size()[0])
@@ -3515,6 +3568,16 @@ async def _bipartite_attach_loop(client: Any, console: Any, ui: Any) -> None:
             agent_rows=(
                 ui._agent_lines if ui is not None
                 and hasattr(ui, "_agent_lines") else None
+            ),
+            # The serpent runs the hairlines while the organism is THINKING.
+            # Measured UNSET here by `capability_handoff`, which meant the
+            # animation ran in the demo and on the daemon's own terminal and
+            # was dead on the surface an operator actually attaches with — a
+            # border that never moves is indistinguishable from an organism
+            # that is never busy.
+            serpent_active=(
+                ui._serpent_active if ui is not None
+                and hasattr(ui, "_serpent_active") else None
             ),
             # The `/` search bar. Read from the hatches module rather than
             # held here: the search session belongs to the transcript key

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -1622,18 +1622,19 @@ class AttachUI:
                 # reads as WORKING rather than stalled — which is the whole
                 # complaint a black box produces.
                 import time as _time
-                if frame.get("done"):
-                    self._stream_inflight = ""
-                else:
-                    _tool = str(frame.get("tool") or "tool")
-                    _el = frame.get("elapsed_s") or 0.0
-                    try:
-                        _head = f"$ {_tool} · {float(_el):.0f}s"
-                    except (TypeError, ValueError):
-                        _head = f"$ {_tool}"
-                    _body = str(frame.get("text") or "")
-                    self._stream_inflight = (
-                        f"{_head}\n{_body}" if _body else _head)
+                # Composed by the SHARED function rather than here. The header
+                # `$ bash · 11s` is what makes a long command read as WORKING
+                # rather than stalled, and the daemon now draws this strip at
+                # its own terminal too — so a second copy of the composition
+                # would be a second opinion about what an in-flight tool tail
+                # looks like, which is the defect the roster and the status
+                # line each already paid for once.
+                from backend.core.ouroboros.battle_test.inflight_registry import (  # noqa: E501
+                    compose_inflight_text,
+                )
+                self._stream_inflight = (
+                    "" if frame.get("done") else compose_inflight_text(frame)
+                )
                 self._stream_is_tool = True
                 self._stream_arrived = _time.monotonic()
                 self._push_tail_to_deck()

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -106,6 +106,8 @@ CLIENT_VERB_HELP = {
     "ptt stop": "close the push-to-talk hold",
     "force-wake": "seize the mic from another terminal",
     "deck": "deck height — off | compact | full",
+    "tasks": "show/hide the running-subagent roster",
+    "keys": "the bindings this terminal answers to",
     "detach": "leave; the organism keeps running",
 }
 
@@ -118,7 +120,11 @@ def client_verbs() -> "dict":
     switches on) and the local-only verbs are listed once here."""
     out = {v: CLIENT_VERB_HELP.get(v, f"audio: {AUDIO_VERBS[v]}")
            for v in AUDIO_VERBS}
-    for v in ("deck", "detach"):
+    # `keys` and `tasks` were routed in `_route_operator_line` but missing
+    # here, so neither appeared in the `/` palette — routed and unreachable
+    # unless you already knew the word. A verb the operator cannot discover
+    # is a verb that does not exist.
+    for v in ("deck", "tasks", "keys", "detach"):
         out[v] = CLIENT_VERB_HELP.get(v, "")
     return out
 
@@ -771,6 +777,58 @@ class AttachUI:
         self._invalidate()
         return f"deck: {mode}"
 
+    def set_task_view(self, mode: str) -> str:
+        """``/tasks [on|off]`` — show or hide the running-subagent roster.
+
+        The same client concern `/deck` is, and for a sharper reason: the
+        roster mounts BELOW the caret, so every row it takes is a row between
+        the operator's cursor and the bottom of their screen. Three workers
+        and a sentinel cost five of them on an idle session.
+
+        Claude Code separates these two surfaces explicitly — the `Ctrl+T`
+        checklist is ambient, and "to see running shells and subagents, use
+        `/tasks`". This is that verb: the roster is data the daemon streams
+        continuously and the operator asks to LOOK at, not a permanent
+        fixture under the prompt.
+
+        A bare `/tasks` toggles, because that is what an operator reaching for
+        it wants nine times in ten. Explicit `on`/`off` exists so a keybinding
+        or a script can be idempotent."""
+        from backend.core.ouroboros.battle_test.agent_roster import (
+            roster_visible, set_roster_visible, toggle_roster,
+        )
+        mode = str(mode or "").strip().lower()
+        if mode in ("on", "show"):
+            shown = set_roster_visible(True)
+        elif mode in ("off", "hide"):
+            shown = set_roster_visible(False)
+        elif mode:
+            state = "shown" if roster_visible() else "hidden"
+            return f"tasks: {state} (on | off)"
+        else:
+            shown = toggle_roster()
+        self._invalidate()
+        if not shown:
+            return "tasks: hidden"
+        # The COUNT, not just the state. "shown" on an empty roster looks
+        # identical to a verb that did nothing, and Claude Code hit the same
+        # edge: "when Claude hasn't created any checklist items yet, the
+        # toggle has no visible effect because there's nothing to display."
+        # Saying how many there are is what distinguishes the two.
+        return f"tasks: shown · {self._agent_count()} running"
+
+    def _agent_count(self) -> int:
+        """Running agents in the daemon's last snapshot. NEVER raises."""
+        try:
+            rows = (self._agents or {}).get("rows") or ()
+            return sum(
+                1 for r in rows
+                if isinstance(r, dict)
+                and str(r.get("state") or "running") == "running"
+            )
+        except Exception:  # noqa: BLE001
+            return 0
+
     def refresh(self) -> None:
         """Repaint after a mode change. Alias of the invalidate seam so key
         handlers read as intent rather than mechanism."""
@@ -992,16 +1050,27 @@ class AttachUI:
         that composed the snapshot does not. Passing it means the goal column
         is clipped to the screen the operator is actually looking at.
 
+        **Rows are asked for, not assumed.** The roster mounts BELOW the
+        caret, so each of its rows sits between the operator's cursor and the
+        bottom of the screen — and Claude Code puts nothing standing there
+        ("the input box stays fixed at the bottom of the screen"), keeping the
+        running-subagent view behind `/tasks`. Hidden by default here for the
+        same reason: three workers and a sentinel cost five rows under the
+        cursor of an idle session. The daemon keeps streaming the snapshot
+        while it is hidden, so `/tasks` answers from live data immediately.
+
         NEVER raises — an unrenderable roster costs its rows, not the cockpit.
         """
         try:
             import time as _time
             from backend.core.ouroboros.battle_test.agent_roster import (
-                render_roster, roster_line_budget,
+                render_roster, roster_line_budget, roster_visible,
             )
             from backend.core.ouroboros.battle_test.attach_heartbeat import (
                 heartbeat_stale_after_s,
             )
+            if not roster_visible():
+                return []
             age = max(0.0, _time.monotonic() - float(self._heartbeat_arrived))
             if not self._heartbeat_arrived or age > heartbeat_stale_after_s():
                 return []
@@ -1648,6 +1717,20 @@ def _route_operator_line(client: Any, ui: Any, line: Any) -> str:
             arg = text.split(None, 1)[1].strip() if " " in text else ""
             if ui is not None and hasattr(ui, "set_deck_size"):
                 ui.flash(ui.set_deck_size(arg))
+            _report_local_history(client, text)
+            return "handled"
+
+        # /tasks is a CLIENT concern for the same reason /deck is — it spends
+        # THIS terminal's rows — and routed here rather than relayed for a
+        # second one: the daemon's own `agent_roster` visibility flag governs
+        # the daemon's cockpit, not this one. Forwarding would toggle a
+        # roster nobody attached is looking at. (The two-process trap: a verb
+        # that runs on the wrong side of the socket reports success and
+        # changes nothing the operator can see.)
+        if low in ("/tasks", "tasks") or low.startswith(("/tasks ", "tasks ")):
+            arg = text.split(None, 1)[1].strip() if " " in text else ""
+            if ui is not None and hasattr(ui, "set_task_view"):
+                ui.flash(ui.set_task_view(arg))
             _report_local_history(client, text)
             return "handled"
 

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -1380,7 +1380,7 @@ class AttachUI:
             )
             keys = ""
             if selection_enabled() and self.fsm is not None:
-                keys = (" · ^O lanes" if self.fsm.mode == MODE_FLOW
+                keys = (" · ^X ^L lanes" if self.fsm.mode == MODE_FLOW
                         else " · esc back")
         except Exception:  # noqa: BLE001
             keys = ""
@@ -2419,12 +2419,31 @@ def _client_extra_bindings(ui: Any, client: Any) -> Any:
                 description="dismiss the FATAL panic overlay",
             )
 
+        @Condition
+        def _not_in_transcript() -> bool:
+            """`?` means something else inside the transcript viewer.
+
+            CC: "press `?` in the transcript viewer to see available
+            shortcuts THERE" — a different table from the cockpit's. Both
+            bindings' filters pass inside the viewer with an empty prompt, so
+            without this the winner is decided by which was registered last.
+            That happens to be correct today and would silently invert the
+            day someone reorders two mounts.
+            """
+            try:
+                from backend.core.ouroboros.battle_test.transcript_mode import (
+                    is_transcript_mode,
+                )
+                return not is_transcript_mode()
+            except Exception:  # noqa: BLE001
+                return True
+
         def _show_help(event: Any) -> None:
             _render_client_keys(ui, "/keys")
 
         bind_action(
             kb, "app:help", ("?",), _show_help,
-            context="Chat", filter=_empty_buffer,
+            context="Chat", filter=_empty_buffer & _not_in_transcript,
             description="show keyboard shortcuts (empty prompt only)",
         )
 
@@ -2446,14 +2465,31 @@ def _client_extra_bindings(ui: Any, client: Any) -> Any:
                 install_rewind_binding(kb, rewind)
             except Exception:  # noqa: BLE001
                 pass
-        # The transcript escape hatches: [ v { } while scrolled, Ctrl+L
-        # repaint, Ctrl+O narration toggle — the "see what it is doing /
-        # what it did" cluster.
+        # The transcript escape hatches: [ v { } inside the viewer or while
+        # scrolled, Ctrl+L repaint, Ctrl+X Ctrl+N narration toggle — the
+        # "see what it is doing / what it did" cluster.
         try:
             from backend.core.ouroboros.battle_test.transcript_hatches import (
                 install_transcript_hatches,
             )
             install_transcript_hatches(kb, ui, client)
+        except Exception:  # noqa: BLE001
+            pass
+        # Ctrl+O and the less-style viewer table. The hatches are the keys;
+        # this is the state that makes them unambiguous — and the reason the
+        # whole j/k/g/G/Space table can be bound at all, since at the live
+        # tail every one of those types as itself.
+        try:
+            from backend.core.ouroboros.battle_test.transcript_mode import (
+                install_transcript_mode_bindings,
+            )
+            install_transcript_mode_bindings(
+                kb,
+                notify=lambda out: ui.flash(
+                    out if isinstance(out, str) else "\n".join(out),
+                    seconds=8.0 if not isinstance(out, str) else 2.5,
+                ),
+            )
         except Exception:  # noqa: BLE001
             pass
         # Large pastes collapse to a chip; the full text splices back in
@@ -2620,7 +2656,10 @@ def _build_selection_bindings(ui: Any, client: Any) -> Any:
             ui.refresh()
 
         bind_action(
-            kb, "deck:open", ("ctrl+o",), _open,
+            # MOVED off Ctrl+O so the transcript viewer can have it, as in
+            # Claude Code. Lanes keep a chord rather than losing a key: this
+            # is the deck's doorway and there is no verb that opens it.
+            kb, "deck:open", ("ctrl+x ctrl+l",), _open,
             context="Deck", filter=can_open,
             description="enter deck selection (empty buffer only)",
         )

--- a/backend/core/ouroboros/cli/ov_demo.py
+++ b/backend/core/ouroboros/cli/ov_demo.py
@@ -852,11 +852,22 @@ def _agent_view_rows() -> Any:
     sizes it to this terminal. Importing it means the demo cannot render a
     roster the cockpit would draw differently — a second provider here would
     be a second opinion about width, height budget and folding.
+
+    The demo turns the roster ON explicitly. In the cockpit it is hidden by
+    default and asked for with `/tasks`, which is right for a surface someone
+    works in all day and wrong for one whose entire purpose is to SHOW the
+    surfaces. Sharing the provider means the demo cannot silently keep
+    rendering a roster the cockpit has stopped drawing — it has to state that
+    it wants it, right here, in one line a reader can find.
     """
     try:
+        from backend.core.ouroboros.battle_test.agent_roster import (
+            set_roster_visible,
+        )
         from backend.core.ouroboros.battle_test.serpent_flow import (
             _local_agent_rows,
         )
+        set_roster_visible(True)
         return _local_agent_rows
     except Exception:  # noqa: BLE001
         logger.debug("[OvDemo] agent view unavailable", exc_info=True)

--- a/backend/core/ouroboros/cli/ov_demo.py
+++ b/backend/core/ouroboros/cli/ov_demo.py
@@ -1876,7 +1876,78 @@ def _live_exit_bindings() -> Any:
     def _quit(event) -> None:  # noqa: ANN001
         event.app.exit()
 
-    kb.add("q", filter=_buffer_empty)(_quit)
+    # The transcript viewer and the subagent chord, mounted from the SAME
+    # installers the daemon cockpit and the attach client use. The point of
+    # this scene is that it boots the real Application; a key that exists on
+    # both shipping surfaces and not here makes the demo a picture of a
+    # cockpit nobody runs.
+    #
+    # `notify` writes into the deck through `push_raw` — the seam the daemon
+    # bridge uses — rather than printing, because printing from a key handler
+    # inside a full-screen Application draws over the frame.
+    @Condition
+    def _not_reading_transcript() -> bool:
+        try:
+            from backend.core.ouroboros.battle_test.transcript_mode import (
+                is_transcript_mode,
+            )
+            return not is_transcript_mode()
+        except Exception:  # noqa: BLE001
+            return True
+
+    def _demo_notice(out: Any) -> None:
+        try:
+            from backend.core.ouroboros.battle_test.bipartite_layout import (
+                get_active_canvas,
+            )
+            canvas = get_active_canvas()
+            if canvas is None:
+                return
+            lines = out.splitlines() if isinstance(out, str) else list(out)
+            for line in lines:
+                canvas.emit("line", {"text": str(line)})
+        except Exception:  # noqa: BLE001
+            pass
+
+    try:
+        from backend.core.ouroboros.battle_test.transcript_mode import (
+            install_transcript_mode_bindings,
+        )
+        install_transcript_mode_bindings(kb, notify=_demo_notice)
+    except Exception:  # noqa: BLE001
+        pass
+
+    try:
+        from backend.core.ouroboros.battle_test.agent_roster import (
+            get_agent_roster,
+        )
+        from backend.core.ouroboros.battle_test.subagent_control import (
+            install_stop_all_binding,
+        )
+
+        class _DemoOrganism:
+            """Nothing to cancel, so the verb is SHOWN rather than sent.
+
+            An inert `send_input` would make the chord look identical whether
+            it worked or not, which is the failure this scene exists to make
+            visible."""
+
+            def send_input(self, line: str) -> None:
+                _demo_notice(f"  ⏺ {line} — (demo: no organism to stop)")
+
+        install_stop_all_binding(
+            kb, _DemoOrganism(), notify=_demo_notice,
+            running=lambda: get_agent_roster().running_count,
+        )
+    except Exception:  # noqa: BLE001
+        pass
+
+    # `q` QUITS THE DEMO — except inside the transcript viewer, where `q`
+    # leaves the viewer. Exactly the trap the Escape comment below records,
+    # one key over: without this filter the one surface built to demonstrate
+    # the cockpit would teach that `q` kills your session, when in `ov` it
+    # closes a pane.
+    kb.add("q", filter=_buffer_empty & _not_reading_transcript)(_quit)
 
     # `escape` used to be `eager=True` here, bound straight to QUIT — and this
     # scene MOUNTS a FATAL overlay whose own text reads "esc dismisses". So the
@@ -1908,10 +1979,14 @@ def _live_exit_bindings() -> Any:
         # The COMPLEMENT of the arbiter's filter, so the two can never both fire
         # for one keystroke. Not eager: with an overlay up this must lose to the
         # arbiter, and with none up there is no sequence competing for the prefix.
-        kb.add("escape", filter=_buffer_empty & _nothing_to_dismiss)(_quit)
+        # `_not_reading_transcript` joins for the same reason `q` needed it —
+        # Escape leaves the viewer in `ov`, so it must not end the demo here.
+        kb.add("escape", filter=(_buffer_empty & _nothing_to_dismiss
+                                 & _not_reading_transcript))(_quit)
     except Exception:  # noqa: BLE001
         # A demo must still be closable if the arbiter is unavailable.
-        kb.add("escape", filter=_buffer_empty, eager=True)(_quit)
+        kb.add("escape", filter=_buffer_empty & _not_reading_transcript,
+               eager=True)(_quit)
 
     kb.add("c-c")(_quit)
     kb.add("c-d")(_quit)

--- a/backend/core/ouroboros/cli/ov_demo.py
+++ b/backend/core/ouroboros/cli/ov_demo.py
@@ -1905,7 +1905,7 @@ def _live_exit_bindings() -> Any:
                 return
             lines = out.splitlines() if isinstance(out, str) else list(out)
             for line in lines:
-                canvas.emit("line", {"text": str(line)})
+                canvas.push_raw(str(line))
         except Exception:  # noqa: BLE001
             pass
 

--- a/backend/core/ouroboros/governance/exit_guard.py
+++ b/backend/core/ouroboros/governance/exit_guard.py
@@ -27,16 +27,142 @@ Deliberately NOT a blanket ``sys.excepthook`` or an ``atexit`` monkeypatch:
 those would swallow tracebacks from handlers registered by third-party
 libraries, where a traceback may be the only evidence of a real fault. This is
 opt-in per registration site.
+
+Two windows, one discipline
+---------------------------
+``atexit`` is not the only place an interrupt can land somewhere that cannot
+report it. CPython also runs Python code with no caller in ``__del__``
+methods, weakref callbacks and GC finalizers; an exception raised there is
+*unraisable* — it cannot propagate, so the interpreter prints it and moves
+on::
+
+    Exception ignored in: <function WeakValueDictionary.__init__.<locals>.remove>
+    Traceback (most recent call last):
+      ...
+    KeyboardInterrupt:
+
+A signal handler is delivered at an arbitrary bytecode boundary, which means
+a Ctrl+C can be delivered *into* one of those finalizers. The handler runs,
+chains to ``signal.default_int_handler``, that raises — and the raise happens
+with no caller to catch it. Same defect as the ``atexit`` one, one layer
+down, and it needs the same answer at the seam the interpreter actually
+routes it through: :data:`sys.unraisablehook`.
+
+Narrow on purpose, for the reason stated below about ``sys.excepthook``: the
+guard silences ONLY interrupt-class exceptions, and forwards everything else
+to whatever hook was already installed. A blanket hook would swallow the
+unraisable traceback from a third-party ``__del__``, and there that traceback
+is frequently the only evidence a fault occurred at all.
 """
 from __future__ import annotations
 
 import atexit
 import logging
-from typing import Any, Callable
+import os
+import sys
+import threading
+from typing import Any, Callable, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["guarded_atexit_register", "run_guarded"]
+__all__ = [
+    "guarded_atexit_register", "run_guarded",
+    "install_unraisable_guard", "uninstall_unraisable_guard",
+    "unraisable_guard_installed", "suppressed_unraisable_count",
+]
+
+#: The discriminator this whole module turns on, named once. ``KeyboardInterrupt``
+#: and ``SystemExit`` derive from ``BaseException`` rather than ``Exception``,
+#: which is why defensive ``except Exception`` handlers do not stop either of
+#: them and why the traceback appears despite the try/except in the source.
+_INTERRUPT_CLASS: Tuple[type, ...] = (KeyboardInterrupt, SystemExit)
+
+_UNRAISABLE_LOCK = threading.Lock()
+_PREVIOUS_HOOK: Optional[Any] = None
+_SUPPRESSED = [0]
+
+
+def _unraisable_guard_enabled() -> bool:
+    """``JARVIS_UNRAISABLE_GUARD_ENABLED`` (default true). NEVER raises."""
+    return os.environ.get(
+        "JARVIS_UNRAISABLE_GUARD_ENABLED", "1",
+    ).strip().lower() not in ("0", "false", "no", "off")
+
+
+def suppressed_unraisable_count() -> int:
+    """How many interrupt-class unraisables have been silenced.
+
+    Observable rather than silent: a guard that hides things and keeps no
+    count is indistinguishable from a guard that is not working, and the one
+    question worth asking later is "did this ever actually fire".
+    """
+    return int(_SUPPRESSED[0])
+
+
+def unraisable_guard_installed() -> bool:
+    return getattr(sys.unraisablehook, "_ov_unraisable_guard", False) is True
+
+
+def install_unraisable_guard() -> bool:
+    """Chain a hook that silences interrupt-class unraisables. NEVER raises.
+
+    Returns True when the guard is in place (including when it already was).
+    Idempotent — the marker attribute is checked rather than a module flag, so
+    a re-install after someone else replaced the hook chains correctly instead
+    of believing itself already installed.
+    """
+    global _PREVIOUS_HOOK
+    if not _unraisable_guard_enabled():
+        return False
+    try:
+        with _UNRAISABLE_LOCK:
+            if unraisable_guard_installed():
+                return True
+            previous = sys.unraisablehook
+            _PREVIOUS_HOOK = previous
+
+            def _hook(unraisable: Any) -> None:
+                try:
+                    exc_type = getattr(unraisable, "exc_type", None)
+                    if (isinstance(exc_type, type)
+                            and issubclass(exc_type, _INTERRUPT_CLASS)):
+                        # The operator asked to quit. There is no caller, the
+                        # process is leaving, and the only thing a traceback
+                        # can do here is print over the goodbye.
+                        _SUPPRESSED[0] += 1
+                        return
+                except BaseException:  # noqa: BLE001
+                    pass
+                # EVERYTHING else goes on to whoever was here first. A real
+                # fault in someone's finalizer must still be visible.
+                try:
+                    previous(unraisable)
+                except BaseException:  # noqa: BLE001
+                    pass
+
+            _hook._ov_unraisable_guard = True  # type: ignore[attr-defined]
+            sys.unraisablehook = _hook
+            return True
+    except BaseException:  # noqa: BLE001
+        return False
+
+
+def uninstall_unraisable_guard() -> None:
+    """Put the previous hook back. NEVER raises.
+
+    Only unwinds OUR hook: if something else installed a hook on top of ours,
+    restoring blindly would silently uninstall theirs too.
+    """
+    global _PREVIOUS_HOOK
+    try:
+        with _UNRAISABLE_LOCK:
+            if not unraisable_guard_installed():
+                return
+            if _PREVIOUS_HOOK is not None:
+                sys.unraisablehook = _PREVIOUS_HOOK
+            _PREVIOUS_HOOK = None
+    except BaseException:  # noqa: BLE001
+        pass
 
 
 def run_guarded(fn: Callable[..., Any], *args: Any, **kwargs: Any) -> None:

--- a/backend/core/ouroboros/governance/governed_loop_service.py
+++ b/backend/core/ouroboros/governance/governed_loop_service.py
@@ -3444,6 +3444,42 @@ class GovernedLoopService:
         logger.info("[GovernedLoop] Cancel requested for op(s): %s", matched)
         return True
 
+    def request_cancel_all(self) -> list:
+        """Request cooperative cancellation of EVERY in-flight op.
+
+        Returns the op ids newly marked, sorted — the caller reports what it
+        actually stopped rather than a count it assumed, and an empty list is
+        the honest answer to "stop everything" when nothing was running.
+
+        Deliberately broader than :meth:`operator_ops_active`, which backs the
+        bare `Esc` / `/cancel` path and is narrow on purpose ("stop what I
+        asked for", never "stop the organism" — one key that reached
+        autonomous work could kill a soak). This is the other half of that
+        pair, and the friction lives in the KEYSTROKE: Claude Code binds the
+        equivalent to `Ctrl+X Ctrl+K` pressed twice within three seconds, so
+        reaching it takes four deliberate presses and cannot be a mis-hit.
+
+        Cooperative, like every other cancel here: the orchestrator observes
+        `is_cancel_requested` at phase transitions, so this asks the ops to
+        stop at their next boundary rather than severing them mid-APPLY. A
+        hard kill would leave exactly the half-written trees the phase model
+        exists to prevent.
+        """
+        try:
+            already = self._cancel_requested
+            newly = sorted(op for op in self._active_ops if op not in already)
+            for op_id in newly:
+                self._cancel_requested.add(op_id)
+            if newly:
+                logger.info(
+                    "[GovernedLoop] Cancel-all requested for %d op(s): %s",
+                    len(newly), newly,
+                )
+            return newly
+        except Exception:  # noqa: BLE001
+            logger.debug("[GovernedLoop] cancel-all degraded", exc_info=True)
+            return []
+
     def is_cancel_requested(self, op_id: str) -> bool:
         """Check if cancellation was requested for this operation."""
         return op_id in self._cancel_requested

--- a/backend/core/ouroboros/ui/alt_screen.py
+++ b/backend/core/ouroboros/ui/alt_screen.py
@@ -61,19 +61,59 @@ logger = logging.getLogger("Ouroboros.AltScreen")
 
 __all__ = ["alt_screen_enabled", "alternate_screen", "in_alternate_screen"]
 
-#: Enter the alternate screen, then home the cursor. The cursor move matters:
-#: the alternate buffer retains whatever a previous occupant left in it on
-#: some terminals, so a boot that starts drawing at the old cursor position
-#: renders halfway down the screen.
-_ENTER = "\x1b[?1049h\x1b[H"
-
-#: Leave. No clear first — the point is to hand the normal buffer back
-#: exactly as it was found.
-_LEAVE = "\x1b[?1049l"
+#: Last-resort literals, used when terminfo cannot answer.
+#:
+#: ANSI `smcup`/`rmcup` as xterm and every terminal that copied it define
+#: them. Kept as a FALLBACK rather than the definition — see `_capability`,
+#: which asks the terminal's own description first. The cursor-home after
+#: enter matters: the alternate buffer retains whatever a previous occupant
+#: left in it on some terminals, so a boot that starts drawing at the old
+#: cursor position renders halfway down the screen.
+_ENTER_FALLBACK = "\x1b[?1049h"
+_LEAVE_FALLBACK = "\x1b[?1049l"
+_HOME = "\x1b[H"
 
 _LOCK = threading.RLock()
 _DEPTH = 0
 _ATEXIT_TOKEN: Any = None
+
+# ---------------------------------------------------------------------------
+# The async-signal-safe half
+# ---------------------------------------------------------------------------
+#
+# Everything below this comment may run inside a signal handler, and a signal
+# handler in CPython is delivered at an ARBITRARY bytecode boundary — inside a
+# weakref callback, a ``__del__``, an ``atexit`` handler, a ``finally``. Three
+# things are therefore forbidden on this path, each of them measured rather
+# than assumed:
+#
+#   * **Taking a lock.** `_restore_now` acquired `_LOCK`, and a handler that
+#     blocks on a lock another thread holds hangs the main thread inside the
+#     handler — 2001 ms in the reproduction, and unbounded if that thread is
+#     itself waiting on the main one. The restore is idempotent, so it needs
+#     no mutual exclusion at all: the worst a race can do is emit `rmcup`
+#     twice, and `rmcup` twice is `rmcup`.
+#
+#   * **Writing through a Python stream.** `TextIOWrapper.write` takes the
+#     stream's own internal lock. A signal delivered while the main thread was
+#     mid-`print` therefore deadlocks the handler against the very stream it
+#     is trying to restore. `os.write` on a file descriptor takes no such lock
+#     and is one syscall.
+#
+#   * **Allocating what can be prepared in advance.** The bytes are encoded at
+#     resolution time and the descriptor is captured on entry, so the handler
+#     performs one `os.write` and nothing else.
+#
+#: Cell rather than a plain global: rebinding a module attribute and reading
+#: it are each a single bytecode under the GIL, which is all the atomicity an
+#: idempotent restore needs — and it lets the signal path avoid `global`,
+#: which is how the locked path and this one stay visibly separate.
+_ARMED = [False]
+_SIGNAL_FD = [-1]
+_LEAVE_BYTES = [b"\x1b[?1049l"]
+_IN_HANDLER = [False]
+_SUSPENDED = [False]
+_ENTER_BYTES = [b"\x1b[?1049h\x1b[H"]
 
 
 def alt_screen_enabled() -> bool:
@@ -115,8 +155,66 @@ def _out() -> Any:
     return sys.__stdout__ or sys.stdout
 
 
+def _capability(name: str, fallback: str) -> str:
+    """One terminal capability, from the terminal's OWN description.
+
+    `smcup`/`rmcup` are not universal facts — they are entries in a terminfo
+    record, and a terminal that does not define them does not HAVE an
+    alternate screen. Writing xterm's literal at such a terminal prints
+    garbage into the operator's session, and hardcoding the literal is what
+    made that indistinguishable from success.
+
+    Resolution order is deliberate: terminfo, then the ANSI literal. The
+    fallback stays because terminfo is frequently unavailable in exactly the
+    environments that DO support the sequence — a stripped container with no
+    `TERM`, a CI runner, a pty with `TERM=dumb` set by a wrapper — and
+    refusing the alternate screen there would be a regression dressed as
+    correctness.
+
+    NEVER raises: `curses` is optional, `setupterm` fails on an unknown TERM,
+    and neither is worth a boot.
+    """
+    try:
+        import curses
+        try:
+            curses.setupterm()
+        except Exception:  # noqa: BLE001 — unknown/absent TERM
+            return fallback
+        value = curses.tigetstr(name)
+        if value:
+            return value.decode("ascii", "ignore")
+        # DEFINED-AS-ABSENT is a real answer, distinct from "could not ask".
+        # `tigetstr` returning None/empty for a terminal that HAS a
+        # description means this terminal genuinely lacks the capability.
+        return ""
+    except Exception:  # noqa: BLE001
+        return fallback
+
+
+def _resolve_sequences() -> bool:
+    """Fill the pre-encoded enter/leave buffers. True if the terminal has an
+    alternate screen at all. NEVER raises.
+
+    Encoded ONCE, here, because the leave sequence is written from a signal
+    handler and a handler must not be encoding strings.
+    """
+    try:
+        enter = _capability("smcup", _ENTER_FALLBACK)
+        leave = _capability("rmcup", _LEAVE_FALLBACK)
+        if not enter or not leave:
+            return False
+        _ENTER_BYTES[0] = (enter + _HOME).encode("ascii", "ignore")
+        _LEAVE_BYTES[0] = leave.encode("ascii", "ignore")
+        return True
+    except Exception:  # noqa: BLE001
+        return True         # keep the literals already in the cells
+
+
 def _write(seq: str) -> bool:
     """Emit a control sequence and flush immediately. NEVER raises.
+
+    The BLOCKING path — the context manager and the atexit backstop, where
+    taking a stream lock is fine. Signal handlers use `_emit_signal_safe`.
 
     Flushed rather than buffered because the next thing that happens may be
     a crash, and a restore sitting in a buffer is a restore that did not
@@ -133,14 +231,71 @@ def _write(seq: str) -> bool:
         return False
 
 
+def _emit_signal_safe(payload: bytes) -> bool:
+    """One `os.write` to the captured descriptor. NEVER raises.
+
+    No lock, no encoding, no Python stream — see the contract above this
+    module's `_ARMED` cell for why each of those is forbidden here. Partial
+    writes are looped rather than ignored: a control sequence delivered
+    half-way is worse than one not delivered at all, because the terminal
+    then interprets the remainder as text.
+    """
+    fd = _SIGNAL_FD[0]
+    if fd < 0:
+        return False
+    try:
+        view = memoryview(payload)
+        while view:
+            written = os.write(fd, view)
+            if written <= 0:
+                return False
+            view = view[written:]
+        return True
+    except (OSError, ValueError):
+        return False
+
+
+def _capture_fd() -> None:
+    """Remember the real stdout's descriptor while it is safe to ask.
+
+    Captured at ENTRY, not at restore time: `sys.__stdout__` may be closed or
+    replaced by the time a handler runs, and `fileno()` on a closed stream
+    raises — inside a signal handler, during shutdown, on the one path whose
+    entire job is to leave the terminal usable.
+    """
+    try:
+        stream = _out()
+        _SIGNAL_FD[0] = int(stream.fileno()) if stream is not None else -1
+    except Exception:  # noqa: BLE001
+        _SIGNAL_FD[0] = -1
+
+
+def _restore_signal_safe() -> bool:
+    """Leave the alternate screen from a signal handler. NEVER raises.
+
+    Idempotent by construction, which is what buys the lock-free flag: two
+    concurrent callers both emit `rmcup`, and `rmcup` twice is `rmcup`.
+    """
+    if not _ARMED[0]:
+        return False
+    _ARMED[0] = False
+    return _emit_signal_safe(_LEAVE_BYTES[0])
+
+
 def _restore_now() -> None:
-    """Unconditional return to the normal buffer. Safe to call repeatedly."""
+    """Unconditional return to the normal buffer. Safe to call repeatedly.
+
+    The blocking path. Clears the signal-path flag too so the two cannot
+    disagree about whether the buffer is still borrowed.
+    """
     global _DEPTH
     with _LOCK:
         if _DEPTH <= 0:
+            _ARMED[0] = False
             return
         _DEPTH = 0
-    _write(_LEAVE)
+    _ARMED[0] = False
+    _write(_LEAVE_BYTES[0].decode("ascii", "ignore"))
 
 
 def _install_backstops() -> None:
@@ -172,6 +327,28 @@ def _install_backstops() -> None:
             logger.debug("[AltScreen] atexit backstop unavailable",
                          exc_info=True)
 
+    # The unraisable guard, armed for exactly as long as we are borrowing the
+    # screen. THE fix for the traceback an operator sees on Ctrl+C:
+    #
+    #   Exception ignored in: <function WeakValueDictionary...remove>
+    #     File ".../alt_screen.py", line ..., in _handler
+    #       _prev(signum, frame)
+    #   KeyboardInterrupt:
+    #
+    # A signal is delivered at an arbitrary bytecode boundary, so `_prev` —
+    # `signal.default_int_handler`, whose whole contract is to RAISE — can be
+    # called from inside a weakref callback or a `__del__`, where there is no
+    # caller to catch anything. The interpreter routes that to
+    # `sys.unraisablehook`, which is where it has to be answered; catching it
+    # here would swallow a KeyboardInterrupt the operator is entitled to.
+    try:
+        from backend.core.ouroboros.governance.exit_guard import (
+            install_unraisable_guard,
+        )
+        install_unraisable_guard()
+    except Exception:  # noqa: BLE001
+        logger.debug("[AltScreen] unraisable guard unavailable", exc_info=True)
+
     try:
         import signal
 
@@ -180,25 +357,75 @@ def _install_backstops() -> None:
             # backstop still covers this case.
             return
 
-        for sig in (signal.SIGINT, signal.SIGTERM, signal.SIGHUP):
-            try:
-                previous = signal.getsignal(sig)
-                if getattr(previous, "_ov_alt_screen_chained", False):
-                    continue
+        def _chain(sig: Any, kind: str) -> None:
+            previous = signal.getsignal(sig)
+            if getattr(previous, "_ov_alt_screen_chained", False):
+                return
 
-                def _handler(signum: int, frame: Any,
-                             _prev: Any = previous) -> None:
-                    _restore_now()
+            def _handler(signum: int, frame: Any, _prev: Any = previous,
+                         _kind: str = kind) -> None:
+                # PHASE 1 — the async-signal-safe part, always, first, and
+                # unconditionally. One `os.write`. Whatever else goes wrong
+                # from here on, the operator gets their terminal back.
+                if _kind == "cont":
+                    # Resuming from a stop we handed the buffer back for.
+                    if _SUSPENDED[0]:
+                        _SUSPENDED[0] = False
+                        _ARMED[0] = True
+                        _emit_signal_safe(_ENTER_BYTES[0])
+                else:
+                    if _kind == "stop":
+                        _SUSPENDED[0] = _ARMED[0]
+                    _restore_signal_safe()
+
+                # PHASE 2 — chaining, which is NOT signal-safe and is
+                # therefore guarded on re-entry. A second Ctrl+C arriving
+                # while a slow predecessor runs (the harness writes a partial
+                # summary here) previously re-entered this handler and ran it
+                # again; an impatient operator must get the process to leave,
+                # not a deeper stack.
+                if _IN_HANDLER[0]:
+                    try:
+                        signal.signal(signum, signal.SIG_DFL)
+                        os.kill(os.getpid(), signum)
+                    except Exception:  # noqa: BLE001
+                        os._exit(128 + int(signum))
+                    return
+                _IN_HANDLER[0] = True
+                try:
                     if callable(_prev):
                         _prev(signum, frame)
                     elif _prev == signal.SIG_DFL:
                         # Re-raise with the default disposition so the exit
-                        # status still reports the signal honestly.
+                        # status still reports the signal honestly — and so a
+                        # stop signal actually stops the process.
                         signal.signal(signum, signal.SIG_DFL)
                         os.kill(os.getpid(), signum)
+                    # SIG_IGN falls through: the predecessor asked for this
+                    # signal to do nothing, and restoring the screen is not a
+                    # reason to overrule them.
+                finally:
+                    _IN_HANDLER[0] = False
 
-                _handler._ov_alt_screen_chained = True  # type: ignore[attr-defined]
-                signal.signal(sig, _handler)
+            _handler._ov_alt_screen_chained = True  # type: ignore[attr-defined]
+            signal.signal(sig, _handler)
+
+        for name, kind in (
+            ("SIGINT", "exit"), ("SIGTERM", "exit"), ("SIGHUP", "exit"),
+            # SIGTSTP/SIGCONT are NOT speculative here. prompt_toolkit wraps
+            # its own Ctrl+Z in `run_in_terminal`, so it hands the buffer back
+            # while IT owns the screen — but this module claims the buffer for
+            # the whole BOOT, before the cockpit mounts and after it exits, and
+            # nothing owns the screen in that window. A `kill -TSTP` there, or
+            # a Ctrl+Z during the crest, left the shell drawing its prompt on
+            # the alternate buffer.
+            ("SIGTSTP", "stop"), ("SIGCONT", "cont"),
+        ):
+            sig = getattr(signal, name, None)
+            if sig is None:
+                continue        # Windows has neither TSTP nor CONT
+            try:
+                _chain(sig, kind)
             except (OSError, ValueError, RuntimeError):
                 continue
     except Exception:  # noqa: BLE001
@@ -225,9 +452,27 @@ def alternate_screen(enabled: Optional[bool] = None) -> Iterator[bool]:
     if want:
         with _LOCK:
             if _DEPTH == 0:
-                entered = _write(_ENTER)
-                if entered:
-                    _DEPTH = 1
+                # Resolve, capture and arm BEFORE the first byte goes out.
+                # Ordering is the whole safety argument: if the process dies
+                # between the write and the arm, nothing knows to restore.
+                # Arming first costs at most one redundant `rmcup` at a
+                # terminal we never entered, which is a no-op.
+                if not _resolve_sequences():
+                    # The terminal has a description and it says there is no
+                    # alternate screen. Writing xterm's literal anyway would
+                    # print it as text into the operator's session.
+                    logger.debug("[AltScreen] terminal has no smcup/rmcup")
+                    want = False
+                else:
+                    _capture_fd()
+                    _ARMED[0] = True
+                    entered = _write(
+                        _ENTER_BYTES[0].decode("ascii", "ignore"),
+                    )
+                    if entered:
+                        _DEPTH = 1
+                    else:
+                        _ARMED[0] = False
             else:
                 _DEPTH += 1
                 entered = True
@@ -241,4 +486,5 @@ def alternate_screen(enabled: Optional[bool] = None) -> Iterator[bool]:
                 _DEPTH = max(0, _DEPTH - 1)
                 leaving = _DEPTH == 0
             if leaving:
-                _write(_LEAVE)
+                _ARMED[0] = False
+                _write(_LEAVE_BYTES[0].decode("ascii", "ignore"))

--- a/tests/battle_test/test_agent_view_wiring.py
+++ b/tests/battle_test/test_agent_view_wiring.py
@@ -26,6 +26,10 @@ from backend.core.ouroboros.battle_test.agent_roster import (
     AgentRoster,
     render_roster,
     reset_roster_for_tests,
+    reset_roster_visibility_for_tests,
+    roster_visible,
+    set_roster_visible,
+    toggle_roster,
 )
 
 
@@ -40,8 +44,30 @@ class _Clock:
 @pytest.fixture(autouse=True)
 def _isolated():
     reset_roster_for_tests()
+    reset_roster_visibility_for_tests()
     yield
     reset_roster_for_tests()
+    reset_roster_visibility_for_tests()
+
+
+@pytest.fixture
+def shown():
+    """The roster VISIBLE, for the tests that are about what it draws.
+
+    Visibility is off by default in production — the roster mounts below the
+    caret and is asked for with `/tasks`. The tests below are about staleness,
+    elapsed time, width and folding, none of which is a question about the
+    mode, so they opt in explicitly rather than inherit it.
+
+    Explicit rather than autouse, and that distinction is load-bearing: an
+    autouse fixture would have quietly kept
+    `test_a_frame_without_agents_does_not_clear_the_roster` passing on
+    `[] == []` when the gate turned it off, which is the shape of a test that
+    guards nothing while reporting green.
+    """
+    set_roster_visible(True)
+    yield
+    reset_roster_visibility_for_tests()
 
 
 @pytest.fixture
@@ -117,7 +143,7 @@ class TestCrossesTheProcessBoundary:
 
 
 class TestStaleness:
-    def test_a_stale_frame_retires_the_roster(self, busy, monkeypatch):
+    def test_a_stale_frame_retires_the_roster(self, busy, shown, monkeypatch):
         """If the daemon dies mid-dispatch, the last frame says three agents
         are running and will say so forever. The roster expires on the SAME
         window as the pulse — one definition of "lost contact", not two that
@@ -137,7 +163,7 @@ class TestStaleness:
         ui._heartbeat_arrived = time.monotonic() - 10_000
         assert ui._agent_lines() == []
 
-    def test_a_frame_without_agents_does_not_clear_the_roster(self, busy):
+    def test_a_frame_without_agents_does_not_clear_the_roster(self, busy, shown):
         """An older daemon that has never heard of `agents` is not a daemon
         reporting an empty roster. Clearing on absence would blank the view
         against a peer that simply predates the field."""
@@ -151,7 +177,7 @@ class TestStaleness:
         ui.on_telemetry({"kind": "heartbeat", "active": True})   # no key
         assert ui._agent_lines() == before
 
-    def test_an_explicit_empty_snapshot_does_clear_it(self, busy):
+    def test_an_explicit_empty_snapshot_does_clear_it(self, busy, shown):
         """That daemon IS saying "nothing is running", which is news."""
         from backend.core.ouroboros.cli.ov import AttachUI
 
@@ -461,3 +487,118 @@ class TestHeightBudget:
             drawn = sum(1 for ln in lines if "Chunk" in ln)
             more = [ln for ln in lines if "more" in ln]
             assert more and str(40 - drawn) in more[0]
+
+
+# ---------------------------------------------------------------------------
+# Rows below the caret are ASKED FOR
+# ---------------------------------------------------------------------------
+
+
+class TestVisibility:
+    """The roster mounts BELOW the input, so every row it takes sits between
+    the operator's cursor and the bottom of their screen.
+
+    Claude Code puts nothing standing there — "the input box stays fixed at
+    the bottom of the screen" — and keeps the running-subagent view behind a
+    verb, stating the separation outright: the Ctrl+T checklist "is separate
+    from the background-task view. To see running shells and subagents, use
+    `/tasks` instead."
+
+    This cockpit had it mounted permanently, so three workers and a sentinel
+    cost five rows under the caret of an IDLE session.
+    """
+
+    def test_hidden_by_default(self):
+        assert roster_visible() is False
+
+    def test_the_env_seeds_the_session_and_the_verb_owns_it(self, monkeypatch):
+        """Lazy resolution, not import-time: the flag is read from a render
+        path, and a harness that imports this module before configuring its
+        environment would otherwise be pinned to a value it never chose."""
+        monkeypatch.setenv("JARVIS_AGENT_VIEW_ROSTER_VISIBLE", "1")
+        reset_roster_visibility_for_tests()
+        assert roster_visible() is True
+        assert set_roster_visible(False) is False
+        assert roster_visible() is False, "the verb must outrank the seed"
+
+    def test_toggle_round_trips(self):
+        assert toggle_roster() is True
+        assert toggle_roster() is False
+
+    def test_a_hidden_roster_costs_zero_rows_on_the_daemon_cockpit(self, busy):
+        from backend.core.ouroboros.battle_test import serpent_flow
+
+        assert serpent_flow._local_agent_rows() == []
+        set_roster_visible(True)
+        # Whether THIS process has agents is beside the point; what must be
+        # true is that the provider stops short of the renderer when hidden
+        # and reaches it when shown.
+        assert isinstance(serpent_flow._local_agent_rows(), list)
+
+    def test_a_hidden_roster_costs_zero_rows_on_the_attach_client(self, busy):
+        from backend.core.ouroboros.cli.ov import AttachUI
+
+        roster, _clock = busy
+        ui = AttachUI()
+        ui.on_telemetry({"kind": "heartbeat", "active": True,
+                         "agents": roster.snapshot()})
+        assert ui._agent_lines() == []
+        set_roster_visible(True)
+        assert ui._agent_lines(), "shown, the same frame must draw"
+
+    def test_the_renderer_holds_no_opinion_about_visibility(self, busy):
+        """The gate belongs to the PROVIDERS.
+
+        Putting it in `render_roster` made every caller that wanted the
+        picture — `/tasks` included — opt out of a mode question it had not
+        asked, and broke seventeen tests that were only ever about folding,
+        width and glyphs.
+        """
+        roster, _clock = busy
+        assert roster_visible() is False
+        assert render_roster(roster.snapshot(), width=100), (
+            "the renderer draws what it is given; the surface decides "
+            "whether to ask"
+        )
+
+    def test_every_provider_is_gated(self):
+        """A PRODUCER-side audit, not a consumer-side one.
+
+        Two of three providers gated is the shape of defect this repo keeps
+        finding late: the surface an operator does not happen to open that
+        week keeps drawing rows the others have stopped drawing, and nothing
+        fails. So the assertion is over the SET of providers, and a fourth
+        one added tomorrow lands in this list or fails here.
+        """
+        import ast
+        import inspect
+
+        from backend.core.ouroboros.battle_test import serpent_flow
+        from backend.core.ouroboros.cli import ov
+
+        providers = (
+            serpent_flow._local_agent_rows,
+            ov.AttachUI._agent_lines,
+        )
+        for fn in providers:
+            tree = ast.parse(inspect.getsource(fn).lstrip())
+            called = {
+                node.func.id for node in ast.walk(tree)
+                if isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+            }
+            assert "roster_visible" in called, (
+                f"{fn.__qualname__} draws roster rows without consulting "
+                "roster_visible — it will keep spending rows below the caret "
+                "after /tasks hides them everywhere else"
+            )
+
+    def test_the_demo_opts_in_explicitly(self):
+        """The demo exists to SHOW the surfaces, so it turns the roster on —
+        and has to say so in code rather than inherit a default, or it would
+        silently keep rendering a roster the cockpit had stopped drawing."""
+        from backend.core.ouroboros.cli import ov_demo
+
+        assert roster_visible() is False
+        ov_demo._agent_view_rows()
+        assert roster_visible() is True

--- a/tests/battle_test/test_agent_view_wiring.py
+++ b/tests/battle_test/test_agent_view_wiring.py
@@ -602,3 +602,136 @@ class TestVisibility:
         assert roster_visible() is False
         ov_demo._agent_view_rows()
         assert roster_visible() is True
+
+
+# ---------------------------------------------------------------------------
+# One clock for every surface the heartbeat feeds
+# ---------------------------------------------------------------------------
+
+
+class TestHeartbeatStaleness:
+    """Three docstrings on `AttachUI` already asked for this in prose — the
+    roster's ("one clock, one definition of 'lost contact'"), the status
+    line's ("rather than three that drift apart and leave a dead daemon's
+    phase showing under an idle pulse") and the countdown's. All three then
+    implemented the rule inline, and the serpent border was about to make a
+    fourth copy.
+
+    The failure it prevents reads as normal operation: a daemon that dies
+    mid-dispatch leaves a last frame saying three agents are running, phase
+    GENERATE, border moving — forever.
+    """
+
+    def _fresh(self, busy):
+        from backend.core.ouroboros.cli.ov import AttachUI
+
+        roster, _clock = busy
+        ui = AttachUI()
+        ui.on_telemetry({"kind": "heartbeat", "active": True,
+                         "agents": roster.snapshot()})
+        return ui
+
+    def test_no_heartbeat_is_not_a_zero_age(self, busy):
+        """A process that has never heard from the daemon has NOT just heard
+        from it. `_heartbeat_arrived == 0.0` compared against a monotonic
+        clock would read as an enormous age on some platforms and as fresh on
+        others — so absence is None, explicitly."""
+        from backend.core.ouroboros.cli.ov import AttachUI
+
+        assert AttachUI()._heartbeat_age() is None
+
+    def test_a_fresh_frame_yields_an_age(self, busy):
+        age = self._fresh(busy)._heartbeat_age()
+        assert age is not None and age >= 0.0
+
+    def test_every_surface_retires_on_the_same_clock(self, busy, shown):
+        """THE property. Not "each one expires eventually" — the SAME
+        instant, or the cockpit shows a coherent, confident, wrong picture of
+        a dead organism."""
+        import time
+
+        ui = self._fresh(busy)
+        assert ui._agent_lines()
+        assert ui._serpent_active() is True
+
+        ui._heartbeat_arrived = time.monotonic() - 10_000
+        assert ui._heartbeat_age() is None
+        assert ui._agent_lines() == []
+        assert ui._status_rows() == []
+        assert ui._pending_apply_rows() == []
+        assert ui._serpent_active() is False
+
+    def test_the_rule_is_declared_once(self):
+        """Not a style point. Four copies of a staleness window drift, and
+        the drift is invisible until a daemon dies."""
+        import ast
+        import inspect
+
+        from backend.core.ouroboros.cli import ov
+
+        callers = 0
+        for name in ("_agent_lines", "_status_rows", "_pending_apply_rows",
+                     "_serpent_active"):
+            src = inspect.getsource(getattr(ov.AttachUI, name)).lstrip()
+            tree = ast.parse(src)
+            names = {
+                n.attr for n in ast.walk(tree) if isinstance(n, ast.Attribute)
+            }
+            assert "_heartbeat_age" in names, (
+                f"{name} does not consult the shared predicate"
+            )
+            assert "heartbeat_stale_after_s" not in inspect.getsource(
+                getattr(ov.AttachUI, name)), (
+                f"{name} re-implements the staleness window inline"
+            )
+            callers += 1
+        assert callers == 4
+
+
+class TestSerpentActive:
+    """`capability_handoff` measured this hook UNSET on `ov`: the animation
+    ran in the demo and on the daemon's own terminal, and was dead on the
+    surface an operator attaches with. A border that never moves is
+    indistinguishable from an organism that is never busy."""
+
+    def _ui(self, active, agents=None):
+        from backend.core.ouroboros.cli.ov import AttachUI
+
+        ui = AttachUI()
+        ui.on_telemetry({"kind": "heartbeat", "active": active})
+        return ui
+
+    def test_it_follows_the_daemons_own_flag(self):
+        assert self._ui(True)._serpent_active() is True
+        assert self._ui(False)._serpent_active() is False
+
+    def test_a_dead_daemon_stops_the_border(self):
+        """The load-bearing half: a border still animating after the daemon
+        dies is the cockpit asserting work is in flight when nothing runs."""
+        import time
+
+        ui = self._ui(True)
+        ui._heartbeat_arrived = time.monotonic() - 10_000
+        assert ui._serpent_active() is False
+
+    def test_a_frame_without_the_field_is_not_active(self):
+        """An older daemon that predates `active` must not animate forever."""
+        from backend.core.ouroboros.cli.ov import AttachUI
+
+        ui = AttachUI()
+        ui.on_telemetry({"kind": "heartbeat"})
+        assert ui._serpent_active() is False
+
+    def test_the_hook_is_actually_handed_to_the_cockpit(self):
+        """The defect class this whole audit exists for: a provider that
+        exists, works, and is never passed."""
+        import ast
+        import inspect
+
+        from backend.core.ouroboros.cli import ov
+
+        tree = ast.parse(inspect.getsource(ov))
+        assert any(
+            isinstance(node, ast.keyword) and node.arg == "serpent_active"
+            for node in ast.walk(tree)
+        ), "ov builds the cockpit without handing it serpent_active"

--- a/tests/battle_test/test_bipartite_layout.py
+++ b/tests/battle_test/test_bipartite_layout.py
@@ -143,3 +143,61 @@ async def test_active_canvas_sink_redirect():
     finally:
         set_active_canvas(None)
         assert get_active_canvas() is None
+
+
+# ---------------------------------------------------------------------------
+# Ctrl+Z — a habit the alternate screen took away
+# ---------------------------------------------------------------------------
+
+
+class TestSuspend:
+    """A normal terminal turns Ctrl+Z into SIGTSTP itself. A full-screen app
+    holds the terminal in raw mode, so the keystroke arrives as an ordinary
+    key and the shell never sees it — the operator's habit silently stopped
+    working the day this cockpit went full-screen.
+    """
+
+    def _app(self):
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            BipartiteLayout, build_bipartite_application,
+        )
+        mux = BipartiteLayout(width=100, height=30)
+        return build_bipartite_application(mux, on_accept=lambda _t: None)
+
+    def test_ctrl_z_is_bound_on_the_cockpit(self):
+        app = self._app()
+        sequences = [
+            tuple(str(k) for k in b.keys) for b in app.key_bindings.bindings
+        ]
+        assert ("Keys.ControlZ",) in sequences
+
+    def test_it_is_remappable(self):
+        from backend.core.ouroboros.battle_test.keymap import action_catalog
+
+        self._app()
+        assert any(s.action == "app:suspend" for s in action_catalog())
+
+    def test_it_delegates_terminal_restoration(self):
+        """`suspend_to_background` leaves the alternate screen, restores
+        cooked mode, raises SIGTSTP and repaints on SIGCONT. Hand-rolling
+        that means owning terminal state across a signal, and getting it
+        wrong strands the operator at a shell with no echo."""
+        import ast
+        import inspect
+
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            build_bipartite_application,
+        )
+        tree = ast.parse(
+            inspect.getsource(build_bipartite_application).lstrip(),
+        )
+        attrs = {
+            node.func.attr for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+        }
+        assert "suspend_to_background" in attrs
+        assert not (attrs & {"raise_signal", "kill", "killpg"}), (
+            "the cockpit reached for a raw signal instead of prompt_toolkit's "
+            "own suspend, which owns the terminal state"
+        )

--- a/tests/battle_test/test_canvas_mouse.py
+++ b/tests/battle_test/test_canvas_mouse.py
@@ -219,3 +219,150 @@ class TestOnTheRealApplication:
             for n in ast.walk(tree)
         )
         assert "on_accept(line)" in src
+
+
+# ---------------------------------------------------------------------------
+# Cmd/Ctrl+click — model-authored text handed to the OS
+# ---------------------------------------------------------------------------
+
+
+def _mod_ev(y, kind="MOUSE_UP", mod="CONTROL"):
+    from prompt_toolkit.data_structures import Point
+    from prompt_toolkit.mouse_events import (
+        MouseButton, MouseEvent, MouseEventType, MouseModifier,
+    )
+    return MouseEvent(Point(x=4, y=y), getattr(MouseEventType, kind),
+                      MouseButton.LEFT,
+                      frozenset({getattr(MouseModifier, mod)}))
+
+
+class TestOpenTargets:
+    """This is the ONE cockpit surface that takes something the organism
+    wrote and hands it to the operating system. Containment — not pattern
+    cleverness — is what makes that safe: a path is offered only when it
+    resolves INSIDE the repo and already exists.
+    """
+
+    def test_a_real_repo_path_is_offered(self):
+        line = "⏺ Read(backend/core/ouroboros/battle_test/canvas_mouse.py)"
+        kind, value = M.target_in_line(line)
+        assert kind == "path" and value.endswith("canvas_mouse.py")
+
+    def test_an_https_url_is_offered(self):
+        kind, value = M.target_in_line("see https://example.com/a/b for more")
+        assert kind == "url" and value == "https://example.com/a/b"
+
+    def test_trailing_punctuation_is_not_part_of_the_url(self):
+        _kind, value = M.target_in_line("docs at https://example.com/x.")
+        assert value == "https://example.com/x"
+
+    @pytest.mark.parametrize("line", [
+        "⏺ Read(/etc/passwd)",
+        "⏺ Read(../../../../etc/passwd)",
+        "cat ~/.ssh/id_rsa",
+        "⏺ Read(/Users/someone/.aws/credentials)",
+    ])
+    def test_paths_outside_the_repo_are_refused(self, line):
+        """Traversal and absolutes are answered by resolving THEN containing,
+        so no regex has to enumerate what to forbid."""
+        assert M.target_in_line(line) is None
+
+    @pytest.mark.parametrize("line", [
+        "open file:///etc/passwd",
+        "click javascript:alert(1) now",
+        "try data:text/html,<script>x</script>",
+    ])
+    def test_dangerous_schemes_are_refused(self, line):
+        """The scheme IS the capability: file:// reaches local disk and
+        javascript:/data: are execution vectors."""
+        assert M.target_in_line(line) is None
+
+    def test_a_path_that_does_not_exist_is_refused(self):
+        assert M.target_in_line("⏺ Read(backend/nope_does_not_exist.py)") is None
+
+    def test_open_target_refuses_a_non_http_url(self):
+        assert M.open_target("url", "file:///etc/passwd") is False
+        assert M.open_target("url", "javascript:alert(1)") is False
+        assert M.open_target("path", "") is False
+
+    def test_open_target_never_uses_a_shell(self):
+        """The value came from the transcript. A shell string would make
+        every metacharacter in it executable."""
+        import ast
+        import inspect
+        import textwrap
+
+        tree = ast.parse(textwrap.dedent(inspect.getsource(M.open_target)))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.keyword) and node.arg == "shell":
+                assert node.value.value is False, "shell=True in open_target"
+        src = inspect.getsource(M.open_target)
+        assert "shell=True" not in src
+        assert "os.system" not in src
+
+
+class TestTheOpenGesture:
+    def _wire(self, rows, opened):
+        control = type("_C", (), {})()
+        M.install_canvas_mouse(control, lambda: rows, lambda _l: None)
+        return control
+
+    def test_a_plain_click_never_opens(self, monkeypatch):
+        """The guard that matters most: a bare click must not launch
+        anything, on any terminal."""
+        opened = []
+        monkeypatch.setattr(M, "open_target",
+                            lambda k, v: opened.append((k, v)) or True)
+        submitted = []
+        control = type("_C", (), {})()
+        M.install_canvas_mouse(
+            control,
+            lambda: ["⏺ Read(backend/core/ouroboros/battle_test/canvas_mouse.py)"],
+            submitted.append)
+        control.mouse_handler(_ev(0, "MOUSE_UP"))
+        assert opened == []
+
+    def test_a_modified_click_opens(self, monkeypatch):
+        opened = []
+        monkeypatch.setattr(M, "open_target",
+                            lambda k, v: opened.append((k, v)) or True)
+        control = type("_C", (), {})()
+        M.install_canvas_mouse(control, lambda: ["see https://example.com/x"],
+                               lambda _l: None)
+        control.mouse_handler(_mod_ev(0))
+        assert opened and opened[0][0] == "url"
+
+    def test_the_modifier_decides_when_a_line_offers_both(self, monkeypatch):
+        """`⏺ Read(x.py) · /expand t-3` is a path AND an expansion. The
+        modifier is the operator saying which they meant."""
+        opened, submitted = [], []
+        monkeypatch.setattr(M, "open_target",
+                            lambda k, v: opened.append((k, v)) or True)
+        row = ("⏺ Read(backend/core/ouroboros/battle_test/canvas_mouse.py)"
+               " · /expand t-3")
+        control = type("_C", (), {})()
+        M.install_canvas_mouse(control, lambda: [row], submitted.append)
+
+        control.mouse_handler(_ev(0, "MOUSE_UP"))
+        assert submitted == ["/expand t-3"] and opened == []
+
+        control.mouse_handler(_mod_ev(0))
+        assert len(opened) == 1 and submitted == ["/expand t-3"]
+
+    def test_a_modified_click_on_nothing_openable_is_not_consumed(self):
+        control = type("_C", (), {})()
+        M.install_canvas_mouse(control, lambda: ["⏺ Read(/etc/passwd)"],
+                               lambda _l: None)
+        assert control.mouse_handler(_mod_ev(0)) is NotImplemented
+
+    def test_alt_also_counts_as_the_gesture(self, monkeypatch):
+        """CC documents that the terminal mouse protocol cannot encode Cmd,
+        so this asks for a modifier the protocol CAN carry."""
+        opened = []
+        monkeypatch.setattr(M, "open_target",
+                            lambda k, v: opened.append(v) or True)
+        control = type("_C", (), {})()
+        M.install_canvas_mouse(control, lambda: ["https://example.com/y"],
+                               lambda _l: None)
+        control.mouse_handler(_mod_ev(0, mod="ALT"))
+        assert opened

--- a/tests/battle_test/test_canvas_mouse.py
+++ b/tests/battle_test/test_canvas_mouse.py
@@ -1,0 +1,221 @@
+"""Clicking a transcript line that says it has more to show.
+
+`mouse_support` was already on — the wheel scrolled — but the cockpit had
+ZERO `MouseEventType` handlers, so every click fell on the floor. Measured
+against CC's documented surface that was the largest single gap: 1 of 13.
+
+Two failures here would read as normal operation, and both are pinned:
+
+  * a click resolving one row off, because the row was DERIVED (logical
+    lines + anchor padding + panel border - scroll offset) instead of read
+    off the rendered output — reported by an operator as "it expanded the
+    wrong thing";
+  * a handler that returns None for events it does not consume, silently
+    taking the mouse WHEEL away — trading the one mouse capability the
+    cockpit already had for the one being added.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.battle_test import canvas_mouse as M
+
+
+def _ev(y, kind):
+    from prompt_toolkit.data_structures import Point
+    from prompt_toolkit.mouse_events import (
+        MouseButton, MouseEvent, MouseEventType,
+    )
+    return MouseEvent(Point(x=4, y=y), getattr(MouseEventType, kind),
+                      MouseButton.LEFT, frozenset())
+
+
+class TestRefResolution:
+    def test_a_line_offering_expand_is_clickable(self):
+        assert M.ref_in_line("  ⎿ 41 lines parked · /expand t-3") == "t-3"
+
+    def test_a_bare_ref_is_clickable(self):
+        """The moltbook feed appends `n-4` with no verb."""
+        assert M.ref_in_line("🐍 @cassandra: the soak refused  n-4") == "n-4"
+
+    def test_the_offer_wins_over_a_mentioned_ref(self):
+        """A line carrying both is resolved by what it OFFERS, not by
+        whichever artifact happens to appear first in it."""
+        line = "⎿ derived from d-9 · /expand t-3"
+        assert M.ref_in_line(line) == "t-3"
+
+    def test_prose_is_not_a_ref(self):
+        """THE false-positive that would make ordinary sentences clickable."""
+        for prose in (
+            "a well-known b-tree traversal",
+            "see the x-ray of the call graph",
+            "rated a-1 by the advisor",          # no digit boundary abuse
+        ):
+            got = M.ref_in_line(prose)
+            assert got is None or "-" in got, prose
+        assert M.ref_in_line("a well-known b-tree traversal") is None
+
+    def test_a_line_with_nothing_to_show_is_not_clickable(self):
+        """CC: 'Only messages that have more to show are clickable.'"""
+        assert M.ref_in_line("⏺ Read(backend/x.py)") is None
+        assert M.ref_in_line("╭───── canvas ─────╮") is None
+        assert M.ref_in_line("") is None
+
+    def test_ansi_is_stripped_before_matching(self):
+        assert M.ref_in_line("\x1b[2m  ⎿ /expand t-7\x1b[0m") == "t-7"
+
+    def test_every_expand_ref_family_resolves(self):
+        """`/expand` dispatches t-/d-/o-/n-/p-/q-/b-. None of that is
+        reimplemented here, so all of it works or none of it does."""
+        for prefix in ("t", "d", "o", "n", "p", "q", "b"):
+            assert M.ref_in_line(f"⎿ more · /expand {prefix}-12") == f"{prefix}-12"
+
+    def test_garbage_never_raises(self):
+        for bad in (None, 42, [], object()):
+            assert M.ref_in_line(bad) is None
+
+
+class TestRowIndexing:
+    ROWS = [
+        "╭──────────── canvas ────────────╮",
+        "│ ⏺ Read(backend/x.py)           │",
+        "│ ⎿ 41 lines parked · /expand t-3│",
+        "╰────────────────────────────────╯",
+    ]
+
+    def test_it_resolves_the_row_it_was_given(self):
+        assert M.ref_at_row(self.ROWS, 2) == "t-3"
+        assert M.ref_at_row(self.ROWS, 1) is None
+
+    def test_border_rows_carry_no_ref(self):
+        """Why no offset arithmetic is needed: the panel's own rows simply
+        do not resolve, so the border costs nothing to account for."""
+        assert M.ref_at_row(self.ROWS, 0) is None
+        assert M.ref_at_row(self.ROWS, 3) is None
+
+    def test_out_of_range_is_none_not_an_error(self):
+        """A click can land during a resize, between the render that sized
+        the frame and the one that filled it."""
+        for row in (99, -1, None, "x"):
+            assert M.ref_at_row(self.ROWS, row) is None
+
+    def test_clickable_rows_is_answerable_without_a_terminal(self):
+        assert M.clickable_rows(self.ROWS) == [2]
+
+    def test_resolve_click_builds_the_verb(self):
+        assert M.resolve_click(self.ROWS, 2) == "/expand t-3"
+        assert M.resolve_click(self.ROWS, 0) is None
+
+
+class TestTheHandler:
+    def _wire(self, rows):
+        submitted = []
+        control = type("_C", (), {})()
+        assert M.install_canvas_mouse(control, lambda: rows, submitted.append)
+        return control, submitted
+
+    def test_a_click_submits_the_verb(self):
+        control, submitted = self._wire(["⎿ /expand t-3"])
+        control.mouse_handler(_ev(0, "MOUSE_UP"))
+        assert submitted == ["/expand t-3"]
+
+    def test_the_wheel_is_not_consumed(self):
+        """THE regression this guard exists for. Returning None here would
+        take scrolling away — the one mouse capability already working."""
+        control, submitted = self._wire(["⎿ /expand t-3"])
+        for kind in ("SCROLL_UP", "SCROLL_DOWN"):
+            assert control.mouse_handler(_ev(0, kind)) is NotImplemented
+        assert submitted == []
+
+    def test_a_press_is_not_a_click(self):
+        """Acting on MOUSE_DOWN fires while the operator is still deciding —
+        including at the start of a drag they meant as a selection."""
+        control, submitted = self._wire(["⎿ /expand t-3"])
+        assert control.mouse_handler(_ev(0, "MOUSE_DOWN")) is NotImplemented
+        assert submitted == []
+
+    def test_a_click_on_a_plain_line_is_not_consumed(self):
+        control, submitted = self._wire(["⏺ Read(x.py)"])
+        assert control.mouse_handler(_ev(0, "MOUSE_UP")) is NotImplemented
+        assert submitted == []
+
+    def test_a_failing_rows_source_never_breaks_the_frame(self):
+        submitted = []
+        control = type("_C", (), {})()
+
+        def _boom():
+            raise RuntimeError("canvas mid-resize")
+
+        M.install_canvas_mouse(control, _boom, submitted.append)
+        assert control.mouse_handler(_ev(0, "MOUSE_UP")) is NotImplemented
+
+    def test_a_failing_submit_never_breaks_the_frame(self):
+        control = type("_C", (), {})()
+
+        def _boom(_line):
+            raise RuntimeError("dispatch gone")
+
+        M.install_canvas_mouse(control, lambda: ["⎿ /expand t-3"], _boom)
+        control.mouse_handler(_ev(0, "MOUSE_UP"))          # no raise
+
+    def test_an_existing_handler_is_chained_not_replaced(self):
+        seen = []
+        control = type("_C", (), {})()
+        control.mouse_handler = lambda e: seen.append(e) or "prior"
+        M.install_canvas_mouse(control, lambda: ["plain"], lambda _l: None)
+        assert control.mouse_handler(_ev(0, "MOUSE_UP")) == "prior"
+        assert len(seen) == 1
+
+    def test_the_kill_switch_keeps_the_wheel(self, monkeypatch):
+        """Distinct from JARVIS_DISABLE_MOUSE, which costs scrolling too —
+        the same split CC draws between DISABLE_MOUSE_CLICKS and
+        DISABLE_MOUSE."""
+        monkeypatch.setenv("JARVIS_CANVAS_MOUSE_ENABLED", "0")
+        control = type("_C", (), {})()
+        assert M.install_canvas_mouse(control, lambda: [], lambda _l: None) is False
+        assert not hasattr(control, "mouse_handler")
+
+
+class TestOnTheRealApplication:
+    def _app(self):
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            BipartiteLayout, build_bipartite_application,
+        )
+        submitted = []
+        mux = BipartiteLayout(width=80, height=14)
+        for line in ("⏺ Read(x.py)", "⎿ 41 lines parked · /expand t-3"):
+            mux.emit("line", {"text": line})
+        app = build_bipartite_application(mux, on_accept=submitted.append)
+        control = next(c for c in app.layout.find_all_controls()
+                       if type(c).__name__ == "_MeasuredCanvasControl")
+        return mux, control, submitted
+
+    def test_the_canvas_control_has_a_handler(self):
+        _mux, control, _submitted = self._app()
+        assert callable(getattr(control, "mouse_handler", None))
+
+    def test_a_click_on_the_rendered_ref_row_expands(self):
+        """Indexed against RENDERED output, so the panel border and the
+        anchor padding need no arithmetic — row Y is whatever is on row Y."""
+        mux, control, submitted = self._app()
+        rows = mux.render_canvas_ansi().splitlines()
+        target = next(i for i, r in enumerate(rows) if "t-3" in r)
+        control.mouse_handler(_ev(target, "MOUSE_UP"))
+        assert submitted == ["/expand t-3"]
+
+    def test_a_click_routes_through_on_accept(self):
+        """A click IS the verb: the same callable a typed line goes through,
+        so no surface grows a second dispatch path to drift."""
+        import ast
+        import inspect
+
+        from backend.core.ouroboros.battle_test import bipartite_layout
+
+        src = inspect.getsource(bipartite_layout.build_bipartite_application)
+        tree = ast.parse(src.lstrip())
+        assert any(
+            isinstance(n, ast.Call)
+            and getattr(n.func, "id", None) == "install_canvas_mouse"
+            for n in ast.walk(tree)
+        )
+        assert "on_accept(line)" in src

--- a/tests/battle_test/test_canvas_selection.py
+++ b/tests/battle_test/test_canvas_selection.py
@@ -1,0 +1,253 @@
+"""Selecting text in the transcript, which has no selection model to borrow.
+
+prompt_toolkit gives selection to BUFFERS, which is why selecting inside the
+ov prompt always worked and needed no code. The canvas is a
+`FormattedTextControl`: styled runs with no cursor, no anchor, and no notion
+that two of its characters might be "between" each other.
+
+The failures pinned here are the ones a naive implementation ships:
+
+  * the single-row case written as the multi-row case with the middle
+    removed — which slices row N from `start` to end AND from start to
+    `end`, copying the row twice;
+  * a backwards drag (up and to the left) selecting nothing;
+  * an inclusive end, so a one-cell drag selects two cells;
+  * a drag treated as a click on release, expanding whatever it began on;
+  * a highlight emitted per CHARACTER rather than per run, handing every
+    downstream renderer a screenful of one-character fragments.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.battle_test import canvas_selection as S
+
+ROWS = [
+    "│ ⏺ Read(backend/x.py)            │",
+    "│ ⎿ collected 41 items            │",
+    "│ ⎿ 3 failed, 38 passed           │",
+]
+
+
+@pytest.fixture(autouse=True)
+def _clean():
+    S.reset_selection_for_tests()
+    yield
+    S.reset_selection_for_tests()
+
+
+class TestGeometry:
+    def test_the_end_is_half_open(self):
+        """A one-cell drag selects one cell. An inclusive end selects two."""
+        sel = S.Selection((1, 2), (1, 3))
+        assert sel.contains(1, 2) and not sel.contains(1, 3)
+
+    def test_a_press_with_no_drag_is_not_a_selection(self):
+        """Load-bearing: a plain click must still reach click-to-expand
+        rather than being swallowed as a zero-width selection."""
+        assert S.Selection((2, 2)).empty is True
+        assert S.Selection((2, 2)).contains(2, 2) is False
+
+    def test_a_backwards_drag_selects(self):
+        """Dragging up and to the left is the same selection dragged the
+        other way. Storing normalised would lose the direction; not ordering
+        on read selects nothing."""
+        back = S.Selection((3, 8), (1, 2))
+        assert back.ordered() == ((1, 2), (3, 8))
+        assert back.contains(2, 0) and back.contains(1, 5)
+        assert not back.contains(0, 9)
+
+    def test_the_first_and_last_rows_are_partial(self):
+        sel = S.Selection((0, 5), (2, 3))
+        assert not sel.contains(0, 4) and sel.contains(0, 5)
+        assert sel.contains(1, 0)                    # middle row: all of it
+        assert sel.contains(2, 2) and not sel.contains(2, 3)
+
+    def test_rows_outside_are_excluded(self):
+        sel = S.Selection((1, 0), (1, 5))
+        assert not sel.contains(0, 2) and not sel.contains(2, 2)
+
+
+class TestExtraction:
+    def test_a_single_row_is_not_the_row_twice(self):
+        """THE off-by-a-whole-line bug: writing the one-row case as the
+        multi-row case with the middle removed slices `[start:]` and
+        `[:end]` of the SAME row."""
+        got = S.extract_text(ROWS, S.Selection((0, 4), (0, 21)))
+        assert got == "Read(backend/x.py"
+        assert got.count("Read") == 1
+
+    def test_a_multi_row_selection_spans_correctly(self):
+        got = S.extract_text(ROWS, S.Selection((0, 4), (2, 24))).splitlines()
+        assert len(got) == 3
+        assert got[0].startswith("Read(")
+        assert got[1] == ROWS[1].rstrip()             # whole middle row
+        assert got[2].endswith("passed")
+
+    def test_trailing_padding_is_trimmed(self):
+        """The canvas pads every row to the panel width; without trimming,
+        every copied line carries a tail of spaces the operator cannot see."""
+        got = S.extract_text(ROWS, S.Selection((1, 2), (1, 40)))
+        assert got == got.rstrip()
+
+    def test_a_selection_past_the_end_clamps(self):
+        """A drag released below the last row selects to the END of the
+        content rather than raising or truncating.
+
+        The last line keeps its border, and that is the contract rather than
+        an oversight: coordinates are RENDERED cells, so selecting to
+        end-of-row selects what is on that row — which is what a terminal's
+        own selection does and what CC documents its selection as capturing,
+        "the hard-wrapped terminal rendering rather than the source text".
+        """
+        got = S.extract_text(ROWS, S.Selection((0, 4), (99, 3)))
+        assert got.splitlines()[-1] == ROWS[-1].rstrip()
+        assert len(got.splitlines()) == len(ROWS)
+
+    def test_an_empty_selection_yields_nothing(self):
+        assert S.extract_text(ROWS, S.Selection((1, 2))) == ""
+        assert S.extract_text(ROWS, None) == ""
+
+    def test_ansi_is_stripped_from_what_is_copied(self):
+        rows = ["\x1b[2m⎿ collected 41 items\x1b[0m"]
+        got = S.extract_text(rows, S.Selection((0, 0), (0, 40)))
+        assert "\x1b" not in got and "collected 41 items" in got
+
+    def test_garbage_never_raises(self):
+        for bad in (None, [], [None, 3]):
+            S.extract_text(bad, S.Selection((0, 0), (1, 1)))
+
+
+class TestHighlight:
+    def test_it_splits_a_run_at_the_boundary(self):
+        out = S.apply_selection([("class:a", "hello")],
+                                S.Selection((0, 1), (0, 4)))
+        assert out == [("class:a", "h"),
+                       ("class:a reverse", "ell"),
+                       ("class:a", "o")]
+
+    def test_it_emits_runs_not_characters(self):
+        """A screenful of one-character fragments is a pathological input
+        for every downstream renderer."""
+        out = S.apply_selection([("", "x" * 40)], S.Selection((0, 5), (0, 35)))
+        assert len(out) == 3
+
+    def test_newlines_advance_the_row_and_reset_the_column(self):
+        out = S.apply_selection([("", "ab\ncd")], S.Selection((1, 0), (1, 1)))
+        text = "".join(t for _s, t in out)
+        assert text == "ab\ncd"
+        assert any("reverse" in s for s, _t in out)
+        selected = "".join(t for s, t in out if "reverse" in s)
+        assert selected == "c"
+
+    def test_nothing_selected_costs_nothing(self):
+        """Returns the input untouched, so an idle canvas walks no chars."""
+        frags = [("class:a", "hello world")]
+        assert S.apply_selection(frags, None) == frags
+        assert S.apply_selection(frags, S.Selection((0, 2))) == frags
+
+    def test_the_style_is_configurable_and_theme_neutral(self, monkeypatch):
+        """A hardcoded highlight colour is the one thing certain to collide
+        with an operator-chosen theme."""
+        assert S.selection_style() == "reverse"
+        monkeypatch.setenv("JARVIS_SELECTION_STYLE", "bg:#333333")
+        out = S.apply_selection([("", "abc")], S.Selection((0, 0), (0, 2)))
+        assert any("bg:#333333" in s for s, _t in out)
+
+    def test_extra_fragment_members_survive(self):
+        """Fragments may carry a third element (a mouse handler). Dropping
+        it would silently unbind whatever it was."""
+        handler = object()
+        out = S.apply_selection([("", "abc", handler)],
+                                S.Selection((0, 0), (0, 2)))
+        assert all(len(f) == 3 and f[2] is handler for f in out)
+
+    def test_malformed_fragments_pass_through(self):
+        out = S.apply_selection([("only-one",), ("", "ab")],
+                                S.Selection((0, 0), (0, 1)))
+        assert out[0] == ("only-one",)
+
+    def test_the_kill_switch_leaves_fragments_alone(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_CANVAS_SELECTION_ENABLED", "0")
+        frags = [("", "abc")]
+        assert S.apply_selection(frags, S.Selection((0, 0), (0, 2))) == frags
+
+
+class TestTheDragGesture:
+    def _wire(self, monkeypatch):
+        """`monkeypatch`, NOT a bare assignment.
+
+        The first cut set `C.copy_text` directly, which is a permanent module
+        mutation that leaked into `test_clipboard_write.py` in the same
+        session and failed four of its tests. A fake that outlives its test
+        is indistinguishable from a broken module.
+        """
+        from backend.core.ouroboros.battle_test import canvas_mouse as M
+        from backend.core.ouroboros.battle_test import clipboard_write as C
+
+        copied, notes, submitted = [], [], []
+        monkeypatch.setattr(
+            C, "copy_text", lambda t, **k: copied.append(t) or "pbcopy")
+        control = type("_C", (), {})()
+        M.install_canvas_mouse(control, lambda: ROWS, submitted.append,
+                               notify=notes.append)
+        return control, copied, notes, submitted
+
+    def _ev(self, y, x, kind):
+        from prompt_toolkit.data_structures import Point
+        from prompt_toolkit.mouse_events import (
+            MouseButton, MouseEvent, MouseEventType,
+        )
+        return MouseEvent(Point(x=x, y=y), getattr(MouseEventType, kind),
+                          MouseButton.LEFT, frozenset())
+
+    def test_a_drag_copies_and_does_not_expand(self, monkeypatch):
+        """A drag that began on a line offering `/expand` must not expand it
+        on release — the operator was selecting, not clicking."""
+        control, copied, notes, submitted = self._wire(monkeypatch)
+        control.mouse_handler(self._ev(1, 2, "MOUSE_DOWN"))
+        control.mouse_handler(self._ev(1, 10, "MOUSE_MOVE"))
+        control.mouse_handler(self._ev(2, 8, "MOUSE_UP"))
+        assert copied and submitted == []
+        assert notes and "copied" in notes[0]
+
+    def test_a_click_still_expands(self, monkeypatch):
+        control, copied, _notes, submitted = self._wire(monkeypatch)
+        row = next(i for i, r in enumerate(ROWS) if "/expand" in r) \
+            if any("/expand" in r for r in ROWS) else None
+        rows = ROWS + ["⎿ 41 parked · /expand t-3"]
+        from backend.core.ouroboros.battle_test import canvas_mouse as M
+        control = type("_C", (), {})()
+        M.install_canvas_mouse(control, lambda: rows, submitted.append)
+        control.mouse_handler(self._ev(3, 5, "MOUSE_DOWN"))
+        control.mouse_handler(self._ev(3, 5, "MOUSE_UP"))
+        assert submitted == ["/expand t-3"]
+
+    def test_the_selection_is_cleared_after_the_copy(self, monkeypatch):
+        """A highlight that outlives the gesture asserts the operator still
+        has something selected — and the next click would extend it."""
+        control, _copied, _notes, _submitted = self._wire(monkeypatch)
+        control.mouse_handler(self._ev(0, 2, "MOUSE_DOWN"))
+        control.mouse_handler(self._ev(0, 9, "MOUSE_UP"))
+        assert S.current_selection() is None
+
+    def test_the_wheel_is_still_not_consumed(self, monkeypatch):
+        control, _c, _n, _s = self._wire(monkeypatch)
+        assert control.mouse_handler(
+            self._ev(0, 0, "SCROLL_DOWN")) is NotImplemented
+
+    def test_copy_on_select_off_still_selects(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_CANVAS_COPY_ON_SELECT", "0")
+        control, copied, _notes, submitted = self._wire(monkeypatch)
+        control.mouse_handler(self._ev(0, 2, "MOUSE_DOWN"))
+        control.mouse_handler(self._ev(0, 9, "MOUSE_UP"))
+        assert copied == [] and submitted == []
+
+    def test_a_failed_copy_says_so(self, monkeypatch):
+        from backend.core.ouroboros.battle_test import clipboard_write as C
+
+        control, _copied, notes, _submitted = self._wire(monkeypatch)
+        monkeypatch.setattr(C, "copy_text", lambda t, **k: None)
+        control.mouse_handler(self._ev(0, 2, "MOUSE_DOWN"))
+        control.mouse_handler(self._ev(0, 9, "MOUSE_UP"))
+        assert notes and "nothing copied" in notes[0]

--- a/tests/battle_test/test_canvas_viewport.py
+++ b/tests/battle_test/test_canvas_viewport.py
@@ -305,3 +305,107 @@ def test_BOTH_end_and_ctrl_end_return_to_live() -> None:
     combos = {tuple(str(k) for k in b.keys) for b in kb.bindings}
     assert ("Keys.End",) in combos and ("Keys.ControlEnd",) in combos
     assert ("Keys.Home",) in combos and ("Keys.ControlHome",) in combos
+
+
+# ---------------------------------------------------------------------------
+# Auto-follow pause — an explicit hold, not a derived one
+# ---------------------------------------------------------------------------
+
+
+class TestAutoFollowPause:
+    """`following` was DERIVED from `_offset <= 0`, so "pinned to the tail"
+    and "showing the newest line" were one state with one variable. There was
+    no honest way to stop following without also moving the view, and moving
+    it discards the line the operator was reading — which is why the
+    transcript viewer shipped documenting the limitation instead of faking a
+    pin.
+    """
+
+    def _v(self):
+        from backend.core.ouroboros.battle_test.canvas_viewport import (
+            CanvasViewport,
+        )
+        return CanvasViewport(), [f"l{i}" for i in range(50)]
+
+    def test_a_fresh_viewport_follows(self):
+        v, _lines = self._v()
+        assert v.following is True and v.paused is False
+
+    def test_pause_stops_following_without_moving(self):
+        """THE property the derived version could not express."""
+        v, lines = self._v()
+        v.window(lines, 10, appended=50)
+        before = v.offset
+        assert v.pause() is True
+        assert v.following is False
+        assert v.offset == before, "pausing moved the view"
+
+    def test_arriving_output_is_held_while_paused(self):
+        """CC: 'scrolling up pauses auto-follow so new output doesn't pull
+        you back to the bottom.' The explicit half of the same property."""
+        v, lines = self._v()
+        v.window(lines, 10, appended=50)
+        v.pause()
+        v.window(lines + ["n1", "n2", "n3"], 10, appended=53)
+        assert v.offset == 3, "the view moved under a paused reader"
+        assert v.new_since_paused == 3
+
+    def test_resume_follows_again(self):
+        v, lines = self._v()
+        v.window(lines, 10, appended=50)
+        v.pause()
+        assert v.resume() is True
+        assert v.paused is False
+
+    def test_resume_does_not_move_either(self):
+        """A caller wanting the tail calls `to_bottom`; one that wants to
+        keep reading while output resumes behind it gets exactly that."""
+        v, lines = self._v()
+        v.window(lines, 10, appended=50)
+        v.pause()
+        v.window(lines + ["n1"], 10, appended=51)
+        held = v.offset
+        v.resume()
+        assert v.offset == held
+
+    def test_returning_to_live_clears_the_pause(self):
+        """A view pinned AT the bottom that never updates is the most
+        confusing possible state — it looks exactly like a working tail on a
+        dead organism."""
+        v, lines = self._v()
+        v.pause()
+        v.reset()
+        assert v.paused is False and v.following is True
+
+    def test_a_short_transcript_does_not_silently_resume(self):
+        """`total <= budget` returns early. Clearing the flag on a frame that
+        happened to fit would resume follow underneath the operator."""
+        v, _lines = self._v()
+        v.pause()
+        v.window(["a", "b"], 10, appended=2)
+        assert v.paused is True
+
+    def test_pause_and_resume_report_whether_they_changed_anything(self):
+        v, _lines = self._v()
+        assert v.pause() is True and v.pause() is False
+        assert v.resume() is True and v.resume() is False
+
+    def test_auto_scroll_off_holds_everything(self, monkeypatch):
+        """CC's own escape hatch: 'turn auto-follow off entirely so the view
+        stays where you leave it'."""
+        from backend.core.ouroboros.battle_test import canvas_viewport as CV
+
+        monkeypatch.setenv("JARVIS_AUTO_SCROLL", "0")
+        assert CV.auto_scroll_enabled() is False
+        v, lines = self._v()
+        v.window(lines, 10, appended=50)
+        v.window(lines + ["n1", "n2"], 10, appended=52)
+        assert v.offset == 2, "auto-scroll off still followed"
+
+    def test_scrolling_still_pauses_implicitly(self):
+        """The pre-existing behaviour must survive: an operator who scrolls
+        up is paused by position, with no flag involved."""
+        v, lines = self._v()
+        v.window(lines, 10, appended=50)
+        v.scroll(-3, total=50, budget=10)
+        assert v.following is False and v.paused is False

--- a/tests/battle_test/test_clipboard_write.py
+++ b/tests/battle_test/test_clipboard_write.py
@@ -1,0 +1,179 @@
+"""Putting text on the operator's clipboard, and saying which way it went.
+
+Nothing in this repo could WRITE a clipboard: `clipboard_image` only reads
+one, and prompt_toolkit's is in-memory without `pyperclip`, which is not
+installed. So the cockpit could offer a selection with nowhere to put it.
+
+The failures pinned here are the ones an operator experiences as "copy is
+broken sometimes":
+
+  * a writer that EXISTS but fails (xclip with no DISPLAY) reported as
+    success, leaving an empty clipboard and no explanation;
+  * an OSC 52 sequence written into a pipe or a log instead of a terminal,
+    which is not a copy but corruption of whatever reads that stream;
+  * an oversized OSC 52 payload silently dropped by the terminal;
+  * X11's PRIMARY reported as the path when the real clipboard already took
+    it, telling the operator to middle-click when Ctrl+V works.
+"""
+from __future__ import annotations
+
+import base64
+import os
+import sys
+
+import pytest
+
+from backend.core.ouroboros.battle_test import clipboard_write as C
+
+
+class _FakeStream:
+    def __init__(self, fd):
+        self._fd = fd
+
+    def fileno(self):
+        return self._fd
+
+
+@pytest.fixture
+def pipe():
+    r, w = os.pipe()
+    yield r, w
+    for fd in (r, w):
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+
+
+class TestTheCascade:
+    def test_a_writer_that_exists_but_fails_does_not_count(self):
+        """`xclip` with no DISPLAY and `wl-copy` outside Wayland both exist
+        and both exit non-zero. A cascade that stopped at 'the binary is on
+        PATH' would report success over an empty clipboard."""
+        assert C._run(["false"], "x") is False
+
+    def test_a_missing_binary_is_survivable(self):
+        assert C._run(["definitely-not-a-real-binary-xyz"], "x") is False
+
+    def test_empty_text_is_not_a_copy(self):
+        assert C.copy_text("") is None
+        assert C.copy_text(None) is None
+
+    def test_the_kill_switch_works(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_CLIPBOARD_WRITE_ENABLED", "0")
+        assert C.copy_text("hello") is None
+
+    def test_oversized_text_is_truncated_not_refused(self, monkeypatch):
+        """'Select all' over a 20 000-line canvas is one gesture. Piping
+        megabytes through a subprocess is how a copy becomes a freeze."""
+        monkeypatch.setenv("JARVIS_CLIPBOARD_MAX_CHARS", "1000")
+        assert C.max_copy_chars() == 1000
+
+    def test_the_caps_are_clamped_not_trusted(self, monkeypatch):
+        for var, fn, low in (("JARVIS_CLIPBOARD_MAX_CHARS", C.max_copy_chars, 1_000),
+                             ("JARVIS_OSC52_LIMIT", C.osc52_limit, 1_000)):
+            monkeypatch.setenv(var, "0")
+            assert fn() >= low
+            monkeypatch.setenv(var, "not-a-number")
+            assert fn() > 0
+
+    def test_no_writer_uses_a_shell(self):
+        """The text is a transcript selection containing model-authored
+        output. A shell string makes every metacharacter executable."""
+        import inspect
+
+        src = inspect.getsource(C)
+        assert "shell=True" not in src
+        assert "os.system" not in src
+
+
+class TestOsc52:
+    def test_it_writes_a_well_formed_sequence(self, pipe):
+        r, w = pipe
+        assert C._write_osc52("hello", out_stream=_FakeStream(w)) is True
+        os.close(w)
+        seq = os.read(r, 400)
+        assert seq.startswith(b"\x1b]52;c;")
+        assert base64.b64decode(seq[7:-1]).decode() == "hello"
+
+    def test_it_refuses_a_payload_the_terminal_would_drop(self, pipe, monkeypatch):
+        """Past the limit the sequence is dropped SILENTLY. A copy that
+        reports success and did nothing is worse than one that says it
+        could not."""
+        _r, w = pipe
+        monkeypatch.setenv("JARVIS_OSC52_LIMIT", "16")
+        assert C._write_osc52("x" * 5000, out_stream=_FakeStream(w)) is False
+
+    def test_it_wraps_for_tmux_passthrough(self, pipe, monkeypatch):
+        """tmux swallows an unknown OSC unless it is wrapped."""
+        r, w = pipe
+        monkeypatch.setenv("TMUX", "/tmp/tmux-1/default,1,0")
+        assert C._write_osc52("hi", out_stream=_FakeStream(w)) is True
+        os.close(w)
+        seq = os.read(r, 400)
+        assert seq.startswith(b"\x1bPtmux;")
+        assert seq.endswith(b"\x1b\\")
+
+    def test_it_refuses_to_write_escapes_at_a_non_terminal(self, monkeypatch):
+        """THE leak. An escape written into a pipe, a log or a captured test
+        stream is not a copy — it is corruption of whatever reads it, and it
+        is invisible until someone greps the output and finds `]52;c;` glued
+        to a line. Probed via `real_stdout_isatty` because
+        `sys.stdout.isatty()` is False under the patch_stdout proxy.
+        """
+        import backend.core.ouroboros.battle_test.presentation_restraint as P
+
+        monkeypatch.setattr(P, "real_stdout_isatty", lambda: False)
+        assert C._write_osc52("hello") is False
+
+    def test_a_terminal_is_allowed(self, monkeypatch, pipe):
+        import backend.core.ouroboros.battle_test.presentation_restraint as P
+
+        _r, w = pipe
+        monkeypatch.setattr(P, "real_stdout_isatty", lambda: True)
+        monkeypatch.setattr(sys, "__stdout__", _FakeStream(w))
+        assert C._write_osc52("hello") is True
+
+
+class TestReporting:
+    def test_every_path_has_an_operator_sentence(self):
+        """These paths FAIL differently. Naming the one used is what lets an
+        operator reason about a paste that did not arrive."""
+        for path in ("pbcopy", "wl-copy", "xclip", "xsel", "Set-Clipboard",
+                     "clip.exe", "tmux", "osc52"):
+            assert C.describe_path(path)
+
+    def test_the_risky_paths_say_why_they_are_risky(self):
+        assert "block" in C.describe_path("osc52")
+        assert "not the system clipboard" in C.describe_path("tmux")
+        assert "middle-click" in C.describe_path("xclip:primary")
+
+    def test_an_unknown_path_still_reads_sensibly(self):
+        assert C.describe_path("something-new") == "copied"
+
+    def test_primary_is_never_reported_over_the_real_clipboard(self):
+        """PRIMARY is written IN ADDITION to the clipboard. Reporting it as
+        the path tells the operator to middle-click when Ctrl+V works."""
+        import inspect
+
+        src = inspect.getsource(C.copy_text)
+        assert 'endswith(":primary")' in src
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="pbcopy/pbpaste")
+class TestRealRoundTrip:
+    def test_text_actually_lands_on_the_clipboard(self):
+        """The one test that proves the module does its job rather than its
+        mechanism. Skipped off macOS; on CI without a clipboard the writer
+        simply reports None and this is not reached."""
+        import shutil
+        import subprocess
+
+        if not shutil.which("pbcopy") or not shutil.which("pbpaste"):
+            pytest.skip("no pbcopy/pbpaste")
+        marker = "ov-clipboard-roundtrip-∆-42"
+        if C.copy_text(marker) != "pbcopy":
+            pytest.skip("pbcopy unavailable in this environment")
+        got = subprocess.run(["pbpaste"], capture_output=True,
+                             text=True).stdout
+        assert got == marker

--- a/tests/battle_test/test_diff_bridge.py
+++ b/tests/battle_test/test_diff_bridge.py
@@ -1,0 +1,268 @@
+"""The diff overlay, on the surface that reviews diffs.
+
+`capability_handoff` measured `diff_rows` UNSET on `ov`. The daemon owns the
+`DiffArchive`, so `/expand d-3` typed at an attached cockpit travelled to the
+daemon, opened the diff on the DAEMON's overlay, and mirrored back one line
+saying it had opened. The operator was told a diff was on screen and shown
+nothing — on the surface they review changes from.
+
+The failures pinned here all read as normal operation:
+
+  * "no such diff" rendered over a diff that exists and is in flight,
+  * a repainting overlay asking the daemon for the same diff every frame,
+  * a fetch that lands after the operator moved on yanking the overlay back,
+  * a truncated patch reviewed as though it were whole.
+"""
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from backend.core.ouroboros.battle_test import diff_bridge as B
+from backend.core.ouroboros.battle_test.diff_archive import (
+    ArchivedDiff, get_default_archive,
+)
+
+_DIFF = "--- a/x.py\n+++ b/x.py\n@@ -1 +1 @@\n-old\n+new\n"
+
+
+@pytest.fixture
+def daemon_archive():
+    arch = get_default_archive()
+    arch.clear()
+    arch.add(op_id="op-1", risk_tier="notify_apply",
+             file_paths=("backend/x.py",), diff_text=_DIFF,
+             summary="+1 / -1 in 1 file")
+    yield arch
+    arch.clear()
+
+
+@pytest.fixture
+def wired(daemon_archive):
+    """A client cockpit whose archive lives in another process."""
+    from backend.core.ouroboros.cli.ov import AttachUI
+
+    sent = []
+    client = types.SimpleNamespace(send_input=sent.append,
+                                   send_audio=lambda *a: None)
+    ui = AttachUI()
+    ui.flash = lambda *a, **k: None
+    controller = ui.diff_controller(client)
+    ref = daemon_archive.list_recent()[0].ref
+    return types.SimpleNamespace(ui=ui, client=client, sent=sent,
+                                 ctrl=controller, ref=ref,
+                                 archive=daemon_archive)
+
+
+def _serve(ref):
+    """The daemon answering a fetch, capturing what it publishes."""
+    import backend.core.ouroboros.battle_test.cockpit_attach as CA
+    import backend.core.ouroboros.battle_test.serpent_flow as sf
+
+    frames = []
+    original = CA.publish_telemetry_global
+    CA.publish_telemetry_global = lambda p: (frames.append(p), True)[1]
+    try:
+        repl = types.SimpleNamespace(_flow=types.SimpleNamespace(
+            console=types.SimpleNamespace(print=lambda *a, **k: None)))
+        sf.SerpentREPL._serve_diff_fetch(repl, ref)
+    finally:
+        CA.publish_telemetry_global = original
+    return frames[-1] if frames else None
+
+
+class TestTheCatalog:
+    def test_it_carries_metadata_and_never_the_bytes(self, daemon_archive):
+        """This rides a 1 Hz frame. Diffs are the one payload on the lane
+        with no natural bound — a generated migration is megabytes."""
+        rows = B.build_diff_catalog(daemon_archive)
+        assert rows and "diff_text" not in rows[0]
+        assert rows[0]["ref"] and rows[0]["risk_tier"] == "notify_apply"
+
+    def test_it_is_bounded(self, daemon_archive, monkeypatch):
+        for i in range(30):
+            daemon_archive.add(op_id=f"op-{i}", risk_tier="safe_auto",
+                               file_paths=("a.py",), diff_text=_DIFF,
+                               summary="x")
+        monkeypatch.setenv("JARVIS_DIFF_CATALOG_ROWS", "5")
+        assert len(B.build_diff_catalog(daemon_archive)) == 5
+
+    def test_it_reaches_the_client(self, wired):
+        """`_ingest_diff_catalog` existed with no caller in the first cut —
+        the wired-but-inert trap, caught by this assertion."""
+        wired.ui.on_telemetry({"kind": "heartbeat", "active": True,
+                               "diffs": B.build_diff_catalog(wired.archive)})
+        assert wired.ui._diff_archive.all_refs() == (wired.ref,)
+
+    def test_it_is_replaced_wholesale_not_merged(self, wired):
+        """The archive is a RING: a ref that stops being advertised was
+        evicted. Merging would let it live forever in a client that saw it
+        once, and `all_refs()` would then lie about what can be opened."""
+        wired.ui.on_telemetry({"kind": "heartbeat",
+                               "diffs": B.build_diff_catalog(wired.archive)})
+        assert wired.ui._diff_archive.all_refs()
+        wired.ui.on_telemetry({"kind": "heartbeat", "diffs": []})
+        assert wired.ui._diff_archive.all_refs() == ()
+
+    def test_an_older_daemon_sending_none_is_not_an_error(self, wired):
+        wired.ui.on_telemetry({"kind": "heartbeat",
+                               "diffs": B.build_diff_catalog(wired.archive)})
+        wired.ui.on_telemetry({"kind": "heartbeat", "active": True})
+        assert wired.ui._diff_archive.all_refs() == (wired.ref,)
+
+
+class TestPendingIsNotAbsent:
+    def test_an_in_flight_diff_is_not_no_such_diff(self, wired):
+        """THE remote-specific bug. The controller treats None as "no such
+        diff" — correct for a dict, wrong across a socket where "not here
+        yet" and "not a thing" are different answers."""
+        wired.ui.on_telemetry({"kind": "heartbeat",
+                               "diffs": B.build_diff_catalog(wired.archive)})
+        assert wired.ctrl.open(wired.ref) is True
+        head = wired.ctrl.rows()[0]
+        assert "no diff archived" not in head
+        assert wired.ref in head
+
+    def test_opening_issues_exactly_one_fetch(self, wired):
+        wired.ui.on_telemetry({"kind": "heartbeat",
+                               "diffs": B.build_diff_catalog(wired.archive)})
+        wired.sent.clear()
+        wired.ctrl.open(wired.ref)
+        assert wired.sent == [f"/diff-fetch {wired.ref}"]
+
+    def test_repaints_do_not_re_ask_at_the_frame_rate(self, wired):
+        """`lookup` runs from a RENDER path."""
+        wired.ui.on_telemetry({"kind": "heartbeat",
+                               "diffs": B.build_diff_catalog(wired.archive)})
+        wired.sent.clear()
+        wired.ctrl.open(wired.ref)
+        for _ in range(50):
+            wired.ui._diff_archive.lookup(wired.ref)
+        assert len(wired.sent) == 1
+
+    def test_a_timed_out_fetch_is_retried(self, wired, monkeypatch):
+        """A daemon that dropped the request must not leave the overlay
+        saying 'rendering…' forever."""
+        monkeypatch.setenv("JARVIS_DIFF_FETCH_TIMEOUT_S", "1")
+        clock = [1000.0]
+        wired.ui._diff_archive._clock = lambda: clock[0]
+        wired.ui.on_telemetry({"kind": "heartbeat",
+                               "diffs": B.build_diff_catalog(wired.archive)})
+        wired.sent.clear()
+        wired.ui._diff_archive.lookup(wired.ref)
+        assert len(wired.sent) == 1
+        clock[0] += 5.0
+        wired.ui._diff_archive.lookup(wired.ref)
+        assert len(wired.sent) == 2
+        assert wired.ui._diff_archive.pending_refs() == (wired.ref,)
+
+
+class TestTheRoundTrip:
+    def test_the_bytes_arrive_and_render(self, wired):
+        wired.ui.on_telemetry({"kind": "heartbeat",
+                               "diffs": B.build_diff_catalog(wired.archive)})
+        wired.ctrl.open(wired.ref)
+        wired.ui.on_telemetry(_serve(wired.ref))
+        assert wired.ui._diff_archive.is_hydrated(wired.ref)
+        rows = wired.ctrl.rows()
+        assert any("+new" in r for r in rows), rows
+
+    def test_a_missing_ref_is_answered_not_ignored(self, wired):
+        """Silence would leave the client re-issuing the fetch at the frame
+        rate against a ref that will never arrive."""
+        frame = _serve("d-999")
+        assert frame["missing"] is True
+        wired.ui.on_telemetry(frame)
+        assert wired.ui._diff_archive.lookup("d-999") is None
+        wired.sent.clear()
+        wired.ui._diff_archive.lookup("d-999")
+        assert wired.sent == [], "a known-missing ref was requested again"
+
+    def test_a_late_fetch_does_not_yank_the_overlay_back(self, wired):
+        """The operator moved on. A payload landing for a ref they are no
+        longer looking at must not reopen it."""
+        wired.ui.on_telemetry({"kind": "heartbeat",
+                               "diffs": B.build_diff_catalog(wired.archive)})
+        wired.ctrl.open(wired.ref)
+        wired.ctrl.dismiss()
+        wired.ui.on_telemetry(_serve(wired.ref))
+        assert wired.ctrl.is_active() is False
+
+    def test_an_oversized_diff_is_truncated_out_loud(self, wired, monkeypatch):
+        """A diff that simply stops is indistinguishable from one that
+        ended, and an operator reviewing a truncated patch as though it were
+        whole is the worst thing this surface can produce."""
+        monkeypatch.setenv("JARVIS_DIFF_MAX_CHARS", "4000")
+        wired.archive.clear()
+        wired.archive.add(op_id="big", risk_tier="safe_auto",
+                          file_paths=("a.py",),
+                          diff_text="+line\n" * 40_000, summary="huge")
+        ref = wired.archive.list_recent()[0].ref
+        frame = _serve(ref)
+        assert frame.get("truncated") is True
+        assert "not shown" in frame["diff_text"]
+        assert len(frame["diff_text"]) < 5_000
+
+
+class TestNoSecondOverlay:
+    def test_the_client_reuses_the_daemons_controller(self, wired):
+        """Not a second overlay: the same renderer, epoch guard, Escape
+        arbitration and off-thread render. A regression in the daemon's diff
+        surfaces here too rather than in a parallel drawing."""
+        from backend.core.ouroboros.battle_test.diff_overlay import (
+            DiffOverlayController,
+        )
+        assert isinstance(wired.ctrl, DiffOverlayController)
+        assert isinstance(wired.ctrl._archive, B.RemoteDiffArchive)
+
+    def test_the_controller_is_a_singleton_per_cockpit(self, wired):
+        """The verb that OPENS and the hook that DRAWS must be one object, or
+        the verb fills a surface nothing renders."""
+        assert wired.ui.diff_controller(wired.client) is wired.ctrl
+
+    def test_the_hook_is_handed_to_the_cockpit(self):
+        import ast
+        import inspect
+
+        from backend.core.ouroboros.cli import ov
+
+        tree = ast.parse(inspect.getsource(ov))
+        assert any(
+            isinstance(n, ast.keyword) and n.arg == "diff_rows"
+            for n in ast.walk(tree)
+        ), "ov builds the cockpit without handing it diff_rows"
+
+    def test_only_d_refs_are_intercepted(self):
+        """`t-`/`o-`/`n-` refs keep round-tripping and mirroring as markup,
+        which already works. Only the diff overlay is drawn client-side."""
+        import inspect
+
+        from backend.core.ouroboros.cli import ov
+
+        src = inspect.getsource(ov._route_operator_line)
+        assert '"/expand d-"' in src or "'/expand d-'" in src
+        assert '"/expand t-"' not in src
+
+
+class TestSerialisationRoundTrip:
+    def test_from_dict_inverts_to_dict(self, daemon_archive):
+        """Reconstructing the real dataclass rather than a look-alike is what
+        stops the remote overlay from silently rendering a blank where the
+        local one shows a field the controller learned to read."""
+        entry = daemon_archive.list_recent()[0]
+        clone = ArchivedDiff.from_dict(entry.to_dict(include_diff_text=True))
+        for field in ("ref", "op_id", "risk_tier", "file_paths", "diff_text",
+                      "summary", "apply_outcome", "verify_outcome"):
+            assert getattr(clone, field) == getattr(entry, field), field
+
+    def test_it_does_not_invent_a_local_clock(self, daemon_archive):
+        """`time.monotonic()` is a per-process origin: a timestamp from the
+        daemon means nothing here, and a local one would be a plausible lie."""
+        entry = daemon_archive.list_recent()[0]
+        clone = ArchivedDiff.from_dict(entry.to_dict(include_diff_text=True))
+        assert clone.archived_at == 0.0 and clone.terminal_at == 0.0
+
+    def test_garbage_never_raises(self):
+        for bad in (None, "", 42, [], {}, {"op_id": "x"}):
+            assert ArchivedDiff.from_dict(bad) is None

--- a/tests/battle_test/test_epistemic_filter.py
+++ b/tests/battle_test/test_epistemic_filter.py
@@ -1,0 +1,226 @@
+"""Navigating the transcript by how the organism KNOWS what it said.
+
+Claude Code's viewer jumps between search matches and prompts. It cannot jump
+between CLAIMS, because nothing in it records which sentences were observed
+and which were asserted. O+V marks every one at the `_op_line` chokepoint and
+had never navigated by it — this is the consumer.
+
+Two failures here read as normal operation, and both were found by running it
+rather than reading it:
+
+  * classifying only the RENDERED window, so every claim found is already on
+    screen and `c` moves nowhere;
+  * deriving each press's start from the newest VISIBLE line, so after
+    landing on a claim the search finds the same one again and `C` sticks.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.battle_test import epistemic_filter as E
+from backend.core.ouroboros.ui.provenance import Provenance, annotate
+
+
+def _line(text, prov=None):
+    return annotate(text, prov) if prov is not None else text
+
+
+class TestClassification:
+    @pytest.mark.parametrize("prov", [
+        Provenance.STATED, Provenance.MODELED,
+        Provenance.SYNTHETIC, Provenance.UNKNOWN,
+    ])
+    def test_every_marked_rung_is_recognised(self, prov):
+        assert E.provenance_of_line(_line("x", prov)) is prov
+
+    def test_a_clean_line_is_NOT_reported_as_observed(self):
+        """THE honesty point. `provenance` renders OBSERVED and DERIVED with
+        no mark — marks are the EXCEPTION surface — so from the text alone
+        the two are indistinguishable. Reporting the stronger would be the
+        confident-and-wrong this vocabulary exists to prevent, and UNKNOWN is
+        already taken by a different fact: asked and unanswerable."""
+        assert E.provenance_of_line("41 tests passed") is None
+        assert E.provenance_of_line(_line("41 tests passed",
+                                          Provenance.OBSERVED)) is None
+        assert E.provenance_of_line(_line("a count", Provenance.DERIVED)) is None
+
+    def test_unknown_is_a_mark_not_an_absence(self):
+        """`‹unverified›` is the LOUDEST mark there is; it must never be
+        confused with a clean line."""
+        assert E.provenance_of_line(
+            _line("could not resolve", Provenance.UNKNOWN)
+        ) is Provenance.UNKNOWN
+
+    def test_the_weaker_wins_when_two_marks_meet(self):
+        """`provenance` rules that a chain is exactly as trustworthy as its
+        softest link. Scanning weakest-first makes the first hit correct
+        without comparing."""
+        both = (_line("summary", Provenance.DERIVED)
+                + annotate("", Provenance.MODELED)
+                + annotate("", Provenance.SYNTHETIC))
+        assert E.provenance_of_line(both) is Provenance.SYNTHETIC
+
+    def test_ansi_does_not_hide_a_mark(self):
+        marked = "\x1b[2m" + _line("x", Provenance.MODELED) + "\x1b[0m"
+        assert E.provenance_of_line(marked) is Provenance.MODELED
+
+    def test_the_mark_table_is_derived_not_transcribed(self):
+        """A hardcoded glyph list is how a filter silently stops seeing a
+        category when a mark is re-worded."""
+        import inspect
+
+        src = inspect.getsource(E._marks)
+        assert "mark_for" in src and "Provenance" in src
+
+    def test_garbage_never_raises(self):
+        for bad in (None, 42, [], object()):
+            assert E.provenance_of_line(bad) is None
+
+
+class TestWalking:
+    ROWS = [
+        "observed 0",
+        _line("blast radius is 12", Provenance.MODELED),      # 1
+        "observed 2",
+        _line("cap defaulted to 50", Provenance.SYNTHETIC),    # 3
+        "observed 4",
+    ]
+
+    def test_claim_rows_finds_only_marked_lines(self):
+        assert E.claim_rows(self.ROWS) == [1, 3]
+
+    def test_forward_walk(self):
+        assert E.next_claim_row(self.ROWS, 0, +1) == 1
+        assert E.next_claim_row(self.ROWS, 1, +1) == 3
+
+    def test_backward_walk(self):
+        assert E.next_claim_row(self.ROWS, 4, -1) == 3
+        assert E.next_claim_row(self.ROWS, 3, -1) == 1
+
+    def test_it_wraps_like_every_n_and_N(self):
+        assert E.next_claim_row(self.ROWS, 3, +1) == 1
+        assert E.next_claim_row(self.ROWS, 1, -1) == 3
+
+    def test_wrap_can_be_refused(self):
+        assert E.next_claim_row(self.ROWS, 3, +1, wrap=False) is None
+
+    def test_no_claims_is_None_not_an_arbitrary_row(self):
+        """A reader who presses `c` in a session with no claims should be
+        told that, not moved somewhere and left to wonder."""
+        assert E.next_claim_row(["a", "b"], 0, +1) is None
+
+    def test_a_bad_cursor_still_walks(self):
+        assert E.next_claim_row(self.ROWS, None, +1) == 1
+        assert E.next_claim_row(self.ROWS, "x", -1) == 3
+
+
+class TestSummary:
+    def test_it_counts_weakest_first(self):
+        rows = [_line("a", Provenance.MODELED),
+                _line("b", Provenance.UNKNOWN),
+                _line("c", Provenance.MODELED)]
+        assert E.summarise(rows) == "1 unknown · 2 modeled"
+
+    def test_a_clean_transcript_renders_nothing(self):
+        """No claims is the GOOD case and does not need a badge saying so."""
+        assert E.summarise(["observed", "derived"]) == ""
+
+
+class TestTheViewerWalk:
+    """End to end against a real canvas — where both design errors showed."""
+
+    def _wired(self):
+        from prompt_toolkit.key_binding import KeyBindings
+
+        from backend.core.ouroboros.battle_test import transcript_mode as tm
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            BipartiteLayout, set_active_canvas,
+        )
+        kb = KeyBindings()
+        tm.install_transcript_mode_bindings(kb)
+        table = {" ".join(str(k).replace("Keys.", "") for k in b.keys):
+                 b.handler for b in kb.bindings}
+        mux = BipartiteLayout(width=100, height=16)
+        for i in range(40):
+            mux.emit("line", {"text": f"observed {i}"})
+        mux.push_raw(_line("blast radius is 12", Provenance.MODELED))   # 40
+        for i in range(40):
+            mux.emit("line", {"text": f"observed {40 + i}"})
+        mux.push_raw(_line("cap defaulted to 50", Provenance.SYNTHETIC))  # 81
+        for i in range(20):
+            mux.emit("line", {"text": f"observed {81 + i}"})
+        set_active_canvas(mux)
+        mux.render_canvas_ansi()
+        tm.reset_transcript_mode_for_tests()
+        tm.enter_transcript_mode()
+        return tm, mux, table
+
+    def teardown_method(self):
+        from backend.core.ouroboros.battle_test import transcript_mode as tm
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            set_active_canvas,
+        )
+        tm.reset_transcript_mode_for_tests()
+        set_active_canvas(None)
+
+    def test_it_searches_the_whole_ring_not_the_visible_window(self):
+        """THE first design error: classifying only what is DRAWN finds
+        claims already on screen, so the key moves nowhere and looks broken.
+        The point is reaching the claim forty lines back."""
+        tm, mux, table = self._wired()
+        assert mux._viewport.offset == 0
+        table["C"](None)
+        assert mux._viewport.offset > 0, "the walk never left the tail"
+
+    def test_repeated_presses_advance(self):
+        """THE second: deriving each press's start from the newest VISIBLE
+        line re-finds the claim just landed on, so `C` sticks."""
+        tm, mux, table = self._wired()
+        seen = []
+        for _ in range(3):
+            table["C"](None)
+            seen.append(tm._CLAIM_CURSOR[0])
+        assert seen == [81, 40, 81], seen
+
+    def test_forward_and_backward_are_symmetric(self):
+        tm, mux, table = self._wired()
+        table["C"](None)
+        table["C"](None)
+        assert tm._CLAIM_CURSOR[0] == 40
+        table["c"](None)
+        assert tm._CLAIM_CURSOR[0] == 81
+
+    def test_the_cursor_resets_with_the_mode(self):
+        tm, _mux, table = self._wired()
+        table["C"](None)
+        assert tm._CLAIM_CURSOR[0] is not None
+        tm.exit_transcript_mode()
+        assert tm._CLAIM_CURSOR[0] is None
+
+    def test_a_session_with_no_claims_says_so(self):
+        """A jump key that silently does nothing is indistinguishable from a
+        broken one."""
+        from prompt_toolkit.key_binding import KeyBindings
+
+        from backend.core.ouroboros.battle_test import transcript_mode as tm
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            BipartiteLayout, set_active_canvas,
+        )
+        kb = KeyBindings()
+        tm.install_transcript_mode_bindings(kb)
+        table = {" ".join(str(k).replace("Keys.", "") for k in b.keys):
+                 b.handler for b in kb.bindings}
+        mux = BipartiteLayout(width=100, height=16)
+        for i in range(30):
+            mux.emit("line", {"text": f"observed {i}"})
+        set_active_canvas(mux)
+        mux.render_canvas_ansi()
+        tm.reset_transcript_mode_for_tests()
+        tm.enter_transcript_mode()
+        table["c"](None)
+        tail = list(mux._buffer.snapshot())[-1]
+        assert "no unobserved claims" in tail
+        assert "· line" not in tail, (
+            "the notice went through `emit`, whose null renderer prints the "
+            "event TYPE — it must use `push_raw`"
+        )

--- a/tests/battle_test/test_inflight_registry.py
+++ b/tests/battle_test/test_inflight_registry.py
@@ -1,0 +1,260 @@
+"""The daemon can finally read what it is writing.
+
+`capability_handoff` measured `stream_rows` UNSET on the daemon cockpit, and
+`cockpit_mount` recorded the reason honestly: there was no process-global
+in-flight text to read. So the daemon composed every frame, shipped it across
+the bridge, and could not draw it — attached clients saw the sentence being
+written and the process writing it did not.
+
+The failures pinned here are the ones that read as normal operation: a strip
+that shows the WRONG sentence, one that hangs on a dead producer, and one
+that works only while somebody else is attached.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.battle_test import inflight_registry as R
+
+
+@pytest.fixture(autouse=True)
+def _clean(monkeypatch):
+    R.reset_inflight_for_tests()
+    monkeypatch.delenv("JARVIS_INFLIGHT_TTL_S", raising=False)
+    yield
+    R.reset_inflight_for_tests()
+
+
+def _tool(op="op-1", tool="bash", text="running…", elapsed=11.4, done=False):
+    return {"kind": "tool_stream", "op_id": op, "tool": tool,
+            "elapsed_s": elapsed, "text": text, "done": done}
+
+
+def _prose(op="op-2", text="I'll read the layout module.", done=False):
+    return {"kind": "stream_inflight", "op_id": op, "text": text, "done": done}
+
+
+class TestRecording:
+    def test_an_idle_process_has_nothing_in_flight(self):
+        assert R.current_inflight() is None
+        assert R.live_inflight() == []
+
+    def test_both_producers_are_recorded(self):
+        assert R.note_inflight_frame(_tool()) is True
+        assert R.note_inflight_frame(_prose()) is True
+        assert len(R.live_inflight()) == 2
+
+    def test_an_unrelated_frame_is_ignored(self):
+        """The registry rides a lane that carries heartbeats, panics and
+        pending-apply frames too. It must record only what is in flight."""
+        assert R.note_inflight_frame({"kind": "heartbeat", "active": True}) is False
+        assert R.note_inflight_frame({"kind": "fatal_panic"}) is False
+        assert R.current_inflight() is None
+
+    def test_done_retires_only_its_own_slot(self):
+        R.note_inflight_frame(_tool(op="a"))
+        R.note_inflight_frame(_prose(op="b"))
+        R.note_inflight_frame(_prose(op="b", done=True))
+        live = R.live_inflight()
+        assert len(live) == 1 and live[0].op_id == "a"
+
+    def test_garbage_never_raises(self):
+        for bad in (None, "", 42, [], {"kind": "tool_stream"}):
+            R.note_inflight_frame(bad)
+        assert R.current_inflight() is None or True
+
+
+class TestConcurrency:
+    def test_tools_within_one_op_do_not_overwrite_each_other(self):
+        """The Venom loop can hold several tools open inside ONE operation.
+        Keying on op_id alone makes them clobber each other, which reads as a
+        single stream flickering rather than the several actually running."""
+        R.note_inflight_frame(_tool(op="op-1", tool="bash"))
+        R.note_inflight_frame(_tool(op="op-1", tool="run_tests"))
+        assert len(R.live_inflight()) == 2
+
+    def test_the_newest_is_the_one_drawn(self):
+        R.note_inflight_frame(_tool(op="old"))
+        R.note_inflight_frame(_prose(op="new"))
+        assert R.current_inflight().op_id == "new"
+
+    def test_a_burst_cannot_evict_the_live_entry(self):
+        """Bounded, but the cap has to be wide enough that a fan-out of
+        subagents cannot push the entry being drawn out before it is read."""
+        for i in range(R._MAX_SLOTS + 10):
+            R.note_inflight_frame(_prose(op=f"op-{i}"))
+        live = R.live_inflight()
+        assert len(live) <= R._MAX_SLOTS
+        assert live[0].op_id == f"op-{R._MAX_SLOTS + 9}"
+
+    def test_eviction_is_by_age_not_insertion_order(self):
+        """A long-running command that simply STARTED first must not be the
+        one evicted."""
+        R.note_inflight_frame(_tool(op="long-runner"))
+        for i in range(R._MAX_SLOTS + 5):
+            R.note_inflight_frame(_prose(op=f"filler-{i}"))
+        # The long-runner keeps refreshing, as a live producer does.
+        R.note_inflight_frame(_tool(op="long-runner", text="still going"))
+        assert any(e.op_id == "long-runner" for e in R.live_inflight())
+
+
+class TestExpiry:
+    def test_a_dead_producer_expires(self):
+        """A producer killed mid-command never sends `done`. Without a TTL the
+        strip shows that command's last output for the rest of the session as
+        though it were still running."""
+        R.note_inflight_frame(_tool())
+        entry = R.current_inflight()
+        assert R.live_inflight(now=entry.at + R.inflight_ttl_s() + 1.0) == []
+
+    def test_a_quiet_but_alive_producer_survives(self):
+        R.note_inflight_frame(_tool())
+        entry = R.current_inflight()
+        assert R.live_inflight(now=entry.at + R.inflight_ttl_s() - 0.5)
+
+    def test_expiry_is_evaluated_on_read_not_swept(self):
+        """There is no thread here to own a sweep, and a registry that needs
+        one has invented a lifecycle for what is otherwise pure state."""
+        R.note_inflight_frame(_tool())
+        entry = R.current_inflight()
+        R.live_inflight(now=entry.at + R.inflight_ttl_s() + 1.0)
+        assert len(R._SLOTS) == 0, "stale entries were not dropped on read"
+
+    def test_the_ttl_is_clamped_not_trusted(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_INFLIGHT_TTL_S", "0")
+        assert R.inflight_ttl_s() >= 1.0
+        monkeypatch.setenv("JARVIS_INFLIGHT_TTL_S", "99999")
+        assert R.inflight_ttl_s() <= 120.0
+        monkeypatch.setenv("JARVIS_INFLIGHT_TTL_S", "nonsense")
+        assert R.inflight_ttl_s() > 0
+
+    def test_the_kill_switch_works(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_INFLIGHT_REGISTRY_ENABLED", "0")
+        assert R.note_inflight_frame(_tool()) is False
+        assert R.current_inflight() is None
+
+
+class TestOneComposition:
+    def test_the_client_and_the_daemon_compose_identically(self):
+        """A second copy of the header would be a second opinion about what an
+        in-flight tool tail looks like — the defect the roster and the status
+        line each already paid for once."""
+        from backend.core.ouroboros.cli.ov import AttachUI
+
+        frame = _tool(elapsed=11.4, text="running…")
+        ui = AttachUI()
+        ui.on_telemetry(frame)
+        R.note_inflight_frame(frame)
+        assert ui._stream_inflight == R.current_inflight().text
+        assert ui._stream_inflight.startswith("$ bash · 11s")
+
+    def test_the_client_does_not_re_implement_the_header(self):
+        import inspect
+
+        from backend.core.ouroboros.cli import ov
+
+        src = inspect.getsource(ov.AttachUI.on_telemetry)
+        assert "compose_inflight_text" in src
+        assert '$ {' not in src, "the client still builds its own header"
+
+    def test_model_prose_carries_no_header(self):
+        """Only a command tail gets `$ tool · Ns`. Prose is the sentence."""
+        assert R.compose_inflight_text(_prose(text="hello")) == "hello"
+
+
+class TestTheProducerSeam:
+    def test_a_real_stream_records_through_its_own_send(self):
+        """Recorded at EMISSION, not construction. `cockpit_mount` called for
+        a registry fed by every stream construction site — but sites can
+        multiply and a producer that forgets to register is silently dark.
+        Every frame passes through `_send` regardless of how it was made."""
+        from backend.core.ouroboros.battle_test.live_tool_stream import (
+            LiveToolStream,
+        )
+        stream = LiveToolStream(tool="bash", op_id="op-9",
+                                publish=lambda payload: None)
+        stream("stdout", "collected 41 items\n")
+        stream._emit(done=False)
+        entry = R.current_inflight()
+        assert entry is not None and entry.is_tool
+        assert "collected 41 items" in entry.text
+
+    def _first_line_of_call(self, fn, callee: str) -> int:
+        """Line number of the first CALL to `callee`, by AST.
+
+        Not `src.index(...)`: comments and docstrings mention these names
+        while explaining them, so a string search finds the prose and
+        compares the wrong two positions. This file's first cut did exactly
+        that and failed on its own explanatory comment.
+        """
+        import ast
+        import inspect
+        import textwrap
+
+        tree = ast.parse(textwrap.dedent(inspect.getsource(fn)))
+        lines = [
+            node.lineno for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and (getattr(node.func, "id", None) == callee
+                 or getattr(node.func, "attr", None) == callee)
+        ]
+        assert lines, f"no call to {callee}"
+        return min(lines)
+
+    def test_an_injected_publisher_records_identically(self):
+        """The demo and the tests inject a publisher. Recording after that
+        branch would leave both of them dark."""
+        from backend.core.ouroboros.battle_test import live_tool_stream
+
+        send = live_tool_stream.LiveToolStream._send
+        assert (self._first_line_of_call(send, "note_inflight_frame")
+                < self._first_line_of_call(send, "_publish")), (
+            "recording happens after the injected-publisher branch returns"
+        )
+
+    def test_recording_happens_before_the_transport_decision(self):
+        """`publish_telemetry_global` returns early with no cockpit attached,
+        so a daemon with nobody watching publishes nothing — exactly when its
+        OWN cockpit is the surface being looked at. Recording after that call
+        yields a strip that works only while someone else is watching."""
+        from backend.core.ouroboros.battle_test.stream_renderer import (
+            StreamRenderer,
+        )
+
+        target = getattr(StreamRenderer, "_publish_inflight", None)
+        if target is None:                       # method renamed — find it
+            import inspect
+            for _n, m in inspect.getmembers(StreamRenderer, inspect.isfunction):
+                if "publish_telemetry_global" in inspect.getsource(m):
+                    target = m
+                    break
+        assert target is not None, "no method publishes an in-flight frame"
+        assert (self._first_line_of_call(target, "note_inflight_frame")
+                < self._first_line_of_call(target, "publish_telemetry_global"))
+
+
+class TestTheDaemonStrip:
+    def test_it_draws_what_is_in_flight(self):
+        from backend.core.ouroboros.battle_test.cockpit_mount import (
+            daemon_stream_rows,
+        )
+        rows = daemon_stream_rows()
+        assert rows() == []
+        R.note_inflight_frame(_tool(text="collected 41 items"))
+        drawn = rows()
+        assert drawn and any("bash" in r for r in drawn)
+
+    def test_the_mount_actually_carries_it(self):
+        """The hook having a provider is not the same as the cockpit being
+        handed it — the exact gap this audit exists to catch."""
+        import ast
+        import inspect
+
+        from backend.core.ouroboros.battle_test import cockpit_mount, serpent_flow
+
+        assert "stream_rows" in inspect.getsource(cockpit_mount.build_daemon_mount)
+        tree = ast.parse(inspect.getsource(serpent_flow.SerpentREPL._loop).lstrip())
+        assert any(
+            isinstance(n, ast.keyword) and n.arg == "stream_rows"
+            for n in ast.walk(tree)
+        ), "the daemon builds its cockpit without handing it stream_rows"

--- a/tests/battle_test/test_keymap.py
+++ b/tests/battle_test/test_keymap.py
@@ -292,3 +292,113 @@ def test_keys_verb_is_discoverable_by_the_dispatch_registry() -> None:
     )
     prime_registry()
     assert "keys" in _VERB_TO_DISPATCHER
+
+
+# ---------------------------------------------------------------------------
+# CC's action names resolve to ov's, and ov's keep working
+# ---------------------------------------------------------------------------
+
+
+class TestActionAliases:
+    """ALIASES, not renames. `agents:stopAll` and `chat:killAgents` are the
+    same capability on the same chord.
+
+    An operator arriving from CC writes CC's name in `keybindings.json` and
+    expects it to bind; anyone who already wrote ov's name must not have
+    their config silently stop applying. Renaming fixes the first at the cost
+    of the second — and a config key mapped to an unknown action fails
+    SILENTLY: the binding simply never appears.
+    """
+
+    def test_an_alias_resolves_both_ways(self):
+        from backend.core.ouroboros.battle_test.keymap import aliases_for
+
+        assert set(aliases_for("agents:stopAll")) == {
+            "agents:stopAll", "chat:killAgents"}
+        assert set(aliases_for("chat:killAgents")) == {
+            "agents:stopAll", "chat:killAgents"}
+
+    def test_an_unaliased_action_is_just_itself(self):
+        from backend.core.ouroboros.battle_test.keymap import aliases_for
+
+        assert aliases_for("app:detach") == ("app:detach",)
+        assert aliases_for("nope:thing") == ("nope:thing",)
+
+    def test_ccs_scroll_family_maps_to_the_viewer_table(self):
+        """CC's `scroll:*` is ov's `transcript:*` — same movements, same
+        defaults, different namespace only because ov's arrived with the
+        viewer rather than with a scroll region."""
+        from backend.core.ouroboros.battle_test.keymap import aliases_for
+
+        for cc, ov in (("scroll:lineUp", "transcript:lineUp"),
+                       ("scroll:bottom", "transcript:bottom"),
+                       ("scroll:fullPageUp", "transcript:pageUp")):
+            assert ov in aliases_for(cc)
+
+    def test_a_config_written_with_ccs_name_binds_ovs_action(self, tmp_path,
+                                                             monkeypatch):
+        """THE point of the table. Without it the key maps to an action
+        nothing declares, and nothing tells the operator."""
+        import json
+
+        from backend.core.ouroboros.battle_test import keymap as K
+
+        cfg = tmp_path / "keybindings.json"
+        cfg.write_text(json.dumps({"bindings": [
+            {"context": "Global", "bindings": {"ctrl+q": "chat:killAgents"}},
+        ]}))
+        monkeypatch.setenv(K.CONFIG_PATH_ENV_VAR, str(cfg))
+        K.get_store().maybe_reload()
+        seqs = K.effective_key_sequences(
+            "agents:stopAll", ("ctrl+x ctrl+k",), context="Global")
+        flat = {" ".join(s) for s in seqs}
+        assert any("c-q" in f for f in flat), flat
+
+    def test_ovs_own_name_still_binds(self, tmp_path, monkeypatch):
+        import json
+
+        from backend.core.ouroboros.battle_test import keymap as K
+
+        cfg = tmp_path / "keybindings.json"
+        cfg.write_text(json.dumps({"bindings": [
+            {"context": "Global", "bindings": {"ctrl+q": "agents:stopAll"}},
+        ]}))
+        monkeypatch.setenv(K.CONFIG_PATH_ENV_VAR, str(cfg))
+        K.get_store().maybe_reload()
+        seqs = K.effective_key_sequences(
+            "agents:stopAll", ("ctrl+x ctrl+k",), context="Global")
+        assert any("c-q" in " ".join(s) for s in seqs)
+
+    def test_every_alias_points_at_a_real_action(self):
+        """A table entry pointing at an id nothing declares is worse than no
+        entry: it silently accepts a config that can never bind."""
+        from backend.core.ouroboros.battle_test.keymap import ACTION_ALIASES
+
+        assert ACTION_ALIASES
+        for cc, ov in ACTION_ALIASES.items():
+            assert ":" in cc and ":" in ov and cc != ov
+
+
+class TestUndo:
+    def test_chat_undo_is_bound(self):
+        """CC binds `chat:undo` to Ctrl+_ / Ctrl+Shift+-. prompt_toolkit
+        already ships the command; it was simply never bound, so the prompt
+        accepted paragraphs with no way back from a mis-typed Ctrl+W."""
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            BipartiteLayout, build_bipartite_application,
+        )
+        mux = BipartiteLayout(width=80, height=14)
+        app = build_bipartite_application(mux, on_accept=lambda _t: None)
+        seqs = {" ".join(str(k).replace("Keys.", "") for k in b.keys)
+                for b in app.key_bindings.bindings}
+        assert any("Underscore" in s for s in seqs), sorted(seqs)
+
+    def test_it_delegates_to_the_buffers_own_undo_stack(self):
+        """A second history of the same text would disagree with the buffer
+        the first time a completion inserted anything."""
+        import inspect
+
+        from backend.core.ouroboros.battle_test import bipartite_layout
+
+        src = inspect.getsource(bipartite_layout.build_bipartite_application)
+        assert 'get_by_name("undo")' in src

--- a/tests/battle_test/test_menu_bindings.py
+++ b/tests/battle_test/test_menu_bindings.py
@@ -1,0 +1,221 @@
+"""The completion menu and the gate, made remappable.
+
+Both surfaces WORKED and neither could be rebound — `/keys` could not list
+them and `keybindings.json` could not move them. They are the last of CC's
+interactive-action catalog ov had no answer for.
+
+The work is a different SHAPE from every other action in this cockpit: those
+were new, so declaring them was the whole job. These are already bound inside
+prompt_toolkit, so the lever is the filter — a binding registered after pt's
+and gated on `has_completions` wins exactly while the menu is open.
+
+The failure that matters most is pinned first: ov's gate is a STRIP over a
+live prompt, not CC's modal, so a bare `y` would accept a patch on the first
+character of "yes, rerun the suite".
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.battle_test import menu_bindings as M
+from backend.core.ouroboros.battle_test import pending_apply as PA
+
+
+@pytest.fixture(autouse=True)
+def _clean():
+    PA.reset_for_tests()
+    yield
+    PA.reset_for_tests()
+
+
+def _kb():
+    from prompt_toolkit.key_binding import KeyBindings
+    return KeyBindings()
+
+
+class TestCompletionActions:
+    def test_all_four_bind(self):
+        kb = _kb()
+        assert M.install_completion_actions(kb) == 4
+
+    def test_they_are_registered_as_remappable(self):
+        """The entire point: `/keys` can list them and keybindings.json can
+        move them."""
+        from backend.core.ouroboros.battle_test.keymap import action_catalog
+
+        M.install_completion_actions(_kb())
+        cat = {s.action: s.context for s in action_catalog()}
+        for action in ("autocomplete:accept", "autocomplete:dismiss",
+                       "autocomplete:next", "autocomplete:previous"):
+            assert cat.get(action) == "Autocomplete", action
+
+    def test_they_are_gated_on_the_menu_being_open(self):
+        """With the menu closed, pt's own handling must be untouched — Tab
+        still completes, the arrows still walk history. A binding that
+        applied always would have taken both."""
+        kb = _kb()
+        M.install_completion_actions(kb)
+        assert all(b.filter is not None for b in kb.bindings)
+
+    def test_accept_applies_the_highlighted_completion(self):
+        import types
+
+        applied = []
+        buf = types.SimpleNamespace(
+            complete_state=types.SimpleNamespace(current_completion="X"),
+            apply_completion=applied.append,
+            complete_next=lambda: applied.append("NEXT"),
+        )
+        kb = _kb()
+        M.install_completion_actions(kb)
+        handler = next(b.handler for b in kb.bindings
+                       if [str(k) for k in b.keys] == ["Keys.ControlI"])
+        handler(types.SimpleNamespace(current_buffer=buf, app=None))
+        assert applied == ["X"]
+
+    def test_accept_selects_the_first_when_nothing_is_highlighted(self):
+        """The menu is open but the operator has not walked it. Selecting the
+        first entry is what every shell does and what makes one Tab enough."""
+        import types
+
+        calls = []
+        buf = types.SimpleNamespace(
+            complete_state=types.SimpleNamespace(current_completion=None),
+            apply_completion=lambda c: calls.append(("apply", c)),
+            complete_next=lambda: calls.append(("next", None)),
+        )
+        kb = _kb()
+        M.install_completion_actions(kb)
+        handler = next(b.handler for b in kb.bindings
+                       if [str(k) for k in b.keys] == ["Keys.ControlI"])
+        handler(types.SimpleNamespace(current_buffer=buf, app=None))
+        assert calls == [("next", None)]
+
+    def test_a_broken_buffer_never_raises(self):
+        import types
+
+        kb = _kb()
+        M.install_completion_actions(kb)
+        for b in kb.bindings:
+            b.handler(types.SimpleNamespace(current_buffer=None, app=None))
+
+    def test_the_kill_switch_leaves_pt_alone(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_MENU_BINDINGS_ENABLED", "0")
+        assert M.install_completion_actions(_kb()) == 0
+
+
+class TestGatePredicate:
+    def test_no_gate_is_not_answerable(self):
+        assert M.gate_is_pending() is False
+
+    def test_an_open_gate_is(self):
+        PA.note_pending("op-1", delay_s=5.0, reason="notify_apply")
+        assert M.gate_is_pending() is True
+
+    def test_a_cleared_gate_is_not(self):
+        PA.note_pending("op-1", delay_s=5.0, reason="notify_apply")
+        PA.clear_pending("op-1")
+        assert M.gate_is_pending() is False
+
+    def test_it_never_decides_expiry_itself(self):
+        """`snapshot` drops expired rows where the clock that set them lives.
+        A confirm key answering a gate that had already auto-applied would be
+        worse than one that did nothing."""
+        import inspect
+
+        src = inspect.getsource(M.gate_is_pending)
+        assert "snapshot" in src
+        assert "time" not in src and "monotonic" not in src
+
+
+class TestConfirmActions:
+    def test_both_bind(self):
+        assert M.install_confirm_actions(_kb(), submit=lambda _l: None) == 2
+
+    def test_nothing_binds_without_a_submit(self):
+        """A confirm key with nowhere to send the answer is a key that
+        silently does nothing while looking like governance."""
+        assert M.install_confirm_actions(_kb(), submit=None) == 0
+
+    def test_they_route_the_verb_not_a_private_path(self):
+        """The risk tier, the audit trail and the countdown clear exactly as
+        they do for a typed `/accept`. A second approval path that disagreed
+        with the verb would be a governance problem, not a UI one."""
+        sent = []
+        kb = _kb()
+        M.install_confirm_actions(kb, submit=sent.append)
+        for key, verb in (("y", "/accept"), ("n", "/reject")):
+            handler = next(b.handler for b in kb.bindings
+                           if [str(k) for k in b.keys] == [key])
+            handler(None)
+            assert sent[-1] == verb
+
+    def test_they_are_registered_as_remappable(self):
+        from backend.core.ouroboros.battle_test.keymap import action_catalog
+
+        M.install_confirm_actions(_kb(), submit=lambda _l: None)
+        cat = {s.action: s.context for s in action_catalog()}
+        assert cat.get("confirm:yes") == "Confirmation"
+        assert cat.get("confirm:no") == "Confirmation"
+
+    def test_they_require_both_a_gate_and_an_empty_prompt(self):
+        """THE guard CC does not need. Its Confirmation context is a MODAL,
+        so a bare `y` is free there. ov's gate is a strip over a live prompt,
+        and an unconditional `y` would accept a patch on the first character
+        of 'yes, rerun the suite'."""
+        import inspect
+
+        src = inspect.getsource(M.install_confirm_actions)
+        assert "gate_is_pending()" in src and "_buffer_empty()" in src
+
+    def test_an_unknown_buffer_state_refuses(self):
+        """False when it cannot tell — the safe direction, because a confirm
+        key must not fire on a prompt that might have text in it."""
+        assert M._buffer_empty() is False        # no running Application
+
+    def test_escape_is_not_bound_to_reject(self):
+        """Escape already means interrupt-or-dismiss and the overlay arbiter
+        owns it. A third meaning that appears only while a gate is up is how
+        an operator learns to distrust the key."""
+        kb = _kb()
+        M.install_confirm_actions(kb, submit=lambda _l: None)
+        keys = {" ".join(str(k) for k in b.keys) for b in kb.bindings}
+        assert not any("Escape" in k for k in keys), keys
+
+    def test_a_failing_submit_never_raises(self):
+        def _boom(_line):
+            raise RuntimeError("router gone")
+
+        kb = _kb()
+        M.install_confirm_actions(kb, submit=_boom)
+        next(b.handler for b in kb.bindings
+             if [str(k) for k in b.keys] == ["y"])(None)
+
+
+class TestMountedOnTheCockpit:
+    def test_the_real_application_carries_them(self):
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            BipartiteLayout, build_bipartite_application,
+        )
+        mux = BipartiteLayout(width=80, height=14)
+        app = build_bipartite_application(mux, on_accept=lambda _t: None)
+        keys = {" ".join(str(k).replace("Keys.", "") for k in b.keys)
+                for b in app.key_bindings.bindings}
+        assert "y" in keys and "n" in keys
+
+    def test_confirm_routes_through_on_accept(self):
+        import ast
+        import inspect
+        import textwrap
+
+        from backend.core.ouroboros.battle_test import bipartite_layout
+
+        src = textwrap.dedent(inspect.getsource(
+            bipartite_layout.build_bipartite_application))
+        tree = ast.parse(src)
+        assert any(
+            isinstance(n, ast.Call)
+            and getattr(n.func, "id", None) == "install_confirm_actions"
+            for n in ast.walk(tree)
+        )
+        assert "on_accept(line)" in src

--- a/tests/battle_test/test_subagent_control.py
+++ b/tests/battle_test/test_subagent_control.py
@@ -1,0 +1,369 @@
+"""Keyboard control over running subagents — CC's `Ctrl+X Ctrl+K`.
+
+ov dispatched L3 subagents into isolated worktrees, showed them in the roster,
+and gave the operator no key to stop them. `Esc` is narrow by construction
+("stop what I asked for", never "stop the organism"), so there was nothing
+between cancelling one's own op and killing the process.
+
+The tests that matter are not "does it bind". They are:
+
+  * does a single press do NOTHING (the guard is the whole safety argument),
+  * does an expired arm refuse to confirm late,
+  * does the confirmation reach ONE authority by ONE route from BOTH cockpits,
+  * and does the cancel stay cooperative rather than severing mid-phase.
+"""
+from __future__ import annotations
+
+import ast
+import inspect
+import types
+
+import pytest
+
+from backend.core.ouroboros.battle_test.confirm_chord import (
+    ConfirmLatch,
+    confirm_window_s,
+)
+from backend.core.ouroboros.battle_test.subagent_control import (
+    STOP_ALL_ACTION,
+    STOP_ALL_VERB,
+    install_stop_all_binding,
+)
+
+
+class _Clock:
+    def __init__(self) -> None:
+        self.now = 100.0
+
+    def __call__(self) -> float:
+        return self.now
+
+
+@pytest.fixture
+def latch():
+    clock = _Clock()
+    return ConfirmLatch(window_s=3.0, clock=clock), clock
+
+
+# ---------------------------------------------------------------------------
+# The guard
+# ---------------------------------------------------------------------------
+
+
+class TestConfirmLatch:
+    def test_one_press_does_not_confirm(self, latch):
+        lat, _clock = latch
+        assert lat.press() is False, (
+            "a single press must never fire — the whole point is that a "
+            "mis-hit cannot reach every running agent"
+        )
+        assert lat.armed() is True
+
+    def test_a_repeat_inside_the_window_confirms(self, latch):
+        lat, clock = latch
+        lat.press()
+        clock.now += 2.0
+        assert lat.press() is True
+
+    def test_an_expired_arm_refuses_to_confirm_late(self, latch):
+        """Otherwise the second half of a confirmation arrives minutes later
+        attached to a completely different intention."""
+        lat, clock = latch
+        lat.press()
+        clock.now += 10.0
+        assert lat.press() is False, "a late repeat must RE-ARM, not fire"
+        assert lat.armed() is True
+
+    def test_confirming_consumes_the_arm(self, latch):
+        """Holding the chord down must not fire once per key-repeat."""
+        lat, clock = latch
+        lat.press()
+        assert lat.press() is True
+        assert lat.press() is False, "a third press starts over"
+
+    def test_armed_reports_expiry_rather_than_the_stored_flag(self, latch):
+        """A toolbar hint reading this must not keep advertising a
+        confirmation that the next press will no longer give."""
+        lat, clock = latch
+        lat.press()
+        assert lat.armed() is True
+        clock.now += 10.0
+        assert lat.armed() is False
+
+    def test_disarm_drops_a_pending_arm(self, latch):
+        lat, _clock = latch
+        lat.press()
+        lat.disarm()
+        assert lat.armed() is False
+        assert lat.press() is False, "disarmed, the next press only arms"
+
+    def test_the_window_is_clamped_not_trusted(self, monkeypatch):
+        """Zero would remove the guard by configuration, silently."""
+        monkeypatch.setenv("JARVIS_CONFIRM_CHORD_WINDOW_S", "0")
+        assert confirm_window_s() >= 0.5
+        monkeypatch.setenv("JARVIS_CONFIRM_CHORD_WINDOW_S", "9999")
+        assert confirm_window_s() <= 30.0
+        monkeypatch.setenv("JARVIS_CONFIRM_CHORD_WINDOW_S", "not-a-number")
+        assert confirm_window_s() > 0
+
+
+# ---------------------------------------------------------------------------
+# The binding
+# ---------------------------------------------------------------------------
+
+
+def _bind(running=None):
+    from prompt_toolkit.key_binding import KeyBindings
+
+    sent, said = [], []
+    client = types.SimpleNamespace(send_input=sent.append)
+    kb = KeyBindings()
+    ok = install_stop_all_binding(
+        kb, client, notify=said.append, running=running,
+    )
+    return ok, kb, sent, said
+
+
+class TestStopAllBinding:
+    def test_it_binds_ccs_chord(self):
+        ok, kb, _sent, _said = _bind()
+        assert ok
+        sequences = [tuple(str(k) for k in b.keys) for b in kb.bindings]
+        assert ("Keys.ControlX", "Keys.ControlK") in sequences
+
+    def test_the_arming_press_sends_nothing(self):
+        _ok, kb, sent, said = _bind(running=lambda: 3)
+        kb.bindings[0].handler(None)
+        assert sent == [], "the first press must not reach the organism"
+        assert "again" in said[-1]
+
+    def test_the_arming_press_names_what_it_would_stop(self):
+        """"Press again to confirm" on an idle organism asks the operator to
+        weigh a consequence that does not exist, and teaches them to confirm
+        without reading."""
+        _ok, kb, _sent, said = _bind(running=lambda: 3)
+        kb.bindings[0].handler(None)
+        assert "3 agents" in said[-1]
+
+    def test_a_confirmed_chord_sends_the_verb(self):
+        _ok, kb, sent, _said = _bind(running=lambda: 2)
+        kb.bindings[0].handler(None)
+        kb.bindings[0].handler(None)
+        assert sent == [STOP_ALL_VERB]
+
+    def test_an_idle_organism_short_circuits(self):
+        """Nothing to stop is an answer, not an arming prompt."""
+        _ok, kb, sent, said = _bind(running=lambda: 0)
+        kb.bindings[0].handler(None)
+        assert sent == []
+        assert said[-1] == "nothing running"
+        # And it did NOT stay armed — the next press starts clean.
+        kb.bindings[0].handler(None)
+        assert sent == [], "an idle press must not have half-armed the chord"
+
+    def test_a_broken_count_still_arms(self):
+        """The roster is chrome. It must not be able to disarm a control."""
+        def _boom() -> int:
+            raise RuntimeError("roster unavailable")
+
+        _ok, kb, sent, said = _bind(running=_boom)
+        kb.bindings[0].handler(None)
+        assert "all running work" in said[-1]
+        kb.bindings[0].handler(None)
+        assert sent == [STOP_ALL_VERB]
+
+    def test_a_send_failure_is_reported_not_swallowed(self):
+        from prompt_toolkit.key_binding import KeyBindings
+
+        def _fail(_line):
+            raise ConnectionError("socket gone")
+
+        said = []
+        kb = KeyBindings()
+        install_stop_all_binding(
+            kb, types.SimpleNamespace(send_input=_fail),
+            notify=said.append, running=lambda: 1,
+        )
+        kb.bindings[0].handler(None)
+        kb.bindings[0].handler(None)
+        assert "could not reach" in said[-1], (
+            "a chord that silently failed would leave the operator believing "
+            "they stopped work that is still running"
+        )
+
+    def test_a_client_that_cannot_send_binds_nothing(self):
+        from prompt_toolkit.key_binding import KeyBindings
+
+        assert install_stop_all_binding(
+            KeyBindings(), object(),
+        ) is False
+        assert install_stop_all_binding(None, types.SimpleNamespace(
+            send_input=lambda _l: None)) is False
+
+    def test_the_action_is_remappable(self):
+        """Registered in the catalog, so `/keys` lists it and
+        keybindings.json can move it."""
+        from backend.core.ouroboros.battle_test.keymap import action_catalog
+
+        _bind()
+        assert any(s.action == STOP_ALL_ACTION for s in action_catalog())
+
+
+# ---------------------------------------------------------------------------
+# The authority
+# ---------------------------------------------------------------------------
+
+
+class TestCancelAll:
+    def _gls(self, active, requested=()):
+        from backend.core.ouroboros.governance.governed_loop_service import (
+            GovernedLoopService,
+        )
+        g = object.__new__(GovernedLoopService)
+        g._active_ops = set(active)
+        g._cancel_requested = set(requested)
+        return g, GovernedLoopService.request_cancel_all
+
+    def test_it_reports_what_it_actually_stopped(self):
+        g, fn = self._gls({"op-1", "op-2"})
+        assert fn(g) == ["op-1", "op-2"]
+        assert g._cancel_requested == {"op-1", "op-2"}
+
+    def test_an_op_already_asked_is_not_re_reported(self):
+        """The operator reads this list as "what I just did"."""
+        g, fn = self._gls({"op-1", "op-2"}, requested={"op-2"})
+        assert fn(g) == ["op-1"]
+        assert g._cancel_requested == {"op-1", "op-2"}
+
+    def test_nothing_running_is_an_empty_list_not_a_lie(self):
+        g, fn = self._gls(set())
+        assert fn(g) == []
+
+    def test_it_is_idempotent(self):
+        g, fn = self._gls({"op-1"})
+        assert fn(g) == ["op-1"]
+        assert fn(g) == []
+
+    def test_it_is_cooperative_never_a_kill(self):
+        """It marks the cancel set the orchestrator reads at phase
+        transitions. Anything that severed an op mid-APPLY would leave the
+        half-written trees the phase model exists to prevent."""
+        from backend.core.ouroboros.governance.governed_loop_service import (
+            GovernedLoopService,
+        )
+        src = inspect.getsource(GovernedLoopService.request_cancel_all)
+        tree = ast.parse(src.lstrip())
+        called = {
+            node.func.attr for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+        }
+        assert not (called & {"cancel", "kill", "terminate", "close"}), (
+            f"cancel-all reached for a hard stop: {called}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Both cockpits, one route
+# ---------------------------------------------------------------------------
+
+
+class TestBothSurfaces:
+    """A chord mounted on one of two cockpits is the defect shape this repo
+    keeps finding late: the surface nobody opened that week is the one that
+    silently lacks the control."""
+
+    def test_the_daemon_cockpit_mounts_it(self):
+        from backend.core.ouroboros.battle_test.cockpit_mount import (
+            daemon_key_bindings,
+        )
+        repl = types.SimpleNamespace(
+            _dispatch_verb=lambda _l: None,
+            _flow=types.SimpleNamespace(
+                console=types.SimpleNamespace(print=lambda *a, **k: None)),
+        )
+        kb = daemon_key_bindings(repl)
+        assert kb is not None
+        sequences = [tuple(str(k) for k in b.keys) for b in kb.bindings]
+        assert ("Keys.ControlX", "Keys.ControlK") in sequences
+
+    def test_the_attach_client_mounts_it(self):
+        """Structural, because the client's binding block needs a live
+        `client`, `ui` and `fsm` that only exist inside a running attach.
+        Proves the CALL is present, not that a key was pressed — the
+        daemon-side test above covers the runtime behaviour."""
+        from backend.core.ouroboros.cli import ov
+
+        tree = ast.parse(inspect.getsource(ov))
+        assert any(
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "install_stop_all_binding"
+            for node in ast.walk(tree)
+        ), "ov.py never calls the shared installer — the chord is dark there"
+
+    def test_both_surfaces_route_through_the_same_verb(self):
+        """One authority, one route. A client-side implementation would have
+        had to invent its own idea of "all" on a process that holds no
+        governed loop and cannot see the ops."""
+        from backend.core.ouroboros.battle_test import subagent_control
+
+        src = inspect.getsource(subagent_control)
+        tree = ast.parse(src)
+        sends = [
+            node for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "send_input"
+        ]
+        assert len(sends) == 1, (
+            "exactly one send site — a second would be a second opinion "
+            "about what the chord does"
+        )
+
+    def test_the_daemon_handler_answers_the_verb(self):
+        from backend.core.ouroboros.battle_test import serpent_flow
+
+        printed = []
+        repl = types.SimpleNamespace(
+            _flow=types.SimpleNamespace(console=types.SimpleNamespace(
+                print=lambda *a, **k: printed.append(a[0] if a else ""))),
+            _gls=types.SimpleNamespace(
+                request_cancel_all=lambda: ["op-aaa", "op-bbb"]),
+        )
+        serpent_flow.SerpentREPL._handle_stop_all(repl)
+        assert "2 ops" in printed[-1]
+        assert "op-aaa" in printed[-1] and "op-bbb" in printed[-1]
+        assert "phase boundary" in printed[-1], (
+            "an operator told 'stopped' who then watches a VERIFY finish "
+            "concludes the verb is broken — say it is cooperative"
+        )
+
+    def test_the_daemon_handler_says_so_when_it_cannot_act(self):
+        from backend.core.ouroboros.battle_test import serpent_flow
+
+        printed = []
+        repl = types.SimpleNamespace(
+            _flow=types.SimpleNamespace(console=types.SimpleNamespace(
+                print=lambda *a, **k: printed.append(a[0] if a else ""))),
+            _gls=None,
+        )
+        serpent_flow.SerpentREPL._handle_stop_all(repl)
+        assert "unavailable" in printed[-1]
+
+    def test_the_verb_is_wired_into_the_dispatch_ladder(self):
+        """Structural: the ladder is a 400-line async method with many early
+        returns, so reaching this branch for real needs a whole REPL. What
+        this pins is that the branch CALLS the handler — which is what was
+        missing when `search_rows` shipped routed-and-dark."""
+        from backend.core.ouroboros.battle_test import serpent_flow
+
+        tree = ast.parse(inspect.getsource(
+            serpent_flow.SerpentREPL._dispatch_repl_command,
+        ).lstrip())
+        assert any(
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "_handle_stop_all"
+            for node in ast.walk(tree)
+        ), "/stop-all has a handler and no branch that reaches it"

--- a/tests/battle_test/test_tier3_statusline_clear.py
+++ b/tests/battle_test/test_tier3_statusline_clear.py
@@ -1,0 +1,239 @@
+"""Tier 3: the status-line contract, the clear chord, and a declared waiver.
+
+Three small closures, each with a failure that reads as normal operation:
+
+  * a status-line runner that pipes nothing, so an operator's existing CC
+    script runs and prints its fallback forever;
+  * a `Ctrl+L` that clears without warning, losing a transcript for someone
+    who was only fixing a garbled screen;
+  * an unfilled hook that is a DESIGN DECISION reported as a defect, which
+    trains people to ignore the audit.
+"""
+from __future__ import annotations
+
+import json
+import os
+import types
+
+import pytest
+
+from backend.core.ouroboros.battle_test import status_line as SL
+from backend.core.ouroboros.battle_test import transcript_hatches as H
+
+
+class TestStatuslinePayload:
+    def test_it_is_json(self):
+        assert isinstance(json.loads(SL._statusline_payload()), dict)
+
+    def test_it_carries_ccs_shape(self):
+        """A script written for CC must run here unchanged — that is the
+        entire value of adopting a contract rather than inventing one."""
+        payload = json.loads(SL._statusline_payload())
+        assert "cwd" in payload
+        assert payload["workspace"]["current_dir"]
+        assert payload["workspace"]["project_dir"]
+
+    def test_ov_specific_state_rides_alongside(self):
+        """`phase` and `route` have no CC counterpart and are what an O+V
+        operator most wants. Additive, not contorted into CC's shape."""
+        snap = SL.StatusSnapshot(phase="GENERATE", route="complex",
+                                 provider="claude", cost_spent_usd=0.42,
+                                 cost_budget_usd=2.5, primary_op_id="op-9")
+        payload = json.loads(SL._statusline_payload(snap))
+        assert payload["phase"] == "GENERATE"
+        assert payload["route"] == "complex"
+        assert payload["model"]["display_name"] == "claude"
+        assert payload["cost"]["total_cost_usd"] == 0.42
+        assert payload["cost"]["budget_usd"] == 2.5
+        assert payload["session_id"] == "op-9"
+
+    def test_unknown_values_are_omitted_not_faked(self):
+        """A script reading `.cost.total_cost_usd` gets a real number or
+        nothing — never a zero that looks like a free session."""
+        payload = json.loads(SL._statusline_payload(SL.StatusSnapshot()))
+        assert "route" not in payload
+        assert "model" not in payload
+        assert "session_id" not in payload
+
+    def test_it_never_raises_on_a_broken_snapshot(self):
+        assert json.loads(SL._statusline_payload(object()))
+
+    def test_the_script_actually_receives_it(self, monkeypatch):
+        """End to end through the real runner: the contract is only real if
+        the bytes arrive on the script's stdin."""
+        monkeypatch.setenv(
+            "JARVIS_STATUSLINE_CMD",
+            "python3 -c 'import sys,json;"
+            'd=json.load(sys.stdin);print("got:"+str(sorted(d)[:2]))\'',
+        )
+        SL._CUSTOM_SEGMENT_CACHE["at"] = 0.0
+        out = SL._custom_segment()
+        assert out.startswith("got:"), out
+
+    def test_a_script_that_ignores_stdin_still_works(self, monkeypatch):
+        """The payload must not break the scripts that predate it."""
+        monkeypatch.setenv("JARVIS_STATUSLINE_CMD", "echo hello")
+        SL._CUSTOM_SEGMENT_CACHE["at"] = 0.0
+        assert SL._custom_segment() == "hello"
+
+
+class _Buf:
+    def __init__(self):
+        self.text = ""
+        self.cursor_position = 0
+        self.handled = []
+
+    def validate_and_handle(self):
+        self.handled.append(self.text)
+
+
+class _App:
+    def __init__(self):
+        self.current_buffer = _Buf()
+        self.redraws = 0
+        self.renderer = types.SimpleNamespace(clear=lambda: None)
+
+    def invalidate(self):
+        self.redraws += 1
+
+
+class TestClearChord:
+    @pytest.fixture(autouse=True)
+    def _fresh(self):
+        H._CLEAR_LATCH = None
+        yield
+        H._CLEAR_LATCH = None
+
+    def test_one_press_redraws_and_does_not_clear(self):
+        """An operator reaching for Ctrl+L is usually recovering a garbled
+        screen and has no intention of clearing anything."""
+        ev = types.SimpleNamespace(app=_App())
+        H.force_redraw(ev)
+        assert ev.app.redraws == 1
+        assert ev.app.current_buffer.handled == []
+
+    def test_two_presses_clear(self):
+        ev = types.SimpleNamespace(app=_App())
+        H.force_redraw(ev)
+        H.force_redraw(ev)
+        assert ev.app.current_buffer.handled == ["/clear"]
+
+    def test_the_redraw_happens_on_both_presses(self):
+        """Arming is a side effect of a key that already did its job, never
+        a mode the operator is put into."""
+        ev = types.SimpleNamespace(app=_App())
+        H.force_redraw(ev)
+        H.force_redraw(ev)
+        assert ev.app.redraws == 2
+
+    def test_a_slow_second_press_does_not_clear(self):
+        from backend.core.ouroboros.battle_test.confirm_chord import (
+            ConfirmLatch,
+        )
+        clock = [100.0]
+        H._CLEAR_LATCH = ConfirmLatch(window_s=2.0, clock=lambda: clock[0])
+        ev = types.SimpleNamespace(app=_App())
+        H.force_redraw(ev)
+        clock[0] += 5.0
+        H.force_redraw(ev)
+        assert ev.app.current_buffer.handled == []
+        assert ev.app.redraws == 2
+
+    def test_the_window_is_ccs_two_seconds_and_clamped(self, monkeypatch):
+        """Two seconds, not the three `Ctrl+X Ctrl+K` uses — killing every
+        agent deserves a longer think than redrawing a screen."""
+        assert H._clear_window_s() == 2.0
+        monkeypatch.setenv("JARVIS_CLEAR_DOUBLE_PRESS_S", "0")
+        assert H._clear_window_s() >= 0.5
+        monkeypatch.setenv("JARVIS_CLEAR_DOUBLE_PRESS_S", "junk")
+        assert H._clear_window_s() > 0
+
+    def test_it_reuses_the_shared_latch(self):
+        """A second timer would be two answers to 'did they press twice'."""
+        import inspect
+
+        assert "ConfirmLatch" in inspect.getsource(H._clear_latch)
+
+    def test_clear_goes_through_the_verb_router(self):
+        """`/clear` is a verb every surface already routes; reaching past
+        that router would clear on some surfaces and not others."""
+        ev = types.SimpleNamespace(app=_App())
+        H.force_redraw(ev)
+        H.force_redraw(ev)
+        assert ev.app.current_buffer.handled == ["/clear"]
+
+    def test_a_broken_app_never_raises(self):
+        H.force_redraw(types.SimpleNamespace(app=None))
+        H.force_redraw(None)
+
+
+class TestDaemonHeaderWaiver:
+    def test_the_daemon_declares_rather_than_omits(self):
+        """An unfilled hook has two causes needing opposite responses:
+        'this surface has no use for it' is a decision, and 'nobody noticed'
+        is the defect. Silence cannot tell them apart."""
+        import ast
+        import inspect
+
+        from backend.core.ouroboros.battle_test import serpent_flow
+
+        # `textwrap.dedent`: a METHOD's source is indented, and
+        # `ast.parse` rejects it. The same trap bit this arc once
+        # already in the inflight-registry tests.
+        import textwrap
+        tree = ast.parse(textwrap.dedent(
+            inspect.getsource(serpent_flow.SerpentREPL._loop)))
+        waived = {
+            n.arg for n in ast.walk(tree)
+            if isinstance(n, ast.keyword)
+            and isinstance(n.value, ast.Call)
+            and getattr(n.value.func, "id", None) == "waived"
+        }
+        assert {"header", "header_height"} <= waived
+
+    def test_the_waiver_is_imported_unaliased(self):
+        """`capability_handoff` matches the call-site spelling, so `as
+        _waived` makes the waiver invisible to the auditor it exists for."""
+        import ast
+        import inspect
+
+        from backend.core.ouroboros.battle_test import serpent_flow
+
+        # `textwrap.dedent`: a METHOD's source is indented, and
+        # `ast.parse` rejects it. The same trap bit this arc once
+        # already in the inflight-registry tests.
+        import textwrap
+        tree = ast.parse(textwrap.dedent(
+            inspect.getsource(serpent_flow.SerpentREPL._loop)))
+        names = [
+            a.asname or a.name
+            for n in ast.walk(tree) if isinstance(n, ast.ImportFrom)
+            and "capability_handoff" in (n.module or "")
+            for a in n.names
+        ]
+        assert "waived" in names
+
+    def test_the_audit_now_reads_clean(self):
+        from backend.core.ouroboros.ui import capability_handoff as C
+
+        sink = ("backend.core.ouroboros.battle_test.bipartite_layout"
+                ".build_bipartite_application")
+        divergent = [d for d in C.audit().divergence() if d[0] == sink]
+        assert divergent == [], divergent
+
+
+class TestSerpentFlowLogger:
+    def test_the_module_defines_the_logger_its_handlers_use(self):
+        """SIX `except` handlers called `logger.debug` and nothing defined
+        it, so each raised NameError FROM THE HANDLER — turning a swallowed
+        degradation into a crash and making every 'NEVER raises' docstring
+        above them false."""
+        from backend.core.ouroboros.battle_test import serpent_flow
+
+        assert hasattr(serpent_flow, "logger")
+
+    def test_a_degraded_handler_returns_instead_of_raising(self):
+        from backend.core.ouroboros.battle_test import serpent_flow
+
+        repl = types.SimpleNamespace(_flow=None, _gls=None)
+        serpent_flow.SerpentREPL._serve_diff_fetch(repl, "d-1")   # no raise

--- a/tests/battle_test/test_transcript_mode.py
+++ b/tests/battle_test/test_transcript_mode.py
@@ -1,0 +1,329 @@
+"""The transcript viewer as a MODE — CC's `Ctrl+O`.
+
+Most of CC's viewer keys were already bound. What was missing is the state
+that makes them a viewer: `transcript_hatches` used "is the operator scrolled
+back" as a stand-in, which is silent, is not the doorway CC teaches, and left
+`j`/`k`/`g`/`G`/`Space` unbindable because at the live tail they type as
+themselves.
+
+Three failure modes here read as normal operation, so they are pinned:
+
+  * a printable key that stays live at the tail (typing `{` teleports the view),
+  * a paging key wired against the viewport's inverted sign (a dead key),
+  * a `?` panel that lists a binding the operator does not actually have.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.battle_test.transcript_mode import (
+    enter_transcript_mode,
+    exit_transcript_mode,
+    install_transcript_mode_bindings,
+    is_transcript_mode,
+    reset_transcript_mode_for_tests,
+    shortcut_panel,
+    toggle_transcript_mode,
+    transcript_surface_active,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean():
+    reset_transcript_mode_for_tests()
+    yield
+    reset_transcript_mode_for_tests()
+    from backend.core.ouroboros.battle_test.bipartite_layout import (
+        set_active_canvas,
+    )
+    set_active_canvas(None)
+
+
+@pytest.fixture
+def canvas():
+    """A live canvas with more lines than fit, registered as the sink."""
+    from backend.core.ouroboros.battle_test.bipartite_layout import (
+        BipartiteLayout, set_active_canvas,
+    )
+    mux = BipartiteLayout(width=100, height=12)
+    for i in range(60):
+        mux.emit("line", {"text": f"line {i}"})
+    set_active_canvas(mux)
+    return mux
+
+
+@pytest.fixture
+def keys():
+    from prompt_toolkit.key_binding import KeyBindings
+
+    said = []
+    kb = KeyBindings()
+    assert install_transcript_mode_bindings(kb, notify=said.append)
+    table = {
+        " ".join(str(k).replace("Keys.", "") for k in b.keys): b.handler
+        for b in kb.bindings
+    }
+    return table, said
+
+
+class TestMode:
+    def test_it_starts_off(self):
+        assert is_transcript_mode() is False
+
+    def test_ctrl_o_toggles(self, keys):
+        table, said = keys
+        table["ControlO"](None)
+        assert is_transcript_mode() is True
+        assert "transcript" in said[-1]
+        table["ControlO"](None)
+        assert is_transcript_mode() is False
+
+    def test_q_and_escape_both_leave(self, keys):
+        table, _said = keys
+        for exit_key in ("q", "Escape"):
+            enter_transcript_mode()
+            table[exit_key](None)
+            assert is_transcript_mode() is False, f"{exit_key} did not exit"
+
+    def test_entering_does_not_move_the_view(self, canvas, keys):
+        """The line the operator pressed the key while reading is the one
+        line they certainly care about."""
+        table, _said = keys
+        before = canvas._viewport.offset
+        table["ControlO"](None)
+        assert canvas._viewport.offset == before
+
+    def test_leaving_returns_to_the_tail(self, canvas, keys):
+        """The organism keeps working while the operator reads. An exit that
+        left the view in history hands back a cockpit that looks live and is
+        showing minutes-old output."""
+        table, _said = keys
+        table["ControlO"](None)
+        table["k"](None)
+        table["k"](None)
+        assert canvas._viewport.offset > 0
+        table["q"](None)
+        assert canvas._viewport.offset == 0
+        assert canvas._viewport.following is True
+
+    def test_toggle_returns_the_new_state(self):
+        assert toggle_transcript_mode() is True
+        assert toggle_transcript_mode() is False
+
+    def test_enter_and_exit_report_whether_they_changed_anything(self):
+        assert enter_transcript_mode() is True
+        assert enter_transcript_mode() is False
+        assert exit_transcript_mode() is True
+        assert exit_transcript_mode() is False
+
+
+class TestMovement:
+    def test_k_and_j_move_one_line(self, canvas, keys):
+        table, _said = keys
+        enter_transcript_mode()
+        table["k"](None)
+        assert canvas._viewport.offset == 1, "k must move toward HISTORY"
+        table["j"](None)
+        assert canvas._viewport.offset == 0
+
+    def test_half_page(self, canvas, keys):
+        table, _said = keys
+        enter_transcript_mode()
+        _total, budget = canvas.scroll_metrics()
+        table["ControlU"](None)
+        assert canvas._viewport.offset == budget // 2
+
+    def test_paging_up_goes_to_history(self, canvas, keys):
+        """THE inverted-sign trap. `CanvasViewport.page` takes +1 for PgUp
+        while `scroll` takes NEGATIVE for older — the two disagree, and the
+        viewport's own docstring records the first PgUp binding getting this
+        backwards and reading as a dead key."""
+        table, _said = keys
+        enter_transcript_mode()
+        for key in ("ControlB", "b"):
+            canvas._viewport.to_bottom()
+            table[key](None)
+            assert canvas._viewport.offset > 0, (
+                f"{key} paged toward the tail the view was already on — "
+                "the sign flip into CanvasViewport.page is inverted"
+            )
+
+    def test_paging_down_returns_toward_the_tail(self, canvas, keys):
+        table, _said = keys
+        enter_transcript_mode()
+        table["ControlB"](None)
+        table["ControlB"](None)
+        deep = canvas._viewport.offset
+        for key in ("ControlF", " "):
+            before = canvas._viewport.offset
+            table[key](None)
+            assert canvas._viewport.offset < before, f"{key} did not go down"
+        assert deep > 0
+
+    def test_g_and_shift_g_are_the_ends(self, canvas, keys):
+        table, _said = keys
+        enter_transcript_mode()
+        table["g"](None)
+        assert canvas._viewport.offset > 0
+        assert canvas._viewport.hit_top or canvas._viewport.offset > 0
+        table["G"](None)
+        assert canvas._viewport.offset == 0
+
+    def test_movement_without_a_canvas_is_silent(self, keys):
+        """The cockpit boots before a canvas is registered, and a key
+        pressed in that window must not raise into dispatch."""
+        table, _said = keys
+        enter_transcript_mode()
+        for key in ("k", "j", "ControlU", "ControlB", "g", "G"):
+            table[key](None)
+
+
+class TestPrintableKeysStayInert:
+    def test_the_surface_predicate_covers_both_doorways(self, canvas):
+        """`[`, `v`, `{`, `}` are characters someone may genuinely type, so
+        they bind only where they cannot be meant literally. Scrolled-back
+        was the only such state; the viewer is now the other one, and both
+        resolve through ONE predicate so they cannot drift."""
+        assert transcript_surface_active() is False
+        enter_transcript_mode()
+        assert transcript_surface_active() is True
+        exit_transcript_mode()
+        assert transcript_surface_active() is False
+        canvas._viewport.scroll(-3, total=60, budget=11)
+        assert transcript_surface_active() is True, (
+            "the pre-existing scrolled-back habit must keep working"
+        )
+
+    def test_the_hatches_use_that_predicate(self):
+        """Widened, not replaced — an operator with the scroll-back habit
+        must not lose it because a mode arrived."""
+        import ast
+        import inspect
+
+        from backend.core.ouroboros.battle_test import transcript_hatches
+
+        src = inspect.getsource(transcript_hatches.install_transcript_hatches)
+        tree = ast.parse(src.lstrip())
+        names = {
+            node.id for node in ast.walk(tree) if isinstance(node, ast.Name)
+        }
+        assert "transcript_surface_active" in names
+        assert "is_scrolled_back" not in names, (
+            "the hatches still filter on scrolled-back alone, so `[`/`v`/"
+            "`{`/`}` are dead inside the viewer"
+        )
+
+
+class TestShortcutPanel:
+    def test_it_lists_the_viewer_keys(self):
+        panel = "\n".join(shortcut_panel())
+        for expected in ("scroll one line up", "search", "next match",
+                         "open in $EDITOR", "leave the viewer"):
+            assert expected in panel
+
+    def test_it_renders_keys_an_operator_can_read(self):
+        """The first cut printed prompt_toolkit's wire form — `c-u`, and the
+        space key as nothing at all: a shortcut reference with a blank in it.
+        """
+        panel = "\n".join(shortcut_panel())
+        assert "ctrl+u" in panel and "c-u" not in panel
+        assert "space" in panel
+
+    def test_it_reads_back_the_effective_keys_not_the_defaults(self):
+        """A panel that confidently lists someone else's bindings is worse
+        than no panel."""
+        import ast
+        import inspect
+
+        from backend.core.ouroboros.battle_test import transcript_mode
+
+        src = inspect.getsource(transcript_mode.shortcut_panel)
+        assert "effective_key_sequences" in src
+        tree = ast.parse(src.lstrip())
+        assert any(
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "effective_key_sequences"
+            for node in ast.walk(tree)
+        )
+
+    def test_question_mark_only_answers_inside_the_viewer(self, keys):
+        table, said = keys
+        before = len(said)
+        table["ControlO"](None)
+        table["?"](None)
+        assert len(said) > before
+        assert any("transcript viewer" in str(s) for s in said)
+
+
+class TestCtrlOCollision:
+    """Three actions claimed Ctrl+O: the deck's `lanes`, the narration
+    toggle, and the legacy TUI's expand. One key cannot serve three."""
+
+    def _defaults_for(self, action: str):
+        from backend.core.ouroboros.battle_test.keymap import action_catalog
+
+        for spec in action_catalog():
+            if spec.action == action:
+                return spec.default_keys
+        return None
+
+    def test_the_viewer_owns_ctrl_o(self, keys):
+        assert self._defaults_for("transcript:toggle") == ("ctrl+o",)
+
+    def test_narration_moved_off_it(self):
+        from prompt_toolkit.key_binding import KeyBindings
+
+        from backend.core.ouroboros.battle_test.transcript_hatches import (
+            install_transcript_hatches,
+        )
+        ui = type("_UI", (), {"flash": lambda self, *a, **k: None})()
+        client = type("_C", (), {"send_input": lambda self, _l: None})()
+        install_transcript_hatches(KeyBindings(), ui, client)
+        keys_ = self._defaults_for("narrate:toggle")
+        assert keys_ is not None and "ctrl+o" not in keys_, (
+            f"narrate:toggle still claims Ctrl+O ({keys_})"
+        )
+
+    def test_lanes_moved_off_it(self):
+        """Read from the source, because building the deck bindings needs a
+        live client, ui and fsm that only exist inside a running attach."""
+        import inspect
+
+        from backend.core.ouroboros.cli import ov
+
+        src = inspect.getsource(ov._build_selection_bindings)
+        assert '"deck:open", ("ctrl+o",)' not in src
+        assert '"deck:open", ("ctrl+x ctrl+l",)' in src
+
+    def test_the_toolbar_advertises_the_key_that_works(self):
+        """A footer naming a key nothing binds is the exact defect the
+        keybinding registry exists to prevent."""
+        import inspect
+
+        from backend.core.ouroboros.cli import ov
+
+        src = inspect.getsource(ov)
+        assert "^O lanes" not in src
+        assert "^X ^L lanes" in src
+
+
+class TestQuestionMarkOwnership:
+    def test_the_cockpit_help_stands_down_inside_the_viewer(self):
+        """`?` is bound twice on the attach client — the cockpit's shortcut
+        list and the viewer's own table. CC has both too ("press `?` in the
+        transcript viewer to see available shortcuts there"), but both
+        filters pass inside the viewer with an empty prompt, so without an
+        explicit exclusion the winner is whichever mount registered last.
+        Correct today, silently inverted the day someone reorders them.
+        """
+        import inspect
+
+        from backend.core.ouroboros.cli import ov
+
+        src = inspect.getsource(ov._build_chat_bindings) if hasattr(
+            ov, "_build_chat_bindings") else inspect.getsource(ov)
+        assert "_not_in_transcript" in src
+        assert "_empty_buffer & _not_in_transcript" in src, (
+            "app:help still fires on ? inside the transcript viewer"
+        )

--- a/tests/cli/test_ov_demo.py
+++ b/tests/cli/test_ov_demo.py
@@ -574,3 +574,105 @@ class TestTheDemoDeclaresItsOwnDensity:
         import backend.core.ouroboros.battle_test.tool_render_policy as tp
         monkeypatch.delattr(tp, "DensityPolicy", raising=False)
         assert d._demo_density() is None
+
+
+# ---------------------------------------------------------------------------
+# The demo boots the REAL Application, so it must carry the real keys
+# ---------------------------------------------------------------------------
+
+
+class TestLiveSceneCarriesTheShippingSurface:
+    """`ov demo live` exists to show the cockpit an operator actually runs.
+
+    A key bound on both shipping surfaces and absent here makes the demo a
+    picture of a cockpit nobody runs — which is the defect class that let
+    `search_rows` ship routed-and-dark on the real client while the demo
+    looked complete.
+    """
+
+    def _keys(self):
+        from backend.core.ouroboros.cli import ov_demo
+
+        kb = ov_demo._live_exit_bindings()
+        return kb, {
+            " ".join(str(k).replace("Keys.", "") for k in b.keys)
+            for b in kb.bindings
+        }
+
+    def test_the_transcript_viewer_is_reachable(self):
+        _kb, keys = self._keys()
+        assert "ControlO" in keys
+        for movement in ("j", "k", "g", "G", "ControlU", "ControlB", "?"):
+            assert movement in keys, f"{movement} is dark in the demo"
+
+    def test_the_stop_all_chord_is_reachable(self):
+        _kb, keys = self._keys()
+        assert "ControlX ControlK" in keys
+
+    def test_q_leaves_the_viewer_rather_than_killing_the_demo(self):
+        """THE trap, one key over from the Escape defect this scene already
+        records: `q` quits the demo, and `q` leaves the transcript viewer in
+        `ov`. Bound naively, the one surface built to demonstrate the cockpit
+        would teach that `q` kills your session.
+
+        The two filters must be mutually exclusive, so exactly one can fire
+        for any keystroke — prompt_toolkit resolving by registration order is
+        not something to depend on.
+        """
+        from backend.core.ouroboros.battle_test import transcript_mode as tm
+
+        kb, _keys = self._keys()
+        q_bindings = [b for b in kb.bindings
+                      if [str(k) for k in b.keys] == ["q"]]
+        assert len(q_bindings) == 2, "expected the viewer's q and the demo's q"
+
+        try:
+            tm.reset_transcript_mode_for_tests()
+            live = [b for b in q_bindings if bool(b.filter())]
+            assert len(live) == 1, "exactly one q may be live at a time"
+
+            tm.enter_transcript_mode()
+            live_inside = [b for b in q_bindings if bool(b.filter())]
+            assert len(live_inside) == 1
+            assert live_inside[0] is not live[0], (
+                "the same q fires inside and outside the viewer — pressing q "
+                "while reading the transcript would end the demo"
+            )
+        finally:
+            tm.reset_transcript_mode_for_tests()
+
+    def test_escape_also_stands_down_inside_the_viewer(self):
+        from backend.core.ouroboros.battle_test import transcript_mode as tm
+
+        kb, _keys = self._keys()
+        escapes = [b for b in kb.bindings
+                   if [str(k) for k in b.keys] == ["Keys.Escape"]]
+        assert escapes, "the demo lost its escape hatch"
+        try:
+            tm.enter_transcript_mode()
+            demo_quits = [b for b in escapes if bool(b.filter())
+                          and "transcript" not in repr(b.handler)]
+            # Whatever remains live must be the viewer's exit, never a quit
+            # that would close the demo out from under a reader.
+            assert len(demo_quits) <= 1
+        finally:
+            tm.reset_transcript_mode_for_tests()
+
+    def test_the_demo_shows_the_chord_instead_of_pretending_it_worked(self):
+        """An inert `send_input` would make the chord look identical whether
+        it worked or not — the failure this scene exists to make visible."""
+        import ast
+        import inspect
+
+        from backend.core.ouroboros.cli import ov_demo
+
+        src = inspect.getsource(ov_demo._live_exit_bindings)
+        assert "_DemoOrganism" in src
+        tree = ast.parse(src.lstrip())
+        sends = [
+            n for n in ast.walk(tree)
+            if isinstance(n, ast.FunctionDef) and n.name == "send_input"
+        ]
+        assert sends, "the demo shim has no send_input"
+        assert len(sends[0].body) > 1 or not isinstance(
+            sends[0].body[0], ast.Pass), "the shim is a silent no-op"

--- a/tests/ui/test_alt_screen_signal_safety.py
+++ b/tests/ui/test_alt_screen_signal_safety.py
@@ -1,0 +1,491 @@
+"""The alternate screen's signal path, which runs where almost nothing may.
+
+The defect an operator reported, verbatim::
+
+    Exception ignored in: <function WeakValueDictionary.__init__.<locals>.remove>
+    Traceback (most recent call last):
+      File ".../weakref.py", line 105, in remove
+      File ".../ui/alt_screen.py", line 193, in _handler
+        _prev(signum, frame)
+    KeyboardInterrupt:
+
+A CPython signal handler is delivered at an ARBITRARY bytecode boundary —
+inside a weakref callback, a ``__del__``, a GC finalizer, an ``atexit``
+handler. Three things are therefore forbidden on that path, and the handler
+did all three. Each is pinned here against the measurement that found it:
+
+  * chaining to a RAISING predecessor (`signal.default_int_handler`) with no
+    caller to catch it — the traceback above,
+  * taking a lock another thread may hold — 2001 ms in the reproduction,
+  * writing through a `TextIOWrapper`, which takes the stream's own lock and
+    can deadlock against the very stream it is restoring.
+
+The signals themselves need a real process, so the delivery tests fork one.
+"""
+from __future__ import annotations
+
+import gc
+import os
+import signal
+import subprocess
+import sys
+import textwrap
+import threading
+import time
+
+import pytest
+
+from backend.core.ouroboros.governance import exit_guard as G
+from backend.core.ouroboros.ui import alt_screen as A
+
+_REPO = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))))
+
+
+@pytest.fixture(autouse=True)
+def _isolated(tmp_path):
+    """Never let a test write a control sequence at the real terminal."""
+    fd = os.open(os.devnull, os.O_WRONLY)
+    saved = (A._DEPTH, A._ARMED[0], A._SIGNAL_FD[0], A._IN_HANDLER[0],
+             A._SUSPENDED[0], signal.getsignal(signal.SIGINT))
+    A._SIGNAL_FD[0] = fd
+    A._ARMED[0] = False
+    A._IN_HANDLER[0] = False
+    A._SUSPENDED[0] = False
+    yield
+    A._DEPTH, A._ARMED[0], A._SIGNAL_FD[0] = saved[0], saved[1], saved[2]
+    A._IN_HANDLER[0], A._SUSPENDED[0] = saved[3], saved[4]
+    try:
+        signal.signal(signal.SIGINT, saved[5])
+    except (ValueError, TypeError):
+        pass
+    os.close(fd)
+    G.uninstall_unraisable_guard()
+
+
+# ---------------------------------------------------------------------------
+# THE reported defect
+# ---------------------------------------------------------------------------
+
+
+class TestUnraisableGuard:
+    def test_the_operators_traceback_is_silenced(self, capfd):
+        """Replayed exactly: the chained raise, from inside a finalizer."""
+        A._DEPTH = 1
+        A._ARMED[0] = True
+        A._install_backstops()
+        handler = signal.getsignal(signal.SIGINT)
+        assert getattr(handler, "_ov_alt_screen_chained", False)
+
+        before = G.suppressed_unraisable_count()
+
+        class _Finalizer:
+            def __del__(self):
+                A._ARMED[0] = True
+                handler(signal.SIGINT, None)
+
+        obj = _Finalizer()
+        del obj
+        gc.collect()
+
+        assert G.suppressed_unraisable_count() > before
+        assert "KeyboardInterrupt" not in capfd.readouterr().err
+
+    def test_a_genuine_finalizer_fault_stays_visible(self):
+        """The guard is narrow ON PURPOSE. A blanket hook would swallow the
+        unraisable traceback from a third-party ``__del__``, where it is
+        frequently the only evidence a fault occurred at all.
+
+        In a CHILD, because pytest's own `unraisableexception` plugin owns
+        `sys.unraisablehook` inside a test run and COLLECTS unraisables
+        rather than printing them. Neither `capsys` nor `capfd` therefore
+        sees the traceback, and a version of this test written with either
+        one passes while asserting nothing — which is precisely the shape of
+        the defect this file exists to catch. The child has no such plugin,
+        so what it prints is what an operator would see.
+        """
+        script = textwrap.dedent(f"""
+            import sys, gc
+            sys.path.insert(0, {_REPO!r})
+            from backend.core.ouroboros.governance.exit_guard import (
+                install_unraisable_guard,
+            )
+            install_unraisable_guard()
+
+            class _Bad:
+                def __del__(self):
+                    raise ValueError("a genuine bug in someone's finalizer")
+
+            obj = _Bad()
+            del obj
+            gc.collect()
+        """)
+        out = subprocess.run(
+            [sys.executable, "-c", script], capture_output=True, text=True,
+            timeout=60,
+        )
+        assert "a genuine bug" in out.stderr, out.stderr
+        assert "Exception ignored" in out.stderr
+
+    def test_an_interrupt_in_a_finalizer_prints_nothing(self):
+        """The mirror of the test above, end to end in a real process: the
+        operator's own reproduction, with the guard in place."""
+        script = textwrap.dedent(f"""
+            import sys, gc, signal
+            sys.path.insert(0, {_REPO!r})
+            from backend.core.ouroboros.governance.exit_guard import (
+                install_unraisable_guard, suppressed_unraisable_count,
+            )
+            install_unraisable_guard()
+
+            class _Interrupted:
+                def __del__(self):
+                    raise KeyboardInterrupt()
+
+            obj = _Interrupted()
+            del obj
+            gc.collect()
+            print("SUPPRESSED", suppressed_unraisable_count())
+        """)
+        out = subprocess.run(
+            [sys.executable, "-c", script], capture_output=True, text=True,
+            timeout=60,
+        )
+        assert "SUPPRESSED 1" in out.stdout, out.stdout
+        assert out.stderr.strip() == "", (
+            f"the operator still sees a traceback: {out.stderr!r}"
+        )
+
+    def test_it_forwards_to_whatever_hook_was_already_there(self):
+        seen = []
+        previous = sys.unraisablehook
+        sys.unraisablehook = lambda u: seen.append(u)
+        try:
+            G.uninstall_unraisable_guard()
+            assert G.install_unraisable_guard()
+
+            class _Bad:
+                def __del__(self):
+                    raise ValueError("forward me")
+
+            obj = _Bad()
+            del obj
+            gc.collect()
+            assert seen, "the previous hook was replaced rather than chained"
+        finally:
+            sys.unraisablehook = previous
+
+    def test_installing_twice_does_not_chain_twice(self):
+        G.uninstall_unraisable_guard()
+        G.install_unraisable_guard()
+        first = sys.unraisablehook
+        G.install_unraisable_guard()
+        assert sys.unraisablehook is first
+
+    def test_uninstall_only_unwinds_its_own_hook(self):
+        """Something else installed on top of ours must not be silently
+        uninstalled by our teardown."""
+        G.uninstall_unraisable_guard()
+        G.install_unraisable_guard()
+        theirs = lambda u: None                              # noqa: E731
+        sys.unraisablehook = theirs
+        G.uninstall_unraisable_guard()
+        assert sys.unraisablehook is theirs
+        sys.unraisablehook = sys.__unraisablehook__
+
+    def test_the_kill_switch_works(self, monkeypatch):
+        G.uninstall_unraisable_guard()
+        monkeypatch.setenv("JARVIS_UNRAISABLE_GUARD_ENABLED", "0")
+        assert G.install_unraisable_guard() is False
+        assert G.unraisable_guard_installed() is False
+
+    def test_suppression_is_counted_not_merely_silent(self):
+        """A guard that hides things and keeps no count is indistinguishable
+        from a guard that is not working."""
+        assert isinstance(G.suppressed_unraisable_count(), int)
+
+
+# ---------------------------------------------------------------------------
+# The forbidden operations
+# ---------------------------------------------------------------------------
+
+
+class TestSignalSafety:
+    def test_the_restore_never_blocks_on_the_lock(self):
+        """MEASURED: the locked version blocked 2001 ms behind a worker."""
+        A._ARMED[0] = True
+        held, release = threading.Event(), threading.Event()
+
+        def _hog():
+            with A._LOCK:
+                held.set()
+                release.wait(2.0)
+
+        threading.Thread(target=_hog, daemon=True).start()
+        assert held.wait(1.0)
+        started = time.monotonic()
+        A._restore_signal_safe()
+        blocked = time.monotonic() - started
+        release.set()
+        assert blocked < 0.05, (
+            f"the signal path blocked {blocked * 1000:.0f}ms on a lock "
+            "another thread held — that is a hang inside a signal handler"
+        )
+
+    def test_the_restore_is_idempotent(self):
+        """What buys the lock-free flag: two callers both emit `rmcup`, and
+        `rmcup` twice is `rmcup`."""
+        A._ARMED[0] = True
+        assert A._restore_signal_safe() is True
+        assert A._restore_signal_safe() is False
+
+    def test_it_writes_to_a_descriptor_not_a_python_stream(self):
+        """`TextIOWrapper.write` takes the stream's internal lock, so a
+        signal delivered mid-`print` deadlocks the handler against the very
+        stream it is restoring."""
+        import ast
+        import inspect
+
+        tree = ast.parse(inspect.getsource(A._emit_signal_safe).lstrip())
+        attrs = {
+            node.func.attr for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+        }
+        assert "write" in attrs and "os" in inspect.getsource(
+            A._emit_signal_safe)
+        assert "flush" not in attrs, "that is a Python stream, not an fd"
+
+    def test_partial_writes_are_looped(self):
+        """A control sequence delivered half-way is worse than one not
+        delivered: the terminal renders the remainder as text."""
+        r, w = os.pipe()
+        try:
+            A._SIGNAL_FD[0] = w
+            A._ARMED[0] = True
+            A._LEAVE_BYTES[0] = b"\x1b[?1049l"
+            calls = []
+            real_write = os.write
+
+            def _dribble(fd, data):
+                calls.append(bytes(data))
+                return real_write(fd, bytes(data)[:1])   # one byte at a time
+
+            A.os.write = _dribble
+            try:
+                assert A._restore_signal_safe() is True
+            finally:
+                A.os.write = real_write
+            assert len(calls) == len(b"\x1b[?1049l")
+            assert os.read(r, 64) == b"\x1b[?1049l"
+        finally:
+            os.close(r)
+            os.close(w)
+
+    def test_a_closed_descriptor_is_survivable(self):
+        r, w = os.pipe()
+        os.close(w)
+        os.close(r)
+        A._SIGNAL_FD[0] = w
+        A._ARMED[0] = True
+        assert A._restore_signal_safe() is False        # no raise
+
+    def test_the_descriptor_is_captured_at_entry(self):
+        """`sys.__stdout__` may be closed by the time a handler runs, and
+        `fileno()` on a closed stream raises — inside a signal handler,
+        during shutdown, on the one path whose job is to leave the terminal
+        usable."""
+        import ast
+        import inspect
+
+        tree = ast.parse(inspect.getsource(A._emit_signal_safe).lstrip())
+        names = {n.attr for n in ast.walk(tree) if isinstance(n, ast.Attribute)}
+        assert "fileno" not in names
+
+
+# ---------------------------------------------------------------------------
+# Terminal capability, asked rather than assumed
+# ---------------------------------------------------------------------------
+
+
+class TestCapability:
+    def _probe(self, env: dict) -> str:
+        script = textwrap.dedent("""
+            import sys
+            sys.path.insert(0, %r)
+            from backend.core.ouroboros.ui import alt_screen as A
+            print(A._resolve_sequences())
+        """) % _REPO
+        environ = dict(os.environ)
+        environ.pop("TERM", None)
+        environ.update(env)
+        out = subprocess.run(
+            [sys.executable, "-c", script], capture_output=True, text=True,
+            env=environ, timeout=60,
+        )
+        return out.stdout.strip()
+
+    def test_a_terminal_without_an_alternate_screen_is_refused(self):
+        """`TERM=dumb` HAS a description and it says there is no alternate
+        screen. Writing xterm's literal there prints it as text into the
+        operator's session — and hardcoding the literal is what made that
+        indistinguishable from success."""
+        assert self._probe({"TERM": "dumb"}) == "False"
+
+    def test_an_unknown_terminal_falls_back_rather_than_refusing(self):
+        """Terminfo is missing in exactly the environments that DO support
+        the sequence — a stripped container, a CI runner. Refusing there
+        would be a regression dressed as correctness."""
+        assert self._probe({}) == "True"
+
+    def test_a_real_terminal_resolves_from_terminfo(self):
+        assert self._probe({"TERM": "xterm-256color"}) == "True"
+
+
+# ---------------------------------------------------------------------------
+# Real signals, in a real process
+# ---------------------------------------------------------------------------
+
+
+def _child(body: str) -> subprocess.CompletedProcess:
+    """Run `body` in a process where the signals are real.
+
+    The preamble is dedented and the body dedented SEPARATELY, then joined at
+    column zero. Interpolating first and dedenting after computes the common
+    prefix across both, which strips the preamble's indent and leaves the
+    body's — an IndentationError in the child and an empty stdout in the
+    assertion.
+    """
+    preamble = textwrap.dedent(f"""
+        import os, sys, signal, time
+        sys.path.insert(0, {_REPO!r})
+        from backend.core.ouroboros.ui import alt_screen as A
+        _r, _w = os.pipe()
+        A._resolve_sequences()
+        A._SIGNAL_FD[0] = _w
+        A._DEPTH = 1
+        A._ARMED[0] = True
+        A._install_backstops()
+    """)
+    script = preamble + textwrap.dedent(body)
+    return subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True,
+        timeout=60,
+    )
+
+
+@pytest.mark.skipif(not hasattr(signal, "SIGTSTP"), reason="POSIX only")
+class TestRealSignals:
+    def test_sigint_restores_and_still_raises(self):
+        """Restoring the terminal must not swallow the interrupt — the
+        operator asked to quit."""
+        out = _child("""
+            try:
+                os.kill(os.getpid(), signal.SIGINT)
+                time.sleep(0.5)
+                print("NO-RAISE")
+            except KeyboardInterrupt:
+                print("RAISED")
+            print("EMITTED", os.read(_r, 64) != b"")
+        """)
+        assert "RAISED" in out.stdout, out.stderr
+        assert "EMITTED True" in out.stdout
+
+    def test_a_stop_signal_hands_the_buffer_back(self):
+        """prompt_toolkit wraps its OWN Ctrl+Z, but this module claims the
+        buffer for the whole boot, before the cockpit mounts. A `kill -TSTP`
+        in that window left the shell drawing its prompt on the alternate
+        buffer."""
+        out = _child("""
+            handler = signal.getsignal(signal.SIGTSTP)
+            signal.signal(signal.SIGTSTP, signal.SIG_IGN)
+            signal.signal(signal.SIGTSTP, handler)
+            handler(signal.SIGTSTP, None)
+            print("LEFT", os.read(_r, 64))
+            print("SUSPENDED_FLAG", A._SUSPENDED[0])
+        """)
+        assert "1049l" in out.stdout or "LEFT b'\\x1b" in out.stdout, out.stdout
+        assert "SUSPENDED_FLAG True" in out.stdout, out.stdout
+
+    def test_resuming_re_enters_the_buffer_it_gave_back(self):
+        out = _child("""
+            tstp = signal.getsignal(signal.SIGTSTP)
+            cont = signal.getsignal(signal.SIGCONT)
+            tstp(signal.SIGTSTP, None)
+            os.read(_r, 64)
+            cont(signal.SIGCONT, None)
+            print("REENTERED", os.read(_r, 64) != b"")
+            print("ARMED", A._ARMED[0])
+        """)
+        assert "REENTERED True" in out.stdout, out.stdout
+        assert "ARMED True" in out.stdout, out.stdout
+
+    def test_resume_without_a_prior_stop_does_nothing(self):
+        """SIGCONT arrives for reasons that have nothing to do with us. Only
+        a stop WE handed the buffer back for may re-enter it."""
+        out = _child("""
+            cont = signal.getsignal(signal.SIGCONT)
+            A._ARMED[0] = False
+            cont(signal.SIGCONT, None)
+            print("ARMED", A._ARMED[0])
+        """)
+        assert "ARMED False" in out.stdout, out.stdout
+
+    def test_a_second_interrupt_leaves_rather_than_re_entering(self, tmp_path):
+        """An impatient operator gets the process to LEAVE, not a deeper
+        stack. The harness's own handler writes a partial summary here, which
+        is slow enough to be a real target for a second Ctrl+C.
+
+        The evidence is the ledger plus the exit status, not stdout: leaving
+        is exactly what stops the child printing. `returncode == -SIGINT`
+        means the second press reached the default disposition — and one line
+        in the ledger means the slow predecessor ran once.
+        """
+        ledger = tmp_path / "entries"
+        out = _child(f"""
+            LEDGER = {str(ledger)!r}
+            def _slow(signum, frame):
+                with open(LEDGER, "a") as fh:
+                    fh.write("entered\\n")
+                    fh.flush()
+                os.kill(os.getpid(), signal.SIGINT)   # the impatient second
+                time.sleep(0.5)
+            signal.signal(signal.SIGINT, _slow)
+            A._install_backstops()
+            h = signal.getsignal(signal.SIGINT)
+            h(signal.SIGINT, None)
+            print("STILL-HERE")
+        """)
+        entries = ledger.read_text().splitlines() if ledger.exists() else []
+        assert len(entries) == 1, (
+            f"the slow predecessor was re-entered {len(entries)} times"
+        )
+        assert out.returncode == -signal.SIGINT, (
+            f"the second interrupt did not reach the default disposition "
+            f"(rc={out.returncode}, stdout={out.stdout!r})"
+        )
+        assert "STILL-HERE" not in out.stdout
+
+    def test_sig_ign_is_not_overruled(self):
+        """A predecessor that asked for this signal to do nothing is not
+        overruled just because we want the screen back."""
+        out = _child("""
+            signal.signal(signal.SIGINT, signal.SIG_IGN)
+            A._install_backstops()
+            h = signal.getsignal(signal.SIGINT)
+            h(signal.SIGINT, None)
+            print("SURVIVED")
+            print("EMITTED", os.read(_r, 64) != b"")
+        """)
+        assert "SURVIVED" in out.stdout, out.stderr
+        assert "EMITTED True" in out.stdout
+
+    def test_chaining_is_not_doubled_on_reinstall(self):
+        out = _child("""
+            A._install_backstops()
+            A._install_backstops()
+            h = signal.getsignal(signal.SIGINT)
+            prev = h.__defaults__[0]
+            print("DOUBLE", getattr(prev, "_ov_alt_screen_chained", False))
+        """)
+        assert "DOUBLE False" in out.stdout, out.stdout


### PR DESCRIPTION
Closes the measured gaps between the `ov` cockpit and Claude Code's documented
interactive surface, plus a signal-safety defect an operator hit on Ctrl+C.

## Measured outcome

`capability_handoff` on the cockpit Application sink: **divergences 5 → 0.**
Mouse capability **1/13 → 6/13** — two of those six turned out to be
prompt_toolkit's already and needed no code.

`ProgressBoard`: **0 dark-and-enabled flags** in the cockpit surface.

## Tier 1 — dead on a shipping surface

- `serpent_active` on the attach client: the "organism is thinking" hairline
  never ran on the surface an operator uses. The fix underneath was bigger —
  three docstrings each asked in prose for ONE heartbeat staleness rule, and
  all three then implemented it inline. `_heartbeat_age()` is now the single
  predicate; a test pins that all four surfaces go dark at the same instant.
- `stream_rows` on the daemon (`inflight_registry`): the daemon composed every
  in-flight frame, shipped it over the bridge, and could not draw it. Also
  closes real-time shell execution display — same root, not a second feature.
- `diff_rows` on the client (`diff_bridge`): `/expand d-3` opened the diff on
  the *daemon's* overlay and mirrored back a line saying it had. The operator
  was told a diff was on screen and shown nothing.

## Tier 2 — the mouse

Click-to-expand, Ctrl/Alt-click to open a path or URL, transcript drag-select
with copy-on-release, and a clipboard writer (none existed — `clipboard_image`
only reads, and `pyperclip` is not installed).

## Tier 3

Statusline JSON contract on stdin, `Ctrl+L`×2 → `/clear`, and a declared
`waived()` for the daemon's `header`/`header_height` — never a defect, since
the daemon puts its identity in the transcript masthead.

## Also fixed

The alt-screen signal path was taking a lock (measured 2001 ms blocked),
writing through a `TextIOWrapper`, and chaining to a raising handler with no
caller — the operator's reported traceback. And `serpent_flow` used
`logger.debug` in six `except` handlers while never defining `logger`, so each
raised `NameError` *from the handler*.

## Not live-proven

Every commit is exercised by tests and by direct handler calls against real
`Application`s. **None has been watched in a terminal.** The riskiest to try
first: `Ctrl+Z` → `fg` (a bad terminal restore strands you at a shell with no
echo), then a click, then a drag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Brings the `ov` cockpit to Claude Code interactive-mode parity (Tiers 1–4) with mouse actions, a real viewer, diff overlay on attached clients, live output on the daemon, remappable completion/confirm keys, and safer terminal signals — plus Tier 5: jump between unobserved claims in the transcript.

- **New Features**
  - Transcript: click to expand collapsed results; Ctrl/Alt-click opens safe URLs/paths; drag-select copies on release.
  - Viewer: Ctrl+O enters a less-style transcript viewer (`j/k/g/G/Space`, inline `?`); exits cleanly back to live.
  - Diffs: overlay renders on attached clients via a remote `DiffArchive` bridge; a catalog rides the heartbeat; diff text fetches on open.
  - Live output: the daemon cockpit shows in-flight tool output and shell execution tails.
  - Auto-follow pause: entering the viewer pauses without moving; new lines are counted and held; leaving returns to live; `JARVIS_AUTO_SCROLL=0` disables globally.
  - Menu and gate: completion menu and apply gate are now remappable (`autocomplete:*`, `confirm:*`); `y/n` submit via the router only when the confirm strip is up and the prompt is empty; `Escape` stays interrupt/dismiss.
  - Keymap: CC action names resolve to `ov` actions (e.g., `chat:killAgents`→`agents:stopAll`, `scroll:*`→`transcript:*`); `chat:undo` is bound (Ctrl+_ / Ctrl+Shift+-).
  - Roster and keys: `/tasks` toggles the running-subagent roster (hidden by default); `/keys` is listed in the palette.
  - Subagent control: Ctrl+X Ctrl+K pressed twice within 3s cooperatively stops all running agents (single authority, both cockpits).
  - Clear and suspend: Ctrl+L redraws; press again within 2s to `/clear`. Ctrl+Z suspends to the shell and restores on return. The demo inherits these bindings.
  - Status line: runner receives JSON on stdin (Claude Code contract) and displays script output.
  - Epistemic navigation (Tier 5): `c`/`C` jump to next/previous unobserved claim using `provenance`; searches the full retained ring and maintains its own cursor.

- **Bug Fixes**
  - Alt-screen signal path hardened: no locks or `TextIOWrapper` in handlers, no chaining to a raising predecessor; respects terminfo, is reentrant, and handles SIGTSTP/SIGCONT safely.
  - Heartbeat staleness unified into one rule across surfaces; `serpent_active` now updates on the attach client.
  - `serpent_flow` defines a module logger to stop `NameError` from `except` blocks.

<sup>Written for commit be6e4d7a7455f832c412409ea48ab2eeddfcd342. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

