### PR TITLE
fix(palette): aliases were stated three ways, none of them the structured one

### DIFF
--- a/backend/core/ouroboros/battle_test/repl_completion.py
+++ b/backend/core/ouroboros/battle_test/repl_completion.py
@@ -102,14 +102,26 @@ _HANDLER_PREFIX: str = "_handle_"
 # Built-in verbs that don't have ``_handle_*`` methods (handled
 # directly in the REPL dispatch loop). They're registered here so
 # the palette is complete.
-_BUILTIN_VERBS: Tuple[Tuple[str, str], ...] = (
-    ("/help", "show available commands"),
-    ("/status", "current op + cost + posture snapshot"),
-    ("/cost", "session cost breakdown"),
-    ("/posture", "current strategic posture (EXPLORE / HARDEN / ...)"),
-    ("/lessons", "session lessons (infra/code tagged learnings)"),
-    ("/quit", "shut down the organism"),
-    ("/exit", "shut down the organism (alias for /quit)"),
+#
+# The third column is ALIASES, and it replaces a row.
+#
+# ``/exit`` used to be its own entry described as "shut down the organism
+# (alias for /quit)" — the aliasing stated in PROSE, in the one column the
+# operator scans for what a verb DOES, while `VerbDescriptor.aliases` (the
+# field built to carry exactly this, and read by typo-suggestion, prefix
+# matching and ``/verb --help``) sat empty on every row in the registry.
+#
+# So the palette showed both spellings as though they were two capabilities,
+# and the second spent its description explaining that it was not. Declaring
+# the alias where the verb is declared costs one tuple element and lights up
+# four existing consumers.
+_BUILTIN_VERBS: Tuple[Tuple[str, str, Tuple[str, ...]], ...] = (
+    ("/help", "show available commands", ()),
+    ("/status", "current op + cost + posture snapshot", ()),
+    ("/cost", "session cost breakdown", ()),
+    ("/posture", "current strategic posture (EXPLORE / HARDEN / ...)", ()),
+    ("/lessons", "session lessons (infra/code tagged learnings)", ()),
+    ("/quit", "shut down the organism", ("/exit",)),
 )
 
 
@@ -1292,15 +1304,20 @@ def discover_verbs(repl_instance: object) -> VerbRegistry:
     # Layer in built-ins (don't override discovered descriptions —
     # but `/help`, `/status`, etc. don't have `_handle_*` so this is
     # additive in practice).
-    for slash, desc in _BUILTIN_VERBS:
+    for slash, desc, aliases in _BUILTIN_VERBS:
         if slash in seen:
             continue
+        # An alias is claimed by its canonical form, so it never becomes a row
+        # of its own. It stays fully reachable: `VerbDescriptor.matches`,
+        # prefix completion and typo suggestion all read `aliases` already.
         seen.add(slash)
+        seen.update(aliases)
         discovered.append(
             VerbDescriptor(
                 slash_form=slash,
                 handler_method="",
                 description=desc,
+                aliases=tuple(aliases),
             )
         )
 
@@ -2362,16 +2379,37 @@ def registry_from_dispatch() -> VerbRegistry:
     # the fuzzy fallback, which answered "/deck" with "/bus, /cost". A palette
     # that invents plausible wrong answers is worse than one that says nothing.
     try:
-        from backend.core.ouroboros.cli.ov import client_verbs
+        from backend.core.ouroboros.cli.ov import (
+            audio_alias_families, client_verbs,
+        )
         known = {d.slash_form for d in descriptors}
+
+        # SYNONYMS COLLAPSE INTO THEIR CANONICAL ROW.
+        #
+        # `client_verbs()` enumerates every spelling the cockpit ACCEPTS,
+        # which is the right answer for routing and the wrong one for a menu:
+        # eleven of its keys carried four meanings, so `/flush`, `/hush` and
+        # `/shh` were three rows for one capability and two of them spent
+        # their description saying "alias of /flush".
+        #
+        # The accept-set is unchanged — `_resolve_audio_verb` still reads
+        # AUDIO_VERBS directly, so every spelling still works. Only the
+        # DISPLAY collapses, and the folded spellings stay discoverable
+        # through `VerbDescriptor.aliases`, which prefix completion, typo
+        # suggestion, `matches()` and `/verb --help` were already reading and
+        # finding empty on every row.
+        families = audio_alias_families()
+        folded = {f"/{a}" for aliases in families.values() for a in aliases}
+
         for verb, help_text in sorted(client_verbs().items()):
             slash = f"/{verb}"
-            if slash in known:
+            if slash in known or slash in folded:
                 continue
             descriptors.append(
                 VerbDescriptor(
                     slash_form=slash, handler_method="",
                     description=help_text or "handled by this cockpit",
+                    aliases=tuple(f"/{a}" for a in families.get(verb, ())),
                 )
             )
     except Exception:  # noqa: BLE001 — daemon verbs alone still complete

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -136,18 +136,88 @@ def _alias_help(verb: str) -> str:
         action = AUDIO_VERBS.get(verb)
         if not action:
             return ""
-        # Preference order, deliberately: the spelling that IS the action name
-        # (``flush`` -> ``flush``), then the first documented sibling in table
-        # order. Both are stable, so the palette does not reshuffle between
-        # runs — an alias target that moves is worse than none.
         siblings = [v for v, a in AUDIO_VERBS.items()
                     if a == action and v != verb and CLIENT_VERB_HELP.get(v)]
         if not siblings:
             return ""
-        canonical = next((v for v in siblings if v == action), siblings[0])
+        # Canonical selection is `_canonical_of`'s job, not a second copy of
+        # the same preference order. This text names a verb, and
+        # `audio_alias_families` decides which verb the palette SHOWS — two
+        # implementations that drifted would point the operator at a row that
+        # had been folded away.
+        canonical = _canonical_of(action, siblings)
         return f"alias of /{canonical} — {CLIENT_VERB_HELP[canonical]}"
     except Exception:  # noqa: BLE001 — a palette must never throw
         return ""
+
+
+def audio_alias_families() -> "dict":
+    """``{canonical verb: (synonyms, ...)}``, derived from AUDIO_VERBS.
+
+    ``AUDIO_VERBS`` is a SYNONYM table — ``wake!``, ``force-wake`` and
+    ``force wake`` all resolve to ``force_wake`` — and the palette enumerated
+    its KEYS, so eleven rows carried four meanings::
+
+        /flush      halt outbound audio now (ducking)
+        /hush       alias of /flush — halt outbound audio now (ducking)
+        /shh        alias of /flush — halt outbound audio now (ducking)
+
+    Three rows for one capability, two of them spending their description
+    saying so. `VerbDescriptor.aliases` exists precisely to express this and
+    was empty on every row in the registry, while four consumers — typo
+    suggestion, prefix matching, ``matches()`` and ``/verb --help`` — were
+    already reading it.
+
+    Sameness is DERIVED from the routing table rather than listed: two verbs
+    are aliases exactly when they fire the same audio command. A hand-written
+    list of families would be a fourth place to state a fact the table already
+    holds, and the first one to go stale.
+
+    Two subtleties that a naive "group by action" gets wrong:
+
+    * ``voice`` and ``listen`` map to ``wake`` here AND have real daemon
+      dispatchers with their own descriptions. They are separate verbs that
+      happen to share an audio effect, so folding them would delete two
+      capabilities from the palette. Deferred to `_daemon_owns`, the same
+      precedence `_resolve_audio_verb` uses.
+    * the canonical is chosen deterministically — the spelling that IS the
+      action, else the first DOCUMENTED sibling in table order. An alias
+      target that reshuffles between runs is worse than none.
+
+    NEVER raises.
+    """
+    try:
+        by_action: "dict" = {}
+        for verb, action in AUDIO_VERBS.items():
+            if _daemon_owns(verb):
+                continue        # a real verb that merely shares an effect
+            by_action.setdefault(action, []).append(verb)
+        families: "dict" = {}
+        for action, verbs in by_action.items():
+            if len(verbs) < 2:
+                continue
+            canonical = _canonical_of(action, verbs)
+            families[canonical] = tuple(v for v in verbs if v != canonical)
+        return families
+    except Exception:  # noqa: BLE001 — a palette must never throw
+        return {}
+
+
+def _canonical_of(action: str, verbs: "Sequence[str]") -> str:
+    """Which spelling of a synonym group is the one to show. NEVER raises.
+
+    ONE definition, shared with :func:`_alias_help` — the alias text says
+    "alias of /X" and the palette shows row X, so if the two disagreed the
+    menu would point at a verb it had also hidden.
+    """
+    try:
+        exact = next((v for v in verbs if v == action), None)
+        if exact:
+            return exact
+        documented = next((v for v in verbs if CLIENT_VERB_HELP.get(v)), None)
+        return documented or verbs[0]
+    except Exception:  # noqa: BLE001
+        return verbs[0] if verbs else ""
 
 
 def _daemon_owns(verb: str) -> bool:

--- a/tests/battle_test/test_verb_description_arbitration.py
+++ b/tests/battle_test/test_verb_description_arbitration.py
@@ -507,6 +507,71 @@ class TestEveryLiveVerbHasADescription:
                 in (Shape.USAGE, Shape.SUBCOMMAND_LIST)]
         assert not weak, f"verbs still without prose: {weak}"
 
