### PR TITLE
feat(consent): nonce challenge-response + Swift drop-ins for Touch ID and mic muting

### DIFF
--- a/JARVIS-Apple/JARVISHUD/Services/MicSuppression.swift
+++ b/JARVIS-Apple/JARVISHUD/Services/MicSuppression.swift
@@ -1,0 +1,130 @@
+//  MicSuppression.swift
+//  JARVISHUD
+//
+//  Stop JARVIS hearing itself — without ever being able to go permanently deaf.
+//
+//  WHAT IS THERE NOW, AND WHY IT IS FRAGILE
+//  ------------------------------------------
+//  `HUDAppDelegate.speak` currently does:
+//
+//      isTTSSpeaking = true
+//      wakeWord.stop()                    // tears the whole audio graph down
+//      ...
+//      didFinish -> try? await Task.sleep(for: .seconds(3.0))   // then rebuild
+//
+//  Three problems, in increasing order of severity:
+//
+//  1. A three-second deaf window after EVERY utterance, imposed because
+//     AVSpeechSynthesizer holds the output device for ~2-3s and rebuilding the
+//     input graph too early throws -10877. The delay is a workaround for a
+//     teardown that did not need to happen.
+//
+//  2. Tearing down and rebuilding a working AVAudioEngine on every sentence is
+//     the most failure-prone thing in the loop, and the -10877 in the existing
+//     comment is that failure already happening.
+//
+//  3. `didCancel` IS NOT IMPLEMENTED. A cancelled utterance never fires
+//     `didFinish`, so `isTTSSpeaking` stays true and the mic is never
+//     restarted. PERMANENT DEAFNESS, with no lockfile in sight — the exact
+//     orphaned-state failure a `/tmp/jarvis_speaking` file would have caused,
+//     already present in memory.
+//
+//  THE FIX: MUTE THE TAP, DO NOT DESTROY THE GRAPH
+//  -------------------------------------------------
+//  The engine keeps running; the tap simply drops buffers while JARVIS speaks.
+//  Nothing to rebuild, so no -10877, no three-second wait, and the mic is live
+//  again on the same runloop turn the utterance ends.
+//
+//  Crash-safety comes free and structurally: the mute is a field on a live
+//  object. If the process dies, the object dies with it. There is no state on
+//  disk that can outlive the thing it describes — which is the whole reason
+//  not to use a lockfile, stated as a property rather than a preference.
+
+import AVFoundation
+
+extension WakeWordListener {
+
+    /// Drop input while JARVIS is speaking, without stopping the engine.
+    ///
+    /// Read from the tap closure, which runs on a REAL-TIME AUDIO THREAD.
+    /// Deliberately a plain flag and not a lock: blocking a render callback on
+    /// a mutex owned by the main thread is a priority inversion that produces
+    /// audio glitches and, under load, drop-outs. The worst case here is that
+    /// one 4096-frame buffer (~85 ms) slips through on the transition — far
+    /// cheaper than stalling the audio thread, and inaudible as an echo.
+    func setMuted(_ muted: Bool) {
+        micMuted = muted
+    }
+
+    var isMicMuted: Bool { micMuted }
+}
+
+// MARK: - Wiring notes (apply inside WakeWordListener.swift)
+//
+//  1. Add the storage. `nonisolated(unsafe)` is the honest annotation: it IS
+//     read off-actor from the audio thread, and the race is benign by the
+//     argument above.
+//
+//         nonisolated(unsafe) fileprivate var micMuted = false
+//
+//  2. Gate the EXISTING tap — one line, no restructuring:
+//
+//         inputNode.installTap(onBus: 0, bufferSize: 4096, format: format) { buffer, _ in
+//             guard !self.micMuted else { return }          // <-- ADD
+//             guard buffer.frameLength > 0 else { return }
+//             req.append(buffer)
+//         }
+//
+//     Dropping the buffer rather than pausing the node keeps the recognition
+//     request alive: `SFSpeechAudioBufferRecognitionRequest` treats a gap as
+//     silence, which is exactly what it was.
+//
+//  3. Unmute in `beginListening()` as well as on didFinish. A restart for any
+//     other reason must never inherit a stale mute — the one way this design
+//     could reproduce the bug it replaces.
+
+// MARK: - Delegate lifecycle (apply inside HUDAppDelegate)
+//
+//  REPLACE the teardown-and-sleep with lifecycle-bound muting. The mute now
+//  begins when the utterance ACTUALLY starts speaking rather than when we
+//  queue it, closing a window where the synthesiser is still warming up and
+//  the mic is already deaf.
+//
+//      // in speak(...): remove `wakeWord.stop()` and keep only
+//      isTTSSpeaking = true
+//      tts.speak(utterance)
+//
+//      nonisolated func speechSynthesizer(_ s: AVSpeechSynthesizer,
+//                                         didStart utterance: AVSpeechUtterance) {
+//          Task { @MainActor [weak self] in self?.wakeWord.setMuted(true) }
+//      }
+//
+//      nonisolated func speechSynthesizer(_ s: AVSpeechSynthesizer,
+//                                         didFinish utterance: AVSpeechUtterance) {
+//          Task { @MainActor [weak self] in
+//              guard let self else { return }
+//              self.isTTSSpeaking = false
+//              self.wakeWord.setMuted(false)      // no 3s sleep: nothing was torn down
+//          }
+//      }
+//
+//      // THE MISSING ONE. Without this a cancelled utterance leaves the mic
+//      // muted forever, which is the deafness this file exists to prevent.
+//      nonisolated func speechSynthesizer(_ s: AVSpeechSynthesizer,
+//                                         didCancel utterance: AVSpeechUtterance) {
+//          Task { @MainActor [weak self] in
+//              guard let self else { return }
+//              self.isTTSSpeaking = false
+//              self.wakeWord.setMuted(false)
+//          }
+//      }
+//
+//  A belt-and-braces reconciliation, because a delegate callback that never
+//  arrives is the one failure this cannot see: on any mic restart, and on
+//  connection-status changes, assert the truth from the synthesiser itself —
+//
+//      wakeWord.setMuted(tts.isSpeaking)
+//
+//  `AVSpeechSynthesizer.isSpeaking` is the authority. Deriving the mute from
+//  it rather than from our own bookkeeping means a dropped callback costs one
+//  cycle of staleness instead of permanent silence.

