### PR TITLE
feat(capability): close the annotation ratchet, and stop one prompt idling the swarm

### DIFF
--- a/backend/core/ouroboros/governance/autonomy/consent_pending_queue.py
+++ b/backend/core/ouroboros/governance/autonomy/consent_pending_queue.py
@@ -1,0 +1,232 @@
+"""A graph node waiting on a human is not a graph that has stopped.
+
+`capability_router` already refuses to hold the LLM's turn open while an
+operator decides — it yields SUSPENDED in 0.0 ms. That fixes ONE task. It does
+not fix the graph: a work unit whose tool call suspended is still, from the
+scheduler's point of view, a unit that was handed out and never came back. With
+a bounded worker pool, enough of those and the whole swarm idles behind one
+unanswered prompt while unrelated, non-dependent branches sit ready.
+
+WHY THIS IS SIX LINES AND NOT A SCHEDULER
+-------------------------------------------
+`SubagentScheduler._compute_ready_units` already answers "what may run now":
+
+    for unit in graph.units:
+        if unit.unit_id in completed | failed | cancelled | running: continue
+        if all(dep in completed for dep in unit.dependency_ids): ready.append(...)
+
+A parked unit is none of those four. It is not running (nothing is executing),
+not completed, not failed, not cancelled — so today it silently re-enters
+`ready` and gets dispatched again, re-asking the operator on every pass.
+
+So the fix is a FIFTH state in that filter, not a second traversal. The
+existing topological logic is correct and stays untouched; it simply gains a
+word for "handed to a human". Everything else — dependency ordering, the
+concurrency limit, wave progression — keeps working because none of it needed
+to change.
+
+A parked unit's DEPENDENTS stay blocked, and that is deliberate: they depend on
+work that has not happened. Only genuinely independent branches proceed, which
+is the whole and only claim being made.
+
+BOUNDED, AND HONEST WHEN IT GIVES UP
+--------------------------------------
+Parking is not free — a unit parked forever is a leak that looks like patience.
+Entries carry the same TTL discipline as the router's consent, and an expired
+park RELEASES the unit rather than deleting it, so the graph resolves the unit
+normally (its tool call will re-ask, or fail closed) instead of the node
+vanishing from a DAG that still lists it.
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+logger = logging.getLogger("Ouroboros.ConsentPendingQueue")
+
+CONSENT_QUEUE_SCHEMA_VERSION: str = "consent_pending_queue.v1"
+
+
+def queue_enabled() -> bool:
+    """Master gate. Default TRUE — failure-path-only: it changes nothing until
+    a unit actually suspends on consent. NEVER raises."""
+    return (os.environ.get("JARVIS_CONSENT_QUEUE_ENABLED", "true")
+            or "").strip().lower() not in ("0", "false", "no", "off")
+
+
+def park_ttl_s() -> float:
+    """How long a unit may sit parked. Clamped. NEVER raises.
+
+    Nothing blocks for this. It bounds how long a graph will hold a slot open
+    for an operator who may never answer.
+    """
+    try:
+        v = float(os.environ.get("JARVIS_CONSENT_PARK_TTL_S", "900"))
+    except (TypeError, ValueError):
+        v = 900.0
+    return max(30.0, min(v, 24 * 3600.0))
+
+
+def max_parked() -> int:
+    """Ring bound per graph. NEVER raises."""
+    try:
+        return max(1, int(os.environ.get("JARVIS_CONSENT_MAX_PARKED", "32")))
+    except (TypeError, ValueError):
+        return 32
+
+
+@dataclass
+class ParkedUnit:
+    """One work unit awaiting operator consent."""
+
+    unit_id: str
+    graph_id: str
+    request_id: str = ""
+    capability: str = ""
+    parked_at: float = field(default_factory=time.time)
+
+    def expired(self) -> bool:
+        return (time.time() - self.parked_at) > park_ttl_s()
+
+    def age_s(self) -> float:
+        return max(0.0, time.time() - self.parked_at)
+
+
+class ConsentPendingQueue:
+    """Units parked on consent, per graph. Every method NEVER raises."""
+
+    def __init__(self) -> None:
+        self._parked: Dict[str, Dict[str, ParkedUnit]] = {}
+        self._stats: Dict[str, int] = {"parked": 0, "released": 0,
+                                       "expired": 0, "rejected": 0}
+
+    def park(self, graph_id: str, unit_id: str, *, request_id: str = "",
+             capability: str = "") -> bool:
+        """Park a unit. Returns False if the graph is at its bound.
+
+        Refusing at the bound rather than evicting: dropping the OLDEST parked
+        unit would silently un-park something an operator is still looking at.
+        A refusal leaves the unit schedulable, which is the safe direction —
+        it will re-ask.
+        """
+        if not queue_enabled():
+            return False
+        try:
+            bucket = self._parked.setdefault(str(graph_id), {})
+            if unit_id in bucket:
+                return True                      # idempotent re-park
+            if len(bucket) >= max_parked():
+                self._stats["rejected"] += 1
+                logger.warning(
+                    "[ConsentQueue] graph %s at the parking bound (%d) — "
+                    "unit %s stays schedulable and will re-ask",
+                    graph_id, max_parked(), unit_id)
+                return False
+            bucket[unit_id] = ParkedUnit(
+                unit_id=str(unit_id), graph_id=str(graph_id),
+                request_id=str(request_id), capability=str(capability))
+            self._stats["parked"] += 1
+            logger.info("[ConsentQueue] unit %s parked on consent for '%s' — "
+                        "graph %s continues on independent branches",
+                        unit_id, capability or "?", graph_id)
+            return True
+        except Exception:  # noqa: BLE001
+            return False
+
+    def release(self, graph_id: str, unit_id: str) -> Optional[ParkedUnit]:
+        """Un-park a resolved unit so the scheduler may pick it up. NEVER raises."""
+        try:
+            bucket = self._parked.get(str(graph_id))
+            if not bucket:
+                return None
+            unit = bucket.pop(str(unit_id), None)
+            if unit is not None:
+                self._stats["released"] += 1
+            if not bucket:
+                self._parked.pop(str(graph_id), None)
+            return unit
+        except Exception:  # noqa: BLE001
+            return None
+
+    def parked_ids(self, graph_id: str) -> Set[str]:
+        """The fifth state for `_compute_ready_units`. NEVER raises.
+
+        Sweeps expirations on read — an expired park RELEASES rather than
+        lingering, so a unit whose operator never answered rejoins the graph
+        instead of disappearing from a DAG that still lists it.
+        """
+        try:
+            bucket = self._parked.get(str(graph_id))
+            if not bucket:
+                return set()
+            for uid, unit in list(bucket.items()):
+                if unit.expired():
+                    bucket.pop(uid, None)
+                    self._stats["expired"] += 1
+                    logger.info(
+                        "[ConsentQueue] unit %s park EXPIRED after %.0fs — "
+                        "returning it to the graph", uid, unit.age_s())
+            if not bucket:
+                self._parked.pop(str(graph_id), None)
+                return set()
+            return set(bucket)
+        except Exception:  # noqa: BLE001
+            return set()
+
+    def snapshot(self, graph_id: str = "") -> List[Dict[str, Any]]:
+        """Transport-safe view for a surface. NEVER raises."""
+        try:
+            out: List[Dict[str, Any]] = []
+            buckets = ([self._parked.get(str(graph_id), {})] if graph_id
+                       else list(self._parked.values()))
+            for bucket in buckets:
+                for u in bucket.values():
+                    out.append({"unit_id": u.unit_id, "graph_id": u.graph_id,
+                                "capability": u.capability,
+                                "request_id": u.request_id,
+                                "age_s": round(u.age_s(), 1)})
+            return out
+        except Exception:  # noqa: BLE001
+            return []
+
+    def clear(self, graph_id: str = "") -> None:
+        """Drop parks for a finished graph. NEVER raises."""
+        try:
+            if graph_id:
+                self._parked.pop(str(graph_id), None)
+            else:
+                self._parked.clear()
+        except Exception:  # noqa: BLE001
+            pass
+
+    def stats(self) -> Dict[str, Any]:
+        try:
+            return {"schema_version": CONSENT_QUEUE_SCHEMA_VERSION,
+                    "enabled": queue_enabled(),
+                    "graphs": len(self._parked),
+                    "pending": sum(len(b) for b in self._parked.values()),
+                    **self._stats}
+        except Exception:  # noqa: BLE001
+            return {"schema_version": CONSENT_QUEUE_SCHEMA_VERSION}
+
+
+_QUEUE: Optional[ConsentPendingQueue] = None
+
+
+def get_consent_queue() -> ConsentPendingQueue:
+    """Process-wide queue. NEVER raises."""
+    global _QUEUE
+    if _QUEUE is None:
+        _QUEUE = ConsentPendingQueue()
+    return _QUEUE
+
+
+def reset_consent_queue() -> None:
+    """Testing seam. NEVER raises."""
+    global _QUEUE
+    _QUEUE = None

--- a/backend/core/ouroboros/governance/autonomy/subagent_scheduler.py
+++ b/backend/core/ouroboros/governance/autonomy/subagent_scheduler.py
@@ -604,6 +604,22 @@ class GenerationSubagentExecutor:
         )
 
 
+def _parked_units(graph: Any) -> set:
+    """Unit ids awaiting operator consent for *graph*. NEVER raises.
+
+    Fail-OPEN: any error yields an empty set, so a broken consent queue makes
+    the scheduler behave exactly as it did before this existed rather than
+    stalling a graph it can no longer reason about.
+    """
+    try:
+        from backend.core.ouroboros.governance.autonomy.consent_pending_queue import (
+            get_consent_queue,
+        )
+        return get_consent_queue().parked_ids(getattr(graph, "graph_id", ""))
+    except Exception:  # noqa: BLE001
+        return set()
+
+
 class SubagentScheduler:
     """Deterministic scheduler for parallel execution graphs."""
 
@@ -1097,10 +1113,23 @@ class SubagentScheduler:
         failed = set(state.failed_units) if state is not None else set()
         cancelled = set(state.cancelled_units) if state is not None else set()
         running = set(state.running_units) if state is not None else set()
+        # THE FIFTH STATE: handed to a human.
+        #
+        # A unit whose tool call suspended on operator consent is not running
+        # (nothing is executing), not completed, not failed and not cancelled —
+        # so without this it re-enters `ready` on every pass and re-asks the
+        # operator forever, while a bounded worker pool can idle behind it.
+        #
+        # Parking is expressed HERE rather than in a second traversal because
+        # the topological logic below is already correct: it only lacked a word
+        # for this condition. Dependents of a parked unit stay blocked, which is
+        # right — they depend on work that has not happened. Independent
+        # branches proceed, which is the entire claim.
+        parked = _parked_units(graph)
 
         ready: List[str] = []
         for unit in graph.units:
-            if unit.unit_id in completed | failed | cancelled | running:
+            if unit.unit_id in completed | failed | cancelled | running | parked:
                 continue
             if all(dep in completed for dep in unit.dependency_ids):
                 ready.append(unit.unit_id)

--- a/backend/system_control/capability_registry.py
+++ b/backend/system_control/capability_registry.py
@@ -120,6 +120,38 @@ _JSON_TYPES: Dict[Any, str] = {
 }
 
 
+class Effect(str, enum.Enum):
+    """PURE observes; EFFECTFUL changes the world.
+
+    Deliberately the same two words `intent_journal.NodeKind` uses, and for the
+    same reason: a node that only reads may be replayed and auto-approved, one
+    that touched the world may be neither. Two vocabularies for one distinction
+    would guarantee they eventually disagree about the same method.
+
+    Mirrored by VALUE rather than imported — `system_control` importing
+    `hud.intent_journal` would invert the layering to share two strings.
+    `test_the_taxonomies_agree` pins them together.
+    """
+
+    PURE = "pure"
+    EFFECTFUL = "effectful"
+
+
+def os_capability(effect: "Effect", *, description: str = "") -> Callable:
+    """Declare an OS capability's effect at its definition site.
+
+    The name the annotation ratchet uses on `macos_controller`. It is a thin
+    spelling of :func:`capability` rather than a second decorator with its own
+    rules — one concept, one implementation, so a future change to how risk is
+    resolved cannot apply to half the codebase.
+    """
+    return capability(
+        reads_only=(effect is Effect.PURE),
+        mutates=(effect is Effect.EFFECTFUL),
+        description=description,
+    )
+
+
 def capability(*, mutates: Optional[bool] = None,
                reads_only: Optional[bool] = None,
                tier: Optional[str] = None,

--- a/backend/system_control/macos_controller.py
+++ b/backend/system_control/macos_controller.py
@@ -18,6 +18,10 @@ import psutil
 # Import async pipeline for non-blocking operations
 from core.async_pipeline import get_async_pipeline
 
+from backend.system_control.capability_registry import (  # noqa: E402
+    Effect, os_capability,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -388,6 +392,7 @@ class MacOSController:
             f"Your screen is locked, Sir. I cannot execute {command_type} commands while locked. Would you like me to unlock your screen first?",
         )
 
+    @os_capability(Effect.EFFECTFUL)
     async def execute_applescript_pipeline(
         self, script: str, timeout: float = 10.0
     ) -> Tuple[bool, str]:
@@ -409,6 +414,7 @@ class MacOSController:
             logger.error(f"Pipeline AppleScript execution failed: {e}")
             return False, str(e)
 
+    @os_capability(Effect.EFFECTFUL)
     def execute_applescript(self, script: str) -> Tuple[bool, str]:
         """Execute AppleScript (LEGACY - synchronous fallback without pipeline)"""
         # Direct execution without pipeline to avoid timeouts
@@ -427,6 +433,7 @@ class MacOSController:
         except Exception as e:
             return False, str(e)
 
+    @os_capability(Effect.EFFECTFUL)
     async def execute_applescript_async(self, script: str, timeout: float = 10.0) -> Tuple[bool, str]:
         """Execute AppleScript asynchronously without blocking the event loop.
 
