### PR TITLE
feat(governance): Config Arbiter + Autonomic Liveness Sensor

### DIFF
--- a/backend/core/ouroboros/governance/config_arbiter.py
+++ b/backend/core/ouroboros/governance/config_arbiter.py
@@ -1,0 +1,335 @@
+"""One env var, one default — enforced, not hoped for.
+
+Two flags were read in two places with two different defaults today, and both
+were real defects rather than curiosities:
+
+``JARVIS_PALETTE_HEIGHT`` was 4 in ``palette_render`` and 12 in
+``bipartite_layout``, so the operator's menu height depended on which
+renderer happened to mount. ``JARVIS_MEMORY_ROUTING_ENABLED`` was OFF in
+``module_routing`` and ON in ``memory_surface``, so ``/memory`` reported
+"routing: on" for the entire period routing was disabled — the surface built
+to tell an operator the truth was the one asserting the falsehood.
+
+A static scan then found **21** such variables. The count is not the point.
+The point is that nothing prevented any of them: ``os.environ.get(NAME,
+default)`` is a decentralised declaration, every call site is free to invent
+its own default, and two of them only disagree where nobody is looking.
+
+Detection is total; the RAISE is a mode
+----------------------------------------
+There are 21 known collisions in this tree right now. An arbiter that raised
+on the default path would make the system unbootable on the first import,
+which is not a safety property — it is an outage.
+
+So collisions are ALWAYS recorded and logged, and
+``JARVIS_CONFIG_ARBITER_STRICT=1`` turns recording into raising. Strict mode
+is what CI and tests run; the runtime default is loud-but-alive with a
+deterministic winner. When the 21 are fixed, strict becomes the default and
+the mode disappears.
+
+The winner is FIRST-REGISTERED, deliberately. "Last wins" makes behaviour
+depend on import order, which changes when an unrelated module adds a lazy
+import — a config value that moves for reasons invisible at the call site is
+worse than a wrong one.
+
+Static scanning covers what runtime cannot
+-------------------------------------------
+Runtime arbitration only sees a collision once BOTH call sites have executed.
+For a pair on rarely-taken branches that may be never, and adoption across
+4,132 flags is not a same-day change.
+
+So :func:`scan_static` finds them by AST instead, with no adoption required
+and no code executed — the same technique that found all 21 in about a
+second. Runtime arbitration then covers new code as it adopts, and the two
+are complementary rather than redundant: static sees every literal default,
+runtime sees computed ones a scanner cannot evaluate.
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import ast
+import inspect
+import logging
+import os
+import threading
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+logger = logging.getLogger("Ouroboros.ConfigArbiter")
+
+CONFIG_ARBITER_SCHEMA_VERSION: str = "config_arbiter.1"
+
+__all__ = [
+    "CONFIG_ARBITER_SCHEMA_VERSION",
+    "ConfigurationCollisionError",
+    "Collision",
+    "collisions",
+    "resolve",
+    "resolve_bool",
+    "resolve_int",
+    "reset_for_tests",
+    "scan_static",
+    "strict_enabled",
+]
+
+
+class ConfigurationCollisionError(RuntimeError):
+    """Two call sites declared different defaults for one env var.
+
+    Carries both declarations so the message names what to reconcile rather
+    than only that something is wrong.
+    """
+
+    def __init__(self, name: str, existing: Any, existing_by: str,
+                 offered: Any, offered_by: str) -> None:
+        super().__init__(
+            f"config collision on {name!r}: {existing_by} declares default "
+            f"{existing!r}, {offered_by} declares {offered!r}. One variable "
+            f"must have one default — move it to a single accessor both "
+            f"call, the way `palette_render.palette_rows` owns "
+            f"JARVIS_PALETTE_HEIGHT."
+        )
+        self.name = name
+        self.existing = existing
+        self.existing_by = existing_by
+        self.offered = offered
+        self.offered_by = offered_by
+
+
+def strict_enabled() -> bool:
+    """``JARVIS_CONFIG_ARBITER_STRICT`` (default false). NEVER raises.
+
+    False records and logs; True raises. Default false ONLY because 21
+    collisions predate this module — see the module docstring.
+    """
+    try:
+        return os.environ.get(
+            "JARVIS_CONFIG_ARBITER_STRICT", "0",
+        ).strip().lower() in ("1", "true", "yes", "on")
+    except Exception:  # noqa: BLE001
+        return False
+
+
+@dataclass(frozen=True)
+class Collision:
+    """One variable declared with more than one default."""
+
+    name: str
+    declarations: Tuple[Tuple[str, str], ...]  # (default_repr, declared_by)
+
+    def describe(self) -> str:
+        return f"{self.name}: " + " vs ".join(
+            f"{d!r} ({who})" for d, who in self.declarations)
+
+
+@dataclass
+class _Registry:
+    #: name -> {default_repr: {declaring modules}}
+    declared: Dict[str, Dict[str, Set[str]]] = field(default_factory=dict)
+    #: name -> the FIRST default seen, which is the one that wins
+    winner: Dict[str, Any] = field(default_factory=dict)
+
+
+_registry = _Registry()
+_lock = threading.RLock()
+
+
+def reset_for_tests() -> None:
+    """Drop all recorded declarations. Test-only."""
+    global _registry  # noqa: PLW0603
+    with _lock:
+        _registry = _Registry()
+
+
+def _caller_module(depth: int = 2) -> str:
+    """The module that asked, for attribution. NEVER raises.
+
+    Derived from the stack rather than passed in: a caller that has to name
+    itself will eventually name itself wrong after a copy-paste, and the
+    whole point is to attribute a declaration to where it actually lives.
+
+    ``depth=2`` is exact for every public entry point: frame 0 is this
+    function, frame 1 is the ``resolve*`` that called it, frame 2 is the
+    declaring module. ``resolve_int``/``resolve_bool`` resolve their own
+    attribution and pass it down rather than letting ``resolve`` re-derive at
+    a different depth — otherwise the answer would depend on which wrapper
+    was used, and a misattributed collision names the wrong file to fix.
+    """
+    try:
+        frame = inspect.stack()[depth]
+        return Path(frame.filename).name
+    except Exception:  # noqa: BLE001
+        return "<unknown>"
+
+
+def _record(name: str, default: Any, by: str) -> None:
+    """Record a declaration; raise in strict mode on conflict. NEVER raises
+    except :class:`ConfigurationCollisionError`."""
+    key = repr(default)
+    with _lock:
+        slot = _registry.declared.setdefault(name, {})
+        if name not in _registry.winner:
+            _registry.winner[name] = default
+        # Snapshot the DIFFERING declarations BEFORE inserting this one.
+        #
+        # Computing the conflict after insertion, then recovering the other
+        # key with a bare `next(...)`, made correctness depend on the
+        # insertion having actually changed the dict — and a bare `next` on
+        # an empty generator raises StopIteration, which is a crash rather
+        # than a collision report. A guard whose failure mode is an exception
+        # in the reporting path is worse than no guard: it converts a config
+        # smell into an outage.
+        prior = sorted(k for k in slot if k != key)
+        slot.setdefault(key, set()).add(by)
+        if not prior:
+            return
+        existing_key = prior[0]
+        existing_by = ", ".join(sorted(slot.get(existing_key, ()))) or "<unknown>"
+        winner = _registry.winner[name]
+
+    if strict_enabled():
+        raise ConfigurationCollisionError(
+            name, existing=winner, existing_by=existing_by,
+            offered=default, offered_by=by,
+        )
+    logger.warning(
+        "[ConfigArbiter] COLLISION %s — %s declares %r, %s declares %r; "
+        "using %r (first registered). Set JARVIS_CONFIG_ARBITER_STRICT=1 to "
+        "make this fatal.",
+        name, existing_by, winner, by, default, winner,
+    )
+
+
+def resolve(name: str, default: Any = "", *,
+            declared_by: Optional[str] = None) -> str:
+    """``os.environ.get`` with the default ARBITRATED. NEVER raises except
+    :class:`ConfigurationCollisionError` in strict mode.
+
+    Returns the environment value when set, otherwise the winning default —
+    which is the first one declared, so an adopted call site cannot have its
+    value changed by a later module's disagreement.
+    """
+    by = declared_by or _caller_module()
+    _record(name, default, by)
+    try:
+        raw = os.environ.get(name)
+    except Exception:  # noqa: BLE001
+        raw = None
+    if raw is not None and raw.strip() != "":
+        return raw
+    with _lock:
+        return str(_registry.winner.get(name, default))
+
+
+def resolve_bool(name: str, default: bool = False, *,
+                 declared_by: Optional[str] = None) -> bool:
+    """Arbitrated boolean. Empty/unset takes the default. NEVER raises."""
+    by = declared_by or _caller_module()
+    raw = resolve(name, default, declared_by=by)
+    try:
+        token = str(raw).strip().lower()
+        if token in ("1", "true", "yes", "on"):
+            return True
+        if token in ("0", "false", "no", "off"):
+            return False
+        return bool(default)
+    except Exception:  # noqa: BLE001
+        return bool(default)
+
+
+def resolve_int(name: str, default: int, lo: Optional[int] = None,
+                hi: Optional[int] = None, *,
+                declared_by: Optional[str] = None) -> int:
+    """Arbitrated, clamped integer. NEVER raises."""
+    by = declared_by or _caller_module()
+    raw = resolve(name, default, declared_by=by)
+    try:
+        value = int(float(str(raw).strip()))
+    except (TypeError, ValueError):
+        value = int(default)
+    if lo is not None:
+        value = max(lo, value)
+    if hi is not None:
+        value = min(hi, value)
+    return value
+
+
+def collisions() -> List[Collision]:
+    """Every variable declared with more than one default. NEVER raises."""
+    out: List[Collision] = []
+    with _lock:
+        for name, slot in sorted(_registry.declared.items()):
+            if len(slot) > 1:
+                out.append(Collision(
+                    name=name,
+                    declarations=tuple(
+                        (k, ", ".join(sorted(v))) for k, v in sorted(slot.items())
+                    ),
+                ))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Static scan — finds collisions without adoption and without executing code
+# ---------------------------------------------------------------------------
+
+
+def _literal(node: ast.AST) -> Optional[str]:
+    """A literal default rendered for comparison, or None if computed.
+
+    Computed defaults (``defaults.poll_interval_s``, ``os.path.join(...)``)
+    are deliberately NOT compared: two call sites naming the same attribute
+    agree, and a scanner that guessed at their values would produce false
+    collisions — which is how a guard stops being read.
+    """
+    if isinstance(node, ast.Constant):
+        return repr(node.value)
+    return None
+
+
+def scan_static(root: Optional[Path] = None, *,
+                prefix: str = "JARVIS_") -> List[Collision]:
+    """Collisions found by AST, no adoption required. NEVER raises.
+
+    Complements runtime arbitration rather than duplicating it: runtime only
+    sees a collision once BOTH sites have executed, which for a pair on
+    rarely-taken branches may be never. This sees every literal default in
+    the tree in about a second.
+    """
+    try:
+        base = Path(root) if root is not None else (
+            Path(__file__).resolve().parents[3])
+        found: Dict[str, Dict[str, Set[str]]] = {}
+        for path in base.rglob("*.py"):
+            if "test" in path.name:
+                continue
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8", errors="replace"))
+            except (SyntaxError, OSError):
+                continue
+            for node in ast.walk(tree):
+                if not (isinstance(node, ast.Call)
+                        and isinstance(node.func, ast.Attribute)
+                        and node.func.attr == "get"
+                        and len(node.args) == 2):
+                    continue
+                name_node = node.args[0]
+                if not (isinstance(name_node, ast.Constant)
+                        and isinstance(name_node.value, str)
+                        and name_node.value.startswith(prefix)):
+                    continue
+                rendered = _literal(node.args[1])
+                if rendered is None:
+                    continue
+                found.setdefault(name_node.value, {}).setdefault(
+                    rendered, set()).add(path.name)
+        return [
+            Collision(name=n, declarations=tuple(
+                (k, ", ".join(sorted(v))) for k, v in sorted(slot.items())))
+            for n, slot in sorted(found.items()) if len(slot) > 1
+        ]
+    except Exception:  # noqa: BLE001
+        logger.debug("[ConfigArbiter] static scan degraded", exc_info=True)
+        return []

--- a/backend/core/ouroboros/governance/intake/intake_layer_service.py
+++ b/backend/core/ouroboros/governance/intake/intake_layer_service.py
@@ -1014,6 +1014,26 @@ class IntakeLayerService:
         except Exception as exc:
             logger.debug("[IntakeLayer] MemoryHygieneSensor skipped: %s", exc)
 
+        # ---- LivenessSensor (the organism notices its own dead limbs) ----
+        try:
+            from backend.core.ouroboros.governance.intake.sensors.liveness_sensor import (
+                LivenessSensor, sensor_enabled as _liveness_enabled,
+            )
+            _liveness_sensor = LivenessSensor(
+                repo="jarvis",
+                router=self._router,
+                project_root=self._config.project_root,
+            )
+            self._sensors.append(_liveness_sensor)
+            self._liveness_sensor = _liveness_sensor
+            logger.info(
+                "[IntakeLayer] LivenessSensor registered enabled=%s "
+                "(set JARVIS_LIVENESS_SENSOR_ENABLED=1)",
+                _liveness_enabled(),
+            )
+        except Exception as exc:
+            logger.debug("[IntakeLayer] LivenessSensor skipped: %s", exc)
+
         # ---- CageHygieneSensor (synthesized worker cages report on themselves) ----
         try:
             from backend.core.ouroboros.governance.intake.sensors.cage_hygiene_sensor import (

--- a/backend/core/ouroboros/governance/intake/intent_envelope.py
+++ b/backend/core/ouroboros/governance/intake/intent_envelope.py
@@ -60,6 +60,11 @@ _VALID_SOURCES = frozenset({
     # names the rule as the fix. Clustered + token-bucketed at the sensor so
     # a runaway worker cannot flood the intake through this door.
     "cage_hygiene",
+    # LivenessSensor (2026-07-31) — the organism reporting capabilities it
+    # DECLARES and cannot reach. Distinct from runtime_health (the OS layer)
+    # and meta_dormancy_alarm (a subsystem disabling itself): this is a
+    # capability that was never wired at all.
+    "capability_severance",
     # P1 Slice 3 (2026-04-26) — SelfGoalFormationEngine proposals reach
     # the intake via BacklogSensor's second-source ledger reader. The
     # distinct source ("auto_proposed") lets routers, sensors, and the

--- a/backend/core/ouroboros/governance/intake/sensors/liveness_sensor.py
+++ b/backend/core/ouroboros/governance/intake/sensors/liveness_sensor.py
@@ -1,0 +1,417 @@
+"""The organism notices its own dead limbs — without being asked.
+
+`capability_liveness.snapshot()` already answers the question that matters:
+of everything O+V declares it can do, what is actually reachable? Run today
+it reported **190 severance candidates**, 107 of them with telemetry that has
+never fired, including `repair_engine` — the L2 self-repair loop that CLAUDE.md
+documents as enabled by default and closing the Ouroboros cycle.
+
+That answer existed all day and nobody had it, because getting it required
+somebody to run a script. A self-perception layer that must be invoked is not
+self-perception; it is a diagnostic tool that happens to live in the repo.
+This makes it autonomic: sampled on a cadence, and severance becomes an
+`IntentSignal` the governed loop schedules work against.
+
+Criticality is DERIVED, not listed
+-----------------------------------
+The obvious implementation hardcodes ``{"repair_engine", "aegis", "cage"}``
+and is wrong within a month — a new safety capability is not in the list, and
+nothing tells you. Every liveness verdict already carries a ``category``
+sourced from the FlagRegistry taxonomy, and 129 of today's 190 candidates are
+``safety``. So severity keys on THAT: a severed safety capability is
+high-severity because the taxonomy already said it was safety-critical, and a
+capability added tomorrow inherits the judgement automatically.
+
+``JARVIS_LIVENESS_CRITICAL_CATEGORIES`` widens the set without code, for the
+case where a deployment's idea of critical differs from the taxonomy's.
+
+Firing status is the second axis, and the sharper one
+------------------------------------------------------
+AST reachability alone over-reports: a symbol dispatched dynamically has no
+static call site and is perfectly alive. The verdicts pair it with a
+telemetry ``firing`` state, and ``SILENT`` — a channel that has never emitted
+— is the signal that a capability is not merely hard to see statically but
+has genuinely never run. ``UNKNOWN`` is reported separately rather than
+folded into either: a capability with no telemetry at all is a different
+problem from one with silent telemetry, and merging them would hide the
+observability gap behind a liveness number.
+
+Reuses the memory-hygiene arc
+------------------------------
+Same lifecycle (``start``/``stop``/``scan_once``/``health``), the same
+debounce + per-scan cap + payload-keyed dedup, and the same token bucket the
+cage sensor uses. A severance condition is persistent by nature — 190
+findings do not resolve between scans — so without dedup this would re-emit
+the same backlog every cycle, which is the alert-fatigue failure the cage
+sensor was built to avoid.
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger("Ouroboros.LivenessSensor")
+
+LIVENESS_SENSOR_SCHEMA_VERSION: str = "liveness_sensor.1"
+
+#: Registered in THREE places — `_VALID_SOURCES`, `SignalSource`,
+#: `_BACKGROUND_SOURCES`. Missing any one fails silently and differently.
+SOURCE = "capability_severance"
+
+__all__ = [
+    "LIVENESS_SENSOR_SCHEMA_VERSION",
+    "SOURCE",
+    "LivenessFinding",
+    "LivenessSensor",
+    "critical_categories",
+    "sensor_enabled",
+    "severity_for",
+]
+
+
+def _flag(name: str, default: str = "1") -> bool:
+    try:
+        return os.environ.get(name, default).strip().lower() not in (
+            "0", "false", "no", "off", "")
+    except Exception:  # noqa: BLE001
+        return True
+
+
+def _num(name: str, default: float, lo: float, hi: float) -> float:
+    try:
+        return min(hi, max(lo, float(os.environ.get(name, "").strip() or default)))
+    except Exception:  # noqa: BLE001
+        return default
+
+
+def sensor_enabled() -> bool:
+    """``JARVIS_LIVENESS_SENSOR_ENABLED`` (default false)."""
+    return _flag("JARVIS_LIVENESS_SENSOR_ENABLED", "0")
+
+
+def critical_categories() -> frozenset:
+    """Categories whose severance is HIGH severity. NEVER raises.
+
+    Defaults to ``safety`` — the FlagRegistry category for kill switches and
+    gates — because that taxonomy already encodes "this matters" and a second
+    hand-kept list would drift from it. Widen with
+    ``JARVIS_LIVENESS_CRITICAL_CATEGORIES`` (comma-separated).
+    """
+    try:
+        raw = os.environ.get("JARVIS_LIVENESS_CRITICAL_CATEGORIES", "").strip()
+        if raw:
+            return frozenset(p.strip().lower() for p in raw.split(",") if p.strip())
+    except Exception:  # noqa: BLE001
+        pass
+    return frozenset({"safety"})
+
+
+def _severed_floor() -> float:
+    """Fraction of a capability's callables that must be unreachable.
+
+    ``JARVIS_LIVENESS_SEVERED_FLOOR``. A capability with one unreferenced
+    helper is normal; one with most of its surface unreachable is not.
+    """
+    return _num("JARVIS_LIVENESS_SEVERED_FLOOR", 0.30, 0.0, 1.0)
+
+
+def _max_emit_per_scan() -> int:
+    """``JARVIS_LIVENESS_MAX_EMIT`` — default 2.
+
+    Today's snapshot held 190 candidates. Emitting them would enqueue 190 ops
+    of archaeology ahead of every real signal, which is the same flood the
+    memory sensor caps at 3.
+    """
+    return int(_num("JARVIS_LIVENESS_MAX_EMIT", 2, 1, 25))
+
+
+def _poll_interval_s() -> float:
+    """``JARVIS_LIVENESS_POLL_S`` — default 6h.
+
+    Severance changes on the timescale of commits, not seconds, and the
+    snapshot walks the whole backend. Sampling it often would cost more than
+    the answer is worth.
+    """
+    return _num("JARVIS_LIVENESS_POLL_S", 21600.0, 60.0, 604800.0)
+
+
+def _debounce_s() -> float:
+    return _num("JARVIS_LIVENESS_DEBOUNCE_S", 60.0, 0.0, 3600.0)
+
+
+class _TokenBucket:
+    """Bounds emissions per unit TIME — the same primitive the cage sensor
+    uses, for the same reason: the per-scan cap bounds a burst, this bounds a
+    sustained drip of distinct findings."""
+
+    def __init__(self) -> None:
+        self._tokens = _num("JARVIS_LIVENESS_BUCKET_CAPACITY", 2.0, 1.0, 50.0)
+        self._last = time.monotonic()
+
+    def take(self) -> bool:
+        try:
+            now = time.monotonic()
+            refill = _num("JARVIS_LIVENESS_BUCKET_REFILL_PER_S",
+                          1.0 / 3600.0, 1.0 / 604800.0, 10.0)
+            cap = _num("JARVIS_LIVENESS_BUCKET_CAPACITY", 2.0, 1.0, 50.0)
+            self._tokens = min(cap, self._tokens + (now - self._last) * refill)
+            self._last = now
+            if self._tokens >= 1.0:
+                self._tokens -= 1.0
+                return True
+            return False
+        except Exception:  # noqa: BLE001
+            return False
+
+    @property
+    def tokens(self) -> float:
+        return self._tokens
+
+
+@dataclass(frozen=True)
+class LivenessFinding:
+    """One capability the organism declares and cannot reach."""
+
+    source_file: str
+    category: str
+    flag: str
+    firing: str
+    fraction_severed: float
+    severed_symbols: Tuple[str, ...]
+    severity: str
+
+    @property
+    def dedup_key(self) -> str:
+        """Keyed on the SYMBOLS, not the file.
+
+        A file whose severed set changes has a genuinely different finding;
+        one that merely got edited does not. Keying on the path would
+        re-report on every unrelated commit, and keying on the count alone
+        would miss a swap of one dead symbol for another.
+        """
+        return f"{self.source_file}|{self.flag}|{','.join(sorted(self.severed_symbols))}"
+
+    @property
+    def rank(self) -> Tuple[int, float]:
+        return (0 if self.severity == "high" else 1, -self.fraction_severed)
+
+
+def severity_for(category: str, firing: str, fraction: float) -> str:
+    """``high`` / ``low``. Pure. NEVER raises.
+
+    HIGH requires BOTH a critical category AND telemetry that has never
+    fired. Either alone is weaker evidence than it looks: a safety capability
+    with FIRING telemetry is alive whatever the AST says, and a SILENT
+    experimental helper is not worth waking anyone for.
+    """
+    try:
+        crit = str(category or "").strip().lower() in critical_categories()
+        silent = str(firing or "").strip().upper() == "SILENT"
+        if crit and silent and float(fraction or 0.0) >= _severed_floor():
+            return "high"
+        return "low"
+    except Exception:  # noqa: BLE001
+        return "low"
+
+
+class LivenessSensor:
+    """Samples `capability_liveness` and emits severance as intake signals.
+
+    Mirrors `MemoryHygieneSensor`'s lifecycle because that is the contract
+    `IntakeLayer` drives; a second sensor shape is a second lifecycle to get
+    wrong.
+    """
+
+    def __init__(self, repo: str, router: Any, *,
+                 project_root: Optional[Any] = None,
+                 poll_interval_s: Optional[float] = None) -> None:
+        self._repo = repo
+        self._router = router
+        self._project_root = project_root
+        self._poll_interval_s = (poll_interval_s if poll_interval_s is not None
+                                 else _poll_interval_s())
+        self._running = False
+        self._task: Optional[asyncio.Task] = None
+        self._seen: Dict[str, float] = {}
+        self._bucket = _TokenBucket()
+        self._scans = 0
+        self._emitted = 0
+        self._throttled = 0
+        self._last_counts: Dict[str, int] = {}
+
+    # -- lifecycle --------------------------------------------------------
+
+    async def start(self) -> None:
+        if self._running or not sensor_enabled():
+            return
+        self._running = True
+        self._task = asyncio.create_task(self._poll_loop())
+        logger.info("[Liveness] started (poll %.0fs)", self._poll_interval_s)
+
+    def stop(self) -> None:
+        self._running = False
+        if self._task is not None and not self._task.done():
+            self._task.cancel()
+        self._task = None
+
+    async def _poll_loop(self) -> None:
+        while self._running:
+            try:
+                await asyncio.sleep(self._poll_interval_s)
+                if self._running:
+                    await self.scan_once()
+            except asyncio.CancelledError:
+                return
+            except Exception:  # noqa: BLE001
+                logger.debug("[Liveness] poll degraded", exc_info=True)
+
+    # -- detection --------------------------------------------------------
+
+    async def collect_findings(self) -> List[LivenessFinding]:
+        """Severed capabilities worth reporting. NEVER raises.
+
+        The snapshot walks the whole backend, so it is dispatched off the
+        event loop — on a full-screen Application that scan would otherwise
+        stall the frame that is meant to be showing its result.
+        """
+        try:
+            from backend.core.ouroboros.governance.capability_liveness import (
+                snapshot,
+            )
+            from backend.core.ouroboros.governance.cooperative_fs_io import (
+                is_offload_error, offload,
+            )
+            result = await offload(snapshot, cpu_bound=False)
+            if is_offload_error(result):
+                result = snapshot()
+            candidates = (result or {}).get("severance_candidates") or []
+        except Exception:  # noqa: BLE001
+            logger.debug("[Liveness] snapshot unavailable", exc_info=True)
+            return []
+
+        floor = _severed_floor()
+        out: List[LivenessFinding] = []
+        counts: Dict[str, int] = {}
+        for row in candidates:
+            try:
+                firing = str(row.get("firing") or "UNKNOWN")
+                counts[firing] = counts.get(firing, 0) + 1
+                fraction = float(row.get("fraction_severed") or 0.0)
+                if fraction < floor:
+                    continue
+                category = str(row.get("category") or "")
+                out.append(LivenessFinding(
+                    source_file=str(row.get("source_file") or "?").split("/")[-1],
+                    category=category,
+                    flag=str(row.get("flag") or ""),
+                    firing=firing,
+                    fraction_severed=fraction,
+                    severed_symbols=tuple(row.get("severed_symbols") or ()),
+                    severity=severity_for(category, firing, fraction),
+                ))
+            except Exception:  # noqa: BLE001
+                continue
+        self._last_counts = counts
+        out.sort(key=lambda f: f.rank)
+        return out
+
+    # -- emission ---------------------------------------------------------
+
+    async def scan_once(self) -> List[LivenessFinding]:
+        """Sample, bound, emit. Returns what was FOUND. NEVER raises."""
+        if not sensor_enabled():
+            return []
+        try:
+            self._scans += 1
+            findings = await self.collect_findings()
+            if not findings:
+                return []
+
+            fresh = [f for f in findings if f.dedup_key not in self._seen]
+            emitted = 0
+            for finding in fresh[:_max_emit_per_scan()]:
+                if not self._bucket.take():
+                    self._throttled += 1
+                    break
+                if await self._emit(finding):
+                    self._seen[finding.dedup_key] = time.time()
+                    emitted += 1
+
+            self._emitted += emitted
+            logger.info(
+                "[Liveness] scan: %d severed (>=%.0f%%), %d fresh, %d emitted "
+                "(cap %d) — firing %s",
+                len(findings), _severed_floor() * 100, len(fresh), emitted,
+                _max_emit_per_scan(), self._last_counts,
+            )
+            return findings
+        except Exception:  # noqa: BLE001
+            logger.debug("[Liveness] scan degraded", exc_info=True)
+            return []
+
+    async def _emit(self, finding: LivenessFinding) -> bool:
+        """One envelope. NEVER raises.
+
+        Urgency is ``low`` even for high-severity findings, matching the cage
+        sensor: severance is archaeology, not an incident, and escalating the
+        ROUTE would put repo-wide static analysis on the Claude tier. The
+        severity rides in the evidence, where an operator surface can show it
+        immediately and for free.
+        """
+        try:
+            from backend.core.ouroboros.governance.intake.intent_envelope import (
+                make_envelope,
+            )
+            symbols = ", ".join(finding.severed_symbols[:4]) or "(none listed)"
+            envelope = make_envelope(
+                source=SOURCE,
+                description=(
+                    f"Capability in {finding.source_file} is "
+                    f"{finding.fraction_severed:.0%} unreachable and its "
+                    f"telemetry is {finding.firing}: {symbols}. Category "
+                    f"{finding.category!r}, flag {finding.flag or '(none)'}. "
+                    f"Either wire it to a production caller, or retire it — a "
+                    f"capability that is declared and unreachable reads as "
+                    f"present from every flag and runs zero times."
+                ),
+                target_files=(finding.source_file,),
+                repo=self._repo,
+                confidence=0.55,
+                urgency="low",
+                evidence={
+                    "schema_version": LIVENESS_SENSOR_SCHEMA_VERSION,
+                    "sensor": "LivenessSensor",
+                    "severity": finding.severity,
+                    "category": finding.category,
+                    "firing": finding.firing,
+                    "fraction_severed": round(finding.fraction_severed, 4),
+                    "severed_symbols": list(finding.severed_symbols[:12]),
+                    "flag": finding.flag,
+                },
+                requires_human_ack=False,
+            )
+            return (await self._router.ingest(envelope)) == "enqueued"
+        except Exception:  # noqa: BLE001
+            logger.debug("[Liveness] emit failed for %s", finding.source_file,
+                         exc_info=True)
+            return False
+
+    def health(self) -> Dict[str, Any]:
+        """Bounded projection. NEVER raises."""
+        return {
+            "schema_version": LIVENESS_SENSOR_SCHEMA_VERSION,
+            "enabled": sensor_enabled(),
+            "running": self._running,
+            "scans": self._scans,
+            "emitted": self._emitted,
+            "throttled": self._throttled,
+            "suppressed": len(self._seen),
+            "firing_counts": dict(self._last_counts),
+            "bucket_tokens": round(self._bucket.tokens, 3),
+        }