--- a/JARVIS-Apple/JARVISHUD/Services/SecureConsent.swift
+++ b/JARVIS-Apple/JARVISHUD/Services/SecureConsent.swift
@@ -1,0 +1,153 @@
+//  SecureConsent.swift
+//  JARVISHUD
+//
+//  Touch ID / Apple Watch approval for gated macOS capabilities.
+//
+//  WHY THIS LIVES IN SWIFT AND NOT PYTHON
+//  ---------------------------------------
+//  Measured on the backend interpreter:
+//
+//      LAContext.canEvaluatePolicy(.deviceOwnerAuthentication) -> false
+//      biometryType                                            -> 0 (none)
+//      NSBundle.mainBundle().bundleIdentifier()                -> nil
+//
+//  LocalAuthentication requires a SIGNED APP BUNDLE identity. A bare
+//  interpreter has none, so LAContext refuses every policy regardless of the
+//  hardware. That is not an obstacle to route around — it is macOS declining
+//  to let an unsigned process speak for the Secure Enclave, and it is the
+//  reason the prompt belongs here. A Python-side LAContext call would have
+//  been the spoofable path, not the safe one.
+//
+//  THE NONCE
+//  ---------
+//  The signed bundle stops an unsigned process from ASKING. It does nothing
+//  about REPLAY — anything that can write to the local IPC socket could
+//  capture one `{"approved": true}` and resend it forever. So Python mints a
+//  one-time `secrets.token_urlsafe(32)` challenge when it suspends the call,
+//  and a verdict is only an answer if it echoes THAT challenge. Python
+//  compares with `hmac.compare_digest` and pops it on use.
+//
+//  We never generate the nonce here and never cache one. Echo only.
+
+import Foundation
+import LocalAuthentication
+
+@MainActor
+final class SecureConsent {
+
+    static let shared = SecureConsent()
+    private init() {}
+
+    /// A consent request as it arrives from the backend over the Brainstem IPC.
+    struct Challenge {
+        let requestId: String
+        let nonce: String
+        let capability: String
+        let detail: String
+
+        init?(_ data: [String: Any]) {
+            guard let requestId = data["request_id"] as? String,
+                  let nonce = data["nonce"] as? String,
+                  !requestId.isEmpty, !nonce.isEmpty else {
+                // Fail CLOSED on a malformed challenge. A request we cannot
+                // identify is a request we must not approve — and silently
+                // treating it as "no consent needed" is how a gate becomes
+                // decorative.
+                return nil
+            }
+            self.requestId = requestId
+            self.nonce = nonce
+            self.capability = (data["capability"] as? String) ?? "unknown"
+            self.detail = (data["detail"] as? String) ?? ""
+        }
+    }
+
+    /// Prompt for owner authentication, then answer the backend.
+    ///
+    /// Uses `.deviceOwnerAuthentication` rather than
+    /// `.deviceOwnerAuthenticationWithBiometrics` deliberately: the biometrics
+    /// policy has NO password fallback, so a wet finger or a closed lid leaves
+    /// the operator unable to approve anything at all. `.deviceOwnerAuthentication`
+    /// falls back to the login password, which is the same secret Touch ID is
+    /// standing in for — no weaker, and it cannot lock the owner out.
+    ///
+    /// No custom UI: the system dialog IS the prompt. Anything we drew
+    /// ourselves would be a phishable imitation of it.
+    func request(_ challenge: Challenge) {
+        let context = LAContext()
+        context.localizedCancelTitle = "Deny"
+
+        // A fresh context per request. Reusing one lets macOS honour a recent
+        // successful evaluation without re-prompting (`touchIDAuthenticationAllowableReuseDuration`),
+        // which would silently approve a SECOND capability on the strength of
+        // the first — exactly the replay the nonce exists to prevent, arriving
+        // from inside the OS instead of over the socket.
+        context.touchIDAuthenticationAllowableReuseDuration = 0
+
+        var policyError: NSError?
+        guard context.canEvaluatePolicy(.deviceOwnerAuthentication,
+                                        error: &policyError) else {
+            // No enrolled biometric AND no password path. Deny, and say why —
+            // an operator who cannot approve needs to know that is the reason,
+            // not watch a request vanish.
+            respond(challenge, approved: false,
+                    reason: "owner authentication unavailable: "
+                          + (policyError?.localizedDescription ?? "unknown"))
+            return
+        }
+
+        let reason = challenge.detail.isEmpty
+            ? "authorise \(challenge.capability)"
+            : challenge.detail
+
+        context.evaluatePolicy(.deviceOwnerAuthentication,
+                               localizedReason: reason) { [weak self] ok, error in
+            // The callback lands on an arbitrary queue; every field we touch is
+            // MainActor-isolated.
+            Task { @MainActor in
+                guard let self else { return }
+                if ok {
+                    self.respond(challenge, approved: true, reason: "")
+                } else {
+                    let code = (error as? LAError)?.code
+                    self.respond(challenge, approved: false,
+                                 reason: Self.describe(code, error))
+                }
+            }
+        }
+    }
+
+    /// Echo the challenge back with the verdict. The nonce is the whole point.
+    private func respond(_ challenge: Challenge, approved: Bool, reason: String) {
+        BrainstemLauncher.shared.sendEvent(
+            eventType: "consent_verdict",
+            data: [
+                "request_id": challenge.requestId,
+                // ECHOED, never regenerated. Python pops it and compares in
+                // constant time; a verdict without it is not an answer.
+                "nonce": challenge.nonce,
+                "approved": approved,
+                "status": approved ? "APPROVED" : "REJECTED",
+                "capability": challenge.capability,
+                "reason": reason,
+            ]
+        )
+    }
+
+    /// Distinguish "the operator said no" from "the machine could not ask".
+    /// Both deny, and they need opposite follow-ups.
+    private static func describe(_ code: LAError.Code?, _ error: Error?) -> String {
+        switch code {
+        case .userCancel:            return "operator denied"
+        case .userFallback:          return "operator chose password fallback"
+        case .authenticationFailed:  return "authentication failed"
+        case .systemCancel:          return "system cancelled the prompt"
+        case .appCancel:             return "app cancelled the prompt"
+        case .biometryLockout:       return "biometry locked out — password required"
+        case .biometryNotEnrolled:   return "no biometry enrolled"
+        case .biometryNotAvailable:  return "biometry unavailable"
+        default:
+            return error?.localizedDescription ?? "denied"
+        }
+    }
+}