@@ -474,6 +481,7 @@ class MacOSController:
             logger.error(f"Async AppleScript execution error: {e}")
             return False, str(e)
 
+    @os_capability(Effect.EFFECTFUL)
     async def execute_shell_async(
         self, command: str, timeout: float = 30.0, safe_mode: bool = True
     ) -> Tuple[bool, str]:
@@ -549,6 +557,7 @@ class MacOSController:
             logger.error(f"[SHELL_ASYNC] Execution error: {e}")
             return False, str(e)
 
+    @os_capability(Effect.EFFECTFUL)
     async def execute_shell_pipeline(
         self, command: str, safe_mode: bool = True, timeout: float = 30.0
     ) -> Tuple[bool, str]:
@@ -580,6 +589,7 @@ class MacOSController:
             logger.error(f"Pipeline shell execution failed: {e}")
             return False, str(e)
 
+    @os_capability(Effect.EFFECTFUL)
     async def execute_shell(
         self, command: str, safe_mode: bool = True, use_pipeline: bool = False
     ) -> Tuple[bool, str]:
@@ -602,6 +612,7 @@ class MacOSController:
 
     # Application Control Methods
 
+    @os_capability(Effect.EFFECTFUL)
     async def open_application_pipeline(self, app_name: str) -> Tuple[bool, str]:
         """Open application through async pipeline — delegates to ApplicationLauncherExecutor
         for unified native app + web service resolution with agentic fallback."""
