### PR TITLE
feat(memory): graduate routing to default-ON, and stop /memory lying about it

### DIFF
--- a/backend/core/ouroboros/battle_test/memory_surface.py
+++ b/backend/core/ouroboros/battle_test/memory_surface.py
@@ -218,10 +218,16 @@ def _routing_row() -> str:
     letting "on · available" stand in for evidence.
     """
     try:
-        flag = os.environ.get("JARVIS_MEMORY_ROUTING_ENABLED", "1")
-        on = flag.strip().lower() not in ("0", "false", "no", "off")
+        # ASK the owner; do not re-derive. This read the same env var with
+        # its own default of "1" while `routing_enabled()` defaulted to OFF,
+        # so this row reported "routing: on" for the entire period routing
+        # was disabled — the surface built to tell the truth asserting the
+        # one falsehood that mattered.
         try:
-            from backend.core.ouroboros.governance import module_routing  # noqa: F401
+            from backend.core.ouroboros.governance.module_routing import (
+                routing_enabled,
+            )
+            on = routing_enabled()
             present = "available"
         except Exception:  # noqa: BLE001
             present = "UNAVAILABLE"

--- a/backend/core/ouroboros/governance/module_routing.py
+++ b/backend/core/ouroboros/governance/module_routing.py
@@ -4,7 +4,7 @@ Given an op's target files, injects ONLY the architecture-memory topics
 relevant to the module under work.  Routing signal = Oracle dependency graph
 (AST-bound), NOT filename string-matching.
 
-Gated default-OFF (``JARVIS_MEMORY_ROUTING_ENABLED``).
+Gated default-ON (``JARVIS_MEMORY_ROUTING_ENABLED``, graduated 2026-07-31).
 Authority-free / advisory: produces prompt text only, fail-silent like
 StrategicDirection.  Never imports oracle / semantic_index / source_crawlers
 at module level — all three are lazy-imported inside methods to avoid reverse
@@ -37,11 +37,30 @@ _ENV_FLAG = "JARVIS_MEMORY_ROUTING_ENABLED"
 
 
 def routing_enabled() -> bool:
-    """Return True iff ``JARVIS_MEMORY_ROUTING_ENABLED`` is set to a truthy value.
+    """Whether architecture-memory routing is active. NEVER raises.
 
-    Default: False (gated default-OFF per spec).
+    Default: **True** (graduated 2026-07-31).
+
+    THE definition of this flag. `memory_surface._routing_row` used to read
+    the same env var with its own default of ``"1"`` while this defaulted to
+    OFF — so ``/memory`` reported ``routing: on`` for the entire period
+    routing was silently disabled. One knob, two answers, and the surface
+    built to tell an operator the truth was the one asserting the falsehood.
+
+    Graduated on evidence, not on age: soak bt-2026-07-31-185316 showed a
+    real op routing 3 topics from a 387-topic git-tracked corpus into a
+    GENERATE prompt, with the admission ledger recording
+    ``considered=387 admitted=3``. The path is fail-soft end to end — any
+    error returns an empty context and the pipeline continues — so the
+    downside of default-ON is a wasted corpus scan, while the downside of
+    default-OFF was an entire subsystem that looked alive and was not.
+
+    ``JARVIS_MEMORY_ROUTING_ENABLED=0`` restores the previous behaviour
+    exactly: `route()` returns empty before any I/O.
     """
     raw = os.environ.get(_ENV_FLAG, "").strip().lower()
+    if not raw:
+        return True
     return raw in {"1", "true", "yes", "on"}
 
 