--- a/backend/main.py
+++ b/backend/main.py
@@ -2164,6 +2164,27 @@ async def parallel_lifespan(app: FastAPI):
                                 )
                             except Exception as e:
                                 logger.error("[HUD] Command dispatch failed: %s", e)
+                    elif event_type == "consent_verdict":
+                        # The signed HUD answering a gated capability.
+                        #
+                        # Delivered as a plain dict straight from the IPC —
+                        # `capability_router.resume` reads `status`/`approved`
+                        # and verifies the echoed `nonce` in constant time, so
+                        # nothing is unwrapped or re-shaped here. A verdict that
+                        # cannot prove which challenge it answers is denied by
+                        # that check, not by this branch.
+                        try:
+                            from backend.system_control.capability_router import (
+                                get_capability_router,
+                            )
+                            rid = str(data.get("request_id") or "")
+                            routed = await get_capability_router().resume(rid, data)
+                            logger.info(
+                                "[HUD] consent verdict for %s → %s (%s)",
+                                data.get("capability") or "?",
+                                routed.outcome, routed.detail or "-")
+                        except Exception as _cv:  # noqa: BLE001
+                            logger.error("[HUD] consent verdict failed: %s", _cv)
                     else:
                         logger.debug("[HUD] Unhandled event: %s", event_type)
 