--- a/backend/core/ouroboros/governance/intent/signals.py
+++ b/backend/core/ouroboros/governance/intent/signals.py
@@ -97,6 +97,9 @@ class SignalSource(str, Enum):
     # memory_hygiene (the topic corpus) and from runtime_health (the OS
     # layer): this is about the least-privilege derivation being wrong.
     CAGE_HYGIENE = "cage_hygiene"
+    # A declared capability with no reachable caller — the reachability
+    # bottleneck made autonomic.
+    CAPABILITY_SEVERANCE = "capability_severance"
     AUTO_PROPOSED = "auto_proposed"
     VISION_SENSOR = "vision_sensor"
     CADENCE_SYNTHETIC = "cadence_synthetic"

--- a/backend/core/ouroboros/governance/urgency_router.py
+++ b/backend/core/ouroboros/governance/urgency_router.py
@@ -158,6 +158,10 @@ _BACKGROUND_SOURCES = frozenset({
     # severity would let an attacker who can trigger denials force IMMEDIATE
     # routing and burn the Claude tier. Severity rides in evidence instead.
     "cage_hygiene",
+    # Severance is archaeology, not an incident. Even a high-severity finding
+    # stays BACKGROUND: escalating the route would put repo-wide static
+    # analysis on the Claude tier, and severity rides in the evidence.
+    "capability_severance",
 })
 
 # Sources that produce SPECULATIVE-eligible signals

