### PR TITLE
fix(intake): a decision that cannot be made yet is deferred, not dropped

### DIFF
--- a/backend/core/ouroboros/governance/intake/sensors/cu_execution_sensor.py
+++ b/backend/core/ouroboros/governance/intake/sensors/cu_execution_sensor.py
@@ -133,9 +133,24 @@ class CUExecutionSensor:
         repo: str = "jarvis",
     ) -> None:
         if self._initialized:
-            # Allow re-wiring the router after construction
+            # Allow re-wiring the router after construction.
+            #
+            # THE BOOT RACE THIS CLOSES. `main.py`'s HUD dispatch reaches this
+            # sensor through `get_cu_execution_sensor()`, which constructs the
+            # singleton with NO router. `IntakeLayerService` attaches the real
+            # router later, during progressive governance boot. A HUD action
+            # landing in that window used to reach `_emit_envelope`, find
+            # `_router is None`, log a warning and DROP the emission — while
+            # the failure window kept the evidence that justified it.
+            #
+            # Attaching a router is therefore not a field assignment; it is the
+            # moment a decision that could not be made becomes makeable. So the
+            # attach RECONCILES.
             if router is not None:
+                _changed = router is not self._router
                 self._router = router
+                if _changed:
+                    self._schedule_reconcile()
             return
         self._initialized = True
         self._router = router
@@ -143,12 +158,27 @@ class CUExecutionSensor:
 
         # Pattern tracking: signature -> list of timestamps
         self._failure_window: Dict[str, List[float]] = defaultdict(list)
+        # Latest record per signature. The window holds TIMESTAMPS only, which
+        # is enough to count a pattern and not enough to describe it — an
+        # envelope needs the record. Kept under the same lifecycle as the
+        # window (pruned together) so it cannot outgrow it.
+        self._latest_by_sig: Dict[str, CUExecutionRecord] = {}
         # Track when we last emitted for each signature (cooldown)
         self._last_emitted: Dict[str, float] = {}
         # Total records for observability
         self._total_records = 0
         self._total_failures = 0
         self._total_envelopes_emitted = 0
+        # Emissions that qualified while no router was attached. Counted rather
+        # than merely logged: "how much did we nearly lose" is the number that
+        # says whether this race is rare or routine (Manifesto §7).
+        self._deferred_emissions = 0
+        self._reconciled_emissions = 0
+        # Set when a qualifying pattern was refused for want of a router. The
+        # lazy half of the recovery: if no event loop was running at attach
+        # time, the next `record()` reconciles instead.
+        self._needs_reconcile = False
+        self._reconciling = False
 
         logger.info("[CUExecutionSensor] initialized")
 
@@ -159,8 +189,129 @@ class CUExecutionSensor:
     def stop(self) -> None:
         """Clear tracking state."""
         self._failure_window.clear()
+        self._latest_by_sig.clear()
         self._last_emitted.clear()
+        self._needs_reconcile = False
         logger.info("[CUExecutionSensor] stopped")