--- a/backend/system_control/capability_router.py
+++ b/backend/system_control/capability_router.py
@@ -102,6 +102,9 @@ class RoutedCall:
     outcome: str
     capability: str = ""
     request_id: str = ""
+    #: The challenge the signed HUD must echo back. Never logged in full and
+    #: never reused — see `_mint_nonce`.
+    nonce: str = ""
     result: Any = None
     #: What to append to the LLM context. ALWAYS populated — a turn that ends
     #: without telling the model why is a turn the model will simply repeat.
@@ -135,6 +138,9 @@ class _Suspended:
     capability: str
     args: Dict[str, Any] = field(default_factory=dict)
     created: float = field(default_factory=time.time)
+    #: One-time challenge. The verdict must echo THIS value or it is not an
+    #: answer to THIS question — see `_verify_nonce`.
+    nonce: str = ""
 
     def expired(self) -> bool:
         return (time.time() - self.created) > consent_ttl_s()
@@ -213,13 +219,14 @@ class CapabilityRouter:
                     outcome=Outcome.DENIED.value, capability=name,
                     context_note=DENIED_PAYLOAD,
                     detail="no approval provider available — failing closed")
-            self._parked[rid] = _Suspended(rid, name, args)
+            nonce = _mint_nonce()
+            self._parked[rid] = _Suspended(rid, name, args, nonce=nonce)
             self._stats["suspended"] += 1
             logger.info("[CapabilityRouter] '%s' SUSPENDED awaiting consent "
                         "(request=%s) — turn released", name, rid[:12])
             return RoutedCall(
                 outcome=Outcome.SUSPENDED.value, capability=name,
-                request_id=rid, context_note=SUSPENDED_NOTE,
+                request_id=rid, nonce=nonce, context_note=SUSPENDED_NOTE,
                 detail="operator consent required")
         except Exception as exc:  # noqa: BLE001 — a router never kills a turn
             self._stats["failed"] += 1
