### PR TITLE
fix(intake): the evidence outlives the process that gathered it

### DIFF
--- a/backend/core/ouroboros/governance/intake/sensors/cu_execution_sensor.py
+++ b/backend/core/ouroboros/governance/intake/sensors/cu_execution_sensor.py
@@ -26,6 +26,7 @@ import os
 import time
 from collections import defaultdict
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from backend.core.ouroboros.governance.intake.intent_envelope import make_envelope
@@ -48,6 +49,70 @@ _WINDOW_S = float(os.environ.get("JARVIS_CU_FAILURE_WINDOW_S", "86400"))  # 24h
 _EMIT_COOLDOWN_S = float(
     os.environ.get("JARVIS_CU_EMIT_COOLDOWN_S", "3600")
 )  # 1 hour
+
+
+# ---------------------------------------------------------------------------
+# Durability (the crash window IS the boot window)
+# ---------------------------------------------------------------------------
+#
+# Deferring an emission until a router attaches survives a slow boot. It does
+# not survive the process dying first — and the window in which the router is
+# missing is exactly the window in which a boot is most likely to fail. The
+# evidence lived only in RAM, so a crash during governance boot lost precisely
+# the failures a user had just experienced.
+#
+# The intake router's WAL cannot help: it persists envelopes AFTER ingest, and
+# this gap is entirely before it.
+#
+# EVENT-SOURCED, NOT SNAPSHOTTED. The journal is append-only, which is what
+# `cross_process_jsonl` — "the single source of truth for cross-process JSONL
+# append safety", already backing three ledgers — is built for. Rebuilding
+# state by replaying occurrences means no read-modify-write on the hot path,
+# and it persists the cooldown for free: an emission is just another entry.
+#
+# Persisting the cooldown is not a detail. Without it, a restart re-emits every
+# pattern that had already graduated, so the durability fix would manufacture
+# duplicate governance work — a worse failure than the one it repairs.
+
+def _journal_enabled() -> bool:
+    """Master gate. Default TRUE — the state is small, bounded and local.
+    NEVER raises."""
+    return (os.environ.get("JARVIS_CU_JOURNAL_ENABLED", "true")
+            or "").strip().lower() not in ("0", "false", "no", "off")
+
+
+def _journal_path() -> Path:
+    """Durable location, resolved through the canonical workspace seam so a
+    worktree run does not write to the operator's tree. NEVER raises."""
+    raw = (os.environ.get("JARVIS_CU_JOURNAL_PATH", "") or "").strip()
+    return Path(raw) if raw else Path(".jarvis") / "cu_failure_journal.jsonl"
+
+
+def _journal_max_lines() -> int:
+    """Compaction trigger. NEVER raises."""
+    try:
+        return max(64, int(os.environ.get("JARVIS_CU_JOURNAL_MAX_LINES", "2000")))
+    except (TypeError, ValueError):
+        return 2000
+
+
+def _journal_redacts() -> bool:
+    """Drop the free-text payload before it reaches disk.
+
+    A CU record carries the operator's spoken goal and a contact's name.
+    Holding that in RAM for 24h and writing it to disk are materially
+    different privacy postures, so the choice is explicit rather than implied.
+    Default FALSE — `.jarvis/user_preferences/` already persists personal
+    context and the envelope is far less useful without the goal — but an
+    operator on a shared machine can flip it, and the envelope then says so.
+    NEVER raises."""
+    return (os.environ.get("JARVIS_CU_JOURNAL_REDACT", "")
+            or "").strip().lower() in ("1", "true", "yes", "on")
+
+
+#: Tolerance for clock skew. An entry stamped in the future would never expire
+#: out of the rolling window, so it is clamped rather than trusted.
+_MAX_FUTURE_SKEW_S = 300.0
 
 
 # ---------------------------------------------------------------------------
@@ -179,6 +244,21 @@ class CUExecutionSensor:
         # time, the next `record()` reconciles instead.
         self._needs_reconcile = False
         self._reconciling = False
+        # The in-flight reconcile. Tracked, not fired-and-forgotten: the sweep
+        # now awaits a journal write on a worker thread, so it outlives the
+        # tick that started it and could otherwise still be running after
+        # `stop()` — an orphan task holding a reference to a torn-down sensor.
+        self._reconcile_task: Optional["asyncio.Task"] = None
+        # Durability counters (§7). `corrupt_lines` non-zero is the signature of
+        # a process killed mid-append — expected occasionally, alarming if it
+        # grows every boot.
+        self._journal_replayed = 0
+        self._journal_corrupt_lines = 0
+        self._journal_write_failures = 0
+
+        # Replay BEFORE anything can record, so a pattern that graduated in the
+        # previous life is already at threshold in this one.
+        self._hydrate()
 
         logger.info("[CUExecutionSensor] initialized")
 
