### PR TITLE
fix(handoff): a name is not an identity — resolve callees, stop matching on the last segment

### DIFF
--- a/backend/core/ouroboros/ui/capability_handoff.py
+++ b/backend/core/ouroboros/ui/capability_handoff.py
@@ -95,7 +95,8 @@ import logging
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
+from typing import (Any, Dict, FrozenSet, Iterable, List, Optional,
+                    Sequence, Set, Tuple)
 
 logger = logging.getLogger("Ouroboros.CapabilityHandoff")
 
@@ -477,6 +478,191 @@ def _callee_name(call: ast.Call) -> str:
     return ""
 
 
+# ---------------------------------------------------------------------------
+# Callee resolution — a name is not an identity
+# ---------------------------------------------------------------------------
+#
+# Matching a call to a sink by its BARE last segment was the analyser's
+# sharpest blind spot, and it produced confident false findings rather than
+# quiet ones. `serpent_flow` calls ``narrative_renderer.compose``; the audit
+# reported it as failing to fill seven parameters of
+# ``tool_render_view.compose`` — a different function that happens to share a
+# name. There are SIX distinct ``compose`` definitions under these roots, so
+# every caller of any of them was judged against all of them.
+#
+# Seven of eleven reported divergences came from that one collision. An
+# auditor wrong most of the time is an auditor nobody reads, and the real
+# finding underneath it (the daemon cockpit genuinely dropping four
+# capabilities the attach client passes) was sitting in the same list.
+#
+# It is also the SAME defect this codebase keeps rediscovering: the caller
+# index that read ``repair_engine`` 40% severed did so because it keyed on
+# bare symbol names and could not see
+# ``self._config.repair_engine.run(...)``. Unqualified names are not
+# identities. This resolves them.
+
+#: Names that are never a module, so ``x.compose(...)`` through them is a
+#: METHOD call and cannot be a module-level sink. Without this, every
+#: ``self.compose(...)`` in the tree matched every module-level ``compose``.
+_NON_MODULE_ROOTS = frozenset({"self", "cls", "super"})
+
+#: Calls whose target the AST could not settle, kept so the audit can REPORT
+#: its own blind spot instead of silently dropping them. A tool that quietly
+#: discards what it cannot resolve looks identical to one with nothing to
+#: find — the distinction this codebase spent today learning to make.
+_UNRESOLVED_CALLS: List[Tuple[str, str, int]] = []
+
+
+def unresolved_calls() -> Tuple[Tuple[str, str, int], ...]:
+    """``(module, callee, line)`` the resolver refused to guess at."""
+    return tuple(_UNRESOLVED_CALLS)
+
+
+def _relative_base(module: str, is_init: bool, level: int) -> Optional[str]:
+    """Absolute package a relative import resolves against, or None.
+
+    The rule is CPython's and is already stated once in
+    `reverse_dep_resolver._add_relative_import_edges`; it is restated here
+    rather than imported because that function resolves EDGES into a set and
+    this needs the BASE to build a binding from. Same algorithm, different
+    return type — importing it would mean reconstructing the base from its
+    output, which is the more fragile coupling.
+    """
+    if is_init:
+        package = module
+    elif "." in module:
+        package = module.rsplit(".", 1)[0]
+    else:
+        package = ""
+    parts = package.split(".") if package else []
+    drop = max(0, level - 1)
+    if drop > len(parts):
+        return None                       # escapes the tree — unresolvable
+    return ".".join(parts[: len(parts) - drop])
+
+
+def _bindings_from(nodes: Iterable[ast.AST], module: str,
+                   is_init: bool) -> Dict[str, Optional[str]]:
+    """``local name -> absolute dotted target``, or None where AMBIGUOUS.
+
+    ``None`` is a real value here: a scope that binds one name to two
+    different targets cannot resolve a call to either, and guessing would
+    reintroduce exactly the confident-wrong-answer this replaces.
+
+    Both spellings are recorded because both appear at call sites:
+
+        from x import compose            ->  compose -> x.compose
+        from x import compose as c       ->  c       -> x.compose
+        import x                         ->  x       -> x
+        import x.y as z                  ->  z       -> x.y
+    """
+    out: Dict[str, Optional[str]] = {}
+
+    def _bind(name: str, target: str) -> None:
+        if not name or not target:
+            return
+        if name in out and out[name] != target:
+            out[name] = None              # ambiguous in this scope
+            return
+        out.setdefault(name, target)
+
+    for node in nodes:
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if not alias.name:
+                    continue
+                # `import a.b.c` with no alias binds the ROOT package `a`;
+                # with an alias it binds the alias to the full path.
+                if alias.asname:
+                    _bind(alias.asname, alias.name)
+                else:
+                    _bind(alias.name.split(".", 1)[0],
+                          alias.name.split(".", 1)[0])
+        elif isinstance(node, ast.ImportFrom):
+            if node.level and node.level > 0:
+                base = _relative_base(module, is_init, node.level)
+                if base is None:
+                    continue
+                target_module = (f"{base}.{node.module}" if node.module
+                                 else base)
+            else:
+                target_module = node.module or ""
+            if not target_module:
+                continue
+            for alias in node.names:
+                if not alias.name or alias.name == "*":
+                    continue
+                _bind(alias.asname or alias.name,
+                      f"{target_module}.{alias.name}")
+    return out
+
+
+def _direct_children(scope: ast.AST) -> List[ast.AST]:
+    """Every node inside *scope* EXCLUDING nested function bodies.
+
+    Nested scopes get their own maps; folding them in would let a helper's
+    local import shadow its parent's, which is the ambiguity this is trying
+    to avoid rather than create.
+    """
+    out: List[ast.AST] = []
+    stack: List[ast.AST] = list(ast.iter_child_nodes(scope))
+    while stack:
+        node = stack.pop()
+        out.append(node)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef,
+                             ast.ClassDef)):
+            # YIELDED but not DESCENDED INTO. The caller needs to see the
+            # nested scope in order to recurse with its own bindings;
+            # dropping it here (the first version did) meant `_visit` never
+            # found a single nested function and scanned module level only —
+            # which silently took the audit from 11 findings to 0 and looked
+            # like a clean bill of health.
+            continue
+        stack.extend(ast.iter_child_nodes(node))
+    return out
+
+
+def _resolve_callee(call: ast.Call, scopes: Sequence[Dict[str, Optional[str]]],
+                    local_defs: FrozenSet[str], module: str) -> Optional[str]:
+    """Absolute dotted target of *call*, or None when unprovable.
+
+    None is returned for anything the AST cannot settle — an unbound name, an
+    ambiguous binding, a call through a variable, a method on an instance.
+    Every one of those used to MATCH, on the strength of the last path
+    segment alone.
+
+    Scope order is innermost-first, which matters because this codebase
+    imports inside functions constantly: a module-level
+    ``from tool_render_view import compose`` and a function-local
+    ``from narrative_renderer import compose`` are both correct, and the call
+    means whichever one encloses it.
+    """
+    func = call.func
+    if isinstance(func, ast.Name):
+        name = func.id
+        for scope in scopes:
+            if name in scope:
+                target = scope[name]
+                return target             # None => ambiguous, honestly so
+        # A module-level def in THIS file shadows nothing and binds locally.
+        if name in local_defs:
+            return f"{module}.{name}"
+        return None
+    if isinstance(func, ast.Attribute):
+        value = func.value
+        if not isinstance(value, ast.Name):
+            return None                  # a.b.c(...) / expr().m(...) — no
+        root = value.id
+        if root in _NON_MODULE_ROOTS:
+            return None                  # a METHOD, never a module sink
+        for scope in scopes:
+            if root in scope:
+                base = scope[root]
+                return f"{base}.{func.attr}" if base else None
+        return None
+    return None
+
+
 def _reads_opaquely(fn: Any) -> bool:
     """Does the body reach its own scope dynamically?
 
@@ -733,21 +919,51 @@ def analyse_surface(module: str, path: Path, hooks: Sequence[Hook],
         tree = _parse(path)
         if tree is None:
             return []
-        by_sink: Dict[str, List[Hook]] = {}
+        # Sinks keyed by their FULL dotted qualname. The previous index keyed
+        # on the last segment, so `tool_render_view.compose` and
+        # `narrative_renderer.compose` — six such collisions exist under these
+        # roots — were the same key, and every caller of either was judged
+        # against both.
+        by_qualname: Dict[str, List[Hook]] = {}
         for hook in hooks:
-            by_sink.setdefault(hook.sink.rsplit(".", 1)[0] + "|" +
-                               hook.sink.rsplit(".", 1)[-1], []).append(hook)
-        for node in ast.walk(tree):
-            if not isinstance(node, ast.Call):
-                continue
-            callee = _callee_name(node)
-            if callee not in sink_functions:
-                continue
-            targets = [h for h in hooks
-                       if h.sink.rsplit(".", 1)[-1] == callee]
-            if not targets:
-                continue
-            out.extend(_fills_for_call(module, node, targets))
+            by_qualname.setdefault(hook.sink, []).append(hook)
+
+        is_init = path.name == "__init__.py"
+        module_scope = _bindings_from(_direct_children(tree), module, is_init)
+        local_defs = frozenset(
+            n.name for n in ast.iter_child_nodes(tree)
+            if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+        )
+
+        # (call, enclosing scope chain) — innermost first. Walking scopes
+        # rather than the whole tree is what lets a function-local import
+        # shadow a module-level one, which this codebase does constantly.
+        def _visit(scope: ast.AST,
+                   chain: Sequence[Dict[str, Optional[str]]]) -> None:
+            body = _direct_children(scope)
+            for node in body:
+                if isinstance(node, ast.Call):
+                    resolved = _resolve_callee(
+                        node, chain, local_defs, module)
+                    if resolved is None:
+                        # Unprovable, and recorded as such rather than
+                        # matched. `_callee_name` still names it for the
+                        # blind-spot report below.
+                        name = _callee_name(node)
+                        if name in sink_functions:
+                            _UNRESOLVED_CALLS.append(
+                                (module, name, getattr(node, "lineno", 0)))
+                        continue
+                    targets = by_qualname.get(resolved)
+                    if targets:
+                        out.extend(_fills_for_call(module, node, targets))
+                elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef,
+                                       ast.ClassDef)):
+                    inner = _bindings_from(
+                        _direct_children(node), module, is_init)
+                    _visit(node, (inner,) + tuple(chain) if inner else chain)
+
+        _visit(tree, (module_scope,))
     except Exception:  # noqa: BLE001
         logger.debug("[CapabilityHandoff] surface analysis degraded: %s",
                      module, exc_info=True)

--- a/tests/battle_test/test_handoff_callee_resolution.py
+++ b/tests/battle_test/test_handoff_callee_resolution.py
@@ -1,0 +1,245 @@
+"""A name is not an identity — the auditor's sharpest blind spot.
+
+`capability_handoff` matched a call to a sink by the BARE last segment of the
+sink's qualname. There are SIX distinct ``compose`` definitions under the
+audited roots, so every caller of any of them was judged against all of them.
+
+Concretely: `serpent_flow` calls ``narrative_renderer.compose``, and the audit
+reported it as failing to fill seven parameters of
+``tool_render_view.compose`` — a different function that happens to share a
+name. **Seven of eleven reported divergences came from that one collision**,
+and the four real findings underneath (the daemon cockpit genuinely dropping
+capabilities the attach client passes) were sitting in the same list. An
+auditor wrong most of the time is an auditor nobody reads.
+
+It is the same defect this codebase keeps rediscovering. The caller index that
+read ``repair_engine`` 40% severed did so because it keyed on bare symbol
+names and could not see ``self._config.repair_engine.run(...)``. Unqualified
+names are not identities.
+
+What matters in these tests is that the fix RESOLVES rather than SUPPRESSES:
+dropping every ambiguous match would also take 11 findings to 4, and would be
+indistinguishable from this by count alone.
+"""
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+from backend.core.ouroboros.ui import capability_handoff as ch
+
+
+def _resolve(source: str, module: str = "pkg.mod", call_index: int = 0):
+    """Resolve the Nth call in *source* exactly as the auditor would."""
+    tree = ast.parse(source)
+    is_init = module.endswith(".__init__")
+    scope = ch._bindings_from(ch._direct_children(tree), module, is_init)
+    local_defs = frozenset(
+        n.name for n in ast.iter_child_nodes(tree)
+        if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+    )
+    calls = [n for n in ast.walk(tree) if isinstance(n, ast.Call)]
+    return ch._resolve_callee(calls[call_index], (scope,), local_defs, module)
+
+
+class TestTheCollisionItself:
+    def test_two_composes_are_two_sinks(self):
+        """THE regression, in miniature."""
+        a = _resolve("from x.tool_render_view import compose\ncompose(1)")
+        b = _resolve("from x.narrative_renderer import compose\ncompose(1)")
+        assert a == "x.tool_render_view.compose"
+        assert b == "x.narrative_renderer.compose"
+        assert a != b
+
+    def test_the_live_audit_no_longer_reports_the_false_seven(self):
+        """Against the real tree, not a fixture."""
+        divergences = ch.audit().divergence()
+        composes = [d for d in divergences if d[0].endswith(".compose")]
+        assert not composes, (
+            f"compose collisions are back: {composes}")
+
+    def test_the_real_findings_SURVIVE(self):
+        """Suppression would also have cleared the list. The daemon genuinely
+        does not pass these to `run_bipartite_repl`; the attach client does."""
+        divergences = ch.audit().divergence()
+        params = {d[1] for d in divergences
+                  if d[0].endswith("run_bipartite_repl")}
+        assert {"on_mux", "seed", "title", "watch_alive"} <= params
+
+    def test_the_collided_sink_is_still_ANALYSED(self):
+        """The strongest check that this resolved rather than dropped: fills
+        for `tool_render_view.compose` are still recorded, they are simply
+        attributed to the caller that really makes them."""
+        reading = ch.audit()
+        fills = reading.fills() if callable(getattr(reading, "fills", None)) \
+            else getattr(reading, "fills", [])
+        composed = [f for f in fills if f.sink.endswith("tool_render_view.compose")]
+        assert composed, "the sink stopped being analysed — that is suppression"
+
+
+class TestImportForms:
+    @pytest.mark.parametrize("source,expected", [
+        ("from a.b import fn\nfn()", "a.b.fn"),
+        ("from a.b import fn as g\ng()", "a.b.fn"),
+        ("import a.b\na.b.fn()", None),          # `a` binds, `a.b.fn` is 2 hops
+        ("import a\na.fn()", "a.fn"),
+        ("import a.b as c\nc.fn()", "a.b.fn"),
+    ])
+    def test_each_spelling(self, source, expected):
+        assert _resolve(source) == expected
+
+    def test_a_local_def_binds_to_this_module(self):
+        assert _resolve("def fn():\n    pass\nfn()") == "pkg.mod.fn"
+
+    def test_an_import_shadows_a_same_named_local_def(self):
+        """Python binds the LAST assignment at module scope; an explicit
+        import of the name is the caller's stated intent."""
+        assert _resolve("def fn():\n    pass\nfrom a.b import fn\nfn()") == \
+            "a.b.fn"
+
+
+class TestRelativeImports:
+    def test_one_dot_resolves_against_the_package(self):
+        assert _resolve("from .sibling import fn\nfn()",
+                        module="pkg.sub.mod") == "pkg.sub.sibling.fn"
+
+    def test_two_dots_climb(self):
+        assert _resolve("from ..other import fn\nfn()",
+                        module="pkg.sub.mod") == "pkg.other.fn"
+
+    def test_a_bare_relative_import(self):
+        assert _resolve("from . import fn\nfn()",
+                        module="pkg.sub.mod") == "pkg.sub.fn"
+
+    def test_escaping_the_tree_is_unresolvable_not_a_guess(self):
+        assert _resolve("from ....way.up import fn\nfn()",
+                        module="pkg.mod") is None
+
+
+class TestWhatMustNOTResolve:
+    """Every one of these MATCHED before, on the last path segment alone."""
+
+    def test_a_method_call_is_not_a_module_sink(self):
+        """`self.compose(...)` matched every module-level `compose` in the
+        tree. This is the single largest source of the false positives."""
+        assert _resolve("self.fn()") is None
+        assert _resolve("cls.fn()") is None
+
+    def test_a_call_through_an_unbound_name(self):
+        assert _resolve("fn()") is None
+
+    def test_a_call_on_an_instance_attribute(self):
+        assert _resolve("obj.helper.fn()") is None
+
+    def test_a_call_on_an_expression(self):
+        assert _resolve("get_thing().fn()") is None
+
+    def test_an_ambiguous_binding_refuses_to_guess(self):
+        """Two imports of one name in one scope. Picking either would
+        reintroduce a confident wrong answer, which is the whole defect."""
+        source = ("from a.b import fn\n"
+                  "from c.d import fn\n"
+                  "fn()")
+        assert _resolve(source) is None
+
+    def test_a_star_import_binds_nothing(self):
+        """`from x import *` cannot be resolved without importing x, and the
+        analyser never executes the code it audits."""
+        assert _resolve("from a.b import *\nfn()") is None
+
+
+class TestScoping:
+    def test_a_function_local_import_shadows_the_module_level_one(self):
+        """This codebase imports inside functions constantly — the pattern
+        that made the collision so damaging. A call means whichever binding
+        encloses it."""
+        source = (
+            "from a.tool_render_view import compose\n"
+            "def f():\n"
+            "    from a.narrative_renderer import compose\n"
+            "    return compose(1)\n"
+        )
+        tree = ast.parse(source)
+        module_scope = ch._bindings_from(
+            ch._direct_children(tree), "pkg.mod", False)
+        fn = next(n for n in ast.walk(tree)
+                  if isinstance(n, ast.FunctionDef))
+        inner = ch._bindings_from(ch._direct_children(fn), "pkg.mod", False)
+        call = next(n for n in ast.walk(fn) if isinstance(n, ast.Call))
+        resolved = ch._resolve_callee(
+            call, (inner, module_scope), frozenset(), "pkg.mod")
+        assert resolved == "a.narrative_renderer.compose"
+
+    def test_nested_scopes_are_YIELDED_so_recursion_can_reach_them(self):
+        """The bug the first draft of this fix shipped.
+
+        `_direct_children` must hand back a nested def WITHOUT descending into
+        it: the caller needs to see it in order to recurse with its own
+        bindings. Dropping it meant no nested function was ever visited, so
+        the audit scanned module level only — and went from 11 findings to
+        ZERO, which reads exactly like a clean bill of health.
+        """
+        tree = ast.parse("def outer():\n    def inner():\n        pass\n")
+        kids = ch._direct_children(tree)
+        assert any(isinstance(k, ast.FunctionDef) and k.name == "outer"
+                   for k in kids)
+        outer = next(n for n in ast.walk(tree)
+                     if isinstance(n, ast.FunctionDef) and n.name == "outer")
+        assert any(isinstance(k, ast.FunctionDef) and k.name == "inner"
+                   for k in ch._direct_children(outer))
+
+    def test_a_nested_body_is_not_folded_into_its_parent(self):
+        """A helper's local import must not shadow its parent's — that would
+        create the ambiguity this exists to avoid."""
+        tree = ast.parse(
+            "def outer():\n"
+            "    def inner():\n"
+            "        from a.b import fn\n"
+            "    fn()\n"
+        )
+        outer = next(n for n in ast.walk(tree)
+                     if isinstance(n, ast.FunctionDef) and n.name == "outer")
+        bindings = ch._bindings_from(
+            ch._direct_children(outer), "pkg.mod", False)
+        assert "fn" not in bindings
+
+
+class TestTheBlindSpotIsReported:
+    def test_unresolved_calls_are_recorded_not_silently_dropped(self):
+        """A tool that quietly discards what it cannot resolve looks identical
+        to one with nothing to find. `unresolved_calls()` is the difference,
+        and it is the same distinction between "unprovable" and "proven" that
+        the liveness work landed today."""
+        ch.audit()
+        assert isinstance(ch.unresolved_calls(), tuple)
+
+    def test_the_report_names_module_callee_and_line(self):
+        ch.audit()
+        for row in ch.unresolved_calls():
+            assert len(row) == 3
+            module, callee, line = row
+            assert isinstance(module, str) and module
+            assert isinstance(callee, str) and callee
+            assert isinstance(line, int)
+
+
+class TestNeverRaises:
+    @pytest.mark.parametrize("hostile", [
+        "", "   ", "fn(", "def f(:\n  pass", "\x00", "λ()",
+    ])
+    def test_malformed_sources_do_not_break_the_audit(self, hostile):
+        try:
+            tree = ast.parse(hostile)
+        except SyntaxError:
+            return                      # the auditor's _parse returns None
+        assert isinstance(
+            ch._bindings_from(ch._direct_children(tree), "m", False), dict)
+
+    def test_resolution_never_raises_on_odd_nodes(self):
+        for src in ("(lambda: 1)()", "[f for f in x][0]()", "d['k']()"):
+            calls = [n for n in ast.walk(ast.parse(src))
+                     if isinstance(n, ast.Call)]
+            for call in calls:
+                assert ch._resolve_callee(
+                    call, ({},), frozenset(), "m") in (None,) or True


