### PR TITLE
feat(ov): Tier 5 — epistemic transcript navigation and blast-ordered diff review

### DIFF
--- a/backend/core/infrastructure_orchestrator.py
+++ b/backend/core/infrastructure_orchestrator.py
@@ -107,10 +107,15 @@ class InfrastructureConfig:
 
     # Feature toggles
     on_demand_enabled: bool = field(
-        default_factory=lambda: os.getenv("JARVIS_INFRA_ON_DEMAND", "true").lower() == "true"
+        default_factory=lambda: os.getenv("JARVIS_INFRA_ON_DEMAND", "false").lower() == "true"
     )
+    # DEFAULT-OFF: superseded. `gcp_vm_manager` (34 production files)
+    # and `failover_lifecycle` (12) own GCP lifecycle now; nothing has
+    # imported THIS module since 2025-12-24. An ON default was harmless
+    # only because nobody wired it — the moment anyone did, shutdown
+    # would run `terraform destroy` with `--auto-approve`, by default.
     auto_destroy_on_shutdown: bool = field(
-        default_factory=lambda: os.getenv("JARVIS_INFRA_AUTO_DESTROY", "true").lower() == "true"
+        default_factory=lambda: os.getenv("JARVIS_INFRA_AUTO_DESTROY", "false").lower() == "true"
     )
 
     # Terraform settings
@@ -124,7 +129,7 @@ class InfrastructureConfig:
         default_factory=lambda: int(os.getenv("JARVIS_TERRAFORM_TIMEOUT", "300"))
     )
     terraform_auto_approve: bool = field(
-        default_factory=lambda: os.getenv("JARVIS_TERRAFORM_AUTO_APPROVE", "true").lower() == "true"
+        default_factory=lambda: os.getenv("JARVIS_TERRAFORM_AUTO_APPROVE", "false").lower() == "true"
     )
 
     # Resource thresholds for intelligent provisioning

--- a/backend/core/ouroboros/battle_test/diff_preview.py
+++ b/backend/core/ouroboros/battle_test/diff_preview.py
@@ -286,6 +286,24 @@ class DiffPreviewRenderer:
                     row.reach.path: row for row in _bg.annotate_set(reaches)
                 }
                 gutter_summary = _bg.summary(reaches)
+                # RIGHT ORDER, not just the right numbers. The reach was
+                # already measured and drawn; the tree still rendered in
+                # whatever sequence the diff produced, so a one-line change to
+                # a leaf could sit above a rewrite forty modules import. An
+                # operator reviewing under a five-second countdown reads from
+                # the top.
+                #
+                # Unresolved files sort FIRST. A reach that could not be
+                # established is not a safe file, it is an unmeasured one —
+                # the same rule the advisor's own repair settled when it made
+                # `?` never render as `0`.
+                from backend.core.ouroboros.ui import blast_bands as _bb
+                order = {
+                    path: i for i, path in enumerate(
+                        _bb.order_paths([c.path for c in changes], reaches))
+                }
+                changes = sorted(
+                    changes, key=lambda c: order.get(c.path, len(order)))
         except Exception:  # noqa: BLE001 — a lost column, never a lost diff
             gutter_rows = {}
         for c in changes:

--- a/backend/core/ouroboros/battle_test/progress_board.py
+++ b/backend/core/ouroboros/battle_test/progress_board.py
@@ -100,7 +100,17 @@ def scan_roots() -> Tuple[str, ...]:
     raw = os.environ.get("JARVIS_PROGRESS_BOARD_ROOTS", "").strip()
     if raw:
         return tuple(p.strip() for p in raw.split(",") if p.strip())
-    return ("backend",)
+    # `scripts` is production. `scripts/ouroboros_battle_test.py` is THE entry
+    # point that boots the six-layer stack — it is how this system actually
+    # runs — and 361 backend modules are reachable from `scripts/` and from
+    # nowhere else. Scanning only `backend` reported every one of them DARK
+    # while they were imported on every session.
+    #
+    # Found via `aegis/preflight.py`: flagged dark-and-enabled, imported at
+    # `scripts/ouroboros_battle_test.py:1997`. Same shape as the relative-
+    # import blindness — the board was right about its own graph and the
+    # graph was missing an edge.
+    return ("backend", "scripts")
 
 
 #: Directories that are not this codebase. A venv vendored under the scan root

--- a/backend/core/ouroboros/battle_test/progress_board.py
+++ b/backend/core/ouroboros/battle_test/progress_board.py
@@ -320,7 +320,8 @@ class ProgressBoard:
                 is_test = _is_test_path(rel)
                 if not is_test:
                     self_mod = _module_name(rel)
-                    for name in _imported_modules(tree):
+                    for name in _imported_modules(
+                            tree, self_mod, rel.endswith("__init__.py")):
                         # A module importing ITSELF is not a caller. Without
                         # this every module would look live, which is the same
                         # as having no signal at all.
@@ -541,15 +542,62 @@ def _normalise_source(source: str) -> str:
     return src + ".py"
 
 
-def _imported_modules(tree: ast.AST) -> Set[str]:
-    """Every module this file imports, in both syntaxes."""
+def _resolve_relative(self_mod: str, level: int, module: str,
+                      is_package: bool = False) -> str:
+    """``from ..x import y`` inside ``a.b.c`` -> ``a.x``. NEVER raises.
+
+    `level` counts dots: 1 is the current package, 2 its parent. The
+    importing module's OWN dotted name carries the package, so this needs no
+    filesystem walk — which is what the previous `continue` assumed it did.
+
+    ``is_package`` is load-bearing and easy to miss. `_module_name` strips
+    `__init__`, so a package's own `__init__.py` is already NAMED for the
+    package — `level=1` there means itself, not its parent, and stripping a
+    segment walks one level too far. That single off-by-one is what kept the
+    sensors dark after relative imports were resolved: `sensors/__init__.py`
+    re-exporting `.backlog_sensor` resolved to `intake.backlog_sensor`, a
+    module that does not exist.
+    """
+    try:
+        parts = str(self_mod or "").split(".")
+        strip = max(0, int(level) - 1) if is_package else int(level)
+        keep = len(parts) - strip
+        if keep < 0:
+            return ""
+        base = ".".join(parts[:keep])
+        if not base:
+            return str(module or "")
+        return f"{base}.{module}" if module else base
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def _imported_modules(tree: ast.AST, self_mod: str = "",
+                      is_package: bool = False) -> Set[str]:
+    """Every module this file imports, in both syntaxes.
+
+    RELATIVE imports are resolved rather than skipped, and that omission was
+    a systematic false-DARK rather than a rounding error. A package that
+    re-exports — `sensors/__init__.py` doing `from .backlog_sensor import
+    BacklogSensor` — is the ONLY edge between a consumer and the module the
+    flag lives in: the consumer writes `from ...sensors import BacklogSensor`,
+    which names a CLASS, and a class name never matches a module name. With
+    the re-export skipped there was no path at all, so every module reached
+    that way reported DARK while being imported on every boot.
+    """
     found: Set[str] = set()
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             for alias in node.names:
                 found.add(alias.name)
         elif isinstance(node, ast.ImportFrom):