--- a/tests/governance/test_config_arbiter.py
+++ b/tests/governance/test_config_arbiter.py
@@ -1,0 +1,147 @@
+"""One env var, one default — or a collision that names both sides.
+
+Two flags were read in two places with two different defaults today, and both
+were real defects: JARVIS_PALETTE_HEIGHT (4 vs 12) made the operator's menu
+height depend on which renderer mounted, and JARVIS_MEMORY_ROUTING_ENABLED
+(OFF vs ON) made `/memory` report "routing: on" for the entire period routing
+was disabled. A static scan then found 29 across the tree.
+
+Nothing prevented any of them: `os.environ.get(NAME, default)` is a
+decentralised declaration and every call site may invent its own default.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance import config_arbiter as ca
+from backend.core.ouroboros.governance.config_arbiter import (
+    ConfigurationCollisionError,
+    collisions,
+    resolve,
+    resolve_bool,
+    resolve_int,
+    scan_static,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean(monkeypatch):
+    monkeypatch.delenv("JARVIS_CONFIG_ARBITER_STRICT", raising=False)
+    ca.reset_for_tests()
+    yield
+    ca.reset_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# The mandate: two modules, same var, different defaults -> strict raises
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_two_modules_declaring_different_defaults_raise_in_strict_mode(
+    monkeypatch,
+):
+    """THE mandate case, using the real collision found in the tree:
+    JARVIS_GOVERNED_TOOL_MAX_ROUNDS is 10 in governed_loop_service and 15 in
+    presentation_restraint — Venom's tool-loop budget disagreeing with itself.
+    """
+    monkeypatch.setenv("JARVIS_CONFIG_ARBITER_STRICT", "1")
+    resolve_int("JARVIS_GOVERNED_TOOL_MAX_ROUNDS", 10,
+                declared_by="governed_loop_service.py")
+    with pytest.raises(ConfigurationCollisionError) as exc:
+        resolve_int("JARVIS_GOVERNED_TOOL_MAX_ROUNDS", 15,
+                    declared_by="presentation_restraint.py")
+    message = str(exc.value)
+    # The error must name BOTH sides — "something collided" is not actionable.
+    assert "governed_loop_service.py" in message
+    assert "presentation_restraint.py" in message
+    assert "10" in message and "15" in message
+
+
+@pytest.mark.asyncio
+async def test_identical_defaults_are_not_a_collision(monkeypatch):
+    """Two call sites agreeing is the normal case and must stay silent."""
+    monkeypatch.setenv("JARVIS_CONFIG_ARBITER_STRICT", "1")
+    resolve_int("JARVIS_SAME", 30, declared_by="a.py")
+    resolve_int("JARVIS_SAME", 30, declared_by="b.py")
+    assert collisions() == []
+
+
+def test_non_strict_records_without_raising():
+    """Default mode must stay ALIVE. 29 collisions predate this module; an
+    arbiter that raised on the default path would make the first import fatal,
+    which is an outage, not a safety property."""
+    resolve_int("JARVIS_X", 10, declared_by="a.py")
+    resolve_int("JARVIS_X", 15, declared_by="b.py")
+    found = collisions()
+    assert len(found) == 1
+    assert "a.py" in found[0].describe() and "b.py" in found[0].describe()
+
+
+def test_the_winner_is_first_registered_not_last():
+    """Last-wins would make config depend on import order, which changes when
+    an unrelated module adds a lazy import — a value that moves for reasons
+    invisible at the call site is worse than a wrong one."""
+    assert resolve_int("JARVIS_W", 10, declared_by="a.py") == 10
+    assert resolve_int("JARVIS_W", 15, declared_by="b.py") == 10
+
+
+def test_the_environment_still_wins_over_any_default(monkeypatch):
+    monkeypatch.setenv("JARVIS_W", "99")
+    assert resolve_int("JARVIS_W", 10, declared_by="a.py") == 99
+
+
+def test_empty_env_value_falls_back_to_the_default(monkeypatch):
+    """`FOO=` is indistinguishable from unset in most shells."""
+    monkeypatch.setenv("JARVIS_W", "")
+    assert resolve_int("JARVIS_W", 7, declared_by="a.py") == 7
+
+
+def test_bool_and_int_share_the_same_arbitration():
+    resolve_bool("JARVIS_B", True, declared_by="a.py")
+    resolve_bool("JARVIS_B", False, declared_by="b.py")
+    assert len(collisions()) == 1
+
+
+def test_int_is_clamped():
+    assert resolve_int("JARVIS_C", 500, lo=1, hi=10, declared_by="a.py") == 10
+
+
+def test_resolution_never_raises_outside_strict_mode():
+    for bad in (None, object(), 1.5):
+        assert resolve("JARVIS_J", bad, declared_by="a.py") is not None
+
+
+def test_caller_attribution_is_derived_when_not_supplied():
+    """A caller that must name itself will eventually name itself wrong."""
+    resolve("JARVIS_ATTR", 1)
+    resolve("JARVIS_ATTR", 2)
+    assert "test_config_arbiter.py" in collisions()[0].describe()
+
+
+# ---------------------------------------------------------------------------
+# Static scan — catches what runtime cannot
+# ---------------------------------------------------------------------------
+
+
+def test_static_scan_finds_real_collisions_without_adoption():
+    """Runtime arbitration only sees a collision once BOTH sites execute; for
+    a pair on rarely-taken branches that may be never."""
+    found = scan_static()
+    assert found, "static scan found nothing — the AST walk is broken"
+    names = {c.name for c in found}
+    assert "JARVIS_CHANNEL_PORT" in names
+
+
+def test_static_scan_ignores_computed_defaults():
+    """`defaults.poll_interval_s` in two files is agreement, not collision.
+
+    A scanner that guessed at computed values would produce false collisions,
+    which is how a guard stops being read.
+    """
+    import ast
+
+    from backend.core.ouroboros.governance.config_arbiter import _literal
+    assert _literal(ast.parse("1").body[0].value) == "1"
+    assert _literal(ast.parse("defaults.x").body[0].value) is None
+    assert _literal(ast.parse("os.path.join(a, b)").body[0].value) is None

--- a/tests/governance/test_liveness_sensor.py
+++ b/tests/governance/test_liveness_sensor.py
@@ -1,0 +1,282 @@
+"""Severance becomes a signal, not a script somebody has to remember to run.
+
+`capability_liveness.snapshot()` reported 190 severance candidates today —
+107 with telemetry that has never fired, including `repair_engine`, which
+CLAUDE.md documents as enabled by default and closing the Ouroboros cycle.
+That answer existed all day and nobody had it, because getting it required
+invoking a script. A self-perception layer that must be asked is not
+self-perception.
+
+The load-bearing test is `test_a_component_with_zero_reachability_emits_high_severity`
+— the mandate case. The second is `test_severity_requires_BOTH_criticality_and_silence`:
+either signal alone over-reports, and an alarm that cries wolf on
+dynamically-dispatched helpers is one nobody reads by the third week.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance.intake.sensors import (
+    liveness_sensor as ls,
+)
+from backend.core.ouroboros.governance.intake.sensors.liveness_sensor import (
+    SOURCE,
+    LivenessFinding,
+    LivenessSensor,
+    critical_categories,
+    severity_for,
+)
+
+
+class _Router:
+    def __init__(self, result="enqueued"):
+        self.seen = []
+        self._result = result
+
+    async def ingest(self, envelope):
+        self.seen.append(envelope)
+        return self._result
+
+
+@pytest.fixture(autouse=True)
+def _on(monkeypatch):
+    monkeypatch.setenv("JARVIS_LIVENESS_SENSOR_ENABLED", "1")
+    monkeypatch.delenv("JARVIS_LIVENESS_CRITICAL_CATEGORIES", raising=False)
+    yield
+
+
+def _ev(envelope, key, default=None):
+    ev = getattr(envelope, "evidence", None)
+    if ev is None and isinstance(envelope, dict):
+        ev = envelope.get("evidence")
+    return (ev or {}).get(key, default)
+
+
+def _candidate(**kw):
+    row = {
+        "source_file": "governance/repair_engine.py",
+        "category": "safety",
+        "flag": "JARVIS_L2_ENABLED",
+        "firing": "SILENT",
+        "fraction_severed": 1.0,
+        "severed_symbols": ["repair_once", "run_repair_loop"],
+    }
+    row.update(kw)
+    return row
+
+
+def _stub_snapshot(sensor, rows):
+    async def _collect():
+        findings = []
+        for r in rows:
+            findings.append(LivenessFinding(
+                source_file=r["source_file"].split("/")[-1],
+                category=r["category"], flag=r["flag"], firing=r["firing"],
+                fraction_severed=r["fraction_severed"],
+                severed_symbols=tuple(r["severed_symbols"]),
+                severity=severity_for(r["category"], r["firing"],
+                                      r["fraction_severed"]),
+            ))
+        findings.sort(key=lambda f: f.rank)
+        return findings
+    sensor.collect_findings = _collect
+    return sensor
+
+
+# ---------------------------------------------------------------------------
+# The mandate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_component_with_zero_reachability_emits_high_severity():
+    """THE mandate case: a safety component drops to 0 inbound edges.
+
+    Modelled on the real finding — `repair_engine`, category `safety`,
+    telemetry SILENT, fully severed.
+    """
+    router = _Router()
+    sensor = _stub_snapshot(LivenessSensor("repo", router), [_candidate()])
+    await sensor.scan_once()
+
+    assert len(router.seen) == 1, "a fully severed safety component did not emit"
+    env = router.seen[0]
+    assert _ev(env, "severity") == "high"
+    assert _ev(env, "firing") == "SILENT"
+    assert _ev(env, "fraction_severed") == 1.0
+    assert "repair_once" in _ev(env, "severed_symbols")
+    desc = getattr(env, "description", "") or ""
+    assert "repair_engine.py" in desc
+
+
+@pytest.mark.asyncio
+async def test_severity_requires_BOTH_criticality_and_silence():
+    """Either signal alone over-reports.
+
+    A safety capability whose telemetry is FIRING is alive whatever the AST
+    says — dynamic dispatch leaves no static edge. A SILENT experimental
+    helper is not worth waking anyone for.
+    """
+    assert severity_for("safety", "SILENT", 1.0) == "high"
+    assert severity_for("safety", "FIRING", 1.0) == "low"
+    assert severity_for("experimental", "SILENT", 1.0) == "low"
+    assert severity_for("safety", "UNKNOWN", 1.0) == "low"
+
+
+def test_criticality_is_derived_from_the_existing_taxonomy():
+    """Not a hardcoded module list.
+
+    A hardcoded {"repair_engine", "aegis", "cage"} is wrong within a month:
+    a new safety capability is not in it and nothing says so. Every verdict
+    already carries a FlagRegistry `category`, and 129 of today's 190
+    candidates are `safety`.
+    """
+    assert "safety" in critical_categories()
+
+
+def test_critical_categories_are_widenable_without_code(monkeypatch):
+    monkeypatch.setenv("JARVIS_LIVENESS_CRITICAL_CATEGORIES", "safety,routing")
+    assert critical_categories() == frozenset({"safety", "routing"})
+    assert severity_for("routing", "SILENT", 0.9) == "high"
+
+
+# ---------------------------------------------------------------------------
+# Bounds — 190 findings must not become 190 ops
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_emission_is_capped_per_scan(monkeypatch):
+    monkeypatch.setenv("JARVIS_LIVENESS_MAX_EMIT", "2")
+    monkeypatch.setenv("JARVIS_LIVENESS_BUCKET_CAPACITY", "50")
+    router = _Router()
+    rows = [_candidate(source_file=f"m{i}.py", severed_symbols=[f"s{i}"])
+            for i in range(40)]
+    sensor = _stub_snapshot(LivenessSensor("repo", router), rows)
+    found = await sensor.scan_once()
+    assert len(found) == 40
+    assert len(router.seen) == 2, "the 190-finding flood is not bounded"
+
+
+@pytest.mark.asyncio
+async def test_high_severity_is_emitted_before_low(monkeypatch):
+    monkeypatch.setenv("JARVIS_LIVENESS_MAX_EMIT", "1")
+    monkeypatch.setenv("JARVIS_LIVENESS_BUCKET_CAPACITY", "50")
+    router = _Router()
+    rows = [
+        _candidate(source_file="cosmetic.py", category="experimental",
+                   severed_symbols=["x"]),
+        _candidate(source_file="repair_engine.py", severed_symbols=["y"]),
+    ]
+    sensor = _stub_snapshot(LivenessSensor("repo", router), rows)
+    await sensor.scan_once()
+    assert "repair_engine.py" in (getattr(router.seen[0], "description", "") or "")
+
+
+@pytest.mark.asyncio
+async def test_a_persistent_condition_reports_once():
+    """190 findings do not resolve between scans; without dedup this would
+    re-emit the same backlog every cycle."""
+    router = _Router()
+    sensor = _stub_snapshot(LivenessSensor("repo", router), [_candidate()])
+    await sensor.scan_once()
+    await sensor.scan_once()
+    await sensor.scan_once()
+    assert len(router.seen) == 1
+
+
+@pytest.mark.asyncio
+async def test_a_changed_severed_set_is_a_new_finding():
+    """Dedup keys on the SYMBOLS, not the path — a file that merely got
+    edited is not news, a different dead set is."""
+    router = _Router()
+    sensor = _stub_snapshot(LivenessSensor("repo", router), [_candidate()])
+    await sensor.scan_once()
+    _stub_snapshot(sensor, [_candidate(severed_symbols=["repair_once", "NEW"])])
+    await sensor.scan_once()
+    assert len(router.seen) == 2
+
+
+@pytest.mark.asyncio
+async def test_below_the_floor_is_not_reported(monkeypatch):
+    """One unreferenced helper is normal; most of a surface is not."""
+    monkeypatch.setenv("JARVIS_LIVENESS_SEVERED_FLOOR", "0.5")
+    from backend.core.ouroboros.governance.intake.sensors.liveness_sensor import (
+        _severed_floor,
+    )
+    assert _severed_floor() == 0.5
+    assert severity_for("safety", "SILENT", 0.2) == "low"
+
+
+@pytest.mark.asyncio
+async def test_token_bucket_bounds_a_sustained_drip(monkeypatch):
+    monkeypatch.setenv("JARVIS_LIVENESS_MAX_EMIT", "25")
+    monkeypatch.setenv("JARVIS_LIVENESS_BUCKET_CAPACITY", "2")
+    monkeypatch.setenv("JARVIS_LIVENESS_BUCKET_REFILL_PER_S", "0.0000012")
+    router = _Router()
+    rows = [_candidate(source_file=f"m{i}.py", severed_symbols=[f"s{i}"])
+            for i in range(20)]
+    sensor = _stub_snapshot(LivenessSensor("repo", router), rows)
+    await sensor.scan_once()
+    assert len(router.seen) <= 2
+    assert sensor.health()["throttled"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# Routing, refusals, wiring
+# ---------------------------------------------------------------------------
+
+
+def test_source_is_registered_in_all_three_places():
+    from backend.core.ouroboros.governance.intake.intent_envelope import (
+        _VALID_SOURCES,
+    )
+    from backend.core.ouroboros.governance.intent.signals import SignalSource
+    from backend.core.ouroboros.governance.urgency_router import (
+        _BACKGROUND_SOURCES,
+    )
+    assert SOURCE in _VALID_SOURCES
+    assert SignalSource(SOURCE) is SignalSource.CAPABILITY_SEVERANCE
+    assert SOURCE in _BACKGROUND_SOURCES
+
+
+@pytest.mark.asyncio
+async def test_high_severity_does_not_escalate_the_route():
+    """Severance is archaeology, not an incident. Escalating would put
+    repo-wide static analysis on the Claude tier."""
+    router = _Router()
+    sensor = _stub_snapshot(LivenessSensor("repo", router), [_candidate()])
+    await sensor.scan_once()
+    env = router.seen[0]
+    urgency = getattr(env, "urgency", None) or (
+        env.get("urgency") if isinstance(env, dict) else None)
+    assert urgency == "low"
+    assert _ev(env, "severity") == "high"
+
+
+@pytest.mark.asyncio
+async def test_disabled_sensor_emits_nothing(monkeypatch):
+    monkeypatch.setenv("JARVIS_LIVENESS_SENSOR_ENABLED", "0")
+    router = _Router()
+    sensor = _stub_snapshot(LivenessSensor("repo", router), [_candidate()])
+    assert await sensor.scan_once() == []
+    assert router.seen == []
+
+
+def test_default_is_off(monkeypatch):
+    monkeypatch.delenv("JARVIS_LIVENESS_SENSOR_ENABLED", raising=False)
+    assert ls.sensor_enabled() is False
+
+
+@pytest.mark.asyncio
+async def test_a_rejected_envelope_is_not_marked_seen():
+    router = _Router(result="rejected")
+    sensor = _stub_snapshot(LivenessSensor("repo", router), [_candidate()])
+    await sensor.scan_once()
+    assert sensor._seen == {}
+
+
+def test_health_is_bounded_and_never_raises():
+    h = LivenessSensor("repo", _Router()).health()
+    assert set(h) >= {"enabled", "running", "scans", "emitted", "throttled",
+                      "firing_counts", "bucket_tokens"}


### PR DESCRIPTION
Two root causes closed structurally rather than patched file by file.

## 1 — Split-brain configuration

`JARVIS_PALETTE_HEIGHT` was **4** in `palette_render` and **12** in `bipartite_layout`. `JARVIS_MEMORY_ROUTING_ENABLED` was **OFF** in `module_routing` and **ON** in `memory_surface` — so `/memory` reported `routing: on` for the entire period routing was disabled. A static scan found **29** across the tree.

Nothing prevented any of them: `os.environ.get(NAME, default)` is a *decentralised declaration* and every call site may invent its own default.

`config_arbiter` centralises it. A collision raises `ConfigurationCollisionError` naming **both sides and the file to fix** — "something collided" isn't actionable.

**Detection is total; the RAISE is a mode.** 29 collisions predate this module, so raising on the default path would make the first import fatal — an outage, not a safety property. `JARVIS_CONFIG_ARBITER_STRICT=1` turns recording into raising (CI/tests run strict); runtime default is loud-but-alive with a deterministic winner. When the 29 are fixed, strict becomes the default and the mode disappears.

Winner is **first**-registered, not last — last-wins makes config depend on import order, which changes when an unrelated module adds a lazy import.

`scan_static` covers what runtime cannot: runtime only sees a collision once *both* sites execute, which for rarely-taken branches may be never. AST finds all 29 with zero adoption. Computed defaults (`defaults.poll_interval_s`) are deliberately not compared — guessing produces false collisions, which is how a guard stops being read.

## 2 — Silent severance

`capability_liveness.snapshot()` reports **190 severance candidates**, 107 with telemetry that has never fired, including `repair_engine` (documented default-ON, closes the Ouroboros cycle). That answer existed all day and nobody had it, because getting it required running a script. **A self-perception layer that must be invoked is not self-perception.**

`LivenessSensor` makes it autonomic — sampled on a cadence, severance becomes an `IntentSignal`.

**Criticality is derived, not listed.** A hardcoded `{repair_engine, aegis, cage}` is wrong within a month. Every verdict already carries a FlagRegistry `category`; 129 of 190 are `safety`. Anything added tomorrow inherits the judgement. `JARVIS_LIVENESS_CRITICAL_CATEGORIES` widens without code.

**HIGH requires BOTH criticality and SILENT telemetry.** Either alone over-reports — a safety capability with FIRING telemetry is alive whatever the AST says (dynamic dispatch leaves no static edge). `UNKNOWN` is reported separately: no telemetry is a different problem from silent telemetry, and merging them hides the observability gap behind a liveness number.

DRY: memory-hygiene lifecycle, cage-sensor token bucket + per-scan cap + dedup. Dedup keys on **severed symbols**, not path — 190 findings don't resolve between scans, so a path key re-emits the backlog every cycle. Urgency stays `low` even at high severity: severance is archaeology, and escalating would put repo-wide static analysis on the Claude tier.

## Verified against reality, not stubs

- Arbiter strict mode raises on the **real** `JARVIS_GOVERNED_TOOL_MAX_ROUNDS` collision (10 vs 15 — Venom's tool-loop budget disagreeing with itself); static scan finds 29.
- Sensor on the **real** snapshot: 37 findings above the 30% floor, 12 high-severity, 2 emitted (cap holding), high-severity ranked first (`replay_from_record` 75% SILENT, `dw_transport_disambiguator` 67% SILENT), `firing_counts` SILENT=107 / UNKNOWN=46 / FIRING=37 matching the manual audit exactly.

## Two defects found while building

`_record` recovered the conflicting key with a bare `next()` — failure mode `StopIteration`. **A guard that crashes in its own reporting path converts a config smell into an outage.** And `_caller_module` walked one frame too far, attributing declarations to pytest internals — naming the wrong file to fix.

The construction guard added earlier today **caught that `LivenessSensor` had no construction site** before it shipped.

28 new tests, 79 green across new and adjacent sensor suites. Both default **OFF**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes env var defaults with a Config Arbiter to prevent split-brain config, and adds an autonomic LivenessSensor that turns capability severance into a background intake signal. This fixes real config collisions and surfaces unreachable safety capabilities without manual scripts.

- **New Features**
  - Config Arbiter: one env var, one default with first-registered winning; strict mode via JARVIS_CONFIG_ARBITER_STRICT=1 (CI/tests), logs otherwise; includes an AST `scan_static()` to find collisions without executing code; typed helpers `resolve`, `resolve_bool`, `resolve_int`.
  - LivenessSensor: periodically samples capability liveness and emits `capability_severance` signals with low urgency; severity is high only when category is critical (default `safety`, widen via JARVIS_LIVENESS_CRITICAL_CATEGORIES) and telemetry is SILENT; dedup keyed on severed symbols, per-scan cap and token bucket; fully wired into intake and router; default off via JARVIS_LIVENESS_SENSOR_ENABLED=0.

- **Bug Fixes**
  - Fixed collision recorder crash on empty prior state and corrected caller attribution so collisions name the right file to fix.

<sup>Written for commit 6f3e076910c7bf10b21fa8b2b0eddf93afa3ce45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

