### PR TITLE
fix(swarm): make the Golden Rule reachable + the cage learns (tighten-only)

### DIFF
--- a/backend/core/ouroboros/governance/autonomy/cage_calibration.py
+++ b/backend/core/ouroboros/governance/autonomy/cage_calibration.py
@@ -1,0 +1,489 @@
+"""The cage learns what the work actually needs — and only ever tightens.
+
+`worker_synthesizer` derives a worker's shape from static AST inspection of
+its sub-goal. That derivation is a PRIOR, and until now there was no
+posterior: a worker granted ``mutation_budget=3`` that never used more than
+one, or one that failed because it was denied a tool, taught the synthesizer
+nothing. The same shape was re-derived, identically wrong, forever.
+
+`ScopedToolBackend` has been recording the evidence the whole time —
+``mutations_count`` against ``max_mutations``, and ``call_records`` stamped
+``authorized`` / ``type_denied`` / ``count_denied``. Nobody consumed it for
+learning. This module closes that loop.
+
+Tighten autonomously; NEVER widen
+----------------------------------
+This is the load-bearing decision, and it is deliberately asymmetric.
+
+Observed under-use is safe to act on alone: a shape class whose workers
+consistently use one mutation of three does not need three, and dropping to
+what the evidence shows is strictly less privilege than the prior already
+granted. Nothing can go wrong that was not already possible.
+
+Observed DENIAL is not. A worker repeatedly denied ``bash`` is evidence that
+something wants ``bash`` — and a system that grants it on that basis has
+built a privilege-escalation ramp out of persistence. Any worker, including a
+prompt-injected one, could widen its own cage by asking enough times.
+
+So denials never widen anything. They become a FINDING: the synthesizer's
+inspection rule for that class of work is wrong, and the rule is what should
+be fixed. That is the root fix; a learned per-class exception would be the
+workaround, and it would erode the cage one class at a time.
+
+Note the direction is the opposite of `UserMemory.matches_path`, where the
+safe move was to WIDEN a guard and never narrow. The invariant is not
+"always widen" or "always tighten" — it is *move only in the direction that
+cannot grant something new*. For a deny-list that means widening; for an
+allow-list it means tightening.
+
+The learning key is the synthesizer's own derivation
+-----------------------------------------------------
+Not ``unit_id`` — those never repeat. The key is ``role`` + ``read_only``,
+both already produced by `worker_synthesizer`. The synthesizer clusters work
+into descriptive roles (``"python-source mutator"``,
+``"test-suite analyzer"``) as a side effect of deriving a shape, so the
+clustering needed for learning already exists and costs nothing. No new
+taxonomy, no hardcoded categories.
+
+Reuses the memory arc's math, not a copy of it
+-----------------------------------------------
+Two `memory_utility.UtilityStore` instances, pointed at their own files. That
+class is already an opaque-key store of decayed, confidence-weighted
+observations with a corpus-mean baseline — exactly the statistics needed
+here, already written and tested. A second implementation would be a second
+definition of "how fast does evidence age".
+
+* the OUTCOME store: weight = did the unit succeed (is this shape working?)
+* the HEADROOM store: weight = mutations_used / mutations_granted (how much
+  does this class of work actually need?)
+
+Cold start changes nothing
+---------------------------
+No observations → the prior is returned unchanged, byte-identical to the
+synthesizer's output. Same invariant `Drift.UNKNOWN` and `memory_utility`
+keep: absence of evidence is not evidence, and a calibration that acted on
+nothing would be a rewrite of the cage disguised as learning.
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import dataclasses
+import logging
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+logger = logging.getLogger("Ouroboros.CageCalibration")
+
+CAGE_CALIBRATION_SCHEMA_VERSION: str = "cage_calibration.1"
+
+__all__ = [
+    "CAGE_CALIBRATION_SCHEMA_VERSION",
+    "CageObservation",
+    "CageFinding",
+    "calibrate_shape",
+    "calibration_enabled",
+    "findings",
+    "observe_unit",
+    "reset_for_tests",
+    "shape_signature",
+]
+
+
+def _flag(name: str, default: str = "1") -> bool:
+    try:
+        return os.environ.get(name, default).strip().lower() not in (
+            "0", "false", "no", "off", "")
+    except Exception:  # noqa: BLE001
+        return True
+
+
+def _num(name: str, default: float, lo: float, hi: float) -> float:
+    try:
+        return min(hi, max(lo, float(os.environ.get(name, "").strip() or default)))
+    except Exception:  # noqa: BLE001
+        return default
+
+
+def calibration_enabled() -> bool:
+    """``JARVIS_CAGE_CALIBRATION_ENABLED`` (default **false**).
+
+    Default-OFF because it narrows a live security boundary from observed
+    data. Tightening is the safe direction, but "safe direction" is not
+    "unsupervised by default" — it earns its default-on by soak, like every
+    other autonomous behaviour here.
+    """
+    return _flag("JARVIS_CAGE_CALIBRATION_ENABLED", "0")
+
+
+def _min_observations() -> int:
+    """Observations of a shape class before its cage may be tightened.
+
+    ``JARVIS_CAGE_CALIBRATION_MIN_OBS``. One worker that happened to need
+    only one mutation is not evidence that the class needs one.
+    """
+    return int(_num("JARVIS_CAGE_CALIBRATION_MIN_OBS", 8, 2, 1000))
+
+
+def _headroom_margin() -> float:
+    """Safety margin above observed peak usage. ``JARVIS_CAGE_HEADROOM_MARGIN``.
+
+    Tightening to the exact observed maximum would make the next slightly
+    harder instance of the same work fail on ``count_denied``. The margin
+    buys that instance room while still shedding unused privilege.
+    """
+    return _num("JARVIS_CAGE_HEADROOM_MARGIN", 1.5, 1.0, 4.0)
+
+
+def _denial_finding_ratio() -> float:
+    """Denial rate at which a shape class becomes a FINDING.
+
+    ``JARVIS_CAGE_DENIAL_FINDING_RATIO``. Not a widening threshold — nothing
+    widens. It is the point at which the synthesizer's inspection rule for
+    this class is worth reporting as wrong.
+    """
+    return _num("JARVIS_CAGE_DENIAL_FINDING_RATIO", 0.25, 0.0, 1.0)
+
+
+# ---------------------------------------------------------------------------
+# The learning key
+# ---------------------------------------------------------------------------
+
+_SIG_CLEAN = re.compile(r"[^a-z0-9]+")
+
+
+def shape_signature(shape: Any) -> str:
+    """The class this shape belongs to. Pure. NEVER raises.
+
+    ``role`` + ``read_only``, both already derived by the synthesizer. Using
+    its own clustering means no second taxonomy exists to drift from the
+    first, and a new role invented by inspection tomorrow automatically
+    becomes a new learning class with no code change.
+    """
+    try:
+        role = _SIG_CLEAN.sub(
+            "-", str(getattr(shape, "role", "") or "unknown").lower()).strip("-")
+        mode = "ro" if bool(getattr(shape, "read_only", False)) else "rw"
+        return f"{role or 'unknown'}:{mode}"
+    except Exception:  # noqa: BLE001
+        return "unknown:rw"
+
+
+# ---------------------------------------------------------------------------
+# Stores — two instances of the memory arc's UtilityStore
+# ---------------------------------------------------------------------------
+
+_stores: Dict[str, Any] = {}
+_root_override: Optional[Path] = None
+
+
+def _store(kind: str) -> Any:
+    """A `UtilityStore` for *kind*, created on first use. NEVER raises."""
+    global _stores  # noqa: PLW0603
+    existing = _stores.get(kind)
+    if existing is not None:
+        return existing
+    try:
+        from backend.core.ouroboros.governance.memory_utility import UtilityStore
+
+        root = _root_override
+        if root is None:
+            root = Path(__file__).resolve().parents[5]
+        store = UtilityStore(root / ".jarvis" / f"cage_{kind}.jsonl")
+        _stores[kind] = store
+        return store
+    except Exception:  # noqa: BLE001
+        logger.debug("[CageCalibration] store unavailable", exc_info=True)
+        return None
+
+
+def reset_for_tests(root: Optional[Path] = None) -> None:
+    """Drop both stores, optionally rebinding their root. Test-only."""
+    global _stores, _root_override  # noqa: PLW0603
+    _root_override = root
+    _stores = {}
+
+
+# ---------------------------------------------------------------------------
+# Observation
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CageObservation:
+    """What one caged worker actually did with what it was given."""
+
+    signature: str
+    granted_mutations: int
+    used_mutations: int
+    denied_tools: Tuple[str, ...]
+    count_denied: int
+    succeeded: bool
+
+    @property
+    def headroom(self) -> float:
+        """``used / granted`` in [0, 1]. 1.0 when nothing was granted.
+
+        A read-only worker granted zero mutations has, by definition, used
+        all of its (zero) budget — reporting 0.0 would drag the class mean
+        toward "needs nothing" using a worker that was never allowed
+        anything.
+        """
+        if self.granted_mutations <= 0:
+            return 1.0
+        return min(1.0, max(0.0, self.used_mutations / self.granted_mutations))
+
+
+def _extract(backend: Any) -> Tuple[int, int, Tuple[str, ...], int]:
+    """``(granted, used, denied_tools, count_denied)`` from a cage. NEVER raises."""
+    try:
+        granted = int(getattr(backend, "max_mutations", 0) or 0)
+        used = int(getattr(backend, "mutations_count", 0) or 0)
+        denied: List[str] = []
+        count_denied = 0
+        for record in (getattr(backend, "call_records", ()) or ()):
+            # (name, call_id, status, t) — the cage's own audit trail.
+            if len(record) < 3:
+                continue
+            name, status = str(record[0]), str(record[2])
+            if status == "type_denied":
+                denied.append(name)
+            elif status == "count_denied":
+                count_denied += 1
+        return granted, used, tuple(denied), count_denied
+    except Exception:  # noqa: BLE001
+        logger.debug("[CageCalibration] cage extraction degraded", exc_info=True)
+        return 0, 0, (), 0
+
+
+def observe_unit(shape: Any, backend: Any, result: Any) -> Optional[CageObservation]:
+    """Record what this worker did with its cage. NEVER raises.
+
+    Returns None when calibration is off or the cage yielded nothing to learn
+    from. Called at the ONE seam where a caged unit finishes, so a worker
+    cannot complete without leaving evidence.
+    """
+    if not calibration_enabled():
+        return None
+    try:
+        import time as _t
+
+        signature = shape_signature(shape)
+        if signature.startswith("unknown:"):
+            # A shape with no derivable role cannot be attributed to a class.
+            # Recording it would credit a real class's statistics with an
+            # observation that belongs to no class — the same reason an
+            # unattributable op earns no memory topic any credit.
+            logger.debug("[CageCalibration] unattributable shape — not recorded")
+            return None
+        granted, used, denied, count_denied = _extract(backend)
+        status = str(getattr(getattr(result, "status", None), "value",
+                             getattr(result, "status", ""))).lower()
+        succeeded = status in ("completed", "complete", "succeeded")
+
+        obs = CageObservation(
+            signature=signature, granted_mutations=granted, used_mutations=used,
+            denied_tools=denied, count_denied=count_denied, succeeded=succeeded,
+        )
+
+        from backend.core.ouroboros.governance.memory_utility import Observation
+
+        now = _t.time()
+        outcome = _store("outcome")
+        if outcome is not None:
+            outcome.add([Observation(signature, 1.0 if succeeded else 0.0, now)])
+        # Headroom is only meaningful when a budget was actually granted AND
+        # the unit succeeded. A FAILED worker may have stopped early for
+        # reasons unrelated to budget, and counting its low usage as "this
+        # class needs less" would tighten the cage on the strength of a crash.
+        headroom = _store("headroom")
+        if headroom is not None and granted > 0 and succeeded:
+            headroom.add([Observation(signature, obs.headroom, now)])
+        if denied or count_denied:
+            denial = _store("denial")
+            if denial is not None:
+                denial.add([Observation(signature, 1.0, now,
+                                        op_id=",".join(sorted(set(denied))[:5]))])
+        logger.debug(
+            "[CageCalibration] %s granted=%d used=%d denied=%s cd=%d ok=%s",
+            signature, granted, used, denied, count_denied, succeeded,
+        )
+        return obs
+    except Exception:  # noqa: BLE001
+        logger.debug("[CageCalibration] observation degraded", exc_info=True)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Calibration — tighten only
+# ---------------------------------------------------------------------------
+
+
+def calibrate_shape(shape: Any) -> Any:
+    """The prior, tightened by evidence. NEVER raises, NEVER widens.
+
+    Returns *shape* unchanged when calibration is off, evidence is thin, or
+    anything at all goes wrong. Every failure path returns the synthesizer's
+    original output, so a broken calibrator costs exactly nothing.
+
+    The post-condition is asserted, not assumed: the returned shape's tool
+    set must be a SUBSET of the prior's and its budget must be ``<=`` the
+    prior's. If the computation ever violated that, the prior is returned
+    instead — a calibrator is not permitted to be the thing that grants
+    privilege.
+    """
+    if not calibration_enabled():
+        return shape
+    try:
+        signature = shape_signature(shape)
+        store = _store("headroom")
+        if store is None:
+            return shape
+        reading = store.reading(signature)
+        if reading.cold or reading.observations < _min_observations():
+            return shape  # thin evidence -> the prior stands
+        if reading.polarity is None:
+            return shape
+
+        granted = int(getattr(shape, "mutation_budget", 0) or 0)
+        if granted <= 0:
+            return shape
+
+        # Decayed mean headroom -> the budget this class actually consumes,
+        # plus a margin so the next slightly-harder instance is not starved.
+        target = int(round(granted * float(reading.polarity) * _headroom_margin()))
+        tightened = max(1, min(granted, target))
+        if tightened >= granted:
+            return shape  # nothing to shed
+
+        candidate = dataclasses.replace(shape, mutation_budget=tightened)
+
+        # Post-condition. Cheap, and the only thing standing between a
+        # subtle arithmetic slip and a widened cage.
+        if not _is_tightening(shape, candidate):
+            logger.warning(
+                "[CageCalibration] %s calibration would not tighten — "
+                "returning the prior", signature)
+            return shape
+
+        logger.info(
+            "[CageCalibration] %s mutation_budget %d -> %d "
+            "(headroom %.2f over n=%d)",
+            signature, granted, tightened, reading.polarity,
+            reading.observations,
+        )
+        return candidate
+    except Exception:  # noqa: BLE001
+        logger.debug("[CageCalibration] calibration degraded", exc_info=True)
+        return shape
+
+
+def _is_tightening(prior: Any, candidate: Any) -> bool:
+    """Whether *candidate* grants nothing the *prior* did not. Pure.
+
+    The structural invariant, checked rather than trusted.
+    """
+    try:
+        prior_tools = set(getattr(prior, "allowed_tools", ()) or ())
+        cand_tools = set(getattr(candidate, "allowed_tools", ()) or ())
+        if not cand_tools.issubset(prior_tools):
+            return False
+        if int(getattr(candidate, "mutation_budget", 0) or 0) > int(
+                getattr(prior, "mutation_budget", 0) or 0):
+            return False
+        if bool(getattr(prior, "read_only", False)) and not bool(
+                getattr(candidate, "read_only", False)):
+            return False
+        return True
+    except Exception:  # noqa: BLE001
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Proactive surface — denials are findings, never widenings
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CageFinding:
+    """A shape class whose synthesized cage is chronically wrong."""
+
+    signature: str
+    kind: str
+    detail: str
+    observations: int
+
+
+def findings() -> List[CageFinding]:
+    """Shape classes the evidence says are mis-synthesized. NEVER raises.
+
+    This is the proactive half, and the reason denials do not widen: the
+    finding names the SYNTHESIZER'S RULE as the thing to fix, which is the
+    root cause. A learned per-class exception would paper over it and erode
+    the cage one class at a time.
+    """
+    out: List[CageFinding] = []
+    if not calibration_enabled():
+        return out
+    try:
+        denial = _store("denial")
+        outcome = _store("outcome")
+        if denial is None or outcome is None:
+            return out
+        floor = _min_observations()
+        ratio_floor = _denial_finding_ratio()
+        for signature in denial.hashes():
+            d = denial.reading(signature)
+            o = outcome.reading(signature)
+            if o.cold or o.observations < floor:
+                continue
+            ratio = d.observations / max(1, o.observations)
+            if ratio < ratio_floor:
+                continue
+            out.append(CageFinding(
+                signature=signature, kind="chronic_denial",
+                detail=(f"workers of class {signature!r} were denied a tool or "
+                        f"exhausted their budget in {d.observations} of "
+                        f"{o.observations} runs ({ratio:.0%}). The synthesizer's "
+                        f"inspection rule for this class is under-granting — fix "
+                        f"the RULE in worker_synthesizer; the cage is not widened "
+                        f"from observed demand by design."),
+                observations=o.observations,
+            ))
+    except Exception:  # noqa: BLE001
+        logger.debug("[CageCalibration] findings degraded", exc_info=True)
+    return out
+
+
+def render_calibration_lines(limit: int = 8) -> List[str]:
+    """Markup lines for an operator surface. NEVER raises."""
+    if not calibration_enabled():
+        return ["  [dim]cage calibration disabled "
+                "(JARVIS_CAGE_CALIBRATION_ENABLED=0)[/dim]"]
+    try:
+        headroom = _store("headroom")
+        outcome = _store("outcome")
+        if headroom is None or outcome is None:
+            return ["  [dim]cage calibration unavailable[/dim]"]
+        sigs = sorted(set(headroom.hashes()) | set(outcome.hashes()))
+        if not sigs:
+            return ["  [bold]swarm · cage calibration[/bold]",
+                    "    [dim]no caged workers observed yet[/dim]"]
+        out = [f"  [bold]swarm · cage calibration[/bold]  "
+               f"[dim]{len(sigs)} shape class(es)[/dim]"]
+        for sig in sigs[:limit]:
+            h = headroom.reading(sig)
+            o = outcome.reading(sig)
+            hp = f"{h.polarity:.2f}" if h.polarity is not None else "—"
+            op = f"{o.polarity:.0%}" if o.polarity is not None else "—"
+            out.append(f"    {sig}  headroom {hp}  success {op}  n={o.observations}")
+        for finding in findings()[:limit]:
+            out.append(f"    [yellow]⚠ {finding.signature}[/yellow] "
+                       f"{finding.kind}")
+        return out
+    except Exception as exc:  # noqa: BLE001
+        return [f"  [dim]cage calibration degraded: "
+                f"{type(exc).__name__}: {exc}[/dim]"]

--- a/backend/core/ouroboros/governance/autonomy/swarm_invoker.py
+++ b/backend/core/ouroboros/governance/autonomy/swarm_invoker.py
@@ -256,6 +256,17 @@ class SwarmUnitInvoker:
                 graph, unit, "swarm_synthesis", f"worker_synthesis_failed:{exc}"
             )
 
+        # Calibrate the PRIOR against observed evidence for this shape class.
+        # Tighten-only and fail-open: a broken calibrator returns the
+        # synthesizer's output unchanged, so this can cost the op nothing.
+        try:
+            from backend.core.ouroboros.governance.autonomy.cage_calibration import (
+                calibrate_shape,
+            )
+            shape = calibrate_shape(shape)
+        except Exception:  # noqa: BLE001 -- calibration is advisory, never fatal.
+            logger.debug("[SwarmInvoker] cage calibration skipped", exc_info=True)
+
         try:
             built = self._cage(graph, unit, shape)
         except Exception as exc:  # noqa: BLE001 -- cage failure -> fail-CLOSED.
@@ -284,7 +295,19 @@ class SwarmUnitInvoker:
         #    catch it and convert to a FAILED unit (never a hang, never a
         #    silent loss -- DAGComposer treats FAILED as ComposeFailure).
         try:
-            return await self._legacy.execute(graph, unit)
+            _result = await self._legacy.execute(graph, unit)
+            # The ONE seam where a caged worker finishes. Recording here means
+            # a worker cannot complete without leaving evidence of what it
+            # actually did with what it was granted.
+            try:
+                from backend.core.ouroboros.governance.autonomy.cage_calibration import (
+                    observe_unit,
+                )
+                observe_unit(shape, getattr(built, "backend", None), _result)
+            except Exception:  # noqa: BLE001 -- telemetry never fails the unit.
+                logger.debug("[SwarmInvoker] cage observation skipped",
+                             exc_info=True)
+            return _result
         except Exception as exc:  # noqa: BLE001 -- deadlock or worker fault.
             if self._is_deadlock(exc):
                 logger.warning(

--- a/backend/core/ouroboros/governance/autonomy/swarm_invoker.py
+++ b/backend/core/ouroboros/governance/autonomy/swarm_invoker.py
@@ -46,6 +46,7 @@ executor, NO new bus/sandbox/worktree. It is purely the routing seam.
 from __future__ import annotations
 
 import logging
+import os
 import time
 from typing import Any, Callable, Optional
 
@@ -109,6 +110,62 @@ def is_graph_parallelizable(graph: ExecutionGraph) -> bool:
 # ---------------------------------------------------------------------------
 
 
+def require_preshaped_units() -> bool:
+    """``JARVIS_SWARM_REQUIRE_PRESHAPED_UNITS`` (default false).
+
+    The ROLLBACK for the eligibility fix below, not a second gate. ON
+    restores the original predicate exactly — swarm only for units that
+    already carry a shape — which is the behaviour that made the master gate
+    inert. It exists so the change can be reverted without touching
+    ``JARVIS_SWARM_ORCHESTRATOR_ENABLED``, never as a default.
+    """
+    return os.environ.get(
+        "JARVIS_SWARM_REQUIRE_PRESHAPED_UNITS", "false",
+    ).strip().lower() in ("1", "true", "yes", "on")
+
+
+def swarm_eligible(unit: WorkUnitSpec) -> bool:
+    """Whether this unit CAN be shaped into a caged swarm worker. NEVER raises.
+
+    The bug this replaces was circular. The predicate asked
+    ``unit.is_swarm_worker`` — True only when the unit ALREADY carries a
+    ``system_prompt_template`` / ``allowed_tools`` / ``worker_role``. But the
+    invoker's whole job is to SYNTHESIZE that shape, and every production
+    graph builder (``parallel_dispatch``, ``iteration_planner``,
+    ``providers``, ``meta_goal_aggregator``, ``graph_coalescer``) leaves all
+    five fields ``None``. The only writer is ``SwarmOrchestrator.define_worker``,
+    which has no production caller.
+
+    So the invoker would only shape a unit that was already shaped, and
+    ``JARVIS_SWARM_ORCHESTRATOR_ENABLED=true`` still did nothing — the same
+    class of defect this module's own docstring says it closed, one layer
+    further in. It closed "nothing CALLS the swarm"; it left "nothing is ever
+    ELIGIBLE for it".
+
+    The fix is to ask what the synthesizer actually needs rather than what a
+    marking says. ``worker_synthesizer`` derives the shape from the sub-goal's
+    ``target_files`` (stdlib ``ast``) and its ``goal`` text, so a unit with
+    both is synthesizable and a unit without either is not.
+
+    Fail-CLOSED in the same direction as everything downstream: no target
+    files or no goal → legacy executor, byte-identical. A unit that cannot be
+    inspected cannot be caged, and an uncaged worker must never run.
+    """
+    try:
+        # An explicitly pre-shaped unit stays eligible — the orchestrator's
+        # own `define_worker` path keeps working unchanged.
+        if bool(getattr(unit, "is_swarm_worker", False)):
+            return True
+        if require_preshaped_units():
+            return False
+        # Synthesizable: the two inputs `synthesize_worker_spec` inspects.
+        if not tuple(getattr(unit, "target_files", ()) or ()):
+            return False
+        return bool(str(getattr(unit, "goal", "") or "").strip())
+    except Exception:  # noqa: BLE001
+        return False
+
+
 class SwarmUnitInvoker:
     """Per-unit routing seam: legacy executor <-> dynamic worker synthesis.
 