+    def test_no_two_rows_carry_the_same_meaning(self):
+        """Eleven rows carried four meanings::
+
+            /flush   halt outbound audio now (ducking)
+            /hush    alias of /flush — halt outbound audio now (ducking)
+            /shh     alias of /flush — halt outbound audio now (ducking)
+
+        `VerbDescriptor.aliases` exists to say exactly this and was empty on
+        every row, while four consumers — typo suggestion, prefix matching,
+        `matches()` and `/verb --help` — were already reading it.
+
+        Asserted over the LIVE registry and by MEANING rather than by known
+        family, so a duplicate arriving from a source nobody has written yet
+        is caught by the same test. Two dispatch verbs pointing at one
+        function would be a different origin and the identical symptom."""
+        from collections import defaultdict
+        by_meaning = defaultdict(list)
+        for v in self._registry():
+            by_meaning[v.description.strip().lower()].append(v.slash_form)
+        dupes = {k: v for k, v in by_meaning.items() if len(v) > 1}
+        assert not dupes, f"rows sharing one meaning: {dupes}"
+
+    def test_no_row_advertises_itself_as_an_alias(self):
+        """A row explaining that it is a duplicate is a row that should not
+        exist. `/exit` spent its description on "alias for /quit" — the
+        aliasing stated in the one column an operator scans for what a verb
+        DOES."""
+        for v in self._registry():
+            assert "alias of" not in v.description.lower(), v.slash_form
+            assert "alias for" not in v.description.lower(), v.slash_form
+
+    def test_every_folded_alias_stays_reachable(self):
+        """Collapsing the DISPLAY must not shrink the ACCEPT set. The router
+        reads AUDIO_VERBS directly and is untouched; this pins the palette
+        side, since a fold that quietly removed a verb would look identical
+        in the row count."""
+        from backend.core.ouroboros.battle_test.repl_completion import (
+            fuzzy_match,
+        )
+        registry = rc.unified_registry(None)
+        aliased = [(v, a) for v in registry.verbs for a in v.aliases]
+        assert aliased, "fixture assumes the registry folds something"
+        for verb, alias in aliased:
+            assert verb.matches(alias), (verb.slash_form, alias)
+            hits = fuzzy_match(alias, registry, max_results=3)
+            assert verb.slash_form in [h.slash_form for h in hits], (
+                f"typing {alias} does not reach {verb.slash_form}")
+
+    def test_folding_did_not_orphan_the_alias_help_text(self):
+        """`_alias_help` names a canonical verb and `audio_alias_families`
+        decides which verb the palette SHOWS. Two implementations of "which
+        spelling is canonical" would eventually point the operator at a row
+        that had been folded away, so they share `_canonical_of`."""
+        from backend.core.ouroboros.battle_test.repl_completion import (
+            unified_registry,
+        )
+        from backend.core.ouroboros.cli import ov
+        rows = {v.slash_form for v in unified_registry(None).verbs}
+        for verb in ov.AUDIO_VERBS:
+            text = ov._alias_help(verb)
+            if not text.startswith("alias of /"):
+                continue
+            target = "/" + text[len("alias of /"):].split(" — ")[0]
+            assert target in rows, f"{verb} points at {target}, which has no row"
+
     def test_no_row_echoes_only_its_own_name(self):
         for v in self._registry():
             name = v.slash_form.lstrip("/").replace("_", " ").lower()

