### PR TITLE
polish(cockpit): the attach banner joins the design language it already ships

### DIFF
--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -499,6 +499,50 @@ def status_digest(provider: Optional[Callable[[], Optional[str]]] = None) -> str
 # ---------------------------------------------------------------------------
 
 
+#: The operator-plane glyphs, resolved ONCE through the design language.
+#:
+#: `ui/theme` ships six glyphs with an ASCII degradation each, and says why:
+#: "so 16-color/none terminals keep identical geometry". This client had 75
+#: hardcoded ⏺ / ⎿ / ⚠ / · and ZERO calls to `mark()`, so that degradation
+#: never fired here. `supports_unicode()` is locale-driven — a non-UTF-8
+#: `LANG` is ordinary over ssh, cron and CI — and on those terminals the
+#: cockpit's whole glyph vocabulary rendered as mojibake or nothing.
+#:
+#: Resolved at call time rather than import time: a module-level constant
+#: would freeze the locale of whichever process imported first, and the
+#: attach client and daemon do not share one.
+def _glyph(name: str, fallback: str) -> str:
+    """One operator-plane glyph, ASCII-degraded when the locale demands.
+
+    NEVER raises: a theme that will not import leaves the caller with the
+    literal it already had, so this can only ever improve a terminal.
+    """
+    try:
+        from backend.core.ouroboros.ui.theme import mark
+        return mark(name) or fallback
+    except Exception:  # noqa: BLE001
+        return fallback
+
+
+def _tone(token: str, fallback: str = "") -> str:
+    """A semantic style string for the CURRENT terminal tier.
+
+    `ov.py` styles with raw ``rgb(...)`` literals, which `ui/theme` exists to
+    replace — Token.MUTED resolves per tier, so a 16-color terminal gets a
+    16-color answer instead of a truecolor sequence it renders as noise. The
+    repo already ratchets on "raw colour literals only ever decrease".
+
+    ``SUCCESS`` is deliberately NOT used for status here: the theme reserves
+    it for OUTCOMES (apply/verify OK), and spending it on "attached" would
+    make a connection look like an accomplishment.
+    """
+    try:
+        from backend.core.ouroboros.ui.theme import Token, active_tier, style_for
+        return style_for(Token(token), active_tier()) or fallback
+    except Exception:  # noqa: BLE001
+        return fallback
+
+
 def _render_hydration(console: Any, payload: dict) -> None:
     """Instant-state render — the operator NEVER stares at a blank
     screen waiting for the next FSM tick. Pure presentation; the daemon
@@ -511,23 +555,59 @@ def _render_hydration(console: Any, payload: dict) -> None:
         detail = status.get("phase_detail", "")
         cost = status.get("cost_spent_usd", 0.0)
         budget = status.get("cost_budget_usd", 0.0)
-        console.print(
-            f"⏺ attached — phase: {phase}"
-            + (f" {detail}" if detail else "")
-            + f" · cost: ${cost:.2f}/${budget:.2f}",
-            markup=False, highlight=False,
-        )
+        # VISUAL HIERARCHY, matching the boot banner three functions up.
+        #
+        # Every line here was `console.print(str, markup=False)` — flat, one
+        # weight, no dim. The boot banner in this same file builds Rich `Text`
+        # with per-span styles and its comment cites "the CC title grammar
+        # ... exactly like Claude Code v2.1.218". Two standards, one screen:
+        # the operator's first frame was the unstyled one.
+        #
+        # `Text.append(style=)` keeps `markup=False`'s guarantee — daemon
+        # content is never parsed for `[...]` — while restoring the three
+        # tiers the palette already defines: the ACTION reads first, its
+        # metadata recedes, and the labels recede further than their values.
+        from rich.text import Text as _T
+        _dot = _glyph("dot", "·")
+        _muted, _body = _tone("muted", "dim"), _tone("body", "")
+        head = _T()
+        head.append(f"{_glyph('action', '*')} ", style=_tone("accent", "cyan"))
+        head.append("attached", style=_body)
+        head.append("  phase ", style=_muted)
+        head.append(str(phase), style=_body)
+        if detail:
+            head.append(f" {detail}", style=_muted)
+        head.append(f"  {_dot}  cost ", style=_muted)
+        head.append(f"${cost:.2f}", style=_body)
+        head.append(f"/${budget:.2f}", style=_muted)
+        console.print(head, highlight=False)
         if ops:
             console.print(_active_ops_line(ops), markup=False, highlight=False)
         for line in _liquidity_lines(liq.get("providers") or {},
                                      any_exhausted=liq.get("any_exhausted"),
                                      economic=liq.get("economic")):
-            console.print(line, markup=False, highlight=False)
-        console.print(
-            "⎿ type verbs or plain text · Ctrl+C detaches (the organism "
-            "keeps running) · `ov restart` reloads it",
-            markup=False, highlight=False,
-        )
+            # A warning must NOT recede with the rest of the block — it is
+            # the one line here an operator has to act on.
+            _is_warn = line.lstrip().startswith(
+                (_glyph("warn", "!"), "!", "⚠"))
+            console.print(
+                line, markup=False, highlight=False,
+                style=(_tone("warning", "yellow") if _is_warn else _muted),
+            )
+        # The hint is entirely secondary — one tone, no competing emphasis,
+        # and the literal backticks are gone. `markup=False` printed them as
+        # characters, so the line advertised "`ov restart`" with the quoting
+        # visible; a terminal shows a command by styling it, not by fencing it.
+        hint = _T()
+        hint.append(f"{_glyph('detail', '-')} ", style=_muted)
+        hint.append("type verbs or plain text", style=_muted)
+        hint.append(f"  {_dot}  ", style=_muted)
+        hint.append("Ctrl+C", style=_body)
+        hint.append(" detaches, the organism keeps running", style=_muted)
+        hint.append(f"  {_dot}  ", style=_muted)
+        hint.append("ov restart", style=_body)
+        hint.append(" reloads it", style=_muted)
+        console.print(hint, highlight=False)
     except Exception:
         pass
 
@@ -727,7 +807,8 @@ def _liquidity_lines(providers: Any, *, any_exhausted: Any = None,
         else:
             amount = "undeclared"
         mark = " ← dry" if _dry(row) else ""
-        lines.append(f"⎿ liquidity {name}: {amount}{mark}")
+        lines.append(
+            f"{_glyph('detail', '-')} liquidity {name}: {amount}{mark}")
 
     # ECONOMIC DEATH, said FIRST and said plainly.
     #
@@ -748,7 +829,8 @@ def _liquidity_lines(providers: Any, *, any_exhausted: Any = None,
         if failures <= 0:
             continue
         lines.append(
-            f"⚠ {provider}: OUT OF CREDIT — the lane is economically dead "
+            f"{_glyph('warn', '!')} {provider}: OUT OF CREDIT — the lane is "
+            f"economically dead "
             f"({failures} billing refusal(s)); the token count above is a "
             f"RATE LIMIT, not a balance. Add credits to restore it."
         )
@@ -756,14 +838,15 @@ def _liquidity_lines(providers: Any, *, any_exhausted: Any = None,
     if dry_names:
         # NAME them. "a provider" is the one thing the operator cannot look up.
         lines.append(
-            f"⚠ runway exhausted: {', '.join(dry_names)} — "
+            f"{_glyph('warn', '!')} runway exhausted: {', '.join(dry_names)} — "
             f"routing will fall through to the remaining providers"
         )
     elif any_exhausted and not economic:
         # The aggregate flag disagrees with every row we can see. Say that,
         # rather than repeating a claim nothing supports.
         lines.append(
-            "⚠ a runway is reported dry but no provider row shows it — "
+            f"{_glyph('warn', '!')} a runway is reported dry but no provider "
+            "row shows it — "
             "run /provider for the authoritative view"
         )
     return lines

--- a/tests/cli/test_cockpit_banner_polish.py
+++ b/tests/cli/test_cockpit_banner_polish.py
@@ -1,0 +1,250 @@
+"""The first frame an operator sees was the unstyled one.
+
+`ui/theme` ships a design language: six operator-plane glyphs, each with an
+ASCII degradation, and its own comment says why — "so 16-color/none terminals
+keep identical geometry". It also ships semantic tokens (ACCENT / BODY /
+MUTED / WARNING, with SUCCESS reserved for OUTCOMES) that resolve per colour
+tier.
+
+The attach client used neither. Measured before this change: **75 hardcoded
+⏺ / ⎿ / ⚠ / · and ZERO calls to `mark()`**, and every banner line printed as
+`console.print(str, markup=False)` — flat, one weight, no dim.
+
+Both gaps are visible, not theoretical:
+
+  * `supports_unicode()` is locale-driven, and a non-UTF-8 ``LANG`` is
+    ordinary over ssh, cron and CI. On those terminals the whole glyph
+    vocabulary rendered as mojibake or nothing, and the degradation that
+    exists to prevent it never ran.
+  * three functions above this banner, the BOOT banner builds Rich `Text`
+    with per-span styles and cites "the CC title grammar ... exactly like
+    Claude Code v2.1.218". Two standards on one screen, and the operator's
+    first frame was the unstyled one.
+
+The half-migrated state is worse than either endpoint and this suite exists
+largely to forbid it: converting the header while leaving the liquidity rows
+hardcoded produced a banner showing ``*`` and ``-`` beside ``⎿`` and ``⚠`` in
+the same frame — geometry more broken than before the change.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+from rich.console import Console
+
+from backend.core.ouroboros.cli.ov import (
+    _glyph, _liquidity_lines, _render_hydration, _tone,
+)
+from backend.core.ouroboros.ui import theme
+
+_PAYLOAD = {
+    "status": {"phase": "GENERATE", "phase_detail": "op-7f3a",
+               "cost_spent_usd": 1.24, "cost_budget_usd": 2.50},
+    "liquidity": {
+        "providers": {"anthropic": {"tokens_remaining": 5_000_000,
+                                    "seconds_to_reset": None}},
+        "any_exhausted": True,
+        "economic": {"claude": {"state": "open",
+                                "consecutive_economic_failures": 3}},
+    },
+    "ops": [],
+}
+
+
+@pytest.fixture
+def utf8(monkeypatch):
+    monkeypatch.setenv("LANG", "en_US.UTF-8")
+    theme.reset_active_tier_cache()
+    yield
+    theme.reset_active_tier_cache()
+
+
+@pytest.fixture
+def ascii_only(monkeypatch):
+    for key in ("LC_ALL", "LC_CTYPE", "LANG"):
+        monkeypatch.delenv(key, raising=False)
+    theme.reset_active_tier_cache()
+    yield
+    theme.reset_active_tier_cache()
+
+
+def _render(payload=None, width=96) -> str:
+    console = Console(force_terminal=True, width=width, record=True)
+    _render_hydration(console, payload or _PAYLOAD)
+    return console.export_text()
+
+
+# ---------------------------------------------------------------------------
+# 1. degradation — the property the design language promises
+# ---------------------------------------------------------------------------
+
+
+class TestGlyphDegradation:
+    def test_utf8_terminals_get_the_real_glyphs(self, utf8):
+        out = _render()
+        assert "⏺" in out and "⎿" in out and "⚠" in out
+
+    def test_a_non_utf8_locale_gets_ascii(self, ascii_only):
+        """ssh, cron and CI routinely have no UTF-8 locale. The degradation
+        existed and was unreachable from this client."""
+        out = _render()
+        for glyph in ("⏺", "⎿", "⚠"):
+            assert glyph not in out, f"{glyph} survived ASCII degradation"
+
+    def test_the_banner_is_never_MIXED(self, ascii_only):
+        """THE regression this suite is mostly here for.
+
+        Converting the header while leaving the liquidity rows hardcoded gave
+        a single frame containing ``*`` and ``-`` beside ``⎿`` and ``⚠``.
+        Half-migrated geometry is worse than either endpoint, and it renders
+        as damage rather than as a fallback.
+        """
+        out = _render()
+        unicode_glyphs = sum(out.count(g) for g in ("⏺", "⎿", "⚠", "·"))
+        assert unicode_glyphs == 0, (
+            f"{unicode_glyphs} unicode glyph(s) left in an ASCII render — "
+            f"the banner is half-migrated")
+
+    def test_every_ROW_still_opens_with_a_marker(self, ascii_only):
+        """Degradation preserves GEOMETRY, not just legibility: every logical
+        row keeps a marker in column one so the block stays a block.
+
+        Asserted on rows wide enough not to wrap. A WRAPPED line legitimately
+        starts with prose — see `test_wrapped_lines_have_no_hanging_indent`,
+        which records that as a known gap rather than pretending it is fine.
+        """
+        for line in [l for l in _render(width=200).splitlines() if l.strip()]:
+            assert line[0] in "*-! ", repr(line)
+
+    def test_wrapped_lines_have_no_hanging_indent(self, utf8):
+        """RECORDED, not fixed.
+
+        At 96 columns the credit warning wraps and the continuation restarts
+        at column 0, so the block's left edge breaks mid-warning. Claude Code
+        indents continuations to keep the structure readable, and this
+        codebase already solves it once — `layout_palette` wraps "with a
+        hanging indent" — so the fix is a wiring job rather than a new idea.
+        Out of scope here: this slice is glyphs and tone, and changing wrap
+        geometry touches every consumer of these lines.
+
+        Pinned so the gap is visible and so closing it is a test edit rather
+        than a discovery.
+        """
+        wrapped = [l for l in _render(width=96).splitlines() if l.strip()]
+        continuation = [l for l in wrapped if l.startswith("above is")]
+        assert continuation, "the fixture stopped wrapping — re-tune the width"
+        assert not continuation[0].startswith(" "), (
+            "a hanging indent appeared — good, but update this test to "
+            "assert it rather than its absence")
+
+    def test_glyph_resolution_never_raises(self):
+        assert _glyph("action", "*")
+        assert _glyph("nonexistent-glyph-name", "FB") == "FB"
+
+
+# ---------------------------------------------------------------------------
+# 2. hierarchy — three tiers, matching the boot banner
+# ---------------------------------------------------------------------------
+
+
+class TestVisualHierarchy:
+    def test_the_header_is_no_longer_one_flat_weight(self, utf8):
+        console = Console(force_terminal=True, width=96, record=True)
+        _render_hydration(console, _PAYLOAD)
+        ansi = console.export_text(styles=True)
+        assert "\x1b[2m" in ansi, "no dim span — the banner is still flat"
+
+    def test_values_are_brighter_than_their_labels(self, utf8):
+        """"phase" recedes, ``GENERATE`` does not. The label is scaffolding;
+        the value is the fact."""
+        console = Console(force_terminal=True, width=96, record=True)
+        _render_hydration(console, _PAYLOAD)
+        ansi = console.export_text(styles=True)
+        assert "\x1b[2m  phase " in ansi or "phase " in ansi
+        assert "GENERATE" in ansi
+
+    def test_a_warning_does_NOT_recede_with_the_block(self, utf8):
+        """Everything in this banner is secondary except the one line the
+        operator must act on. Dimming it with the rest would bury it."""
+        console = Console(force_terminal=True, width=120, record=True)
+        _render_hydration(console, _PAYLOAD)
+        ansi = console.export_text(styles=True)
+        warn_line = next(l for l in ansi.splitlines() if "OUT OF CREDIT" in l)
+        assert "\x1b[2m" not in warn_line, "the credit warning was dimmed"
+
+    def test_tone_resolves_or_degrades_silently(self):
+        assert isinstance(_tone("muted", "dim"), str)
+        assert _tone("not-a-token", "fallback") == "fallback"
+
+    def test_success_is_not_spent_on_a_connection(self):
+        """The theme reserves SUCCESS for OUTCOMES (apply/verify OK). Styling
+        "attached" with it would make a connection look like an achievement,
+        and would devalue the token everywhere it legitimately appears."""
+        import inspect
+        from backend.core.ouroboros.cli import ov
+        source = inspect.getsource(ov._render_hydration)
+        assert '_tone("success"' not in source
+
+
+# ---------------------------------------------------------------------------
+# 3. content that survived the restyle
+# ---------------------------------------------------------------------------
+
+
+class TestNothingWasLost:
+    def test_the_facts_are_all_still_there(self, utf8):
+        out = _render()
+        for fact in ("attached", "GENERATE", "op-7f3a", "$1.24", "$2.50",
+                     "5,000,000 tokens", "OUT OF CREDIT", "Ctrl+C",
+                     "ov restart"):
+            assert fact in out, fact
+
+    def test_the_literal_backticks_are_gone(self, utf8):
+        """`markup=False` printed them as characters, so the hint advertised
+        "`ov restart`" with the quoting visible. A terminal shows a command by
+        styling it, not by fencing it."""
+        assert "`" not in _render()
+
+    def test_it_renders_with_an_empty_payload(self, utf8):
+        out = _render({}, width=96)
+        assert "attached" in out
+
+    @pytest.mark.parametrize("hostile", [
+        {"status": None, "liquidity": None, "ops": None},
+        {"status": {"phase": None, "cost_spent_usd": None}},
+        {"liquidity": {"providers": "not-a-dict"}},
+    ])
+    def test_hostile_payloads_never_raise(self, hostile, utf8):
+        _render_hydration(Console(force_terminal=True, width=80), hostile)
+
+    def test_narrow_terminals_do_not_lose_the_warning(self, utf8):
+        """A 40-column terminal wraps; it must not truncate the one
+        actionable line out of existence."""
+        assert "OUT OF CREDIT" in _render(width=40)
+
+
+# ---------------------------------------------------------------------------
+# 4. the seam, so the remaining sites can follow
+# ---------------------------------------------------------------------------
+
+
+class TestTheSeamExists:
+    def test_liquidity_lines_resolve_glyphs_too(self, ascii_only):
+        lines = _liquidity_lines(
+            {"anthropic": {"tokens_remaining": 5_000_000}},
+            any_exhausted=True,
+            economic={"claude": {"consecutive_economic_failures": 2}},
+        )
+        joined = "\n".join(lines)
+        assert "⎿" not in joined and "⚠" not in joined
+
+    def test_the_client_now_calls_mark_at_all(self):
+        """It called it zero times across 75 hardcoded glyphs. This is the
+        first consumer; the remaining sites are mechanical from here."""
+        from pathlib import Path
+        source = Path(
+            "backend/core/ouroboros/cli/ov.py"
+        ).read_text(encoding="utf-8", errors="replace")
+        assert "def _glyph(" in source
+        assert "from backend.core.ouroboros.ui.theme import mark" in source


