### PR TITLE
test(ov): a machine presses the keys, and the demo's deck exists

### DIFF
--- a/backend/core/infrastructure_orchestrator.py
+++ b/backend/core/infrastructure_orchestrator.py
@@ -107,10 +107,15 @@ class InfrastructureConfig:
 
     # Feature toggles
     on_demand_enabled: bool = field(
-        default_factory=lambda: os.getenv("JARVIS_INFRA_ON_DEMAND", "true").lower() == "true"
+        default_factory=lambda: os.getenv("JARVIS_INFRA_ON_DEMAND", "false").lower() == "true"
     )
+    # DEFAULT-OFF: superseded. `gcp_vm_manager` (34 production files)
+    # and `failover_lifecycle` (12) own GCP lifecycle now; nothing has
+    # imported THIS module since 2025-12-24. An ON default was harmless
+    # only because nobody wired it — the moment anyone did, shutdown
+    # would run `terraform destroy` with `--auto-approve`, by default.
     auto_destroy_on_shutdown: bool = field(
-        default_factory=lambda: os.getenv("JARVIS_INFRA_AUTO_DESTROY", "true").lower() == "true"
+        default_factory=lambda: os.getenv("JARVIS_INFRA_AUTO_DESTROY", "false").lower() == "true"
     )
 
     # Terraform settings
@@ -124,7 +129,7 @@ class InfrastructureConfig:
         default_factory=lambda: int(os.getenv("JARVIS_TERRAFORM_TIMEOUT", "300"))
     )
     terraform_auto_approve: bool = field(
-        default_factory=lambda: os.getenv("JARVIS_TERRAFORM_AUTO_APPROVE", "true").lower() == "true"
+        default_factory=lambda: os.getenv("JARVIS_TERRAFORM_AUTO_APPROVE", "false").lower() == "true"
     )
 
     # Resource thresholds for intelligent provisioning

--- a/backend/core/ouroboros/battle_test/diff_preview.py
+++ b/backend/core/ouroboros/battle_test/diff_preview.py
@@ -286,6 +286,24 @@ class DiffPreviewRenderer:
                     row.reach.path: row for row in _bg.annotate_set(reaches)
                 }
                 gutter_summary = _bg.summary(reaches)
+                # RIGHT ORDER, not just the right numbers. The reach was
+                # already measured and drawn; the tree still rendered in
+                # whatever sequence the diff produced, so a one-line change to
+                # a leaf could sit above a rewrite forty modules import. An
+                # operator reviewing under a five-second countdown reads from
+                # the top.
+                #
+                # Unresolved files sort FIRST. A reach that could not be
+                # established is not a safe file, it is an unmeasured one —
+                # the same rule the advisor's own repair settled when it made
+                # `?` never render as `0`.
+                from backend.core.ouroboros.ui import blast_bands as _bb
+                order = {
+                    path: i for i, path in enumerate(
+                        _bb.order_paths([c.path for c in changes], reaches))
+                }
+                changes = sorted(
+                    changes, key=lambda c: order.get(c.path, len(order)))
         except Exception:  # noqa: BLE001 — a lost column, never a lost diff
             gutter_rows = {}
         for c in changes:

--- a/backend/core/ouroboros/battle_test/progress_board.py
+++ b/backend/core/ouroboros/battle_test/progress_board.py
@@ -100,7 +100,17 @@ def scan_roots() -> Tuple[str, ...]:
     raw = os.environ.get("JARVIS_PROGRESS_BOARD_ROOTS", "").strip()
     if raw:
         return tuple(p.strip() for p in raw.split(",") if p.strip())
-    return ("backend",)
+    # `scripts` is production. `scripts/ouroboros_battle_test.py` is THE entry
+    # point that boots the six-layer stack — it is how this system actually
+    # runs — and 361 backend modules are reachable from `scripts/` and from
+    # nowhere else. Scanning only `backend` reported every one of them DARK
+    # while they were imported on every session.
+    #
+    # Found via `aegis/preflight.py`: flagged dark-and-enabled, imported at
+    # `scripts/ouroboros_battle_test.py:1997`. Same shape as the relative-
+    # import blindness — the board was right about its own graph and the
+    # graph was missing an edge.
+    return ("backend", "scripts")
 
 
 #: Directories that are not this codebase. A venv vendored under the scan root

--- a/backend/core/ouroboros/battle_test/progress_board.py
+++ b/backend/core/ouroboros/battle_test/progress_board.py
@@ -320,7 +320,8 @@ class ProgressBoard:
                 is_test = _is_test_path(rel)
                 if not is_test:
                     self_mod = _module_name(rel)
-                    for name in _imported_modules(tree):
+                    for name in _imported_modules(
+                            tree, self_mod, rel.endswith("__init__.py")):
                         # A module importing ITSELF is not a caller. Without
                         # this every module would look live, which is the same
                         # as having no signal at all.
@@ -541,15 +542,62 @@ def _normalise_source(source: str) -> str:
     return src + ".py"
 
 
-def _imported_modules(tree: ast.AST) -> Set[str]:
-    """Every module this file imports, in both syntaxes."""
+def _resolve_relative(self_mod: str, level: int, module: str,
+                      is_package: bool = False) -> str:
+    """``from ..x import y`` inside ``a.b.c`` -> ``a.x``. NEVER raises.
+
+    `level` counts dots: 1 is the current package, 2 its parent. The
+    importing module's OWN dotted name carries the package, so this needs no
+    filesystem walk — which is what the previous `continue` assumed it did.
+
+    ``is_package`` is load-bearing and easy to miss. `_module_name` strips
+    `__init__`, so a package's own `__init__.py` is already NAMED for the
+    package — `level=1` there means itself, not its parent, and stripping a
+    segment walks one level too far. That single off-by-one is what kept the
+    sensors dark after relative imports were resolved: `sensors/__init__.py`
+    re-exporting `.backlog_sensor` resolved to `intake.backlog_sensor`, a
+    module that does not exist.
+    """
+    try:
+        parts = str(self_mod or "").split(".")
+        strip = max(0, int(level) - 1) if is_package else int(level)
+        keep = len(parts) - strip
+        if keep < 0:
+            return ""
+        base = ".".join(parts[:keep])
+        if not base:
+            return str(module or "")
+        return f"{base}.{module}" if module else base
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def _imported_modules(tree: ast.AST, self_mod: str = "",
+                      is_package: bool = False) -> Set[str]:
+    """Every module this file imports, in both syntaxes.
+
+    RELATIVE imports are resolved rather than skipped, and that omission was
+    a systematic false-DARK rather than a rounding error. A package that
+    re-exports — `sensors/__init__.py` doing `from .backlog_sensor import
+    BacklogSensor` — is the ONLY edge between a consumer and the module the
+    flag lives in: the consumer writes `from ...sensors import BacklogSensor`,
+    which names a CLASS, and a class name never matches a module name. With
+    the re-export skipped there was no path at all, so every module reached
+    that way reported DARK while being imported on every boot.
+    """
     found: Set[str] = set()
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             for alias in node.names:
                 found.add(alias.name)
         elif isinstance(node, ast.ImportFrom):
-            if node.level:  # relative import — not resolvable without a package walk
+            if node.level:
+                resolved = _resolve_relative(
+                    self_mod, node.level, node.module or "", is_package)
+                if resolved:
+                    found.add(resolved)
+                    for alias in node.names:
+                        found.add(f"{resolved}.{alias.name}")
                 continue
             module = node.module or ""
             if module:

--- a/backend/core/ouroboros/battle_test/progress_board.py
+++ b/backend/core/ouroboros/battle_test/progress_board.py
@@ -461,7 +461,24 @@ class ProgressBoard:
                               value=value)
 
         module = _module_name(module_rel)
+        # BOTH spellings of the same module.
+        #
+        # `backend/` is on `sys.path` at runtime, so 597 files import their
+        # siblings as `from core.x import y` rather than
+        # `from backend.core.x import y`. This resolves FILE PATHS to the
+        # fully-qualified form, so the two never matched and every module
+        # imported that way counted zero importers and reported DARK.
+        #
+        # Found via `transport_handlers`: flagged dark-and-enabled with
+        # destructive COMPUTER_USE defaults, and imported three times from
+        # `backend/api/` as `from core.transport_handlers import ...`. It was
+        # one edit away from being defaulted off as "unreached" while live.
         importers = int(self._importers.get(module, 0))