@@ -648,6 +659,7 @@ class MacOSController:
             logger.error(f"Failed to open {app_name}: {e}")
             return False, f"I'm unable to open {app_name}, Sir"
 
+    @os_capability(Effect.EFFECTFUL)
     def open_application(self, app_name: str) -> Tuple[bool, str]:
         """Open an application directly without pipeline (for system commands).
 
@@ -684,6 +696,7 @@ class MacOSController:
         # via ApplicationLauncherExecutor → PrimeRouter.
         return False, f"Couldn't find application: {app_name}"
 
+    @os_capability(Effect.EFFECTFUL)
     def close_application(self, app_name: str) -> Tuple[bool, str]:
         """Close an application gracefully"""
         # Check if screen is locked
@@ -729,6 +742,7 @@ class MacOSController:
 
         return False, f"Failed to close {app_name}: {message}"
 
+    @os_capability(Effect.EFFECTFUL)
     def switch_to_application(self, app_name: str) -> Tuple[bool, str]:
         """Switch to an already open application"""
         # Check if screen is locked
@@ -750,6 +764,7 @@ class MacOSController:
             return True, f"Switched to {app_name}"
         return False, f"Failed to switch to {app_name}: {message}"
 
+    @os_capability(Effect.PURE)
     def list_open_applications(self) -> List[str]:
         """Get list of currently open applications"""
         script = """
@@ -764,6 +779,7 @@ class MacOSController:
             return [app.strip() for app in apps if app.strip()]
         return []
 
+    @os_capability(Effect.EFFECTFUL)
     def minimize_all_windows(self) -> Tuple[bool, str]:
         """Minimize all windows"""
         script = """
@@ -773,6 +789,7 @@ class MacOSController:
         """
         return self.execute_applescript(script)
 
