### PR TITLE
feat(cockpit): mount the forensic strip on every surface that renders

### DIFF
--- a/backend/core/ouroboros/battle_test/attach_heartbeat.py
+++ b/backend/core/ouroboros/battle_test/attach_heartbeat.py
@@ -62,6 +62,20 @@ def _pending_apply_payload() -> Optional[dict]:
         return None
 
 
+def _forensics_payload() -> Optional[list]:
+    """Pending crashed-step confirmations, or None. NEVER raises.
+
+    None rather than [] — "nothing crashed" and "the daemon never told us" are
+    different facts, and conflating them would have a remote operator conclude
+    the machine is healthy because a bridge went quiet.
+    """
+    try:
+        from backend.vision.black_box import snapshot
+        return snapshot()
+    except Exception:  # noqa: BLE001
+        return None
+
+
 def _input_queue_payload() -> dict:
     """The attached-input queue's depth, or {}. NEVER raises."""
     try:
@@ -366,6 +380,12 @@ def build_heartbeat_payload() -> Optional[Dict[str, Any]]:
             # that draws it locally repaints eight times a second, and the
             # bridge is a line stream.
             "pending_apply": _pending_apply_payload(),
+            # A crashed UI step awaiting confirm/abort. Carried as STATE
+            # for the same reason the countdown is: the strip repaints
+            # locally and the bridge is a line stream. It is also the
+            # only way a remote operator learns the daemon lost a step —
+            # the crash happens where they are not sitting.
+            "forensics": _forensics_payload(),
             "effort": effort,
             "provider": provider,
             "provider_label": provider_label,

