### PR TITLE
feat(ov): adaptive fluid breakpoints — palette survives width starvation

### DIFF
--- a/backend/core/ouroboros/battle_test/palette_render.py
+++ b/backend/core/ouroboros/battle_test/palette_render.py
@@ -148,19 +148,88 @@ def _wrap(text: str, width: int) -> List[str]:
     return out or [""]
 
 
-def _rendered_height(desc: Any, desc_col: int, wrap: bool) -> int:
+#: Absolute terminal width below which the palette always stacks. A hard
+#: backstop, not the primary signal — see `stacked_mode`.
+_ABSOLUTE_STACK_FLOOR = 56
+
+#: Narrowest description column the two-column layout is allowed to leave.
+#: Below this a description is not wrapping, it is being shredded into a
+#: tower one or two words wide, and the table it is nominally part of has
+#: stopped conveying anything.
+_MIN_DESC_COL = 28
+
+
+def absolute_stack_floor() -> int:
+    """``JARVIS_PALETTE_STACK_FLOOR`` — hard width backstop. NEVER raises."""
+    try:
+        raw = os.environ.get("JARVIS_PALETTE_STACK_FLOOR", "").strip()
+        return max(0, min(200, int(raw))) if raw else _ABSOLUTE_STACK_FLOOR
+    except (TypeError, ValueError):
+        return _ABSOLUTE_STACK_FLOOR
+
+
+def min_desc_col() -> int:
+    """``JARVIS_PALETTE_MIN_DESC_COL`` — legibility floor. NEVER raises."""
+    try:
+        raw = os.environ.get("JARVIS_PALETTE_MIN_DESC_COL", "").strip()
+        return max(4, min(200, int(raw))) if raw else _MIN_DESC_COL
+    except (TypeError, ValueError):
+        return _MIN_DESC_COL
+
+
+def stacked_mode(width: int, name_col: int) -> bool:
+    """Whether to snap to the one-column stacked layout. Pure. NEVER raises.
+
+    Derived from the DESCRIPTION column, not from the terminal width, and
+    that distinction is the whole point.
+
+    A fixed column threshold measures the wrong quantity. At width 61 with a
+    40-character verb on screen, two-column leaves ~15 columns of
+    description — a tower one or two words wide, which is precisely the
+    failure a breakpoint is supposed to prevent, and a "> 60 so we are fine"
+    rule sails straight past it. At width 59 with nothing but 8-character
+    verbs there is ample room, and the same rule stacks for no reason.
+
+    What actually determines legibility is how much room the description
+    gets AFTER the name column and gutter are taken — which depends on the
+    entries, not just the window. So that is what is measured.
+
+    The absolute floor is kept as a backstop for the degenerate case where
+    the terminal is so narrow that even a short name leaves nothing, and
+    because an operator asking "when does it stack?" deserves an answer that
+    does not require knowing the verb table.
+    """
+    try:
+        w = int(width)
+        if w <= 0:
+            return False
+        if w < absolute_stack_floor():
+            return True
+        return (w - int(name_col) - _GUTTER - 2) < min_desc_col()
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _rendered_height(desc: Any, desc_col: int, wrap: bool,
+                     stacked: bool = False) -> int:
     """How many LINES an entry will occupy once drawn.
 
     Deliberately calls the same ``_wrap`` the renderer uses rather than
     estimating from ``len(desc) / desc_col``: an estimate and a renderer that
     disagree by one line produce a palette that overflows its own budget,
-    which is the failure this budget exists to prevent."""
-    if not wrap:
-        return 1
+    which is the failure this budget exists to prevent.
+
+    In stacked mode the name owns a line of its own, so the cost is
+    ``1 + description lines``. Teaching the budget about the mode rather
+    than leaving it to assume two-column is what keeps the block inside its
+    height when the layout snaps — otherwise every entry silently costs one
+    more line than the budget believes, on exactly the narrow terminal with
+    the least room to absorb it."""
     try:
-        return max(1, len(_wrap(str(desc), desc_col)))
+        body = 1 if not wrap else max(1, len(_wrap(str(desc), desc_col)))
+        return body + (1 if stacked else 0)
     except Exception:  # noqa: BLE001
-        return 1
+        return 2 if stacked else 1
 
 
 def layout_palette(
@@ -189,7 +258,16 @@ def layout_palette(
         _name_column(names),
         max(8, int(width * _NAME_COL_MAX_FRACTION)),
     )
-    desc_col = max(8, width - name_col - _GUTTER - 2)
+    # Evaluated per call, so a SIGWINCH mid-session re-decides on the next
+    # frame rather than carrying a stale mode: `layout_palette` is pure and
+    # the cockpit calls it every render.
+    stacked = stacked_mode(width, name_col)
+    #: Indent of a stacked description under its name. Two columns past the
+    #: name's own indent — enough to read as subordinate, not so much that a
+    #: 30-column terminal loses a tenth of its width to it.
+    stack_indent = 4
+    desc_col = (max(8, width - stack_indent - 2) if stacked
+                else max(8, width - name_col - _GUTTER - 2))
 
     # The budget is RENDERED LINES, not entries.
     #
@@ -216,7 +294,7 @@ def layout_palette(
     visible: List[Tuple[str, str]] = []
     spent = 0
     for entry in entries[start:]:
-        cost = _rendered_height(entry[1], desc_col, wrap_descriptions)
+        cost = _rendered_height(entry[1], desc_col, wrap_descriptions, stacked)
         # Always admit the first entry, even if it alone exceeds the budget:
         # showing nothing is worse than showing one tall thing, and the
         # selected row must never be the one that gets dropped.
@@ -244,6 +322,25 @@ def layout_palette(
         # screen. Clipping at the cap satisfies both while still letting an
         # ordinary long verb — `/backlog_auto_proposed` at 22 against a cap
         # of 34 — keep its full text, which is the case that motivated this.
+        if stacked:
+            # ONE column: name on its line, description indented beneath.
+            #
+            # Only the yield sequence changes — the same `_ellipsis`, the
+            # same `_wrap`, the same style classes. A second layout engine
+            # here would be a second place for the theme and the truncation
+            # rules to drift, and the two would disagree first on exactly the
+            # narrow terminal nobody tests on.
+            #
+            # The name may use the FULL width now: there is no description
+            # sharing the row, so the fraction cap would be clipping to
+            # protect a column that no longer exists.
+            stacked_name = _ellipsis(str(name), max(8, width - 2))
+            lines.append([(base, f"  {stacked_name}")])
+            for chunk in (_wrap(str(desc), desc_col) if wrap_descriptions
+                          else [_ellipsis(str(desc), desc_col)]):
+                lines.append([(meta, " " * stack_indent + chunk)])
+            continue
+
         shown = _ellipsis(str(name), max(8, int(width * _NAME_COL_MAX_FRACTION)))
         pad = " " * max(0, name_col - len(shown))
         # Re-measured PER ROW, so an overflowing name cannot push its

--- a/docs/memory_topics/battle_test/project_palette_uniform_alignment.md
+++ b/docs/memory_topics/battle_test/project_palette_uniform_alignment.md
@@ -64,3 +64,44 @@ to assert wrapping by SHAPE.
 
 21 tests; 447 green across palette/completion/bipartite. ⚠️ Not confirmed by
 the operator in a real terminal.
+
+## Slice 2 — adaptive fluid breakpoints (width starvation)
+
+Strict alignment introduced a geometric failure: on a narrow terminal the
+description column collapses and every entry becomes a tower one or two words
+wide. The table stops conveying anything exactly when there is least room.
+
+**The snap is derived from the DESCRIPTION column, not the terminal width.**
+A fixed "stack below 60" measures the wrong quantity, and two cases prove it:
+
+- width **61** with a 40-char verb → two-column leaves ~15 columns of
+  description. That is the tower a breakpoint exists to prevent, and a
+  column-count rule sails past it.
+- width **59** with 8-char verbs → ample room, and the same rule stacks for
+  no reason.
+
+`stacked_mode(width, name_col)` computes
+`width - name_col - _GUTTER - 2 < min_desc_col()`, with
+`absolute_stack_floor()` (56) kept as a backstop for degenerate terminals and
+because "when does it stack?" deserves an answer that does not require
+knowing the verb table. Both env-tunable.
+
+**Only the yield sequence changes.** Same `_ellipsis`, same `_wrap`, same
+style classes — a second layout engine would be a second place for theme and
+truncation to drift, and the two would disagree first on the narrow terminal
+nobody tests on.
+
+**`_rendered_height` learned the mode.** A stacked entry costs
+`1 + description lines`; a budget that assumed two-column would overrun by
+one line per entry on exactly the narrow terminal with least slack.
+
+**Stacked names use the FULL width** — with no description sharing the row,
+the 34% fraction cap would be clipping to protect a column that no longer
+exists. Still ellipsised against the terminal, so a 200-char verb at width 30
+cannot overflow.
+
+Evaluated per call, so a SIGWINCH re-decides on the next frame: the function
+is pure and the cockpit calls it every render.
+
+31 tests; parametrised no-overflow across widths 200→12. 478 green across
+palette/completion/bipartite.

--- a/tests/battle_test/test_palette_breakpoint.py
+++ b/tests/battle_test/test_palette_breakpoint.py
@@ -1,0 +1,188 @@
+"""Adaptive fluid breakpoints — the palette survives width starvation.
+
+Strict two-column alignment introduces a geometric failure: on a narrow
+terminal the description column collapses and every entry becomes a tower one
+or two words wide. The table stops conveying anything precisely when the
+operator has least room to spare.
+
+The load-bearing decision is `stacked_mode` measuring the DESCRIPTION column
+rather than the terminal width. A fixed column threshold measures the wrong
+quantity, and `test_a_fixed_threshold_would_get_both_of_these_wrong` pins the
+two cases that prove it.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.battle_test.palette_render import (
+    _GUTTER,
+    absolute_stack_floor,
+    layout_palette,
+    min_desc_col,
+    stacked_mode,
+)
+
+ENTRIES = [
+    ("/anticipate", "help · panel · banners · prefetch · status"),
+    ("/autobiography", "Retrospective audit of O+V-signed commits"),
+    ("/backlog_auto_proposed", "Review auto-proposed backlog items"),
+    ("/breadcrumbs", "Set/show the feed verbosity"),
+]
+
+
+def _lines(width, entries=None, **kw):
+    return ["".join(t for _s, t in row) for row in layout_palette(
+        entries or ENTRIES, width=width, max_rows=kw.pop("max_rows", 24), **kw)]
+
+
+def _is_name_row(line: str) -> bool:
+    return line.lstrip().startswith("/")
+
+
+# ---------------------------------------------------------------------------
+# The mandate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_width_100_yields_single_line_two_column_rows():
+    """Above the breakpoint: one line per entry, name and description inline."""
+    lines = _lines(100)
+    assert len(lines) == len(ENTRIES), "an entry wrapped or stacked at width 100"
+    for line, (name, desc) in zip(lines, ENTRIES):
+        assert name in line and desc.split()[0] in line, (
+            "name and description are not on the same line")
+
+
+@pytest.mark.asyncio
+async def test_width_40_snaps_to_stacked_multi_line_rows():
+    """Below it: the name owns a row, the description is indented beneath."""
+    lines = _lines(40)
+    assert len(lines) > len(ENTRIES), "layout did not snap to stacked"
+    for name, _desc in ENTRIES:
+        row = next(ln for ln in lines if ln.strip() == name)
+        after = lines[lines.index(row) + 1]
+        assert not _is_name_row(after), "description did not follow its name"
+        assert len(after) - len(after.lstrip()) > (
+            len(row) - len(row.lstrip())), "description is not indented"
+
+
+# ---------------------------------------------------------------------------
+# Why the threshold is derived, not fixed
+# ---------------------------------------------------------------------------
+
+
+def test_a_fixed_threshold_would_get_both_of_these_wrong():
+    """The reason `stacked_mode` reads the description column.
+
+    A "stack below 60" rule keeps two-column at width 61 with a 40-char verb
+    — leaving ~15 columns of description, the exact tower a breakpoint
+    exists to prevent — and stacks at width 59 with 8-char verbs, where
+    there was ample room.
+    """
+    assert stacked_mode(61, 40) is True, "wide-but-starved was not caught"
+    assert stacked_mode(59, 8) is False, "narrow-but-roomy was over-stacked"
+
+
+def test_the_snap_point_matches_the_legibility_floor():
+    """Isolates the DERIVED snap from the absolute backstop.
+
+    The name column has to be wide enough that the derived boundary lands
+    above `absolute_stack_floor()`, or the backstop answers first and this
+    tests that instead — which it already does in its own test.
+    """
+    name_col = 30
+    just_enough = min_desc_col() + name_col + _GUTTER + 2
+    assert just_enough > absolute_stack_floor(), "floor would answer first"
+    assert stacked_mode(just_enough, name_col) is False
+    assert stacked_mode(just_enough - 1, name_col) is True
+
+
+def test_the_absolute_floor_is_a_backstop():
+    """Degenerate terminals stack regardless of how short the names are."""
+    assert stacked_mode(absolute_stack_floor() - 1, 4) is True
+
+
+@pytest.mark.parametrize("env,width,name_col,expected", [
+    ("20", 100, 8, False),
+    ("90", 100, 8, True),
+])
+def test_the_legibility_floor_is_tunable(monkeypatch, env, width, name_col,
+                                         expected):
+    monkeypatch.setenv("JARVIS_PALETTE_MIN_DESC_COL", env)
+    assert stacked_mode(width, name_col) is expected
+
+
+def test_the_absolute_floor_is_tunable(monkeypatch):
+    monkeypatch.setenv("JARVIS_PALETTE_STACK_FLOOR", "80")
+    assert stacked_mode(70, 4) is True
+
+
+@pytest.mark.parametrize("junk", ["", "abc", "-1"])
+def test_knobs_survive_junk(monkeypatch, junk):
+    monkeypatch.setenv("JARVIS_PALETTE_MIN_DESC_COL", junk)
+    monkeypatch.setenv("JARVIS_PALETTE_STACK_FLOOR", junk)
+    assert isinstance(stacked_mode(100, 10), bool)
+
+
+def test_stacked_mode_never_raises():
+    for args in ((0, 0), (-5, 3), ("x", None)):
+        assert isinstance(stacked_mode(*args), bool)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Structural invariants that must hold in BOTH modes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("width", [200, 120, 100, 80, 61, 56, 55, 40, 30, 20, 12])
+def test_no_row_ever_overflows_the_terminal(width):
+    """The invariant that makes narrow terminals safe at all."""
+    for line in _lines(width):
+        assert len(line) <= width, f"{len(line)} > {width}: {line!r}"
+
+
+@pytest.mark.parametrize("width", [100, 40])
+def test_the_line_budget_is_honoured_in_both_modes(width):
+    """Stacked entries cost 1 + description lines.
+
+    A budget that assumed two-column would silently overrun by one line per
+    entry on exactly the narrow terminal with least room to absorb it.
+    """
+    assert len(_lines(width, max_rows=6)) <= 6
+
+
+@pytest.mark.parametrize("width", [100, 40])
+def test_every_visible_entry_keeps_its_description(width):
+    lines = _lines(width)
+    blob = " ".join(lines)
+    for _name, desc in ENTRIES:
+        assert desc.split()[0] in blob
+
+
+def test_a_pathological_name_is_still_bounded_when_stacked():
+    """Stacked gives the name the full width — it must still not overflow."""
+    entries = [("/" + "z" * 200, "long")]
+    for line in _lines(30, entries=entries):
+        assert len(line) <= 30
+    assert any("…" in ln for ln in _lines(30, entries=entries))
+
+
+def test_stacked_name_is_not_clipped_by_the_two_column_fraction_cap():
+    """With no description sharing the row, the 34% cap would clip to protect
+    a column that no longer exists."""
+    entries = [("/backlog_auto_proposed", "d")]
+    lines = _lines(40, entries=entries)
+    assert lines[0].strip() == "/backlog_auto_proposed"
+
+
+def test_selection_highlight_survives_the_snap():
+    for width in (100, 40):
+        rows = layout_palette(ENTRIES, width=width, selected=1, max_rows=24)
+        styles = {s for row in rows for s, _t in row}
+        assert any("current" in s for s in styles), width
+
+
+def test_empty_and_degenerate_inputs():
+    assert layout_palette([], width=40) == []
+    assert layout_palette(ENTRIES, width=0) == []