@@ -249,6 +256,20 @@ class CapabilityRouter:
                     outcome=Outcome.EXPIRED.value, capability=parked.capability,
                     request_id=request_id, context_note=EXPIRED_PAYLOAD,
                     detail=f"consent not given within {consent_ttl_s():.0f}s")
+            # CHALLENGE-RESPONSE. A verdict is only an answer to THIS question
+            # if it carries THIS question's nonce. Without it, anything that can
+            # write to the IPC socket can replay a captured approval — the
+            # attack the signed-bundle boundary exists to stop, defeated one
+            # layer below it.
+            if parked.nonce and not _verify_nonce(parked.nonce, decision):
+                self._stats["denied"] += 1
+                logger.warning(
+                    "[CapabilityRouter] verdict for '%s' failed the nonce "
+                    "challenge — treating as DENIED", parked.capability)
+                return RoutedCall(
+                    outcome=Outcome.DENIED.value, capability=parked.capability,
+                    request_id=request_id, context_note=DENIED_PAYLOAD,
+                    detail="verdict did not echo the challenge nonce")
             if _approved(decision):
                 out = await self._execute(parked.capability, parked.args)
                 out.request_id = request_id
@@ -341,6 +362,45 @@ class _ConsentContext:
         return f"Run macOS capability '{self.capability}' with {self.args or '{}'}"
 
 
+def _mint_nonce() -> str:
+    """A one-time challenge. NEVER raises.
+
+    `secrets.token_urlsafe` rather than uuid4: this is an anti-replay token, so
+    it wants a CSPRNG, and uuid4's guarantee is uniqueness rather than
+    unpredictability. 32 bytes because the cost is nothing and the value is a
+    socket anyone on the box can write to.
+    """
+    try:
+        import secrets
+        return secrets.token_urlsafe(32)
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def _verify_nonce(expected: str, decision: Any) -> bool:
+    """Does this verdict answer THIS challenge? NEVER raises.
+
+    Constant-time compare — a verdict arriving over a local socket is attacker-
+    influenced input, and an early-exit `==` leaks the prefix one byte at a
+    time to anything that can time it.
+
+    Fails CLOSED on a missing or unreadable nonce: a verdict that cannot prove
+    which question it answers is not an answer.
+    """
+    try:
+        import hmac
+        got = ""
+        if isinstance(decision, dict):
+            got = str(decision.get("nonce") or "")
+        else:
+            got = str(getattr(decision, "nonce", "") or "")
+        if not got or not expected:
+            return False
+        return hmac.compare_digest(str(expected), got)
+    except Exception:  # noqa: BLE001
+        return False
+
+
 def _approved(decision: Any) -> bool:
     """Did the operator say yes? NEVER raises.
 
@@ -351,9 +411,18 @@ def _approved(decision: Any) -> bool:
     try:
         if decision is None:
             return False
-        status = getattr(decision, "status", decision)
+        # The IPC delivers JSON, so a verdict from the signed HUD arrives as a
+        # dict. Reading only `.status` would have made every real verdict from
+        # Swift fall through to denial — safe, and completely broken.
+        if isinstance(decision, dict):
+            status = decision.get("status", decision.get("approved"))
+            if isinstance(status, bool):
+                return status
+        else:
+            status = getattr(decision, "status", decision)
         name = getattr(status, "name", None) or str(status)
-        return str(name).strip().upper() in ("APPROVED", "APPROVE", "YES", "Y")
+        return str(name).strip().upper() in ("APPROVED", "APPROVE", "YES", "Y",
+                                             "TRUE")
     except Exception:  # noqa: BLE001
         return False
 

--- a/tests/system_control/test_capability_router.py
+++ b/tests/system_control/test_capability_router.py
@@ -91,10 +91,16 @@ class _Provider:
 
 
 class _Decision:
-    """Shaped like `ApprovalResult` — only `.status.name` is read."""
+    """Shaped like `ApprovalResult`.
 