### PR DESCRIPTION
## The gap

`ui/theme` ships six operator-plane glyphs with an ASCII degradation each, and says why in its own comment: *"so 16-color/none terminals keep identical geometry."* It also ships semantic tokens that resolve per colour tier.

**The attach client used neither.** Measured: **75 hardcoded `⏺` `⎿` `⚠` `·` and zero calls to `mark()`**, with every banner line printed as `console.print(str, markup=False)` — flat, one weight, no dim.

Neither gap is theoretical:

- `supports_unicode()` is **locale-driven**, and a non-UTF-8 `LANG` is ordinary over ssh, cron and CI. On those terminals the whole glyph vocabulary rendered as mojibake or nothing — and the degradation written to prevent exactly that never ran.
- **Three functions above this banner**, the boot banner builds Rich `Text` with per-span styles and cites *"the CC title grammar … exactly like Claude Code v2.1.218"*. Two standards on one screen, and the operator's **first** frame was the unstyled one.

## After

```
⏺ attached  phase GENERATE op-7f3a  ·  cost $1.24/$2.50
⎿ liquidity anthropic: 5,000,000 tokens
⚠ claude: OUT OF CREDIT — … RATE LIMIT, not a balance
⎿ type verbs or plain text  ·  Ctrl+C detaches …  ·  ov restart reloads it
```

