### PR TITLE
fix(reachability): 39 orphans were six entry points, three import shapes, and one real finding

### DIFF
--- a/backend/core/ouroboros/battle_test/surface_reachability.py
+++ b/backend/core/ouroboros/battle_test/surface_reachability.py
@@ -82,6 +82,137 @@ _DEFAULT_ROOTS: Tuple[str, ...] = (
 )
 
 
+#: Where the package DECLARES its console entry points. Read rather than
+#: transcribed: a script added tomorrow becomes a root with no edit here.
+_PYPROJECT = "pyproject.toml"
+
+#: Scripts invoked directly rather than imported. The battle-test harness is
+#: reached this way and reaches a large subtree nothing else does.
+_SCRIPT_DIR = "scripts"
+
+
+def _pyproject_entry_modules(base: "Path") -> List[str]:
+    """Dotted modules named by ``[project.scripts]``. NEVER raises.
+
+    ``ov = "backend.core.ouroboros.cli.ov:main"`` → the module before the
+    colon. Parsed with the stdlib TOML reader when available and by a narrow
+    line match when not, because this must work on 3.9 where `tomllib` does
+    not exist and the audit is not worth a dependency.
+    """
+    out: List[str] = []
+    try:
+        path = base / _PYPROJECT
+        if not path.is_file():
+            return []
+        text = path.read_text(encoding="utf-8", errors="replace")
+        try:
+            import tomllib          # 3.11+
+            table = tomllib.loads(text).get("project", {}).get("scripts", {})
+            for target in table.values():
+                mod = str(target).split(":", 1)[0].strip()
+                if mod:
+                    out.append(mod)
+            return out
+        except Exception:  # noqa: BLE001 — fall through to the line reader
+            pass
+        in_scripts = False
+        for raw in text.splitlines():
+            line = raw.strip()
+            if line.startswith("["):
+                in_scripts = line == "[project.scripts]"
+                continue
+            if not in_scripts or "=" not in line or line.startswith("#"):
+                continue
+            value = line.split("=", 1)[1].strip().strip('"\'')
+            mod = value.split(":", 1)[0].strip()
+            if mod:
+                out.append(mod)
+    except Exception:  # noqa: BLE001
+        return out
+    return out
+
+
+def _main_guarded(index: Mapping[str, "Path"]) -> List[str]:
+    """Modules with an ``if __name__ == "__main__":`` block.
+
+    A module that can be run is a module that can be entered, and nothing
+    in-tree needs to import it for that to be true.
+    """
+    out: List[str] = []
+    for module, path in index.items():
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8", errors="replace"))
+        except Exception:  # noqa: BLE001
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.If):
+                continue
+            try:
+                test = ast.unparse(node.test).replace(" ", "")
+            except Exception:  # noqa: BLE001
+                continue
+            if test.startswith("__name__=="):
+                out.append(module)
+                break
+    return out
+
+
+def _script_reached(base: "Path", index: Mapping[str, "Path"]) -> List[str]:
+    """Modules imported by a top-level ``scripts/*.py``.
+
+    THE case that dominated this audit. ``scripts/ouroboros_battle_test.py``
+    imports `harness`, which boots the six-layer stack — so the harness and
+    everything it owns (termination hooks, session recording, watchdogs,
+    preflight, telemetry) sits at the head of a large subtree.
+
+    The direction is what made it invisible: the harness BOOTS the rendering
+    surfaces, and a surface never imports the thing that started it. Measuring
+    reachability from the surfaces alone therefore reported an entire
+    entry-point's worth of live code as unreachable.
+    """
+    out: List[str] = []
+    try:
+        directory = base / _SCRIPT_DIR
+        if not directory.is_dir():
+            return []
+        for path in sorted(directory.glob("*.py")):
+            for edge in _edges(path):
+                if edge in index:
+                    out.append(edge)
+    except Exception:  # noqa: BLE001
+        return out
+    return out
+
+
+def derived_entries(base: "Path",
+                    index: Mapping[str, "Path"]) -> Tuple[Tuple[str, str], ...]:
+    """Entry points DISCOVERED rather than transcribed. NEVER raises.
+
+    The audit measured three RENDERING surfaces, which is a fair question and
+    the wrong root set for "is this module dead". The package declares three
+    console scripts, ships modules that run themselves, and boots its primary
+    workload from ``scripts/``; of 39 reported orphans, **32 were reachable
+    from an entry point the audit did not know about**.
+
+    Adding those three names to `_DEFAULT_SURFACES` would have fixed today's
+    number and rotted on the next script. Each source here is a structural
+    fact — a declaration in ``pyproject.toml``, a ``__main__`` guard, an
+    import from ``scripts/`` — so the root set tracks the package.
+    """
+    out: List[Tuple[str, str]] = []
+    seen = set()
+    for label, modules in (
+        ("script", _pyproject_entry_modules(base)),
+        ("runnable", _main_guarded(index)),
+        ("soak", _script_reached(base, index)),
+    ):
+        for module in modules:
+            if module in index and module not in seen:
+                seen.add(module)
+                out.append((label, module))
+    return tuple(out)
+
+
 def audit_enabled() -> bool:
     """Default ON. This reads source; it never imports or executes it."""
     return os.environ.get(
@@ -149,6 +280,10 @@ class SurfaceReading:
     unresolved_entries: Tuple[str, ...] = ()
     #: Modules that IMPORT a surface — boot paths, above the graph.
     roots: FrozenSet[str] = frozenset()
+    #: Reachable from ANY entry point by a plain closure. Distinct from
+    #: `reached_by`, which is per-surface and barriered: that answers "who
+    #: reaches it first", this answers "is it alive at all".
+    entry_reachable: FrozenSet[str] = frozenset()
     schema_version: str = SURFACE_REACHABILITY_SCHEMA_VERSION
 
     def asymmetric(self) -> List[ModuleReach]:
@@ -159,12 +294,25 @@ class SurfaceReading:
         )
 
     def orphans(self) -> List[ModuleReach]:
-        """Unreached AND not a boot path. `harness` reaches every surface and
-        nothing reaches it; calling that an orphan would bury the real ones
-        under the entry points of the program."""
+        """Unreached by any SURFACE, any ENTRY POINT, and not a boot path.
+
+        `harness` reaches every surface and nothing reaches it; calling that an
+        orphan would bury the real ones under the entry points of the program.
+
+        ``entry_reachable`` is the correction that mattered most. The surface
+        walk answers "does the cockpit reach this on its own", which needs the
+        other surfaces as barriers — and that same barrier makes it the wrong
+        instrument for "is this dead". Of 39 modules once reported orphaned,
+        **32 were reachable from an entry point the audit never knew about**:
+        three console scripts declared in ``pyproject.toml``, modules that run
+        themselves, and the battle-test harness that ``scripts/`` boots. The
+        harness case is the instructive one — it BOOTS the rendering surfaces,
+        and a surface never imports what started it, so an entire entry
+        point's subtree read as unreachable."""
         return sorted(
             (m for m in self.modules
-             if m.orphan and m.module not in self.roots),
+             if m.orphan and m.module not in self.roots
+             and m.module not in self.entry_reachable),
             key=lambda m: m.module,
         )
 
@@ -208,12 +356,15 @@ def _index(roots: Tuple[str, ...]) -> Dict[str, Path]:
     return out
 
 
-def _edges(path: Path) -> Set[str]:
+def _edges(path: Path, module: str = "") -> Set[str]:
     """Modules this file imports — module-level AND inside functions.
 
-    Reuses the board's extractor rather than writing a second one: two AST
-    walkers over the same syntax would eventually disagree about which
-    import shapes count, and the disagreement would be invisible.
+    Reuses the canonical extractor rather than writing a second one: two AST
+    walkers over the same syntax would eventually disagree about which import
+    shapes count, and the disagreement would be invisible.
+
+    ``module`` is the importing module's dotted name, required to resolve
+    relative imports against its package.
     """
     try:
         source = path.read_text(encoding="utf-8", errors="replace")
