### PR TITLE
fix(cockpit): the daemon/client asymmetry was three declined decisions and one false finding

### DIFF
--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -6725,6 +6725,37 @@ class SerpentREPL:
                     _mount = {}
                 await run_bipartite_repl(
                     on_accept=_on_accept,
+                    # THE THREE HOOKS THIS SURFACE DECLINES, and why.
+                    #
+                    # `capability_handoff` reported all three as the daemon
+                    # dropping capabilities the attach client passes. It is
+                    # the right question — a hook one surface fills and
+                    # another ignores is usually a gap — and here the answer
+                    # is no in three different ways. Declared rather than
+                    # left silent, because "this surface has no use for it"
+                    # and "nobody noticed it existed" need opposite responses
+                    # and an omission cannot tell them apart.
+                    #
+                    # Each `waived(...)` is runtime-identical to omitting the
+                    # argument: the callee's `is not None` guard sees exactly
+                    # what it saw before.
+                    watch_alive=waived(
+                        "the client polls bool(client.connected) so it can "
+                        "exit when the daemon dies; this IS the daemon, and "
+                        "a process watching its own liveness either always "
+                        "says yes or races its own shutdown"),
+                    seed=waived(
+                        "supplied by another route — seed_daemon_masthead() "
+                        "writes the identity block straight onto the active "
+                        "canvas above, which is idempotent under a boot-time "
+                        "resize storm in a way a seed list is not"),
+                    on_mux=waived(
+                        "the client captures the mux to call "
+                        "set_streaming_tail(), composing in-flight model text "
+                        "INTO the transcript. This process has no in-flight "
+                        "text producer — grep set_streaming_tail: only "
+                        "bipartite_layout and ov.py — so capturing the mux "
+                        "here would wire an object nothing reads"),
                     completer=getattr(_bp_wiring, "completer", None),
                     history=getattr(_bp_wiring, "history", None),
                     auto_suggest=getattr(_bp_wiring, "auto_suggest", None),

--- a/backend/core/ouroboros/ui/capability_handoff.py
+++ b/backend/core/ouroboros/ui/capability_handoff.py
@@ -218,6 +218,12 @@ class FillState(enum.Enum):
     UNSET = "unset"
     #: The caller splats ``**kwargs``, so no call site enumerates the name.
     OPAQUE = "opaque"
+    #: The caller passed exactly the sink's own default. Distinct from FILLED
+    #: because it is NOT evidence of a capability: a surface that omits the
+    #: parameter makes the identical call, so this must not make that surface
+    #: look deficient by comparison. Distinct from UNSET because the caller
+    #: did write it down, which is worth seeing when defaults later change.
+    DEFAULTED = "defaulted"
 
 
 @dataclass(frozen=True)
@@ -231,6 +237,11 @@ class Hook:
     consumption: Consumption
     #: Sinks this parameter is handed onward to, unexamined.
     forwards_to: Tuple[str, ...] = ()
+    #: The sink's OWN default for this parameter, rendered from its AST, or
+    #: None when it has none. Carried so a caller that passes exactly the
+    #: default can be told apart from one that passes something else — see
+    #: `_default_equivalent`.
+    default_repr: Optional[str] = None
 
     @property
     def short_sink(self) -> str:
@@ -663,6 +674,58 @@ def _resolve_callee(call: ast.Call, scopes: Sequence[Dict[str, Optional[str]]],
     return None
 
 
+def _default_reprs(fn: Any) -> Dict[str, str]:
+    """``parameter -> rendered default`` for every default the sink declares.
+
+    Rendered with ``ast.unparse`` rather than evaluated: the analyser never
+    executes the code it audits, and a default may reference module state it
+    has no business importing.
+    """
+    out: Dict[str, str] = {}
+    try:
+        args = fn.args
+        pairs = [
+            (args.args[len(args.args) - len(args.defaults):], args.defaults),
+            (args.kwonlyargs, args.kw_defaults),
+        ]
+        for names, values in pairs:
+            for arg, value in zip(names, values):
+                if value is None:
+                    continue          # kwonly with no default
+                try:
+                    out[arg.arg] = ast.unparse(value)
+                except Exception:  # noqa: BLE001
+                    continue
+    except Exception:  # noqa: BLE001
+        return {}
+    return out
+
+
+def _default_equivalent(hook: Hook, value: ast.AST) -> bool:
+    """Is this argument literally the sink's own default?
+
+    Then passing it and omitting it are the SAME CALL, and reporting the
+    omission as a missing capability is a false finding — the loudest kind,
+    because it names a real surface and a real parameter.
+
+    `ov` passes ``title="◇ O+V · proactive canvas"``, which is character-for-
+    character `run_bipartite_repl`'s default. The daemon omits it and gets the
+    identical title. That divergence was reported as the daemon dropping a
+    capability; it drops nothing.
+
+    Compared as rendered SOURCE, deliberately. Evaluating both sides would
+    mean executing audited code, and equality on unparsed text is exactly the
+    question being asked: did the caller write the same thing the signature
+    already says?
+    """
+    if hook.default_repr is None:
+        return False
+    try:
+        return ast.unparse(value).strip() == hook.default_repr.strip()
+    except Exception:  # noqa: BLE001
+        return False
+
+
 def _reads_opaquely(fn: Any) -> bool:
     """Does the body reach its own scope dynamically?
 
@@ -772,6 +835,7 @@ def analyse_sink(spec: SinkSpec, *,
         if fn is None:
             return []
         names, kwargs_opaque = _hook_names(fn)
+        defaults = _default_reprs(fn)
         opaque_body = _reads_opaquely(fn)
         onward = set(sink_names or ())
         out: List[Hook] = []
@@ -781,6 +845,7 @@ def analyse_sink(spec: SinkSpec, *,
             else:
                 consumption, forwards = _classify(fn, name, onward)
             out.append(Hook(name=name, sink=spec.qualname,
+                            default_repr=defaults.get(name),
                             positional=positional, required=required,
                             consumption=consumption, forwards_to=forwards))
         return out
@@ -1000,6 +1065,13 @@ def _fills_for_call(surface: str, call: ast.Call,
         if reason is not None:
             out.append(Fill(surface, sink, hook.name, FillState.WAIVED,
                             reason=reason, line=line))
+        elif _default_equivalent(hook, value):
+            # Passing the signature's own default is not supplying a
+            # capability — it is writing down what would happen anyway. A
+            # caller that omits it makes the IDENTICAL call, so this must not
+            # count as evidence that the omitting surface is missing something.
+            out.append(Fill(surface, sink, hook.name, FillState.DEFAULTED,
+                            line=line))
         else:
             out.append(Fill(surface, sink, hook.name, FillState.FILLED,
                             line=line))

--- a/tests/battle_test/test_handoff_callee_resolution.py
+++ b/tests/battle_test/test_handoff_callee_resolution.py
@@ -59,13 +59,79 @@ class TestTheCollisionItself:
         assert not composes, (
             f"compose collisions are back: {composes}")
 
-    def test_the_real_findings_SURVIVE(self):
-        """Suppression would also have cleared the list. The daemon genuinely
-        does not pass these to `run_bipartite_repl`; the attach client does."""
-        divergences = ch.audit().divergence()
-        params = {d[1] for d in divergences
-                  if d[0].endswith("run_bipartite_repl")}
-        assert {"on_mux", "seed", "title", "watch_alive"} <= params
+    def test_the_real_findings_ARE_STILL_VISIBLE(self):
+        """SUPERSEDED 2026-08-01: was ``<= divergent params``.
+
+        When this was written the four `run_bipartite_repl` hooks were open
+        divergences, and asserting their survival was how the resolver was
+        held to resolving rather than suppressing — a blanket drop of
+        ambiguous matches would also have taken 11 to 4.
+
+        They are no longer divergences, and not because anything was
+        suppressed: investigation showed the daemon declines three of them for
+        three different real reasons, which are now DECLARED via
+        ``waived(...)``, and that `title` was never a finding at all — `ov`
+        passes the signature's own default, so omitting it is the identical
+        call.
+
+        The original purpose is kept and sharpened. Vanishing and being
+        declined are different outcomes, and only one of them is acceptable:
+        each hook must still be VISIBLE, carrying a reason a reader can check.
+        """
+        fills = ch.audit().fills
+        waived = {
+            f.hook: f.reason for f in fills
+            if f.sink.endswith("run_bipartite_repl")
+            and f.state is ch.FillState.WAIVED
+        }
+        assert {"on_mux", "seed", "watch_alive"} <= set(waived), (
+            f"a declined hook went silent instead of declared: {waived}")
+        for hook, reason in waived.items():
+            assert reason and len(reason) > 20, (
+                f"{hook} is waived with no usable reason — a waiver without "
+                f"one is a shrug, which is the state it exists to replace")
+
+    def test_title_was_never_a_finding(self):
+        """`ov` passes ``title="◇ O+V · proactive canvas"``, which is
+        character-for-character the sink's default. The daemon omits it and
+        gets the same title. Reporting that as a dropped capability named a
+        real surface and a real parameter and was still wrong."""
+        fills = ch.audit().fills
+        titles = [f for f in fills
+                  if f.sink.endswith("run_bipartite_repl") and f.hook == "title"]
+        assert titles, "the hook stopped being analysed entirely"
+        assert any(f.state is ch.FillState.DEFAULTED for f in titles)
+        assert not any(f.state is ch.FillState.FILLED for f in titles)
+
+    def test_the_auditor_can_still_find_a_REAL_divergence(self):
+        """Zero findings must mean "nothing diverges", never "the instrument
+        stopped working" — the failure this fix already shipped once, when a
+        recursion bug took the count to zero and read as a clean bill.
+
+        A synthetic sink with one filling caller and one omitting caller must
+        still be reported."""
+        reading = ch.HandoffReading(
+            sinks=(),
+            fills=(
+                ch.Fill("surface_a", "m.sink", "hook", ch.FillState.FILLED),
+                ch.Fill("surface_b", "m.sink", "hook", ch.FillState.UNSET),
+            ),
+        )
+        found = reading.divergence()
+        assert len(found) == 1
+        assert found[0][1] == "hook"
+        assert found[0][2] == ("surface_a",) and found[0][3] == ("surface_b",)
+
+    def test_a_defaulted_fill_does_not_manufacture_a_divergence(self):
+        """The other half: DEFAULTED must not read as FILLED."""
+        reading = ch.HandoffReading(
+            sinks=(),
+            fills=(
+                ch.Fill("surface_a", "m.sink", "hook", ch.FillState.DEFAULTED),
+                ch.Fill("surface_b", "m.sink", "hook", ch.FillState.UNSET),
+            ),
+        )
+        assert reading.divergence() == []
 
     def test_the_collided_sink_is_still_ANALYSED(self):
         """The strongest check that this resolved rather than dropped: fills


### PR DESCRIPTION
## I reviewed this wrong

I told you the daemon's cockpit was "a degraded copy of the client's, missing four capabilities." I investigated each one before passing four kwargs. **None of the four is a dropped capability.**

| hook | what it actually is |
|---|---|
| `title` | `ov` passes `"◇ O+V · proactive canvas"` — **character-for-character the signature's own default**. The daemon omits it and gets the identical title. Never a finding. |
| `watch_alive` | the client polls `bool(client.connected)` to exit when the daemon dies. This *is* the daemon — a process watching its own liveness either always says yes or races its own shutdown. |
| `seed` | supplied by another route: `seed_daemon_masthead()` writes the identity block straight onto the active canvas, idempotent under a boot-time resize storm in a way a seed list is not. |
| `on_mux` | the client captures the mux for `set_streaming_tail()`. Grep: that method has exactly two callers, `bipartite_layout` and `ov.py`. This process has **no in-flight text producer**, so capturing the mux here would wire an object nothing reads. |

Passing the four kwargs would have been the workaround — and one of them would have made the daemon poll a client it doesn't have.

## Two fixes, neither of them "pass the argument"

**1. The auditor learns default-equivalence.** A caller passing the signature's own default isn't supplying a capability — it's writing down what would happen anyway, so a surface that omits it makes the *identical call*. New `FillState.DEFAULTED`, distinct from `FILLED` (not evidence of a capability) and from `UNSET` (the caller did write it, which matters when defaults later change). Compared as rendered source via `ast.unparse` — never evaluated, because the analyser doesn't execute what it audits.

**2. The daemon declares its three decisions** with `waived(reason)` — the mechanism already built for exactly this, and runtime-identical to omitting the argument. As its own docstring says: *"this surface has no use for it"* and *"nobody noticed it existed"* need opposite responses, and silence can't tell them apart. A sentence can.

```
11  →  4   (name collision, #70321)
    →  3   (default-equivalence)
    →  0   (declared)
```

Zero is now the *true* state rather than an unexamined one.

## Guarding the zero

A count of zero must mean "nothing diverges", never "the instrument stopped working" — the failure **this arc already shipped once**, when a recursion bug took the count to zero and read as a clean bill of health. So:

- a synthetic sink with one filling and one omitting caller must still be reported
- `DEFAULTED` must not be able to manufacture a divergence either
- the superseded test now asserts the three hooks are still **visible as waivers with usable reasons** — vanishing and being declined are different outcomes and only one is acceptable

## Residual, recorded not built

The daemon terminal has no in-flight streaming producer, so its transcript can't show model text as it arrives the way an attached cockpit does. That's a **feature gap, not a wiring defect** — and inventing a producer to satisfy an audit row would be the tail wagging the dog.

## Testing

36 tests in file; **252 green** across the handoff + cockpit surface.

Static analysis only — the waivers are runtime-identical to the omissions they replace, so behaviour is unchanged by construction, but the daemon terminal still deserves a live look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect cockpit handoff audit: adds default-equivalence detection, explicitly waives three daemon hooks, and ensures zero divergences mean “no differences” rather than “instrument silent.”

- **New Features**
  - Added `FillState.DEFAULTED` in `capability_handoff` to detect calls that pass a sink’s own default (compared via `ast.unparse`), so defaults don’t count as capabilities.

- **Bug Fixes**
  - Daemon declares `waived(reason)` for `watch_alive`, `seed`, and `on_mux` on `run_bipartite_repl`; behavior unchanged, reasons visible.
  - `title` identified as default-equivalent, removing a false divergence without suppression.
  - Guarded “zero divergences”: synthetic mixed-fill still reports; `DEFAULTED` doesn’t create divergence; tests updated (252 passing).

<sup>Written for commit 7b96a424b52b499f5c8d738846e718ab85227cbb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70322?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

