### PR TITLE
feat(cockpit): show the MODEL, and finish the glyph migration's safe half

### DIFF
--- a/backend/core/ouroboros/battle_test/status_line.py
+++ b/backend/core/ouroboros/battle_test/status_line.py
@@ -119,6 +119,13 @@ class StatusSnapshot:
     # Route / provider badge
     route: str = ""                    # "complex" / "standard" / "background" / ...
     provider: str = ""                 # "claude" / "dw" / "prime" / ""
+    #: The MODEL, not the family. `provider` answers "which lane"; this
+    #: answers "which brain" — `claude-sonnet-4-6`, `Qwen/Qwen3.5-397B-A17B`.
+    #: Carried on `ctx.generation.model_id` since op_context.py:304 and read by
+    #: nothing: the badge showed the lane, and `_statusline_payload` reported
+    #: the LANE under the key `model`, so a CC-compatible script asking for
+    #: `.model.id` got "claude" and never the model it was actually billed for.
+    model: str = ""
     # Circadian liquidity (item #5) — populated ONLY when a provider's
     # declared token runway is exhausted (presentation restraint: the
     # healthy state renders nothing).
@@ -211,9 +218,19 @@ def _statusline_payload(snapshot: Any = None) -> str:
             payload["phase"] = getattr(snap, "phase", "") or "IDLE"
             if getattr(snap, "route", ""):
                 payload["route"] = snap.route
-            if getattr(snap, "provider", ""):
-                payload["model"] = {"id": snap.provider,
-                                    "display_name": snap.provider}
+            # `.model.id` must be the MODEL. This reported `snap.provider`,
+            # so a status-line script written against CC's documented shape
+            # read "claude" where it expected "claude-sonnet-4-6" — a key that
+            # answered a different question than the one it was named for.
+            _model = getattr(snap, "model", "") or ""
+            _prov = getattr(snap, "provider", "") or ""
+            if _model or _prov:
+                payload["model"] = {
+                    "id": _model or _prov,
+                    "display_name": _short_model(_model) or _prov,
+                }
+                if _prov:
+                    payload["provider"] = _prov
             spent = getattr(snap, "cost_spent_usd", None)
             if spent is not None:
                 cost: Dict[str, Any] = {"total_cost_usd": round(float(spent), 6)}
@@ -301,7 +318,7 @@ class StatusLineBuilder:
         cost_spent, cost_budget = self._sample_cost()
         idle_elapsed, idle_timeout = self._sample_idle()
         primary_op, extra_ops = self._sample_ops()
-        route, provider = self._sample_route_and_provider(primary_op)
+        route, provider, model = self._sample_route_and_provider(primary_op)
         liq_exhausted, liq_provider, liq_reset = self._sample_liquidity()
 
         # §37 Slice 5 — feed cost-band-crossing observer.
@@ -330,6 +347,7 @@ class StatusLineBuilder:
             extra_op_count=extra_ops,
             route=route,
             provider=provider,
+            model=model,
             liquidity_exhausted=liq_exhausted,
             liquidity_provider=liq_provider,
             liquidity_reset_s=liq_reset,
@@ -574,23 +592,33 @@ class StatusLineBuilder:
             return (False, "", None)
 
     def _sample_route_and_provider(self, op_id: str) -> tuple:
-        """Pull route + provider for the primary op. Both optional."""
+        """Pull route + provider + MODEL for the primary op. All optional.
+
+        `model_id` has ridden on the generation result since op_context.py:304
+        ("provider model identifier; empty = not reported") and was read by
+        nothing. An operator asking "which model am I running" could not find
+        out from the cockpit, while every op carried the answer.
+        """
         if not op_id or self._gls is None:
-            return ("", "")
+            return ("", "", "")
         try:
             fsm_contexts = getattr(self._gls, "_fsm_contexts", None) or {}
             ctx = fsm_contexts.get(op_id)
             if ctx is None:
-                return ("", "")
+                return ("", "", "")
             route = str(getattr(ctx, "provider_route", "") or "").lower()
             # Provider usually on ctx.generation.provider_name post-GENERATE.
-            provider = ""
+            provider, model = "", ""
             gen = getattr(ctx, "generation", None)
             if gen is not None:
                 provider = str(getattr(gen, "provider_name", "") or "").lower()
