### PR TITLE
fix(repl): the _handle_ convention was wired for display but not for execution

### DIFF
--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -6476,6 +6476,27 @@ class SerpentREPL:
             except Exception:
                 pass  # best-effort; never break the REPL
 
+        # LAST RESORT BEFORE THE EXTERNAL HANDLER: the discovered `_handle_*`
+        # convention, dispatched generically.
+        #
+        # `repl_completion._HANDLER_PREFIX` is `"_handle_"`, and
+        # `discover_verbs` walks this class for those methods to BUILD THE
+        # PALETTE. So the codebase already treats `_handle_<verb>` as the
+        # definition of a verb — it just never dispatched on it. Execution was
+        # 30 hand-written `self._handle_*(...)` calls in a 495-line ladder,
+        # with no generic path at all.
+        #
+        # A convention wired for DISPLAY but not for EXECUTION drifts in
+        # exactly one direction: `_handle_trace` is discovered, appears in the
+        # palette, and had no route to run. Advertised and inert.
+        #
+        # Placed AFTER the auto-dispatch registry, deliberately. Before it, a
+        # `_handle_<verb>` would shadow a registered module dispatcher — which
+        # is the defect `/cost` and `/posture` already demonstrate, and adding
+        # a second source of it while closing the first would be absurd.
+        if await self._dispatch_discovered_verb(line):
+            return True
+
         # Delegate to external handler
         if self._on_command is not None:
             try:
@@ -6488,6 +6509,69 @@ class SerpentREPL:
                     highlight=False,
                 )
         return False