@@ -167,7 +224,7 @@ class SwarmUnitInvoker:
     # -- routing decision -------------------------------------------------
 
     def _should_route_swarm(self, graph: ExecutionGraph, unit: WorkUnitSpec) -> bool:
-        """Swarm iff master gate ON AND graph parallelizable AND swarm unit."""
+        """Swarm iff master gate ON AND graph parallelizable AND unit ELIGIBLE."""
         try:
             from backend.core.ouroboros.governance.autonomy.swarm_orchestrator import (
                 is_orchestrator_enabled,
@@ -177,7 +234,7 @@ class SwarmUnitInvoker:
                 return False
             if not is_graph_parallelizable(graph):
                 return False
-            return bool(getattr(unit, "is_swarm_worker", False))
+            return swarm_eligible(unit)
         except Exception:  # noqa: BLE001 -- any decision error -> legacy (safe).
             logger.debug(
                 "[SwarmInvoker] route decision raised -> legacy (non-fatal)",

--- a/docs/memory_topics/ouroboros/project_swarm_reachability_fix.md
+++ b/docs/memory_topics/ouroboros/project_swarm_reachability_fix.md
@@ -71,3 +71,52 @@ Cage failure → `FAILED/swarm_cage`, never uncaged.
   This one.
 
 Both still default-OFF. ⚠️ Not soaked.
+
+## Slice 2 — the cage learns (`autonomy/cage_calibration.py`)
+
+Making the synthesizer reachable exposed that it is **open-loop**: a derived
+PRIOR with no posterior. A worker granted `mutation_budget=3` that never used
+more than one taught it nothing; the same shape was re-derived, identically
+wrong, forever. Exactly the defect `memory_utility` fixed for topics, one
+layer down.
+
+`ScopedToolBackend` was recording the evidence all along — `mutations_count`
+vs `max_mutations`, `call_records` stamped `authorized`/`type_denied`/
+`count_denied`. Nobody consumed it for learning.
+
+**Tighten autonomously; NEVER widen.** The asymmetry is the whole design.
+Observed under-use is safe to act on — dropping to what evidence shows grants
+strictly less than the prior already did. Observed DENIAL is not: widening a
+cage because a worker kept asking builds a privilege-escalation ramp out of
+persistence, reachable by any worker including a prompt-injected one. So
+denials become a FINDING naming `worker_synthesizer`'s RULE as the thing to
+fix — the root cause. A learned per-class exception would erode the cage one
+class at a time.
+
+Note this is the OPPOSITE direction from `UserMemory.matches_path`, where the
+safe move was to widen a guard. The invariant is not "always widen" or
+"always tighten" — it is *move only in the direction that cannot grant
+something new*. Deny-list → widen. Allow-list → tighten.
+
+`_is_tightening` asserts the post-condition rather than trusting it: tools
+must be a SUBSET and budget `<=`, or the prior is returned. A calibrator is
+not permitted to be the thing that grants privilege.
+
+**Learning key = the synthesizer's own clustering.** `role` + `read_only`,
+both already derived. No second taxonomy to drift; a new role invented by
+inspection tomorrow becomes a new learning class with zero code change.
+
+**Reuse:** two `memory_utility.UtilityStore` instances (outcome, headroom) —
+already an opaque-key store of decayed, confidence-weighted observations with
+a corpus-mean baseline. A second implementation would be a second definition
+of "how fast does evidence age".
+
+Refusals: cold start → prior unchanged; thin evidence → prior; FAILED units
+never teach the cage to shrink (a crash's low usage is not "needs less");
+unattributable shapes are not recorded at all.
+
+Wired at the ONE seam in `_execute_swarm` — calibrate between synthesis and
+cage, observe after execution. Both fail-open.
+
+Default **OFF** (`JARVIS_CAGE_CALIBRATION_ENABLED`) — it narrows a live
+security boundary from data. 18 tests; 761 green across autonomy.

--- a/docs/memory_topics/ouroboros/project_swarm_reachability_fix.md
+++ b/docs/memory_topics/ouroboros/project_swarm_reachability_fix.md
@@ -1,0 +1,73 @@
+---
+title: Swarm reachability — the Golden Rule was never reached
+modules: [backend/core/ouroboros/governance/autonomy/swarm_invoker.py, backend/core/ouroboros/governance/autonomy/worker_synthesizer.py, backend/core/ouroboros/governance/autonomy/subagent_scheduler.py, backend/core/ouroboros/governance/autonomy/subagent_factory.py]
+status: active
+source: session 2026-07-31, liveness audit
+---
+
+# Swarm reachability
+
+## The audit
+
+`worker_synthesizer` is O+V's most radical piece: a worker's persona, tool
+allowlist, mutation budget and context budget are **synthesized from AST +
+semantic inspection of the sub-goal** — "NO static enum, NO dictionary of
+Agent Roles". Fail-closed to read-only.
+
+It never ran in production.
+
+## The chain
+
+```
+GovernedLoopService  l3_enabled=true (DEFAULT ON)     ✅ live
+  → SubagentScheduler._execute_unit_guarded            ✅ unconditional, every unit
+    → _get_swarm_invoker()                             ✅ wired (line 1050)
+      → SwarmUnitInvoker.execute()
+        → _should_route_swarm()                        ❌ ALWAYS FALSE
+        → synthesize_worker_spec()                     ⛔ never reached
+```
+
+`_should_route_swarm` ended in `return bool(unit.is_swarm_worker)`, and
+`is_swarm_worker` is True only when the unit ALREADY carries
+`system_prompt_template` / `allowed_tools` / `worker_role`. **All five
+production builders leave them None** (`parallel_dispatch`,
+`iteration_planner`, `providers`, `meta_goal_aggregator`, `graph_coalescer`);
+`subagent_types.execution_graph_from_dict` only round-trips them. The only
+writer is `SwarmOrchestrator.define_worker`, which has **zero production
+callers** — in the invoker it is an injectable test seam defaulting to None.
+
+So the invoker would only shape a unit that was already shaped. Circular.
+`swarm_invoker`'s own docstring says it closed "nothing CALLS the swarm"; it
+left "nothing is ever ELIGIBLE for it" — the same defect one layer in.
+
+**The suite asserted the bug was correct.** `test_swarm_on_legacy_unit_in_multi_graph_uses_legacy`
+pinned "a non-swarm unit → legacy even in a multi DAG", which under the old
+predicate means *every real unit, always*. That is why it stayed green.
+
+## The fix
+
+`swarm_eligible(unit)` asks what the synthesizer NEEDS, not what a marking
+says: a unit with `target_files` (dataclass-guaranteed non-empty) and a
+non-blank `goal` is synthesizable. Pre-shaped units stay eligible so the
+`define_worker` path is unchanged. Fail-CLOSED: blank goal → legacy.
+
+Rollback: `JARVIS_SWARM_REQUIRE_PRESHAPED_UNITS=1` restores the old predicate
+without touching the master gate.
+
+## Proven
+
+A unit with NO swarm fields (exactly `parallel_dispatch`'s shape) now routes
+SWARM and derives: `role='python-source mutator'`,
+`tools=(read_file, search_code, list_dir, get_callers, edit_file)`,
+`mutation_budget=3`, `ctx=18180`. A read-only goal gets **no** mutation tool.
+Cage failure → `FAILED/swarm_cage`, never uncaged.
+
+## Two things called "swarm"
+
+- `JARVIS_SWARM_ROUTING_ENABLED` → `candidate_generator._maybe_swarm_short_circuit`
+  → `full_content_interceptor` → `agentic_super_agent`. Genuinely wired on the
+  live GENERATE path. **Does not touch the synthesizer.**
+- `JARVIS_SWARM_ORCHESTRATOR_ENABLED` → scheduler → invoker → synthesizer.
+  This one.
+
+Both still default-OFF. ⚠️ Not soaked.

--- a/tests/governance/autonomy/test_swarm_invoker.py
+++ b/tests/governance/autonomy/test_swarm_invoker.py
@@ -239,11 +239,87 @@ async def test_swarm_on_single_node_uses_legacy_no_swarm(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_swarm_on_legacy_unit_in_multi_graph_uses_legacy(monkeypatch):
-    """A non-swarm unit (no synthesized fields) -> legacy even in a multi DAG."""
+async def test_unshaped_unit_in_multi_graph_is_now_SWARMED(monkeypatch):
+    """A production-shaped unit in a parallel DAG must reach the swarm.
+
+    This test previously asserted the OPPOSITE — "a non-swarm unit (no
+    synthesized fields) -> legacy even in a multi DAG" — and that assertion
+    was the defect written down as a contract. Every production graph builder
+    leaves the swarm fields None, so under the old predicate NO real unit was
+    ever eligible: `JARVIS_SWARM_ORCHESTRATOR_ENABLED=true` did nothing, and
+    this suite stayed green while the feature was dead.
+
+    The invoker's job is to SYNTHESIZE the shape. Requiring the shape to
+    already exist was circular. See `swarm_invoker.swarm_eligible`.
+    """
     from backend.core.ouroboros.governance.autonomy import swarm_invoker as si
 
     _set_swarm(monkeypatch, "true")
+    inner = _RecordingExecutor()
+    define_calls: list = []
+
+    class _Shape:
+        is_mutating = True
+        read_only = False
+        allowed_tools = ("read_file", "edit_file")
+        mutation_budget = 3
+        role = "python-source mutator"
+
+    def _define(sg):
+        define_calls.append(getattr(sg, "unit_id", sg))
+        return _Shape()
+
+    invoker = si.SwarmUnitInvoker(
+        legacy_executor=inner,
+        define_worker=_define,
+        build_worker=lambda *a, **k: None,
+    )
+
+    graph = _multi_node_graph([_legacy_unit("u1", "a.py"), _legacy_unit("u2", "b.py")])
+    result = await invoker.execute(graph, graph.unit_map["u1"])
+
+    # Routed to the swarm: the shaper ran and the legacy executor did not.
+    assert define_calls, "unshaped unit never reached the shaper"
+    assert inner.calls == []
+    # `build_worker` returning None is no cage -> fail-CLOSED, never uncaged.
+    assert result.status is WorkUnitState.FAILED
+    assert "uncaged" in (result.error or "")
+
+
+async def test_unshapeable_unit_still_uses_legacy(monkeypatch):
+    """What genuinely stays legacy: a unit the synthesizer cannot inspect.
+
+    The eligibility predicate is fail-CLOSED — no goal means nothing to derive
+    a cage from, and an uncageable worker must not run at all.
+    """
+    from backend.core.ouroboros.governance.autonomy import swarm_invoker as si
+
+    _set_swarm(monkeypatch, "true")
+    inner = _RecordingExecutor()
+    define_calls: list = []
+
+    invoker = si.SwarmUnitInvoker(
+        legacy_executor=inner,
+        define_worker=lambda sg: define_calls.append(sg),
+        build_worker=lambda *a, **k: None,
+    )
+
+    goalless = WorkUnitSpec(unit_id="u1", repo="JARVIS", goal="   ",
+                            target_files=("a.py",), owned_paths=("a.py",))
+    graph = _multi_node_graph([goalless, _legacy_unit("u2", "b.py")])
+    result = await invoker.execute(graph, graph.unit_map["u1"])
+
+    assert result.status is WorkUnitState.COMPLETED
+    assert inner.calls == ["u1"]
+    assert define_calls == []
+
+
+async def test_rollback_flag_restores_the_preshaped_only_contract(monkeypatch):
+    """`JARVIS_SWARM_REQUIRE_PRESHAPED_UNITS` reverts to the old predicate."""
+    from backend.core.ouroboros.governance.autonomy import swarm_invoker as si
+
+    _set_swarm(monkeypatch, "true")
+    monkeypatch.setenv("JARVIS_SWARM_REQUIRE_PRESHAPED_UNITS", "1")
     inner = _RecordingExecutor()
     define_calls: list = []
 

--- a/tests/governance/test_cage_calibration.py
+++ b/tests/governance/test_cage_calibration.py
@@ -1,0 +1,262 @@
+"""Regression spine for cage calibration — tighten only, never widen.
+
+`worker_synthesizer` derives a worker's cage from static AST inspection. That
+is a PRIOR with no posterior: a worker granted three mutations that never used
+more than one taught it nothing. `ScopedToolBackend` was recording the
+evidence all along (`mutations_count` vs `max_mutations`, `call_records`
+stamped `type_denied` / `count_denied`) and nobody consumed it.
+
+The load-bearing test here is `test_calibration_can_never_widen_a_cage`.
+Observed under-use is safe to act on — dropping to what the evidence shows
+grants strictly less than the prior already did. Observed DENIAL is not: a
+system that widens a cage because a worker kept asking has built a
+privilege-escalation ramp out of persistence, reachable by any worker
+including a prompt-injected one. Denials become findings about the
+SYNTHESIZER'S RULE instead, which is the root cause.
+"""
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance.autonomy import cage_calibration as cc
+from backend.core.ouroboros.governance.autonomy.cage_calibration import (
+    CageObservation,
+    _is_tightening,
+    calibrate_shape,
+    findings,
+    observe_unit,
+    shape_signature,
+)
+from backend.core.ouroboros.governance.autonomy.worker_synthesizer import (
+    WorkerShape,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_CAGE_CALIBRATION_ENABLED", "1")
+    monkeypatch.setenv("JARVIS_CAGE_CALIBRATION_MIN_OBS", "4")
+    cc.reset_for_tests(tmp_path)
+    yield
+    cc.reset_for_tests(None)
+
+
+def _shape(budget=4, tools=("read_file", "edit_file"), role="python-source mutator",
+           read_only=False):
+    return WorkerShape(
+        role=role, allowed_tools=tuple(tools), mutation_budget=budget,
+        context_budget_tokens=8000, read_only=read_only,
+    )
+
+
+class _Cage:
+    """A stand-in ScopedToolBackend exposing the real public surface."""
+
+    def __init__(self, granted=4, used=1, denied=(), count_denied=0):
+        self.max_mutations = granted
+        self.mutations_count = used
+        self.call_records = tuple(
+            (name, f"c{i}", "type_denied", time.time())
+            for i, name in enumerate(denied)
+        ) + tuple(
+            ("edit_file", f"x{i}", "count_denied", time.time())
+            for i in range(count_denied)
+        )
+
+
+class _Result:
+    def __init__(self, ok=True):
+        self.status = "completed" if ok else "failed"
+
+
+def _feed(n, *, granted=4, used=1, ok=True, shape=None, **cage_kw):
+    shape = shape or _shape(budget=granted)
+    for _ in range(n):
+        observe_unit(shape, _Cage(granted=granted, used=used, **cage_kw),
+                     _Result(ok))
+    return shape
+
+
+# ---------------------------------------------------------------------------
+# The invariant
+# ---------------------------------------------------------------------------
+
+
+def test_calibration_can_never_widen_a_cage():
+    """The load-bearing test.
+
+    No sequence of observations — however many, however emphatic — may
+    produce a shape granting anything the prior did not.
+    """
+    prior = _shape(budget=2, tools=("read_file",))
+    # Hammer it with maximal demand: every run exhausts budget AND is denied
+    # tools it does not have. A naive "learn from demand" calibrator widens.
+    _feed(50, granted=2, used=2, ok=True, shape=prior,
+          denied=("bash", "write_file", "web_fetch"), count_denied=9)
+    out = calibrate_shape(prior)
+    assert set(out.allowed_tools).issubset(set(prior.allowed_tools))
+    assert out.mutation_budget <= prior.mutation_budget
+    assert "bash" not in out.allowed_tools
+
+
+def test_denial_pressure_produces_a_finding_not_a_widening():
+    """Denials name the synthesizer's RULE as the defect — the root cause."""
+    prior = _shape(budget=2, tools=("read_file",))
+    _feed(10, granted=2, used=2, ok=True, shape=prior, denied=("run_tests",))
+    found = findings()
+    assert found, "chronic denial produced no finding"
+    assert found[0].kind == "chronic_denial"
+    assert "worker_synthesizer" in found[0].detail
+    assert calibrate_shape(prior).allowed_tools == prior.allowed_tools
+
+
+def test_tightening_predicate_rejects_any_grant():
+    prior = _shape(budget=3, tools=("read_file", "edit_file"))
+    assert _is_tightening(prior, _shape(budget=1, tools=("read_file",))) is True
+    assert _is_tightening(prior, _shape(budget=5, tools=("read_file",))) is False
+    assert _is_tightening(
+        prior, _shape(budget=1, tools=("read_file", "bash"))) is False
+    # A read-only prior may never become mutating.
+    ro = _shape(budget=0, tools=("read_file",), read_only=True)
+    assert _is_tightening(ro, _shape(budget=0, tools=("read_file",))) is False
+
+
+# ---------------------------------------------------------------------------
+# Tightening actually happens
+# ---------------------------------------------------------------------------
+
+
+def test_consistent_under_use_sheds_budget():
+    prior = _shape(budget=8)
+    _feed(12, granted=8, used=1, ok=True, shape=prior)
+    out = calibrate_shape(prior)
+    assert out.mutation_budget < prior.mutation_budget
+    assert out.mutation_budget >= 1, "must never tighten to zero"
+
+
+def test_full_use_keeps_the_budget():
+    prior = _shape(budget=4)
+    _feed(12, granted=4, used=4, ok=True, shape=prior)
+    assert calibrate_shape(prior).mutation_budget == prior.mutation_budget
+
+
+def test_margin_keeps_room_above_observed_peak(monkeypatch):
+    """Tightening to the exact observed max would starve the next slightly
+    harder instance of the same work."""
+    monkeypatch.setenv("JARVIS_CAGE_HEADROOM_MARGIN", "2.0")
+    prior = _shape(budget=8)
+    _feed(12, granted=8, used=2, ok=True, shape=prior)
+    out = calibrate_shape(prior)
+    assert out.mutation_budget > 2
+
+
+# ---------------------------------------------------------------------------
+# Refusals
+# ---------------------------------------------------------------------------
+
+
+def test_cold_start_returns_the_prior_unchanged():
+    prior = _shape(budget=5)
+    assert calibrate_shape(prior) is prior
+
+
+def test_thin_evidence_returns_the_prior_unchanged(monkeypatch):
+    monkeypatch.setenv("JARVIS_CAGE_CALIBRATION_MIN_OBS", "20")
+    prior = _shape(budget=8)
+    _feed(5, granted=8, used=1, shape=prior)
+    assert calibrate_shape(prior) is prior
+
+
+def test_disabled_is_a_strict_noop(monkeypatch):
+    prior = _shape(budget=8)
+    _feed(30, granted=8, used=1, shape=prior)
+    monkeypatch.setenv("JARVIS_CAGE_CALIBRATION_ENABLED", "0")
+    assert calibrate_shape(prior) is prior
+    assert observe_unit(prior, _Cage(), _Result()) is None
+
+
+def test_default_is_off(monkeypatch):
+    """It narrows a live security boundary from data — earns default-on by soak."""
+    monkeypatch.delenv("JARVIS_CAGE_CALIBRATION_ENABLED", raising=False)
+    assert cc.calibration_enabled() is False
+
+
+def test_failed_units_do_not_teach_the_cage_to_shrink():
+    """A crashed worker may have stopped early for unrelated reasons.
+
+    Counting its low usage as "this class needs less" would tighten the cage
+    on the strength of a crash.
+    """
+    prior = _shape(budget=8)
+    _feed(20, granted=8, used=0, ok=False, shape=prior)
+    assert calibrate_shape(prior) is prior
+
+
+def test_calibration_never_raises_on_a_foreign_shape():
+    assert calibrate_shape(object()) is not None
+
+
+def test_unattributable_shape_is_not_recorded():
+    """An observation that belongs to no class must not be credited to one.
+
+    A shape with no derivable role degrades to `unknown:rw`. Recording it
+    would pollute a real class's statistics with a datum from nowhere — the
+    same reason an unattributable op earns no memory topic any credit.
+    """
+    assert observe_unit(object(), object(), object()) is None
+    assert cc._store("outcome").hashes() == ()
+
+
+# ---------------------------------------------------------------------------
+# Signature + headroom semantics
+# ---------------------------------------------------------------------------
+
+
+def test_signature_uses_the_synthesizers_own_clustering():
+    """No second taxonomy — a new role becomes a new class with no code change."""
+    assert shape_signature(_shape(role="python-source mutator")) == \
+        "python-source-mutator:rw"
+    assert shape_signature(_shape(role="test-suite analyzer", read_only=True)) == \
+        "test-suite-analyzer:ro"
+
+
+def test_distinct_roles_learn_independently():
+    a = _shape(budget=8, role="python-source mutator")
+    b = _shape(budget=8, role="config editor")
+    _feed(12, granted=8, used=1, shape=a)
+    assert calibrate_shape(a).mutation_budget < 8
+    assert calibrate_shape(b) is b  # b has its own, empty, history
+
+
+def test_zero_budget_worker_reports_full_headroom():
+    """A read-only worker granted nothing has used all of its nothing.
+
+    Reporting 0.0 would drag the class mean toward "needs nothing" using a
+    worker that was never allowed anything.
+    """
+    obs = CageObservation(signature="s", granted_mutations=0, used_mutations=0,
+                          denied_tools=(), count_denied=0, succeeded=True)
+    assert obs.headroom == 1.0
+
+
+def test_headroom_is_clamped():
+    obs = CageObservation(signature="s", granted_mutations=2, used_mutations=99,
+                          denied_tools=(), count_denied=0, succeeded=True)
+    assert obs.headroom == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Wiring
+# ---------------------------------------------------------------------------
+
+
+def test_swarm_invoker_calibrates_and_observes():
+    """Both seams live in the ONE place a caged worker is shaped and finishes."""
+    src = (Path(__file__).resolve().parents[2]
+           / "backend/core/ouroboros/governance/autonomy/swarm_invoker.py"
+           ).read_text(encoding="utf-8")
+    assert "calibrate_shape" in src
+    assert "observe_unit" in src

--- a/tests/governance/test_swarm_reachability.py
+++ b/tests/governance/test_swarm_reachability.py
@@ -1,0 +1,230 @@
+"""Regression spine for swarm reachability — the Golden Rule must be REACHED.
+
+`swarm_invoker`'s docstring says it closed the gap where "setting
+``JARVIS_SWARM_ORCHESTRATOR_ENABLED=true`` did nothing because nothing invoked
+them". It closed that one and left the next: the invoker WAS called on every
+work unit, but its eligibility predicate asked ``unit.is_swarm_worker`` —
+True only for a unit that ALREADY carries a synthesized shape.
+
+Every production graph builder (`parallel_dispatch`, `iteration_planner`,
+`providers`, `meta_goal_aggregator`, `graph_coalescer`) leaves those fields
+``None``, and the only writer — ``SwarmOrchestrator.define_worker`` — has no
+production caller. So the invoker would only shape a unit that was already
+shaped, and the master flag still did nothing.
+
+The load-bearing test here is `test_synthesizer_is_reachable_from_a_production_unit`.
+It is the guard that would have caught the original bug, and it asserts
+against a unit built the way production builds them — no swarm fields — rather
+than against a hand-marked fixture, which is exactly how the bug survived its
+own test suite.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from backend.core.ouroboros.governance.autonomy.subagent_types import (
+    ExecutionGraph,
+    WorkUnitSpec,
+)
+from backend.core.ouroboros.governance.autonomy.swarm_invoker import (
+    SwarmUnitInvoker,
+    is_graph_parallelizable,
+    swarm_eligible,
+)
+
+TARGET = "backend/core/ouroboros/governance/memory_corpus.py"
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    for var in ("JARVIS_SWARM_ORCHESTRATOR_ENABLED",
+                "JARVIS_SWARM_REQUIRE_PRESHAPED_UNITS"):
+        monkeypatch.delenv(var, raising=False)
+    yield
+
+
+def _unit(uid="u0", goal="refactor the timeout handling", **kw):
+    """A unit shaped the way PRODUCTION builders shape one — no swarm fields."""
+    base = dict(unit_id=uid, repo="r", goal=goal, target_files=(TARGET,))
+    base.update(kw)
+    return WorkUnitSpec(**base)
+
+
+def _graph(units=None, concurrency_limit=2):
+    units = units or (_unit("u0"), _unit("u1"))
+    return ExecutionGraph(graph_id="g", op_id="op-1", planner_id="p",
+                          schema_version=1, units=units,
+                          concurrency_limit=concurrency_limit)
+
+
+class _Legacy:
+    def __init__(self):
+        self.calls = 0
+
+    async def execute(self, graph, unit):
+        self.calls += 1
+        return "LEGACY"
+
+
+def _halt(*_a, **_k):
+    """Stop the swarm path right after synthesis, before any execution."""
+    raise RuntimeError("halt after synthesis")
+
+
+def _run(coro):
+    return asyncio.get_event_loop_policy().new_event_loop().run_until_complete(
+        coro)
+
+
+# ---------------------------------------------------------------------------
+# The load-bearing guard
+# ---------------------------------------------------------------------------
+
+
+def test_synthesizer_is_reachable_from_a_production_unit(monkeypatch):
+    """The Golden Rule must actually RUN on a unit production would build.
+
+    This is the regression that would have caught the original defect. It
+    deliberately uses a unit with NO swarm fields — a hand-marked fixture
+    would pass against the bug, which is how the bug survived.
+    """
+    monkeypatch.setenv("JARVIS_SWARM_ORCHESTRATOR_ENABLED", "true")
+    from backend.core.ouroboros.governance.autonomy import worker_synthesizer
+
+    seen = {}
+    real = worker_synthesizer.synthesize_worker_spec
+
+    def spy(unit, **kw):
+        shape = real(unit, **kw)
+        seen[unit.unit_id] = shape
+        return shape
+
+    monkeypatch.setattr(worker_synthesizer, "synthesize_worker_spec", spy)
+
+    graph = _graph()
+    legacy = _Legacy()
+    result = _run(SwarmUnitInvoker(
+        legacy_executor=legacy, build_worker=_halt).execute(graph, graph.units[0]))
+
+    assert legacy.calls == 0, "unit fell through to legacy — swarm unreachable"
+    assert seen, "synthesize_worker_spec never ran"
+    shape = seen["u0"]
+    # The shape is DERIVED, not looked up: a mutating goal on a real Python
+    # source file must yield a mutation tool and a bounded budget.
+    assert "edit_file" in tuple(shape.allowed_tools)
+    assert shape.mutation_budget > 0
+    assert shape.role and not shape.role.isupper(), "role should be a derived phrase"
+    # Fail-CLOSED still holds: no cage -> FAILED, never an uncaged run.
+    assert getattr(result, "failure_class", "") == "swarm_cage"
+
+
+def test_read_only_goal_gets_no_mutation_tool(monkeypatch):
+    """Least privilege, derived. The cage is the point of reaching this path."""
+    monkeypatch.setenv("JARVIS_SWARM_ORCHESTRATOR_ENABLED", "true")
+    from backend.core.ouroboros.governance.autonomy.worker_synthesizer import (
+        synthesize_worker_spec,
+    )
+    shape = synthesize_worker_spec(
+        _unit(goal="analyze and report on the call graph"))
+    tools = tuple(shape.allowed_tools)
+    assert "edit_file" not in tools and "write_file" not in tools
+
+
+# ---------------------------------------------------------------------------
+# Eligibility
+# ---------------------------------------------------------------------------
+
+
+def test_production_shaped_unit_is_eligible():
+    assert swarm_eligible(_unit()) is True
+
+
+def test_preshaped_unit_stays_eligible():
+    """The `define_worker` path keeps working unchanged."""
+    assert swarm_eligible(_unit(worker_role="explicit")) is True
+
+
+def test_goalless_unit_fails_closed():
+    """No goal → nothing to inspect → legacy. A worker that cannot be
+    inspected cannot be caged."""
+    assert swarm_eligible(_unit(goal="   ")) is False
+
+
+def test_eligibility_never_raises_on_a_foreign_object():
+    assert swarm_eligible(object()) is False  # type: ignore[arg-type]
+
+
+def test_rollback_flag_restores_the_old_predicate(monkeypatch):
+    monkeypatch.setenv("JARVIS_SWARM_REQUIRE_PRESHAPED_UNITS", "1")
+    assert swarm_eligible(_unit()) is False
+    assert swarm_eligible(_unit(worker_role="explicit")) is True
+
+
+# ---------------------------------------------------------------------------
+# The gates that must still hold
+# ---------------------------------------------------------------------------
+
+
+def test_master_gate_off_is_byte_identical_legacy():
+    """Default OFF must remain a strict no-op."""
+    graph = _graph()
+    legacy = _Legacy()
+    result = _run(SwarmUnitInvoker(
+        legacy_executor=legacy, build_worker=_halt).execute(graph, graph.units[0]))
+    assert result == "LEGACY"
+    assert legacy.calls == 1
+
+
+def test_serial_graph_never_fans_out(monkeypatch):
+    """A non-parallelizable DAG stays on the legacy executor."""
+    monkeypatch.setenv("JARVIS_SWARM_ORCHESTRATOR_ENABLED", "true")
+    serial = _graph(units=(_unit("u0"),), concurrency_limit=1)
+    assert is_graph_parallelizable(serial) is False
+    legacy = _Legacy()
+    result = _run(SwarmUnitInvoker(
+        legacy_executor=legacy, build_worker=_halt).execute(serial, serial.units[0]))
+    assert result == "LEGACY"
+
+
+def test_dependency_chain_is_not_parallelizable():
+    chained = ExecutionGraph(
+        graph_id="g", op_id="o", planner_id="p", schema_version=1,
+        units=(_unit("u0"), _unit("u1", dependency_ids=("u0",))),
+        concurrency_limit=4)
+    assert is_graph_parallelizable(chained) is False
+
+
+# ---------------------------------------------------------------------------
+# The structural fact the fix depends on
+# ---------------------------------------------------------------------------
+
+
+def test_production_builders_still_leave_swarm_fields_unset():
+    """Pins WHY the predicate had to change.
+
+    If a builder ever starts setting these, the eligibility predicate should
+    be revisited rather than silently doing two things. This test is the
+    tripwire for that.
+    """
+    import ast
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[2] / "backend/core/ouroboros/governance"
+    builders = ("parallel_dispatch.py", "meta_goal_aggregator.py",
+                "graph_coalescer.py", "autonomy/iteration_planner.py")
+    swarm_fields = {"worker_role", "system_prompt_template", "allowed_tools",
+                    "mutation_budget", "context_budget_tokens"}
+    for name in builders:
+        path = root / name
+        if not path.is_file():
+            continue
+        for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+            if (isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Name)
+                    and node.func.id == "WorkUnitSpec"):
+                used = {kw.arg for kw in node.keywords if kw.arg}
+                assert not (used & swarm_fields), (
+                    f"{name} now sets swarm fields {used & swarm_fields} — "
+                    f"revisit swarm_eligible()")


### PR DESCRIPTION
## The audit

`worker_synthesizer` is O+V's most radical piece — a worker's persona, tool allowlist, mutation budget and context budget are **synthesized from AST + semantic inspection**, with "NO static enum, NO dictionary of Agent Roles". **It never ran in production.**

The chain was wired correctly right up to the last predicate:

```
_execute_unit_guarded          ✅ unconditional, every unit, l3_enabled=true
  → _get_swarm_invoker()        ✅ wired
    → _should_route_swarm()     ❌ return bool(unit.is_swarm_worker)
      → synthesize_worker_spec  ⛔ never reached
```

`is_swarm_worker` is True only if the unit **already carries** a synthesized shape — while the invoker's entire job is to synthesize it. Circular. All five production builders leave those fields `None`; the only writer (`SwarmOrchestrator.define_worker`) has zero production callers.

**The suite asserted the bug was correct.** `test_swarm_on_legacy_unit_in_multi_graph_uses_legacy` pinned *"a non-swarm unit → legacy even in a multi DAG"* — under that predicate, every real unit, always. That's why it stayed green while the feature was dead. Rewritten here to the corrected contract, with the genuinely-legacy cases pinned separately.

## Slice 1 — reachability

`swarm_eligible()` asks what the synthesizer **needs** (target_files + non-blank goal) rather than what a marking says. Pre-shaped units unchanged. Fail-closed. Rollback: `JARVIS_SWARM_REQUIRE_PRESHAPED_UNITS=1`.

Proven: a unit with no swarm fields now derives `role='python-source mutator'`, `tools=(read_file, search_code, list_dir, get_callers, edit_file)`, `mutation_budget=3`, `ctx=18180`. A read-only goal gets **no** mutation tool.

## Slice 2 — the cage learns, and only ever tightens

The synthesizer was open-loop: a prior with no posterior. `ScopedToolBackend` was already recording `mutations_count` vs `max_mutations` and `call_records` stamped `type_denied`/`count_denied` — unconsumed.

**Tighten autonomously; never widen.** Under-use is safe to act on (strictly less than the prior). Denial is not: widening a cage because a worker kept asking builds **a privilege-escalation ramp out of persistence**, reachable by any worker including a prompt-injected one. Denials become a finding naming `worker_synthesizer`'s **rule** as the fix — the root cause.

This is the *opposite* direction from the `matches_path` fix in #70307, where widening a guard was safe. The invariant is *move only in the direction that cannot grant something new*: deny-list → widen, allow-list → tighten.

`_is_tightening` **asserts** the post-condition (subset tools, `<=` budget) rather than trusting it. The load-bearing test hammers 50 runs of maximal demand — exhausted budget *and* denied tools — and proves it still cannot widen.

Learning key is the synthesizer's own clustering (`role` + `read_only`) — no second taxonomy to drift. Reuses two `memory_utility.UtilityStore` instances for the decay/confidence math.

Refusals: cold start → prior byte-identical; thin evidence → prior; **failed units never teach the cage to shrink**; unattributable shapes aren't recorded at all.

## Verification

29 new tests; **761 green** across `tests/governance/autonomy` plus the reused memory store's suite. The 1 red (`test_l3_telemetry` worktree lifespan) is identical at HEAD in a clean worktree.

Both gates default-OFF: `JARVIS_SWARM_ORCHESTRATOR_ENABLED`, `JARVIS_CAGE_CALIBRATION_ENABLED`. **Not soaked.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a circular swarm eligibility check so the worker synthesizer actually runs, and adds a tighten‑only cage calibration that learns safe mutation budgets from real usage without ever widening privileges. Changes are fail‑closed and behind default‑OFF flags.

- **Bug Fixes**
  - Replaced `unit.is_swarm_worker` check with `swarm_eligible(unit)` that requires non‑blank `goal` and `target_files`.
  - Pre‑shaped units remain eligible; non‑synthesizable units fall back to legacy executor.
  - Rollback: set `JARVIS_SWARM_REQUIRE_PRESHAPED_UNITS=1` to restore the old predicate.
  - Updated tests to assert the synthesizer is reached and read‑only goals get no mutation tools.

- **New Features**
  - Added `cage_calibration.py`:
    - `observe_unit(...)` records actual usage; `calibrate_shape(...)` tightens budgets only (subset tools, budget <= prior). Denials create findings; they never widen access.
    - Learning key is `role` + `read_only`; stores use `memory_utility.UtilityStore`.
    - Wired into `swarm_invoker`: calibrate after synthesis, observe after execution; both fail‑open.
  - Flags: `JARVIS_CAGE_CALIBRATION_ENABLED` (default off), `JARVIS_CAGE_CALIBRATION_MIN_OBS`, `JARVIS_CAGE_HEADROOM_MARGIN`, `JARVIS_CAGE_DENIAL_FINDING_RATIO`.

<sup>Written for commit 1b97d789cc4a24ae0bc90398b400691a6ad285c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

