### PR TITLE
feat(security): refuse to boot blind; stop telemetry from being able to break unlock

### DIFF
--- a/backend/system_control/tcc_sentinel.py
+++ b/backend/system_control/tcc_sentinel.py
@@ -1,0 +1,262 @@
+"""Refuse to boot blind rather than fail silently mid-DAG.
+
+macOS gates screen capture and UI automation behind TCC grants that attach to a
+CODE IDENTITY, not to a path. An app launched from Xcode has a different
+identity than the same app launched from Finder, so grants do not carry over —
+and nothing announces it. The APIs simply start returning nothing.
+
+That is not hypothetical here. Measured on this machine, in this process:
+
+    AXIsProcessTrusted()             -> False
+    CGPreflightScreenCaptureAccess() -> False
+
+Which is exactly why `cg_window_capture` returned no windows and the black box
+recorded "window list unavailable" — a permissions problem wearing the costume
+of a bug. A vision tool that returns an empty list looks, to a model, like a
+screen with nothing on it. It will reason confidently from that.
+
+WHY A SENTINEL AND NOT A try/except AT EACH CALL SITE
+-------------------------------------------------------
+Per-call handling means every consumer independently guesses whether "no
+windows" means "no windows". The grant is a BOOT-TIME fact about this process's
+identity — it cannot change while running — so it is checked once, loudly, at
+the point where a bad answer is still cheap.
+
+FAIL FAST, BUT ONLY WHERE FAST IS SAFE
+----------------------------------------
+Blocking the boot is the correct response for a HUD whose whole job is seeing
+the screen. It is the WRONG response for a headless CI run, a unit test, or a
+soak on a Linux node, where these grants are meaningless and unobtainable.
+
+So the Sentinel reports, and `enforce()` blocks only when the caller declares
+that it needs the grant. Non-macOS and no-GUI sessions are NOT failures — they
+are environments where the question does not apply, which is a different fact
+and gets a different verdict.
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import ctypes
+import enum
+import logging
+import os
+import platform
+import sys
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger("JARVIS.TCCSentinel")
+
+TCC_SENTINEL_SCHEMA_VERSION: str = "tcc_sentinel.v1"
+
+_APPLICATION_SERVICES = (
+    "/System/Library/Frameworks/ApplicationServices.framework/ApplicationServices"
+)
+_CORE_GRAPHICS = "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics"
+
+
+class TCCMissingError(RuntimeError):
+    """A required macOS privacy grant is absent for THIS process identity."""
+
+    def __init__(self, missing: List[str], detail: str = "") -> None:
+        self.missing = list(missing)
+        self.code = "TCC_MISSING"
+        super().__init__(detail or f"TCC_MISSING: {', '.join(missing)}")
+
+
+class Grant(str, enum.Enum):
+    ACCESSIBILITY = "accessibility"
+    SCREEN_RECORDING = "screen_recording"
+
+
+class Verdict(str, enum.Enum):
+    """Three states, because two would lie about one of them."""
+
+    GRANTED = "granted"
+    DENIED = "denied"
+    #: Not macOS, or no GUI session. The question does not apply — which is not
+    #: the same as the answer being no, and must not block a Linux soak node.
+    NOT_APPLICABLE = "not_applicable"
+
+
+def sentinel_enabled() -> bool:
+    """Master gate. Default TRUE — read-only probes. NEVER raises."""
+    return (os.environ.get("JARVIS_TCC_SENTINEL_ENABLED", "true")
+            or "").strip().lower() not in ("0", "false", "no", "off")
+
+
+def _is_macos_gui() -> bool:
+    """Is this a macOS session where TCC even has meaning? NEVER raises."""
+    try:
+        if platform.system() != "Darwin":
+            return False
+        # A launchd daemon or ssh session has no window server connection, so
+        # the grants are unobtainable rather than missing.
+        return bool(os.environ.get("__CFBundleIdentifier")
+                    or os.environ.get("TERM_SESSION_ID")
+                    or os.environ.get("SSH_TTY") is None)
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _probe_accessibility() -> Verdict:
+    """`AXIsProcessTrusted()` — may this process drive other apps' UI?
+
+    ctypes against the system framework rather than a pyobjc wrapper: the
+    `ApplicationServices` wrapper is NOT installed here (verified), and adding
+    a pip dependency to ask a yes/no question the OS answers directly would be
+    a heavier fix than the problem. NEVER raises.
+    """
+    if not _is_macos_gui():
+        return Verdict.NOT_APPLICABLE
+    try:
+        lib = ctypes.CDLL(_APPLICATION_SERVICES)
+        lib.AXIsProcessTrusted.restype = ctypes.c_bool
+        return Verdict.GRANTED if lib.AXIsProcessTrusted() else Verdict.DENIED
+    except Exception:  # noqa: BLE001
+        logger.debug("[TCCSentinel] accessibility probe degraded", exc_info=True)
+        return Verdict.NOT_APPLICABLE
+
+
+def _probe_screen_recording() -> Verdict:
+    """`CGPreflightScreenCaptureAccess()` — PREFLIGHT, never Request.
+
+    `CGRequestScreenCaptureAccess` shows a system dialog and, on first denial,
+    permanently poisons the answer until the app is re-added by hand. A boot
+    probe must observe, not prompt. NEVER raises.
+    """
+    if not _is_macos_gui():
+        return Verdict.NOT_APPLICABLE
+    try:
+        cg = ctypes.CDLL(_CORE_GRAPHICS)
+        fn = getattr(cg, "CGPreflightScreenCaptureAccess", None)
+        if fn is None:
+            return Verdict.NOT_APPLICABLE      # pre-10.15
+        fn.restype = ctypes.c_bool
+        return Verdict.GRANTED if fn() else Verdict.DENIED
+    except Exception:  # noqa: BLE001
+        logger.debug("[TCCSentinel] screen-recording probe degraded",
+                     exc_info=True)
+        return Verdict.NOT_APPLICABLE
+
+
+def _bundle_identity() -> str:
+    """Which code identity the grants would attach to. NEVER raises.
+
+    The whole reason grants vanish under Xcode: TCC keys on this, and a bare
+    interpreter has none.
+    """
+    try:
+        from Foundation import NSBundle
+        return str(NSBundle.mainBundle().bundleIdentifier() or "")
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+@dataclass
+class TCCReading:
+    """What this process identity may actually do."""
+
+    accessibility: str = Verdict.NOT_APPLICABLE.value
+    screen_recording: str = Verdict.NOT_APPLICABLE.value
+    bundle_identifier: str = ""
+    executable: str = ""
+    schema_version: str = TCC_SENTINEL_SCHEMA_VERSION
+    notes: List[str] = field(default_factory=list)
+
+    def verdict(self, grant: Grant) -> Verdict:
+        raw = (self.accessibility if grant is Grant.ACCESSIBILITY
+               else self.screen_recording)
+        try:
+            return Verdict(raw)
+        except ValueError:
+            return Verdict.NOT_APPLICABLE
+
+    def denied(self, required: Optional[List[Grant]] = None) -> List[str]:
+        """Required grants explicitly DENIED. NOT_APPLICABLE is not denial."""
+        req = required if required is not None else list(Grant)
+        return [g.value for g in req if self.verdict(g) is Verdict.DENIED]
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {"schema_version": self.schema_version,
+                "accessibility": self.accessibility,
+                "screen_recording": self.screen_recording,
+                "bundle_identifier": self.bundle_identifier or "(none)",
+                "executable": self.executable, "notes": list(self.notes)}
+
+
+def probe() -> TCCReading:
+    """Read this process's grants. NEVER raises."""
+    reading = TCCReading()
+    if not sentinel_enabled():
+        reading.notes.append("sentinel disabled by env")
+        return reading
+    try:
+        reading.accessibility = _probe_accessibility().value
+        reading.screen_recording = _probe_screen_recording().value
+        reading.bundle_identifier = _bundle_identity()
+        reading.executable = str(sys.executable or "")
+        if not reading.bundle_identifier and platform.system() == "Darwin":
+            reading.notes.append(
+                "no bundle identifier — TCC grants attach to a CODE IDENTITY, "
+                "so a bare interpreter cannot inherit an app's grants")
+    except Exception:  # noqa: BLE001
+        logger.debug("[TCCSentinel] probe degraded", exc_info=True)
+    return reading
+
+
+def render(reading: Optional[TCCReading] = None,
+           required: Optional[List[Grant]] = None) -> List[str]:
+    """The loud diagnostic. NEVER raises.
+
+    Says what to DO, not merely what is wrong: a boot-blocking error whose fix
+    is "open the right pane of System Settings" should name the pane.
+    """
+    try:
+        r = reading if reading is not None else probe()
+        rows = [
+            "⚠ macOS privacy grants missing for THIS process identity",
+            f"   accessibility     : {r.accessibility}",
+            f"   screen recording  : {r.screen_recording}",
+            f"   bundle identifier : {r.bundle_identifier or '(none)'}",
+            f"   executable        : {r.executable}",
+        ]
+        rows.extend(f"   note: {n}" for n in r.notes)
+        if r.denied(required):
+            rows += [
+                "",
+                "   TCC grants attach to a CODE IDENTITY, not a path — an app",
+                "   launched from Xcode is a DIFFERENT identity from the same",
+                "   app launched from Finder, so grants do not carry over.",
+                "",
+                "   Fix: System Settings → Privacy & Security →",
+                "        Accessibility  AND  Screen Recording",
+                "        …add the binary shown above, then relaunch.",
+                "",
+                "   Refusing to boot: vision tools would return EMPTY rather",
+                "   than error, and a model cannot tell an empty screen from",
+                "   an unreadable one.",
+            ]
+        return rows
+    except Exception:  # noqa: BLE001
+        return ["⚠ TCC sentinel unavailable"]
+
+
+def enforce(required: Optional[List[Grant]] = None, *,
+            reading: Optional[TCCReading] = None) -> TCCReading:
+    """Raise `TCCMissingError` if a REQUIRED grant is denied. NEVER raises otherwise.
+
+    The caller declares what it needs, so a headless soak imports this module
+    without inheriting a HUD's requirements. NOT_APPLICABLE never blocks: an
+    environment where the question is meaningless is not a failure.
+    """
+    r = reading if reading is not None else probe()
+    missing = r.denied(required)
+    if not missing:
+        return r
+    for line in render(r, required):
+        logger.error("%s", line)
+    raise TCCMissingError(missing, detail=(
+        f"TCC_MISSING: {', '.join(missing)} denied for identity "
+        f"{r.bundle_identifier or '(no bundle)'} — refusing to boot blind"))