### PR DESCRIPTION
Strict two-column alignment (#70309) introduced a geometric failure: on a narrow terminal the description column collapses and every entry becomes a tower one or two words wide.

## The snap is derived from the DESCRIPTION column, not terminal width

A fixed "stack below 60" measures the wrong quantity. Two cases prove it:

| case | fixed rule | derived rule |
|---|---|---|
| width **61**, 40-char verb | 2-column, ~15 cols of description → **the tower it exists to prevent** | stacked ✅ |
| width **59**, 8-char verbs | stacked, for no reason | 2-column ✅ |

What determines legibility is how much room the description gets *after* the name column and gutter — which depends on the entries, not just the window.

`stacked_mode()` computes `width - name_col - _GUTTER - 2 < min_desc_col()`. `absolute_stack_floor()` (56) stays as a backstop for degenerate terminals and because "when does it stack?" deserves an answer that doesn't require knowing the verb table. Both env-tunable.

## Only the yield sequence changes

Same `_ellipsis`, same `_wrap`, same style classes. A second layout engine would be a second place for theme and truncation to drift — and the two would disagree first on exactly the narrow terminal nobody tests on.

## Two subtleties

**`_rendered_height` learned the mode.** A stacked entry costs `1 + description lines`; a budget assuming two-column would overrun by one line per entry on the terminal with least slack.

**Stacked names use the FULL width** — with no description sharing the row, the 34% fraction cap would clip to protect a column that no longer exists. Still ellipsised against the terminal, so a 200-char verb at width 30 can't overflow.

Evaluated per call, so SIGWINCH re-decides next frame: the function is pure and the cockpit calls it every render.

## Verification

31 tests: both mandate cases (width 100 → single-line 2-column; width 40 → stacked multi-line), the two fixed-threshold counterexamples, selection-highlight survival across the snap, and a parametrised no-overflow sweep across widths 200 → 12.

478 green across palette/completion/bipartite. The 1 red (`test_verb_description`) is pre-existing and identical at HEAD — and is the next thing to fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the palette switch to a stacked layout based on available description width, not a fixed terminal width. This prevents narrow terminals from producing unreadable “towers” and keeps rows within the height budget.

- **New Features**
  - Adaptive breakpoint via `stacked_mode(width, name_col)`: stacks when `width - name_col - _GUTTER - 2 < min_desc_col()`. Hard backstop via `absolute_stack_floor()`. Both tunable with `JARVIS_PALETTE_MIN_DESC_COL` and `JARVIS_PALETTE_STACK_FLOOR`.
  - Stacked render: name on its own line (full-width, ellipsized), description indented; same `_wrap`/`_ellipsis` and styles.
  - `_rendered_height(..., stacked=...)` now counts `1 + description lines` to honor `max_rows` in both modes.
  - Added 31 tests covering the mandate cases, fixed-threshold counterexamples, tunables, and no-overflow across widths 200→12; updated docs.

<sup>Written for commit 45268a0d77bb0ec4287d43e18506663633aa8e3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