--- a/tests/governance/test_module_routing.py
+++ b/tests/governance/test_module_routing.py
@@ -103,11 +103,19 @@ TOPIC_UNRELATED = textwrap.dedent("""\
 # ---------------------------------------------------------------------------
 
 class TestRoutingEnabled:
-    def test_default_false(self, monkeypatch):
-        """routing_enabled() must be False when env var is absent."""
+    def test_default_true(self, monkeypatch):
+        """routing_enabled() is True when the env var is absent.
+
+        Graduated 2026-07-31 on soak evidence (bt-2026-07-31-185316: a real
+        op routed 3 topics from a 387-topic git-tracked corpus into a
+        GENERATE prompt). Default-OFF meant the admission ledger and the
+        outcome loop were enabled but starved, and `/memory` reported
+        "routing: on" the whole time because it read the same env var with
+        its own opposite default.
+        """
         monkeypatch.delenv("JARVIS_MEMORY_ROUTING_ENABLED", raising=False)
         from backend.core.ouroboros.governance.module_routing import routing_enabled
-        assert routing_enabled() is False
+        assert routing_enabled() is True
 
     def test_truthy_values(self, monkeypatch):
         from backend.core.ouroboros.governance.module_routing import routing_enabled
@@ -115,11 +123,25 @@ class TestRoutingEnabled:
             monkeypatch.setenv("JARVIS_MEMORY_ROUTING_ENABLED", val)
             assert routing_enabled() is True, f"expected True for {val!r}"
 
-    def test_falsy_values(self, monkeypatch):
+    def test_falsy_values_still_disable(self, monkeypatch):
+        """The rollback path. An explicit falsy value must still turn it off."""
         from backend.core.ouroboros.governance.module_routing import routing_enabled
-        for val in ("0", "false", "False", "no", "off", ""):
+        for val in ("0", "false", "False", "no", "off"):
             monkeypatch.setenv("JARVIS_MEMORY_ROUTING_ENABLED", val)
             assert routing_enabled() is False, f"expected False for {val!r}"
+
+    def test_empty_string_means_UNSET_not_off(self, monkeypatch):
+        """`FOO=` is indistinguishable from unset in most shells.
+
+        Under default-OFF both read as False and the distinction never
+        mattered. Under default-ON it decides the outcome, so it is pinned:
+        an empty value is absence, and absence takes the default.
+        """
+        from backend.core.ouroboros.governance.module_routing import routing_enabled
+        monkeypatch.setenv("JARVIS_MEMORY_ROUTING_ENABLED", "")
+        assert routing_enabled() is True
+        monkeypatch.setenv("JARVIS_MEMORY_ROUTING_ENABLED", "   ")
+        assert routing_enabled() is True
 
 
 # ---------------------------------------------------------------------------
@@ -128,8 +150,13 @@ class TestRoutingEnabled:
 
 class TestFlagOff:
     async def test_route_returns_empty_when_flag_off(self, tmp_path, monkeypatch):
-        """When JARVIS_MEMORY_ROUTING_ENABLED is false, route() returns empty."""
-        monkeypatch.delenv("JARVIS_MEMORY_ROUTING_ENABLED", raising=False)
+        """When JARVIS_MEMORY_ROUTING_ENABLED is false, route() returns empty.
+
+        Sets the flag EXPLICITLY. It used to delete it and rely on the
+        default being off — so the day the default flipped, this stopped
+        testing the flag-off path and started testing the flag-on one.
+        """
+        monkeypatch.setenv("JARVIS_MEMORY_ROUTING_ENABLED", "0")
 
         topics_dir = tmp_path / "memory_topics"
         topics_dir.mkdir()


### PR DESCRIPTION
`JARVIS_MEMORY_ROUTING_ENABLED` defaulted to **False** and nothing in production set it. Routing is the front door — with it off, `route()` returns before any I/O, so the admission ledger and outcome loop were "enabled" and **starved**, and the proactive sensor had nothing to observe. The whole arc read as alive from every flag and ran zero times.

## A split-brain hid it

`memory_surface._routing_row` read the **same env var with its own default of `"1"`** while `routing_enabled()` defaulted to OFF. So `/memory` reported **`routing: on` for the entire period routing was disabled** — one knob, two answers, and the surface built to tell an operator the truth was the one asserting the falsehood.

Same defect found on `JARVIS_PALETTE_HEIGHT` earlier today (#70309), in a place where it mattered more. `routing_enabled()` is now THE definition and the surface asks it. A reader that re-implements a flag's default is a second source of truth, and the two only disagree where nobody is looking.

## Graduated on evidence, not age

Soak `bt-2026-07-31-185316`: a real op routed 3 topics from a 387-topic git-tracked corpus into a GENERATE prompt, ledger recording `considered=387 admitted=3`.

The path is fail-soft end to end — any error yields an empty context and the pipeline continues — so the downside of default-ON is a wasted corpus scan, while the downside of default-OFF was an entire subsystem that looked alive and was not. `JARVIS_MEMORY_ROUTING_ENABLED=0` restores the old behaviour exactly.

## Empty string now means UNSET, not OFF

`FOO=` is indistinguishable from absent in most shells. Under default-OFF both read False and the distinction never mattered; under default-ON it decides the outcome. Pinned by test.

## A test that would have gone quietly wrong

`test_route_returns_empty_when_flag_off` **deleted** the env var and relied on the default being off — so the day the default flipped, it would have stopped testing the flag-off path and started testing the flag-on one, **while staying green**. It now sets the flag explicitly. Three tests updated, none deleted.

## Verified on a DEFAULT boot

`bt-2026-07-31-195823`, launched with `env -u` stripping every memory flag:

```
[ModuleRouter]    corpus 387 topics [git_tracked] (0 untracked excluded)
[ModuleRouter]    op=…7b98-sig topics=3 inject_site=context_expansion
[MemoryAdmission] consumer=main corpus=387/git_tracked
```

## Still default-OFF, unchanged

The proactive hygiene sensor (it enqueues autonomous work and has **237 pending findings**), the swarm orchestrator, and cage calibration.

178 tests green across the memory subsystem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Graduates memory routing to default-ON and fixes `/memory` to reflect the true routing state. Prevents silent starvation; set `JARVIS_MEMORY_ROUTING_ENABLED=0` to disable.

- **New Features**
  - `JARVIS_MEMORY_ROUTING_ENABLED` now defaults to ON; routing runs fail-soft by default.
  - Opt-out: set `JARVIS_MEMORY_ROUTING_ENABLED=0` to restore previous behavior.

- **Bug Fixes**
  - `/memory` now calls `routing_enabled()` (single source of truth), fixing the prior “routing: on” mismatch.
  - Empty env value (`JARVIS_MEMORY_ROUTING_ENABLED=""`) is treated as unset, not OFF.
  - Tests updated to set the flag explicitly and keep the flag-off path covered.

<sup>Written for commit b13515c7729088477748972aabfd9656c25b2dbb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70313?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