--- a/backend/core/ouroboros/battle_test/bipartite_layout.py
+++ b/backend/core/ouroboros/battle_test/bipartite_layout.py
@@ -1181,6 +1181,7 @@ def build_bipartite_application(
     search_rows: Optional[Callable[[], Any]] = None,
     status_rows: Optional[Callable[[], Any]] = None,
     pending_rows: Optional[Callable[[], Any]] = None,
+    forensic_rows: Optional[Callable[[], Any]] = None,
     stream_rows: Optional[Callable[[], Any]] = None,
     queue_rows: Optional[Callable[[], Any]] = None,
     panic_rows: Optional[Callable[[], Any]] = None,
@@ -1783,6 +1784,19 @@ def build_bipartite_application(
     # The rejection window, above the search bar and the caret. It is the
     # most time-critical row the cockpit ever draws — the operator has
     # seconds — so it sits where the eye already is.
+    # A crashed step's forensic delta sits directly ABOVE the countdown, for
+    # the same reason the countdown sits where it does: it is a decision the
+    # operator has to make NOW, and it must not be discovered by scrolling.
+    # It is above rather than below because a pending apply is a clock running
+    # down and this is a question already waiting — the clock keeps the seat
+    # nearest the caret.
+    if forensic_rows is not None:
+        try:
+            _forensic_row = build_dynamic_rows(forensic_rows)
+            if _forensic_row is not None:
+                rows += [_forensic_row]
+        except Exception:  # noqa: BLE001
+            logger.debug("[Bipartite] forensic row unavailable", exc_info=True)
     if pending_rows is not None:
         try:
             _pending_row = build_dynamic_rows(pending_rows)
@@ -2250,6 +2264,7 @@ async def run_bipartite_repl(
     search_rows: Optional[Callable[[], Any]] = None,
     status_rows: Optional[Callable[[], Any]] = None,
     pending_rows: Optional[Callable[[], Any]] = None,
+    forensic_rows: Optional[Callable[[], Any]] = None,
     stream_rows: Optional[Callable[[], Any]] = None,
     queue_rows: Optional[Callable[[], Any]] = None,
     panic_rows: Optional[Callable[[], Any]] = None,
@@ -2296,7 +2311,8 @@ async def run_bipartite_repl(
             completer=completer, history=history, auto_suggest=auto_suggest,
             turn_spinner=turn_spinner, agent_rows=agent_rows,
             search_rows=search_rows, status_rows=status_rows,
-            pending_rows=pending_rows, stream_rows=stream_rows,
+            pending_rows=pending_rows, forensic_rows=forensic_rows,
+            stream_rows=stream_rows,
             queue_rows=queue_rows, panic_rows=panic_rows,
             diff_rows=diff_rows,
             serpent_active=serpent_active,

--- a/backend/core/ouroboros/battle_test/cockpit_mount.py
+++ b/backend/core/ouroboros/battle_test/cockpit_mount.py
@@ -176,6 +176,27 @@ def _panic_payload(panic: Any) -> Optional[dict]:
         return None
 
 
+def daemon_forensic_rows() -> List[str]:
+    """A crashed UI step's black box, for the process the crash HAPPENED in.
+
+    The same direction of blindness this module was written about: the daemon
+    RUNS the step executor, so it is the only process that can see the machine
+    either side of a step — and until now the evidence was legible only from a
+    remote client, if at all.
+
+    ``width`` is the daemon's own terminal; the attach client passes its own,
+    because the two cockpits are not the same size and a strip laid out for the
+    wrong one wraps in a way that hides the verdict line.
+    """
+    try:
+        from backend.core.ouroboros.battle_test.forensic_delta import rows_for
+        from backend.vision.black_box import snapshot
+        return rows_for(snapshot(), width=_terminal_width())
+    except Exception:  # noqa: BLE001
+        logger.debug("[CockpitMount] forensic rows unavailable", exc_info=True)
+        return []
+
+
 def daemon_queue_rows() -> List[str]:
     """The operator's own backlog — lines typed ahead of the organism."""
     try:
@@ -600,6 +621,10 @@ def build_daemon_mount(repl: Any = None) -> "dict":
         "pending_rows": daemon_pending_rows,
         "panic_rows": daemon_panic_rows,
         "queue_rows": daemon_queue_rows,
+        # The crashed-step confirmation. A factory, not a resolved
+        # value: unlike `search_rows` this strip CAN start empty and
+        # fill later, so it must be re-read per repaint.
+        "forensic_rows": daemon_forensic_rows,
         # Resolved (not a factory): a strip whose provider can never yield should
         # not be in the layout at all.
         "search_rows": daemon_search_rows(),

--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -6853,6 +6853,12 @@ class SerpentREPL:
                     status_rows=_local_status_rows,
                     # Same rule, extended to the strips that were missing it.
                     pending_rows=_mount.get("pending_rows"),
+                    # The crashed-step confirmation. THIS process runs the
+                    # step executor, so it is where the crash happens and
+                    # the only one that can see the machine either side of
+                    # it — the same direction of blindness `cockpit_mount`
+                    # was written about.
+                    forensic_rows=_mount.get("forensic_rows"),
                     panic_rows=_mount.get("panic_rows"),
                     queue_rows=_mount.get("queue_rows"),
                     search_rows=_mount.get("search_rows"),

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -969,6 +969,11 @@ class AttachUI:
         self._status: dict = {}
         #: Applies waiting out their rejection window, as of the last frame.
         self._pending_apply: dict = {}
+        #: Crashed-step confirmations from the daemon's heartbeat. None
+        #: means the daemon has not said — distinct from [] meaning
+        #: nothing is pending, which is why the strip can tell an idle
+        #: organism from a silent bridge.
+        self._forensics: Optional[list] = None
         #: Submitted-but-unprocessed operator lines, as of the last frame.
         self._input_queue: dict = {}
         #: The last FATAL_PANIC, until the operator dismisses it. Sticky
@@ -1547,6 +1552,26 @@ class AttachUI:
         except Exception:  # noqa: BLE001
             return []
 
+    def _forensic_rows(self) -> List[str]:
+        """A crashed UI step's black box, as seen from the other process.
+
+        Same renderer as the daemon's own strip — `forensic_delta.rows_for` —
+        different source, which is the rule `cockpit_mount` states: neither
+        surface learns where the other's state came from.
+
+        Retires on the same staleness window as the countdown and the roster.
+        A dead daemon must not leave a confirmation prompt on screen: the
+        operator would answer a question about a process that is gone, and the
+        answer would go nowhere.
+        """
+        try:
+            from backend.core.ouroboros.battle_test.forensic_delta import rows_for
+            if self._heartbeat_age() is None:
+                return []
+            return rows_for(self._forensics, width=self._terminal_size()[0])
+        except Exception:  # noqa: BLE001
+            return []
+
     def _push_tail_to_deck(self) -> None:
         """Compose the in-flight text into the transcript. NEVER raises.
 
@@ -1947,6 +1972,7 @@ class AttachUI:
                 # closed, and a countdown that outlives its op is telling the
                 # operator they can still stop something that already ran.
                 self._pending_apply = frame.get("pending_apply") or {}
+                self._forensics = frame.get("forensics")
                 # Lines the operator submitted that the organism has not
                 # reached yet. Cleared by absence for the same reason the
                 # countdown is: a stale backlog tells them work is
@@ -4031,6 +4057,14 @@ async def _bipartite_attach_loop(client: Any, console: Any, ui: Any) -> None:
             pending_rows=(
                 ui._pending_apply_rows if ui is not None
                 and hasattr(ui, "_pending_apply_rows") else None
+            ),
+            # The crashed-step confirmation. Passed by NAME like every other
+            # hook: `capability_handoff` reads a `**splat` as OPAQUE, so a
+            # mount that spread itself would blind the audit that proves this
+            # strip reached both surfaces.
+            forensic_rows=(
+                ui._forensic_rows if ui is not None
+                and hasattr(ui, "_forensic_rows") else None
             ),
             # The sentence being written — directly under the deck it is
             # about to become part of.

--- a/backend/core/ouroboros/cli/ov_demo.py
+++ b/backend/core/ouroboros/cli/ov_demo.py
@@ -1628,6 +1628,43 @@ def _demo_search_rows() -> Any:
 _PENDING_AT = (20.4, 22.0)
 
 
+#: When the scripted crash lands, in demo-seconds.
+_FORENSIC_BEAT_S: float = float(
+    __import__('os').environ.get('JARVIS_DEMO_FORENSIC_BEAT_S', '14'))
+
+
+def _demo_forensic_rows(elapsed: float, width: int) -> list:
+    """The forensic strip, on a scripted beat. NEVER raises.
+
+    Renders through the SAME `forensic_delta.rows_for` both live surfaces use,
+    so the demo cannot drift into showing a layout that does not exist — the
+    rule the roster and countdown already follow.
+
+    Appears late and stays: a confirmation is a question that WAITS, unlike the
+    countdown beside it which expires. Showing it flicker would teach exactly
+    the wrong reflex.
+    """
+    try:
+        if elapsed < _FORENSIC_BEAT_S:
+            return []
+        from backend.core.ouroboros.battle_test.forensic_delta import rows_for
+        return rows_for([{
+            "step_index": 2,
+            "action": "type",
+            "target": "message body",
+            "value": "on my way",
+            "error": "TimeoutError('VLA layer stalled')",
+            "before": {"app": "Messages", "window_title": "New Message — Alice",
+                       "availability": "observed"},
+            "after": None,
+            "post_captured": False,
+            "changed": None,
+            "summary": "state change could not be determined",
+        }], width=width)
+    except Exception:  # noqa: BLE001
+        return []
+
+
 def _pending_rows(elapsed: float, width: int) -> List[str]:
     """The NOTIFY_APPLY countdown, through the REAL renderer. NEVER raises.
 
@@ -2157,6 +2194,13 @@ def scene_live(console: Any, argv: Sequence[str] = ()) -> int:
         pending_rows=lambda: _pending_rows(
             (clock() - start[0]) * speed,
             _deck_width(),
+        ),
+        # A crashed UI step's confirmation, scripted. The demo exists so an
+        # operator recognises a surface BEFORE meeting it live, and a prompt
+        # asking whether a half-applied action landed is precisely the one they
+        # should not be seeing for the first time in anger.
+        forensic_rows=lambda: _demo_forensic_rows(
+            (clock() - start[0]) * speed, _deck_width(),
         ),
     )
     try:

--- a/backend/vision/black_box.py
+++ b/backend/vision/black_box.py
@@ -266,3 +266,76 @@ def forensic_payload(*, step_index: int, action: str, target: str,
     except Exception:  # noqa: BLE001
         return {"schema_version": BLACK_BOX_SCHEMA_VERSION,
                 "step_index": step_index, "error": "payload build failed"}
+
+
+# ---------------------------------------------------------------------------
+# The pending-confirmation store — process-global, transport-safe
+# ---------------------------------------------------------------------------
+#
+# A renderer needs a SOURCE, and the forensics are produced deep inside a step
+# executor instance that no cockpit holds a reference to. `pending_apply` solved
+# exactly this shape for the NOTIFY_APPLY countdown — a module-level store the
+# producer notes into and any surface can snapshot — so this mirrors it rather
+# than inventing a second way for a strip to find its state.
+#
+# Bounded, because an operator who ignores confirmations must not grow the
+# process without limit, and because the strip renders the newest few anyway.
+
+_PENDING_FORENSICS: List[Dict[str, Any]] = []
+
+
+def strip_enabled() -> bool:
+    """Whether the forensic strip renders at all. NEVER raises."""
+    return (os.environ.get("JARVIS_FORENSIC_STRIP_ENABLED", "true")
+            or "").strip().lower() not in ("0", "false", "no", "off")
+
+
+def max_pending() -> int:
+    """Ring bound. NEVER raises."""
+    try:
+        return max(1, int(os.environ.get("JARVIS_FORENSIC_MAX_PENDING", "8")))
+    except (TypeError, ValueError):
+        return 8
+
+
+def note_forensics(payload: Optional[Dict[str, Any]]) -> None:
+    """Record a crash's black box for the surfaces to draw. NEVER raises."""
+    if not payload:
+        return
+    try:
+        _PENDING_FORENSICS.append(dict(payload))
+        while len(_PENDING_FORENSICS) > max_pending():
+            _PENDING_FORENSICS.pop(0)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def resolve_forensics(step_index: Optional[int] = None) -> None:
+    """Drop a confirmation once the operator has answered it. NEVER raises."""
+    try:
+        if step_index is None:
+            _PENDING_FORENSICS.clear()
+            return
+        for i, p in enumerate(list(_PENDING_FORENSICS)):
+            if p.get("step_index") == step_index:
+                _PENDING_FORENSICS.pop(i)
+                return
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def snapshot() -> Optional[List[Dict[str, Any]]]:
+    """Pending confirmations as a transport-safe list, or None. NEVER raises.
+
+    ``None`` rather than ``[]``, for the reason `pending_apply.snapshot` gives:
+    "no confirmation is pending" and "the daemon never told us" are different
+    facts, and a client that cannot tell them apart draws the first when it
+    means the second — which here would be an operator concluding nothing
+    crashed because a bridge went quiet.
+    """
+    try:
+        if not strip_enabled():
+            return None
+        return [dict(p) for p in _PENDING_FORENSICS]
+    except Exception:  # noqa: BLE001
+        return None

--- a/backend/vision/cu_step_executor.py
+++ b/backend/vision/cu_step_executor.py
@@ -606,6 +606,11 @@ class CUStepExecutor:
                 value=str(getattr(step, "value", "") or ""),
                 error=repr(_exc), before=_before, after=None,
             )
+            # ALSO into the process-global store, because the surfaces that
+            # draw this hold no reference to a step-executor instance. Same
+            # shape as `pending_apply.note_pending`: the producer notes, any
+            # surface snapshots.
+            _bb.note_forensics(self._bb_forensics)
             self._bb_last = None
             raise
         _after = await _bb.capture()

--- a/tests/battle_test/test_forensic_strip_mount.py
+++ b/tests/battle_test/test_forensic_strip_mount.py
@@ -1,0 +1,170 @@
+"""The strip has to be MOUNTED, on every surface, or it is not a feature.
+
+This codebase has a specific way of failing: a capability is finished, correct,
+tested — and reachable from nowhere. Five zero-caller features landed in one
+day, one of them inert *inside the fix for inertness*, and three tests passed
+throughout by asserting a handler's source contained a flag literal.
+
+`forensic_delta` was in exactly that state when it was written: a renderer with
+no mounted caller. So this file asserts the wiring, not the rendering.
+
+WHAT THE AUDIT CAUGHT WHILE MOUNTING
+--------------------------------------
+Adding the provider to `build_daemon_mount` was not enough. `capability_handoff`
+reported the hook `FILLED` on `ov` and `UNSET` on `serpent_flow`, because the
+daemon passes each hook BY NAME and the new name was not at its call site —
+the two-surfaces split, caught by the instrument written for it, one run after
+the mistake. That is why the assertions below name surfaces individually rather
+than trusting a single "it works here".
+"""
+from __future__ import annotations
+
+import pytest
+
+
+class TestBothRealSurfacesMountIt:
+    def test_the_handoff_audit_sees_no_divergence(self):
+        """THE assertion. A hook one surface fills and another ignores is the
+        failure this whole module exists to prevent."""
+        from backend.core.ouroboros.ui import capability_handoff as ch
+        reading = ch.audit()
+        ch.propagate_fills(reading)
+        div = [d for d in reading.divergence() if "forensic_rows" in str(d)]
+        assert div == [], f"forensic_rows diverges across surfaces: {div}"
+
+    @pytest.mark.parametrize("surface", [
+        "backend.core.ouroboros.battle_test.serpent_flow",   # the daemon
+        "backend.core.ouroboros.cli.ov",                     # the attach client
+        "backend.core.ouroboros.cli.ov_demo",                # the demo
+    ])
+    def test_every_surface_fills_the_hook(self, surface):
+        from backend.core.ouroboros.ui import capability_handoff as ch
+        reading = ch.audit()
+        ch.propagate_fills(reading)
+        states = {str(getattr(f, "state", ""))
+                  for f in reading.fills
+                  if getattr(f, "hook", "") == "forensic_rows"
+                  and getattr(f, "surface", "") == surface}
+        assert states, f"{surface} never names forensic_rows"
+        assert any("FILLED" in s for s in states), (
+            f"{surface} declares forensic_rows but leaves it {states}")
+
+    def test_the_hook_is_passed_by_name_never_splatted(self):
+        """`capability_handoff` reads a `**splat` as OPAQUE, so a mount that
+        spread itself would blind the audit that proves this reached both
+        surfaces — the reason `build_daemon_mount` returns values instead of
+        splatting them."""
+        from pathlib import Path
+        for f in ("backend/core/ouroboros/battle_test/serpent_flow.py",
+                  "backend/core/ouroboros/cli/ov.py"):
+            src = Path(f).read_text(encoding="utf-8", errors="replace")
+            assert "forensic_rows=" in src, f"{f} does not name the hook"
+
+
+class TestTheLayoutActuallyDrawsIt:
+    def test_the_builder_accepts_the_hook(self):
+        import inspect
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            build_bipartite_application, run_bipartite_repl,
+        )
+        for fn in (build_bipartite_application, run_bipartite_repl):
+            assert "forensic_rows" in inspect.signature(fn).parameters, (
+                f"{fn.__name__} cannot receive the hook")
+
+    def test_it_is_mounted_through_the_shared_geometry_primitive(self):
+        """`build_dynamic_rows` is the ONE variable-height strip primitive —
+        exactly as tall as what it holds, zero rows when empty. A hand-rolled
+        Window here would be a second answer to 'collapse when empty'."""
+        from pathlib import Path
+        src = Path("backend/core/ouroboros/battle_test/bipartite_layout.py"
+                   ).read_text(encoding="utf-8", errors="replace")
+        assert "build_dynamic_rows(forensic_rows)" in src
+
+    def test_an_idle_cockpit_costs_zero_rows(self):
+        """Nothing pending must render nothing — a Window drawing an empty
+        string still occupies a line."""
+        from backend.core.ouroboros.battle_test.cockpit_mount import (
+            daemon_forensic_rows,
+        )
+        from backend.vision import black_box as bb
+        bb.resolve_forensics()
+        assert daemon_forensic_rows() == []
+
+
+class TestTheDaemonSeesWhatItProduces:
+    def test_the_daemon_mount_carries_the_provider(self):
+        from backend.core.ouroboros.battle_test.cockpit_mount import (
+            build_daemon_mount,
+        )
+        assert callable(build_daemon_mount().get("forensic_rows"))
+
+    def test_a_crash_reaches_the_daemon_strip(self):
+        """The direction that matters: the daemon RUNS the executor, so it is
+        where the crash happens — and it was the surface most likely to be
+        blind to it."""
+        from backend.core.ouroboros.battle_test.cockpit_mount import (
+            daemon_forensic_rows,
+        )
+        from backend.vision import black_box as bb
+        bb.resolve_forensics()
+        bb.note_forensics({
+            "step_index": 2, "action": "type", "target": "message body",
+            "error": "TimeoutError()", "changed": None,
+            "before": {"app": "Messages", "window_title": "New Message",
+                       "availability": "observed"},
+            "after": None,
+        })
+        try:
+            rows = daemon_forensic_rows()
+            assert any("step 2" in r for r in rows)
+            assert any("Messages" in r for r in rows)
+            assert any("could not determine" in r for r in rows)
+        finally:
+            bb.resolve_forensics()
+
+
+class TestTheClientGetsItAcrossTheBridge:
+    def test_the_heartbeat_carries_forensics(self):
+        from pathlib import Path
+        src = Path("backend/core/ouroboros/battle_test/attach_heartbeat.py"
+                   ).read_text(encoding="utf-8", errors="replace")
+        assert '"forensics": _forensics_payload()' in src
+
+    def test_the_payload_distinguishes_silence_from_nothing_pending(self):
+        """None means the daemon never said; [] means nothing crashed. A client
+        that cannot tell them apart draws 'healthy' when it means 'deaf'."""
+        from backend.core.ouroboros.battle_test import attach_heartbeat as hb
+        from backend.vision import black_box as bb
+        bb.resolve_forensics()
+        assert hb._forensics_payload() == []
+        import os
+        os.environ["JARVIS_FORENSIC_STRIP_ENABLED"] = "0"
+        try:
+            assert hb._forensics_payload() is None
+        finally:
+            os.environ.pop("JARVIS_FORENSIC_STRIP_ENABLED", None)
+
+    def test_a_stale_heartbeat_retires_the_prompt(self):
+        """A dead daemon must not leave a confirmation on screen — the operator
+        would answer a question about a process that is gone, and the answer
+        would go nowhere."""
+        from pathlib import Path
+        src = Path("backend/core/ouroboros/cli/ov.py").read_text(
+            encoding="utf-8", errors="replace")
+        i = src.index("def _forensic_rows")
+        body = src[i:i + 1200]
+        assert "_heartbeat_age()" in body and "return []" in body
+
+
+class TestTheDemoShowsItBeforeItMatters:
+    def test_the_demo_renders_through_the_same_renderer(self):
+        """A demo with its own layout drifts into showing a cockpit that does
+        not exist."""
+        from backend.core.ouroboros.cli.ov_demo import _demo_forensic_rows
+        assert _demo_forensic_rows(0.0, 100) == []
+        late = _demo_forensic_rows(9_999.0, 100)
+        assert late and any("could not determine" in r for r in late)
+
+    def test_the_beat_is_env_tunable(self):
+        from backend.core.ouroboros.cli import ov_demo
+        assert isinstance(ov_demo._FORENSIC_BEAT_S, float)


### PR DESCRIPTION
#70339 left the renderer with no mounted caller and said so. This mounts it — daemon, attach client, and demo — and proves it with the instrument written for exactly this question.

## The audit caught the mistake one run after it was made

Adding the provider to `build_daemon_mount` wasn't enough. `capability_handoff` reported:

```
forensic_rows   ov            FILLED
forensic_rows   serpent_flow  UNSET
forensic_rows   ov_demo       UNSET
```

The daemon passes every hook **by name** — deliberately, since a `**splat` reads as OPAQUE and would blind the audit — so a new name absent from that call site is simply not mounted. The two-surfaces split, in the module written about the two-surfaces split, found by its own instrument.

After wiring: **divergence 0, all three FILLED.**

## Same renderer, three sources

| surface | source |
|---|---|
| **daemon** | `black_box.snapshot()` in-process. The daemon *runs* the step executor, so it's where the crash happens — and was the surface most likely to be blind to it. Same direction of blindness this module was written about for `pending_apply` and `panic_arbiter`. |
| **client** | the heartbeat frame, retiring on the same staleness window as the countdown and roster. A dead daemon must not leave a confirmation on screen: the operator would answer a question about a process that's gone, and the answer would go nowhere. |
| **demo** | a scripted beat, through the **same** `rows_for`, so the demo can't drift into showing a cockpit that doesn't exist. |

## No new mechanism

`black_box` gains a process-global pending store mirroring `pending_apply` exactly — `note_forensics` / `snapshot` / `resolve_forensics` — because a renderer needs a *source* and the forensics are produced inside an executor instance no cockpit holds.

`snapshot()` returns `None` rather than `[]` for the reason `pending_apply.snapshot` gives: *"nothing crashed"* and *"the daemon never told us"* are different facts, and a client that conflates them draws a healthy organism when it means a silent bridge.

The strip mounts through `build_dynamic_rows` — the one variable-height primitive, exactly as tall as it holds, zero rows when empty — rather than a hand-rolled Window that would be a second answer to "collapse when empty". It sits directly **above** the countdown: both are decisions the operator must make now, and the clock keeps the seat nearest the caret because it expires while a question waits.

The heartbeat carries it as **state**, not mirrored text, for the same reason the countdown is: the strip repaints locally and the bridge is a line stream.

## Tests

15 new mount tests asserting the **wiring** rather than the rendering — this codebase's specific failure is a finished capability reachable from nowhere, and three tests once passed by checking a handler's source contained a flag literal.

98 green across handoff + mount + forensics + journal; 128 green across the six edited modules' own suites. The 1 red in `test_attach_heartbeat` is pre-existing, identical on a clean HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mounted the crash forensics strip on all cockpit surfaces (daemon, attach client, demo) so operators can confirm or abort failed UI steps reliably. Routes a single source of truth through heartbeat and shared layout to remove blind spots and demo drift.

- **New Features**
  - Mounted `forensic_rows` by name in `serpent_flow`, `ov`, and `ov_demo` to satisfy `capability_handoff` audit.
  - Added `black_box` pending store: `note_forensics`, `snapshot`, `resolve_forensics`; `snapshot()` returns `None` when disabled or daemon silent (`JARVIS_FORENSIC_STRIP_ENABLED`), not `[]`.
  - Rendered via `build_dynamic_rows` above the countdown; collapses to zero rows when empty.
  - Heartbeat now carries `forensics` state; client retires the prompt on stale frames.
  - Demo renders through `forensic_delta.rows_for` with an env-tunable beat (`JARVIS_DEMO_FORENSIC_BEAT_S`); uses the same layout as live.

<sup>Written for commit 26e45bbea3e17ea2bbd670a6da125ed2784475cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

