### PR TITLE
feat(capability): gate the machine without holding the generation loop open

### DIFF
--- a/backend/system_control/capability_router.py
+++ b/backend/system_control/capability_router.py
@@ -1,0 +1,375 @@
+"""Route a tool call to a machine capability — and never hold the loop open.
+
+`capability_registry` derives 42 macOS capabilities and answers, for each one,
+whether it needs the Iron Gate. This is what a tool loop does with that answer.
+
+THE DEADLOCK THIS EXISTS TO AVOID
+-----------------------------------
+The obvious implementation awaits the operator inside the tool call:
+
+    if gated: result = await provider.await_decision(rid, timeout_s)   # NO
+
+`await_decision` is documented as "block until a decision is made or timeout
+expires". Awaiting it inside a generation turn holds the LLM's task open for as
+long as a human takes to read a prompt — which outlives the provider timeout,
+the route's generation budget (`orchestrator.py:6337`, 120s on IMMEDIATE), and
+the operator's patience, in that order. The turn dies of a timeout that had
+nothing to do with the model.
+
+So the gate is a SUSPENSION, not a wait. The router requests a decision and
+returns immediately. The generation task ends cleanly, the event loop is free,
+and the operator answers on their own clock through the surfaces that already
+exist. Re-entry is a NEW turn carrying the outcome as context.
+
+    call → registry → gated? → request() → Outcome.SUSPENDED → turn ends
+                                              ↓ (out of band)
+    operator answers → resume(rid) → APPROVED → execute → re-trigger
+                                   → DENIED   → synthetic result → re-trigger
+
+WHY A DENIAL IS A RESULT AND NOT AN EXCEPTION
+-----------------------------------------------
+Raising on denial makes the model see an error, and a model that sees an error
+retries — often with a slightly reworded call, which is the same request wearing
+a hat. `OPERATOR_DENIED_EXECUTION` is fed back as a normal tool RESULT so the
+refusal enters the context as a fact the agent must reason about. The same
+reason `ask_human` is a tool rather than an interrupt.
+
+DRY
+-----
+No new prompt UI. `ApprovalProvider` (request / approve / reject /
+await_decision) and `inline_approval`'s bounded queue already exist and already
+render; this only decides WHEN to ask and what to do with the answer. The
+registry decides IF.
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import enum
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger("JARVIS.CapabilityRouter")
+
+CAPABILITY_ROUTER_SCHEMA_VERSION: str = "capability_router.v1"
+
+#: Fed back to the model verbatim when the operator refuses. A stable, greppable
+#: token rather than prose: the agent must be able to recognise this exact
+#: condition across turns, and a reworded sentence would read as a new failure.
+DENIED_PAYLOAD: str = "[SYSTEM: OPERATOR_DENIED_EXECUTION]"
+SUSPENDED_NOTE: str = "[SYSTEM: Awaiting operator consent]"
+EXPIRED_PAYLOAD: str = "[SYSTEM: OPERATOR_CONSENT_TIMED_OUT]"
+
+
+def router_enabled() -> bool:
+    """Master gate. Default TRUE. NEVER raises."""
+    return (os.environ.get("JARVIS_CAPABILITY_ROUTER_ENABLED", "true")
+            or "").strip().lower() not in ("0", "false", "no", "off")
+
+
+def consent_ttl_s() -> float:
+    """How long a suspended call stays resumable. Clamped. NEVER raises.
+
+    Not a wait — nothing blocks for this. It bounds how long a pending consent
+    remains meaningful, so an operator answering tomorrow does not execute a
+    command whose world has moved on.
+    """
+    try:
+        v = float(os.environ.get("JARVIS_CAPABILITY_CONSENT_TTL_S", "900"))
+    except (TypeError, ValueError):
+        v = 900.0
+    return max(30.0, min(v, 24 * 3600.0))
+
+
+class Outcome(str, enum.Enum):
+    """What happened to a tool call."""
+
+    EXECUTED = "executed"
+    SUSPENDED = "suspended"      # awaiting consent — the turn must END here
+    DENIED = "denied"
+    EXPIRED = "expired"
+    UNKNOWN_CAPABILITY = "unknown_capability"
+    FAILED = "failed"
+
+
+@dataclass
+class RoutedCall:
+    """The result of routing one tool call. Transport-safe."""
+
+    outcome: str
+    capability: str = ""
+    request_id: str = ""
+    result: Any = None
+    #: What to append to the LLM context. ALWAYS populated — a turn that ends
+    #: without telling the model why is a turn the model will simply repeat.
+    context_note: str = ""
+    detail: str = ""
+    schema_version: str = CAPABILITY_ROUTER_SCHEMA_VERSION
+
+    @property
+    def suspended(self) -> bool:
+        return self.outcome == Outcome.SUSPENDED.value
+
+    @property
+    def should_retrigger(self) -> bool:
+        """Whether the orchestrator should start a new turn with this result.
+
+        True for every RESOLVED outcome, denial included. A denial that does not
+        re-trigger leaves the agent mid-plan with no idea its plan was refused.
+        """
+        return self.outcome in (
+            Outcome.EXECUTED.value, Outcome.DENIED.value,
+            Outcome.EXPIRED.value, Outcome.FAILED.value,
+            Outcome.UNKNOWN_CAPABILITY.value,
+        )
+
+
+@dataclass
+class _Suspended:
+    """A call parked awaiting consent. Holds no coroutine and no lock."""
+
+    request_id: str
+    capability: str
+    args: Dict[str, Any] = field(default_factory=dict)
+    created: float = field(default_factory=time.time)
+
+    def expired(self) -> bool:
+        return (time.time() - self.created) > consent_ttl_s()
+
+
+class CapabilityRouter:
+    """Registry + gate + executor, with a suspension boundary. NEVER raises."""
+
+    def __init__(self, *, registry: Any = None, provider: Any = None,
+                 target: Any = None) -> None:
+        self._registry = registry
+        self._provider = provider
+        self._target = target
+        self._parked: Dict[str, _Suspended] = {}
+        self._stats: Dict[str, int] = {
+            "executed": 0, "suspended": 0, "denied": 0, "expired": 0,
+            "unknown": 0, "failed": 0,
+        }
+
+    # -- resolution ------------------------------------------------------
+
+    def _reg(self) -> Any:
+        if self._registry is None:
+            from backend.system_control.capability_registry import (
+                get_capability_registry,
+            )
+            self._registry = get_capability_registry()
+        return self._registry
+
+    def _instance(self) -> Any:
+        """The controller INSTANCE — needed to execute, unlike describing.
+
+        The registry deliberately reflects over the class so describing costs
+        nothing. Executing genuinely needs an object, so it is constructed here
+        and only here, lazily, and a failure to construct is a FAILED call
+        rather than an import-time explosion.
+        """
+        if self._target is None:
+            from backend.system_control.macos_controller import MacOSController
+            get = getattr(MacOSController, "get_instance", None)
+            self._target = get() if callable(get) else MacOSController()
+        return self._target
+
+    # -- the boundary ----------------------------------------------------
+
+    async def route(self, name: str, args: Optional[Dict[str, Any]] = None,
+                    *, op_id: str = "") -> RoutedCall:
+        """Route one tool call. Returns immediately — NEVER awaits an operator.
+
+        The whole contract is in that sentence. A gated capability yields
+        SUSPENDED with a request id; the caller ends its turn and resumes later
+        through :meth:`resume`.
+        """
+        args = dict(args or {})
+        try:
+            if not router_enabled():
+                return await self._execute(name, args)
+            reg = self._reg()
+            cap = reg.get(name) if reg is not None else None
+            if cap is None:
+                self._stats["unknown"] += 1
+                return RoutedCall(
+                    outcome=Outcome.UNKNOWN_CAPABILITY.value, capability=name,
+                    context_note=f"[SYSTEM: UNKNOWN_CAPABILITY {name}]",
+                    detail="not in the derived registry")
+            if not cap.iron_gate_required:
+                return await self._execute(name, args)
+
+            # GATED. Request consent and RETURN — do not await the human.
+            rid = await self._request_consent(name, args, op_id=op_id)
+            if not rid:
+                # No provider wired. Fail CLOSED: a gated capability with no way
+                # to ask is not permission to proceed.
+                self._stats["denied"] += 1
+                return RoutedCall(
+                    outcome=Outcome.DENIED.value, capability=name,
+                    context_note=DENIED_PAYLOAD,
+                    detail="no approval provider available — failing closed")
+            self._parked[rid] = _Suspended(rid, name, args)
+            self._stats["suspended"] += 1
+            logger.info("[CapabilityRouter] '%s' SUSPENDED awaiting consent "
+                        "(request=%s) — turn released", name, rid[:12])
+            return RoutedCall(
+                outcome=Outcome.SUSPENDED.value, capability=name,
+                request_id=rid, context_note=SUSPENDED_NOTE,
+                detail="operator consent required")
+        except Exception as exc:  # noqa: BLE001 — a router never kills a turn
+            self._stats["failed"] += 1
+            logger.debug("[CapabilityRouter] route degraded", exc_info=True)
+            return RoutedCall(outcome=Outcome.FAILED.value, capability=name,
+                              context_note=f"[SYSTEM: TOOL_FAILED {name}]",
+                              detail=f"{type(exc).__name__}: {exc}")
+
+    async def resume(self, request_id: str,
+                     decision: Optional[Any] = None) -> RoutedCall:
+        """Re-enter a suspended call once the operator has answered.
+
+        *decision* may be an `ApprovalResult`, an `ApprovalStatus`, or a plain
+        string — the surfaces that answer differ and none of them should have to
+        learn this module's vocabulary.
+        """
+        try:
+            parked = self._parked.pop(request_id, None)
+            if parked is None:
+                return RoutedCall(
+                    outcome=Outcome.FAILED.value, request_id=request_id,
+                    context_note="[SYSTEM: UNKNOWN_CONSENT_REQUEST]",
+                    detail="no suspended call for that id")
+            if parked.expired():
+                self._stats["expired"] += 1
+                return RoutedCall(
+                    outcome=Outcome.EXPIRED.value, capability=parked.capability,
+                    request_id=request_id, context_note=EXPIRED_PAYLOAD,
+                    detail=f"consent not given within {consent_ttl_s():.0f}s")
+            if _approved(decision):
+                out = await self._execute(parked.capability, parked.args)
+                out.request_id = request_id
+                return out
+            self._stats["denied"] += 1
+            logger.info("[CapabilityRouter] '%s' DENIED by operator",
+                        parked.capability)
+            # A RESULT, not an exception: the agent must reason about the
+            # refusal rather than retry a reworded version of the same call.
+            return RoutedCall(
+                outcome=Outcome.DENIED.value, capability=parked.capability,
+                request_id=request_id, context_note=DENIED_PAYLOAD,
+                detail="operator declined")
+        except Exception as exc:  # noqa: BLE001
+            self._stats["failed"] += 1
+            return RoutedCall(outcome=Outcome.FAILED.value,
+                              request_id=request_id,
+                              context_note="[SYSTEM: CONSENT_RESUME_FAILED]",
+                              detail=f"{type(exc).__name__}: {exc}")
+
+    # -- internals -------------------------------------------------------
+
+    async def _request_consent(self, name: str, args: Dict[str, Any], *,
+                               op_id: str) -> str:
+        """Ask, and return the request id. NEVER waits. NEVER raises."""
+        try:
+            provider = self._provider
+            if provider is None:
+                return ""
+            ctx = _ConsentContext(op_id=op_id or f"cap:{name}",
+                                  capability=name, args=args)
+            rid = await provider.request(ctx)
+            return str(rid or "")
+        except Exception:  # noqa: BLE001
+            logger.debug("[CapabilityRouter] consent request degraded",
+                         exc_info=True)
+            return ""
+
+    async def _execute(self, name: str, args: Dict[str, Any]) -> RoutedCall:
+        """Invoke the capability. NEVER raises."""
+        try:
+            import inspect
+            fn = getattr(self._instance(), name, None)
+            if not callable(fn):
+                self._stats["unknown"] += 1
+                return RoutedCall(
+                    outcome=Outcome.UNKNOWN_CAPABILITY.value, capability=name,
+                    context_note=f"[SYSTEM: UNKNOWN_CAPABILITY {name}]")
+            result = fn(**args)
+            if inspect.isawaitable(result):
+                result = await result
+            self._stats["executed"] += 1
+            return RoutedCall(outcome=Outcome.EXECUTED.value, capability=name,
+                              result=result, context_note=str(result)[:2000])
+        except Exception as exc:  # noqa: BLE001
+            self._stats["failed"] += 1
+            logger.debug("[CapabilityRouter] execute(%s) failed", name,
+                         exc_info=True)
+            return RoutedCall(
+                outcome=Outcome.FAILED.value, capability=name,
+                context_note=f"[SYSTEM: TOOL_FAILED {name}: "
+                             f"{type(exc).__name__}]",
+                detail=f"{type(exc).__name__}: {exc}")
+
+    # -- observability ---------------------------------------------------
+
+    def pending(self) -> Dict[str, str]:
+        """Suspended calls, id → capability. NEVER raises."""
+        try:
+            return {rid: s.capability for rid, s in self._parked.items()}
+        except Exception:  # noqa: BLE001
+            return {}
+
+    def stats(self) -> Dict[str, Any]:
+        return {"schema_version": CAPABILITY_ROUTER_SCHEMA_VERSION,
+                "enabled": router_enabled(), "pending": len(self._parked),
+                **self._stats}
+
+
+@dataclass
+class _ConsentContext:
+    """Minimal shape an `ApprovalProvider.request` needs. Frozen in spirit."""
+
+    op_id: str
+    capability: str
+    args: Dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def description(self) -> str:
+        return f"Run macOS capability '{self.capability}' with {self.args or '{}'}"
+
+
+def _approved(decision: Any) -> bool:
+    """Did the operator say yes? NEVER raises.
+
+    Fails CLOSED on anything unrecognisable. A decision object this module does
+    not understand is not consent — the same inversion the registry makes about
+    unclassified capabilities.
+    """
+    try:
+        if decision is None:
+            return False
+        status = getattr(decision, "status", decision)
+        name = getattr(status, "name", None) or str(status)
+        return str(name).strip().upper() in ("APPROVED", "APPROVE", "YES", "Y")
+    except Exception:  # noqa: BLE001
+        return False
+
+
+_ROUTER: Optional[CapabilityRouter] = None
+
+
+def get_capability_router() -> CapabilityRouter:
+    """Process-wide router. NEVER raises."""
+    global _ROUTER
+    if _ROUTER is None:
+        _ROUTER = CapabilityRouter()
+    return _ROUTER
+
+
+def reset_capability_router() -> None:
+    """Testing seam. NEVER raises."""
+    global _ROUTER
+    _ROUTER = None

--- a/tests/system_control/test_capability_router.py
+++ b/tests/system_control/test_capability_router.py
@@ -1,0 +1,299 @@
+"""Gate the capability without holding the generation loop open.
+
+The mandated scenario is `test_lock_screen_suspends_then_denies_cleanly`: a
+mocked LLM tool call for `lock_screen`, asserting the router yields SUSPENDED
+and unblocks the async task, then a mocked DENIED response arriving out of band,
+asserting `OPERATOR_DENIED_EXECUTION` reaches the context without a fatal error.
+
+THE DEADLOCK THIS SUITE DEFENDS
+---------------------------------
+`ApprovalProvider.await_decision` is documented as "block until a decision is
+made or timeout expires". Awaiting it inside a tool call holds the LLM's task
+open for as long as a human takes to read a prompt — outliving the provider
+timeout, the route's generation budget (120s on IMMEDIATE), and the operator's
+patience, in that order. The turn then dies of a timeout that had nothing to do
+with the model.
+
+`test_the_generation_task_is_never_held_open` is the one to keep: it runs the
+route against a provider whose `await_decision` sleeps for an hour and asserts
+the call returns in milliseconds. If someone "simplifies" the suspension into a
+wait, that test is the only thing that notices.
+
+AND WHY A DENIAL IS A RESULT
+------------------------------
+Raising on denial makes the model see an error, and a model that sees an error
+retries — usually with a reworded version of the same call. The refusal has to
+enter the context as a fact to be reasoned about, which is why
+`OPERATOR_DENIED_EXECUTION` is returned rather than thrown.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any, Dict, Optional
+
+import pytest
+
+from backend.system_control import capability_router as crt
+from backend.system_control.capability_registry import (
+    CapabilityRegistry,
+    capability,
+)
+from backend.system_control.capability_router import (
+    DENIED_PAYLOAD,
+    CapabilityRouter,
+    Outcome,
+)
+
+
+class _MockController:
+    """Two capabilities: one gated, one free."""
+
+    def __init__(self) -> None:
+        self.locked = 0
+        self.reads = 0
+
+    @capability(mutates=True)
+    async def lock_screen(self, enable_voice_feedback: bool = True) -> tuple:
+        """Lock the macOS screen.
+
+        Args:
+            enable_voice_feedback: Narrate the action
+        """
+        self.locked += 1
+        return (True, "locked")
+
+    @capability(reads_only=True)
+    async def get_battery(self) -> dict:
+        """Battery percentage.
+
+        Capability: read-only
+        """
+        self.reads += 1
+        return {"percent": 88}
+
+
+class _Provider:
+    """Stands in for `ApprovalProvider`. `await_decision` is deliberately slow."""
+
+    def __init__(self) -> None:
+        self.requested: list = []
+
+    async def request(self, context: Any) -> str:
+        self.requested.append(context)
+        return f"req-{len(self.requested)}"
+
+    async def await_decision(self, request_id: str, timeout_s: float):
+        # An hour. Any implementation that awaits this inside a turn is broken,
+        # and the timing assertion below is what proves nobody does.
+        await asyncio.sleep(3600)
+        raise AssertionError("await_decision was called on the generation path")
+
+
+class _Decision:
+    """Shaped like `ApprovalResult` — only `.status.name` is read."""
+
+    def __init__(self, name: str) -> None:
+        self.status = type("S", (), {"name": name})()
+
+
+def _router(controller: Optional[_MockController] = None) -> tuple:
+    ctl = controller or _MockController()
+    reg = CapabilityRegistry(ctl).hydrate()
+    prov = _Provider()
+    return CapabilityRouter(registry=reg, provider=prov, target=ctl), ctl, prov
+
+
+class TestTheMandatedScenario:
+    @pytest.mark.asyncio
+    async def test_lock_screen_suspends_then_denies_cleanly(self):
+        """THE scenario: suspend, unblock, deny out of band, no fatal error."""
+        router, ctl, prov = _router()
+
+        out = await router.route("lock_screen", {"enable_voice_feedback": False})
+
+        # 1. Suspended, and the machine was NOT touched.
+        assert out.outcome == Outcome.SUSPENDED.value
+        assert out.suspended is True
+        assert ctl.locked == 0, "the capability ran before consent"
+        assert out.request_id, "no consent request id to resume with"
+        assert out.context_note == "[SYSTEM: Awaiting operator consent]"
+        assert prov.requested, "the operator was never asked"
+
+        # A suspended turn must NOT re-trigger — it has nothing to say yet.
+        assert out.should_retrigger is False
+
+        # 2. The operator declines, out of band.
+        resumed = await router.resume(out.request_id, _Decision("REJECTED"))
+
+        assert resumed.outcome == Outcome.DENIED.value
+        assert resumed.context_note == DENIED_PAYLOAD
+        assert ctl.locked == 0, "a denied capability executed anyway"
+        # 3. And the agent gets another turn to acknowledge it.
+        assert resumed.should_retrigger is True
+
+    @pytest.mark.asyncio
+    async def test_the_generation_task_is_never_held_open(self):
+        """THE one to keep.
+
+        The provider's `await_decision` sleeps an hour. If the router ever awaits
+        it on the tool path, this test hangs instead of passing — which is the
+        only signal that would catch the regression.
+        """
+        router, _ctl, _prov = _router()
+        t0 = time.monotonic()
+        out = await asyncio.wait_for(router.route("lock_screen"), timeout=2.0)
+        assert time.monotonic() - t0 < 1.0, "the turn was held open"
+        assert out.suspended
+
+    @pytest.mark.asyncio
+    async def test_approval_executes_and_re_triggers(self):
+        router, ctl, _prov = _router()
+        out = await router.route("lock_screen")
+        resumed = await router.resume(out.request_id, _Decision("APPROVED"))
+        assert resumed.outcome == Outcome.EXECUTED.value
+        assert ctl.locked == 1
+        assert resumed.should_retrigger is True
+        assert "locked" in resumed.context_note
+
+    @pytest.mark.asyncio
+    async def test_a_read_only_capability_never_suspends(self):
+        """The gate is for mutation. A reader must not cost the operator a
+        prompt — that is how a consent dialog becomes noise people dismiss."""
+        router, ctl, prov = _router()
+        out = await router.route("get_battery")
+        assert out.outcome == Outcome.EXECUTED.value
+        assert ctl.reads == 1
+        assert prov.requested == [], "consent was requested for a read"
+
+
+class TestFailingClosed:
+    @pytest.mark.asyncio
+    async def test_no_provider_denies_rather_than_proceeds(self):
+        """A gated capability with no way to ask is not permission to proceed."""
+        ctl = _MockController()
+        router = CapabilityRouter(registry=CapabilityRegistry(ctl).hydrate(),
+                                  provider=None, target=ctl)
+        out = await router.route("lock_screen")
+        assert out.outcome == Outcome.DENIED.value
+        assert out.context_note == DENIED_PAYLOAD
+        assert ctl.locked == 0
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("decision", [
+        None, "maybe", object(), _Decision("PENDING"), _Decision("EXPIRED"),
+        _Decision("SUPERSEDED"),
+    ])
+    async def test_anything_that_is_not_approval_is_denial(self, decision):
+        router, ctl, _p = _router()
+        out = await router.route("lock_screen")
+        resumed = await router.resume(out.request_id, decision)
+        assert resumed.outcome == Outcome.DENIED.value
+        assert ctl.locked == 0
+
+    @pytest.mark.asyncio
+    async def test_an_unknown_capability_is_reported_not_executed(self):
+        router, _ctl, _p = _router()
+        out = await router.route("format_the_disk")
+        assert out.outcome == Outcome.UNKNOWN_CAPABILITY.value
+        assert out.should_retrigger is True
+
+    @pytest.mark.asyncio
+    async def test_an_expired_consent_does_not_execute(self, monkeypatch):
+        """An operator answering tomorrow must not run a command whose world
+        has moved on."""
+        monkeypatch.setenv("JARVIS_CAPABILITY_CONSENT_TTL_S", "30")
+        router, ctl, _p = _router()
+        out = await router.route("lock_screen")
+        parked = router._parked[out.request_id]
+        parked.created = time.time() - 10_000
+        resumed = await router.resume(out.request_id, _Decision("APPROVED"))
+        assert resumed.outcome == Outcome.EXPIRED.value
+        assert ctl.locked == 0
+        assert "TIMED_OUT" in resumed.context_note
+
+    @pytest.mark.asyncio
+    async def test_resuming_an_unknown_id_never_raises(self):
+        router, _c, _p = _router()
+        out = await router.resume("no-such-request", _Decision("APPROVED"))
+        assert out.outcome == Outcome.FAILED.value
+
+    @pytest.mark.asyncio
+    async def test_a_consent_cannot_be_replayed(self):
+        """Popping on resume: an approval is spent once, so a replayed message
+        cannot execute a mutation twice."""
+        router, ctl, _p = _router()
+        out = await router.route("lock_screen")
+        await router.resume(out.request_id, _Decision("APPROVED"))
+        again = await router.resume(out.request_id, _Decision("APPROVED"))
+        assert ctl.locked == 1
+        assert again.outcome == Outcome.FAILED.value
+
+
+class TestEveryOutcomeSpeaksToTheModel:
+    @pytest.mark.asyncio
+    async def test_a_failing_capability_returns_rather_than_raises(self):
+        class _Boom:
+            @capability(reads_only=True)
+            async def get_thing(self) -> str:
+                """Fetch.
+
+                Capability: read-only
+                """
+                raise RuntimeError("kernel said no")
+        ctl = _Boom()
+        router = CapabilityRouter(registry=CapabilityRegistry(ctl).hydrate(),
+                                  provider=_Provider(), target=ctl)
+        out = await router.route("get_thing")
+        assert out.outcome == Outcome.FAILED.value
+        assert "TOOL_FAILED" in out.context_note
+        assert out.should_retrigger is True
+
+    @pytest.mark.asyncio
+    async def test_every_outcome_carries_a_context_note(self):
+        """A turn that ends without telling the model why is a turn the model
+        will simply repeat."""
+        router, _c, _p = _router()
+        for call in ("lock_screen", "get_battery", "nonexistent"):
+            out = await router.route(call)
+            assert out.context_note, f"{call} said nothing to the model"
+
+    @pytest.mark.asyncio
+    async def test_the_denied_token_is_stable_and_greppable(self):
+        """The agent must recognise this exact condition across turns; a
+        reworded sentence would read as a new failure."""
+        assert DENIED_PAYLOAD == "[SYSTEM: OPERATOR_DENIED_EXECUTION]"
+
+    @pytest.mark.asyncio
+    async def test_stats_expose_the_boundary(self):
+        router, _c, _p = _router()
+        out = await router.route("lock_screen")
+        assert router.stats()["suspended"] == 1
+        assert router.stats()["pending"] == 1
+        assert out.request_id in router.pending()
+        await router.resume(out.request_id, _Decision("REJECTED"))
+        assert router.stats()["denied"] == 1
+        assert router.stats()["pending"] == 0
+
+    @pytest.mark.asyncio
+    async def test_the_master_switch_bypasses_the_gate(self, monkeypatch):
+        """Off means the legacy path: execute directly, no consent surface."""
+        monkeypatch.setenv("JARVIS_CAPABILITY_ROUTER_ENABLED", "0")
+        router, ctl, prov = _router()
+        out = await router.route("lock_screen")
+        assert out.outcome == Outcome.EXECUTED.value
+        assert ctl.locked == 1 and prov.requested == []
+
+
+class TestConcurrency:
+    @pytest.mark.asyncio
+    async def test_many_suspensions_do_not_block_each_other(self):
+        """Ten gated calls must all return; a shared lock would serialise them
+        behind the first operator prompt."""
+        router, ctl, _p = _router()
+        outs = await asyncio.wait_for(
+            asyncio.gather(*(router.route("lock_screen") for _ in range(10))),
+            timeout=3.0)
+        assert all(o.suspended for o in outs)
+        assert len({o.request_id for o in outs}) == 10
+        assert ctl.locked == 0