@@ -221,12 +372,31 @@ def _edges(path: Path) -> Set[str]:
     except Exception:  # noqa: BLE001 — a file that will not parse has no edges
         return set()
     try:
-        from backend.core.ouroboros.battle_test.progress_board import (
-            _imported_modules,
+        # `reverse_dep_resolver` calls itself "THE single import extractor"
+        # and is the only one here that RESOLVES RELATIVE IMPORTS.
+        #
+        # The board's extractor returns the bare tail for
+        # ``from .wake_sequence import X`` — a name matching no indexed
+        # module, so the edge dangles and the target reads as unreachable.
+        # `wake_sequence` was reported orphaned on exactly that basis while
+        # `awakening.py` imports it on line 45.
+        #
+        # Third import shape this audit could not see, after entry points and
+        # `scripts/`. Same disease every time: an edge the extractor cannot
+        # spell becomes an absence it reports as a finding.
+        from backend.core.ouroboros.governance.reverse_dep_resolver import (
+            extract_module_imports,
         )
-        return set(_imported_modules(tree))
+        return set(extract_module_imports(
+            tree, module, path.name == "__init__.py"))
     except Exception:  # noqa: BLE001
-        return set()
+        try:
+            from backend.core.ouroboros.battle_test.progress_board import (
+                _imported_modules,
+            )
+            return set(_imported_modules(tree))
+        except Exception:  # noqa: BLE001
+            return set()
 
 
 def _reach(
@@ -270,7 +440,7 @@ def _reach(
         path = index.get(current)
         if path is None:
             continue
-        for target in _edges(path):
+        for target in _edges(path, current):
             # Only follow edges that stay in scope. Third-party and
             # governance-core imports are real, and out of this question.
             if target in index and target not in seen:
@@ -289,7 +459,7 @@ def _roots(index: Mapping[str, Path], entries: FrozenSet[str]) -> Set[str]:
     for module, path in index.items():
         if module in entries:
             continue
-        if _edges(path) & entries:
+        if _edges(path, module) & entries:
             out.add(module)
     return out
 
@@ -310,8 +480,28 @@ def audit(
         if not audit_enabled():
             return reading
         scope = roots or audit_roots()
-        table = entries or surfaces()
         index = _index(scope)
+        # SURFACES ONLY. Entry points are deliberately NOT added here.
+        #
+        # `_reach` treats every other surface as a BARRIER — reached but not
+        # traversed — because a plain closure "reported that every module is
+        # reachable from every surface, which is true and useless". Feeding
+        # the package's entry points into this table therefore does the
+        # opposite of what it looks like: each new entry becomes another wall,
+        # every surface's reach SHRINKS, and the orphan count goes UP. Adding
+        # 20 discovered entries here took 39 orphans to 23 the wrong way, by
+        # making live modules look less reachable rather than more.
+        #
+        # Two different questions were being answered by one number:
+        #
+        #   ASYMMETRY  — does THIS surface reach it on its own? Needs the
+        #                barriers, and is what `_DEFAULT_SURFACES` is for.
+        #   ORPHANHOOD — does ANY entry point reach it at all? Needs a plain
+        #                closure over every entry, and barriers would be
+        #                actively wrong.
+        #
+        # They are computed separately below.
+        table = entries or surfaces()
         reading.scanned = len(index)
         reading.surface_labels = tuple(label for label, _ in table)
 
@@ -329,6 +519,30 @@ def audit(
             reach[label] = _reach(entry, index, barriers=entry_set)
         reading.unresolved_entries = tuple(missing)
         reading.roots = frozenset(_roots(index, entry_set))
+
+        # ORPHANHOOD, computed separately and WITHOUT barriers. A module is
+        # dead only if no entry point reaches it at all; which particular
+        # surface got there first is the asymmetry question, answered above.
+        entry_reachable: Set[str] = set()
+        try:
+            for _, entry in derived_entries(_repo_root(), index):
+                entry_reachable |= _reach(entry, index, barriers=frozenset())
+            for _, entry in table:
+                if entry in index:
+                    entry_reachable |= _reach(
+                        entry, index, barriers=frozenset())
+        except Exception:  # noqa: BLE001 — a failed walk must not invent deaths
+            entry_reachable = set()
+        # A PACKAGE is reachable if any of its modules is. Nothing imports
+        # `backend.core.ouroboros.cli` by name — importing
+        # `...cli.ov` executes the package `__init__` implicitly — so an
+        # `__init__.py` is structurally invisible to an import-edge walk and
+        # was reported as an orphan on that basis alone.
+        for module in list(entry_reachable):
+            parts = module.split(".")
+            for depth in range(1, len(parts)):
+                entry_reachable.add(".".join(parts[:depth]))
+        reading.entry_reachable = frozenset(entry_reachable)
 
         entry_modules = entry_set
         for module in sorted(index):

--- a/tests/battle_test/test_reachability_entry_points.py
+++ b/tests/battle_test/test_reachability_entry_points.py
@@ -1,0 +1,210 @@
+"""Thirty-nine orphans, one of them real.
+
+`surface_reachability` measured reachability from three RENDERING surfaces —
+`serpent_flow`, `ov`, `bipartite_layout` — and reported 39 modules unreached.
+That is a fair question badly matched to the conclusion drawn from it, because
+the package has at least six entry points and the audit knew about three.
+
+Three blind spots, found by checking each orphan rather than believing the
+count:
+
+  1. **Entry points.** `pyproject.toml` declares `ov`, `jarvis` and `trinity`
+     as console scripts; two of the three were not surfaces. Six modules,
+     including the whole `trinity_*` cluster.
+  2. **`scripts/`.** `scripts/ouroboros_battle_test.py` imports `harness`,
+     which boots the six-layer stack. The direction is what hid it: the
+     harness BOOTS the rendering surfaces, and a surface never imports what
+     started it — so an entire entry point's subtree (termination hooks,
+     session recording, watchdogs, preflight, telemetry) read as unreachable.
+  3. **Relative imports.** The board's extractor returns the bare tail for
+     ``from .wake_sequence import X``, which matches no indexed module, so the
+     edge dangles. `wake_sequence` was called orphaned while `awakening.py`
+     imports it on line 45.
+
+Plus package ``__init__`` modules, which no import names directly.
+
+**37 of 39 were the instrument. One is real** — `port_binder`, which has tests
+and no production caller, and whose intended consumer
+(``unified_supervisor._detect_best_port``) has since been deleted.
+
+The correction that mattered most is NOT more roots. Feeding entry points into
+`surfaces()` makes the count WORSE: `_reach` treats other surfaces as
+barriers, so each added entry becomes another wall and every surface's reach
+shrinks — 39 became 23 by making live modules look deader. Two questions were
+riding one number:
+
+    ASYMMETRY   does THIS surface reach it on its own?   needs barriers
+    ORPHANHOOD  does ANY entry point reach it at all?    barriers are wrong
+
+They are computed separately now, and both are asserted below.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.battle_test import surface_reachability as sr
+
+
+@pytest.fixture(scope="module")
+def reading():
+    return sr.audit()
+
+
+class TestBothQuestionsSurvive:
+    def test_orphans_collapsed_to_the_real_residual(self, reading):
+        orphans = {m.module.rsplit(".", 1)[-1] for m in reading.orphans()}
+        assert len(orphans) <= 3, (
+            f"the blind spots are back: {sorted(orphans)}")
+
+    def test_the_asymmetry_signal_is_NOT_collapsed(self, reading):
+        """The load-bearing guard.
+
+        Everything here could be 'fixed' by widening reach until nothing is
+        ever unreached — which would also destroy the per-surface asymmetry
+        the module exists to measure. That number must stay in the same
+        neighbourhood it was before (80), not fall toward zero.
+        """
+        assert len(reading.asymmetric()) > 50, (
+            "asymmetry collapsed — reach was widened until the instrument "
+            "stopped distinguishing surfaces, which is the failure mode "
+            "`_reach`'s barriers exist to prevent")
+
+    def test_the_surface_table_is_still_the_three_renderers(self, reading):
+        """Entry points must NOT be added to `surfaces()`. Doing so turns each
+        into a barrier and shrinks every surface's reach — measured, that took
+        39 orphans to 23 in the wrong direction."""
+        assert reading.surface_labels == ("daemon", "attach", "cockpit")
+
+    def test_orphanhood_is_computed_without_barriers(self, reading):
+        """`entry_reachable` is a plain closure. If it were barriered it would
+        be a second copy of the asymmetry walk and would inherit its blind
+        spot for exactly the modules this fixes."""
+        assert len(reading.entry_reachable) > len(reading.modules) // 2
+
+
+class TestEntryPointDiscovery:
+    def test_console_scripts_come_from_pyproject_not_a_list(self):
+        """Declared data, single source of truth. A script added tomorrow
+        becomes a root with no edit to this module."""
+        mods = sr._pyproject_entry_modules(sr._repo_root())
+        assert "backend.core.ouroboros.cli.ov" in mods
+        assert "backend.core.ouroboros.cli.jarvis_thin" in mods
+        assert "backend.core.ouroboros.cli.trinity_launcher" in mods
+
+    def test_a_missing_pyproject_is_not_an_error(self, tmp_path):
+        assert sr._pyproject_entry_modules(tmp_path) == []
+
+    def test_a_malformed_pyproject_never_raises(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text(
+            "[project.scripts\nov = broken", encoding="utf-8")
+        assert isinstance(sr._pyproject_entry_modules(tmp_path), list)
+
+    def test_main_guarded_modules_are_entries(self):
+        """A module that can be RUN can be entered, and nothing in-tree needs
+        to import it for that to be true."""
+        index = sr._index(sr.audit_roots())
+        mains = sr._main_guarded(index)
+        assert "backend.core.ouroboros.cli.ov" in mains
+
+    def test_the_harness_is_reached_through_scripts(self):
+        """THE case that dominated the count. Direction is everything: the
+        harness boots the surfaces, so no surface imports it."""
+        index = sr._index(sr.audit_roots())
+        reached = sr._script_reached(sr._repo_root(), index)
+        assert "backend.core.ouroboros.battle_test.harness" in reached
+
+    def test_derived_entries_are_labelled_by_provenance(self):
+        index = sr._index(sr.audit_roots())
+        labels = {label for label, _ in
+                  sr.derived_entries(sr._repo_root(), index)}
+        assert labels <= {"script", "runnable", "soak"}
+        assert labels, "no entry point discovered at all"
+
+    def test_discovery_never_raises_on_a_bare_tree(self, tmp_path):
+        assert sr.derived_entries(tmp_path, {}) == ()
+
+
+class TestRelativeImportsResolve:
+    def test_the_extractor_now_resolves_a_relative_import(self, tmp_path):
+        """`from .wake_sequence import X` must yield the ABSOLUTE target.
+
+        The board's extractor returns the bare tail, which matches no indexed
+        module — so the edge dangles and the target reads as unreachable while
+        being imported on line 45 of its neighbour.
+        """
+        path = tmp_path / "awakening.py"
+        path.write_text("from .wake_sequence import R\n", encoding="utf-8")
+        edges = sr._edges(path, "backend.core.ouroboros.ui.awakening")
+        assert "backend.core.ouroboros.ui.wake_sequence" in edges
+
+    def test_a_two_dot_relative_climbs(self, tmp_path):
+        path = tmp_path / "m.py"
+        path.write_text("from ..sibling import R\n", encoding="utf-8")
+        edges = sr._edges(path, "a.b.c.m")
+        assert "a.b.sibling" in edges
+
+    def test_absolute_imports_still_resolve(self, tmp_path):
+        path = tmp_path / "m.py"
+        path.write_text("from a.b import R\n", encoding="utf-8")
+        assert "a.b" in sr._edges(path, "a.b.c.m")
+
+    def test_wake_sequence_is_no_longer_orphaned(self, reading):
+        orphans = {m.module for m in reading.orphans()}
+        assert "backend.core.ouroboros.ui.wake_sequence" not in orphans
+
+    def test_an_unparseable_file_has_no_edges(self, tmp_path):
+        path = tmp_path / "bad.py"
+        path.write_text("def f(:\n", encoding="utf-8")
+        assert sr._edges(path, "m") == set()
+
+
+class TestPackages:
+    def test_a_package_is_reachable_if_a_submodule_is(self, reading):
+        """Nothing imports `backend.core.ouroboros.cli` by name — importing
+        `...cli.ov` runs its `__init__` implicitly — so a package is
+        structurally invisible to an import-edge walk."""
+        orphans = {m.module for m in reading.orphans()}
+        assert "backend.core.ouroboros.cli" not in orphans
+        assert "backend.core.ouroboros.cli" in reading.entry_reachable
+
+
+class TestTheOneRealFinding:
+    def test_port_binder_is_still_reported(self, reading):
+        """The whole point of the exercise. 37 false findings were hiding one
+        true one, and an auditor that cries wolf 37 times gets muted before
+        the 38th.
+
+        `port_binder` has tests and NO production caller, and the code it was
+        authorised to replace — `unified_supervisor._detect_best_port` — has
+        since been deleted. Reported, not deleted: superseded is not the same
+        as dead, and that call is the operator's.
+        """
+        orphans = {m.module for m in reading.orphans()}
+        assert "backend.core.ouroboros.cli.port_binder" in orphans
+
+    def test_the_count_cannot_reach_zero_by_going_blind(self, reading):
+        """A zero must mean "nothing is orphaned", never "the walk stopped
+        walking" — the failure this arc already shipped once, when a recursion
+        bug in the handoff auditor took its count to zero and read as a clean
+        bill of health."""
+        assert reading.scanned > 100, "the index stopped indexing"
+        assert reading.modules, "no modules measured at all"
+        assert not reading.unresolved_entries, (
+            f"an entry module fell outside the scanned roots: "
+            f"{reading.unresolved_entries}")
+
+    def test_a_synthetic_dead_module_would_still_be_caught(self, tmp_path):
+        """Proof by construction that the widened reach did not blind it."""
+        pkg = tmp_path / "pkg"
+        pkg.mkdir()
+        (pkg / "entry.py").write_text("from pkg.used import x\n", encoding="utf-8")
+        (pkg / "used.py").write_text("x = 1\n", encoding="utf-8")
+        (pkg / "dead.py").write_text("y = 2\n", encoding="utf-8")
+        index = {
+            "pkg.entry": pkg / "entry.py",
+            "pkg.used": pkg / "used.py",
+            "pkg.dead": pkg / "dead.py",
+        }
+        reached = sr._reach("pkg.entry", index, barriers=frozenset())
+        assert "pkg.used" in reached
+        assert "pkg.dead" not in reached


### PR DESCRIPTION
## 39 → 1

The audit measured reachability from three **rendering** surfaces and reported 39 modules unreached. Checking each one instead of believing the count: **37 were the instrument.**

| blind spot | what it hid |
|---|---|
| **Entry points** | `pyproject.toml` declares `ov`, `jarvis`, `trinity` as console scripts. Two of three weren't surfaces — the whole `trinity_*` cluster plus `jarvis_thin`. |
| **`scripts/`** | `scripts/ouroboros_battle_test.py` imports `harness`, which boots the six-layer stack. **Direction is what hid it**: the harness boots the surfaces, and a surface never imports what started it — so an entire entry point's subtree (termination hooks, session recording, watchdogs, preflight, telemetry) read as unreachable. |
| **Relative imports** | The board's extractor returns the bare tail for `from .wake_sequence import X`, matching no indexed module, so the edge dangles. `wake_sequence` was called orphaned while `awakening.py` imports it on line 45. |
| **Packages** | Nothing imports `backend.core.ouroboros.cli` by name; importing `...cli.ov` runs its `__init__` implicitly. |

## The correction that mattered isn't "more roots"

Feeding the discovered entry points into `surfaces()` makes it **worse**, and measurably so. `_reach` treats every other surface as a **barrier** — reached but never traversed — because a plain closure *"reported that every module is reachable from every surface, which is true and useless."*

Each added entry becomes another wall. Every surface's reach shrinks. **39 orphans became 23 by making live modules look deader.**

Two questions were riding one number:

```
ASYMMETRY   does THIS surface reach it on its own?   needs barriers
ORPHANHOOD  does ANY entry point reach it at all?    barriers are wrong
```

They're computed separately now. `surfaces()` is untouched — still the three renderers, still barriered — and `entry_reachable` is a plain closure over every discovered entry.

**Asymmetry stayed at 79–80 throughout.** That's the proof this didn't just widen reach until nothing looked dead, and there's a test pinning it above 50.

Entry points are **discovered, not transcribed**: a declaration in `pyproject.toml`, a `__main__` guard, an import from `scripts/`. Adding three names to `_DEFAULT_SURFACES` would have fixed today's number and rotted on the next script.

## The one real finding — reported, not deleted

`cli/port_binder.py`: tests, **no production caller**, and the code it was authorised to replace (`unified_supervisor._detect_best_port`) has since been deleted along with the supervisor.

Superseded is not the same as dead, and that call is yours.

## Guards

A small number can be a broken instrument — this arc already shipped a zero that was a recursion bug. So: the index must still be populated, no entry may fall outside the roots, asymmetry must stay above 50, and a synthetic dead module in a synthetic tree must still be caught.

## Testing

20 new tests; **111 green** across the audit tooling.

One **pre-existing** red remains in `test_surface_reachability.py`: `rewind_menu` is now daemon-reachable via `diff_overlay → overlay_arbiter`, so the test's `frozenset({"attach"})` went stale. Verified identical with these changes stashed — left alone because whether the daemon *should* reach it is a design call, not a test edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the reachability audit to account for entry points, relative imports, and package modules. This collapses 39 reported orphans to the single real orphan, `backend.core.ouroboros.cli.port_binder`, while keeping per-surface asymmetry intact.

- **Bug Fixes**
  - Discover entry points from `pyproject.toml` (`[project.scripts]`), `__main__` guards, and `scripts/`, and compute `entry_reachable` via an unbarriered closure.
  - Keep `surfaces()` unchanged and barriered; update orphan calculation to exclude boot paths and anything in `entry_reachable`.
  - Resolve relative imports by switching `_edges` to `reverse_dep_resolver.extract_module_imports` and passing the importing module; fixes cases like `backend.core.ouroboros.ui.wake_sequence`.
  - Treat a package as reachable if any submodule is (e.g., `backend.core.ouroboros.cli` via `...cli.ov`).
  - Add targeted tests covering entry discovery, relative import resolution, package reachability, and safety guards.

<sup>Written for commit 6acf4be36fe9673b4f6600b385c3788e4068a622. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

