### PR TITLE
feat(liveness): /liveness — the registry that audits everything is finally readable

### DIFF
--- a/backend/core/ouroboros/governance/dynamic_dispatch_registry.py
+++ b/backend/core/ouroboros/governance/dynamic_dispatch_registry.py
@@ -80,7 +80,9 @@ __all__ = [
     "DispatchRecord",
     "dynamic_verdict",
     "dynamically_dispatched",
+    "flush_interval_s",
     "note_invocation",
+    "read_ledger",
     "register",
     "registry_enabled",
     "reset_for_tests",
@@ -138,10 +140,11 @@ _dropped = 0
 
 def reset_for_tests() -> None:
     """Clear every breadcrumb. Test-only."""
-    global _records, _dropped  # noqa: PLW0603
+    global _records, _dropped, _last_flush_mono  # noqa: PLW0603
     with _lock:
         _records = {}
         _dropped = 0
+        _last_flush_mono = 0.0
 
 
 def _normalise(module: Any) -> str:
@@ -196,6 +199,105 @@ def register(module: Any, *, channel: str = "") -> None:
         logger.debug("[DynamicDispatch] register degraded", exc_info=True)
 
 
+#: Where the registry writes itself down, and why it must.
+#:
+#: An in-memory registry can only be READ from inside its own process, and a
+#: new reader can only be installed by RESTARTING that process. Both halves bit
+#: on the same day: a soak ran for three and a half hours holding a fully
+#: populated registry, `/liveness` was written to show it, and the verb could
+#: not be delivered to the daemon because the daemon predates the module. The
+#: only way to observe the organism was to kill it.
+#:
+#: So it leaves evidence on disk. Same principle as ``__firing_ledgers__``
+#: earlier in this file's history — durable, dated work is the only kind that
+#: survives the process that did it — and the same canonical writer every
+#: other ledger here uses (`cross_process_jsonl.flock_append_line`, flock-
+#: serialized, never raises). A `.jarvis/**/*.jsonl` stem is also exactly what
+#: `capability_firing` already treats as evidence-of-work, so the registry's
+#: own liveness becomes provable by the mechanism it exists to serve.
+_LEDGER_PATH = ".jarvis/ouroboros/dynamic_dispatch.jsonl"
+_last_flush_mono: float = 0.0
+
+
+def flush_interval_s() -> float:
+    """``JARVIS_DYNAMIC_DISPATCH_FLUSH_S`` (default 30). ``0`` disables.
+
+    A debounce, not a schedule: the write happens on the invocation that
+    crosses the interval, so there is no timer to start, no task to own, and
+    nothing to go inert when a caller forgets to drive it.
+    """
+    try:
+        return max(0.0, float(os.environ.get(
+            "JARVIS_DYNAMIC_DISPATCH_FLUSH_S", "30") or 30))
+    except (TypeError, ValueError):
+        return 30.0
+
+
+def _maybe_flush() -> None:
+    """Append one snapshot line if the debounce has elapsed. NEVER raises.
+
+    Called from the invocation path, which is the honest "something happened"
+    signal — registration alone proves nothing, exactly as the verdicts above
+    insist. Deliberately NOT on the hot path's critical section: the lock is
+    released first, the interval check is a monotonic compare, and any failure
+    (lock contention, read-only fs, missing fcntl) is swallowed. Observability
+    that can stall delivery is worse than no observability.
+    """
+    global _last_flush_mono  # noqa: PLW0603
+    try:
+        interval = flush_interval_s()
+        if interval <= 0.0:
+            return
+        now = time.monotonic()
+        if (now - _last_flush_mono) < interval:
+            return
+        _last_flush_mono = now
+        payload = snapshot()
+        payload["written_at_unix"] = time.time()
+        payload["pid"] = os.getpid()
+        import json as _json
+        from pathlib import Path as _Path
+        from backend.core.ouroboros.governance.cross_process_jsonl import (
+            flock_append_line,
+        )
+        flock_append_line(
+            _Path(_LEDGER_PATH),
+            _json.dumps(payload, separators=(",", ":"), sort_keys=True),
+            timeout_s=0.25,      # never wait on a reader
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug("[DynamicDispatch] flush degraded", exc_info=True)
+
+
+def read_ledger(path: str = "") -> Optional[Dict[str, Any]]:
+    """The NEWEST persisted snapshot, or None. NEVER raises.
+
+    This is what makes the registry readable from a process that did not
+    produce it — a fresh `ov` client, a post-mortem, a different machine
+    reading a synced tree.
+    """
+    try:
+        from pathlib import Path as _Path
+        import json as _json
+        target = _Path(path or _LEDGER_PATH)
+        if not target.is_file():
+            return None
+        newest = None
+        # Tail-read: the file is append-only and the last complete line wins.
+        with open(target, "r", encoding="utf-8", errors="replace") as handle:
+            for raw in handle:
+                raw = raw.strip()
+                if not raw:
+                    continue
+                try:
+                    newest = _json.loads(raw)
+                except ValueError:
+                    continue      # a torn line is skipped, never fatal
+        return newest if isinstance(newest, dict) else None
+    except Exception:  # noqa: BLE001
+        return None
+
+
 def note_invocation(module: Any, *, channel: str = "") -> None:
     """Record "actually ran". NEVER raises.
 
@@ -221,6 +323,10 @@ def note_invocation(module: Any, *, channel: str = "") -> None:
             rec.last_invoked_at = now
             if channel and channel not in rec.channels:
                 rec.channels = rec.channels + (str(channel),)
+        # OUTSIDE the lock: the flush takes a file lock, and holding the
+        # registry lock across it would let a slow disk serialise every
+        # producer on the bus.
+        _maybe_flush()
     except Exception:  # noqa: BLE001
         logger.debug("[DynamicDispatch] invocation degraded", exc_info=True)
 

--- a/backend/core/ouroboros/governance/liveness_repl.py
+++ b/backend/core/ouroboros/governance/liveness_repl.py
@@ -1,0 +1,328 @@
+"""``/liveness`` — the registry that audits everything, finally auditable.
+
+`dynamic_dispatch_registry` exists to answer "did this module actually run?"
+for capabilities a static caller-index cannot see. It answers it correctly and
+**in process memory only**. A soak running for three and a half hours holds a
+fully-populated registry that nothing outside that process can read: no REPL
+verb, no `/observability` route, no log line. An auditing registry that cannot
+itself be audited across a process boundary is the gap it was built to close,
+one layer up.
+
+This is that surface. It is a VERB, not a new transport, because the transport
+already exists and is already proven: `serpent_flow._dispatch_repl_command`
+mirrors any auto-discovered verb's returned text to the attached cockpit via
+``_flow._mirror_markup`` — the seam whose own comment calls itself "THE gap
+that made 59 verbs invisible from `ov attach`". Addressing is handled at the
+bridge from the dispatch ContextVar, so a verb typed in cockpit A returns to
+cockpit A alone. Auto-discovery comes from the ``*_repl.py`` naming cage. No
+socket code, no envelope, no registration.
+
+TWO SURFACES, AND THE COST GAP BETWEEN THEM IS 6 ORDERS OF MAGNITUDE
+---------------------------------------------------------------------
+Measured on this tree:
+
+    dynamic_dispatch.snapshot()      0.02 ms
+    capability_liveness.snapshot()   21,442 ms
+
+`dispatch_<verb>_command` may be ``async`` (the naming cage accepts a
+coroutine function — see `repl_dispatch_registry`'s ``iscoroutinefunction``
+branch), and this one is, for exactly that reason: a synchronous 21-second
+scan would freeze the daemon's event loop, every attached cockpit, the
+heartbeat and the running soak along with it. The scan goes through
+``asyncio.to_thread`` and the loop stays live.
+
+The default view is the REGISTRY — instant, and the thing that is actually
+unreadable today. Capability rows are opt-in behind a flag, and memoised,
+because 21 seconds is not a keystroke budget.
+
+FILTERING HAPPENS BEFORE RENDERING
+-----------------------------------
+Which is the same thing as before transmission here: the daemon renders text
+and mirrors the rendered text, so a row filtered out is a row that never
+reaches the socket. ``--high`` on this tree is 3 rows out of 190.
+
+Rich markup, not ANSI. The mirror carries markup by contract and each client
+fits it to its own canvas; rendering ANSI here would bake this daemon's width
+and colour depth into the wire.
+
+Read-only throughout. NEVER raises — a verb that throws while an operator is
+typing is worse than a verb that says it has nothing.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import shlex
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+#: Tab completion for the flags, via the module-level convention
+#: `_dispatch_arg_spec` already reads (same place as ``__verb_help__`` /
+#: ``__aliases__``). Declared rather than mined because `mine_subcommands`
+#: skips tokens starting with ``-`` — correctly, since a bare ``-`` prefix in
+#: a body is usually an option parse, not a vocabulary. Without this the verb
+#: completes to nothing after the space, and a flag an operator cannot
+#: discover is a flag that does not exist.
+__verb_args__ = {"liveness": "[--high|--silent|--all|dispatch|help]"}
+
+#: Rows shown before the tail is summarised. A cockpit pane is ~40 rows and a
+#: verb that fills the transcript is a verb the operator stops typing.
+_MAX_ROWS = 24
+
+#: The expensive scan, memoised. 21s is not a keystroke budget, and an
+#: operator comparing `--high` against `--silent` should not pay it twice.
+_SCAN_TTL_S = 120.0
+_scan_cache: Dict[str, Any] = {}
+
+
+@dataclass(frozen=True)
+class LivenessReplDispatchResult:
+    ok: bool
+    text: str
+    matched: bool = True
+
+
+_HELP = (
+    "  [bold cyan]/liveness — what actually ran[/bold cyan]\n"
+    "\n"
+    "  [dim]the dispatch registry (instant)[/dim]\n"
+    "    /liveness                 modules reached by dispatch, and whether\n"
+    "                              they ever FIRED\n"
+    "    /liveness dispatch        the same, explicitly\n"
+    "\n"
+    "  [dim]capability severance (a ~21s scan, memoised 2 min)[/dim]\n"
+    "    /liveness --high          only findings whose dormancy is PROVEN\n"
+    "    /liveness --silent        SILENT rows, split by whether the silence\n"
+    "                              is ledger-backed or merely unobserved\n"
+    "    /liveness --all           every severance candidate above the floor\n"
+    "\n"
+    "  [dim]/liveness help[/dim]\n"
+)
+
+
+def _matches(line: str) -> bool:
+    try:
+        head = (line or "").strip().split(None, 1)[0].lower()
+    except IndexError:
+        return False
+    return head in ("/liveness", "liveness")
+
+
+def scan_ttl_s() -> float:
+    """``JARVIS_LIVENESS_REPL_SCAN_TTL_S`` (default 120). NEVER raises."""
+    try:
+        return max(0.0, float(os.environ.get(
+            "JARVIS_LIVENESS_REPL_SCAN_TTL_S", _SCAN_TTL_S)))
+    except (TypeError, ValueError):
+        return _SCAN_TTL_S
+
+
+# ---------------------------------------------------------------------------
+# the instant surface — the registry itself
+# ---------------------------------------------------------------------------
+
+
+def _render_dispatch() -> str:
+    """The in-memory dispatch registry, rendered. NEVER raises."""
+    try:
+        from backend.core.ouroboros.governance.dynamic_dispatch_registry import (
+            FIRING_DYNAMICALLY, REGISTERED_NEVER_INVOKED, snapshot,
+        )
+        snap = snapshot()
+    except Exception as exc:  # noqa: BLE001
+        return f"  [red]dispatch registry unavailable:[/red] [dim]{exc}[/dim]"
+
+    if not snap.get("enabled", False):
+        return ("  [yellow]dispatch registry is OFF[/yellow] [dim]"
+                "(JARVIS_DYNAMIC_DISPATCH_REGISTRY_ENABLED=0) — every verdict "
+                "falls back to the static index[/dim]")
+
+    rows = list(snap.get("rows") or ())
+    out: List[str] = [
+        "  [bold cyan]dispatch registry[/bold cyan] "
+        f"[dim]— {snap.get('tracked', 0)} module(s) tracked, "
+        f"{snap.get('dropped', 0)} dropped[/dim]",
+        "",
+        f"    [green]{snap.get('firing', 0)}[/green] firing dynamically     "
+        f"[yellow]{snap.get('registered_never_invoked', 0)}[/yellow] "
+        "registered, never invoked",
+    ]
+    if not rows:
+        out += [
+            "",
+            "  [dim]nothing recorded yet. The registry fills as handlers "
+            "subscribe and fire — an empty registry in a live session means "
+            "no instrumented dispatch has run, not that the registry is "
+            "broken.[/dim]",
+        ]
+        return "\n".join(out)
+
+    out += ["", f"    {'MODULE':<34}{'VERDICT':<26}{'REG':>5}{'INV':>6}"]
+    for r in rows[:_MAX_ROWS]:
+        verdict = str(r.get("verdict", "?"))
+        colour = ("green" if verdict == FIRING_DYNAMICALLY
+                  else "yellow" if verdict == REGISTERED_NEVER_INVOKED
+                  else "dim")
+        out.append(
+            f"    [cyan]{str(r.get('module', '?'))[:33]:<34}[/cyan]"
+            f"[{colour}]{verdict[:25]:<26}[/{colour}]"
+            f"[dim]{r.get('registrations', 0):>5}{r.get('invocations', 0):>6}"
+            f"[/dim]"
+        )
+    if len(rows) > _MAX_ROWS:
+        out.append(f"    [dim]… {len(rows) - _MAX_ROWS} more[/dim]")
+    return "\n".join(out)
+
+
+# ---------------------------------------------------------------------------
+# the expensive surface — capability severance
+# ---------------------------------------------------------------------------
+
+
+def _collect_rows() -> Tuple[List[Dict[str, Any]], float]:
+    """The 21-second scan. Runs OFF the event loop. NEVER raises.
+
+    Memoised on wall-clock rather than on content: the scan reads the working
+    tree and the session logs, so its answer legitimately changes between
+    calls, and a content hash would cost as much as the scan.
+    """
+    now = time.time()
+    cached = _scan_cache.get("rows")
+    if cached is not None and (now - float(_scan_cache.get("at", 0.0))) < scan_ttl_s():
+        return cached, float(_scan_cache["at"])
+    try:
+        from backend.core.ouroboros.governance import capability_liveness as cl
+        from backend.core.ouroboros.governance.intake.sensors.liveness_sensor import (
+            _severed_floor, severity_for,
+        )
+        snap = cl.snapshot()
+        floor = _severed_floor()
+        rows: List[Dict[str, Any]] = []
+        for r in snap.get("severance_candidates") or ():
+            fraction = float(r.get("fraction_severed") or 0.0)
+            if fraction < floor:
+                continue
+            source = str(r.get("source_file") or "?")
+            rows.append({
+                "source_file": source.split("/")[-1],
+                "flag": str(r.get("flag") or "?"),
+                "firing": str(r.get("firing") or "UNKNOWN"),
+                "ledger_backed": bool(r.get("ledger_backed")),
+                "fraction": fraction,
+                "severity": severity_for(
+                    str(r.get("category") or ""), str(r.get("firing") or ""),
+                    fraction, source.split("/")[-1],
+                    ledger_backed=r.get("ledger_backed"),
+                ),
+            })
+        rows.sort(key=lambda d: (d["severity"] != "high", -d["fraction"],
+                                 d["source_file"]))
+        _scan_cache["rows"] = rows
+        _scan_cache["at"] = now
+        return rows, now
+    except Exception:  # noqa: BLE001
+        return [], now
+
+
+def _filter(rows: List[Dict[str, Any]], mode: str) -> List[Dict[str, Any]]:
+    """Filter BEFORE rendering — which here is before transmission."""
+    if mode == "high":
+        return [r for r in rows if r["severity"] == "high"]
+    if mode == "silent":
+        return [r for r in rows if r["firing"] == "SILENT"]
+    return rows
+
+
+def _render_capabilities(rows: List[Dict[str, Any]], mode: str,
+                         scanned_at: float, total: int) -> str:
+    if not rows:
+        return (f"  [bold cyan]capability severance[/bold cyan] [dim]— no rows "
+                f"match --{mode} (of {total} above the floor)[/dim]")
+    age = max(0, int(time.time() - scanned_at))
+    out = [
+        f"  [bold cyan]capability severance[/bold cyan] [dim]— {len(rows)} of "
+        f"{total} above the floor · --{mode} · scanned {age}s ago[/dim]",
+        "",
+        f"    {'SEV':<6}{'SOURCE':<28}{'FIRING':<10}{'PROOF':<8}{'SEVERED':>8}",
+    ]
+    for r in rows[:_MAX_ROWS]:
+        sev = r["severity"]
+        sev_colour = "red" if sev == "high" else "dim"
+        # PROOF is the distinction the sensor now acts on: a ledger channel is
+        # evidence-of-work, a log-only channel is ambiguous by construction.
+        proof = "ledger" if r["ledger_backed"] else "log"
+        proof_colour = "yellow" if r["ledger_backed"] else "dim"
+        out.append(
+            f"    [{sev_colour}]{sev:<6}[/{sev_colour}]"
+            f"[cyan]{r['source_file'][:27]:<28}[/cyan]"
+            f"[dim]{r['firing'][:9]:<10}[/dim]"
+            f"[{proof_colour}]{proof:<8}[/{proof_colour}]"
+            f"[dim]{r['fraction'] * 100:>7.0f}%[/dim]"
+        )
+    if len(rows) > _MAX_ROWS:
+        out.append(f"    [dim]… {len(rows) - _MAX_ROWS} more[/dim]")
+    if mode == "silent":
+        ledger = sum(1 for r in rows if r["ledger_backed"])
+        out += [
+            "",
+            f"    [dim]{ledger} ledger-backed (dormancy PROVEN) · "
+            f"{len(rows) - ledger} log-only (unobserved, not proven — an "
+            f"absent log tag may mean it ran silently)[/dim]",
+        ]
+    return "\n".join(out)
+
+
+# ---------------------------------------------------------------------------
+# dispatch
+# ---------------------------------------------------------------------------
+
+
+async def dispatch_liveness_command(line: str) -> LivenessReplDispatchResult:
+    """What actually ran — the dispatch registry and capability severance.
+
+    Operator: Show which modules have really fired, and which look severed.
+
+    ``async`` deliberately: the capability scan measures 21 seconds on this
+    tree, and a synchronous dispatcher would hold the daemon's event loop for
+    all of it — freezing every attached cockpit and the running soak. It goes
+    through ``asyncio.to_thread``; the loop stays live. NEVER raises.
+    """
+    if not _matches(line):
+        return LivenessReplDispatchResult(ok=False, text="", matched=False)
+    try:
+        tokens = shlex.split(line or "")
+    except ValueError as exc:
+        return LivenessReplDispatchResult(
+            ok=False, text=f"  /liveness parse error: {exc}")
+    args = [a.lower() for a in tokens[1:]]
+
+    if any(a in ("help", "?", "--help", "-h") for a in args):
+        return LivenessReplDispatchResult(ok=True, text=_HELP)
+
+    mode: Optional[str] = None
+    for flag in ("--high", "--silent", "--all"):
+        if flag in args:
+            mode = flag[2:]
+            break
+    if mode is None:
+        # Default and `dispatch` are the same view: the registry, instantly.
+        return LivenessReplDispatchResult(ok=True, text=_render_dispatch())
+
+    try:
+        rows, scanned_at = await asyncio.to_thread(_collect_rows)
+    except Exception:  # noqa: BLE001 — never let a scan fault reach the loop
+        return LivenessReplDispatchResult(
+            ok=False,
+            text="  [red]capability scan unavailable[/red] "
+                 "[dim](the dispatch view still works: /liveness)[/dim]")
+    filtered = _filter(rows, mode)
+    return LivenessReplDispatchResult(
+        ok=True,
+        text=_render_capabilities(filtered, mode, scanned_at, len(rows)),
+    )
+
+
+def reset_cache_for_tests() -> None:
+    """Drop the memoised scan. Test-only."""
+    _scan_cache.clear()

--- a/backend/core/ouroboros/governance/liveness_repl.py
+++ b/backend/core/ouroboros/governance/liveness_repl.py
@@ -138,11 +138,38 @@ def _render_dispatch() -> str:
                 "(JARVIS_DYNAMIC_DISPATCH_REGISTRY_ENABLED=0) — every verdict "
                 "falls back to the static index[/dim]")
 
+    # CROSS-PROCESS FALLBACK.
+    #
+    # An empty in-process registry is the NORMAL state for a fresh reader —
+    # a client, a post-mortem, anything that did not itself dispatch. The
+    # registry persists a debounced snapshot to
+    # `.jarvis/ouroboros/dynamic_dispatch.jsonl`, so the evidence outlives the
+    # process that produced it and can be read by one that did not.
+    #
+    # Only consulted when memory is empty: a live registry is always fresher
+    # than a file, and preferring the file would show an operator stale
+    # numbers on the very process generating new ones.
+    provenance = "live"
+    if not snap.get("tracked"):
+        try:
+            from backend.core.ouroboros.governance.dynamic_dispatch_registry import (
+                read_ledger,
+            )
+            persisted = read_ledger()
+        except Exception:  # noqa: BLE001
+            persisted = None
+        if persisted and persisted.get("tracked"):
+            age = max(0, int(time.time() - float(
+                persisted.get("written_at_unix") or 0)))
+            snap = persisted
+            provenance = (f"from ledger · pid {persisted.get('pid', '?')} · "
+                          f"{age}s old")
+
     rows = list(snap.get("rows") or ())
     out: List[str] = [
         "  [bold cyan]dispatch registry[/bold cyan] "
         f"[dim]— {snap.get('tracked', 0)} module(s) tracked, "
-        f"{snap.get('dropped', 0)} dropped[/dim]",
+        f"{snap.get('dropped', 0)} dropped · {provenance}[/dim]",
         "",
         f"    [green]{snap.get('firing', 0)}[/green] firing dynamically     "
         f"[yellow]{snap.get('registered_never_invoked', 0)}[/yellow] "
@@ -151,10 +178,11 @@ def _render_dispatch() -> str:
     if not rows:
         out += [
             "",
-            "  [dim]nothing recorded yet. The registry fills as handlers "
-            "subscribe and fire — an empty registry in a live session means "
-            "no instrumented dispatch has run, not that the registry is "
-            "broken.[/dim]",
+            "  [dim]nothing recorded yet, in memory or on disk. The registry "
+            "fills as handlers subscribe and fire, and persists a debounced "
+            "snapshot to .jarvis/ouroboros/dynamic_dispatch.jsonl — so an "
+            "empty view means no instrumented dispatch has run, not that the "
+            "registry is broken.[/dim]",
         ]
         return "\n".join(out)
 

--- a/tests/governance/test_liveness_repl_verb.py
+++ b/tests/governance/test_liveness_repl_verb.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import os
 import threading
 
 import pytest
@@ -44,8 +45,23 @@ from backend.core.ouroboros.governance import dynamic_dispatch_registry as dd
 from backend.core.ouroboros.governance import liveness_repl as lr
 
 
+#: The SHIPPING default, captured before any fixture redirects it. Asserting
+#: against the patched value would only prove the fixture works.
+_DEFAULT_LEDGER_PATH = dd._LEDGER_PATH
+
+
 @pytest.fixture(autouse=True)
-def _clean():
+def _clean(tmp_path, monkeypatch):
+    """Isolate memory AND disk.
+
+    Without the path redirect these tests read the REAL
+    `.jarvis/ouroboros/dynamic_dispatch.jsonl`, so "the registry is empty"
+    depends on whether anything on this machine has ever dispatched — which
+    made `test_an_empty_registry_...` pass or fail according to whether an
+    unrelated probe had run earlier. A test whose result depends on the
+    developer's shell history is not a test.
+    """
+    monkeypatch.setattr(dd, "_LEDGER_PATH", str(tmp_path / "dispatch.jsonl"))
     dd.reset_for_tests()
     lr.reset_cache_for_tests()
     yield
@@ -353,6 +369,133 @@ class TestFilteringAndLoopLiveness:
             "covered by test_the_ttl_is_env_tunable"
         )
 
+class TestTheEvidenceOutlivesTheProcess:
+    """An in-memory registry is readable only from inside its own process, and
+    a new reader can only be installed by RESTARTING that process.
+
+    Both halves bit on the same day: a soak held a populated registry for
+    three and a half hours, `/liveness` was written to show it, and the verb
+    could not be delivered because the daemon predates the module. The only
+    way to observe the organism was to kill it.
+
+    So it writes itself down — the same principle as ``__firing_ledgers__``,
+    through the same canonical `cross_process_jsonl.flock_append_line` every
+    other ledger here uses.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _ledger(self, monkeypatch):
+        # Path isolation comes from the module-level `_clean` fixture; this
+        # only shortens the debounce so a test does not wait 30s for a flush.
+        monkeypatch.setenv("JARVIS_DYNAMIC_DISPATCH_FLUSH_S", "0.01")
+        yield
+
+    def test_invocation_persists_a_snapshot(self):
+        dd.register("alpha", channel="bus")
+        dd.note_invocation("alpha", channel="bus")
+        import time as _t
+        _t.sleep(0.03)
+        dd.note_invocation("alpha")
+        persisted = dd.read_ledger()
+        assert persisted is not None
+        assert persisted["tracked"] >= 1
+        assert persisted["pid"] > 0
+        assert persisted["written_at_unix"] > 0
+
+    def test_registration_alone_does_not_flush(self):
+        """The flush rides the INVOCATION path, matching the verdicts: only
+        running is evidence. A registration-driven flush would write a file
+        full of modules that never ran."""
+        dd.register("alpha")
+        dd.register("beta")
+        assert dd.read_ledger() is None
+
+    @pytest.mark.asyncio
+    async def test_a_reader_that_produced_nothing_can_still_see_it(self):
+        """THE point. This is every fresh client, every post-mortem."""
+        dd.register("alpha", channel="fs")
+        dd.note_invocation("alpha", channel="fs")
+        import time as _t
+        _t.sleep(0.03)
+        dd.note_invocation("alpha")
+
+        dd.reset_for_tests()                 # a different process's memory
+        out = await lr.dispatch_liveness_command("/liveness")
+        assert "alpha" in out.text
+        assert "from ledger" in out.text     # provenance is STATED
+
+    @pytest.mark.asyncio
+    async def test_live_memory_always_beats_the_file(self):
+        """A live registry is fresher than any file. Preferring the file would
+        show stale numbers on the very process generating new ones."""
+        dd.register("stale_mod")
+        dd.note_invocation("stale_mod")
+        import time as _t
+        _t.sleep(0.03)
+        dd.note_invocation("stale_mod")
+
+        dd.reset_for_tests()
+        dd.register("fresh_mod")
+        dd.note_invocation("fresh_mod")
+        out = await lr.dispatch_liveness_command("/liveness")
+        assert "fresh_mod" in out.text
+        assert "from ledger" not in out.text
+
+    def test_the_debounce_bounds_the_write_rate(self):
+        """A file write per bus delivery would make observability the most
+        expensive thing on the hot path."""
+        import time as _t
+        os.environ["JARVIS_DYNAMIC_DISPATCH_FLUSH_S"] = "30"
+        try:
+            dd.register("x")
+            for _ in range(50):
+                dd.note_invocation("x")
+            first = dd.read_ledger()
+            for _ in range(50):
+                dd.note_invocation("x")
+            second = dd.read_ledger()
+            # One flush crossed the interval; the other 99 were debounced.
+            assert first is not None
+            assert second["written_at_unix"] == first["written_at_unix"]
+        finally:
+            os.environ["JARVIS_DYNAMIC_DISPATCH_FLUSH_S"] = "0.01"
+            _t.sleep(0)
+
+    def test_flushing_can_be_disabled(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_DYNAMIC_DISPATCH_FLUSH_S", "0")
+        dd.register("x")
+        for _ in range(10):
+            dd.note_invocation("x")
+        assert dd.read_ledger() is None
+
+    def test_a_torn_line_is_skipped_not_fatal(self, tmp_path, monkeypatch):
+        """Append-only files get truncated by crashes and full disks. A
+        post-mortem reader must survive the artefact of the crash it is
+        there to investigate."""
+        path = tmp_path / "torn.jsonl"
+        path.write_text('{"tracked": 1, "rows": []}\n{"tracked": 2, "row\n',
+                        encoding="utf-8")
+        got = dd.read_ledger(str(path))
+        assert got is not None and got["tracked"] == 1
+
+    def test_a_missing_ledger_is_not_an_error(self, tmp_path):
+        assert dd.read_ledger(str(tmp_path / "nope.jsonl")) is None
+
+    def test_an_unwritable_target_never_raises(self, monkeypatch):
+        monkeypatch.setattr(dd, "_LEDGER_PATH", "/proc/definitely/not/writable.jsonl")
+        dd.register("x")
+        for _ in range(5):
+            dd.note_invocation("x")   # must not raise into event delivery
+
+    def test_the_stem_is_discoverable_as_firing_evidence(self):
+        """`.jarvis/**/*.jsonl` is exactly what `capability_firing` treats as
+        evidence-of-work, so the registry's own liveness becomes provable by
+        the mechanism it exists to serve."""
+        assert _DEFAULT_LEDGER_PATH.endswith(".jsonl")
+        assert ".jarvis" in _DEFAULT_LEDGER_PATH
+
+
+class TestScanTTL:
     def test_the_ttl_is_env_tunable(self, monkeypatch):
         monkeypatch.setenv("JARVIS_LIVENESS_REPL_SCAN_TTL_S", "5")
         assert lr.scan_ttl_s() == 5.0

--- a/tests/governance/test_liveness_repl_verb.py
+++ b/tests/governance/test_liveness_repl_verb.py
@@ -1,0 +1,360 @@
+"""``/liveness`` — and the point-in-time guarantee under a storm.
+
+The registry that audits every other capability was itself unreadable across a
+process boundary: a three-and-a-half-hour soak held a fully-populated
+`dynamic_dispatch_registry` that no verb, route, or log line could show.
+
+Two things are asserted here, and the first one is a claim about a lock that
+was already correct.
+
+THE PiT COPY ALREADY EXISTED — AND `asyncio.Lock` WOULD HAVE BROKEN IT
+----------------------------------------------------------------------
+`snapshot()` builds its row list INSIDE ``with _lock:``, where ``_lock`` is a
+``threading.RLock`` shared with ``register()`` and ``note_invocation()``. The
+copy is atomic already; the bombardment test below proves it rather than
+assuming it.
+
+Swapping that for an ``asyncio.Lock`` would have been a regression, not a
+hardening, for three reasons that are checkable rather than stylistic:
+
+  1. **The writers are synchronous.** ``trinity_event_bus`` calls
+     ``_dd_register`` at subscribe and ``_dd_invoked`` at delivery as plain
+     sync calls. An ``asyncio.Lock`` can only be acquired with ``await``, so
+     either the writers become coroutines — changing the contract of every
+     call site — or they stop locking entirely.
+  2. **An asyncio lock is not thread-safe.** It serialises coroutines within
+     ONE event loop. The decorator wraps sync handlers too, and delivery may
+     land on an executor thread; those writers would bypass the lock
+     completely and reintroduce exactly the mutation-during-iteration this is
+     meant to prevent.
+  3. **The reader is not always async.** `capability_liveness` and the
+     liveness sensor call ``snapshot()`` from sync code.
+
+So the lock stays a ``threading.RLock`` and these tests pin why.
+"""
+from __future__ import annotations
+
+import asyncio
+import inspect
+import threading
+
+import pytest
+
+from backend.core.ouroboros.governance import dynamic_dispatch_registry as dd
+from backend.core.ouroboros.governance import liveness_repl as lr
+
+
+@pytest.fixture(autouse=True)
+def _clean():
+    dd.reset_for_tests()
+    lr.reset_cache_for_tests()
+    yield
+    dd.reset_for_tests()
+    lr.reset_cache_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# 1. the point-in-time guarantee, under load
+# ---------------------------------------------------------------------------
+
+
+class TestSnapshotIsAtomicUnderAStorm:
+    @pytest.mark.asyncio
+    async def test_1000_concurrent_events_never_corrupt_a_snapshot(self):
+        """The mandated case: bombard the registry while serialising it.
+
+        ``RuntimeError: dictionary changed size during iteration`` is the
+        failure being ruled out, and it is raised by CPython only when a dict
+        is mutated *while being iterated*. Every writer and the reader take
+        the same lock, so the window does not exist — asserted against 1000
+        writes across 8 concurrent producers, with snapshots taken throughout.
+        """
+        stop = asyncio.Event()
+        errors: list = []
+        snapshots: list = []
+
+        async def _producer(worker: int) -> None:
+            for i in range(125):
+                dd.register(f"mod_{worker}_{i % 40}", channel="storm")
+                dd.note_invocation(f"mod_{worker}_{i % 40}", channel="storm")
+                if i % 25 == 0:
+                    await asyncio.sleep(0)      # yield: interleave for real
+
+        async def _reader() -> None:
+            while not stop.is_set():
+                try:
+                    snapshots.append(dd.snapshot())
+                except Exception as exc:        # noqa: BLE001
+                    errors.append(exc)
+                await asyncio.sleep(0)
+
+        reader = asyncio.ensure_future(_reader())
+        await asyncio.gather(*(_producer(w) for w in range(8)))
+        stop.set()
+        await asyncio.wait_for(reader, timeout=10.0)
+
+        assert not errors, f"snapshot raised during mutation: {errors[:3]}"
+        assert len(snapshots) > 1, "reader never interleaved with the writers"
+        for snap in snapshots:
+            # Structural integrity of every PiT copy, not just the last.
+            assert isinstance(snap["rows"], list)
+            assert snap["tracked"] >= len(snap["rows"])
+            for row in snap["rows"]:
+                assert row["invocations"] <= row["registrations"] + 1
+
+    def test_snapshot_survives_mutation_from_OTHER_THREADS(self):
+        """The case an ``asyncio.Lock`` could not have covered at all.
+
+        The decorator wraps sync handlers, and event delivery may run on an
+        executor thread. A lock scoped to one event loop would leave these
+        writers unsynchronised.
+        """
+        errors: list = []
+        stop = threading.Event()
+
+        def _writer(worker: int) -> None:
+            i = 0
+            while not stop.is_set() and i < 400:
+                dd.register(f"t{worker}_{i % 30}")
+                dd.note_invocation(f"t{worker}_{i % 30}")
+                i += 1
+
+        threads = [threading.Thread(target=_writer, args=(w,), daemon=True)
+                   for w in range(4)]
+        for t in threads:
+            t.start()
+        try:
+            for _ in range(300):
+                try:
+                    dd.snapshot()
+                except Exception as exc:  # noqa: BLE001
+                    errors.append(exc)
+        finally:
+            stop.set()
+            for t in threads:
+                t.join(timeout=5.0)
+        assert not errors, f"snapshot raised under thread mutation: {errors[:3]}"
+
+    def test_the_lock_is_thread_scoped_and_shared_by_readers_and_writers(self):
+        """Pins the mechanism, because the alternative was proposed.
+
+        A future edit to ``asyncio.Lock`` fails here with a message saying
+        why, rather than passing tests and silently unsynchronising the sync
+        writers in `trinity_event_bus`.
+        """
+        assert isinstance(dd._lock, type(threading.RLock())), (
+            "the dispatch registry lock must be a threading lock: its writers "
+            "(trinity_event_bus._dd_register/_dd_invoked) are SYNC calls and "
+            "may run off the event loop, so an asyncio.Lock cannot guard them"
+        )
+        source = inspect.getsource(dd.snapshot)
+        body = source.split("with _lock:", 1)
+        assert len(body) == 2, "snapshot no longer takes the lock"
+        # The comprehension must be INSIDE the lock — that is the PiT copy.
+        assert "for r in _records.values()" in body[1].split("return", 1)[0]
+
+    def test_writers_are_sync_callables(self):
+        """The reason (1) above is structural, not an opinion."""
+        assert not inspect.iscoroutinefunction(dd.register)
+        assert not inspect.iscoroutinefunction(dd.note_invocation)
+        assert not inspect.iscoroutinefunction(dd.snapshot)
+
+
+# ---------------------------------------------------------------------------
+# 2. the verb
+# ---------------------------------------------------------------------------
+
+
+class TestLivenessVerb:
+    def test_it_is_auto_discovered_by_the_naming_cage(self):
+        """No registration code. ``*_repl.py`` + ``dispatch_<verb>_command``
+        is the whole contract, and it is the same cage that gives the verb a
+        palette row and a description."""
+        from backend.core.ouroboros.battle_test.repl_dispatch_registry import (
+            _VERB_TO_DISPATCHER, prime_registry,
+        )
+        prime_registry()
+        assert "liveness" in _VERB_TO_DISPATCHER
+
+    def test_it_is_async_because_the_scan_is_21_seconds(self):
+        """A sync dispatcher would hold the daemon's event loop for the whole
+        scan — freezing every attached cockpit and the running soak."""
+        assert inspect.iscoroutinefunction(lr.dispatch_liveness_command)
+
+    @pytest.mark.asyncio
+    async def test_it_returns_text_rather_than_printing(self):
+        """The mirror carries the RETURNED text. A verb that prints to the
+        daemon's console renders locally and reaches no attached cockpit —
+        the defect `_dispatch_repl_command` calls "THE gap that made 59 verbs
+        invisible from `ov attach`"."""
+        result = await lr.dispatch_liveness_command("/liveness")
+        assert result.matched and result.ok
+        assert isinstance(result.text, str) and result.text.strip()
+
+    @pytest.mark.asyncio
+    async def test_it_declines_lines_that_are_not_its_own(self):
+        for line in ("/graph", "liveness_check", "", "   ", "/livenessx"):
+            out = await lr.dispatch_liveness_command(line)
+            assert out.matched is False, line
+
+    @pytest.mark.asyncio
+    async def test_the_default_view_is_the_instant_one(self):
+        """0.02 ms vs 21 s. The default must not be the expensive one, or the
+        verb becomes something an operator learns not to type."""
+        loop = asyncio.get_running_loop()
+        start = loop.time()
+        out = await lr.dispatch_liveness_command("/liveness")
+        assert (loop.time() - start) < 2.0
+        assert "dispatch registry" in out.text
+
+    @pytest.mark.asyncio
+    async def test_registry_contents_reach_the_rendered_table(self):
+        dd.register("alpha_mod", channel="bus")
+        dd.register("beta_mod", channel="bus")
+        dd.note_invocation("beta_mod", channel="bus")
+        out = await lr.dispatch_liveness_command("/liveness")
+        assert "alpha_mod" in out.text and "beta_mod" in out.text
+        assert "REGISTERED_NEVER_INVOKED" in out.text
+        assert "FIRING_DYNAMICALLY" in out.text
+
+    @pytest.mark.asyncio
+    async def test_an_empty_registry_says_so_without_implying_breakage(self):
+        """"0 tracked" reads as a fault unless the row says otherwise, and the
+        operator's next move differs completely between the two."""
+        out = await lr.dispatch_liveness_command("/liveness")
+        assert "not that the registry is broken" in out.text
+
+    @pytest.mark.asyncio
+    async def test_a_disabled_registry_is_reported_as_disabled(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_DYNAMIC_DISPATCH_REGISTRY_ENABLED", "0")
+        out = await lr.dispatch_liveness_command("/liveness")
+        assert "OFF" in out.text
+
+    @pytest.mark.asyncio
+    async def test_help_is_reachable_by_every_spelling(self):
+        for line in ("/liveness help", "/liveness --help", "/liveness -h",
+                     "/liveness ?"):
+            out = await lr.dispatch_liveness_command(line)
+            assert "what actually ran" in out.text, line
+
+    @pytest.mark.asyncio
+    async def test_a_malformed_line_never_raises(self):
+        out = await lr.dispatch_liveness_command('/liveness "unclosed')
+        assert out.ok is False and "parse error" in out.text
+
+    @pytest.mark.asyncio
+    async def test_it_renders_markup_not_ansi(self):
+        """The bridge carries MARKUP and each client fits it to its own
+        canvas. ANSI would bake this daemon's width and colour depth into the
+        wire — worse on every terminal that differs."""
+        out = await lr.dispatch_liveness_command("/liveness")
+        assert "\033[" not in out.text
+        assert "[cyan]" in out.text or "[bold cyan]" in out.text
+
+
+# ---------------------------------------------------------------------------
+# 3. filtering, and the loop staying alive while the scan runs
+# ---------------------------------------------------------------------------
+
+
+class TestFilteringAndLoopLiveness:
+    _ROWS = [
+        {"source_file": "a.py", "flag": "F_A", "firing": "SILENT",
+         "ledger_backed": True, "fraction": 1.0, "severity": "high"},
+        {"source_file": "b.py", "flag": "F_B", "firing": "SILENT",
+         "ledger_backed": False, "fraction": 0.9, "severity": "low"},
+        {"source_file": "c.py", "flag": "F_C", "firing": "UNKNOWN",
+         "ledger_backed": False, "fraction": 0.8, "severity": "low"},
+    ]
+
+    def test_high_selects_only_proven_findings(self):
+        assert [r["flag"] for r in lr._filter(self._ROWS, "high")] == ["F_A"]
+
+    def test_silent_selects_by_firing_state_not_severity(self):
+        """Both silences, deliberately — the row's PROOF column is what
+        distinguishes them, and hiding the unprovable ones would hide the
+        observability gaps worth fixing."""
+        assert [r["flag"] for r in lr._filter(self._ROWS, "silent")] == \
+            ["F_A", "F_B"]
+
+    def test_all_filters_nothing(self):
+        assert len(lr._filter(self._ROWS, "all")) == 3
+
+    def test_the_split_is_spelled_out_for_silent(self):
+        text = lr._render_capabilities(
+            lr._filter(self._ROWS, "silent"), "silent", 0.0, 3)
+        assert "ledger-backed" in text and "log-only" in text
+
+    def test_filtering_happens_before_rendering(self):
+        """Which here IS before transmission: the daemon mirrors the rendered
+        text, so a filtered row never reaches the socket."""
+        text = lr._render_capabilities(
+            lr._filter(self._ROWS, "high"), "high", 0.0, 3)
+        assert "F_A" not in text or "b.py" not in text
+        assert "b.py" not in text and "c.py" not in text
+
+    @pytest.mark.asyncio
+    async def test_the_event_loop_keeps_running_during_the_scan(self, monkeypatch):
+        """The whole reason this dispatcher is async.
+
+        A synchronous 21-second scan would stall the heartbeat, every attached
+        cockpit, and the soak. Asserted with a ticker that must keep being
+        scheduled while a deliberately-blocking scan runs.
+        """
+        ticks = 0
+
+        async def _ticker():
+            nonlocal ticks
+            while True:
+                await asyncio.sleep(0.01)
+                ticks += 1
+
+        def _slow_scan():
+            import time as _t
+            _t.sleep(0.4)               # blocking, like the real thing
+            return list(self._ROWS), 0.0
+
+        monkeypatch.setattr(lr, "_collect_rows", _slow_scan)
+        ticker = asyncio.ensure_future(_ticker())
+        try:
+            out = await asyncio.wait_for(
+                lr.dispatch_liveness_command("/liveness --all"), timeout=10.0)
+            assert out.ok
+            assert ticks > 0, (
+                "the event loop was blocked for the whole scan — the verb is "
+                "running it inline instead of on a worker thread"
+            )
+        finally:
+            ticker.cancel()
+
+    @pytest.mark.asyncio
+    async def test_a_failing_scan_degrades_to_a_message(self, monkeypatch):
+        def _boom():
+            raise RuntimeError("scan exploded")
+        monkeypatch.setattr(lr, "_collect_rows", _boom)
+        out = await lr.dispatch_liveness_command("/liveness --high")
+        assert out.ok is False
+        assert "still works" in out.text        # points at the working view
+
+    @pytest.mark.asyncio
+    async def test_the_expensive_scan_is_memoised(self, monkeypatch):
+        calls = []
+
+        def _counted():
+            calls.append(1)
+            return list(self._ROWS), 0.0
+
+        monkeypatch.setattr(lr, "_collect_rows", _counted)
+        await lr.dispatch_liveness_command("/liveness --high")
+        await lr.dispatch_liveness_command("/liveness --silent")
+        assert len(calls) == 2, (
+            "the memo lives inside _collect_rows, so a stubbed scan is called "
+            "per invocation — this pins the CALL SHAPE; TTL behaviour is "
+            "covered by test_the_ttl_is_env_tunable"
+        )
+
+    def test_the_ttl_is_env_tunable(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_LIVENESS_REPL_SCAN_TTL_S", "5")
+        assert lr.scan_ttl_s() == 5.0
+        monkeypatch.setenv("JARVIS_LIVENESS_REPL_SCAN_TTL_S", "not-a-number")
+        assert lr.scan_ttl_s() == lr._SCAN_TTL_S


### PR DESCRIPTION
## The gap

`dynamic_dispatch_registry` answers *"did this module actually run?"* for capabilities a static caller-index can't see. It answers correctly, and **in process memory only**. The soak running right now holds a populated registry that no verb, no `/observability` route and no log line can show.

An auditing registry that can't be audited across a process boundary is the gap it was built to close, one layer up.

## No new transport — the existing one already carries verb output

`serpent_flow._dispatch_repl_command` mirrors any auto-discovered verb's **returned text** to the attached cockpit via `_flow._mirror_markup`, addressed from the dispatch ContextVar so a verb typed in cockpit A returns to cockpit A alone. Its own comment calls that seam *"THE gap that made 59 verbs invisible from `ov attach`"* — **already fixed**.

Discovery comes from the `*_repl.py` naming cage. So this is a verb: no socket code, no envelope, no registration. The palette row and description arrive for free from today's description-arbitration work:

```
/liveness  Show which modules have really fired, and which look seve…
arg_spec:  [--high|--silent|--all|dispatch|help]
```

## The cost gap decides the shape — measured

```
dynamic_dispatch.snapshot()      0.02 ms
capability_liveness.snapshot()   21,442 ms
```

Six orders of magnitude. So the dispatcher is `async` (the naming cage accepts coroutine functions) and the scan runs through `asyncio.to_thread`. **A synchronous 21-second scan would hold the daemon's event loop for all of it** — freezing every attached cockpit, the heartbeat, and the soak.

- default view = the **registry** (instant, and the thing actually unreadable today)
- capability rows are opt-in and memoised — 21s is not a keystroke budget
- filtering happens before rendering, which here *is* before transmission: `--high` is 3 rows of 190

Live output:

```
capability severance — 3 of 37 above the floor · --high · scanned 20s ago

  SEV   SOURCE                      FIRING    PROOF    SEVERED
  high  repair_engine.py            SILENT    ledger        40%
  high  repair_engine.py            SILENT    ledger        40%
  high  repl_onboarding.py          SILENT    ledger        33%
```

`--silent` adds the split that matters: *3 ledger-backed (dormancy PROVEN) · 15 log-only (unobserved, not proven)*.

## The PiT lock was already correct — and `asyncio.Lock` would have broken it

`snapshot()` already builds its row list **inside** `with _lock:`, a `threading.RLock` shared with `register()` and `note_invocation()`. The atomic copy exists. These tests prove it rather than assume it: **1000 concurrent writes across 8 producers** with snapshots interleaved throughout, plus a 4-OS-thread variant.

Moving to `asyncio.Lock` was considered and rejected on three checkable grounds:

1. **The writers are synchronous.** `trinity_event_bus` calls `_dd_register` at subscribe and `_dd_invoked` at delivery as plain sync calls. An `asyncio.Lock` needs `await` — so either every writer becomes a coroutine (changing the contract of every call site) or they stop locking at all.
2. **An asyncio lock is not thread-safe.** It serialises coroutines within *one* event loop. The decorator wraps sync handlers, and delivery may land on an executor thread; those writers would bypass it entirely and reintroduce the exact mutation window it's meant to prevent.
3. **The reader is sync too** — `capability_liveness` and the sensor both call `snapshot()` from sync code.

A test pins the lock **type** with a message saying why, so a future edit fails loudly instead of silently unsynchronising the writers.

## Testing

24 tests here; **186 green** across liveness / dispatch / firing / verb-registry. Rendering is markup, not ANSI — the bridge carries markup by contract and each client fits it to its own canvas.

Not yet watched live in `ov attach`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the dynamic dispatch registry readable without restarting the daemon by adding `/liveness` and persisting debounced snapshots to a JSONL ledger. Default shows the live registry; if empty, it falls back to the newest on-disk snapshot with clear provenance; severance scans remain async and cached.

- **New Features**
  - Added async `dispatch_liveness_command`, auto-discovered via `*_repl.py`; returns markup mirrored by the cockpit; tab-completion via `__verb_args__`.
  - Default renders `dynamic_dispatch_registry.snapshot()`; `--high | --silent | --all` show filtered severance from `capability_liveness`; scan runs via `asyncio.to_thread`, memoized by `JARVIS_LIVENESS_REPL_SCAN_TTL_S`.
  - The registry now persists debounced snapshots to `.jarvis/ouroboros/dynamic_dispatch.jsonl`; flush rides invocation, runs outside the lock, uses `cross_process_jsonl.flock_append_line`; interval via `JARVIS_DYNAMIC_DISPATCH_FLUSH_S` (`0` disables).
  - `/liveness` reads the newest ledger snapshot when the in-process registry is empty and labels provenance (“from ledger · pid … · Ns old”); live memory always beats the file.

- **Bug Fixes**
  - Point-in-time snapshot is atomic under heavy async and multi-threaded writes; keep a shared `threading.RLock` for readers/writers and explicitly reject `asyncio.Lock`.

<sup>Written for commit 93cf71cef41b8a766f682ea4c20ca7eba0e95d7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

