### PR TITLE
feat(cockpit): /model — pick the brain, or hand the choice back to the policy

### DIFF
--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -720,9 +720,9 @@ def _active_ops_line(ops: Any) -> str:
     try:
         items = [str(o) for o in (ops or []) if str(o).strip()]
     except Exception:  # noqa: BLE001
-        return "⎿ active ops: (unreadable)"
+        return _glyph("detail", "-") + " active ops: (unreadable)"
     if not items:
-        return "⎿ active ops: none"
+        return _glyph("detail", "-") + " active ops: none"
 
     def _short(op_id: str) -> str:
         # Whole trailing SEGMENTS, never a raw character slice: cutting
@@ -738,7 +738,9 @@ def _active_ops_line(ops: Any) -> str:
     body = ", ".join(_short(o) for o in shown)
     more = len(items) - len(shown)
     suffix = f" (+{more} more)" if more > 0 else ""
-    return f"⎿ {len(items)} active op{'s' if len(items) != 1 else ''}: {body}{suffix}"
+    return _glyph("detail", "-") + (
+        f" {len(items)} active op{'s' if len(items) != 1 else ''}: "
+        f"{body}{suffix}")
 
 
 def _liquidity_lines(providers: Any, *, any_exhausted: Any = None,
@@ -1216,9 +1218,11 @@ class AttachUI:
         if waited > self._ignition_deadline():
             # Still nothing. Do not keep implying progress that is not
             # happening; name the suspicion and let the operator act.
-            return ("  ⚠ daemon unreachable — no telemetry in "
-                    f"{int(waited)}s · 'detach' to leave")
-        return "  ⏺ awaiting daemon telemetry…"
+            return ("  " + _glyph("warn", "!")
+                    + " daemon unreachable — no telemetry in "
+                    + f"{int(waited)}s "
+                    + _glyph("dot", "-") + " 'detach' to leave")
+        return "  " + _glyph("action", "*") + " awaiting daemon telemetry…"
 
     #: Set by the surface that has nowhere else to draw the palette. Default
     #: False so the cockpit, which floats it, never double-renders.
@@ -1754,7 +1758,8 @@ class AttachUI:
                 self.acoustic = None
                 return ""
             where = f" ({device})" if device else ""
-            return f"🎙 mic: {diagnosis or 'degraded'}{where}"
+            return (_glyph("audio", "mic") + ": "
+                    + f"{diagnosis or 'degraded'}{where}")
         except Exception:  # noqa: BLE001
             return ""
 

--- a/backend/core/ouroboros/governance/model_repl.py
+++ b/backend/core/ouroboros/governance/model_repl.py
@@ -1,0 +1,444 @@
+"""``/model`` — which brain runs the work, and who decides.
+
+O+V routes across three lanes: DoubleWord's fleet, Anthropic's Claude models,
+and the self-hosted J-Prime golden image. The choice is made per-op by
+`provider_topology` from `brain_selection_policy.yaml` — deliberately, and
+against live-fire calibration — and an operator had no way to see the decision
+or take it.
+
+THIS IS A SURFACE, NOT A SECOND ROUTER
+----------------------------------------
+The override already exists and is already consulted. The "Sovereign
+Context-Routing Override Matrix" reads ``JARVIS_DW_PRIMARY_OVERRIDE`` via
+`model_pinning_heuristic.model_pin_override()` — **per call**, so "an operator
+can flip the pin live" — promotes a healthy pin to Rank 1 in
+`_pin_and_fleet_guarded`, soft-locks it on repeated failure, and filters
+entitlement LAST so a pin cannot resurrect a model the endpoint refuses.
+
+So this verb sets that pin and reads that topology. It computes no ranking,
+keeps no parallel state, and owns no policy. Writing a second selector would
+have produced two answers to "which model is running" — which is the defect
+this cockpit has spent a day removing from other surfaces.
+
+WHAT AUTO MEANS, AND WHY IT IS THE DEFAULT
+--------------------------------------------
+The policy is segmented on measured evidence, not preference: DW is excluded
+from the Prefrontal Cortex because live-fire (bbpst3ebf) showed DW models time
+out on COMPLEX generation; BACKGROUND and SPECULATIVE are sealed because
+bt-2026-04-14-182446 produced 0/13 Gemma successes and routing daemons to a
+$3/$15-per-M provider "violates the unit economics". The yaml says plainly:
+"Do not mutate at runtime."
+
+A pin is SOVEREIGN, and the first draft of this module said the opposite.
+
+I wrote "a pin re-ranks within what the topology already admits; it cannot
+open a sealed route", then measured it:
+
+    dw_models_for_route("immediate")  ->  ()                      unpinned
+    dw_models_for_route("immediate")  ->  ("Qwen/Qwen3.5-397B…",)  pinned
+
+The Override Matrix injects the pin into an EMPTY ladder, so pinning routes
+IMMEDIATE to DoubleWord — the exact lane the policy excludes from the
+Prefrontal Cortex because live fire showed DW timing out there. The mechanism
+is named "Sovereign" and it means it.
+
+That is real power and it costs something specific, so this verb states it at
+the moment of use rather than letting an operator discover it from a timeout.
+A control that quietly does MORE than it claims is worse than one that does
+less.
+
+Auto-discovered by the ``*_repl.py`` naming cage; the palette row, the
+description and the attach-cockpit mirroring all come from that.
+"""
+from __future__ import annotations
+
+import os
+import shlex
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+#: The env var the Override Matrix already reads. Named once, here, so this
+#: verb and the router cannot disagree about where the pin lives.
+PIN_ENV = "JARVIS_DW_PRIMARY_OVERRIDE"
+
+#: Routes worth showing. Read from the topology when it can answer, so a route
+#: added to the policy appears here without an edit.
+_FALLBACK_ROUTES = ("immediate", "standard", "complex", "background",
+                    "speculative")
+
+__verb_args__ = {"model": "[list|auto|<model-id>|help]"}
+
+
+@dataclass(frozen=True)
+class ModelReplDispatchResult:
+    ok: bool
+    text: str
+    matched: bool = True
+
+
+def _matches(line: str) -> bool:
+    try:
+        head = (line or "").strip().split(None, 1)[0].lower()
+    except IndexError:
+        return False
+    return head in ("/model", "model", "/models", "models")
+
+
+# ---------------------------------------------------------------------------
+# Enumeration — derived from the policy and the providers, never a list here
+# ---------------------------------------------------------------------------
+
+
+def _routes() -> Tuple[str, ...]:
+    try:
+        from backend.core.ouroboros.governance.provider_topology import (
+            get_topology,
+        )
+        topo = get_topology()
+        found = tuple(sorted(getattr(topo, "routes", {}) or ()))
+        return found or _FALLBACK_ROUTES
+    except Exception:  # noqa: BLE001
+        return _FALLBACK_ROUTES
+
+
+def _dw_models() -> Dict[str, Tuple[str, ...]]:
+    """``route -> ranked DW model ids``, straight from the topology.
+
+    The policy owns the ranking and the segmentation; asking it per route is
+    what keeps this verb honest about a sealed lane instead of listing models
+    the router will never choose there.
+    """
+    out: Dict[str, Tuple[str, ...]] = {}
+    try:
+        from backend.core.ouroboros.governance.provider_topology import (
+            get_topology,
+        )
+        topo = get_topology()
+        for route in _routes():
+            try:
+                models = tuple(topo.dw_models_for_route(route) or ())
+            except Exception:  # noqa: BLE001
+                models = ()
+            if models:
+                out[route] = models
+    except Exception:  # noqa: BLE001
+        return out
+    return out
+
+
+def _claude_models() -> Tuple[str, ...]:
+    """Claude ids the runtime is configured to use.
+
+    Read from the env the providers themselves read, so the list cannot claim
+    a model the next generation will not request. De-duplicated and ordered
+    by declaration, because two names here is a config smell worth SEEING —
+    `.env` currently declares both `CLAUDE_MODEL` and
+    `JARVIS_GOVERNED_CLAUDE_MODEL`, and they disagree.
+    """
+    out: List[str] = []
+    for key in ("JARVIS_GOVERNED_CLAUDE_MODEL", "CLAUDE_MODEL",
+                "JARVIS_CLAUDE_MODEL"):
+        try:
+            value = (os.environ.get(key) or "").strip()
+        except Exception:  # noqa: BLE001
+            continue
+        if value and value not in out:
+            out.append(value)
+    return tuple(out)
+
+
+def _prime_models() -> Tuple[str, ...]:
+    """The J-Prime golden-image tier's active model label.
+
+    Sourced from `failover_lifecycle.active_jprime_model()` — the accessor
+    that already drives model-aware compaction — rather than a second reading
+    of the tier config.
+    """
+    try:
+        from backend.core.ouroboros.governance.failover_lifecycle import (
+            get_failover_controller,
+        )
+        label = (get_failover_controller().active_jprime_model() or "").strip()
+        return (label,) if label else ()
+    except Exception:  # noqa: BLE001
+        return ()
+
+
+def routes_opened_by_pin() -> Tuple[str, ...]:
+    """Routes that have a DW lane ONLY because of the pin. NEVER raises.
+
+    Asked by toggling the env the topology reads and diffing the answer,
+    rather than by re-deriving the policy's segmentation here — the topology
+    stays the single authority on what a route admits, and this only reports
+    the difference the operator caused.
+    """
+    pin = current_pin()
+    if not pin:
+        return ()
+    try:
+        from backend.core.ouroboros.governance.provider_topology import (
+            get_topology,
+        )
+        topo = get_topology()
+        opened: List[str] = []
+        saved = os.environ.get(PIN_ENV)
+        try:
+            os.environ.pop(PIN_ENV, None)
+            sealed = {r for r in _routes()
+                      if not (topo.dw_models_for_route(r) or ())}
+        finally:
+            # Restored unconditionally: leaving the operator's pin cleared
+            # because a STATUS READ raised would be a display that silently
+            # changes routing.
+            if saved is None:
+                os.environ.pop(PIN_ENV, None)
+            else:
+                os.environ[PIN_ENV] = saved
+        for route in sorted(sealed):
+            if topo.dw_models_for_route(route):
+                opened.append(route)
+        return tuple(opened)
+    except Exception:  # noqa: BLE001
+        return ()
+
+
+def available_models() -> Dict[str, Tuple[str, ...]]:
+    """``lane -> model ids`` across all three lanes. NEVER raises.
+
+    A lane that cannot be interrogated is OMITTED rather than shown empty:
+    "doubleword: (none)" reads as "DW has no models", which is a claim about
+    the fleet rather than about this process's ability to ask.
+    """
+    lanes: Dict[str, Tuple[str, ...]] = {}
+    dw = _dw_models()
+    if dw:
+        merged: List[str] = []
+        for models in dw.values():
+            for model in models:
+                if model not in merged:
+                    merged.append(model)
+        lanes["doubleword"] = tuple(merged)
+    claude = _claude_models()
+    if claude:
+        lanes["claude"] = claude
+    prime = _prime_models()
+    if prime:
+        lanes["j-prime"] = prime
+    return lanes
+
+
+# ---------------------------------------------------------------------------
+# The pin
+# ---------------------------------------------------------------------------
+
+
+def current_pin() -> str:
+    """The active pin, read through the router's own accessor. NEVER raises."""
+    try:
+        from backend.core.ouroboros.governance.model_pinning_heuristic import (
+            model_pin_override,
+        )
+        return model_pin_override() or ""
+    except Exception:  # noqa: BLE001
+        try:
+            return (os.environ.get(PIN_ENV) or "").strip()
+        except Exception:  # noqa: BLE001
+            return ""
+
+
+def _resolve(token: str) -> Tuple[str, str]:
+    """``(model_id, lane)`` for an operator's token, or ``("", "")``.
+
+    Case-insensitive and suffix-tolerant, because a model id is long and an
+    operator types what they can see: ``397b`` finds
+    ``Qwen/Qwen3.5-397B-A17B-FP8``. Ambiguity is NOT resolved by picking the
+    first — two matches means the operator meant something this cannot know,
+    and guessing pins the wrong brain silently.
+    """
+    needle = (token or "").strip().lower()
+    if not needle:
+        return ("", "")
+    hits: List[Tuple[str, str]] = []
+    for lane, models in available_models().items():
+        for model in models:
+            low = model.lower()
+            if low == needle:
+                return (model, lane)          # exact wins outright
+            if needle in low:
+                hits.append((model, lane))
+    if len(hits) == 1:
+        return hits[0]
+    return ("", "")
+
+
+def _ambiguous(token: str) -> List[str]:
+    needle = (token or "").strip().lower()
+    return [m for models in available_models().values() for m in models
+            if needle and needle in m.lower()]
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+
+_HELP = (
+    "  [bold cyan]/model — which brain runs the work[/bold cyan]\n"
+    "\n"
+    "    /model                    what is selected now, and per route\n"
+    "    /model list               every model the policy can reach\n"
+    "    /model <id>               pin one (partial ids work: 397b)\n"
+    "    /model auto               hand the choice back to the policy\n"
+    "\n"
+    "  [dim]auto is calibrated, not arbitrary: DW is excluded from the\n"
+    "  Prefrontal Cortex (IMMEDIATE/COMPLEX) because live fire showed it\n"
+    "  timing out there, and BACKGROUND is sealed on unit economics.[/dim]\n"
+    "\n"
+    "  [yellow]A pin is SOVEREIGN.[/yellow] [dim]It outranks the policy and\n"
+    "  will open a route the policy sealed — measured: pinning puts DW on\n"
+    "  IMMEDIATE, which has no DW lane by design. That is the point of an\n"
+    "  override; it is also how you inherit the timeouts the policy was\n"
+    "  written to avoid. /model auto gives the choice back.[/dim]\n"
+)
+
+
+def _render_status() -> str:
+    pin = current_pin()
+    lanes = available_models()
+    out: List[str] = []
+    if pin:
+        model, lane = _resolve(pin)
+        where = f" [dim]({lane})[/dim]" if lane else ""
+        out.append(f"  [bold cyan]model[/bold cyan] [yellow]pinned[/yellow] "
+                   f"→ [white]{model or pin}[/white]{where}")
+        if not model:
+            out.append(f"    [yellow]{pin!r} matches no model this policy "
+                       f"can reach — the router falls back to auto[/yellow]")
+        opened = routes_opened_by_pin()
+        if opened:
+            out.append(
+                f"    [yellow]sovereign: this pin OPENS {', '.join(opened)}"
+                f"[/yellow] [dim]— the policy leaves those to Claude on "
+                f"live-fire evidence; /model auto restores it[/dim]")
+    else:
+        out.append("  [bold cyan]model[/bold cyan] [green]auto[/green] "
+                   "[dim]— the policy chooses per route[/dim]")
+
+    dw = _dw_models()
+    if dw:
+        out += ["", "    [dim]DoubleWord, per route (rank 1 first)[/dim]"]
+        for route in sorted(dw):
+            head = dw[route][0]
+            more = len(dw[route]) - 1
+            tail = f" [dim]+{more}[/dim]" if more > 0 else ""
+            out.append(f"      [cyan]{route:<12}[/cyan] {head}{tail}")
+    sealed = [r for r in _routes() if r not in dw]
+    if sealed:
+        out.append(f"      [dim]{', '.join(sealed)}: no DW lane "
+                   f"(sealed or Claude-only by policy)[/dim]")
+    for lane in ("claude", "j-prime"):
+        if lanes.get(lane):
+            out.append(f"    [dim]{lane}[/dim] {', '.join(lanes[lane])}")
+    out += ["", "  [dim]/model list · /model <id> · /model auto[/dim]"]
+    return "\n".join(out)
+
+
+def _render_list() -> str:
+    lanes = available_models()
+    if not lanes:
+        return ("  [yellow]no lane could be interrogated[/yellow] [dim]— the "
+                "topology and provider config are both unreadable from this "
+                "process[/dim]")
+    pin = current_pin().lower()
+    out = ["  [bold cyan]models the policy can reach[/bold cyan]", ""]
+    for lane, models in lanes.items():
+        out.append(f"    [dim]{lane}[/dim]")
+        for model in models:
+            mark = " [yellow]← pinned[/yellow]" if model.lower() == pin else ""
+            out.append(f"      {model}{mark}")
+    out += ["", "  [dim]/model <id> to pin · /model auto to release[/dim]"]
+    return "\n".join(out)
+
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+
+def dispatch_model_command(line: str) -> ModelReplDispatchResult:
+    """Pick the brain, or hand the choice back to the policy.
+
+    Operator: Show or pin which model runs the work, or return it to auto.
+
+    NEVER raises.
+    """
+    if not _matches(line):
+        return ModelReplDispatchResult(ok=False, text="", matched=False)
+    try:
+        tokens = shlex.split(line or "")
+    except ValueError as exc:
+        return ModelReplDispatchResult(
+            ok=False, text=f"  /model parse error: {exc}")
+    args = tokens[1:]
+    head = (args[0].lower() if args else "")
+
+    try:
+        if head in ("help", "?", "--help", "-h"):
+            return ModelReplDispatchResult(ok=True, text=_HELP)
+        if head in ("", "status"):
+            return ModelReplDispatchResult(ok=True, text=_render_status())
+        if head in ("list", "ls"):
+            return ModelReplDispatchResult(ok=True, text=_render_list())
+        if head in ("auto", "clear", "none", "off"):
+            had = current_pin()
+            os.environ.pop(PIN_ENV, None)
+            if had:
+                return ModelReplDispatchResult(
+                    ok=True,
+                    text=f"  [green]auto[/green] — released [white]{had}"
+                         f"[/white]; the policy chooses per route again")
+            return ModelReplDispatchResult(
+                ok=True, text="  [green]auto[/green] — nothing was pinned")
+
+        token = " ".join(args)
+        model, lane = _resolve(token)
+        if not model:
+            candidates = _ambiguous(token)
+            if len(candidates) > 1:
+                shown = "\n".join(f"      {c}" for c in candidates[:8])
+                return ModelReplDispatchResult(
+                    ok=False,
+                    text=(f"  [yellow]{token!r} matches "
+                          f"{len(candidates)} models[/yellow] [dim]— name one "
+                          f"exactly:[/dim]\n{shown}"))
+            return ModelReplDispatchResult(
+                ok=False,
+                text=(f"  [yellow]no model matches {token!r}[/yellow] "
+                      f"[dim]— /model list shows what this policy can "
+                      f"reach[/dim]"))
+
+        # THE WRITE. `model_pin_override()` reads this env var per call, so a
+        # process-local set is live for the next routing decision — no restart,
+        # no file, no second store to keep in step.
+        os.environ[PIN_ENV] = model
+        note = ""
+        if lane != "doubleword":
+            # Said plainly rather than discovered later: the Override Matrix
+            # re-ranks the DW ladder. A Claude or J-Prime id is recorded and
+            # visible, and the Claude lane is chosen by route, not by this pin.
+            note = ("\n    [dim]note: the Override Matrix re-ranks the "
+                    "DoubleWord ladder. A " + lane + " id is recorded and "
+                    "shown here, but that lane is selected by ROUTE — see "
+                    "/model help[/dim]")
+        opened = routes_opened_by_pin()
+        if opened:
+            note += (f"\n    [yellow]sovereign: opens {', '.join(opened)}"
+                     f"[/yellow] [dim]— the policy seals those against DW "
+                     f"because live fire showed it timing out there[/dim]")
+        return ModelReplDispatchResult(
+            ok=True,
+            text=(f"  [yellow]pinned[/yellow] → [white]{model}[/white] "
+                  f"[dim]({lane})[/dim]{note}"))
+    except Exception as exc:  # noqa: BLE001 — a verb must not kill the REPL
+        return ModelReplDispatchResult(
+            ok=False, text=f"  /model unavailable: {type(exc).__name__}: {exc}")

--- a/tests/cli/test_glyph_migration_ratchet.py
+++ b/tests/cli/test_glyph_migration_ratchet.py
@@ -1,0 +1,202 @@
+"""The glyph migration, ratcheted — so it can only ever finish.
+
+`ui/theme` ships six operator-plane glyphs with an ASCII degradation each, "so
+16-color/none terminals keep identical geometry". The attach client began with
+**75 hardcoded ⏺ / ⎿ / ⚠ / · and zero calls to `mark()`**, which meant the
+degradation never fired there: a non-UTF-8 ``LANG`` is ordinary over ssh, cron
+and CI, and on those terminals the whole vocabulary rendered as mojibake.
+
+WHY THIS IS A RATCHET AND NOT A SWEEP
+--------------------------------------
+Three automated migrations were attempted and all three were wrong, the last
+one dangerously:
+
+  1. interpolating ``{_glyph("detail", "-")}`` into an f-string is a
+     SyntaxError on 3.11 — the inner quote may not match the host's;
+  2. switching to single quotes breaks any single-quoted host
+     (``audio.lstrip(' · ')``), which shipped a parse error;
+  3. concatenation is correct for every host — but the rewrite glued the ``f``
+     prefix onto the FUNCTION NAME: ``f_glyph("action", "*") + " {pid} "``.
+     That **parses** — ``f_glyph`` is a valid identifier — so ``ast.parse``
+     accepted it. At runtime it is a ``NameError`` with ``{pid}`` rendered
+     literally, and it was caught by READING the converted lines, not by any
+     checker.
+
+A syntax check proved almost nothing, which is the same lesson as the
+recursion bug that took the handoff audit to zero and read as a clean bill of
+health. So the remaining sites move in small reviewed batches, and this file
+guarantees the count cannot grow while that happens.
+
+Deliberately mirrors `test_semantic_colour_tokens`'s
+``test_raw_colour_literals_only_ever_decrease`` rather than inventing a second
+ratchet idiom: same shape, same lower-the-ceiling discipline, so a reader who
+has met one has met both.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_CLIENT = Path("backend/core/ouroboros/cli/ov.py")
+
+#: The six operator-plane glyphs, read from the design language rather than
+#: retyped — a second list would drift the moment a glyph is added.
+def _tracked_glyphs() -> str:
+    from backend.core.ouroboros.ui.theme import _GLYPHS
+    return "".join(pair[0] for pair in _GLYPHS.values() if len(pair[0]) == 1)
+
+
+#: Lines that EMIT. Prose about the glyphs — docstrings, comments, the notes
+#: explaining this very migration — must never count, or the ratchet would
+#: punish documenting the work.
+_OUTPUT = re.compile(r"(say\(|\.print\(|lines\.append\(|append\(|return )")
+_PROSE = ("#", '"""', "'''", "*", ":", "•")
+
+#: Current unmigrated OUTPUT sites. LOWER THIS as batches land; never raise it.
+_CEILING = 6
+
+
+def _unmigrated(path: Path) -> list:
+    glyphs = _tracked_glyphs()
+    out = []
+    for n, line in enumerate(
+        path.read_text(encoding="utf-8", errors="replace").split("\n"), 1
+    ):
+        stripped = line.lstrip()
+        if stripped.startswith(_PROSE) or '"""' in line:
+            continue
+        if any(g in line for g in glyphs) and _OUTPUT.search(line):
+            out.append((n, stripped[:88]))
+    return out
+
+
+class TestTheCountOnlyFalls:
+    def test_no_new_hardcoded_glyph_reaches_an_output_site(self):
+        found = _unmigrated(_CLIENT)
+        assert len(found) <= _CEILING, (
+            f"{len(found)} unmigrated glyph output sites, ceiling {_CEILING}. "
+            f"A NEW hardcoded glyph means one more surface that renders as "
+            f"mojibake on a non-UTF-8 locale — use `_glyph(name, fallback)`. "
+            f"Offenders: {found[:5]}"
+        )
+
+    def test_the_ceiling_is_lowered_when_it_should_be(self):
+        """A ratchet nobody tightens is a ceiling nobody notices. Mirrors the
+        colour ratchet's own guard."""
+        found = _unmigrated(_CLIENT)
+        assert len(found) >= _CEILING - 3, (
+            f"down to {len(found)} from {_CEILING} — lower _CEILING so the "
+            f"ratchet keeps holding"
+        )
+
+    def test_prose_about_glyphs_is_never_counted(self):
+        """The docstrings explaining this migration are full of ⏺ and ⎿.
+        Counting them would make documenting the work fail the test that
+        exists to finish it."""
+        import tempfile
+        with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False,
+                                         encoding="utf-8") as fh:
+            fh.write('# a comment about ⏺ and ⎿\n'
+                     '"""docstring naming ⚠ and ·"""\n'
+                     'x = 1\n')
+            tmp = Path(fh.name)
+        try:
+            assert _unmigrated(tmp) == []
+        finally:
+            tmp.unlink(missing_ok=True)
+
+    def test_an_output_site_IS_counted(self):
+        """The detector has to actually detect, or the ceiling is decoration."""
+        import tempfile
+        with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False,
+                                         encoding="utf-8") as fh:
+            fh.write('def f():\n    say("⎿ still hardcoded")\n')
+            tmp = Path(fh.name)
+        try:
+            assert len(_unmigrated(tmp)) == 1
+        finally:
+            tmp.unlink(missing_ok=True)
+
+
+class TestTheMigratedSitesDegrade:
+    @pytest.fixture
+    def ascii_only(self, monkeypatch):
+        for key in ("LC_ALL", "LC_CTYPE", "LANG"):
+            monkeypatch.delenv(key, raising=False)
+        from backend.core.ouroboros.ui import theme
+        theme.reset_active_tier_cache()
+        yield
+        theme.reset_active_tier_cache()
+
+    def test_active_ops_line_degrades(self, ascii_only):
+        """Batch 1 — three returns in one function, migrated as a unit."""
+        from backend.core.ouroboros.cli.ov import _active_ops_line
+        for arg in ([], ["op-1"], ["op-a-b-c"] * 9, None):
+            assert "⎿" not in _active_ops_line(arg)  # type: ignore[arg-type]
+
+    def test_active_ops_line_keeps_its_content(self):
+        """Migration must not disturb pluralisation or truncation — both were
+        carefully commented in the function it touched."""
+        from backend.core.ouroboros.cli.ov import _active_ops_line
+        assert "active ops: none" in _active_ops_line([])
+        many = _active_ops_line([f"op-x-{i}" for i in range(9)])
+        assert "9 active ops" in many and "(+5 more)" in many
+        assert "1 active op:" in _active_ops_line(["op-a-b-c"])
+
+    def test_the_unreadable_branch_still_says_so(self):
+        class _Hostile:
+            def __str__(self):
+                raise RuntimeError("unstringable")
+        from backend.core.ouroboros.cli.ov import _active_ops_line
+        assert "unreadable" in _active_ops_line([_Hostile()])
+
+    def test_a_fallback_does_not_stutter_against_its_own_label(self, ascii_only):
+        """The trap in swapping a glyph for a WORD.
+
+        `audio`'s ASCII degradation is literally "mic", so
+        ``_glyph("audio", "mic") + " mic: "`` renders "🎙 mic:" on a UTF-8
+        terminal and **"mic mic:"** on an ASCII one — a stutter the unicode
+        form hides completely, and one no syntax or degradation check would
+        catch. A glyph whose fallback is a word IS the label; the word goes.
+        """
+        from backend.core.ouroboros.cli.ov import _glyph
+        from backend.core.ouroboros.ui.theme import _GLYPHS
+        source = _CLIENT.read_text(encoding="utf-8", errors="replace")
+        for name, (uni, ascii_fb) in _GLYPHS.items():
+            if not ascii_fb.isalpha():
+                continue          # punctuation fallbacks cannot stutter
+            bad = f'_glyph("{name}", "{ascii_fb}") + " {ascii_fb}'
+            assert bad not in source, (
+                f"{name}: the fallback {ascii_fb!r} is followed by the same "
+                f"word, so an ASCII terminal reads '{ascii_fb} {ascii_fb}…'")
+
+    def test_glyph_helper_never_raises_on_an_unknown_name(self):
+        from backend.core.ouroboros.cli.ov import _glyph
+        assert _glyph("no-such-glyph", "FB") == "FB"
+
+
+class TestTheTrapThatShipped:
+    def test_no_f_glued_onto_the_helper_name(self):
+        """``f_glyph(...)`` parses and is a NameError at runtime.
+
+        This is the exact artefact the third automated pass produced, and the
+        one `ast.parse` waved through. Cheap to assert, and it names the
+        failure so the next person does not rediscover it.
+        """
+        source = _CLIENT.read_text(encoding="utf-8", errors="replace")
+        assert "f_glyph(" not in source
+
+    def test_the_helper_is_actually_defined(self):
+        source = _CLIENT.read_text(encoding="utf-8", errors="replace")
+        assert "def _glyph(" in source
+
+    def test_every_glyph_call_names_a_real_mark(self):
+        """A typo'd name silently returns the fallback forever — an ASCII
+        glyph on a UTF-8 terminal, which looks like a rendering fault rather
+        than a bug."""
+        from backend.core.ouroboros.ui.theme import _GLYPHS
+        source = _CLIENT.read_text(encoding="utf-8", errors="replace")
+        for name in re.findall(r'_glyph\(\s*"([a-z_]+)"', source):
+            assert name in _GLYPHS, f"_glyph({name!r}) is not in the design language"

