### PR TITLE
fix: the memory arc never ran — two inert sensors and a stale latency gate

### DIFF
--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -912,6 +912,26 @@ def _dw_tier_param_known_unsupported(model_id: str) -> bool:
         return False
 
 
+def dw_realtime_plane_active() -> bool:
+    """True when DW generation goes down the REALTIME plane, not the batch one.
+
+    The realtime plane is SSE + the ``service_tier`` selector; the batch plane
+    is the cheap asynchronous lane. They differ in latency by two orders of
+    magnitude — RT TTFT is measured in seconds (p50 8.9s in the 2026-07-21
+    soak), batch in minutes — so any decision phrased as "is this fast enough
+    to be worth doing" has to read the PLANE, never merely "is DoubleWord the
+    primary provider".
+
+    Derived from the same two knobs ``apply_rt_service_tier`` consults, so
+    there is one definition of "RT is in play" and it cannot drift from the
+    code that actually stamps the request.
+    """
+    try:
+        return dw_service_tier_enabled() and bool(_dw_rt_service_tier())
+    except Exception:  # noqa: BLE001
+        return False
+
+
 def apply_rt_service_tier(body: dict, model_id: str) -> dict:
     """Stamp the realtime-plane tier selector onto a /chat/completions body.
 

--- a/backend/core/ouroboros/governance/governed_loop_service.py
+++ b/backend/core/ouroboros/governance/governed_loop_service.py
@@ -5823,9 +5823,54 @@ class GovernedLoopService:
         # file context + AST index, making expansion less critical.
         _dw_primary = getattr(self, "_doubleword_is_primary", False)
         _ctx_expansion = self._config.context_expansion_enabled if hasattr(self._config, "context_expansion_enabled") else True
-        if _dw_primary:
+
+        # Operator override wins over any inference below. NEVER raises.
+        _ctx_override = os.environ.get(
+            "JARVIS_CONTEXT_EXPANSION_ENABLED", "",
+        ).strip().lower()
+        if _ctx_override in ("0", "false", "no", "off"):
             _ctx_expansion = False
-            logger.info("[GovernedLoop] Context expansion disabled (Doubleword primary — batch API too slow for plan())")
+            logger.info("[GovernedLoop] Context expansion disabled "
+                        "(JARVIS_CONTEXT_EXPANSION_ENABLED=0)")
+        elif _ctx_override in ("1", "true", "yes", "on"):
+            _ctx_expansion = True
+            logger.info("[GovernedLoop] Context expansion forced ON "
+                        "(JARVIS_CONTEXT_EXPANSION_ENABLED=1)")
+        elif _dw_primary:
+            # This used to disable expansion whenever DoubleWord was primary,
+            # full stop, because DW was BATCH-ONLY and a plan() round-trip took
+            # 2-4 minutes. That judgement was right for its time and its
+            # PREMISE has since changed: DW's realtime plane (SSE + priority
+            # service_tier) is the default now, with TTFT measured in seconds.
+            #
+            # The question the guard is really asking is "will an expansion
+            # call come back fast enough to be worth making" — a LATENCY
+            # question. Phrased as "is DoubleWord primary" it silently
+            # answered a provider question instead, and kept answering the old
+            # way after the latency changed.
+            #
+            # The cost of getting it wrong is not small: skipping
+            # CONTEXT_EXPANSION skips the ENTIRE architecture-memory arc
+            # (ModuleContextRouter, the admission ledger, operator rules) plus
+            # Oracle dependency injection. A 28-minute armed soak
+            # (bt-2026-07-31-171143) ran 79 ops and logged zero memory
+            # routing for exactly this reason.
+            from backend.core.ouroboros.governance.doubleword_provider import (
+                dw_realtime_plane_active,
+            )
+            if dw_realtime_plane_active():
+                logger.info(
+                    "[GovernedLoop] Context expansion KEPT — DoubleWord is "
+                    "primary but on the REALTIME plane (SSE + service_tier); "
+                    "the batch-latency rationale does not apply",
+                )
+            else:
+                _ctx_expansion = False
+                logger.info(
+                    "[GovernedLoop] Context expansion disabled — DoubleWord "
+                    "primary on the BATCH plane (async lane is too slow for "
+                    "plan(); set JARVIS_CONTEXT_EXPANSION_ENABLED=1 to force)",
+                )
 
         orch_config = OrchestratorConfig(
             project_root=self._config.project_root,

--- a/backend/core/ouroboros/governance/intake/intake_layer_service.py
+++ b/backend/core/ouroboros/governance/intake/intake_layer_service.py
@@ -987,6 +987,52 @@ class IntakeLayerService:
         except Exception as exc:
             logger.debug("[IntakeLayer] DocStalenessSensor skipped: %s", exc)
 
+        # ---- MemoryHygieneSensor (memory reports defects in ITSELF) ----
+        #
+        # Constructed UNCONDITIONALLY and gated by its own
+        # ``sensor_enabled()``, mirroring VisionSensor. A sensor that is only
+        # constructed when its flag is on cannot be seen in the boot log when
+        # it is off — "absent" and "registered but disabled" render
+        # identically, which is exactly how these two shipped registered in
+        # three source registries and never built at all.
+        try:
+            from backend.core.ouroboros.governance.intake.sensors.memory_hygiene_sensor import (
+                MemoryHygieneSensor, sensor_enabled as _mem_hyg_enabled,
+            )
+            _mem_hyg_sensor = MemoryHygieneSensor(
+                repo="jarvis",
+                router=self._router,
+                project_root=self._config.project_root,
+            )
+            self._sensors.append(_mem_hyg_sensor)
+            self._memory_hygiene_sensor = _mem_hyg_sensor
+            logger.info(
+                "[IntakeLayer] MemoryHygieneSensor registered enabled=%s "
+                "(set JARVIS_MEMORY_HYGIENE_SENSOR_ENABLED=1)",
+                _mem_hyg_enabled(),
+            )
+        except Exception as exc:
+            logger.debug("[IntakeLayer] MemoryHygieneSensor skipped: %s", exc)
+
+        # ---- CageHygieneSensor (synthesized worker cages report on themselves) ----
+        try:
+            from backend.core.ouroboros.governance.intake.sensors.cage_hygiene_sensor import (
+                CageHygieneSensor, sensor_enabled as _cage_hyg_enabled,
+            )
+            _cage_hyg_sensor = CageHygieneSensor(
+                repo="jarvis",
+                router=self._router,
+            )
+            self._sensors.append(_cage_hyg_sensor)
+            self._cage_hygiene_sensor = _cage_hyg_sensor
+            logger.info(
+                "[IntakeLayer] CageHygieneSensor registered enabled=%s "
+                "(set JARVIS_CAGE_HYGIENE_SENSOR_ENABLED=1)",
+                _cage_hyg_enabled(),
+            )
+        except Exception as exc:
+            logger.debug("[IntakeLayer] CageHygieneSensor skipped: %s", exc)
+
         # ---- GitHubIssueSensor (auto-resolve issues across Trinity repos) ----
         if _sensor_disabled("GITHUB_ISSUE_SENSOR"):
             logger.info(

--- a/tests/governance/test_context_expansion_gate.py
+++ b/tests/governance/test_context_expansion_gate.py
@@ -1,0 +1,112 @@
+"""CONTEXT_EXPANSION is gated on LATENCY, not on which provider is primary.
+
+The guard disabled expansion whenever DoubleWord was primary, because DW was
+batch-only and a plan() round-trip took 2-4 minutes. That judgement was right
+for its time. Its PREMISE changed when DW's realtime plane (SSE + priority
+service_tier) became the default, with TTFT in seconds — and the guard kept
+answering the old way, because it was phrased as a provider question rather
+than the latency question it actually asks.
+
+The cost was not small. Skipping CONTEXT_EXPANSION skips the ENTIRE
+architecture-memory arc — ModuleContextRouter, the admission ledger, operator
+rules — plus Oracle dependency injection. A 28-minute armed soak
+(bt-2026-07-31-171143) ran 79 ops through GENERATE and logged zero memory
+routing for exactly this reason, while every flag involved read as "on".
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance.doubleword_provider import (
+    dw_realtime_plane_active,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean(monkeypatch):
+    for var in ("JARVIS_DW_SERVICE_TIER_ENABLED", "JARVIS_DW_RT_SERVICE_TIER",
+                "JARVIS_CONTEXT_EXPANSION_ENABLED"):
+        monkeypatch.delenv(var, raising=False)
+    yield
+
+
+def test_realtime_plane_is_active_by_default():
+    """RT is the default plane, so the batch rationale does not apply."""
+    assert dw_realtime_plane_active() is True
+
+
+def test_disabling_service_tier_means_batch_plane(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_SERVICE_TIER_ENABLED", "0")
+    assert dw_realtime_plane_active() is False
+
+
+def test_empty_tier_means_batch_plane(monkeypatch):
+    """An empty tier is how `apply_rt_service_tier` is told to skip
+    injection — so it is also how the plane reads as batch."""
+    monkeypatch.setenv("JARVIS_DW_RT_SERVICE_TIER", "")
+    assert dw_realtime_plane_active() is False
+
+
+def test_the_predicate_shares_its_inputs_with_the_stamper():
+    """One definition of "RT is in play".
+
+    `dw_realtime_plane_active` and `apply_rt_service_tier` must consult the
+    same two knobs, or the gate can believe RT is active on a request the
+    stamper declined to mark — which is the drift this predicate exists to
+    prevent.
+    """
+    import inspect
+
+    from backend.core.ouroboros.governance import doubleword_provider as dwp
+
+    src = inspect.getsource(dwp.dw_realtime_plane_active)
+    assert "dw_service_tier_enabled" in src
+    assert "_dw_rt_service_tier" in src
+
+
+@pytest.mark.parametrize("junk", ["   ", "!!!", "priority ", "TRUE", "0"])
+def test_predicate_never_raises_on_odd_values(monkeypatch, junk):
+    """A null byte cannot be tested here — os.environ rejects it on SET, so
+    the exception would be the test's, not the predicate's. These are the
+    values that can actually reach it."""
+    monkeypatch.setenv("JARVIS_DW_RT_SERVICE_TIER", junk)
+    monkeypatch.setenv("JARVIS_DW_SERVICE_TIER_ENABLED", junk)
+    assert isinstance(dw_realtime_plane_active(), bool)
+
+
+# ---------------------------------------------------------------------------
+# The gate itself
+# ---------------------------------------------------------------------------
+
+
+def _gate_source() -> str:
+    from pathlib import Path
+    return (Path(__file__).resolve().parents[2]
+            / "backend/core/ouroboros/governance/governed_loop_service.py"
+            ).read_text(encoding="utf-8")
+
+
+def test_the_gate_no_longer_disables_on_dw_primary_alone():
+    """The regression that would reintroduce the silence."""
+    src = _gate_source()
+    assert "dw_realtime_plane_active" in src, (
+        "the gate no longer consults the plane — DW-primary would disable "
+        "expansion again, taking the whole memory arc with it")
+
+
+def test_the_batch_rationale_is_preserved():
+    """The original judgement still applies on the batch plane.
+
+    Flipping the gate to always-on would have been the workaround: it fixes
+    the RT case by breaking the case the guard was written for.
+    """
+    src = _gate_source()
+    assert "BATCH plane" in src
+
+
+def test_an_operator_override_exists_and_wins():
+    src = _gate_source()
+    assert "JARVIS_CONTEXT_EXPANSION_ENABLED" in src
+    # The override is checked BEFORE the provider inference, so it wins.
+    assert src.index("JARVIS_CONTEXT_EXPANSION_ENABLED") < src.index(
+        "dw_realtime_plane_active")

--- a/tests/governance/test_sensor_construction_liveness.py
+++ b/tests/governance/test_sensor_construction_liveness.py
@@ -1,0 +1,123 @@
+"""Every sensor class must actually be BUILT somewhere.
+
+The defect this closes: `MemoryHygieneSensor` and `CageHygieneSensor` were
+registered in all three source registries (`_VALID_SOURCES`,
+`SignalSource`, `_BACKGROUND_SOURCES`), flag-gated, lifecycle-matched to
+`DocStalenessSensor`, and covered by 45 passing tests — and never
+constructed. Turning their flags on could not have worked.
+
+Nothing structurally required them to exist. A source token is accepted by
+three registries, none of which asks whether anything builds the sensor that
+emits it, so "registered" and "running" are different facts that read
+identically from every surface an operator can see.
+
+Their own tests could not catch it either: a unit test constructs the sensor
+itself, so it proves the class works and says nothing about whether
+production ever calls it. This asserts the fact the unit tests structurally
+cannot.
+
+The same shape as `test_synthesizer_is_reachable_from_a_production_unit` for
+the swarm — reachability is a property of the CALLERS, and has to be
+asserted from outside the thing being called.
+"""
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+OUROBOROS = Path(__file__).resolve().parents[2] / "backend/core/ouroboros"
+SENSOR_DIR = OUROBOROS / "governance/intake/sensors"
+
+
+def _sensor_classes() -> dict:
+    """``{ClassName: defining_filename}`` for every ``*Sensor`` in the package.
+
+    Discovered by walking the directory rather than from a hand-kept list —
+    a new sensor is covered the moment it is written, which is the only way
+    a guard like this stays true.
+    """
+    out = {}
+    for path in sorted(SENSOR_DIR.glob("*_sensor.py")):
+        for node in ast.parse(path.read_text(encoding="utf-8")).body:
+            if isinstance(node, ast.ClassDef) and node.name.endswith("Sensor"):
+                out[node.name] = path.name
+    return out
+
+
+def _construction_sites(name: str, defining_file: str) -> list:
+    """Production files that CALL ``name(...)``.
+
+    Excludes the defining module (a class referencing itself proves nothing)
+    and anything under a test path (a test building its own subject proves
+    the class works, not that production uses it).
+    """
+    hits = []
+    pattern = re.compile(rf"\b{re.escape(name)}\s*\(")
+    for path in OUROBOROS.rglob("*.py"):
+        if path.name == defining_file or "test" in path.name:
+            continue
+        try:
+            if pattern.search(path.read_text(encoding="utf-8")):
+                hits.append(str(path.relative_to(OUROBOROS)))
+        except OSError:
+            continue
+    return hits
+
+
+def test_every_sensor_class_has_a_production_construction_site():
+    """THE guard. A sensor nothing builds is a sensor that cannot fire."""
+    sensors = _sensor_classes()
+    assert sensors, "no sensor classes discovered — the walk is broken"
+    inert = {
+        name: defining
+        for name, defining in sensors.items()
+        if not _construction_sites(name, defining)
+    }
+    assert not inert, (
+        "these sensor classes are never constructed in production, so their "
+        "flags cannot do anything:\n  "
+        + "\n  ".join(f"{n}  ({f})" for n, f in sorted(inert.items()))
+    )
+
+
+@pytest.mark.parametrize("sensor", ["MemoryHygieneSensor", "CageHygieneSensor"])
+def test_the_two_that_shipped_inert_are_registered_by_the_intake_layer(sensor):
+    """Pins WHERE, not just THAT.
+
+    A construction site in some unrelated helper would satisfy the guard
+    above while leaving the sensor out of the layer that actually starts it.
+    `IntakeLayerService` is the canonical registrar — the same place
+    `DocStalenessSensor` is built.
+    """
+    src = (OUROBOROS / "governance/intake/intake_layer_service.py").read_text(
+        encoding="utf-8")
+    assert re.search(rf"\b{sensor}\s*\(", src), (
+        f"{sensor} is not constructed by IntakeLayerService")
+    assert "self._sensors.append" in src
+
+
+@pytest.mark.parametrize("sensor", ["MemoryHygieneSensor", "CageHygieneSensor"])
+def test_registration_is_unconditional_so_disabled_is_visible(sensor):
+    """Registered-but-off must be DISTINGUISHABLE from absent.
+
+    Constructing a sensor only when its flag is on makes the boot log
+    identical in both cases, which is precisely how two sensors were believed
+    to be present for a whole session while being absent. VisionSensor's
+    pattern — always construct, log the enabled state — is the one that keeps
+    the distinction visible.
+    """
+    src = (OUROBOROS / "governance/intake/intake_layer_service.py").read_text(
+        encoding="utf-8")
+    block = src.split(f"{sensor}(")[0].rsplit("# ----", 1)[-1]
+    assert "if " not in block.replace("if exc", ""), (
+        f"{sensor} construction appears to be behind a conditional")
+    assert f"{sensor} registered enabled=" in src, (
+        f"{sensor} does not log its enabled state at registration")
+
+
+def test_the_guard_would_have_caught_the_original_defect():
+    """A guard nobody has seen fail is a guard nobody knows works."""
+    assert _construction_sites("NoSuchSensorClassXyz", "nothing.py") == []


### PR DESCRIPTION
An armed 28-minute soak (`bt-2026-07-31-171143`) ran **79 ops through GENERATE with every relevant flag reading "on" and logged zero lines from the entire memory arc.** Two independent root causes, both of the same family: a capability that exists, is flagged on, and is unreachable.

## 1 — Two sensors registered but never constructed (`5c194caa1d`)

`MemoryHygieneSensor` and `CageHygieneSensor` were in all three source registries (`_VALID_SOURCES`, `SignalSource`, `_BACKGROUND_SOURCES`), flag-gated, lifecycle-matched to `DocStalenessSensor`, covered by 45 passing tests — **and never built.** Turning their flags on could not have worked.

Nothing structurally required them to exist. Three registries accept a token and none asks whether anything constructs the sensor, so "registered" and "running" read identically from every operator-visible surface. Their own tests couldn't catch it: **a unit test constructs its own subject**, which proves the class works and says nothing about whether production calls it.

Construction is now **unconditional**, mirroring `VisionSensor`, logging the enabled state:

```
[IntakeLayer] MemoryHygieneSensor registered enabled=False (set JARVIS_MEMORY_HYGIENE_SENSOR_ENABLED=1)
```

That's root-cause, not cosmetic — constructing only when the flag is on makes "absent" and "disabled" identical in the boot log, which is exactly how these were believed present for a whole session.

`test_sensor_construction_liveness.py` closes the class: walks the package (new sensors covered automatically), asserts a production construction site, excluding the defining module and every test file. **Audit: 22 sensor classes, 22 constructed, 0 inert.**

## 2 — CONTEXT_EXPANSION gated on the wrong question (`2a02aba842`)

```python
if _dw_primary:
    _ctx_expansion = False   # "batch API too slow for plan()"
```

Right when written — DW was batch-only, `plan()` took 2–4 min. **The premise changed** when DW's realtime plane (SSE + `service_tier`) became default, TTFT in seconds. The guard kept answering the old way because it asked a **provider** question when it actually asks a **latency** one.

Cost: skipping CONTEXT_EXPANSION skips `ModuleContextRouter`, the admission ledger, operator rules *and* Oracle dependency summaries. The runners fired `CLASSIFY → ROUTE → PLAN → GENERATE` with no `CONTEXTEXPANSIONRunner`, and **nothing said why** — only the disable branch logged, so "expansion is on" was the *absence* of a line.

Flipping it to always-on would fix RT by breaking the batch case. Instead the gate reads the **plane**: `dw_realtime_plane_active()` derives from the same two knobs `apply_rt_service_tier` consults, so one definition of "RT is in play" that cannot drift. Batch keeps the original disable. `JARVIS_CONTEXT_EXPANSION_ENABLED` overrides, checked before the inference.

## Verified live — `bt-2026-07-31-185316`

First time this arc has run outside a unit test:

```
Context expansion KEPT — DoubleWord is primary but on the REALTIME plane
[ModuleRouter]    corpus 387 topics [git_tracked] (0 untracked excluded)
[ModuleRouter]    op=…5ce2-sig topics=3 inject_site=context_expansion
[MemoryAdmission] consumer=main corpus=387/git_tracked considered=387 admitted=3
[MemoryHygiene]   scan: 237 finding(s), 3 emitted (cap 3) — orphaned=2, drifted=235
MemoryHygieneSensor registered enabled=True
CageHygieneSensor  registered enabled=True
```

- `corpus 387 [git_tracked], 0 untracked excluded` — the ghost-corpus fix holding in production (684 before)
- memory reached a real GENERATE prompt
- **237 findings → 3 emitted** — the flood guard against a real corpus, not a mock

## Not proven

`SwarmInvoker`/`CageCalibration` logged nothing — no genuinely parallelizable multi-node DAG arrived. Needs an inherently multi-file goal. Operator rules fired but selected 0 (no path-scoped rules stored yet).

18 new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a production gap that stopped the memory arc: two hygiene sensors were never constructed, and context expansion was disabled based on provider rather than latency. Sensors are now always built, and the gate checks the realtime vs batch plane with an operator override.

- **Bug Fixes**
  - Construct `MemoryHygieneSensor` and `CageHygieneSensor` unconditionally in `backend/core/ouroboros/governance/intake/intake_layer_service.py`, append to the sensor roster, and log their enabled state.
  - Gate context expansion on latency plane via `dw_realtime_plane_active()` in `backend/core/ouroboros/governance/doubleword_provider.py`; keep the batch-plane disable; add `JARVIS_CONTEXT_EXPANSION_ENABLED` override (checked first); add clear logs for both branches.
  - Add guards/tests: sensor construction liveness across the package and correctness of the context-expansion gate.

<sup>Written for commit 2a02aba8425c52142f93868b6028e2044c945ce5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

