### PR TITLE
feat(governance): Hybrid Liveness — bridge the static/dynamic observability gap

### DIFF
--- a/backend/core/ouroboros/governance/dynamic_dispatch_registry.py
+++ b/backend/core/ouroboros/governance/dynamic_dispatch_registry.py
@@ -1,0 +1,314 @@
+"""What AST cannot see: modules reached by dispatch rather than by name.
+
+Static reachability under-reports by construction. A pub/sub handler, an
+``importlib`` load, a ``getattr`` route — none leaves an edge a caller index
+can follow, so a live capability reads as dead. `capability_liveness` says so
+itself: its verdict reason ends "may be dynamically dispatched — a review
+candidate, not proven dead."
+
+This is the other half of that sentence.
+
+REGISTERED is not FIRING, and conflating them hides the bug
+------------------------------------------------------------
+The tempting design records a breadcrumb when a module subscribes or is
+loaded, then treats anything in the registry as alive. That would be worse
+than no registry at all.
+
+Subscribing proves the module was IMPORTED and asked to be called. It proves
+nothing about whether it ever was. A handler that registers at boot and never
+receives an event is exactly the failure being hunted — and under
+"registered ⇒ alive" it would flip from ``SILENT, investigate`` to
+``dynamically dispatched, ignore``, which is the audit confidently clearing
+the one case it exists to catch.
+
+So two facts are tracked separately and they are not interchangeable:
+
+``register(module)``
+    "I am reachable by dispatch." Written at subscribe/load time.
+
+``note_invocation(module)``
+    "I actually ran." Written when the handler fires.
+
+Only the second earns ``FIRING_DYNAMICALLY``. The first earns
+``REGISTERED_NEVER_INVOKED`` — a verdict with no static equivalent, and
+arguably the sharpest one available: the module declared itself reachable and
+still never ran, which is a stronger claim than "no caller found" because it
+rules out the innocent explanation.
+
+Attribute-routed calls are a STATIC gap, not a dynamic one
+-----------------------------------------------------------
+Worth recording where this does NOT apply. ``repair_engine`` appeared 40%
+severed, and the cause was not dynamic dispatch: its entry point is called at
+``orchestrator.py:13014`` as
+``self._config.repair_engine.run(ctx, ...)``. That is a perfectly static
+call, invisible only to an index keyed on bare symbol names. A runtime
+breadcrumb would have "fixed" that verdict while leaving the caller index
+just as blind for every other injected dependency.
+
+Cheap enough to leave on
+-------------------------
+Two dict writes under a lock, no I/O, bounded by
+``JARVIS_DYNAMIC_DISPATCH_MAX_MODULES``. A breadcrumb that cost anything
+would be turned off, and a breadcrumb that is off records nothing.
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import functools
+import logging
+import os
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Optional, Tuple
+
+logger = logging.getLogger("Ouroboros.DynamicDispatch")
+
+DYNAMIC_DISPATCH_SCHEMA_VERSION: str = "dynamic_dispatch.1"
+
+#: Verdicts this registry can contribute. Deliberately three, not two.
+FIRING_DYNAMICALLY = "FIRING_DYNAMICALLY"
+REGISTERED_NEVER_INVOKED = "REGISTERED_NEVER_INVOKED"
+UNSEEN = "UNSEEN"
+
+__all__ = [
+    "DYNAMIC_DISPATCH_SCHEMA_VERSION",
+    "FIRING_DYNAMICALLY",
+    "REGISTERED_NEVER_INVOKED",
+    "UNSEEN",
+    "DispatchRecord",
+    "dynamic_verdict",
+    "dynamically_dispatched",
+    "note_invocation",
+    "register",
+    "registry_enabled",
+    "reset_for_tests",
+    "snapshot",
+]
+
+
+def registry_enabled() -> bool:
+    """``JARVIS_DYNAMIC_DISPATCH_REGISTRY_ENABLED`` (default true).
+
+    Default-ON because the cost is two dict writes and the alternative is an
+    auditor that keeps calling live pub/sub handlers dead. OFF makes every
+    lookup return ``UNSEEN``, which is the pre-registry behaviour exactly.
+    """
+    try:
+        return os.environ.get(
+            "JARVIS_DYNAMIC_DISPATCH_REGISTRY_ENABLED", "1",
+        ).strip().lower() not in ("0", "false", "no", "off", "")
+    except Exception:  # noqa: BLE001
+        return True
+
+
+def _max_modules() -> int:
+    try:
+        return max(16, min(100000, int(os.environ.get(
+            "JARVIS_DYNAMIC_DISPATCH_MAX_MODULES", "4096") or 4096)))
+    except (TypeError, ValueError):
+        return 4096
+
+
+@dataclass
+class DispatchRecord:
+    """One module's dynamic-reachability facts."""
+
+    module: str
+    registered_at: float = 0.0
+    registrations: int = 0
+    invocations: int = 0
+    last_invoked_at: float = 0.0
+    channels: Tuple[str, ...] = ()
+
+    @property
+    def verdict(self) -> str:
+        if self.invocations > 0:
+            return FIRING_DYNAMICALLY
+        if self.registrations > 0:
+            return REGISTERED_NEVER_INVOKED
+        return UNSEEN
+
+
+_records: Dict[str, DispatchRecord] = {}
+_lock = threading.RLock()
+_dropped = 0
+
+
+def reset_for_tests() -> None:
+    """Clear every breadcrumb. Test-only."""
+    global _records, _dropped  # noqa: PLW0603
+    with _lock:
+        _records = {}
+        _dropped = 0
+
+
+def _normalise(module: Any) -> str:
+    """A stable module key. NEVER raises.
+
+    Accepts a module object, a dotted path, or a bare name, and reduces to
+    the basename — which is what `capability_liveness` reports in
+    ``source_file``. Keying on anything else means the intersection silently
+    matches nothing, which would look exactly like "no dynamic evidence".
+    """
+    try:
+        name = getattr(module, "__name__", None) or str(module or "")
+        name = name.strip().replace("\\", "/")
+        # Directories FIRST, then the extension, then a dotted package path.
+        # Doing the extension first and splitting only on "." left
+        # "governance/repair_engine.py" as "governance/repair_engine" — a key
+        # that matches nothing, which is indistinguishable from "no dynamic
+        # evidence" and would quietly re-report a live module as dead.
+        name = name.rsplit("/", 1)[-1]
+        if name.endswith(".py"):
+            name = name[:-3]
+        return name.rsplit(".", 1)[-1] if "." in name else name
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def register(module: Any, *, channel: str = "") -> None:
+    """Record "reachable by dispatch". NEVER raises.
+
+    Called at subscribe/plugin-load time. This does NOT assert the module
+    ran — see :func:`note_invocation`.
+    """
+    global _dropped  # noqa: PLW0603
+    if not registry_enabled():
+        return
+    try:
+        key = _normalise(module)
+        if not key:
+            return
+        with _lock:
+            rec = _records.get(key)
+            if rec is None:
+                if len(_records) >= _max_modules():
+                    _dropped += 1
+                    return
+                rec = DispatchRecord(module=key, registered_at=time.time())
+                _records[key] = rec
+            rec.registrations += 1
+            if channel and channel not in rec.channels:
+                rec.channels = rec.channels + (str(channel),)
+    except Exception:  # noqa: BLE001
+        logger.debug("[DynamicDispatch] register degraded", exc_info=True)
+
+
+def note_invocation(module: Any, *, channel: str = "") -> None:
+    """Record "actually ran". NEVER raises.
+
+    The ONLY thing that earns ``FIRING_DYNAMICALLY``.
+    """
+    global _dropped  # noqa: PLW0603
+    if not registry_enabled():
+        return
+    try:
+        key = _normalise(module)
+        if not key:
+            return
+        now = time.time()
+        with _lock:
+            rec = _records.get(key)
+            if rec is None:
+                if len(_records) >= _max_modules():
+                    _dropped += 1
+                    return
+                rec = DispatchRecord(module=key, registered_at=now)
+                _records[key] = rec
+            rec.invocations += 1
+            rec.last_invoked_at = now
+            if channel and channel not in rec.channels:
+                rec.channels = rec.channels + (str(channel),)
+    except Exception:  # noqa: BLE001
+        logger.debug("[DynamicDispatch] invocation degraded", exc_info=True)
+
+
+def dynamic_verdict(module: Any) -> str:
+    """``FIRING_DYNAMICALLY`` / ``REGISTERED_NEVER_INVOKED`` / ``UNSEEN``.
+
+    Pure lookup. NEVER raises. ``UNSEEN`` when the registry is off, so a
+    disabled registry cannot silently vouch for anything.
+    """
+    if not registry_enabled():
+        return UNSEEN
+    try:
+        key = _normalise(module)
+        with _lock:
+            rec = _records.get(key)
+        return rec.verdict if rec is not None else UNSEEN
+    except Exception:  # noqa: BLE001
+        return UNSEEN
+
+
+def snapshot() -> Dict[str, Any]:
+    """Bounded projection for observability surfaces. NEVER raises."""
+    try:
+        with _lock:
+            rows = [
+                {"module": r.module, "verdict": r.verdict,
+                 "registrations": r.registrations,
+                 "invocations": r.invocations,
+                 "channels": list(r.channels)}
+                for r in _records.values()
+            ]
+            dropped = _dropped
+        rows.sort(key=lambda r: (r["verdict"], r["module"]))
+        return {
+            "schema_version": DYNAMIC_DISPATCH_SCHEMA_VERSION,
+            "enabled": registry_enabled(),
+            "tracked": len(rows),
+            "dropped": dropped,
+            "firing": sum(1 for r in rows if r["verdict"] == FIRING_DYNAMICALLY),
+            "registered_never_invoked": sum(
+                1 for r in rows if r["verdict"] == REGISTERED_NEVER_INVOKED),
+            "rows": rows[:200],
+        }
+    except Exception:  # noqa: BLE001
+        return {"schema_version": DYNAMIC_DISPATCH_SCHEMA_VERSION,
+                "enabled": False, "tracked": 0, "rows": []}
+
+
+def dynamically_dispatched(
+    fn: Optional[Callable] = None, *, channel: str = "",
+) -> Callable:
+    """Mark a handler as dispatch-reached, and record when it FIRES.
+
+    Registers at decoration time (import) and notes an invocation on every
+    call, so one decorator produces both facts and they cannot drift apart.
+    Wrapping is transparent for sync and async handlers alike; a breadcrumb
+    that changed a handler's contract would not survive contact with the
+    codebase.
+
+    Usage::
+
+        @dynamically_dispatched(channel="fs.changed")
+        async def _on_fs_event(event): ...
+    """
+    def _decorate(func: Callable) -> Callable:
+        module = getattr(func, "__module__", "") or ""
+        register(module, channel=channel)
+
+        try:
+            import asyncio
+            is_async = asyncio.iscoroutinefunction(func)
+        except Exception:  # noqa: BLE001
+            is_async = False
+
+        if is_async:
+            @functools.wraps(func)
+            async def _async_wrapper(*args: Any, **kwargs: Any) -> Any:
+                note_invocation(module, channel=channel)
+                return await func(*args, **kwargs)
+            return _async_wrapper
+
+        @functools.wraps(func)
+        def _sync_wrapper(*args: Any, **kwargs: Any) -> Any:
+            note_invocation(module, channel=channel)
+            return func(*args, **kwargs)
+        return _sync_wrapper
+
+    if fn is not None:          # bare @dynamically_dispatched
+        return _decorate(fn)
+    return _decorate            # @dynamically_dispatched(channel=...)

