### PR TITLE
feat(hud): write-ahead intent journal — and the replay rule that keeps it safe

### DIFF
--- a/backend/hud/intent_journal.py
+++ b/backend/hud/intent_journal.py
@@ -1,0 +1,492 @@
+"""Write-ahead journal for voice intents — and the replay rule that keeps it safe.
+
+A spoken command enters at `VoiceCommandRouter.route()`, is classified by a
+model, planned, and executed as N UI steps. If the process dies at step 3 the
+whole command is gone: the operator said a sentence, watched half of it happen,
+and has no way to know which half. Nothing in the HUD path checkpoints — that
+was verified, not assumed (`grep fsm_checkpoint backend/hud/ backend/vision/`
+returns nothing).
+
+WHY THIS IS NOT A COPY OF `fsm_checkpoint`
+--------------------------------------------
+`fsm_checkpoint` already does suspend-and-resume for the Ouroboros op FSM, to
+`.ouroboros/checkpoints`, HMAC-signed, so a preempted DAG "resumes where it left
+off instead of re-paying the explore-from-scratch cost". That is the same
+shape — and the voice path never reaches it, because `route()` dispatches
+straight to executors and never enters the governed loop. So this reuses its
+DIRECTORY convention (`.ouroboros/`), its append primitive
+(`cross_process_jsonl.flock_append_line`), and its fail-soft posture, while
+covering a path it does not.
+
+THE RULE THAT SHAPES EVERYTHING: NOT EVERY NODE MAY BE REPLAYED
+-----------------------------------------------------------------
+The obvious design — journal each phase, resume from the last incomplete one —
+is correct for *pure* work and dangerous for the rest. The CU executor's steps
+are ``type``, ``click``, ``drag``, ``scroll``, ``hotkey``. They act on the real
+world. Re-running "step 3 of message Alice" does not recompute a value; it
+sends a second message.
+
+So nodes declare what they are:
+
+    PURE       classification, planning, parsing. Deterministic given the same
+               input, no outside effect. Replay REUSES the recorded result and
+               never re-calls the model — genuinely idempotent, and a real
+               saving.
+    EFFECTFUL  it touched something outside this process. NEVER auto-replayed.
+
+And for an EFFECTFUL node that started and never finished, the honest state is
+not "done" and not "not done" — it is UNKNOWN. The journal says so and the
+resume plan asks rather than guesses. That is the same discipline as
+`UNKNOWN != UNSET` in the provenance layer and `unverified != unsafe` in the
+coordination probe: a system that cannot tell must not pick the convenient
+answer and call it a fact.
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import asyncio
+import enum
+import json
+import logging
+import os
+import time
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+logger = logging.getLogger("JARVIS.IntentJournal")
+
+INTENT_JOURNAL_SCHEMA_VERSION: str = "intent_journal.v1"
+
+
+def journal_enabled() -> bool:
+    """Master gate. Default TRUE — append-only, bounded, local. NEVER raises."""
+    return (os.environ.get("JARVIS_INTENT_JOURNAL_ENABLED", "true")
+            or "").strip().lower() not in ("0", "false", "no", "off")
+
+
+def journal_path() -> Path:
+    """`.ouroboros/intents/journal.jsonl` beside the checkpoint ledger.
+
+    Same directory convention as `fsm_checkpoint.checkpoint_dir()` so an
+    operator finds every resume artefact in one place. NEVER raises."""
+    raw = (os.environ.get("JARVIS_INTENT_JOURNAL_PATH", "") or "").strip() 
+    if raw:
+        return Path(raw)
+    base = (os.environ.get("JARVIS_INTENT_JOURNAL_DIR", "")
+            or os.path.join(".ouroboros", "intents"))
+    return Path(base) / "journal.jsonl"
+
+
+def retention_s() -> float:
+    """How long a completed intent stays replayable. NEVER raises."""
+    try:
+        v = float(os.environ.get("JARVIS_INTENT_JOURNAL_RETENTION_S", "86400"))
+    except (TypeError, ValueError):
+        v = 86400.0
+    return max(60.0, min(v, 30 * 86400.0))
+
+
+def max_lines() -> int:
+    """Compaction trigger. NEVER raises."""
+    try:
+        return max(64, int(os.environ.get("JARVIS_INTENT_JOURNAL_MAX_LINES", "5000")))
+    except (TypeError, ValueError):
+        return 5000
+
+
+class NodeKind(str, enum.Enum):
+    """Whether a node may be replayed after a crash."""
+
+    PURE = "pure"
+    EFFECTFUL = "effectful"
+
+
+class NodeState(str, enum.Enum):
+    STARTED = "started"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    #: Started, never finished, and EFFECTFUL — so whether the world changed is
+    #: unknown. Not a synonym for failed: a failed node is known not to have
+    #: taken effect, this one might have.
+    INDETERMINATE = "indeterminate"
+
+
+class ResumeAction(str, enum.Enum):
+    SKIP = "skip"              # PURE and completed — reuse the recorded result
+    REDO = "redo"              # safe to run again
+    CONFIRM = "confirm"        # EFFECTFUL and indeterminate — ASK, never guess
+    START = "start"            # never attempted
+
+
+@dataclass
+class NodeVerdict:
+    node: str
+    action: ResumeAction
+    kind: NodeKind = NodeKind.PURE
+    result: Any = None
+    detail: str = ""
+
+
+@dataclass
+class ResumePlan:
+    """What to do with an interrupted intent. NEVER guesses."""
+
+    intent_id: str
+    command: str = ""
+    payload: Dict[str, Any] = field(default_factory=dict)
+    verdicts: List[NodeVerdict] = field(default_factory=list)
+    schema_version: str = INTENT_JOURNAL_SCHEMA_VERSION
+
+    def for_node(self, node: str) -> NodeVerdict:
+        for v in self.verdicts:
+            if v.node == node:
+                return v
+        return NodeVerdict(node=node, action=ResumeAction.START)
+
+    @property
+    def needs_confirmation(self) -> List[NodeVerdict]:
+        return [v for v in self.verdicts if v.action is ResumeAction.CONFIRM]
+
+    @property
+    def resumable(self) -> bool:
+        """True when replay can proceed without asking a human."""
+        return not self.needs_confirmation
+
+
+class IntentJournal:
+    """Append-only WAL for voice intents. Every method NEVER raises."""
+
+    def __init__(self, path: Optional[Path] = None) -> None:
+        self._path = path or journal_path()
+        self._writes = 0
+        self._write_failures = 0
+        self._corrupt_lines = 0
+
+    # -- writing ---------------------------------------------------------
+
+    async def _append(self, entry: Dict[str, Any]) -> bool:
+        if not journal_enabled():
+            return False
+        try:
+            entry.setdefault("v", 1)
+            entry.setdefault("t", time.time())
+            line = json.dumps(entry, separators=(",", ":"), default=str)
+
+            def _write() -> bool:
+                from backend.core.ouroboros.governance.cross_process_jsonl import (
+                    flock_append_line,
+                )
+                return flock_append_line(self._path, line)
+
+            # Off-thread: `flock` blocks under contention, and a spoken command
+            # must not wait on another process's journal write.
+            ok = await asyncio.to_thread(_write)
+            if ok:
+                self._writes += 1
+            else:
+                self._write_failures += 1
+            return ok
+        except Exception:  # noqa: BLE001 — a journal never breaks the command
+            self._write_failures += 1
+            logger.debug("[IntentJournal] append degraded", exc_info=True)
+            return False
+
+    async def open_intent(self, command: str, *,
+                          payload: Optional[Dict[str, Any]] = None,
+                          intent_id: Optional[str] = None) -> str:
+        """Record the raw command BEFORE anything executes. Returns its id.
+
+        This is the write-ahead half: if the process dies one instruction
+        later, the operator's sentence still exists somewhere.
+        """
+        iid = intent_id or uuid.uuid4().hex
+        await self._append({
+            "k": "intent", "id": iid, "command": command,
+            "payload": payload or {},
+            "schema_version": INTENT_JOURNAL_SCHEMA_VERSION,
+        })
+        return iid
+
+    async def node_started(self, intent_id: str, node: str,
+                           kind: NodeKind = NodeKind.PURE) -> None:
+        await self._append({"k": "node", "id": intent_id, "node": node,
+                            "kind": kind.value, "s": NodeState.STARTED.value})
+
+    async def node_completed(self, intent_id: str, node: str,
+                             result: Any = None,
+                             kind: NodeKind = NodeKind.PURE) -> None:
+        """Record the node's OUTPUT for PURE nodes so replay can reuse it.
+
+        An effectful node's result is not stored for replay — it would invite
+        exactly the reuse that is unsafe — only that it finished.
+        """
+        entry: Dict[str, Any] = {
+            "k": "node", "id": intent_id, "node": node, "kind": kind.value,
+            "s": NodeState.COMPLETED.value,
+        }
+        if kind is NodeKind.PURE:
+            entry["result"] = result
+        await self._append(entry)
+
+    async def node_failed(self, intent_id: str, node: str, error: str,
+                          kind: NodeKind = NodeKind.PURE) -> None:
+        await self._append({"k": "node", "id": intent_id, "node": node,
+                            "kind": kind.value, "s": NodeState.FAILED.value,
+                            "error": str(error)[:500]})
+
+    async def close_intent(self, intent_id: str, *, success: bool,
+                           detail: str = "") -> None:
+        await self._append({"k": "close", "id": intent_id,
+                            "ok": bool(success), "detail": detail[:500]})
+
+    # -- reading ---------------------------------------------------------
+
+    def _read(self) -> List[Dict[str, Any]]:
+        """Every parseable entry. Tolerant per LINE — a process killed
+        mid-append leaves a torn last line, and discarding the journal for a
+        missing byte would lose what it exists to keep. NEVER raises."""
+        out: List[Dict[str, Any]] = []
+        try:
+            from backend.core.ouroboros.governance.workspace_resolver import (
+                resolve_durable_path,
+            )
+            path = resolve_durable_path(self._path)
+            if not path.exists():
+                return out
+            for raw in path.read_text(encoding="utf-8",
+                                      errors="replace").splitlines():
+                raw = raw.strip()
+                if not raw:
+                    continue
+                try:
+                    e = json.loads(raw)
+                    if isinstance(e, dict):
+                        out.append(e)
+                    else:
+                        self._corrupt_lines += 1
+                except Exception:  # noqa: BLE001
+                    self._corrupt_lines += 1
+        except Exception:  # noqa: BLE001
+            logger.debug("[IntentJournal] read degraded", exc_info=True)
+        return out
+
+    def unfinished(self) -> List[str]:
+        """Intent ids opened, never closed, still inside retention. NEVER raises."""
+        try:
+            now = time.time()
+            opened: Dict[str, float] = {}
+            closed = set()
+            for e in self._read():
+                iid = e.get("id")
+                if not isinstance(iid, str):
+                    continue
+                if e.get("k") == "intent":
+                    opened[iid] = float(e.get("t", now))
+                elif e.get("k") == "close":
+                    closed.add(iid)
+            cutoff = now - retention_s()
+            return [i for i, t in opened.items()
+                    if i not in closed and t >= cutoff]
+        except Exception:  # noqa: BLE001
+            return []
+
+    def resume_plan(self, intent_id: str) -> ResumePlan:
+        """What may be skipped, redone, or must be asked about. NEVER raises."""
+        plan = ResumePlan(intent_id=intent_id)
+        try:
+            states: Dict[str, Tuple[NodeState, NodeKind, Any]] = {}
+            order: List[str] = []
+            for e in self._read():
+                if e.get("id") != intent_id:
+                    continue
+                if e.get("k") == "intent":
+                    plan.command = str(e.get("command", ""))
+                    payload = e.get("payload")
+                    plan.payload = payload if isinstance(payload, dict) else {}
+                elif e.get("k") == "node":
+                    node = e.get("node")
+                    if not isinstance(node, str):
+                        continue
+                    if node not in order:
+                        order.append(node)
+                    try:
+                        st = NodeState(e.get("s"))
+                        kind = NodeKind(e.get("kind", "pure"))
+                    except ValueError:
+                        self._corrupt_lines += 1
+                        continue
+                    prev = states.get(node)
+                    # A later terminal state supersedes STARTED; a STARTED must
+                    # never overwrite a COMPLETED (retry then crash).
+                    if prev and prev[0] is NodeState.COMPLETED \
+                            and st is NodeState.STARTED:
+                        continue
+                    states[node] = (st, kind, e.get("result"))
+            for node in order:
+                st, kind, result = states[node]
+                if st is NodeState.COMPLETED:
+                    if kind is NodeKind.PURE:
+                        plan.verdicts.append(NodeVerdict(
+                            node, ResumeAction.SKIP, kind, result,
+                            "pure and already computed — reuse the result"))
+                    else:
+                        plan.verdicts.append(NodeVerdict(
+                            node, ResumeAction.SKIP, kind, None,
+                            "effect already applied — must not repeat it"))
+                elif st is NodeState.FAILED:
+                    # Known NOT to have taken effect: it reported failure.
+                    plan.verdicts.append(NodeVerdict(
+                        node, ResumeAction.REDO, kind, None,
+                        "failed cleanly — safe to attempt again"))
+                else:  # STARTED, never resolved
+                    if kind is NodeKind.PURE:
+                        plan.verdicts.append(NodeVerdict(
+                            node, ResumeAction.REDO, kind, None,
+                            "pure — recomputing costs time, never correctness"))
+                    else:
+                        plan.verdicts.append(NodeVerdict(
+                            node, ResumeAction.CONFIRM, kind, None,
+                            "started and never finished, and it touches the "
+                            "world — whether it applied is UNKNOWN"))
+        except Exception:  # noqa: BLE001
+            logger.debug("[IntentJournal] resume_plan degraded", exc_info=True)
+        return plan
+
+    def stats(self) -> Dict[str, Any]:
+        return {
+            "schema_version": INTENT_JOURNAL_SCHEMA_VERSION,
+            "enabled": journal_enabled(),
+            "path": str(self._path),
+            "writes": self._writes,
+            "write_failures": self._write_failures,
+            "corrupt_lines": self._corrupt_lines,
+            "unfinished": len(self.unfinished()),
+        }
+
+    def compact(self) -> int:
+        """Drop entries for intents closed outside retention. Returns lines
+        kept. Under the cross-process lock — the read-trim-write a plain append
+        cannot express. NEVER raises."""
+        try:
+            from backend.core.ouroboros.governance.cross_process_jsonl import (
+                flock_critical_section,
+            )
+            from backend.core.ouroboros.governance.workspace_resolver import (
+                resolve_durable_path,
+            )
+            path = resolve_durable_path(self._path)
+            if not path.exists():
+                return 0
+            with flock_critical_section(path) as ok:
+                if not ok:
+                    return -1
+                now = time.time()
+                cutoff = now - retention_s()
+                raw_lines = path.read_text(encoding="utf-8",
+                                           errors="replace").splitlines()
+                stale = set()
+                for raw in raw_lines:
+                    try:
+                        e = json.loads(raw)
+                    except Exception:  # noqa: BLE001
+                        continue
+                    if e.get("k") == "close" and float(e.get("t", now)) < cutoff:
+                        stale.add(e.get("id"))
+                kept = []
+                for raw in raw_lines:
+                    try:
+                        if json.loads(raw).get("id") in stale:
+                            continue
+                    except Exception:  # noqa: BLE001
+                        continue      # corrupt lines are dropped by compaction
+                    kept.append(raw)
+                tmp = path.with_suffix(path.suffix + ".compact")
+                tmp.write_text("\n".join(kept) + ("\n" if kept else ""),
+                               encoding="utf-8")
+                os.replace(tmp, path)
+                return len(kept)
+        except Exception:  # noqa: BLE001
+            logger.debug("[IntentJournal] compact degraded", exc_info=True)
+            return -1
+
+
+_JOURNAL: Optional[IntentJournal] = None
+
+
+def get_intent_journal() -> IntentJournal:
+    """Process-wide journal. NEVER raises."""
+    global _JOURNAL
+    if _JOURNAL is None:
+        _JOURNAL = IntentJournal()
+    return _JOURNAL
+
+
+def reset_intent_journal() -> None:
+    """Testing seam. NEVER raises."""
+    global _JOURNAL
+    _JOURNAL = None
+
+
+# ---------------------------------------------------------------------------
+# The replay engine
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Node:
+    """One step of an intent's DAG."""
+
+    name: str
+    run: Any                      # async callable(ctx) -> result
+    kind: NodeKind = NodeKind.PURE
+
+
+async def run_dag(nodes: Sequence[Node], *, command: str,
+                  journal: Optional[IntentJournal] = None,
+                  intent_id: Optional[str] = None,
+                  payload: Optional[Dict[str, Any]] = None,
+                  ctx: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Run *nodes* in order, journalling each, resuming a prior attempt.
+
+    Resuming is driven entirely by the journal, so it works across a process
+    death — the case a retry loop inside the executor cannot survive.
+
+    Returns ``{intent_id, results, completed, blocked_on}``. ``blocked_on`` is
+    non-empty when an EFFECTFUL node was interrupted and replay would have to
+    guess; the DAG stops rather than risk repeating a real-world action.
+    """
+    j = journal or get_intent_journal()
+    ctx = dict(ctx or {})
+    plan: Optional[ResumePlan] = None
+    if intent_id:
+        plan = j.resume_plan(intent_id)
+        if plan.needs_confirmation:
+            return {"intent_id": intent_id, "results": {}, "completed": False,
+                    "blocked_on": [v.node for v in plan.needs_confirmation]}
+    else:
+        intent_id = await j.open_intent(command, payload=payload)
+
+    results: Dict[str, Any] = {}
+    for node in nodes:
+        verdict = plan.for_node(node.name) if plan else None
+        if verdict is not None and verdict.action is ResumeAction.SKIP:
+            results[node.name] = verdict.result
+            ctx[node.name] = verdict.result
+            logger.info("[IntentJournal] %s: skipping '%s' — %s",
+                        intent_id[:8], node.name, verdict.detail)
+            continue
+        await j.node_started(intent_id, node.name, node.kind)
+        try:
+            result = await node.run(ctx)
+        except Exception as exc:  # noqa: BLE001 — the caller decides retry
+            await j.node_failed(intent_id, node.name, repr(exc), node.kind)
+            raise
+        results[node.name] = result
+        ctx[node.name] = result
+        await j.node_completed(intent_id, node.name, result, node.kind)
+    await j.close_intent(intent_id, success=True)
+    return {"intent_id": intent_id, "results": results, "completed": True,
+            "blocked_on": []}

--- a/backend/hud/voice_command_router.py
+++ b/backend/hud/voice_command_router.py
@@ -49,36 +49,115 @@ class VoiceCommandRouter:
         self._query = QueryExecutor(doubleword)
         self._tool_orchestrator = ToolUseOrchestrator(doubleword, narrate_fn=narrate_fn)
 
-    async def route(self, command: str, screenshot_b64: Optional[str] = None) -> CommandResult:
-        """Classify and route a voice command."""
-        logger.info("[VoiceRouter] Command: %s", command[:100])
+    async def route(self, command: str, screenshot_b64: Optional[str] = None,
+                    intent_id: Optional[str] = None) -> CommandResult:
+        """Classify and route a voice command.
 
-        # Step 1: Classify intent via 35B
-        classification = await self._classify(command)
+        WRITE-AHEAD. The raw command is journalled before anything executes, so
+        a process death mid-flight leaves the operator's sentence recoverable
+        rather than gone. Nothing else in the HUD path checkpoints — the
+        Ouroboros FSM's `.ouroboros/checkpoints` resume machinery covers the
+        governed loop, which `route()` never enters.
+
+        Classification is journalled as a PURE node: deterministic given the
+        same command, no outside effect, so a resumed intent reuses the recorded
+        category instead of paying the model again. Execution deliberately is
+        NOT — see `intent_journal`: the CU steps are type/click/drag/scroll,
+        and replaying one does not recompute a value, it sends a second
+        message.
+        """
+        logger.info("[VoiceRouter] Command: %s", command[:100])
+        _journal = None
+        try:
+            from backend.hud.intent_journal import (
+                NodeKind, get_intent_journal,
+            )
+            _journal = get_intent_journal()
+            if intent_id is None:
+                intent_id = await _journal.open_intent(
+                    command, payload={"has_screenshot": bool(screenshot_b64)})
+        except Exception:  # noqa: BLE001 — a journal never blocks a command
+            _journal = None
+
+        # Step 1: Classify intent via 35B — PURE, so a resume can reuse it.
+        classification = None
+        if _journal is not None and intent_id:
+            try:
+                _v = _journal.resume_plan(intent_id).for_node("classify")
+                if _v.result is not None and _v.action.value == "skip":
+                    classification = _v.result
+                    logger.info("[VoiceRouter] reusing journalled "
+                                "classification (no model call)")
+            except Exception:  # noqa: BLE001
+                classification = None
+        if classification is None:
+            if _journal is not None and intent_id:
+                await _journal.node_started(intent_id, "classify", NodeKind.PURE)
+            classification = await self._classify(command)
+            if _journal is not None and intent_id:
+                await _journal.node_completed(
+                    intent_id, "classify", classification, NodeKind.PURE)
         category = classification.get("category", "composite")
         needs_vision = classification.get("needs_vision", False)
         needs_tools = classification.get("needs_tools", False)
 
         logger.info("[VoiceRouter] Classified: %s (vision=%s, tools=%s)", category, needs_vision, needs_tools)
 
-        # Step 2: Route to executor
-        if category == "app_action":
-            return await self._execute_app_action(command)
-
-        if category == "navigation":
-            return await self._execute_navigation(command)
-
-        if category == "query":
-            return await self._execute_query(command, screenshot_b64)
-
-        if category == "vision_action":
-            return await self._execute_vision(command, screenshot_b64)
-
-        if category == "code_action":
-            return await self._execute_code_action(command)
-
-        # composite or unknown -> tool-use loop (397B)
-        return await self._tool_orchestrator.execute(command, screenshot_b64)
+        # Step 2: Route to executor.
+        #
+        # The dispatch is EFFECTFUL — every branch below can touch the world —
+        # so the journal records that it began and how it ended, and never
+        # offers to replay it. An interrupted dispatch resolves to CONFIRM, not
+        # to a silent second attempt.
+        if _journal is not None and intent_id:
+            try:
+                await _journal.node_started(intent_id, "dispatch",
+                                            NodeKind.EFFECTFUL)
+            except Exception:  # noqa: BLE001
+                pass
+        result: Optional[CommandResult] = None
+        try:
+            if category == "app_action":
+                result = await self._execute_app_action(command)
+            elif category == "navigation":
+                result = await self._execute_navigation(command)
+            elif category == "query":
+                result = await self._execute_query(command, screenshot_b64)
+            elif category == "vision_action":
+                result = await self._execute_vision(command, screenshot_b64)
+            elif category == "code_action":
+                result = await self._execute_code_action(command)
+            else:
+                # composite or unknown -> tool-use loop (397B)
+                result = await self._tool_orchestrator.execute(
+                    command, screenshot_b64)
+            return result
+        except Exception as exc:  # noqa: BLE001 — record, then propagate
+            if _journal is not None and intent_id:
+                try:
+                    # Record the failure and leave the intent OPEN.
+                    #
+                    # Closing here would be the natural-looking mistake: an
+                    # intent is closed when we have stopped caring about it,
+                    # and `unfinished()` is precisely the replay queue. A
+                    # first-attempt timeout that closed its own intent would
+                    # be unrecoverable — measured, when the end-to-end proof
+                    # reported `unfinished intents: 0` after a crash.
+                    # Retention bounds how long it stays open.
+                    await _journal.node_failed(intent_id, "dispatch",
+                                               repr(exc), NodeKind.EFFECTFUL)
+                except Exception:  # noqa: BLE001
+                    pass
+            raise
+        finally:
+            if _journal is not None and intent_id and result is not None:
+                try:
+                    await _journal.node_completed(intent_id, "dispatch", None,
+                                                  NodeKind.EFFECTFUL)
+                    await _journal.close_intent(
+                        intent_id, success=bool(getattr(result, "success", True)))
+                except Exception:  # noqa: BLE001
+                    pass
 
     async def _classify(self, command: str) -> dict:
         """Classify intent via Doubleword 35B."""

--- a/tests/hud/test_intent_journal.py
+++ b/tests/hud/test_intent_journal.py
@@ -1,0 +1,387 @@
+"""A spoken command must survive the process that was executing it.
+
+The mandated scenario is `test_a_timeout_at_node_2_resumes_at_node_2`: three
+nodes, a `TimeoutError` injected at the second, and a resume that skips node 1,
+re-runs node 2, and completes node 3 with no operator intervention.
+
+THE RULE THE SUITE EXISTS TO PROTECT
+--------------------------------------
+"Refactor the phases so they are strictly idempotent" is right for
+classification and planning and IMPOSSIBLE for the rest. The CU executor's
+steps are ``type``, ``click``, ``drag``, ``scroll``, ``hotkey`` — verified by
+reading it. They act on the world. Re-running "step 3 of message Alice" does
+not recompute a value; it sends a second message.
+
+So an EFFECTFUL node that STARTED and never reported is not "failed" and not
+"done" — it is UNKNOWN, and the plan asks instead of guessing. Same discipline
+as `UNKNOWN != UNSET` in provenance and `unverified != unsafe` in the
+coordination probe: a system that cannot tell must not pick the convenient
+answer and call it a fact.
+
+`test_an_interrupted_effectful_node_is_never_silently_replayed` is the one to
+keep. Without it, this journal would be a machine for sending duplicate
+messages.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from backend.hud import intent_journal as ij
+from backend.hud.intent_journal import (
+    IntentJournal,
+    Node,
+    NodeKind,
+    ResumeAction,
+    run_dag,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_INTENT_JOURNAL_PATH",
+                       str(tmp_path / "intents" / "journal.jsonl"))
+    ij.reset_intent_journal()
+    yield tmp_path / "intents" / "journal.jsonl"
+    ij.reset_intent_journal()
+
+
+def _journal() -> IntentJournal:
+    return IntentJournal(ij.journal_path())
+
+
+class TestTheMandatedScenario:
+    @pytest.mark.asyncio
+    async def test_a_timeout_at_node_2_resumes_at_node_2(self):
+        """Three nodes, TimeoutError at node 2, resume skips node 1 and
+        finishes node 3 — no operator intervention."""
+        calls = {"one": 0, "two": 0, "three": 0}
+        explode = {"on": True}
+
+        async def _one(ctx):
+            calls["one"] += 1
+            return "classified"
+
+        async def _two(ctx):
+            calls["two"] += 1
+            if explode["on"]:
+                raise asyncio.TimeoutError("J-Prime timed out mid-DAG")
+            return "planned"
+
+        async def _three(ctx):
+            calls["three"] += 1
+            return f"executed({ctx['one']}/{ctx['two']})"
+
+        nodes = [Node("one", _one), Node("two", _two), Node("three", _three)]
+        j = _journal()
+
+        # First attempt — dies at node 2.
+        with pytest.raises(asyncio.TimeoutError):
+            await run_dag(nodes, command="message alice", journal=j)
+        assert calls == {"one": 1, "two": 1, "three": 0}
+
+        # The crash left exactly one unfinished intent.
+        pending = j.unfinished()
+        assert len(pending) == 1
+
+        # Autonomic replay.
+        explode["on"] = False
+        out = await run_dag(nodes, command="message alice", journal=j,
+                            intent_id=pending[0])
+
+        assert out["completed"] is True
+        assert calls["one"] == 1, "node 1 was re-executed — the journal was ignored"
+        assert calls["two"] == 2, "node 2 was not retried"
+        assert calls["three"] == 1, "node 3 never ran"
+        assert out["results"]["three"] == "executed(classified/planned)"
+
+    @pytest.mark.asyncio
+    async def test_the_command_is_journalled_before_anything_runs(self):
+        """The write-ahead half: if the process dies one instruction later, the
+        operator's sentence still exists."""
+        seen = {}
+
+        async def _capture(ctx):
+            seen["lines"] = _journal()._read()
+            return 1
+
+        await run_dag([Node("only", _capture)], command="lock the front door",
+                      journal=_journal())
+        kinds = [e.get("k") for e in seen["lines"]]
+        assert "intent" in kinds
+        assert any(e.get("command") == "lock the front door"
+                   for e in seen["lines"] if e.get("k") == "intent")
+
+    @pytest.mark.asyncio
+    async def test_a_completed_pure_node_reuses_its_recorded_result(self):
+        """Not merely skipped — the VALUE is reused, so downstream nodes see
+        what they would have seen. Skipping without the result would leave the
+        DAG resuming into a hole."""
+        async def _expensive(ctx):
+            return {"category": "vision_action", "cost": "one model call"}
+
+        async def _boom(ctx):
+            raise asyncio.TimeoutError("boom")
+
+        j = _journal()
+        with pytest.raises(asyncio.TimeoutError):
+            await run_dag([Node("classify", _expensive), Node("plan", _boom)],
+                          command="x", journal=j)
+        plan = j.resume_plan(j.unfinished()[0])
+        v = plan.for_node("classify")
+        assert v.action is ResumeAction.SKIP
+        assert v.result["category"] == "vision_action"
+
+
+class TestTheReplaySafetyRule:
+    @pytest.mark.asyncio
+    async def test_an_interrupted_effectful_node_is_never_silently_replayed(self):
+        """THE one to keep.
+
+        A node that started, touched the world, and never reported has an
+        UNKNOWN outcome. Auto-replaying it sends the message twice.
+        """
+        j = _journal()
+        iid = await j.open_intent("message alice saying hi")
+        await j.node_started(iid, "send", NodeKind.EFFECTFUL)   # …then death
+
+        plan = j.resume_plan(iid)
+        v = plan.for_node("send")
+        assert v.action is ResumeAction.CONFIRM
+        assert plan.resumable is False
+        assert "UNKNOWN" in v.detail
+
+    @pytest.mark.asyncio
+    async def test_the_dag_refuses_to_resume_past_an_unknown_effect(self):
+        ran = {"n": 0}
+
+        async def _after(ctx):
+            ran["n"] += 1
+            return "should not happen"
+
+        j = _journal()
+        iid = await j.open_intent("message alice")
+        await j.node_started(iid, "send", NodeKind.EFFECTFUL)
+
+        out = await run_dag([Node("send", _after, NodeKind.EFFECTFUL),
+                             Node("verify", _after)],
+                            command="message alice", journal=j, intent_id=iid)
+        assert out["completed"] is False
+        assert out["blocked_on"] == ["send"]
+        assert ran["n"] == 0, "a world-mutating node was replayed blind"
+
+    @pytest.mark.asyncio
+    async def test_a_completed_effectful_node_is_skipped_not_repeated(self):
+        ran = {"n": 0}
+
+        async def _send(ctx):
+            ran["n"] += 1
+            return "sent"
+
+        j = _journal()
+        iid = await j.open_intent("message alice")
+        await j.node_started(iid, "send", NodeKind.EFFECTFUL)
+        await j.node_completed(iid, "send", "sent", NodeKind.EFFECTFUL)
+
+        out = await run_dag([Node("send", _send, NodeKind.EFFECTFUL)],
+                            command="message alice", journal=j, intent_id=iid)
+        assert ran["n"] == 0, "the message was sent twice"
+        assert out["completed"] is True
+
+    @pytest.mark.asyncio
+    async def test_an_effectful_node_result_is_not_stored_for_reuse(self):
+        """Storing it would invite exactly the reuse that is unsafe."""
+        j = _journal()
+        iid = await j.open_intent("c")
+        await j.node_completed(iid, "click", {"pixel": [10, 20]},
+                               NodeKind.EFFECTFUL)
+        assert all("result" not in e for e in j._read()
+                   if e.get("node") == "click")
+
+    @pytest.mark.asyncio
+    async def test_a_cleanly_failed_node_is_safe_to_redo(self):
+        """Failure REPORTED is different from failure UNKNOWN — a node that
+        raised is known not to have applied."""
+        j = _journal()
+        iid = await j.open_intent("c")
+        await j.node_started(iid, "click", NodeKind.EFFECTFUL)
+        await j.node_failed(iid, "click", "target not found", NodeKind.EFFECTFUL)
+        assert j.resume_plan(iid).for_node("click").action is ResumeAction.REDO
+
+    @pytest.mark.asyncio
+    async def test_an_interrupted_PURE_node_is_simply_redone(self):
+        """Recomputing a classification costs time, never correctness."""
+        j = _journal()
+        iid = await j.open_intent("c")
+        await j.node_started(iid, "classify", NodeKind.PURE)
+        assert j.resume_plan(iid).for_node("classify").action is ResumeAction.REDO
+
+
+class TestJournalIntegrity:
+    @pytest.mark.asyncio
+    async def test_a_torn_final_line_does_not_lose_the_journal(self, _isolated):
+        j = _journal()
+        iid = await j.open_intent("survive me")
+        await j.node_completed(iid, "a", 1)
+        with _isolated.open("a") as fh:
+            fh.write('{"k":"node","id":')          # killed mid-append
+        assert j.resume_plan(iid).for_node("a").action is ResumeAction.SKIP
+        assert j.stats()["corrupt_lines"] >= 1
+
+    @pytest.mark.asyncio
+    async def test_a_retry_then_crash_does_not_unmark_a_completed_node(self):
+        """STARTED arriving after COMPLETED must not demote it — otherwise a
+        retry that crashes makes finished work look unfinished."""
+        j = _journal()
+        iid = await j.open_intent("c")
+        await j.node_completed(iid, "a", "done", NodeKind.PURE)
+        await j.node_started(iid, "a", NodeKind.PURE)
+        assert j.resume_plan(iid).for_node("a").action is ResumeAction.SKIP
+
+    @pytest.mark.asyncio
+    async def test_closed_intents_are_not_pending(self):
+        j = _journal()
+        await run_dag([Node("a", lambda ctx: _ok())], command="c", journal=j)
+        assert j.unfinished() == []
+
+    @pytest.mark.asyncio
+    async def test_stale_unfinished_intents_fall_out_of_retention(
+            self, monkeypatch):
+        monkeypatch.setenv("JARVIS_INTENT_JOURNAL_RETENTION_S", "60")
+        j = _journal()
+        iid = await j.open_intent("ancient")
+        # Rewrite its timestamp to long ago.
+        path = ij.journal_path()
+        lines = []
+        for raw in path.read_text().splitlines():
+            e = json.loads(raw)
+            e["t"] = time.time() - 10_000
+            lines.append(json.dumps(e))
+        path.write_text("\n".join(lines) + "\n")
+        assert iid not in j.unfinished()
+
+    @pytest.mark.asyncio
+    async def test_compaction_drops_closed_intents_past_retention(
+            self, monkeypatch, _isolated):
+        monkeypatch.setenv("JARVIS_INTENT_JOURNAL_RETENTION_S", "60")
+        j = _journal()
+        iid = await j.open_intent("old")
+        await j.close_intent(iid, success=True)
+        lines = []
+        for raw in _isolated.read_text().splitlines():
+            e = json.loads(raw)
+            e["t"] = time.time() - 10_000
+            lines.append(json.dumps(e))
+        _isolated.write_text("\n".join(lines) + "\n")
+        assert j.compact() == 0
+
+    @pytest.mark.asyncio
+    async def test_an_unwritable_journal_never_breaks_the_command(
+            self, monkeypatch):
+        """Fail-open: the operator's command matters more than the record of it."""
+        monkeypatch.setenv("JARVIS_INTENT_JOURNAL_PATH", "/proc/nope/j.jsonl")
+        ij.reset_intent_journal()
+        out = await run_dag([Node("a", lambda ctx: _ok())], command="c")
+        assert out["completed"] is True
+
+    @pytest.mark.asyncio
+    async def test_the_master_switch_disables_writes(self, monkeypatch, _isolated):
+        monkeypatch.setenv("JARVIS_INTENT_JOURNAL_ENABLED", "0")
+        await run_dag([Node("a", lambda ctx: _ok())], command="c",
+                      journal=_journal())
+        assert not _isolated.exists()
+
+    def test_it_lives_beside_the_checkpoint_ledger(self, monkeypatch):
+        """Same `.ouroboros/` convention as `fsm_checkpoint`, so an operator
+        finds every resume artefact in one place."""
+        monkeypatch.delenv("JARVIS_INTENT_JOURNAL_PATH", raising=False)
+        monkeypatch.delenv("JARVIS_INTENT_JOURNAL_DIR", raising=False)
+        assert ".ouroboros" in str(ij.journal_path())
+
+
+async def _ok():
+    return "ok"
+
+
+class TestTheRouterIsWired:
+    """The journal is only worth having if the front door actually uses it."""
+
+    @staticmethod
+    def _fake_router(fail_first: bool = True):
+        from backend.hud.voice_command_router import VoiceCommandRouter
+
+        calls = {"classify": 0, "dispatch": 0}
+
+        class _Fake(VoiceCommandRouter):
+            def __init__(self):
+                pass
+
+            async def _classify(self, command):
+                calls["classify"] += 1
+                return {"category": "app_action"}
+
+            async def _execute_app_action(self, command):
+                calls["dispatch"] += 1
+                if fail_first and calls["dispatch"] == 1:
+                    raise asyncio.TimeoutError("J-Prime timed out mid-DAG")
+
+                class _R:
+                    success = True
+                return _R()
+
+        return _Fake(), calls
+
+    @pytest.mark.asyncio
+    async def test_a_crashed_command_stays_replayable(self):
+        """Closing the intent on failure would make it unrecoverable —
+        `unfinished()` IS the replay queue. Measured as `unfinished: 0` before
+        this was fixed."""
+        router, _calls = self._fake_router()
+        j = ij.get_intent_journal()
+        with pytest.raises(asyncio.TimeoutError):
+            await router.route("open safari")
+        assert len(j.unfinished()) == 1, "the crashed intent was not replayable"
+
+    @pytest.mark.asyncio
+    async def test_the_raw_command_survives_the_crash(self):
+        router, _calls = self._fake_router()
+        j = ij.get_intent_journal()
+        with pytest.raises(asyncio.TimeoutError):
+            await router.route("open safari")
+        assert j.resume_plan(j.unfinished()[0]).command == "open safari"
+
+    @pytest.mark.asyncio
+    async def test_resume_does_not_pay_for_classification_twice(self):
+        router, calls = self._fake_router()
+        j = ij.get_intent_journal()
+        with pytest.raises(asyncio.TimeoutError):
+            await router.route("open safari")
+        iid = j.unfinished()[0]
+        await router.route(j.resume_plan(iid).command, intent_id=iid)
+        assert calls["classify"] == 1, "the model was called again on resume"
+        assert calls["dispatch"] == 2
+        assert j.unfinished() == []
+
+    @pytest.mark.asyncio
+    async def test_dispatch_is_journalled_as_EFFECTFUL(self):
+        """Every branch of the dispatch can touch the world, so an interrupted
+        one must resolve to CONFIRM rather than a silent second attempt."""
+        router, _calls = self._fake_router(fail_first=False)
+        j = ij.get_intent_journal()
+        await router.route("open safari")
+        assert any(e.get("node") == "dispatch" and e.get("kind") == "effectful"
+                   for e in j._read())
+
+    @pytest.mark.asyncio
+    async def test_a_journal_failure_never_blocks_the_command(
+            self, monkeypatch):
+        monkeypatch.setenv("JARVIS_INTENT_JOURNAL_PATH", "/proc/nope/j.jsonl")
+        ij.reset_intent_journal()
+        router, calls = self._fake_router(fail_first=False)
+        result = await router.route("open safari")
+        assert result.success is True
+        assert calls["dispatch"] == 1


### PR DESCRIPTION
## The gap

A spoken command entered `route()`, was classified by a model, and dispatched. If the process died mid-flight the whole command was gone — the operator said a sentence, watched half of it happen, and had no way to know which half. Nothing in the HUD path checkpointed (verified: `grep fsm_checkpoint backend/hud/ backend/vision/` returns nothing).

## Four premises checked first; three changed the design

**1. `.ouroboros/ledgers` doesn't exist.** The real conventions are `.ouroboros/checkpoints` (fsm_checkpoint) and `.jarvis/` for sensor state; the append primitive is `cross_process_jsonl.flock_append_line`. This lands at `.ouroboros/intents/` — beside the checkpoint ledger, same primitive.

**2. Transcription is not in this DAG.** `SFSpeechRecognizer` runs on-device in Swift (`WakeWordListener.swift`); Python receives text. A "don't re-transcribe" node couldn't exist here — the audio buffer is gone before this process sees anything.

**3. The resume substrate already exists and doesn't cover this path.** `fsm_checkpoint` suspends and resumes the Ouroboros op FSM so a preempted DAG *"resumes where it left off instead of re-paying the explore-from-scratch cost"* — but `route()` dispatches straight to executors and never enters the governed loop. Its conventions are reused; its coverage is extended.

**4. The one that matters: CU steps cannot be made idempotent.** They are `type`, `click`, `drag`, `scroll`, `hotkey` — read out of the executor, not guessed. They act on the world. *"Refactor the phases so they are strictly idempotent"* is right for classification and planning and **dangerous** for execution: re-running "step 3 of message Alice" doesn't recompute a value, it sends a second message.

## So nodes declare what they are

| | |
|---|---|
| `PURE` | deterministic, no outside effect. Replay **reuses** the recorded result and never re-calls the model — genuinely idempotent, and a real saving. |
| `EFFECTFUL` | touched something outside this process. **Never auto-replayed.** |

An `EFFECTFUL` node that **started and never reported** is neither done nor not-done — it is `UNKNOWN`. The plan returns `CONFIRM` and the DAG stops rather than guess. Same discipline as `UNKNOWN != UNSET` in provenance and `unverified != unsafe` in the coordination probe. An effectful node's *result* isn't even stored, because storing it invites the reuse that's unsafe.

A node that **failed** is different from one that vanished: it reported, so it's known not to have applied, and `REDO` is safe.

## The bug the end-to-end proof found

The first wiring **closed** the intent when dispatch raised. `unfinished()` *is* the replay queue, so a first-attempt timeout closed its own recovery path — the proof printed `unfinished intents: 0` after a crash. A crash now records the failure and leaves the intent open; retention bounds how long.

## Measured, through the real router

```
life1 : crashed mid-dispatch · unfinished: 1
        command recovered: 'open safari'
        classify → skip (reuse, no model call) · dispatch → redo
life2 : classify calls = 1 (NOT re-classified) · dispatch calls = 2
        unfinished now: 0
```

## Tests

22 new — including the mandated three-node DAG with `TimeoutError` at node 2 resuming at node 2 — plus 35 existing router tests green. Fail-open throughout: an unwritable journal costs durability, never the command.

## Scope, stated plainly

This lands the journal, the replay engine, and the router's ingress. `cu_step_executor` (1,096 lines) is **not** refactored — its steps are the `EFFECTFUL` class above, so per-step journalling buys a safer `CONFIRM` rather than an automatic resume, and it deserves its own slice with the executor actually read end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a write-ahead intent journal and safe replay for voice commands so commands survive crashes and never duplicate real-world actions. PURE steps are reused on resume; EFFECTFUL steps are never auto-replayed.

- New Features
  - Write-ahead journal at `.ouroboros/intents/journal.jsonl` using `cross_process_jsonl.flock_append_line`, with retention, compaction, and fail-open behavior.
  - Node kinds and replay rules: PURE (reuse/skip), EFFECTFUL (confirm), plus actions SKIP/REDO/CONFIRM/START.
  - Replay engine `run_dag(...)` that resumes from the journal and blocks on unknown EFFECTFUL outcomes.
  - Router integration: `VoiceCommandRouter.route()` journals the raw command, stores classification as PURE (reused on resume), and records dispatch as EFFECTFUL; accepts `intent_id` to resume.
  - Environment flags: `JARVIS_INTENT_JOURNAL_ENABLED`, `JARVIS_INTENT_JOURNAL_PATH`, `JARVIS_INTENT_JOURNAL_DIR`, `JARVIS_INTENT_JOURNAL_RETENTION_S`, `JARVIS_INTENT_JOURNAL_MAX_LINES`.
  - 22 new tests covering write-ahead, replay, safety rules, retention, compaction, and router wiring.

- Bug Fixes
  - Fixed crash path that closed the intent on dispatch errors, which made replay impossible; failures are recorded and the intent stays open until retention.
  - Tolerant reads of torn lines; a late STARTED no longer overwrites a COMPLETED; unwritable journal never blocks command execution.

<sup>Written for commit 7339bde71db914f9de170b0a65bd1f16a9a3f9e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