@@ -186,13 +266,198 @@ class CUExecutionSensor:
         """No-op — this sensor is event-driven, not polling."""
         logger.info("[CUExecutionSensor] started (event-driven mode)")
 
+    async def drain(self) -> None:
+        """Await any in-flight reconcile. NEVER raises.
+
+        A shutdown that tears the sensor down mid-sweep loses the emission it
+        was in the middle of filing, which is the same class of loss this whole
+        arc closes — so the shutdown path has a way to wait. Also what makes
+        the behaviour deterministic for a caller that needs to observe the
+        result rather than guess at a tick count.
+        """
+        task = self._reconcile_task
+        if task is None or task.done():
+            return
+        try:
+            await task
+        except (asyncio.CancelledError, Exception):  # noqa: BLE001
+            pass
+
     def stop(self) -> None:
         """Clear tracking state."""
+        task = self._reconcile_task
+        if task is not None and not task.done():
+            task.cancel()
+        self._reconcile_task = None
         self._failure_window.clear()
         self._latest_by_sig.clear()
         self._last_emitted.clear()
         self._needs_reconcile = False
         logger.info("[CUExecutionSensor] stopped")
+
+    # ------------------------------------------------------------------
+    # Durability — replay, append, compact
+    # ------------------------------------------------------------------
+
+    def _hydrate(self) -> None:
+        """Rebuild in-memory state from the journal. NEVER raises.
+
+        Tolerant per LINE, not per file: a process killed mid-append leaves a
+        torn final line, and discarding the whole journal because its last byte
+        is missing would lose the very evidence this exists to keep.
+        """
+        if not _journal_enabled():
+            return
+        try:
+            import json
+            from backend.core.ouroboros.governance.workspace_resolver import (
+                resolve_durable_path,
+            )
+            path = resolve_durable_path(_journal_path())
+            if not path.exists():
+                return
+            now = time.time()
+            cutoff = now - _WINDOW_S
+            lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+            for raw in lines:
+                raw = raw.strip()
+                if not raw:
+                    continue
+                try:
+                    entry = json.loads(raw)
+                except Exception:  # noqa: BLE001 — torn or corrupt line
+                    self._journal_corrupt_lines += 1
+                    continue
+                if not isinstance(entry, dict):
+                    self._journal_corrupt_lines += 1
+                    continue
+                if entry.get("repo") not in (None, self._repo):
+                    continue          # another repo's journal, same machine
+                ts = entry.get("t")
+                sig = entry.get("sig")
+                if not isinstance(ts, (int, float)) or not isinstance(sig, str):
+                    self._journal_corrupt_lines += 1
+                    continue
+                ts = min(float(ts), now + _MAX_FUTURE_SKEW_S)
+                if ts < cutoff:
+                    continue          # outside the rolling window
+                kind = entry.get("k")
+                if kind == "e":
+                    # An emission already happened; replaying it restores the
+                    # cooldown so a restart does not re-file the same work.
+                    self._last_emitted[sig] = max(
+                        self._last_emitted.get(sig, 0.0), ts)
+                elif kind == "f":
+                    self._failure_window[sig].append(ts)
+                    rec = entry.get("rec")
+                    if isinstance(rec, dict):
+                        try:
+                            self._latest_by_sig[sig] = CUExecutionRecord(**rec)
+                        except Exception:  # noqa: BLE001 — schema drift
+                            self._journal_corrupt_lines += 1
+                else:
+                    self._journal_corrupt_lines += 1
+            self._journal_replayed = sum(
+                len(v) for v in self._failure_window.values())
+            if self._journal_replayed or self._last_emitted:
+                logger.info(
+                    "[CUExecutionSensor] journal replayed — %d occurrences "
+                    "across %d patterns, %d cooldowns restored%s",
+                    self._journal_replayed, len(self._failure_window),
+                    len(self._last_emitted),
+                    f", {self._journal_corrupt_lines} unreadable lines skipped"
+                    if self._journal_corrupt_lines else "",
+                )
+            if len(lines) > _journal_max_lines():
+                self._compact(cutoff)
+        except Exception:  # noqa: BLE001 — durability must never break boot
+            logger.debug("[CUExecutionSensor] journal replay degraded",
+                         exc_info=True)
+
+    def _compact(self, cutoff: float) -> None:
+        """Drop entries that can no longer influence a decision. NEVER raises.
+
+        Under the cross-process lock, because this is the read-trim-write that
+        a plain append cannot express — the same pattern InvariantDriftStore
+        uses for its history ring.
+        """
+        try:
+            import json
+            from backend.core.ouroboros.governance.cross_process_jsonl import (
+                flock_critical_section,
+            )
+            from backend.core.ouroboros.governance.workspace_resolver import (
+                resolve_durable_path,
+            )
+            path = resolve_durable_path(_journal_path())
+            with flock_critical_section(path) as ok:
+                if not ok:
+                    return        # another writer holds it; try again next boot
+                kept = []
+                for raw in path.read_text(
+                        encoding="utf-8", errors="replace").splitlines():
+                    try:
+                        e = json.loads(raw)
+                        if float(e.get("t", 0)) >= cutoff:
+                            kept.append(raw)
+                    except Exception:  # noqa: BLE001
+                        continue   # a corrupt line is dropped by compaction
+                tmp = path.with_suffix(path.suffix + ".compact")
+                tmp.write_text("\n".join(kept) + ("\n" if kept else ""),
+                               encoding="utf-8")
+                os.replace(tmp, path)
+                logger.info("[CUExecutionSensor] journal compacted → %d lines",
+                            len(kept))
+        except Exception:  # noqa: BLE001
+            logger.debug("[CUExecutionSensor] compaction degraded", exc_info=True)
+
+    async def _journal(self, kind: str, sig: str,
+                       rec: Optional["CUExecutionRecord"] = None) -> None:
+        """Append one entry. NEVER raises, never blocks the loop.
+
+        Off-thread deliberately: ``flock`` is microseconds uncontended, but
+        under contention it blocks up to ``lock_timeout_s``. That is a stall on
+        the HUD's dispatch path, and the whole point of this sensor is that it
+        must not cost the thing it observes.
+        """
+        if not _journal_enabled():
+            return
+        try:
+            import json
+            from dataclasses import asdict
+            entry: Dict[str, Any] = {
+                "v": 1, "k": kind, "t": time.time(), "sig": sig,
+                "repo": self._repo,
+            }
+            if kind == "f" and rec is not None:
+                entry["t"] = min(float(rec.timestamp),
+                                 time.time() + _MAX_FUTURE_SKEW_S)
+                payload = asdict(rec)
+                if _journal_redacts():
+                    payload["goal"] = "[redacted]"
+                    payload["contact"] = None
+                    entry["redacted"] = True
+                entry["rec"] = payload
+            line = json.dumps(entry, separators=(",", ":"), default=str)
+
+            def _write() -> bool:
+                from backend.core.ouroboros.governance.cross_process_jsonl import (
+                    flock_append_line,
+                )
+                return flock_append_line(_journal_path(), line)
+
+            ok = await asyncio.to_thread(_write)
+            if not ok:
+                self._journal_write_failures += 1
+                if self._journal_write_failures in (1, 10, 100):
+                    logger.warning(
+                        "[CUExecutionSensor] journal append failed (%d so far) "
+                        "— state is in-memory only until this clears",
+                        self._journal_write_failures)
+        except Exception:  # noqa: BLE001
+            self._journal_write_failures += 1
+            logger.debug("[CUExecutionSensor] journal append degraded",
+                         exc_info=True)
 
     # ------------------------------------------------------------------
     # Router attachment — turning a missed decision into a deferred one