-    def __init__(self, name: str) -> None:
+    Carries a `nonce` because a verdict without one is no longer an answer:
+    the challenge landed after these tests were written, and they were updated
+    to satisfy it rather than the check being relaxed to satisfy them.
+    """
+
+    def __init__(self, name: str, nonce: str = "") -> None:
         self.status = type("S", (), {"name": name})()
+        self.nonce = nonce
 
 
 def _router(controller: Optional[_MockController] = None) -> tuple:
@@ -150,7 +156,8 @@ class TestTheMandatedScenario:
     async def test_approval_executes_and_re_triggers(self):
         router, ctl, _prov = _router()
         out = await router.route("lock_screen")
-        resumed = await router.resume(out.request_id, _Decision("APPROVED"))
+        resumed = await router.resume(out.request_id,
+                                      _Decision("APPROVED", out.nonce))
         assert resumed.outcome == Outcome.EXECUTED.value
         assert ctl.locked == 1
         assert resumed.should_retrigger is True
@@ -224,8 +231,9 @@ class TestFailingClosed:
         cannot execute a mutation twice."""
         router, ctl, _p = _router()
         out = await router.route("lock_screen")
-        await router.resume(out.request_id, _Decision("APPROVED"))
-        again = await router.resume(out.request_id, _Decision("APPROVED"))
+        await router.resume(out.request_id, _Decision("APPROVED", out.nonce))
+        again = await router.resume(out.request_id,
+                                    _Decision("APPROVED", out.nonce))
         assert ctl.locked == 1
         assert again.outcome == Outcome.FAILED.value
 
@@ -297,3 +305,105 @@ class TestConcurrency:
         assert all(o.suspended for o in outs)
         assert len({o.request_id for o in outs}) == 10
         assert ctl.locked == 0
