### PR TITLE
chore(hud): keep the intent journal out of the index and out of tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,9 @@ backend/swift_bridge/*.pyc
 .ouroboros/sessions/
 .ouroboros/state/
 .ouroboros/parse_failures/
+# Voice-intent write-ahead journal — runtime replay state, regenerated
+# on every command. Same churn class as sessions/state above.
+.ouroboros/intents/
 
 # Ouroboros benchmark diagnostic outputs (contain API response bodies; copy to
 # docs/benchmarks/artifacts/ explicitly if you want to include in a report)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -213,4 +213,12 @@ def _isolate_durable_sensor_state(tmp_path, monkeypatch):
         "JARVIS_CU_JOURNAL_PATH",
         str(tmp_path / "cu_journal" / "cu_failure_journal.jsonl"),
     )
+    # The voice-intent WAL is the same hazard with a different name: it is
+    # durable, it lives under `.ouroboros/intents/`, and `unfinished()` is a
+    # replay queue — so a test run against the real path could hand the
+    # operator's next boot a queue of synthetic commands to resume.
+    monkeypatch.setenv(
+        "JARVIS_INTENT_JOURNAL_PATH",
+        str(tmp_path / "intents" / "journal.jsonl"),
+    )
     yield


### PR DESCRIPTION
Two follow-ups to #70337, both found by checking rather than assuming.

**1. `.ouroboros/intents/` was not gitignored.** `.gitignore` covers `sessions/`, `state/`, `parse_failures/` and `benchmarks/` — the new journal is the same churn class and was missed. It's untracked so nothing leaked, but a `git add -A` would have committed a replay queue containing spoken commands. The 20K this session's end-to-end proofs wrote there is removed.

(`plugins/` stays tracked — it's real code. `slice45_trace/` has a deliberately tracked file and is left alone. `soak_logs/` is untracked and arguably belongs here too, but it isn't mine.)

**2. Tests could write the operator's real journal.** The CU sensor already taught this lesson: a full run put 29KB of synthetic failures into `.jarvis/cu_failure_journal.jsonl`, and the cooldowns it recorded then silenced three unrelated tests.

The intent journal is the same hazard with a worse tail — `unfinished()` **is** a replay queue, so a test run against the default path could hand the operator's next boot a set of synthetic commands to resume. Isolated per test in the existing conftest fixture, beside the CU one.

Fixed in the test layer again, not by teaching the module about pytest.

22 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the voice-intent journal out of version control and isolate it during tests to prevent accidental commits and replay of synthetic commands.

- **Bug Fixes**
  - Add `.ouroboros/intents/` to `.gitignore` to exclude the voice-intent write-ahead journal (runtime replay state).
  - In `tests/conftest.py`, set `JARVIS_INTENT_JOURNAL_PATH` to a per-test temp path to avoid writing to the real journal and cross-test interference.

<sup>Written for commit 9c368cc3d9c34772db9c9c280e895ca4972a84bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70338?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