--- a/backend/core/ouroboros/governance/intake/sensors/liveness_sensor.py
+++ b/backend/core/ouroboros/governance/intake/sensors/liveness_sensor.py
@@ -71,6 +71,7 @@ __all__ = [
     "LivenessSensor",
     "critical_categories",
     "sensor_enabled",
+    "effective_firing",
     "severity_for",
 ]
 
@@ -202,18 +203,60 @@ class LivenessFinding:
         return (0 if self.severity == "high" else 1, -self.fraction_severed)
 
 
-def severity_for(category: str, firing: str, fraction: float) -> str:
-    """``high`` / ``low``. Pure. NEVER raises.
+def effective_firing(source_file: str, firing: str) -> str:
+    """AST/telemetry firing state, corrected by the dynamic registry.
+
+    Static reachability cannot see a pub/sub handler, an ``importlib`` load,
+    or a ``getattr`` route, so a live capability reads as dead.
+    `dynamic_dispatch_registry` records what actually happened at those
+    seams, and this is where the two are intersected.
+
+    Only INVOCATION clears a finding. A module that merely REGISTERED asked
+    to be called and may never have been — reporting that as alive would let
+    the audit confidently clear the exact failure it exists to catch, so it
+    is surfaced under its own name instead. ``REGISTERED_NEVER_INVOKED`` is
+    a sharper verdict than ``SILENT``, not a softer one: it rules out the
+    innocent explanation that nothing ever tried.
+    """
+    try:
+        from backend.core.ouroboros.governance.dynamic_dispatch_registry import (
+            FIRING_DYNAMICALLY, REGISTERED_NEVER_INVOKED, dynamic_verdict,
+        )
+        verdict = dynamic_verdict(source_file)
+        if verdict == FIRING_DYNAMICALLY:
+            return FIRING_DYNAMICALLY
+        if verdict == REGISTERED_NEVER_INVOKED:
+            return REGISTERED_NEVER_INVOKED
+    except Exception:  # noqa: BLE001 — registry absent -> static verdict stands
+        pass
+    return str(firing or "UNKNOWN")
+
+
+def severity_for(category: str, firing: str, fraction: float,
+                 source_file: str = "") -> str:
+    """``high`` / ``low``. NEVER raises.
 
     HIGH requires BOTH a critical category AND telemetry that has never
     fired. Either alone is weaker evidence than it looks: a safety capability
     with FIRING telemetry is alive whatever the AST says, and a SILENT
     experimental helper is not worth waking anyone for.