+
+    # ------------------------------------------------------------------
+    # Router attachment — turning a missed decision into a deferred one
+    # ------------------------------------------------------------------
+
+    def _schedule_reconcile(self) -> None:
+        """Re-evaluate every live pattern now that a router exists.
+
+        Two paths, because a router can be attached from either world and
+        neither may assume the other:
+
+        * **Eager** — `IntakeLayerService` constructs this sensor inside an
+          async boot, so a loop is running and the sweep starts immediately.
+        * **Lazy** — no running loop (a sync test, a CLI, a boot ordering we
+          have not met). A flag is set and the next `record()` reconciles.
+
+        NEVER raises: a failure here must not break governance boot, and the
+        lazy path is the fallback for the eager one failing.
+        """
+        self._needs_reconcile = True
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            logger.debug(
+                "[CUExecutionSensor] router attached with no running loop — "
+                "reconcile deferred to next record()")
+            return
+        try:
+            loop.create_task(self._reconcile())
+        except Exception:  # noqa: BLE001 — the flag still covers us
+            logger.debug("[CUExecutionSensor] eager reconcile not scheduled",
+                         exc_info=True)
+
+    async def _reconcile(self) -> None:
+        """Emit for every pattern that qualified while nothing could receive it.
+
+        Idempotent and cheap: bounded by the number of live signatures, guarded
+        against re-entry, and each candidate still passes the ordinary
+        threshold and cooldown checks — so a pattern already emitted stays
+        silent and a pattern below threshold stays pending. Replaying is
+        therefore always safe, which is what lets both the eager and lazy paths
+        call it without coordinating.
+        """
+        if self._reconciling or self._router is None:
+            return
+        self._reconciling = True
+        try:
+            self._needs_reconcile = False
+            now = time.time()
+            # Snapshot: `_maybe_emit` awaits, and the window can be mutated by
+            # a concurrent record() while we are suspended.
+            for sig in list(self._failure_window.keys()):
+                count = self._live_count(sig, now)
+                if count < _GRADUATION_THRESHOLD:
+                    continue
+                rec = self._latest_by_sig.get(sig)
+                if rec is None:
+                    # Window entry with no record — pre-upgrade state or a
+                    # pruned pairing. Cannot describe it honestly, so skip
+                    # rather than emit a fabricated envelope.
+                    continue
+                if await self._maybe_emit(sig, rec, count, deferred=True):
+                    self._reconciled_emissions += 1
+        except Exception:  # noqa: BLE001
+            logger.debug("[CUExecutionSensor] reconcile degraded", exc_info=True)
+        finally:
+            self._reconciling = False
+
+    def _live_count(self, sig: str, now: float) -> int:
+        """Occurrences of *sig* inside the rolling window, pruning in place.
+
+        Pruning here rather than only in `record()` is what makes reconcile
+        honest: a pattern that crossed the threshold hours ago must not emit on
+        the strength of entries that have since expired.
+        """
+        cutoff = now - _WINDOW_S
+        kept = [t for t in self._failure_window.get(sig, ()) if t > cutoff]
+        if kept:
+            self._failure_window[sig] = kept
+        else:
+            # Drop the pairing together so `_latest_by_sig` cannot outlive the
+            # window it is indexed by.
+            self._failure_window.pop(sig, None)
+            self._latest_by_sig.pop(sig, None)
+        return len(kept)
+
+    async def _maybe_emit(self, sig: str, rec: "CUExecutionRecord",
+                          count: int, *, deferred: bool = False) -> bool:
+        """The ONE place that decides whether a pattern emits.
+
+        Extracted from `record()` so the decision can be RE-ENTERED. The bug
+        this closes was never lost data — the window kept every occurrence —
+        it was that the decision was evaluated exactly once, at a moment chosen
+        by a producer with no knowledge of consumer readiness. Making it
+        re-entrant is the whole fix; the window is already the buffer.
+
+        Returns True if an envelope was actually ingested.
+        """
+        if count < _GRADUATION_THRESHOLD:
+            return False
+        now = time.time()
+        last = self._last_emitted.get(sig, 0)
+        if now - last < _EMIT_COOLDOWN_S:
+            logger.debug(
+                "[CUExecutionSensor] Pattern '%s' graduated but in cooldown "
+                "(%.0fs remaining)", sig, _EMIT_COOLDOWN_S - (now - last))
+            return False
+        if self._router is None:
+            # Not a failure to emit — a decision that cannot be made YET.
+            self._deferred_emissions += 1
+            self._needs_reconcile = True
+            logger.warning(
+                "[CUExecutionSensor] Pattern '%s' qualified (%dx) with no "
+                "router attached — emission DEFERRED, will reconcile when "
+                "governance boot completes (deferred_total=%d)",
+                sig, count, self._deferred_emissions,
+            )
+            return False
+        return await self._emit_envelope(sig, rec, count, deferred=deferred)
 
     # ------------------------------------------------------------------
     # Public API: called by ActionDispatcher after CU execution
@@ -187,17 +338,15 @@ class CUExecutionSensor:
         self._total_failures += 1
         sig = rec.failure_signature
 
-        # Add to rolling window
+        # Add to rolling window, keyed on the record's OWN timestamp rather
+        # than now(): a record replayed from the HUD's pending-event queue
+        # describes when the action failed, not when the IPC reconnected, and
+        # a 24h window judged on arrival time would be judging the wrong thing.
+        self._failure_window[sig].append(rec.timestamp)
+        self._latest_by_sig[sig] = rec
+
         now = time.time()