-            if node.level:  # relative import — not resolvable without a package walk
+            if node.level:
+                resolved = _resolve_relative(
+                    self_mod, node.level, node.module or "", is_package)
+                if resolved:
+                    found.add(resolved)
+                    for alias in node.names:
+                        found.add(f"{resolved}.{alias.name}")
                 continue
             module = node.module or ""
             if module:

--- a/backend/core/ouroboros/battle_test/progress_board.py
+++ b/backend/core/ouroboros/battle_test/progress_board.py
@@ -461,7 +461,24 @@ class ProgressBoard:
                               value=value)
 
         module = _module_name(module_rel)
+        # BOTH spellings of the same module.
+        #
+        # `backend/` is on `sys.path` at runtime, so 597 files import their
+        # siblings as `from core.x import y` rather than
+        # `from backend.core.x import y`. This resolves FILE PATHS to the
+        # fully-qualified form, so the two never matched and every module
+        # imported that way counted zero importers and reported DARK.
+        #
+        # Found via `transport_handlers`: flagged dark-and-enabled with
+        # destructive COMPUTER_USE defaults, and imported three times from
+        # `backend/api/` as `from core.transport_handlers import ...`. It was
+        # one edit away from being defaulted off as "unreached" while live.
         importers = int(self._importers.get(module, 0))
