### PR TITLE
feat(vision): a black box around world-touching steps, so CONFIRM is not a guess

### DIFF
--- a/backend/core/ouroboros/battle_test/forensic_delta.py
+++ b/backend/core/ouroboros/battle_test/forensic_delta.py
@@ -1,0 +1,138 @@
+"""Rows for a CONFIRM prompt, so the operator is not guessing.
+
+`intent_journal` halts on an EFFECTFUL step whose outcome is UNKNOWN and asks.
+Asking without evidence is only marginally better than replaying blind: "did the
+click land before it died?" is unanswerable by looking at the screen afterwards,
+because whatever ran next has already overwritten it.
+
+This renders the black box the executor kept: what the machine looked like going
+in, what it looked like coming out (or that it never got to look), and what the
+step was trying to do.
+
+SAME CONTRACT AS THE OTHER STRIPS
+-----------------------------------
+``render(payload, *, width) -> List[str]``, mirroring
+`pending_apply.render` — a pure function from a payload dict to lines, with no
+prompt_toolkit import and no knowledge of where it is mounted. That is what lets
+one renderer serve the daemon's own console and a remote `ov attach` client
+without the two drifting, and it is why `build_dynamic_rows` can host it: the
+strip is exactly as tall as what it currently holds, and zero rows cost zero
+lines.
+
+THE LINE THIS MUST NOT CROSS
+------------------------------
+It renders `changed: None` as "could not determine", never as "no change".
+A three-valued fact flattened to a boolean at the render layer would undo the
+care taken to preserve it — the operator would read a confident "nothing
+happened" that the system never claimed. Same rule as marks being an EXCEPTION
+surface in `ui/provenance`: the uncertain case is the one that must be loud.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger("Ouroboros.ForensicDelta")
+
+FORENSIC_DELTA_SCHEMA_VERSION: str = "forensic_delta.v1"
+
+_UNKNOWN = "?"
+
+
+def _clip(text: Any, limit: int) -> str:
+    s = str(text if text is not None else "")
+    return s if len(s) <= limit else s[: max(1, limit - 1)] + "…"
+
+
+def _snapshot_line(label: str, snap: Optional[Dict[str, Any]],
+                   width: int) -> str:
+    """One side of the delta.
+
+    An absent snapshot is rendered explicitly rather than skipped: for the
+    POST side, absence IS the finding — the step died before anything could be
+    observed — and a missing row would read as an unremarkable gap.
+    """
+    if not snap:
+        return f"  {label:<7} (never captured — the step did not return)"
+    avail = str(snap.get("availability", "observed"))
+    if avail != "observed":
+        detail = _clip(snap.get("detail", ""), 48)
+        return f"  {label:<7} unreadable ({avail}{': ' + detail if detail else ''})"
+    app = _clip(snap.get("app") or _UNKNOWN, 28)
+    title = snap.get("window_title")
+    if title is None:
+        # No screen-recording grant, or no titled window. NOT an empty title.
+        return f"  {label:<7} {app}  · window title unavailable"
+    return f"  {label:<7} {app}  · {_clip(title, max(12, width - len(app) - 22))}"
+
+
+def render(payload: Optional[Dict[str, Any]], *,
+           width: Optional[int] = None) -> List[str]:
+    """Rows for the forensic strip, or [] when there is nothing to show.
+
+    NEVER raises — a renderer that can crash the cockpit while reporting a
+    crash is not a diagnostic.
+    """
+    if not payload:
+        return []
+    w = max(40, int(width or 100))
+    try:
+        rows: List[str] = []
+        idx = payload.get("step_index")
+        action = _clip(payload.get("action") or _UNKNOWN, 16)
+        target = _clip(payload.get("target") or "", 40)
+        step_label = f"step {idx}" if idx is not None else "step"
+
+        rows.append(f"⚠ {step_label} did not report — outcome UNKNOWN")
+        detail = f"  action  {action}"
+        if target:
+            detail += f" → {target}"
+        val = _clip(payload.get("value") or "", 40)
+        if val:
+            detail += f"  value {val!r}"
+        rows.append(detail)
+
+        err = _clip(payload.get("error") or "", w - 12)
+        if err:
+            rows.append(f"  error   {err}")
+
+        rows.append(_snapshot_line("before", payload.get("before"), w))
+        rows.append(_snapshot_line("after", payload.get("after"), w))
+
+        changed = payload.get("changed")
+        summary = _clip(payload.get("summary") or "", w - 12)
+        if changed is None:
+            # THE line that must not become "no change".
+            rows.append(f"  verdict could not determine whether it applied"
+                        f"{' — ' + summary if summary else ''}")
+        elif changed:
+            rows.append(f"  verdict the machine CHANGED — {summary}")
+        else:
+            rows.append(f"  verdict no observable change — {summary}")
+        # Key hint OUTSIDE the word: `[c]onfirm` splits the word with a
+        # bracket, so neither an operator scanning for "confirm" nor a
+        # test asserting on it finds anything.
+        rows.append("  [c] confirm it completed   ·   [a] abort and re-run")
+        return rows
+    except Exception:  # noqa: BLE001
+        logger.debug("[ForensicDelta] render degraded", exc_info=True)
+        return ["⚠ forensic delta unavailable (render failed)"]
+
+
+def rows_for(payloads: Optional[List[Dict[str, Any]]], *,
+             width: Optional[int] = None, limit: int = 3) -> List[str]:
+    """Strip provider: the pending confirmations, newest first. NEVER raises.
+
+    Shaped for `build_dynamic_rows`, which takes a callable returning the
+    CURRENT lines — so the source (a local singleton, a heartbeat snapshot)
+    stays the caller's concern and this never learns which surface it is on.
+    """
+    try:
+        if not payloads:
+            return []
+        out: List[str] = []
+        for p in list(payloads)[-max(1, limit):]:
+            out.extend(render(p, width=width))
+        return out
+    except Exception:  # noqa: BLE001
+        return []

--- a/backend/vision/black_box.py
+++ b/backend/vision/black_box.py
@@ -1,0 +1,268 @@
+"""What the machine looked like either side of a step that touched it.
+
+`intent_journal` refuses to auto-replay an EFFECTFUL step whose outcome is
+UNKNOWN — correct, and it leaves the operator holding a boolean decision with
+no evidence. "Did the click land before it died?" is not answerable by staring
+at the screen thirty seconds later, because whatever happened next has already
+overwritten it.
+
+So the executor keeps a black box: a small, bounded snapshot of the OS context
+immediately before and after each world-touching step. When a step dies, the
+last-known state and the delta up to it go into the journal, and the CONFIRM
+prompt renders evidence rather than a question.
+
+MEASURED, NOT ASSUMED
+-----------------------
+``NSWorkspace.frontmostApplication()`` costs **67 ms** on this machine, and
+``CGWindowListCopyWindowInfo`` returns ``None`` in a process without a
+screen-recording grant. Both facts shape the design:
+
+* **Off the event loop, and bounded.** 67 ms twice per step is 1.3 s of
+  overhead on a ten-step macro. Captured in a worker thread under a timeout,
+  it overlaps the step's own latency and costs approximately nothing — and a
+  hung accessibility call can never stall the automation it is observing.
+
+* **The post-snapshot of step N is the pre-snapshot of step N+1.** Halves the
+  captures, and is also more honest: it is literally the same instant.
+
+* **Unavailable is not empty.** No screen-recording permission means the
+  window title cannot be read; recording ``None`` there and ``""`` for a
+  genuinely untitled window would make an absent capability look like an
+  observation. `availability` says which happened, for the same reason
+  `coordination_substrate` distinguishes `unverified` from `unsafe`.
+
+REUSE
+-------
+No new macOS accessibility hooks. `AppKit.NSWorkspace` is the same API the
+assistant surfaces already use, and window enumeration goes through
+`vision.cg_window_capture`, which owns the CoreGraphics list, its filtering and
+its cache. This module only decides WHEN to look and what to keep.
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import asyncio
+import enum
+import logging
+import os
+import time
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger("JARVIS.BlackBox")
+
+BLACK_BOX_SCHEMA_VERSION: str = "black_box.v1"
+
+
+def enabled() -> bool:
+    """Master gate. Default TRUE — bounded, read-only, off-thread. NEVER raises."""
+    return (os.environ.get("JARVIS_BLACK_BOX_ENABLED", "true")
+            or "").strip().lower() not in ("0", "false", "no", "off")
+
+
+def capture_timeout_s() -> float:
+    """Ceiling on one snapshot. Clamped: a black box that can stall the
+    automation it observes is worse than no black box. NEVER raises."""
+    try:
+        v = float(os.environ.get("JARVIS_BLACK_BOX_TIMEOUT_S", "0.5"))
+    except (TypeError, ValueError):
+        v = 0.5
+    return max(0.05, min(v, 5.0))
+
+
+def title_capture_enabled() -> bool:
+    """Window TITLES can contain document names, message text, URLs.
+
+    Default TRUE because the forensic value is exactly in the title ("was the
+    compose window still open?"), but an operator on a shared machine can drop
+    it and keep the app name. NEVER raises."""
+    return (os.environ.get("JARVIS_BLACK_BOX_TITLES", "true")
+            or "").strip().lower() not in ("0", "false", "no", "off")
+
+
+class Availability(str, enum.Enum):
+    """Why a field is missing — never conflated with the field being empty."""
+
+    OBSERVED = "observed"
+    UNAVAILABLE = "unavailable"     # no permission / API returned nothing
+    TIMED_OUT = "timed_out"
+    DISABLED = "disabled"
+
+
+@dataclass
+class Snapshot:
+    """One bounded look at the machine. Small enough to journal per step."""
+
+    t: float = field(default_factory=time.time)
+    app: Optional[str] = None
+    app_pid: Optional[int] = None
+    window_title: Optional[str] = None
+    window_count: Optional[int] = None
+    availability: str = Availability.OBSERVED.value
+    detail: str = ""
+    schema_version: str = BLACK_BOX_SCHEMA_VERSION
+
+    @property
+    def observed(self) -> bool:
+        return self.availability == Availability.OBSERVED.value
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+#: One-shot latch for a window-list backend that cannot load. See the comment
+#: at its assignment: a failed import is re-attempted on every call, which turns
+#: a missing optional dependency into a per-step cost.
+_window_list_unavailable: list = [""]
+
+
+def _blocking_capture() -> Snapshot:
+    """Read the OS context. Runs on a worker thread. NEVER raises."""
+    snap = Snapshot()
+    try:
+        from AppKit import NSWorkspace
+        app = NSWorkspace.sharedWorkspace().frontmostApplication()
+        if app is None:
+            snap.availability = Availability.UNAVAILABLE.value
+            snap.detail = "no frontmost application"
+            return snap
+        snap.app = str(app.localizedName() or "")
+        try:
+            snap.app_pid = int(app.processIdentifier())
+        except Exception:  # noqa: BLE001
+            pass
+    except Exception as exc:  # noqa: BLE001 — headless, no AppKit, no GUI session
+        snap.availability = Availability.UNAVAILABLE.value
+        snap.detail = f"{type(exc).__name__}"
+        return snap
+
+    if not title_capture_enabled():
+        snap.detail = "titles disabled"
+        return snap
+
+    # Window title + count via the module that already owns the CoreGraphics
+    # list. Absent a screen-recording grant this returns nothing — which is
+    # recorded as UNAVAILABLE for the title, NOT as an untitled window.
+    if _window_list_unavailable[0]:
+        snap.detail = snap.detail or _window_list_unavailable[0]
+        return snap
+    try:
+        # `CGWindowCapture.get_all_windows` is a STATICMETHOD on the legacy
+        # compatibility wrapper, not a module-level function — checked, because
+        # importing the name that does not exist would have failed into the
+        # `except` below and rendered every title "unavailable" while looking
+        # like a permissions problem.
+        from backend.vision.cg_window_capture import CGWindowCapture
+        windows = CGWindowCapture.get_all_windows() or []
+        snap.window_count = len(windows)
+        for w in windows:
+            owner = (w.get("owner") if isinstance(w, dict)
+                     else getattr(w, "owner", "")) or ""
+            if snap.app and owner == snap.app:
+                name = (w.get("name") if isinstance(w, dict)
+                        else getattr(w, "name", "")) or ""
+                if name:
+                    snap.window_title = str(name)
+                    break
+        if snap.window_title is None and snap.window_count == 0:
+            snap.detail = (snap.detail or
+                           "window list empty — screen-recording grant?")
+    except Exception as exc:  # noqa: BLE001
+        # LATCH the failure. `cg_window_capture` raises at IMPORT time when
+        # Quartz is absent — it guards the import (`CG = None`) and then
+        # evaluates `CG.kCGWindowImageDefault` in a class body, so the guard
+        # does nothing. Python does not cache a module that raised while
+        # importing, so retrying per step re-pays the whole failed import:
+        # measured 427 ms per capture against 67 ms for NSWorkspace alone.
+        # One attempt per process, then app-name-only.
+        _window_list_unavailable[0] = (f"window list unavailable: "
+                                       f"{type(exc).__name__}")
+        snap.detail = snap.detail or _window_list_unavailable[0]
+    return snap
+
+
+async def capture() -> Snapshot:
+    """A bounded snapshot, off the event loop. NEVER raises.
+
+    A timeout yields a TIMED_OUT snapshot rather than nothing: knowing the
+    machine could not be read in half a second is itself forensic.
+    """
+    if not enabled():
+        return Snapshot(availability=Availability.DISABLED.value)
+    try:
+        return await asyncio.wait_for(
+            asyncio.to_thread(_blocking_capture), timeout=capture_timeout_s())
+    except asyncio.TimeoutError:
+        return Snapshot(availability=Availability.TIMED_OUT.value,
+                        detail=f"exceeded {capture_timeout_s():.2f}s")
+    except Exception as exc:  # noqa: BLE001
+        return Snapshot(availability=Availability.UNAVAILABLE.value,
+                        detail=type(exc).__name__)
+
+
+def delta(before: Optional[Snapshot],
+          after: Optional[Snapshot]) -> Dict[str, Any]:
+    """What changed between two snapshots. NEVER raises.
+
+    ``changed`` is deliberately three-valued. If either side could not be
+    observed the answer is ``None`` — not ``False``. "The app did not change"
+    and "I could not tell whether the app changed" lead an operator to
+    opposite decisions, and a forensic record that conflates them is worse than
+    one that admits the gap.
+    """
+    out: Dict[str, Any] = {
+        "schema_version": BLACK_BOX_SCHEMA_VERSION,
+        "before": before.to_dict() if before else None,
+        "after": after.to_dict() if after else None,
+    }
+    try:
+        if before is None or after is None or not (
+                before.observed and after.observed):
+            out["changed"] = None
+            out["summary"] = "state change could not be determined"
+            return out
+        app_changed = before.app != after.app
+        title_changed = before.window_title != after.window_title
+        out["changed"] = bool(app_changed or title_changed)
+        out["app_changed"] = app_changed
+        out["title_changed"] = title_changed
+        out["elapsed_s"] = round(max(0.0, after.t - before.t), 3)
+        if app_changed:
+            out["summary"] = f"foreground moved {before.app!r} → {after.app!r}"
+        elif title_changed:
+            out["summary"] = (f"{after.app}: window title changed "
+                              f"{before.window_title!r} → "
+                              f"{after.window_title!r}")
+        else:
+            out["summary"] = f"{after.app}: no observable change"
+    except Exception:  # noqa: BLE001
+        out["changed"] = None
+        out["summary"] = "delta computation failed"
+    return out
+
+
+def forensic_payload(*, step_index: int, action: str, target: str,
+                     value: str, error: str,
+                     before: Optional[Snapshot],
+                     after: Optional[Snapshot]) -> Dict[str, Any]:
+    """The record a CONFIRM prompt is rendered from. NEVER raises.
+
+    ``after`` is normally absent — the step died before it could be taken —
+    and its absence is the point: it is the difference between "the click
+    landed and then we crashed" and "we crashed and cannot say".
+    """
+    try:
+        return {
+            "schema_version": BLACK_BOX_SCHEMA_VERSION,
+            "step_index": step_index,
+            "action": action,
+            "target": (target or "")[:200],
+            "value": (value or "")[:200],
+            "error": (error or "")[:400],
+            "post_captured": after is not None,
+            **delta(before, after),
+        }
+    except Exception:  # noqa: BLE001
+        return {"schema_version": BLACK_BOX_SCHEMA_VERSION,
+                "step_index": step_index, "error": "payload build failed"}