--- a/tests/cli/test_slash_palette.py
+++ b/tests/cli/test_slash_palette.py
@@ -107,16 +107,60 @@ def test_deck_resolves_to_itself_not_to_noise() -> None:
 
 
 def test_the_palette_and_the_router_share_one_table() -> None:
-    """DRY, asserted: a verb the router dispatches must be offerable, so the
-    menu cannot drift from what the CLI actually accepts."""
+    """DRY, asserted: a verb the router dispatches must be REACHABLE, so the
+    menu cannot drift from what the CLI actually accepts.
+
+    SUPERSEDED 2026-07-31: was ``verb in {row.slash_form for row in ...}`` —
+    every router verb had to be its own ROW.
+
+    That measured presence-as-a-row because `VerbDescriptor.aliases` was empty
+    on every row in the registry, so row-set and reachable-set were the same
+    set and the difference could not show. It stopped being true when the
+    audio synonyms folded: ``wake!``, ``shh``, ``hush``, ``mute``, ``ptt off``
+    and ``ptt-stop`` are all still accepted, still completable, and no longer
+    rows of their own — which is the point, since they were eleven rows
+    carrying four meanings.
+
+    The property was never "has a row"; it was "the operator can get there".
+    Asserted two ways now, both stronger than the original: the verb resolves
+    to a descriptor, AND typing it actually completes. A verb that were truly
+    dropped would fail both.
+    """
+    from backend.core.ouroboros.battle_test.repl_completion import (
+        fuzzy_match, unified_registry,
+    )
     from backend.core.ouroboros.cli.ov import AUDIO_VERBS, client_verbs
 
