### PR TITLE
fix(liveness+swarm): unprovable is not dead, and a predicate must carry information

### DIFF
--- a/backend/core/ouroboros/governance/autonomy/swarm_invoker.py
+++ b/backend/core/ouroboros/governance/autonomy/swarm_invoker.py
@@ -48,7 +48,7 @@ from __future__ import annotations
 import logging
 import os
 import time
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, Tuple
 
 from backend.core.ouroboros.governance.autonomy.subagent_types import (
     ExecutionGraph,
@@ -124,32 +124,62 @@ def require_preshaped_units() -> bool:
     ).strip().lower() in ("1", "true", "yes", "on")
 
 
-def swarm_eligible(unit: WorkUnitSpec) -> bool:
+def swarm_eligible(unit: WorkUnitSpec, *, shape: Any = None) -> bool:
     """Whether this unit CAN be shaped into a caged swarm worker. NEVER raises.
 
-    The bug this replaces was circular. The predicate asked
-    ``unit.is_swarm_worker`` — True only when the unit ALREADY carries a
-    ``system_prompt_template`` / ``allowed_tools`` / ``worker_role``. But the
-    invoker's whole job is to SYNTHESIZE that shape, and every production
-    graph builder (``parallel_dispatch``, ``iteration_planner``,
-    ``providers``, ``meta_goal_aggregator``, ``graph_coalescer``) leaves all
-    five fields ``None``. The only writer is ``SwarmOrchestrator.define_worker``,
-    which has no production caller.
+    THE PREDICATE CARRIED ALMOST NO INFORMATION
+    --------------------------------------------
+    The version this replaces asked for a non-empty ``target_files`` and a
+    non-empty ``goal``. ``WorkUnitSpec.__post_init__`` already raises without
+    either, so the ``target_files`` branch could never be False for a
+    constructible unit — the original circularity inverted rather than
+    repaired: the first predicate answered no to everything (``eligible ⟺
+    already shaped``), the second answered yes to nearly everything.
 
-    So the invoker would only shape a unit that was already shaped, and
-    ``JARVIS_SWARM_ORCHESTRATOR_ENABLED=true`` still did nothing — the same
-    class of defect this module's own docstring says it closed, one layer
-    further in. It closed "nothing CALLS the swarm"; it left "nothing is ever
-    ELIGIBLE for it".
+    "Nearly", and the exception is instructive. ``if not self.goal`` is False
+    for ``"   "``, so a whitespace-only goal IS constructible and the
+    ``goal.strip()`` branch really did reject it. That check is kept below —
+    measured, a taskless unit against a parseable file still scores
+    ``confidence=0.50``, because confidence blends "I read the targets" with
+    "I understood the task". Deleting it as redundant would have widened
+    eligibility to workers with no instruction.
 
-    The fix is to ask what the synthesizer actually needs rather than what a
-    marking says. ``worker_synthesizer`` derives the shape from the sub-goal's
-    ``target_files`` (stdlib ``ast``) and its ``goal`` text, so a unit with
-    both is synthesizable and a unit without either is not.
+    What both versions shared is guessing at proxies for a judgement that
+    lives somewhere else.
 
-    Fail-CLOSED in the same direction as everything downstream: no target
-    files or no goal → legacy executor, byte-identical. A unit that cannot be
-    inspected cannot be caged, and an uncaged worker must never run.
+    So this asks the component that actually knows. ``synthesize_worker_spec``
+    inspects the target files by AST and classifies the goal's intent, and it
+    reports what it managed with ``confidence`` — 0.90 for a goal it
+    understood against a file it parsed, 0.00 for the degenerate read-only
+    fallback it emits when the sub-goal is unparseable or the files are not
+    there. Eligibility is that verdict, not a re-derivation of it.
+
+    ``shape`` lets the caller pass a shape it has ALREADY synthesized.
+    Synthesis reads and parses every target file; the routing decision and the
+    execution path both need it, and doing it twice per unit would be the cost
+    of asking the question in the first place. Passing it through means the
+    honest predicate is also the cheaper one.
+
+    THE ORIGINAL BUG, kept because both failures share one cause
+    -------------------------------------------------------------
+    The first predicate asked ``unit.is_swarm_worker`` — True only when the
+    unit ALREADY carried a ``system_prompt_template`` / ``allowed_tools`` /
+    ``worker_role``. But the invoker's whole job is to SYNTHESIZE that shape,
+    and every production graph builder (``parallel_dispatch``,
+    ``iteration_planner``, ``providers``, ``meta_goal_aggregator``,
+    ``graph_coalescer``) leaves all five fields ``None``. The only writer is
+    ``SwarmOrchestrator.define_worker``, which has no production caller. So
+    the invoker would only shape a unit that was already shaped, and
+    ``JARVIS_SWARM_ORCHESTRATOR_ENABLED=true`` still did nothing.
+
+    Both versions failed the same way: each invented a LOCAL test for a
+    question the synthesizer answers. Marking, then preconditions, now the
+    synthesizer's own verdict — and only the third one cannot drift from it,
+    because it IS it.
+
+    Fail-CLOSED in the same direction as everything downstream: no derivable
+    shape → legacy executor, byte-identical. A unit that cannot be inspected
+    cannot be caged, and an uncaged worker must never run.
     """
     try:
         # An explicitly pre-shaped unit stays eligible — the orchestrator's
@@ -158,12 +188,83 @@ def swarm_eligible(unit: WorkUnitSpec) -> bool:
             return True
         if require_preshaped_units():
             return False