--- a/backend/voice_unlock/intelligent_voice_unlock_service.py
+++ b/backend/voice_unlock/intelligent_voice_unlock_service.py
@@ -64,6 +64,24 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
+class _NullMetrics:
+    """Absorbs every telemetry call. See the note at its only construction.
+
+    Deliberately permissive: it cannot know which methods the logger has, so it
+    answers all of them with another absorber rather than a curated list that
+    would drift the first time a stage type is added.
+    """
+
+    def __getattr__(self, _name: str):
+        return self
+
+    def __call__(self, *_a, **_kw):
+        return self
+
+    def __bool__(self) -> bool:
+        return False        # `if metrics_logger:` reads as "no telemetry"
+
+
 # Phase 6: EcapaFacade is the sole ECAPA lifecycle owner (flag removed)
 
 # =============================================================================
@@ -1573,10 +1591,39 @@ class IntelligentVoiceUnlockService:
         # Initialize diagnostics
         diagnostics = UnlockDiagnostics()
 
-        # Initialize advanced metrics logger with stage tracking
-        from voice_unlock.unlock_metrics_logger import get_metrics_logger, StageMetrics
-        metrics_logger = get_metrics_logger()
-        stages: List[StageMetrics] = []
+        # Initialize advanced metrics logger with stage tracking.
+        #
+        # GUARDED, and absolute-first. This import was bare
+        # (`from voice_unlock...`), which resolves ONLY when `backend/` is on
+        # sys.path, and it was UNGUARDED at the top of the unlock handler. So a
+        # launch-path change did not merely stop the telemetry — it raised
+        # ModuleNotFoundError before any unlock could happen. Telemetry must
+        # never be able to break the thing it observes; the metrics record
+        # ending abruptly on 2025-11-29 is consistent with exactly this.
+        metrics_logger = None
+        stages: List[Any] = []
+        try:
+            try:
+                from backend.voice_unlock.unlock_metrics_logger import (
+                    get_metrics_logger,
+                )
+            except ImportError:          # legacy sys.path layout
+                from voice_unlock.unlock_metrics_logger import (  # type: ignore
+                    get_metrics_logger,
+                )
+            metrics_logger = get_metrics_logger()
+        except Exception as _mx:  # noqa: BLE001
+            logger.warning(
+                "[VoiceUnlock] metrics logger unavailable (%s) — unlock "
+                "continues WITHOUT telemetry", type(_mx).__name__)
+        if metrics_logger is None:
+            # NULL OBJECT, not None. There are call sites downstream doing
+            # `metrics_logger.create_stage(...)`; handing them None would trade
+            # an ImportError for an AttributeError a thousand lines later —
+            # the same crash with a worse stack. This absorbs every call and
+            # returns something that absorbs every call, so the unlock path is
+            # byte-identical minus the recording.
+            metrics_logger = _NullMetrics()
 
         # =============================================================================
         # 🧠 UPFRONT VOICE BIOMETRIC INTELLIGENCE: Verify and announce FIRST

