### PR TITLE
feat(ov): /memory — the organism can say what it knows; board sees the kernel

### DIFF
--- a/backend/core/ouroboros/battle_test/memory_surface.py
+++ b/backend/core/ouroboros/battle_test/memory_surface.py
@@ -63,27 +63,58 @@ def memory_surface_enabled() -> bool:
     ).strip().lower() not in ("0", "false", "no", "off")
 
 
-#: iCloud's conflict-copy suffix: `battle_test 2`, `slices 3`. This repo lives
-#: under a `.nosync` mount precisely because iCloud corrupted `.git` once, and
-#: the duplicate DIRECTORIES it left behind are still on disk.
+#: Hard ceiling on what one `/memory` may put on the wire.
 #:
-#: Counting them doubled every number on first render — "763 topics" for a
-#: corpus of ~382. That is the one failure mode a memory surface must not
-#: have: it does not merely mis-count, it tells the operator the organism
-#: knows twice what it does, in the exact place they came to find out.
-_CLOUD_DUP = __import__("re").compile(r"^.+ \d+$")
+#: The verb sends per-domain COUNTS and a capped hit list — never the corpus —
+#: so a bare `/memory` is ~700 bytes and a search is bounded by `limit`. This
+#: is the guard that keeps it that way: a future section, or a corpus that
+#: grows an order of magnitude, cannot quietly turn a summary into a flood
+#: that costs the TUI its frame budget.
+#:
+#: Enforced by TRUNCATION with a visible marker rather than by refusing to
+#: answer. An operator who asked what the organism knows should get a short
+#: answer that says it was shortened, never an error.
+_MAX_PAYLOAD_BYTES = 8192
 
 
-def _is_cloud_duplicate(name: str) -> bool:
-    """True for an iCloud conflict copy. Pure. NEVER raises.
+def _tracked_topic_paths(root: Path) -> Optional[List[Path]]:
+    """The topic files the REPO declares, or None if git cannot say.
 
-    Matches a trailing space-and-digits, which is iCloud's format and not a
-    convention any real topic domain here uses.
+    This is the root fix, and it is not a filter.
+
+    The corpus is not "every .md under a directory" — it is what the
+    repository tracks. Reading the working tree instead made the surface
+    count things the repo has explicitly disowned: iCloud conflict copies
+    (`battle_test 2/`, created because this repo lives under a synced
+    `~/Documents`) are UNTRACKED and already gitignored at `.gitignore:270`.
+    Nothing in iCloud is part of O+V's memory; the sync client simply
+    littered inside the working tree.
+
+    So the answer is to ask the authority that already knows. That
+    generalises past iCloud for free — editor backups, a vendored second
+    checkout, stray downloads — because "ignored" is the repo stating that a
+    file is not part of itself, and no pattern list has to be maintained to
+    keep up.
+
+    Returns None (not an empty list) when git is unavailable, so the caller
+    can fall back to walking the tree rather than reporting a corpus of zero.
+    An absent VCS must not read as an empty mind.
     """
     try:
-        return bool(_CLOUD_DUP.match(str(name or "")))
+        import subprocess
+
+        proc = subprocess.run(
+            ["git", "ls-files", "-z", "--", "docs/memory_topics"],
+            cwd=str(root), capture_output=True, timeout=10.0, check=False,
+        )
+        if proc.returncode != 0:
+            return None
+        names = [n for n in proc.stdout.decode(
+            "utf-8", "replace").split("\0") if n.endswith(".md")]
+        return [root / n for n in names]
     except Exception:  # noqa: BLE001
-        return False
+        logger.debug("[MemorySurface] git ls-files unavailable", exc_info=True)
+        return None
 
 
 def _repo_root() -> Path:
@@ -152,8 +183,15 @@ def topic_counts() -> Dict[str, int]:
         root = _repo_root() / "docs" / "memory_topics"
         if not root.is_dir():
             return out
+        tracked = _tracked_topic_paths(_repo_root())
+        if tracked is not None:
+            for path in tracked:
+                domain = path.parent.name
+                out[domain] = out.get(domain, 0) + 1
+            return out
+        # git unavailable — walk the tree, and say nothing false about it.
         for child in sorted(root.iterdir()):
-            if not child.is_dir() or _is_cloud_duplicate(child.name):
+            if not child.is_dir():
                 continue
             n = sum(1 for _ in child.glob("*.md"))
             if n:
@@ -180,9 +218,10 @@ def search_topics(term: str, limit: int = _DEFAULT_LIMIT) -> List[str]:
         if not root.is_dir():
             return []
         hits: List[str] = []
-        for path in sorted(root.rglob("*.md")):
-            if _is_cloud_duplicate(path.parent.name):
-                continue
+        tracked = _tracked_topic_paths(_repo_root())
+        candidates = (sorted(tracked) if tracked is not None
+                      else sorted(root.rglob("*.md")))
+        for path in candidates:
             if needle in path.name.lower():
                 hits.append(f"    {path.parent.name}/{path.name}")
                 if len(hits) >= max(1, int(limit)):
@@ -225,6 +264,37 @@ def _routing_row() -> str:
 # ---------------------------------------------------------------------------
 
 
+def _clamp_payload(rows: List[str],
+                   limit: int = _MAX_PAYLOAD_BYTES) -> List[str]:
+    """Rows truncated to fit ``limit`` bytes, with a visible marker.
+
+    The guard, not the design. This verb sends per-domain COUNTS and a capped
+    hit list — never the corpus — so it is ~700 bytes today and nothing about
+    it wants to grow. What this prevents is a LATER section, or a corpus an
+    order of magnitude larger, quietly turning a summary into a flood that
+    costs the TUI its frame budget across the socket.
+
+    Truncates rather than refusing. An operator who asked what the organism
+    knows should get a short answer that admits it was shortened, never an
+    error — and never a silent tail-drop, which would read as "that is all
+    there is". Pure. NEVER raises.
+    """
+    try:
+        out: List[str] = []
+        used = 0
+        for row in rows or ():
+            size = len(str(row).encode("utf-8", "replace")) + 1
+            if used + size > int(limit):
+                out.append(f"  [dim]… truncated at {int(limit)} bytes "
+                           f"({len(rows) - len(out)} rows withheld)[/dim]")
+                break
+            out.append(row)
+            used += size
+        return out
+    except Exception:  # noqa: BLE001
+        return list(rows or ())
+
+
 def compose_memory_lines(arg: str = "") -> List[str]:
     """Markup lines for ``/memory [search-term]``. NEVER raises.
 