-        # Synthesizable: the two inputs `synthesize_worker_spec` inspects.
-        if not tuple(getattr(unit, "target_files", ()) or ()):
+        if shape is None:
+            from backend.core.ouroboros.governance.autonomy.worker_synthesizer import (  # noqa: E501
+                synthesize_worker_spec,
+            )
+            shape = synthesize_worker_spec(unit)
+        if not _has_instruction(unit):
             return False
+        if shape is None:
+            return False
+        # ABSENT confidence is not zero confidence.
+        #
+        # The floor below is `synthesize_worker_spec`'s own fail-CLOSED signal
+        # read back, so it means something only for shapes IT produced. A
+        # shape from an injected `define_worker` — the orchestrator's
+        # `define_worker` path, or a test's — may carry no `confidence` field
+        # at all, and defaulting that to 0.0 rejected it: a perfectly good
+        # custom shape silently routed to the legacy executor, which is the
+        # inertness class this whole predicate exists to have escaped.
+        #
+        # Present-and-0.0 still fails: that IS the synthesizer reporting it
+        # could not read the sub-goal.
+        confidence = getattr(shape, "confidence", None)
+        if confidence is None:
+            return True
+        try:
+            return float(confidence) > _min_shape_confidence()
+        except (TypeError, ValueError):
+            return True      # unreadable field -> not ours to judge
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _has_instruction(unit: Any) -> bool:
+    """Does this unit tell a worker what to DO? NEVER raises.
+
+    A worker with no instruction cannot be caged usefully however well its
+    files parse. ``WorkUnitSpec.__post_init__`` rejects ``goal=""`` but
+    accepts ``goal="   "`` — ``if not self.goal`` is False for whitespace — so
+    this catches a unit the type system lets through, and measured, the
+    synthesizer scores that unit ``confidence=0.50`` on the strength of the
+    FILES alone. Confidence blends "I read the targets" with "I understood the
+    task"; a taskless worker fails the second even when the first went
+    perfectly.
+
+    Separate from the confidence floor because it must run BEFORE synthesis:
+    synthesis reads and parses every target file, and paying that for a unit
+    already known to be ineligible is waste the routing path should not incur.
+    """
+    try:
         return bool(str(getattr(unit, "goal", "") or "").strip())
     except Exception:  # noqa: BLE001
         return False
+
+
+def _min_shape_confidence() -> float:
+    """The floor a synthesized shape must clear to be worth caging.
+
+    Default ``0.0``, and the comparison is STRICTLY greater — so the bar is
+    "the synthesizer derived something", not a tuned number.
+
+    That is not an arbitrary constant, it is the synthesizer's own fail-CLOSED
+    signal read back. ``synthesize_worker_spec`` documents that "an
+    unparseable / empty sub-goal yields the minimal read-only shape", and
+    measured against real units that shape carries ``confidence=0.00`` while
+    every unit it could actually inspect scores 0.40–0.90. Zero is the value
+    the synthesizer emits when it could not do its job.
+
+    Raising it (``JARVIS_SWARM_MIN_SHAPE_CONFIDENCE=0.5``) narrows the swarm to
+    high-confidence shapes without touching this file — the knob an operator
+    wants after watching a soak, expressed in the units the synthesizer
+    already reports.
+    """
+    try:
+        return max(0.0, min(1.0, float(os.environ.get(
+            "JARVIS_SWARM_MIN_SHAPE_CONFIDENCE", "0.0") or 0.0)))
+    except (TypeError, ValueError):
+        return 0.0
 
 
 class SwarmUnitInvoker:
@@ -217,40 +318,80 @@ class SwarmUnitInvoker:
         legacy executor (byte-identical). Eligible -> synthesize + cage +
         caged execute, fail-CLOSED on synthesis/cage failure, deadlock-aware.
         """
-        if not self._should_route_swarm(graph, unit):
+        route, shape = self._route_decision(graph, unit)
+        if not route:
             return await self._legacy.execute(graph, unit)
-        return await self._execute_swarm(graph, unit)
+        # The shape the DECISION was made on is the shape that gets caged.
+        # Re-synthesizing here would parse every target file a second time and,
+        # worse, could disagree with the verdict that routed the unit — a
+        # worker caged from a shape nobody approved.
+        return await self._execute_swarm(graph, unit, shape=shape)
 
     # -- routing decision -------------------------------------------------
 
-    def _should_route_swarm(self, graph: ExecutionGraph, unit: WorkUnitSpec) -> bool:
-        """Swarm iff master gate ON AND graph parallelizable AND unit ELIGIBLE."""
+    def _route_decision(
+        self, graph: ExecutionGraph, unit: WorkUnitSpec,
+    ) -> Tuple[bool, Any]:
+        """``(route_to_swarm, shape)``. Swarm iff master gate ON AND graph
+        parallelizable AND unit ELIGIBLE.
+
+        Returns the SHAPE alongside the verdict because eligibility is now the
+        synthesizer's verdict rather than a guess about it — so deciding
+        produces the very artefact the swarm path needs. Handing it forward
+        keeps synthesis to once per unit and makes it impossible for the shape
+        that was judged and the shape that gets caged to differ.
+
+        The cheap gates run FIRST: with the master flag off, no file is read
+        and no AST is parsed, so an OFF swarm costs exactly what it did before.
+        """
         try:
             from backend.core.ouroboros.governance.autonomy.swarm_orchestrator import (
                 is_orchestrator_enabled,
             )
 
             if not is_orchestrator_enabled():
-                return False
+                return False, None
             if not is_graph_parallelizable(graph):
-                return False
-            return swarm_eligible(unit)
+                return False, None
+            if bool(getattr(unit, "is_swarm_worker", False)):
+                # Pre-shaped: `_synthesize` honours the injected
+                # `define_worker`, so let the swarm path resolve it as before.
+                return True, None
+            if require_preshaped_units():
+                return False, None
+            # CHEAP GATES BEFORE SYNTHESIS. `_synthesize` runs the injected
+            # `define_worker` and otherwise reads + AST-parses every target
+            # file; a unit that cannot be eligible must not pay for that, and
+            # a definer must not be called about a unit that was already
+            # refused.
+            if not _has_instruction(unit):
+                return False, None
+            shape = self._synthesize(unit)
+            return swarm_eligible(unit, shape=shape), shape
         except Exception:  # noqa: BLE001 -- any decision error -> legacy (safe).
             logger.debug(
                 "[SwarmInvoker] route decision raised -> legacy (non-fatal)",
                 exc_info=True,
             )
-            return False
+            return False, None
+
+    def _should_route_swarm(self, graph: ExecutionGraph, unit: WorkUnitSpec) -> bool:
+        """Back-compat boolean view of :meth:`_route_decision`. NEVER raises."""
+        return self._route_decision(graph, unit)[0]
 
     # -- the swarm path ---------------------------------------------------
 
     async def _execute_swarm(
-        self, graph: ExecutionGraph, unit: WorkUnitSpec
+        self, graph: ExecutionGraph, unit: WorkUnitSpec, *, shape: Any = None,
     ) -> WorkUnitResult:
         # 1. + 2. synthesize the worker shape + build its cage. Fail-CLOSED:
         #    any failure here -> FAILED unit, NEVER an uncaged execution.
+        #
+        # `shape` arrives from the routing decision, which had to synthesize it
+        # to judge eligibility. None (a pre-shaped unit, or a direct call) ->
+        # synthesize here, unchanged.
         try:
-            shape = self._synthesize(unit)
+            shape = shape if shape is not None else self._synthesize(unit)
         except Exception as exc:  # noqa: BLE001 -- synthesis failure -> fail-CLOSED.
             return self._failed(
                 graph, unit, "swarm_synthesis", f"worker_synthesis_failed:{exc}"

--- a/backend/core/ouroboros/governance/capability_firing.py
+++ b/backend/core/ouroboros/governance/capability_firing.py
@@ -57,6 +57,42 @@ _LEDGER_STEM_RE = re.compile(r"""([A-Za-z0-9_]{2,64})\.jsonl""")
 # A bracket marker present in a debug.log line: ``[MerkleCartographer]``.
 _LOGLINE_TAG_RE = re.compile(r"\[([A-Z][A-Za-z0-9_.]{1,48})\]")
 
+# A module DECLARING evidence it writes through a collaborator:
+#
+#     __firing_ledgers__ = ("repair_tree",)
+#     __firing_tags__ = ("Treefinement",)
+#
+# Marker derivation is SOURCE-LOCAL: a stem is found only if the literal
+# ``name.jsonl`` appears in the capability's own text. That is right for a
+# module that opens its own file and wrong for one that delegates, and
+# delegating is the better design — so the observability layer was penalising
+# exactly the code that separates concerns.
+#
+# ``repair_engine`` is the case that surfaced it. L2 persists every attempt:
+# `repair_engine` → `repair_tree._archive_result` → `repair_tree_archive` →
+# ``.jarvis/ouroboros/repair_tree.jsonl``, via the canonical flock append. Two
+# hops, so ``repair_engine.py`` contains no ``.jsonl`` literal, so it derived
+# LOG TAGS ONLY — and a log-only silence is explicitly ambiguous (see
+# `firing_verdict`). L2 was therefore unprovable rather than dormant, and the
+# liveness sensor scored that unprovability as a HIGH-severity severance of a
+# ``safety`` capability.
+#
+# Following import edges instead was considered and rejected: `repair_engine`
+# imports a dozen modules, most of which write ledgers of their own, and
+# inheriting all of them would make every capability look FIRING — trading a
+# false-dead for a false-alive, which is strictly worse for an auditor.
+#
+# So the module says so itself. This is the convention this codebase already
+# uses for module-level metadata (``__verb_help__``, ``__aliases__``), and it
+# keeps the declaration next to the code that would change if the evidence
+# path did. Parsed from TEXT, not imported — derivation must stay pure and
+# must never execute a capability to ask about it.
+_DECLARED_LEDGERS_RE = re.compile(
+    r"""__firing_ledgers__\s*=\s*\(([^)]*)\)""", re.S)
+_DECLARED_TAGS_RE = re.compile(
+    r"""__firing_tags__\s*=\s*\(([^)]*)\)""", re.S)
+_STRING_ITEM_RE = re.compile(r"""["']([A-Za-z0-9_.\-]{1,64})["']""")
+
 
 # ---------------------------------------------------------------------------
 # Env knobs — additive, clamped, read-only
@@ -137,6 +173,17 @@ def derive_markers(source: str) -> DerivedMarkers:
                 tags.add(comp)
         for m in _LEDGER_STEM_RE.finditer(source):
             ledgers.add(m.group(1))
+        # Evidence written THROUGH a collaborator, declared by the module that
+        # causes it. Unioned with the scanned markers rather than replacing
+        # them: a module may both open its own ledger and drive another's.
+        for m in _DECLARED_LEDGERS_RE.finditer(source):
+            for item in _STRING_ITEM_RE.finditer(m.group(1)):
+                stem = item.group(1)
+                ledgers.add(stem[:-len(".jsonl")]
+                            if stem.endswith(".jsonl") else stem)
+        for m in _DECLARED_TAGS_RE.finditer(source):
+            for item in _STRING_ITEM_RE.finditer(m.group(1)):
+                tags.add(item.group(1).split(".")[-1])
     except Exception:  # noqa: BLE001
         pass
     # Drop generic/noise tags that would over-match (common Python builtins that

--- a/backend/core/ouroboros/governance/intake/sensors/liveness_sensor.py
+++ b/backend/core/ouroboros/governance/intake/sensors/liveness_sensor.py
@@ -233,7 +233,8 @@ def effective_firing(source_file: str, firing: str) -> str:
 
 
 def severity_for(category: str, firing: str, fraction: float,
-                 source_file: str = "") -> str:
+                 source_file: str = "",
+                 ledger_backed: Optional[bool] = None) -> str:
     """``high`` / ``low``. NEVER raises.
 
     HIGH requires BOTH a critical category AND telemetry that has never
@@ -245,6 +246,33 @@ def severity_for(category: str, firing: str, fraction: float,
     a static index that could not see the edge is the index's limitation, not
     the module's fault. ``REGISTERED_NEVER_INVOKED`` stays eligible for high:
     it is evidence OF severance, not against it.
+
+    ``ledger_backed`` decides whether a SILENT verdict is PROOF
+    -------------------------------------------------------------
+    `capability_firing.firing_verdict` says it outright: a ``ledger`` channel
+    is reliable evidence-of-work, whereas a ``log``-only channel "is ambiguous
+    (an absent log tag may mean 'ran silently' — an observability gap — not
+    proven dormancy)". `capability_liveness` acts on that distinction, sorting
+    ALIVE capabilities into ``dormant`` (ledger-backed) and
+    ``observability_gaps`` (log-only), and publishes ``ledger_backed`` on
+    every verdict.
+
+    This function ignored it. Measured against the live snapshot, **11 of the
+    12 rows scoring HIGH did so on log-only silence** — the sensor escalating
+    capabilities whose dormancy is not merely unproven but *unprovable*. One
+    of them was ``JARVIS_L2_ENABLED``: the loop that closes the Ouroboros
+    cycle, reported severed because it delegates its bookkeeping to
+    ``repair_tree`` and so writes no ``.jsonl`` literal of its own.
+
+    An auditor that cries wolf 11 times out of 12 gets ignored on the twelfth,
+    which is the one that mattered. So a SILENT verdict now escalates only
+    when it is ledger-backed.
+
+    ``None`` — the row did not carry the field — is treated as NOT proven, for
+    the same reason `firing_verdict` refuses to turn "no derivable markers"
+    into SILENT: absence of evidence is not evidence of absence, in either
+    direction. A finding is still EMITTED at ``low``; nothing is hidden, it
+    just stops being an alarm.
     """
     try:
         from backend.core.ouroboros.governance.dynamic_dispatch_registry import (
@@ -255,7 +283,13 @@ def severity_for(category: str, firing: str, fraction: float,
         if resolved == FIRING_DYNAMICALLY:
             return "low"
         crit = str(category or "").strip().lower() in critical_categories()
-        dead = resolved.strip().upper() in ("SILENT", "REGISTERED_NEVER_INVOKED")
+        state = resolved.strip().upper()
+        if state == "SILENT" and ledger_backed is not True:
+            # Unprovable silence. NOT the same as REGISTERED_NEVER_INVOKED
+            # below, which is positive evidence: the module declared itself
+            # reachable and still never ran.
+            return "low"
+        dead = state in ("SILENT", "REGISTERED_NEVER_INVOKED")
         if crit and dead and float(fraction or 0.0) >= _severed_floor():
             return "high"
         return "low"
@@ -355,7 +389,15 @@ class LivenessSensor:
                 if fraction < floor:
                     continue
                 category = str(row.get("category") or "")
-                severity = severity_for(category, firing, fraction, source_file)
+                # `ledger_backed` rides along from the verdict. Computing the
+                # distinction upstream and dropping it here is what let 11 of
+                # 12 HIGH findings rest on unprovable silence.
+                raw_backed = row.get("ledger_backed")
+                severity = severity_for(
+                    category, firing, fraction, source_file,
+                    ledger_backed=(bool(raw_backed)
+                                   if raw_backed is not None else None),
+                )
                 if firing == "FIRING_DYNAMICALLY":
                     # Demonstrably ran. Reporting it would train the operator
                     # to ignore this sensor, which costs more than the finding

--- a/backend/core/ouroboros/governance/repair_engine.py
+++ b/backend/core/ouroboros/governance/repair_engine.py
@@ -39,6 +39,27 @@ _logger = logging.getLogger(__name__)
 # L2 test target resolution (Slice 9 — real failing tests, not the candidate)
 # ---------------------------------------------------------------------------
 
+#: Durable evidence L2 causes, declared because it is written two hops away.
+#:
+#: Every repair attempt lands in ``.jarvis/ouroboros/repair_tree.jsonl``:
+#: this module drives ``repair_tree``, whose ``_archive_result`` calls
+#: ``repair_tree_archive``, which flock-appends the row. The work is durable
+#: and dated — exactly the "evidence of work" `capability_firing` treats as
+#: reliable — but marker derivation is source-local, and this file contains no
+#: ``.jsonl`` literal.
+#:
+#: So L2 derived LOG TAGS ONLY, and a log-only silence is documented as
+#: AMBIGUOUS: an absent tag may mean "ran silently", not "never ran". The
+#: liveness sensor read that ambiguity as proven death and scored
+#: ``JARVIS_L2_ENABLED`` — a ``safety`` capability — a HIGH-severity
+#: severance. The loop that closes the Ouroboros cycle looked dead because it
+#: delegates its bookkeeping.
+#:
+#: Declaring the stem makes the verdict PROVABLE in both directions. If L2
+#: genuinely has not run, that becomes ledger-backed dormancy — a real signal
+#: worth acting on — instead of an unfalsifiable one.
+__firing_ledgers__ = ("repair_tree",)
+
 
 def _l2_test_threading_enabled() -> bool:
     return os.environ.get(

--- a/tests/governance/test_dynamic_dispatch_registry.py
+++ b/tests/governance/test_dynamic_dispatch_registry.py
@@ -86,8 +86,10 @@ def _stub(sensor, rows):
                 source_file=sf, category=r["category"], flag=r["flag"],
                 firing=firing, fraction_severed=r["fraction_severed"],
                 severed_symbols=tuple(r["severed_symbols"]),
-                severity=ls.severity_for(r["category"], firing,
-                                         r["fraction_severed"], sf)))
+                severity=ls.severity_for(
+                    r["category"], firing, r["fraction_severed"], sf,
+                    # Mirrors the production `scan()` seam.
+                    ledger_backed=r.get("ledger_backed", True))))
         out.sort(key=lambda f: f.rank)
         return out
     sensor.collect_findings = _collect
