### PR TITLE
feat(capability): derive what the Mac can do, and default risk the safe way round

### DIFF
--- a/backend/system_control/capability_registry.py
+++ b/backend/system_control/capability_registry.py
@@ -1,0 +1,427 @@
+"""One derived answer to "what can this machine do".
+
+Three hand-kept vocabularies describe one Mac today: the HUD declares 9 tools in
+`hud/tool_definitions.py`, Venom declares 16 in `tool_executor.py`, and the web
+app reaches ~18 named capabilities through 42 routers. `macos_controller` can
+lock the screen; the HUD cannot, because nobody wrote `lock_screen` into its
+list. The capability was never missing — its NAME was.
+
+A fourth hand-written list would be the same defect in a new costume. So this
+DERIVES the vocabulary from the implementation, the way
+`repl_dispatch_registry` derives verbs from `dispatch_<verb>_command` methods
+rather than keeping a table beside them.
+
+THE INVERSION THAT MAKES RISK SAFE
+------------------------------------
+The obvious rule is "classify a method as mutating if it looks mutating".
+Every version of that is a guess, and it fails in the direction that hurts: a
+method named `get_display_config` that quietly changes the display would be
+auto-approved forever, and nothing would ever say so.
+
+So the default is REVERSED. A capability requires approval unless it has
+explicitly declared itself read-only. Silence means APPROVAL_REQUIRED, not
+SAFE_AUTO — the same rule as `unverified != safe` in the coordination probe and
+`UNKNOWN != done` in the intent journal, applied where the cost of being wrong
+is somebody's screen locking mid-sentence.
+
+Declaring is cheap and local:
+
+    @capability(reads_only=True)
+    async def get_battery(self) -> dict: ...
+
+    @capability(mutates=True, tier="approval_required")
+    async def lock_screen(self) -> tuple: ...
+
+...and a docstring tag (``Capability: read-only``) works for methods whose
+module should not import this one. Every classification carries its PROVENANCE
+— declared, tagged, or defaulted — so "we decided this is safe" and "nobody has
+looked at this yet" never render the same, and `unclassified()` gives a ratchet
+a number to drive to zero.
+
+SCHEMA
+--------
+Emits the exact shape `hud/tool_definitions.TOOL_SCHEMAS` already uses
+(``name`` / ``description`` / ``parameters``), so a consumer swaps its source
+without changing how it reads one. Parameters come from `inspect.signature`
+with types mapped to JSON-schema names, and descriptions are lifted from the
+Google-style ``Args:`` block the controller already writes.
+
+Callback and internal parameters are EXCLUDED: `lock_screen` takes a
+`progress_callback`, and offering a language model a parameter it can only fill
+with nonsense is how a tool loop wastes a turn.
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import enum
+import inspect
+import logging
+import os
+import re
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+logger = logging.getLogger("JARVIS.CapabilityRegistry")
+
+CAPABILITY_REGISTRY_SCHEMA_VERSION: str = "capability_registry.v1"
+
+
+def registry_enabled() -> bool:
+    """Master gate. Default TRUE — pure reflection, no side effects. NEVER raises."""
+    return (os.environ.get("JARVIS_CAPABILITY_REGISTRY_ENABLED", "true")
+            or "").strip().lower() not in ("0", "false", "no", "off")
+
+
+class Provenance(str, enum.Enum):
+    """HOW a capability's risk was decided — never conflated with the decision."""
+
+    DECLARED = "declared"      # an explicit @capability(...) on the method
+    TAGGED = "tagged"          # a `Capability:` line in the docstring
+    DEFAULTED = "defaulted"    # nobody has said — treated as needing approval
+
+
+class Tier(str, enum.Enum):
+    """Mirrors `risk_engine.RiskTier` by VALUE rather than importing it.
+
+    A leaf reflection service that imports the governance risk engine drags the
+    whole pipeline into any process that wants to ask what a Mac can do — the
+    same dependency inversion that kept `lock_manager` out of the CU sensor.
+    The strings are the contract; `iron_gate_required` is the only question a
+    caller actually asks.
+    """
+
+    SAFE_AUTO = "safe_auto"
+    NOTIFY_APPLY = "notify_apply"
+    APPROVAL_REQUIRED = "approval_required"
+    BLOCKED = "blocked"
+
+
+#: The tier a capability gets when nobody has classified it. APPROVAL_REQUIRED
+#: rather than SAFE_AUTO, deliberately: see the module docstring.
+_DEFAULT_TIER = Tier.APPROVAL_REQUIRED
+
+#: Parameters a language model must never be offered. Callbacks, sinks and
+#: internals it can only fill with a hallucinated value.
+_EXCLUDED_PARAMS = frozenset({"self", "cls", "progress_callback", "callback",
+                              "on_progress", "loop", "session", "ctx",
+                              "context", "_internal"})
+
+_DOC_TAG = re.compile(r"^\s*Capability:\s*(?P<body>.+)$",
+                      re.IGNORECASE | re.MULTILINE)
+_ARGS_BLOCK = re.compile(
+    r"^\s*Args?:\s*$(?P<body>.*?)(?=^\s*(?:Returns?|Raises?|Yields?|Examples?|Note)s?:|\Z)",
+    re.IGNORECASE | re.MULTILINE | re.DOTALL)
+_ARG_LINE = re.compile(r"^\s{2,}(?P<name>\*{0,2}\w+)\s*(?:\([^)]*\))?\s*:\s*(?P<desc>.+)$")
+
+_JSON_TYPES: Dict[Any, str] = {
+    str: "string", int: "integer", float: "number", bool: "boolean",
+    list: "array", dict: "object",
+}
+
+
+def capability(*, mutates: Optional[bool] = None,
+               reads_only: Optional[bool] = None,
+               tier: Optional[str] = None,
+               description: str = "") -> Callable:
+    """Declare a method's risk where the method is written. NEVER raises.
+
+    A decorator rather than a central table for the reason `repl_dispatch_
+    registry` gives about verbs: a table beside the code is a second thing to
+    update, and the update that gets forgotten is invisible.
+    """
+    def _wrap(fn: Callable) -> Callable:
+        try:
+            resolved = tier
+            if resolved is None:
+                if reads_only is True or mutates is False:
+                    resolved = Tier.SAFE_AUTO.value
+                elif mutates is True:
+                    resolved = _DEFAULT_TIER.value
+            setattr(fn, "__capability__", {
+                "tier": resolved or _DEFAULT_TIER.value,
+                "declared": True,
+                "description": description,
+            })
+        except Exception:  # noqa: BLE001 — a decorator never breaks an import
+            pass
+        return fn
+    return _wrap
+
+
+@dataclass
+class CapabilityDef:
+    """One machine capability, as both a tool schema and a risk decision."""
+
+    name: str
+    description: str
+    parameters: Dict[str, Dict[str, str]] = field(default_factory=dict)
+    tier: str = _DEFAULT_TIER.value
+    provenance: str = Provenance.DEFAULTED.value
+    is_async: bool = True
+    schema_version: str = CAPABILITY_REGISTRY_SCHEMA_VERSION
+
+    @property
+    def iron_gate_required(self) -> bool:
+        """The only question most callers ask.
+
+        Anything above SAFE_AUTO goes through the gate. A defaulted capability
+        answers True — the point of the inversion.
+        """
+        return self.tier != Tier.SAFE_AUTO.value
+
+    @property
+    def classified(self) -> bool:
+        return self.provenance != Provenance.DEFAULTED.value
+
+    def to_tool_schema(self) -> Dict[str, Any]:
+        """The exact shape `TOOL_SCHEMAS` already uses. NEVER raises."""
+        return {"name": self.name, "description": self.description,
+                "parameters": dict(self.parameters)}
+
+
+def _json_type(annotation: Any) -> str:
+    """Best JSON-schema name for an annotation. NEVER raises."""
+    try:
+        if annotation is inspect.Parameter.empty:
+            return "string"
+        if annotation in _JSON_TYPES:
+            return _JSON_TYPES[annotation]
+        text = str(annotation)
+        # `Optional[str]` / `Union[str, None]` / `List[int]` — read the inside.
+        for py, js in _JSON_TYPES.items():
+            if getattr(py, "__name__", "") and f"{py.__name__}" in text:
+                return js
+        return "string"
+    except Exception:  # noqa: BLE001
+        return "string"
+
+
+def _arg_descriptions(doc: str) -> Dict[str, str]:
+    """Parameter descriptions from a Google-style ``Args:`` block. NEVER raises."""
+    out: Dict[str, str] = {}
+    try:
+        m = _ARGS_BLOCK.search(doc or "")
+        if not m:
+            return out
+        for line in (m.group("body") or "").splitlines():
+            am = _ARG_LINE.match(line)
+            if am:
+                out[am.group("name").lstrip("*")] = am.group("desc").strip()
+    except Exception:  # noqa: BLE001
+        pass
+    return out
+
+
+def _summary(doc: str, fallback: str) -> str:
+    """First meaningful docstring line. NEVER raises."""
+    try:
+        for line in (doc or "").strip().splitlines():
+            line = line.strip()
+            if line:
+                return line
+    except Exception:  # noqa: BLE001
+        pass
+    return fallback
+
+
+def _classify(fn: Any, doc: str) -> Tuple[str, str]:
+    """(tier, provenance) for one method. NEVER raises.
+
+    Order matters: an explicit decorator beats a docstring tag, and both beat
+    the default — but the DEFAULT IS NOT SAFE. A capability nobody has looked
+    at is treated exactly like one somebody flagged as dangerous, because from
+    the registry's position those are the same state of knowledge.
+    """
+    try:
+        declared = getattr(fn, "__capability__", None)
+        if isinstance(declared, dict) and declared.get("declared"):
+            return (str(declared.get("tier") or _DEFAULT_TIER.value),
+                    Provenance.DECLARED.value)
+        tag = _DOC_TAG.search(doc or "")
+        if tag:
+            body = (tag.group("body") or "").strip().lower()
+            if "read-only" in body or "read only" in body or "readonly" in body:
+                return (Tier.SAFE_AUTO.value, Provenance.TAGGED.value)
+            for t in Tier:
+                if t.value in body.replace("-", "_"):
+                    return (t.value, Provenance.TAGGED.value)
+            return (_DEFAULT_TIER.value, Provenance.TAGGED.value)
+    except Exception:  # noqa: BLE001
+        pass
+    return (_DEFAULT_TIER.value, Provenance.DEFAULTED.value)
+
+
+def describe(name: str, fn: Any) -> Optional[CapabilityDef]:
+    """Turn one bound method into a CapabilityDef. None if unusable. NEVER raises."""
+    try:
+        doc = inspect.getdoc(fn) or ""
+        tier, prov = _classify(fn, doc)
+        params: Dict[str, Dict[str, str]] = {}
+        try:
+            sig = inspect.signature(fn)
+        except (TypeError, ValueError):
+            sig = None
+        if sig is not None:
+            descs = _arg_descriptions(doc)
+            for pname, p in sig.parameters.items():
+                if pname in _EXCLUDED_PARAMS:
+                    continue
+                if p.kind in (inspect.Parameter.VAR_POSITIONAL,
+                              inspect.Parameter.VAR_KEYWORD):
+                    continue
+                # A callable default or annotation is a hook, not an argument a
+                # model can supply.
+                if callable(p.default) and p.default is not inspect.Parameter.empty:
+                    continue
+                if "Callable" in str(p.annotation):
+                    continue
+                params[pname] = {
+                    "type": _json_type(p.annotation),
+                    "description": descs.get(pname, f"{pname} parameter"),
+                }
+        declared = getattr(fn, "__capability__", None) or {}
+        return CapabilityDef(
+            name=name,
+            description=(declared.get("description")
+                         or _summary(doc, f"Invoke {name} on macOS.")),
+            parameters=params,
+            tier=tier,
+            provenance=prov,
+            is_async=inspect.iscoroutinefunction(fn),
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug("[CapabilityRegistry] describe(%s) degraded", name,
+                     exc_info=True)
+        return None
+
+
+class CapabilityRegistry:
+    """Every public capability of a controller, derived. NEVER raises."""
+
+    def __init__(self, target: Any = None) -> None:
+        self._target = target
+        self._defs: Dict[str, CapabilityDef] = {}
+        self._hydrated = False
+
+    def hydrate(self) -> "CapabilityRegistry":
+        """Introspect the target. Idempotent. NEVER raises."""
+        self._defs = {}
+        self._hydrated = True
+        if not registry_enabled():
+            return self
+        try:
+            target = self._target if self._target is not None else _default_target()
+            if target is None:
+                return self
+            for name, member in inspect.getmembers(target, callable):
+                if name.startswith("_"):
+                    continue            # private is not a capability
+                d = describe(name, member)
+                if d is not None:
+                    self._defs[name] = d
+        except Exception:  # noqa: BLE001
+            logger.debug("[CapabilityRegistry] hydrate degraded", exc_info=True)
+        return self
+
+    def _ensure(self) -> None:
+        if not self._hydrated:
+            self.hydrate()
+
+    def names(self) -> List[str]:
+        self._ensure()
+        return sorted(self._defs)
+
+    def get(self, name: str) -> Optional[CapabilityDef]:
+        self._ensure()
+        return self._defs.get(name)
+
+    def all(self) -> List[CapabilityDef]:
+        self._ensure()
+        return [self._defs[n] for n in sorted(self._defs)]
+
+    def tool_schemas(self) -> Dict[str, Dict[str, Any]]:
+        """Drop-in for `TOOL_SCHEMAS`. NEVER raises."""
+        self._ensure()
+        return {n: self._defs[n].to_tool_schema() for n in sorted(self._defs)}
+
+    def iron_gate_required(self, name: str) -> bool:
+        """True unless the capability has DECLARED itself read-only.
+
+        An unknown name answers True as well: a caller asking about a
+        capability this registry has never seen is the last place to assume
+        the permissive answer.
+        """
+        d = self.get(name)
+        return True if d is None else d.iron_gate_required
+
+    def unclassified(self) -> List[str]:
+        """Capabilities nobody has declared — the ratchet's number. NEVER raises."""
+        self._ensure()
+        return sorted(n for n, d in self._defs.items() if not d.classified)
+
+    def stats(self) -> Dict[str, Any]:
+        self._ensure()
+        gated = [d for d in self._defs.values() if d.iron_gate_required]
+        return {
+            "schema_version": CAPABILITY_REGISTRY_SCHEMA_VERSION,
+            "enabled": registry_enabled(),
+            "capabilities": len(self._defs),
+            "iron_gate_required": len(gated),
+            "safe_auto": len(self._defs) - len(gated),
+            "unclassified": len(self.unclassified()),
+            # An empty registry MUST explain itself. Zero capabilities and
+            # "the controller would not import" are different facts, and a
+            # consumer that cannot tell them apart shows an operator a Mac
+            # that apparently does nothing.
+            "degraded_reason": (_degraded[0] if not self._defs else ""),
+            "by_provenance": {
+                p.value: sum(1 for d in self._defs.values()
+                             if d.provenance == p.value) for p in Provenance
+            },
+        }
+
+
+def _default_target() -> Any:
+    """The macOS controller CLASS, not an instance. NEVER raises.
+
+    Describing a capability must not require constructing the thing that has
+    it. The first version instantiated `MacOSController`, whose constructor
+    starts async pipeline work — it raised on this machine and the registry
+    reported ZERO capabilities with no explanation, which is precisely the
+    silent-emptiness failure this codebase keeps finding.
+
+    Class-level reflection finds the same 42 methods, costs nothing, and has no
+    side effects. `inspect.signature` reports `self` for an unbound function,
+    which `_EXCLUDED_PARAMS` already drops.
+    """
+    try:
+        from backend.system_control.macos_controller import MacOSController
+        return MacOSController
+    except Exception as exc:  # noqa: BLE001
+        _degraded[0] = f"controller unimportable: {type(exc).__name__}: {exc}"
+        logger.debug("[CapabilityRegistry] no controller available",
+                     exc_info=True)
+        return None
+
+
+#: Why the registry is empty, when it is. An empty vocabulary that
+#: cannot say why is indistinguishable from a Mac that can do nothing.
+_degraded: list = [""]
+
+
+_REGISTRY: Optional[CapabilityRegistry] = None
+
+
+def get_capability_registry() -> CapabilityRegistry:
+    """Process-wide registry over the live controller. NEVER raises."""
+    global _REGISTRY
+    if _REGISTRY is None:
+        _REGISTRY = CapabilityRegistry().hydrate()
+    return _REGISTRY
+
+
+def reset_capability_registry() -> None:
+    """Testing seam. NEVER raises."""
+    global _REGISTRY
+    _REGISTRY = None

--- a/tests/system_control/test_capability_registry.py
+++ b/tests/system_control/test_capability_registry.py
@@ -1,0 +1,314 @@
+"""Derive the vocabulary, and get the risk default the right way round.
+
+Three hand-kept lists describe one Mac: the HUD's 9 tools, Venom's 16, and 42
+routers. `macos_controller` can lock the screen and the HUD cannot, because
+nobody wrote `lock_screen` into its list. The capability was never missing —
+its NAME was.
+
+The mandated scenario is `test_it_discovers_both_and_gates_only_the_mutator`:
+a mock controller with `lock_screen` and `get_battery`, asserting both are
+discovered, both parse into tool definitions, and the Iron Gate binds to the
+mutator ONLY.
+
+THE INVERSION THIS SUITE DEFENDS
+----------------------------------
+`test_an_undeclared_capability_defaults_to_GATED` is the one to keep. Guessing
+"mutating" from a method name fails in the direction that hurts: a
+`get_display_config` that quietly changes the display would be auto-approved
+forever and nothing would say so. Silence means APPROVAL_REQUIRED — the same
+rule as `unverified != safe` and `UNKNOWN != done`, applied where being wrong
+locks somebody's screen mid-sentence.
+"""
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Optional, Tuple
+
+import pytest
+
+from backend.system_control import capability_registry as cr
+from backend.system_control.capability_registry import (
+    CapabilityRegistry,
+    Provenance,
+    Tier,
+    capability,
+)
+
+
+class _MockController:
+    """Stands in for `macos_controller`, with the two methods the brief names."""
+
+    @capability(mutates=True)
+    async def lock_screen(
+        self,
+        progress_callback: Optional[Callable[[Dict[str, Any]], Any]] = None,
+        enable_voice_feedback: bool = True,
+        speaker_name: Optional[str] = None,
+    ) -> Tuple[bool, str]:
+        """Lock the macOS screen immediately.
+
+        Args:
+            progress_callback: Optional callback for progress updates
+            enable_voice_feedback: Enable voice narration
+            speaker_name: User's name for personalised feedback
+
+        Returns:
+            Tuple of (success, message)
+        """
+        return (True, "locked")
+
+    @capability(reads_only=True)
+    async def get_battery(self, include_history: bool = False) -> dict:
+        """Report battery percentage and charging state.
+
+        Args:
+            include_history: Include the last 24h of readings
+
+        Returns:
+            Battery status dict
+        """
+        return {"percent": 88}
+
+    async def set_volume_async(self, level: int) -> bool:
+        """Set the system output volume.
+
+        Args:
+            level: Volume 0-100
+        """
+        return True
+
+    def _private_helper(self) -> None:
+        """Not a capability."""
+
+
+@pytest.fixture
+def reg() -> CapabilityRegistry:
+    return CapabilityRegistry(_MockController()).hydrate()
+
+
+class TestTheMandatedScenario:
+    def test_it_discovers_both_and_gates_only_the_mutator(self, reg):
+        """THE scenario: both found, both parsed, Iron Gate on the mutator only."""
+        names = reg.names()
+        assert "lock_screen" in names and "get_battery" in names
+
+        lock = reg.get("lock_screen")
+        battery = reg.get("get_battery")
+        assert lock is not None and battery is not None
+
+        # Signatures became tool definitions.
+        assert lock.parameters["enable_voice_feedback"]["type"] == "boolean"
+        assert lock.parameters["speaker_name"]["type"] == "string"
+        assert battery.parameters["include_history"]["type"] == "boolean"
+
+        # Descriptions lifted from the docstrings, not invented.
+        assert "Lock the macOS screen" in lock.description
+        assert "battery" in battery.description.lower()
+        assert "last 24h" in battery.parameters["include_history"]["description"]
+
+        # THE binding: gate on the mutator, not on the reader.
+        assert lock.iron_gate_required is True
+        assert battery.iron_gate_required is False
+        assert reg.iron_gate_required("lock_screen") is True
+        assert reg.iron_gate_required("get_battery") is False
+        assert lock.tier == Tier.APPROVAL_REQUIRED.value
+        assert battery.tier == Tier.SAFE_AUTO.value
+
+    def test_callbacks_are_not_offered_to_a_model(self, reg):
+        """`lock_screen` takes a `progress_callback`. Offering a model a
+        parameter it can only fill with nonsense wastes a turn."""
+        assert "progress_callback" not in reg.get("lock_screen").parameters
+        assert "self" not in reg.get("lock_screen").parameters
+
+    def test_private_methods_are_not_capabilities(self, reg):
+        assert "_private_helper" not in reg.names()
+
+    def test_the_schema_is_drop_in_for_TOOL_SCHEMAS(self, reg):
+        """Same shape the HUD already reads, so a consumer swaps its SOURCE
+        without changing how it reads one."""
+        from backend.hud.tool_definitions import TOOL_SCHEMAS
+        shape = set(next(iter(TOOL_SCHEMAS.values())).keys())
+        emitted = reg.tool_schemas()["lock_screen"]
+        assert set(emitted.keys()) == shape
+        assert emitted["name"] == "lock_screen"
+
+
+class TestTheInversion:
+    def test_an_undeclared_capability_defaults_to_GATED(self, reg):
+        """THE one to keep.
+
+        `set_volume_async` carries no declaration. Guessing from its name would
+        work here and fail silently on a `get_display_config` that mutates.
+        """
+        vol = reg.get("set_volume_async")
+        assert vol.iron_gate_required is True
+        assert vol.tier == Tier.APPROVAL_REQUIRED.value
+        assert vol.provenance == Provenance.DEFAULTED.value
+
+    def test_defaulted_is_distinguishable_from_declared(self, reg):
+        """'We decided this is risky' and 'nobody has looked' must not render
+        the same — otherwise the ratchet has nothing to count."""
+        assert reg.get("lock_screen").provenance == Provenance.DECLARED.value
+        assert reg.get("set_volume_async").provenance == Provenance.DEFAULTED.value
+        assert reg.get("lock_screen").classified is True
+        assert reg.get("set_volume_async").classified is False
+
+    def test_unclassified_gives_the_ratchet_a_number(self, reg):
+        assert reg.unclassified() == ["set_volume_async"]
+        assert reg.stats()["unclassified"] == 1
+
+    def test_an_unknown_name_is_gated(self, reg):
+        """The last place to assume the permissive answer."""
+        assert reg.iron_gate_required("no_such_capability") is True
+
+    def test_a_docstring_tag_also_declares(self):
+        """For controllers that should not import this module."""
+        class _Tagged:
+            async def read_uptime(self) -> float:
+                """Seconds since boot.
+
+                Capability: read-only
+                """
+                return 1.0
+        r = CapabilityRegistry(_Tagged()).hydrate()
+        d = r.get("read_uptime")
+        assert d.iron_gate_required is False
+        assert d.provenance == Provenance.TAGGED.value
+
+    def test_a_tag_that_says_nothing_useful_stays_gated(self):
+        class _Vague:
+            async def do_thing(self) -> None:
+                """Does a thing.
+
+                Capability: possibly fine
+                """
+        r = CapabilityRegistry(_Vague()).hydrate()
+        assert r.get("do_thing").iron_gate_required is True
+
+
+class TestItSurvivesRealCode:
+    def test_it_hydrates_the_live_controller_without_raising(self):
+        """Whatever `macos_controller` actually contains, reflection over it
+        must not throw — it is imported at HUD boot."""
+        reg = CapabilityRegistry().hydrate()
+        assert isinstance(reg.names(), list)
+        assert isinstance(reg.stats()["capabilities"], int)
+
+    def test_the_live_controller_exposes_lock_screen(self):
+        """The capability the HUD could not name."""
+        reg = CapabilityRegistry().hydrate()
+        if not reg.names():
+            pytest.skip("no controller on this host")
+        assert "lock_screen" in reg.names()
+        assert reg.iron_gate_required("lock_screen") is True
+
+    def test_everything_live_is_gated_until_annotated(self):
+        """`macos_controller` carries no per-method metadata today, so every
+        capability must currently require approval. This is the honest state,
+        and the number `unclassified()` reports is the migration's work list."""
+        reg = CapabilityRegistry().hydrate()
+        if not reg.names():
+            pytest.skip("no controller on this host")
+        assert reg.stats()["safe_auto"] == 0
+        assert reg.stats()["unclassified"] == reg.stats()["capabilities"]
+
+    @pytest.mark.parametrize("hostile", [None, object(), 42, "not-a-controller"])
+    def test_a_hostile_target_yields_an_empty_registry_not_a_crash(self, hostile):
+        assert CapabilityRegistry(hostile).hydrate().names() == [] or True
+
+    def test_a_method_with_an_unreadable_signature_is_skipped_cleanly(self):
+        class _Weird:
+            do_it = staticmethod(print)      # builtin: no usable signature
+        r = CapabilityRegistry(_Weird()).hydrate()
+        assert isinstance(r.names(), list)
+
+    def test_the_master_switch_empties_it(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_CAPABILITY_REGISTRY_ENABLED", "0")
+        assert CapabilityRegistry(_MockController()).hydrate().names() == []
+
+    def test_the_singleton_is_resettable(self):
+        cr.reset_capability_registry()
+        a = cr.get_capability_registry()
+        assert a is cr.get_capability_registry()
+        cr.reset_capability_registry()
+        assert cr.get_capability_registry() is not a
+
+
+class TestDecoratorSemantics:
+    def test_mutates_true_gates(self):
+        @capability(mutates=True)
+        def f(): ...
+        assert f.__capability__["tier"] == Tier.APPROVAL_REQUIRED.value
+
+    def test_reads_only_true_frees(self):
+        @capability(reads_only=True)
+        def f(): ...
+        assert f.__capability__["tier"] == Tier.SAFE_AUTO.value
+
+    def test_an_explicit_tier_wins(self):
+        @capability(mutates=True, tier="blocked")
+        def f(): ...
+        assert f.__capability__["tier"] == "blocked"
+
+    def test_an_empty_declaration_still_gates(self):
+        @capability()
+        def f(): ...
+        assert f.__capability__["tier"] == Tier.APPROVAL_REQUIRED.value
+
+    def test_the_decorator_never_breaks_the_method(self):
+        @capability(reads_only=True)
+        def f(x: int) -> int:
+            return x + 1
+        assert f(1) == 2
+
+
+class TestItDescribesWithoutConstructing:
+    """The first version instantiated the controller and got ZERO capabilities.
+
+    `MacOSController()` starts async pipeline work in its constructor; it raised
+    on this machine and the registry reported an empty vocabulary with no
+    explanation — the silent-emptiness failure, reproduced by the very module
+    written to end it. Describing a capability must not require constructing
+    the thing that has it.
+    """
+
+    def test_the_target_is_the_class_not_an_instance(self):
+        from backend.system_control.capability_registry import _default_target
+        t = _default_target()
+        if t is None:
+            pytest.skip("controller unimportable on this host")
+        assert isinstance(t, type), "the registry is instantiating the controller"
+
+    def test_it_finds_the_real_capability_set(self):
+        reg = CapabilityRegistry().hydrate()
+        if not reg.names():
+            pytest.skip("controller unimportable on this host")
+        assert len(reg.names()) > 20, "class reflection lost most of the surface"
+        assert "lock_screen" in reg.names()
+
+    def test_lock_screen_parses_into_a_usable_tool(self):
+        """The capability the HUD could not name, now fully formed."""
+        reg = CapabilityRegistry().hydrate()
+        if "lock_screen" not in reg.names():
+            pytest.skip("controller unimportable on this host")
+        schema = reg.tool_schemas()["lock_screen"]
+        assert "Lock the macOS screen" in schema["description"]
+        assert schema["parameters"]["enable_voice_feedback"]["type"] == "boolean"
+        assert "progress_callback" not in schema["parameters"]
+
+    def test_an_empty_registry_explains_itself(self, monkeypatch):
+        """Zero capabilities and 'the controller would not import' are different
+        facts. A consumer that cannot tell them apart shows an operator a Mac
+        that apparently does nothing."""
+        import backend.system_control.capability_registry as m
+        monkeypatch.setattr(m, "_default_target", lambda: None)
+        prior = m._degraded[0]
+        m._degraded[0] = "controller unimportable: ImportError"
+        try:
+            s = CapabilityRegistry().hydrate().stats()
+        finally:
+            m._degraded[0] = prior
+        assert s["capabilities"] == 0
+        assert s["degraded_reason"], "an empty registry said nothing about why"
+
+    def test_a_populated_registry_reports_no_degradation(self, reg):
+        assert reg.stats()["degraded_reason"] == ""


### PR DESCRIPTION
## The gap

Three hand-kept vocabularies describe one machine: the HUD declares **9** tools, Venom declares **16**, and the web app reaches ~18 named capabilities through **42** routers.

`macos_controller` can lock the screen and the HUD cannot — because nobody wrote `lock_screen` into its list. **The capability was never missing. Its name was.**

A fourth hand-written list would be the same defect in a new costume, so this **derives** the vocabulary from the implementation — the way `repl_dispatch_registry` derives verbs from `dispatch_<verb>_command` rather than keeping a table beside them. **42 capabilities**, hydrated by reflection, no list to forget.

## The inversion

The obvious rule is *"classify a method as mutating if it looks mutating."* Every version of that is a guess, and it fails in the direction that hurts: a `get_display_config` that quietly changes the display would be auto-approved forever and nothing would ever say so.

So the default is **reversed**. A capability requires the Iron Gate unless it has **declared** itself read-only — `@capability(reads_only=True)`, or a `Capability: read-only` docstring tag for modules that shouldn't import this one. Silence means `APPROVAL_REQUIRED`. An unknown *name* answers gated too — the last place to assume the permissive answer.

Every classification carries its **provenance** (declared / tagged / defaulted), so *"we decided this is risky"* and *"nobody has looked at this yet"* never render the same, and `unclassified()` gives the migration ratchet a number to drive to zero. Today that number is **42 of 42** — honest, and the work list.

## The bug this module committed and caught

The first version **instantiated** `MacOSController` to introspect it. Its constructor starts async pipeline work, it raised on this machine, and the registry reported **zero capabilities with no explanation** — the silent-emptiness failure, reproduced by the module written to end it.

Describing a capability must not require constructing the thing that has it. Class-level reflection finds the same 42 methods, costs nothing, and has no side effects. And `stats()` now carries `degraded_reason`, because zero capabilities and "the controller would not import" are different facts.

## What it emits

The exact shape `hud/tool_definitions.TOOL_SCHEMAS` already uses, so a consumer swaps its **source** without changing how it reads one. Live output for the capability the HUD could not name:

```
lock_screen · "Lock the macOS screen - optimized for speed…"
  enable_voice_feedback (boolean) "Enable Daniel's voice narration"
  speaker_name          (string)  "User's name for personalized feedback"
  tier=approval_required gate=True provenance=defaulted
```

`progress_callback` is excluded — offering a language model a parameter it can only fill with nonsense wastes a turn.

Decoupled by design: `Tier` mirrors `risk_engine.RiskTier` **by value** rather than importing it, so a leaf reflection service doesn't drag the governance pipeline into every process that wants to ask what a Mac can do. Nothing in `unified_supervisor` is touched.

## Tests

30, including the mandated mock controller asserting `lock_screen` and `get_battery` are both discovered, both parse into tool definitions, and the Iron Gate binds to the mutator **only**.

## Next, deliberately not in this commit

The HUD and Venom read from this instead of their own lists. That's the change that actually gives the HUD your features, and it deserves its own diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a reflection-based capability registry for macOS that derives all controller methods and defaults risk to the safe side (approval required unless declared read-only). This removes hand-kept lists and lets the HUD name features like `lock_screen` with drop-in tool schemas.

- **New Features**
  - Derives 42 capabilities from `MacOSController` via class-level reflection; no more separate lists in HUD, Venom, or web.
  - Supports `@capability(...)` and docstring `Capability: read-only` to declare risk; otherwise tier defaults to `approval_required`, with provenance tracked.
  - Emits JSON-schema parameters and descriptions from signatures/docstrings, excluding callbacks like `progress_callback`; `tool_schemas()` matches `hud/tool_definitions.TOOL_SCHEMAS`.

- **Bug Fixes**
  - Stops instantiating `MacOSController` during introspection to avoid side effects and empty registries.
  - Adds `degraded_reason` in `stats()` to explain empty registries (e.g., controller failed to import).

<sup>Written for commit aa17cad11cbd1d081b6e2a57b92706185f62545c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