+    @os_capability(Effect.EFFECTFUL)
     def activate_mission_control(self) -> Tuple[bool, str]:
         """Activate Mission Control"""
         script = """
@@ -782,11 +799,13 @@ class MacOSController:
 
     # File Operations
 
+    @os_capability(Effect.PURE)
     def is_safe_path(self, path: Path) -> bool:
         """Check if a path is in a safe directory"""
         path = path.resolve()
         return any(path.is_relative_to(safe_dir) for safe_dir in self.safe_directories)
 
+    @os_capability(Effect.EFFECTFUL)
     def open_file(self, file_path: str) -> Tuple[bool, str]:
         """Open a file with its default application"""
         # Check if screen is locked
@@ -808,6 +827,7 @@ class MacOSController:
             return True, f"Opened {path.name}"
         return False, f"Failed to open file: {message}"
 
+    @os_capability(Effect.EFFECTFUL)
     def create_file(self, file_path: str, content: str = "") -> Tuple[bool, str]:
         """Create a new file"""
         # Check if screen is locked
@@ -828,6 +848,7 @@ class MacOSController:
         except Exception as e:
             return False, f"Failed to create file: {str(e)}"
 
+    @os_capability(Effect.EFFECTFUL)
     def delete_file(self, file_path: str, confirm: bool = True) -> Tuple[bool, str]:
         """Delete a file (requires confirmation)"""
         # Check if screen is locked
@@ -854,6 +875,7 @@ class MacOSController:
         except Exception as e:
             return False, f"Failed to delete file: {str(e)}"
 
+    @os_capability(Effect.PURE)
     def search_files(self, query: str, directory: Optional[str] = None) -> List[str]:
         """Search for files using Spotlight"""
         if directory:
@@ -874,6 +896,7 @@ class MacOSController:
 
     # System Settings Control
 
+    @os_capability(Effect.EFFECTFUL)
     async def set_volume_async(self, level: int) -> Tuple[bool, str]:
         """Set system volume (0-100) - ASYNC VERSION for better performance"""
         from api.jarvis_voice_api import async_osascript
@@ -886,6 +909,7 @@ class MacOSController:
             return True, f"Setting volume to {level}%"
         return False, "I couldn't adjust the volume"
 
+    @os_capability(Effect.EFFECTFUL)
     def set_volume(self, level: int) -> Tuple[bool, str]:
         """Set system volume (0-100) - LEGACY sync version"""
         level = max(0, min(100, level))
@@ -896,6 +920,7 @@ class MacOSController:
             return True, f"Setting volume to {level}%"
         return False, "I couldn't adjust the volume"
 
+    @os_capability(Effect.EFFECTFUL)
     async def mute_volume_async(self, mute: bool = True) -> Tuple[bool, str]:
         """Mute or unmute system volume - ASYNC VERSION for better performance"""
         from api.jarvis_voice_api import async_osascript
@@ -908,6 +933,7 @@ class MacOSController:
             return True, f"Volume {state}"
         return False, "Failed to change mute state"
 
+    @os_capability(Effect.EFFECTFUL)
     def mute_volume(self, mute: bool = True) -> Tuple[bool, str]:
         """Mute or unmute system volume - LEGACY sync version"""
         script = f"set volume output muted {str(mute).lower()}"
@@ -918,11 +944,13 @@ class MacOSController:
             return True, f"Volume {state}"
         return False, "Failed to change mute state"
 
+    @os_capability(Effect.EFFECTFUL)
     def adjust_brightness(self, level: float) -> Tuple[bool, str]:
         """Adjust screen brightness (0.0-1.0)"""
         # This requires additional setup with brightness control tools
         return False, "Brightness control requires additional setup"
 
+    @os_capability(Effect.EFFECTFUL)
     def toggle_wifi(self, enable: bool) -> Tuple[bool, str]:
         """Toggle WiFi on/off"""
         action = "on" if enable else "off"
@@ -932,6 +960,7 @@ class MacOSController:
             return True, f"WiFi turned {action}"
         return False, f"Failed to toggle WiFi: {message}"
 
+    @os_capability(Effect.EFFECTFUL)
     def take_screenshot(self, save_path: Optional[str] = None) -> Tuple[bool, str]:
         """Take a screenshot"""
         if save_path:
@@ -953,6 +982,7 @@ class MacOSController:
             return True, f"Screenshot saved to {path.name}"
         return False, f"Failed to take screenshot: {message}"
 
+    @os_capability(Effect.EFFECTFUL)
     def sleep_display(self) -> Tuple[bool, str]:
         """Put display to sleep"""
         success, message = self.execute_shell("pmset displaysleepnow")
@@ -961,6 +991,7 @@ class MacOSController:
             return True, "Display sleeping"
         return False, f"Failed to sleep display: {message}"
 
+    @os_capability(Effect.EFFECTFUL)
     async def click_at(self, x: int, y: int) -> Tuple[bool, str]:
         """Click at specific coordinates"""
         # Check if screen is locked
@@ -989,6 +1020,7 @@ class MacOSController:
         except Exception as e:
             return False, f"Click error: {str(e)}"
 
+    @os_capability(Effect.EFFECTFUL)
     async def click_and_hold(self, x: int, y: int, hold_duration: float = 0.2) -> Tuple[bool, str]:
         """Click and hold at specific coordinates (simulates human press-and-hold)"""
         # Check if screen is locked
@@ -1027,6 +1059,7 @@ class MacOSController:
             logger.error(f"Click and hold at {x},{y} failed: {e}")
             return False, str(e)
 
+    @os_capability(Effect.EFFECTFUL)
     async def key_press(self, key: str) -> Tuple[bool, str]:
         """Press a keyboard key"""
         try:
@@ -1061,6 +1094,7 @@ class MacOSController:
 
     # Web Integration
 
+    @os_capability(Effect.EFFECTFUL)
     def open_new_tab(
         self, browser: Optional[str] = None, url: Optional[str] = None
     ) -> Tuple[bool, str]:
@@ -1104,6 +1138,7 @@ class MacOSController:
                 return True, f"Opening new tab in {browser}"
         return False, f"Failed to open new tab: {message}"
 
+    @os_capability(Effect.EFFECTFUL)
     def type_in_browser(
         self, text: str, browser: Optional[str] = None, press_enter: bool = False
     ) -> Tuple[bool, str]:
@@ -1148,6 +1183,7 @@ class MacOSController:
                 return True, f"Typing '{text}'"
         return False, f"Failed to type: {message}"
 
+    @os_capability(Effect.EFFECTFUL)
     async def click_search_bar_async(self, browser: Optional[str] = None) -> Tuple[bool, str]:
         """Click on the browser's search/address bar (ASYNC)"""
         # Check if screen is locked