@@ -238,6 +240,15 @@ def test_the_event_bus_records_registration_and_invocation_separately():
 
 
 def test_severity_demotes_only_on_real_invocation():
-    assert severity_for("safety", "SILENT", 1.0, "ghost.py") == "high"
+    """``ledger_backed=True`` because this test is about the DYNAMIC registry.
+
+    Since 2026-07-31 a SILENT verdict escalates only when it is ledger-backed
+    — log-only silence is an observability gap, not proven dormancy. Passing
+    it here holds that new axis fixed so the assertion still isolates the one
+    it is about: whether a runtime invocation demotes the severity.
+    """
+    assert severity_for("safety", "SILENT", 1.0, "ghost.py",
+                        ledger_backed=True) == "high"
     note_invocation("ghost.py")
-    assert severity_for("safety", "SILENT", 1.0, "ghost.py") == "low"
+    assert severity_for("safety", "SILENT", 1.0, "ghost.py",
+                        ledger_backed=True) == "low"

--- a/tests/governance/test_firing_evidence_declaration.py
+++ b/tests/governance/test_firing_evidence_declaration.py
@@ -1,0 +1,180 @@
+"""A capability that delegates its bookkeeping was being called dead.
+
+Firing markers are derived SOURCE-LOCALLY: a ledger counts only if the literal
+``name.jsonl`` appears in the capability's own text. That is right for a module
+that opens its own file and wrong for one that delegates — and delegating is
+the better design, so the observability layer was penalising exactly the code
+that separates concerns.
+
+``repair_engine`` is the case that surfaced it. L2 persists every attempt:
+``repair_engine`` → ``repair_tree._archive_result`` → ``repair_tree_archive``
+→ ``.jarvis/ouroboros/repair_tree.jsonl``, through the canonical flock append.
+Two hops, so ``repair_engine.py`` contains no ``.jsonl`` literal, so it derived
+LOG TAGS ONLY — and `firing_verdict` documents a log-only silence as
+*ambiguous*: "an absent log tag may mean 'ran silently' — an observability
+gap — not proven dormancy".
+
+The liveness sensor read that ambiguity as proven death and scored
+``JARVIS_L2_ENABLED`` — a ``safety`` capability, the loop that closes the
+Ouroboros cycle — a HIGH-severity severance.
+
+Measured on the live snapshot: **11 of the 12 rows scoring HIGH did so on
+log-only silence.** An auditor wrong 11 times in 12 is ignored on the twelfth.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance.capability_firing import (
+    FiringEvidence, derive_markers, firing_verdict,
+)
+from backend.core.ouroboros.governance.intake.sensors.liveness_sensor import (
+    severity_for,
+)
+
+_REPO = Path(__file__).resolve().parents[2]
+_REPAIR = _REPO / "backend/core/ouroboros/governance/repair_engine.py"
+
+
+# ---------------------------------------------------------------------------
+# 1. the declaration
+# ---------------------------------------------------------------------------
+
+
+class TestDeclaredEvidence:
+    def test_a_module_can_declare_a_ledger_it_writes_through_a_collaborator(self):
+        markers = derive_markers(
+            '__firing_ledgers__ = ("repair_tree",)\n'
+            'logger.info("[Thing] hello")\n'
+        )
+        assert "repair_tree" in markers.ledgers
+        assert "Thing" in markers.tags
+
+    def test_declared_ledgers_union_with_scanned_ones(self):
+        """A module may both open its own ledger and drive another's. The
+        declaration ADDS; it never replaces what the scan found."""
+        markers = derive_markers(
+            '__firing_ledgers__ = ("repair_tree",)\n'
+            'PATH = "own_history.jsonl"\n'
+        )
+        assert {"repair_tree", "own_history"} <= set(markers.ledgers)
+
+    def test_a_jsonl_suffix_in_the_declaration_is_tolerated(self):
+        """``("repair_tree.jsonl",)`` means the same thing to a human, so it
+        must mean the same thing here — evidence is compared by STEM."""
+        assert "repair_tree" in derive_markers(
+            '__firing_ledgers__ = ("repair_tree.jsonl",)').ledgers
+
+    def test_tags_can_be_declared_too(self):
+        """A module that logs under a name its own text never spells — a
+        delegated logger, a renamed component — has the same blind spot."""
+        assert "Treefinement" in derive_markers(
+            '__firing_tags__ = ("Treefinement",)').tags
+
+    def test_declaration_is_PARSED_not_imported(self):
+        """Derivation must stay pure. Importing a capability to ask whether it
+        is alive would run its module body — side effects, logging config, and
+        a circular dependency for anything the auditor itself imports."""
+        markers = derive_markers(
+            '__firing_ledgers__ = ("never_imported_module_xyz",)')
+        assert "never_imported_module_xyz" in markers.ledgers
+
+    @pytest.mark.parametrize("hostile", [
+        "__firing_ledgers__ = (", "__firing_ledgers__ = ()",
+        "__firing_ledgers__", "", "__firing_ledgers__ = (1, 2)",
+    ])
+    def test_malformed_declarations_never_raise(self, hostile):
+        assert isinstance(derive_markers(hostile).ledgers, tuple)
+
+    def test_l2_now_derives_its_real_evidence_channel(self):
+        """The live file, not a fixture — the declaration has to be ON it."""
+        markers = derive_markers(_REPAIR.read_text(encoding="utf-8"))
+        assert "repair_tree" in markers.ledgers, (
+            "repair_engine lost its __firing_ledgers__ declaration; its "
+            "dormancy is unprovable again"
+        )
+        assert "RepairEngine" in markers.tags
+
+
+# ---------------------------------------------------------------------------
+# 2. what the declaration BUYS — provability, in both directions
+# ---------------------------------------------------------------------------
+
+
+class TestProvability:
+    def test_an_inactive_declared_ledger_is_PROVEN_dormancy(self):
+        """The point is not to make L2 look alive. It is to make the answer
+        falsifiable: with no ledger row in-window, the verdict is SILENT on a
+        ``ledger`` channel — reliable evidence-of-work absent, which is a real
+        signal worth acting on."""
+        verdict, hits, channels = firing_verdict(
+            '__firing_ledgers__ = ("repair_tree",)\nlog("[RepairEngine] x")',
+            FiringEvidence(present_markers=set(), active_ledgers=set()),
+        )
+        assert verdict == "SILENT"
+        assert "ledger" in channels
+        assert not hits
+
+    def test_an_active_declared_ledger_flips_it_to_FIRING(self):
+        verdict, hits, _ = firing_verdict(
+            '__firing_ledgers__ = ("repair_tree",)',
+            FiringEvidence(active_ledgers={"repair_tree"}),
+        )
+        assert verdict == "FIRING"
+        assert "ledger:repair_tree" in hits
+
+    def test_without_the_declaration_the_channel_is_log_only(self):
+        """The state this fixes: markers derivable, but only ambiguous ones."""
+        _, _, channels = firing_verdict(
+            'log("[RepairEngine] x")',
+            FiringEvidence(present_markers=set(), active_ledgers=set()),
+        )
+        assert channels == ["log"]
+
+
+# ---------------------------------------------------------------------------
+# 3. the consumer — a computed distinction that was being dropped
+# ---------------------------------------------------------------------------
+
+
+class TestSeverityHonoursProvenance:
+    def test_log_only_silence_cannot_raise_an_alarm(self):
+        assert severity_for("safety", "SILENT", 1.0, ledger_backed=False) == "low"
+
+    def test_ledger_backed_silence_still_does(self):
+        assert severity_for("safety", "SILENT", 1.0, ledger_backed=True) == "high"
+
+    def test_missing_provenance_is_not_proof(self):
+        assert severity_for("safety", "SILENT", 1.0) == "low"
+
+    def test_the_distinction_already_existed_upstream(self):
+        """Not a new concept — `CapabilityVerdict.ledger_backed` has been
+        computed and published all along, and `capability_liveness` already
+        sorts ALIVE capabilities into ``dormant`` vs ``observability_gaps`` on
+        it. It was simply never consulted where it decides whether to wake
+        someone."""
+        from backend.core.ouroboros.governance.capability_liveness import (
+            CapabilityVerdict,
+        )
+        v = CapabilityVerdict(flag="F", source_file="x.py", category="safety",
+                              live_on=(), verdict="SEVERED",
+                              firing="SILENT", firing_channels=("log",))
+        assert v.ledger_backed is False
+        assert "ledger_backed" in v.to_dict()
+
+    def test_the_sensor_forwards_it(self):
+        """The seam itself. Computing the distinction upstream and dropping it
+        at the consumer is what let 11 of 12 HIGH findings rest on unprovable
+        silence — and a grep for the field name would have passed the whole
+        time, since it is present three modules away."""
+        import inspect
+        from backend.core.ouroboros.governance.intake.sensors import (
+            liveness_sensor,
+        )
+        scan_src = inspect.getsource(liveness_sensor.LivenessSensor)
+        assert "ledger_backed" in scan_src, (
+            "the sensor stopped forwarding ledger_backed; severity is being "
+            "decided on evidence it was given and threw away"
+        )

--- a/tests/governance/test_liveness_sensor.py
+++ b/tests/governance/test_liveness_sensor.py
@@ -58,6 +58,13 @@ def _candidate(**kw):
         "category": "safety",
         "flag": "JARVIS_L2_ENABLED",
         "firing": "SILENT",
+        # LEDGER-BACKED, because the real row now is. `repair_engine` declares
+        # `__firing_ledgers__ = ("repair_tree",)` — the durable evidence L2
+        # writes two hops away, through `repair_tree._archive_result` — so its
+        # silence is PROVABLE rather than merely unobserved. A fixture still
+        # carrying log-only silence would model a row that no longer exists
+        # and would quietly stop exercising the escalation path.
+        "ledger_backed": True,
         "fraction_severed": 1.0,
         "severed_symbols": ["repair_once", "run_repair_loop"],
     }
@@ -74,8 +81,13 @@ def _stub_snapshot(sensor, rows):
                 category=r["category"], flag=r["flag"], firing=r["firing"],
                 fraction_severed=r["fraction_severed"],
                 severed_symbols=tuple(r["severed_symbols"]),
+                # Mirrors the production `scan()` seam, which forwards
+                # `ledger_backed` from the verdict. A stub that dropped it
+                # would score every fixture `low` and silently stop testing
+                # severity at all.
                 severity=severity_for(r["category"], r["firing"],
-                                      r["fraction_severed"]),
+                                      r["fraction_severed"],
+                                      ledger_backed=r.get("ledger_backed")),
             ))
         findings.sort(key=lambda f: f.rank)
         return findings
@@ -110,17 +122,58 @@ async def test_a_component_with_zero_reachability_emits_high_severity():
 
 
 @pytest.mark.asyncio
-async def test_severity_requires_BOTH_criticality_and_silence():
-    """Either signal alone over-reports.
+async def test_severity_requires_criticality_and_PROVEN_silence():
+    """Either signal alone over-reports, and SILENT is two different claims.
 
     A safety capability whose telemetry is FIRING is alive whatever the AST
     says — dynamic dispatch leaves no static edge. A SILENT experimental
     helper is not worth waking anyone for.
+
+    SUPERSEDED 2026-07-31: was ``severity_for("safety", "SILENT", 1.0) ==
+    "high"`` with no third state.
+
+    `capability_firing.firing_verdict` distinguishes them and says so plainly:
+    a ``ledger`` channel is reliable evidence-of-work, a ``log``-only channel
+    "is ambiguous (an absent log tag may mean 'ran silently' — an
+    observability gap — not proven dormancy)". Measured against the live
+    snapshot, 11 of the 12 rows this function scored HIGH did so on log-only
+    silence. An auditor wrong 11 times in 12 is ignored on the twelfth.
     """
