### PR TITLE
feat(vbia+hud): measure the biometric before trusting it; give the HUD its 42 capabilities

### DIFF
--- a/backend/hud/tool_definitions.py
+++ b/backend/hud/tool_definitions.py
@@ -128,7 +128,7 @@ def validate_tool_call(call: ToolCall) -> Tuple[bool, str]:
 
     Returns (is_safe, reason). If is_safe is False, the call MUST NOT execute.
     """
-    if call.name not in TOOL_SCHEMAS:
+    if call.name not in TOOL_SCHEMAS and call.name not in derived_tool_names():
         return False, f"Unknown tool '{call.name}' — blocked"
 
     if call.name == "bash":
@@ -195,8 +195,13 @@ async def execute_tool(
             return ToolResult(call_id=call.call_id, name=call.name, success=True,
                               output=f"Vision action '{call.name}' dispatched to VLA pipeline.")
         else:
-            return ToolResult(call_id=call.call_id, name=call.name, success=False,
-                              output="", error=f"No executor for tool '{call.name}'")
+            # THE SEAM. The hand-written list above covers 9 generic tools; the
+            # derived registry knows 42 named macOS capabilities, and
+            # `lock_screen` was simply never in the list. Rather than a tenth
+            # hand-written branch — which is how the list drifted from the
+            # machine in the first place — unknown names route through the
+            # capability boundary, which gates them by declared effect.
+            return await _exec_derived_capability(call)
     except Exception as exc:
         return ToolResult(call_id=call.call_id, name=call.name, success=False,
                           output="", error=str(exc))
@@ -322,3 +327,63 @@ def _discover_app(name: str) -> str:
         except OSError:
             continue
     return name  # Return as-is, let macOS try
+
+
+def derived_tool_names() -> frozenset:
+    """Capabilities the registry derives from `macos_controller`. NEVER raises.
+
+    Read per call rather than snapshotted at import: a capability annotated
+    tomorrow becomes callable without a restart, which is the whole point of
+    deriving rather than declaring.
+    """
+    try:
+        from backend.system_control.capability_registry import (
+            get_capability_registry,
+        )
+        return frozenset(get_capability_registry().names())
+    except Exception:  # noqa: BLE001 — the hand-written tools still work
+        return frozenset()
+
+
+def derived_tool_schemas() -> Dict[str, Dict[str, Any]]:
+    """`TOOL_SCHEMAS` UNION the derived capabilities, for the prompt.
+
+    The hand-written entries win on a name collision: `take_screenshot` exists
+    in both, and the hand-written one is wired to the vision analyzer while the
+    derived one is not. Deriving must never silently downgrade a tool that was
+    deliberately specialised.
+    """
+    try:
+        from backend.system_control.capability_registry import (
+            get_capability_registry,
+        )
+        merged = dict(get_capability_registry().tool_schemas())
+        merged.update(TOOL_SCHEMAS)
+        return merged
+    except Exception:  # noqa: BLE001
+        return dict(TOOL_SCHEMAS)
+
+
+async def _exec_derived_capability(call: "ToolCall") -> "ToolResult":
+    """Route a derived capability through the consent boundary. NEVER raises.
+
+    Returns rather than raises on every outcome — a SUSPENDED call is not an
+    error, and the model needs the note in its context to end the turn cleanly
+    rather than retry.
+    """
+    try:
+        from backend.system_control.capability_router import (
+            Outcome, get_capability_router,
+        )
+        routed = await get_capability_router().route(
+            call.name, dict(call.args or {}), op_id=call.call_id or "")
+        return ToolResult(
+            call_id=call.call_id, name=call.name,
+            success=(routed.outcome == Outcome.EXECUTED.value),
+            output=routed.context_note or "",
+            error=("" if routed.outcome == Outcome.EXECUTED.value
+                   else routed.detail or routed.outcome),
+        )
+    except Exception as exc:  # noqa: BLE001
+        return ToolResult(call_id=call.call_id, name=call.name, success=False,
+                          output="", error=f"capability route failed: {exc}")

--- a/backend/hud/tool_use_orchestrator.py
+++ b/backend/hud/tool_use_orchestrator.py
@@ -20,6 +20,7 @@ from typing import Any, Dict, List, Optional
 
 from backend.hud.tool_definitions import (
     TOOL_SCHEMAS,
+    derived_tool_schemas,
     ToolCall,
     ToolResult,
     execute_tool,
@@ -93,7 +94,11 @@ class ToolUseOrchestrator:
     async def execute(self, goal: str, screenshot_b64: Optional[str] = None) -> CommandResult:
         """Execute a goal using the 397B tool-use loop."""
         t0 = time.monotonic()
-        tool_list = json.dumps(list(TOOL_SCHEMAS.values()), indent=2)
+        # The DERIVED vocabulary, not the hand-written nine. This is the
+        # line that lets the model say 'lock the screen' at all — the
+        # capability existed in `macos_controller` the whole time and was
+        # simply never named in the prompt.
+        tool_list = json.dumps(list(derived_tool_schemas().values()), indent=2)
 
         system_prompt = (
             "You are JARVIS, an AI organism controlling a MacBook Pro. "

--- a/backend/voice_unlock/biometric_calibration.py
+++ b/backend/voice_unlock/biometric_calibration.py
@@ -1,0 +1,337 @@
+"""Is the voice biometric fit to guard anything? — measured, not assumed.
+
+Before binding screen unlock to VBIA, somebody has to answer what its error
+rates actually are. This reads the metrics the unlock service ALREADY writes
+(`unlock_metrics_logger`, live at `intelligent_voice_unlock_service.py:1577`)
+and computes the answer. No new logging: the data was there, nobody had added
+it up.
+
+WHAT THE FIRST RUN FOUND
+--------------------------
+34 attempts, one speaker, across three days in Nov 2025:
+
+    threshold actually used : 0.35
+    accepted                : 19        rejected: 0
+    confidence  min 0.438 · p50 0.593 · mean 0.596 · max 0.950
+    against VBIA's OWN declared thresholds:
+        >= instant   0.92 :  2/34   (6%)
+        >= confident 0.85 :  2/34   (6%)
+        >= rejection 0.60 : 17/34  (50%)
+    impostor trials         : 0
+
+Three facts, each disqualifying on its own:
+
+1. **The operating threshold is below the module's own rejection floor.**
+   `voice_biometric_intelligence` declares `VBI_REJECTION_THRESHOLD=0.60`; the
+   recorded decisions used 0.35. The gate ran at roughly half the strictness
+   the code claims.
+
+2. **Half the OWNER's attempts score below that declared floor** (median
+   0.593). So the threshold cannot simply be raised to 0.60 — that would lock
+   the real owner out of every other attempt. The model does not currently
+   separate the owner from its own stated boundary.
+
+3. **Zero impostor trials, zero rejections, ever.** A biometric that has never
+   said no has no measured false-accept rate. Not a low one — an unmeasured
+   one.
+
+WHY FAR IS NOT REPORTED AS A NUMBER
+-------------------------------------
+A false-accept rate needs trials where the speaker was NOT the owner and the
+truth is known. The logs contain neither. Computing "0% FAR" from 34
+owner-only samples would be arithmetic pretending to be evidence, and it is
+exactly the kind of confident-sounding figure a security decision should never
+rest on. `far_measurable` is False and says why, in the same spirit as
+`coordination_substrate` distinguishing `unverified` from `unsafe`.
+
+THE VERDICT IS FAIL-CLOSED
+----------------------------
+`binding_readiness()` answers whether this biometric may gate a capability. It
+returns NOT_READY unless impostor trials exist, the operating threshold is at
+least the declared floor, and the owner clears that floor reliably. Absence of
+evidence is not evidence of safety — the same inversion the capability registry
+makes about unclassified methods.
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import enum
+import glob
+import json
+import logging
+import os
+import statistics
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger("JARVIS.BiometricCalibration")
+
+BIOMETRIC_CALIBRATION_SCHEMA_VERSION: str = "biometric_calibration.v1"
+
+
+def metrics_dir() -> Path:
+    """Where `unlock_metrics_logger` already writes. NEVER raises."""
+    raw = (os.environ.get("JARVIS_UNLOCK_METRICS_DIR", "") or "").strip()
+    if raw:
+        return Path(raw)
+    return Path.home() / ".jarvis" / "logs" / "unlock_metrics"
+
+
+def declared_rejection_threshold() -> float:
+    """VBIA's OWN floor, read from the same env it reads. NEVER raises.
+
+    Read rather than duplicated: a second copy of this number would drift, and
+    the whole finding here is that two numbers for one threshold already
+    disagreed.
+    """
+    try:
+        return float(os.environ.get("VBI_REJECTION_THRESHOLD", "0.60"))
+    except (TypeError, ValueError):
+        return 0.60
+
+
+def min_trials() -> int:
+    """Attempts required before any rate is worth quoting. NEVER raises."""
+    try:
+        return max(1, int(os.environ.get("JARVIS_VBIA_MIN_TRIALS", "200")))
+    except (TypeError, ValueError):
+        return 200
+
+
+def min_impostor_trials() -> int:
+    """Impostor attempts required before a FAR exists at all. NEVER raises."""
+    try:
+        return max(1, int(os.environ.get("JARVIS_VBIA_MIN_IMPOSTORS", "30")))
+    except (TypeError, ValueError):
+        return 30
+
+
+class Readiness(str, enum.Enum):
+    """Whether this biometric may gate a capability."""
+
+    READY = "ready"
+    NOT_READY = "not_ready"
+    NO_DATA = "no_data"
+
+
+@dataclass
+class Calibration:
+    """What the recorded attempts actually say. Frozen in spirit."""
+
+    trials: int = 0
+    accepted: int = 0
+    rejected: int = 0
+    owner_trials: int = 0
+    impostor_trials: int = 0
+    speakers: Tuple[str, ...] = ()
+    thresholds_used: Tuple[float, ...] = ()
+    declared_threshold: float = 0.60
+    confidence_min: float = 0.0
+    confidence_p50: float = 0.0
+    confidence_mean: float = 0.0
+    confidence_max: float = 0.0
+    owner_below_declared: int = 0
+    reasons: List[str] = field(default_factory=list)
+    schema_version: str = BIOMETRIC_CALIBRATION_SCHEMA_VERSION
+
+    @property
+    def accept_rate(self) -> Optional[float]:
+        d = self.accepted + self.rejected
+        return (self.accepted / d) if d else None
+
+    @property
+    def far_measurable(self) -> bool:
+        """A false-accept rate needs impostor trials with known truth."""
+        return self.impostor_trials >= min_impostor_trials()
+
+    @property
+    def false_accept_rate(self) -> Optional[float]:
+        """None when unmeasurable — never 0.0.
+
+        Reporting zero from owner-only data would be arithmetic pretending to
+        be evidence.
+        """
+        return None if not self.far_measurable else None
+
+    @property
+    def owner_clears_declared(self) -> Optional[float]:
+        """Fraction of OWNER attempts at or above the declared floor.
+
+        The number that decides whether the threshold can be raised to what the
+        module claims without locking the owner out.
+        """
+        if not self.owner_trials:
+            return None
+        return 1.0 - (self.owner_below_declared / self.owner_trials)
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "trials": self.trials, "accepted": self.accepted,
+            "rejected": self.rejected, "accept_rate": self.accept_rate,
+            "owner_trials": self.owner_trials,
+            "impostor_trials": self.impostor_trials,
+            "speakers": list(self.speakers),
+            "thresholds_used": list(self.thresholds_used),
+            "declared_threshold": self.declared_threshold,
+            "confidence": {"min": self.confidence_min, "p50": self.confidence_p50,
+                           "mean": self.confidence_mean, "max": self.confidence_max},
+            "far_measurable": self.far_measurable,
+            "false_accept_rate": self.false_accept_rate,
+            "owner_clears_declared": self.owner_clears_declared,
+            "reasons": list(self.reasons),
+        }
+
+
+def load(directory: Optional[Path] = None) -> List[Dict[str, Any]]:
+    """Every recorded attempt. Tolerant per FILE. NEVER raises."""
+    out: List[Dict[str, Any]] = []
+    try:
+        d = Path(directory or metrics_dir())
+        for path in sorted(glob.glob(str(d / "unlock_metrics_*.json"))):
+            try:
+                raw = Path(path).read_text(encoding="utf-8", errors="replace")
+                data = json.loads(raw)
+                out.extend(data if isinstance(data, list) else [data])
+            except Exception:  # noqa: BLE001 — one bad day is not all of them
+                logger.debug("[BiometricCalibration] unreadable: %s", path)
+    except Exception:  # noqa: BLE001
+        pass
+    return out
+
+
+def calibrate(rows: Optional[List[Dict[str, Any]]] = None, *,
+              owner: str = "") -> Calibration:
+    """Compute the calibration from recorded attempts. NEVER raises.
+
+    *owner* names the enrolled speaker. When omitted the most frequent speaker
+    is assumed to be the owner — and every other speaker is counted as an
+    impostor trial, which is the only way the existing logs could ever yield a
+    FAR without new labelling.
+    """
+    cal = Calibration(declared_threshold=declared_rejection_threshold())
+    try:
+        rows = rows if rows is not None else load()
+        if not rows:
+            cal.reasons.append("no recorded attempts")
+            return cal
+        cal.trials = len(rows)
+        confs: List[float] = []
+        speakers: Dict[str, int] = {}
+        thresholds: set = set()
+        bios: List[Tuple[str, Dict[str, Any]]] = []
+        for r in rows:
+            name = str(r.get("speaker_name") or "")
+            speakers[name] = speakers.get(name, 0) + 1
+            b = r.get("biometrics")
+            if isinstance(b, dict) and "speaker_confidence" in b:
+                bios.append((name, b))
+        if not bios:
+            cal.reasons.append("attempts recorded, none with biometrics")
+            return cal
+        if not owner:
+            owner = max(speakers, key=lambda k: speakers[k]) if speakers else ""
+        cal.speakers = tuple(sorted(s for s in speakers if s))
+
+        for name, b in bios:
+            try:
+                c = float(b["speaker_confidence"])
+            except (TypeError, ValueError, KeyError):
+                continue
+            confs.append(c)
+            if b.get("threshold") is not None:
+                try:
+                    thresholds.add(round(float(b["threshold"]), 4))
+                except (TypeError, ValueError):
+                    pass
+            if b.get("above_threshold") is True:
+                cal.accepted += 1
+            elif b.get("above_threshold") is False:
+                cal.rejected += 1
+            if name == owner:
+                cal.owner_trials += 1
+                if c < cal.declared_threshold:
+                    cal.owner_below_declared += 1
+            else:
+                cal.impostor_trials += 1
+
+        cal.thresholds_used = tuple(sorted(thresholds))
+        if confs:
+            cal.confidence_min = round(min(confs), 4)
+            cal.confidence_p50 = round(statistics.median(confs), 4)
+            cal.confidence_mean = round(statistics.mean(confs), 4)
+            cal.confidence_max = round(max(confs), 4)
+    except Exception:  # noqa: BLE001
+        cal.reasons.append("calibration degraded")
+        logger.debug("[BiometricCalibration] calibrate degraded", exc_info=True)
+    return cal
+
+
+def binding_readiness(cal: Optional[Calibration] = None) -> Tuple[Readiness, List[str]]:
+    """May this biometric gate a capability? FAIL-CLOSED. NEVER raises.
+
+    Every check must pass. Absence of evidence is not evidence of safety —
+    the same inversion the capability registry makes about unclassified
+    methods, applied where the consequence is somebody else's screen.
+    """
+    reasons: List[str] = []
+    try:
+        c = cal if cal is not None else calibrate()
+        if not c.trials:
+            return (Readiness.NO_DATA, ["no recorded attempts"])
+        if c.trials < min_trials():
+            reasons.append(
+                f"only {c.trials} trials (need >= {min_trials()} before a rate "
+                f"means anything)")
+        if not c.far_measurable:
+            reasons.append(
+                f"{c.impostor_trials} impostor trials (need >= "
+                f"{min_impostor_trials()}) — a biometric that has never been "
+                f"shown a stranger has an UNMEASURED false-accept rate, not a "
+                f"low one")
+        if c.rejected == 0:
+            reasons.append(
+                "zero rejections ever recorded — it is unproven that this "
+                "biometric can say no at all")
+        below = [t for t in c.thresholds_used if t < c.declared_threshold]
+        if below:
+            reasons.append(
+                f"operating threshold {below} is BELOW the module's own "
+                f"declared rejection floor {c.declared_threshold} — the gate "
+                f"runs looser than the code claims")
+        clears = c.owner_clears_declared
+        if clears is not None and clears < 0.95:
+            reasons.append(
+                f"the owner clears the declared floor only "
+                f"{clears * 100:.0f}% of the time — raising the threshold to "
+                f"{c.declared_threshold} would lock the owner out")
+        return ((Readiness.READY, []) if not reasons
+                else (Readiness.NOT_READY, reasons))
+    except Exception:  # noqa: BLE001
+        return (Readiness.NOT_READY, ["readiness check degraded"])
+
+
+def render(cal: Optional[Calibration] = None) -> List[str]:
+    """Operator-readable summary. NEVER raises."""
+    try:
+        c = cal if cal is not None else calibrate()
+        state, reasons = binding_readiness(c)
+        rows = [
+            f"voice biometric calibration ({c.schema_version})",
+            f"  trials {c.trials} · accepted {c.accepted} · rejected {c.rejected}"
+            f" · speakers {len(c.speakers)}",
+            f"  confidence  min {c.confidence_min:.3f} · p50 {c.confidence_p50:.3f}"
+            f" · max {c.confidence_max:.3f}",
+            f"  threshold used {list(c.thresholds_used)} vs declared "
+            f"{c.declared_threshold}",
+            f"  false-accept rate: "
+            + ("measurable" if c.far_measurable
+               else f"UNMEASURABLE ({c.impostor_trials} impostor trials)"),
+            f"  binding readiness: {state.value.upper()}",
+        ]
+        rows.extend(f"    - {r}" for r in reasons)
+        return rows
+    except Exception:  # noqa: BLE001
+        return ["voice biometric calibration unavailable"]

