### PR TITLE
fix(ov): real descriptions for 36 palette verbs, and two normalizer defects

### DIFF
--- a/backend/core/ouroboros/battle_test/verb_description.py
+++ b/backend/core/ouroboros/battle_test/verb_description.py
@@ -54,6 +54,11 @@ _IMPL_OPENERS = (
     "parse", "handle", "dispatch", "implement", "process", "route",
     "execute", "perform", "run the", "entry point for", "entrypoint for",
     "helper for", "wrapper for", "callback for", "hook for",
+    # Naming-cage scaffolding. "canonical entry point — auto-discovered"
+    # describes how the REGISTRY finds the verb, which is a fact about the
+    # dispatch convention and tells an operator nothing about what typing it
+    # does. Left in, it surfaced as the description "Auto-discovered".
+    "canonical entry point", "auto-discovered", "auto discovered",
 )
 
 #: Connectives left dangling after an opener is removed.
@@ -262,8 +267,20 @@ def _strip_verb_name(text: str, verb: str) -> str:
     )
     if named.search(text):
         return named.sub("", text, count=1)
+    # IDEMPOTENT: matches with OR without the leading slash.
+    #
+    # This is called twice — once before the dangling-article sweep and once
+    # after — and the first pass rewrites "/attach a file" to "attach a
+    # file". With `^/` required, the second pass no longer recognised the
+    # acting form, fell through to the catch-all below, and deleted the word
+    # the first pass had just protected. The result was "File or image to the
+    # next generation": a fragment about files where an instruction to attach
+    # one used to be, produced by the very rule written to prevent it.
+    #
+    # A transform applied more than once has to be a fixed point, or the
+    # number of times it runs becomes part of its contract.
     acting = re.compile(
-        rf"^/{re.escape(name)}\b(?=\s+(?:a|an|the|to|for|with|from|into|on)\b)",
+        rf"^/?{re.escape(name)}\b(?=\s+(?:a|an|the|to|for|with|from|into|on)\b)",
         re.IGNORECASE,
     )
     if acting.search(text):

--- a/backend/core/ouroboros/governance/budget_repl.py
+++ b/backend/core/ouroboros/governance/budget_repl.py
@@ -140,7 +140,9 @@ def dispatch_budget_command(
     *,
     tracker: Optional[EpistemicBudgetTracker] = None,
 ) -> BudgetReplDispatchResult:
-    """Parse a ``/budget`` line and dispatch. NEVER raises."""
+    """Show and tune the epistemic exploration budget.
+
+    Parse a ``/budget`` line and dispatch. NEVER raises."""
     if not _matches(line):
         return BudgetReplDispatchResult(
             ok=False, text="", matched=False,

--- a/backend/core/ouroboros/governance/canvas_repl.py
+++ b/backend/core/ouroboros/governance/canvas_repl.py
@@ -93,7 +93,9 @@ def _matches(line: str) -> bool:
 
 
 def dispatch_canvas_command(line: str) -> CanvasDispatchResult:
-    """Parse a ``/canvas`` line and dispatch. NEVER raises."""
+    """Show the op dependency canvas — parent/child tree and parallel fan-out.
+
+    Parse a ``/canvas`` line and dispatch. NEVER raises."""
     if not _matches(line):
         return CanvasDispatchResult(
             ok=False, text="", matched=False,

--- a/backend/core/ouroboros/governance/cognitive_metrics_repl.py
+++ b/backend/core/ouroboros/governance/cognitive_metrics_repl.py
@@ -200,7 +200,9 @@ def dispatch_cognitive_command(
     project_root: Optional[Path] = None,
     service: Optional[CognitiveMetricsService] = None,
 ) -> CognitiveDispatchResult:
-    """Parse `/cognitive ...` and dispatch.
+    """Inspect the cognitive-metrics audit ledger.
+
+    Parse `/cognitive ...` and dispatch.
 
     Tests inject ``service`` directly; production resolves a singleton
     via ``cognitive_metrics.get_default_service``."""

--- a/backend/core/ouroboros/governance/coherence_repl.py
+++ b/backend/core/ouroboros/governance/coherence_repl.py
@@ -134,7 +134,9 @@ def _parse_limit(args: List[str]) -> int:
 def dispatch_coherence_command(
     line: str,
 ) -> CoherenceDispatchResult:
-    """Parse a ``/coherence`` line and dispatch. NEVER raises."""
+    """Show coherence readings for recent operations.
+
+    Parse a ``/coherence`` line and dispatch. NEVER raises."""
     if not _matches(line):
         return CoherenceDispatchResult(
             ok=False, text="", matched=False,

--- a/backend/core/ouroboros/governance/commit_repl.py
+++ b/backend/core/ouroboros/governance/commit_repl.py
@@ -137,7 +137,9 @@ def _parse_opts(args: List[str]) -> dict:
 
 
 async def dispatch_commit_command(line: str) -> CommitDispatchResult:
-    """Parse a ``/commit`` line and dispatch. ``matched=False``
+    """Grant, revoke and review operator commit authority.
+
+    Parse a ``/commit`` line and dispatch. ``matched=False``
     short-circuit lets the registry fall through. NEVER raises.
 
     ``async`` because ``/commit status`` awaits

--- a/backend/core/ouroboros/governance/compact_repl.py
+++ b/backend/core/ouroboros/governance/compact_repl.py
@@ -163,7 +163,9 @@ def dispatch_compact_command(
     dialogue_entries: Optional[List[Dict[str, Any]]] = None,
     op_id: Optional[str] = None,
 ) -> CompactDispatchResult:
-    """Parse a ``/compact`` line + dispatch.
+    """Inspect context-compaction config and what is queued to compact.
+
+    Parse a ``/compact`` line + dispatch.
 
     ``compactor`` is the substrate ``ContextCompactor`` instance —
     tests inject; production calls ``set_default_compactor`` at

--- a/backend/core/ouroboros/governance/conversation_repl.py
+++ b/backend/core/ouroboros/governance/conversation_repl.py
@@ -450,7 +450,9 @@ def _parse_limit(
 def dispatch_conversation_command(
     line: str,
 ) -> ConversationReplDispatchResult:
-    """Parse a ``/conversation`` line and dispatch. NEVER raises."""
+    """Export and inspect the live conversation bridge buffer.
+
+    Parse a ``/conversation`` line and dispatch. NEVER raises."""
     if not _matches(line):
         return ConversationReplDispatchResult(
             ok=False, text="", matched=False,

--- a/backend/core/ouroboros/governance/curiosity_repl.py
+++ b/backend/core/ouroboros/governance/curiosity_repl.py
@@ -173,7 +173,9 @@ def dispatch_curiosity_command(
     *,
     collector: Optional[CuriosityCollector] = None,
 ) -> CuriosityReplDispatchResult:
-    """Parse a ``/curiosity`` line and dispatch. NEVER raises."""
+    """Show what the organism chose to explore, and why.
+
+    Parse a ``/curiosity`` line and dispatch. NEVER raises."""
     if not _matches(line):
         return CuriosityReplDispatchResult(
             ok=False, text="", matched=False,

--- a/backend/core/ouroboros/governance/decisions_repl.py
+++ b/backend/core/ouroboros/governance/decisions_repl.py
@@ -163,7 +163,9 @@ def _parse_limit(args, *, default, ceiling):
 def dispatch_decisions_command(
     line: str,
 ) -> DecisionsReplDispatchResult:
-    """Parse a ``/decisions`` line and dispatch. NEVER raises."""
+    """Review recorded decisions and the reasoning behind them.
+
+    Parse a ``/decisions`` line and dispatch. NEVER raises."""
     if not _matches(line):
         return DecisionsReplDispatchResult(
             ok=False, text="", matched=False,

--- a/backend/core/ouroboros/governance/doll_metric_repl.py
+++ b/backend/core/ouroboros/governance/doll_metric_repl.py
@@ -103,7 +103,9 @@ def _master_enabled() -> bool:
 def dispatch_doll_metric_command(
     line: str,
 ) -> DollMetricReplDispatchResult:
-    """Canonical §32.11 Slice 4 entry point — auto-discovered by
+    """Show per-axis doll-completion stages and the overall ratio.
+
+    Canonical §32.11 Slice 4 entry point — auto-discovered by
     naming convention (``dispatch_<basename>_command``).
     """
     if not _matches(line):

--- a/backend/core/ouroboros/governance/failures_repl.py
+++ b/backend/core/ouroboros/governance/failures_repl.py
@@ -122,7 +122,9 @@ def _parse_limit(args: List[str]) -> int:
 
 
 def dispatch_failures_command(line: str) -> FailuresDispatchResult:
-    """Parse a ``/failures`` line and dispatch. NEVER raises."""
+    """Review recorded failure modes and their mitigations.
+
+    Parse a ``/failures`` line and dispatch. NEVER raises."""
     if not _matches(line):
         return FailuresDispatchResult(
             ok=False, text="", matched=False,

--- a/backend/core/ouroboros/governance/fast_path_qa_repl.py
+++ b/backend/core/ouroboros/governance/fast_path_qa_repl.py
@@ -193,7 +193,9 @@ def _parse_limit(
 def dispatch_fast_path_qa_command(
     line: str,
 ) -> FastPathQAReplDispatchResult:
-    """Parse a ``/fast_path_qa`` line and dispatch. NEVER raises."""
+    """Inspect the fast-path QA ring of recent answers.
+
+    Parse a ``/fast_path_qa`` line and dispatch. NEVER raises."""
     if not _matches(line):
         return FastPathQAReplDispatchResult(
             ok=False, text="", matched=False,

--- a/backend/core/ouroboros/governance/governor_repl.py
+++ b/backend/core/ouroboros/governance/governor_repl.py
@@ -95,7 +95,9 @@ def dispatch_governor_command(
     governor: Any = None,
     gate: Any = None,
 ) -> GovernorDispatchResult:
-    """Parse ``/governor ...`` and dispatch. Tests inject collaborators."""
+    """Show sensor budget caps, memory pressure and brake status.
+
+    Parse ``/governor ...`` and dispatch. Tests inject collaborators."""
     if not _matches(line):
         return GovernorDispatchResult(ok=False, text="", matched=False)
     try:

--- a/backend/core/ouroboros/governance/graduation_repl.py
+++ b/backend/core/ouroboros/governance/graduation_repl.py
@@ -134,7 +134,9 @@ def _matches(line: str) -> bool:
 def dispatch_graduation_command(
     line: str,
 ) -> GraduationReplDispatchResult:
-    """Parse a ``/graduation`` line and dispatch. NEVER raises —
+    """Show which capabilities have graduated and which are pending.
+
+    Parse a ``/graduation`` line and dispatch. NEVER raises —
     exceptions surface as non-ok results.
 
     Auto-discovered by :mod:`repl_dispatch_registry` (§32.11

--- a/backend/core/ouroboros/governance/health_repl.py
+++ b/backend/core/ouroboros/governance/health_repl.py
@@ -366,7 +366,9 @@ def _render_unhealthy() -> str:
 def dispatch_health_command(
     line: str,
 ) -> HealthReplDispatchResult:
-    """Parse a ``/health`` line and dispatch. NEVER raises."""
+    """Show per-component health state and transition history.
+
+    Parse a ``/health`` line and dispatch. NEVER raises."""
     if not _matches(line):
         return HealthReplDispatchResult(
             ok=False, text="", matched=False,

--- a/backend/core/ouroboros/governance/help_dispatcher.py
+++ b/backend/core/ouroboros/governance/help_dispatcher.py
@@ -376,7 +376,9 @@ def dispatch_help_command(
     verb_registry: Optional[VerbRegistry] = None,
     current_posture_fn: Optional[Callable[[], Optional[Any]]] = None,
 ) -> HelpDispatchResult:
-    """Parse a ``/help`` line and dispatch.
+    """List every REPL verb and every registered env flag.
+
+    Parse a ``/help`` line and dispatch.
 
     ``flag_registry`` defaults to ``ensure_seeded()`` from flag_registry.
     ``verb_registry`` defaults to the module singleton.

--- a/backend/core/ouroboros/governance/history_repl.py
+++ b/backend/core/ouroboros/governance/history_repl.py
@@ -73,7 +73,9 @@ def _matches(line: str) -> bool:
 
 
 def dispatch_history_command(line: str) -> HistoryDispatchResult:
-    """Parse a ``/history`` line and dispatch. NEVER raises."""
+    """Query the session archive by flag, date or text.
+
+    Parse a ``/history`` line and dispatch. NEVER raises."""
     if not _matches(line):
         return HistoryDispatchResult(
             ok=False, text="", matched=False,

--- a/backend/core/ouroboros/governance/listen_repl.py
+++ b/backend/core/ouroboros/governance/listen_repl.py
@@ -386,7 +386,9 @@ def _render_stats() -> str:
 def dispatch_listen_command(
     line: str,
 ) -> ListenReplDispatchResult:
-    """Parse a ``/listen`` line and dispatch. NEVER raises."""
+    """Watch the live event stream the IDE consumers see.
+
+    Parse a ``/listen`` line and dispatch. NEVER raises."""
     if not _matches(line):
         return ListenReplDispatchResult(
             ok=False, text="", matched=False,

--- a/backend/core/ouroboros/governance/m10/repl.py
+++ b/backend/core/ouroboros/governance/m10/repl.py
@@ -158,7 +158,9 @@ def _parse_limit(args, *, default, ceiling):
 
 
 def dispatch_m10_command(line: str) -> M10ReplDispatchResult:
-    """Parse a ``/m10`` line and dispatch. NEVER raises."""
+    """Inspect the M10 substrate ledger.
+
+    Parse a ``/m10`` line and dispatch. NEVER raises."""
     if not _matches(line):
         return M10ReplDispatchResult(
             ok=False, text="", matched=False,

--- a/backend/core/ouroboros/governance/mode_repl.py
+++ b/backend/core/ouroboros/governance/mode_repl.py
@@ -68,7 +68,9 @@ def _matches(line: str) -> bool:
 
 
 def dispatch_mode_command(line: str) -> ModeDispatchResult:
-    """Parse a ``/mode`` line and dispatch.
+    """Show or set the current operation mode.
+
+    Parse a ``/mode`` line and dispatch.
 
     Returns a :class:`ModeDispatchResult` with ``matched=True``
     only when the line begins with ``/mode``. Other input

--- a/backend/core/ouroboros/governance/outcomes_repl.py
+++ b/backend/core/ouroboros/governance/outcomes_repl.py
@@ -129,7 +129,9 @@ def _parse_limit(args: List[str]) -> int:
 
 
 def dispatch_outcomes_command(line: str) -> OutcomesDispatchResult:
-    """Parse an ``/outcomes`` line and dispatch. NEVER raises."""
+    """Review recorded action outcomes and their weights.
+
+    Parse an ``/outcomes`` line and dispatch. NEVER raises."""
     if not _matches(line):
         return OutcomesDispatchResult(
             ok=False, text="", matched=False,

--- a/backend/core/ouroboros/governance/phase9_repl.py
+++ b/backend/core/ouroboros/governance/phase9_repl.py
@@ -67,7 +67,9 @@ def _matches(line: str) -> bool:
 
 
 def dispatch_phase9_command(line: str) -> Phase9DispatchResult:
-    """Parse a ``/phase9`` line and dispatch. NEVER raises."""
+    """Show the Phase 9 orchestrator dashboard.
+
+    Parse a ``/phase9`` line and dispatch. NEVER raises."""
     if not _matches(line):
         return Phase9DispatchResult(
             ok=False, text="", matched=False,

--- a/backend/core/ouroboros/governance/posture_repl.py
+++ b/backend/core/ouroboros/governance/posture_repl.py
@@ -142,7 +142,9 @@ def dispatch_posture_command(
     override_state: Optional[Any] = None,
     audit_sink: Optional[Any] = None,
 ) -> PostureDispatchResult:
-    """Parse a ``/posture`` line and dispatch.
+    """Show or override the inferred strategic posture.
+
+    Parse a ``/posture`` line and dispatch.
 
     Tests inject collaborators explicitly; production wires defaults.
     ``audit_sink`` is optional — when ``None`` the handler falls back

--- a/backend/core/ouroboros/governance/probe_repl.py
+++ b/backend/core/ouroboros/governance/probe_repl.py
@@ -114,7 +114,9 @@ def _master_enabled() -> bool:
 
 
 def dispatch_probe_command(line: str) -> ProbeDispatchResult:
-    """Parse a ``/probe`` line and dispatch. NEVER raises."""
+    """Show probe readings for recent operations.
+
+    Parse a ``/probe`` line and dispatch. NEVER raises."""
     if not _matches(line):
         return ProbeDispatchResult(
             ok=False, text="", matched=False,

--- a/backend/core/ouroboros/governance/quorum_repl.py
+++ b/backend/core/ouroboros/governance/quorum_repl.py
@@ -131,7 +131,9 @@ def _parse_limit(args: List[str]) -> Optional[int]:
 
 
 def dispatch_quorum_command(line: str) -> QuorumDispatchResult:
-    """Parse a ``/quorum`` line and dispatch. NEVER raises."""
+    """Show generative-quorum readings and agreement.
+
+    Parse a ``/quorum`` line and dispatch. NEVER raises."""
     if not _matches(line):
         return QuorumDispatchResult(
             ok=False, text="", matched=False,

--- a/backend/core/ouroboros/governance/radar_repl.py
+++ b/backend/core/ouroboros/governance/radar_repl.py
@@ -98,7 +98,9 @@ def _master_enabled() -> bool:
 def dispatch_radar_command(
     line: str,
 ) -> RadarReplDispatchResult:
-    """Parse a ``/radar`` line and dispatch. NEVER raises."""
+    """Show the activity radar — what is moving right now.
+
+    Parse a ``/radar`` line and dispatch. NEVER raises."""
     if not _matches(line):
         return RadarReplDispatchResult(
             ok=False, text="", matched=False,

--- a/backend/core/ouroboros/governance/render_repl.py
+++ b/backend/core/ouroboros/governance/render_repl.py
@@ -128,7 +128,9 @@ def _matches(line: str) -> bool:
 
 
 def dispatch_render_command(line: str) -> RenderDispatchResult:
-    """Parse a ``/render`` line and dispatch.
+    """Inspect the render conductor — flags, backends and observers.
+
+    Parse a ``/render`` line and dispatch.
 
     Read-only: never mutates substrate state. Subcommands map to
     private ``_status / _flags / _backends / _observers`` handlers.

--- a/backend/core/ouroboros/governance/repair_tree_repl.py
+++ b/backend/core/ouroboros/governance/repair_tree_repl.py
@@ -161,7 +161,9 @@ def _parse_limit(
 def dispatch_repair_tree_command(
     line: str,
 ) -> RepairTreeReplDispatchResult:
-    """Parse a ``/repair_tree`` line and dispatch. NEVER raises."""
+    """Inspect the repair-tree archive of past repair attempts.
+
+    Parse a ``/repair_tree`` line and dispatch. NEVER raises."""
     if not _matches(line):
         return RepairTreeReplDispatchResult(
             ok=False, text="", matched=False,

--- a/backend/core/ouroboros/governance/replay_repl.py
+++ b/backend/core/ouroboros/governance/replay_repl.py
@@ -365,7 +365,9 @@ def _render_show_session_phase(
 def dispatch_replay_command(
     line: str,
 ) -> ReplayReplDispatchResult:
-    """Parse a ``/replay`` line and dispatch. NEVER raises."""
+    """Replay an operation deterministically from its recorded trace.
+
+    Parse a ``/replay`` line and dispatch. NEVER raises."""
     if not _matches(line):
         return ReplayReplDispatchResult(
             ok=False, text="", matched=False,

--- a/backend/core/ouroboros/governance/scope_repl.py
+++ b/backend/core/ouroboros/governance/scope_repl.py
@@ -69,7 +69,9 @@ def _matches(line: str) -> bool:
 
 
 def dispatch_scope_command(line: str) -> ScopeDispatchResult:
-    """Parse a ``/scope`` line and dispatch. NEVER raises."""
+    """Inspect and register per-component tool scopes.
+
+    Parse a ``/scope`` line and dispatch. NEVER raises."""
     if not _matches(line):
         return ScopeDispatchResult(
             ok=False, text="", matched=False,

--- a/backend/core/ouroboros/governance/semantic_budget_repl.py
+++ b/backend/core/ouroboros/governance/semantic_budget_repl.py
@@ -142,7 +142,9 @@ def _matches(line: str) -> bool:
 def dispatch_semantic_budget_command(
     line: str,
 ) -> SemanticBudgetReplDispatchResult:
-    """Parse a ``/semantic_budget`` line and dispatch. NEVER
+    """Show cross-op semantic budget spend and headroom.
+
+    Parse a ``/semantic_budget`` line and dispatch. NEVER
     raises — exceptions surface as non-ok results.
 
     Auto-discovered by :mod:`repl_dispatch_registry` (§32.11

--- a/backend/core/ouroboros/governance/show_plan_repl.py
+++ b/backend/core/ouroboros/governance/show_plan_repl.py
@@ -391,7 +391,9 @@ def _render_complexity_distribution() -> str:
 def dispatch_show_plan_command(
     line: str,
 ) -> ShowPlanReplDispatchResult:
-    """Parse a ``/show_plan`` line and dispatch. NEVER raises."""
+    """Show the model-reasoned PLAN output for an operation.
+
+    Parse a ``/show_plan`` line and dispatch. NEVER raises."""
     if not _matches(line):
         return ShowPlanReplDispatchResult(
             ok=False, text="", matched=False,

--- a/backend/core/ouroboros/governance/tool_permissions_repl.py
+++ b/backend/core/ouroboros/governance/tool_permissions_repl.py
@@ -177,7 +177,9 @@ def _parse_limit(
 def dispatch_tool_permissions_command(
     line: str,
 ) -> ToolPermissionsReplDispatchResult:
-    """Parse a ``/tool_permissions`` line and dispatch. NEVER raises."""
+    """Review recorded tool-permission decisions.
+
+    Parse a ``/tool_permissions`` line and dispatch. NEVER raises."""
     if not _matches(line):
         return ToolPermissionsReplDispatchResult(
             ok=False, text="", matched=False,

--- a/backend/core/ouroboros/governance/verification/replay_repl.py
+++ b/backend/core/ouroboros/governance/verification/replay_repl.py
@@ -101,7 +101,9 @@ def _master_enabled() -> bool:
 def dispatch_replay_command(
     line: str,
 ) -> ReplayDispatchResult:
-    """Parse ``/replay ...`` and dispatch. NEVER raises — every
+    """Show counterfactual replay state and recurrence reduction.
+
+    Parse ``/replay ...`` and dispatch. NEVER raises — every
     error path produces a friendly text result.
 
     The dispatcher is sync but ``run`` subcommand wraps Slice 2's

--- a/backend/core/ouroboros/governance/voice_repl.py
+++ b/backend/core/ouroboros/governance/voice_repl.py
@@ -109,7 +109,9 @@ def _matches(line: str) -> bool:
 def dispatch_voice_command(
     line: str,
 ) -> VoiceReplDispatchResult:
-    """Parse a ``/voice`` line and dispatch. NEVER raises."""
+    """Control Karen's voice — status, mute and announcements.
+
+    Parse a ``/voice`` line and dispatch. NEVER raises."""
     if not _matches(line):
         return VoiceReplDispatchResult(
             ok=False, text="", matched=False,

--- a/backend/core/ouroboros/governance/why_changed_repl.py
+++ b/backend/core/ouroboros/governance/why_changed_repl.py
@@ -389,7 +389,9 @@ def _render_config() -> str:
 def dispatch_why_changed_command(
     line: str,
 ) -> WhyChangedReplDispatchResult:
-    """Parse a ``/why_changed`` line and dispatch. NEVER raises."""
+    """Explain why the organism changed its behaviour.
+
+    Parse a ``/why_changed`` line and dispatch. NEVER raises."""
     if not _matches(line):
         return WhyChangedReplDispatchResult(
             ok=False, text="", matched=False,


### PR DESCRIPTION
The `/` palette rendered a **subcommand list where a description should be**, for 35 verbs. One copy-pasted implementer docstring, repeated verbatim across the codebase:

```
"""Parse a ``/<verb>`` line and dispatch. NEVER raises."""
```

`to_operator_voice` is deliberately **subtractive** — *"no word appears that the author did not write, because a palette that paraphrases can be confidently wrong and the operator acts on it."* It strips that sentence to nothing, correctly, and can never rescue a docstring that never described the verb. **The fix had to be at the source.**

## What changed

36 first lines are now real descriptions, grounded in each module's **own prose** rather than invented:

| verb | before | after |
|---|---|---|
| `/governor` | *(subcommand list)* | Show sensor budget caps, memory pressure and brake status |
| `/commit` | *(subcommand list)* | Grant, revoke and review operator commit authority |
| `/replay` | *(subcommand list)* | Replay an operation deterministically from its recorded trace |

The two modules that both expose `/replay` get descriptions that distinguish them. **The original first line is preserved as the next paragraph in every case**, so no contract text (`NEVER raises`, the naming-cage note) is lost — only what the palette reads changes.

## Two normalizer defects found while verifying

Both were producing exactly the broken descriptions this work is about.

**`_strip_verb_name` was not idempotent.** It's applied twice — once before the dangling-article sweep, once after. The acting-verb branch rewrites `/attach a file` → `attach a file` on pass 1; pass 2 required a leading `/` to recognise the acting form, didn't find one, fell through to the catch-all and **deleted the word pass 1 had just protected**. Output: `"File or image to the next generation"` — a fragment about files where an instruction to attach one used to be, produced by the very rule written to prevent it.

> A transform applied more than once has to be a fixed point, or the number of times it runs becomes part of its contract.

**`"canonical entry point"` / `"auto-discovered"` were missing from `_IMPL_OPENERS`**, so a naming-cage note surfaced as the description `"Auto-discovered"` — a fact about how the registry finds the verb, which tells an operator nothing about what typing it does.

## Verification

`test_every_palette_verb_has_a_real_description` was **RED on main** and is now green. The suite goes **22 passed / 3 failed at `origin/main` → 25 passed / 0 failed** here.

**853 green** across palette/completion/verb/bipartite/repl.

The governance transport cluster is **24 failed / 61 passed in BOTH this tree and a clean `origin/main` worktree** — sandbox `PermissionError` on WAL disk writes, unrelated to docstrings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces placeholder docstrings with real one-line descriptions for 36 palette verbs so the `/` palette shows clear, useful help. Also fixes two normalizer bugs that hid or mangled descriptions.

- **New Features**
  - Real first-line descriptions for 36 verbs, taken from each module’s own prose; the dispatcher sentence is kept as the next paragraph.
  - Distinct summaries for the two `/replay` modules.

- **Bug Fixes**
  - Made `_strip_verb_name` idempotent by matching with or without a leading `/`.
  - Added "canonical entry point" and "auto-discovered" to `_IMPL_OPENERS` to prevent scaffolding from appearing as the description.
  - `test_every_palette_verb_has_a_real_description` now passes (suite: 25 passed / 0 failed).

<sup>Written for commit a516f56c70bb6b9a62cb6348da7904043c6eadea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