-    offered = {t.lstrip("/") for t, _m in _completions("/")}
+    registry = unified_registry(None)
     for verb in AUDIO_VERBS:
-        if " " in verb:          # multi-word forms are typed, not completed
-            continue
-        assert verb in offered, f"router accepts {verb!r}; palette omits it"
+        slash = f"/{verb}"
+        resolved = [v for v in registry.verbs if v.matches(slash)]
+        assert resolved, f"router accepts {verb!r}; palette cannot resolve it"
+        # And it must be TYPEABLE, not merely present in a data structure.
+        assert fuzzy_match(slash, registry, max_results=3), (
+            f"router accepts {verb!r}; typing it completes to nothing"
+        )
     assert "deck" in client_verbs()
+
+
+def test_a_folded_alias_is_not_a_second_row() -> None:
+    """The other half of the invariant above, and the reason it changed.
+
+    Reachability must not be bought back by re-listing: if a folded spelling
+    reappeared as its own row the duplicates would return, and both tests
+    would pass."""
+    from backend.core.ouroboros.battle_test.repl_completion import (
+        unified_registry,
+    )
+    from backend.core.ouroboros.cli.ov import audio_alias_families
+
+    rows = {v.slash_form for v in unified_registry(None).verbs}
+    for canonical, aliases in audio_alias_families().items():
+        assert f"/{canonical}" in rows, canonical
+        for alias in aliases:
+            assert f"/{alias}" not in rows, (
+                f"/{alias} is folded into /{canonical} and still has a row"
+            )
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## The duplicates

Eleven rows carried four meanings:

```
/flush      halt outbound audio now (ducking)
/hush       alias of /flush — halt outbound audio now (ducking)
/shh        alias of /flush — halt outbound audio now (ducking)
```

Three rows for one capability, two of them spending their description explaining that they shouldn't exist.

## Root cause

`VerbDescriptor.aliases` exists to express exactly this, and **four consumers already read it** — `matches()`, prefix completion, typo suggestion, and `/verb --help`. It was **empty on every row in the registry**.