+
+
+class TestTheNonceChallenge:
+    """A verdict is only an answer to THIS question if it carries THIS nonce.
+
+    The signed-bundle boundary stops an unsigned process from speaking for the
+    Secure Enclave. It does nothing about REPLAY: anything that can write to
+    the local IPC socket could capture one approval and resend it forever,
+    defeating the boundary one layer below it. The nonce closes that.
+    """
+
+    class _Verdict:
+        def __init__(self, name: str, nonce: str = "") -> None:
+            self.status = type("S", (), {"name": name})()
+            self.nonce = nonce
+
+    @pytest.mark.asyncio
+    async def test_a_suspension_mints_a_challenge(self):
+        router, _c, _p = _router()
+        out = await router.route("lock_screen")
+        assert out.nonce, "no challenge was issued with the suspension"
+        assert len(out.nonce) >= 32, "challenge is too short to resist guessing"
+
+    @pytest.mark.asyncio
+    async def test_the_right_nonce_is_accepted(self):
+        router, ctl, _p = _router()
+        out = await router.route("lock_screen")
+        res = await router.resume(out.request_id,
+                                  self._Verdict("APPROVED", out.nonce))
+        assert res.outcome == Outcome.EXECUTED.value
+        assert ctl.locked == 1
+
+    @pytest.mark.asyncio
+    async def test_a_replayed_verdict_from_another_request_is_denied(self):
+        """THE attack. Capture an approval for one call, replay it at the next."""
+        router, ctl, _p = _router()
+        first = await router.route("lock_screen")
+        await router.resume(first.request_id,
+                            self._Verdict("APPROVED", first.nonce))
+        assert ctl.locked == 1
+
+        second = await router.route("lock_screen")
+        replayed = await router.resume(second.request_id,
+                                       self._Verdict("APPROVED", first.nonce))
+        assert replayed.outcome == Outcome.DENIED.value
+        assert ctl.locked == 1, "a replayed approval executed a second lock"
+        assert "nonce" in replayed.detail
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("nonce", ["", None, "wrong", "x" * 43])
+    async def test_a_missing_or_wrong_nonce_fails_closed(self, nonce):
+        router, ctl, _p = _router()
+        out = await router.route("lock_screen")
+        res = await router.resume(out.request_id,
+                                  self._Verdict("APPROVED", nonce))
+        assert res.outcome == Outcome.DENIED.value
+        assert ctl.locked == 0
+
+    @pytest.mark.asyncio
+    async def test_a_dict_verdict_works_too(self):
+        """The IPC delivers JSON, so the verdict arrives as a dict — the
+        surfaces that answer should not have to learn a Python class."""
+        router, ctl, _p = _router()
+        out = await router.route("lock_screen")
+        res = await router.resume(out.request_id,
+                                  {"status": "APPROVED", "nonce": out.nonce})
+        assert res.outcome == Outcome.EXECUTED.value and ctl.locked == 1
+
+    @pytest.mark.asyncio
+    async def test_the_challenge_is_single_use(self):
+        """Consent is popped on resume, so even the CORRECT nonce cannot run
+        the capability twice."""
+        router, ctl, _p = _router()
+        out = await router.route("lock_screen")
+        await router.resume(out.request_id,
+                            self._Verdict("APPROVED", out.nonce))
+        again = await router.resume(out.request_id,
+                                    self._Verdict("APPROVED", out.nonce))
+        assert ctl.locked == 1
+        assert again.outcome == Outcome.FAILED.value
+
+    @pytest.mark.asyncio
+    async def test_two_suspensions_get_different_challenges(self):
+        router, _c, _p = _router()
+        a = await router.route("lock_screen")
+        b = await router.route("lock_screen")
+        assert a.nonce != b.nonce
+
+    def test_comparison_is_constant_time(self):
+        """A verdict over a local socket is attacker-influenced input; an
+        early-exit `==` leaks the prefix one byte at a time to anything that
+        can time it."""
+        import inspect
+        from backend.system_control import capability_router as m
+        assert "compare_digest" in inspect.getsource(m._verify_nonce)
+
+    def test_the_challenge_uses_a_csprng(self):
+        """`uuid4` guarantees uniqueness; an anti-replay token needs
+        UNPREDICTABILITY."""
+        import inspect
+        from backend.system_control import capability_router as m
+        assert "secrets" in inspect.getsource(m._mint_nonce)


### PR DESCRIPTION
## Python — the challenge

The signed-bundle boundary stops an *unsigned* process from speaking for the Secure Enclave. It does nothing about **replay**: anything that can write to the local IPC socket could capture one `{"approved": true}` and resend it forever, defeating the boundary one layer below it.

A suspension now mints a one-time `secrets.token_urlsafe(32)` challenge, and a verdict is only an answer if it echoes **that** challenge. `secrets` rather than `uuid4` because uuid4 guarantees uniqueness where an anti-replay token needs **unpredictability**. Compared with `hmac.compare_digest` — a verdict over a local socket is attacker-influenced input, and an early-exit `==` leaks the prefix a byte at a time to anything that can time it.

**Proven:**

```
1. python suspends            → nonce _l0wZ4Zcfglu… (43 chars)
2. swift verdict, echoed      → executed · locked = 1
3. same payload replayed      → denied   · locked = 1
   "verdict did not echo the challenge nonce"
```