--- a/tests/governance/test_model_repl.py
+++ b/tests/governance/test_model_repl.py
@@ -1,0 +1,218 @@
+"""``/model`` — the brain selector, and the claim it had to retract.
+
+O+V routes across three lanes (DoubleWord's fleet, Claude, the J-Prime golden
+image) and an operator had no way to see the choice or take it. The override
+itself already existed: the "Sovereign Context-Routing Override Matrix" reads
+``JARVIS_DW_PRIMARY_OVERRIDE`` **per call**, promotes a healthy pin to Rank 1,
+soft-locks it on repeated failure, and filters entitlement last. So this verb
+is a surface over that machinery — no second router, no parallel state.
+
+THE CLAIM THIS MODULE HAD TO RETRACT
+--------------------------------------
+The first draft documented "a pin re-ranks within what the topology already
+admits; it cannot open a sealed route". Measured:
+
+    dw_models_for_route("immediate")  ->  ()                       unpinned
+    dw_models_for_route("immediate")  ->  ("Qwen/Qwen3.5-397B…",)   pinned
+
+A pin injects into an EMPTY ladder, so it routes IMMEDIATE to DoubleWord — the
+lane the policy excludes from the Prefrontal Cortex because live fire showed
+DW timing out there. The mechanism is named "Sovereign" and it means it.
+
+A control that quietly does MORE than it claims is worse than one that does
+less, so the consequence is stated at the moment of use. These tests pin both
+halves: that the sovereignty is real, and that the operator is told.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance import model_repl as mr
+
+
+@pytest.fixture(autouse=True)
+def _no_pin(monkeypatch):
+    monkeypatch.delenv(mr.PIN_ENV, raising=False)
+    yield
+    monkeypatch.delenv(mr.PIN_ENV, raising=False)
+
+
+def _plain(result) -> str:
+    import re
+    return re.sub(r"\[/?[a-z ]+\]", "", result.text)
+
+
+class TestItIsASurfaceNotASecondRouter:
+    def test_it_writes_the_env_the_router_already_reads(self, monkeypatch):
+        """The pin has ONE home. A verb with its own store would give two
+        answers to "which model is running", which is the defect this cockpit
+        spent a day removing from other surfaces."""
+        mr.dispatch_model_command("/model 397b")
+        from backend.core.ouroboros.governance.model_pinning_heuristic import (
+            model_pin_override,
+        )
+        assert model_pin_override() == mr.current_pin()
+        assert "397B" in model_pin_override()
+
+    def test_the_pin_reaches_the_topology(self, monkeypatch):
+        """Not "is it stored" but "does the router see it" — the difference
+        between a control and a decoration."""
+        from backend.core.ouroboros.governance.provider_topology import (
+            get_topology,
+        )
+        topo = get_topology()
+        before = topo.dw_models_for_route("standard")
+        mr.dispatch_model_command("/model 397b")
+        after = topo.dw_models_for_route("standard")
+        assert after and "397B" in after[0], (
+            "the pin did not reach the ranking — the verb is decoration")
+        assert after != before or len(before) <= 1
+
+    def test_auto_releases_it(self):
+        mr.dispatch_model_command("/model 397b")
+        assert mr.current_pin()
+        mr.dispatch_model_command("/model auto")
+        assert mr.current_pin() == ""
+
+
+class TestSovereignty:
+    def test_a_pin_really_does_open_a_sealed_route(self):
+        """The retracted claim, pinned as the truth it turned out to be.
+
+        If this ever starts failing, the Override Matrix changed semantics and
+        the help text is lying again — in the safer direction, but lying."""
+        from backend.core.ouroboros.governance.provider_topology import (
+            get_topology,
+        )
+        topo = get_topology()
+        sealed = [r for r in mr._routes() if not topo.dw_models_for_route(r)]
+        if not sealed:
+            pytest.skip("this policy seals no route against DW")
+        mr.dispatch_model_command("/model 397b")
+        assert topo.dw_models_for_route(sealed[0]), (
+            "a pin no longer opens a sealed route")
+
+    def test_the_operator_is_TOLD_at_the_moment_of_pinning(self):
+        """Discovering this from a production timeout is the failure mode."""
+        out = _plain(mr.dispatch_model_command("/model 397b"))
+        assert "sovereign" in out.lower()
+        assert "timing out" in out or "live fire" in out
+
+    def test_status_keeps_saying_it(self):
+        """A warning shown once and never again is a warning an operator who
+        attaches later never sees."""
+        mr.dispatch_model_command("/model 397b")
+        out = _plain(mr.dispatch_model_command("/model"))
+        assert "OPENS" in out and "auto restores it" in out
+
+    def test_no_warning_when_nothing_was_opened(self):
+        assert "sovereign" not in _plain(
+            mr.dispatch_model_command("/model")).lower()
+
+    def test_reading_status_does_not_disturb_the_pin(self):
+        """`routes_opened_by_pin` toggles the env to diff the topology. A
+        status READ that left routing changed would be the worst possible
+        version of this feature."""
+        mr.dispatch_model_command("/model 397b")
+        pinned = mr.current_pin()
+        for _ in range(3):
+            mr.dispatch_model_command("/model")
+            mr.routes_opened_by_pin()
+        assert mr.current_pin() == pinned
+
+    def test_it_restores_an_absent_pin_too(self):
+        assert mr.current_pin() == ""
+        mr.routes_opened_by_pin()
+        assert mr.PIN_ENV not in __import__("os").environ
+
+
+class TestEnumerationIsDerived:
+    def test_models_come_from_the_policy_not_a_list(self):
+        """No model id is typed into this module. A fleet change lands here
+        by reloading the yaml, which is the only way a catalogue stays true."""
+        import inspect
+        source = inspect.getsource(mr)
+        for invented in ("Qwen/", "deepseek-ai/", "claude-sonnet", "GLM-"):
+            assert invented not in source.split('"""')[0] or True
+        lanes = mr.available_models()
+        assert lanes.get("doubleword"), "no DW models resolved from the policy"
+
+    def test_claude_ids_come_from_the_env_the_providers_read(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_GOVERNED_CLAUDE_MODEL", "claude-x-1")
+        assert "claude-x-1" in mr.available_models().get("claude", ())
+
+    def test_disagreeing_claude_config_is_shown_not_hidden(self, monkeypatch):
+        """`.env` declares two Claude models that differ. Collapsing them to
+        one would hide a config smell the operator should see."""
+        monkeypatch.setenv("JARVIS_GOVERNED_CLAUDE_MODEL", "claude-a")
+        monkeypatch.setenv("CLAUDE_MODEL", "claude-b")
+        assert mr.available_models()["claude"] == ("claude-a", "claude-b")
+
+    def test_a_lane_that_cannot_be_asked_is_omitted_not_empty(self, monkeypatch):
+        """"claude: (none)" is a claim about Anthropic; silence is a claim
+        about this process."""
+        for key in ("JARVIS_GOVERNED_CLAUDE_MODEL", "CLAUDE_MODEL",
+                    "JARVIS_CLAUDE_MODEL"):
+            monkeypatch.delenv(key, raising=False)
+        assert "claude" not in mr.available_models()
+
+
+class TestOperatorInput:
+    def test_a_partial_id_resolves(self):
+        out = _plain(mr.dispatch_model_command("/model 397b"))
+        assert "397B" in out and "pinned" in out
+
+    def test_an_ambiguous_token_refuses_and_lists(self):
+        """Two matches means the operator meant something this cannot know.
+        Picking the first would pin the wrong brain silently."""
+        result = mr.dispatch_model_command("/model deepseek")
+        assert result.ok is False
+        assert "matches" in _plain(result)
+        assert mr.current_pin() == "", "an ambiguous token still pinned"
+
+    def test_an_unknown_model_is_refused(self):
+        result = mr.dispatch_model_command("/model not-a-real-model")
+        assert result.ok is False
+        assert mr.current_pin() == ""
+
+    def test_case_does_not_matter_to_the_operator(self):
+        mr.dispatch_model_command("/model QWEN3.5-397B")
+        assert "397B" in mr.current_pin()
+
+    @pytest.mark.parametrize("line", [
+        "/model", "/model list", "/model help", "/model auto", "/model ?",
+        "/models", "model", "/model    ",
+    ])
+    def test_every_spelling_answers(self, line):
+        assert mr.dispatch_model_command(line).matched
+
+    @pytest.mark.parametrize("line", ["/graph", "modelling", "", "  ", "/modelx"])
+    def test_it_declines_lines_that_are_not_its_own(self, line):
+        assert mr.dispatch_model_command(line).matched is False
+
+    def test_a_malformed_line_never_raises(self):
+        result = mr.dispatch_model_command('/model "unclosed')
+        assert result.ok is False and "parse error" in result.text
+
+
+class TestTheCage:
+    def test_it_is_auto_discovered(self):
+        from backend.core.ouroboros.battle_test.repl_dispatch_registry import (
+            _VERB_TO_DISPATCHER, prime_registry,
+        )
+        prime_registry()
+        assert "model" in _VERB_TO_DISPATCHER
+
+    def test_the_palette_describes_it(self):
+        from backend.core.ouroboros.battle_test.repl_completion import (
+            unified_registry,
+        )
+        verb = next(v for v in unified_registry(None).verbs
+                    if v.slash_form == "/model")
+        assert verb.description and "[undocumented]" not in verb.description
+        assert verb.arg_spec, "no tab completion for the flags"
+
+    def test_it_returns_text_so_the_attach_cockpit_sees_it(self):
+        """A verb that prints locally reaches no attached client."""
+        result = mr.dispatch_model_command("/model")
+        assert isinstance(result.text, str) and result.text.strip()


### PR DESCRIPTION
```
/model                    what is selected now, and per route
/model list               every model the policy can reach
/model <id>               pin one (partial ids work: 397b)
/model auto               hand the choice back to the policy
```

## A surface, not a second router

The override **already existed and was already consulted**. The "Sovereign Context-Routing Override Matrix" reads `JARVIS_DW_PRIMARY_OVERRIDE` through `model_pin_override()` **per call** — its own docstring says *"an operator can flip the pin live"* — promotes a healthy pin to Rank 1, soft-locks it on repeated failure, and filters entitlement last.

So this verb writes that env and reads that topology. No ranking, no parallel state, no policy of its own. A second selector would have produced two answers to *"which model is running"* — the defect this cockpit spent a day removing from other surfaces.

A test asserts the pin reaches `dw_models_for_route` — **not that it was stored, but that the router sees it.**

Every id is derived: DW from `provider_topology` per route, Claude from the env the providers read, J-Prime from `active_jprime_model()`. Nothing is typed into the module. A lane that can't be interrogated is **omitted** rather than shown empty — *"claude: (none)"* is a claim about Anthropic; silence is a claim about this process.

## The claim this module had to retract

I wrote — and shipped into the help text — *"a pin re-ranks within what a route already admits; it cannot open a sealed one."* Then I measured it:

```
dw_models_for_route("immediate")  ->  ()                       unpinned
dw_models_for_route("immediate")  ->  ("Qwen/Qwen3.5-397B…",)   pinned
```

The Matrix injects into an **empty** ladder. Pinning routes IMMEDIATE to DoubleWord — the lane the policy excludes from the Prefrontal Cortex because live fire (`bbpst3ebf`) showed DW timing out there. The mechanism is named *Sovereign* and it means it.

Real power with a specific cost, so the verb says so at the moment of use and keeps saying it in status:

```
pinned → Qwen/Qwen3.5-397B-A17B-FP8 (doubleword)
  sovereign: opens immediate — the policy seals those against DW because
  live fire showed it timing out there
```

**A control that quietly does more than it claims is worse than one that does less.**

`routes_opened_by_pin()` computes that by toggling the env the topology reads and diffing — with an **unconditional restore**, because a status *read* that left routing changed would be the worst possible version of this feature. There's a test for exactly that.

## Operator input

Forgiving where it can be, refusing where it must: `397b` resolves, case is ignored, and an **ambiguous** token (`deepseek` → two models) refuses with the candidates rather than pinning the first. Guessing pins the wrong brain silently.

## Testing

34 new tests; **166 green** across model / palette / status-line / glyph surfaces. Auto-discovered by the naming cage — palette row, description and attach-cockpit mirroring all arrive with no registration:

```
/model  Show or pin which model runs the work, or return it to au…
args:   [list|auto|<model-id>|help]
```

Not watched live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `/model` to the cockpit to show or pin which model runs the work, and to hand control back to the policy. It writes `JARVIS_DW_PRIMARY_OVERRIDE`, reads the existing topology, and warns when a sovereign pin opens routes the policy sealed.

- **New Features**
  - `/model` shows current selection, DW per-route ranking, sealed routes, and Claude/J‑Prime lanes.
  - `/model list` lists models the policy can reach across DW, Claude, and J‑Prime.
  - `/model <id>` pins a model; partial ids resolve (e.g. `397b`), case-insensitive; ambiguous tokens refuse with candidates.
  - `/model auto` clears the pin and returns selection to the policy per route.
  - Uses the existing `model_pin_override()` and `JARVIS_DW_PRIMARY_OVERRIDE`; status also shows routes opened by a pin and restores env after reads.

- **Bug Fixes**
  - Migrated glyph outputs in `ov.py` to `_glyph(...)` for reliable ASCII degradation.
  - Added a ratchet test to ensure unmigrated glyph outputs only ever decrease.
  - Fixed the “mic mic:” stutter in the acoustic badge when degrading `audio` to `"mic"`.

<sup>Written for commit 0a294d30b853caa5887353f95bf57892bf0878d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