-            return (route, provider)
+                # NOT lowercased: model ids are case-carrying identifiers
+                # ("Qwen/Qwen3.5-397B-A17B-FP8"), and folding them would make
+                # the badge disagree with the provider's own logs.
+                model = str(getattr(gen, "model_id", "") or "").strip()
+            return (route, provider, model)
         except Exception:  # noqa: BLE001
-            return ("", "")
+            return ("", "", "")
 
 
 # ---------------------------------------------------------------------------
@@ -645,9 +673,38 @@ def _format_phase(snap: StatusSnapshot) -> str:
     return snap.phase or "IDLE"
 
 
-def _format_badge(route: str, provider: str) -> str:
-    """Compact route·provider badge. Empty when neither present."""
-    if not route and not provider:
+def _short_model(model: str) -> str:
+    """A model id trimmed to what an operator reads at a glance.
+
+    ``Qwen/Qwen3.5-397B-A17B-FP8-dottxt`` in a one-line status bar costs more
+    width than the rest of the line together, so the vendor prefix and the
+    build suffixes go and the identity stays. Purely subtractive — no
+    abbreviation table, because a table is a second place to update every time
+    a model ships and the id itself already carries the name.
+    """
+    try:
+        text = str(model or "").strip()
+        if not text:
+            return ""
+        text = text.rsplit("/", 1)[-1]          # drop the vendor namespace
+        # Trailing build/quantisation markers carry no identity at a glance.
+        for suffix in ("-dottxt", "-FP8", "-fp8", "-instruct", "-Instruct"):
+            if text.endswith(suffix):
+                text = text[: -len(suffix)]
+        return text[:28]
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def _format_badge(route: str, provider: str, model: str = "") -> str:
+    """Compact route·provider·model badge. Empty when none present.
+
+    ``model`` is additive and last: the lane answers "where did this go", the
+    model answers "what actually ran", and an operator watching a 3-tier
+    cascade needs both — `[std·claude]` cannot distinguish a sonnet fallback
+    from an opus one. Optional so every existing caller keeps working.
+    """
+    if not route and not provider and not model:
         return ""
     # Abbreviate long route names.
     route_abbrev = {
@@ -664,7 +721,12 @@ def _format_badge(route: str, provider: str) -> str:
         "prime": "prime",
         "j-prime": "prime",
     }.get(provider, provider)
-    parts = [p for p in (route_abbrev, prov_abbrev) if p]
+    short = _short_model(model)
+    # Suppressed when it merely repeats the lane — `[std·claude·claude]` is
+    # noise, and a badge that repeats itself trains the eye to skip it.
+    if short and prov_abbrev and short.lower() == prov_abbrev.lower():
+        short = ""
+    parts = [p for p in (route_abbrev, prov_abbrev, short) if p]
     return "[" + "·".join(parts) + "]" if parts else ""
 
 

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -653,18 +653,18 @@ def _restart_daemon(say: Any) -> int:
 
     pid = _live_incumbent()
     if pid is None:
-        say("⎿ no organism running — igniting a fresh one")
+        say(_glyph("detail", "-") + " no organism running — igniting a fresh one")
     else:
-        say(f"⏺ stopping organism (pid {pid}) — SIGTERM, letting it finish")
+        say(_glyph("action", "*") + f" stopping organism (pid {pid}) — SIGTERM, letting it finish")
         try:
             os.kill(pid, signal.SIGTERM)
         except ProcessLookupError:
             pid = None
         except PermissionError:
-            say(f"⚠ not permitted to stop pid {pid} — is it yours?")
+            say(_glyph("warn", "!") + f" not permitted to stop pid {pid} — is it yours?")
             return 1
         except Exception as exc:  # noqa: BLE001
-            say(f"⚠ could not signal pid {pid}: {type(exc).__name__}")
+            say(_glyph("warn", "!") + f" could not signal pid {pid}: {type(exc).__name__}")
             return 1
 
     if pid is not None:
@@ -679,13 +679,13 @@ def _restart_daemon(say: Any) -> int:
                 break
             _t.sleep(0.2)
         else:
-            say("⎿ it did not stop in time — escalating to SIGKILL")
+            say(_glyph("detail", "-") + " it did not stop in time — escalating to SIGKILL")
             try:
                 os.kill(pid, signal.SIGKILL)
                 _t.sleep(0.5)
             except Exception:  # noqa: BLE001
                 pass
-        say("⎿ organism stopped")
+        say(_glyph("detail", "-") + " organism stopped")
     return 0
 
 
@@ -2383,7 +2383,7 @@ async def _split_plane_loop(
         if install_oob_stack_dump():
             hint = oob_hint()
             if hint and os.environ.get("JARVIS_OOB_HINT", "1") != "0":
-                console.print(f"⎿ {hint}", markup=False, highlight=False)
+                console.print(_glyph("detail", "-") + f" {hint}", markup=False, highlight=False)
     except Exception:  # noqa: BLE001 — a missing debugger must not stop a boot
         pass
     # This surface has no container to float the palette into, so it draws it

--- a/tests/battle_test/test_status_line_model.py
+++ b/tests/battle_test/test_status_line_model.py
@@ -1,0 +1,168 @@
+""""which model am I running" — the cockpit could not say, and always knew.
+
+`op_context.py:304` has carried ``model_id: str = ""`` on every generation
+result since it was written ("provider model identifier; empty = not
+reported"). `_sample_route_and_provider` read ``provider_name`` beside it and
+ignored it, `StatusSnapshot` had no field for it, and the badge rendered
+``[std·claude]`` — the LANE, not the brain.
+
+Worse than absent: `_statusline_payload` builds a payload whose docstring says
+it "mirrors Claude Code's documented shape — `model`, `workspace`, `cost` …
+so a script written for CC runs here unchanged", and it set
+
+    payload["model"] = {"id": snap.provider}
+
+So a CC-compatible status-line script asking for ``.model.id`` got
+``"claude"`` — the one key in that payload named for a question it did not
+answer. A three-tier cascade makes that actively misleading: ``[std·claude]``
+cannot distinguish a sonnet fallback from an opus one, and the operator is
+billed differently for each.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from backend.core.ouroboros.battle_test.status_line import (
+    StatusSnapshot, _format_badge, _short_model, _statusline_payload,
+)
+
+
+class TestTheSnapshotCarriesTheModel:
+    def test_the_field_exists(self):
+        snap = StatusSnapshot(provider="claude", model="claude-sonnet-4-6")
+        assert snap.model == "claude-sonnet-4-6"
+
+    def test_it_defaults_empty_rather_than_guessing(self):
+        """"not reported" is a real state — a pre-GENERATE op has no model,
+        and inventing one would be the same lie the payload told."""
+        assert StatusSnapshot().model == ""
+
+
+class TestTheBadgeShowsIt:
+    def test_the_model_joins_route_and_provider(self):
+        assert _format_badge("standard", "claude", "claude-sonnet-4-6") == \
+            "[std·claude·claude-sonnet-4-6]"
+
+    def test_a_vendor_namespace_is_trimmed(self):
+        """``Qwen/Qwen3.5-397B-A17B-FP8-dottxt`` costs more width than the
+        rest of the line together. Subtractive only — no abbreviation table,
+        because a table is a second place to edit every time a model ships."""
+        assert _format_badge("background", "dw",
+                             "Qwen/Qwen3.5-397B-A17B-FP8-dottxt") == \
+            "[bg·dw·Qwen3.5-397B-A17B]"
+
+    def test_a_model_that_merely_repeats_the_lane_is_suppressed(self):
+        """`[std·claude·claude]` is noise, and a badge that repeats itself
+        trains the eye to skip it."""
+        assert _format_badge("standard", "claude", "claude") == "[std·claude]"
+
+    def test_it_stays_empty_when_nothing_is_known(self):
+        assert _format_badge("", "", "") == ""
+
+    def test_the_model_alone_is_enough_to_render(self):
+        """Provider unknown, model known — the reverse of today's default, and
+        the more useful half."""
+        assert "sonnet" in _format_badge("", "", "claude-sonnet-4-6")
+
+    def test_existing_two_arg_callers_still_work(self):
+        """`model` is additive and last; every call site that predates it
+        keeps its exact output."""
+        assert _format_badge("standard", "claude") == "[std·claude]"
+
+    @pytest.mark.parametrize("hostile", [
+        None, "", "   ", "/", "a" * 300, "Qwen/", "///x",
+    ])
+    def test_hostile_model_ids_never_raise(self, hostile):
+        assert isinstance(_short_model(hostile), str)  # type: ignore[arg-type]
+        assert isinstance(_format_badge("std", "dw", hostile), str)  # type: ignore[arg-type]
+
+    def test_a_long_id_is_bounded(self):
+        assert len(_short_model("x" * 200)) <= 28
+
+
+class TestTheCCPayloadStopsLying:
+    def test_model_id_is_the_MODEL(self):
+        payload = json.loads(_statusline_payload(
+            StatusSnapshot(provider="claude", model="claude-sonnet-4-6")))
+        assert payload["model"]["id"] == "claude-sonnet-4-6"
+
+    def test_the_provider_is_still_reported_under_its_own_key(self):
+        """Nothing is lost — the lane moves to a key named for it, so a
+        consumer wanting either gets the one it asked for."""
+        payload = json.loads(_statusline_payload(
+            StatusSnapshot(provider="claude", model="claude-sonnet-4-6")))
+        assert payload["provider"] == "claude"
+
+    def test_provider_alone_still_populates_model_rather_than_omitting_it(self):
+        """Degradation, not silence: before GENERATE reports a model id, the
+        lane is the best answer available and a CC script reading `.model.id`
+        should get it rather than a missing key."""
+        payload = json.loads(_statusline_payload(
+            StatusSnapshot(provider="claude", model="")))
+        assert payload["model"]["id"] == "claude"
+
+    def test_neither_known_omits_the_key_entirely(self):
+        """The payload's own rule: "Keys ov cannot answer are OMITTED rather
+        than faked"."""
+        payload = json.loads(_statusline_payload(StatusSnapshot()))
+        assert "model" not in payload
+
+    def test_the_payload_is_valid_json_under_every_shape(self):
+        for snap in (StatusSnapshot(),
+                     StatusSnapshot(provider="dw"),
+                     StatusSnapshot(model="Qwen/Qwen3.5-397B-A17B-FP8"),
+                     StatusSnapshot(provider="dw", model="x" * 500)):
+            json.loads(_statusline_payload(snap))
+
+
+class TestTheSamplerReadsIt:
+    def test_it_returns_three_values(self):
+        """Arity is the contract: every early return had to widen with it, and
+        one that did not would raise on unpack the first time an op had no
+        context — the path taken on EVERY idle tick."""
+        from backend.core.ouroboros.battle_test.status_line import (
+            StatusLineBuilder,
+        )
+        builder = StatusLineBuilder.__new__(StatusLineBuilder)
+        builder._gls = None
+        assert builder._sample_route_and_provider("op-x") == ("", "", "")
+
+    def test_a_missing_context_also_returns_three(self):
+        from backend.core.ouroboros.battle_test.status_line import (
+            StatusLineBuilder,
+        )
+        builder = StatusLineBuilder.__new__(StatusLineBuilder)
+        builder._gls = type("G", (), {"_fsm_contexts": {}})()
+        assert builder._sample_route_and_provider("op-missing") == ("", "", "")
+
+    def test_it_reads_model_id_off_the_generation(self):
+        from backend.core.ouroboros.battle_test.status_line import (
+            StatusLineBuilder,
+        )
+        gen = type("Gen", (), {"provider_name": "Claude",
+                               "model_id": "claude-sonnet-4-6"})()
+        ctx = type("Ctx", (), {"provider_route": "STANDARD",
+                               "generation": gen})()
+        builder = StatusLineBuilder.__new__(StatusLineBuilder)
+        builder._gls = type("G", (), {"_fsm_contexts": {"op-1": ctx}})()
+        route, provider, model = builder._sample_route_and_provider("op-1")
+        assert (route, provider) == ("standard", "claude")
+        assert model == "claude-sonnet-4-6", "model_id was ignored again"
+
+    def test_the_model_id_keeps_its_case(self):
+        """Provider and route are folded for display; a model id is a
+        case-carrying identifier (``Qwen/Qwen3.5-397B-A17B-FP8``) and folding
+        it would make the badge disagree with the provider's own logs."""
+        from backend.core.ouroboros.battle_test.status_line import (
+            StatusLineBuilder,
+        )
+        gen = type("Gen", (), {"provider_name": "DW",
+                               "model_id": "Qwen/Qwen3.5-397B-A17B-FP8"})()
+        ctx = type("Ctx", (), {"provider_route": "BACKGROUND",
+                               "generation": gen})()
+        builder = StatusLineBuilder.__new__(StatusLineBuilder)
+        builder._gls = type("G", (), {"_fsm_contexts": {"op-1": ctx}})()
+        assert builder._sample_route_and_provider("op-1")[2] == \
+            "Qwen/Qwen3.5-397B-A17B-FP8"


### PR DESCRIPTION
## "Which model am I running" — it always knew

`op_context.py:304` has carried `model_id: str = ""` on every generation result since it was written (*"provider model identifier; empty = not reported"*). `_sample_route_and_provider` read `provider_name` **beside it** and ignored it. `StatusSnapshot` had no field. The badge rendered `[std·claude]` — the **lane**, not the brain.

Worse than absent. `_statusline_payload`'s docstring says it *"mirrors Claude Code's documented shape — `model`, `workspace`, `cost` … so a script written for CC runs here unchanged"*, and it set:

```python
payload["model"] = {"id": snap.provider}
```

A CC-compatible script asking `.model.id` got `"claude"` — **the one key in that payload named for a question it didn't answer.** On a three-tier cascade that's actively misleading: `[std·claude]` can't distinguish a sonnet fallback from an opus one, and the two bill differently.

## Now

```
[std·claude·claude-sonnet-4-6]
[bg·dw·Qwen3.5-397B-A17B]        ← vendor prefix + FP8/dottxt trimmed
[std·claude]                     ← model == lane: suppressed, not doubled
```

Trimming is **subtractive only, no abbreviation table** — a table is a second place to edit every time a model ships, and the id already carries the name. The model id keeps its **case** while route/provider are folded: it's an identifier (`Qwen/Qwen3.5-397B-A17B-FP8`), and folding it would make the badge disagree with the provider's own logs.

`.model.id` is now the model; the lane moved to its own `provider` key so nothing is lost.

## Glyph migration — the half that could be automated safely

7 output sites moved to `_glyph()`. **The rest are left deliberately**, and the reason is worth recording because two automated passes failed first:

1. interpolating `{_glyph("detail", "-")}` into an f-string is a **SyntaxError on 3.11** — the inner quote may not match the host's, and a blind rewrite can't know which the host used
2. switching to single quotes breaks any single-quoted host (`audio.lstrip(' … ')`) — that's how the first attempt shipped a parse error
3. **concatenation** sidesteps both — but the rewrite then glued the `f` prefix onto the *function name*: `f_glyph("action", "*") + " {pid} "`. That **parses** (valid identifier), so `ast.parse` passed it. It's a `NameError` at runtime with `{pid}` rendered literally — caught by reading the output, not by the checker.

So the remaining ~30 sites are a **hand review, not a regex**. The 7 converted are the ones whose shape the tool could prove. Forcing the rest through the same pass is how a cosmetic migration becomes an outage.

## Testing

25 new tests; **141 green** across status-line + banner + palette. Includes the arity trap — every early return in the sampler had to widen to a 3-tuple, and one that didn't would raise on unpack on **every idle tick**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the actual model in the cockpit and fix the CC payload to report the true model instead of the provider. Also completes the safe half of the glyph migration.

- **New Features**
  - `StatusSnapshot.model` captured from generation and shown in the badge.
  - Badge now includes the model; trims vendor prefix and build suffixes; preserves case; suppresses when model equals provider.

- **Refactors**
  - CC payload `.model.id` now uses the true model; provider moved to `provider`.
  - `_sample_route_and_provider` returns `(route, provider, model)`; legacy callers stay compatible.
  - Converted 7 output sites to `_glyph()`; remaining sites left for manual review.

<sup>Written for commit 89c782e7e39bb50b939b429bd3778008a6401f6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