--- a/backend/vision/cu_step_executor.py
+++ b/backend/vision/cu_step_executor.py
@@ -42,6 +42,15 @@ import numpy as np
 
 logger = logging.getLogger(__name__)
 
+
+def _bb_enabled() -> bool:
+    """Black-box capture gate, read per call. NEVER raises."""
+    try:
+        from backend.vision.black_box import enabled
+        return enabled()
+    except Exception:  # noqa: BLE001
+        return False
+
 # ---------------------------------------------------------------------------
 # Env-driven config (Manifesto: no hardcoding)
 # ---------------------------------------------------------------------------
@@ -552,7 +561,72 @@ class CUStepExecutor:
             logger.warning("[CUExec] SHM read failed: %s", exc)
             return None
 
+    #: Actions that touch the world. `wait` is the only one that does not, so
+    #: it needs no black box and no CONFIRM on resume — everything else can
+    #: leave the machine changed, which is exactly what makes a blind replay
+    #: unsafe and a forensic record necessary.
+    _EFFECTFUL_ACTIONS = frozenset({
+        "click", "double_click", "right_click", "type", "key", "hotkey",
+        "scroll", "drag", "move",
+    })
+
     async def execute_step(
+        self,
+        step: Any,  # CUStep
+        frame: Optional[np.ndarray] = None,
+        step_index: int = 0,
+    ) -> StepResult:
+        """Execute a single step, keeping a black box around world-touching ones.
+
+        THE WRAPPER, not a rewrite. The cascade below is untouched; this adds a
+        bounded pre/post snapshot so that when a step dies mid-flight the
+        operator's CONFIRM prompt shows evidence instead of asking them to
+        guess from a screen that has since moved on.
+
+        The PRE snapshot is the PREVIOUS step's POST — literally the same
+        instant, and it halves the captures.
+        """
+        _action = str(getattr(step, "action", "") or "").lower()
+        if not _bb_enabled() or _action not in self._EFFECTFUL_ACTIONS:
+            return await self._execute_step_inner(step, frame, step_index)
+
+        from backend.vision import black_box as _bb
+        _before = getattr(self, "_bb_last", None)
+        if _before is None:
+            _before = await _bb.capture()
+        try:
+            _result = await self._execute_step_inner(step, frame, step_index)
+        except BaseException as _exc:      # includes CancelledError/TimeoutError
+            # The step did not return. `after` stays None deliberately — its
+            # ABSENCE is the finding, and fabricating a post-snapshot taken
+            # after the crash would describe a machine that had already moved.
+            self._bb_forensics = _bb.forensic_payload(
+                step_index=step_index, action=_action,
+                target=str(getattr(step, "target", "") or ""),
+                value=str(getattr(step, "value", "") or ""),
+                error=repr(_exc), before=_before, after=None,
+            )
+            self._bb_last = None
+            raise
+        _after = await _bb.capture()
+        self._bb_last = _after            # becomes the next step's `before`
+        self._bb_delta = _bb.delta(_before, _after)
+        return _result
+
+    def take_forensics(self) -> Optional[dict]:
+        """Pop the last crash's black box, if any. NEVER raises.
+
+        Popped rather than read so a later successful run cannot surface a
+        stale confirmation for a step that has since been resolved.
+        """
+        try:
+            payload = getattr(self, "_bb_forensics", None)
+            self._bb_forensics = None
+            return payload
+        except Exception:  # noqa: BLE001
+            return None
+
+    async def _execute_step_inner(
         self,
         step: Any,  # CUStep
         frame: Optional[np.ndarray] = None,

--- a/tests/vision/test_black_box_forensics.py
+++ b/tests/vision/test_black_box_forensics.py
@@ -1,0 +1,276 @@
+"""A CONFIRM prompt with no evidence is a coin toss with consequences.
+
+`intent_journal` halts on an EFFECTFUL step whose outcome is UNKNOWN and asks.
+Asking without evidence is barely better than replaying blind: "did the click
+land before it died?" cannot be answered by looking at the screen afterwards,
+because whatever ran next has already overwritten it.
+
+The mandated scenario is `test_a_crash_at_step_2_captures_the_forensic_delta`:
+a three-step effectful macro, a crash injected at step 2, and an assertion that
+the black box captured the active-window state and packaged it for the UI.
+
+THE LINE THIS SUITE DEFENDS
+-----------------------------
+`changed` is THREE-valued. `None` means "could not determine", and it must
+never render as "no change". A flattened boolean would hand the operator a
+confident "nothing happened" that the system never claimed — the failure this
+whole arc has been removing, one layer at a time.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any, Optional
+
+import pytest
+
+from backend.core.ouroboros.battle_test import forensic_delta as fd
+from backend.vision import black_box as bb
+
+
+class _Step:
+    def __init__(self, action="click", target="Send", value=""):
+        self.action = action
+        self.target = target
+        self.value = value
+        self.description = ""
+        self.app_name = "Messages"
+
+
+def _snap(app="Messages", title="New Message", *, availability="observed",
+          t=None) -> bb.Snapshot:
+    return bb.Snapshot(t=t or time.time(), app=app, app_pid=42,
+                       window_title=title, window_count=3,
+                       availability=availability)
+
+
+class TestTheMandatedScenario:
+    @pytest.mark.asyncio
+    async def test_a_crash_at_step_2_captures_the_forensic_delta(self, monkeypatch):
+        """Three effectful steps, crash at step 2, forensics packaged for the UI."""
+        from backend.vision.cu_step_executor import CUStepExecutor
+
+        ex = CUStepExecutor.__new__(CUStepExecutor)
+        ran = []
+
+        async def _inner(step, frame=None, step_index=0):
+            ran.append(step_index)
+            if step_index == 2:
+                raise asyncio.TimeoutError("VLA layer stalled")
+            return {"ok": True, "step": step_index}
+
+        monkeypatch.setattr(ex, "_execute_step_inner", _inner, raising=False)
+        # Mock the OS context so the assertion is about OUR wiring, not about
+        # whatever window happens to be frontmost on the test machine.
+        seq = [_snap("Messages", "New Message"),
+               _snap("Messages", "New Message"),
+               _snap("Messages", "Sent")]
+        monkeypatch.setattr(bb, "capture",
+                            lambda: _pop(seq), raising=False)
+
+        steps = [_Step("click", "Compose"), _Step("type", "hi"),
+                 _Step("click", "Send")]
+        for i, s in enumerate(steps, start=1):
+            try:
+                await ex.execute_step(s, None, i)
+            except asyncio.TimeoutError:
+                break
+
+        assert ran == [1, 2], "the macro did not stop at the crashing step"
+
+        payload = ex.take_forensics()
+        assert payload is not None, "no black box was captured"
+        assert payload["step_index"] == 2
+        assert payload["action"] == "type"
+        assert "TimeoutError" in payload["error"]
+
+        # The active-window state at the moment before the step.
+        assert payload["before"]["app"] == "Messages"
+        assert payload["before"]["window_title"] == "New Message"
+
+        # And the finding: there is no `after`, because it never returned.
+        assert payload["after"] is None
+        assert payload["post_captured"] is False
+        assert payload["changed"] is None, (
+            "an uncaptured post-state must read as UNDETERMINED, not 'no change'")
+
+        # Packaged for the UI without the caller doing any work.
+        rows = fd.render(payload, width=100)
+        assert any("step 2" in r for r in rows)
+        assert any("Messages" in r for r in rows)
+        assert any("could not determine" in r for r in rows)
+        assert any("confirm" in r.lower() for r in rows)
+
+    @pytest.mark.asyncio
+    async def test_the_forensics_are_popped_not_left_behind(self, monkeypatch):
+        """A later successful run must not surface a stale confirmation."""
+        from backend.vision.cu_step_executor import CUStepExecutor
+        ex = CUStepExecutor.__new__(CUStepExecutor)
+
+        async def _inner(step, frame=None, step_index=0):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(ex, "_execute_step_inner", _inner, raising=False)
+        monkeypatch.setattr(bb, "capture", lambda: _pop([_snap()]),
+                            raising=False)
+        with pytest.raises(RuntimeError):
+            await ex.execute_step(_Step(), None, 1)
+        assert ex.take_forensics() is not None
+        assert ex.take_forensics() is None, "forensics were not popped"
+
+    @pytest.mark.asyncio
+    async def test_a_non_effectful_step_is_not_instrumented(self, monkeypatch):
+        """`wait` cannot change the machine, so it needs no black box and no
+        CONFIRM on resume."""
+        from backend.vision.cu_step_executor import CUStepExecutor
+        ex = CUStepExecutor.__new__(CUStepExecutor)
+        captures = {"n": 0}
+
+        async def _inner(step, frame=None, step_index=0):
+            return {"ok": True}
+
+        async def _counting():
+            captures["n"] += 1
+            return _snap()
+
+        monkeypatch.setattr(ex, "_execute_step_inner", _inner, raising=False)
+        monkeypatch.setattr(bb, "capture", _counting, raising=False)
+        await ex.execute_step(_Step(action="wait"), None, 1)
+        assert captures["n"] == 0
+
+    @pytest.mark.asyncio
+    async def test_the_post_snapshot_becomes_the_next_pre(self, monkeypatch):
+        """Halves the captures, and is more honest — it is the same instant."""
+        from backend.vision.cu_step_executor import CUStepExecutor
+        ex = CUStepExecutor.__new__(CUStepExecutor)
+        captures = {"n": 0}
+
+        async def _inner(step, frame=None, step_index=0):
+            return {"ok": True}
+
+        async def _counting():
+            captures["n"] += 1
+            return _snap()
+
+        monkeypatch.setattr(ex, "_execute_step_inner", _inner, raising=False)
+        monkeypatch.setattr(bb, "capture", _counting, raising=False)
+        for i in range(1, 4):
+            await ex.execute_step(_Step(), None, i)
+        # 1 pre + 3 posts, not 6.
+        assert captures["n"] == 4, f"{captures['n']} captures for 3 steps"
+
+
+class TestThreeValuedChange:
+    def test_an_unobserved_side_makes_the_verdict_undetermined(self):
+        d = bb.delta(_snap(availability="unavailable"), _snap())
+        assert d["changed"] is None
+
+    def test_a_real_change_is_reported(self):
+        d = bb.delta(_snap("Messages", "New Message"), _snap("Safari", "Docs"))
+        assert d["changed"] is True
+        assert "Messages" in d["summary"] and "Safari" in d["summary"]
+
+    def test_no_change_is_distinguishable_from_unknown(self):
+        assert bb.delta(_snap(), _snap())["changed"] is False
+
+    def test_a_missing_snapshot_is_undetermined(self):
+        assert bb.delta(_snap(), None)["changed"] is None
+        assert bb.delta(None, None)["changed"] is None
+
+
+class TestTheRendererNeverLies:
+    def test_undetermined_never_renders_as_no_change(self):
+        """THE line. A flattened boolean would hand the operator a confident
+        'nothing happened' the system never claimed."""
+        rows = fd.render({"step_index": 1, "action": "click", "changed": None,
+                          "summary": "", "before": None, "after": None})
+        joined = " ".join(rows).lower()
+        assert "could not determine" in joined
+        assert "no observable change" not in joined
+
+    def test_an_absent_after_is_stated_not_skipped(self):
+        rows = fd.render({"step_index": 1, "action": "click",
+                          "before": _snap().to_dict(), "after": None,
+                          "changed": None})
+        assert any("never captured" in r for r in rows)
+
+    def test_an_unreadable_snapshot_says_why(self):
+        rows = fd.render({"step_index": 1, "action": "click", "changed": None,
+                          "before": _snap(availability="timed_out").to_dict(),
+                          "after": None})
+        assert any("timed_out" in r for r in rows)
+
+    def test_a_missing_title_is_not_an_empty_title(self):
+        snap = _snap(title=None).to_dict()
+        rows = fd.render({"step_index": 1, "action": "click", "changed": None,
+                          "before": snap, "after": None})
+        assert any("title unavailable" in r for r in rows)
+
+    def test_empty_payload_renders_nothing(self):
+        assert fd.render(None) == []
+        assert fd.render({}) == []
+
+    def test_render_never_raises(self):
+        for hostile in ({"step_index": object()}, {"before": "not-a-dict"},
+                        {"changed": "maybe"}, {"action": None}):
+            assert isinstance(fd.render(hostile), list)
+
+    def test_rows_for_bounds_the_strip(self):
+        payloads = [{"step_index": i, "action": "click", "changed": None,
+                     "before": None, "after": None} for i in range(10)]
+        rows = fd.rows_for(payloads, width=90, limit=2)
+        assert rows and sum(1 for r in rows if r.startswith("⚠")) == 2
+
+    def test_rows_for_is_empty_when_nothing_pending(self):
+        assert fd.rows_for(None) == []
+        assert fd.rows_for([]) == []
+
+
+class TestCaptureIsBounded:
+    @pytest.mark.asyncio
+    async def test_a_slow_capture_times_out_rather_than_stalling(
+            self, monkeypatch):
+        """A black box that can stall the automation it observes is worse than
+        no black box."""
+        monkeypatch.setenv("JARVIS_BLACK_BOX_TIMEOUT_S", "0.05")
+
+        def _slow():
+            time.sleep(2.0)
+            return _snap()
+
+        monkeypatch.setattr(bb, "_blocking_capture", _slow)
+        t0 = time.monotonic()
+        snap = await bb.capture()
+        assert time.monotonic() - t0 < 1.0
+        assert snap.availability == bb.Availability.TIMED_OUT.value
+
+    @pytest.mark.asyncio
+    async def test_the_master_switch_disables_capture(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_BLACK_BOX_ENABLED", "0")
+        assert (await bb.capture()).availability == bb.Availability.DISABLED.value
+
+    @pytest.mark.asyncio
+    async def test_capture_never_raises(self, monkeypatch):
+        monkeypatch.setattr(bb, "_blocking_capture",
+                            lambda: (_ for _ in ()).throw(OSError("nope")))
+        assert isinstance(await bb.capture(), bb.Snapshot)
+
+    @pytest.mark.asyncio
+    async def test_a_real_capture_returns_a_usable_snapshot(self):
+        """Whatever this machine is — GUI, headless, no permissions — the
+        snapshot must be usable and honest about what it could not see."""
+        snap = await bb.capture()
+        assert snap.availability in {a.value for a in bb.Availability}
+        assert isinstance(snap.to_dict(), dict)
+
+    def test_titles_can_be_dropped_for_privacy(self, monkeypatch):
+        """Window titles carry document names, message text, URLs."""
+        monkeypatch.setenv("JARVIS_BLACK_BOX_TITLES", "0")
+        assert bb.title_capture_enabled() is False
+
+
+def _pop(seq):
+    """Async stand-in that yields the next mocked snapshot."""
+    async def _inner():
+        return seq.pop(0) if seq else _snap()
+    return _inner()


### PR DESCRIPTION
## The gap

`intent_journal` halts on an `EFFECTFUL` step whose outcome is `UNKNOWN` and asks. Asking **without evidence** is barely better than replaying blind: *"did the click land before it died?"* can't be answered by looking at the screen afterwards, because whatever ran next has already overwritten it.

## Measured, not assumed

- `NSWorkspace.frontmostApplication()` = **67 ms**
- `CGWindowListCopyWindowInfo` returns `None` with no screen-recording grant

Capture runs **off the event loop under a clamped timeout**, so 67 ms overlaps a step's own latency instead of adding to it, and a hung accessibility call can never stall the automation it observes. The **POST snapshot of step N becomes the PRE of step N+1** — half the captures, and more honest, since it's literally the same instant. Pinned: 3 steps cost 4 captures, not 6.

## A latent bug this surfaced

First real capture cost **427 ms**, not 67. `cg_window_capture` guards its Quartz import (`CG = None`) then evaluates `CG.kCGWindowImageDefault` **in a class body** — so the guard does nothing and the module raises at import. Python doesn't cache a module that raised while importing, so every capture re-paid the whole failed import. Latched to one attempt per process: **288 ms once, then 0 ms**.

The underlying fragility in `cg_window_capture` is left alone — not this change's to fix — but recorded so the next reader doesn't re-diagnose it as a permissions problem.

Also checked rather than assumed: `get_all_windows` is a **staticmethod on the legacy wrapper**, not module-level. Importing the name that doesn't exist would have failed into the same `except` and rendered every title "unavailable" while looking exactly like a missing grant.

## Three-valued, end to end

`changed` is `True` / `False` / `None`, and `None` means **"could not determine"** — never "no change". An unobserved side, a timed-out capture, or an absent POST all yield `None`, and the renderer prints *"could not determine whether it applied"*.

A boolean flattened at the render layer would hand the operator a confident "nothing happened" the system never claimed — the exact failure this arc has been removing a layer at a time. Same rule as `UNKNOWN != UNSET` and `unverified != unsafe`.

The absent POST renders explicitly (*"never captured — the step did not return"*) rather than being skipped: for that side, absence **is** the finding.

```
⚠ step 2 did not report — outcome UNKNOWN
  action  type → message body  value 'on my way'
  error   TimeoutError('VLA layer stalled')
  before  Messages  · New Message — Alice
  after   (never captured — the step did not return)
  verdict could not determine whether it applied
  [c] confirm it completed   ·   [a] abort and re-run
```

## Reuse

No new macOS accessibility hooks — `AppKit.NSWorkspace` and `vision.cg_window_capture`, both already present. `forensic_delta.render(payload, *, width) -> List[str]` mirrors `pending_apply.render` exactly, so one renderer serves the daemon console and a remote `ov attach` client without drifting, and `build_dynamic_rows` can host it. `execute_step` is **wrapped, not rewritten** — the 1,096-line cascade is untouched.

Fixed while testing: the affordance read `[c]onfirm`, where the bracket splits the word so neither an operator scanning for "confirm" nor a test asserting on it finds anything.

## Tests

21 new, including the mandated three-step macro with a crash at step 2 asserting the active-window state is captured and packaged. The 4 reds in `tests/test_cu_step_executor.py` are **pre-existing** — identical on a clean HEAD.

## Scope

The payload is produced and rendered. **Mounting the strip on a live cockpit surface is not claimed here** — `take_forensics()` is the seam a surface would pull from, and per this codebase's own repeated lesson, a renderer with no mounted caller is not a feature yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a bounded “black box” OS snapshot around effectful steps and renders it in the CONFIRM prompt, so operators confirm with evidence instead of guessing. Captures run off-thread with timeouts, reuse between steps, and report a three‑valued change state.

- **New Features**
  - Added `backend.vision.black_box` with async `capture()` returning a `Snapshot` (`observed`, `unavailable`, `timed_out`, `disabled`), configurable via `JARVIS_BLACK_BOX_ENABLED`, `JARVIS_BLACK_BOX_TIMEOUT_S`, `JARVIS_BLACK_BOX_TITLES`.
  - Wrapped `CUStepExecutor.execute_step` to capture pre/post around effectful actions; `wait` is excluded. Post of step N becomes pre of step N+1 to halve captures.
  - Introduced `delta(...)` and `forensic_payload(...)` with `changed: True/False/None` (`None` = “could not determine”), never flattened to “no change”.
  - Added `backend/core/ouroboros/battle_test/forensic_delta.render(payload, *, width)` mirroring `pending_apply.render`; explicitly shows absent POST as “never captured” and adds `[c] confirm` / `[a] abort` hints. Provides `rows_for(...)` for `build_dynamic_rows`.
  - Latched `vision.cg_window_capture` import failures once per process to avoid repeated slow retries; record reason in `detail`. Added `CUStepExecutor.take_forensics()` as the surface seam.

- **Tests**
  - 21 new tests cover crash-at-step-2 packaging, snapshot reuse, non-effectful steps, bounded timeouts, renderer honesty, and strip bounding. Pre-existing reds in `tests/test_cu_step_executor.py` remain unchanged.

<sup>Written for commit b293834e056133b638ffdc6009ee5a8d6e1cf12a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