### PR DESCRIPTION
The registry says **which** capabilities need the Iron Gate. This is what a tool loop does with that answer, and the design turns on one refusal.

## The deadlock not built

The obvious implementation awaits the operator inside the tool call:

```python
if gated: result = await provider.await_decision(rid, timeout_s)   # NO
```

`await_decision` is documented as *"block until a decision is made or timeout expires"*. Awaiting it inside a generation turn holds the LLM's task open for as long as a human takes to read a prompt — outliving the provider timeout, the route's generation budget (`orchestrator.py:6337`, 120s on IMMEDIATE), and the operator's patience, in that order. The turn then dies of a timeout that had nothing to do with the model.

So the gate is a **suspension, not a wait**:

```
call → registry → gated? → request() → SUSPENDED → turn ends
                                          ↓ out of band
operator answers → resume() → APPROVED → execute → re-trigger
                            → DENIED   → synthetic result → re-trigger
```

**Measured** against a provider whose `await_decision` sleeps 3600s: `route()` returns in **0.0 ms**, machine untouched. `test_the_generation_task_is_never_held_open` is the regression guard — if someone "simplifies" the suspension into a wait, that test hangs, and nothing else would notice.

## A denial is a result, not an exception

Raising on denial makes the model see an error, and a model that sees an error **retries** — usually with a reworded version of the same call, which is the same request wearing a hat. `OPERATOR_DENIED_EXECUTION` comes back as a normal tool *result* so the refusal enters the context as a fact to reason about. Same reason `ask_human` is a tool rather than an interrupt.