+        for root in scan_roots():
+            prefix = f"{root}."
+            if module.startswith(prefix):
+                importers += int(
+                    self._importers.get(module[len(prefix):], 0))
 
         if enabled is False:
             return FeatureRow(flag, OFF, module_rel, category, enabled,

--- a/backend/core/ouroboros/governance/op_fanout_tree.py
+++ b/backend/core/ouroboros/governance/op_fanout_tree.py
@@ -312,7 +312,18 @@ def aggregate_fanout_rows(
                 continue
             parent = getattr(block, "parent_op_id", "")
             depths[block.op_id] = depths.get(parent, 0) + 1
-        for block in subtree:
+        # DEPTH-FIRST for RENDERING, from a breadth-first walk.
+        #
+        # `walk_subtree` promises BFS and other callers rely on that, so the
+        # conversion belongs here rather than there. It matters because
+        # `format_fanout_tree` indents by `depth` IN ROW ORDER: fed BFS, a
+        # grandchild emitted after its uncle renders nested under the uncle.
+        #
+        # That is not a cosmetic defect. The tree's whole claim is "this op
+        # caused that one", and drawn from BFS rows it asserts a parentage
+        # the graph does not record — a surface confidently showing the wrong
+        # answer, which is worse than showing none.
+        for block in _depth_first(subtree, root.op_id):
             if len(rows) >= line_clamp:
                 break
             row = _block_to_row(
@@ -320,6 +331,51 @@ def aggregate_fanout_rows(
             )
             rows.append(row)
     return tuple(rows)
+
+
+def _depth_first(subtree: Any, root_op_id: str) -> List[Any]:
+    """Reorder a BFS subtree depth-first, parent immediately before its
+    children. Pure. NEVER raises.
+
+    Sibling order is PRESERVED from the input, because the BFS order is
+    spawn order and that is meaningful — the first subagent dispatched
+    should read first.
+
+    Any block unreachable from the root is appended at the end rather than
+    dropped: an edge lost to eviction must not make an op vanish from the
+    tree, and a visible orphan is a far better failure than a silent one.
+    """
+    try:
+        blocks = list(subtree or ())
+        if not blocks:
+            return []
+        children: Dict[str, List[Any]] = {}
+        for block in blocks:
+            parent = str(getattr(block, "parent_op_id", "") or "")
+            if parent:
+                children.setdefault(parent, []).append(block)
+        ordered: List[Any] = []
+        seen: set = set()
+
+        def _walk(block: Any) -> None:
+            op_id = str(getattr(block, "op_id", "") or "")
+            if not op_id or op_id in seen:
+                return          # visited-guard: a cycle cannot spin this
+            seen.add(op_id)
+            ordered.append(block)
+            for child in children.get(op_id, ()):
+                _walk(child)
+
+        for block in blocks:
+            if str(getattr(block, "op_id", "") or "") == str(root_op_id):
+                _walk(block)
+                break
+        for block in blocks:               # orphans, visibly, at the end
+            if str(getattr(block, "op_id", "") or "") not in seen:
+                _walk(block)
+        return ordered
+    except Exception:  # noqa: BLE001
+        return list(subtree or ())
 
 
 def _block_to_row(

--- a/backend/core/ouroboros/ui/blast_bands.py
+++ b/backend/core/ouroboros/ui/blast_bands.py
@@ -1,0 +1,210 @@
+"""Reading a diff riskiest-first.
+
+`blast_gutter` already measures every changed file's reach and draws it — the
+bar, the scale, the per-set summary are all there. What nothing did was USE
+that number to decide reading ORDER: the file tree rendered in whatever
+sequence the diff produced, so a one-line change to a leaf could sit above a
+rewrite that forty modules import.
+
+An operator reviewing under a five-second NOTIFY_APPLY countdown reads from
+the top. Putting the widest-reaching change there is the whole feature.
+
+UNRESOLVED sorts FIRST, not last
+---------------------------------
+`peek` is read-only by construction — it returns what the advisor has already
+computed and never scans, because a cold blast scan is a 39–43 second burn
+and paying it at a gate would freeze the preview the operator is waiting on.
+So some files genuinely have no reach yet.
+
+Those sort to the TOP. A file whose blast radius could not be established is
+not a safe file; it is an unmeasured one, and the two must never be rendered
+as the same thing. This is the same rule the advisor's own repair settled —
+`?` never `0`, unknown never presented as measured — and the same rule the
+provenance vocabulary states when it calls UNKNOWN the loudest mark there is.
+
+Sorting them last, or treating a missing count as zero, would put exactly the
+files nobody can vouch for at the bottom of a list read under time pressure.
+
+What this does NOT do
+---------------------
+It does not let an operator accept one band and reject another. Apply is
+per-OPERATION — `/accept <op-id>` — and splitting it by file would be a
+partial apply: a governance change needing orchestrator support, rollback
+semantics for a half-applied candidate, and a VERIFY that knows which half
+ran. That is not a presentation slice, and building the UI for it here would
+be an affordance the engine cannot honour.
+
+Ordering and naming the bands is the honest half, and it is the half that
+actually helps someone reading under a countdown.
+"""
+from __future__ import annotations
+
+import enum
+import logging
+import os
+from typing import Any, List, Optional, Sequence, Tuple
+
+logger = logging.getLogger("Ouroboros.BlastBands")
+
+BLAST_BANDS_SCHEMA_VERSION: str = "blast_bands.1"
+
+__all__ = [
+    "BLAST_BANDS_SCHEMA_VERSION",
+    "Band",
+    "band_of",
+    "bands_enabled",
+    "review_order",
+    "sort_key",
+    "summarise_bands",
+    "thresholds",
+]
+
+
+class Band(enum.IntEnum):
+    """Review priority. Lower sorts FIRST — read this one first.
+
+    ``IntEnum`` so the ordering IS the enum rather than a separate table that
+    can disagree with it.
+    """
+
+    #: No reach could be established. Not safe — unmeasured.
+    UNKNOWN = 0
+    #: Reaches far beyond itself.
+    WIDE = 1
+    #: A handful of dependents.
+    MODERATE = 2
+    #: Reaches nothing but itself.
+    CONTAINED = 3
+
+    @property
+    def label(self) -> str:
+        return self.name.lower()
+
+
+def bands_enabled() -> bool:
+    """``JARVIS_BLAST_BANDS_ENABLED`` (default true). NEVER raises.
+
+    Off, the tree renders in the order the diff produced — the status quo, so
+    the rollback is exact.
+    """
+    return os.environ.get(
+        "JARVIS_BLAST_BANDS_ENABLED", "1",
+    ).strip().lower() not in ("0", "false", "no", "off")
+
+
+def thresholds() -> Tuple[int, int]:
+    """``(wide_at, moderate_at)`` dependent counts. NEVER raises.
+
+    Env-tunable because "wide" is a property of the REPOSITORY, not of this
+    module: eleven dependents is unremarkable in a hub package and alarming
+    in a leaf. Clamped and ordered so a mis-set pair cannot invert the bands.
+    """
+    def _read(name: str, fallback: int) -> int:
+        try:
+            return max(1, min(10_000, int(
+                os.environ.get(name, "") or fallback)))
+        except (TypeError, ValueError):
+            return fallback
+
+    wide = _read("JARVIS_BLAST_WIDE_AT", 10)
+    moderate = _read("JARVIS_BLAST_MODERATE_AT", 3)
+    # WIDE must be the larger boundary; swapped values would make every file
+    # wide and none moderate, silently.
+    if moderate > wide:
+        moderate, wide = wide, moderate
+    return wide, moderate
+
+
+def band_of(reach: Any) -> Band:
+    """Which band a reach falls in. Pure. NEVER raises.
+
+    ``resolved`` is consulted BEFORE ``count``, because an unresolved reach
+    reports ``count == 0`` and zero-as-a-number means "reaches nothing" —
+    the most reassuring answer there is, attached to the file we know least
+    about.
+    """
+    try:
+        if reach is None:
+            return Band.UNKNOWN
+        if not bool(getattr(reach, "resolved", False)):
+            return Band.UNKNOWN
+        count = int(getattr(reach, "count", 0) or 0)
+        wide, moderate = thresholds()
+        if count >= wide:
+            return Band.WIDE
+        if count >= moderate:
+            return Band.MODERATE
+        return Band.CONTAINED
+    except Exception:  # noqa: BLE001
+        return Band.UNKNOWN
+
+
+def sort_key(reach: Any) -> Tuple[int, int, str]:
+    """``(band, -count, path)`` — the review order, as a key. Pure.
+
+    Path breaks ties so the order is STABLE across renders. A tree that
+    reshuffles equal-risk files between frames is one an operator cannot
+    keep their place in.
+    """
+    try:
+        band = int(band_of(reach))
+        count = int(getattr(reach, "count", 0) or 0)
+        path = str(getattr(reach, "path", "") or "")
+        return (band, -count, path)
+    except Exception:  # noqa: BLE001
+        return (int(Band.UNKNOWN), 0, "")
+
+
+def review_order(reaches: Sequence[Any]) -> List[Any]:
+    """Reaches, riskiest first. Pure. NEVER raises."""
+    try:
+        if not bands_enabled():
+            return list(reaches or ())
+        return sorted(list(reaches or ()), key=sort_key)
+    except Exception:  # noqa: BLE001
+        return list(reaches or ())
+
+
+def order_paths(paths: Sequence[str], reaches: Sequence[Any]) -> List[str]:
+    """Order arbitrary paths by the reach known for each. NEVER raises.
+
+    Takes the paths rather than returning reaches, because the caller has
+    `FileChange` objects and only needs to know the SEQUENCE. A path with no
+    matching reach is treated as unresolved — which sorts it first, the same
+    way an unmeasured file does, because that is exactly what it is.
+    """
+    try:
+        if not bands_enabled():
+            return list(paths or ())
+        by_path = {str(getattr(r, "path", "")): r for r in (reaches or ())}
+        return sorted(
+            list(paths or ()),
+            key=lambda p: sort_key(by_path.get(str(p))),
+        )
+    except Exception:  # noqa: BLE001
+        return list(paths or ())
+
+
+def summarise_bands(reaches: Sequence[Any]) -> str:
+    """``1 unknown · 2 wide · 4 contained`` — riskiest first. NEVER raises.
+
+    Empty when there is nothing to say. A diff whose every file is contained
+    does not need a badge announcing that it is fine; the absence of the
+    warning IS the signal, which is the restraint the rest of this cockpit
+    already keeps.
+    """
+    try:
+        from collections import Counter
+
+        counts: Any = Counter(band_of(r) for r in (reaches or ()))
+        if not counts:
+            return ""
+        interesting = {b: n for b, n in counts.items() if b != Band.CONTAINED}
+        if not interesting:
+            return ""
+        return " · ".join(
+            f"{n} {band.label}"
+            for band, n in sorted(counts.items(), key=lambda kv: int(kv[0]))
+        )
+    except Exception:  # noqa: BLE001
+        return ""

--- a/tests/battle_test/test_progress_board_relative.py
+++ b/tests/battle_test/test_progress_board_relative.py
@@ -1,0 +1,110 @@
+"""The import graph could not see a package re-export.
+
+`ProgressBoard` calls a flag DARK when nothing in production imports the
+module it lives in. Relative imports were skipped outright — "not resolvable
+without a package walk" — and that was a systematic false negative, not a
+rounding error.
+
+The chain it broke is the one this codebase uses everywhere:
+
+    consumer:            from ...intake.sensors import BacklogSensor
+    sensors/__init__.py: from .backlog_sensor import BacklogSensor
+
+The consumer names a CLASS, and a class name never matches a module name. The
+`__init__.py` re-export is the ONLY edge to the module the flag lives in — and
+it is relative, so it was skipped. Every module reached that way reported DARK
+while being imported on every boot.
+
+546 dark -> 328. 78 dark-and-enabled -> 42.
+"""
+from __future__ import annotations
+
+import ast
+
+from backend.core.ouroboros.battle_test.progress_board import (
+    _imported_modules, _module_name, _resolve_relative,
+)
+
+
+class TestResolveRelative:
+    def test_one_dot_is_the_containing_package(self):
+        assert _resolve_relative("a.b.c", 1, "x") == "a.b.x"
+
+    def test_two_dots_is_the_parent(self):
+        assert _resolve_relative("a.b.c", 2, "x") == "a.x"
+
+    def test_a_bare_from_dot_import(self):
+        assert _resolve_relative("a.b.c", 1, "") == "a.b"
+
+    def test_a_package_init_is_already_named_for_its_package(self):
+        """THE off-by-one. `_module_name` strips `__init__`, so a package's
+        own `__init__.py` is already named for the package: `level=1` means
+        ITSELF, not its parent. Stripping a segment walks one level too far
+        and resolves to a module that does not exist."""
+        pkg = _module_name("backend/core/ouroboros/governance/intake/"
+                           "sensors/__init__.py")
+        assert pkg.endswith("intake.sensors")
+        assert _resolve_relative(pkg, 1, "backlog_sensor", True) == (
+            pkg + ".backlog_sensor")
+
+    def test_a_plain_module_is_unaffected_by_the_package_rule(self):
+        assert _resolve_relative("a.b.c", 1, "x", False) == "a.b.x"
+
+    def test_over_deep_is_refused_not_wrapped(self):
+        assert _resolve_relative("a", 5, "x") == ""
+
+    def test_garbage_never_raises(self):
+        for args in (("", 1, "x"), (None, 1, "x"), ("a.b", "z", "x")):
+            _resolve_relative(*args)  # type: ignore[arg-type]
+
+
+class TestImportedModules:
+    def test_absolute_imports_still_both_shapes(self):
+        tree = ast.parse("import a.b.c\nfrom d.e import f\n")
+        got = _imported_modules(tree, "z")
+        assert "a.b.c" in got and "d.e" in got and "d.e.f" in got
+
+    def test_a_relative_import_is_resolved_not_skipped(self):
+        tree = ast.parse("from .backlog_sensor import BacklogSensor\n")
+        got = _imported_modules(tree, "pkg.sensors", is_package=True)
+        assert "pkg.sensors.backlog_sensor" in got
+
+    def test_the_re_export_edge_carries_the_symbol_too(self):
+        """`from .m import C` reaches module `pkg.m`; recording
+        `pkg.m.C` as well costs nothing and matches the absolute path's
+        existing behaviour."""
+        tree = ast.parse("from .m import C\n")
+        got = _imported_modules(tree, "pkg", is_package=True)
+        assert "pkg.m" in got and "pkg.m.C" in got
+
+    def test_a_module_inside_a_package_resolves_against_its_parent(self):
+        tree = ast.parse("from .sibling import Thing\n")
+        got = _imported_modules(tree, "pkg.mod", is_package=False)
+        assert "pkg.sibling" in got
+
+
+class TestAgainstTheRealTree:
+    def test_the_sensors_are_no_longer_dark(self):
+        """The regression that motivated this. `BacklogSensor` and
+        `OpportunityMinerSensor` are constructed at boot by
+        `intake_layer_service`, and their flags read DARK — a board that
+        reports a booting sensor as dead teaches operators to ignore it."""
+        from backend.core.ouroboros.battle_test.progress_board import (
+            ProgressBoard,
+        )
+        rows = ProgressBoard().read().rows
+        dark_on = {r.flag for r in rows if r.state == "dark" and r.enabled}
+        for flag in ("JARVIS_BACKLOG_FS_EVENTS_ENABLED",
+                     "JARVIS_MINER_BACKPRESSURE_ENABLED",
+                     "JARVIS_BACKLOG_AUTO_PROPOSED_ENABLED"):
+            assert flag not in dark_on, f"{flag} still reads dark"
+
+    def test_the_board_still_finds_genuinely_dark_flags(self):
+        """The fix must not launder every flag to LIVE. If nothing is dark
+        the signal is gone, which is the same as having no board."""
+        from backend.core.ouroboros.battle_test.progress_board import (
+            ProgressBoard,
+        )
+        rows = ProgressBoard().read().rows
+        assert any(r.state == "dark" for r in rows)
+        assert any(r.state == "live" for r in rows)

--- a/tests/battle_test/test_progress_board_relative.py
+++ b/tests/battle_test/test_progress_board_relative.py
@@ -108,3 +108,51 @@ class TestAgainstTheRealTree:
         rows = ProgressBoard().read().rows
         assert any(r.state == "dark" for r in rows)
         assert any(r.state == "live" for r in rows)
+
+
+class TestScanRootsIncludeScripts:
+    """`scripts/` is production.
+
+    `scripts/ouroboros_battle_test.py` is THE entry point that boots the
+    six-layer stack — it is how this system actually runs — and 361 backend
+    modules are reachable from `scripts/` and nowhere else. Scanning only
+    `backend` reported every one of them DARK while they were imported on
+    every session.
+
+    Found via `aegis/preflight.py`: flagged dark-and-enabled, imported at
+    `scripts/ouroboros_battle_test.py:1997`.
+    """
+
+    def test_scripts_is_a_default_root(self):
+        from backend.core.ouroboros.battle_test.progress_board import scan_roots
+
+        assert "scripts" in scan_roots()
+        assert "backend" in scan_roots()
+
+    def test_the_env_override_still_wins(self, monkeypatch):
+        """A knob, not a constant: what counts as production differs between
+        this repo and a consumer of it."""
+        from backend.core.ouroboros.battle_test.progress_board import scan_roots
+
+        monkeypatch.setenv("JARVIS_PROGRESS_BOARD_ROOTS", "lib, pkg")
+        assert scan_roots() == ("lib", "pkg")
+
+    def test_a_module_imported_only_from_scripts_is_not_dark(self):
+        """THE regression. `preflight` is imported by the battle-test entry
+        point and by nothing under `backend/`."""
+        from backend.core.ouroboros.battle_test.progress_board import (
+            ProgressBoard,
+        )
+        rows = ProgressBoard().read().rows
+        dark_on = {r.flag for r in rows if r.state == "dark" and r.enabled}
+        assert "JARVIS_AEGIS_DEP_VALIDATION_ENABLED" not in dark_on
+
+    def test_the_board_still_discriminates(self):
+        """Widening the roots must not launder everything to LIVE. A board
+        with nothing dark has no signal, which is the same as no board."""
+        from backend.core.ouroboros.battle_test.progress_board import (
+            ProgressBoard,
+        )
+        rows = ProgressBoard().read().rows
+        assert any(r.state == "dark" for r in rows)
+        assert any(r.state == "live" for r in rows)

--- a/tests/battle_test/test_progress_board_relative.py
+++ b/tests/battle_test/test_progress_board_relative.py
@@ -156,3 +156,38 @@ class TestScanRootsIncludeScripts:
         rows = ProgressBoard().read().rows
         assert any(r.state == "dark" for r in rows)
         assert any(r.state == "live" for r in rows)
+
+
+class TestBarePrefixImports:
+    """`backend/` is on `sys.path`, so siblings import each other bare.
+
+    597 files write `from core.x import y` rather than
+    `from backend.core.x import y`. The board resolves FILE PATHS to the
+    fully-qualified form, so the two never matched and every module imported
+    that way counted zero importers and reported DARK.
+
+    Found via `transport_handlers`: flagged dark-and-enabled with destructive
+    COMPUTER_USE defaults, and imported three times from `backend/api/` as
+    `from core.transport_handlers import ...`. It was one edit away from
+    being defaulted off as "unreached" while it was live on the unlock path.
+    """
+
+    def test_a_bare_prefix_importer_counts(self):
+        from backend.core.ouroboros.battle_test.progress_board import (
+            ProgressBoard,
+        )
+        rows = ProgressBoard().read().rows
+        dark_on = {r.flag for r in rows if r.state == "dark" and r.enabled}
+        assert "JARVIS_COMPUTER_USE_ENABLED" not in dark_on
+
+    def test_the_board_still_discriminates(self):
+        """Three blindness fixes in one day moved 546 dark to 205. If the
+        fixes ever launder everything to LIVE the signal is gone, which is
+        the same as having no board."""
+        from backend.core.ouroboros.battle_test.progress_board import (
+            ProgressBoard,
+        )
+        rows = ProgressBoard().read().rows
+        assert any(r.state == "dark" for r in rows)
+        assert any(r.state == "live" for r in rows)
+        assert any(r.state == "off" for r in rows)

--- a/tests/governance/test_op_fanout_order.py
+++ b/tests/governance/test_op_fanout_order.py
@@ -1,0 +1,148 @@
+"""The causality tree must draw the parentage it recorded.
+
+The op-DAG view was complete: a contextvar, an acyclic-guarded
+`register_parent`, a 777-line renderer and a verb. Two master flags gate it
+(`JARVIS_OP_DEPENDENCY_GRAPH_ENABLED` records the edges,
+`JARVIS_OP_FANOUT_TREE_ENABLED` renders them), both default false.
+
+Turned on, it drew the wrong tree. `walk_subtree` promises BREADTH-first and
+other callers rely on that; `format_fanout_tree` indents by `depth` IN ROW
+ORDER, which needs DEPTH-first. Fed BFS, a grandchild emitted after its uncle
+renders nested under the uncle.
+
+Not cosmetic. The tree's entire claim is "this op caused that one", and drawn
+from BFS rows it asserts a parentage the graph does not record — a surface
+confidently showing the wrong answer, which is worse than showing none.
+"""
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.usefixtures("_flags")
+
+
+@pytest.fixture
+def _flags(monkeypatch):
+    monkeypatch.setenv("JARVIS_OP_DEPENDENCY_GRAPH_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_OP_FANOUT_TREE_ENABLED", "true")
+    yield
+
+
+@pytest.fixture
+def graph():
+    """A > (B > D), C — the shape that exposes the ordering."""
+    from backend.core.ouroboros.battle_test import op_block_buffer as OB
+
+    OB.reset_default_buffer_for_tests() if hasattr(
+        OB, "reset_default_buffer_for_tests") else None
+    buf = OB.get_default_buffer()
+    buf.start_op("A")
+    with OB.executing("A"):
+        buf.start_op("B")
+        buf.start_op("C")
+        with OB.executing("B"):
+            buf.start_op("D")
+    return buf
+
+
+class TestTheGraphIsRecorded:
+    def test_edges_register_through_the_contextvar(self, graph):
+        """`executing()` sets the parent; `start_op` links it. Nobody has to
+        thread `parent_op_id` through a signature."""
+        from backend.core.ouroboros.governance import op_fanout_tree as F
+
+        by_op = {r.op_id: r for r in F.aggregate_fanout_rows()}
+        assert by_op["B"].parent_op_id == "A"
+        assert by_op["C"].parent_op_id == "A"
+        assert by_op["D"].parent_op_id == "B"
+
+    def test_depths_are_computed_from_the_chain(self, graph):
+        from backend.core.ouroboros.governance import op_fanout_tree as F
+
+        by_op = {r.op_id: r for r in F.aggregate_fanout_rows()}
+        assert (by_op["A"].depth, by_op["B"].depth, by_op["D"].depth) == (0, 1, 2)
+
+
+class TestRowOrder:
+    def test_rows_are_depth_first(self, graph):
+        """THE fix. BFS gives A B C D; rendering that depth-indented puts D
+        under C, which is not D's parent."""
+        from backend.core.ouroboros.governance import op_fanout_tree as F
+
+        assert [r.op_id for r in F.aggregate_fanout_rows()] == ["A", "B", "D", "C"]
+
+    def test_sibling_order_is_preserved(self, graph):
+        """BFS order is SPAWN order, and that is meaningful — the first
+        subagent dispatched should read first."""
+        from backend.core.ouroboros.governance import op_fanout_tree as F
+
+        order = [r.op_id for r in F.aggregate_fanout_rows()]
+        assert order.index("B") < order.index("C")
+
+    def test_the_child_follows_its_own_parent(self, graph):
+        from backend.core.ouroboros.governance import op_fanout_tree as F
+
+        order = [r.op_id for r in F.aggregate_fanout_rows()]
+        assert order[order.index("B") + 1] == "D"
+
+
+class TestRendering:
+    def test_the_grandchild_nests_under_its_parent(self, graph):
+        from backend.core.ouroboros.governance import op_fanout_tree as F
+
+        lines = F.format_fanout_tree(F.aggregate_fanout_rows()).splitlines()
+        assert lines[0].startswith("●") and " A" in lines[0]
+        assert lines[1].lstrip().startswith("├─") and " B" in lines[1]
+        assert " D" in lines[2], f"D did not follow B: {lines}"
+        assert lines[3].lstrip().startswith("└─") and " C" in lines[3]
+
+    def test_the_continuation_glyph_marks_an_open_branch(self, graph):
+        """`│` under B says C is still coming. Without it the grandchild
+        reads as a sibling of the branch it hangs from."""
+        from backend.core.ouroboros.governance import op_fanout_tree as F
+
+        lines = F.format_fanout_tree(F.aggregate_fanout_rows()).splitlines()
+        assert "│" in lines[2], lines
+
+    def test_a_single_op_with_no_fanout_renders_nothing(self):
+        """Documented: fan-out is the load-bearing signal. A lone op is not
+        a tree and does not need a badge saying so."""
+        from backend.core.ouroboros.battle_test import op_block_buffer as OB
+        from backend.core.ouroboros.governance import op_fanout_tree as F
+
+        buf = OB.get_default_buffer()
+        buf.start_op("lonely")
+        rows = tuple(r for r in F.aggregate_fanout_rows()
+                     if r.op_id == "lonely")
+        assert F.format_fanout_tree(rows) == ""
+
+
+class TestDepthFirstHelper:
+    def _blocks(self, pairs):
+        import types
+        return [types.SimpleNamespace(op_id=o, parent_op_id=p)
+                for o, p in pairs]
+
+    def test_an_orphan_is_kept_visible(self):
+        """An edge lost to eviction must not make an op VANISH from the
+        tree. A visible orphan is a far better failure than a silent one."""
+        from backend.core.ouroboros.governance.op_fanout_tree import _depth_first
+
+        blocks = self._blocks([("A", ""), ("B", "A"), ("Z", "GONE")])
+        got = [b.op_id for b in _depth_first(blocks, "A")]
+        assert got[:2] == ["A", "B"] and "Z" in got
+
+    def test_a_cycle_cannot_spin_the_walk(self):
+        """`register_parent` refuses cycles, but this renders on the
+        operator's frame and must not depend on that being airtight."""
+        from backend.core.ouroboros.governance.op_fanout_tree import _depth_first
+
+        blocks = self._blocks([("A", "B"), ("B", "A")])
+        got = [b.op_id for b in _depth_first(blocks, "A")]
+        assert sorted(got) == ["A", "B"]
+
+    def test_empty_and_garbage_are_survivable(self):
+        from backend.core.ouroboros.governance.op_fanout_tree import _depth_first
+
+        assert _depth_first([], "A") == []
+        assert _depth_first(None, "A") == []

--- a/tests/ui/test_blast_bands.py
+++ b/tests/ui/test_blast_bands.py
@@ -1,0 +1,160 @@
+"""Reading a diff riskiest-first.
+
+`blast_gutter` already measured every changed file's reach and drew it. What
+nothing did was use that number to decide reading ORDER — the tree rendered
+in whatever sequence the diff produced, so a one-line change to a leaf could
+sit above a rewrite forty modules import. An operator reviewing under a
+five-second NOTIFY_APPLY countdown reads from the top.
+
+The failure pinned hardest is the one that would be actively dangerous: an
+UNRESOLVED reach reports `count == 0`, and zero-as-a-number means "reaches
+nothing" — the most reassuring answer there is, attached to the file we know
+least about.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.ui import blast_bands as BB
+from backend.core.ouroboros.ui.blast_gutter import Reach
+
+
+def _r(path, count, resolved=True, provenance="measured"):
+    return Reach(path=path, count=count, provenance=provenance,
+                 resolved=resolved)
+
+
+class TestBanding:
+    def test_a_hub_is_wide(self):
+        assert BB.band_of(_r("hub.py", 42)) is BB.Band.WIDE
+
+    def test_a_handful_is_moderate(self):
+        assert BB.band_of(_r("mid.py", 5)) is BB.Band.MODERATE
+
+    def test_a_leaf_is_contained(self):
+        assert BB.band_of(_r("leaf.py", 0)) is BB.Band.CONTAINED
+
+    def test_an_unresolved_reach_is_UNKNOWN_not_contained(self):
+        """THE dangerous case. `peek` is read-only and returns count 0 for a
+        file the advisor has not measured. Reading that as "reaches nothing"
+        marks the least-known file as the safest."""
+        assert BB.band_of(_r("mystery.py", 0, resolved=False)) is BB.Band.UNKNOWN
+
+    def test_resolved_is_consulted_before_count(self):
+        """Even a nonzero count means nothing if the reach is unresolved."""
+        assert BB.band_of(_r("x.py", 99, resolved=False)) is BB.Band.UNKNOWN
+
+    def test_none_and_garbage_are_unknown(self):
+        for bad in (None, object(), "nope"):
+            assert BB.band_of(bad) is BB.Band.UNKNOWN
+
+
+class TestOrder:
+    ROWS = [
+        _r("leaf.py", 0),
+        _r("hub.py", 42),
+        _r("mid.py", 5),
+        _r("mystery.py", 0, resolved=False),
+        _r("also_mid.py", 5),
+    ]
+
+    def test_unknown_sorts_first(self):
+        """Not last. A file whose blast radius could not be established is
+        not safe, it is unmeasured — the same rule the advisor's repair
+        settled when it made `?` never render as `0`."""
+        assert BB.review_order(self.ROWS)[0].path == "mystery.py"
+
+    def test_then_widest_first(self):
+        order = [r.path for r in BB.review_order(self.ROWS)]
+        assert order[:2] == ["mystery.py", "hub.py"]
+        assert order[-1] == "leaf.py"
+
+    def test_ties_break_on_path_so_the_order_is_stable(self):
+        """A tree that reshuffles equal-risk files between frames is one an
+        operator cannot keep their place in."""
+        order = [r.path for r in BB.review_order(self.ROWS)]
+        assert order.index("also_mid.py") < order.index("mid.py")
+        assert BB.review_order(self.ROWS) == BB.review_order(self.ROWS)
+
+    def test_order_paths_treats_an_unknown_path_as_unresolved(self):
+        """A path with no matching reach sorts first for the same reason an
+        unmeasured file does — that is exactly what it is."""
+        paths = ["leaf.py", "ghost.py", "hub.py"]
+        got = BB.order_paths(paths, [_r("leaf.py", 0), _r("hub.py", 42)])
+        assert got[0] == "ghost.py"
+
+    def test_the_kill_switch_restores_diff_order(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_BLAST_BANDS_ENABLED", "0")
+        assert BB.review_order(self.ROWS) == self.ROWS
+        paths = ["b.py", "a.py"]
+        assert BB.order_paths(paths, []) == paths
+
+    def test_empty_input_is_survivable(self):
+        assert BB.review_order([]) == []
+        assert BB.order_paths([], []) == []
+
+
+class TestThresholds:
+    def test_they_are_env_tunable(self, monkeypatch):
+        """"Wide" is a property of the REPOSITORY: eleven dependents is
+        unremarkable in a hub package and alarming in a leaf."""
+        monkeypatch.setenv("JARVIS_BLAST_WIDE_AT", "4")
+        monkeypatch.setenv("JARVIS_BLAST_MODERATE_AT", "2")
+        assert BB.thresholds() == (4, 2)
+        assert BB.band_of(_r("x", 4)) is BB.Band.WIDE
+
+    def test_inverted_thresholds_are_repaired_not_obeyed(self, monkeypatch):
+        """Swapped values would make every file wide and none moderate,
+        silently."""
+        monkeypatch.setenv("JARVIS_BLAST_WIDE_AT", "3")
+        monkeypatch.setenv("JARVIS_BLAST_MODERATE_AT", "9")
+        wide, moderate = BB.thresholds()
+        assert wide >= moderate
+
+    def test_garbage_falls_back(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_BLAST_WIDE_AT", "not-a-number")
+        assert BB.thresholds()[0] > 0
+
+
+class TestSummary:
+    def test_it_names_the_risky_bands_first(self):
+        rows = [_r("a", 42), _r("b", 0, resolved=False), _r("c", 0)]
+        assert BB.summarise_bands(rows) == "1 unknown · 1 wide · 1 contained"
+
+    def test_an_all_contained_diff_says_nothing(self):
+        """The absence of the warning IS the signal — the restraint the rest
+        of this cockpit already keeps."""
+        assert BB.summarise_bands([_r("a", 0), _r("b", 1)]) == ""
+
+    def test_empty_is_empty(self):
+        assert BB.summarise_bands([]) == ""
+
+
+class TestWiredIntoTheTree:
+    def test_the_preview_orders_by_reach(self):
+        import ast
+        import inspect
+        import textwrap
+
+        from backend.core.ouroboros.battle_test import diff_preview
+
+        src = textwrap.dedent(inspect.getsource(
+            diff_preview.DiffPreviewRenderer._build_file_tree))
+        tree = ast.parse(src)
+        assert any(
+            isinstance(n, ast.Attribute) and n.attr == "order_paths"
+            for n in ast.walk(tree)
+        ), "the file tree still renders in diff order"
+
+    def test_it_does_not_promise_partial_apply(self):
+        """Apply is per-OPERATION. Splitting it by band would need
+        orchestrator support, rollback for a half-applied candidate, and a
+        VERIFY that knows which half ran. Offering the UI for it would be an
+        affordance the engine cannot honour."""
+        import inspect
+
+        src = inspect.getsource(BB)
+        assert "does NOT" in src and "partial apply" in src
+        for forbidden in ("def accept_band", "def reject_band",
+                          "def apply_band"):
+            assert forbidden not in src

--- a/tests/unit/core/test_infra_orchestrator_defaults.py
+++ b/tests/unit/core/test_infra_orchestrator_defaults.py
@@ -1,0 +1,85 @@
+"""The superseded infrastructure orchestrator must not arm itself.
+
+`infrastructure_orchestrator.py` provisions and tears down GCP resources —
+`terraform destroy -target=<what we created>` on shutdown, with
+`--auto-approve`. All three of its master flags defaulted to **true**.
+
+That was harmless for one reason only: nothing imports the module. It has had
+zero production importers since 2025-12-24, and `gcp_vm_manager` (34
+production files) plus `failover_lifecycle` (12) own GCP lifecycle now. The
+moment anyone wired this module back up — which is exactly what "bring the
+dark flags to the light" would mean — shutdown would run a destroy with
+auto-approve, on by default, with no operator ever having asked for it.
+
+A dormant module with destructive defaults is a loaded gun with the safety
+off, sitting in a drawer. Deleting it is a separate decision that needs
+feature-parity review against `gcp_vm_manager`; taking the safety off the
+table costs nothing today and is worth doing first.
+"""
+from __future__ import annotations
+
+import ast
+import inspect
+import pathlib
+
+import pytest
+
+_SRC = pathlib.Path("backend/core/infrastructure_orchestrator.py")
+
+DESTRUCTIVE = (
+    "JARVIS_INFRA_AUTO_DESTROY",
+    "JARVIS_TERRAFORM_AUTO_APPROVE",
+    "JARVIS_INFRA_ON_DEMAND",
+)
+
+
+def _default_for(flag: str) -> str:
+    """The literal default in the module's own env read."""
+    tree = ast.parse(_SRC.read_text())
+    for node in ast.walk(tree):
+        if (isinstance(node, ast.Call)
+                and getattr(node.func, "attr", "") == "getenv"
+                and node.args
+                and isinstance(node.args[0], ast.Constant)
+                and node.args[0].value == flag):
+            return str(node.args[1].value) if len(node.args) > 1 else ""
+    raise AssertionError(f"{flag} not read in {_SRC}")
+
+
+@pytest.mark.parametrize("flag", DESTRUCTIVE)
+def test_the_default_is_off(flag):
+    """Not 'true'. An ON default on an unimported module is a hazard that
+    arms itself the day someone adopts it."""
+    assert _default_for(flag).lower() in ("false", "0", "no", "off"), flag
+
+
+def test_the_config_object_agrees_with_the_literal(monkeypatch):
+    """The literal and the resolved value must not drift — a source-grep pin
+    alone would pass while a factory overrode it."""
+    import dataclasses
+
+    for flag in DESTRUCTIVE:
+        monkeypatch.delenv(flag, raising=False)
+    import backend.core.infrastructure_orchestrator as M
+
+    cfgs = [c for c in vars(M).values()
+            if dataclasses.is_dataclass(c) and isinstance(c, type)
+            and "auto_destroy_on_shutdown" in {f.name for f in dataclasses.fields(c)}]
+    assert cfgs, "config dataclass not found"
+    cfg = cfgs[0]()
+    assert cfg.auto_destroy_on_shutdown is False
+
+
+def test_an_operator_can_still_turn_it_on():
+    """Default-off, not removed. The capability is intact for anyone who
+    deliberately wants it — this only stops it arming itself."""
+    src = _SRC.read_text()
+    for flag in DESTRUCTIVE:
+        assert flag in src
+
+
+def test_the_reason_is_recorded_where_the_next_reader_will_look():
+    """A bare `false` invites someone to 'fix' it back to true."""
+    src = _SRC.read_text()
+    assert "superseded" in src.lower()
+    assert "gcp_vm_manager" in src


### PR DESCRIPTION
Two capabilities that are not parity work — Claude Code cannot do either,
because neither has a substrate in a tool that does not mark its own claims
or measure its own blast radius.

## `c` / `C` — walk the transcript by epistemic provenance

CC's viewer jumps between search matches and prompts. It cannot jump between
CLAIMS. O+V marks every line at the `_op_line` chokepoint via `ui/provenance`
and had never navigated by it.

A clean line is reported as **None**, not OBSERVED: marks are the exception
surface, so observed and derived are indistinguishable from rendered text, and
UNKNOWN already means something else — asked and unanswerable.

Three defects, all found by running it rather than reading it: it classified
only the rendered window (so every claim found was already on screen); each
press re-derived its start from the newest visible line (so `C` stuck); and
`mux.emit("line", …)` was the typed-event path at four sites, rendering every
notice as `· line`.

## Blast-ordered diff review

`blast_gutter` already measured and drew every file's reach. Nothing used it
to decide reading ORDER, so a one-line leaf change could sit above a rewrite
forty modules import — read from the top under a five-second countdown.

Unresolved reaches sort **first**. `peek` is read-only and reports `count == 0`
for a file the advisor has not measured; reading that as "reaches nothing"
marks the least-known file as the safest. Same rule the advisor's locality
repair settled: `?` never rendered as `0`.

Deliberately **not** per-band accept/reject. Apply is per-operation, and
splitting it by file is a governance change — orchestrator support, rollback
for a half-applied candidate, a VERIFY that knows which half ran. A test pins
that no `accept_band` ever appears.

## Verification

44 new tests. Not live-proven: exercised by tests and direct handler calls
against real Applications, never watched in a terminal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sorts the diff preview by blast radius so reviewers read the highest‑risk files first. Also fixes op fanout parentage, makes `ProgressBoard` see package re‑exports, `scripts/`, and bare‑prefix imports, and turns off destructive defaults in the superseded infra orchestrator.

- **New Features**
  - Added `backend/core/ouroboros/ui/blast_bands.py` for banding and ordering (unknown → wide → moderate → contained), with stable tie‑breaks by path.
  - Wired into `DiffPreviewRenderer._build_file_tree` via `order_paths` so the file tree renders in risk order.
  - Unresolved reaches sort first by consulting `resolved` before `count`.
  - Env toggles: `JARVIS_BLAST_BANDS_ENABLED` (default on); thresholds via `JARVIS_BLAST_WIDE_AT` and `JARVIS_BLAST_MODERATE_AT` (inverted values auto‑repaired).
  - No per‑band accept/reject; apply remains per operation. Tests cover banding, ordering, thresholds, and integration.

- **Bug Fixes**
  - Causality tree: convert BFS to depth‑first in `aggregate_fanout_rows` (via `_depth_first`) so children render under their real parent; preserves sibling order, appends orphans, cycle‑safe.
  - `ProgressBoard` import graph: resolve relative imports and package re‑exports (`_resolve_relative`; `_imported_modules(self_mod, is_package)`), count bare‑prefix imports when `backend/` is on `sys.path` (treat `core.x` and `backend.core.x` as the same), and scan `scripts` by default in `scan_roots()` while keeping the env override. Tests verify sensors, `scripts/` modules, and bare‑prefix imports no longer read dark.
  - Superseded infra orchestrator: default OFF for `JARVIS_INFRA_ON_DEMAND`, `JARVIS_INFRA_AUTO_DESTROY`, and `JARVIS_TERRAFORM_AUTO_APPROVE` to avoid accidental `terraform destroy` when adopted; production unaffected as the module is not imported.

<sup>Written for commit 80caca2a3dd988563d594755aa242df674dbc593. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