@@ -1179,6 +1215,7 @@ class MacOSController:
             return True, f"Focusing on search bar"
         return False, f"Failed to focus search bar: {message}"
 
+    @os_capability(Effect.EFFECTFUL)
     def click_search_bar(self, browser: Optional[str] = None) -> Tuple[bool, str]:
         """Click on the browser's search/address bar"""
         # Check if screen is locked
@@ -1210,6 +1247,7 @@ class MacOSController:
             return True, f"Focusing on search bar"
         return False, f"Failed to focus search bar: {message}"
 
+    @os_capability(Effect.EFFECTFUL)
     async def open_url(self, url: str, browser: Optional[str] = None, skip_lock_check: bool = False) -> Tuple[bool, str]:
         """Open URL in browser (async - non-blocking)
         
@@ -1313,6 +1351,7 @@ class MacOSController:
                     return True, f"Navigating to {domain}, Sir"
             return False, f"Failed to open URL: {message}"
 
+    @os_capability(Effect.EFFECTFUL)
     async def web_search(
         self, query: str, engine: str = "google", browser: Optional[str] = None
     ) -> Tuple[bool, str]:
@@ -1329,6 +1368,7 @@ class MacOSController:
 
     # Complex Workflows
 
+    @os_capability(Effect.EFFECTFUL)
     async def execute_workflow(self, workflow_name: str) -> Tuple[bool, str]:
         """Execute predefined workflows"""
         workflows = {
@@ -1374,6 +1414,7 @@ class MacOSController:
 
     # Utility Methods
 
+    @os_capability(Effect.PURE)
     def get_system_info(self) -> Dict[str, Any]:
         """Get system information"""
         info = {
@@ -1390,6 +1431,7 @@ class MacOSController:
 
         return info
 
+    @os_capability(Effect.PURE)
     def validate_command(self, command: str, category: CommandCategory) -> SafetyLevel:
         """Validate command safety level"""
         if category == CommandCategory.DANGEROUS:
@@ -1416,6 +1458,7 @@ class MacOSController:
 
         return SafetyLevel.CAUTION
 
+    @os_capability(Effect.PURE)
     def find_installed_application(self, partial_name: str) -> Optional[str]:
         """Find installed application by partial name"""
         # Common application directories
@@ -1436,6 +1479,7 @@ class MacOSController:
 
         return None
 
+    @os_capability(Effect.EFFECTFUL)
     async def lock_screen(
         self,
         progress_callback: Optional[Callable[[Dict[str, Any]], Any]] = None,
@@ -1592,6 +1636,7 @@ class MacOSController:
             await _progress("error", 90, f"Lock error: {e}")
             return False, f"❌ Failed to lock screen: {str(e)}"
 
+    @os_capability(Effect.EFFECTFUL)
     async def unlock_screen(self, password: Optional[str] = None) -> Tuple[bool, str]:
         """
         Unlock the macOS screen using direct async methods (avoiding full pipeline loops)
@@ -1753,6 +1798,7 @@ class MacOSController:
             logger.error(f"[UnlockScreen] Error unlocking screen: {e}")
             return False, f"Failed to unlock screen: {str(e)}"
 