-    assert severity_for("safety", "SILENT", 1.0) == "high"
-    assert severity_for("safety", "FIRING", 1.0) == "low"
-    assert severity_for("experimental", "SILENT", 1.0) == "low"
-    assert severity_for("safety", "UNKNOWN", 1.0) == "low"
+    assert severity_for("safety", "SILENT", 1.0, ledger_backed=True) == "high"
+    assert severity_for("safety", "FIRING", 1.0, ledger_backed=True) == "low"
+    assert severity_for("experimental", "SILENT", 1.0, ledger_backed=True) == "low"
+    assert severity_for("safety", "UNKNOWN", 1.0, ledger_backed=True) == "low"
+
+
+@pytest.mark.asyncio
+async def test_unprovable_silence_does_not_raise_an_alarm():
+    """A log-only SILENT is an observability gap, not a severance.
+
+    Still EMITTED — at ``low``. Nothing is hidden; it stops being an alarm.
+    """
+    assert severity_for("safety", "SILENT", 1.0, ledger_backed=False) == "low"
+
+
+@pytest.mark.asyncio
+async def test_absent_provenance_is_not_treated_as_proof():
+    """``None`` — the row carried no ``ledger_backed`` — is not evidence.
+
+    Same discipline `firing_verdict` applies when it refuses to turn "no
+    derivable markers" into SILENT: absence of evidence is not evidence of
+    absence, in either direction.
+    """
+    assert severity_for("safety", "SILENT", 1.0) == "low"
+    assert severity_for("safety", "SILENT", 1.0, ledger_backed=None) == "low"
+
+
+@pytest.mark.asyncio
+async def test_registered_never_invoked_still_escalates():
+    """Positive evidence OF severance, and unaffected by the ledger question.
+
+    The module declared itself reachable by dispatch and still never ran —
+    which rules out the innocent explanation a SILENT log channel leaves open.
+    """
+    assert severity_for("safety", "REGISTERED_NEVER_INVOKED", 1.0) == "high"
 
 
 def test_criticality_is_derived_from_the_existing_taxonomy():