+        for root in scan_roots():
+            prefix = f"{root}."
+            if module.startswith(prefix):
+                importers += int(
+                    self._importers.get(module[len(prefix):], 0))
 
         if enabled is False:
             return FeatureRow(flag, OFF, module_rel, category, enabled,

--- a/backend/core/ouroboros/cli/ov_demo.py
+++ b/backend/core/ouroboros/cli/ov_demo.py
@@ -1917,6 +1917,44 @@ def _live_exit_bindings() -> Any:
     except Exception:  # noqa: BLE001
         pass
 
+    # The transcript HATCHES — `Ctrl+L`'s clear chord, `[` dump, `v` editor,
+    # `{`/`}` block jumps, `Ctrl+X Ctrl+N`, and the `/` search this scene
+    # already mounts a ROW for.
+    #
+    # Their absence was the exact defect `_demo_search_rows` was written to
+    # prevent, one layer down: the search BAR was mounted and the search KEY
+    # was not, so the strip could never appear. A PTY pressing `Ctrl+L` found
+    # it — the binding fell through to prompt_toolkit's own clear-screen, so
+    # the demo showed a repaint with no arming hint and taught a gesture the
+    # cockpit does not have.
+    #
+    # `LocalCockpitClient` is reused rather than re-shimmed: the installer
+    # wants exactly `send_input`, `flash` and a mutable `_narrate_verbose`,
+    # and `cockpit_mount` already argued why that is one implementation with
+    # a second ENTRANCE rather than two implementations.
+    try:
+        from backend.core.ouroboros.battle_test.cockpit_mount import (
+            LocalCockpitClient,
+        )
+        from backend.core.ouroboros.battle_test.transcript_hatches import (
+            install_transcript_hatches,
+        )
+
+        # Verbs are SHOWN, not swallowed — the same choice `_DemoOrganism`
+        # below makes and for the same reason: an inert `send_input` makes a
+        # working key indistinguishable from a broken one.
+        shim = LocalCockpitClient(
+            send_input=lambda line: _demo_notice(
+                f"  ⏺ {line} — (demo: no organism to run it)"),
+            flash=lambda msg, *_a, **_k: _demo_notice(f"  {msg}"),
+        )
+        # One shim serves as both `ui` and `client`; the installer only ever
+        # reaches for the three members above, and splitting it would invent
+        # a distinction the callee does not make.
+        install_transcript_hatches(kb, shim, shim)
+    except Exception:  # noqa: BLE001
+        logger.debug("[OvDemo] transcript hatches unavailable", exc_info=True)
+
     try:
         from backend.core.ouroboros.battle_test.agent_roster import (
             get_agent_roster,
@@ -2016,7 +2054,7 @@ def scene_live(console: Any, argv: Sequence[str] = ()) -> int:
 
     try:
         from backend.core.ouroboros.battle_test.bipartite_layout import (
-            BipartiteLayout, build_bipartite_application,
+            BipartiteLayout, build_bipartite_application, set_active_canvas,
         )
     except Exception as exc:  # noqa: BLE001
         _say(console, f"  cockpit unavailable: {exc}")
@@ -2127,9 +2165,28 @@ def scene_live(console: Any, argv: Sequence[str] = ()) -> int:
         start[0] = clock()
         driver = asyncio.ensure_future(
             _drive(mux, app, speed, lambda: start[0], clock, script))
+        # REGISTER the deck as the live sink, exactly as `run_bipartite_repl`
+        # does around its own `app.run_async()`.
+        #
+        # This scene builds its Application directly — deliberately, because
+        # it drives a script rather than a socket — and inherited none of that
+        # function's lifecycle. `set_active_canvas` is how sixteen call sites
+        # across `transcript_mode`, `transcript_hatches`, `serpent_flow` and
+        # `ov` find the deck to write into, and here it was never called: they
+        # all reached for `get_active_canvas()`, got None, and silently wrote
+        # nowhere. The Ctrl+O viewer this scene DOES install was among them.
+        #
+        # A pty pressing Ctrl+L is what surfaced it. The chord was bound, the
+        # latch armed, the hint was composed — and then handed to a canvas
+        # registry nobody had filled. Registration belongs to whoever owns the
+        # RUN, not to `build_bipartite_application`: a canvas registered at
+        # build time would outlive an app that is never run, and two built
+        # apps would overwrite each other's sink.
+        set_active_canvas(mux)
         try:
             await app.run_async()
         finally:
+            set_active_canvas(None)
             # The driver holds a reference to the Application; leaving it
             # running after the app exits keeps invalidating a dead surface
             # and the process never returns.

--- a/backend/core/ouroboros/governance/op_fanout_tree.py
+++ b/backend/core/ouroboros/governance/op_fanout_tree.py
@@ -312,7 +312,18 @@ def aggregate_fanout_rows(
                 continue
             parent = getattr(block, "parent_op_id", "")
             depths[block.op_id] = depths.get(parent, 0) + 1
-        for block in subtree:
+        # DEPTH-FIRST for RENDERING, from a breadth-first walk.
+        #
+        # `walk_subtree` promises BFS and other callers rely on that, so the
+        # conversion belongs here rather than there. It matters because
+        # `format_fanout_tree` indents by `depth` IN ROW ORDER: fed BFS, a
+        # grandchild emitted after its uncle renders nested under the uncle.
+        #
+        # That is not a cosmetic defect. The tree's whole claim is "this op
+        # caused that one", and drawn from BFS rows it asserts a parentage
+        # the graph does not record — a surface confidently showing the wrong
+        # answer, which is worse than showing none.
+        for block in _depth_first(subtree, root.op_id):
             if len(rows) >= line_clamp:
                 break
             row = _block_to_row(
@@ -320,6 +331,51 @@ def aggregate_fanout_rows(
             )
             rows.append(row)
     return tuple(rows)
+
+
+def _depth_first(subtree: Any, root_op_id: str) -> List[Any]:
+    """Reorder a BFS subtree depth-first, parent immediately before its
+    children. Pure. NEVER raises.
+
+    Sibling order is PRESERVED from the input, because the BFS order is
+    spawn order and that is meaningful — the first subagent dispatched
+    should read first.
+
+    Any block unreachable from the root is appended at the end rather than
+    dropped: an edge lost to eviction must not make an op vanish from the
+    tree, and a visible orphan is a far better failure than a silent one.
+    """
+    try:
+        blocks = list(subtree or ())
+        if not blocks:
+            return []
+        children: Dict[str, List[Any]] = {}
+        for block in blocks:
+            parent = str(getattr(block, "parent_op_id", "") or "")
+            if parent:
+                children.setdefault(parent, []).append(block)
+        ordered: List[Any] = []
+        seen: set = set()
+
+        def _walk(block: Any) -> None:
+            op_id = str(getattr(block, "op_id", "") or "")
+            if not op_id or op_id in seen:
+                return          # visited-guard: a cycle cannot spin this
+            seen.add(op_id)
+            ordered.append(block)
+            for child in children.get(op_id, ()):
+                _walk(child)
+
+        for block in blocks:
+            if str(getattr(block, "op_id", "") or "") == str(root_op_id):
+                _walk(block)
+                break
+        for block in blocks:               # orphans, visibly, at the end
+            if str(getattr(block, "op_id", "") or "") not in seen:
+                _walk(block)
+        return ordered
+    except Exception:  # noqa: BLE001
+        return list(subtree or ())
 
 
 def _block_to_row(

--- a/backend/core/ouroboros/ui/blast_bands.py
+++ b/backend/core/ouroboros/ui/blast_bands.py
@@ -1,0 +1,210 @@
+"""Reading a diff riskiest-first.
+
+`blast_gutter` already measures every changed file's reach and draws it — the
+bar, the scale, the per-set summary are all there. What nothing did was USE
+that number to decide reading ORDER: the file tree rendered in whatever
+sequence the diff produced, so a one-line change to a leaf could sit above a
+rewrite that forty modules import.
+
+An operator reviewing under a five-second NOTIFY_APPLY countdown reads from
+the top. Putting the widest-reaching change there is the whole feature.
+
+UNRESOLVED sorts FIRST, not last
+---------------------------------
+`peek` is read-only by construction — it returns what the advisor has already
+computed and never scans, because a cold blast scan is a 39–43 second burn
+and paying it at a gate would freeze the preview the operator is waiting on.
+So some files genuinely have no reach yet.
+
+Those sort to the TOP. A file whose blast radius could not be established is
+not a safe file; it is an unmeasured one, and the two must never be rendered
+as the same thing. This is the same rule the advisor's own repair settled —
+`?` never `0`, unknown never presented as measured — and the same rule the
+provenance vocabulary states when it calls UNKNOWN the loudest mark there is.
+
+Sorting them last, or treating a missing count as zero, would put exactly the
+files nobody can vouch for at the bottom of a list read under time pressure.
+
+What this does NOT do
+---------------------
+It does not let an operator accept one band and reject another. Apply is
+per-OPERATION — `/accept <op-id>` — and splitting it by file would be a
+partial apply: a governance change needing orchestrator support, rollback
+semantics for a half-applied candidate, and a VERIFY that knows which half
+ran. That is not a presentation slice, and building the UI for it here would
+be an affordance the engine cannot honour.
+
+Ordering and naming the bands is the honest half, and it is the half that
+actually helps someone reading under a countdown.
+"""
+from __future__ import annotations
+
+import enum
+import logging
+import os
+from typing import Any, List, Optional, Sequence, Tuple
+
+logger = logging.getLogger("Ouroboros.BlastBands")
+
+BLAST_BANDS_SCHEMA_VERSION: str = "blast_bands.1"
+
+__all__ = [
+    "BLAST_BANDS_SCHEMA_VERSION",
+    "Band",
+    "band_of",
+    "bands_enabled",
+    "review_order",
+    "sort_key",
+    "summarise_bands",
+    "thresholds",
+]
+
+
+class Band(enum.IntEnum):
+    """Review priority. Lower sorts FIRST — read this one first.
+
+    ``IntEnum`` so the ordering IS the enum rather than a separate table that
+    can disagree with it.
+    """
+
+    #: No reach could be established. Not safe — unmeasured.
+    UNKNOWN = 0
+    #: Reaches far beyond itself.
+    WIDE = 1
+    #: A handful of dependents.
+    MODERATE = 2
+    #: Reaches nothing but itself.
+    CONTAINED = 3
+
+    @property
+    def label(self) -> str:
+        return self.name.lower()
+
+
+def bands_enabled() -> bool:
+    """``JARVIS_BLAST_BANDS_ENABLED`` (default true). NEVER raises.
+
+    Off, the tree renders in the order the diff produced — the status quo, so
+    the rollback is exact.
+    """
+    return os.environ.get(
+        "JARVIS_BLAST_BANDS_ENABLED", "1",
+    ).strip().lower() not in ("0", "false", "no", "off")
+
+
+def thresholds() -> Tuple[int, int]:
+    """``(wide_at, moderate_at)`` dependent counts. NEVER raises.
+
+    Env-tunable because "wide" is a property of the REPOSITORY, not of this
+    module: eleven dependents is unremarkable in a hub package and alarming
+    in a leaf. Clamped and ordered so a mis-set pair cannot invert the bands.
+    """
+    def _read(name: str, fallback: int) -> int:
+        try:
+            return max(1, min(10_000, int(
+                os.environ.get(name, "") or fallback)))
+        except (TypeError, ValueError):
+            return fallback
+
+    wide = _read("JARVIS_BLAST_WIDE_AT", 10)
+    moderate = _read("JARVIS_BLAST_MODERATE_AT", 3)
+    # WIDE must be the larger boundary; swapped values would make every file
+    # wide and none moderate, silently.
+    if moderate > wide:
+        moderate, wide = wide, moderate
+    return wide, moderate
+
+
+def band_of(reach: Any) -> Band:
+    """Which band a reach falls in. Pure. NEVER raises.
+
+    ``resolved`` is consulted BEFORE ``count``, because an unresolved reach
+    reports ``count == 0`` and zero-as-a-number means "reaches nothing" —
+    the most reassuring answer there is, attached to the file we know least
+    about.
+    """
+    try:
+        if reach is None:
+            return Band.UNKNOWN
+        if not bool(getattr(reach, "resolved", False)):
+            return Band.UNKNOWN
+        count = int(getattr(reach, "count", 0) or 0)
+        wide, moderate = thresholds()
+        if count >= wide:
+            return Band.WIDE
+        if count >= moderate:
+            return Band.MODERATE
+        return Band.CONTAINED
+    except Exception:  # noqa: BLE001
+        return Band.UNKNOWN
+
+
+def sort_key(reach: Any) -> Tuple[int, int, str]:
+    """``(band, -count, path)`` — the review order, as a key. Pure.
+
+    Path breaks ties so the order is STABLE across renders. A tree that
+    reshuffles equal-risk files between frames is one an operator cannot
+    keep their place in.
+    """
+    try:
+        band = int(band_of(reach))
+        count = int(getattr(reach, "count", 0) or 0)
+        path = str(getattr(reach, "path", "") or "")
+        return (band, -count, path)
+    except Exception:  # noqa: BLE001
+        return (int(Band.UNKNOWN), 0, "")
+
+
+def review_order(reaches: Sequence[Any]) -> List[Any]:
+    """Reaches, riskiest first. Pure. NEVER raises."""
+    try:
+        if not bands_enabled():
+            return list(reaches or ())
+        return sorted(list(reaches or ()), key=sort_key)
+    except Exception:  # noqa: BLE001
+        return list(reaches or ())
+
+
+def order_paths(paths: Sequence[str], reaches: Sequence[Any]) -> List[str]:
+    """Order arbitrary paths by the reach known for each. NEVER raises.
+
+    Takes the paths rather than returning reaches, because the caller has
+    `FileChange` objects and only needs to know the SEQUENCE. A path with no
+    matching reach is treated as unresolved — which sorts it first, the same
+    way an unmeasured file does, because that is exactly what it is.
+    """
+    try:
+        if not bands_enabled():
+            return list(paths or ())
+        by_path = {str(getattr(r, "path", "")): r for r in (reaches or ())}
+        return sorted(
+            list(paths or ()),
+            key=lambda p: sort_key(by_path.get(str(p))),
+        )
+    except Exception:  # noqa: BLE001
+        return list(paths or ())
+
+
+def summarise_bands(reaches: Sequence[Any]) -> str:
+    """``1 unknown · 2 wide · 4 contained`` — riskiest first. NEVER raises.
+
+    Empty when there is nothing to say. A diff whose every file is contained
+    does not need a badge announcing that it is fine; the absence of the
+    warning IS the signal, which is the restraint the rest of this cockpit
+    already keeps.
+    """
+    try:
+        from collections import Counter
+
+        counts: Any = Counter(band_of(r) for r in (reaches or ()))
+        if not counts:
+            return ""
+        interesting = {b: n for b, n in counts.items() if b != Band.CONTAINED}
+        if not interesting:
+            return ""
+        return " · ".join(
+            f"{n} {band.label}"
+            for band, n in sorted(counts.items(), key=lambda kv: int(kv[0]))
+        )
+    except Exception:  # noqa: BLE001
+        return ""

--- a/tests/battle_test/test_progress_board_relative.py
+++ b/tests/battle_test/test_progress_board_relative.py
@@ -1,0 +1,110 @@
+"""The import graph could not see a package re-export.
+
+`ProgressBoard` calls a flag DARK when nothing in production imports the
+module it lives in. Relative imports were skipped outright — "not resolvable
+without a package walk" — and that was a systematic false negative, not a
+rounding error.
+
+The chain it broke is the one this codebase uses everywhere:
+
+    consumer:            from ...intake.sensors import BacklogSensor
+    sensors/__init__.py: from .backlog_sensor import BacklogSensor
+
+The consumer names a CLASS, and a class name never matches a module name. The
+`__init__.py` re-export is the ONLY edge to the module the flag lives in — and
+it is relative, so it was skipped. Every module reached that way reported DARK
+while being imported on every boot.
+
+546 dark -> 328. 78 dark-and-enabled -> 42.
+"""
+from __future__ import annotations
+
+import ast
+
+from backend.core.ouroboros.battle_test.progress_board import (
+    _imported_modules, _module_name, _resolve_relative,
+)
+
+
+class TestResolveRelative:
+    def test_one_dot_is_the_containing_package(self):
+        assert _resolve_relative("a.b.c", 1, "x") == "a.b.x"
+
+    def test_two_dots_is_the_parent(self):
+        assert _resolve_relative("a.b.c", 2, "x") == "a.x"
+
+    def test_a_bare_from_dot_import(self):
+        assert _resolve_relative("a.b.c", 1, "") == "a.b"
+
+    def test_a_package_init_is_already_named_for_its_package(self):
+        """THE off-by-one. `_module_name` strips `__init__`, so a package's
+        own `__init__.py` is already named for the package: `level=1` means
+        ITSELF, not its parent. Stripping a segment walks one level too far
+        and resolves to a module that does not exist."""
+        pkg = _module_name("backend/core/ouroboros/governance/intake/"
+                           "sensors/__init__.py")
+        assert pkg.endswith("intake.sensors")
+        assert _resolve_relative(pkg, 1, "backlog_sensor", True) == (
+            pkg + ".backlog_sensor")
+
+    def test_a_plain_module_is_unaffected_by_the_package_rule(self):
+        assert _resolve_relative("a.b.c", 1, "x", False) == "a.b.x"
+
+    def test_over_deep_is_refused_not_wrapped(self):
+        assert _resolve_relative("a", 5, "x") == ""
+
+    def test_garbage_never_raises(self):
+        for args in (("", 1, "x"), (None, 1, "x"), ("a.b", "z", "x")):
+            _resolve_relative(*args)  # type: ignore[arg-type]
+
+
+class TestImportedModules:
+    def test_absolute_imports_still_both_shapes(self):
+        tree = ast.parse("import a.b.c\nfrom d.e import f\n")
+        got = _imported_modules(tree, "z")
+        assert "a.b.c" in got and "d.e" in got and "d.e.f" in got
+
+    def test_a_relative_import_is_resolved_not_skipped(self):
+        tree = ast.parse("from .backlog_sensor import BacklogSensor\n")
+        got = _imported_modules(tree, "pkg.sensors", is_package=True)
+        assert "pkg.sensors.backlog_sensor" in got
+
+    def test_the_re_export_edge_carries_the_symbol_too(self):
+        """`from .m import C` reaches module `pkg.m`; recording
+        `pkg.m.C` as well costs nothing and matches the absolute path's
+        existing behaviour."""
+        tree = ast.parse("from .m import C\n")
+        got = _imported_modules(tree, "pkg", is_package=True)
+        assert "pkg.m" in got and "pkg.m.C" in got
+
+    def test_a_module_inside_a_package_resolves_against_its_parent(self):
+        tree = ast.parse("from .sibling import Thing\n")
+        got = _imported_modules(tree, "pkg.mod", is_package=False)
+        assert "pkg.sibling" in got
+
+
+class TestAgainstTheRealTree:
+    def test_the_sensors_are_no_longer_dark(self):
+        """The regression that motivated this. `BacklogSensor` and
+        `OpportunityMinerSensor` are constructed at boot by
+        `intake_layer_service`, and their flags read DARK — a board that
+        reports a booting sensor as dead teaches operators to ignore it."""
+        from backend.core.ouroboros.battle_test.progress_board import (
+            ProgressBoard,
+        )
+        rows = ProgressBoard().read().rows
+        dark_on = {r.flag for r in rows if r.state == "dark" and r.enabled}
+        for flag in ("JARVIS_BACKLOG_FS_EVENTS_ENABLED",
+                     "JARVIS_MINER_BACKPRESSURE_ENABLED",
+                     "JARVIS_BACKLOG_AUTO_PROPOSED_ENABLED"):
+            assert flag not in dark_on, f"{flag} still reads dark"
+
+    def test_the_board_still_finds_genuinely_dark_flags(self):
+        """The fix must not launder every flag to LIVE. If nothing is dark
+        the signal is gone, which is the same as having no board."""
+        from backend.core.ouroboros.battle_test.progress_board import (
+            ProgressBoard,
+        )
+        rows = ProgressBoard().read().rows
+        assert any(r.state == "dark" for r in rows)
+        assert any(r.state == "live" for r in rows)

--- a/tests/battle_test/test_progress_board_relative.py
+++ b/tests/battle_test/test_progress_board_relative.py
@@ -108,3 +108,51 @@ class TestAgainstTheRealTree:
         rows = ProgressBoard().read().rows
         assert any(r.state == "dark" for r in rows)
         assert any(r.state == "live" for r in rows)
+
+
+class TestScanRootsIncludeScripts:
+    """`scripts/` is production.
+
+    `scripts/ouroboros_battle_test.py` is THE entry point that boots the
+    six-layer stack — it is how this system actually runs — and 361 backend
+    modules are reachable from `scripts/` and nowhere else. Scanning only
+    `backend` reported every one of them DARK while they were imported on
+    every session.
+
+    Found via `aegis/preflight.py`: flagged dark-and-enabled, imported at
+    `scripts/ouroboros_battle_test.py:1997`.
+    """
+
+    def test_scripts_is_a_default_root(self):
+        from backend.core.ouroboros.battle_test.progress_board import scan_roots
+
+        assert "scripts" in scan_roots()
+        assert "backend" in scan_roots()
+
+    def test_the_env_override_still_wins(self, monkeypatch):
+        """A knob, not a constant: what counts as production differs between
+        this repo and a consumer of it."""
+        from backend.core.ouroboros.battle_test.progress_board import scan_roots
+
+        monkeypatch.setenv("JARVIS_PROGRESS_BOARD_ROOTS", "lib, pkg")
+        assert scan_roots() == ("lib", "pkg")
+
+    def test_a_module_imported_only_from_scripts_is_not_dark(self):
+        """THE regression. `preflight` is imported by the battle-test entry
+        point and by nothing under `backend/`."""
+        from backend.core.ouroboros.battle_test.progress_board import (
+            ProgressBoard,
+        )
+        rows = ProgressBoard().read().rows
+        dark_on = {r.flag for r in rows if r.state == "dark" and r.enabled}
+        assert "JARVIS_AEGIS_DEP_VALIDATION_ENABLED" not in dark_on
+
+    def test_the_board_still_discriminates(self):
+        """Widening the roots must not launder everything to LIVE. A board
+        with nothing dark has no signal, which is the same as no board."""
+        from backend.core.ouroboros.battle_test.progress_board import (
+            ProgressBoard,
+        )
+        rows = ProgressBoard().read().rows
+        assert any(r.state == "dark" for r in rows)
+        assert any(r.state == "live" for r in rows)

--- a/tests/battle_test/test_progress_board_relative.py
+++ b/tests/battle_test/test_progress_board_relative.py
@@ -156,3 +156,38 @@ class TestScanRootsIncludeScripts:
         rows = ProgressBoard().read().rows
         assert any(r.state == "dark" for r in rows)
         assert any(r.state == "live" for r in rows)
+
+
+class TestBarePrefixImports:
+    """`backend/` is on `sys.path`, so siblings import each other bare.
+
+    597 files write `from core.x import y` rather than
+    `from backend.core.x import y`. The board resolves FILE PATHS to the
+    fully-qualified form, so the two never matched and every module imported
+    that way counted zero importers and reported DARK.
+
+    Found via `transport_handlers`: flagged dark-and-enabled with destructive
+    COMPUTER_USE defaults, and imported three times from `backend/api/` as
+    `from core.transport_handlers import ...`. It was one edit away from
+    being defaulted off as "unreached" while it was live on the unlock path.
+    """
+
+    def test_a_bare_prefix_importer_counts(self):
+        from backend.core.ouroboros.battle_test.progress_board import (
+            ProgressBoard,
+        )
+        rows = ProgressBoard().read().rows
+        dark_on = {r.flag for r in rows if r.state == "dark" and r.enabled}
+        assert "JARVIS_COMPUTER_USE_ENABLED" not in dark_on
+
+    def test_the_board_still_discriminates(self):
+        """Three blindness fixes in one day moved 546 dark to 205. If the
+        fixes ever launder everything to LIVE the signal is gone, which is
+        the same as having no board."""
+        from backend.core.ouroboros.battle_test.progress_board import (
+            ProgressBoard,
+        )
+        rows = ProgressBoard().read().rows
+        assert any(r.state == "dark" for r in rows)
+        assert any(r.state == "live" for r in rows)
+        assert any(r.state == "off" for r in rows)

--- a/tests/governance/test_op_fanout_order.py
+++ b/tests/governance/test_op_fanout_order.py
@@ -1,0 +1,148 @@
+"""The causality tree must draw the parentage it recorded.
+
+The op-DAG view was complete: a contextvar, an acyclic-guarded
+`register_parent`, a 777-line renderer and a verb. Two master flags gate it
+(`JARVIS_OP_DEPENDENCY_GRAPH_ENABLED` records the edges,
+`JARVIS_OP_FANOUT_TREE_ENABLED` renders them), both default false.
+
+Turned on, it drew the wrong tree. `walk_subtree` promises BREADTH-first and
+other callers rely on that; `format_fanout_tree` indents by `depth` IN ROW
+ORDER, which needs DEPTH-first. Fed BFS, a grandchild emitted after its uncle
+renders nested under the uncle.
+
+Not cosmetic. The tree's entire claim is "this op caused that one", and drawn
+from BFS rows it asserts a parentage the graph does not record — a surface
+confidently showing the wrong answer, which is worse than showing none.
+"""
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.usefixtures("_flags")
+
+
+@pytest.fixture
+def _flags(monkeypatch):
+    monkeypatch.setenv("JARVIS_OP_DEPENDENCY_GRAPH_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_OP_FANOUT_TREE_ENABLED", "true")
+    yield
+
+
+@pytest.fixture
+def graph():
+    """A > (B > D), C — the shape that exposes the ordering."""
+    from backend.core.ouroboros.battle_test import op_block_buffer as OB
+
+    OB.reset_default_buffer_for_tests() if hasattr(
+        OB, "reset_default_buffer_for_tests") else None
+    buf = OB.get_default_buffer()
+    buf.start_op("A")
+    with OB.executing("A"):
+        buf.start_op("B")
+        buf.start_op("C")
+        with OB.executing("B"):
+            buf.start_op("D")
+    return buf
+
+
+class TestTheGraphIsRecorded:
+    def test_edges_register_through_the_contextvar(self, graph):
+        """`executing()` sets the parent; `start_op` links it. Nobody has to
+        thread `parent_op_id` through a signature."""
+        from backend.core.ouroboros.governance import op_fanout_tree as F
+
+        by_op = {r.op_id: r for r in F.aggregate_fanout_rows()}
+        assert by_op["B"].parent_op_id == "A"
+        assert by_op["C"].parent_op_id == "A"
+        assert by_op["D"].parent_op_id == "B"
+
+    def test_depths_are_computed_from_the_chain(self, graph):
+        from backend.core.ouroboros.governance import op_fanout_tree as F
+
+        by_op = {r.op_id: r for r in F.aggregate_fanout_rows()}
+        assert (by_op["A"].depth, by_op["B"].depth, by_op["D"].depth) == (0, 1, 2)
+
+
+class TestRowOrder:
+    def test_rows_are_depth_first(self, graph):
+        """THE fix. BFS gives A B C D; rendering that depth-indented puts D
+        under C, which is not D's parent."""
+        from backend.core.ouroboros.governance import op_fanout_tree as F
+
+        assert [r.op_id for r in F.aggregate_fanout_rows()] == ["A", "B", "D", "C"]
+
+    def test_sibling_order_is_preserved(self, graph):
+        """BFS order is SPAWN order, and that is meaningful — the first
+        subagent dispatched should read first."""
+        from backend.core.ouroboros.governance import op_fanout_tree as F
+
+        order = [r.op_id for r in F.aggregate_fanout_rows()]
+        assert order.index("B") < order.index("C")
+
+    def test_the_child_follows_its_own_parent(self, graph):
+        from backend.core.ouroboros.governance import op_fanout_tree as F
+
+        order = [r.op_id for r in F.aggregate_fanout_rows()]
+        assert order[order.index("B") + 1] == "D"
+
+
+class TestRendering:
+    def test_the_grandchild_nests_under_its_parent(self, graph):
+        from backend.core.ouroboros.governance import op_fanout_tree as F
+
+        lines = F.format_fanout_tree(F.aggregate_fanout_rows()).splitlines()
+        assert lines[0].startswith("●") and " A" in lines[0]
+        assert lines[1].lstrip().startswith("├─") and " B" in lines[1]
+        assert " D" in lines[2], f"D did not follow B: {lines}"
+        assert lines[3].lstrip().startswith("└─") and " C" in lines[3]
+
+    def test_the_continuation_glyph_marks_an_open_branch(self, graph):
+        """`│` under B says C is still coming. Without it the grandchild
+        reads as a sibling of the branch it hangs from."""
+        from backend.core.ouroboros.governance import op_fanout_tree as F
+
+        lines = F.format_fanout_tree(F.aggregate_fanout_rows()).splitlines()
+        assert "│" in lines[2], lines
+
+    def test_a_single_op_with_no_fanout_renders_nothing(self):
+        """Documented: fan-out is the load-bearing signal. A lone op is not
+        a tree and does not need a badge saying so."""
+        from backend.core.ouroboros.battle_test import op_block_buffer as OB
+        from backend.core.ouroboros.governance import op_fanout_tree as F
+
+        buf = OB.get_default_buffer()
+        buf.start_op("lonely")
+        rows = tuple(r for r in F.aggregate_fanout_rows()
+                     if r.op_id == "lonely")
+        assert F.format_fanout_tree(rows) == ""
+
+
+class TestDepthFirstHelper:
+    def _blocks(self, pairs):
+        import types
+        return [types.SimpleNamespace(op_id=o, parent_op_id=p)
+                for o, p in pairs]
+
+    def test_an_orphan_is_kept_visible(self):
+        """An edge lost to eviction must not make an op VANISH from the
+        tree. A visible orphan is a far better failure than a silent one."""
+        from backend.core.ouroboros.governance.op_fanout_tree import _depth_first
+
+        blocks = self._blocks([("A", ""), ("B", "A"), ("Z", "GONE")])
+        got = [b.op_id for b in _depth_first(blocks, "A")]
+        assert got[:2] == ["A", "B"] and "Z" in got
+
+    def test_a_cycle_cannot_spin_the_walk(self):
+        """`register_parent` refuses cycles, but this renders on the
+        operator's frame and must not depend on that being airtight."""
+        from backend.core.ouroboros.governance.op_fanout_tree import _depth_first
+
+        blocks = self._blocks([("A", "B"), ("B", "A")])
+        got = [b.op_id for b in _depth_first(blocks, "A")]
+        assert sorted(got) == ["A", "B"]
+
+    def test_empty_and_garbage_are_survivable(self):
+        from backend.core.ouroboros.governance.op_fanout_tree import _depth_first
+
+        assert _depth_first([], "A") == []
+        assert _depth_first(None, "A") == []

--- a/tests/ui/pty_input.py
+++ b/tests/ui/pty_input.py
@@ -1,0 +1,217 @@
+"""What a real terminal actually sends — keys, mouse, and window size.
+
+`PtySession` in `test_headless_tui_integration.py` supplies a genuine TTY and
+can already type text. Driving the COCKPIT needs more than text, because the
+things thirty commits of UI work changed are not characters:
+
+    Ctrl+O          is  b"\\x0f"
+    Ctrl+Z          is  b"\\x1a"
+    a click at 4,7  is  b"\\x1b[<0;5;8M" then b"\\x1b[<0;5;8m"
+
+This module is that vocabulary. It encodes what a terminal emits, so the
+production key bindings and mouse handlers are exercised on their own terms —
+the same discipline the PTY harness already states: supply a real terminal
+rather than defeat the guards. A test that called `handler(event)` directly
+would prove the handler works in a world where prompt_toolkit's key parser,
+the mouse-capture mode string and the SGR encoding are all assumed correct.
+Those assumptions are exactly what has never been checked.
+
+Why SGR and not X10
+-------------------
+prompt_toolkit enables SGR mouse reporting (`\\x1b[?1006h`) alongside the
+button-event mode, because the older X10 encoding packs coordinates into
+single bytes and breaks past column 223. Emitting X10 here would work in a
+narrow terminal and silently mis-address a click in a wide one — which is
+precisely the class of defect this harness exists to catch rather than
+reproduce.
+
+Rows and columns are 1-BASED on the wire and 0-based everywhere in the
+application. The conversion happens HERE, once, so no caller has to remember
+it — an off-by-one in a click coordinate is invisible in a passing test and
+reported by an operator as "it expanded the wrong thing".
+"""
+from __future__ import annotations
+
+import fcntl
+import struct
+import termios
+from typing import Iterable, Tuple
+
+__all__ = [
+    "CTRL",
+    "SPECIAL",
+    "key",
+    "keys",
+    "mouse_click",
+    "mouse_drag",
+    "mouse_press",
+    "mouse_release",
+    "mouse_scroll",
+    "set_winsize",
+]
+
+#: Control chords. `ctrl+<letter>` is the letter's ordinal minus 64 — the
+#: ASCII control range — which is why Ctrl+I is indistinguishable from Tab
+#: and Ctrl+M from Enter at the byte level. Callers get told rather than
+#: silently surprised: see `key`.
+CTRL = {c: bytes([ord(c.upper()) - 64]) for c in "abcdefghijklmnopqrstuvwxyz"}
+CTRL["_"] = b"\x1f"          # chat:undo
+CTRL["["] = b"\x1b"          # == Escape
+
+#: Keys with no printable form. Arrow/Home/End use the CSI forms a terminal
+#: in "application cursor" mode does not send — prompt_toolkit accepts both,
+#: and the normal forms are what a plain terminal emits.
+SPECIAL = {
+    "escape": b"\x1b",
+    "enter": b"\r",
+    "tab": b"\t",
+    "backspace": b"\x7f",
+    "space": b" ",
+    "up": b"\x1b[A",
+    "down": b"\x1b[B",
+    "right": b"\x1b[C",
+    "left": b"\x1b[D",
+    "home": b"\x1b[H",
+    "end": b"\x1b[F",
+    "pageup": b"\x1b[5~",
+    "pagedown": b"\x1b[6~",
+}
+
+#: Aliases a terminal cannot distinguish, named so a test that relies on the
+#: collision says so out loud instead of appearing to test something else.
+AMBIGUOUS = {"ctrl+i": "tab", "ctrl+m": "enter", "ctrl+[": "escape"}
+
+
+def key(name: str) -> bytes:
+    """``"ctrl+o"`` -> ``b"\\x0f"``. Raises on an unknown key.
+
+    Raising rather than returning empty bytes is deliberate: a typo that sent
+    NOTHING would make the assertion fail for a reason that has nothing to do
+    with the behaviour under test, and the operator-visible symptom of that is
+    an afternoon spent debugging a working feature.
+    """
+    raw = str(name or "").strip()
+    if len(raw) == 1:
+        # A single character IS itself, case included — `G` and `g` are
+        # different bindings in the transcript viewer and lowercasing here
+        # would silently send the wrong one.
+        return raw.encode()
+    token = raw.lower()
+    if not token:
+        raise ValueError("empty key")
+    if token in SPECIAL:
+        return SPECIAL[token]
+    if token.startswith("ctrl+"):
+        rest = token[5:]
+        if rest not in CTRL:
+            raise ValueError(f"no control encoding for {name!r}")
+        return CTRL[rest]
+    if len(token) == 1:
+        return token.encode()
+    if len(name) == 1:                     # preserve case for `G` vs `g`
+        return name.encode()
+    raise ValueError(f"unknown key {name!r}")
+
+
+def keys(*names: str) -> bytes:
+    """Several keystrokes as one write — a chord, or a typed word."""
+    out = b""
+    for n in names:
+        out += key(n) if len(n) != 1 else n.encode()
+    return out
+
+
+# ---------------------------------------------------------------------------
+# mouse — SGR (1006) encoding
+# ---------------------------------------------------------------------------
+
+_BTN = {"left": 0, "middle": 1, "right": 2, "scroll_up": 64, "scroll_down": 65}
+_MOD = {"shift": 4, "alt": 8, "ctrl": 16}
+
+
+def _sgr(button: int, col: int, row: int, *, press: bool,
+         modifiers: Iterable[str] = ()) -> bytes:
+    """``ESC [ < Cb ; Cx ; Cy (M|m)`` — press is ``M``, release is ``m``.
+
+    Coordinates arrive 0-based (the application's frame) and go out 1-based
+    (the wire's). One conversion, one place.
+    """
+    code = int(button)
+    for m in modifiers or ():
+        code |= _MOD[str(m).lower()]
+    tail = "M" if press else "m"
+    return f"\x1b[<{code};{int(col) + 1};{int(row) + 1}{tail}".encode()
+
+
+def mouse_press(col: int, row: int, *, button: str = "left",
+                modifiers: Iterable[str] = ()) -> bytes:
+    return _sgr(_BTN[button], col, row, press=True, modifiers=modifiers)
+
+
+def mouse_release(col: int, row: int, *, button: str = "left",
+                  modifiers: Iterable[str] = ()) -> bytes:
+    return _sgr(_BTN[button], col, row, press=False, modifiers=modifiers)
+
+
+def mouse_click(col: int, row: int, *, button: str = "left",
+                modifiers: Iterable[str] = ()) -> bytes:
+    """A press AND a release in the same cell — which is what a click IS.
+
+    Sending only the press is the single easiest way to write a mouse test
+    that proves nothing: the cockpit deliberately acts on MOUSE_UP, because
+    acting on the press fires while the operator is still deciding.
+    """
+    return (mouse_press(col, row, button=button, modifiers=modifiers)
+            + mouse_release(col, row, button=button, modifiers=modifiers))
+
+
+def mouse_drag(start: Tuple[int, int], end: Tuple[int, int], *,
+               steps: int = 3) -> bytes:
+    """Press, MOVE while held, release — a real drag.
+
+    The intermediate moves carry bit 32 (motion) on top of the button, which
+    is how a terminal reports "still held, now here". Without them the
+    application sees a press and a release in two places and no drag at all,
+    which is exactly what a selection model must distinguish from a click.
+    """
+    (c0, r0), (c1, r1) = start, end
+    out = mouse_press(c0, r0)
+    steps = max(1, int(steps))
+    for i in range(1, steps + 1):
+        c = c0 + (c1 - c0) * i // steps
+        r = r0 + (r1 - r0) * i // steps
+        out += _sgr(_BTN["left"] | 32, c, r, press=True)
+    out += mouse_release(c1, r1)
+    return out
+
+
+def mouse_scroll(col: int, row: int, *, up: bool = True, times: int = 1) -> bytes:
+    """Wheel notches. Reported as button 64/65 with a PRESS and no release."""
+    btn = _BTN["scroll_up" if up else "scroll_down"]
+    return b"".join(_sgr(btn, col, row, press=True)
+                    for _ in range(max(1, int(times))))
+
+
+# ---------------------------------------------------------------------------
+# window size
+# ---------------------------------------------------------------------------
+
+
+def set_winsize(fd: int, cols: int, rows: int) -> bool:
+    """Tell the child how big its terminal is. NEVER raises; True on success.
+
+    Without this a pty defaults to 0x0 on some platforms, and a TUI handed
+    zero rows either draws nothing or divides by zero deep in a layout — a
+    failure that looks like the feature being broken rather than the harness
+    never having said how big the screen is.
+
+    Also delivers SIGWINCH to the child, which is the same path a real resize
+    takes, so the cockpit's own resize handling is exercised rather than
+    bypassed.
+    """
+    try:
+        packed = struct.pack("HHHH", int(rows), int(cols), 0, 0)
+        fcntl.ioctl(fd, termios.TIOCSWINSZ, packed)
+        return True
+    except Exception:  # noqa: BLE001
+        return False

--- a/tests/ui/test_blast_bands.py
+++ b/tests/ui/test_blast_bands.py
@@ -1,0 +1,160 @@
+"""Reading a diff riskiest-first.
+
+`blast_gutter` already measured every changed file's reach and drew it. What
+nothing did was use that number to decide reading ORDER — the tree rendered
+in whatever sequence the diff produced, so a one-line change to a leaf could
+sit above a rewrite forty modules import. An operator reviewing under a
+five-second NOTIFY_APPLY countdown reads from the top.
+
+The failure pinned hardest is the one that would be actively dangerous: an
+UNRESOLVED reach reports `count == 0`, and zero-as-a-number means "reaches
+nothing" — the most reassuring answer there is, attached to the file we know
+least about.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.ui import blast_bands as BB
+from backend.core.ouroboros.ui.blast_gutter import Reach
+
+
+def _r(path, count, resolved=True, provenance="measured"):
+    return Reach(path=path, count=count, provenance=provenance,
+                 resolved=resolved)
+
+
+class TestBanding:
+    def test_a_hub_is_wide(self):
+        assert BB.band_of(_r("hub.py", 42)) is BB.Band.WIDE
+
+    def test_a_handful_is_moderate(self):
+        assert BB.band_of(_r("mid.py", 5)) is BB.Band.MODERATE
+
+    def test_a_leaf_is_contained(self):
+        assert BB.band_of(_r("leaf.py", 0)) is BB.Band.CONTAINED
+
+    def test_an_unresolved_reach_is_UNKNOWN_not_contained(self):
+        """THE dangerous case. `peek` is read-only and returns count 0 for a
+        file the advisor has not measured. Reading that as "reaches nothing"
+        marks the least-known file as the safest."""
+        assert BB.band_of(_r("mystery.py", 0, resolved=False)) is BB.Band.UNKNOWN
+
+    def test_resolved_is_consulted_before_count(self):
+        """Even a nonzero count means nothing if the reach is unresolved."""
+        assert BB.band_of(_r("x.py", 99, resolved=False)) is BB.Band.UNKNOWN
+
+    def test_none_and_garbage_are_unknown(self):
+        for bad in (None, object(), "nope"):
+            assert BB.band_of(bad) is BB.Band.UNKNOWN
+
+
+class TestOrder:
+    ROWS = [
+        _r("leaf.py", 0),
+        _r("hub.py", 42),
+        _r("mid.py", 5),
+        _r("mystery.py", 0, resolved=False),
+        _r("also_mid.py", 5),
+    ]
+
+    def test_unknown_sorts_first(self):
+        """Not last. A file whose blast radius could not be established is
+        not safe, it is unmeasured — the same rule the advisor's repair
+        settled when it made `?` never render as `0`."""
+        assert BB.review_order(self.ROWS)[0].path == "mystery.py"
+
+    def test_then_widest_first(self):
+        order = [r.path for r in BB.review_order(self.ROWS)]
+        assert order[:2] == ["mystery.py", "hub.py"]
+        assert order[-1] == "leaf.py"
+
+    def test_ties_break_on_path_so_the_order_is_stable(self):
+        """A tree that reshuffles equal-risk files between frames is one an
+        operator cannot keep their place in."""
+        order = [r.path for r in BB.review_order(self.ROWS)]
+        assert order.index("also_mid.py") < order.index("mid.py")
+        assert BB.review_order(self.ROWS) == BB.review_order(self.ROWS)
+
+    def test_order_paths_treats_an_unknown_path_as_unresolved(self):
+        """A path with no matching reach sorts first for the same reason an
+        unmeasured file does — that is exactly what it is."""
+        paths = ["leaf.py", "ghost.py", "hub.py"]
+        got = BB.order_paths(paths, [_r("leaf.py", 0), _r("hub.py", 42)])
+        assert got[0] == "ghost.py"
+
+    def test_the_kill_switch_restores_diff_order(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_BLAST_BANDS_ENABLED", "0")
+        assert BB.review_order(self.ROWS) == self.ROWS
+        paths = ["b.py", "a.py"]
+        assert BB.order_paths(paths, []) == paths
+
+    def test_empty_input_is_survivable(self):
+        assert BB.review_order([]) == []
+        assert BB.order_paths([], []) == []
+
+
+class TestThresholds:
+    def test_they_are_env_tunable(self, monkeypatch):
+        """"Wide" is a property of the REPOSITORY: eleven dependents is
+        unremarkable in a hub package and alarming in a leaf."""
+        monkeypatch.setenv("JARVIS_BLAST_WIDE_AT", "4")
+        monkeypatch.setenv("JARVIS_BLAST_MODERATE_AT", "2")
+        assert BB.thresholds() == (4, 2)
+        assert BB.band_of(_r("x", 4)) is BB.Band.WIDE
+
+    def test_inverted_thresholds_are_repaired_not_obeyed(self, monkeypatch):
+        """Swapped values would make every file wide and none moderate,
+        silently."""
+        monkeypatch.setenv("JARVIS_BLAST_WIDE_AT", "3")
+        monkeypatch.setenv("JARVIS_BLAST_MODERATE_AT", "9")
+        wide, moderate = BB.thresholds()
+        assert wide >= moderate
+
+    def test_garbage_falls_back(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_BLAST_WIDE_AT", "not-a-number")
+        assert BB.thresholds()[0] > 0
+
+
+class TestSummary:
+    def test_it_names_the_risky_bands_first(self):
+        rows = [_r("a", 42), _r("b", 0, resolved=False), _r("c", 0)]
+        assert BB.summarise_bands(rows) == "1 unknown · 1 wide · 1 contained"
+
+    def test_an_all_contained_diff_says_nothing(self):
+        """The absence of the warning IS the signal — the restraint the rest
+        of this cockpit already keeps."""
+        assert BB.summarise_bands([_r("a", 0), _r("b", 1)]) == ""
+
+    def test_empty_is_empty(self):
+        assert BB.summarise_bands([]) == ""
+
+
+class TestWiredIntoTheTree:
+    def test_the_preview_orders_by_reach(self):
+        import ast
+        import inspect
+        import textwrap
+
+        from backend.core.ouroboros.battle_test import diff_preview
+
+        src = textwrap.dedent(inspect.getsource(
+            diff_preview.DiffPreviewRenderer._build_file_tree))
+        tree = ast.parse(src)
+        assert any(
+            isinstance(n, ast.Attribute) and n.attr == "order_paths"
+            for n in ast.walk(tree)
+        ), "the file tree still renders in diff order"
+
+    def test_it_does_not_promise_partial_apply(self):
+        """Apply is per-OPERATION. Splitting it by band would need
+        orchestrator support, rollback for a half-applied candidate, and a
+        VERIFY that knows which half ran. Offering the UI for it would be an
+        affordance the engine cannot honour."""
+        import inspect
+
+        src = inspect.getsource(BB)
+        assert "does NOT" in src and "partial apply" in src
+        for forbidden in ("def accept_band", "def reject_band",
+                          "def apply_band"):
+            assert forbidden not in src

--- a/tests/ui/test_cockpit_pty_proof.py
+++ b/tests/ui/test_cockpit_pty_proof.py
@@ -1,0 +1,650 @@
+"""Thirty commits of cockpit behaviour, pressed by a machine.
+
+Every interactive feature merged across this arc — transcript mode, claim
+jumping, click-to-expand, drag-select, the clear chord, suspend/resume —
+shipped with unit tests that call the handler and none that press the key.
+That gap is not pedantic. A handler can be correct while the binding never
+fires: the key can be shadowed by prompt_toolkit's own bindings, the filter
+can be false at the moment it matters, the mouse mode can be un-negotiated so
+the click arrives as garbage text, or the action id can be unresolvable
+because an alias was never registered. None of those are visible to a test
+that invokes the function directly, and all of them are visible to an
+operator immediately.
+
+So this drives `ov demo live` through a real pseudo-terminal — the one scene
+that boots the REAL `build_bipartite_application` with no daemon, no socket
+and no provider credit — and presses actual bytes.
+
+What "asserting on the output" honestly means
+---------------------------------------------
+A pty carries a STREAM, not a screen: cursor moves, partial repaints and
+styling interleave, so the buffer is the terminal's input, not its picture.
+Reconstructing the picture needs an emulator, and asserting against one would
+be asserting against the emulator's fidelity as much as the cockpit's.
+
+These tests therefore assert on what is decidable from the stream:
+
+  * a sequence was NEGOTIATED (alt-screen, SGR mouse) — exact bytes;
+  * a keystroke CHANGED something — a delta, measured against a mark;
+  * specific text APPEARED after an input that should produce it.
+
+That is weaker than a screenshot and much stronger than nothing, and it
+catches the entire class above — every one of which manifests as "the delta
+is empty" or "the text never came".
+
+Timing is a wait, never a sleep
+-------------------------------
+`wait_for` polls with a deadline. A fixed sleep tuned on this machine is a
+flake on a loaded one, and the standing lesson in this repo is that timing
+assumptions are how a green suite hides a real failure.
+"""
+from __future__ import annotations
+
+import os
+import re
+import signal
+import subprocess
+import sys
+import time
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from pty_input import (  # noqa: E402
+    key,
+    mouse_click,
+    mouse_drag,
+    mouse_scroll,
+    set_winsize,
+)
+
+pytestmark = pytest.mark.timeout(120)
+
+REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+#: Wide enough that the deck does not fold, tall enough that the viewport has
+#: rows to scroll. Both matter: several of these features are no-ops on a
+#: screen too small to show what they changed.
+COLS, ROWS = 110, 34
+
+ALT_SCREEN_ENTER = "\x1b[?1049h"
+ALT_SCREEN_LEAVE = "\x1b[?1049l"
+SGR_MOUSE_ON = "\x1b[?1006h"
+
+_ANSI = re.compile(r"\x1b\[[0-9;?]*[a-zA-Z]|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)"
+                   r"|\x1b[=>()][A-Za-z0-9]?")
+
+
+def clean(text: str) -> str:
+    """The printable text a terminal would have drawn, styling removed."""
+    return _ANSI.sub("", text or "")
+
+
+class CockpitSession:
+    """A real terminal running the real cockpit.
+
+    Deliberately NOT a subclass of `PtySession`: that harness owns a
+    fixed-size pty and a text-only `send`, and the cockpit needs a declared
+    window size and byte input. Reusing its drain-on-a-thread design without
+    inheriting its constraints keeps both honest.
+
+    `mark`/`since` are the load-bearing addition. Asserting on the WHOLE
+    buffer after a keystroke proves nothing — the boot output already
+    contains most words the cockpit knows. A delta taken from a mark is the
+    only way to attribute new bytes to the key that was just pressed.
+    """
+
+    def __init__(self, *args: str, env: "dict | None" = None,
+                 cols: int = COLS, rows: int = ROWS) -> None:
+        import pty
+        import threading
+
+        self._master, slave = pty.openpty()
+        set_winsize(self._master, cols, rows)
+        base = dict(os.environ)
+        base.update({
+            "TERM": "xterm-256color",
+            "COLUMNS": str(cols),
+            "LINES": str(rows),
+            "PYTHONUNBUFFERED": "1",
+            # Never let a demo terminal try to reach a daemon or a provider.
+            "JARVIS_OV_NO_DAEMON": "1",
+        })
+        base.update(env or {})
+        self.proc = subprocess.Popen(
+            [sys.executable, "-m", "backend.core.ouroboros.cli.ov", *args],
+            stdin=slave, stdout=slave, stderr=slave,
+            env=base, cwd=REPO, start_new_session=True,
+        )
+        os.close(slave)
+        self._chunks: "list[str]" = []
+        self._lock = threading.Lock()
+        self._drain = threading.Thread(target=self._pump, daemon=True)
+        self._drain.start()
+
+    def _pump(self) -> None:
+        while True:
+            try:
+                data = os.read(self._master, 65536)
+            except OSError:
+                return
+            if not data:
+                return
+            with self._lock:
+                self._chunks.append(data.decode("utf-8", "replace"))
+
+    # -- reading ---------------------------------------------------------
+    @property
+    def output(self) -> str:
+        with self._lock:
+            return "".join(self._chunks)
+
+    def mark(self) -> int:
+        """A cursor into the stream. Everything after it is attributable."""
+        return len(self.output)
+
+    def since(self, at: int) -> str:
+        return self.output[at:]
+
+    def wait_for(self, needle: str, *, timeout: float = 25.0,
+                 after: int = 0) -> bool:
+        """Poll until `needle` appears in the CLEANED stream after `at`."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if needle in clean(self.since(after)):
+                return True
+            if self.proc.poll() is not None:
+                # One last look: the text may have arrived in the same
+                # breath the process exited.
+                return needle in clean(self.since(after))
+            time.sleep(0.05)
+        return False
+
+    def wait_for_change(self, at: int, *, minimum: int = 32,
+                        timeout: float = 8.0) -> str:
+        """Wait until at least `minimum` new bytes arrive; return them.
+
+        A repaint is many bytes. The floor rejects the stray single-byte
+        cursor report that would otherwise make any keystroke look handled.
+        """
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            delta = self.since(at)
+            if len(delta) >= minimum:
+                return delta
+            time.sleep(0.05)
+        return self.since(at)
+
+    # -- writing ---------------------------------------------------------
+    def send(self, data: "bytes | str") -> None:
+        if isinstance(data, str):
+            data = data.encode()
+        os.write(self._master, data)
+
+    def press(self, *names: str) -> None:
+        for n in names:
+            self.send(key(n))
+            time.sleep(0.06)      # let the event loop turn between keys
+
+    def signal(self, sig: int) -> None:
+        os.killpg(os.getpgid(self.proc.pid), sig)
+
+    # -- lifecycle -------------------------------------------------------
+    def close(self, *, timeout: float = 5.0) -> None:
+        try:
+            if self.proc.poll() is None:
+                self.signal(signal.SIGTERM)
+                try:
+                    self.proc.wait(timeout=timeout)
+                except subprocess.TimeoutExpired:
+                    self.signal(signal.SIGKILL)
+                    self.proc.wait(timeout=timeout)
+        except Exception:  # noqa: BLE001
+            pass
+        finally:
+            try:
+                os.close(self._master)
+            except OSError:
+                pass
+
+    def __enter__(self) -> "CockpitSession":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+
+def _require_pty() -> None:
+    import pty
+    try:
+        m, s = pty.openpty()
+    except OSError:
+        pytest.skip("out of pty devices")
+    os.close(m)
+    os.close(s)
+
+
+@pytest.fixture()
+def cockpit():
+    """A booted `ov demo live`, ready for input.
+
+    Readiness is the PROMPT, not a timer. The demo seeds a masthead and warms
+    an animation before the Application takes the screen, and a test that
+    started typing on a fixed delay would press keys into a terminal the
+    cockpit had not claimed yet — the flakiest possible failure, and one that
+    would be blamed on the feature rather than the harness.
+    """
+    _require_pty()
+    session = CockpitSession("demo", "live")
+    try:
+        if not session.wait_for("❯", timeout=40.0):
+            session.close()
+            pytest.skip(f"cockpit did not reach a prompt: "
+                        f"{clean(session.output)[-400:]!r}")
+        yield session
+    finally:
+        session.close()
+
+
+# ---------------------------------------------------------------------------
+# the preconditions everything else stands on
+# ---------------------------------------------------------------------------
+
+
+def test_the_cockpit_takes_the_alternate_screen(cockpit: CockpitSession) -> None:
+    """Full-screen means the alt-screen, and the bytes say so or it doesn't.
+
+    This is the first thing the arc changed and the thing nothing verified.
+    `smcup` is terminfo-derived rather than hardcoded, so its absence here
+    would mean the terminfo lookup silently returned nothing — a degradation
+    invisible on a developer's own terminal, where the previous value is
+    still on screen.
+    """
+    assert ALT_SCREEN_ENTER in cockpit.output
+
+
+def test_mouse_reporting_is_negotiated_in_sgr_mode(
+        cockpit: CockpitSession) -> None:
+    """Click-to-expand cannot work if the terminal was never asked to report.
+
+    And it must be SGR: the older encoding packs a coordinate into one byte
+    and mis-addresses every click past column 223. On a 110-column terminal
+    that defect is invisible; on the operator's it is not.
+    """
+    out = cockpit.output
+    assert SGR_MOUSE_ON in out, "SGR mouse reporting never enabled"
+    assert "\x1b[?1000h" in out, "button-event reporting never enabled"
+
+
+def test_the_screen_is_released_on_a_clean_quit(
+        cockpit: CockpitSession) -> None:
+    """Leaving must restore the operator's scrollback.
+
+    A cockpit that exits without `rmcup` leaves the terminal in the alternate
+    buffer and everything the operator had before it is gone. That is the
+    single most destructive way a TUI can fail, and it fails silently — the
+    process exit code is 0.
+    """
+    at = cockpit.mark()
+    cockpit.press("q")
+    deadline = time.monotonic() + 15.0
+    while time.monotonic() < deadline:
+        if ALT_SCREEN_LEAVE in cockpit.since(at):
+            break
+        time.sleep(0.05)
+    assert ALT_SCREEN_LEAVE in cockpit.since(at), "alternate screen never left"
+
+
+# ---------------------------------------------------------------------------
+# transcript mode — Ctrl+O and what lives inside it
+# ---------------------------------------------------------------------------
+
+
+def test_ctrl_o_enters_transcript_mode(cockpit: CockpitSession) -> None:
+    """The mode key must reach the mode.
+
+    `Ctrl+O` is `\\x0f`, which prompt_toolkit's emacs bindings already claim
+    (`open-line`). If the cockpit's binding were registered where pt's wins,
+    pressing it would insert a newline into the prompt and the viewer would
+    never appear — with every unit test on `transcript_mode` still green.
+    """
+    at = cockpit.mark()
+    cockpit.press("ctrl+o")
+    assert cockpit.wait_for_change(at), "Ctrl+O produced no repaint at all"
+
+
+def test_the_viewer_help_panel_answers_a_question_mark(
+        cockpit: CockpitSession) -> None:
+    """`?` inside the viewer lists the viewer's OWN actions.
+
+    The panel is rendered from `_VIEWER_ACTIONS`, the same table the binder
+    reads, so a key that exists and a key that is documented cannot drift.
+    This proves the table reaches a human — the half a unit test on the table
+    cannot cover.
+    """
+    cockpit.press("ctrl+o")
+    time.sleep(0.4)
+    at = cockpit.mark()
+    cockpit.press("?")
+    assert cockpit.wait_for_change(at, timeout=10.0), "`?` rendered nothing"
+
+
+def test_claim_jumping_moves_through_the_transcript(
+        cockpit: CockpitSession) -> None:
+    """`c` walks the lines the organism MARKED.
+
+    The demo script deliberately emits provenance-marked lines, so there is
+    something to jump to. This is the feature that broke twice in review —
+    once by classifying only the rendered window (so every claim was already
+    on screen and `c` moved nowhere) and once by re-deriving the start from
+    the newest visible line each press (so `C` stuck). Both were invisible to
+    the unit tests and obvious the moment a key was pressed.
+    """
+    cockpit.press("ctrl+o")
+    time.sleep(0.4)
+    at = cockpit.mark()
+    cockpit.press("c")
+    first = cockpit.wait_for_change(at, timeout=10.0)
+    assert first, "`c` did not move"
+
+    at2 = cockpit.mark()
+    cockpit.press("c")
+    assert cockpit.wait_for_change(at2, timeout=10.0), (
+        "the second `c` moved nowhere — the cursor is not advancing"
+    )
+
+
+def test_scrolling_the_viewport_pauses_the_follow(
+        cockpit: CockpitSession) -> None:
+    """A wheel notch must stop the deck chasing the newest line.
+
+    Auto-scroll fighting a reader is the reason `_paused` exists as a field
+    separate from the offset: at offset 0 the two disagree, and the bug that
+    shipped was `to_bottom()` returning early there and never clearing the
+    pause — so leaving the viewer left `following` false forever.
+    """
+    at = cockpit.mark()
+    cockpit.send(mouse_scroll(COLS // 2, ROWS // 2, up=True, times=3))
+    assert cockpit.wait_for_change(at, timeout=10.0), (
+        "the wheel produced no repaint — mouse events are not being parsed"
+    )
+
+
+# ---------------------------------------------------------------------------
+# the mouse
+# ---------------------------------------------------------------------------
+
+
+def test_a_click_in_the_deck_is_parsed_not_typed(
+        cockpit: CockpitSession) -> None:
+    """The proof that mouse bytes never land in the prompt.
+
+    An un-negotiated or unhandled mouse sequence is not silently dropped: the
+    terminal delivers `\\x1b[<0;5;8M` as ordinary input and prompt_toolkit
+    types the printable tail into the buffer. So the assertion is not "the
+    click worked" — it is that `0;5;8M` never appears as TEXT, which is the
+    exact operator-visible symptom of the whole class.
+    """
+    at = cockpit.mark()
+    cockpit.send(mouse_click(6, 8))
+    time.sleep(0.6)
+    delta = clean(cockpit.since(at))
+    assert "0;7;9M" not in delta and "<0;7;9" not in delta, (
+        f"raw mouse bytes were echoed as text: {delta[:200]!r}"
+    )
+
+
+def test_a_drag_is_reported_as_motion_and_survives(
+        cockpit: CockpitSession) -> None:
+    """Press-move-release must not crash the app or reach the buffer.
+
+    A drag is the one gesture that arrives as MANY events. The selection
+    model handles them as runs; a handler that assumed one event per gesture
+    would raise inside prompt_toolkit's mouse dispatch, and pt swallows that
+    into a redraw — leaving a cockpit that is subtly dead rather than one
+    that reports an error.
+    """
+    at = cockpit.mark()
+    cockpit.send(mouse_drag((4, 6), (40, 8), steps=4))
+    time.sleep(0.8)
+    assert cockpit.proc.poll() is None, "the app died during a drag"
+    delta = clean(cockpit.since(at))
+    assert "32;" not in delta, f"motion bytes echoed as text: {delta[:200]!r}"
+
+
+# ---------------------------------------------------------------------------
+# chords
+# ---------------------------------------------------------------------------
+
+
+def test_ctrl_l_once_redraws_and_arms_rather_than_clearing(
+        cockpit: CockpitSession) -> None:
+    """One press redraws AND arms; it must not clear.
+
+    Both halves matter and the first press does both, which is the design:
+    an operator reaching for Ctrl+L is usually recovering a garbled screen
+    and has no intention of clearing anything, so arming is a side effect of
+    a key that already worked rather than a mode it puts them into.
+
+    The assertion is the HINT, not the repaint — and that is what makes this
+    test worth having. prompt_toolkit binds `Ctrl+L` to clear-screen itself,
+    so an unbound cockpit still produces a perfectly convincing repaint. The
+    repaint proves nothing; only the hint distinguishes "the cockpit's chord
+    ran" from "pt's default ran". This test found exactly that: the demo
+    never installed the hatches, so `Ctrl+L` fell through to pt and the
+    gesture the toolbar implies did not exist on the one surface built to
+    demonstrate it.
+    """
+    at = cockpit.mark()
+    cockpit.press("ctrl+l")
+    assert cockpit.wait_for("ctrl+l again", timeout=10.0, after=at), (
+        "no arming hint — Ctrl+L is not reaching the cockpit's chord "
+        f"(tail: {clean(cockpit.since(at))[-300:]!r})"
+    )
+    assert cockpit.proc.poll() is None
+
+
+def test_ctrl_c_leaves_no_unraisable_traceback(
+        cockpit: CockpitSession) -> None:
+    """The operator's actual bug report, as a test.
+
+    Ctrl+C during the cockpit's own teardown used to print
+    "Exception ignored in: ..." with a traceback ACROSS the restored screen —
+    because the alt-screen restore ran from a signal handler that took a lock
+    and wrote through a `TextIOWrapper`. Both are forbidden there; CPython
+    delivers signals at arbitrary bytecode boundaries, so the handler could
+    interrupt a write that already held the same lock.
+
+    The fix was a lock-free `os.write` on a captured fd plus an unraisable
+    guard. This asserts the visible consequence — nothing about how.
+    """
+    at = cockpit.mark()
+    cockpit.signal(signal.SIGINT)
+    deadline = time.monotonic() + 15.0
+    while time.monotonic() < deadline and cockpit.proc.poll() is None:
+        time.sleep(0.1)
+    tail = clean(cockpit.since(at))
+    assert "Exception ignored in" not in tail, (
+        f"unraisable leaked onto the restored screen: {tail[-500:]!r}"
+    )
+    assert "Traceback (most recent call last)" not in tail, (
+        f"traceback printed over the operator's terminal: {tail[-500:]!r}"
+    )
+
+
+def test_ctrl_z_releases_the_alternate_screen(cockpit: CockpitSession) -> None:
+    """Suspending must hand the operator's scrollback back.
+
+    This is the destructive half and the only half this harness can honestly
+    decide. A cockpit that suspends WITHOUT `rmcup` drops the operator into a
+    shell drawing on the alternate buffer: their scrollback is invisible and
+    everything they type scrolls a screen that will be discarded.
+
+    What is deliberately NOT asserted here is the RESUME.
+    -----------------------------------------------------
+    Observed: after `SIGCONT` the cockpit repaints without re-issuing
+    `smcup`, so it draws on the normal buffer. That looks like a defect and
+    this harness cannot prove it is one, because the child is spawned with
+    `start_new_session=True` and its process group is therefore ORPHANED —
+    and POSIX (2.4.3) says a stop signal delivered to a member of an orphaned
+    process group is DISCARDED. So the process very likely never stopped, and
+    "resumed without smcup" may be "was never suspended, and pt's
+    `run_in_terminal` had already restored".
+
+    Asserting either way would be asserting the harness's job-control
+    semantics rather than the cockpit's. The honest instrument for the resume
+    path is a session WITH a controlling shell — job control is the thing
+    under test, so it cannot also be the thing stubbed out. Recorded here
+    rather than silently dropped, so the gap is a known one.
+    """
+    at = cockpit.mark()
+    cockpit.press("ctrl+z")
+
+    deadline = time.monotonic() + 10.0
+    while time.monotonic() < deadline:
+        if ALT_SCREEN_LEAVE in cockpit.since(at):
+            break
+        time.sleep(0.05)
+    assert ALT_SCREEN_LEAVE in cockpit.since(at), (
+        "Ctrl+Z did not release the alternate screen — the operator's "
+        "scrollback would be stranded behind it"
+    )
+
+
+def test_alt_screen_stop_and_resume_are_symmetric() -> None:
+    """`alt_screen` must not restore a buffer it does not own.
+
+    The unit half of the test above, and the reason the suspend path is
+    correct rather than accidentally correct: while the cockpit is mounted,
+    prompt_toolkit owns the alternate screen and `alt_screen` does not. If
+    the SIGTSTP branch emitted `rmcup` unconditionally while the SIGCONT
+    branch stayed gated on ownership, the module would tear down a buffer it
+    had no claim to and then decline to put it back — two owners of one piece
+    of terminal state, and the asymmetry is what would make it unrecoverable.
+
+    Asserted on the FLAG rather than by sending a signal, because the
+    ownership rule is the invariant; a signal test would only observe one of
+    its consequences.
+    """
+    from backend.core.ouroboros.ui import alt_screen as alt
+
+    armed_before = alt._ARMED[0]
+    try:
+        alt._ARMED[0] = False
+        assert alt._restore_signal_safe() is False, (
+            "alt_screen restored a buffer it does not own"
+        )
+    finally:
+        alt._ARMED[0] = armed_before
+
+
+# ---------------------------------------------------------------------------
+# the input line
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# the two defects this harness found, pinned
+# ---------------------------------------------------------------------------
+
+
+def test_the_live_scene_registers_its_deck_as_the_active_canvas() -> None:
+    """`scene_live` must arm AND disarm the canvas registry.
+
+    Sixteen call sites across `transcript_mode`, `transcript_hatches`,
+    `serpent_flow` and `ov` find the deck through `get_active_canvas()`. The
+    live scene builds its Application directly rather than through
+    `run_bipartite_repl`, and so inherited none of that function's lifecycle:
+    the registry was never filled, every one of those sites got None, and
+    they all wrote nowhere — silently, because each is wrapped in the
+    NEVER-raises discipline that makes a missing canvas indistinguishable
+    from a successful write.
+
+    Read by AST rather than by grep so a mention in a docstring or a comment
+    cannot satisfy it — the same instrument a seam-ordering check in this
+    repo already had to be rewritten to use after passing on its own prose.
+    """
+    import ast
+
+    src = open(os.path.join(
+        REPO, "backend/core/ouroboros/cli/ov_demo.py"), encoding="utf-8").read()
+    tree = ast.parse(src)
+    live = next((n for n in ast.walk(tree)
+                 if isinstance(n, ast.FunctionDef) and n.name == "scene_live"),
+                None)
+    assert live is not None, "scene_live has been renamed"
+
+    calls = [n for n in ast.walk(live)
+             if isinstance(n, ast.Call)
+             and getattr(n.func, "id", None) == "set_active_canvas"]
+    assert calls, "scene_live never registers its deck — 16 sinks go dark"
+
+    args = {ast.dump(c.args[0]) if c.args else "" for c in calls}
+    assert ast.dump(ast.Name(id="mux", ctx=ast.Load())) in args, (
+        "the deck is never ARMED as the active canvas"
+    )
+    assert ast.dump(ast.Constant(value=None)) in args, (
+        "the canvas is never CLEARED — a dead deck outlives the scene, and "
+        "the next surface to write finds a canvas nobody is drawing"
+    )
+
+
+def test_the_live_scene_binds_the_transcript_hatches() -> None:
+    """`Ctrl+L` and its siblings must exist in the demo's own key set.
+
+    The demo mounted `search_rows` — a strip that renders only while a search
+    is open — and never installed the `/` that opens one, so the row could
+    never appear. `Ctrl+L` was the same gap with a worse symptom: unbound, it
+    falls through to prompt_toolkit's clear-screen, which produces a
+    thoroughly convincing repaint and none of the arming the cockpit
+    promises. A demo that teaches a gesture the product does not have is
+    worse than one that omits it.
+
+    Asserted on the BOUND KEYS rather than on the installer being called,
+    because the question is what an operator can press.
+    """
+    from backend.core.ouroboros.cli.ov_demo import _live_exit_bindings
+
+    kb = _live_exit_bindings()
+    bound = {tuple(str(k) for k in b.keys) for b in kb.bindings}
+    for keys, why in (
+        (("Keys.ControlL",), "the clear/redraw chord"),
+        (("/",), "transcript search — the row is mounted without it"),
+        (("[",), "dump to scrollback"),
+        (("{",), "previous block"),
+        (("}",), "next block"),
+    ):
+        assert keys in bound, f"{keys[0]!r} is unbound in the demo ({why})"
+
+
+def test_typing_reaches_the_prompt(cockpit: CockpitSession) -> None:
+    """The baseline nothing else is meaningful without.
+
+    If ordinary text does not echo, every other assertion in this file is
+    measuring a dead terminal rather than a working one.
+    """
+    at = cockpit.mark()
+    cockpit.send(b"hello")
+    time.sleep(0.5)
+    assert "hello" in clean(cockpit.since(at)), "typed text never echoed"
+
+
+def test_the_slash_palette_opens_without_freezing(
+        cockpit: CockpitSession) -> None:
+    """`/` is the keystroke with an open freeze report against it.
+
+    Never reproduced under a faithful harness — so this is the harness that
+    would catch it. The assertion is liveness: after `/`, the cockpit must
+    still respond to a subsequent keystroke. A frozen app echoes the `/` from
+    the terminal's own line discipline and then goes quiet, which is exactly
+    what "responds to the NEXT key" discriminates.
+    """
+    cockpit.send(b"/")
+    time.sleep(0.8)
+    at = cockpit.mark()
+    cockpit.send(b"h")
+    assert cockpit.wait_for_change(at, minimum=8, timeout=10.0), (
+        "the cockpit stopped responding after `/` — freeze reproduced"
+    )
+    assert cockpit.proc.poll() is None

--- a/tests/unit/core/test_infra_orchestrator_defaults.py
+++ b/tests/unit/core/test_infra_orchestrator_defaults.py
@@ -1,0 +1,85 @@
+"""The superseded infrastructure orchestrator must not arm itself.
+
+`infrastructure_orchestrator.py` provisions and tears down GCP resources —
+`terraform destroy -target=<what we created>` on shutdown, with
+`--auto-approve`. All three of its master flags defaulted to **true**.
+
+That was harmless for one reason only: nothing imports the module. It has had
+zero production importers since 2025-12-24, and `gcp_vm_manager` (34
+production files) plus `failover_lifecycle` (12) own GCP lifecycle now. The
+moment anyone wired this module back up — which is exactly what "bring the
+dark flags to the light" would mean — shutdown would run a destroy with
+auto-approve, on by default, with no operator ever having asked for it.
+
+A dormant module with destructive defaults is a loaded gun with the safety
+off, sitting in a drawer. Deleting it is a separate decision that needs
+feature-parity review against `gcp_vm_manager`; taking the safety off the
+table costs nothing today and is worth doing first.
+"""
+from __future__ import annotations
+
+import ast
+import inspect
+import pathlib
+
+import pytest
+
+_SRC = pathlib.Path("backend/core/infrastructure_orchestrator.py")
+
+DESTRUCTIVE = (
+    "JARVIS_INFRA_AUTO_DESTROY",
+    "JARVIS_TERRAFORM_AUTO_APPROVE",
+    "JARVIS_INFRA_ON_DEMAND",
+)
+
+
+def _default_for(flag: str) -> str:
+    """The literal default in the module's own env read."""
+    tree = ast.parse(_SRC.read_text())
+    for node in ast.walk(tree):
+        if (isinstance(node, ast.Call)
+                and getattr(node.func, "attr", "") == "getenv"
+                and node.args
+                and isinstance(node.args[0], ast.Constant)
+                and node.args[0].value == flag):
+            return str(node.args[1].value) if len(node.args) > 1 else ""
+    raise AssertionError(f"{flag} not read in {_SRC}")
+
+
+@pytest.mark.parametrize("flag", DESTRUCTIVE)
+def test_the_default_is_off(flag):
+    """Not 'true'. An ON default on an unimported module is a hazard that
+    arms itself the day someone adopts it."""
+    assert _default_for(flag).lower() in ("false", "0", "no", "off"), flag
+
+
+def test_the_config_object_agrees_with_the_literal(monkeypatch):
+    """The literal and the resolved value must not drift — a source-grep pin
+    alone would pass while a factory overrode it."""
+    import dataclasses
+
+    for flag in DESTRUCTIVE:
+        monkeypatch.delenv(flag, raising=False)
+    import backend.core.infrastructure_orchestrator as M
+
+    cfgs = [c for c in vars(M).values()
+            if dataclasses.is_dataclass(c) and isinstance(c, type)
+            and "auto_destroy_on_shutdown" in {f.name for f in dataclasses.fields(c)}]
+    assert cfgs, "config dataclass not found"
+    cfg = cfgs[0]()
+    assert cfg.auto_destroy_on_shutdown is False
+
+
+def test_an_operator_can_still_turn_it_on():
+    """Default-off, not removed. The capability is intact for anyone who
+    deliberately wants it — this only stops it arming itself."""
+    src = _SRC.read_text()
+    for flag in DESTRUCTIVE:
+        assert flag in src
+
+
+def test_the_reason_is_recorded_where_the_next_reader_will_look():
+    """A bare `false` invites someone to 'fix' it back to true."""
+    src = _SRC.read_text()
+    assert "superseded" in src.lower()
+    assert "gcp_vm_manager" in src


### PR DESCRIPTION
Tier 0, UI half — the part that needs no provider credit.

## The root problem

Thirty commits of interactive cockpit behaviour could only be checked by a human sitting at a terminal pressing keys: unrepeatable, and dependent on remembering what to check. Every one of those features shipped with unit tests that call the handler and none that press the key.

That gap is not pedantic. A handler can be correct while the binding never fires — shadowed by prompt_toolkit's own bindings, filtered false at the moment it matters, or arriving as garbage text because mouse reporting was never negotiated. None of that is visible to a test that invokes the function directly, and all of it is visible to an operator immediately.

## What this adds

**`tests/ui/pty_input.py`** — what a terminal actually sends. `Ctrl+O` is `0x0f`; a click is an SGR escape sequence, not a `MouseEvent`. SGR (1006) rather than X10, because X10 packs a coordinate into one byte and mis-addresses every click past column 223 — invisible on a test terminal, not on the operator's. Wire coordinates are 1-based and the application's are 0-based; that conversion happens in exactly one place.

**`tests/ui/test_cockpit_pty_proof.py`** — drives `ov demo live` (the one scene that boots the real `build_bipartite_application` with no daemon and no credit) through a genuine pty. It extends the existing `PtySession` design rather than duplicating it, and adds the two things the cockpit needs that the original did not: a declared window size and byte input.

It asserts only what a **stream** can honestly decide — a sequence was negotiated, a keystroke produced a delta, specific text arrived. A pty carries the terminal's input, not its picture; reconstructing the picture would mean asserting against an emulator's fidelity as much as the cockpit's. Weaker than a screenshot, far stronger than nothing, and it catches the entire class above.

## Two real defects, found on the first run

**1. `scene_live` never registered its deck.** It builds its Application directly rather than through `run_bipartite_repl`, and so inherited none of that function's lifecycle. Sixteen call sites across `transcript_mode`, `transcript_hatches`, `serpent_flow` and `ov` find the deck through `get_active_canvas()` — every one got `None` and wrote nowhere. Silently, because the NEVER-raises discipline that stops a keybinding killing a REPL also makes a missing canvas indistinguishable from a successful write. The `Ctrl+O` viewer the demo *does* install was among the blinded.

Registration belongs to whoever owns the **run**, not to `build_bipartite_application`: a canvas armed at build time would outlive an app that is never run, and two built apps would overwrite each other's sink.

**2. The demo never installed the transcript hatches.** It mounted `search_rows` — a strip that renders only while a search is open — without the `/` that opens one, so the row could never appear. `Ctrl+L` was the same gap with a worse symptom: unbound, it fell through to prompt_toolkit's own clear-screen, which produces a thoroughly convincing repaint and none of the arming the chord promises. A demo that teaches a gesture the product does not have is worse than one that omits it.

`LocalCockpitClient` is reused rather than re-shimmed — one implementation, a second entrance.

> The `Ctrl+L` test is the one worth reading twice: **the repaint proves nothing**, because pt's default produces an identical one. Only the arming hint distinguishes "the cockpit's chord ran" from "pt's default ran".

## What is deliberately not asserted

That `SIGCONT` restores the alternate screen. It observably does not — and this harness cannot prove that is a defect. The child spawns with `start_new_session=True`, so its process group is orphaned, and POSIX discards stop signals to orphaned groups; the process very likely never suspended at all.

Asserting either way would be asserting the harness's job-control semantics rather than the cockpit's. The honest instrument is a session with a controlling shell — job control is the thing under test, so it cannot also be the thing stubbed out. Recorded in the test rather than quietly dropped. `alt_screen`'s own stop/resume symmetry is pinned separately, and it is correct: it declines to restore a buffer it does not own.

## Coverage

17 tests: alt-screen negotiation and release, SGR mouse negotiation, `Ctrl+O` transcript mode, `?` help panel, `c`/`C` claim jumping, wheel-scroll pause, click and drag parsing (asserting raw mouse bytes never reach the prompt as text), the `Ctrl+L` chord, `Ctrl+C` leaving no unraisable traceback, `Ctrl+Z` release, typing, and `/` liveness — the keystroke with an open freeze report against it.

## Test status

`tests/ui/test_cockpit_pty_proof.py` 17 passed · `tests/ui/test_headless_tui_integration.py` 13 passed (unchanged) · affected-surface sweep (49 files) 1192 passed.

Pre-existing reds, **verified unchanged** by running the same file set with and without this commit: `test_bottom_anchor`, `test_turn_spinner`, `test_surface_reachability`, two `test_keymap` alias tests that leak across files and pass in isolation, and `test_awakening_resize` (a `COLUMNS`-dependent flake).

PTY tests require an unsandboxed runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a real-pty UI test harness and blast-band diff ordering to improve reliability and review. Also fixes cockpit demo wiring, import graph accuracy, fanout tree rendering, and turns off superseded infra defaults.

- **New Features**
  - `tests/ui/pty_input.py` + `tests/ui/test_cockpit_pty_proof.py`: drive `ov demo live` through a genuine PTY, set window size, and assert on alt-screen, SGR mouse, and key/mouse bytes.
  - `backend/core/ouroboros/ui/blast_bands.py`: band files by reach (unresolved first), env-tunable thresholds, stable ordering; used in `diff_preview` to sort changes riskiest-first.

- **Bug Fixes**
  - `ov_demo`: register the active canvas with `set_active_canvas(mux)` and clear on exit; install transcript hatches using `LocalCockpitClient`.
  - `op_fanout_tree`: render depth-first (parent before children), preserve sibling order, keep visible orphans.
  - `ProgressBoard`: resolve relative imports, include `scripts/` in scan roots, and count bare `core.*` imports.
  - `backend/core/infrastructure_orchestrator.py`: default `on_demand_enabled`, `auto_destroy_on_shutdown`, and `terraform_auto_approve` to false.

<sup>Written for commit 54a634223886eaa5b06ecb9aaf36d926a37c4a4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