So "these two verbs are the same" was being said three other ways instead, none of which the palette could act on:

- **`AUDIO_VERBS`** is a synonym table (`wake!` / `force-wake` / `force wake` all fire `force_wake`) and the palette enumerated its *keys*;
- **`_BUILTIN_VERBS`** declared `/exit` as `"shut down the organism (alias for /quit)"` — the aliasing stated in the **description column**, the one an operator scans for what a verb *does*;
- **yesterday's `_alias_help`** made it worse in the honest direction: it replaced `audio: force_wake` with `alias of /force-wake — …`. Truthful, and still a row whose entire job was to announce it shouldn't be one.

## The fix

Sameness is **derived from the routing table**, not listed. `audio_alias_families()` groups `AUDIO_VERBS` by the command each key fires — a hand-written list of families would have been a *fourth* place to state a fact the table already holds, and the first to go stale.

Two subtleties a naive group-by-action gets wrong:

- `voice` and `listen` map to `wake` **and** have real daemon dispatchers with their own descriptions. They're separate verbs that happen to share an effect; folding them would delete two capabilities. Deferred to `_daemon_owns` — the same precedence `_resolve_audio_verb` uses.
- canonical selection is `_canonical_of`, **shared** with `_alias_help`. The alias text names a verb and the folding decides which verb has a row; two implementations would eventually point the operator at a row that had been folded away.

**The accept set is untouched.** The router still reads `AUDIO_VERBS` directly, so every spelling still works. Only the display collapses.

**84 rows → 76.** Zero duplicate meanings.

```
/flush        halt outbound audio now (ducking)      aliases: /shh, /hush
/force-wake   seize the mic from another terminal    aliases: /wake!, /force wake
/ptt stop     close the push-to-talk hold            aliases: /ptt-stop, /ptt off
/quit         shut down the organism                 aliases: /exit
/sleep        disarm the microphone                  aliases: /mute
```

## A test that measured the wrong thing

`test_the_palette_and_the_router_share_one_table` asserted every router verb had its own **row**. It could only measure presence-as-a-row because `aliases` was empty everywhere — row-set and reachable-set were the same set, so the difference could not show.

The property was never *"has a row"*, it was *"the operator can get there"*. Now asserted twice over — by resolution **and** by typing the alias — both stronger than the original. A companion test pins the other half: reachability must not be bought back by re-listing.

The duplicate check is **by meaning over the live registry**, not by known family, so a duplicate from a source nobody has written yet is caught the same way. Two dispatch verbs pointing at one function would be a different origin and an identical symptom.

## On CC parity

The other half of the question — the top-level `/` menu shows name + description, and argument hints appear once you start typing args (`/posture ` → `help|status|explain|history|…`). Both already match CC; verified, not changed. The duplicates were the real gap.

## Testing

**551 palette/completion tests green.** Chunk baselines unchanged (2 keymap, 5 colour/render) — all previously proven pre-existing on clean HEAD.

Still not watched live in `ov`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Collapsed duplicate audio verbs in the slash palette by deriving alias families from the routing table and populating `VerbDescriptor.aliases`. The palette now shows one canonical row per capability, with aliases still fully reachable. 84 rows → 76.

- **Bug Fixes**
  - Added `audio_alias_families()` to group synonyms from `AUDIO_VERBS`, and `_canonical_of()` for deterministic canonical selection shared with `_alias_help`.
  - Populated `VerbDescriptor.aliases` for built-ins; removed prose-only alias rows (e.g. `/exit` now aliases `/quit`).
  - Excluded daemon-owned verbs (`voice`, `listen`) from folding so their distinct capabilities remain.
  - Display collapses synonyms; routing unchanged. Aliases still resolve, complete, and show in `/verb --help`.

- **Tests**
  - Updated reachability invariant: router verbs must resolve and complete, not necessarily have their own row.
  - Added guard to ensure folded aliases don’t reappear as rows.
  - Added duplicate-meaning check over the live registry.
  - All 551 palette/completion tests pass.

<sup>Written for commit 66e21f56f82f956086deea725d164a145e8b71e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