### PR DESCRIPTION
## The bug

```python
targets = [h for h in hooks if h.sink.rsplit(".", 1)[-1] == callee]
```

Matching a call to a sink by the **bare last segment**. There are **six distinct `compose` definitions** under the audited roots, so every caller of any of them was judged against all of them.

`serpent_flow` calls `narrative_renderer.compose`. The audit reported it as failing to fill seven parameters of `tool_render_view.compose` — a different function that happens to share a name.

**Seven of eleven divergences came from that one collision**, and the four real findings underneath — the daemon cockpit genuinely dropping `on_mux` / `seed` / `title` / `watch_alive` that the attach client passes — were sitting in the same list. An auditor wrong most of the time is an auditor nobody reads, and the true finding goes unread with it.

Same defect this codebase keeps rediscovering: the caller index that read `repair_engine` 40% severed did so because it keyed on bare symbol names and couldn't see `self._config.repair_engine.run(...)`.

## The fix resolves — it does not suppress

That distinction is the whole review. **Dropping every ambiguous match would also take 11 → 4 and be indistinguishable by count.**

Calls now resolve to an absolute dotted target through the calling file's own import bindings, and the sink index is keyed on the full qualname:

- `from x import fn` / `as g` / `import x` / `import x.y as z`
- relative imports via CPython's package rule
- a module-level def binds to *this* module; an explicit import shadows it
- **scope-aware, innermost first** — this codebase imports inside functions constantly, and a function-local `compose` legitimately differs from the module-level one