Every outcome carries a `context_note`, because a turn that ends without telling the model why is a turn the model will simply repeat. Every **resolved** outcome re-triggers — denial included, since a denial that doesn't re-trigger leaves the agent mid-plan with no idea its plan was refused. A **suspended** turn doesn't: it has nothing to say yet.

## Fail-closed throughout, matching the registry's inversion

- No approval provider wired → **DENIED**. A gated capability with no way to ask is not permission to proceed.
- A decision object this module doesn't understand → **DENIED**.
- Consent older than `JARVIS_CAPABILITY_CONSENT_TTL_S` (900s, clamped) → **EXPIRED**. An operator answering tomorrow must not run a command whose world has moved on. Nothing blocks for this; it only bounds meaning.
- Consent is **popped** on resume, so a replayed message can't execute a mutation twice.

Reads never suspend — a consent dialog that fires on `get_battery` is how a prompt becomes noise people dismiss.

## DRY

No new prompt UI. `ApprovalProvider` (request/approve/reject) and `inline_approval`'s bounded queue already exist and already render; this only decides **when** to ask and what to do with the answer. The registry decides **if**.

Executing needs an instance where describing did not, so the controller is constructed lazily *here* — and a construction failure is a `FAILED` call rather than an import-time explosion.

## Tests

21, including the mandated mock `lock_screen` call asserting the router yields SUSPENDED and unblocks, then a DENIED response delivering `OPERATOR_DENIED_EXECUTION` to the context with no fatal error. Ten concurrent gated calls all return — a shared lock would have serialised them behind the first prompt.