@@ -137,7 +190,7 @@ def test_criticality_is_derived_from_the_existing_taxonomy():
 def test_critical_categories_are_widenable_without_code(monkeypatch):
     monkeypatch.setenv("JARVIS_LIVENESS_CRITICAL_CATEGORIES", "safety,routing")
     assert critical_categories() == frozenset({"safety", "routing"})
-    assert severity_for("routing", "SILENT", 0.9) == "high"
+    assert severity_for("routing", "SILENT", 0.9, ledger_backed=True) == "high"
 
 
 # ---------------------------------------------------------------------------
@@ -205,7 +258,7 @@ async def test_below_the_floor_is_not_reported(monkeypatch):
         _severed_floor,
     )
     assert _severed_floor() == 0.5
-    assert severity_for("safety", "SILENT", 0.2) == "low"
+    assert severity_for("safety", "SILENT", 0.2, ledger_backed=True) == "low"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Two subsystems, one disease: **a judgement computed in the right place and discarded at the consumer that acts on it.**

## L2 was not silent — it was *unprovable*

`capability_firing` derives evidence markers **source-locally**: a ledger counts only if the literal `name.jsonl` appears in the module's own text. That's right for a module that opens its own file and wrong for one that delegates — and delegating is the better design, so the observability layer was penalising exactly the code that separates concerns.