+    @os_capability(Effect.EFFECTFUL)
     async def handle_command(self, command: str) -> Dict[str, Any]:
         """
         Main command handler for system commands

--- a/tests/governance/autonomy/test_consent_context_switch.py
+++ b/tests/governance/autonomy/test_consent_context_switch.py
@@ -1,0 +1,253 @@
+"""One node waiting on a human must not idle the swarm.
+
+`capability_router` already refuses to hold the LLM's turn open — SUSPENDED in
+0.0 ms. That frees one TASK. It does not free the GRAPH: a work unit whose tool
+call suspended is, to the scheduler, a unit that was dispatched and never came
+back. With a bounded pool, enough of those and everything idles behind one
+unanswered prompt while unrelated branches sit ready.
+
+The mandated scenario is `test_node_B_runs_while_node_A_awaits_consent`:
+Node A needs consent, Node B is parallel and read-only, and B must execute
+without waiting for A.
+
+WHY THE FIX IS A WORD AND NOT A SCHEDULER
+-------------------------------------------
+`_compute_ready_units` already answers "what may run now" by excluding
+`completed | failed | cancelled | running`. A parked unit is none of those four,
+so before this it silently re-entered `ready` every pass and re-asked the
+operator forever. The repair is a FIFTH state in that filter — the topological
+logic was already right, it only lacked a word for "handed to a human".
+
+`test_a_dependent_of_a_parked_unit_stays_blocked` is the other half and matters
+as much: context-switching must not mean running work that depends on the thing
+nobody has approved.
+"""
+from __future__ import annotations
+
+import time
+from typing import Any, List, Optional, Tuple
+
+import pytest
+
+from backend.core.ouroboros.governance.autonomy import consent_pending_queue as cq
+from backend.core.ouroboros.governance.autonomy.consent_pending_queue import (
+    ConsentPendingQueue,
+    get_consent_queue,
+    reset_consent_queue,
+)
+
+
+@pytest.fixture(autouse=True)
+def _fresh():
+    reset_consent_queue()
+    yield
+    reset_consent_queue()
+
+
+class _Unit:
+    """Shaped like `WorkUnitSpec` — only the two fields readiness reads."""
+
+    def __init__(self, unit_id: str, deps: Tuple[str, ...] = ()) -> None:
+        self.unit_id = unit_id
+        self.dependency_ids = deps
+
+
+class _Graph:
+    def __init__(self, units: List[_Unit], graph_id: str = "g-1") -> None:
+        self.graph_id = graph_id
+        self.units = tuple(units)
+
+
+class _State:
+    def __init__(self, **kw: Any) -> None:
+        self.completed_units = kw.get("completed", ())
+        self.failed_units = kw.get("failed", ())
+        self.cancelled_units = kw.get("cancelled", ())
+        self.running_units = kw.get("running", ())
+
+
+def _ready(graph: _Graph, state: Optional[_State] = None) -> List[str]:
+    """Drive the REAL readiness computation, not a copy of it."""
+    from backend.core.ouroboros.governance.autonomy.subagent_scheduler import (
+        SubagentScheduler,
+    )
+    sched = SubagentScheduler.__new__(SubagentScheduler)
+    return SubagentScheduler._compute_ready_units(sched, graph, state)
+
+
+class TestTheMandatedScenario:
+    def test_node_B_runs_while_node_A_awaits_consent(self):
+        """A needs consent, B is parallel and read-only. B must not wait."""
+        graph = _Graph([_Unit("A"), _Unit("B")])
+
+        # Both start ready.
+        assert _ready(graph) == ["A", "B"]
+
+        # A's tool call suspended on `lock_screen`; the orchestrator parks it.
+        assert get_consent_queue().park("g-1", "A", request_id="req-1",
+                                        capability="lock_screen") is True
+
+        # THE assertion: B is still schedulable, A is not re-offered.
+        assert _ready(graph) == ["B"], (
+            "the graph stalled behind an unanswered prompt")
+
+    def test_the_operator_answers_and_A_rejoins(self):
+        graph = _Graph([_Unit("A"), _Unit("B")])
+        get_consent_queue().park("g-1", "A", capability="lock_screen")
+        assert _ready(graph) == ["B"]
+
+        # Resolved out of band — B may have finished by now.
+        get_consent_queue().release("g-1", "A")
+        assert _ready(graph, _State(completed=("B",))) == ["A"]
+
+    def test_a_dependent_of_a_parked_unit_stays_blocked(self):
+        """Context-switching must not run work that depends on the thing
+        nobody has approved."""
+        graph = _Graph([_Unit("A"), _Unit("B"), _Unit("C", deps=("A",))])
+        get_consent_queue().park("g-1", "A", capability="lock_screen")
+        ready = _ready(graph)
+        assert "B" in ready
+        assert "C" not in ready, "a dependent of an unapproved unit ran"
+        assert "A" not in ready
+
+    def test_without_parking_the_unit_is_re_offered_forever(self):
+        """The defect this closes. A suspended unit is not running, completed,
+        failed or cancelled — so without the fifth state it comes straight
+        back around and re-asks."""
+        graph = _Graph([_Unit("A"), _Unit("B")])
+        for _ in range(3):
+            assert "A" in _ready(graph)      # no park: A keeps returning
+
+    def test_many_parked_units_do_not_block_the_rest(self):
+        units = [_Unit(f"n{i}") for i in range(10)]
+        graph = _Graph(units)
+        for i in range(0, 10, 2):
+            get_consent_queue().park("g-1", f"n{i}", capability="lock_screen")
+        ready = _ready(graph)
+        assert ready == ["n1", "n3", "n5", "n7", "n9"]
+
+
+class TestParkingIsBounded:
+    def test_an_expired_park_returns_the_unit_to_the_graph(self, monkeypatch):
+        """A unit parked forever is a leak that looks like patience."""
+        monkeypatch.setenv("JARVIS_CONSENT_PARK_TTL_S", "30")
+        q = get_consent_queue()
+        q.park("g-1", "A", capability="lock_screen")
+        assert q.parked_ids("g-1") == {"A"}
+        q._parked["g-1"]["A"].parked_at = time.time() - 10_000
+        assert q.parked_ids("g-1") == set(), "an expired park still held a slot"
+        assert q.stats()["expired"] >= 1
+
+    def test_at_the_bound_it_refuses_rather_than_evicting(self, monkeypatch):
+        """Evicting the OLDEST would silently un-park something an operator is
+        still looking at. Refusing leaves the unit schedulable — it re-asks."""
+        monkeypatch.setenv("JARVIS_CONSENT_MAX_PARKED", "2")
+        q = ConsentPendingQueue()
+        assert q.park("g", "a") and q.park("g", "b")
+        assert q.park("g", "c") is False
+        assert q.parked_ids("g") == {"a", "b"}
+        assert q.stats()["rejected"] == 1
+
+    def test_parking_is_idempotent(self):
+        q = get_consent_queue()
+        assert q.park("g", "A") and q.park("g", "A")
+        assert q.parked_ids("g") == {"A"}
+
+    def test_graphs_do_not_leak_into_each_other(self):
+        q = get_consent_queue()
+        q.park("g-1", "A")
+        q.park("g-2", "A")
+        assert q.parked_ids("g-1") == {"A"} and q.parked_ids("g-2") == {"A"}
+        q.release("g-1", "A")
+        assert q.parked_ids("g-1") == set() and q.parked_ids("g-2") == {"A"}
+
+    def test_clearing_a_finished_graph(self):
+        q = get_consent_queue()
+        q.park("g-1", "A")
+        q.clear("g-1")
+        assert q.parked_ids("g-1") == set()
+
+
+class TestItFailsOpen:
+    def test_a_broken_queue_leaves_the_scheduler_as_it_was(self, monkeypatch):
+        """A consent queue that cannot answer must not stall a graph it can no
+        longer reason about."""
+        import backend.core.ouroboros.governance.autonomy.subagent_scheduler as sch
+        monkeypatch.setattr(
+            sch, "_parked_units",
+            lambda g: (_ for _ in ()).throw(RuntimeError("queue down")),
+            raising=False)
+        graph = _Graph([_Unit("A"), _Unit("B")])
+        with pytest.raises(RuntimeError):
+            sch._parked_units(graph)          # the stub really raises…
+        # …and the real helper swallows it, so readiness is unaffected.
+        monkeypatch.undo()
+        assert _ready(graph) == ["A", "B"]
+
+    def test_the_master_switch_disables_parking(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_CONSENT_QUEUE_ENABLED", "0")
+        q = ConsentPendingQueue()
+        assert q.park("g", "A") is False
+        assert q.parked_ids("g") == set()
+
+    def test_releasing_an_unparked_unit_never_raises(self):
+        assert get_consent_queue().release("nope", "nope") is None
+
+    @pytest.mark.parametrize("bad", [None, 42, object()])
+    def test_hostile_ids_never_raise(self, bad):
+        q = ConsentPendingQueue()
+        q.park(bad, bad)          # type: ignore[arg-type]
+        assert isinstance(q.parked_ids(bad), set)   # type: ignore[arg-type]
+
+
+class TestObservability:
+    def test_a_surface_can_see_who_is_waiting(self):
+        q = get_consent_queue()
+        q.park("g-1", "A", request_id="req-9", capability="lock_screen")
+        snap = q.snapshot("g-1")
+        assert snap and snap[0]["unit_id"] == "A"
+        assert snap[0]["capability"] == "lock_screen"
+        assert snap[0]["request_id"] == "req-9"
+        assert snap[0]["age_s"] >= 0
+
+    def test_stats_count_the_boundary(self):
+        q = get_consent_queue()
+        q.park("g", "A", capability="lock_screen")
+        assert q.stats()["pending"] == 1 and q.stats()["parked"] == 1
+        q.release("g", "A")
+        assert q.stats()["pending"] == 0 and q.stats()["released"] == 1
+
+
+class TestItComposesWithTheRouter:
+    @pytest.mark.asyncio
+    async def test_a_suspended_call_is_what_gets_parked(self):
+        """End to end: the router suspends, the queue parks THAT request, and
+        the graph moves on."""
+        from backend.system_control.capability_registry import (
+            CapabilityRegistry, capability,
+        )
+        from backend.system_control.capability_router import (
+            CapabilityRouter, Outcome,
+        )
+
+        class _Ctl:
+            @capability(mutates=True)
+            async def lock_screen(self) -> tuple:
+                """Lock."""
+                return (True, "locked")
+
+        class _Prov:
+            async def request(self, ctx: Any) -> str:
+                return "req-42"
+
+        ctl = _Ctl()
+        router = CapabilityRouter(registry=CapabilityRegistry(ctl).hydrate(),
+                                  provider=_Prov(), target=ctl)
+        out = await router.route("lock_screen")
+        assert out.outcome == Outcome.SUSPENDED.value
+
+        get_consent_queue().park("g-1", "A", request_id=out.request_id,
+                                 capability=out.capability)
+        graph = _Graph([_Unit("A"), _Unit("B")])
+        assert _ready(graph) == ["B"]
+        assert get_consent_queue().snapshot("g-1")[0]["request_id"] == "req-42"

--- a/tests/system_control/test_capability_registry.py
+++ b/tests/system_control/test_capability_registry.py
@@ -201,15 +201,59 @@ class TestItSurvivesRealCode:
         assert "lock_screen" in reg.names()
         assert reg.iron_gate_required("lock_screen") is True
 
-    def test_everything_live_is_gated_until_annotated(self):
-        """`macos_controller` carries no per-method metadata today, so every
-        capability must currently require approval. This is the honest state,
-        and the number `unclassified()` reports is the migration's work list."""
+    def test_the_annotation_ratchet_is_CLOSED(self):
+        """THE ratchet. Every capability must be explicitly declared.
+
+        This test superseded `test_everything_live_is_gated_until_annotated`,
+        which pinned the pre-annotation state — 42 of 42 unclassified — as the
+        contract. That WAS the honest state when the registry landed with no
+        metadata to read; it stopped being honest the moment the methods were
+        annotated, and a test asserting the old number would have blocked the
+        very work it was written to motivate.
+
+        `unclassified() == 0` is the invariant from here. A new capability
+        added without an `@os_capability(...)` fails this — which is the point:
+        it defaults to APPROVAL_REQUIRED and would otherwise prompt the
+        operator forever with nobody noticing why.
+        """
         reg = CapabilityRegistry().hydrate()
         if not reg.names():
             pytest.skip("no controller on this host")