-        self._failure_window[sig].append(now)
-
-        # Prune entries outside the window
-        cutoff = now - _WINDOW_S
-        self._failure_window[sig] = [
-            t for t in self._failure_window[sig] if t > cutoff
-        ]
-
-        count = len(self._failure_window[sig])
+        count = self._live_count(sig, now)
         logger.info(
             "[CUExecutionSensor] Failure #%d for pattern '%s': %s",
             count,
@@ -205,19 +354,15 @@ class CUExecutionSensor:
             rec.error or "partial completion",
         )
 
-        # Check graduation threshold
-        if count >= _GRADUATION_THRESHOLD:
-            # Check cooldown
-            last = self._last_emitted.get(sig, 0)
-            if now - last < _EMIT_COOLDOWN_S:
-                logger.debug(
-                    "[CUExecutionSensor] Pattern '%s' graduated but in cooldown (%.0fs remaining)",
-                    sig,
-                    _EMIT_COOLDOWN_S - (now - last),
-                )
-                return
+        await self._maybe_emit(sig, rec, count)
 
-            await self._emit_envelope(sig, rec, count)
+        # Lazy half of the recovery. If a router arrived while no loop was
+        # running — or an earlier pattern was refused for want of one — this
+        # is the next moment we are certainly inside the loop, so sweep the
+        # OTHER signatures too. Costs one bounded pass and only when something
+        # is actually outstanding.
+        if self._needs_reconcile and self._router is not None:
+            await self._reconcile()
 
     # ------------------------------------------------------------------
     # Envelope emission
@@ -228,14 +373,23 @@ class CUExecutionSensor:
         signature: str,
         latest: CUExecutionRecord,
         occurrence_count: int,
-    ) -> None:
-        """Emit an IntentEnvelope to Ouroboros for a graduated failure pattern."""
+        *,
+        deferred: bool = False,
+    ) -> bool:
+        """Emit an IntentEnvelope to Ouroboros for a graduated failure pattern.
+
+        Returns True if the router accepted it. *deferred* marks an envelope
+        that qualified before a router existed and is only now being sent —
+        the evidence says so explicitly, because a late signal that renders
+        identically to a fresh one is exactly the provenance failure this
+        codebase keeps finding.
+        """
         if self._router is None:
             logger.warning(
                 "[CUExecutionSensor] No router wired — cannot emit envelope for '%s'",
                 signature,
             )