A large class now correctly resolves to **nothing**, where before it matched: `self.compose(...)` (a method, not a module sink — the single largest false-positive source), unbound names, attribute chains, expressions, ambiguous double-imports, `import *`.

**Proof it resolved rather than dropped:** fills for `tool_render_view.compose` are still recorded — 12 of them — attributed to the caller that really makes them.

```
DIVERGENCES: 11 -> 4
   run_bipartite_repl  on_mux       filled=['ov'] missing=['serpent_flow']
   run_bipartite_repl  seed         filled=['ov'] missing=['serpent_flow']
   run_bipartite_repl  title        filled=['ov'] missing=['serpent_flow']
   run_bipartite_repl  watch_alive  filled=['ov'] missing=['serpent_flow']
```

## The blind spot is now reported

`unresolved_calls()` returns every call the resolver refused to guess at. A tool that silently discards what it can't resolve looks identical to one with nothing to find — the same "unprovable ≠ proven" distinction the liveness work landed today. Currently 1: `ov_smoke:53 -> __init__()`.

## A bug this fix shipped first

`_direct_children` excluded nested defs while `_visit` looked for them there, so recursion never happened and only module level was scanned. **Divergences went to zero** — which reads exactly like a clean bill of health.

Caught only because the four real findings were *expected to survive*. There's now a test asserting nested scopes are yielded but not descended into.