-        assert reg.stats()["safe_auto"] == 0
-        assert reg.stats()["unclassified"] == reg.stats()["capabilities"]
+        assert reg.unclassified() == [], (
+            f"undeclared capabilities: {reg.unclassified()} — annotate them "
+            f"with @os_capability(Effect.PURE|EFFECTFUL)")
+        assert reg.stats()["by_provenance"]["defaulted"] == 0
+
+    def test_the_pure_set_is_small_and_deliberate(self):
+        """Reads that must never cost the operator a prompt. Kept explicit so
+        widening it is a visible decision rather than a drift."""
+        reg = CapabilityRegistry().hydrate()
+        if not reg.names():
+            pytest.skip("no controller on this host")
+        pure = {d.name for d in reg.all() if not d.iron_gate_required}
+        assert pure == {
+            "find_installed_application", "get_system_info", "is_safe_path",
+            "list_open_applications", "search_files", "validate_command",
+        }
+
+    def test_take_screenshot_is_EFFECTFUL_because_it_writes_a_file(self):
+        """The classification that had to be READ rather than guessed.
+
+        "Screenshot" sounds like an observation; `take_screenshot` shells out
+        to `screencapture '{path}'` and puts a file on disk. Guessing from the
+        name would have made it PURE and auto-approved.
+        """
+        reg = CapabilityRegistry().hydrate()
+        if not reg.names():
+            pytest.skip("no controller on this host")
+        assert reg.iron_gate_required("take_screenshot") is True
+
+    def test_the_taxonomies_agree(self):
+        """`Effect` mirrors `intent_journal.NodeKind` by value. Two vocabularies
+        for one distinction would eventually disagree about the same method."""
+        from backend.hud.intent_journal import NodeKind
+        from backend.system_control.capability_registry import Effect
+        assert {e.value for e in Effect} == {k.value for k in NodeKind}
 
     @pytest.mark.parametrize("hostile", [None, object(), 42, "not-a-controller"])
     def test_a_hostile_target_yields_an_empty_registry_not_a_crash(self, hostile):