-            return
+            return False
 
         description = (
             f"CU execution failure pattern detected ({occurrence_count}x in "
@@ -279,6 +433,12 @@ class CUExecutionSensor:
             "antipatterns_blocked": latest.antipatterns_blocked,
             "window_hours": _WINDOW_S / 3600,
             "threshold": _GRADUATION_THRESHOLD,
+            # Provenance: was this sent when it qualified, or held until a
+            # router existed? `age_s` is measured from the occurrence that
+            # crossed the threshold, so a postmortem can tell a slow boot from
+            # a slow failure.
+            "deferred_by_boot": deferred,
+            "age_s": round(max(0.0, time.time() - latest.timestamp), 2),
         }
 
         envelope = make_envelope(
@@ -297,17 +457,26 @@ class CUExecutionSensor:
             self._last_emitted[signature] = time.time()
             self._total_envelopes_emitted += 1
             logger.info(
-                "[CUExecutionSensor] Envelope emitted for '%s' → %s (count=%d)",
+                "[CUExecutionSensor] Envelope emitted for '%s' → %s "
+                "(count=%d%s)",
                 signature,
                 result,
                 occurrence_count,
+                ", DEFERRED-then-reconciled" if deferred else "",
             )
+            return True
         except Exception as exc:
+            # Deliberately NOT stamping `_last_emitted` on failure: a transient
+            # router error must leave the pattern eligible, so the next record
+            # or reconcile retries rather than serving a cooldown for an
+            # envelope nobody received.
             logger.warning(
                 "[CUExecutionSensor] Envelope emission failed for '%s': %s",
                 signature,
                 exc,
             )
+            self._needs_reconcile = True
+            return False
 
     # ------------------------------------------------------------------
     # Observability
@@ -319,6 +488,14 @@ class CUExecutionSensor:
             "total_records": self._total_records,
             "total_failures": self._total_failures,
             "total_envelopes_emitted": self._total_envelopes_emitted,
+            # The boot-race counters. `deferred_emissions` is how often a
+            # pattern qualified with no router attached — it should be small
+            # and non-zero on a cold start, and a growing value means
+            # governance boot is not completing at all.
+            "deferred_emissions": self._deferred_emissions,
+            "reconciled_emissions": self._reconciled_emissions,
+            "router_attached": self._router is not None,
+            "pending_reconcile": self._needs_reconcile,
             "active_patterns": len(self._failure_window),
             "pattern_counts": {
                 sig: len(timestamps)

--- a/tests/governance/intake/test_cu_execution_spine.py
+++ b/tests/governance/intake/test_cu_execution_spine.py
@@ -70,15 +70,32 @@ async def test_graduation_emits_envelope_to_router(fresh_cu_sensor):
 
 
 @pytest.mark.asyncio
-async def test_no_router_logs_warning_and_drops(fresh_cu_sensor, caplog):
-    """Without a router, graduation logs a warning and does not raise."""
+async def test_no_router_defers_rather_than_drops(fresh_cu_sensor, caplog):
+    """Without a router, graduation DEFERS — it no longer drops.
+
+    This test previously asserted the defect as the contract: its name was
+    ``test_no_router_logs_warning_and_drops`` and it pinned the behaviour where
+    a qualifying pattern hit ``_emit_envelope``, found no router, logged
+    "No router wired", and discarded the emission.
+
+    That path is real in production. `main.py`'s HUD dispatch reaches this
+    sensor through ``get_cu_execution_sensor()`` (no router) while
+    `IntakeLayerService` attaches the router later in governance boot, so a HUD
+    action failing during that window lost its envelope. The emission is now
+    deferred and reconciled when the router attaches; the still-no-router case
+    is what this test now pins.
+    """
     sensor = CUExecutionSensor(router=None, repo="jarvis")
 
     for _ in range(3):
         await sensor.record(_make_failure_record())
 
+    # Nothing emitted — there is genuinely nowhere to send it yet.
     assert sensor._total_envelopes_emitted == 0
-    assert "No router wired" in caplog.text
+    # But it is recorded as owed, not forgotten.
+    assert sensor.get_stats()["deferred_emissions"] >= 1
+    assert sensor.get_stats()["pending_reconcile"] is True
+    assert "DEFERRED" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/governance/test_cu_sensor_boot_race.py
+++ b/tests/governance/test_cu_sensor_boot_race.py
@@ -1,0 +1,326 @@
+"""The HUD's first failures must survive governance boot.
+
+THE RACE
+----------
+`main.py`'s HUD dispatch reaches this sensor through
+`get_cu_execution_sensor()`, which constructs the singleton with **no
+router**. `IntakeLayerService` attaches the real router later, during
+progressive governance boot (`hud_governance_boot` Step 3). A HUD action that
+failed in that window reached `_emit_envelope`, found `_router is None`, logged
+a warning, and **dropped the emission** — while `_failure_window` kept the very
+evidence that justified it.
+
+The data was never lost. What was lost is subtler and worse: the *decision* was
+evaluated exactly once, at a moment chosen by a producer that has no knowledge
+of consumer readiness. If the third occurrence of a pattern landed pre-boot and
+a fourth never came, the signal was gone despite having crossed the threshold.
+
+THE FIX IS NOT A QUEUE
+------------------------
+The rolling window is already the buffer. Making the emission decision
+**re-enterable** — one `_maybe_emit`, called from `record()` and again from
+`_reconcile()` when a router attaches — is the whole repair. No second store,
+no persistence layer, no new subsystem to keep in step.
+
+The only genuinely missing state was `_latest_by_sig`: the window holds
+timestamps, which is enough to COUNT a pattern and not enough to DESCRIBE one,
+and an envelope needs the record.
+
+WHY THIS SENSOR AND NOT THE OTHER
+-----------------------------------
+`deep_analysis_sensor` has the same `router is None` guard and does NOT need
+this: it polls, so the next tick re-evaluates. `CUExecutionSensor` is
+event-driven — "async start() — no-op" — so a missed evaluation is only
+retried if the same real-world action fails again. Polling sensors self-heal;
+event-driven ones cannot. That is the principled boundary for this fix.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Optional
+
+import pytest
+
+from backend.core.ouroboros.governance.intake.sensors import cu_execution_sensor as ces
+from backend.core.ouroboros.governance.intake.sensors.cu_execution_sensor import (
+    CUExecutionRecord,
+    CUExecutionSensor,
+)
+
+
+class _Router:
+    """Minimal router. Records what it was handed."""
+
+    def __init__(self):
+        self.ingested = []
+
+    async def ingest(self, envelope):
+        self.ingested.append(envelope)
+        return "accepted"
+
+
+class _FlakyRouter(_Router):
+    """Fails N times, then accepts."""
+
+    def __init__(self, failures: int):
+        super().__init__()
+        self._left = failures
+
+    async def ingest(self, envelope):
+        if self._left > 0:
+            self._left -= 1
+            raise RuntimeError("router transient")
+        return await super().ingest(envelope)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_singleton():
+    """The sensor is a process singleton; every test needs a clean one."""
+    CUExecutionSensor._instance = None
+    yield
+    CUExecutionSensor._instance = None
+
+
+def _fail(goal: str = "message alice saying hi", app: str = "Messages",
+          ts: Optional[float] = None) -> CUExecutionRecord:
+    rec = CUExecutionRecord(
+        goal=goal, success=False, steps_completed=1, steps_total=3,
+        elapsed_s=1.0, error="target not found", is_messaging=True,
+        contact="alice", app=app,
+    )
+    if ts is not None:
+        rec.timestamp = ts
+    return rec
+
+
+async def _fail_n(sensor, n: int, **kw):
+    for _ in range(n):
+        await sensor.record(_fail(**kw))
+
+
+class TestTheRaceItself:
+    @pytest.mark.asyncio
+    async def test_pre_boot_failures_are_deferred_not_dropped(self):
+        """THE regression. Three failures with no router used to log a warning
+        and vanish."""
+        sensor = CUExecutionSensor()                     # router=None
+        await _fail_n(sensor, ces._GRADUATION_THRESHOLD)
+        assert sensor.get_stats()["deferred_emissions"] >= 1
+        assert sensor.get_stats()["pending_reconcile"] is True
+
+        router = _Router()
+        CUExecutionSensor(router=router)                  # governance boots
+        await asyncio.sleep(0)                            # let the task run
+        assert router.ingested, "the deferred pattern never reconciled"
+
+    @pytest.mark.asyncio
+    async def test_the_reconciled_envelope_says_it_was_deferred(self):
+        """A late signal that renders identically to a fresh one is the
+        provenance failure this codebase keeps finding."""
+        sensor = CUExecutionSensor()
+        await _fail_n(sensor, ces._GRADUATION_THRESHOLD)
+        router = _Router()
+        CUExecutionSensor(router=router)
+        await asyncio.sleep(0)
+        ev = router.ingested[0]
+        evidence = getattr(ev, "evidence", None) or ev["evidence"]
+        assert evidence["deferred_by_boot"] is True
+        assert evidence["age_s"] >= 0
+
+    @pytest.mark.asyncio
+    async def test_the_normal_path_is_not_marked_deferred(self):
+        router = _Router()
+        sensor = CUExecutionSensor(router=router)
+        await _fail_n(sensor, ces._GRADUATION_THRESHOLD)
+        ev = router.ingested[0]
+        evidence = getattr(ev, "evidence", None) or ev["evidence"]
+        assert evidence["deferred_by_boot"] is False
+
+    @pytest.mark.asyncio
+    async def test_below_threshold_stays_pending_across_the_attach(self):
+        """Reconcile must not lower the bar. Two failures is not three."""
+        sensor = CUExecutionSensor()
+        await _fail_n(sensor, ces._GRADUATION_THRESHOLD - 1)
+        router = _Router()
+        CUExecutionSensor(router=router)
+        await asyncio.sleep(0)
+        assert router.ingested == []
+        await sensor.record(_fail())          # the one that qualifies
+        assert len(router.ingested) == 1
+
+
+class TestItCannotStorm:
+    @pytest.mark.asyncio
+    async def test_a_cold_start_burst_emits_once_per_pattern(self):
+        """Twenty pre-boot failures of one pattern is still one envelope —
+        the cooldown is the guard and reconcile respects it."""
+        sensor = CUExecutionSensor()
+        await _fail_n(sensor, 20)
+        router = _Router()
+        CUExecutionSensor(router=router)
+        await asyncio.sleep(0)
+        assert len(router.ingested) == 1
+
+    @pytest.mark.asyncio
+    async def test_distinct_patterns_each_get_one(self):
+        sensor = CUExecutionSensor()
+        await _fail_n(sensor, ces._GRADUATION_THRESHOLD, app="Messages")
+        await _fail_n(sensor, ces._GRADUATION_THRESHOLD, app="Slack")
+        router = _Router()
+        CUExecutionSensor(router=router)
+        await asyncio.sleep(0)
+        assert len(router.ingested) == 2
+
+    @pytest.mark.asyncio
+    async def test_reconcile_is_idempotent(self):
+        """Re-attaching the same router must not re-emit."""
+        sensor = CUExecutionSensor()
+        await _fail_n(sensor, ces._GRADUATION_THRESHOLD)
+        router = _Router()
+        for _ in range(4):
+            CUExecutionSensor(router=router)
+            await asyncio.sleep(0)
+        assert len(router.ingested) == 1
+
+    @pytest.mark.asyncio
+    async def test_reentrancy_is_guarded(self):
+        """Concurrent reconciles must not double-emit."""
+        sensor = CUExecutionSensor()
+        await _fail_n(sensor, ces._GRADUATION_THRESHOLD)
+        sensor._router = _Router()
+        await asyncio.gather(*(sensor._reconcile() for _ in range(5)))
+        assert len(sensor._router.ingested) == 1
+
+
+class TestTheWindowStaysHonest:
+    @pytest.mark.asyncio
+    async def test_expired_occurrences_do_not_reconcile(self):
+        """A pattern that crossed the threshold yesterday must not emit today
+        on the strength of entries that have since expired."""
+        sensor = CUExecutionSensor()
+        old = time.time() - (ces._WINDOW_S + 60)
+        for _ in range(ces._GRADUATION_THRESHOLD):
+            await sensor.record(_fail(ts=old))
+        router = _Router()
+        CUExecutionSensor(router=router)
+        await asyncio.sleep(0)
+        assert router.ingested == []
+
+    @pytest.mark.asyncio
+    async def test_the_record_timestamp_is_used_not_arrival(self):
+        """The HUD replays queued events when IPC reconnects. A 24h window
+        judged on ARRIVAL would be judging when the socket came back, not when
+        the action failed."""
+        sensor = CUExecutionSensor()
+        old = time.time() - (ces._WINDOW_S + 60)
+        await sensor.record(_fail(ts=old))
+        sig = _fail().failure_signature
+        assert sensor._failure_window.get(sig, []) == [] or \
+            all(t <= old for t in sensor._failure_window[sig])
+
+    @pytest.mark.asyncio
+    async def test_pruning_drops_the_record_with_the_window(self):
+        """`_latest_by_sig` must not outlive the window it is indexed by, or
+        it is an unbounded leak keyed on an unbounded signature space."""
+        sensor = CUExecutionSensor()
+        old = time.time() - (ces._WINDOW_S + 60)
+        await sensor.record(_fail(ts=old))
+        sensor._live_count(_fail().failure_signature, time.time())
+        assert sensor._latest_by_sig == {}
+        assert sensor._failure_window == {}
+
+
+class TestDegradedPaths:
+    @pytest.mark.asyncio
+    async def test_a_transient_router_error_is_retried_immediately(self):
+        """Stamping the cooldown on a failed ingest would serve a one-hour
+        silence for an envelope nobody received. Instead the failure sets
+        `_needs_reconcile`, and the sweep at the end of `record()` retries
+        within the same call — so a one-off router blip costs nothing.
+
+        This test originally asserted the weaker guarantee (retry on the NEXT
+        occurrence) and failed because the implementation is better than the
+        expectation.
+        """
+        router = _FlakyRouter(failures=1)
+        sensor = CUExecutionSensor(router=router)
+        await _fail_n(sensor, ces._GRADUATION_THRESHOLD)
+        assert len(router.ingested) == 1, "the transient blip was not retried"
+
+    @pytest.mark.asyncio
+    async def test_a_persistently_failing_router_does_not_spin(self):
+        """The other side of it: retry must be BOUNDED. The re-entry guard
+        means one extra attempt per record, never a loop."""
+        router = _FlakyRouter(failures=10_000)
+        sensor = CUExecutionSensor(router=router)
+        await _fail_n(sensor, ces._GRADUATION_THRESHOLD)
+        assert router.ingested == []
+        assert sensor._reconciling is False       # unwound cleanly
+        assert sensor._needs_reconcile is True    # still eligible
+
+    @pytest.mark.asyncio
+    async def test_a_failed_ingest_never_starts_a_cooldown(self):
+        router = _FlakyRouter(failures=10_000)
+        sensor = CUExecutionSensor(router=router)
+        await _fail_n(sensor, ces._GRADUATION_THRESHOLD)
+        sig = _fail().failure_signature
+        assert sig not in sensor._last_emitted
+
+    def test_attaching_with_no_running_loop_does_not_raise(self):
+        """The lazy half. A sync caller (CLI, test, odd boot order) must not
+        crash, and must leave the flag for `record()` to pick up."""
+        sensor = CUExecutionSensor()
+        sensor._needs_reconcile = False
+        CUExecutionSensor(router=_Router())      # no loop running here
+        assert sensor._needs_reconcile is True
+
+    @pytest.mark.asyncio
+    async def test_the_lazy_path_reconciles_on_the_next_record(self):
+        sensor = CUExecutionSensor()
+        await _fail_n(sensor, ces._GRADUATION_THRESHOLD, app="Messages")
+        # Attach WITHOUT letting the eager task run.
+        sensor._router = _Router()
+        sensor._needs_reconcile = True
+        await sensor.record(_fail(app="Slack"))   # unrelated pattern
+        sigs = {e.evidence["signature"] if hasattr(e, "evidence")
+                else e["evidence"]["signature"] for e in sensor._router.ingested}
+        assert any("messages" in s for s in sigs), (
+            "the pre-boot pattern never reconciled on the lazy path")
+
+    @pytest.mark.asyncio
+    async def test_a_window_entry_with_no_record_is_skipped_not_faked(self):
+        """Pre-upgrade state has timestamps and no record. Emitting would mean
+        describing a pattern we cannot describe."""
+        sensor = CUExecutionSensor()
+        sig = "orphan:target_miss"
+        sensor._failure_window[sig] = [time.time()] * ces._GRADUATION_THRESHOLD
+        sensor._router = _Router()
+        await sensor._reconcile()
+        assert sensor._router.ingested == []
+
+    @pytest.mark.asyncio
+    async def test_successes_never_emit(self):
+        """Unchanged behaviour, pinned: the sensor learns from failure only."""
+        router = _Router()
+        sensor = CUExecutionSensor(router=router)
+        for _ in range(10):
+            await sensor.record(CUExecutionRecord(
+                goal="g", success=True, steps_completed=3, steps_total=3,
+                elapsed_s=1.0))
+        assert router.ingested == []
+        assert sensor.get_stats()["total_records"] == 10
+
+    @pytest.mark.asyncio
+    async def test_stats_expose_the_race(self, ):
+        """§7 — the counter is how you learn the race is happening at all."""
+        sensor = CUExecutionSensor()
+        await _fail_n(sensor, ces._GRADUATION_THRESHOLD)
+        s = sensor.get_stats()
+        assert s["router_attached"] is False
+        assert s["deferred_emissions"] >= 1
+        CUExecutionSensor(router=_Router())
+        await asyncio.sleep(0)
+        s2 = sensor.get_stats()
+        assert s2["router_attached"] is True
+        assert s2["reconciled_emissions"] >= 1


### PR DESCRIPTION
## The race

`main.py`'s HUD dispatch reaches `CUExecutionSensor` through `get_cu_execution_sensor()`, which constructs the singleton with **no router**. `IntakeLayerService` attaches the real one later, in governance boot (`hud_governance_boot` Step 3).

A HUD action failing in that window reached `_emit_envelope`, found `_router is None`, logged *"No router wired"*, and **discarded the emission** — while `_failure_window` kept the very evidence that justified it.

The data was never lost. What was lost is subtler: the emission decision was evaluated **exactly once**, at a moment chosen by a producer with no knowledge of consumer readiness. If the third occurrence of a pattern landed pre-boot and a fourth never came, the signal was gone despite having crossed the threshold — and on a cold start, the first failures are exactly the ones a user notices.

## The fix is not a queue

The rolling window is already the buffer. Making the decision **re-enterable** is the whole repair: one `_maybe_emit`, called from `record()` and again from `_reconcile()` when a router attaches. No second store, no persistence layer, no new subsystem to keep in step with the first.

The only genuinely missing state was `_latest_by_sig` — the window holds *timestamps*, which is enough to **count** a pattern and not enough to **describe** one, and an envelope needs the record. It's pruned in lockstep with the window so it can't leak on an unbounded signature space.

Attaching a router is therefore not a field assignment. It's the moment a decision that could not be made becomes makeable, so the attach reconciles.

## Two paths, because neither may assume the other

- **Eager** — `IntakeLayerService` constructs the sensor inside an async boot, so a loop is running and the sweep starts immediately.
- **Lazy** — no running loop (sync caller, CLI, an ordering we haven't met). A flag is set and the next `record()` sweeps.

Both idempotent, so they need no coordination. Honors Progressive Awakening (§2): nothing blocks boot waiting for a consumer.

## Why this sensor and not `deep_analysis_sensor`

It has the same `router is None` guard and does **not** need this — it polls, so the next tick re-evaluates. `CUExecutionSensor` is event-driven (*"async start() — no-op"*), so a missed evaluation is only retried if the same real-world action fails again. **Polling sensors self-heal; event-driven ones cannot.** Structural boundary, not an arbitrary one.

## Nuances that are easy to get wrong

- Window entries key on `rec.timestamp`, not `now()`. The HUD replays queued events when IPC reconnects (`BrainstemLauncher.pendingEvents`), so a 24h window judged on **arrival** would judge when the socket came back rather than when the action failed.
- `_live_count` prunes during reconcile, so a pattern that crossed the threshold yesterday can't emit today on expired entries.
- A failed ingest does **not** stamp `_last_emitted` — serving a one-hour cooldown for an envelope nobody received is the opposite of the fix. It marks `_needs_reconcile`, so a transient blip retries within the same `record()`, bounded by the re-entry guard.
- A window entry with no paired record is **skipped, never emitted**: describing a pattern we cannot describe would be fabrication.
- The envelope carries `deferred_by_boot` and `age_s`. A late signal that renders identically to a fresh one is the provenance failure this codebase keeps finding.
- `deferred_emissions` / `reconciled_emissions` / `router_attached` join `get_stats()` (§7) — a growing deferred count means governance boot isn't completing at all, which the old warning could never tell you.

## Proven on the real sequence

```
boot     : router_attached = False
pre-boot : emitted=0 deferred=1 pending=True
post-boot: emitted=1 reconciled=1 pending=False
envelope : deferred_by_boot=True → backend/vision/cu_retry_handler.py
```

## Tests

19 new + 5 existing green. One pre-existing test is **superseded, not massaged**: `test_no_router_logs_warning_and_drops` pinned the *defect* as the contract — its own name says `and_drops` — and is now `test_no_router_defers_rather_than_drops`.

One of my new tests also failed on first run because the implementation turned out **better** than the expectation: a transient router error retries within the same `record()` rather than waiting for the next occurrence. The test now asserts the real behaviour, plus a bound proving a persistently-failing router can't spin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pre-boot CU failure signals are now deferred instead of dropped, then emitted when the router attaches. This makes `CUExecutionSensor` reliable during governance boot and cold starts.

- **Bug Fixes**
  - Made emission decision re-enterable via `_maybe_emit`, invoked from `record()` and `_reconcile()` when a router attaches (eager task if a loop is running; lazy flag picked up on next `record()`).
  - Added `_latest_by_sig` to retain the latest record per signature; pruned in `_live_count` with the rolling window to avoid leaks.
  - Windowing now uses `rec.timestamp` (not arrival time) to correctly handle replayed HUD events.
  - Failed ingests no longer start cooldowns; retries are bounded and idempotent, and reconcile skips entries without a paired record.
  - Envelopes include `deferred_by_boot` and `age_s`; `get_stats()` adds `deferred_emissions`, `reconciled_emissions`, `router_attached`, and `pending_reconcile`.

<sup>Written for commit e98e70df65ded00c6b8bf68e9447cc4fbac75257. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

