### PR TITLE
fix(cockpit): a rate-limit bucket is not an account balance

### DIFF
--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -4745,10 +4745,56 @@ class BattleTestHarness:
                             "tokens_remaining": tokens,
                             "seconds_to_reset": secs,
                         }
-                    return {
+                    payload = {
                         "providers": providers,
                         "any_exhausted": any_runway_exhausted(),
                     }
+                    # ECONOMIC DEATH IS A DIFFERENT AXIS FROM RATE LIMIT.
+                    #
+                    # This ledger records `anthropic-ratelimit-tokens-remaining`
+                    # — a per-period bucket that REFILLS. An account with no
+                    # credit has a full bucket and cannot spend a token of it,
+                    # so the cockpit rendered
+                    # `liquidity anthropic: 5,000,000 tokens` for 20 hours
+                    # while every request returned 400 "Your credit balance is
+                    # too low" (soak bt-2026-08-01-015739: 23 ops, 0 completed,
+                    # $0.00).
+                    #
+                    # The system KNEW. `claude_circuit_breaker` had recorded an
+                    # economic exhaustion and Slice 238 was suppressing the
+                    # lane as "known-dead" on every op. That state simply never
+                    # reached the surface an operator reads, so maximum
+                    # displayed health and total inability to spend looked
+                    # identical.
+                    #
+                    # Read-only, fail-soft: a breaker that cannot be inspected
+                    # leaves the ledger exactly as it was.
+                    try:
+                        from backend.core.ouroboros.governance.claude_circuit_breaker import (  # noqa: E501
+                            get_claude_circuit_breaker,
+                        )
+                        breaker = get_claude_circuit_breaker().snapshot()
+                        economic = int(
+                            breaker.get("consecutive_economic_failures") or 0)
+                        if economic > 0 or str(
+                            breaker.get("state") or "").lower() == "open":
+                            payload["economic"] = {
+                                "claude": {
+                                    "state": breaker.get("state"),
+                                    "consecutive_economic_failures": economic,
+                                    "recovery_window_s": breaker.get(
+                                        "effective_recovery_window_s"),
+                                }
+                            }
+                            # An economically dead lane IS an exhausted runway,
+                            # whatever the rate-limit bucket says. Without this
+                            # the banner keeps its cheerful token count and the
+                            # `any_exhausted` warning never fires.
+                            if economic > 0:
+                                payload["any_exhausted"] = True
+                    except Exception:  # noqa: BLE001 — telemetry, never fatal
+                        pass
+                    return payload
                 except Exception:  # noqa: BLE001
                     return {}
 

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -520,7 +520,8 @@ def _render_hydration(console: Any, payload: dict) -> None:
         if ops:
             console.print(_active_ops_line(ops), markup=False, highlight=False)
         for line in _liquidity_lines(liq.get("providers") or {},
-                                     any_exhausted=liq.get("any_exhausted")):
+                                     any_exhausted=liq.get("any_exhausted"),
+                                     economic=liq.get("economic")):
             console.print(line, markup=False, highlight=False)
         console.print(
             "⎿ type verbs or plain text · Ctrl+C detaches (the organism "
@@ -660,7 +661,8 @@ def _active_ops_line(ops: Any) -> str:
     return f"⎿ {len(items)} active op{'s' if len(items) != 1 else ''}: {body}{suffix}"
 
 
-def _liquidity_lines(providers: Any, *, any_exhausted: Any = None) -> list:
+def _liquidity_lines(providers: Any, *, any_exhausted: Any = None,
+                     economic: Any = None) -> list:
     """Provider runways, ordered by what an operator needs to act on.
 
     Three defects this replaces, and they compounded:
@@ -727,13 +729,37 @@ def _liquidity_lines(providers: Any, *, any_exhausted: Any = None) -> list:
         mark = " ← dry" if _dry(row) else ""
         lines.append(f"⎿ liquidity {name}: {amount}{mark}")
 
+    # ECONOMIC DEATH, said FIRST and said plainly.
+    #
+    # A rate-limit bucket and an account balance are different axes, and the
+    # cockpit only ever showed the first. During soak bt-2026-08-01-015739 it
+    # displayed `liquidity anthropic: 5,000,000 tokens` for 20 hours while
+    # every request returned 400 "Your credit balance is too low" — 23 ops, 0
+    # completed, $0.00 spent. Maximum displayed health and total inability to
+    # spend rendered identically.
+    #
+    # "Add credits" is also the one remedy in this whole banner the operator
+    # can act on immediately, so it leads.
+    for provider, detail in sorted((economic or {}).items()):
+        try:
+            failures = int(detail.get("consecutive_economic_failures") or 0)
+        except Exception:  # noqa: BLE001
+            failures = 0
+        if failures <= 0:
+            continue
+        lines.append(
+            f"⚠ {provider}: OUT OF CREDIT — the lane is economically dead "
+            f"({failures} billing refusal(s)); the token count above is a "
+            f"RATE LIMIT, not a balance. Add credits to restore it."
+        )
+
     if dry_names:
         # NAME them. "a provider" is the one thing the operator cannot look up.
         lines.append(
             f"⚠ runway exhausted: {', '.join(dry_names)} — "
             f"routing will fall through to the remaining providers"
         )
-    elif any_exhausted:
+    elif any_exhausted and not economic:
         # The aggregate flag disagrees with every row we can see. Say that,
         # rather than repeating a claim nothing supports.
         lines.append(

--- a/tests/cli/test_liquidity_economic_truth.py
+++ b/tests/cli/test_liquidity_economic_truth.py
@@ -1,0 +1,141 @@
+"""``liquidity anthropic: 5,000,000 tokens`` — while every request 400'd.
+
+Soak bt-2026-08-01-015739 ran 20.7 hours and produced 23 operations, **0
+completed, $0.00 spent**. Both providers were out of credit:
+
+    DoubleWord  402 "Account balance too low. Please add credits to continue."
+    Anthropic   400 "Your credit balance is too low to access the Anthropic API."
+
+(The Anthropic line was confirmed by probing the API directly with the same
+key the soak used — both configured model ids return it.)
+
+The control flow handled this correctly. Slice 127 reclassified the 400 to
+``terminal_quota`` rather than sticky config-error, the Claude economic
+breaker opened, and Slice 238 suppressed further attempts as a "known-dead
+lane" so ops degraded cleanly instead of hammering a provider that could not
+pay. A latched breaker for 20 hours was the RIGHT behaviour.
+
+What failed was telling anyone. The cockpit banner read
+``liquidity anthropic: 5,000,000 tokens`` throughout, because the liquidity
+ledger records ``anthropic-ratelimit-tokens-remaining`` — a per-period bucket
+that REFILLS — and an account with no credit has a full bucket it cannot spend
+a token of.
+
+**Two different exhaustion axes, one display.** Maximum health and total
+inability to spend rendered identically, and the operator had no way to tell
+them apart. `_liquidity_lines`' own docstring already worried that
+"``5,000,000 tokens`` beside 'a runway is dry' reads as a contradiction" — this
+is that contradiction, with the dry half missing.
+
+The state existed the whole time: `claude_circuit_breaker.snapshot()` carried
+``consecutive_economic_failures``, one import away from the harness function
+that builds the banner's payload. Computed, and dropped one frame short of the
+eye — the same shape as every other defect this codebase keeps finding.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.cli.ov import _liquidity_lines
+
+_FULL_BUCKET = {"anthropic": {"tokens_remaining": 5_000_000,
+                              "seconds_to_reset": None}}
+_DEAD = {"claude": {"state": "open", "consecutive_economic_failures": 3,
+                    "recovery_window_s": 60.0}}
+
+
+def _joined(**kw) -> str:
+    return "\n".join(_liquidity_lines(_FULL_BUCKET, **kw))
+
+
+class TestTheSoakBanner:
+    def test_a_full_bucket_alone_still_reads_healthy(self):
+        """The regression case, preserved. Nothing about a rate-limit bucket
+        is wrong — it is simply not a balance."""
+        out = _joined()
+        assert "5,000,000 tokens" in out
+        assert "OUT OF CREDIT" not in out
+
+    def test_economic_death_is_stated_beside_the_healthy_number(self):
+        out = _joined(any_exhausted=True, economic=_DEAD)
+        assert "5,000,000 tokens" in out          # the fact is not suppressed
+        assert "OUT OF CREDIT" in out             # nor is the one that matters
+
+    def test_it_names_the_axis_the_operator_would_otherwise_confuse(self):
+        """"You have 5M tokens" and "you cannot spend anything" are both true.
+        Only saying so removes the contradiction."""
+        out = _joined(any_exhausted=True, economic=_DEAD)
+        assert "RATE LIMIT, not a balance" in out
+
+    def test_it_names_the_remedy(self):
+        """The one action in this banner an operator can take immediately."""
+        assert "Add credits" in _joined(any_exhausted=True, economic=_DEAD)
+
+    def test_it_names_the_provider(self):
+        """"a provider" is the one thing the operator cannot look up — the
+        rule the dry-runway line already follows."""
+        assert "claude:" in _joined(any_exhausted=True, economic=_DEAD)
+
+
+class TestItDoesNotCryWolf:
+    def test_zero_economic_failures_says_nothing(self):
+        quiet = {"claude": {"state": "closed",
+                            "consecutive_economic_failures": 0}}
+        assert "OUT OF CREDIT" not in _joined(economic=quiet)
+
+    def test_the_vague_fallback_yields_to_the_specific_one(self):
+        """`any_exhausted` with no matching row prints "a runway is reported
+        dry but no provider row shows it — run /provider". That hedge is right
+        when nothing better is known and noise once the cause is named."""
+        out = _joined(any_exhausted=True, economic=_DEAD)
+        assert "no provider row shows it" not in out
+
+    def test_the_vague_fallback_SURVIVES_when_there_is_no_economic_detail(self):
+        out = _joined(any_exhausted=True)
+        assert "no provider row shows it" in out
+
+    @pytest.mark.parametrize("hostile", [
+        None, {}, {"claude": {}}, {"claude": None},
+        {"claude": {"consecutive_economic_failures": "three"}},
+        {"claude": {"consecutive_economic_failures": -1}},
+    ])
+    def test_malformed_economic_payloads_never_raise(self, hostile):
+        lines = _liquidity_lines(_FULL_BUCKET, economic=hostile)
+        assert isinstance(lines, list)
+        assert any("liquidity" in row for row in lines)
+
+
+class TestTheProducerSide:
+    def test_the_harness_reads_the_breaker(self):
+        """The state was always one import away from the payload builder.
+
+        Asserted on the harness source because the function is a closure
+        inside a 200-line boot sequence — reaching it any other way would mean
+        booting a cockpit to test a dictionary.
+        """
+        from pathlib import Path
+        source = Path(
+            "backend/core/ouroboros/battle_test/harness.py"
+        ).read_text(encoding="utf-8", errors="replace")
+        assert "claude_circuit_breaker" in source
+        assert '"economic"' in source
+
+    def test_economic_death_forces_the_exhausted_flag(self):
+        """An economically dead lane IS an exhausted runway whatever the
+        bucket says. Without this the aggregate warning never fires and the
+        banner keeps its cheerful count."""
+        from pathlib import Path
+        source = Path(
+            "backend/core/ouroboros/battle_test/harness.py"
+        ).read_text(encoding="utf-8", errors="replace")
+        assert 'payload["any_exhausted"] = True' in source
+
+    def test_the_breaker_exposes_what_the_banner_needs(self):
+        """Contract check against the real class, so a renamed field fails
+        here rather than silently emptying the warning."""
+        from backend.core.ouroboros.governance.claude_circuit_breaker import (
+            get_claude_circuit_breaker,
+        )
+        snap = get_claude_circuit_breaker().snapshot()
+        assert "consecutive_economic_failures" in snap
+        assert "state" in snap


### PR DESCRIPTION
## What the 20-hour soak was actually doing

23 operations, **0 completed, $0.00 spent.** Both providers out of credit:

```
DoubleWord  402 "Account balance too low. Please add credits to continue."
Anthropic   400 "Your credit balance is too low to access the Anthropic API."
```

The Anthropic line is confirmed — I probed the API directly with the same key the soak used; both configured model ids return it.

## The control flow was right

Slice 127 reclassified the 400 to `terminal_quota` rather than sticky config-error. The Claude economic breaker opened. Slice 238 then suppressed further attempts as a *"known-dead lane (no terminal_quota poison)"* so ops degraded cleanly instead of hammering a provider that couldn't pay.

**A breaker latched for 20 hours was correct.** Every attempt in that window would have failed. I went looking for a bug in the latch and didn't find one.

## What failed was telling anyone

The cockpit read `liquidity anthropic: 5,000,000 tokens` the entire time.

The ledger records `anthropic-ratelimit-tokens-remaining` — a per-period bucket that **refills**. An account with no credit has a full bucket it cannot spend a token of. Two different exhaustion axes, one display: **maximum health and total inability to spend rendered identically.**

`_liquidity_lines`' own docstring already worried that *"5,000,000 tokens beside 'a runway is dry' reads as a contradiction."* This was that contradiction with the dry half missing.

And the state existed the whole time — `claude_circuit_breaker.snapshot()` carries `consecutive_economic_failures`, one import away from the harness closure that builds the banner payload. Computed, and dropped one frame short of the eye.

## The fix

```
⎿ liquidity anthropic: 5,000,000 tokens
⚠ claude: OUT OF CREDIT — the lane is economically dead (3 billing refusal(s));
  the token count above is a RATE LIMIT, not a balance. Add credits to restore it.
```

Both facts, neither suppressed, with the **axis named** — because "you have 5M tokens" and "you cannot spend anything" are both true, and only saying so removes the contradiction.

It leads the block because *"add credits"* is the one remedy in this banner an operator can act on immediately. It also forces `any_exhausted`, so the aggregate warning stops disagreeing with reality.

Read-only and fail-soft throughout: an uninspectable breaker leaves the ledger untouched, a lane with zero economic failures says nothing, and the existing vague fallback (*"a runway is reported dry but no provider row shows it — run /provider"*) is preserved for when nothing better is known, yielding to the specific message when it is.

## Not fixed here

`.env` configures two disagreeing Claude model ids (`claude-sonnet-4-5-20250929` vs `claude-sonnet-4-6`). Not the cause — both fail identically for billing — and worth tidying separately.

## Testing

17 new tests; **74 green** across the banner + dispatch surface. Harness import verified.

The banner rendering is asserted directly on `_liquidity_lines`, not watched live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