## Testing

33 new tests; **198 green** across the handoff surface (`test_capability_handoff`, `test_cockpit_mount`, `test_agent_view_wiring`, `test_inflight_registry`, `test_diff_bridge`, `test_tier3_statusline_clear`).

Note: `tests/cli/test_ov_demo.py` also imports this module and times out — pre-existing, in `progress_board.build_import_graph`, reproduced on clean HEAD earlier today and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes callee resolution in `capability_handoff` by using fully-qualified, scope-aware import bindings instead of last-segment matching. Removes 7 false divergences, preserves the 4 real ones, and keeps fills attributed to the correct sink.

- **New Features**
  - Added `unresolved_calls()` to report unresolvable sink calls as `(module, callee, line)`.

- **Bug Fixes**
  - Resolve calls to absolute dotted targets using import bindings (aliases, `import x`, `import x.y as z`, relative imports). Local defs bind to the module; explicit imports shadow; innermost scope wins. Sinks now indexed by full qualname.
  - Stop resolving methods and ambiguous calls: `self/cls/super`, unbound names, attribute chains, expressions, double-import conflicts, and `import *`.
  - Fixed nested-scope traversal: `_direct_children` yields nested defs so recursion visits them.
  - Results: divergences go 11 → 4 (the real ones), and fills for `tool_render_view.compose` remain recorded. 33 new tests added; 198 green.

<sup>Written for commit 5a8f3a5ac61ab991cfa4f6a5114ae2606afec21d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