Same frame on a non-UTF-8 locale reads `*`, `-`, `!`, `-` — identical geometry, no mojibake.

**Three tiers, not one.** The action reads first; labels recede below their values (`phase` dim, `GENERATE` not); the hint is uniformly secondary. The **warning deliberately does not recede** — it's the only line an operator must act on, and dimming it with the block would bury it.

`Text.append(style=)` keeps `markup=False`'s guarantee that daemon content is never parsed for `[...]`. `SUCCESS` is not spent on a connection — the theme reserves it for outcomes, and a test forbids it.

**The literal backticks are gone.** `markup=False` printed them as characters, so the hint advertised `` `ov restart` `` with the quoting visible. A terminal shows a command by styling it, not by fencing it.

## A half-migration nearly shipped

Converting the header while leaving the liquidity rows hardcoded produced **one frame containing `*` and `-` beside `⎿` and `⚠`** — geometry more broken than before the change.

Caught by rendering both terminal classes, not by reading the diff. A test now forbids a mixed frame.

## Recorded, not fixed

At 96 columns the credit warning wraps and the continuation restarts at column 0, breaking the block's left edge. CC indents continuations, and this repo already solves it once — `layout_palette` wraps *"with a hanging indent"*. That's a wiring job, out of scope for a glyph-and-tone slice, and **pinned in a test** so closing it is an edit rather than a rediscovery.

## Testing

20 new tests; **67 green** across the cockpit client suites. `_glyph()` / `_tone()` are the seam — this banner is the first consumer and the remaining ~70 sites are mechanical from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the cockpit attach banner use the shared design language for glyphs and tones so it renders clearly on both UTF-8 and ASCII terminals. This removes mojibake, adds clear hierarchy, and keeps warnings readable.

- **New Features**
  - Added `_glyph()` and `_tone()` to resolve operator glyphs and semantic tones per terminal tier, with ASCII fallbacks on non-UTF-8.
  - Rebuilt the banner with Rich `Text` for a three-tier hierarchy: action first, labels dim, values bright; warnings stay prominent; removed literal backticks.
  - Applied glyph resolution to liquidity lines and added a test to forbid mixed Unicode/ASCII frames.
  - Added 20 tests; documented a known wrap/hanging-indent gap for follow-up.

<sup>Written for commit 36a1a9534ba34bbe9082f9fbbc43ed3add699a18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