L2 persists every attempt:

```
repair_engine → repair_tree._archive_result → repair_tree_archive
              → .jarvis/ouroboros/repair_tree.jsonl   (canonical flock append)
```

Two hops. So `repair_engine.py` holds no `.jsonl` literal, so it derived **log tags only** — and `firing_verdict` documents that state as ambiguous in its own words: *"an absent log tag may mean 'ran silently' — an observability gap — not proven dormancy."*

`severity_for` ignored that and scored SILENT as dead. Measured on the live snapshot:

> **11 of the 12 rows scoring HIGH did so on log-only silence.**

`JARVIS_L2_ENABLED` was one of them — the loop that closes the Ouroboros cycle, reported severed because it delegates its bookkeeping. An auditor wrong 11 times in 12 is ignored on the twelfth.

### Fixed at both ends, reusing what was already there

**A module may declare evidence it causes through a collaborator** — `__firing_ledgers__ = ("repair_tree",)`. Same module-level metadata convention as `__verb_help__` / `__aliases__`, parsed from text so derivation stays pure and never imports a capability to ask whether it's alive.

*Following import edges was considered and rejected*: `repair_engine` imports a dozen ledger-writing modules and would inherit all of them — trading a false-dead for a false-alive, which is strictly worse for an auditor.

**`severity_for` honours `ledger_backed`** — a field already computed on every verdict, already published in `to_dict()`, and already used by `capability_liveness` to split ALIVE capabilities into `dormant` vs `observability_gaps`. It was simply never consulted where it decides whether to wake a human. `None` is treated as not-proven — the same discipline `firing_verdict` applies when it refuses to turn "no derivable markers" into SILENT.

