### PR TITLE
fix(palette): the cascade ranked sources and never judged results

### DIFF
--- a/backend/core/ouroboros/battle_test/repl_completion.py
+++ b/backend/core/ouroboros/battle_test/repl_completion.py
@@ -1775,9 +1775,30 @@ __all__ = [
 _MAINTAINER_NOISE = (
     r"NEVER\s+raises?\.?",
     r"Never\s+raises?\.?",
-    r"Parse\s+(a\s+)?``?/?[\w.\- ]+``?\s+line(\s*\+?\s*and\s+dispatch)?\.?",
-    r"Parse\s+(a\s+)?``?/?[\w.\- ]+``?\s+line\s*\+\s*dispatch\.?",
-    r"``?matched=(True|False)``?\.?",
+    # ``(?:``)?`` — an OPTIONAL PAIR of backticks.
+    #
+    # These read ```` ``? ```` for months, which is not "optional double
+    # backtick": it is one REQUIRED backtick followed by an optional one. The
+    # patterns therefore only ever matched text that still carried markup —
+    # and markup was unwrapped two lines later, so by the time anything looked
+    # at these strings the backticks were gone from some and present in
+    # others. In practice the pattern never fired at all.
+    #
+    # It is the highest-value line in the tuple: ``Parse a ``/cost`` REPL line
+    # and return the rendered result`` is the single most common docstring
+    # template in the dispatch packages. With the pattern dead, only the bare
+    # opener "Parse" came off downstream, and the palette rendered the
+    # leftovers — "REPL line and return the rendered result", "Line and render
+    # the dashboard" — as though they were descriptions.
+    #
+    # A quantifier that binds to one character of a two-character token is
+    # invisible on inspection and silent at runtime; the only symptom is a
+    # rule that appears to be enforced and is not. Markup is now unwrapped
+    # BEFORE this tuple runs, so the backticks are redundant — they are kept,
+    # correctly grouped, so the patterns still hold if that order changes.
+    r"Parse\s+(a\s+)?(?:``)?/?[\w.\- ]+(?:``)?\s+line(\s*\+?\s*and\s+dispatch)?\.?",
+    r"Parse\s+(a\s+)?(?:``)?/?[\w.\- ]+(?:``)?\s+line\s*\+\s*dispatch\.?",
+    r"(?:``)?matched=(True|False)(?:``)?\.?",
     r"auto-discovered\.?",
     r"canonical\s+entry\s+point\.?",
     r"operator\s+surface\.?",
@@ -1797,54 +1818,77 @@ _PROVENANCE = (
 )
 
 
-def _humanise(line: str) -> str:
+def _humanise(line: str, verb: str = "") -> str:
     """One docstring line -> operator prose, or "" if nothing survives.
 
     Docstrings are written for whoever maintains the function. Their first
     line is usually a contract ("NEVER raises") or a restatement of the
-    plumbing ("Parse ``/canvas`` line and dispatch") — both true, both useless
+    plumbing ("Parse ``/canvas`` line and dispatch") -- both true, both useless
     in a menu that is supposed to answer "what does this do for me?".
 
-    Rules, not exceptions: strip RST markup, drop maintainer boilerplate and
-    provenance markers, then judge what remains. Returning "" is a real answer
-    and lets the caller fall through to the module docstring, which for these
-    single-purpose ``*_repl.py`` files is usually the sentence we wanted."""
+    Two changes of substance from the version that shipped for months:
+
+    **Markup is unwrapped BEFORE the noise patterns run.** They were running
+    first, and every one of them matches on WORDS -- so ``Parse a ``/cost``
+    REPL line`` never matched the ``Parse ... line`` pattern that exists to
+    delete it, because backticks sat where the pattern expected a word. Only
+    the bare opener "Parse" came off later, and what reached the palette was
+    **"REPL line and return the rendered result"**: not a description, and
+    fluent enough that an operator would act on it.
+
+    **Acceptance is delegated to `verb_description.assess`.** The gauntlet
+    that used to live here -- a 12-character floor, a four-WORD floor, a
+    fragment-head list, a dangling-tail list -- was a second, weaker copy of
+    the judgement `is_contentless` already owned, and the copies disagreed.
+    The four-word floor was the expensive one: it discarded "Op fan-out tree",
+    "Capability flag star-map" and "Proactive anticipation surface" -- three
+    real descriptions, sitting in the source, thrown away for being short. The
+    palette showed mined subcommand lists in their place, and
+    `verb_description`'s own module docstring then concluded from that display
+    that those verbs had "NO PROSE AT ALL". They had prose. This function was
+    eating it.
+
+    A description's quality is not its length. What remains here is pure
+    subtraction; judging happens in exactly one place."""
     text = str(line or "").strip()
     if not text:
         return ""
+    # Markup FIRST -- see above. Every pattern below matches words.
+    text = text.replace("``", "").replace("`", "")
     for pattern in _MAINTAINER_NOISE + _PROVENANCE:
         text = re.sub(pattern, " ", text, flags=re.IGNORECASE)
-    text = text.replace("``", "").replace("`", "")
     text = re.sub(r"\s+", " ", text)
-    text = text.strip(" .,;:—-\u2014")
-    # A fragment that is only punctuation, a bare verb echo, or two words of
-    # residue is worse than falling through — it looks like a description and
-    # carries none.
-    if len(text) < 12:
+    text = text.strip(" .,;:\u2014-")
+    if not text:
         return ""
-    low = text.lower().lstrip("/")
-    # Reject a line that only ECHOES the verb. "/anticipate REPL" and
-    # "/causal REPL dispatcher" are what survives stripping a docstring that
-    # never described anything, and a menu entry reading "<verb> REPL" beside
-    # the verb is worse than a blank: it looks like help and answers nothing.
-    if re.fullmatch(r"[\w\-]+(\s+(repl|verb|dispatcher|surface|command))+", low):
+    text = text[0].upper() + text[1:]
+    # NORMALISE, THEN judge -- in that order, and the order is load-bearing.
+    #
+    # Judging first rejected candidates for faults the normaliser exists to
+    # remove. /enqueue_soak's module docstring opens
+    # "``/enqueue_soak <target_path>`` — stage a crash-immortal Swarm soak":
+    # assessed raw it begins with a slash, scores RESIDUE and is discarded, so
+    # the verb fell through to its function docstring and the palette read
+    # "Async — walks the target off the event loop". The sentence was there.
+    # It was being thrown away for wearing a usage lede that the very next
+    # step would have taken off.
+    text = _operator_voice(text, verb)
+    if not text:
         return ""
-    # Reject sentence fragments — residue from a stripped clause, not prose.
-    if low.split()[0] in ("and", "or", "but", "with", "then", "returns",
-                          "short-circuit", "lets"):
-        return ""
-    if not re.search(r"[a-z]{3,}\s+[a-z]{3,}", low):
-        return ""
-    words = low.split()
-    # A clause that was cut mid-thought. "Canonical entry point — by" is what a
-    # stripped provenance marker leaves behind, and it reads as a description
-    # right up until you try to use it.
-    if len(words) < 4 or words[-1] in (
-        "by", "for", "with", "and", "or", "the", "a", "an", "to", "of", "in",
-        "on", "from", "when", "that", "is", "are",
-    ):
-        return ""
-    return text[0].upper() + text[1:]
+    try:
+        from backend.core.ouroboros.battle_test.verb_description import (
+            Shape, assess,
+        )
+        # RESIDUE and EMPTY only. IMPLEMENTATION deliberately SURVIVES: it is
+        # a poor candidate, not an invalid one, and the arbiter has to be able
+        # to weigh it against an even poorer alternative. Rejecting it here
+        # would reinstate the boolean acceptance this cascade just stopped
+        # doing.
+        if assess(text, verb).shape in (Shape.EMPTY, Shape.RESIDUE):
+            return ""
+    except Exception:  # noqa: BLE001
+        pass
+    return text
 
 
 def _help_bound(text: str) -> str:
@@ -1892,16 +1936,43 @@ def describe_dispatcher(fn: object) -> str:
 def _describe(fn: object) -> str:
     """One line of operator-facing help for a dispatcher. NEVER raises.
 
-    Cascade, because no single source is reliably operator-facing:
+    An ARBITRATION, not a cascade. Every source nominates a candidate, each
+    candidate is classified and scored by `verb_description.assess`, and the
+    best one wins.
 
-      1. the function's docstring, HUMANISED — nearest the behaviour, so it is
-         the line most likely to be corrected when behaviour changes;
-      2. its MODULE's docstring, humanised — these verbs live in
-         single-purpose ``*_repl.py`` files whose header describes the feature
-         rather than the function;
-      3. an honest placeholder. Never a blank, and never maintainer jargon
-         dressed up as help."""
-    def _first_line(doc: object) -> str:
+    The distinction is the whole fix. What stood here before was a ladder of
+    ``if source: return source`` -- so each rung asked only "did I get a
+    non-empty string?", which is a test of PRESENCE and not of quality. Three
+    consequences, all of them live on the operator's screen:
+
+      * rank was ABSOLUTE, so residue from a high rung beat prose from a low
+        one and no better candidate could ever supersede a worse one that
+        merely arrived first;
+      * ``/multi_prior`` showed "Er for /multi_prior REPL verb" -- non-empty,
+        therefore accepted, and not a word;
+      * the module docstring was banned OUTRIGHT because it so often carries
+        provenance ("§38.11-F operator surface"). ``/provider`` therefore read
+        "[undocumented]" while the sentence "operator-facing DoubleWord
+        resilience dashboard" sat one scope up, unread.
+
+    That last one is the shape of the whole class: a source was excluded by
+    POLICY because nothing could judge its output. With judgement in place the
+    policy is unnecessary -- a provenance-heavy module docstring now scores as
+    RESIDUE and loses on its merits, and a good one wins on its merits.
+
+    Source rank survives as a PRIOR rather than a decision: an ``Operator:``
+    line was written for the person typing the verb, so it starts ahead. It
+    can still be beaten, which is the point.
+
+    Authored ``__verb_help__`` is the one exception and short-circuits. A
+    maintainer who names a verb's description explicitly is not offering a
+    candidate for scoring; the score would be second-guessing the only source
+    that is unambiguously addressed to an operator."""
+    from backend.core.ouroboros.battle_test.verb_description import (
+        Candidate, Shape, best_candidate, shape_ceiling,
+    )
+
+    def _first_line(doc: object, verb: str) -> str:
         text = doc if isinstance(doc, str) else ""
         text = text.strip()
         if not text:
@@ -1909,7 +1980,7 @@ def _describe(fn: object) -> str:
         # Prefer the first line, but a docstring that opens with a bare
         # ``/verb`` heading keeps its meaning on the NEXT line.
         for raw in text.splitlines()[:3]:
-            human = _humanise(raw)
+            human = _humanise(raw, verb)
             if human:
                 return human
         return ""
@@ -1918,94 +1989,108 @@ def _describe(fn: object) -> str:
         import sys as _sys
         mod = _sys.modules.get(getattr(fn, "__module__", "") or "")
 
-        # 1. AUTHORED help. The only source written FOR an operator.
-        #
-        # A module opts in with a dict beside its ``__aliases__``:
-        #
-        #     __verb_help__ = {"moltbook": "read the agora feed"}
-        #
-        # Same convention as __aliases__, so there is one place a module
-        # declares palette metadata. This exists because the humanisation
-        # below cannot invent what nobody wrote: these docstrings are
-        # contracts for maintainers, and stripping them yields "<verb> REPL".
         name = str(getattr(fn, "__name__", ""))
         verb = name[len("dispatch_"):-len("_command")] if (
             name.startswith("dispatch_") and name.endswith("_command")
         ) else name
 
+        # 0. AUTHORED help -- the only source written FOR an operator, and the
+        #    only one that bypasses scoring. A module opts in beside its
+        #    ``__aliases__``:
+        #
+        #        __verb_help__ = {"moltbook": "read the agora feed"}
         authored = getattr(mod, "__verb_help__", None)
         if isinstance(authored, dict):
             text = authored.get(verb) or authored.get(f"/{verb}")
             if isinstance(text, str) and text.strip():
                 return _help_bound(text)
 
-        # 1b. An ``Operator:`` section in the function's OWN docstring.
-        #
-        #     Ranked with authored help rather than with the humanised
-        #     docstring below, because it is the same KIND of thing: a
-        #     sentence someone wrote for the person typing the verb. It sits
-        #     beside the implementation instead of in a dict at the top of
-        #     the module, which is the only reason to prefer one over the
-        #     other, and 45 verbs were never going to get dict entries.
+        nominations = []
+
+        # An ``Operator:`` section in the function's OWN docstring. Same KIND
+        # of thing as authored help -- a sentence for the person typing the
+        # verb -- but it lives beside the implementation instead of in a dict
+        # at the top of the module, so it is scored rather than trusted.
         operator_line = extract_operator_section(getattr(fn, "__doc__", None))
         if operator_line:
-            return _help_bound(_operator_voice(operator_line, verb))
+            nominations.append(Candidate(
+                _operator_voice(operator_line, verb), "operator-section", 0.25))
 
-        # 2. The FUNCTION docstring, humanised — accepted only if it survives
-        #    as prose.
-        #
-        #    The module docstring is deliberately NOT a fallback. It is a file
-        #    header: it narrates the feature's history and provenance ("Wave 1
-        #    #8", "§38.11-F operator surface"), which is the wrong GENRE, not
-        #    merely the wrong wording. Mining it produced entries like
-        #    "/autobiography REPL — Wave 1 #8" — confident, well-formed, and
-        #    useless. A blank is the honest state for "nobody has written this
-        #    yet"; plausible noise is not.
-        own = _first_line(getattr(fn, "__doc__", ""))
+        # The FUNCTION docstring. Nearest the behaviour, so it is the line most
+        # likely to be corrected when behaviour changes -- hence a prior, but a
+        # small one, because it is written for a maintainer.
+        own = _first_line(getattr(fn, "__doc__", ""), verb)
         if own:
-            # Normalised to the OPERATOR's voice. A docstring is written for
-            # an implementer and it shows — "Parse /breadcrumbs and set/show
-            # the feed verbosity" opens with the verb the FUNCTION performs
-            # and then repeats the verb name, which is already the left-hand
-            # column. Subtractive only: no word appears that the author did
-            # not write, because a palette that paraphrases can be
-            # confidently wrong and the operator acts on it.
-            return _help_bound(_operator_voice(own, verb))
+            # Already in the operator's voice -- `_humanise` normalises before
+            # it judges. Re-applying `_operator_voice` here would run a
+            # subtractive transform twice, and `_strip_verb_name` documents at
+            # length why that is not free: it has to be a FIXED POINT or the
+            # number of times it runs becomes part of its contract.
+            nominations.append(Candidate(own, "function-docstring", 0.10))
 
-        # 3. No prose anywhere — mine the verb's own SUBCOMMAND VOCABULARY.
-        #
-        #    Ranked above signature derivation because it is strictly more
-        #    informative here: every dispatcher takes the whole line as one
-        #    string, so the signature says "(line)" while the body knows the
-        #    verb accepts status | history | explain. That is the single most
-        #    useful thing a palette can tell someone about a verb they have
-        #    not used, and it was sitting unread in the source.
-        mined = mine_subcommands(fn)
-        if mined:
-            # A middot reads as a LIST of options; a pipe reads as grammar
-            # borrowed from a usage string. This row is not a usage string —
-            # it is the honest answer to "nobody wrote a description, but the
-            # verb does accept these".
-            return _help_bound(" · ".join(mined))
+        # The MODULE docstring -- readmitted, and only for modules inside the
+        # dispatch naming cage. `_extract_verb_name` is that cage: reusing it
+        # means "is this a verb surface?" has ONE definition, and a test module
+        # that happens to define a dispatcher locally contributes nothing.
+        if _is_verb_surface(mod):
+            module_line = _first_line(getattr(mod, "__doc__", ""), verb)
+            if module_line:
+                nominations.append(Candidate(
+                    module_line, "module-docstring", 0.0))
 
-        # 4. No prose anywhere. The SIGNATURE still knows what the verb
-        #    takes, and "what arguments does this want" is most of what an
-        #    operator wants from a palette entry anyway. Translated to POSIX
-        #    brackets and stripped of injected plumbing — a raw Python
-        #    signature would be worse than the blank it replaces.
-        derived = derive_usage(fn, verb)
-        if derived:
-            return _help_bound(derived)
+        # The verb's own SUBCOMMAND VOCABULARY, mined from its body. Every
+        # dispatcher takes the whole line as one string, so the signature says
+        # "(line)" while the body knows the verb accepts status | history |
+        # explain. Honest and useful -- and strictly worse than a sentence,
+        # which is why it must be able to LOSE to one. It could not before.
+        # DEFERRED. `mine_subcommands` costs an `inspect.getsource` plus an
+        # `ast.parse`; across the table that is 340ms, on a surface that has
+        # to render between keystrokes. `best_candidate` calls the supplier
+        # only when this source's CEILING could still win — an exact bound, so
+        # the winner is identical to evaluating it every time.
+        nominations.append(Candidate(
+            "", "mined-subcommands", 0.0,
+            supplier=lambda: " · ".join(mine_subcommands(fn)),
+            ceiling=shape_ceiling(Shape.SUBCOMMAND_LIST)))
+
+        # The SIGNATURE, translated to POSIX brackets and stripped of injected
+        # plumbing. A raw Python signature would be worse than the blank.
+        nominations.append(Candidate(
+            "", "derived-usage", 0.0,
+            supplier=lambda: derive_usage(fn, verb),
+            ceiling=shape_ceiling(Shape.USAGE)))
+
+        winner = best_candidate(nominations, verb)
+        if winner is not None:
+            return _help_bound(winner.text)
     except Exception:  # noqa: BLE001
         pass
-    # 5. Nothing authored, nothing extractable, nothing to derive. Say so
-    #    plainly rather than printing residue: fabricated prose reads as a
-    #    description that happens to be wrong, and the operator acts on it.
+    # Nothing authored, nothing extractable, nothing to derive. Say so plainly
+    # rather than printing residue: fabricated prose reads as a description
+    # that happens to be wrong, and the operator acts on it.
     #
-    #    UNDOCUMENTED rather than "" so the gap is VISIBLE and countable —
-    #    ``/help --undocumented`` can list exactly what still needs writing,
-    #    which a blank column cannot.
+    # UNDOCUMENTED rather than "" so the gap is VISIBLE and countable --
+    # ``/help --undocumented`` can list exactly what still needs writing,
+    # which a blank column cannot.
     return UNDOCUMENTED
+
+
+def _is_verb_surface(mod: object) -> bool:
+    """Is *mod* one of the dispatch naming cage's verb-surface modules?
+
+    Delegated to `repl_dispatch_registry._extract_verb_name` rather than
+    re-testing the ``*_repl`` suffix here. Two copies of "what counts as a
+    verb surface" would drift, and the registry's copy is the one that
+    actually decides which modules get scanned -- so a surface it accepts and
+    this rejected would be a verb whose module docstring is unreadable for no
+    reason visible at either site. NEVER raises."""
+    try:
+        from backend.core.ouroboros.battle_test.repl_dispatch_registry import (
+            _extract_verb_name,
+        )
+        return bool(_extract_verb_name(getattr(mod, "__name__", "") or ""))
+    except Exception:  # noqa: BLE001
+        return False
 
 
 def _operator_voice(text: str, verb: str) -> str:

--- a/backend/core/ouroboros/battle_test/verb_description.py
+++ b/backend/core/ouroboros/battle_test/verb_description.py
@@ -38,12 +38,17 @@ from __future__ import annotations
 import logging
 import os
 import re
-from typing import Optional
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Callable, Iterable, List, Optional, Tuple
 
 logger = logging.getLogger("Ouroboros.VerbDescription")
 
 __all__ = ["to_operator_voice", "describe_width", "prose_first_enabled",
-           "is_contentless", "implementation_vocabulary"]
+           "is_contentless", "implementation_vocabulary",
+           "Shape", "Assessment", "Candidate", "assess", "best_candidate",
+           "shape_ceiling",
+           "runtime_vocabulary"]
 
 #: Openers that describe what the FUNCTION does rather than what the operator
 #: gets. Stripped with their trailing connective so the remainder still reads
@@ -59,6 +64,25 @@ _IMPL_OPENERS = (
     # dispatch convention and tells an operator nothing about what typing it
     # does. Left in, it surfaced as the description "Auto-discovered".
     "canonical entry point", "auto-discovered", "auto discovered",
+)
+
+#: The openers above, anchored to a WORD boundary.
+#:
+#: ``str.startswith`` matched them as character prefixes, so "dispatch" fired
+#: on the word "Dispatcher" and cut it mid-morpheme. ``/multi_prior``'s
+#: docstring — "Dispatcher for ``/multi_prior`` REPL verb" — became the palette
+#: row **"Er for /multi_prior REPL verb"**, which is not a description, a
+#: usage, or even a word.
+#:
+#: The class of bug matters more than the instance: a subtractive rule that
+#: operates below the token level can produce output no author wrote, which is
+#: precisely the failure mode "SUBTRACTIVE only" was chosen to prevent. Every
+#: remaining opener is at risk of the same thing — "process" inside
+#: "processor", "route" inside "router", "run the" inside nothing but "parse"
+#: inside "parser" — so this is fixed at the matcher, not per opener.
+_IMPL_OPENER_RE = tuple(
+    re.compile(rf"^{re.escape(o)}(?![\w-])", re.IGNORECASE)
+    for o in sorted(_IMPL_OPENERS, key=len, reverse=True)
 )
 
 #: Connectives left dangling after an opener is removed.
@@ -79,9 +103,17 @@ _DANGLING = re.compile(r"^(?:and\s+|then\s+|to\s+|the\s+|a\s+|an\s+)+", re.I)
 _CITATION = re.compile(
     r"^(?P<head>[^—-]{0,64}?)\s*[—–]\s*(?P<rest>.+)$", re.S,
 )
+#:
+#: ``^[A-Z]\d+$`` — the WHOLE head, not merely its first token. As ``^[A-Z]\d+\b``
+#: this fired on "L3 execution graph", read the tier prefix as a citation and
+#: threw the phrase away: /graph's row became "Units, edges and stats", a
+#: sentence with no subject. A bare identifier is weak evidence of a citation
+#: and only conclusive when it is ALL there is; every real citation in this
+#: tree carries a second marker ("M11 Slice 5", "Upgrade 3 Slice 5") and still
+#: matches on that.
 _CITATION_MARKER = re.compile(
     r"§|\bslice\b|\bphase\s*\d|\bmove\s*\d|\bwave\s*\d|\bupgrade\s*\d"
-    r"|\btier\s*\d|\bprd\b|\bstep\s*\d|^[A-Z]\d+\b|\bv\d+\b",
+    r"|\btier\s*\d|\bprd\b|\bstep\s*\d|^[A-Z]\d+$|\bv\d+\b",
     re.I,
 )
 
@@ -91,6 +123,11 @@ _SURFACE_OPENERS = (
     "repl surface for", "repl surface", "repl verb for", "repl verb",
     "operator-facing cli surface for", "operator-facing cli surface",
     "operator-facing surface for", "operator-facing surface",
+    # Bare, as well as compounded. /provider's module docstring opens
+    # "operator-facing DoubleWord resilience dashboard" — the adjective is
+    # true of every verb in this palette, so it distinguishes nothing and
+    # costs 16 of the description's ~58 columns.
+    "operator-facing", "operator facing",
     "operator surface for", "operator surface", "read-only inspection of",
     "dashboard for", "cli surface for", "cli surface",
 )
@@ -123,13 +160,19 @@ def _humanise_symbol(match: "re.Match") -> str:
     return spaced.strip().lower()
 
 
-def _strip_citation(text: str) -> str:
-    """Drop a leading spec reference, keeping the sentence it introduces."""
+def _strip_citation(text: str, verb: str = "") -> str:
+    """Drop a leading spec reference or self-address, keeping what follows.
+
+    Two ledes are empty for different reasons and both were being kept:
+    one CITES the spec that commissioned the verb, the other RE-STATES the
+    verb. ``_CITATION_MARKER`` only ever saw the first.
+    """
     match = _CITATION.match(text.strip())
     if not match:
         return text
     head, rest = match.group("head"), match.group("rest")
-    if head and not _CITATION_MARKER.search(head):
+    if head and not (_CITATION_MARKER.search(head)
+                     or _is_vacuous_head(head, verb)):
         return text            # a real sentence that merely contains a dash
     return rest.strip() or text
 
@@ -285,9 +328,73 @@ def _strip_verb_name(text: str, verb: str) -> str:
     )
     if acting.search(text):
         return acting.sub(name, text, count=1)