@@ -245,7 +315,7 @@ def compose_memory_lines(arg: str = "") -> List[str]:
             hits = search_topics(term)
             out.append(f"  [bold]memory · topics matching[/bold] {term!r}")
             out.extend(hits or ["    [dim](no topic name matches)[/dim]"])
-            return out
+            return _clamp_payload(out)
 
         out.append("  [bold]memory[/bold]")
 
@@ -268,8 +338,8 @@ def compose_memory_lines(arg: str = "") -> List[str]:
             out.append("    [dim](docs/memory_topics not found)[/dim]")
 
         out.append(_routing_row())
-        out.append("  [dim]/memory <term> searches topic names[/dim]")
-        return out
+        out.append("  [dim]/memory topics <term> searches topic names[/dim]")
+        return _clamp_payload(out)
     except Exception as exc:  # noqa: BLE001
         logger.debug("[MemorySurface] compose degraded", exc_info=True)
         return [f"  [dim]memory surface degraded: "

--- a/backend/core/ouroboros/battle_test/memory_surface.py
+++ b/backend/core/ouroboros/battle_test/memory_surface.py
@@ -1,0 +1,276 @@
+"""What the organism remembers, made visible.
+
+O+V carries fifteen memory modules and, in this repo, 764 written topics. The
+cockpit had no verb for any of it. An operator could see what the organism was
+DOING at every phase and had no way to ask what it KNEW — which is the half
+that explains the doing.
+
+That gap matters more here than it would in a reactive tool. O+V acts
+unprompted, so the operator's question is never only "what did it do" but
+"what did it believe when it decided to". Memory is the answer to the second,
+and an answer nobody can read is not an answer.
+
+Reads, never writes
+-------------------
+This composes lines from stores that already exist and owns none of them.
+`UserPreferenceStore` is the authority on preferences, `docs/memory_topics` on
+architecture, `ModuleContextRouter` on what gets injected where. A surface
+that could edit memory would be a second write path into state the governance
+pipeline depends on — and the one place a display must not become is an
+authority.
+
+The same reason `/posture`'s override is the only write-surface it has, and
+the same reason the blast-radius gutter reads through `peek` and never scans.
+
+Degrades per-SOURCE, not globally
+----------------------------------
+Each section is gathered independently and a failure in one is reported in
+place rather than emptying the panel. A memory surface that renders nothing
+because one store is unavailable teaches the operator that the organism
+remembers nothing, which is the opposite of true and worse than a partial
+answer that says which part is missing.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger("Ouroboros.MemorySurface")
+
+MEMORY_SURFACE_SCHEMA_VERSION: str = "memory_surface.1"
+
+__all__ = [
+    "MEMORY_SURFACE_SCHEMA_VERSION",
+    "compose_memory_lines",
+    "memory_surface_enabled",
+    "preference_rows",
+    "search_topics",
+    "topic_counts",
+]
+
+#: How many rows a bare `/memory` may spend. The cockpit deck is finite and a
+#: verb that floods it is one an operator stops typing — the restraint the
+#: rest of this surface already keeps.
+_DEFAULT_LIMIT = 12
+
+
+def memory_surface_enabled() -> bool:
+    """``JARVIS_MEMORY_SURFACE_ENABLED`` (default true). NEVER raises."""
+    return os.environ.get(
+        "JARVIS_MEMORY_SURFACE_ENABLED", "1",
+    ).strip().lower() not in ("0", "false", "no", "off")
+
+
+#: iCloud's conflict-copy suffix: `battle_test 2`, `slices 3`. This repo lives
+#: under a `.nosync` mount precisely because iCloud corrupted `.git` once, and
+#: the duplicate DIRECTORIES it left behind are still on disk.
+#:
+#: Counting them doubled every number on first render — "763 topics" for a
+#: corpus of ~382. That is the one failure mode a memory surface must not
+#: have: it does not merely mis-count, it tells the operator the organism
+#: knows twice what it does, in the exact place they came to find out.
+_CLOUD_DUP = __import__("re").compile(r"^.+ \d+$")
+
+
+def _is_cloud_duplicate(name: str) -> bool:
+    """True for an iCloud conflict copy. Pure. NEVER raises.
+
+    Matches a trailing space-and-digits, which is iCloud's format and not a
+    convention any real topic domain here uses.
+    """
+    try:
+        return bool(_CLOUD_DUP.match(str(name or "")))
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _repo_root() -> Path:
+    """The repo root, derived from THIS file's location. NEVER raises.
+
+    Derived rather than read from an env var: a memory surface that pointed
+    at the wrong tree would report another project's knowledge as this one's,
+    and be entirely convincing while doing it.
+    """
+    try:
+        return Path(__file__).resolve().parents[4]
+    except Exception:  # noqa: BLE001
+        return Path.cwd()
+
+
+# ---------------------------------------------------------------------------
+# preferences — what the operator taught it
+# ---------------------------------------------------------------------------
+
+
+def preference_rows(limit: int = _DEFAULT_LIMIT) -> Tuple[List[str], str]:
+    """``(rows, error)`` from `UserPreferenceStore`. NEVER raises.
+
+    Returns the ERROR rather than logging it and yielding nothing: "the
+    preference store is unavailable" and "you have taught it nothing" render
+    identically as an empty list, and they are opposite facts.
+    """
+    try:
+        from backend.core.ouroboros.governance.user_preference_memory import (
+            get_default_store,
+        )
+
+        memories = list(get_default_store().list_all() or ())
+        if not memories:
+            return [], ""
+        rows: List[str] = []
+        for mem in memories[: max(1, int(limit))]:
+            kind = getattr(getattr(mem, "type", None), "value", "?")
+            name = str(getattr(mem, "name", "") or getattr(mem, "id", "?"))
+            desc = str(getattr(mem, "description", "") or "").strip()
+            rows.append(f"    [{kind}] {name} — {desc}" if desc
+                        else f"    [{kind}] {name}")
+        if len(memories) > limit:
+            rows.append(f"    … {len(memories) - limit} more")
+        return rows, ""
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[MemorySurface] preferences degraded", exc_info=True)
+        return [], f"{type(exc).__name__}: {exc}"
+
+
+# ---------------------------------------------------------------------------
+# topics — what it was told about its own architecture
+# ---------------------------------------------------------------------------
+
+
+def topic_counts() -> Dict[str, int]:
+    """``{domain: count}`` under `docs/memory_topics`. NEVER raises.
+
+    Counted from disk rather than from an index file. `INDEX.md` is written
+    by hand and can lag; the directory cannot, and a memory surface that
+    reports a stale count is telling the operator something false about how
+    much the organism knows.
+    """
+    out: Dict[str, int] = {}
+    try:
+        root = _repo_root() / "docs" / "memory_topics"
+        if not root.is_dir():
+            return out
+        for child in sorted(root.iterdir()):
+            if not child.is_dir() or _is_cloud_duplicate(child.name):
+                continue
+            n = sum(1 for _ in child.glob("*.md"))
+            if n:
+                out[child.name] = n
+    except Exception:  # noqa: BLE001
+        logger.debug("[MemorySurface] topic scan degraded", exc_info=True)
+    return out
+
+
+def search_topics(term: str, limit: int = _DEFAULT_LIMIT) -> List[str]:
+    """Topic paths whose NAME matches ``term``. NEVER raises.
+
+    Filename-only, deliberately. Grepping 764 bodies from a key handler would
+    block the event loop on a full-screen Application — the render stalls the
+    async-diff work already had to move off-thread to avoid. Names are
+    descriptive here by convention (`project_*`, `feedback_*`, `slice*`), so
+    the cheap match is also the useful one; `/expand` on a hit reads the body.
+    """
+    try:
+        needle = str(term or "").strip().lower()
+        if not needle:
+            return []
+        root = _repo_root() / "docs" / "memory_topics"
+        if not root.is_dir():
+            return []
+        hits: List[str] = []
+        for path in sorted(root.rglob("*.md")):
+            if _is_cloud_duplicate(path.parent.name):
+                continue
+            if needle in path.name.lower():
+                hits.append(f"    {path.parent.name}/{path.name}")
+                if len(hits) >= max(1, int(limit)):
+                    break
+        return hits
+    except Exception:  # noqa: BLE001
+        logger.debug("[MemorySurface] topic search degraded", exc_info=True)
+        return []
+
+
+# ---------------------------------------------------------------------------
+# routing — where memory actually lands in a prompt
+# ---------------------------------------------------------------------------
+
+
+def _routing_row() -> str:
+    """One line on `ModuleContextRouter`. NEVER raises.
+
+    Worth its own row because it answers the question the other two cannot:
+    memory that exists and memory that reaches a GENERATE prompt are different
+    things, and this codebase has repeatedly shipped the first while believing
+    it shipped the second.
+    """
+    try:
+        flag = os.environ.get("JARVIS_MEMORY_ROUTING_ENABLED", "1")
+        on = flag.strip().lower() not in ("0", "false", "no", "off")
+        try:
+            from backend.core.ouroboros.governance import module_routing  # noqa: F401
+            present = "available"
+        except Exception:  # noqa: BLE001
+            present = "UNAVAILABLE"
+        return (f"    routing: {'on' if on else 'off'} · "
+                f"ModuleContextRouter {present}")
+    except Exception:  # noqa: BLE001
+        return "    routing: unknown"
+
+
+# ---------------------------------------------------------------------------
+# composition
+# ---------------------------------------------------------------------------
+
+
+def compose_memory_lines(arg: str = "") -> List[str]:
+    """Markup lines for ``/memory [search-term]``. NEVER raises.
+
+    Pure composition — takes no console and prints nothing, so the daemon
+    terminal and the attach cockpit render the SAME text through their own
+    sinks. Returning lines rather than printing is what let this verb be
+    mirrored at all; the ~76 handlers that print directly are invisible on
+    the attach client for exactly that reason.
+    """
+    if not memory_surface_enabled():
+        return ["  [dim]memory surface disabled "
+                "(JARVIS_MEMORY_SURFACE_ENABLED=0)[/dim]"]
+    try:
+        term = str(arg or "").strip()
+        out: List[str] = []
+
+        if term:
+            hits = search_topics(term)
+            out.append(f"  [bold]memory · topics matching[/bold] {term!r}")
+            out.extend(hits or ["    [dim](no topic name matches)[/dim]"])
+            return out
+
+        out.append("  [bold]memory[/bold]")
+
+        prefs, err = preference_rows()
+        out.append("  [dim]taught by you[/dim]")
+        if err:
+            out.append(f"    [dim]unavailable — {err}[/dim]")
+        elif prefs:
+            out.extend(prefs)
+        else:
+            out.append("    [dim](nothing recorded yet)[/dim]")
+
+        counts = topic_counts()
+        total = sum(counts.values())
+        out.append(f"  [dim]written topics[/dim] · {total}")
+        if counts:
+            ranked = sorted(counts.items(), key=lambda kv: -kv[1])[:6]
+            out.append("    " + " · ".join(f"{d} {n}" for d, n in ranked))
+        else:
+            out.append("    [dim](docs/memory_topics not found)[/dim]")
+
+        out.append(_routing_row())
+        out.append("  [dim]/memory <term> searches topic names[/dim]")
+        return out
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[MemorySurface] compose degraded", exc_info=True)
+        return [f"  [dim]memory surface degraded: "
+                f"{type(exc).__name__}: {exc}[/dim]"]

--- a/backend/core/ouroboros/battle_test/progress_board.py
+++ b/backend/core/ouroboros/battle_test/progress_board.py
@@ -110,7 +110,27 @@ def scan_roots() -> Tuple[str, ...]:
     # `scripts/ouroboros_battle_test.py:1997`. Same shape as the relative-
     # import blindness — the board was right about its own graph and the
     # graph was missing an edge.
-    return ("backend", "scripts")
+    # "." is the REPO ROOT, and leaving it out was the fifth blindness.
+    #
+    # `unified_supervisor.py` — the 102K-line kernel, the thing that actually
+    # boots this system — lives at the root, so none of its import edges were
+    # ever scanned. Every module reached ONLY from the kernel read DARK.
+    #
+    # Found via `elite_dashboard.py`: flagged dark-and-enabled and one step
+    # from deletion, while the kernel imports it at Zone 6.14, calls
+    # `get_elite_dashboard()`, `await start()`, `install_narrator_hook()` and
+    # keeps the instance. A dashboard that runs on every boot, invisible to
+    # the board that exists to say what runs.
+    #
+    # Same shape as the four before it: the board was right about its own
+    # graph, and the graph was missing an edge. This one was the largest —
+    # the entry point itself.
+    #
+    # The walker already prunes `_EXCLUDE_DIRS`, so adding "." costs the
+    # root's own files plus directories not otherwise listed; it does not
+    # re-walk `backend` twice, because paths are normalised to module names
+    # and the set is deduplicated.
+    return (".", "backend", "scripts")
 
 
 #: Directories that are not this codebase. A venv vendored under the scan root

--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -8302,6 +8302,42 @@ class SerpentREPL:
                 highlight=False,
             )
 
+    def _handle_memory(self, line: str = "") -> None:
+        """``/memory [term]`` — what the organism remembers.
+
+        Preferences you taught it, the written topic corpus, and whether
+        `ModuleContextRouter` is actually injecting any of it. With a term,
+        searches topic NAMES.
+
+        O+V acts unprompted, so the operator's question is never only "what
+        did it do" but "what did it believe when it decided to". Fifteen
+        memory modules and 764 topics had no verb; this is the eye on them.
+
+        Mirrored, not printed. `compose_memory_lines` returns text and takes
+        no console, so the daemon terminal and the attach cockpit render the
+        same rows through their own sinks — the ~76 handlers that call
+        `console.print` directly are invisible on the attach client, and a
+        new verb should not join them.
+        """
+        try:
+            from backend.core.ouroboros.battle_test.memory_surface import (
+                compose_memory_lines,
+            )
+            arg = str(line or "")
+            # Strip the verb itself when the dispatcher hands the whole line.
+            for prefix in ("/memory", "memory"):
+                if arg.strip().startswith(prefix):
+                    arg = arg.strip()[len(prefix):]
+                    break
+            for row in compose_memory_lines(arg.strip()):
+                self._flow._mirror_markup(row)
+                self._flow.console.print(row, highlight=False)
+        except Exception as exc:  # noqa: BLE001
+            self._flow.console.print(
+                f"  [{_SEM['death']}]/memory error: {exc}[/{_SEM['death']}]",
+                highlight=False,
+            )
+
     # ── Gap #3 Slice 3 — unified /expand verb ───────────────────
 
     def _handle_expand(self, line: str) -> None:

--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -8302,42 +8302,6 @@ class SerpentREPL:
                 highlight=False,
             )
 
-    def _handle_memory(self, line: str = "") -> None:
-        """``/memory [term]`` — what the organism remembers.
-
-        Preferences you taught it, the written topic corpus, and whether
-        `ModuleContextRouter` is actually injecting any of it. With a term,
-        searches topic NAMES.
-
-        O+V acts unprompted, so the operator's question is never only "what
-        did it do" but "what did it believe when it decided to". Fifteen
-        memory modules and 764 topics had no verb; this is the eye on them.
-
-        Mirrored, not printed. `compose_memory_lines` returns text and takes
-        no console, so the daemon terminal and the attach cockpit render the
-        same rows through their own sinks — the ~76 handlers that call
-        `console.print` directly are invisible on the attach client, and a
-        new verb should not join them.
-        """
-        try:
-            from backend.core.ouroboros.battle_test.memory_surface import (
-                compose_memory_lines,
-            )
-            arg = str(line or "")
-            # Strip the verb itself when the dispatcher hands the whole line.
-            for prefix in ("/memory", "memory"):
-                if arg.strip().startswith(prefix):
-                    arg = arg.strip()[len(prefix):]
-                    break
-            for row in compose_memory_lines(arg.strip()):
-                self._flow._mirror_markup(row)
-                self._flow.console.print(row, highlight=False)
-        except Exception as exc:  # noqa: BLE001
-            self._flow.console.print(
-                f"  [{_SEM['death']}]/memory error: {exc}[/{_SEM['death']}]",
-                highlight=False,
-            )
-
     # ── Gap #3 Slice 3 — unified /expand verb ───────────────────
 
     def _handle_expand(self, line: str) -> None:
@@ -9700,7 +9664,45 @@ class SerpentREPL:
           /memory rm <id>                 — remove a memory by id
           /memory forbid <path>           — shortcut: add a FORBIDDEN_PATH memory
           /memory show <id>               — print a single memory's full content
+          /memory topics [term]           — the written corpus + whether
+                                            ModuleContextRouter is injecting it
+
+        ``topics`` is handled HERE rather than at the harness, and is the one
+        subcommand that reads something other than `UserPreferenceStore`.
+        Preferences are what the operator taught the organism; topics are what
+        it was told about its own architecture, and until now nothing could
+        ask about the second — 382 written topics with no verb.
+
+        It answers the question the CRUD half cannot: whether any of it
+        actually reaches a GENERATE prompt. Memory that exists and memory that
+        is INJECTED are different facts, and this codebase has shipped the
+        first believing it shipped the second more than once.
+
+        Composed, then mirrored. `compose_memory_lines` returns text and takes
+        no console, so the daemon terminal and the attach cockpit render the
+        same rows through their own sinks — the handlers that `console.print`
+        directly are invisible on the attach client.
         """
+        arg = str(line or "").strip()
+        for prefix in ("/memory", "memory"):
+            if arg.startswith(prefix):
+                arg = arg[len(prefix):].strip()
+                break
+        if arg.split(" ", 1)[0].lower() == "topics":
+            try:
+                from backend.core.ouroboros.battle_test.memory_surface import (
+                    compose_memory_lines,
+                )
+                term = arg.split(" ", 1)[1].strip() if " " in arg else ""
+                for row in compose_memory_lines(term):
+                    self._flow._mirror_markup(row)
+                    self._flow.console.print(row, highlight=False)
+            except Exception as exc:  # noqa: BLE001
+                self._flow.console.print(
+                    f"  [{_SEM['death']}]/memory topics error: {exc}"
+                    f"[/{_SEM['death']}]", highlight=False,
+                )
+            return
         await self._delegate_to_harness(line, error_label="Memory error")
 
     async def _handle_remember(self, line: str) -> None:

--- a/backend/core/ouroboros/governance/module_routing.py
+++ b/backend/core/ouroboros/governance/module_routing.py
@@ -21,7 +21,7 @@ import re
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, List, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple
 
 if TYPE_CHECKING:  # pragma: no cover
     pass
@@ -138,7 +138,27 @@ class TopicFragment:
 
 
 def _hash_content(text: str) -> str:
-    return hashlib.sha256(text.encode("utf-8", errors="replace")).hexdigest()[:16]
+    """SHA-256 of the NORMALISED payload, truncated. Pure. NEVER raises.
+
+    Normalisation is what makes this an identity rather than a checksum.
+    Two copies of one topic differ in ways that are not content: CRLF from a
+    Windows checkout, a trailing newline an editor added, indentation
+    whitespace a sync client rewrote. Hashing the raw bytes would call those
+    different documents and defeat the deduplication they are supposed to
+    enable.
+
+    Deliberately does NOT strip interior blank lines or normalise case: two
+    topics that differ only in emphasis or paragraphing ARE different
+    documents, and a hash aggressive enough to merge them would silently drop
+    real memory. Normalise transport artefacts; preserve authorship.
+    """
+    normalised = "\n".join(
+        line.rstrip() for line in str(text or "").replace("\r\n", "\n")
+                                                 .replace("\r", "\n")
+                                                 .split("\n")
+    ).strip()
+    return hashlib.sha256(
+        normalised.encode("utf-8", errors="replace")).hexdigest()[:16]
 
 
 def _extract_title(content: str, path: Path) -> str:
@@ -168,6 +188,27 @@ def _load_topic_fragments_worker(
         return []
 
     fragments: List[TopicFragment] = []
+    #: content_hash -> the URI that claimed it first. Identity is the PAYLOAD,
+    #: never the path.
+    #
+    #: This loader walked `rglob("*.md")` and injected whatever the filesystem
+    #: held, so an iCloud conflict copy (`battle_test 2/`, from this repo
+    #: living under a synced `~/Documents`) was loaded as a SECOND topic —
+    #: every duplicated fragment paying full tokens in a GENERATE prompt to
+    #: say what the first one already said.
+    #
+    #: Filtering the name would have fixed that one cause and no other.
+    #: Hashing the payload immunises against every cause at once — sync
+    #: copies, symlink loops, a hand copy-paste, a vendored second checkout —
+    #: because none of them can change what the document IS. `_hash_content`
+    #: was already computed here for every fragment and simply never
+    #: consulted; the deduplication was one comparison away the whole time.
+    #:
+    #: FIRST path wins, and `sorted()` above makes "first" deterministic: the
+    #: same corpus yields the same surviving URI on every boot, so a topic's
+    #: recorded provenance does not shuffle between runs.
+    seen_hashes: Dict[str, str] = {}
+    duplicates = 0
     for md_file in sorted(topics_dir.rglob("*.md")):
         try:
             content = md_file.read_text(encoding="utf-8", errors="replace")
@@ -183,6 +224,20 @@ def _load_topic_fragments_worker(
             modules = tuple(_parse_modules_frontmatter(content))
             content_hash = _hash_content(content)
 
+            first = seen_hashes.get(content_hash)
+            if first is not None:
+                # Silently, per the mandate — but COUNTED. A dedup that
+                # leaves no trace is indistinguishable from a loader that
+                # never saw the file, and the difference matters the day
+                # someone asks why a topic they wrote is not in a prompt.
+                duplicates += 1
+                logger.debug(
+                    "[ModuleRouter] duplicate payload %s == %s (hash %s)",
+                    uri, first, content_hash,
+                )
+                continue
+            seen_hashes[content_hash] = uri
+
             fragments.append(
                 TopicFragment(
                     source_id=source_id,
@@ -196,6 +251,11 @@ def _load_topic_fragments_worker(
         except Exception:  # noqa: BLE001 — fail-soft per spec
             logger.debug("[ModuleRouter] skipping topic file %s (read error)", md_file, exc_info=True)
 
+    if duplicates:
+        logger.info(
+            "[ModuleRouter] corpus %d topics (%d duplicate payloads dropped)",
+            len(fragments), duplicates,
+        )
     return fragments
 
 

--- a/tests/governance/test_memory_dedup_and_payload.py
+++ b/tests/governance/test_memory_dedup_and_payload.py
@@ -1,0 +1,164 @@
+"""Identity is the payload; the wire has a ceiling.
+
+Two invariants, both about a loader trusting the wrong thing.
+
+The router walked `rglob("*.md")` and injected whatever the filesystem held,
+so an iCloud conflict copy was a SECOND topic — paying full tokens in a
+GENERATE prompt to repeat what the first one already said. Filtering the NAME
+would have fixed one cause; hashing the PAYLOAD immunises against every cause
+at once, because none of them can change what the document is.
+
+The surface sends counts and a capped hit list, never the corpus. These pin
+that it stays that way.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# 1 — content-addressed deduplication
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_identical_payloads_under_different_names_load_once(
+        tmp_path: Path) -> None:
+    """The mandate, stated exactly: same content, unrelated names, one topic.
+
+    The two filenames share no substring a pattern could key on — no
+    ` 2` suffix, no `copy`, nothing. That is the point: this must hold for a
+    duplicate that no naming convention could have caught, which is what
+    separates a content hash from the filter it replaces.
+    """
+    from backend.core.ouroboros.governance.module_routing import (
+        _load_topic_fragments_worker,
+    )
+
+    body = (
+        "---\nmodules: [backend/core/ouroboros/governance/orchestrator.py]\n---\n"
+        "# Blast Radius Provenance\n\nUnknown is never zero.\n"
+    )
+    topics = tmp_path / "docs" / "memory_topics" / "ouroboros"
+    topics.mkdir(parents=True)
+    (topics / "project_blast_provenance.md").write_text(body, encoding="utf-8")
+    (topics / "zzz_unrelated_filename.md").write_text(body, encoding="utf-8")
+
+    frags = _load_topic_fragments_worker(
+        str(tmp_path / "docs" / "memory_topics"), str(tmp_path))
+
+    assert len(frags) == 1, (
+        f"corpus incremented twice for one document: "
+        f"{[f.uri for f in frags]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_transport_artefacts_do_not_defeat_the_hash(
+        tmp_path: Path) -> None:
+    """CRLF and trailing whitespace are not authorship.
+
+    A sync client or a Windows checkout rewrites line endings without
+    touching a word. Hashing raw bytes would call those different documents
+    and defeat the deduplication entirely — the normalisation is what makes
+    the hash an identity rather than a checksum.
+    """
+    from backend.core.ouroboros.governance.module_routing import (
+        _load_topic_fragments_worker,
+    )
+
+    body = "# Posture\n\nEXPLORE, CONSOLIDATE, HARDEN, MAINTAIN.\n"
+    topics = tmp_path / "t"
+    topics.mkdir()
+    (topics / "a.md").write_text(body, encoding="utf-8")
+    (topics / "b.md").write_text(
+        body.replace("\n", "\r\n") + "   \n", encoding="utf-8")
+
+    frags = _load_topic_fragments_worker(str(topics), str(tmp_path))
+    assert len(frags) == 1, "CRLF/trailing-space copy loaded as a second topic"
+
+
+@pytest.mark.asyncio
+async def test_genuinely_different_topics_both_survive(tmp_path: Path) -> None:
+    """The guard against a hash so aggressive it eats real memory.
+
+    A deduplicator that merged distinct documents would silently delete
+    knowledge — a worse failure than the duplication it fixes, and a silent
+    one. Two topics differing by a single sentence must both load.
+    """
+    from backend.core.ouroboros.governance.module_routing import (
+        _load_topic_fragments_worker,
+    )
+
+    topics = tmp_path / "t"
+    topics.mkdir()
+    (topics / "a.md").write_text("# A\n\nOne fact.\n", encoding="utf-8")
+    (topics / "b.md").write_text("# A\n\nOne fact. And another.\n",
+                                 encoding="utf-8")
+
+    frags = _load_topic_fragments_worker(str(topics), str(tmp_path))
+    assert len(frags) == 2, "distinct documents were merged — memory was lost"
+
+
+# ---------------------------------------------------------------------------
+# 2 — the payload never floods the socket
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_memory_payload_respects_the_byte_ceiling() -> None:
+    """Every form of the verb stays under the cap, against the REAL corpus.
+
+    Run against this repo's own 383 topics rather than a fixture, because the
+    question is not whether the clamp works on synthetic input — it is
+    whether the verb's actual composition stays bounded as the corpus grows.
+    """
+    from backend.core.ouroboros.battle_test.memory_surface import (
+        _MAX_PAYLOAD_BYTES, compose_memory_lines,
+    )
+
+    for arg in ("", "project", "advisor", "e", "a"):
+        rows = compose_memory_lines(arg)
+        size = sum(len(r.encode("utf-8")) + 1 for r in rows)
+        assert size <= _MAX_PAYLOAD_BYTES, (
+            f"/memory topics {arg!r} put {size} bytes on the wire "
+            f"(cap {_MAX_PAYLOAD_BYTES})"
+        )
+
+
+@pytest.mark.asyncio
+async def test_truncation_announces_itself() -> None:
+    """A clamped payload must say so.
+
+    A silent tail-drop reads as "that is all there is", which is the one
+    thing a memory surface must never imply. Asserted at a tiny cap so the
+    marker is forced regardless of corpus size.
+    """
+    from backend.core.ouroboros.battle_test.memory_surface import _clamp_payload
+
+    rows = [f"  row {i} " + "x" * 40 for i in range(50)]
+    out = _clamp_payload(rows, limit=256)
+
+    assert len(out) < len(rows), "nothing was truncated at a 256-byte cap"
+    assert "truncated" in out[-1], f"truncation was silent: {out[-1]!r}"
+    assert sum(len(r.encode()) + 1 for r in out[:-1]) <= 256
+
+
+@pytest.mark.asyncio
+async def test_the_corpus_is_what_the_repo_tracks() -> None:
+    """Untracked files are not memory.
+
+    The root fix. iCloud conflict copies live in the working tree and are
+    gitignored; asking git rather than the filesystem excludes them — and
+    every other class of stray — without a pattern list to maintain.
+    """
+    from backend.core.ouroboros.battle_test.memory_surface import topic_counts
+
+    counts = topic_counts()
+    assert counts, "no topics found at all"
+    for domain in counts:
+        assert not domain.endswith((" 2", " 3")), (
+            f"an untracked sync copy entered the corpus: {domain!r}"
+        )


### PR DESCRIPTION
Two things, both the same shape: **the capability existed and nothing could see it.**

## `/memory` (new)

O+V carries **fifteen memory modules and 382 written topics**, and the cockpit had no verb for any of it. An operator could watch what the organism was *doing* at every phase and had no way to ask what it *knew* — which is the half that explains the doing.

That gap matters more in a proactive system than a reactive one. O+V acts unprompted, so the question is never only "what did it do" but "what did it believe when it decided to". Memory answers the second, and an answer nobody can read is not an answer.

Three sections, gathered independently so one unavailable store reports in place instead of emptying the panel:

- **taught by you** — from `UserPreferenceStore`
- **written topics** — counted from disk, because `INDEX.md` is hand-written and can lag
- **routing** — whether `ModuleContextRouter` is actually injecting any of it

That last row earns its place: memory that *exists* and memory that *reaches a GENERATE prompt* are different things, and this codebase has repeatedly shipped the first believing it shipped the second.

**Mirrored, not printed.** `compose_memory_lines` returns text and takes no console, so the daemon terminal and the attach cockpit render the same rows through their own sinks. The ~76 handlers that call `console.print` directly are invisible on the attach client; a new verb should not join them.

**Reads, never writes.** `UserPreferenceStore` stays the authority — a display that could edit memory would be a second write path into state the governance pipeline depends on.

> **Caught on first render:** the count said **763** for a corpus of **382**. iCloud conflict copies (`battle_test 2`, `slices 3` — this repo lives under `.nosync` because iCloud corrupted `.git` once) were counted twice. That is the one failure mode a memory surface must not have: not mis-counting, but telling the operator the organism knows twice what it does, in the exact place they came to find out.

```
  memory
  taught by you
    [feedback] rejection_4b_parity — Rejected approach: 4b parity
    [project] Session W mutation calibration baseline — 28.6% mutation score …
  written topics · 382
    ouroboros 147 · slices 90 · battle_test 66 · infra 18 · intake 15 · sovereign 14
    routing: on · ModuleContextRouter available
  /memory <term> searches topic names
```

## `progress_board`: scan the repo root — the fifth blindness

`scan_roots()` was `("backend", "scripts")`. **`unified_supervisor.py` — the 102K-line kernel, the thing that actually boots this system — is at the repo root**, so none of its import edges were ever scanned. Every module reached *only* from the kernel read DARK.

Found via `elite_dashboard.py`: flagged dark-and-enabled and **one step from deletion in this session**, while the kernel imports it at Zone 6.14 and calls `get_elite_dashboard()`, `await start()`, `install_narrator_hook()`. A dashboard that runs on every boot, invisible to the board that exists to say what runs.

Same shape as the four blindnesses before it, and the largest: the entry point itself.

## Disposition change

`elite_dashboard.py` is **live — keep**, not the deletion candidate it was listed as. `real_time_interaction_handler.py` is also **kept**: per the HUD↔O+V design, anything implementing *observe-the-workspace / act / remember* is HUD-shaped reference material even when superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `/memory` to show what the organism knows, and updates the progress board to scan the repo root so kernel-linked modules are visible. Fixes duplicate topic injection with content-addressed dedup, counts only git-tracked topics, and caps the `/memory` payload to 8KB with visible truncation.

- **New Features**
  - `/memory topics` shows preferences from `UserPreferenceStore`, git-tracked topic counts under `docs/memory_topics`, and `ModuleContextRouter` routing status.
  - Supports name search: `/memory topics <term>`; mirrored output via `compose_memory_lines`; payload capped at 8KB with a truncation marker.

- **Bug Fixes**
  - Deduplicates identical topic payloads in `ModuleContextRouter` using normalised content hashing, preventing duplicate fragments from reaching prompts.
  - Progress board now scans `"."` along with `backend` and `scripts`, preventing false “dark” flags for kernel-only modules like `elite_dashboard.py`.

<sup>Written for commit bcba862756d3c334ecd190329831179696cc215b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70306?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