### PR DESCRIPTION
Two hazards, one commit — the second only exists once the first is real.

## The ratchet: 42/42 → `unclassified: 0`

`@os_capability(Effect.PURE|EFFECTFUL)` applied to every public method of `macos_controller`. **6 PURE, 36 EFFECTFUL**, and a test asserting `unclassified() == 0` stays there — a new capability added without a declaration fails that test rather than silently prompting the operator forever.

`Effect` mirrors `intent_journal.NodeKind` **by value** (pinned by a test) rather than importing it: `system_control` importing `hud` to share two strings would invert the layering. `os_capability` is a thin spelling of `capability`, not a second decorator with its own rules.

## The classification that had to be read, not guessed

**`take_screenshot` sounds like an observation.** It shells out to `screencapture '{path}'` and puts a file on disk. Guessing from the name would have made it PURE and auto-approved forever.

Four ambiguous methods were opened and read before classifying: `web_search` launches a browser (EFFECTFUL), while `search_files` runs `mdfind` and `get_system_info` reads psutil (both PURE). The PURE set is pinned explicitly so widening it is a visible decision rather than a drift.

## The context-switch is a word, not a scheduler

`capability_router` already frees the **task** — SUSPENDED in 0.0 ms. It doesn't free the **graph**: a unit whose tool call suspended is, to the scheduler, one that was dispatched and never returned. With a bounded pool, enough of those and everything idles behind one unanswered prompt.

`_compute_ready_units` already answers "what may run now" by excluding `completed | failed | cancelled | running`. A parked unit is **none of those four** — so before this it re-entered `ready` every pass and re-asked the operator forever.

The repair is a **fifth state in that filter**. The topological logic was already correct; it only lacked a word for "handed to a human". No second traversal, no new scheduler, no change to dependency ordering or the concurrency limit.

Dependents of a parked unit stay blocked, deliberately — they depend on work that hasn't happened.

## Measured end to end

```
DAG: A, B parallel · C depends on A
  ready initially      : ['A', 'B']
  A calls lock_screen  → suspended  [SYSTEM: Awaiting operator consent]
  ready while A parked : ['B']       ← B runs, C correctly blocked
  operator answers     → ['A', 'B']
```

## Bounded and honest

A unit parked forever is a leak that looks like patience. Entries carry a TTL, and an expired park **releases** the unit back to the graph rather than deleting it, so a node whose operator never answered rejoins instead of vanishing from a DAG that still lists it.

At the per-graph bound the queue **refuses rather than evicting** — dropping the oldest would silently un-park something an operator is still looking at, while a refusal leaves the unit schedulable and it re-asks. `_parked_units` fails **open**: a broken consent queue makes the scheduler behave exactly as it did before this existed.

## One superseded test, replaced rather than deleted

`test_everything_live_is_gated_until_annotated` pinned the pre-annotation state (42 of 42 unclassified) as the contract. That was honest when the registry landed with no metadata to read, and it would have blocked the very work it was written to motivate. It's now `test_the_annotation_ratchet_is_CLOSED`.

## Tests

73 green across capability + consent; **732** across the autonomy suites. The 4 reds in `test_l3_telemetry` / `test_swarm_deadlock_immunity` are pre-existing, identical on a clean HEAD.

## Still not done, stated plainly

`tool_use_orchestrator` and Venom **do not yet call `route()`**. Registry, gate, suspension and context-switch are all in place and unit-proven; the hand-kept dispatch lists are still what actually runs. That's the last wire, and it belongs in its own diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes the capability annotation gap and prevents one pending consent from stalling the swarm. All OS capabilities are now explicitly classified, and the scheduler respects consent-parked units.

- New Features
  - Added `@os_capability(Effect.PURE|Effect.EFFECTFUL)` to every public method in `macos_controller` (6 PURE, 36 EFFECTFUL); `unclassified()` is enforced to stay empty.
  - `Effect` mirrors `intent_journal.NodeKind` by value; `os_capability` is a thin alias of `capability`.
  - Introduced `ConsentPendingQueue` with TTL and per-graph bound; provides `snapshot()`/`stats()` and fails open.
  - Scheduler adds a fifth state: `_compute_ready_units` now excludes `parked` (via `_parked_units()`), so independent branches run while dependents of a parked unit remain blocked.
  - Tests pin the small, explicit PURE set and ensure `take_screenshot` is EFFECTFUL since it writes to disk. Replaced the old “everything unclassified” test with `test_the_annotation_ratchet_is_CLOSED`.

<sup>Written for commit 7dbeae2575f6312f2d598c964eaa566ff340a64c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