Found while wiring it: `_approved` read only `.status` on an object, so a verdict arriving as **JSON from Swift** — which is how every real one will arrive — fell through to denial. Safe, and completely broken. Two earlier tests were updated to carry a nonce rather than the check being relaxed to accept them.

## Swift — `SecureConsent.swift`

**`.deviceOwnerAuthentication`, not `.deviceOwnerAuthenticationWithBiometrics`.** The biometrics policy has no password fallback, so a wet finger or a closed lid would leave you unable to approve anything at all. The fallback is the login password — the same secret Touch ID stands in for, so no weaker, and it can't lock you out.

**`touchIDAuthenticationAllowableReuseDuration = 0`**, deliberately. macOS will otherwise honour a recent successful evaluation without re-prompting — silently approving a *second* capability on the strength of the first. That's the same replay the nonce prevents, arriving from inside the OS instead of over the socket.

No custom UI: the system dialog **is** the prompt. Anything we drew would be a phishable imitation of it.

## Swift — `MicSuppression.swift`

The current code tears the audio graph down (`wakeWord.stop()`) and rebuilds it after `try? await Task.sleep(for: .seconds(3.0))` — a delay that exists because AVSpeechSynthesizer holds the output device and rebuilding too early throws `-10877`. A workaround for a teardown that didn't need to happen.

**And `didCancel` is not implemented.** A cancelled utterance never fires `didFinish`, so `isTTSSpeaking` stays true and the mic never restarts: **permanent deafness, already present in memory, with no lockfile in sight.** The `/tmp` file was never the cause — only the most visible shape of it.

The fix mutes the **tap** instead of destroying the graph. Nothing to rebuild, so no `-10877` and no three-second deaf window. Crash-safety is structural rather than promised: the mute is a field on a live object, so if the process dies the state dies with it.

The flag is read from a **real-time audio thread** and is deliberately not a lock — blocking a render callback on a main-thread mutex is a priority inversion that produces drop-outs. Worst case one 4096-frame buffer (~85 ms) slips through on the transition, which is inaudible; a stalled audio thread is not.

Belt-and-braces: derive the mute from `AVSpeechSynthesizer.isSpeaking` on every mic restart, so a dropped delegate callback costs one cycle of staleness rather than permanent silence.

## Tests

102 green across capability + HUD. Python receiver wired in `_hud_dispatch` — the verdict dict goes straight to `router.resume`, which does the nonce check.

## Remaining, and only doable in Xcode

Add both files to the target, route `consent_verdict` requests from the IPC to `SecureConsent.shared.request`, and apply the three marked edits inside `WakeWordListener` / `HUDAppDelegate`. **The Swift half cannot be compiled or run from here and is not claimed as working.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds nonce-based challenge-response for capability consent to block replay attacks and adds Swift drop-ins for secure owner authentication and safe mic muting. Prevents silent approvals, removes the 3s mic-deaf window, and fixes verdict parsing from Swift.

- New Features
  - Nonce challenge for consent: mint on suspend, verify in constant time on resume, single-use.
  - Backend forwards `consent_verdict` dicts directly to the router.
  - Swift `SecureConsent`: uses `.deviceOwnerAuthentication`, sets `touchIDAuthenticationAllowableReuseDuration = 0`, and echoes the `nonce` in responses.
  - Mic suppression: mutes the input tap during TTS (no engine teardown), handles start/finish/cancel, and derives mute from `AVSpeechSynthesizer.isSpeaking`.

- Migration
  - Add `SecureConsent.swift` and `MicSuppression.swift` to the HUD target.
  - Wire the IPC to call `SecureConsent.shared.request(...)` when a consent request arrives.
  - Apply the marked edits in `WakeWordListener` and `HUDAppDelegate`.

<sup>Written for commit 378497d8a06fdb67389a06de3ccfd3568174977d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