**HIGH findings: 12 → 3.** And the L2 finding *survives*:

```
repair_engine.py   flag=JARVIS_L2_ENABLED   firing=SILENT   ledger_backed=True
```

The declaration didn't make L2 look alive — `.jarvis/ouroboros/repair_tree.jsonl` doesn't exist, so **L2's dormancy is now provable instead of unfalsifiable.** The alarm got quieter and the surviving one got stronger.

## Swarm eligibility carried almost no information

The predicate asked for non-empty `target_files` and `goal`. `__post_init__` already raises without either, so the `target_files` branch could never be False — the original circularity inverted, not repaired: the first version answered *no* to everything (`eligible ⟺ already shaped`), the second *yes* to nearly everything.

**"Nearly" — and I had this wrong first.** `if not self.goal` is False for `"   "`, so a whitespace-only goal *is* constructible and that branch really did reject it. Measured, such a unit scores `confidence=0.50` on the strength of the **files alone**, because confidence blends "I read the targets" with "I understood the task". Deleting it as redundant would have widened eligibility to workers with no instruction. It's kept as `_has_instruction`, and it runs **before** synthesis so a refused unit never pays for an AST parse.

Eligibility now asks the component that knows. `synthesize_worker_spec` reports what it managed as `confidence` — 0.90 for a goal it understood against a file it parsed, **0.00** for the degenerate read-only fallback. The floor is that fail-closed signal read back, not a tuned number (`JARVIS_SWARM_MIN_SHAPE_CONFIDENCE` widens it).

**Absent confidence is not zero confidence.** A shape from an injected `define_worker` may carry no such field, and defaulting it to `0.0` routed a perfectly good custom shape to legacy — the inertness class this predicate exists to have escaped. Caught by an existing test, not by inspection.

`_route_decision` now returns `(route, shape)`, so the shape that was **judged** is the shape that gets **caged** — one synthesis per unit, and no way for the two to disagree.

## Testing

**79 green** across firing/liveness/swarm; **264** across all 9 consumer files. 19 new tests covering the declaration mechanism, provability in both directions, and the forwarding seam.

Updated tests were superseded, not loosened — each now states the new contract and the log-only case gained its own coverage. The fixture models `repair_engine`, so it carries `ledger_backed: True` because the real row now does.

The 2 `test_coherence_auditor` reds are **pre-existing** — identical with these changes stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make liveness findings provable and route swarm work using real synthesis confidence. False HIGH alerts drop from 12 to 3, and swarm runs only when a useful worker shape exists.

- **New Features**
  - Add module-level evidence declarations: `__firing_ledgers__` and `__firing_tags__` parsed from source in `capability_firing.derive_markers`.
  - Apply to `repair_engine` (`__firing_ledgers__ = ("repair_tree",)`) so L2 dormancy is now ledger-backed and provable.
  - Optional env knob `JARVIS_SWARM_MIN_SHAPE_CONFIDENCE` to raise the swarm routing floor.

- **Bug Fixes**
  - `liveness_sensor.severity_for` now respects `ledger_backed`; log-only SILENT is “low”, ledger-backed SILENT can be “high”. The sensor forwards `ledger_backed` from verdicts.
  - Swarm eligibility uses `worker_synthesizer.synthesize_worker_spec`’s `confidence` and a pre-check `_has_instruction` (reject whitespace-only goals before parsing).
  - Treat missing `confidence` as “not ours to judge” (eligible); present `0.0` still fails closed.
  - `SwarmUnitInvoker._route_decision` returns `(route, shape)` and passes the same shape into execution to avoid double synthesis and drift; cheap gates run before synthesis.

<sup>Written for commit 5b344a050937e89e8af83f6d1ba5dc9449d9f9fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