+
+    async def _dispatch_discovered_verb(self, line: str) -> bool:
+        """Route `/verb` to `_handle_verb` when nothing else claimed it.
+
+        Closes the loop on a convention that was already half-wired: the
+        palette is BUILT from these methods (`repl_completion.discover_verbs`
+        walks `_handle_*`), so a verb that exists for display and not for
+        dispatch is a row the operator can select and cannot run.
+
+        Adapts by SIGNATURE rather than by a table, because the handlers
+        genuinely differ and a table would be a third place to keep in step:
+        22 take `(line)`, 5 take `()`, and both sync and async forms exist.
+        A handler needing more than one argument is left alone — `_handle_cancel`
+        takes `(op_id, immediate)` and is hand-routed above with the parsing
+        that implies.
+
+        NEVER raises: a verb that throws is reported and swallowed, exactly as
+        the hand-written branches do. Returns True only when a handler
+        actually ran, so an unknown verb still reaches the typo suggestion.
+        """
+        try:
+            text = (line or "").strip()
+            if not text:
+                return False
+            verb = text.split(None, 1)[0].lstrip("/")
+            # The `getattr` is on ATTACKER-INFLUENCED text, so the name is
+            # constrained before it is used: lowercase identifier only. Without
+            # this, `/__class__` or `/_flow` would reach attributes that are
+            # not verbs at all — and the prefix alone does not save you,
+            # because `_handle_` + arbitrary text is still arbitrary.
+            if not verb or not verb.replace("_", "").isalnum():
+                return False
+            if not verb[0].isalpha() or verb != verb.lower():
+                return False
+            handler = getattr(self, f"_handle_{verb}", None)
+            if not callable(handler):
+                return False
+
+            import inspect as _inspect
+            try:
+                params = [
+                    p for p in _inspect.signature(handler).parameters.values()
+                    if p.kind in (p.POSITIONAL_OR_KEYWORD, p.POSITIONAL_ONLY)
+                ]
+            except (TypeError, ValueError):
+                return False
+            required = [p for p in params if p.default is _inspect.Parameter.empty]
+            if len(required) > 1:
+                return False        # bespoke — the ladder owns it
+
+            result = handler(text) if required else handler()
+            if _inspect.isawaitable(result):
+                await result
+            return True
+        except Exception as exc:  # noqa: BLE001 — a verb must not kill the REPL
+            try:
+                self._flow.console.print(
+                    f"  [{_SEM['death']}]Error: {exc}[/{_SEM['death']}]",
+                    highlight=False,
+                )
+            except Exception:  # noqa: BLE001
+                pass
+            return True
 
     def _register_completion_providers(self) -> None:
         """Register the dynamic arg-completion providers. Idempotent —

--- a/tests/battle_test/test_discovered_verb_dispatch.py
+++ b/tests/battle_test/test_discovered_verb_dispatch.py
@@ -1,0 +1,278 @@
+"""A convention wired for DISPLAY but not for EXECUTION.
+
+`repl_completion._HANDLER_PREFIX` is ``"_handle_"``, and `discover_verbs`
+walks `SerpentREPL` for those methods to BUILD THE PALETTE. So the codebase
+already treats ``_handle_<verb>`` as the definition of a verb.
+
+It never dispatched on it. Execution was 30 hand-written
+``self._handle_*(...)`` calls inside a 495-line ladder of 48 branches, and
+``grep`` for a generic route returned nothing. A convention half-wired that
+way drifts in exactly one direction, and it had: **`_handle_trace` is
+discovered, appears in the palette, and had no path to run.**
+
+Two more consequences visible from the same measurement:
+
+  * ``/cost`` and ``/posture`` have BOTH a ladder branch and a registered
+    module dispatcher. The ladder runs first and returns, so the module
+    version is unreachable — while the palette describes the module version.
+    ``/cost`` is advertised as "per phase and per provider" (that is
+    `cost_repl`'s sentence) and the operator gets `_print_cost`'s session
+    counters instead.
+  * every new REPL-local verb costs a hand-written branch, which is why the
+    method is 495 lines.
+
+The fallback is placed AFTER the auto-dispatch registry on purpose. Before it,
+a `_handle_<verb>` would shadow a registered module dispatcher — creating a
+second instance of the very defect the two shadows above already are.
+"""
+from __future__ import annotations
+
+import asyncio
+import inspect
+import re
+from pathlib import Path
+
+import pytest
+
+_SOURCE = Path(
+    "backend/core/ouroboros/battle_test/serpent_flow.py"
+).resolve()
+
+
+def _repl_class():
+    from backend.core.ouroboros.battle_test.serpent_flow import SerpentREPL
+    return SerpentREPL
+
+
+class _Console:
+    def __init__(self):
+        self.lines = []
+
+    def print(self, *a, **k):
+        self.lines.append(" ".join(str(x) for x in a))
+
+
+class _Flow:
+    def __init__(self):
+        self.console = _Console()
+
+
+def _bare_repl():
+    """A SerpentREPL with only what the dispatcher touches.
+
+    Constructed without ``__init__`` deliberately: the real one boots a
+    cockpit's worth of collaborators, and this is a test about routing.
+    """
+    cls = _repl_class()
+    repl = cls.__new__(cls)
+    repl._flow = _Flow()
+    repl._on_command = None
+    return repl
+
+
+# ---------------------------------------------------------------------------
+# 1. the gap that motivated it
+# ---------------------------------------------------------------------------
+
+
+class TestEveryDiscoveredVerbCanRun:
+    def test_no_handler_is_discovered_without_a_route(self):
+        """THE invariant. A verb in the palette that cannot be dispatched is a
+        row the operator can select and nothing happens.
+
+        Asserted over the live class, so a `_handle_*` added tomorrow is
+        covered by a test written today.
+        """
+        cls = _repl_class()
+        handlers = {
+            name[len("_handle_"):] for name in dir(cls)
+            if name.startswith("_handle_") and callable(getattr(cls, name, None))
+        }
+        assert handlers, "the discovery convention itself vanished"
+
+        source = _SOURCE.read_text(encoding="utf-8", errors="replace")
+        hand_routed = set(re.findall(r"self\._handle_([a-z_]+)\(", source))
+        repl = _bare_repl()
+
+        unreachable = []
+        for verb in sorted(handlers):
+            if verb in hand_routed:
+                continue                      # the ladder owns it
+            handler = getattr(repl, f"_handle_{verb}", None)
+            params = [
+                p for p in inspect.signature(handler).parameters.values()
+                if p.kind in (p.POSITIONAL_OR_KEYWORD, p.POSITIONAL_ONLY)
+            ]
+            required = [p for p in params
+                        if p.default is inspect.Parameter.empty]
+            if len(required) > 1:
+                continue                      # bespoke, needs parsing
+            # Everything else MUST be reachable through the generic route.
+            if not asyncio.run(repl._dispatch_discovered_verb(f"/{verb}")):
+                unreachable.append(verb)
+        assert not unreachable, (
+            f"discovered but undispatchable: {unreachable}")
+
+    def test_trace_specifically_now_routes(self):
+        """The concrete instance: `_handle_trace` was in the palette with no
+        caller anywhere in the file."""
+        repl = _bare_repl()
+        assert hasattr(repl, "_handle_trace")
+        assert asyncio.run(repl._dispatch_discovered_verb("/trace"))
+
+
+# ---------------------------------------------------------------------------
+# 2. signature adaptation — by shape, not by a table
+# ---------------------------------------------------------------------------
+
+
+class TestSignatureAdaptation:
+    def test_a_line_taking_handler_receives_the_line(self):
+        repl = _bare_repl()
+        seen = []
+        repl._handle_probe = lambda line: seen.append(line)
+        assert asyncio.run(repl._dispatch_discovered_verb("/probe a b"))
+        assert seen == ["/probe a b"]
+
+    def test_a_zero_arg_handler_is_called_bare(self):
+        repl = _bare_repl()
+        seen = []
+        repl._handle_probe = lambda: seen.append("called")
+        assert asyncio.run(repl._dispatch_discovered_verb("/probe"))
+        assert seen == ["called"]
+
+    def test_an_async_handler_is_awaited(self):
+        repl = _bare_repl()
+        seen = []
+
+        async def _h(line):
+            await asyncio.sleep(0)
+            seen.append(line)
+
+        repl._handle_probe = _h
+        assert asyncio.run(repl._dispatch_discovered_verb("/probe x"))
+        assert seen == ["/probe x"]
+
+    def test_a_multi_required_arg_handler_is_LEFT_to_the_ladder(self):
+        """`_handle_cancel(op_id, immediate)` needs parsing the ladder already
+        does. Guessing at the split would be worse than declining."""
+        repl = _bare_repl()
+        repl._handle_probe = lambda op_id, immediate: None
+        assert asyncio.run(repl._dispatch_discovered_verb("/probe x")) is False
+
+    def test_defaulted_args_do_not_count_as_required(self):
+        repl = _bare_repl()
+        seen = []
+        repl._handle_probe = lambda line, extra=None: seen.append(line)
+        assert asyncio.run(repl._dispatch_discovered_verb("/probe q"))
+        assert seen == ["/probe q"]
+
+
+# ---------------------------------------------------------------------------
+# 3. the getattr is on operator-controlled text
+# ---------------------------------------------------------------------------
+
+
+class TestNameConfinement:
+    @pytest.mark.parametrize("hostile", [
+        "/__class__", "/_flow", "/../x", "/a-b", "/a.b", "/A", "/1abc",
+        "/", "//", "/ ", "", "   ", "/a b/../c",
+    ])
+    def test_hostile_verbs_never_reach_an_attribute(self, hostile):
+        """``getattr(self, "_handle_" + text)`` on unconstrained input reaches
+        attributes that are not verbs. The prefix alone does not save you —
+        ``_handle_`` plus arbitrary text is still arbitrary — so the name is
+        constrained to a lowercase identifier first."""
+        repl = _bare_repl()
+        assert asyncio.run(repl._dispatch_discovered_verb(hostile)) is False
+
+    def test_a_non_callable_attribute_is_refused(self):
+        repl = _bare_repl()
+        repl._handle_probe = "not a function"
+        assert asyncio.run(repl._dispatch_discovered_verb("/probe")) is False
+
+    def test_an_unknown_verb_falls_through_to_the_typo_path(self):
+        """Returning True would swallow the line and the operator would get
+        silence instead of a suggestion."""
+        repl = _bare_repl()
+        assert asyncio.run(
+            repl._dispatch_discovered_verb("/definitelynotaverb")) is False
+
+
+# ---------------------------------------------------------------------------
+# 4. failure containment
+# ---------------------------------------------------------------------------
+
+
+class TestNeverKillsTheRepl:
+    def test_a_throwing_handler_is_reported_not_raised(self):
+        repl = _bare_repl()
+
+        def _boom(line):
+            raise RuntimeError("handler exploded")
+
+        repl._handle_probe = _boom
+        assert asyncio.run(repl._dispatch_discovered_verb("/probe")) is True
+        assert any("exploded" in row for row in repl._flow.console.lines)
+
+    def test_a_throwing_async_handler_is_contained(self):
+        repl = _bare_repl()
+
+        async def _boom(line):
+            raise RuntimeError("async exploded")
+
+        repl._handle_probe = _boom
+        assert asyncio.run(repl._dispatch_discovered_verb("/probe")) is True
+
+    def test_a_broken_console_does_not_re_raise(self):
+        repl = _bare_repl()
+
+        class _Bad:
+            def print(self, *a, **k):
+                raise RuntimeError("console down")
+
+        repl._flow.console = _Bad()
+        repl._handle_probe = lambda line: (_ for _ in ()).throw(
+            RuntimeError("x"))
+        assert asyncio.run(repl._dispatch_discovered_verb("/probe")) is True
+
+
+# ---------------------------------------------------------------------------
+# 5. ordering — the fallback must not become a new shadow
+# ---------------------------------------------------------------------------
+
+
+class TestItRunsAfterTheRegistry:
+    def test_the_call_site_is_below_the_auto_dispatch(self):
+        """Placement is the whole safety argument.
+
+        Above `_try_dispatch`, a `_handle_<verb>` would shadow a registered
+        module dispatcher — the exact defect `/cost` and `/posture` already
+        are. Asserted on ORDER in the source because that is what decides it.
+        """
+        source = _SOURCE.read_text(encoding="utf-8", errors="replace")
+        registry = source.index("_try_dispatch(line)")
+        fallback = source.index("_dispatch_discovered_verb(line)")
+        assert registry < fallback, (
+            "the generic fallback moved above the auto-dispatch registry and "
+            "now shadows every registered module dispatcher")
+
+    def test_the_known_shadows_are_recorded(self):
+        """`/cost` and `/posture` have a ladder branch AND a registered
+        dispatcher; the ladder wins and the palette describes the loser.
+
+        Recorded rather than silently fixed: choosing which implementation an
+        operator should get is a product decision. `_print_cost` shows this
+        session's counters, `cost_repl` shows the per-phase/per-provider
+        rollup, and both are real answers to different questions.
+        """
+        from backend.core.ouroboros.battle_test.repl_dispatch_registry import (
+            _VERB_TO_DISPATCHER, prime_registry,
+        )
+        prime_registry()
+        source = _SOURCE.read_text(encoding="utf-8", errors="replace")
+        ladder = set(re.findall(r'line in \("([a-z_]+)", "/\1"\)', source))
+        shadows = sorted(v for v in ladder if v in _VERB_TO_DISPATCHER)
+        assert shadows == ["cost", "posture"], (
+            f"the shadow set changed: {shadows}. A NEW shadow means a verb's "
+            f"palette description now describes code that cannot run.")

--- a/tests/battle_test/test_surface_reachability.py
+++ b/tests/battle_test/test_surface_reachability.py
@@ -193,11 +193,59 @@ class TestItIsSafeToRun:
 
 class TestAgainstTheRealTree:
     def test_it_finds_the_asymmetry_that_motivated_it(self):
-        """`rewind_menu` is reached from `ov.py` and from nothing else — the
-        shape that has now recurred five times."""
+        """The instrument must still distinguish one surface from another.
+
+        SUPERSEDED 2026-08-01: was
+        ``by.get("rewind_menu") == frozenset({"attach"})``.
+
+        `rewind_menu` WAS attach-only, and that was the shape this module was
+        built to find. It is now reached by all three — the daemon gained a
+        diff overlay (`diff_overlay` → `overlay_arbiter` → `rewind_menu`) and
+        the cockpit followed. The capability spread; the test did not, and it
+        had been failing on that basis before anything in this branch touched
+        it.
+
+        Pinning a single module name made the test a hostage to the codebase
+        improving. What the module actually promises is that a surface's
+        reach is DISTINGUISHABLE from its neighbours' — so that is what is
+        asserted, over whatever the tree currently contains. Today: attach
+        reaches 27 modules alone, cockpit 9, daemon 8.
+
+        A specific example is still checked, but derived rather than
+        transcribed: if it ever becomes empty the message says which surface
+        stopped being distinguishable, which is the fact worth having.
+        """
+        reading = sr.audit()
+        solo: dict = {}
+        for module in reading.modules:
+            if len(module.reached_by) == 1:
+                solo.setdefault(next(iter(module.reached_by)), []).append(
+                    module.short)
+
+        for label in reading.surface_labels:
+            assert solo.get(label), (
+                f"no module is reached by {label!r} alone — either the "
+                f"surfaces have converged or `_reach`'s barriers stopped "
+                f"cutting, and the second would make every asymmetry "
+                f"finding vanish silently"
+            )
+
+    def test_the_original_case_is_recorded_even_though_it_healed(self):
+        """`rewind_menu` reached by everything is a RESULT, not a regression.
+
+        Kept as a named check so the healing is visible: a future change that
+        made it attach-only again would be a capability the other surfaces
+        lost, and that deserves to be noticed rather than silently matching an
+        old assertion.
+        """
         reading = sr.audit()
         by = {m.short: m.reached_by for m in reading.modules}
-        assert by.get("rewind_menu") == frozenset({"attach"})
+        assert by.get("rewind_menu") == frozenset(
+            {"attach", "cockpit", "daemon"}), (
+            "rewind_menu's reach changed — if it narrowed, a surface lost the "
+            "rewind overlay; if it widened, this expectation needs updating "
+            "with the reason"
+        )
 
     def test_the_three_surfaces_all_resolve(self):
         reading = sr.audit()


### PR DESCRIPTION
## 1. The stale asymmetry test

`rewind_menu` **was** attach-only, and that was the shape `surface_reachability` was built to find. It's now reached by all three — the daemon gained a diff overlay (`diff_overlay → overlay_arbiter → rewind_menu`) and the cockpit followed. **The capability spread; the test didn't.**

Pinning one module name made the test a hostage to the codebase improving. What the module actually promises is that a surface's reach is *distinguishable*, so that's what's asserted now, over whatever the tree contains — today attach reaches 27 modules alone, cockpit 9, daemon 8. The original case is kept as its own check so a future **narrowing** is still caught.

## 2. serpent_flow: size was the symptom

I reviewed this as "10,263 lines, decompose it." Measuring first changed the answer:

- `_dispatch_repl_command` is 495 lines, 48 branches, 45 slash literals
- **only 2 of 45** are also registered module dispatchers — so the ladder is *not* a duplicate of the naming cage; 42 genuinely need `self`
- `SerpentREPL` already has **28 `_handle_*` methods**, and `repl_completion._HANDLER_PREFIX` is `"_handle_"` — `discover_verbs` walks them **to build the palette**
- and there are **30 hand-written `self._handle_*(...)` calls with no generic dispatch anywhere**

So the convention is wired for **display** and not for **execution**. That drifts in exactly one direction, and it had:

> **`_handle_trace` is discovered, appears in the palette, and had no route to run.**

The fix closes the loop instead of cutting the file. `_dispatch_discovered_verb` routes `/verb` → `_handle_verb`, adapting **by signature** (22 take `line`, 5 take none, both sync and async; anything needing >1 required arg is left to the ladder, where `_handle_cancel(op_id, immediate)` belongs).

**Placed after the auto-dispatch registry, deliberately.** Above it, a `_handle_<verb>` would shadow a registered module dispatcher — the exact defect `/cost` and `/posture` already are. A test asserts that ordering *in the source*, because ordering is the whole safety argument.

Every existing branch is untouched: the 27 hand-routed verbs behave byte-identically. What changes is that a `_handle_*` added tomorrow is dispatchable without a 16th hand-written branch.

## The `getattr` is on operator text

`getattr(self, "_handle_" + text)` on unconstrained input reaches attributes that aren't verbs — and the prefix doesn't save you, because `_handle_` plus arbitrary text is still arbitrary. The name is confined to a lowercase identifier first; `/__class__`, `/_flow`, `/a.b`, `/../x`, `/A` are all refused, with a test each.

## Recorded, not silently fixed

`/cost` and `/posture` have a ladder branch **and** a registered dispatcher. The ladder runs first and returns, so the module version is unreachable — while the **palette describes the module version**. `/cost` is advertised as *"per phase and per provider"* (that's `cost_repl`'s sentence) and the operator gets `_print_cost`'s session counters.

Left as a pinned test rather than resolved: `_print_cost` answers *"what has this session spent"*, `cost_repl` answers *"how does it break down by phase and provider"*. Both are real, and choosing which one `/cost` means is a product decision, not a refactor.

## Testing

27 new tests; **245 green** across palette + dispatch + reachability.

The dispatcher itself is unit-tested but not exercised through a live REPL — the fallback only fires for verbs the ladder doesn't claim, which today is `/trace` alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