+
+    ``FIRING_DYNAMICALLY`` demotes to low — the module demonstrably ran, and
+    a static index that could not see the edge is the index's limitation, not
+    the module's fault. ``REGISTERED_NEVER_INVOKED`` stays eligible for high:
+    it is evidence OF severance, not against it.
     """
     try:
+        from backend.core.ouroboros.governance.dynamic_dispatch_registry import (
+            FIRING_DYNAMICALLY,
+        )
+        resolved = effective_firing(source_file, firing) if source_file else (
+            str(firing or ""))
+        if resolved == FIRING_DYNAMICALLY:
+            return "low"
         crit = str(category or "").strip().lower() in critical_categories()
-        silent = str(firing or "").strip().upper() == "SILENT"
-        if crit and silent and float(fraction or 0.0) >= _severed_floor():
+        dead = resolved.strip().upper() in ("SILENT", "REGISTERED_NEVER_INVOKED")
+        if crit and dead and float(fraction or 0.0) >= _severed_floor():
             return "high"
         return "low"
     except Exception:  # noqa: BLE001
@@ -300,20 +343,32 @@ class LivenessSensor:
         counts: Dict[str, int] = {}
         for row in candidates:
             try:
-                firing = str(row.get("firing") or "UNKNOWN")
+                source_file = str(row.get("source_file") or "?").split("/")[-1]
+                # Correct the STATIC verdict with runtime evidence before
+                # anything downstream counts or ranks it — otherwise the
+                # health projection reports a severance the sensor has
+                # already decided is a false positive.
+                firing = effective_firing(
+                    source_file, str(row.get("firing") or "UNKNOWN"))
                 counts[firing] = counts.get(firing, 0) + 1
                 fraction = float(row.get("fraction_severed") or 0.0)
                 if fraction < floor:
                     continue
                 category = str(row.get("category") or "")
+                severity = severity_for(category, firing, fraction, source_file)
+                if firing == "FIRING_DYNAMICALLY":
+                    # Demonstrably ran. Reporting it would train the operator
+                    # to ignore this sensor, which costs more than the finding
+                    # is worth.
+                    continue
                 out.append(LivenessFinding(
-                    source_file=str(row.get("source_file") or "?").split("/")[-1],
+                    source_file=source_file,
                     category=category,
                     flag=str(row.get("flag") or ""),
                     firing=firing,
                     fraction_severed=fraction,
                     severed_symbols=tuple(row.get("severed_symbols") or ()),
-                    severity=severity_for(category, firing, fraction),
+                    severity=severity,
                 ))
             except Exception:  # noqa: BLE001
                 continue

--- a/backend/core/trinity_event_bus.py
+++ b/backend/core/trinity_event_bus.py
@@ -1115,6 +1115,25 @@ class TrinityEventBus:
         Returns:
             Subscription ID
         """