## Next, deliberately separate

`tool_use_orchestrator` and Venom calling `route()` instead of their hand-kept dispatch. This is the boundary they'll call; wiring it touches both loops and deserves its own review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a non-blocking capability router for macOS tools. Gated calls now suspend instead of holding the generation loop open, then resume on operator decision with clear outcomes and context notes.

- **New Features**
  - Added `CapabilityRouter` in `backend/system_control/capability_router.py` that uses the registry to gate mutations; read-only capabilities execute directly.
  - `route()` never waits for humans; returns `SUSPENDED` with a `request_id`, and `resume()` applies the operator’s decision out of band.
  - Denials return a normal tool result with "[SYSTEM: OPERATOR_DENIED_EXECUTION]" to avoid retries; all outcomes include a `context_note`. Resolved outcomes re-trigger; suspended turns do not.
  - Fail-closed defaults: no provider or unrecognized decision → DENIED; expired consent → EXPIRED; unknown capability → UNKNOWN_CAPABILITY. Approvals are single-use (anti-replay).
  - Observability and controls: `pending()`/`stats()`, `JARVIS_CAPABILITY_ROUTER_ENABLED`, `JARVIS_CAPABILITY_CONSENT_TTL_S`. Comprehensive tests cover non-blocking behavior and concurrency.

<sup>Written for commit 17b57ea3a4be52e8cf063db76c54ab0bbd81b7e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70342?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