--- a/tests/voice_unlock/test_biometric_calibration.py
+++ b/tests/voice_unlock/test_biometric_calibration.py
@@ -1,0 +1,140 @@
+"""Is the voice biometric fit to guard anything? Measured, then answered.
+
+Before binding screen unlock to VBIA somebody had to compute its error rates.
+The data was already being written by `unlock_metrics_logger` (live at
+`intelligent_voice_unlock_service.py:1577`); nobody had added it up.
+
+WHAT THE FIRST RUN FOUND — 34 attempts, one speaker, Nov 2025
+
+    threshold used 0.35  ·  declared rejection floor 0.60
+    accepted 19 · rejected 0 · impostor trials 0
+    confidence  min 0.438 · p50 0.593 · max 0.950
+
+Three disqualifying facts, and this suite pins each so a future change cannot
+quietly declare readiness without fixing them:
+
+1. the gate ran at roughly HALF the strictness the module's own config claims
+2. half the OWNER's attempts fall below that declared floor, so the threshold
+   cannot simply be raised without locking the owner out
+3. zero impostor trials and zero rejections ever — an UNMEASURED false-accept
+   rate, not a low one
+
+`test_far_is_never_reported_as_a_number_without_impostors` is the one to keep.
+Computing "0% FAR" from owner-only samples is arithmetic pretending to be
+evidence, and it is exactly the figure a security decision must never rest on.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from backend.voice_unlock import biometric_calibration as bc
+from backend.voice_unlock.biometric_calibration import (
+    Calibration, Readiness, binding_readiness, calibrate,
+)
+
+
+def _row(speaker="Derek", conf=0.6, above=True, threshold=0.35):
+    return {"speaker_name": speaker, "success": True,
+            "biometrics": {"speaker_confidence": conf, "threshold": threshold,
+                           "above_threshold": above}}
+
+
+class TestItReadsWhatIsAlreadyRecorded:
+    def test_it_computes_accept_and_reject_counts(self):
+        cal = calibrate([_row(conf=0.8), _row(conf=0.4, above=False)])
+        assert cal.accepted == 1 and cal.rejected == 1
+        assert cal.accept_rate == 0.5
+
+    def test_it_surfaces_the_threshold_actually_used(self):
+        cal = calibrate([_row(threshold=0.35)])
+        assert cal.thresholds_used == (0.35,)
+
+    def test_a_second_speaker_counts_as_an_impostor_trial(self):
+        """The only way the existing logs could ever yield a FAR without new
+        labelling: the majority speaker is the owner, everyone else is not."""
+        cal = calibrate([_row("Derek")] * 5 + [_row("Someone Else")])
+        assert cal.owner_trials == 5 and cal.impostor_trials == 1
+
+    def test_empty_data_is_reported_not_guessed(self):
+        cal = calibrate([])
+        assert cal.trials == 0 and "no recorded attempts" in cal.reasons
+
+    def test_unreadable_files_never_raise(self, tmp_path):
+        (tmp_path / "unlock_metrics_bad.json").write_text("{not json")
+        assert bc.load(tmp_path) == []
+
+
+class TestTheHonestyRules:
+    def test_far_is_never_reported_as_a_number_without_impostors(self):
+        """THE one to keep."""
+        cal = calibrate([_row()] * 100)
+        assert cal.impostor_trials == 0
+        assert cal.far_measurable is False
+        assert cal.false_accept_rate is None, (
+            "a false-accept rate was quoted from owner-only data")
+
+    def test_owner_only_data_is_never_READY(self):
+        assert binding_readiness(calibrate([_row()] * 500))[0] is Readiness.NOT_READY
+
+    def test_a_loose_threshold_is_named_explicitly(self, monkeypatch):
+        monkeypatch.setenv("VBI_REJECTION_THRESHOLD", "0.60")
+        _state, reasons = binding_readiness(calibrate([_row(threshold=0.35)]))
+        assert any("BELOW the module's own declared" in r for r in reasons)
+
+    def test_zero_rejections_is_called_out(self):
+        _state, reasons = binding_readiness(calibrate([_row()] * 10))
+        assert any("zero rejections" in r and "say no" in r for r in reasons)
+
+    def test_the_owner_lockout_risk_is_quantified(self, monkeypatch):
+        """Half the owner's attempts below the declared floor means raising the
+        threshold locks the owner out — the number that makes this a real
+        trade-off rather than a slider to nudge."""
+        monkeypatch.setenv("VBI_REJECTION_THRESHOLD", "0.60")
+        cal = calibrate([_row(conf=0.9)] * 5 + [_row(conf=0.4)] * 5)
+        assert cal.owner_clears_declared == 0.5
+        assert any("lock the owner out" in r for r in binding_readiness(cal)[1])
+
+    def test_no_data_is_distinct_from_not_ready(self):
+        """Never measured and measured-and-failed need opposite responses."""
+        assert binding_readiness(calibrate([]))[0] is Readiness.NO_DATA
+
+
+class TestFailClosed:
+    def test_readiness_requires_every_check(self, monkeypatch):
+        """Enough trials, real impostors, real rejections, a sane threshold and
+        an owner who clears it — only then READY."""
+        monkeypatch.setenv("JARVIS_VBIA_MIN_TRIALS", "10")
+        monkeypatch.setenv("JARVIS_VBIA_MIN_IMPOSTORS", "3")
+        monkeypatch.setenv("VBI_REJECTION_THRESHOLD", "0.60")
+        rows = ([_row("Derek", conf=0.9, threshold=0.60)] * 10
+                + [_row("Impostor", conf=0.3, above=False, threshold=0.60)] * 3)
+        state, reasons = binding_readiness(calibrate(rows, owner="Derek"))
+        assert state is Readiness.READY, reasons
+
+    def test_one_missing_check_is_enough_to_refuse(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_VBIA_MIN_TRIALS", "10")
+        monkeypatch.setenv("JARVIS_VBIA_MIN_IMPOSTORS", "3")
+        rows = [_row("Derek", conf=0.9, threshold=0.60)] * 10   # no impostors
+        assert binding_readiness(calibrate(rows, owner="Derek"))[0] is Readiness.NOT_READY
+
+    def test_a_degraded_calibration_refuses(self, monkeypatch):
+        monkeypatch.setattr(bc, "calibrate",
+                            lambda *a, **k: (_ for _ in ()).throw(RuntimeError()))
+        assert binding_readiness()[0] is Readiness.NOT_READY
+
+    def test_render_never_raises(self):
+        assert bc.render(Calibration())
+
+
+class TestAgainstTheRealRecordedData:
+    def test_the_live_verdict_is_NOT_READY(self):
+        """The finding, pinned. If this ever flips to READY it must be because
+        impostor trials were collected — not because a check was softened."""
+        cal = calibrate()
+        if not cal.trials:
+            pytest.skip("no recorded unlock attempts on this host")
+        state, reasons = binding_readiness(cal)
+        assert state is Readiness.NOT_READY
+        assert reasons


### PR DESCRIPTION
Two things. The measurement decides whether the second may ever gate on voice.

## Part 1 — VBIA measured, and it is not fit to guard anything yet

The data was already being written by `unlock_metrics_logger` (live at `intelligent_voice_unlock_service.py:1577`). Nobody had added it up. **No new logging** — `biometric_calibration` reads what exists:

```
trials 34 · accepted 19 · rejected 0 · speakers 1
confidence  min 0.438 · p50 0.593 · max 0.950
threshold used [0.35] vs declared 0.60
false-accept rate: UNMEASURABLE (0 impostor trials)
binding readiness: NOT_READY
```

Four findings, each disqualifying alone:

- **The operating threshold is 0.35.** `voice_biometric_intelligence` declares `VBI_REJECTION_THRESHOLD=0.60`. The gate ran at roughly **half** the strictness its own code claims — two numbers for one threshold, already disagreeing.
- **Half the owner's attempts fall below that declared floor** (p50 0.593). So the threshold can't simply be raised to 0.60 — that would reject the real owner every other attempt. The model doesn't currently separate the owner from its own stated boundary.
- **Zero impostor trials and zero rejections, ever.** It is unproven this biometric can say no at all.
- Only **6%** of attempts clear the "confident" tier (0.85) it defines.

**FAR is reported as `None`, never as `0.0`.** A false-accept rate needs trials where the speaker was not the owner and the truth is known; the logs contain neither. Computing "0% FAR" from 34 owner-only samples is arithmetic pretending to be evidence — exactly the figure a security decision must never rest on.

`binding_readiness()` is fail-closed. `NO_DATA` is distinct from `NOT_READY`: never-measured and measured-and-failed need opposite responses.

**Conclusion: binding screen unlock to this today would be security theatre.** The instrument now exists so the decision rests on a number, and a test pins the live verdict so a future flip to READY must come from collecting impostor trials rather than softening a check.

## Part 2 — the HUD can now say "lock my screen"

`macos_controller.lock_screen` existed the whole time; the HUD's prompt listed 9 hand-written tools and it wasn't among them. **The capability was never missing — its name was.**

`derived_tool_schemas()` unions the 42 derived capabilities with the 9 hand-written: **49 offered to the model**. Hand-written entries **win** a name collision — `take_screenshot` exists in both and the hand-written one is wired to the vision analyzer, so deriving must never silently downgrade a tool that was deliberately specialised.

The dispatch's `else` branch became the seam. Rather than a tenth hand-written branch — which is how the list drifted from the machine in the first place — an unknown name routes through `capability_router`, gated by declared effect.

**Measured end to end through the real HUD path:**

```
validate 'lock_screen' : True
execute  → success: False
           output : [SYSTEM: Awaiting operator consent]
           pending: {'req-hud-1': 'lock_screen'}
```

The model is told consent is pending and ends its turn; the Mac is untouched until the operator answers.

Names are read per call, not snapshotted at import, so a capability annotated tomorrow becomes callable without a restart.

## Tests

70 green across calibration + capability; 43 across the HUD suites.

## Still required before `lock_screen` works for real

An `ApprovalProvider` wired into the router at HUD boot. Without one the gate fails **closed** and denies — correct, and not yet useful. That's the next wire, and it's small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a voice biometric calibration that reads existing unlock logs to decide if VBIA is safe to gate anything. Expands the HUD tool prompt to include 42 derived macOS capabilities, enabling `lock_screen` behind consent routing.

- **New Features**
  - Voice biometric calibration (`backend/voice_unlock/biometric_calibration.py`) reads `unlock_metrics_logger` data, compares thresholds used vs declared `VBI_REJECTION_THRESHOLD`, and summarizes owner/impostor trials.
  - FAR is never reported from owner-only data; it is marked unmeasurable until enough impostor trials exist.
  - `binding_readiness()` fails closed and returns `NO_DATA` or `NOT_READY` with reasons until impostor coverage, sane threshold, and owner reliability are met.
  - HUD prompt now uses `derived_tool_schemas()` (42 derived + 9 hand-written); hand-written entries win name collisions (e.g., `take_screenshot`).
  - Unknown tool names are routed via `capability_router` with operator consent; model sees a pending note and stops, no action taken without approval.
  - `lock_screen` becomes callable via the HUD; capabilities are read per call, so new annotations are available without restart.

- **Migration**
  - No breaking changes.
  - To allow `lock_screen` (and similar) to execute, wire an `ApprovalProvider` into the router at HUD boot; without it the gate denies by design.

<sup>Written for commit e8ce1bf07d97ffa74da35ec22626a08e6e13eb7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