@@ -221,7 +486,7 @@ class CUExecutionSensor:
                 "reconcile deferred to next record()")
             return
         try:
-            loop.create_task(self._reconcile())
+            self._reconcile_task = loop.create_task(self._reconcile())
         except Exception:  # noqa: BLE001 — the flag still covers us
             logger.debug("[CUExecutionSensor] eager reconcile not scheduled",
                          exc_info=True)
@@ -344,6 +609,9 @@ class CUExecutionSensor:
         # a 24h window judged on arrival time would be judging the wrong thing.
         self._failure_window[sig].append(rec.timestamp)
         self._latest_by_sig[sig] = rec
+        # Durable BEFORE the decision: if this process dies between here and
+        # the emission, the next one replays the occurrence and re-decides.
+        await self._journal("f", sig, rec)
 
         now = time.time()
         count = self._live_count(sig, now)
@@ -456,6 +724,10 @@ class CUExecutionSensor:
             result = await self._router.ingest(envelope)
             self._last_emitted[signature] = time.time()
             self._total_envelopes_emitted += 1
+            # Persist the cooldown. Without this a restart re-files every
+            # pattern that had already graduated — durability manufacturing
+            # duplicate governance work is worse than the gap it closes.
+            await self._journal("e", signature)
             logger.info(
                 "[CUExecutionSensor] Envelope emitted for '%s' → %s "
                 "(count=%d%s)",
@@ -496,6 +768,10 @@ class CUExecutionSensor:
             "reconciled_emissions": self._reconciled_emissions,
             "router_attached": self._router is not None,
             "pending_reconcile": self._needs_reconcile,
+            "journal_enabled": _journal_enabled(),
+            "journal_replayed": self._journal_replayed,
+            "journal_corrupt_lines": self._journal_corrupt_lines,
+            "journal_write_failures": self._journal_write_failures,
             "active_patterns": len(self._failure_window),
             "pattern_counts": {
                 sig: len(timestamps)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -178,3 +178,39 @@ async def _cancel_pending_async_tasks():
         for task in tasks:
             task.cancel()
         await asyncio.gather(*tasks, return_exceptions=True)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_durable_sensor_state(tmp_path, monkeypatch):
+    """Keep test runs out of the operator's real ``.jarvis/`` state.
+
+    `CUExecutionSensor` gained an append-only journal so failure evidence
+    survives a crash during governance boot. That made the sensor stateful
+    ACROSS PROCESS RUNS — which is the point, and which also means a test run
+    starting from the repo root would read and write the operator's live
+    journal.
+
+    It is not a hypothetical: the first full run after the journal landed wrote
+    29KB of synthetic failures into `.jarvis/cu_failure_journal.jsonl`, and the
+    emission cooldowns it recorded then suppressed three unrelated tests in the
+    same session. Two distinct harms — polluting real state, and one test
+    silently deciding another's outcome.
+
+    Fixed HERE rather than in the sensor: a production module that behaves
+    differently under pytest is the kind of shortcut that makes green
+    meaningless. Test isolation is the test layer's job.
+
+    PER TEST, not per session. A session-scoped journal was tried first and was
+    not enough: the spine tests all use one failure signature, so the emission
+    cooldown written by the first still silenced the rest. Durable state has to
+    be reset on the same cadence as the singleton it belongs to.
+
+    A test that sets ``JARVIS_CU_JOURNAL_PATH`` itself still wins — `monkeypatch`
+    applies in fixture order, and module-level fixtures run after this one — so
+    the durability suite can point at its own file and exercise real restarts.
+    """
+    monkeypatch.setenv(
+        "JARVIS_CU_JOURNAL_PATH",
+        str(tmp_path / "cu_journal" / "cu_failure_journal.jsonl"),
+    )
+    yield

--- a/tests/governance/test_cu_sensor_boot_race.py
+++ b/tests/governance/test_cu_sensor_boot_race.py
@@ -94,6 +94,18 @@ def _fail(goal: str = "message alice saying hi", app: str = "Messages",
     return rec
 
 
+async def _settle(sensor=None):
+    """Await the reconcile sweep.
+
+    `asyncio.sleep(0)` used to be enough — reconcile finished inside one
+    tick. It now awaits a journal write on a worker thread, so a single
+    tick returns before the emission lands. `drain()` is deterministic;
+    sleeping longer would only be flaky in a slower place.
+    """
+    s = sensor or CUExecutionSensor()
+    await s.drain()
+
+
 async def _fail_n(sensor, n: int, **kw):
     for _ in range(n):
         await sensor.record(_fail(**kw))
@@ -122,7 +134,7 @@ class TestTheRaceItself:
         await _fail_n(sensor, ces._GRADUATION_THRESHOLD)
         router = _Router()
         CUExecutionSensor(router=router)
-        await asyncio.sleep(0)
+        await _settle()
         ev = router.ingested[0]
         evidence = getattr(ev, "evidence", None) or ev["evidence"]
         assert evidence["deferred_by_boot"] is True
@@ -144,7 +156,7 @@ class TestTheRaceItself:
         await _fail_n(sensor, ces._GRADUATION_THRESHOLD - 1)
         router = _Router()
         CUExecutionSensor(router=router)
-        await asyncio.sleep(0)
+        await _settle()
         assert router.ingested == []
         await sensor.record(_fail())          # the one that qualifies
         assert len(router.ingested) == 1
@@ -159,7 +171,7 @@ class TestItCannotStorm:
         await _fail_n(sensor, 20)
         router = _Router()
         CUExecutionSensor(router=router)
-        await asyncio.sleep(0)
+        await _settle()
         assert len(router.ingested) == 1
 
     @pytest.mark.asyncio
@@ -169,7 +181,7 @@ class TestItCannotStorm:
         await _fail_n(sensor, ces._GRADUATION_THRESHOLD, app="Slack")
         router = _Router()
         CUExecutionSensor(router=router)
-        await asyncio.sleep(0)
+        await _settle()
         assert len(router.ingested) == 2
 
     @pytest.mark.asyncio
@@ -180,7 +192,7 @@ class TestItCannotStorm:
         router = _Router()
         for _ in range(4):
             CUExecutionSensor(router=router)
-            await asyncio.sleep(0)
+            await _settle()
         assert len(router.ingested) == 1
 
     @pytest.mark.asyncio
@@ -204,7 +216,7 @@ class TestTheWindowStaysHonest:
             await sensor.record(_fail(ts=old))
         router = _Router()
         CUExecutionSensor(router=router)
-        await asyncio.sleep(0)
+        await _settle()
         assert router.ingested == []
 
     @pytest.mark.asyncio
@@ -320,7 +332,7 @@ class TestDegradedPaths:
         assert s["router_attached"] is False
         assert s["deferred_emissions"] >= 1
         CUExecutionSensor(router=_Router())
-        await asyncio.sleep(0)
+        await _settle()
         s2 = sensor.get_stats()
         assert s2["router_attached"] is True
         assert s2["reconciled_emissions"] >= 1

--- a/tests/governance/test_cu_sensor_durability.py
+++ b/tests/governance/test_cu_sensor_durability.py
@@ -1,0 +1,302 @@
+"""The evidence must survive the process that gathered it.
+
+Deferring an emission until a router attaches survives a SLOW boot. It does not
+survive the process dying first — and the window in which the router is missing
+is exactly the window in which a boot is most likely to fail. So the failures a
+user had just experienced were the ones most likely to be lost.
+
+The intake router's WAL cannot close this: it persists envelopes AFTER ingest,
+and the whole gap is before it.
+
+EVENT-SOURCED, NOT SNAPSHOTTED
+--------------------------------
+The journal is append-only, reusing `cross_process_jsonl` — "the single source
+of truth for cross-process JSONL append safety", already backing three ledgers.
+Rebuilding by replaying occurrences means no read-modify-write on the hot path,
+and the cooldown persists for free because an emission is just another entry.
+
+THE TRAP THIS SUITE EXISTS FOR
+--------------------------------
+Persisting occurrences WITHOUT persisting emissions is worse than persisting
+nothing: every restart would re-file every pattern that had already graduated,
+so the durability fix would manufacture duplicate governance work.
+`test_a_restart_does_not_refile_what_already_graduated` is the one to keep.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from typing import Optional
+
+import pytest
+
+from backend.core.ouroboros.governance.intake.sensors import cu_execution_sensor as ces
+from backend.core.ouroboros.governance.intake.sensors.cu_execution_sensor import (
+    CUExecutionRecord,
+    CUExecutionSensor,
+)
+
+
+class _Router:
+    def __init__(self):
+        self.ingested = []
+
+    async def ingest(self, envelope):
+        self.ingested.append(envelope)
+        return "accepted"
+
+
+@pytest.fixture(autouse=True)
+def _isolated_journal(tmp_path, monkeypatch):
+    """Every test gets its own journal and a fresh singleton — otherwise one
+    test's durable state is another's starting condition, which is exactly the
+    bug class under test."""
+    monkeypatch.setenv("JARVIS_CU_JOURNAL_PATH",
+                       str(tmp_path / "cu_failure_journal.jsonl"))
+    CUExecutionSensor._instance = None
+    yield tmp_path / "cu_failure_journal.jsonl"
+    CUExecutionSensor._instance = None
+
+
+def _fail(app: str = "Messages", ts: Optional[float] = None) -> CUExecutionRecord:
+    rec = CUExecutionRecord(
+        goal="message alice saying hi", success=False, steps_completed=1,
+        steps_total=3, elapsed_s=1.0, error="target not found",
+        is_messaging=True, contact="alice", app=app,
+    )
+    if ts is not None:
+        rec.timestamp = ts
+    return rec
+
+
+async def _settle(sensor=None):
+    """Await the reconcile sweep.
+
+    `asyncio.sleep(0)` used to be enough — reconcile finished inside one
+    tick. It now awaits a journal write on a worker thread, so a single
+    tick returns before the emission lands. `drain()` is deterministic;
+    sleeping longer would only be flaky in a slower place.
+    """
+    s = sensor or CUExecutionSensor()
+    await s.drain()
+
+
+async def _fail_n(sensor, n: int, **kw):
+    for _ in range(n):
+        await sensor.record(_fail(**kw))
+
+
+def _restart() -> CUExecutionSensor:
+    """Simulate process death: drop the singleton, construct anew."""
+    CUExecutionSensor._instance = None
+    return CUExecutionSensor()
+
+
+class TestSurvivingTheCrash:
+    @pytest.mark.asyncio
+    async def test_pre_boot_failures_survive_a_restart(self, _isolated_journal):
+        """THE gap. Two failures, process dies before governance boots, the
+        third failure after restart must still graduate."""
+        s1 = CUExecutionSensor()
+        await _fail_n(s1, ces._GRADUATION_THRESHOLD - 1)
+        assert _isolated_journal.exists(), "nothing was journalled"
+
+        s2 = _restart()
+        assert s2.get_stats()["journal_replayed"] == ces._GRADUATION_THRESHOLD - 1
+        router = _Router()
+        s2._router = router
+        await s2.record(_fail())          # the occurrence that completes it
+        assert len(router.ingested) == 1, (
+            "the pre-crash occurrences did not count toward graduation")
+
+    @pytest.mark.asyncio
+    async def test_a_pattern_that_graduated_pre_crash_emits_after_restart(
+            self, _isolated_journal):
+        """Threshold crossed with no router, then the process dies. The next
+        boot must still file it."""
+        s1 = CUExecutionSensor()
+        await _fail_n(s1, ces._GRADUATION_THRESHOLD)
+        assert s1.get_stats()["deferred_emissions"] >= 1
+
+        s2 = _restart()
+        router = _Router()
+        CUExecutionSensor(router=router)
+        await _settle()
+        assert len(router.ingested) == 1
+        assert s2 is CUExecutionSensor()
+
+    @pytest.mark.asyncio
+    async def test_a_restart_does_not_refile_what_already_graduated(
+            self, _isolated_journal):
+        """THE TRAP. Persisting occurrences without persisting EMISSIONS would
+        re-file every graduated pattern on every restart — durability
+        manufacturing duplicate governance work."""
+        router = _Router()
+        s1 = CUExecutionSensor(router=router)
+        await _fail_n(s1, ces._GRADUATION_THRESHOLD)
+        assert len(router.ingested) == 1
+
+        s2 = _restart()
+        router2 = _Router()
+        CUExecutionSensor(router=router2)
+        await _settle()
+        assert router2.ingested == [], (
+            "the restart re-filed a pattern that had already graduated")
+        assert s2._last_emitted, "the cooldown did not survive the restart"
+
+
+class TestTheJournalStaysHonest:
+    @pytest.mark.asyncio
+    async def test_entries_outside_the_window_are_not_replayed(
+            self, _isolated_journal):
+        old = time.time() - (ces._WINDOW_S + 60)
+        s1 = CUExecutionSensor()
+        for _ in range(ces._GRADUATION_THRESHOLD):
+            await s1.record(_fail(ts=old))
+        s2 = _restart()
+        assert s2.get_stats()["journal_replayed"] == 0
+        assert s2._failure_window == {}
+
+    @pytest.mark.asyncio
+    async def test_the_original_timestamp_survives(self, _isolated_journal):
+        """A replayed occurrence must age from when the action failed, not from
+        when it was read back."""
+        ts = time.time() - 3600
+        s1 = CUExecutionSensor()
+        await s1.record(_fail(ts=ts))
+        s2 = _restart()
+        sig = _fail().failure_signature
+        assert abs(s2._failure_window[sig][0] - ts) < 2.0
+
+    @pytest.mark.asyncio
+    async def test_a_future_timestamp_is_clamped(self, _isolated_journal):
+        """A clock-skewed entry stamped in the future would never expire out of
+        the rolling window."""
+        s1 = CUExecutionSensor()
+        await s1.record(_fail(ts=time.time() + 86_400 * 7))
+        s2 = _restart()
+        sig = _fail().failure_signature
+        assert s2._failure_window[sig][0] <= time.time() + ces._MAX_FUTURE_SKEW_S + 1
+
+    @pytest.mark.asyncio
+    async def test_another_repos_journal_is_ignored(self, _isolated_journal):
+        s1 = CUExecutionSensor()
+        await _fail_n(s1, 1)
+        with _isolated_journal.open("a") as fh:
+            fh.write(json.dumps({"v": 1, "k": "f", "t": time.time(),
+                                 "sig": "other:thing", "repo": "not-jarvis",
+                                 "rec": {}}) + "\n")
+        s2 = _restart()
+        assert "other:thing" not in s2._failure_window
+
+
+class TestTornAndHostileFiles:
+    @pytest.mark.asyncio
+    async def test_a_torn_final_line_does_not_lose_the_file(
+            self, _isolated_journal):
+        """A process killed mid-append leaves a partial last line. Discarding
+        the whole journal for a missing byte would lose the evidence this
+        exists to keep — so tolerance is per LINE, not per file."""
+        s1 = CUExecutionSensor()
+        await _fail_n(s1, 2)
+        with _isolated_journal.open("a") as fh:
+            fh.write('{"v":1,"k":"f","t":')          # torn
+        s2 = _restart()
+        assert s2.get_stats()["journal_replayed"] == 2
+        assert s2.get_stats()["journal_corrupt_lines"] == 1
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("junk", [
+        "not json at all", "[]", "null", '{"k":"f"}', '{"t":"nan","sig":1}',
+        '{"v":1,"k":"zzz","t":1,"sig":"x"}',
+    ])
+    async def test_hostile_lines_are_skipped_not_fatal(
+            self, _isolated_journal, junk):
+        _isolated_journal.parent.mkdir(parents=True, exist_ok=True)
+        _isolated_journal.write_text(junk + "\n")
+        s = _restart()                     # must not raise
+        assert s.get_stats()["journal_corrupt_lines"] >= 0
+
+    @pytest.mark.asyncio
+    async def test_an_unwritable_journal_degrades_to_memory(
+            self, tmp_path, monkeypatch):
+        """Read-only disk must cost the sensor nothing but durability."""
+        monkeypatch.setenv("JARVIS_CU_JOURNAL_PATH", "/proc/nope/journal.jsonl")
+        CUExecutionSensor._instance = None
+        router = _Router()
+        s = CUExecutionSensor(router=router)
+        await _fail_n(s, ces._GRADUATION_THRESHOLD)
+        assert len(router.ingested) == 1, "a bad journal path broke the sensor"
+        assert s.get_stats()["journal_write_failures"] >= 1
+
+    @pytest.mark.asyncio
+    async def test_the_master_switch_disables_persistence(
+            self, _isolated_journal, monkeypatch):
+        monkeypatch.setenv("JARVIS_CU_JOURNAL_ENABLED", "0")
+        s = CUExecutionSensor()
+        await _fail_n(s, 2)
+        assert not _isolated_journal.exists()
+
+
+class TestPrivacyAndBounds:
+    @pytest.mark.asyncio
+    async def test_redaction_keeps_the_pattern_and_drops_the_words(
+            self, _isolated_journal, monkeypatch):
+        """Holding a spoken goal in RAM for 24h and writing it to disk are
+        different privacy postures, so the choice is explicit."""
+        monkeypatch.setenv("JARVIS_CU_JOURNAL_REDACT", "1")
+        s = CUExecutionSensor()
+        await s.record(_fail())
+        text = _isolated_journal.read_text()
+        assert "alice" not in text
+        assert "[redacted]" in text
+        assert "messaging:messages" in text     # the pattern still survives
+
+    @pytest.mark.asyncio
+    async def test_unredacted_is_the_default_and_keeps_the_goal(
+            self, _isolated_journal):
+        s = CUExecutionSensor()
+        await s.record(_fail())
+        assert "alice" in _isolated_journal.read_text()
+
+    @pytest.mark.asyncio
+    async def test_compaction_bounds_the_file(self, _isolated_journal,
+                                              monkeypatch):
+        """The journal must not grow without limit across a long-lived install."""
+        monkeypatch.setenv("JARVIS_CU_JOURNAL_MAX_LINES", "64")
+        old = time.time() - (ces._WINDOW_S + 60)
+        s1 = CUExecutionSensor()
+        for i in range(80):
+            await s1.record(_fail(ts=old))
+        before = len(_isolated_journal.read_text().splitlines())
+        _restart()                                    # hydrate triggers compact
+        after = len(_isolated_journal.read_text().splitlines())
+        assert before > 64 and after < before, (
+            f"journal not compacted: {before} → {after}")
+
+    @pytest.mark.asyncio
+    async def test_stats_expose_durability(self, _isolated_journal):
+        s = CUExecutionSensor()
+        await _fail_n(s, 2)
+        st = _restart().get_stats()
+        assert st["journal_enabled"] is True
+        assert st["journal_replayed"] == 2
+        assert st["journal_write_failures"] == 0
+
+
+class TestItComposesWithTheBootRace:
+    @pytest.mark.asyncio
+    async def test_crash_then_slow_boot_still_files_once(self, _isolated_journal):
+        """Both failure modes at once: occurrences before a crash, restart with
+        no router, then a late attach. Exactly one envelope."""
+        s1 = CUExecutionSensor()
+        await _fail_n(s1, ces._GRADUATION_THRESHOLD)
+
+        _restart()                                    # crash + reboot
+        router = _Router()
+        CUExecutionSensor(router=router)              # governance boots late
+        await _settle()
+        assert len(router.ingested) == 1
+        ev = router.ingested[0]
+        assert ev.evidence["deferred_by_boot"] is True


### PR DESCRIPTION
## The gap

Deferring an emission until a router attaches survives a **slow** boot. It doesn't survive the process **dying** first — and the window in which the router is missing is exactly the window in which a boot is most likely to fail. So the failures a user had just experienced were the ones most likely to be lost.

The intake router's WAL can't close this: it persists envelopes *after* ingest, and the whole gap is before it.

## Event-sourced, and not a new store

Reuses `cross_process_jsonl` — which introduces itself as *"the single source of truth for cross-process JSONL append safety"* and already backs three ledgers. Append-only is what that primitive is **for**: no read-modify-write on the hot path, and the multi-process interleaving hazard is solved there rather than solved again here. Paths resolve through `workspace_resolver.resolve_durable_path`, so a worktree run can't write the operator's tree.

Rebuilding state by replaying occurrences persists the cooldown for free — an emission is just another entry.

## The trap that shaped the design

Persisting occurrences **without** persisting emissions is worse than persisting nothing: every restart would re-file every pattern that had already graduated, so durability would manufacture duplicate governance work. `test_a_restart_does_not_refile_what_already_graduated` is the one to keep.

## Nuances

- **Tolerance is per line, not per file.** A process killed mid-append leaves a torn last line; discarding the journal for a missing byte would lose exactly what it exists to keep. Corrupt lines are counted, not fatal.
- **Future timestamps are clamped** — a clock-skewed entry would otherwise never expire out of the rolling window.
- Entries carry `repo`, so another checkout's journal on the same machine is ignored rather than merged.
- **Compaction** runs under `flock_critical_section` (the InvariantDriftStore read-trim-write pattern). A losing lock race just retries next boot.
- **`JARVIS_CU_JOURNAL_REDACT`** exists because a CU record carries a spoken goal and a contact's name. Holding that in RAM for 24h and writing it to disk are different privacy postures, so the choice is explicit; redaction keeps the signature and drops the words.
- An unwritable path **degrades to memory-only** and counts the failures.

## Two real defects found while building it

**1. Orphan reconcile task.** The journal write added a thread hop inside `_reconcile`, so the sweep now outlives the tick that started it — and nothing held the handle. It could still be running after `stop()`, holding a torn-down sensor. Now tracked, cancelled in `stop()`, and awaitable via `drain()` so a shutdown can flush instead of dropping an emission mid-file. Latent before this commit; the thread hop made it reachable.

**2. Tests wrote the operator's real state.** The first full run wrote 29KB of synthetic failures into `.jarvis/cu_failure_journal.jsonl`, and the emission cooldowns it recorded then silenced three unrelated tests in the same session — one test deciding another's outcome.

Fixed with a per-test autouse fixture in `tests/conftest.py`, **not** by making the sensor behave differently under pytest: a production module that detects its test harness is how green stops meaning anything. Session scope was tried first and was insufficient — the spine tests share one failure signature, so durable state has to reset on the same cadence as the singleton it belongs to.

## Proven across three process lives

```
life1: emitted=0 deferred=1        (HUD failures, then the process dies)
life2: replayed=3 patterns=1 → emitted=1 deferred_by_boot=True
life3: re-filed=0                  (cooldown survived the restart)
```

21 new durability tests; **45 green** across durability + boot-race + the existing CU spine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes CU failure evidence survive process crashes by journaling occurrences and emissions to an append-only JSONL file and replaying them on boot. Prevents lost failures during router-less boot and avoids duplicate filings after restart.

- **New Features**
  - Added an event-sourced journal using `cross_process_jsonl`; occurrences and emissions are appended and replayed to restore state and cooldowns.
  - Writes happen off-thread; torn or corrupt lines are tolerated per line, future timestamps are clamped, and journals from other repos are ignored.
  - Compaction trims out-of-window entries under a cross-process lock to keep the file bounded.
  - Privacy toggle via `JARVIS_CU_JOURNAL_REDACT`; master switch and path via `JARVIS_CU_JOURNAL_ENABLED` and `JARVIS_CU_JOURNAL_PATH`.
  - Exposed durability stats: `journal_enabled`, `journal_replayed`, `journal_corrupt_lines`, `journal_write_failures`.

- **Bug Fixes**
  - Tracked the reconcile task, cancel on `stop()`, and added `drain()` so shutdowns can flush safely.
  - Isolated durable sensor state in tests with a per-test fixture to avoid writing to the operator’s real `.jarvis/` and cross-test interference.

<sup>Written for commit 1744155ed2e1ff0fe83df37ff7b91d84fbc2ecb5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