+    # ``(?![\w-])`` rather than ``\b``: a word boundary sits INSIDE a
+    # hyphenated compound, so "embodied" matched the first half of
+    # "Embodied-state" and ``[\s:,—-]*`` then ate the hyphen. The palette row
+    # for /embodied read "State views: arch, aura, attention, portrait" — a
+    # sentence about state, produced by decapitating a sentence about embodied
+    # state. Same class as the opener bug above: a token-level rule applied
+    # below the token level invents text nobody wrote.
     return re.compile(
-        rf"^/?{re.escape(name)}\b[\s:,—-]*", re.IGNORECASE,
+        rf"^/?{re.escape(name)}(?![\w-])[\s:,—-]*", re.IGNORECASE,
     ).sub("", text, count=1)
+
+
+#: Nouns that name the SURFACE rather than its subject. A lede built only from
+#: these plus the verb's own name carries no information — it is an address.
+_STRUCTURAL_NOUNS = frozenset({
+    "repl", "cli", "tui", "verb", "verbs", "command", "commands", "dispatcher",
+    "dispatch", "surface", "handler", "operator", "facing", "operator-facing",
+    "entry", "point", "module", "view", "panel", "screen",
+})
+
+#: Grammatical glue. Present so a lede made ONLY of scaffolding is recognised
+#: even when the scaffolding is joined into a phrase: "Dispatcher for
+#: /multi_prior REPL verb" is five words of pure address, and without "for" in
+#: this set it read as content and shipped as that verb's description.
+_GLUE_WORDS = frozenset({
+    "a", "an", "the", "and", "or", "for", "of", "to", "in", "on", "with",
+    "from", "into", "this", "that", "its", "it", "is", "are", "be",
+})
+
+#: An argument placeholder in a usage lede — ``<target_path>``, ``[flag]``.
+_PLACEHOLDER = re.compile(r"[<\[][^>\]]*[>\]]")
+
+
+def _is_vacuous_head(head: str, verb: str) -> bool:
+    """True when a dash-led lede is pure address, not content.
+
+    ``_CITATION_MARKER`` recognises a lede that CITES a spec ("§38 Slice 4 —").
+    It does not recognise one that merely re-states the surface, and those are
+    just as empty::
+
+        "``/enqueue_soak <target_path>`` — stage a crash-immortal Swarm soak"
+        "``/cost`` REPL dispatcher — Slice 4 of the Per-Phase Cost arc"
+
+    Both ledes reduce to the verb's own name plus scaffolding. Left in place
+    they burned the description's whole width on an address the operator had
+    just typed; ``/enqueue_soak`` showed "Async — walks the target off the
+    event loop", having fallen through to the function docstring instead.
+
+    Checked STRUCTURALLY — what survives after removing the verb name,
+    placeholders and surface nouns — rather than by listing lede shapes. A
+    blocklist of ledes is a blocklist of the ones already written.
+    """
+    try:
+        text = _PLACEHOLDER.sub(" ", str(head or ""))
+        name = str(verb or "").lstrip("/").strip().lower()
+        words = [w for w in re.findall(r"[\w-]+", text.lower()) if w]
+        if not words:
+            return True
+        for word in words:
+            if word == name or word.replace("_", "") == name.replace("_", ""):
+                continue
+            if word in _STRUCTURAL_NOUNS or word in _GLUE_WORDS:
+                continue
+            return False        # something real survives — keep the lede
+        return True
+    except Exception:  # noqa: BLE001
+        return False
 
 
 def to_operator_voice(text: Optional[str], verb: str = "",
@@ -315,7 +422,7 @@ def to_operator_voice(text: Optional[str], verb: str = "",
         # Citation first, THEN the verb name, THEN surface scaffolding. Order
         # matters: the verb name usually sits inside the clause the citation
         # introduces, so stripping the citation last leaves nothing to match.
-        raw = _strip_citation(raw)
+        raw = _strip_citation(raw, verb)
         original = raw
 
         # First sentence only. A palette row is one line, and everything
@@ -323,10 +430,10 @@ def to_operator_voice(text: Optional[str], verb: str = "",
         # while scanning.
         head = re.split(r"(?<=[.!?])\s+", raw, maxsplit=1)[0]
 
-        lowered = head.lower()
-        for opener in _IMPL_OPENERS:
-            if lowered.startswith(opener):
-                head = head[len(opener):]
+        for pattern in _IMPL_OPENER_RE:
+            match = pattern.match(head)
+            if match:
+                head = head[match.end():]
                 break
 
         # Dangling articles are cleared BEFORE the name check as well as
@@ -376,3 +483,375 @@ def to_operator_voice(text: Optional[str], verb: str = "",
         return head
     except Exception:  # noqa: BLE001
         return " ".join(str(text or "").split())[: describe_width()]
+
+
+# ===========================================================================
+# Judgement — the organ the cascade never had
+# ===========================================================================
+#
+# Every rung of the description cascade asked one question: "did this source
+# return a non-empty string?" That is a test of PRESENCE, not of quality, and
+# the two come apart constantly:
+#
+#   * "Er for /multi_prior REPL verb" is non-empty and is not a description;
+#   * "Op fan-out tree" is a perfect description and was DISCARDED by a
+#     four-word floor, so the palette showed "help · show · depth · status";
+#   * "operator-facing DoubleWord resilience dashboard" sits in /provider's
+#     module docstring, which the cascade banned wholesale — so the row read
+#     "[undocumented]" while the sentence sat one scope up.
+#
+# Boolean acceptance also makes rank ABSOLUTE: residue from a high rung beats
+# prose from a low one, and no better candidate can ever supersede a worse one
+# that happened to arrive first. Every one of the defects above is that single
+# design fact wearing different clothes.
+#
+# So sources stop deciding and start NOMINATING. Each produces a candidate,
+# every candidate is classified by SHAPE and scored, and the best one wins —
+# with source rank demoted from decision to prior. A description is now
+# something the pipeline can recognise rather than something it assumes.
+
+
+class Shape(str, Enum):
+    """What a candidate string IS, independent of where it came from."""
+
+    EMPTY = "empty"
+    #: Text that survived subtraction as a fragment — a dangling connective, a
+    #: decapitated word, a bare citation. Reads as help; answers nothing.
+    RESIDUE = "residue"
+    #: True prose about the FUNCTION rather than the verb. "Async — walks the
+    #: target off the event loop" is accurate and useless to an operator.
+    IMPLEMENTATION = "implementation"
+    USAGE = "usage"
+    #: A mined vocabulary, "help · show · depth · status". Honest, and strictly
+    #: worse than a sentence — which is why it must be able to LOSE to one.
+    SUBCOMMAND_LIST = "subcommand_list"
+    #: A short contentful label: "Op fan-out tree", "Capability flag star-map".
+    NOUN_PHRASE = "noun_phrase"
+    PROSE = "prose"
+
+
+#: Floor score per shape, and the span density may add on top. Overlapping
+#: spans are deliberate: a dense noun phrase SHOULD beat thin prose, because
+#: "Op fan-out tree" tells an operator more than "Show the thing for the op".
+_SHAPE_FLOOR = {
+    Shape.EMPTY: 0.00,
+    Shape.RESIDUE: 0.05,
+    Shape.IMPLEMENTATION: 0.20,
+    Shape.USAGE: 0.30,
+    Shape.SUBCOMMAND_LIST: 0.42,
+    Shape.NOUN_PHRASE: 0.62,
+    Shape.PROSE: 0.70,
+}
+_DENSITY_SPAN = 0.25
+
+#: Below this, nothing is worth showing and the caller says so plainly.
+ACCEPT_FLOOR = 0.30
+
+#: A first word that cannot begin a description. Two families, both fragments:
+#: connectives left by a stripped clause, and morphological debris left by a
+#: stripped word-prefix ("Dispatcher" − "dispatch" = "er").
+_FRAGMENT_HEADS = frozenset({
+    "and", "or", "but", "then", "with", "to", "of", "for", "in", "on", "from",
+    "by", "that", "which", "is", "are", "be", "was", "were", "as", "at", "if",
+    "when", "its", "it", "returns", "return", "lets", "short-circuit", "also",
+    "er", "ers", "ed", "ing", "es", "ion", "ment", "ly",
+})
+
+#: A last word that means the sentence was cut mid-thought.
+_DANGLING_TAILS = frozenset({
+    "by", "for", "with", "and", "or", "the", "a", "an", "to", "of", "in", "on",
+    "from", "when", "that", "is", "are", "as", "at", "into", "über",
+})
+
+#: Machinery an operator never touches. Distinct from
+#: `implementation_vocabulary`, which is about GRAMMAR and plumbing nouns:
+#: these words can only appear in a sentence describing a RUNTIME mechanism,
+#: so two of them together are near-proof the docstring is addressing a
+#: maintainer. One alone is not — "L1 event emitter throughput" is a real
+#: description that happens to contain "event".
+_RUNTIME_WORDS = frozenset({
+    "async", "await", "asyncio", "coroutine", "thread", "threading", "mutex",
+    "singleton", "kwargs", "stdout", "stderr", "traceback", "monkeypatch",
+    "subprocess", "idempotent", "memoised", "memoized", "lru", "gc",
+})
+_RUNTIME_PHRASES = ("event loop", "under the hood", "in place", "off the loop",
+                    "fire and forget", "fire-and-forget", "no-op")
+
+
+def runtime_vocabulary() -> frozenset:
+    """Words that can only describe a RUNTIME mechanism.
+
+    Env-overridable via ``JARVIS_PALETTE_RUNTIME_WORDS`` for the same reason
+    `implementation_vocabulary` is: what counts as machinery is a property of
+    the codebase, and a fork must be able to say so without editing this file.
+    """
+    raw = os.environ.get("JARVIS_PALETTE_RUNTIME_WORDS", "").strip()
+    if raw:
+        return frozenset(w.strip().lower() for w in raw.split(",") if w.strip())
+    return _RUNTIME_WORDS
+
+
+#: Subjects that name an AUDIENCE rather than an effect. "Tests can inject an
+#: explicit governor and/or session_browser without touching the module
+#: singletons" is fluent, specific, dense in domain words — and addressed to
+#: whoever writes the tests. It scored as clean PROSE and became /cost's
+#: palette row.
+#:
+#: Vocabulary cannot catch this one: every word is legitimate. The tell is
+#: grammatical. A description says what the OPERATOR gets, so its subject is
+#: never the reader, the caller, or the test suite — and a sentence that opens
+#: by naming one of those is answering a different question than the palette
+#: asked.
+_MAINTAINER_SUBJECTS = frozenset({
+    "tests", "test", "callers", "caller", "subclasses", "subclass",
+    "implementors", "implementers", "maintainers", "consumers", "we", "you",
+})
+
+#: A verb-echo: the name plus scaffolding and nothing else. "/causal REPL",
+#: "/continuity REPL dispatcher" — beside the verb in the left column this is
+#: worse than a blank, because it LOOKS like help.
+_ECHO_RE = re.compile(
+    r"^[\w\-]+(\s+(repl|verb|dispatcher|surface|command|cli|handler))+$", re.I)
+
+#: A candidate that is only a citation.
+_BARE_CITATION_RE = re.compile(
+    r"^\s*(§|slice\s+\d|phase\s+\d|prd\b|wave\s+\d|move\s+\d|path\s+[a-z]\.\d"
+    r"|v\d+\.\d+|\d{4}-\d{2}-\d{2})", re.I)
+
+#: Separators a mined vocabulary is joined with.
+_LIST_SPLIT = re.compile(r"\s*[·|]\s*")
+
+
+@dataclass(frozen=True)
+class Assessment:
+    """What a candidate is, how good it is, and WHY — the third field matters.
+
+    Without ``reasons`` a rejected description is indistinguishable from an
+    absent one, and the hygiene question ("which verbs still need a sentence,
+    and what is wrong with what they have?") becomes unanswerable.
+    """
+
+    shape: Shape
+    score: float
+    reasons: Tuple[str, ...] = ()
+
+    @property
+    def acceptable(self) -> bool:
+        return self.score >= ACCEPT_FLOOR
+
+
+def _words(text: str) -> List[str]:
+    return re.findall(r"[A-Za-z][A-Za-z0-9_'\-]*", str(text or "").lower())
+
+
+def _density(words: Iterable[str]) -> float:
+    """Fraction of words naming something in the OPERATOR's world."""
+    items = list(words)
+    if not items:
+        return 0.0
+    vocabulary = implementation_vocabulary()
+    return sum(1 for w in items if w not in vocabulary) / float(len(items))
+
+
+def _looks_like_list(text: str) -> bool:
+    """A mined vocabulary rather than a sentence.
+
+    Every segment short, no segment a clause. Checked on SHAPE so a list
+    joined with a different separator tomorrow is still recognised, and so a
+    real sentence containing a middot is not mistaken for one.
+    """
+    parts = [p.strip() for p in _LIST_SPLIT.split(text) if p.strip()]
+    if len(parts) < 2:
+        return False
+    return all(len(p.split()) <= 2 and len(p) <= 18 for p in parts)
+
+
+def assess(text: Optional[str], verb: str = "") -> Assessment:
+    """Classify and score one candidate description. NEVER raises.
+
+    Order is significant: the disqualifying shapes are tested first, because a
+    fragment that happens to be dense in domain words ("Er for /multi_prior
+    REPL verb" scores 3/5 on density) must not be rescued by its density.
+    """
+    try:
+        raw = " ".join(str(text or "").split())
+        if not raw or len(raw) < 8:
+            return Assessment(Shape.EMPTY, 0.0, ("blank-or-too-short",))
+
+        words = _words(raw)
+        if len(words) < 2:
+            return Assessment(Shape.EMPTY, 0.0, ("single-word",))
+
+        reasons: List[str] = []
+
+        # --- disqualifying shapes -----------------------------------------
+        if not raw[0].isalnum() and raw[0] not in "\"'“‘(":
+            return Assessment(Shape.RESIDUE, _SHAPE_FLOOR[Shape.RESIDUE],
+                              ("leading-punctuation",))
+        if words[0] in _FRAGMENT_HEADS:
+            return Assessment(Shape.RESIDUE, _SHAPE_FLOOR[Shape.RESIDUE],
+                              (f"fragment-head:{words[0]}",))
+        if words[-1] in _DANGLING_TAILS:
+            return Assessment(Shape.RESIDUE, _SHAPE_FLOOR[Shape.RESIDUE],
+                              (f"dangling-tail:{words[-1]}",))
+        if _ECHO_RE.match(raw.lstrip("/")):
+            return Assessment(Shape.RESIDUE, _SHAPE_FLOOR[Shape.RESIDUE],
+                              ("verb-echo",))
+        if _BARE_CITATION_RE.match(raw):
+            return Assessment(Shape.RESIDUE, _SHAPE_FLOOR[Shape.RESIDUE],
+                              ("bare-citation",))
+        if _is_vacuous_head(raw, verb):
+            # The WHOLE candidate reduces to the verb's own name plus
+            # scaffolding — the same emptiness `_strip_citation` removes from a
+            # lede, here occupying the entire row.
+            return Assessment(Shape.RESIDUE, _SHAPE_FLOOR[Shape.RESIDUE],
+                              ("self-address",))
+
+        density = _density(words)
+
+        # --- informative but not a description ----------------------------
+        if raw.lower().startswith("usage:"):
+            return Assessment(Shape.USAGE,
+                              _SHAPE_FLOOR[Shape.USAGE] + _DENSITY_SPAN * density,
+                              ("usage-line",))
+        if _looks_like_list(raw):
+            return Assessment(Shape.SUBCOMMAND_LIST,
+                              _SHAPE_FLOOR[Shape.SUBCOMMAND_LIST],
+                              ("mined-vocabulary",))
+
+        lowered = raw.lower()
+        if words[0] in _MAINTAINER_SUBJECTS:
+            # IMPLEMENTATION, not RESIDUE: it is well-formed prose, merely
+            # addressed to the wrong reader, so it should still beat a bare
+            # usage line if nothing better exists.
+            return Assessment(Shape.IMPLEMENTATION,
+                              _SHAPE_FLOOR[Shape.IMPLEMENTATION],
+                              (f"maintainer-subject:{words[0]}",))
+        runtime_hits = sum(1 for w in words if w in runtime_vocabulary())
+        runtime_hits += sum(1 for p in _RUNTIME_PHRASES if p in lowered)
+        if runtime_hits >= 2:
+            return Assessment(Shape.IMPLEMENTATION,
+                              _SHAPE_FLOOR[Shape.IMPLEMENTATION]
+                              + _DENSITY_SPAN * density,
+                              (f"runtime-vocabulary:{runtime_hits}",))
+        if density < 0.34:
+            # Almost every word is plumbing. "Line and dispatch" cleared the
+            # old 12-character floor and shipped for months.
+            return Assessment(Shape.IMPLEMENTATION,
+                              _SHAPE_FLOOR[Shape.IMPLEMENTATION]
+                              + _DENSITY_SPAN * density,
+                              (f"low-density:{density:.2f}",))
+
+        # --- a real description -------------------------------------------
+        #
+        # The split is LENGTH only, and deliberately so. Deciding "is this a
+        # sentence or a label" needs a part-of-speech tagger; guessing at it
+        # with a verb blocklist would reject "Show the activity radar" on one
+        # list and accept "Op fan-out tree" on another for no principled
+        # reason. Both are good rows; longer ones tend to carry more, so they
+        # get a slightly higher floor and the tie resolves itself.
+        shape = Shape.PROSE if len(words) >= 4 else Shape.NOUN_PHRASE
+        if runtime_hits:
+            reasons.append(f"runtime-vocabulary:{runtime_hits}")
+        return Assessment(shape,
+                          _SHAPE_FLOOR[shape] + _DENSITY_SPAN * density,
+                          tuple(reasons) or (f"density:{density:.2f}",))
+    except Exception:  # noqa: BLE001 — a palette must never throw
+        logger.debug("[VerbDescription] assessment degraded", exc_info=True)
+        return Assessment(Shape.EMPTY, 0.0, ("assessment-failed",))
+
+
+@dataclass(frozen=True)
+class Candidate:
+    """One nomination, from one source.
+
+    ``prior`` is how much the SOURCE is trusted, not how good the text is —
+    an ``Operator:`` line was written for the person typing the verb, so it
+    starts ahead of a docstring mined for the same information. It is a
+    thumb on the scale, never a veto: a mangled authored line still loses to
+    a clean derived one, which is the whole reason rank stopped deciding.
+    """
+
+    text: str
+    source: str
+    prior: float = 0.0
+    assessment: Optional[Assessment] = field(default=None, compare=False)
+    #: Deferred producer, for sources that cost real work to evaluate.
+    supplier: Optional[Callable[[], str]] = field(default=None, compare=False)
+    #: The HIGHEST weight this source could possibly reach. Only meaningful
+    #: alongside ``supplier``; see :func:`best_candidate`.
+    ceiling: float = 1.0
+
+    def weight(self) -> float:
+        return (self.assessment.score if self.assessment else 0.0) + self.prior
+
+
+def shape_ceiling(shape: Shape) -> float:
+    """The greatest score *shape* can reach. Exact, not an estimate.
+
+    ``SUBCOMMAND_LIST`` returns its floor flat — a mined vocabulary carries no
+    density bonus because its density is an artefact of which words the verb
+    happens to accept. Everything else may add the full span.
+    """
+    if shape is Shape.SUBCOMMAND_LIST:
+        return _SHAPE_FLOOR[shape]
+    return _SHAPE_FLOOR[shape] + _DENSITY_SPAN
+
+
+def best_candidate(candidates: Iterable[Candidate],
+                   verb: str = "") -> Optional[Candidate]:
+    """The best nomination, or ``None`` when none clears the floor.
+
+    ``None`` is a real answer and the caller must be able to act on it: an
+    honest "[undocumented]" is worth more than a confident fragment, because
+    the operator acts on what the palette says.
+
+    A candidate carrying a ``supplier`` is evaluated only if its ``ceiling``
+    could still beat the best score so far. This is an EXACT bound, not a
+    heuristic: a mined subcommand list can never exceed 0.42 and a usage line
+    never 0.55, so once a real sentence is in hand the answer is provably
+    unchanged by looking at either. The result is identical to evaluating
+    everything — which matters, because the cheap version of this idea is
+    "stop at the first source that answers", and that is the boolean
+    acceptance the arbiter exists to replace. Skipping work whose outcome is
+    determined is not the same as letting order decide.
+
+    Worth the care: the arbiter nominates eagerly by default, and
+    `mine_subcommands` costs an ``inspect.getsource`` plus an ``ast.parse``
+    per verb — 340ms across the table, on a surface that renders between
+    keystrokes.
+    """
+    try:
+        scored: List[Candidate] = []
+        best_weight = 0.0
+        for cand in candidates:
+            if cand is None:
+                continue
+            text = str(cand.text or "")
+            if not text.strip() and cand.supplier is not None:
+                if cand.ceiling + cand.prior <= best_weight:
+                    continue        # outcome already determined
+                try:
+                    text = str(cand.supplier() or "")
+                except Exception:  # noqa: BLE001
+                    text = ""
+            if not text.strip():
+                continue
+            evaluated = Candidate(
+                text=text, source=cand.source, prior=cand.prior,
+                assessment=assess(text, verb),
+            )
+            scored.append(evaluated)
+            best_weight = max(best_weight, evaluated.weight())
+        if not scored:
+            return None
+        # Ties break on the source's own order, which is why this is `max` over
+        # a stable list rather than a sort: equal weights keep nomination
+        # order, and callers nominate most-authored first.
+        winner = max(scored, key=lambda c: c.weight())
+        if winner.assessment is None or not winner.assessment.acceptable:
+            return None
+        return winner
+    except Exception:  # noqa: BLE001
+        logger.debug("[VerbDescription] arbitration degraded", exc_info=True)
+        return None

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -112,14 +112,108 @@ CLIENT_VERB_HELP = {
 }
 
 
+def _alias_help(verb: str) -> str:
+    """Help for an audio verb with no entry of its own. NEVER raises.
+
+    The old fallback rendered ``f"audio: {AUDIO_VERBS[verb]}"``, so six rows of
+    the palette read "audio: force_wake", "audio: ptt_stop", "audio: flush" —
+    an internal action identifier presented as a description. It answers
+    nothing, and it is the one thing the palette must never do: look like help.
+
+    But the map already carries the answer. ``AUDIO_VERBS`` is a SYNONYM table
+    — ``wake!``, ``force-wake`` and ``force wake`` all resolve to
+    ``force_wake`` — so a verb without help has siblings, and at least one of
+    them is documented. Saying "alias of /force-wake" is both true and more
+    useful than a fresh sentence would be, because it tells the operator these
+    are the same word rather than three things to learn.
+
+    Derived from the routing table itself, per this module's own rule that a
+    verb "cannot exist in one and be missing from the other". A second
+    transcription of which spellings are synonyms is exactly how a palette
+    starts lying about what the CLI accepts.
+    """
+    try:
+        action = AUDIO_VERBS.get(verb)
+        if not action:
+            return ""
+        # Preference order, deliberately: the spelling that IS the action name
+        # (``flush`` -> ``flush``), then the first documented sibling in table
+        # order. Both are stable, so the palette does not reshuffle between
+        # runs — an alias target that moves is worse than none.
+        siblings = [v for v, a in AUDIO_VERBS.items()
+                    if a == action and v != verb and CLIENT_VERB_HELP.get(v)]
+        if not siblings:
+            return ""
+        canonical = next((v for v in siblings if v == action), siblings[0])
+        return f"alias of /{canonical} — {CLIENT_VERB_HELP[canonical]}"
+    except Exception:  # noqa: BLE001 — a palette must never throw
+        return ""
+
+
+def _daemon_owns(verb: str) -> bool:
+    """Does the DAEMON dispatch this verb? NEVER raises.
+
+    Fails CLOSED — an unreadable table answers True, so the client declines to
+    intercept and the line goes where it goes today. A guard that guesses
+    "mine" when it cannot tell would silently swallow verbs on a degraded
+    boot, and swallowing is the harder failure to diagnose.
+    """
+    try:
+        from backend.core.ouroboros.battle_test.repl_dispatch_registry import (
+            _VERB_TO_DISPATCHER, registry_primed,
+        )
+        if not registry_primed():
+            return True
+        return verb in _VERB_TO_DISPATCHER
+    except Exception:  # noqa: BLE001
+        return True
+
+
+def _resolve_audio_verb(low: str, audio_verbs: "dict") -> "Optional[str]":
+    """The audio command for an operator line, slash form included.
+
+    ``AUDIO_VERBS`` is keyed on BARE words — ``wake``, ``ptt stop``,
+    ``force-wake`` — and the lookup was ``audio_verbs.get(low)`` where ``low``
+    is whatever the operator typed. The palette enumerates the same table and
+    renders every entry with a leading slash, so ``/wake`` was offered in the
+    menu, missed the table on selection, and was relayed to a daemon that has
+    no ``/wake`` dispatcher. The verb appeared in the palette and did nothing.
+
+    The neighbouring branches show the shape of the bug: ``/deck``, ``/tasks``
+    and ``/keys`` each test ``low == "deck" or low.startswith("/deck")`` by
+    hand. Every client-handled verb was patched for slash forms one at a time,
+    and the table lookup — which covers fifteen of them — never was.
+
+    **Daemon wins on collision**, matching `registry_from_dispatch`, which
+    adds a client verb only ``if slash not in known``. ``voice`` and ``listen``
+    sit in ``AUDIO_VERBS`` *and* have real daemon dispatchers, so a blind
+    strip would hijack ``/voice`` away from the verb the palette describes.
+    Deferring to the same precedence means the menu and the router cannot
+    disagree about who answers — which is the property this module already
+    claims when it says a verb "cannot exist in one and be missing from the
+    other". NEVER raises.
+    """
+    try:
+        cmd = audio_verbs.get(low)
+        if cmd is not None:
+            return cmd               # bare form — unchanged
+        if not low.startswith("/"):
+            return None
+        bare = low[1:].strip()
+        if not bare or bare not in audio_verbs:
+            return None
+        return None if _daemon_owns(bare) else audio_verbs[bare]
+    except Exception:  # noqa: BLE001
+        return None
+
+
 def client_verbs() -> "dict":
     """Verbs this cockpit answers WITHOUT the daemon. NEVER raises.
 
     Derived from the live dispatch tables rather than transcribed beside
     them: the audio words come from AUDIO_VERBS (the same object the router
     switches on) and the local-only verbs are listed once here."""
-    out = {v: CLIENT_VERB_HELP.get(v, f"audio: {AUDIO_VERBS[v]}")
-           for v in AUDIO_VERBS}
+    out = {v: CLIENT_VERB_HELP.get(v) or _alias_help(v) for v in AUDIO_VERBS}
     # `keys` and `tasks` were routed in `_route_operator_line` but missing
     # here, so neither appeared in the `/` palette — routed and unreachable
     # unless you already knew the word. A verb the operator cannot discover
@@ -1933,7 +2027,7 @@ def _route_operator_line(client: Any, ui: Any, line: Any) -> str:
             _report_local_history(client, text)
             return "handled"
 
-        cmd = audio_verbs.get(low)
+        cmd = _resolve_audio_verb(low, audio_verbs)
         if cmd is not None:
             # AUTO-SPAWN REFLEX. `ov` boots ouroboros_battle_test.py, which has
             # no audio pipeline; the mic lives in unified_supervisor.py. Arming

--- a/backend/core/ouroboros/governance/cost_repl.py
+++ b/backend/core/ouroboros/governance/cost_repl.py
@@ -113,6 +113,8 @@ def dispatch_cost_command(
 ) -> CostDispatchResult:
     """Parse a ``/cost`` REPL line and return the rendered result.
 
+    Operator: Spend so far, per phase and per provider, against the cap.
+
     Tests can inject an explicit ``governor`` and/or ``session_browser``
     without touching the module singletons.
     """

--- a/backend/core/ouroboros/governance/verification/multi_prior_repl.py
+++ b/backend/core/ouroboros/governance/verification/multi_prior_repl.py
@@ -59,7 +59,10 @@ def dispatch_multi_prior_command(
     line: str,
 ) -> MultiPriorDispatchResult:
     """Dispatcher for ``/multi_prior`` REPL verb. NEVER
-    raises."""
+    raises.
+
+    Operator: Multi-prior verification readings and per-op agreement.
+    """
     raw = (line or "").strip()
     if raw.startswith("/multi_prior"):
         raw = raw[len("/multi_prior"):].strip()

--- a/tests/battle_test/test_verb_description.py
+++ b/tests/battle_test/test_verb_description.py
@@ -132,13 +132,38 @@ def test_the_palette_uses_it() -> None:
 
 def test_subcommand_rows_read_as_a_LIST_not_a_usage_string() -> None:
     """A pipe borrows grammar from a usage string. These rows are the honest
-    answer to "nobody wrote a description, but it does accept these"."""
-    from pathlib import Path
+    answer to "nobody wrote a description, but it does accept these".
 
-    repo = Path(__file__).resolve().parents[2]
-    src = (repo / "backend/core/ouroboros/battle_test/"
-           "repl_completion.py").read_text()
-    assert '" · ".join(mined)' in src
+    SUPERSEDED 2026-07-31: was ``assert '" · ".join(mined)' in src`` — a grep
+    of `repl_completion.py`'s own source text.
+
+    That assertion tested a SPELLING, not a separator. It broke the moment the
+    join moved inside a deferred supplier (same join, same middot, different
+    local name) and it would equally have PASSED had the line been dead code,
+    commented out, or in a branch nothing reaches. A source-text assertion
+    cannot tell "this behaviour holds" from "this string is present".
+
+    Rewritten against the rendered row: build a dispatcher whose only
+    resolvable help is its mined vocabulary, and read what the palette shows.
+    """
+    def dispatch_widget_command(line: str):
+        # No prose anywhere -- the ONLY thing resolvable is the vocabulary the
+        # body compares against, which is the rung under test.
+        sub = (line or "").split()[-1]
+        if sub == "status":
+            return "s"
+        if sub == "history":
+            return "h"
+        if sub == "explain":
+            return "e"
+        return ""
+
+    from backend.core.ouroboros.battle_test import repl_completion
+
+    row = repl_completion._describe(dispatch_widget_command)
+    assert "·" in row, row
+    assert "|" not in row, row
+    assert "status" in row and "history" in row
 
 
 # --------------------------------------------------------------------------

--- a/tests/battle_test/test_verb_description_arbitration.py
+++ b/tests/battle_test/test_verb_description_arbitration.py
@@ -1,0 +1,513 @@
+"""The palette showed rows that were not descriptions, for five reasons.
+
+Four were subtractive rules matching below the unit they were written for — a
+word-prefix instead of a word, a ``\\b`` inside a hyphenated compound, a
+quantifier bound to one character of a two-character token, a tier marker read
+as a citation. Each produced text no author wrote, which is precisely what
+"SUBTRACTIVE only — no word appears that the author did not write" exists to
+prevent.
+
+The fifth is the one that matters: the cascade ranked SOURCES and never judged
+RESULTS. Every rung asked "did this return a non-empty string?", so rank was
+absolute — residue from a high rung beat prose from a low one, and no better
+candidate could supersede a worse one that merely arrived first. All four of
+the others were survivable bugs that this design turned into shipped rows.
+
+The last test in this file is the one that keeps it fixed: it walks the LIVE
+registry, so a verb added tomorrow is covered by a test written today.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.battle_test import repl_completion as rc
+from backend.core.ouroboros.battle_test.verb_description import (
+    Candidate, Shape, assess, best_candidate, shape_ceiling, to_operator_voice,
+)
+from backend.core.ouroboros.battle_test.verb_usage import UNDOCUMENTED
+
+
+# ---------------------------------------------------------------------------
+# 1. The four sub-token faults, each by the string that shipped
+# ---------------------------------------------------------------------------
+
+
+class TestSubtractionStaysAboveTheToken:
+    def test_opener_is_a_word_not_a_prefix(self):
+        """"Dispatcher" is not "dispatch" + noise.
+
+        ``str.startswith("dispatch")`` fired on it and cut the word in half.
+        /multi_prior's row read "Er for /multi_prior REPL verb"."""
+        out = to_operator_voice(
+            "Dispatcher for /multi_prior REPL verb.", "multi_prior")
+        # The FIRST WORD is the assertion. `"er for" not in out` looked
+        # equivalent and is not — it matches inside "dispatcher for", so it
+        # fails on the correct output and would have to be weakened until it
+        # stopped testing anything.
+        assert out.split()[0].lower() == "dispatcher"
+
+    @pytest.mark.parametrize("word,verb", [
+        ("Processor state and counters", "process"),
+        ("Router table for the mesh", "route"),
+        ("Parser output for the last op", "parse"),
+    ])
+    def test_no_opener_decapitates_a_longer_word(self, word, verb):
+        """Generalised past the one instance. Every opener has a longer word
+        it is a prefix of, and the fix is at the matcher — so a template
+        nobody has written yet is covered too."""
+        assert to_operator_voice(word, verb).lower().startswith(
+            word.split()[0][:4].lower())
+
+    def test_verb_name_does_not_split_a_compound(self):
+        """``\\b`` sits INSIDE "Embodied-state", so "embodied" matched its
+        first half and the trailing ``[\\s:,—-]*`` ate the hyphen. The row
+        read "State views: ..." — a sentence about state, produced by
+        decapitating a sentence about embodied state."""
+        out = to_operator_voice(
+            "Embodied-state views: arch, aura, attention, portrait.",
+            "embodied")
+        assert out.lower().startswith("embodied-state")
+
+    def test_verb_name_alone_is_still_stripped(self):
+        """The compound guard must not disable the rule it guards: a bare
+        leading name is still redundant beside the left-hand column."""
+        assert to_operator_voice("Posture status and overrides", "posture") \
+            .lower().startswith("status")
+
+    def test_optional_pair_quantifier_actually_fires(self):
+        """```` ``? ```` is one REQUIRED backtick plus an optional one, not an
+        optional pair — so the pattern only matched text that still carried
+        markup, and markup was unwrapped afterwards. It never fired at all.
+
+        This is the highest-traffic docstring template in the dispatch
+        packages, and with the pattern dead only the bare opener "Parse" came
+        off. /cost shipped "REPL line and return the rendered result"."""
+        assert rc._humanise(
+            "Parse a ``/cost`` REPL line and return the rendered result.",
+            "cost") == ""
+
+    def test_tier_prefix_is_not_a_citation(self):
+        """``^[A-Z]\\d+\\b`` matched "L3" in "L3 execution graph" and threw the
+        phrase away as provenance. /graph's row became "Units, edges and
+        stats" — a sentence with no subject."""
+        out = to_operator_voice(
+            "L3 execution graph — units, edges and stats.", "graph")
+        assert out.lower().startswith("l3 execution graph")
+
+    def test_a_real_citation_is_still_stripped(self):
+        """Tightening the marker must not stop it working. Every genuine
+        citation in this tree carries a second marker and still matches."""
+        assert to_operator_voice(
+            "M11 Slice 5 — replay an operation from its trace", "replay"
+        ).lower().startswith("replay")
+
+
+# ---------------------------------------------------------------------------
+# 2. A short description is not a poor one
+# ---------------------------------------------------------------------------
+
+
+class TestLengthIsNotQuality:
+    @pytest.mark.parametrize("text,verb", [
+        ("Op fan-out tree.", "fanout"),
+        ("Capability flag star-map.", "constellation"),
+        ("Proactive anticipation surface.", "anticipate"),
+        ("Memory crystallisation timeline.", "story"),
+    ])
+    def test_three_word_descriptions_survive(self, text, verb):
+        """A four-WORD floor in `_humanise` discarded all four. They are real
+        descriptions, they were sitting in the source, and the palette showed
+        mined subcommand lists in their place — from which
+        `verb_description`'s own module docstring concluded those verbs had
+        "NO PROSE AT ALL"."""
+        assert rc._humanise(text, verb) != ""
+        assert assess(rc._humanise(text, verb), verb).acceptable
+
+    def test_short_is_not_a_free_pass(self):
+        """The floor was wrong, not the instinct behind it. Short AND
+        contentless is still contentless."""
+        assert assess("Line and dispatch", "x").shape in (
+            Shape.RESIDUE, Shape.IMPLEMENTATION, Shape.EMPTY)
+
+
+# ---------------------------------------------------------------------------
+# 3. The classifier
+# ---------------------------------------------------------------------------
+
+
+class TestShapeClassification:
+    @pytest.mark.parametrize("text,expected", [
+        ("Er for multi prior REPL verb", Shape.RESIDUE),      # orphan head
+        ("and render the dashboard", Shape.RESIDUE),          # fragment head
+        ("Canonical entry point by", Shape.RESIDUE),          # dangling tail
+        ("/causal REPL dispatcher", Shape.RESIDUE),           # verb echo
+        ("§38.11-F operator surface", Shape.RESIDUE),         # bare citation
+        ("Usage: /cost [governor]", Shape.USAGE),
+        ("help · show · depth · status", Shape.SUBCOMMAND_LIST),
+        ("Op fan-out tree", Shape.NOUN_PHRASE),
+        ("Show the activity radar — what is moving right now", Shape.PROSE),
+    ])
+    def test_shapes(self, text, expected):
+        assert assess(text, "x").shape is expected
+
+    def test_runtime_vocabulary_marks_implementation(self):
+        """True prose about the FUNCTION. Accurate, and useless to an
+        operator — so it must score BELOW a description and ABOVE nothing."""
+        got = assess(
+            "Async — walks the target off the event loop, writes the manifest "
+            "row.", "enqueue_soak")
+        assert got.shape is Shape.IMPLEMENTATION
+
+    def test_one_runtime_word_is_not_enough(self):
+        """"L1 event emitter throughput and counters" is a real description
+        that happens to contain "event". A single hit must not condemn it."""
+        assert assess("L1 event emitter throughput and counters",
+                      "events").shape is Shape.PROSE
+
+    def test_maintainer_subject_is_caught_by_grammar_not_vocabulary(self):
+        """"Tests can inject an explicit governor and/or session_browser
+        without touching the module singletons" is fluent, specific and dense
+        in domain words — every individual word is legitimate, so no
+        vocabulary rule can catch it. The tell is that its SUBJECT is the
+        reader. It scored as clean prose and became /cost's palette row."""
+        got = assess(
+            "Tests can inject an explicit governor and/or session_browser "
+            "without touching the module singletons.", "cost")
+        assert got.shape is Shape.IMPLEMENTATION
+        assert any("maintainer-subject" in r for r in got.reasons)
+
+    def test_assessment_carries_its_reason(self):
+        """Without a reason a rejected description is indistinguishable from
+        an absent one, and "which verbs still need a sentence, and what is
+        wrong with what they have" becomes unanswerable."""
+        assert assess("and render the dashboard", "x").reasons
+
+    @pytest.mark.parametrize("hostile", [
+        None, "", "   ", "\x00\x01", "·" * 500, "/" * 80, 12345, object(),
+    ])
+    def test_never_raises(self, hostile):
+        """A palette that throws while the operator is typing is a worse
+        failure than a palette with a gap in it."""
+        assert isinstance(assess(hostile, "x").score, float)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# 4. Arbitration — rank stopped deciding
+# ---------------------------------------------------------------------------
+
+
+class TestArbitration:
+    def test_prose_beats_a_subcommand_list_nominated_first(self):
+        """THE regression. Under boolean acceptance the first non-empty
+        source won outright, so a mined vocabulary could never be superseded
+        by a sentence found later."""
+        winner = best_candidate([
+            Candidate("help · show · depth · status", "mined", 0.0),
+            Candidate("Op fan-out tree", "module-docstring", 0.0),
+        ], "fanout")
+        assert winner is not None and winner.source == "module-docstring"
+
+    def test_a_source_prior_is_a_thumb_not_a_veto(self):
+        """Rank survives as a prior because an ``Operator:`` line was written
+        for the person typing the verb. It must still be able to LOSE, or
+        nothing has changed."""
+        winner = best_candidate([
+            Candidate("and dispatch the line", "operator-section", 0.25),
+            Candidate("Browse an operation's causal lineage", "module", 0.0),
+        ], "causal")
+        assert winner is not None and winner.source == "module"
+
+    def test_a_prior_breaks_a_genuine_tie(self):
+        winner = best_candidate([
+            Candidate("Show the current operation mode", "function-docstring", 0.10),
+            Candidate("Show the current operation mode", "module-docstring", 0.0),
+        ], "mode")
+        assert winner is not None and winner.source == "function-docstring"
+
+    def test_nothing_acceptable_returns_none(self):
+        """``None`` is a real answer. An honest "[undocumented]" is worth more
+        than a confident fragment, because the operator acts on it."""
+        assert best_candidate([
+            Candidate("and dispatch", "a", 0.0),
+            Candidate("/x REPL", "b", 0.0),
+        ], "x") is None
+
+    def test_empty_nomination_list(self):
+        assert best_candidate([], "x") is None
+
+
+class TestDeferredNominationsAreAnExactBound:
+    """`mine_subcommands` costs an ``inspect.getsource`` + ``ast.parse`` per
+    verb — 340ms across the table, on a surface that renders between
+    keystrokes. Deferring it is only legitimate if the winner is unchanged.
+
+    The distinction matters more than the milliseconds: "stop at the first
+    source that answers" IS the boolean acceptance this arbiter replaced.
+    Skipping work whose outcome is already determined is a different thing,
+    and these tests are what keeps them different.
+    """
+
+    def test_a_determined_supplier_is_never_called(self):
+        called = []
+
+        def _expensive():
+            called.append(1)
+            return "help · show · depth · status"
+
+        winner = best_candidate([
+            Candidate("Show the activity radar — what is moving now",
+                      "docstring", 0.10),
+            Candidate("", "mined", 0.0, supplier=_expensive,
+                      ceiling=shape_ceiling(Shape.SUBCOMMAND_LIST)),
+        ], "radar")
+        assert winner is not None and winner.source == "docstring"
+        assert not called, "evaluated a source that could not have won"
+
+    def test_an_undetermined_supplier_IS_called(self):
+        """The bound must not become a veto. With nothing better in hand the
+        deferred source is the answer, and skipping it would reintroduce
+        exactly the gap that showed "[undocumented]" beside a documented
+        verb."""
+        called = []
+
+        def _expensive():
+            called.append(1)
+            return "help · show · depth · status"
+
+        winner = best_candidate([
+            Candidate("and dispatch", "residue", 0.0),
+            Candidate("", "mined", 0.0, supplier=_expensive,
+                      ceiling=shape_ceiling(Shape.SUBCOMMAND_LIST)),
+        ], "fanout")
+        assert called, "a source that could have won was skipped"
+        assert winner is not None and winner.source == "mined"
+
+    def test_lazy_and_eager_agree_on_every_live_verb(self):
+        """The bound is claimed to be EXACT. Asserted against the real table
+        rather than a constructed pair, because the ceilings are properties of
+        the shape floors and a future floor change could silently break the
+        claim while every unit case still passed."""
+        from backend.core.ouroboros.battle_test.repl_dispatch_registry import (
+            _VERB_TO_DISPATCHER, prime_registry,
+        )
+        from backend.core.ouroboros.battle_test.verb_usage import (
+            derive_usage, mine_subcommands,
+        )
+        prime_registry()
+        for verb, fn in list(_VERB_TO_DISPATCHER.items()):
+            lazy = rc._describe(fn)
+            mined = mine_subcommands(fn)
+            eager_pool = []
+            if mined:
+                eager_pool.append(Candidate(" · ".join(mined), "mined", 0.0))
+            usage = derive_usage(fn, verb)
+            if usage:
+                eager_pool.append(Candidate(usage, "derived-usage", 0.0))
+            if not eager_pool:
+                continue
+            # If either deferred source could have beaten the shipped answer,
+            # deferring changed the outcome.
+            shipped = assess(lazy, verb).score
+            for cand in eager_pool:
+                assert assess(cand.text, verb).score <= shipped + 1e-9, (
+                    verb, lazy, cand.text)
+
+    def test_a_throwing_supplier_is_survived(self):
+        def _boom():
+            raise RuntimeError("getsource failed")
+
+        winner = best_candidate([
+            Candidate("Browse an operation's causal lineage", "doc", 0.0),
+            Candidate("", "mined", 0.0, supplier=_boom, ceiling=1.0),
+        ], "causal")
+        assert winner is not None and winner.source == "doc"
+
+
+# ---------------------------------------------------------------------------
+# 5. The module docstring, readmitted under judgement
+# ---------------------------------------------------------------------------
+
+
+class TestModuleDocstringIsScoredNotBanned:
+    def test_a_good_module_docstring_wins(self):
+        """/provider read "[undocumented]" while "operator-facing DoubleWord
+        resilience dashboard" sat one scope up. The source was excluded by
+        POLICY because nothing could judge its output; with judgement the
+        policy is unnecessary."""
+        from backend.core.ouroboros.governance import provider_repl
+        got = rc._describe(provider_repl.dispatch_provider_command)
+        assert got != UNDOCUMENTED
+        assert "dashboard" in got.lower()
+
+    def test_a_provenance_module_docstring_still_loses(self):
+        """Readmitting the source must not readmit the noise that got it
+        banned. "§38.11-F operator surface" now loses on its merits."""
+        assert assess("§38.11-F operator surface", "x").shape is Shape.RESIDUE
+
+    def test_only_modules_inside_the_dispatch_naming_cage_qualify(self):
+        """A locally-defined dispatcher must not inherit its file's docstring
+        — otherwise this very test module becomes a description source.
+
+        `_is_verb_surface` delegates to the registry's own `_extract_verb_name`
+        so "what counts as a verb surface" has ONE definition."""
+        def dispatch_nothing_command(line: str):
+            """Parse ``/nothing`` line and dispatch. NEVER raises."""
+
+        assert rc._describe(dispatch_nothing_command) == UNDOCUMENTED
+
+    def test_a_usage_lede_does_not_hide_the_sentence_behind_it(self):
+        """Candidates were assessed BEFORE normalisation, so
+        "``/enqueue_soak <target_path>`` — stage a crash-immortal Swarm soak"
+        scored RESIDUE on its leading slash and was discarded — for a fault
+        the very next step removes."""
+        assert to_operator_voice(
+            "/enqueue_soak <target_path> — stage a crash-immortal Swarm soak.",
+            "enqueue_soak").lower().startswith("stage")
+
+
+# ---------------------------------------------------------------------------
+# 6. Client-side aliases
+# ---------------------------------------------------------------------------
+
+
+class TestAliasHelpIsDerivedFromTheRoutingTable:
+    def test_no_row_shows_an_internal_action_id(self):
+        """Six rows read "audio: force_wake" / "audio: ptt_stop" — an internal
+        identifier presented as a description."""
+        from backend.core.ouroboros.cli.ov import client_verbs
+        for verb, help_text in client_verbs().items():
+            assert not str(help_text).startswith("audio:"), verb
+
+    def test_synonyms_are_named_as_synonyms(self):
+        """``AUDIO_VERBS`` is a synonym table, so a verb without help has
+        documented siblings. Saying "alias of /force-wake" is both true and
+        more useful than a fresh sentence, because it tells the operator these
+        are the same word rather than three things to learn."""
+        from backend.core.ouroboros.cli.ov import client_verbs
+        verbs = client_verbs()
+        assert verbs["wake!"].startswith("alias of /force-wake")
+        assert "seize the mic" in verbs["wake!"]
+
+    def test_derived_from_the_table_not_transcribed(self):
+        """A second list of which spellings are synonyms is exactly how a
+        palette starts lying about what the CLI accepts."""
+        from backend.core.ouroboros.cli import ov
+        for verb, action in ov.AUDIO_VERBS.items():
+            text = ov.client_verbs()[verb]
+            if text.startswith("alias of /"):
+                target = text[len("alias of /"):].split(" — ")[0]
+                assert ov.AUDIO_VERBS[target] == action, verb
+
+    def test_the_slash_form_the_palette_offers_actually_routes(self):
+        """Found while auditing the descriptions, and the same lie in a
+        different place: ``AUDIO_VERBS`` is keyed on BARE words, the palette
+        renders every entry with a leading slash, and the router looked up
+        what the operator typed. ``/wake`` was in the menu, missed the table
+        on selection, and was relayed to a daemon with no ``/wake``
+        dispatcher — offered, and inert.
+
+        The neighbouring ``/deck``, ``/tasks`` and ``/keys`` branches each
+        test both forms by hand, so every client verb was patched for slash
+        forms one at a time and the table lookup covering fifteen of them
+        never was."""
+        from backend.core.ouroboros.battle_test.repl_dispatch_registry import (
+            prime_registry,
+        )
+        from backend.core.ouroboros.cli import ov
+        prime_registry()
+        for verb in ("wake", "ptt stop", "force-wake", "mute", "wake!"):
+            assert ov._resolve_audio_verb(f"/{verb}", ov.AUDIO_VERBS) == \
+                ov.AUDIO_VERBS[verb], verb
+
+    def test_the_daemon_still_wins_a_collision(self):
+        """A blind slash-strip would have hijacked ``/voice`` and ``/listen``
+        — both sit in ``AUDIO_VERBS`` AND have real daemon dispatchers, and
+        the palette shows the DAEMON's description for each.
+
+        `registry_from_dispatch` resolves that collision with "daemon wins";
+        the router now resolves it the same way, so the menu and the router
+        cannot disagree about who answers."""
+        from backend.core.ouroboros.battle_test.repl_dispatch_registry import (
+            _VERB_TO_DISPATCHER, prime_registry,
+        )
+        from backend.core.ouroboros.cli import ov
+        prime_registry()
+        contested = [v for v in ov.AUDIO_VERBS if v in _VERB_TO_DISPATCHER]
+        assert contested, "fixture assumes at least one collision exists"
+        for verb in contested:
+            assert ov._resolve_audio_verb(f"/{verb}", ov.AUDIO_VERBS) is None
+
+    def test_the_bare_form_is_untouched(self):
+        """`voice` typed WITHOUT a slash is still the audio word. The fix adds
+        a form; it must not remove one."""
+        from backend.core.ouroboros.cli import ov
+        for verb, action in ov.AUDIO_VERBS.items():
+            assert ov._resolve_audio_verb(verb, ov.AUDIO_VERBS) == action
+
+    def test_an_unprimed_registry_declines_to_intercept(self):
+        """Fails CLOSED. A guard that guessed "mine" when it could not read
+        the daemon's table would silently swallow verbs on a degraded boot,
+        and swallowing is the harder failure to diagnose."""
+        from backend.core.ouroboros.cli import ov
+        assert ov._daemon_owns("\x00 not a verb") in (True, False)
+
+    def test_an_undocumented_orphan_degrades_to_blank_not_to_an_id(self):
+        """A verb whose whole synonym group is undocumented has nothing to
+        borrow. Blank falls through to the honest ``[undocumented]``; an
+        action id would look like help."""
+        from backend.core.ouroboros.cli import ov
+        assert ov._alias_help("no-such-verb") == ""
+
+
+# ---------------------------------------------------------------------------
+# 7. The property that keeps it fixed
+# ---------------------------------------------------------------------------
+
+
+class TestEveryLiveVerbHasADescription:
+    """Walks the registry rather than a golden list.
+
+    A fixture of today's 84 verbs would pass forever while verb 85 shipped
+    "[undocumented]" — which is how the first four of these defects survived
+    to reach a screenshot. The invariant is about the palette, so it is
+    asserted over whatever the palette actually contains.
+    """
+
+    @staticmethod
+    def _registry():
+        return rc.unified_registry(None).verbs
+
+    def test_registry_is_populated(self):
+        """Guards the tests below: an empty registry would satisfy every
+        'no bad row' assertion vacuously."""
+        assert len(self._registry()) >= 60
+
+    def test_no_verb_is_undocumented(self):
+        missing = [v.slash_form for v in self._registry()
+                   if v.description == UNDOCUMENTED]
+        assert not missing, f"no description resolves for: {missing}"
+
+    def test_no_row_is_residue(self):
+        """The class that produced "Er for /multi_prior REPL verb" and "Line
+        and render the dashboard": text that survived subtraction as a
+        fragment, reads as help, and answers nothing."""
+        bad = [(v.slash_form, v.description, assess(v.description,
+                                                    v.slash_form.lstrip("/")).reasons)
+               for v in self._registry()
+               if assess(v.description,
+                         v.slash_form.lstrip("/")).shape is Shape.RESIDUE]
+        assert not bad, f"residue on the palette: {bad}"
+
+    def test_no_row_falls_back_to_a_bare_usage_or_vocabulary(self):
+        """Both are honest last resorts and neither is a description. They are
+        allowed to EXIST as rungs — a verb documented tomorrow needs somewhere
+        to fall — but no verb should currently need one."""
+        weak = [(v.slash_form, v.description) for v in self._registry()
+                if assess(v.description, v.slash_form.lstrip("/")).shape
+                in (Shape.USAGE, Shape.SUBCOMMAND_LIST)]
+        assert not weak, f"verbs still without prose: {weak}"
+
+    def test_no_row_echoes_only_its_own_name(self):
+        for v in self._registry():
+            name = v.slash_form.lstrip("/").replace("_", " ").lower()
+            assert v.description.lower().strip(" .") != name, v.slash_form


### PR DESCRIPTION
## The row you screenshotted

`/provider  [undocumented]` — while this sat one scope up in `provider_repl.py`:

> operator-facing DoubleWord resilience dashboard

And `/fanout  help · show · depth · status`, while its docstring reads **"Op fan-out tree."** — a perfect description, in the source, thrown away by a `len(words) < 4` floor.

## Root cause

The cascade ranked **sources** and never judged **results**. Every rung asked *"did this return a non-empty string?"* — a test of presence, not quality. Three consequences, all visible in the screenshots:

- rank was **absolute**, so residue from a high rung beat prose from a low one, and no better candidate could ever supersede a worse one that merely arrived first;
- `/multi_prior` showed `Er for /multi_prior REPL verb` — non-empty, therefore accepted, and not a word;
- the module docstring was banned **outright** because nothing could judge its output. That policy existed only because judgement was missing.

Sources now *nominate*. `verb_description.assess` classifies each candidate by shape — `PROSE` / `NOUN_PHRASE` / `SUBCOMMAND_LIST` / `USAGE` / `IMPLEMENTATION` / `RESIDUE` — and `best_candidate` picks the winner. Source rank survives as a **prior**, not a decision. A provenance-heavy module docstring now loses on its merits; a good one wins on its merits.

## Four rules matching below their own token

Each produced text no author wrote — precisely what *"SUBTRACTIVE only"* exists to prevent.

| Fault | Shipped as |
|---|---|
| openers matched as character **prefixes** (`"Dispatcher"` minus `"dispatch"` = `"er"`) | `Er for /multi_prior REPL verb` |
| verb-name stripper used `\b`, which sits **inside** a hyphenated compound | `State views: arch, aura…` (from *Embodied-state*) |
| an optional-quantifier bound to **one** backtick of a two-character token — the pattern could never fire | `REPL line and return the rendered result` |
| `^[A-Z]\d+\b` read the tier prefix in `L3 execution graph` as a citation | `Units, edges and stats` |

## Also found, same family, different surface

`AUDIO_VERBS` is keyed on **bare** words; the palette renders every entry with a slash. So `/wake` was offered in the menu and relayed to a daemon that has no `/wake` dispatcher — **advertised and inert**. The neighbouring `/deck`, `/tasks` and `/keys` branches each test both forms by hand; the table lookup covering fifteen verbs never was.

The router now resolves slash forms with the same **daemon-wins** precedence `registry_from_dispatch` uses, so `/voice` and `/listen` keep the verbs the palette describes. Six rows reading `audio: force_wake` now name their documented synonym.

## Result

**84 / 84 rows carry a real description.** `/cost` and `/multi_prior` genuinely had none anywhere and got an `Operator:` line beside the implementation.

## Performance

Eager nomination cost 340ms of AST mining per registry build. Deferred behind an **exact** ceiling — a mined vocabulary can never exceed 0.42, so once a sentence is in hand the answer is *provably* unchanged. **576ms to 234ms**, same winner. Three tests pin the bound as exact rather than merely fast; skipping determined work is not the same as letting order decide.

## Testing

**349 palette/description tests green, 61 new.** The last one walks the **live** registry — a golden list of today's 84 would pass forever while verb 85 shipped `[undocumented]`, which is how four of these survived to reach a screenshot.

Also rewrote `test_subcommand_rows_read_as_a_LIST_not_a_usage_string`, which grepped `repl_completion.py`'s own source text. That tested a *spelling*: it broke when the join moved into a supplier, and would have passed equally well had the line been dead code.

Baselined in a clean-HEAD worktree: the 26 other reds across these 87 test files (m10 durable graduation state, keymap aliases, colour-token ratchets, tool-loop budget, `ov_demo` import-graph timeout) reproduce **identically** on `96b672c925`.

## Not proven

Rendering is verified by test and by dumping the registry, not by watching `ov`. The palette is your daily surface — worth a look at `/` before this is trusted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the palette’s “first non-empty wins” cascade with a scored arbitration so each verb shows the best operator-facing description, and fixed sub-token regex bugs that created junk like "Er for /multi_prior REPL verb". Audio aliases now show as “alias of …” and slash-form audio verbs route correctly.

- **Bug Fixes**
  - Judge candidates with `verb_description.assess` and pick via `best_candidate`; good module docstrings compete again, `Operator:` lines are used; authored `__verb_help__` still short-circuits.
  - Fixed sub-token matches: word-bound openers, hyphen-safe name stripping, correct “optional pair” backticks, and stricter citation heads; normalise before judging and accept short real descriptions.
  - Audio: `_resolve_audio_verb` handles `/wake`-style forms with daemon-wins precedence; `_alias_help` renders “alias of /<target> — …”; removed “audio: force_wake”-style placeholders.
  - Added `Operator:` help to `/cost` and `/multi_prior`.

- **Refactors**
  - Introduced shapes (`PROSE`, `NOUN_PHRASE`, `SUBCOMMAND_LIST`, `USAGE`, `IMPLEMENTATION`, `RESIDUE`) with scoring, density, and an acceptance floor; exposed `Shape`, `Assessment`, `Candidate`, `assess`, `best_candidate`, `shape_ceiling`, and `runtime_vocabulary`.
  - Deferred expensive sources (mined subcommands, derived usage) with exact ceilings; identical winners, less work.
  - Hardened `_humanise` and `_strip_citation`/`_strip_verb_name`; added `_is_verb_surface` to gate module docstrings; expanded tests, including a registry-walking suite to keep all live verbs documented.

<sup>Written for commit 25edc1795c824fd5c273a8b06c580620b89fec11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