--- a/tests/system_control/test_tcc_sentinel.py
+++ b/tests/system_control/test_tcc_sentinel.py
@@ -1,0 +1,152 @@
+"""Refuse to boot blind rather than fail silently mid-DAG.
+
+macOS gates screen capture and UI automation behind grants that attach to a
+CODE IDENTITY, not a path. An app launched from Xcode is a different identity
+from the same app launched from Finder, so grants do not carry over — and
+nothing announces it. The APIs just start returning nothing.
+
+Measured in this very process while writing this:
+
+    AXIsProcessTrusted()             -> False
+    CGPreflightScreenCaptureAccess() -> False
+    bundleIdentifier                 -> None
+
+Which is exactly why `cg_window_capture` returned no windows and the black box
+recorded "window list unavailable" — a permissions problem wearing the costume
+of a bug. An empty window list looks, to a model, like a screen with nothing on
+it, and it will reason confidently from that.
+
+THE DISTINCTION THIS SUITE DEFENDS
+------------------------------------
+`NOT_APPLICABLE` is not `DENIED`. A Linux soak node or a headless CI run cannot
+obtain these grants and does not need them; blocking there would make the
+Sentinel a thing people disable, which is how a safety check dies. Only an
+explicit DENIED on a REQUIRED grant blocks a boot.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.system_control import tcc_sentinel as ts
+from backend.system_control.tcc_sentinel import (
+    Grant, TCCMissingError, TCCReading, Verdict, enforce, probe, render,
+)
+
+
+def _reading(acc=Verdict.GRANTED, scr=Verdict.GRANTED, **kw) -> TCCReading:
+    return TCCReading(accessibility=acc.value, screen_recording=scr.value, **kw)
+
+
+class TestTheMandatedScenario:
+    def test_untrusted_accessibility_aborts_the_boot(self, monkeypatch):
+        """THE scenario: AXIsProcessTrusted() False → TCC_MISSING, boot blocked."""
+        monkeypatch.setattr(ts, "_probe_accessibility", lambda: Verdict.DENIED)
+        monkeypatch.setattr(ts, "_probe_screen_recording", lambda: Verdict.GRANTED)
+        with pytest.raises(TCCMissingError) as ei:
+            enforce([Grant.ACCESSIBILITY])
+        assert ei.value.code == "TCC_MISSING"
+        assert "accessibility" in ei.value.missing
+
+    def test_the_error_names_what_to_do(self, monkeypatch):
+        """A boot-blocking error whose fix is a settings pane should name the
+        pane. Otherwise the operator's next move is a search engine."""
+        rows = render(_reading(acc=Verdict.DENIED), [Grant.ACCESSIBILITY])
+        joined = "\n".join(rows)
+        assert "System Settings" in joined
+        assert "Accessibility" in joined and "Screen Recording" in joined
+        assert "Xcode" in joined, "the identity trap is not explained"
+
+    def test_a_granted_process_boots(self, monkeypatch):
+        monkeypatch.setattr(ts, "_probe_accessibility", lambda: Verdict.GRANTED)
+        monkeypatch.setattr(ts, "_probe_screen_recording", lambda: Verdict.GRANTED)
+        assert enforce([Grant.ACCESSIBILITY, Grant.SCREEN_RECORDING])
+
+    def test_screen_recording_denial_also_blocks(self):
+        with pytest.raises(TCCMissingError) as ei:
+            enforce([Grant.SCREEN_RECORDING],
+                    reading=_reading(scr=Verdict.DENIED))
+        assert ei.value.missing == ["screen_recording"]
+
+    def test_both_missing_are_reported_together(self):
+        with pytest.raises(TCCMissingError) as ei:
+            enforce(reading=_reading(acc=Verdict.DENIED, scr=Verdict.DENIED))
+        assert set(ei.value.missing) == {"accessibility", "screen_recording"}
+
+
+class TestNotApplicableIsNotDenied:
+    def test_a_non_macos_host_is_not_a_failure(self):
+        """A Linux soak node cannot obtain these and does not need them.
+        Blocking there makes the Sentinel a thing people disable."""
+        r = _reading(acc=Verdict.NOT_APPLICABLE, scr=Verdict.NOT_APPLICABLE)
+        assert r.denied() == []
+        assert enforce(reading=r) is r
+
+    def test_a_failed_probe_degrades_to_not_applicable(self, monkeypatch):
+        """Unable to ASK is not the same as being told no."""
+        monkeypatch.setattr(ts, "_is_macos_gui", lambda: True)
+        monkeypatch.setattr(
+            ts.ctypes, "CDLL",
+            lambda *_a, **_k: (_ for _ in ()).throw(OSError("no framework")))
+        assert ts._probe_accessibility() is Verdict.NOT_APPLICABLE
+        assert ts._probe_screen_recording() is Verdict.NOT_APPLICABLE
+
+    def test_only_the_REQUIRED_grants_are_enforced(self):
+        """A component that needs no screen access must not be blocked by its
+        absence."""
+        r = _reading(acc=Verdict.GRANTED, scr=Verdict.DENIED)
+        assert enforce([Grant.ACCESSIBILITY], reading=r) is r
+        with pytest.raises(TCCMissingError):
+            enforce([Grant.SCREEN_RECORDING], reading=r)
+
+
+class TestItProbesRatherThanPrompts:
+    def test_it_never_calls_the_requesting_api(self):
+        """`CGRequestScreenCaptureAccess` shows a dialog and, on first denial,
+        poisons the answer until the app is re-added by hand. A boot probe must
+        observe, not prompt."""
+        import inspect
+        src = inspect.getsource(ts)
+        assert "CGPreflightScreenCaptureAccess" in src
+        assert "CGRequestScreenCaptureAccess" not in src.split('"""')[-1]
+
+    def test_the_probe_never_raises_on_this_host(self):
+        """Whatever this machine is, probing must return a usable reading."""
+        r = probe()
+        assert r.accessibility in {v.value for v in Verdict}
+        assert r.screen_recording in {v.value for v in Verdict}
+        assert isinstance(r.as_dict(), dict)
+
+    def test_a_missing_bundle_identity_is_explained(self):
+        """The root cause of the Xcode trap, surfaced rather than inferred."""
+        r = probe()
+        import platform
+        if platform.system() != "Darwin":
+            pytest.skip("macOS only")
+        if not r.bundle_identifier:
+            assert any("code identity" in n.lower() for n in r.notes)
+
+    def test_the_master_switch_disables_probing(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_TCC_SENTINEL_ENABLED", "0")
+        r = probe()
+        assert r.denied() == []
+        assert any("disabled" in n for n in r.notes)
+
+    def test_render_never_raises(self):
+        assert render(TCCReading())
+        assert render(_reading(acc=Verdict.DENIED))
+
+
+class TestAgainstThisMachine:
+    def test_it_explains_the_black_box_window_failure(self):
+        """The measured link: no screen-recording grant is why
+        `cg_window_capture` returned nothing and the black box recorded
+        'window list unavailable' — which read as a bug, not a permission."""
+        import platform
+        if platform.system() != "Darwin":
+            pytest.skip("macOS only")
+        r = probe()
+        if r.verdict(Grant.SCREEN_RECORDING) is Verdict.DENIED:
+            from backend.vision import black_box as bb
+            snap = bb._blocking_capture()
+            assert snap.window_title is None, (
+                "titles resolved without a screen-recording grant?")


### PR DESCRIPTION
## The TCC Sentinel — measured on this machine, in this process

```
AXIsProcessTrusted()             -> False
CGPreflightScreenCaptureAccess() -> False
bundleIdentifier                 -> None
```

That's the cause of the black box's *"window list unavailable"* and of `cg_window_capture` returning nothing: **a permissions problem wearing the costume of a bug.** An empty window list looks, to a model, like a screen with nothing on it — and it will reason confidently from that.

macOS grants attach to a **code identity**, not a path, so an app launched from Xcode is a different identity from the same app launched from Finder and the grants don't carry over. Nothing announces it.

**`NOT_APPLICABLE` is not `DENIED`.** A Linux soak node can't obtain these grants and doesn't need them; blocking there would make the Sentinel a thing people disable, which is how a safety check dies. Callers declare which grants they *require*, and only an explicit denial of a required grant blocks.

**Preflight, never Request** — `CGRequestScreenCaptureAccess` shows a dialog and, on first denial, poisons the answer until the app is re-added by hand. A boot probe observes; it doesn't prompt. Pinned by a test.

ctypes against the system frameworks rather than pyobjc wrappers — verified `ApplicationServices` and `LocalAuthentication` wrappers are **not installed** here, and adding pip dependencies to ask a yes/no question the OS answers directly would be a heavier fix than the problem.

## Telemetry resurrection — the blackout was worse than lost logging

```python
from voice_unlock.unlock_metrics_logger import ...   # bare, UNGUARDED
```

That resolves **only** when `backend/` is on `sys.path`, and it sat unguarded at the top of the unlock handler. So a launch-path change didn't merely stop telemetry — it raised `ModuleNotFoundError` **before any unlock could happen**. Metrics ending abruptly on 2025-11-29 is consistent with exactly that.

Now absolute-first with a legacy fallback, and guarded. The guard *alone* would have traded an ImportError for an `AttributeError` a thousand lines later — 11 downstream call sites do `metrics_logger.create_stage(...)` — so the failure path installs a **null object** that absorbs every call. The unlock path is byte-identical minus the recording.

**Telemetry must never be able to break the thing it observes.**

## Touch ID: the architecture the measurement dictates — not built here

```
LAContext.canEvaluatePolicy(DeviceOwnerAuthentication) -> False
biometryType                                          -> 0 (none)
NSBundle.mainBundle().bundleIdentifier()              -> None
```

LocalAuthentication requires a **signed app bundle identity**. A bare interpreter has none, so `LAContext` refuses every policy regardless of the hardware. **Touch ID cannot be triggered from the Python backend at all** — not a limitation to work around, but the OS refusing to let an unsigned process speak for the Secure Enclave.

Which makes the correct design also the more secure one, and exactly what the anti-terminal-hijacking mandate asks for: the prompt must originate in the **signed Swift HUD** (which already has a bundle, entitlements and an Info.plist), with the verdict returning over the IPC `BrainstemLauncher.sendEvent` already carries. A Python-side `LAContext` call would have been the spoofable path, not the safe one.

## Tests

14, including the mandated `AXIsProcessTrusted -> False` abort with `TCC_MISSING`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a macOS TCC Sentinel that blocks startup only when required privacy grants are explicitly denied, preventing silent “empty window list” failures. Also makes telemetry non-fatal so unlock continues even if the metrics logger is missing.

- New Features
  - Added `tcc_sentinel` with `probe()` and `enforce()` to check `AXIsProcessTrusted` and `CGPreflightScreenCaptureAccess` once at boot, tied to the current code identity.
  - Treats non-macOS/headless as `NOT_APPLICABLE`; only denies on required grants. Uses `ctypes`, preflights only (no system prompts). `JARVIS_TCC_SENTINEL_ENABLED=0` disables.
  - Clear remediation in logs, including the exact System Settings panes.

- Bug Fixes
  - Guarded import of `voice_unlock.unlock_metrics_logger` with a legacy-path fallback and a `_NullMetrics` sink so telemetry can’t crash unlock.
  - Added 14 tests covering denial, non-applicable paths, no-prompt behavior, and remediation messaging.

<sup>Written for commit 304991d1aa0806f2b01106f89f05bd04a727f7ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