+        # Dynamic-dispatch breadcrumb, on the EXISTING subscribe seam rather
+        # than a parallel tracker. A pub/sub handler leaves no static call
+        # edge, so `capability_liveness` reads it as unreachable — its own
+        # verdict text says "may be dynamically dispatched". This is where
+        # that ambiguity is resolved, at the one place every subscription
+        # passes through.
+        #
+        # This records REGISTRATION only. Subscribing proves the handler
+        # asked to be called, never that it was — and treating those as the
+        # same fact would clear the exact bug the audit hunts. Invocation is
+        # recorded at delivery; see `_deliver_event`.
+        try:
+            from backend.core.ouroboros.governance.dynamic_dispatch_registry import (
+                register as _dd_register,
+            )
+            _dd_register(getattr(handler, "__module__", ""), channel=pattern)
+        except Exception:  # noqa: BLE001 — a breadcrumb must never break a subscribe
+            pass
+
         sub = Subscription(
             pattern=pattern,
             handler=handler,
@@ -1365,6 +1384,20 @@ class TrinityEventBus:
         event: TrinityEvent,
     ) -> None:
         """Execute a subscription handler."""
+        # Invocation breadcrumb — the fact that EARNS `FIRING_DYNAMICALLY`.
+        # Recorded here and not at subscribe time because those are different
+        # claims: a handler that subscribed at boot and never fired is still
+        # severed, and that is precisely the case the liveness audit exists
+        # to surface.
+        try:
+            from backend.core.ouroboros.governance.dynamic_dispatch_registry import (
+                note_invocation as _dd_invoked,
+            )
+            _dd_invoked(getattr(sub.handler, "__module__", ""),
+                        channel=getattr(event, "topic", ""))
+        except Exception:  # noqa: BLE001 — never fail a delivery for telemetry
+            pass
+
         try:
             await asyncio.wait_for(
                 sub.handler(event),

--- a/tests/governance/test_dynamic_dispatch_registry.py
+++ b/tests/governance/test_dynamic_dispatch_registry.py
@@ -1,0 +1,243 @@
+"""AST cannot see dispatch — and REGISTERED is not FIRING.
+
+`capability_liveness` under-reports by construction: a pub/sub handler, an
+`importlib` load and a `getattr` route leave no static edge, so a live
+capability reads as dead. Its own verdict text admits it ("may be dynamically
+dispatched — a review candidate, not proven dead"). This registry is the
+other half of that sentence.
+
+The load-bearing test is `test_registration_alone_does_NOT_clear_a_finding`.
+The tempting design treats anything in the registry as alive — but
+subscribing proves a handler ASKED to be called, never that it WAS. A handler
+that registers at boot and never fires is exactly the failure being hunted,
+and "registered ⇒ alive" would let the audit confidently clear the one case
+it exists to catch.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance import dynamic_dispatch_registry as ddr
+from backend.core.ouroboros.governance.dynamic_dispatch_registry import (
+    FIRING_DYNAMICALLY,
+    REGISTERED_NEVER_INVOKED,
+    UNSEEN,
+    dynamic_verdict,
+    dynamically_dispatched,
+    note_invocation,
+    register,
+    snapshot,
+)
+from backend.core.ouroboros.governance.intake.sensors.liveness_sensor import (
+    LivenessFinding,
+    LivenessSensor,
+    effective_firing,
+    severity_for,
+)
+
+
+class _Router:
+    def __init__(self):
+        self.seen = []
+
+    async def ingest(self, envelope):
+        self.seen.append(envelope)
+        return "enqueued"
+
+
+@pytest.fixture(autouse=True)
+def _clean(monkeypatch):
+    monkeypatch.setenv("JARVIS_LIVENESS_SENSOR_ENABLED", "1")
+    monkeypatch.delenv("JARVIS_DYNAMIC_DISPATCH_REGISTRY_ENABLED", raising=False)
+    ddr.reset_for_tests()
+    yield
+    ddr.reset_for_tests()
+
+
+ISOLATED = "phantom_handler_module"
+
+
+def _severed_row(**kw):
+    """A capability AST says is 100% unreachable."""
+    row = {
+        "source_file": f"governance/{ISOLATED}.py",
+        "category": "safety",
+        "flag": "JARVIS_PHANTOM_ENABLED",
+        "firing": "SILENT",
+        "fraction_severed": 1.0,
+        "severed_symbols": ["handle_event", "on_signal"],
+    }
+    row.update(kw)
+    return row
+
+
+def _stub(sensor, rows):
+    async def _collect():
+        from backend.core.ouroboros.governance.intake.sensors import (
+            liveness_sensor as ls,
+        )
+        out = []
+        for r in rows:
+            sf = r["source_file"].split("/")[-1]
+            firing = ls.effective_firing(sf, r["firing"])
+            if firing == FIRING_DYNAMICALLY:
+                continue
+            out.append(LivenessFinding(
+                source_file=sf, category=r["category"], flag=r["flag"],
+                firing=firing, fraction_severed=r["fraction_severed"],
+                severed_symbols=tuple(r["severed_symbols"]),
+                severity=ls.severity_for(r["category"], firing,
+                                         r["fraction_severed"], sf)))
+        out.sort(key=lambda f: f.rank)
+        return out
+    sensor.collect_findings = _collect
+    return sensor
+
+
+# ---------------------------------------------------------------------------
+# The mandate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_an_isolated_module_is_flagged_dead_before_the_breadcrumb():
+    """Baseline: zero static edges -> high-severity severance."""
+    router = _Router()
+    sensor = _stub(LivenessSensor("repo", router), [_severed_row()])
+    found = await sensor.scan_once()
+    assert len(found) == 1
+    assert found[0].severity == "high"
+    assert found[0].firing == "SILENT"
+    assert len(router.seen) == 1, "a fully severed safety module did not emit"
+
+
+@pytest.mark.asyncio
+async def test_the_breadcrumb_reclassifies_it_and_prevents_a_false_positive():
+    """THE mandate case: register + INVOKE, and the alert must disappear."""
+    register(f"{ISOLATED}.py", channel="fs.changed")
+    note_invocation(f"{ISOLATED}.py", channel="fs.changed")
+
+    assert dynamic_verdict(f"{ISOLATED}.py") == FIRING_DYNAMICALLY
+    assert effective_firing(f"{ISOLATED}.py", "SILENT") == FIRING_DYNAMICALLY
+
+    router = _Router()
+    sensor = _stub(LivenessSensor("repo", router), [_severed_row()])
+    found = await sensor.scan_once()
+
+    assert found == [], "a demonstrably-running module was still reported dead"
+    assert router.seen == [], "false-positive dead-code alert was emitted"
+
+
+@pytest.mark.asyncio
+async def test_registration_alone_does_NOT_clear_a_finding():
+    """The load-bearing refusal.
+
+    Subscribing proves the handler asked to be called, never that it was.
+    "Registered ⇒ alive" would flip the exact bug being hunted from
+    "investigate" to "ignore".
+    """
+    register(f"{ISOLATED}.py", channel="fs.changed")   # no invocation
+    assert dynamic_verdict(f"{ISOLATED}.py") == REGISTERED_NEVER_INVOKED
+
+    router = _Router()
+    sensor = _stub(LivenessSensor("repo", router), [_severed_row()])
+    found = await sensor.scan_once()
+
+    assert len(found) == 1, "registration silently cleared a severed module"
+    assert found[0].firing == REGISTERED_NEVER_INVOKED
+    assert found[0].severity == "high", (
+        "registered-but-never-invoked is evidence OF severance, not against it")
+
+
+# ---------------------------------------------------------------------------
+# The registry
+# ---------------------------------------------------------------------------
+
+
+def test_unseen_when_nothing_was_recorded():
+    assert dynamic_verdict("never_heard_of_it") == UNSEEN
+
+
+def test_a_disabled_registry_vouches_for_nothing(monkeypatch):
+    note_invocation("m.py")
+    monkeypatch.setenv("JARVIS_DYNAMIC_DISPATCH_REGISTRY_ENABLED", "0")
+    assert dynamic_verdict("m.py") == UNSEEN
+    assert effective_firing("m.py", "SILENT") == "SILENT"
+
+
+def test_module_keys_normalise_to_the_basename_liveness_reports():
+    """Keying on anything else makes the intersection match nothing, which
+    looks identical to "no dynamic evidence"."""
+    note_invocation("backend.core.ouroboros.governance.repair_engine")
+    assert dynamic_verdict("repair_engine") == FIRING_DYNAMICALLY
+    assert dynamic_verdict("governance/repair_engine.py") == FIRING_DYNAMICALLY
+
+
+def test_registry_is_bounded(monkeypatch):
+    monkeypatch.setenv("JARVIS_DYNAMIC_DISPATCH_MAX_MODULES", "16")
+    ddr.reset_for_tests()
+    for i in range(200):
+        register(f"m{i}.py")
+    snap = snapshot()
+    assert snap["tracked"] <= 16
+    assert snap["dropped"] > 0
+
+
+def test_breadcrumbs_never_raise_on_junk():
+    for bad in (None, "", 123, object()):
+        register(bad)
+        note_invocation(bad)
+        assert isinstance(dynamic_verdict(bad), str)
+
+
+@pytest.mark.asyncio
+async def test_the_decorator_records_both_facts():
+    calls = []
+
+    @dynamically_dispatched(channel="test.topic")
+    async def _handler(evt):
+        calls.append(evt)
+        return "ok"
+
+    # Decoration alone is registration, not invocation.
+    assert dynamic_verdict(_handler.__module__) == REGISTERED_NEVER_INVOKED
+    assert await _handler("e") == "ok"
+    assert calls == ["e"]
+    assert dynamic_verdict(_handler.__module__) == FIRING_DYNAMICALLY
+
+
+def test_the_decorator_is_transparent_for_sync_handlers():
+    @dynamically_dispatched
+    def _sync(a, b=2):
+        return a + b
+
+    assert _sync(1) == 3
+    assert _sync.__name__ == "_sync"
+
+
+# ---------------------------------------------------------------------------
+# Wiring — the EXISTING seams, not a parallel tracker
+# ---------------------------------------------------------------------------
+
+
+def test_the_event_bus_records_registration_and_invocation_separately():
+    """DRY: attached to TrinityEventBus's own subscribe/deliver seams.
+
+    They must be DIFFERENT seams — recording invocation at subscribe time
+    would make every subscriber look alive forever.
+    """
+    from pathlib import Path
+    src = (Path(__file__).resolve().parents[2]
+           / "backend/core/trinity_event_bus.py").read_text(encoding="utf-8")
+    assert "dynamic_dispatch_registry" in src
+    assert "register as _dd_register" in src
+    assert "note_invocation as _dd_invoked" in src
+    # Registration in subscribe, invocation in delivery — not the same place.
+    assert src.index("register as _dd_register") < src.index(
+        "note_invocation as _dd_invoked")
+
+
+def test_severity_demotes_only_on_real_invocation():
+    assert severity_for("safety", "SILENT", 1.0, "ghost.py") == "high"
+    note_invocation("ghost.py")
+    assert severity_for("safety", "SILENT", 1.0, "ghost.py") == "low"


### PR DESCRIPTION
## The `repair_engine` verdict: NOT severed — and the audit was wrong about *why*

The auditor's own data settles it:

- `public_symbols`: `from_env`, `current_iteration`, `max_iterations_live`, `is_running`, **`run`**
- `severed_symbols`: `current_iteration`, `max_iterations_live` — **two unused progress accessors**

`run` — the L2 entry point — is called at `orchestrator.py:13014`:

```python
l2_result = await self._config.repair_engine.run(ctx, best_validation, deadline)
```

**A perfectly static call.** Invisible only because the caller index keys on bare symbol names and this routes through an injected dependency. So the 40% was a false positive from an **attribute-routed static call, not dynamic dispatch** — and a runtime breadcrumb would have "fixed" that reading while leaving the index just as blind for every other injected dependency in the tree. Recorded in the module docstring so the distinction survives.

What **is** real: `firing=SILENT`. L2 is wired and its telemetry has never emitted — an observability gap, not a severance.

## REGISTERED is not FIRING

The obvious registry records a breadcrumb at subscribe/load time and treats anything present as alive. **That is worse than no registry.**

Subscribing proves a handler was imported and *asked* to be called. It proves nothing about whether it ever was — and a handler that registers at boot and never fires is exactly the failure being hunted. Under "registered ⇒ alive" it flips from `SILENT, investigate` to `dynamically dispatched, ignore`: the audit confidently clearing the one case it exists to catch.

So two facts, tracked separately:

| call | claim | verdict |
|---|---|---|
| `register()` | "reachable by dispatch" | `REGISTERED_NEVER_INVOKED` |
| `note_invocation()` | "actually ran" | `FIRING_DYNAMICALLY` |

Only the second clears a finding. The first stays eligible for **HIGH** severity — it is evidence *of* severance, not against it, and rules out the innocent explanation that nothing ever tried.

## DRY — existing seams, two different points

`TrinityEventBus.subscribe` records registration; `_deliver_event` records invocation. **Deliberately different sites** — recording invocation at subscribe time would make every subscriber look alive forever. No parallel pub/sub tracker. Both try/except-wrapped so a breadcrumb can never fail a subscribe or a delivery.

The sensor intersects *before* anything counts or ranks, so the health projection can't report a severance already ruled a false positive. `FIRING_DYNAMICALLY` findings are dropped entirely — reporting a module that demonstrably ran trains the operator to ignore the sensor.

## A normalisation bug worth naming

`_normalise` stripped `.py` then split only on `.`, leaving `governance/repair_engine.py` as `governance/repair_engine` — a key matching nothing. Since `capability_liveness` reports `source_file` as a **path**, every intersection would have silently missed, and a total miss is indistinguishable from "no dynamic evidence." Caught by the test that pins the key space rather than the behaviour.

## Bounds

Two dict writes under a lock, no I/O, capped by `JARVIS_DYNAMIC_DISPATCH_MAX_MODULES`. Default-ON because the cost is negligible and the alternative is an auditor that keeps calling live pub/sub handlers dead. OFF returns `UNSEEN` everywhere — **a disabled registry vouches for nothing.**

## Verification

12 new tests including the mandate case: an isolated module AST-flagged 100% severed emits a high-severity finding, is reclassified and silenced after `register`+`invoke`, and is **not** silenced by registration alone.

46 green across the new governance suites; 20 green on the instrumented event bus.

## Not yet proven

The registry only helps modules that actually run during a session, so its value is unproven until a real soak populates it. I'd want one armed run showing a non-empty `dynamic_dispatch.snapshot()` before treating hybrid verdicts as trustworthy enough to gate a global ON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Hybrid Liveness to combine static analysis with runtime breadcrumbs so we stop flagging live, dispatch-reached modules as dead. Registered-but-never-invoked handlers are now surfaced explicitly and can still be high severity.

- **New Features**
  - Added `backend/core/ouroboros/governance/dynamic_dispatch_registry.py` to track per-module registration and invocation with verdicts `FIRING_DYNAMICALLY`, `REGISTERED_NEVER_INVOKED`, and `UNSEEN`. Bounded by `JARVIS_DYNAMIC_DISPATCH_MAX_MODULES` and default-on via `JARVIS_DYNAMIC_DISPATCH_REGISTRY_ENABLED`.
  - Instrumented `TrinityEventBus.subscribe` and handler execution to record registration and invocation separately. Added `@dynamically_dispatched` decorator (sync/async) to auto-register and note calls.
  - Updated `backend/core/ouroboros/governance/intake/sensors/liveness_sensor.py` with `effective_firing` to intersect AST data with runtime verdicts. Findings that are `FIRING_DYNAMICALLY` are demoted and dropped from alerts. A disabled registry returns `UNSEEN` and never vouches for liveness.

- **Bug Fixes**
  - Fixed module key normalization to use the basename before stripping `.py`, so `source_file` paths match the registry.
  - Severity rules tightened: `REGISTERED_NEVER_INVOKED` remains eligible for `high`; only `FIRING_DYNAMICALLY` demotes to `low`.

<sup>Written for commit 8dc7725c04c930fe021f7b9a51a3b5a8bc864db8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

