### PR TITLE
feat(coordination): say which mutual exclusion a path can actually provide

### DIFF
--- a/backend/core/ouroboros/governance/coordination_substrate.py
+++ b/backend/core/ouroboros/governance/coordination_substrate.py
@@ -1,0 +1,242 @@
+"""What mutual-exclusion guarantee can this path actually provide?
+
+`cross_process_jsonl` is careful about POSIX vs Windows and says nothing about
+the filesystem underneath — reasonably, because it was written for one host.
+But ``fcntl.flock`` is a HOST-LOCAL primitive. Two machines sharing a checkout
+over NFS each take the lock successfully, each believe they hold it, and both
+proceed. The failure is silent on both sides: no error, no timeout, just two
+processes in a critical section that promised to hold one.
+
+The honest response is not to pretend a distributed lock exists. It is to
+answer, per path, WHICH guarantee is available, and to say so when the answer
+is "less than you think":
+
+    CROSS_HOST   a distributed backend answered — real mutual exclusion
+    HOST_LOCAL   flock on a filesystem we VERIFIED is local — correct here
+    UNVERIFIED   flock, and we could not determine the filesystem
+    UNSAFE       flock on a filesystem we VERIFIED is shared, with no
+                 distributed backend — the guarantee does not hold
+
+`UNVERIFIED` is deliberately distinct from `HOST_LOCAL`, and neither warns.
+Most installs are a laptop, and a module that cried "possible split-brain!" on
+every ordinary machine would train its operator to ignore the one time it
+mattered. Silence and verified-safe are different facts, so they are different
+values — the same rule that made `waived()` distinct from an omitted argument
+and `UNKNOWN` distinct from `UNSET`.
+
+REUSE
+-------
+Nothing here implements locking. `cross_process_jsonl` owns the file lock and
+`core.distributed_lock_manager` (v3.0 — Redis backend, fencing tokens, lease
+keepalive, "works across VMs, GCP instances, Docker") owns the distributed one.
+This module only decides WHICH to ask, and reports what it asked.
+
+Escalation is adaptive rather than configured: the distributed manager is used
+when the substrate needs it and it is actually reachable. Imposing Redis on a
+single laptop would buy nothing and add a dependency that can be down.
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import enum
+import logging
+import os
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import AsyncIterator, Optional, Tuple
+
+logger = logging.getLogger("Ouroboros.CoordinationSubstrate")
+
+COORDINATION_SCHEMA_VERSION: str = "coordination_substrate.v1"
+
+#: Filesystems where a host-local lock says nothing about another host.
+#: Extended (never replaced) by `JARVIS_COORDINATION_SHARED_FSTYPES` so a site
+#: with an exotic clustered filesystem does not need a code change.
+_SHARED_FSTYPES = frozenset({
+    "nfs", "nfs3", "nfs4", "cifs", "smb", "smbfs", "smb2", "afs", "afpfs",
+    "glusterfs", "ceph", "cephfs", "lustre", "gpfs", "ocfs2", "gfs2",
+    "beegfs", "fuse.sshfs", "fuse.s3fs", "fuse.gcsfuse", "fuse.rclone",
+    "davfs", "webdav", "9p", "virtiofs",
+})
+
+
+class Guarantee(str, enum.Enum):
+    """What mutual exclusion is actually available for a path."""
+
+    CROSS_HOST = "cross_host"
+    HOST_LOCAL = "host_local"
+    UNVERIFIED = "unverified"
+    UNSAFE = "unsafe"
+
+    @property
+    def is_sufficient(self) -> bool:
+        """True when the guarantee covers every writer that could exist.
+
+        `UNVERIFIED` counts: it is the ordinary laptop case, where flock is
+        correct and we simply could not read the mount table. Treating "did not
+        check" as "unsafe" would make the honest signal worthless.
+        """
+        return self in (Guarantee.CROSS_HOST, Guarantee.HOST_LOCAL,
+                        Guarantee.UNVERIFIED)
+
+
+@dataclass(frozen=True)
+class SubstrateReading:
+    """What we learned about a path. Frozen — safe to share and to stamp."""
+
+    guarantee: Guarantee
+    fstype: str = ""
+    mountpoint: str = ""
+    detail: str = ""
+    schema_version: str = COORDINATION_SCHEMA_VERSION
+
+    def as_evidence(self) -> dict:
+        """Splattable into telemetry — the provenance of a coordinated decision."""
+        return {
+            "coordination": self.guarantee.value,
+            "coordination_fstype": self.fstype or "unknown",
+            "coordination_verified": self.guarantee is not Guarantee.UNVERIFIED,
+        }
+
+
+def shared_fstypes() -> frozenset:
+    """The shared-filesystem set, EXTENDED by env. NEVER raises."""
+    try:
+        raw = (os.environ.get("JARVIS_COORDINATION_SHARED_FSTYPES", "") or "").strip()
+        extra = {p.strip().lower() for p in raw.split(",") if p.strip()}
+        return frozenset(_SHARED_FSTYPES | extra)
+    except Exception:  # noqa: BLE001
+        return _SHARED_FSTYPES
+
+
+def _mount_for(path: Path) -> Tuple[str, str]:
+    """(mountpoint, fstype) for *path* — longest matching mount. NEVER raises.
+
+    Walks up to an existing ancestor first: the journal may not exist yet, and
+    a path that does not exist has no mount of its own.
+    """
+    try:
+        target = path.resolve()
+        while not target.exists() and target.parent != target:
+            target = target.parent
+        resolved = str(target)
+        import psutil
+        best = ("", "")
+        for part in psutil.disk_partitions(all=True):
+            mp = part.mountpoint
+            if resolved == mp or resolved.startswith(
+                    mp if mp.endswith(os.sep) else mp + os.sep):
+                if len(mp) > len(best[0]):
+                    best = (mp, (part.fstype or "").lower())
+        return best
+    except Exception:  # noqa: BLE001 — psutil missing, /proc unreadable, sandbox
+        return ("", "")
+
+
+def _distributed_reachable() -> bool:
+    """Is a real cross-host backend answering right now? NEVER raises.
+
+    Asks the existing manager rather than re-deriving Redis configuration:
+    two opinions about whether the backend is up would be one opinion too many.
+    """
+    try:
+        from backend.core.distributed_lock_manager import get_lock_manager
+        import asyncio
+        loop = asyncio.get_running_loop()  # noqa: F841 — presence check only
+        mgr = getattr(get_lock_manager, "_cached_manager", None)
+        if mgr is None:
+            return False
+        return bool(getattr(mgr, "_redis_available", False))
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def probe(path: Path) -> SubstrateReading:
+    """What guarantee can *path* support? NEVER raises."""
+    try:
+        mountpoint, fstype = _mount_for(Path(path))
+        if not fstype:
+            return SubstrateReading(
+                Guarantee.UNVERIFIED, mountpoint=mountpoint,
+                detail="mount table unreadable")
+        if fstype not in shared_fstypes():
+            return SubstrateReading(Guarantee.HOST_LOCAL, fstype=fstype,
+                                    mountpoint=mountpoint,
+                                    detail="local filesystem")
+        if _distributed_reachable():
+            return SubstrateReading(Guarantee.CROSS_HOST, fstype=fstype,
+                                    mountpoint=mountpoint,
+                                    detail="shared filesystem, distributed lock")
+        return SubstrateReading(
+            Guarantee.UNSAFE, fstype=fstype, mountpoint=mountpoint,
+            detail="shared filesystem, no distributed backend — a host-local "
+                   "lock cannot exclude another host")
+    except Exception:  # noqa: BLE001
+        return SubstrateReading(Guarantee.UNVERIFIED, detail="probe failed")
+
+
+#: Probes are cached per resolved path: a mount does not change under a running
+#: process often enough to pay `disk_partitions()` on every critical section,
+#: and that call shells out to the kernel.
+_CACHE: dict = {}
+
+
+def cached_probe(path: Path) -> SubstrateReading:
+    """`probe`, memoised per path. NEVER raises."""
+    try:
+        key = str(Path(path).resolve())
+    except Exception:  # noqa: BLE001
+        key = str(path)
+    reading = _CACHE.get(key)
+    if reading is None:
+        reading = probe(Path(path))
+        _CACHE[key] = reading
+        if reading.guarantee is Guarantee.UNSAFE:
+            # ONCE per path, at WARNING. This is the one case worth the noise:
+            # the operator has a real split-brain exposure and no error will
+            # ever surface it — both hosts succeed.
+            logger.warning(
+                "[Coordination] %s is on %s — a host-local lock cannot exclude "
+                "another host. Decisions coordinated here may DUPLICATE across "
+                "machines. Configure the distributed lock backend (Redis) to "
+                "close this, or keep one host per checkout.",
+                key, reading.fstype,
+            )
+    return reading
+
+
+def reset_cache() -> None:
+    """Testing seam. NEVER raises."""
+    _CACHE.clear()
+
+
+@asynccontextmanager
+async def exclusive(path: Path, key: str, *,
+                    timeout_s: Optional[float] = None,
+                    ttl_s: Optional[float] = None
+                    ) -> AsyncIterator[Tuple[bool, SubstrateReading]]:
+    """Hold the strongest available exclusion for *key*, and say which it was.
+
+    Yields ``(acquired, reading)``. The reading travels with the acquisition so
+    a caller can stamp the decision's provenance — a duplicate produced under
+    `UNSAFE` is then explicable after the fact instead of a mystery.
+
+    NEVER raises: on any failure it yields ``(False, reading)`` and the caller
+    takes its own degraded path, exactly as it would on a lock timeout.
+    """
+    reading = cached_probe(path)
+    if reading.guarantee is not Guarantee.CROSS_HOST:
+        # Host-local is the right tool and the fast one. The caller's existing
+        # flock path stays authoritative; we only report what it is worth.
+        yield (False, reading)
+        return
+    try:
+        from backend.core.distributed_lock_manager import get_lock_manager
+        mgr = await get_lock_manager()
+        async with mgr.acquire(key, timeout=timeout_s, ttl=ttl_s) as acquired:
+            yield (bool(acquired), reading)
+    except Exception:  # noqa: BLE001
+        logger.debug("[Coordination] distributed acquire degraded", exc_info=True)
+        yield (False, reading)

--- a/backend/core/ouroboros/governance/intake/sensors/cu_execution_sensor.py
+++ b/backend/core/ouroboros/governance/intake/sensors/cu_execution_sensor.py
@@ -324,6 +324,8 @@ class CUExecutionSensor:
         # are contending and duplicates are possible.
         self._claim_lock_failures = 0
         self._owner = _owner_token()
+        # Last coordination reading — what the lock we took was worth.
+        self._substrate: Optional[Any] = None
 
         # Replay BEFORE anything can record, so a pattern that graduated in the
         # previous life is already at threshold in this one.
@@ -483,6 +485,18 @@ class CUExecutionSensor:
             resolve_durable_path,
         )
         path = resolve_durable_path(_journal_path())
+        # What is a host-local lock actually worth here? `flock` excludes other
+        # PROCESSES; on a shared filesystem it does not exclude other HOSTS,
+        # and both sides succeed silently. The reading travels with the
+        # decision so a duplicate produced under a shared mount is explicable
+        # afterwards rather than a mystery.
+        try:
+            from backend.core.ouroboros.governance.coordination_substrate import (
+                cached_probe,
+            )
+            self._substrate = cached_probe(path)
+        except Exception:  # noqa: BLE001
+            self._substrate = None
         with flock_critical_section(path) as ok:
             if not ok:
                 # Another daemon holds it past the timeout. Fall back to the
@@ -911,6 +925,8 @@ class CUExecutionSensor:
             # crossed the threshold, so a postmortem can tell a slow boot from
             # a slow failure.
             "deferred_by_boot": deferred,
+            **(self._substrate.as_evidence() if self._substrate is not None
+               else {}),
             "age_s": round(max(0.0, time.time() - latest.timestamp), 2),
         }
 
@@ -982,6 +998,8 @@ class CUExecutionSensor:
             # but duplicates become possible.
             "claim_lock_failures": self._claim_lock_failures,
             "owner": self._owner,
+            "coordination": (self._substrate.guarantee.value
+                             if self._substrate is not None else "unprobed"),
             "active_patterns": len(self._failure_window),
             "pattern_counts": {
                 sig: len(timestamps)

--- a/tests/governance/test_coordination_substrate.py
+++ b/tests/governance/test_coordination_substrate.py
@@ -1,0 +1,238 @@
+"""`flock` excludes processes. It does not exclude hosts.
+
+Two machines sharing a checkout over NFS each take the lock successfully, each
+believe they hold it, and both proceed. Nothing errors. Nothing times out. The
+critical section simply is not one.
+
+This module does not implement a distributed lock — `core.distributed_lock_
+manager` (v3.0: Redis backend, fencing tokens, lease keepalive) already does,
+and `cross_process_jsonl` already owns the file lock. It answers the prior
+question: *which of those is worth asking here*, and says so when the answer is
+"less than you think".
+
+THE DESIGN DECISION WORTH DEFENDING
+-------------------------------------
+`UNVERIFIED` is a distinct value from `HOST_LOCAL`, and neither warns. Most
+installs are a laptop. A module that cried "possible split-brain!" every time
+it could not read a mount table would train its operator to ignore the one
+occasion it mattered. Silence and verified-safe are different facts, so they
+are different values — the same rule that keeps `waived()` distinct from an
+omitted argument, and `UNKNOWN` distinct from `UNSET`.
+
+Only `UNSAFE` — a filesystem we VERIFIED is shared, with no distributed
+backend — is worth a warning, because it is the one case where no error will
+ever surface the exposure. Both hosts succeed.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance import coordination_substrate as cs
+from backend.core.ouroboros.governance.coordination_substrate import Guarantee
+
+
+@pytest.fixture(autouse=True)
+def _clean_cache():
+    cs.reset_cache()
+    yield
+    cs.reset_cache()
+
+
+def _mount(monkeypatch, fstype: str, mountpoint: str = "/"):
+    """Pretend the world is mounted a particular way."""
+    monkeypatch.setattr(cs, "_mount_for", lambda p: (mountpoint, fstype))
+
+
+class TestReadingTheSubstrate:
+    def test_a_local_filesystem_is_host_local(self, monkeypatch):
+        _mount(monkeypatch, "apfs")
+        assert probe_g(monkeypatch) is Guarantee.HOST_LOCAL
+
+    @pytest.mark.parametrize("fstype", [
+        "nfs", "nfs4", "cifs", "smbfs", "glusterfs", "cephfs", "lustre",
+        "fuse.sshfs", "9p", "virtiofs",
+    ])
+    def test_shared_filesystems_are_unsafe_without_a_backend(
+            self, monkeypatch, fstype):
+        _mount(monkeypatch, fstype)
+        monkeypatch.setattr(cs, "_distributed_reachable", lambda: False)
+        assert probe_g(monkeypatch) is Guarantee.UNSAFE
+
+    def test_a_shared_filesystem_with_a_backend_is_cross_host(self, monkeypatch):
+        _mount(monkeypatch, "nfs4")
+        monkeypatch.setattr(cs, "_distributed_reachable", lambda: True)
+        assert probe_g(monkeypatch) is Guarantee.CROSS_HOST
+
+    def test_an_unreadable_mount_table_is_UNVERIFIED_not_unsafe(self, monkeypatch):
+        """The distinction the whole module turns on. `UNVERIFIED` is the
+        ordinary laptop case where flock IS correct and we simply could not
+        read `/proc/mounts`. Calling it unsafe would cry wolf everywhere and
+        make the real signal worthless."""
+        monkeypatch.setattr(cs, "_mount_for", lambda p: ("", ""))
+        r = cs.probe(Path("/anywhere"))
+        assert r.guarantee is Guarantee.UNVERIFIED
+        assert r.guarantee is not Guarantee.UNSAFE
+
+    def test_unverified_is_still_sufficient_to_proceed(self):
+        assert Guarantee.UNVERIFIED.is_sufficient
+        assert Guarantee.HOST_LOCAL.is_sufficient
+        assert Guarantee.CROSS_HOST.is_sufficient
+        assert not Guarantee.UNSAFE.is_sufficient
+
+    def test_the_real_journal_path_reads_cleanly(self):
+        """Whatever this machine is, the probe must return a usable answer."""
+        r = cs.probe(Path(".jarvis") / "cu_failure_journal.jsonl")
+        assert isinstance(r.guarantee, Guarantee)
+        assert r.schema_version == cs.COORDINATION_SCHEMA_VERSION
+
+
+def probe_g(monkeypatch) -> Guarantee:
+    return cs.probe(Path("/tmp/x/journal.jsonl")).guarantee
+
+
+class TestItNeverRaises:
+    def test_a_nonexistent_path_walks_up_to_a_real_ancestor(self):
+        """The journal may not exist yet, and a path that does not exist has no
+        mount of its own."""
+        r = cs.probe(Path("/tmp/does/not/exist/anywhere/journal.jsonl"))
+        assert isinstance(r.guarantee, Guarantee)
+
+    def test_psutil_exploding_degrades_to_unverified(self, monkeypatch):
+        import psutil
+        monkeypatch.setattr(psutil, "disk_partitions",
+                            lambda **kw: (_ for _ in ()).throw(OSError("nope")))
+        assert cs.probe(Path("/tmp/x")).guarantee is Guarantee.UNVERIFIED
+
+    def test_a_hostile_probe_still_yields_a_reading(self, monkeypatch):
+        monkeypatch.setattr(cs, "_mount_for",
+                            lambda p: (_ for _ in ()).throw(RuntimeError()))
+        assert cs.probe(Path("/tmp/x")).guarantee is Guarantee.UNVERIFIED
+
+    def test_a_broken_backend_check_does_not_claim_cross_host(self, monkeypatch):
+        """Failing to prove a distributed backend must never READ as one."""
+        _mount(monkeypatch, "nfs")
+        monkeypatch.setattr(cs, "_distributed_reachable",
+                            lambda: (_ for _ in ()).throw(RuntimeError()))
+        assert cs.probe(Path("/tmp/x")).guarantee is Guarantee.UNVERIFIED
+
+
+class TestConfigurability:
+    def test_the_shared_set_is_extended_never_replaced(self, monkeypatch):
+        """A site with an exotic clustered filesystem should not need a code
+        change — and must not be able to blank the built-ins by setting it."""
+        monkeypatch.setenv("JARVIS_COORDINATION_SHARED_FSTYPES", "myclusterfs")
+        types = cs.shared_fstypes()
+        assert "myclusterfs" in types
+        assert "nfs4" in types, "extending the set dropped the built-ins"
+
+    def test_a_malformed_env_falls_back(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_COORDINATION_SHARED_FSTYPES", ",,,  ,")
+        assert "nfs" in cs.shared_fstypes()
+
+    def test_a_custom_type_then_reads_as_unsafe(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_COORDINATION_SHARED_FSTYPES", "weirdfs")
+        _mount(monkeypatch, "weirdfs")
+        monkeypatch.setattr(cs, "_distributed_reachable", lambda: False)
+        assert probe_g(monkeypatch) is Guarantee.UNSAFE
+
+
+class TestTheWarningIsScarce:
+    def test_unsafe_warns_exactly_once_per_path(self, monkeypatch, caplog):
+        import logging
+        _mount(monkeypatch, "nfs")
+        monkeypatch.setattr(cs, "_distributed_reachable", lambda: False)
+        with caplog.at_level(logging.WARNING):
+            for _ in range(5):
+                cs.cached_probe(Path("/mnt/share/journal.jsonl"))
+        warns = [r for r in caplog.records if "host-local lock" in r.getMessage()]
+        assert len(warns) == 1, f"warned {len(warns)}x — that is how a signal dies"
+
+    def test_the_ordinary_cases_are_silent(self, monkeypatch, caplog):
+        import logging
+        with caplog.at_level(logging.WARNING):
+            _mount(monkeypatch, "apfs")
+            cs.cached_probe(Path("/a/journal.jsonl"))
+            monkeypatch.setattr(cs, "_mount_for", lambda p: ("", ""))
+            cs.cached_probe(Path("/b/journal.jsonl"))
+        assert not [r for r in caplog.records if "host-local lock" in r.getMessage()]
+
+    def test_the_probe_is_cached(self, monkeypatch):
+        calls = {"n": 0}
+
+        def _counting(p):
+            calls["n"] += 1
+            return ("/", "apfs")
+        monkeypatch.setattr(cs, "_mount_for", _counting)
+        for _ in range(4):
+            cs.cached_probe(Path("/same/journal.jsonl"))
+        assert calls["n"] == 1, "disk_partitions() on every critical section"
+
+
+class TestProvenanceTravelsWithTheDecision:
+    def test_the_reading_is_splattable_evidence(self, monkeypatch):
+        _mount(monkeypatch, "nfs")
+        monkeypatch.setattr(cs, "_distributed_reachable", lambda: False)
+        ev = cs.probe(Path("/tmp/x")).as_evidence()
+        assert ev["coordination"] == "unsafe"
+        assert ev["coordination_fstype"] == "nfs"
+        assert ev["coordination_verified"] is True
+
+    def test_unverified_says_so_rather_than_claiming_local(self, monkeypatch):
+        """A duplicate envelope produced under a shared mount must be
+        explicable after the fact, not a mystery."""
+        monkeypatch.setattr(cs, "_mount_for", lambda p: ("", ""))
+        ev = cs.probe(Path("/tmp/x")).as_evidence()
+        assert ev["coordination"] == "unverified"
+        assert ev["coordination_verified"] is False
+
+    @pytest.mark.asyncio
+    async def test_exclusive_yields_the_reading_even_when_not_acquired(
+            self, monkeypatch):
+        """Host-local paths do not take a distributed lock — the caller's own
+        flock stays authoritative — but the reading still travels."""
+        _mount(monkeypatch, "apfs")
+        async with cs.exclusive(Path("/tmp/x"), "k") as (acquired, reading):
+            assert acquired is False
+            assert reading.guarantee is Guarantee.HOST_LOCAL
+
+    @pytest.mark.asyncio
+    async def test_exclusive_never_raises_on_a_broken_backend(self, monkeypatch):
+        _mount(monkeypatch, "nfs4")
+        monkeypatch.setattr(cs, "_distributed_reachable", lambda: True)
+        async with cs.exclusive(Path("/tmp/x"), "k") as (acquired, reading):
+            assert acquired in (True, False)
+            assert isinstance(reading.guarantee, Guarantee)
+
+
+class TestTheSensorStampsIt:
+    @pytest.mark.asyncio
+    async def test_an_envelope_carries_the_coordination_provenance(
+            self, tmp_path, monkeypatch):
+        monkeypatch.setenv("JARVIS_CU_JOURNAL_PATH", str(tmp_path / "j.jsonl"))
+        from backend.core.ouroboros.governance.intake.sensors import (
+            cu_execution_sensor as ces,
+        )
+        ces.CUExecutionSensor._instance = None
+
+        class _R:
+            def __init__(self):
+                self.got = []
+
+            async def ingest(self, e):
+                self.got.append(e)
+                return "ok"
+
+        s = ces.CUExecutionSensor(router=_R())
+        for _ in range(ces._GRADUATION_THRESHOLD):
+            await s.record(ces.CUExecutionRecord(
+                goal="message alice saying hi", success=False,
+                steps_completed=1, steps_total=3, elapsed_s=1.0,
+                error="target not found", is_messaging=True,
+                contact="alice", app="Messages"))
+        ces.CUExecutionSensor._instance = None
+        assert s._router.got, "no envelope emitted"
+        ev = s._router.got[0]
+        assert "coordination" in ev.evidence
+        assert ev.evidence["coordination"] in {g.value for g in Guarantee}


### PR DESCRIPTION
## The gap

`flock` excludes **processes**. It does not exclude **hosts**. Two machines sharing a checkout over NFS each take the lock successfully, each believe they hold it, and both proceed. Nothing errors, nothing times out — the critical section simply is not one, silently, on both sides.

`cross_process_jsonl` is careful about POSIX vs Windows and says nothing about the filesystem underneath — reasonably, because it was written for one host.

## Not a new lock

Nothing here implements locking. `cross_process_jsonl` owns the file lock; `core.distributed_lock_manager` (v3.0 — Redis backend, fencing tokens, lease keepalive, *"works across VMs, GCP instances, Docker"*) owns the distributed one. This module answers the **prior** question — which of those is worth asking here — and reports what it asked.

Escalation is **adaptive rather than configured**: the distributed manager is used when the substrate needs it *and* is reachable. Imposing Redis on a laptop buys nothing and adds a dependency that can be down.

## Four answers, and the distinction that matters

| | |
|---|---|
| `CROSS_HOST` | a distributed backend answered — real mutual exclusion |
| `HOST_LOCAL` | flock on a filesystem **verified** local — correct here |
| `UNVERIFIED` | flock, and the mount table could not be read |
| `UNSAFE` | flock on a filesystem **verified** shared, no backend |

`UNVERIFIED` is deliberately **not** `UNSAFE`, and neither warns. Most installs are a laptop; a module that cried *"possible split-brain!"* whenever it couldn't read `/proc/mounts` would train its operator to ignore the one time it mattered. Silence and verified-safe are different facts, so they're different values — the rule that keeps `waived()` distinct from an omitted argument and `UNKNOWN` distinct from `UNSET`.

Only `UNSAFE` warns, **once per path**, because it's the single case where no error will ever surface the exposure: both hosts succeed.

## The honest part is the load-bearing part

On a shared mount without a backend the sensor **still emits** — a host-local lock isn't *wrong*, it isn't *enough* — but the envelope now carries:

```
coordination      : unsafe
fstype            : nfs4
verified          : True
```

A duplicate produced by a split brain becomes explicable after the fact instead of a mystery. Same discipline as `deferred_by_boot`.

## Detection

psutil `disk_partitions(all=True)`, longest-matching mount, walking up to an existing ancestor first (the journal may not exist yet). Cached per path — a mount doesn't change often enough to pay a kernel call per critical section.

`JARVIS_COORDINATION_SHARED_FSTYPES` **extends** the built-in set and cannot blank it, so an exotic clustered filesystem needs no code change and a typo can't disable the check.

Every failure degrades to `UNVERIFIED`, never to a claim of safety: failing to prove a distributed backend must not *read* as having one.

## Tests

30 new, including a simulated NFS mount (the case that can't be reproduced on this hardware); **59 green** across the four CU suites.

## Scope, stated plainly

This closes the **detection and declaration** gap and wires the escalation path. It's defense-in-depth for a deployment that doesn't exist today — the HUD is one Mac, and J-Prime is a provider rather than a second sensor host. What it buys now is that the day that changes, the system says so instead of splitting in silence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies the lock guarantee for a given path (host-local vs cross-host) and includes that provenance in emitted envelopes to make split-brain duplicates explainable. Escalates to the distributed lock when on a shared filesystem and the backend is reachable; warns once per path when the lock is unsafe.

- **New Features**
  - Added `backend/core/ouroboros/governance/coordination_substrate.py` with `probe`, `cached_probe`, and `exclusive` to determine and use the strongest available guarantee.
  - Guarantees: `CROSS_HOST`, `HOST_LOCAL`, `UNVERIFIED`, `UNSAFE` (only `UNSAFE` warns, once per path).
  - Adaptive use of the existing distributed lock manager (Redis); failures degrade to `UNVERIFIED`, never to a false claim of safety.
  - Mount detection via `psutil` with per-path caching; shared FS types extendable via `JARVIS_COORDINATION_SHARED_FSTYPES` (extends, does not replace).
  - `cu_execution_sensor` now stamps `coordination`, `coordination_fstype`, `coordination_verified` in evidence and exposes `coordination` in `get_stats`.
  - 30 new tests, including simulated NFS and cache behavior.

<sup>Written for commit bfa17cc05555b5b6d86d591a215a03db7f2404dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

