### PR TITLE
feat(capability): federate multi-space, video and ghost touch into the HUD

### DIFF
--- a/JARVIS-Apple/JARVIS-Apple.xcodeproj/project.pbxproj
+++ b/JARVIS-Apple/JARVIS-Apple.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		95909137A4CE7F24654D6776 /* JARVISKit in Frameworks */ = {isa = PBXBuildFile; productRef = 31F47BC187C21A0EAA566686 /* JARVISKit */; };
 		9675A57D67D07E9D157B8468 /* JARVISPhoneApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 698E4531C1F4FD5A0215C9B1 /* JARVISPhoneApp.swift */; };
 		993234F1A4D7A1BCA27374BB /* BrainstemLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6A777442955E499D4E22D3B /* BrainstemLauncher.swift */; };
+		5EC04E11A2B3C4D5E6F70002 /* SecureConsent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC04E11A2B3C4D5E6F70001 /* SecureConsent.swift */; };
 		99C3D3109F5801D5ED6F638A /* HapticEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 266CC1C8FBBB302AD623A3D9 /* HapticEngine.swift */; };
 		9FC588C57049591237CF032F /* HUDView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A0A5C4460F31FD5CB53DD10 /* HUDView.swift */; };
 		A0BD7790CE0BF3EDAC6D6372 /* ArcReactorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26744ECD2240E57AF517188D /* ArcReactorView.swift */; };
@@ -60,6 +61,7 @@
 		853E0D7E9218220610520FB8 /* StatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusView.swift; sourceTree = "<group>"; };
 		899F7DC5BF2FA227AA8CEA81 /* LivingBorderWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LivingBorderWindow.swift; sourceTree = "<group>"; };
 		A6A777442955E499D4E22D3B /* BrainstemLauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrainstemLauncher.swift; sourceTree = "<group>"; };
+		5EC04E11A2B3C4D5E6F70001 /* SecureConsent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConsent.swift; sourceTree = "<group>"; };
 		AF2D1789D766C67E4B4A3D2A /* JARVISHUD.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JARVISHUD.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B91850E89902256710524BEA /* LoadingHUDView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingHUDView.swift; sourceTree = "<group>"; };
 		BD8C21EBA8B80C1A39D30C8A /* JARVISPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JARVISPanel.swift; sourceTree = "<group>"; };
@@ -166,6 +168,7 @@
 				4784C00A28BAB42B47C1A4F1 /* AppState.swift */,
 				A6A777442955E499D4E22D3B /* BrainstemLauncher.swift */,
 				7F97771D9894460348ABB0ED /* ScreenCaptureService.swift */,
+				5EC04E11A2B3C4D5E6F70001 /* SecureConsent.swift */,
 				62C68475EAAD735E3FB66AAE /* WakeWordListener.swift */,
 			);
 			path = Services;
@@ -414,6 +417,7 @@
 				FBBDB0313A52CEA7D67AFF62 /* LivingBorderWindow.swift in Sources */,
 				F2372C4356B52F4C5EE16B1C /* LoadingHUDView.swift in Sources */,
 				D3F64926FE39007A1202CB78 /* ScreenCaptureService.swift in Sources */,
+				5EC04E11A2B3C4D5E6F70002 /* SecureConsent.swift in Sources */,
 				8343F8E9601E5B1F4058448D /* TransparentWindow.swift in Sources */,
 				7E167813DA477376FA50A02A /* WakeWordListener.swift in Sources */,
 			);

--- a/JARVIS-Apple/JARVISHUD/Services/BrainstemLauncher.swift
+++ b/JARVIS-Apple/JARVISHUD/Services/BrainstemLauncher.swift
@@ -428,12 +428,65 @@ final class BrainstemLauncher {
                     continue
                 }
 
-                // Other events can be handled here in the future
                 print("[Brainstem] Received IPC event: \(eventType)")
+                dispatchInbound(eventType: eventType, json: json)
             } catch {
                 // Skip malformed lines silently
                 continue
             }
+        }
+    }
+
+    /// Route one inbound backend event to whoever handles it.
+    ///
+    /// The socket carried traffic in one direction for its whole life and this
+    /// was a `print` with a comment about the future. That is why the consent
+    /// gate was decorative: `SecureConsent` was complete and waiting for a
+    /// challenge, `main.py` was handling the verdict, and the question in
+    /// between was never delivered — so every gated capability on the backend
+    /// resolved to "no approval provider available" and the operator was never
+    /// asked anything.
+    ///
+    /// Unknown event types are IGNORED rather than treated as errors: the
+    /// backend ships independently of this app, and a HUD that logged a warning
+    /// for every event it had not learned about yet would be noisy about
+    /// nothing.
+    private func dispatchInbound(eventType: String, json: [String: Any]) {
+        let data = (json["data"] as? [String: Any]) ?? [:]
+
+        switch eventType {
+        case "consent_request":
+            // Fields are lifted to Strings HERE, before the hop. `[String: Any]`
+            // is not Sendable, so capturing `data` in a `@MainActor` Task is a
+            // Swift 6 concurrency error — and the fix is not to silence it. Only
+            // these four values are needed, all of them Strings, all Sendable.
+            let requestId = (data["request_id"] as? String) ?? ""
+            let nonce = (data["nonce"] as? String) ?? ""
+            let capability = (data["capability"] as? String) ?? "unknown"
+            let detail = (data["detail"] as? String) ?? ""
+
+            // `SecureConsent` is MainActor-isolated: LAContext must present its
+            // dialog from the main thread, and this handler runs on the
+            // connection's background queue.
+            Task { @MainActor in
+                // Parsing fails CLOSED on a malformed challenge — a request we
+                // cannot bind to a nonce is one we must not answer at all,
+                // because a verdict that cannot prove which question it answers
+                // is replayable by anything that can write to the socket.
+                guard let challenge = SecureConsent.Challenge([
+                    "request_id": requestId,
+                    "nonce": nonce,
+                    "capability": capability,
+                    "detail": detail,
+                ]) else {
+                    print("[Brainstem] consent_request rejected — malformed challenge")
+                    return
+                }
+                SecureConsent.shared.request(challenge)
+            }
+
+        default:
+            break
         }
     }
 

--- a/backend/ghost_hands/orchestrator.py
+++ b/backend/ghost_hands/orchestrator.py
@@ -350,6 +350,21 @@ class GhostHandsOrchestrator:
 
     Connects N-Optic Nerve (vision), Background Actuator (actions), and
     Narration Engine (voice) into a unified intelligent automation system.
+
+    Capability-Namespace: touch
+    Capability-Factory: get_instance
+
+    Shares the `touch` namespace with `SilentActuator`, and that sharing is the
+    reason `as=` exists. Both classes have `start` and `stop`; in a flat
+    vocabulary one would silently shadow the other and a model asking to "start"
+    would reach whichever sorted first. Both rename themselves AT THE
+    DECLARATION — `start_ghost_hands` here, `start_actuator` there — so twelve
+    existing call sites keep the method names they already use and the rename is
+    readable from the thing being renamed rather than from a table elsewhere.
+
+    `Capability-Factory: get_instance` because this is a `__new__`-based
+    singleton: constructing it a second time would hand back the same object
+    with `_initialized` reset, and the factory is the accessor that knows that.
     """
 
     _instance: Optional["GhostHandsOrchestrator"] = None
@@ -401,7 +416,16 @@ class GhostHandsOrchestrator:
         return cls(config)
 
     async def start(self) -> bool:
-        """Start the Ghost Hands system."""
+        """Start the Ghost Hands system.
+
+        Capability: session-start, release=stop_ghost_hands, as=start_ghost_hands
+
+        Brings up vision watchers, the actuator subprocess and the narration
+        engine, and leaves all three running. `release=` names the EXPORT
+        (`stop_ghost_hands`), not the method — the reaper calls capabilities, and
+        a release pointing at `stop` would resolve to whatever else in this
+        namespace is called that.
+        """
         if self._is_running:
             return True
 
@@ -444,7 +468,10 @@ class GhostHandsOrchestrator:
         return True
 
     async def stop(self) -> None:
-        """Stop the Ghost Hands system."""
+        """Stop the Ghost Hands system.
+
+        Capability: session-end, as=stop_ghost_hands
+        """
         logger.info("[GHOST-HANDS] Stopping Ghost Hands system...")
 
         self._shutdown_event.set()
@@ -711,7 +738,16 @@ class GhostHandsOrchestrator:
         task.state = GhostTaskState.WATCHING
 
     async def pause_task(self, name: str) -> bool:
-        """Pause a task (stops watching but keeps task defined)."""
+        """Pause a task (stops watching but keeps task defined).
+
+        Capability: notify_apply
+
+        Not a session-end: the task survives, so no lease is discharged. Pausing
+        a watcher only stops it acting, which is the safe direction.
+
+        Args:
+            name: The ghost task's name
+        """
         if name not in self._tasks:
             return False
 
@@ -729,7 +765,17 @@ class GhostHandsOrchestrator:
         return True
 
     async def resume_task(self, name: str) -> bool:
-        """Resume a paused task."""
+        """Resume a paused task.
+
+        Capability: approval_required
+
+        Asymmetric with `pause_task` on purpose. Pausing removes an autonomous
+        actor's ability to type into applications; resuming gives it back. The
+        tiers follow the CONSEQUENCE, not the symmetry of the method names.
+
+        Args:
+            name: The ghost task's name
+        """
         if name not in self._tasks:
             return False
 
@@ -742,7 +788,13 @@ class GhostHandsOrchestrator:
         return True
 
     async def cancel_task(self, name: str) -> bool:
-        """Cancel and remove a task."""
+        """Cancel and remove a task.
+
+        Capability: notify_apply
+
+        Args:
+            name: The ghost task's name
+        """
         if name not in self._tasks:
             return False
 
@@ -763,11 +815,20 @@ class GhostHandsOrchestrator:
                 await self._n_optic.stop_watching(window_id)
 
     def get_task(self, name: str) -> Optional[GhostTask]:
-        """Get a task by name."""
+        """Get a task by name.
+
+        Capability: read-only
+
+        Args:
+            name: The ghost task's name
+        """
         return self._tasks.get(name)
 
     def list_tasks(self) -> List[Dict[str, Any]]:
-        """List all tasks with their status."""
+        """List all tasks with their status.
+
+        Capability: read-only
+        """
         return [
             {
                 "name": task.name,
@@ -1072,6 +1133,22 @@ class GhostHandsOrchestrator:
         """
         Convenience method to quickly set up a watch-and-react task.
 
+        Capability: approval_required
+
+        The flagship ghost-touch verb, and the one that most deserves its tier.
+        It ARMS something: from here on, text appearing in another app causes
+        keystrokes to be typed into it, with no human in the loop at the moment
+        it fires. Approving this is approving every future firing of it, which
+        is a different question from approving one click — so it is asked once,
+        deliberately, rather than degraded to a notify because the call itself
+        returns quickly.
+
+        Deliberately not a session. The task it creates is durable state this
+        orchestrator already tracks and already exposes through `list_tasks` and
+        `cancel_task`; wrapping it in a lease would put a TTL on an automation
+        the operator asked to persist, and a reaper would cancel it at 3am for
+        no reason it could name.
+
         Args:
             app_name: Application to watch
             trigger_text: Text that triggers the reaction
@@ -1111,6 +1188,14 @@ class GhostHandsOrchestrator:
         """
         Set up automatic retry when a failure is detected.
 
+        Capability: approval_required
+
+        Strictly sharper than `watch_and_react`: the reaction is a SHELL
+        COMMAND, re-run automatically up to `max_retries` times with nobody
+        watching. Same tier because there is no sharper one short of BLOCKED,
+        and blocking a capability the operator explicitly asked for would be the
+        registry deciding rather than asking.
+
         Args:
             app_name: Application to watch (e.g., "Terminal")
             failure_text: Text indicating failure (e.g., "BUILD FAILED")
@@ -1142,6 +1227,13 @@ class GhostHandsOrchestrator:
         """
         Set up notification when a task completes.
 
+        Capability: notify_apply
+
+        The one watcher in this trio that only SPEAKS. It narrates and types
+        nothing, so it does not need the tier its two neighbours do — tiering it
+        the same out of family resemblance would train an operator to approve
+        watchers without reading which kind they are.
+
         Args:
             app_name: Application to watch
             completion_text: Text indicating completion
@@ -1164,7 +1256,10 @@ class GhostHandsOrchestrator:
     # =========================================================================
 
     def get_stats(self) -> Dict[str, Any]:
-        """Get orchestrator statistics."""
+        """Get orchestrator statistics.
+
+        Capability: read-only
+        """
         component_status = {
             "n_optic": self._n_optic is not None,
             "actuator": self._actuator is not None,
@@ -1185,7 +1280,13 @@ class GhostHandsOrchestrator:
         }
 
     def get_execution_history(self, limit: int = 10) -> List[Dict[str, Any]]:
-        """Get recent execution history."""
+        """Get recent execution history.
+
+        Capability: read-only
+
+        Args:
+            limit: How many recent executions to return
+        """
         return [
             {
                 "task_name": r.task_name,

--- a/backend/ghost_hands/silent_actuator.py
+++ b/backend/ghost_hands/silent_actuator.py
@@ -32,7 +32,16 @@ _WORKER_START_TIMEOUT_S = float(os.environ.get("ACTUATOR_START_TIMEOUT_S", "10.0
 
 
 class SilentActuator:
-    """Async interface to the CGEvent worker subprocess."""
+    """Async interface to the CGEvent worker subprocess.
+
+    Capability-Namespace: touch
+    Capability-Factory: get_instance
+
+    Tags below are read by `capability_federation` via a static AST scan and by
+    `capability_registry` at hydrate time. They are DOCSTRING tags rather than
+    decorators on purpose: this module gains no import, and `ghost_hands` stays
+    free of any dependency on `system_control`.
+    """
 
     _instance: Optional["SilentActuator"] = None
 
@@ -52,7 +61,18 @@ class SilentActuator:
     # ------------------------------------------------------------------
 
     async def start(self) -> bool:
-        """Start the CGEvent worker subprocess."""
+        """Start the CGEvent worker subprocess.
+
+        Capability: session-start, release=stop_actuator, as=start_actuator
+
+        A session in the most literal sense — this spawns a PROCESS. Leak the
+        lease and you leak a pid, so the reaper is not a nicety here.
+
+        `as=` because `GhostHandsOrchestrator.start` shares this name, and in a
+        flat vocabulary one would silently shadow the other. Renamed at the
+        declaration rather than in a table elsewhere, and the method keeps the
+        name its twelve existing callers use.
+        """
         if self._started and self._proc and self._proc.returncode is None:
             return True
 
@@ -96,7 +116,10 @@ class SilentActuator:
             return False
 
     async def stop(self) -> None:
-        """Stop the worker subprocess."""
+        """Stop the worker subprocess.
+
+        Capability: session-end, as=stop_actuator
+        """
         await self._kill_proc()
         self._started = False
 

--- a/backend/hud/consent_bridge.py
+++ b/backend/hud/consent_bridge.py
@@ -1,0 +1,172 @@
+"""Ask the signed HUD for consent — and never wait for the answer.
+
+`SecureConsent.swift` has been complete for a while: it parses a challenge,
+prompts for Touch ID with a fresh `LAContext`, and echoes the nonce back as a
+`consent_verdict`. `main.py` has been handling that verdict for just as long.
+Between them sat nothing at all. Python never sent the question, so every gated
+capability resolved to "no approval provider available — failing closed" and the
+operator was never asked anything.
+
+A gate that always denies looks identical to a gate that works, right up until
+somebody tries to use the capability behind it. `lock_screen`,
+`video.start_streaming`, `touch.watch_and_react` — all reachable, all named, all
+refused.
+
+WHY THIS RETURNS INSTEAD OF WAITING
+-------------------------------------
+`ApprovalProvider` also offers `await_decision`, and using it here would be the
+obvious mistake. It blocks until a human answers, which outlives the provider
+timeout, the route's generation budget, and the operator's patience, in that
+order — and it holds the LLM's task open the whole time. So this only ASKS. The
+router parks the call, the turn ends cleanly, and the verdict re-enters through
+`resume` as a new turn. The whole suspension design depends on this function
+being boring.
+
+WHY A COUNT OF ZERO IS A DENIAL
+---------------------------------
+`publish` reports how many HUDs it reached. Zero means the question was never
+asked — the HUD is not running, or the socket is not connected. Returning a
+request id anyway would park a call that nothing can ever answer, and it would
+sit there until its TTL looking exactly like a human who is thinking about it.
+An unasked question is not a pending one.
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import uuid
+from typing import Any, Callable, Dict, Optional
+
+logger = logging.getLogger("JARVIS.HUDConsent")
+
+HUD_CONSENT_SCHEMA_VERSION: str = "hud_consent.v1"
+
+#: The event the Swift side listens for. Must match the string
+#: `BrainstemLauncher.processReceiveBuffer` dispatches on — a mismatch here is
+#: silent on both sides, which is why it is a named constant rather than a
+#: literal in the one place that sends it.
+CONSENT_REQUEST_EVENT: str = "consent_request"
+
+
+def hud_consent_enabled() -> bool:
+    """Master gate. Default TRUE. NEVER raises.
+
+    Off does not mean "approve everything" — it means no provider, which the
+    router treats as failing closed. There is deliberately no setting that turns
+    a gated capability into an ungated one.
+    """
+    return (os.environ.get("JARVIS_HUD_CONSENT_ENABLED", "true")
+            or "").strip().lower() not in ("0", "false", "no", "off")
+
+
+class HUDConsentProvider:
+    """An `ApprovalProvider` that asks the signed HUD over the IPC. NEVER raises.
+
+    Implements `request` only. `approve`, `reject` and `await_decision` are
+    absent on purpose: the verdict arrives as an inbound IPC event and goes
+    straight to `CapabilityRouter.resume`, so a second path for the same answer
+    would be a second place for the nonce check to be forgotten.
+    """
+
+    def __init__(self, publish: Optional[Callable[[str, Dict[str, Any]], int]] = None) -> None:
+        self._publish = publish
+        self._asked = 0
+        self._unreachable = 0
+
+    def _publisher(self) -> Optional[Callable[[str, Dict[str, Any]], int]]:
+        if self._publish is None:
+            try:
+                from backend.hud.ipc_server import publish
+                self._publish = publish
+            except Exception:  # noqa: BLE001
+                logger.debug("[HUDConsent] no IPC publisher", exc_info=True)
+        return self._publish
+
+    async def request(self, ctx: Any) -> str:
+        """Send the challenge and return its id. NEVER waits. NEVER raises.
+
+        Returns "" when nothing was reached, which the router reads as a denial.
+        """
+        try:
+            if not hud_consent_enabled():
+                return ""
+            publish = self._publisher()
+            if publish is None:
+                return ""
+            request_id = uuid.uuid4().hex
+            nonce = str(getattr(ctx, "nonce", "") or "")
+            if not nonce:
+                # `SecureConsent.Challenge` fails closed on an empty nonce, so a
+                # challenge without one is a prompt the operator will never see.
+                # Refusing here makes that a denial with a REASON rather than a
+                # request that silently evaporates on the Swift side.
+                logger.error("[HUDConsent] refusing to ask without a nonce — "
+                             "the verdict could not be bound to the question")
+                return ""
+            reached = publish(CONSENT_REQUEST_EVENT, {
+                "schema_version": HUD_CONSENT_SCHEMA_VERSION,
+                "request_id": request_id,
+                # The challenge the verdict must echo. Sent, never stored here —
+                # the router owns it and compares in constant time.
+                "nonce": nonce,
+                "capability": str(getattr(ctx, "capability", "") or "unknown"),
+                "detail": str(getattr(ctx, "description", "") or ""),
+                "op_id": str(getattr(ctx, "op_id", "") or ""),
+                # Lets the HUD say "this will keep running" in its own words
+                # without having to know which capabilities are sessions.
+                "session": str(getattr(ctx, "session", "") or ""),
+            })
+            if reached <= 0:
+                self._unreachable += 1
+                logger.warning(
+                    "[HUDConsent] no HUD connected — '%s' cannot be approved "
+                    "and will be denied. An unasked question is not a pending "
+                    "one.", getattr(ctx, "capability", "?"))
+                return ""
+            self._asked += 1
+            logger.info("[HUDConsent] asked %d HUD(s) to approve '%s' "
+                        "(request=%s)", reached,
+                        getattr(ctx, "capability", "?"), request_id[:12])
+            return request_id
+        except Exception:  # noqa: BLE001
+            logger.debug("[HUDConsent] request degraded", exc_info=True)
+            return ""
+
+    def stats(self) -> Dict[str, Any]:
+        try:
+            from backend.hud.ipc_server import connected_clients
+            connected = connected_clients()
+        except Exception:  # noqa: BLE001
+            connected = -1
+        return {"schema_version": HUD_CONSENT_SCHEMA_VERSION,
+                "enabled": hud_consent_enabled(), "asked": self._asked,
+                "unreachable": self._unreachable, "hud_clients": connected}
+
+
+def install(router: Any = None) -> bool:
+    """Give the capability router a way to ask. Idempotent. NEVER raises.
+
+    Called from the HUD boot. Without it the router's `_provider` is None and
+    every gated capability denies — which is safe, and completely useless.
+    """
+    try:
+        if not hud_consent_enabled():
+            logger.info("[HUDConsent] disabled — gated capabilities will deny")
+            return False
+        if router is None:
+            from backend.system_control.capability_router import (
+                get_capability_router,
+            )
+            router = get_capability_router()
+        if getattr(router, "_provider", None) is not None:
+            return True
+        router._provider = HUDConsentProvider()
+        logger.info("[HUDConsent] installed — gated capabilities will now "
+                    "prompt for Touch ID on the signed HUD")
+        return True
+    except Exception:  # noqa: BLE001
+        logger.error("[HUDConsent] install failed — gated capabilities will "
+                     "deny", exc_info=True)
+        return False

--- a/backend/hud/ipc_server.py
+++ b/backend/hud/ipc_server.py
@@ -17,11 +17,103 @@ import json
 import logging
 import os
 import threading
-from typing import Any, Callable, Coroutine, Dict, Optional
+from typing import Any, Callable, Coroutine, Dict, Optional, Set
 
 logger = logging.getLogger("jarvis.hud.ipc")
 
 DEFAULT_IPC_PORT = 8742
+
+# ---------------------------------------------------------------------------
+# Backend -> HUD.
+#
+# The socket was read-only for its whole life: `_handle_client` consumed lines
+# and never wrote one. That was fine while every conversation started at the
+# HUD — and it is exactly why the consent gate was decorative. `SecureConsent`
+# on the Swift side is complete, waiting for a challenge that nothing could
+# send, so every gated capability failed closed with "no approval provider
+# available" and the operator was never asked anything.
+#
+# Writers are held here rather than passed around because the thing that needs
+# to ask (the capability router, on a dispatch thread, several frames deep) has
+# no path to a StreamWriter and should not grow one.
+# ---------------------------------------------------------------------------
+
+_CLIENTS: Set[asyncio.StreamWriter] = set()
+#: The loop the server runs on. Captured because `publish` is called from the
+#: per-dispatch threads, and touching a StreamWriter from a foreign loop is
+#: undefined behaviour that usually presents as a silently dropped write.
+_SERVER_LOOP: Optional[asyncio.AbstractEventLoop] = None
+
+
+def connected_clients() -> int:
+    """How many HUDs are listening. NEVER raises."""
+    return len(_CLIENTS)
+
+
+def publish(event_type: str, data: Dict[str, Any]) -> int:
+    """Push one event to every connected HUD. Returns the number reached.
+
+    Thread-safe and NON-BLOCKING: schedules the write onto the server's loop
+    and returns immediately. NEVER raises — a failed push must degrade the
+    thing that wanted to speak, not kill it.
+
+    Returning a COUNT rather than a bool is what lets a caller fail closed
+    honestly. Zero means nobody heard the question, which for a consent request
+    is a denial and not a silence to interpret optimistically.
+    """
+    try:
+        loop = _SERVER_LOOP
+        if loop is None or not _CLIENTS:
+            return 0
+        payload = (json.dumps({"event_type": event_type, "data": data})
+                   + "\n").encode("utf-8")
+        reached = len(_CLIENTS)
+        loop.call_soon_threadsafe(_write_all, payload)
+        return reached
+    except Exception:  # noqa: BLE001
+        logger.debug("[IPC] publish(%s) failed", event_type, exc_info=True)
+        return 0
+
+
+def _write_all(payload: bytes) -> None:
+    """Write to every client. Runs ON the server loop. NEVER raises."""
+    for writer in list(_CLIENTS):
+        try:
+            if writer.is_closing():
+                _CLIENTS.discard(writer)
+                continue
+            writer.write(payload)
+        except Exception:  # noqa: BLE001
+            _CLIENTS.discard(writer)
+
+
+def _principal_of(msg: dict, peer: Any) -> str:
+    """Who this connection is acting for. NEVER raises.
+
+    A HUD may declare a stable `client_id`; otherwise the peer address is used.
+    The difference matters for exactly one thing: a peer address changes on
+    every reconnect, so a HUD that is rebuilt and relaunched comes back as a
+    NEW principal and its previous sessions are reaped. That is the correct
+    default — a quit HUD's screen capture should not outlive it — but a client
+    that intends to survive a restart can say so and keep its stream.
+    """
+    try:
+        msg = msg or {}
+        # Read the envelope AND the payload. `BrainstemLauncher.sendEvent`
+        # builds the envelope itself and only lets a caller populate `data`, so
+        # `data.client_id` is the only place the real Swift client can actually
+        # put one. Reading solely the top level made the declared-identity path
+        # unreachable from the one client it exists for.
+        payload = msg.get("data")
+        declared = str(msg.get("client_id")
+                       or (payload.get("client_id") if isinstance(payload, dict)
+                           else "")
+                       or "").strip()
+        if declared:
+            return f"hud:{declared[:64]}"
+        return f"peer:{peer[0]}:{peer[1]}" if peer else "peer:unknown"
+    except Exception:  # noqa: BLE001
+        return "peer:unknown"
 
 
 async def start_ipc_server(
@@ -39,19 +131,47 @@ async def start_ipc_server(
     Returns:
         The asyncio.Server instance (caller should manage lifetime).
     """
-    ipc_port = port or int(os.environ.get("JARVIS_IPC_PORT", str(DEFAULT_IPC_PORT)))
+    # `port is None` rather than `port or ...`: 0 is a MEANINGFUL value — it
+    # asks the OS for an ephemeral port — and the falsy test silently turned it
+    # back into 8742, which is the one port a second instance is guaranteed to
+    # collide on.
+    ipc_port = (int(os.environ.get("JARVIS_IPC_PORT", str(DEFAULT_IPC_PORT)))
+                if port is None else int(port))
 
-    def _dispatch_in_thread(event_type: str, data: dict) -> None:
+    def _dispatch_in_thread(event_type: str, data: dict, principal: str) -> None:
         """Run async dispatch in a fresh event loop on a daemon thread.
 
         macOS subprocess contexts make call_soon_threadsafe unreliable,
         so each dispatch gets its own short-lived loop.
+
+        The principal is stamped INSIDE this function rather than passed down
+        through dispatch: a new thread starts with an empty context, so setting
+        the contextvar here is what makes it visible to everything the dispatch
+        awaits — and scoping it to this thread is what stops two clients'
+        sessions from being attributed to each other.
         """
+        try:
+            from backend.system_control.capability_leases import set_principal
+            set_principal(principal)
+        except Exception:  # noqa: BLE001 — an unowned lease still has a TTL
+            pass
         loop = asyncio.new_event_loop()
         try:
             loop.run_until_complete(dispatch(event_type, data))
         finally:
             loop.close()
+
+    def _note(present: bool, principal: str) -> None:
+        """Tell the lease book this principal came or went. NEVER raises."""
+        try:
+            from backend.system_control.capability_leases import get_lease_book
+            book = get_lease_book()
+            if present:
+                book.note_arrival(principal)
+            else:
+                book.note_departure(principal)
+        except Exception:  # noqa: BLE001
+            logger.debug("[IPC] lease presence update failed", exc_info=True)
 
     async def _handle_client(
         reader: asyncio.StreamReader,
@@ -59,6 +179,12 @@ async def start_ipc_server(
     ) -> None:
         peer = writer.get_extra_info("peername")
         logger.info("[IPC] Client connected: %s", peer)
+        # Provisional until a message declares a `client_id`. Held in a list so
+        # the `finally` block reaps whatever the principal turned out to BE,
+        # rather than the address it first connected from.
+        principal = _principal_of({}, peer)
+        _note(True, principal)
+        _CLIENTS.add(writer)
         try:
             while True:
                 line = await reader.readline()
@@ -71,10 +197,19 @@ async def start_ipc_server(
                     msg = json.loads(text)
                     event_type = msg.get("event_type", "")
                     data = msg.get("data", {})
+                    declared = _principal_of(msg, peer)
+                    if declared != principal:
+                        # The connection just told us who it really is. The
+                        # provisional identity must stop being treated as
+                        # present, or its (empty) departure never fires and the
+                        # book accumulates ghosts of every reconnect.
+                        _note(False, principal)
+                        principal = declared
+                        _note(True, principal)
                     logger.info("[IPC] Received event: %s (%d bytes)", event_type, len(line))
                     threading.Thread(
                         target=_dispatch_in_thread,
-                        args=(event_type, data),
+                        args=(event_type, data, principal),
                         daemon=True,
                     ).start()
                 except json.JSONDecodeError as je:
@@ -88,11 +223,17 @@ async def start_ipc_server(
         except Exception as exc:
             logger.error("[IPC] Client handler error: %s", exc)
         finally:
+            _CLIENTS.discard(writer)
             try:
                 writer.close()
                 await writer.wait_closed()
             except Exception:
                 pass
+            # A dropped socket starts a GRACE window, it does not reap. A HUD
+            # rebuild and a one-second blip look identical from here, and
+            # killing a screen capture for either would be worse than the leak
+            # this is guarding against. The reaper decides, on its own clock.
+            _note(False, principal)
             logger.info("[IPC] Client disconnected: %s", peer)
 
     # 2MB limit per line — screenshots from the HUD can be 200-500KB as base64 JPEG.
@@ -104,5 +245,7 @@ async def start_ipc_server(
         reuse_address=True,
         limit=2 * 1024 * 1024,
     )
+    global _SERVER_LOOP
+    _SERVER_LOOP = asyncio.get_running_loop()
     logger.info("[IPC] TCP server listening on localhost:%d", ipc_port)
     return server

--- a/backend/hud/tool_definitions.py
+++ b/backend/hud/tool_definitions.py
@@ -330,38 +330,153 @@ def _discover_app(name: str) -> str:
 
 
 def derived_tool_names() -> frozenset:
-    """Capabilities the registry derives from `macos_controller`. NEVER raises.
+    """Every capability the model may name. NEVER raises.
 
     Read per call rather than snapshotted at import: a capability annotated
-    tomorrow becomes callable without a restart, which is the whole point of
-    deriving rather than declaring.
+    tomorrow becomes callable without a restart, and a namespace that finishes
+    hydrating a second from now becomes callable a second from now — which is
+    the whole point of deriving rather than declaring.
+
+    THE GATE THIS FEEDS
+    ---------------------
+    `validate_tool_call` blocks any name that is in neither `TOOL_SCHEMAS` nor
+    this set. So a federated capability missing from here is not merely
+    unmentioned in the prompt — it is BLOCKED at the Iron Gate even when the
+    model somehow guesses it correctly. This function and `derived_tool_schemas`
+    must therefore draw from the same sources, which is why they share
+    `_federated_schemas` instead of each reaching for what it needs.
     """
     try:
         from backend.system_control.capability_registry import (
             get_capability_registry,
         )
-        return frozenset(get_capability_registry().names())
+        local = set(get_capability_registry().names())
     except Exception:  # noqa: BLE001 — the hand-written tools still work
-        return frozenset()
+        local = set()
+    return frozenset(local | set(_federated_schemas()))
+
+
+def _federated_schemas() -> Dict[str, Dict[str, Any]]:
+    """Namespaced capabilities from every hydrated subsystem. NEVER raises.
+
+    Multi-space intelligence, video streaming and ghost touch reach the HUD
+    through this one call. They were never missing — roughly 11,000 lines of
+    working capability sat behind a vocabulary derived from a single controller,
+    so nothing in the prompt could NAME them. The same defect the registry was
+    built to delete, one level up.
+
+    Only HYDRATED namespaces contribute, and that is a feature rather than a
+    compromise: hydration measured 8.4 s for `space` alone, so blocking a prompt
+    on it would stall the turn, and offering a tool whose provider has not
+    imported would produce a call that cannot be served. A namespace that is not
+    ready is simply not offered YET — `warm()` at boot is what makes "yet" mean
+    "for the first few seconds" rather than "until someone asks twice".
+    """
+    try:
+        from backend.system_control.capability_federation import (
+            federation_enabled, get_federation,
+        )
+        if not federation_enabled():
+            return {}
+        return dict(get_federation().tool_schemas())
+    except Exception:  # noqa: BLE001
+        logger.debug("[Tools] federated schemas unavailable", exc_info=True)
+        return {}
 
 
 def derived_tool_schemas() -> Dict[str, Dict[str, Any]]:
-    """`TOOL_SCHEMAS` UNION the derived capabilities, for the prompt.
+    """`TOOL_SCHEMAS` UNION the derived capabilities UNION the federated ones.
 
-    The hand-written entries win on a name collision: `take_screenshot` exists
-    in both, and the hand-written one is wired to the vision analyzer while the
-    derived one is not. Deriving must never silently downgrade a tool that was
-    deliberately specialised.
+    Precedence runs federated → local-derived → hand-written, weakest first, and
+    the hand-written entries win outright. `take_screenshot` exists in both the
+    list and the registry, and the hand-written one is wired to the vision
+    analyzer while the derived one is not; deriving must never silently
+    downgrade a tool that was deliberately specialised.
+
+    Federated names cannot collide with either — they all carry a namespace and
+    a dot — so their position in that order is a statement of intent rather than
+    a live contest: if a bare name ever did clash, the specialised
+    implementation is still the one that wins.
     """
+    merged: Dict[str, Dict[str, Any]] = {}
+    try:
+        merged.update(_federated_schemas())
+    except Exception:  # noqa: BLE001
+        pass
     try:
         from backend.system_control.capability_registry import (
             get_capability_registry,
         )
-        merged = dict(get_capability_registry().tool_schemas())
-        merged.update(TOOL_SCHEMAS)
-        return merged
+        merged.update(get_capability_registry().tool_schemas())
     except Exception:  # noqa: BLE001
-        return dict(TOOL_SCHEMAS)
+        pass
+    merged.update(TOOL_SCHEMAS)
+    return merged
+
+
+def open_sessions_note() -> str:
+    """What is currently running, phrased for the model. "" if nothing is.
+
+    NEVER raises. The other half of `RoutedCall.lease_id`: telling the model it
+    opened a session at the moment it opens one is necessary but not sufficient,
+    because a tool loop is many turns and a turn is a fresh prompt. Four turns
+    later, nothing in the context says the camera is still on — so the model
+    plans as though it is not, and never stops it.
+
+    The TTL and the reaper mean nothing leaks either way. This is about the
+    organism being able to reason about what it holds, rather than merely being
+    cleaned up after.
+    """
+    try:
+        from backend.system_control.capability_leases import get_lease_book
+        active = get_lease_book().active()
+        if not active:
+            return ""
+        lines = sorted({
+            f"- '{l.capability}' has been running for {int(l.age_s)}s "
+            f"(stop it with '{l.release}')"
+            for l in active
+        })
+        return ("\nSessions you currently have open — these keep running until "
+                "stopped:\n" + "\n".join(lines))
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def tool_surface_report() -> Dict[str, Any]:
+    """What the model can currently reach, and what it cannot. NEVER raises.
+
+    Exists because "the HUD offers 9 tools" was true for months while 42 derived
+    macOS capabilities and three whole subsystems sat one name away. A count
+    nobody prints is a count nobody notices is wrong, so this is what the boot
+    log and `/observability` both read — including the DEGRADED namespaces,
+    which are the ones an operator can actually do something about.
+    """
+    out: Dict[str, Any] = {"handwritten": len(TOOL_SCHEMAS)}
+    try:
+        from backend.system_control.capability_registry import (
+            get_capability_registry,
+        )
+        out["derived_macos"] = len(get_capability_registry().names())
+    except Exception:  # noqa: BLE001
+        out["derived_macos"] = 0
+    try:
+        from backend.system_control.capability_federation import get_federation
+        fed = get_federation()
+        stats = fed.stats()
+        out["federated"] = len(fed.names())
+        out["namespaces"] = {
+            n: d.get("readiness") for n, d in stats.get("namespaces", {}).items()
+        }
+        out["degraded"] = sorted(
+            n for n, d in stats.get("namespaces", {}).items()
+            if d.get("readiness") != "ready")
+        out["conflicts"] = stats.get("conflicts", {})
+        out["unbuildable"] = stats.get("unbuildable", {})
+    except Exception:  # noqa: BLE001
+        out["federated"] = 0
+    out["total"] = len(derived_tool_schemas())
+    return out
 
 
 async def _exec_derived_capability(call: "ToolCall") -> "ToolResult":

--- a/backend/hud/tool_use_orchestrator.py
+++ b/backend/hud/tool_use_orchestrator.py
@@ -21,6 +21,7 @@ from typing import Any, Dict, List, Optional
 from backend.hud.tool_definitions import (
     TOOL_SCHEMAS,
     derived_tool_schemas,
+    open_sessions_note,
     ToolCall,
     ToolResult,
     execute_tool,
@@ -100,12 +101,29 @@ class ToolUseOrchestrator:
         # simply never named in the prompt.
         tool_list = json.dumps(list(derived_tool_schemas().values()), indent=2)
 
+        # Namespaced tools reach whole subsystems — multi-space intelligence,
+        # video streaming, ghost touch. The model needs to be told the dot is
+        # part of the name, or it will helpfully "correct" `video.start_
+        # streaming` to `start_streaming` and be blocked by the Iron Gate for a
+        # tool that exists.
+        namespace_note = (
+            "\nSome tools are namespaced (e.g. 'space.analyze_desktop_spaces', "
+            "'video.start_streaming', 'touch.watch_and_react'). Call them by "
+            "their FULL name including the dot — 'space' reaches multi-space "
+            "desktop intelligence, 'video' reaches continuous screen capture, "
+            "'touch' reaches background UI automation.\n"
+            "Tools that START a session keep running after they return. Only "
+            "start one when the goal actually needs continuous observation, and "
+            "stop it when you are done.\n"
+        )
+
         system_prompt = (
             "You are JARVIS, an AI organism controlling a MacBook Pro. "
             "You have tools to interact with the Mac. Use them to accomplish the goal.\n\n"
             "The user is Derek J. Russell. When they say 'my profile' or 'my account', "
             "use their name to find the right page.\n\n"
-            "Available tools:\n" + tool_list + "\n\n"
+            "Available tools:\n" + tool_list + "\n"
+            + namespace_note + open_sessions_note() + "\n"
             "To call a tool, respond with JSON: {\"tool_calls\": [{\"name\": \"...\", \"args\": {...}}]}\n"
             "When the task is complete, respond with: {\"done\": true, \"summary\": \"what you did\"}\n"
             "If you cannot complete the task, respond with: {\"done\": true, \"summary\": \"why it failed\", \"error\": \"reason\"}\n\n"

--- a/backend/main.py
+++ b/backend/main.py
@@ -2193,8 +2193,128 @@ async def parallel_lifespan(app: FastAPI):
                     shutdown=_hud_shutdown,
                 )
                 logger.info("[HUD] IPC server started — Swift HUD can connect")
+
+                # Give the router a way to ASK. `SecureConsent.swift` has been
+                # complete and waiting; `consent_verdict` above has been handled
+                # all along; nothing sent the question, so every gated
+                # capability denied with "no approval provider available". A
+                # gate that always refuses looks exactly like a gate that works.
+                try:
+                    from backend.hud.consent_bridge import install as _install_consent
+                    _install_consent()
+                except Exception as _ce:  # noqa: BLE001
+                    logger.error("[HUD] consent bridge install failed: %s", _ce)
             except Exception as e:
                 logger.error("[HUD] IPC server failed to start: %s", e)
+
+            # =============================================================
+            # CAPABILITY FEDERATION — multi-space, video, ghost touch
+            # =============================================================
+            # Three subsystems the HUD could name none of: multi-space
+            # intelligence, video multi-space intelligence, and ghost touch.
+            # Roughly 11,000 lines of working capability behind a vocabulary
+            # derived from a single controller — the capabilities were never
+            # missing, their NAMES were.
+            #
+            # This block is what makes the federation live. Without it the
+            # module is present, tested, and reaches nothing: `discover()` is
+            # never called, no namespace ever hydrates, and `derived_tool_
+            # schemas` unions in an empty dict forever. Wired-but-inert is the
+            # failure mode that looks most like success.
+            try:
+                from backend.system_control import capability_federation as _fed
+
+                if _fed.federation_enabled():
+                    # 1. BIND what providers cannot construct for themselves.
+                    #    `VideoStreamCapture` takes a required `vision_analyzer`
+                    #    and the HUD already builds one. Bound as a FACTORY so
+                    #    nothing is constructed until a video capability is
+                    #    actually called — binding an eager instance here would
+                    #    put a model client on the boot path.
+                    def _bind_vision_analyzer():
+                        from backend.hud.tool_use_orchestrator import (
+                            ToolUseOrchestrator,
+                        )
+                        from backend.core.ouroboros.governance.doubleword_provider import (
+                            DoublewordProvider,
+                        )
+                        router = getattr(app.state, "voice_router", None)
+                        orch = getattr(router, "_tool_orchestrator", None)
+                        if orch is None:
+                            orch = ToolUseOrchestrator(DoublewordProvider())
+                        return orch._vision_analyzer
+
+                    _fed.bind("vision_analyzer", _bind_vision_analyzer)
+
+                    # 2. WARM off the boot path. Hydration measured 8.4s for
+                    #    `space` alone; awaiting it here would add that to
+                    #    startup, and `ensure()` is what correctness depends on
+                    #    anyway. This only decides whether the FIRST command
+                    #    pays for it.
+                    _fed_federation = _fed.get_federation()
+                    logger.info(
+                        "[HUD] Capability federation: %d provider(s) across %s",
+                        len(_fed_federation.providers()),
+                        ", ".join(_fed_federation.namespaces()) or "no namespaces")
+
+                    async def _warm_federation() -> None:
+                        try:
+                            result = await _fed_federation.warm()
+                            from backend.hud.tool_definitions import (
+                                tool_surface_report,
+                            )
+                            report = tool_surface_report()
+                            logger.info(
+                                "[HUD] Capability surface: %d tools "
+                                "(%d hand-written + %d macOS + %d federated) — %s",
+                                report.get("total", 0),
+                                report.get("handwritten", 0),
+                                report.get("derived_macos", 0),
+                                report.get("federated", 0), result)
+                            # Defects that are cheap here and expensive at 3am.
+                            stats = _fed_federation.stats()
+                            for label, key in (
+                                ("name claimed by two providers", "conflicts"),
+                                ("session with no declared release", "unreleasable"),
+                                ("release the reaper cannot call", "broken_releases"),
+                            ):
+                                if stats.get(key):
+                                    logger.error(
+                                        "[HUD] Capability federation — %s: %s",
+                                        label, stats[key])
+                            if report.get("degraded"):
+                                logger.warning(
+                                    "[HUD] DEGRADED namespaces (their "
+                                    "capabilities are NOT offered): %s",
+                                    report["degraded"])
+                        except Exception as _we:  # noqa: BLE001
+                            logger.warning("[HUD] federation warm failed: %s", _we)
+
+                    asyncio.create_task(_warm_federation())
+
+                    # 3. REAP. The organ that stops a video stream surviving
+                    #    the HUD that asked for it. Deliberately blind to every
+                    #    application state-ledger — it reads monotonic time and
+                    #    the lease book, so a WEDGED session is still reapable
+                    #    (CLAUDE.md Slice 47, Watchdog Isolation Invariant).
+                    from backend.system_control.capability_leases import (
+                        get_lease_book, leases_enabled,
+                    )
+                    if leases_enabled():
+                        _lease_book = get_lease_book()
+                        # Install the releaser now rather than on first use, so
+                        # a session opened by any path can be reaped even if
+                        # nothing has routed through the singleton router yet.
+                        from backend.system_control.capability_router import (
+                            get_capability_router,
+                        )
+                        _lease_book.set_releaser(
+                            get_capability_router()._release)
+                        asyncio.create_task(
+                            _lease_book.run_reaper(stop=_hud_shutdown))
+            except Exception as _fe:  # noqa: BLE001 — the HUD boots regardless
+                logger.error("[HUD] capability federation wiring failed: %s", _fe,
+                             exc_info=True)
 
             # Optional: SSE consumer for Vercel cloud relay
             try:
@@ -2350,6 +2470,28 @@ async def parallel_lifespan(app: FastAPI):
                 logger.info("[HUD] IPC server shutdown complete")
             except Exception as e:
                 logger.debug(f"[HUD] IPC shutdown error (non-critical): {e}")
+
+            # Close every open session BEFORE the loop goes away. A screen
+            # capture, a purple recording indicator and a spawned actuator pid
+            # do not stop because their Python process did — this is the only
+            # moment left where something can still call their release, and it
+            # runs while the operator is watching the app quit. Whatever cannot
+            # be closed is logged BY NAME as an orphan rather than forgotten.
+            try:
+                from backend.system_control.capability_leases import (
+                    get_lease_book,
+                )
+                _book = get_lease_book()
+                if _book.active():
+                    logger.info("[HUD] releasing %d open capability session(s)",
+                                len(_book.active()))
+                    await asyncio.wait_for(_book.release_all(), timeout=30)
+            except asyncio.TimeoutError:
+                logger.error("[HUD] session release exceeded 30s — sessions may "
+                             "still be running: %s",
+                             [l.capability for l in get_lease_book().active()])
+            except Exception as e:  # noqa: BLE001
+                logger.warning("[HUD] session release failed: %s", e)
 
         await initializer.shutdown()
 
@@ -7137,6 +7279,54 @@ async def contract_capabilities():
         "policy_hash": policy_hash,
         "timestamp": _time.time(),
     }
+
+
+@app.get("/capabilities/surface")
+async def capability_surface():
+    """What the organism can currently NAME, and what is currently RUNNING.
+
+    Deliberately separate from `/capabilities` above, which answers a different
+    question — that one is the cross-repo contract manifest the Unified
+    Supervisor probes. This one is about reach: how many capabilities the tool
+    loop can actually call, which federated namespaces are ready, and which
+    sessions are open right now.
+
+    Read-only and authority-free. It reports state; it never hydrates a
+    namespace, constructs a provider, or closes a session — an observability
+    surface that changes what it observes is how a dashboard becomes a cause.
+
+    The two lists worth watching are `degraded` (a namespace whose capabilities
+    are NOT being offered) and `sessions.orphaned_capabilities` (something is
+    still running that nothing left in this process can stop).
+    """
+    import time as _time
+
+    out = {"schema_version": "capability_surface.v1", "timestamp": _time.time()}
+    try:
+        from backend.hud.tool_definitions import tool_surface_report
+        out["surface"] = tool_surface_report()
+    except Exception as exc:  # noqa: BLE001
+        out["surface"] = {"error": f"{type(exc).__name__}: {exc}"}
+    try:
+        from backend.system_control.capability_federation import get_federation
+        fed = get_federation()
+        out["federation"] = fed.stats()
+        out["names"] = fed.names()
+    except Exception as exc:  # noqa: BLE001
+        out["federation"] = {"error": f"{type(exc).__name__}: {exc}"}
+    try:
+        from backend.system_control.capability_leases import get_lease_book
+        out["sessions"] = get_lease_book().stats()
+    except Exception as exc:  # noqa: BLE001
+        out["sessions"] = {"error": f"{type(exc).__name__}: {exc}"}
+    try:
+        from backend.system_control.capability_router import (
+            get_capability_router,
+        )
+        out["router"] = get_capability_router().stats()
+    except Exception as exc:  # noqa: BLE001
+        out["router"] = {"error": f"{type(exc).__name__}: {exc}"}
+    return out
 
 
 # ============================================================================

--- a/backend/system_control/capability_federation.py
+++ b/backend/system_control/capability_federation.py
@@ -1,0 +1,747 @@
+"""Many subsystems, one vocabulary — derived, namespaced, and lazily paid for.
+
+`capability_registry` answered "what can this Mac do" for ONE controller. The
+same question over the whole organism has three more answers that were never
+reachable from the HUD: multi-space intelligence, video multi-space
+intelligence, and ghost touch. Roughly 6,500 lines of working capability that
+the HUD could not name — the same defect the registry was built to delete, one
+level up.
+
+WHY NOT A LIST OF PROVIDERS
+-----------------------------
+A `PROVIDERS = [...]` table beside the code is the hand-kept vocabulary again,
+and the entry that gets forgotten is invisible. So providers are DISCOVERED the
+way the surface is: a class opts in by saying so in its own docstring.
+
+    class MultiSpaceCaptureEngine:
+        '''...
+
+        Capability-Namespace: space
+        '''
+
+One mark does two jobs — it declares the namespace AND it IS the discovery
+signal. Discovery is a static AST scan, so finding providers costs no imports
+at all; only a namespace someone actually calls is ever loaded.
+
+THREE MEASURED FACTS THAT SHAPED THIS
+---------------------------------------
+1. **Importing the ten candidate classes takes 6.5 s** (`EnhancedMultiSpaceSystem`
+   alone 4.3 s). That cannot sit on a boot path, so hydration is off-boot and
+   concurrent, and `ensure()` awaits only the ONE namespace a call needs.
+
+2. **Five method names collide across subsystems** — `start`, `stop`,
+   `get_instance`, `cleanup`, `register_callback`. In a flat namespace one
+   silently shadows another and the model asking for "start" gets whichever
+   sorted first. Namespacing is correctness here, not decoration; and a
+   collision that survives namespacing is REFUSED and reported, never resolved
+   by arrival order.
+
+3. **`public and callable` over-collects on a subsystem class.** These are not
+   capability façades: the same rule that was right for `MacOSController` also
+   yields `get_instance` and `cleanup`. Hence `require_declaration` — silence
+   means "not offered" rather than "gated", which is strictly safer and makes
+   the ratchet honest.
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import ast
+import asyncio
+import enum
+import importlib
+import inspect
+import logging
+import os
+import re
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from backend.system_control.capability_registry import (
+    CapabilityDef,
+    CapabilityRegistry,
+)
+
+logger = logging.getLogger("JARVIS.CapabilityFederation")
+
+CAPABILITY_FEDERATION_SCHEMA_VERSION: str = "capability_federation.v1"
+
+#: The declaration that makes a class a provider AND names its namespace.
+_NS_TAG = re.compile(r"^\s*Capability-Namespace:\s*(?P<ns>[a-z0-9_]+)\s*$",
+                     re.IGNORECASE | re.MULTILINE)
+#: Optional: how to obtain the live instance. Resolved on the class first, then
+#: the module — `get_ghost_hands` is module-level and async, `get_instance` is a
+#: classmethod, and both are legitimate.
+_FACTORY_TAG = re.compile(r"^\s*Capability-Factory:\s*(?P<fn>[A-Za-z_][A-Za-z0-9_]*)\s*$",
+                          re.IGNORECASE | re.MULTILINE)
+
+#: Where to look. Package ROOTS, not module names — the point is that adding a
+#: provider means annotating a class, never editing this file.
+_DEFAULT_ROOTS = ("backend/vision", "backend/ghost_hands", "backend/system_control")
+
+
+def federation_enabled() -> bool:
+    """Master gate. Default TRUE — discovery is a static scan. NEVER raises."""
+    return (os.environ.get("JARVIS_CAPABILITY_FEDERATION_ENABLED", "true")
+            or "").strip().lower() not in ("0", "false", "no", "off")
+
+
+def scan_roots() -> Tuple[str, ...]:
+    """Package roots to scan. NEVER raises."""
+    raw = (os.environ.get("JARVIS_CAPABILITY_FEDERATION_ROOTS") or "").strip()
+    if not raw:
+        return _DEFAULT_ROOTS
+    return tuple(p.strip() for p in raw.split(",") if p.strip())
+
+
+def hydrate_timeout_s() -> float:
+    """Per-namespace hydration budget. NEVER raises.
+
+    A provider whose import wedges must not wedge the federation. 4.3 s was the
+    measured worst case, so the default leaves real headroom without being
+    unbounded.
+    """
+    try:
+        return max(1.0, float(os.environ.get(
+            "JARVIS_CAPABILITY_HYDRATE_TIMEOUT_S", "30")))
+    except (TypeError, ValueError):
+        return 30.0
+
+
+class Readiness(str, enum.Enum):
+    """Whether a namespace can answer — with UNKNOWN kept distinct from EMPTY.
+
+    A namespace that has not been hydrated yet and one that hydrated to nothing
+    are different facts, and a surface that renders them the same shows an
+    operator a Mac that apparently cannot see its own screens.
+    """
+
+    UNHYDRATED = "unhydrated"
+    READY = "ready"
+    DEGRADED = "degraded"      # tried, and could not — `detail` says why
+
+
+class ProviderBindings:
+    """Values a provider's constructor needs and the federation cannot invent.
+
+    `VideoStreamCapture.__init__(self, vision_analyzer, config=None)` takes a
+    REQUIRED collaborator. `_construct`'s `cls()` fallback raises `TypeError` on
+    it, so the single most valuable provider in the video namespace could never
+    be built — discovered, described, offered to the model, and then dead on the
+    first call.
+
+    The two obvious fixes are both wrong. Special-casing the class here is the
+    hand-kept table this whole module exists to delete. Making the parameter
+    optional edits a working subsystem to suit its consumer, and gives it a
+    half-built object to fail on later instead of a clear failure now.
+
+    So dependencies are resolved BY PARAMETER NAME from a registry the host
+    fills once at boot. `vision_analyzer` is a thing the HUD already builds —
+    `tool_use_orchestrator._make_vision_analyzer` — and this is how the one that
+    already exists gets handed to the provider that needs one, rather than a
+    second one being constructed in the dark.
+
+    A name nobody bound stays UNRESOLVED, and the provider says so. That is the
+    same inversion as the rest of this stack: silence is "not offered", never
+    "improvise something".
+    """
+
+    def __init__(self) -> None:
+        self._values: Dict[str, Any] = {}
+
+    def bind(self, name: str, value: Any) -> None:
+        """Supply one dependency by parameter name. NEVER raises.
+
+        *value* may be the collaborator itself or a zero-arg callable returning
+        it. The callable form exists because the honest boot order is that a
+        provider's dependency is often not built yet when binding happens, and
+        deferring is better than binding a None that looks like a real object.
+        """
+        try:
+            if name:
+                self._values[str(name)] = value
+        except Exception:  # noqa: BLE001
+            pass
+
+    def resolve(self, name: str) -> Tuple[bool, Any]:
+        """(found, value). NEVER raises.
+
+        Returns a PAIR rather than a value-or-None because `None` is a legal
+        thing to bind, and a resolver that cannot distinguish "bound to None"
+        from "not bound" would silently construct providers with missing
+        collaborators.
+        """
+        try:
+            if name not in self._values:
+                return (False, None)
+            v = self._values[name]
+            if callable(v) and not inspect.isclass(v):
+                try:
+                    sig = inspect.signature(v)
+                    required = [p for p in sig.parameters.values()
+                                if p.default is inspect.Parameter.empty
+                                and p.kind not in (p.VAR_POSITIONAL, p.VAR_KEYWORD)]
+                    # A zero-arg callable is a FACTORY. Anything else is the
+                    # dependency itself — `vision_analyzer` is an async
+                    # callable, and calling it here would fire a vision request
+                    # instead of binding one.
+                    if not required and not inspect.iscoroutinefunction(v):
+                        return (True, v())
+                except (TypeError, ValueError):
+                    pass
+            return (True, v)
+        except Exception:  # noqa: BLE001
+            return (False, None)
+
+    def names(self) -> List[str]:
+        return sorted(self._values)
+
+
+_BINDINGS: Optional[ProviderBindings] = None
+
+
+def get_bindings() -> ProviderBindings:
+    """Process-wide provider bindings. NEVER raises."""
+    global _BINDINGS
+    if _BINDINGS is None:
+        _BINDINGS = ProviderBindings()
+    return _BINDINGS
+
+
+def bind(name: str, value: Any) -> None:
+    """Shorthand for `get_bindings().bind`. NEVER raises."""
+    get_bindings().bind(name, value)
+
+
+def reset_bindings() -> None:
+    """Testing seam. NEVER raises."""
+    global _BINDINGS
+    _BINDINGS = None
+
+
+@dataclass
+class ProviderSpec:
+    """One annotated class, found statically. Nothing imported yet."""
+
+    namespace: str
+    module: str
+    class_name: str
+    factory: str = ""
+    source: str = ""
+
+    @property
+    def key(self) -> str:
+        return f"{self.module}:{self.class_name}"
+
+
+@dataclass
+class _NamespaceState:
+    readiness: str = Readiness.UNHYDRATED.value
+    detail: str = ""
+    hydrate_ms: float = 0.0
+    #: Bare export name -> (spec, CapabilityDef).
+    defs: Dict[str, Tuple[ProviderSpec, CapabilityDef]] = field(default_factory=dict)
+    #: name -> the owners that wanted it. Refused, never silently resolved.
+    conflicts: Dict[str, List[str]] = field(default_factory=dict)
+    instances: Dict[str, Any] = field(default_factory=dict)
+    #: provider key -> why it could not be built. A provider that DESCRIBES
+    #: fine and CONSTRUCTS never is the worst shape available: the model is
+    #: offered a tool that fails on every call. Recorded so it is a number on a
+    #: dashboard rather than a mystery in a log.
+    construct_errors: Dict[str, str] = field(default_factory=dict)
+
+
+def _docstring_of(node: ast.AST) -> str:
+    try:
+        return ast.get_docstring(node) or ""   # type: ignore[arg-type]
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def _module_name(path: Path, repo_root: Path) -> str:
+    try:
+        rel = path.relative_to(repo_root).with_suffix("")
+        return ".".join(rel.parts)
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def discover(roots: Optional[Tuple[str, ...]] = None,
+             repo_root: Optional[Path] = None) -> List[ProviderSpec]:
+    """Find annotated provider classes by AST. Imports NOTHING. NEVER raises.
+
+    Static rather than dynamic deliberately: importing every module under
+    `backend/vision` to ask which ones are providers would cost far more than
+    the 6.5 s measured for ten known classes, and would run arbitrary
+    module-level code to answer a question the source text already answers.
+    """
+    out: List[ProviderSpec] = []
+    if not federation_enabled():
+        return out
+    try:
+        root = repo_root or Path(__file__).resolve().parents[2]
+        for rel in (roots or scan_roots()):
+            base = root / rel
+            if not base.is_dir():
+                continue
+            for path in sorted(base.rglob("*.py")):
+                if "__pycache__" in path.parts:
+                    continue
+                try:
+                    text = path.read_text(encoding="utf-8", errors="replace")
+                except OSError:
+                    continue
+                # Cheap reject before paying for a parse — the tag is rare and
+                # these trees are thousands of files.
+                if "Capability-Namespace" not in text:
+                    continue
+                try:
+                    tree = ast.parse(text)
+                except SyntaxError:
+                    logger.debug("[Federation] unparseable: %s", path)
+                    continue
+                mod = _module_name(path, root)
+                if not mod:
+                    continue
+                for node in ast.walk(tree):
+                    if not isinstance(node, ast.ClassDef):
+                        continue
+                    doc = _docstring_of(node)
+                    m = _NS_TAG.search(doc)
+                    if not m:
+                        continue
+                    fm = _FACTORY_TAG.search(doc)
+                    out.append(ProviderSpec(
+                        namespace=m.group("ns").strip().lower(),
+                        module=mod, class_name=node.name,
+                        factory=(fm.group("fn").strip() if fm else ""),
+                        source=str(path)))
+    except Exception:  # noqa: BLE001
+        logger.debug("[Federation] discovery degraded", exc_info=True)
+    return sorted(out, key=lambda s: (s.namespace, s.module, s.class_name))
+
+
+def _export_name(namespace: str, bare: str) -> str:
+    return f"{namespace}.{bare}"
+
+
+def split(name: str) -> Tuple[str, str]:
+    """`space.capture` -> ("space", "capture"). NEVER raises."""
+    ns, _, bare = (name or "").partition(".")
+    return (ns, bare) if bare else ("", ns)
+
+
+class CapabilityFederation:
+    """Every namespace's capabilities, derived on demand. NEVER raises.
+
+    Duck-compatible with `CapabilityRegistry` for the three things
+    `CapabilityRouter` asks — `get`, `iron_gate_required`, `tool_schemas` — so
+    the router federates by being handed one of these instead of the other.
+    """
+
+    def __init__(self, specs: Optional[List[ProviderSpec]] = None) -> None:
+        self._specs = specs if specs is not None else discover()
+        self._ns: Dict[str, _NamespaceState] = {}
+        self._locks: Dict[str, asyncio.Lock] = {}
+
+    # -- discovery-time facts (no imports) --------------------------------
+
+    def namespaces(self) -> List[str]:
+        return sorted({s.namespace for s in self._specs})
+
+    def providers(self, namespace: str = "") -> List[ProviderSpec]:
+        return [s for s in self._specs
+                if not namespace or s.namespace == namespace]
+
+    # -- hydration ---------------------------------------------------------
+
+    def _state(self, ns: str) -> _NamespaceState:
+        st = self._ns.get(ns)
+        if st is None:
+            st = _NamespaceState()
+            self._ns[ns] = st
+        return st
+
+    def _lock(self, ns: str) -> asyncio.Lock:
+        lk = self._locks.get(ns)
+        if lk is None:
+            lk = asyncio.Lock()
+            self._locks[ns] = lk
+        return lk
+
+    def _hydrate_ns_blocking(self, ns: str) -> _NamespaceState:
+        """Import and reflect ONE namespace. Runs off-loop. NEVER raises."""
+        st = _NamespaceState()
+        t0 = time.perf_counter()
+        failures: List[str] = []
+        for spec in self.providers(ns):
+            try:
+                mod = importlib.import_module(spec.module)
+                cls = getattr(mod, spec.class_name, None)
+                if cls is None:
+                    failures.append(f"{spec.class_name}: missing")
+                    continue
+                # Reflect over the CLASS: describing must not require
+                # constructing, the lesson `_default_target` paid for.
+                reg = CapabilityRegistry(cls, require_declaration=True).hydrate()
+                for d in reg.all():
+                    # `export_name` is the method's own `as=` when it declared
+                    # one. Parsed by the registry with every other attribute of
+                    # the tag — this module used to re-read the docstring with a
+                    # second regex, which is two parsers for one grammar.
+                    bare = d.export_name
+                    prior = st.defs.get(bare)
+                    if prior is not None and prior[0].key != spec.key:
+                        # Two providers, one name. REFUSE — the whole reason
+                        # namespacing exists is that arrival order must never
+                        # decide which subsystem a caller reached.
+                        st.conflicts.setdefault(bare, [prior[0].key]).append(spec.key)
+                        st.defs.pop(bare, None)
+                        continue
+                    if bare in st.conflicts:
+                        st.conflicts[bare].append(spec.key)
+                        continue
+                    st.defs[bare] = (spec, d)
+            except BaseException as exc:  # noqa: BLE001 — an import may do anything
+                failures.append(f"{spec.class_name}: {type(exc).__name__}: {exc}")
+                logger.debug("[Federation] %s failed to hydrate", spec.key,
+                             exc_info=True)
+        st.hydrate_ms = (time.perf_counter() - t0) * 1000.0
+        if st.defs:
+            st.readiness = Readiness.READY.value
+            st.detail = "; ".join(failures)          # partial success says so
+        else:
+            st.readiness = Readiness.DEGRADED.value
+            st.detail = ("; ".join(failures)
+                         or "no declared capabilities in this namespace")
+        return st
+
+    async def ensure(self, namespace: str) -> _NamespaceState:
+        """Hydrate ONE namespace if needed. NEVER raises.
+
+        Off-loop via `to_thread`: these imports measured 4.3 s at worst and
+        blocking the event loop for that long would stall the IPC read loop the
+        HUD depends on. Bounded, because a wedged import must not become a
+        wedged federation.
+        """
+        st = self._state(namespace)
+        if st.readiness != Readiness.UNHYDRATED.value:
+            return st
+        try:
+            async with self._lock(namespace):
+                st = self._state(namespace)
+                if st.readiness != Readiness.UNHYDRATED.value:
+                    return st
+                fresh = await asyncio.wait_for(
+                    _to_thread(self._hydrate_ns_blocking, namespace),
+                    timeout=hydrate_timeout_s())
+                self._ns[namespace] = fresh
+                logger.info("[Federation] '%s' %s — %d capabilities in %.0fms",
+                            namespace, fresh.readiness, len(fresh.defs),
+                            fresh.hydrate_ms)
+                return fresh
+        except asyncio.TimeoutError:
+            st = _NamespaceState(
+                readiness=Readiness.DEGRADED.value,
+                detail=f"hydration exceeded {hydrate_timeout_s():.0f}s")
+            self._ns[namespace] = st
+            logger.warning("[Federation] '%s' hydration timed out", namespace)
+            return st
+        except Exception as exc:  # noqa: BLE001
+            st = _NamespaceState(readiness=Readiness.DEGRADED.value,
+                                 detail=f"{type(exc).__name__}: {exc}")
+            self._ns[namespace] = st
+            return st
+
+    async def warm(self) -> Dict[str, str]:
+        """Hydrate every namespace CONCURRENTLY, off the boot path. NEVER raises.
+
+        Serial cost measured at 6.5 s; concurrently it is bounded by the
+        slowest single namespace. Intended to be fired as a background task at
+        boot so the first voice command does not pay for it — and it is only an
+        optimisation: `ensure()` is what correctness depends on.
+        """
+        try:
+            names = self.namespaces()
+            await asyncio.gather(*(self.ensure(n) for n in names),
+                                 return_exceptions=True)
+            return {n: self._state(n).readiness for n in names}
+        except Exception:  # noqa: BLE001
+            return {}
+
+    # -- the registry-shaped surface --------------------------------------
+
+    def get(self, name: str) -> Optional[CapabilityDef]:
+        """Look up `namespace.capability`. NEVER raises, NEVER hydrates.
+
+        Synchronous because the router's fast path is synchronous. An
+        unhydrated namespace answers None, which the router treats as unknown —
+        and `ensure()` is what the caller does about it.
+        """
+        try:
+            ns, bare = split(name)
+            entry = self._state(ns).defs.get(bare)
+            return entry[1] if entry else None
+        except Exception:  # noqa: BLE001
+            return None
+
+    def iron_gate_required(self, name: str) -> bool:
+        """True unless DECLARED read-only. Unknown answers True."""
+        d = self.get(name)
+        return True if d is None else d.iron_gate_required
+
+    def resolve_target(self, name: str) -> Any:
+        """The live instance that owns `name`, constructed lazily. NEVER raises.
+
+        Construction is deferred to the first EXECUTION and cached per provider:
+        reflection is free, but `MultiSpaceCaptureEngine()` starts real work.
+        A failure here is a failed call, never an import-time explosion — the
+        doctrine `capability_router._instance` already follows.
+        """
+        try:
+            ns, bare = split(name)
+            st = self._state(ns)
+            entry = st.defs.get(bare)
+            if entry is None:
+                return None
+            spec, _ = entry
+            inst = st.instances.get(spec.key)
+            if inst is None:
+                inst, err = _construct(spec)
+                if inst is not None:
+                    st.instances[spec.key] = inst
+                    st.construct_errors.pop(spec.key, None)
+                else:
+                    st.construct_errors[spec.key] = err
+            return inst
+        except Exception:  # noqa: BLE001
+            logger.debug("[Federation] resolve_target(%s) degraded", name,
+                         exc_info=True)
+            return None
+
+    def method_for(self, name: str) -> str:
+        """The METHOD to call for an exported name. NEVER raises.
+
+        `touch.stop_actuator` is exported under its alias and implemented as
+        `stop`. A caller that invoked the export name on the instance would get
+        `AttributeError` — the collision fix breaking the calls it was added to
+        make possible. This is the one translation, and it lives beside the one
+        that created the alias.
+        """
+        try:
+            ns, bare = split(name)
+            entry = self._state(ns).defs.get(bare)
+            return entry[1].name if entry else ""
+        except Exception:  # noqa: BLE001
+            return ""
+
+    def names(self) -> List[str]:
+        out: List[str] = []
+        for ns, st in self._ns.items():
+            out.extend(_export_name(ns, b) for b in st.defs)
+        return sorted(out)
+
+    def tool_schemas(self) -> Dict[str, Dict[str, Any]]:
+        """Drop-in for `TOOL_SCHEMAS`, namespaced. NEVER raises."""
+        out: Dict[str, Dict[str, Any]] = {}
+        try:
+            for ns, st in self._ns.items():
+                for bare, (_, d) in st.defs.items():
+                    full = _export_name(ns, bare)
+                    schema = d.to_tool_schema()
+                    schema["name"] = full
+                    out[full] = schema
+        except Exception:  # noqa: BLE001
+            pass
+        return dict(sorted(out.items()))
+
+    # -- observability -----------------------------------------------------
+
+    def conflicts(self) -> Dict[str, List[str]]:
+        """Names two providers both claimed. Refused, not resolved. NEVER raises."""
+        out: Dict[str, List[str]] = {}
+        for ns, st in self._ns.items():
+            for bare, owners in st.conflicts.items():
+                out[_export_name(ns, bare)] = sorted(set(owners))
+        return out
+
+    def sessions(self) -> List[str]:
+        return sorted(_export_name(ns, b)
+                      for ns, st in self._ns.items()
+                      for b, (_, d) in st.defs.items() if d.starts_session)
+
+    def unreleasable(self) -> List[str]:
+        """Session starts with no named release — an invisible leak. NEVER raises."""
+        return sorted(_export_name(ns, b)
+                      for ns, st in self._ns.items()
+                      for b, (_, d) in st.defs.items()
+                      if d.starts_session and not d.release)
+
+    def broken_releases(self) -> Dict[str, str]:
+        """START capabilities whose named release is not a usable END. NEVER raises.
+
+        `unreleasable()` catches the start that named NOTHING. This catches the
+        subtler one: a start that names a release which was misspelled, lives in
+        another namespace, or was never tagged `session-end` — so it is not
+        forced SAFE_AUTO and the reaper's call would SUSPEND awaiting consent
+        that, by then, nobody is there to give.
+
+        A defect a test can fail on, rather than a stream that quietly outlives
+        every attempt to stop it.
+        """
+        out: Dict[str, str] = {}
+        try:
+            for ns, st in self._ns.items():
+                for bare, (_, d) in st.defs.items():
+                    if not d.starts_session or not d.release:
+                        continue
+                    target = st.defs.get(d.release)
+                    full = _export_name(ns, bare)
+                    if target is None:
+                        out[full] = (f"release '{d.release}' is not an exported "
+                                     f"capability of namespace '{ns}'")
+                    elif not target[1].ends_session:
+                        out[full] = (f"release '{d.release}' exists but is not "
+                                     f"tagged session-end, so it is gated and "
+                                     f"the reaper cannot call it")
+        except Exception:  # noqa: BLE001
+            pass
+        return out
+
+    def unbuildable(self) -> Dict[str, str]:
+        """Providers that described fine and could not be constructed. NEVER raises."""
+        out: Dict[str, str] = {}
+        for st in self._ns.values():
+            out.update({k: v[:300] for k, v in st.construct_errors.items()})
+        return out
+
+    def stats(self) -> Dict[str, Any]:
+        return {
+            "schema_version": CAPABILITY_FEDERATION_SCHEMA_VERSION,
+            "enabled": federation_enabled(),
+            "providers": len(self._specs),
+            "bindings": get_bindings().names(),
+            "namespaces": {
+                n: {"readiness": self._state(n).readiness,
+                    "capabilities": len(self._state(n).defs),
+                    "hydrate_ms": round(self._state(n).hydrate_ms, 1),
+                    "detail": self._state(n).detail[:300]}
+                for n in self.namespaces()
+            },
+            "capabilities": len(self.names()),
+            "conflicts": self.conflicts(),
+            "sessions": len(self.sessions()),
+            "unreleasable": self.unreleasable(),
+            "broken_releases": self.broken_releases(),
+            "unbuildable": self.unbuildable(),
+        }
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def _construct(spec: ProviderSpec) -> Tuple[Any, str]:
+    """Get a live instance for a provider. Returns (instance, error). NEVER raises.
+
+    Order: declared factory, then `get_instance`, then the constructor with its
+    required parameters resolved from :class:`ProviderBindings`. An async
+    factory is NOT awaited here — `resolve_target` is synchronous by design — so
+    a provider needing async construction declares a sync accessor.
+
+    Returning `(None, why)` is the point. A half-built instance would be worse
+    than no instance, and an empty `why` was how the `VideoStreamCapture`
+    `TypeError` stayed a debug log for as long as it did.
+    """
+    try:
+        mod = importlib.import_module(spec.module)
+        cls = getattr(mod, spec.class_name, None)
+        if cls is None:
+            return (None, f"{spec.class_name} not found in {spec.module}")
+        for cand in ([spec.factory] if spec.factory else []) + ["get_instance"]:
+            if not cand:
+                continue
+            fn = getattr(cls, cand, None) or getattr(mod, cand, None)
+            if callable(fn) and not inspect.iscoroutinefunction(fn):
+                try:
+                    inst = fn()
+                except TypeError:
+                    # A factory with its own required arguments is not a
+                    # factory this can drive. Fall through to the constructor,
+                    # which CAN have its dependencies resolved by name.
+                    continue
+                if inst is not None and not inspect.isawaitable(inst):
+                    return (inst, "")
+        kwargs, missing = _resolve_ctor_args(cls)
+        if missing:
+            return (None,
+                    f"unbound constructor dependencies: {', '.join(missing)} — "
+                    f"call capability_federation.bind('{missing[0]}', ...) "
+                    f"during boot")
+        return (cls(**kwargs), "")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[Federation] cannot construct %s: %s: %s",
+                       spec.key, type(exc).__name__, exc)
+        return (None, f"{type(exc).__name__}: {exc}")
+
+
+def _resolve_ctor_args(cls: Any) -> Tuple[Dict[str, Any], List[str]]:
+    """Fill a constructor's REQUIRED parameters from bindings. NEVER raises.
+
+    Only the required ones. A parameter with a default is the provider's own
+    considered choice, and overriding it from a global registry because the
+    names happened to match would be spooky action — `cache_size_mb=200` means
+    the engine picked 200, not that it is waiting to be told.
+
+    Unresolvable names are RETURNED rather than skipped, so the caller reports a
+    provider that cannot be built instead of calling `cls()` and translating a
+    `TypeError` into a shrug.
+    """
+    kwargs: Dict[str, Any] = {}
+    missing: List[str] = []
+    try:
+        sig = inspect.signature(cls.__init__)
+    except (TypeError, ValueError):
+        return ({}, [])
+    bindings = get_bindings()
+    for pname, p in sig.parameters.items():
+        if pname in ("self", "cls"):
+            continue
+        if p.kind in (p.VAR_POSITIONAL, p.VAR_KEYWORD):
+            continue
+        if p.default is not inspect.Parameter.empty:
+            continue
+        found, value = bindings.resolve(pname)
+        if found:
+            kwargs[pname] = value
+        else:
+            missing.append(pname)
+    return (kwargs, missing)
+
+
+async def _to_thread(fn, *args):
+    """`asyncio.to_thread` without requiring 3.9+. NEVER raises on its own."""
+    try:
+        return await asyncio.to_thread(fn, *args)      # 3.9+
+    except AttributeError:                             # pragma: no cover
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(None, lambda: fn(*args))
+
+
+_FEDERATION: Optional[CapabilityFederation] = None
+
+
+def get_federation() -> CapabilityFederation:
+    """Process-wide federation. Discovery only — no imports. NEVER raises."""
+    global _FEDERATION
+    if _FEDERATION is None:
+        _FEDERATION = CapabilityFederation()
+    return _FEDERATION
+
+
+def reset_federation() -> None:
+    """Testing seam. NEVER raises."""
+    global _FEDERATION
+    _FEDERATION = None

--- a/backend/system_control/capability_leases.py
+++ b/backend/system_control/capability_leases.py
@@ -1,0 +1,693 @@
+"""What holds a capability open, and what closes it when nobody is left.
+
+`capability_registry.Session` gave the vocabulary: a START outlives its own
+call, an END releases it, and START is never SAFE_AUTO while END always is.
+What it could not give is the BOOK — the record of which sessions are currently
+open, who wanted them, and what happens when that someone goes away.
+
+Without one, `video.start_streaming` is a call that returns True and then holds
+the display capture open forever. The HUD that asked for it can quit, crash, or
+be rebuilt; the green recording dot stays lit. That is the defect this exists to
+delete, and it is a leak of a PHYSICAL resource — a camera indicator, a capture
+session, a spawned pid — not of a dict entry.
+
+REFCOUNTS, NOT OWNERSHIP
+--------------------------
+The obvious design gives each lease its own release: A opens the stream, A goes
+away, the stream stops. It is wrong the moment there are two of anything. If the
+HUD and a voice session both hold `video.start_streaming` and the HUD quits, a
+per-lease release stops a stream the voice session is still using — and the
+provider is a singleton, so there is no second stream to fall back to.
+
+So leases REFCOUNT by capability. N leases on one capability release it exactly
+once, when the last of them closes. This is the same reason a file descriptor is
+not closed by whichever holder happens to exit first.
+
+A DISCONNECT IS NOT IMMEDIATELY A DEPARTURE
+---------------------------------------------
+Reaping the instant a socket drops makes every HUD rebuild kill a stream the
+operator wanted, and makes a one-second network hiccup indistinguishable from a
+quit. So a departed principal enters a GRACE window; if the same principal comes
+back before it expires, the reap is cancelled and nothing was ever interrupted.
+The window is the only place absence is interpreted, and it is time-based, which
+is the one thing a reaper is allowed to read.
+
+WHAT THIS DELIBERATELY DOES NOT KNOW
+--------------------------------------
+The reaper reads `time.monotonic()` and this book. NOTHING else — not the
+router's pending table, not a phase, not a liveness signal from the subsystem
+whose session it is about to close. That is the Watchdog Isolation Invariant
+(CLAUDE.md, Slice 47) applied one layer down: a reaper that waits for the thing
+it guards to look healthy deadlocks WITH it when that thing wedges, which is
+precisely the state a leaked session is usually in. A wedged `stop_streaming`
+must not stop the reaper from noticing the next leak.
+
+A FAILED RELEASE IS NOT A CLOSED LEASE
+----------------------------------------
+If `stop_streaming` raises, deleting the record would make the book report zero
+open sessions while the camera light stays on — the leak plus a lie. Such a
+lease goes to ORPHANED and STAYS in the book, counted and named, because the
+number an operator can act on is the whole value of keeping a book at all.
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import asyncio
+import contextvars
+import enum
+import logging
+import os
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, Dict, List, Optional
+
+logger = logging.getLogger("JARVIS.CapabilityLeases")
+
+#: WHO a session belongs to, carried ambiently rather than threaded through
+#: every signature between the socket and the router.
+#:
+#: A contextvar because the alternative is an `owner=` parameter on `route`, on
+#: `execute_tool`, on `_exec_derived_capability` and on the tool loop — five
+#: signatures changed so that one string can travel, and five places for a
+#: caller to forget it. Forgetting here yields "" (unowned), which is honest:
+#: an unowned lease is still reaped by TTL, just not by disconnect.
+#:
+#: Set at the IPC boundary, which is the only place that actually KNOWS which
+#: principal is speaking. Reads correctly across `await` because contextvars are
+#: per-task, and the HUD dispatcher gives each event its own thread and its own
+#: fresh context — so two clients' sessions can never be attributed to each
+#: other, which a module-global would not guarantee.
+_PRINCIPAL: "contextvars.ContextVar[str]" = contextvars.ContextVar(
+    "jarvis_capability_principal", default="")
+
+
+def set_principal(principal: str) -> Any:
+    """Declare who the current task is acting for. Returns a reset token."""
+    try:
+        return _PRINCIPAL.set(str(principal or ""))
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def current_principal() -> str:
+    """Who the current task is acting for, or "" if nobody said. NEVER raises."""
+    try:
+        return _PRINCIPAL.get()
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+#: The owner a reaper-initiated release runs under. Named rather than blank so
+#: an audit can tell "the machine cleaned this up" from "nobody said".
+REAPER_PRINCIPAL: str = "system:reaper"
+
+CAPABILITY_LEASES_SCHEMA_VERSION: str = "capability_leases.v1"
+
+#: Signature of the thing that actually releases a session. Injected rather
+#: than imported: the book must not depend on the router, because the router
+#: depends on the book. The router hands its own routing function in, so
+#: releases still pass through the ONE gate rather than around it.
+Releaser = Callable[[str, Dict[str, Any]], Awaitable[bool]]
+
+
+def leases_enabled() -> bool:
+    """Master gate. Default TRUE. NEVER raises.
+
+    Off means sessions are still TAGGED and still gated — only the bookkeeping
+    and the reaper stop. That is a real position to hold while debugging a
+    provider, and it is honest about what it costs: leaks become invisible
+    again rather than merely unreaped.
+    """
+    return (os.environ.get("JARVIS_CAPABILITY_LEASES_ENABLED", "true")
+            or "").strip().lower() not in ("0", "false", "no", "off")
+
+
+def default_ttl_s() -> float:
+    """How long a session may live unrenewed. Clamped. NEVER raises.
+
+    A ceiling, not a schedule. Most sessions are closed by their END capability
+    long before this; the TTL is what catches the ones whose owner vanished in a
+    way no disconnect signal described — a killed thread, a dropped task, a
+    coroutine that was cancelled between opening and recording.
+    """
+    try:
+        v = float(os.environ.get("JARVIS_CAPABILITY_LEASE_TTL_S", "1800"))
+    except (TypeError, ValueError):
+        v = 1800.0
+    return max(30.0, min(v, 24 * 3600.0))
+
+
+def disconnect_grace_s() -> float:
+    """How long a departed principal may be gone before its sessions die.
+
+    Long enough that a HUD rebuild or a socket blip does not interrupt a stream;
+    short enough that a real quit is not a lease held for the rest of the day.
+    """
+    try:
+        v = float(os.environ.get("JARVIS_CAPABILITY_LEASE_GRACE_S", "20"))
+    except (TypeError, ValueError):
+        v = 20.0
+    return max(0.0, min(v, 3600.0))
+
+
+def reaper_interval_s() -> float:
+    """Sweep cadence. NEVER raises."""
+    try:
+        v = float(os.environ.get("JARVIS_CAPABILITY_LEASE_SWEEP_S", "5"))
+    except (TypeError, ValueError):
+        v = 5.0
+    return max(1.0, min(v, 300.0))
+
+
+def release_timeout_s() -> float:
+    """Budget for one release call. NEVER raises.
+
+    Bounded because a release is exactly the call most likely to hang: the
+    subsystem is already in the state that produced the leak. An unbounded await
+    here would wedge the sweep and turn one orphan into all of them.
+    """
+    try:
+        v = float(os.environ.get("JARVIS_CAPABILITY_RELEASE_TIMEOUT_S", "20"))
+    except (TypeError, ValueError):
+        v = 20.0
+    return max(1.0, min(v, 300.0))
+
+
+def max_release_attempts() -> int:
+    """How many times to retry a failing release before calling it orphaned."""
+    try:
+        return max(1, min(int(os.environ.get(
+            "JARVIS_CAPABILITY_RELEASE_ATTEMPTS", "3")), 20))
+    except (TypeError, ValueError):
+        return 3
+
+
+class LeaseState(str, enum.Enum):
+    """Where a lease is. ORPHANED is the one that earns its keep.
+
+    CLOSED and ORPHANED are both "no longer holding a refcount", and a book that
+    rendered them the same would let a failed release read as a success.
+    """
+
+    OPEN = "open"
+    RELEASING = "releasing"
+    CLOSED = "closed"
+    ORPHANED = "orphaned"          # release was attempted and did not succeed
+
+
+class ReapReason(str, enum.Enum):
+    """Why a lease was closed. Recorded because 'it stopped' is not a story."""
+
+    EXPLICIT = "explicit"          # the END capability was called
+    EXPIRED = "ttl_expired"
+    OWNER_GONE = "owner_disconnected"
+    SHUTDOWN = "shutdown"
+
+
+@dataclass
+class Lease:
+    """One holder's claim on one open session."""
+
+    lease_id: str
+    capability: str                # the START name, e.g. "video.start_streaming"
+    release: str                   # the END name, e.g. "video.stop_streaming"
+    owner: str = ""
+    args: Dict[str, Any] = field(default_factory=dict)
+    #: Monotonic, because a lease must survive the operator changing the clock
+    #: and NTP stepping it backwards mid-stream.
+    opened_at: float = field(default_factory=time.monotonic)
+    #: Wall-clock, for humans reading a dashboard. NEVER used for a decision.
+    opened_wall: float = field(default_factory=time.time)
+    ttl_s: float = field(default_factory=default_ttl_s)
+    state: str = LeaseState.OPEN.value
+    attempts: int = 0
+    detail: str = ""
+
+    @property
+    def age_s(self) -> float:
+        return max(0.0, time.monotonic() - self.opened_at)
+
+    @property
+    def holding(self) -> bool:
+        """Whether this lease still contributes to its capability's refcount."""
+        return self.state in (LeaseState.OPEN.value, LeaseState.RELEASING.value)
+
+    def expired(self, now: Optional[float] = None) -> bool:
+        if self.ttl_s <= 0:
+            return False
+        return ((now if now is not None else time.monotonic())
+                - self.opened_at) > self.ttl_s
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "lease_id": self.lease_id, "capability": self.capability,
+            "release": self.release, "owner": self.owner, "state": self.state,
+            "age_s": round(self.age_s, 1), "ttl_s": round(self.ttl_s, 1),
+            "opened_wall": self.opened_wall, "attempts": self.attempts,
+            "detail": self.detail[:200],
+        }
+
+
+class LeaseBook:
+    """Open sessions, refcounted by capability, reaped on time. NEVER raises."""
+
+    def __init__(self, releaser: Optional[Releaser] = None) -> None:
+        self._leases: Dict[str, Lease] = {}
+        self._releaser = releaser
+        #: principal -> monotonic deadline after which its leases are reaped.
+        #: Presence in this dict IS the "currently absent" fact; a reconnect
+        #: removes the entry and the pending reap simply stops being pending.
+        self._departing: Dict[str, float] = {}
+        #: One lock per capability, so releasing a video stream never serialises
+        #: behind releasing an unrelated ghost-hands session.
+        self._locks: Dict[str, asyncio.Lock] = {}
+        self._counters: Dict[str, int] = {
+            "opened": 0, "closed": 0, "orphaned": 0,
+            "reaped_expired": 0, "reaped_owner": 0, "reaped_shutdown": 0,
+            "release_failed": 0, "coalesced": 0,
+        }
+
+    # -- wiring ------------------------------------------------------------
+
+    def set_releaser(self, releaser: Optional[Releaser]) -> None:
+        """Install what actually stops a session. NEVER raises.
+
+        Idempotent and late-bindable on purpose: the book is constructed before
+        the router exists, and a book with no releaser still records leases
+        correctly — it simply cannot close them, which it says out loud rather
+        than pretending.
+        """
+        self._releaser = releaser
+
+    # -- the book ----------------------------------------------------------
+
+    def open(self, capability: str, release: str, *, owner: str = "",
+             args: Optional[Dict[str, Any]] = None,
+             ttl_s: Optional[float] = None) -> Optional[Lease]:
+        """Record a session that just started. NEVER raises.
+
+        Returns None when leasing is disabled or the START named no release —
+        and returning None is deliberate rather than raising, because the
+        session itself SUCCEEDED. Refusing to acknowledge a started stream would
+        not un-start it; it would only remove the last record that it exists.
+        """
+        try:
+            if not leases_enabled():
+                return None
+            if not capability:
+                return None
+            if not release:
+                # A start with no named release cannot be reaped, so the book
+                # would be recording an obligation it can never discharge.
+                # `federation.unreleasable()` surfaces this at hydrate time; by
+                # here it is a defect that already shipped, so it is LOUD.
+                logger.error(
+                    "[Leases] '%s' started a session with no declared release — "
+                    "it cannot be reaped. Declare `release=` on its tag.",
+                    capability)
+                return None
+            # A principal that opens a lease is, by definition, present.
+            if owner:
+                self._departing.pop(owner, None)
+            lease = Lease(
+                lease_id=uuid.uuid4().hex, capability=capability,
+                release=release, owner=owner or "", args=dict(args or {}),
+                ttl_s=(default_ttl_s() if ttl_s is None else float(ttl_s)))
+            self._leases[lease.lease_id] = lease
+            self._counters["opened"] += 1
+            holders = self.holders(capability)
+            if holders > 1:
+                self._counters["coalesced"] += 1
+            logger.info("[Leases] OPEN %s owner=%s holders=%d lease=%s",
+                        capability, owner or "-", holders, lease.lease_id[:8])
+            return lease
+        except Exception:  # noqa: BLE001 — bookkeeping never breaks a capability
+            logger.debug("[Leases] open(%s) degraded", capability, exc_info=True)
+            return None
+
+    def holders(self, capability: str) -> int:
+        """How many live claims exist on one capability. NEVER raises."""
+        try:
+            return sum(1 for l in self._leases.values()
+                       if l.capability == capability and l.holding)
+        except Exception:  # noqa: BLE001
+            return 0
+
+    def active(self) -> List[Lease]:
+        """Leases still holding something open. NEVER raises."""
+        try:
+            return [self._leases[k] for k in sorted(self._leases)
+                    if self._leases[k].holding]
+        except Exception:  # noqa: BLE001
+            return []
+
+    def orphans(self) -> List[Lease]:
+        """Sessions whose release failed. Kept, counted, named. NEVER raises."""
+        try:
+            return [self._leases[k] for k in sorted(self._leases)
+                    if self._leases[k].state == LeaseState.ORPHANED.value]
+        except Exception:  # noqa: BLE001
+            return []
+
+    def by_owner(self, owner: str) -> List[Lease]:
+        return [l for l in self.active() if l.owner == owner]
+
+    # -- closing -----------------------------------------------------------
+
+    async def close(self, lease_id: str, *,
+                    reason: str = ReapReason.EXPLICIT.value) -> bool:
+        """Drop ONE claim, releasing only if it was the last. NEVER raises.
+
+        Idempotent: closing an already-closed lease is a no-op that reports
+        success, because a caller that retries a close must not be told its
+        session is somehow still open.
+        """
+        try:
+            lease = self._leases.get(lease_id)
+            if lease is None or not lease.holding:
+                return True
+            return await self._close_lease(lease, reason)
+        except Exception:  # noqa: BLE001
+            logger.debug("[Leases] close(%s) degraded", lease_id, exc_info=True)
+            return False
+
+    async def close_capability(self, capability: str, *, owner: str = "",
+                               reason: str = ReapReason.EXPLICIT.value) -> int:
+        """Drop the claims on one capability. NEVER raises.
+
+        This is what an operator calling the END capability directly means: they
+        said "stop streaming", not "drop my particular lease". Scoped to *owner*
+        when one is given, so one principal ending its own session does not end
+        somebody else's — and the refcount still decides whether the provider is
+        actually stopped.
+        """
+        n = 0
+        try:
+            for lease in list(self.active()):
+                if lease.capability != capability:
+                    continue
+                if owner and lease.owner != owner:
+                    continue
+                if await self._close_lease(lease, reason):
+                    n += 1
+        except Exception:  # noqa: BLE001
+            logger.debug("[Leases] close_capability(%s) degraded", capability,
+                         exc_info=True)
+        return n
+
+    def discharge(self, release: str, *, owner: str = "") -> int:
+        """Record that a release ALREADY ran. Calls nothing. NEVER raises.
+
+        What happens when the operator (or the model) invokes the END capability
+        directly: by the time this is reached, the stream is genuinely stopped.
+        Routing that through `close` would call `stop_streaming` a second time —
+        and worse, it would RE-ENTER, because a reaper-driven release goes
+        router → execute → here, and `_close_lease` holds a non-reentrant lock
+        on the way in. Leases already in RELEASING are therefore skipped: the
+        reaper is mid-flight on those and will record their own outcome.
+
+        Deliberately NOT owner-scoped for the closing itself. The provider is a
+        singleton, so one principal calling `stop_streaming` stops it for
+        everyone whether the book likes it or not, and a book that kept the
+        other holders' leases OPEN would be reporting a stream that is not
+        running. It says so in the log instead of quietly disagreeing with
+        reality.
+        """
+        n = 0
+        try:
+            if not release:
+                return 0
+            victims = [l for l in self.active()
+                       if l.release == release
+                       and l.state != LeaseState.RELEASING.value]
+            others = [l for l in victims if owner and l.owner and l.owner != owner]
+            for lease in victims:
+                lease.state = LeaseState.CLOSED.value
+                lease.detail = f"discharged by explicit {release}"
+                self._counters["closed"] += 1
+                n += 1
+            if others:
+                logger.warning(
+                    "[Leases] '%s' by %s also ended %d session(s) held by %s — "
+                    "the provider is shared, so it stopped for everyone",
+                    release, owner or "-", len(others),
+                    ", ".join(sorted({l.owner for l in others})))
+            elif n:
+                logger.info("[Leases] discharged %d lease(s) via explicit %s",
+                            n, release)
+        except Exception:  # noqa: BLE001
+            logger.debug("[Leases] discharge(%s) degraded", release, exc_info=True)
+        return n
+
+    async def _close_lease(self, lease: Lease, reason: str) -> bool:
+        """Refcount down, and release when the count reaches zero. NEVER raises."""
+        try:
+            async with self._lock(lease.capability):
+                if not lease.holding:
+                    return True
+                # Count the OTHER holders explicitly rather than by marking this
+                # one first and re-counting. `holding` is true for RELEASING —
+                # correctly, since a session mid-release is still open — so a
+                # state-based count included this very lease and every release
+                # concluded that somebody else still needed the provider. The
+                # stream was never stopped, by anyone, ever.
+                remaining = sum(
+                    1 for other in self._leases.values()
+                    if other is not lease
+                    and other.capability == lease.capability
+                    and other.holding)
+                if remaining > 0:
+                    # Somebody else is still using it. This claim is done; the
+                    # session is not. No release call is made at all.
+                    lease.state = LeaseState.CLOSED.value
+                    lease.detail = f"{reason}; {remaining} holder(s) remain"
+                    self._counters["closed"] += 1
+                    logger.info("[Leases] CLOSE %s lease=%s (%d remain — "
+                                "provider left running)", lease.capability,
+                                lease.lease_id[:8], remaining)
+                    return True
+                # Last holder. Mark RELEASING so a concurrent `discharge`
+                # arriving from the router on the way back out of this very
+                # call leaves it alone.
+                lease.state = LeaseState.RELEASING.value
+                ok, detail = await self._invoke_release(lease)
+                if ok:
+                    lease.state = LeaseState.CLOSED.value
+                    lease.detail = reason
+                    self._counters["closed"] += 1
+                    logger.info("[Leases] RELEASED %s via %s (%s)",
+                                lease.capability, lease.release, reason)
+                    return True
+                lease.attempts += 1
+                lease.detail = detail
+                if lease.attempts >= max_release_attempts():
+                    lease.state = LeaseState.ORPHANED.value
+                    self._counters["orphaned"] += 1
+                    # LOUD. The session is still running and nothing left in
+                    # this process is going to stop it.
+                    logger.error(
+                        "[Leases] ORPHANED %s — %s failed %d time(s): %s. The "
+                        "session is STILL OPEN and will not be reaped.",
+                        lease.capability, lease.release, lease.attempts,
+                        detail[:200])
+                else:
+                    # Back to OPEN so the next sweep tries again. Staying in
+                    # RELEASING would hold a refcount nobody would ever clear.
+                    lease.state = LeaseState.OPEN.value
+                    logger.warning("[Leases] release of %s failed (attempt "
+                                   "%d/%d): %s", lease.capability,
+                                   lease.attempts, max_release_attempts(),
+                                   detail[:200])
+                self._counters["release_failed"] += 1
+                return False
+        except Exception as exc:  # noqa: BLE001
+            lease.state = LeaseState.OPEN.value
+            lease.detail = f"{type(exc).__name__}: {exc}"
+            logger.debug("[Leases] _close_lease degraded", exc_info=True)
+            return False
+
+    async def _invoke_release(self, lease: Lease) -> "tuple":
+        """Call the releaser, bounded. Returns (ok, detail). NEVER raises."""
+        if self._releaser is None:
+            return (False, "no releaser installed")
+        try:
+            ok = await asyncio.wait_for(
+                self._releaser(lease.release, dict(lease.args or {})),
+                timeout=release_timeout_s())
+            return (bool(ok), "" if ok else "releaser reported failure")
+        except asyncio.TimeoutError:
+            return (False, f"release exceeded {release_timeout_s():.0f}s")
+        except Exception as exc:  # noqa: BLE001
+            return (False, f"{type(exc).__name__}: {exc}")
+
+    # -- reaping -----------------------------------------------------------
+
+    def note_departure(self, owner: str) -> None:
+        """A principal's connection dropped. Start its grace window. NEVER raises.
+
+        Records an INTENT to reap rather than reaping: the caller here is a
+        socket handler, which is the wrong place to be awaiting a provider's
+        shutdown, and the whole point of the grace window is that this may yet
+        turn out not to have been a departure at all.
+        """
+        try:
+            if not owner:
+                return
+            grace = disconnect_grace_s()
+            self._departing[owner] = time.monotonic() + grace
+            n = len(self.by_owner(owner))
+            if n:
+                logger.info("[Leases] '%s' departed holding %d session(s) — "
+                            "reaping in %.0fs unless it returns", owner, n, grace)
+        except Exception:  # noqa: BLE001
+            pass
+
+    def note_arrival(self, owner: str) -> None:
+        """A principal is present. Cancels any pending reap. NEVER raises."""
+        try:
+            if owner and self._departing.pop(owner, None) is not None:
+                logger.info("[Leases] '%s' returned within grace — its "
+                            "session(s) were never interrupted", owner)
+        except Exception:  # noqa: BLE001
+            pass
+
+    async def sweep(self) -> int:
+        """One pass: expired TTLs and elapsed grace windows. NEVER raises.
+
+        Reads `time.monotonic()` and this book. Nothing else — see the module
+        docstring on why a reaper that consults the health of what it guards is
+        not a reaper.
+        """
+        closed = 0
+        try:
+            now = time.monotonic()
+            gone = [o for o, deadline in list(self._departing.items())
+                    if now >= deadline]
+            for owner in gone:
+                self._departing.pop(owner, None)
+                for lease in self.by_owner(owner):
+                    if await self._close_lease(lease, ReapReason.OWNER_GONE.value):
+                        self._counters["reaped_owner"] += 1
+                        closed += 1
+            for lease in list(self.active()):
+                if lease.expired(now):
+                    logger.warning(
+                        "[Leases] '%s' exceeded its %.0fs TTL (owner=%s) — "
+                        "reaping", lease.capability, lease.ttl_s,
+                        lease.owner or "-")
+                    if await self._close_lease(lease, ReapReason.EXPIRED.value):
+                        self._counters["reaped_expired"] += 1
+                        closed += 1
+        except Exception:  # noqa: BLE001
+            logger.debug("[Leases] sweep degraded", exc_info=True)
+        return closed
+
+    async def run_reaper(self, stop: Optional[asyncio.Event] = None) -> None:
+        """Sweep forever. Intended as a background task. NEVER raises.
+
+        Survives its own failures by construction: one bad sweep logs and the
+        loop continues, because a reaper that dies on the first surprise is
+        indistinguishable from no reaper at all — and only discoverable later,
+        by the leak it did not catch.
+        """
+        logger.info("[Leases] reaper started (sweep=%.0fs ttl=%.0fs grace=%.0fs)",
+                    reaper_interval_s(), default_ttl_s(), disconnect_grace_s())
+        while True:
+            try:
+                if stop is not None and stop.is_set():
+                    return
+                await self.sweep()
+            except asyncio.CancelledError:
+                logger.info("[Leases] reaper cancelled")
+                raise
+            except Exception:  # noqa: BLE001
+                logger.debug("[Leases] reaper iteration degraded", exc_info=True)
+            try:
+                if stop is not None:
+                    try:
+                        await asyncio.wait_for(stop.wait(),
+                                               timeout=reaper_interval_s())
+                        return
+                    except asyncio.TimeoutError:
+                        continue
+                await asyncio.sleep(reaper_interval_s())
+            except asyncio.CancelledError:
+                raise
+            except Exception:  # noqa: BLE001
+                await asyncio.sleep(reaper_interval_s())
+
+    async def release_all(self, *,
+                          reason: str = ReapReason.SHUTDOWN.value) -> int:
+        """Close every open session. For process shutdown. NEVER raises.
+
+        The last line of defence, and the only one that runs while the operator
+        is watching the app quit. What it cannot close it leaves ORPHANED and
+        logs by name — a shutdown that silently abandoned a live screen capture
+        would be the exact failure this module exists to make impossible.
+        """
+        n = 0
+        try:
+            for lease in list(self.active()):
+                if await self._close_lease(lease, reason):
+                    self._counters["reaped_shutdown"] += 1
+                    n += 1
+            remaining = self.active() + self.orphans()
+            if remaining:
+                logger.error("[Leases] shutdown left %d session(s) unclosed: %s",
+                             len(remaining),
+                             ", ".join(sorted({l.capability for l in remaining})))
+        except Exception:  # noqa: BLE001
+            logger.debug("[Leases] release_all degraded", exc_info=True)
+        return n
+
+    # -- observability -----------------------------------------------------
+
+    def _lock(self, capability: str) -> asyncio.Lock:
+        lk = self._locks.get(capability)
+        if lk is None:
+            lk = asyncio.Lock()
+            self._locks[capability] = lk
+        return lk
+
+    def stats(self) -> Dict[str, Any]:
+        """NEVER raises."""
+        try:
+            active = self.active()
+            orphans = self.orphans()
+            return {
+                "schema_version": CAPABILITY_LEASES_SCHEMA_VERSION,
+                "enabled": leases_enabled(),
+                "active": len(active),
+                "orphaned": len(orphans),
+                "departing": sorted(self._departing),
+                "capabilities": sorted({l.capability for l in active}),
+                # Named, not just counted: an orphan is something an operator
+                # has to go and stop by hand, and they need to know what.
+                "orphaned_capabilities": sorted({l.capability for l in orphans}),
+                "ttl_s": default_ttl_s(),
+                "grace_s": disconnect_grace_s(),
+                "leases": [l.to_dict() for l in active],
+                **self._counters,
+            }
+        except Exception:  # noqa: BLE001
+            return {"schema_version": CAPABILITY_LEASES_SCHEMA_VERSION,
+                    "enabled": False, "active": 0, "orphaned": 0}
+
+
+_BOOK: Optional[LeaseBook] = None
+
+
+def get_lease_book() -> LeaseBook:
+    """Process-wide book. NEVER raises."""
+    global _BOOK
+    if _BOOK is None:
+        _BOOK = LeaseBook()
+    return _BOOK
+
+
+def reset_lease_book() -> None:
+    """Testing seam. NEVER raises."""
+    global _BOOK
+    _BOOK = None

--- a/backend/system_control/capability_registry.py
+++ b/backend/system_control/capability_registry.py
@@ -60,7 +60,7 @@ import logging
 import os
 import re
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, NamedTuple, Optional
 
 logger = logging.getLogger("JARVIS.CapabilityRegistry")
 
@@ -120,6 +120,32 @@ _JSON_TYPES: Dict[Any, str] = {
 }
 
 
+class Session(str, enum.Enum):
+    """A capability that OUTLIVES its own call.
+
+    `lock_screen` finishes when it returns. `start_streaming` returns
+    immediately and then holds the display capture open forever. The registry
+    had no word for the difference, and without one every long-running claim
+    looks like a completed action — which is how a video stream survives the
+    HUD that asked for it.
+
+    Two forced rules make the lease design safe, and both are stated here
+    because they are load-bearing rather than stylistic:
+
+    * **START is never SAFE_AUTO**, even tagged read-only. One screenshot and a
+      permanent screen recording differ in KIND, not degree; duration is itself
+      the risk. A continuous observer gets asked for, every time.
+    * **END is always SAFE_AUTO.** If stopping needed consent, a leaked session
+      could not be reaped without a human — and the reaper runs precisely when
+      no human is there. A gate on the release path is a deadlock wearing the
+      costume of caution.
+    """
+
+    NONE = ""
+    START = "start"
+    END = "end"
+
+
 class Effect(str, enum.Enum):
     """PURE observes; EFFECTFUL changes the world.
 
@@ -155,7 +181,10 @@ def os_capability(effect: "Effect", *, description: str = "") -> Callable:
 def capability(*, mutates: Optional[bool] = None,
                reads_only: Optional[bool] = None,
                tier: Optional[str] = None,
-               description: str = "") -> Callable:
+               description: str = "",
+               session: str = Session.NONE.value,
+               release: str = "",
+               alias: str = "") -> Callable:
     """Declare a method's risk where the method is written. NEVER raises.
 
     A decorator rather than a central table for the reason `repl_dispatch_
@@ -174,6 +203,9 @@ def capability(*, mutates: Optional[bool] = None,
                 "tier": resolved or _DEFAULT_TIER.value,
                 "declared": True,
                 "description": description,
+                "session": session,
+                "release": release,
+                "alias": alias,
             })
         except Exception:  # noqa: BLE001 — a decorator never breaks an import
             pass
@@ -191,7 +223,32 @@ class CapabilityDef:
     tier: str = _DEFAULT_TIER.value
     provenance: str = Provenance.DEFAULTED.value
     is_async: bool = True
+    #: "" | "start" | "end" — see :class:`Session`.
+    session: str = Session.NONE.value
+    #: For a START, the capability that releases it. The lease reaper calls
+    #: THIS, so a start whose release is unnamed cannot be cleaned up — which
+    #: `Session.START` refuses to be, at hydrate time rather than at 3am.
+    release: str = ""
+    #: The name this capability is EXPORTED as, when its method name would
+    #: collide with another provider's in the same namespace. Declared at the
+    #: method (``as=stop_actuator``) rather than in a table elsewhere, so the
+    #: method keeps the name its existing callers already use and the rename is
+    #: readable from the thing being renamed.
+    alias: str = ""
     schema_version: str = CAPABILITY_REGISTRY_SCHEMA_VERSION
+
+    @property
+    def export_name(self) -> str:
+        """What a federated vocabulary should call this. NEVER raises."""
+        return self.alias or self.name
+
+    @property
+    def starts_session(self) -> bool:
+        return self.session == Session.START.value
+
+    @property
+    def ends_session(self) -> bool:
+        return self.session == Session.END.value
 
     @property
     def iron_gate_required(self) -> bool:
@@ -230,16 +287,35 @@ def _json_type(annotation: Any) -> str:
 
 
 def _arg_descriptions(doc: str) -> Dict[str, str]:
-    """Parameter descriptions from a Google-style ``Args:`` block. NEVER raises."""
+    """Parameter descriptions from a Google-style ``Args:`` block. NEVER raises.
+
+    Continuation lines are JOINED onto the parameter they belong to. Google
+    style wraps a long description across lines, and matching only the first one
+    cut every wrapped description at the wrap — the model was being handed
+    "What to find out across the desktop spaces, in plain", which reads as a
+    sentence that simply stops. Silent truncation of the text whose entire job
+    is to tell a model what to put in a field.
+    """
     out: Dict[str, str] = {}
     try:
         m = _ARGS_BLOCK.search(doc or "")
         if not m:
             return out
+        current = ""
         for line in (m.group("body") or "").splitlines():
             am = _ARG_LINE.match(line)
             if am:
-                out[am.group("name").lstrip("*")] = am.group("desc").strip()
+                current = am.group("name").lstrip("*")
+                out[current] = am.group("desc").strip()
+                continue
+            # An indented line that is not a new parameter continues the last
+            # one. A blank line ends the run, so a stray paragraph after the
+            # block cannot graft itself onto the final argument.
+            text = line.strip()
+            if current and text and line[:1].isspace():
+                out[current] = f"{out[current]} {text}".strip()
+            elif not text:
+                current = ""
     except Exception:  # noqa: BLE001
         pass
     return out
@@ -257,8 +333,72 @@ def _summary(doc: str, fallback: str) -> str:
     return fallback
 
 
-def _classify(fn: Any, doc: str) -> Tuple[str, str]:
-    """(tier, provenance) for one method. NEVER raises.
+class _Classification(NamedTuple):
+    tier: str
+    provenance: str
+    session: str = Session.NONE.value
+    release: str = ""
+    alias: str = ""
+
+
+def _apply_session_rules(c: _Classification) -> _Classification:
+    """The two rules from :class:`Session`, enforced in ONE place. NEVER raises.
+
+    Written here rather than at each tag site so a future capability cannot opt
+    out of them by being declared somewhere new.
+    """
+    if c.session == Session.START.value:
+        # Duration is the risk. A read-only tag describes the ACTION; it says
+        # nothing about holding that action open indefinitely.
+        if c.tier == Tier.SAFE_AUTO.value:
+            return c._replace(tier=_DEFAULT_TIER.value)
+    elif c.session == Session.END.value:
+        # The reaper runs when nobody is watching. It must never need consent.
+        return c._replace(tier=Tier.SAFE_AUTO.value)
+    return c
+
+
+def _parse_tag(body: str) -> _Classification:
+    """Read one ``Capability:`` tag body. NEVER raises.
+
+    Grammar is comma-separated attributes so one line carries every fact:
+
+        Capability: read-only
+        Capability: session-start, release=stop_streaming
+        Capability: session-end, as=stop_actuator
+
+    Attributes are parsed HERE and only here. The federation used to re-read the
+    same docstring with its own regex to find ``as=``, which is two parsers for
+    one grammar — the arrangement that guarantees they eventually disagree about
+    the same line.
+    """
+    parts = [p.strip() for p in (body or "").lower().split(",") if p.strip()]
+    joined = " ".join(parts)
+    session, release, alias = Session.NONE.value, "", ""
+    for p in parts:
+        if p.startswith("release="):
+            release = p.split("=", 1)[1].strip()
+        elif p.startswith("as=") or p.startswith("alias="):
+            alias = p.split("=", 1)[1].strip()
+        elif p in ("session-start", "session_start"):
+            session = Session.START.value
+        elif p in ("session-end", "session_end"):
+            session = Session.END.value
+
+    tier = _DEFAULT_TIER.value
+    if any(k in joined for k in ("read-only", "read only", "readonly")):
+        tier = Tier.SAFE_AUTO.value
+    else:
+        for t in Tier:
+            if t.value in joined.replace("-", "_"):
+                tier = t.value
+                break
+    return _apply_session_rules(
+        _Classification(tier, Provenance.TAGGED.value, session, release, alias))
+
+
+def _classify(fn: Any, doc: str) -> _Classification:
+    """Tier, provenance and session shape for one method. NEVER raises.
 
     Order matters: an explicit decorator beats a docstring tag, and both beat
     the default — but the DEFAULT IS NOT SAFE. A capability nobody has looked
@@ -268,27 +408,25 @@ def _classify(fn: Any, doc: str) -> Tuple[str, str]:
     try:
         declared = getattr(fn, "__capability__", None)
         if isinstance(declared, dict) and declared.get("declared"):
-            return (str(declared.get("tier") or _DEFAULT_TIER.value),
-                    Provenance.DECLARED.value)
+            return _apply_session_rules(_Classification(
+                str(declared.get("tier") or _DEFAULT_TIER.value),
+                Provenance.DECLARED.value,
+                str(declared.get("session") or Session.NONE.value),
+                str(declared.get("release") or ""),
+                str(declared.get("alias") or "")))
         tag = _DOC_TAG.search(doc or "")
         if tag:
-            body = (tag.group("body") or "").strip().lower()
-            if "read-only" in body or "read only" in body or "readonly" in body:
-                return (Tier.SAFE_AUTO.value, Provenance.TAGGED.value)
-            for t in Tier:
-                if t.value in body.replace("-", "_"):
-                    return (t.value, Provenance.TAGGED.value)
-            return (_DEFAULT_TIER.value, Provenance.TAGGED.value)
+            return _parse_tag(tag.group("body") or "")
     except Exception:  # noqa: BLE001
         pass
-    return (_DEFAULT_TIER.value, Provenance.DEFAULTED.value)
+    return _Classification(_DEFAULT_TIER.value, Provenance.DEFAULTED.value)
 
 
 def describe(name: str, fn: Any) -> Optional[CapabilityDef]:
     """Turn one bound method into a CapabilityDef. None if unusable. NEVER raises."""
     try:
         doc = inspect.getdoc(fn) or ""
-        tier, prov = _classify(fn, doc)
+        cls = _classify(fn, doc)
         params: Dict[str, Dict[str, str]] = {}
         try:
             sig = inspect.signature(fn)
@@ -318,9 +456,12 @@ def describe(name: str, fn: Any) -> Optional[CapabilityDef]:
             description=(declared.get("description")
                          or _summary(doc, f"Invoke {name} on macOS.")),
             parameters=params,
-            tier=tier,
-            provenance=prov,
+            tier=cls.tier,
+            provenance=cls.provenance,
             is_async=inspect.iscoroutinefunction(fn),
+            session=cls.session,
+            release=cls.release,
+            alias=cls.alias,
         )
     except Exception:  # noqa: BLE001
         logger.debug("[CapabilityRegistry] describe(%s) degraded", name,
@@ -331,10 +472,26 @@ def describe(name: str, fn: Any) -> Optional[CapabilityDef]:
 class CapabilityRegistry:
     """Every public capability of a controller, derived. NEVER raises."""
 
-    def __init__(self, target: Any = None) -> None:
+    def __init__(self, target: Any = None, *,
+                 require_declaration: bool = False) -> None:
         self._target = target
         self._defs: Dict[str, CapabilityDef] = {}
         self._hydrated = False
+        #: Export ONLY what has been classified.
+        #:
+        #: `MacOSController` is a capability façade — every public method IS a
+        #: capability, so collecting them all is right there. A federated
+        #: subsystem is not: measured on the real classes, `public and callable`
+        #: also yields `get_instance`, `cleanup` and `register_callback` —
+        #: lifecycle plumbing that a language model can only waste a turn on.
+        #:
+        #: The fix is not a list of exclusions (that is the hand-kept table this
+        #: module exists to delete). It is the same inversion applied one level
+        #: up: a method joins the surface by SAYING SO. Silence stops meaning
+        #: "gated" and starts meaning "not offered" — strictly safer, and it
+        #: makes `unclassified()` the honest measure of remaining work rather
+        #: than a number inflated by plumbing nobody will ever declare.
+        self._require_declaration = bool(require_declaration)
 
     def hydrate(self) -> "CapabilityRegistry":
         """Introspect the target. Idempotent. NEVER raises."""
@@ -350,8 +507,11 @@ class CapabilityRegistry:
                 if name.startswith("_"):
                     continue            # private is not a capability
                 d = describe(name, member)
-                if d is not None:
-                    self._defs[name] = d
+                if d is None:
+                    continue
+                if self._require_declaration and not d.classified:
+                    continue
+                self._defs[name] = d
         except Exception:  # noqa: BLE001
             logger.debug("[CapabilityRegistry] hydrate degraded", exc_info=True)
         return self
@@ -392,6 +552,23 @@ class CapabilityRegistry:
         self._ensure()
         return sorted(n for n, d in self._defs.items() if not d.classified)
 
+    def sessions(self) -> List[CapabilityDef]:
+        """Capabilities that outlive their own call. NEVER raises."""
+        self._ensure()
+        return [self._defs[n] for n in sorted(self._defs)
+                if self._defs[n].starts_session]
+
+    def unreleasable(self) -> List[str]:
+        """Session starts whose release nobody named. NEVER raises.
+
+        A leak that is CURRENTLY invisible: the stream runs, the lease expires,
+        and the reaper has nothing to call. Surfacing it as a number means the
+        defect is found at hydrate time by a test, not at 3am by a fan.
+        """
+        self._ensure()
+        return sorted(n for n, d in self._defs.items()
+                      if d.starts_session and not d.release)
+
     def stats(self) -> Dict[str, Any]:
         self._ensure()
         gated = [d for d in self._defs.values() if d.iron_gate_required]
@@ -402,6 +579,8 @@ class CapabilityRegistry:
             "iron_gate_required": len(gated),
             "safe_auto": len(self._defs) - len(gated),
             "unclassified": len(self.unclassified()),
+            "sessions": len(self.sessions()),
+            "unreleasable": len(self.unreleasable()),
             # An empty registry MUST explain itself. Zero capabilities and
             # "the controller would not import" are different facts, and a
             # consumer that cannot tell them apart shows an operator a Mac

--- a/backend/system_control/capability_router.py
+++ b/backend/system_control/capability_router.py
@@ -110,6 +110,10 @@ class RoutedCall:
     #: without telling the model why is a turn the model will simply repeat.
     context_note: str = ""
     detail: str = ""
+    #: Set when this call OPENED a session. Surfaced rather than kept internal
+    #: because a model that started a stream and was never told it holds
+    #: something open has no reason to ever stop it.
+    lease_id: str = ""
     schema_version: str = CAPABILITY_ROUTER_SCHEMA_VERSION
 
     @property
@@ -150,10 +154,21 @@ class CapabilityRouter:
     """Registry + gate + executor, with a suspension boundary. NEVER raises."""
 
     def __init__(self, *, registry: Any = None, provider: Any = None,
-                 target: Any = None) -> None:
+                 target: Any = None, federation: Any = None,
+                 leases: Any = None) -> None:
         self._registry = registry
         self._provider = provider
         self._target = target
+        self._federation = federation
+        self._leases = leases
+        # Distinct "we already tried and could not" flags rather than parking a
+        # False in the slot itself. Overloading the value would make `None` mean
+        # both "not looked up yet" and "unavailable", and every reader would
+        # have to know which — the same conflation `Readiness.UNHYDRATED` exists
+        # to prevent one layer up.
+        self._federation_tried = federation is not None
+        self._leases_tried = leases is not None
+        self._releaser_installed = False
         self._parked: Dict[str, _Suspended] = {}
         self._stats: Dict[str, int] = {
             "executed": 0, "suspended": 0, "denied": 0, "expired": 0,
@@ -169,6 +184,73 @@ class CapabilityRouter:
             )
             self._registry = get_capability_registry()
         return self._registry
+
+    def _fed(self) -> Any:
+        """The federated vocabulary. NEVER raises.
+
+        Separate from `_reg` rather than merged behind one resolver because the
+        two answer different questions. The registry describes ONE controller
+        and needs no hydration; the federation spans subsystems whose imports
+        measured 8.4 s, and a call that silently blocked on that inside `route`
+        would stall the IPC loop the HUD reads from. Keeping them distinct is
+        what makes `get()` honestly synchronous on both.
+        """
+        if self._federation is None and not self._federation_tried:
+            self._federation_tried = True
+            try:
+                from backend.system_control.capability_federation import (
+                    get_federation,
+                )
+                self._federation = get_federation()
+            except Exception:  # noqa: BLE001 — macOS capabilities still work
+                logger.debug("[CapabilityRouter] federation unavailable",
+                             exc_info=True)
+        return self._federation
+
+    def _book(self) -> Any:
+        """The lease book, with this router installed as its releaser.
+
+        Installed HERE rather than at import: the book is constructed before any
+        router exists, and a releaser bound at import time would capture whatever
+        singleton happened to exist first — which in tests is never the one under
+        test.
+        """
+        if self._leases is None and not self._leases_tried:
+            self._leases_tried = True
+            try:
+                from backend.system_control.capability_leases import (
+                    get_lease_book,
+                )
+                self._leases = get_lease_book()
+            except Exception:  # noqa: BLE001
+                logger.debug("[CapabilityRouter] lease book unavailable",
+                             exc_info=True)
+        book = self._leases
+        if book is not None and not self._releaser_installed:
+            try:
+                book.set_releaser(self._release)
+                self._releaser_installed = True
+            except Exception:  # noqa: BLE001
+                pass
+        return book
+
+    def _lookup(self, name: str) -> Any:
+        """The CapabilityDef for a name, local or federated. NEVER raises.
+
+        A dot decides. `lock_screen` is the derived macOS vocabulary;
+        `video.start_streaming` is a federated namespace. Trying both for every
+        name would let a federated capability shadow a controller method that
+        happened to share its bare name, which is exactly the ambiguity
+        namespacing was introduced to end.
+        """
+        try:
+            if "." in (name or ""):
+                fed = self._fed()
+                return fed.get(name) if fed is not None else None
+            reg = self._reg()
+            return reg.get(name) if reg is not None else None
+        except Exception:  # noqa: BLE001
+            return None
 
     def _instance(self) -> Any:
         """The controller INSTANCE — needed to execute, unlike describing.
@@ -198,28 +280,35 @@ class CapabilityRouter:
         try:
             if not router_enabled():
                 return await self._execute(name, args)
-            reg = self._reg()
-            cap = reg.get(name) if reg is not None else None
+            cap = self._lookup(name)
             if cap is None:
                 self._stats["unknown"] += 1
                 return RoutedCall(
                     outcome=Outcome.UNKNOWN_CAPABILITY.value, capability=name,
                     context_note=f"[SYSTEM: UNKNOWN_CAPABILITY {name}]",
-                    detail="not in the derived registry")
+                    detail=self._why_unknown(name))
             if not cap.iron_gate_required:
                 return await self._execute(name, args)
 
             # GATED. Request consent and RETURN — do not await the human.
-            rid = await self._request_consent(name, args, op_id=op_id)
+            #
+            # The nonce is minted BEFORE the request, not after. The signed HUD
+            # must ECHO this exact challenge, so it has to travel WITH the
+            # question; minting it afterwards meant the prompt went out with no
+            # nonce, `SecureConsent.Challenge` failed closed on the empty field,
+            # and the request vanished without the operator ever seeing it.
+            nonce = _mint_nonce()
+            rid = await self._request_consent(name, args, op_id=op_id,
+                                              nonce=nonce)
             if not rid:
-                # No provider wired. Fail CLOSED: a gated capability with no way
-                # to ask is not permission to proceed.
+                # No provider wired, or nothing connected to ask. Fail CLOSED: a
+                # gated capability with no way to ask is not permission to
+                # proceed.
                 self._stats["denied"] += 1
                 return RoutedCall(
                     outcome=Outcome.DENIED.value, capability=name,
                     context_note=DENIED_PAYLOAD,
                     detail="no approval provider available — failing closed")
-            nonce = _mint_nonce()
             self._parked[rid] = _Suspended(rid, name, args, nonce=nonce)
             self._stats["suspended"] += 1
             logger.info("[CapabilityRouter] '%s' SUSPENDED awaiting consent "
@@ -293,14 +382,15 @@ class CapabilityRouter:
     # -- internals -------------------------------------------------------
 
     async def _request_consent(self, name: str, args: Dict[str, Any], *,
-                               op_id: str) -> str:
+                               op_id: str, nonce: str = "") -> str:
         """Ask, and return the request id. NEVER waits. NEVER raises."""
         try:
             provider = self._provider
             if provider is None:
                 return ""
             ctx = _ConsentContext(op_id=op_id or f"cap:{name}",
-                                  capability=name, args=args)
+                                  capability=name, args=args, nonce=nonce,
+                                  session=self._session_kind(name))
             rid = await provider.request(ctx)
             return str(rid or "")
         except Exception:  # noqa: BLE001
@@ -308,22 +398,102 @@ class CapabilityRouter:
                          exc_info=True)
             return ""
 
+    def _session_kind(self, name: str) -> str:
+        """"start" if approving this opens something continuous. NEVER raises."""
+        try:
+            cap = self._lookup(name)
+            return "start" if getattr(cap, "starts_session", False) else ""
+        except Exception:  # noqa: BLE001
+            return ""
+
+    def _why_unknown(self, name: str) -> str:
+        """Explain an unknown name. NEVER raises.
+
+        "Not in the derived registry" is true of a typo AND of a real capability
+        whose namespace has not finished importing — and a model told the same
+        sentence for both will abandon a tool that would have worked in another
+        second. UNHYDRATED and ABSENT are different facts, so they get different
+        words, the same distinction `Readiness` refuses to collapse.
+        """
+        try:
+            if "." not in (name or ""):
+                return "not in the derived registry"
+            fed = self._fed()
+            if fed is None:
+                return "federation unavailable; namespaced capabilities are off"
+            from backend.system_control.capability_federation import (
+                Readiness, split,
+            )
+            ns, _ = split(name)
+            if ns not in fed.namespaces():
+                return (f"no namespace '{ns}' — known: "
+                        f"{', '.join(fed.namespaces()) or 'none'}")
+            st = fed.stats().get("namespaces", {}).get(ns, {})
+            readiness = st.get("readiness")
+            if readiness == Readiness.UNHYDRATED.value:
+                return (f"namespace '{ns}' has not hydrated yet — retry, or "
+                        f"call warm() at boot")
+            if readiness == Readiness.DEGRADED.value:
+                return (f"namespace '{ns}' is DEGRADED: "
+                        f"{str(st.get('detail') or 'no detail')[:160]}")
+            return f"namespace '{ns}' is ready but exports no '{name}'"
+        except Exception:  # noqa: BLE001
+            return "not in the derived registry"
+
+    def _resolve_call(self, name: str) -> Any:
+        """(callable, capability_def) for a name. (None, def) if uncallable.
+
+        The one place a federated EXPORT name becomes a METHOD. `stop_actuator`
+        is exported under an alias and implemented as `stop`; invoking the
+        export name on the instance would raise `AttributeError` — the collision
+        fix breaking the very calls it was added to make possible.
+        """
+        cap = self._lookup(name)
+        if "." not in (name or ""):
+            return (getattr(self._instance(), name, None), cap)
+        fed = self._fed()
+        if fed is None:
+            return (None, cap)
+        target = fed.resolve_target(name)
+        if target is None:
+            return (None, cap)
+        return (getattr(target, fed.method_for(name) or "", None), cap)
+
     async def _execute(self, name: str, args: Dict[str, Any]) -> RoutedCall:
-        """Invoke the capability. NEVER raises."""
+        """Invoke the capability, and book its session if it opened one.
+
+        NEVER raises. This is the ONE seam both entry paths funnel through —
+        an ungated direct call and a post-consent `resume` — which is why the
+        lease bookkeeping lives here and not in `route`. Putting it in `route`
+        would have left every approved session unbooked, and an approved session
+        is precisely the long-running one.
+        """
         try:
             import inspect
-            fn = getattr(self._instance(), name, None)
+            fn, cap = self._resolve_call(name)
             if not callable(fn):
                 self._stats["unknown"] += 1
                 return RoutedCall(
                     outcome=Outcome.UNKNOWN_CAPABILITY.value, capability=name,
-                    context_note=f"[SYSTEM: UNKNOWN_CAPABILITY {name}]")
+                    context_note=f"[SYSTEM: UNKNOWN_CAPABILITY {name}]",
+                    detail=self._unbuildable_detail(name))
             result = fn(**args)
             if inspect.isawaitable(result):
                 result = await result
             self._stats["executed"] += 1
-            return RoutedCall(outcome=Outcome.EXECUTED.value, capability=name,
-                              result=result, context_note=str(result)[:2000])
+            out = RoutedCall(outcome=Outcome.EXECUTED.value, capability=name,
+                             result=result, context_note=str(result)[:2000])
+            self._book_session(name, args, cap, result, out)
+            return out
+        except TypeError as exc:
+            # Separated from the general case because it is almost always the
+            # model inventing an argument, and a note that says so is worth more
+            # to the next turn than a bare type name.
+            self._stats["failed"] += 1
+            return RoutedCall(
+                outcome=Outcome.FAILED.value, capability=name,
+                context_note=f"[SYSTEM: TOOL_FAILED {name}: bad arguments]",
+                detail=f"{exc} — check the tool's declared parameters")
         except Exception as exc:  # noqa: BLE001
             self._stats["failed"] += 1
             logger.debug("[CapabilityRouter] execute(%s) failed", name,
@@ -333,6 +503,88 @@ class CapabilityRouter:
                 context_note=f"[SYSTEM: TOOL_FAILED {name}: "
                              f"{type(exc).__name__}]",
                 detail=f"{type(exc).__name__}: {exc}")
+
+    def _unbuildable_detail(self, name: str) -> str:
+        """Why a KNOWN federated capability had no instance. NEVER raises."""
+        try:
+            fed = self._fed()
+            if fed is None or "." not in name:
+                return "capability is not callable on its target"
+            from backend.system_control.capability_federation import split
+            ns, _ = split(name)
+            for key, why in fed.unbuildable().items():
+                if any(s.key == key for s in fed.providers(ns)):
+                    return f"provider {key} could not be constructed: {why}"
+            return "capability is not callable on its target"
+        except Exception:  # noqa: BLE001
+            return "capability is not callable on its target"
+
+    def _book_session(self, name: str, args: Dict[str, Any], cap: Any,
+                      result: Any, out: RoutedCall) -> None:
+        """Open or discharge a lease for a call that just succeeded. NEVER raises.
+
+        A START that RETURNED FALSE opened nothing, and booking it would have
+        the reaper later call `stop_streaming` on a stream that never started —
+        harmless here, but it is the shape of bug that makes a lease book stop
+        being believed.
+        """
+        try:
+            if cap is None:
+                return
+            book = self._book()
+            if book is None:
+                return
+            from backend.system_control.capability_leases import (
+                current_principal,
+            )
+            if getattr(cap, "starts_session", False):
+                if result is False:
+                    logger.info("[CapabilityRouter] '%s' reported failure — "
+                                "no lease opened", name)
+                    return
+                lease = book.open(
+                    name, _qualify(name, cap.release),
+                    owner=current_principal(), args=dict(args or {}))
+                if lease is not None:
+                    out.lease_id = lease.lease_id
+                    out.context_note = (
+                        f"{out.context_note}\n[SYSTEM: SESSION OPEN — '{name}' "
+                        f"is now running continuously. Call "
+                        f"'{_qualify(name, cap.release)}' to stop it.]")[:2400]
+            elif getattr(cap, "ends_session", False):
+                # The release already ran; this only records it. See
+                # `LeaseBook.discharge` on why this must not call anything.
+                book.discharge(name, owner=current_principal())
+        except Exception:  # noqa: BLE001
+            logger.debug("[CapabilityRouter] session bookkeeping degraded",
+                         exc_info=True)
+
+    async def _release(self, name: str, args: Dict[str, Any]) -> bool:
+        """Stop a session on the reaper's behalf. NEVER raises.
+
+        Goes through `route`, not around it. An END is forced SAFE_AUTO at
+        classification time, so this executes without consent by the RULE rather
+        than by a bypass — and if that rule is ever violated the call SUSPENDS,
+        which is reported here as a failure the operator can see instead of a
+        silent success the book would believe.
+        """
+        try:
+            from backend.system_control.capability_leases import (
+                REAPER_PRINCIPAL, set_principal,
+            )
+            set_principal(REAPER_PRINCIPAL)
+            routed = await self.route(name, args)
+            if routed.outcome != Outcome.EXECUTED.value:
+                logger.error("[CapabilityRouter] release '%s' did not execute "
+                             "(%s: %s) — the session is still open", name,
+                             routed.outcome, routed.detail or "-")
+                return False
+            # A stop method returning None is the normal Python spelling of
+            # "done". Only an explicit False is a refusal.
+            return routed.result is not False
+        except Exception as exc:  # noqa: BLE001
+            logger.error("[CapabilityRouter] release '%s' raised: %s", name, exc)
+            return False
 
     # -- observability ---------------------------------------------------
 
@@ -344,9 +596,24 @@ class CapabilityRouter:
             return {}
 
     def stats(self) -> Dict[str, Any]:
-        return {"schema_version": CAPABILITY_ROUTER_SCHEMA_VERSION,
-                "enabled": router_enabled(), "pending": len(self._parked),
-                **self._stats}
+        out: Dict[str, Any] = {
+            "schema_version": CAPABILITY_ROUTER_SCHEMA_VERSION,
+            "enabled": router_enabled(), "pending": len(self._parked),
+            **self._stats,
+        }
+        # Folded in rather than left to a second endpoint: "what is running"
+        # and "what did the router do" are one question when the answer is a
+        # session somebody has to go and stop.
+        try:
+            book = self._leases
+            if book is not None:
+                ls = book.stats()
+                out["sessions_active"] = ls.get("active", 0)
+                out["sessions_orphaned"] = ls.get("orphaned", 0)
+                out["sessions"] = ls.get("capabilities", [])
+        except Exception:  # noqa: BLE001
+            pass
+        return out
 
 
 @dataclass
@@ -356,10 +623,41 @@ class _ConsentContext:
     op_id: str
     capability: str
     args: Dict[str, Any] = field(default_factory=dict)
+    #: The one-time challenge the verdict must echo. Carried WITH the question
+    #: because a challenge that arrives after the prompt is not a challenge.
+    nonce: str = ""
+    #: "start" when approving this opens something that keeps running.
+    session: str = ""
 
     @property
     def description(self) -> str:
-        return f"Run macOS capability '{self.capability}' with {self.args or '{}'}"
+        """What the operator is actually being asked. This becomes the text of
+        the Touch ID dialog, so it says what will happen rather than naming a
+        method — and it says out loud when a session is about to be opened,
+        because approving a continuous observer is a different decision from
+        approving one action that ends when it returns.
+        """
+        detail = f"Run '{self.capability}'"
+        if self.args:
+            detail += f" with {self.args}"
+        if self.session == "start":
+            detail += " — this will KEEP RUNNING until it is stopped"
+        return detail
+
+
+def _qualify(start_name: str, release: str) -> str:
+    """Put a release in the same namespace as the start that named it.
+
+    A tag says ``release=stop_streaming`` because that is what the author of
+    `video.start_streaming` calls it. The reaper routes by FULL name, so an
+    unqualified release would be looked up as a bare macOS capability, miss, and
+    leave the session open — a leak whose only symptom is an
+    `UNKNOWN_CAPABILITY` line in a log nobody is reading at the time.
+    """
+    if not release or "." in release:
+        return release
+    ns, _, bare = (start_name or "").partition(".")
+    return f"{ns}.{release}" if bare else release
 
 
 def _mint_nonce() -> str:

--- a/backend/vision/enhanced_multi_space_integration.py
+++ b/backend/vision/enhanced_multi_space_integration.py
@@ -25,6 +25,20 @@ logger = logging.getLogger(__name__)
 class EnhancedMultiSpaceSystem:
     """
     Enhanced multi-space system with all improvements integrated
+
+    Capability-Namespace: space
+
+    The natural-language door into multi-space intelligence, and the reason the
+    capture engine's own `capture_all_spaces` is left undeclared: a model asking
+    "what am I working on across my desktops" should hand over a SENTENCE, not
+    assemble a `SpaceCaptureRequest`. Everything underneath — native space
+    detection, reliable capture, cross-space context analysis — is reached
+    through this one string.
+
+    Both methods here are read-only in the sense that matters: they observe
+    screens and return a description. Neither holds anything open, so neither is
+    a session; the engine's `start_monitoring_session` is where that distinction
+    lives.
     """
 
     def __init__(self, vision_intelligence=None):
@@ -47,6 +61,12 @@ class EnhancedMultiSpaceSystem:
     async def analyze_desktop_spaces(self, query: str) -> Dict[str, Any]:
         """
         Main entry point for desktop space analysis with all enhancements
+
+        Capability: read-only
+
+        Args:
+            query: What to find out across the desktop spaces, in plain
+                language (e.g. "what is running on my other desktops")
         """
         start_time = datetime.now()
 
@@ -346,6 +366,17 @@ Be specific and mention actual applications, files, and content you observe."""
     async def handle_vision_command(self, command: str) -> Dict[str, Any]:
         """
         Main handler for vision commands - replaces existing handler
+
+        Capability: read-only
+
+        Routes to `analyze_desktop_spaces` when its adaptive detector is
+        confident the command is multi-space, and otherwise returns
+        `handled: False` rather than guessing. Declared alongside the method it
+        delegates to because a caller that cannot tell whether a command is
+        multi-space is exactly who should be allowed to ask.
+
+        Args:
+            command: The user's vision command, verbatim
         """
         # Check if this is a multi-space query using enhanced detection
         intent, confidence = self.adaptive_learning.detect_intent_adaptive(command)

--- a/backend/vision/multi_space_capture_engine.py
+++ b/backend/vision/multi_space_capture_engine.py
@@ -368,6 +368,21 @@ class MultiSpaceCaptureEngine:
     """
     Core engine for capturing screenshots across multiple desktop spaces
     Implements PRD requirements FR-1.1 through FR-1.6
+
+    Capability-Namespace: space
+
+    That one line is what makes this engine reachable from the HUD. It is a
+    DOCSTRING tag rather than a decorator so this module gains no import and
+    `vision` stays free of any dependency on `system_control` — the same
+    inversion `silent_actuator` uses. `capability_federation` finds it with a
+    static AST scan, so being discovered costs nothing until something calls it.
+
+    Only methods carrying their own `Capability:` tag are exported. Silence
+    means "not offered", not "gated": `capture_all_spaces` takes a
+    `SpaceCaptureRequest` and `prefetch_spaces` takes a `CaptureQuality`, and
+    offering a language model a parameter it can only fill with a hallucinated
+    object wastes a turn. The natural-language door into this subsystem is
+    `EnhancedMultiSpaceSystem.analyze_desktop_spaces`, which is tagged.
     """
 
     def __init__(self, cache_size_mb: int = 200, memory_manager=None):
@@ -455,6 +470,8 @@ class MultiSpaceCaptureEngine:
     async def check_system_health(self) -> Tuple[bool, str, Optional[Any]]:
         """
         Check system health before capture operations.
+
+        Capability: read-only
 
         Returns:
             Tuple of (is_healthy, message, state_info)
@@ -1155,6 +1172,8 @@ class MultiSpaceCaptureEngine:
         """
         Enumerate all available desktop spaces
         Implements PRD FR-1.2: Enumerate all available desktop spaces
+
+        Capability: read-only
         """
         try:
             # Use window detector to get space info
@@ -1183,6 +1202,8 @@ class MultiSpaceCaptureEngine:
         """
         Get the currently active space
         Implements PRD FR-1.3: Identify which space is currently active
+
+        Capability: read-only
         """
         try:
             from .multi_space_window_detector import MultiSpaceWindowDetector
@@ -1205,6 +1226,8 @@ class MultiSpaceCaptureEngine:
         1. Configured monitored_spaces list (if set)
         2. Memory pressure (active only if under pressure)
         3. All spaces (if no pressure and no filter)
+
+        Capability: read-only
         """
         # If specific spaces configured, use those
         if self.monitored_spaces:
@@ -1258,7 +1281,10 @@ class MultiSpaceCaptureEngine:
         return requested_quality
 
     def get_cache_stats(self) -> Dict[str, Any]:
-        """Get cache statistics"""
+        """Get cache statistics
+
+        Capability: read-only
+        """
         stats = self.cache.get_stats()
 
         # Add memory manager stats if available
@@ -1268,7 +1294,17 @@ class MultiSpaceCaptureEngine:
         return stats
 
     async def clear_cache(self, space_ids: Optional[List[int]] = None):
-        """Clear cache for specific spaces or all"""
+        """Clear cache for specific spaces or all
+
+        Capability: notify_apply
+
+        Not read-only — it discards state. Not approval-required either: the
+        worst case is a re-capture, and a tier that asks a human before dropping
+        a screenshot cache trains them to approve without reading.
+
+        Args:
+            space_ids: Spaces to clear, or omit to clear every cached space
+        """
         if space_ids:
             # Clear specific spaces
             for space_id in space_ids:
@@ -1322,7 +1358,17 @@ class MultiSpaceCaptureEngine:
             logger.info("Space monitoring session timeout, stopping")
 
     async def start_monitoring_session(self) -> bool:
-        """Start monitoring session with purple indicator"""
+        """Start monitoring session with purple indicator
+
+        Capability: session-start, release=stop_monitoring_session
+
+        The purple indicator IS the argument for the session rules. This holds
+        a Swift capture open and lights a system-level recording dot that stays
+        lit until something calls the release — so it is never SAFE_AUTO no
+        matter how read-only the capture itself is, and the lease book must know
+        it is open so the reaper can turn that dot off when whoever asked for it
+        goes away.
+        """
         if self.monitoring_active:
             logger.info("Monitoring session already active")
             return True
@@ -1355,7 +1401,13 @@ class MultiSpaceCaptureEngine:
             return True
 
     def stop_monitoring_session(self):
-        """Stop monitoring session and remove purple indicator"""
+        """Stop monitoring session and remove purple indicator
+
+        Capability: session-end
+
+        Already idempotent — it returns early when nothing is active — which is
+        what lets the reaper call it without first asking whether it needs to.
+        """
         if not self.monitoring_active:
             logger.info("No active monitoring session to stop")
             return

--- a/backend/vision/multi_space_monitor.py
+++ b/backend/vision/multi_space_monitor.py
@@ -97,6 +97,15 @@ class MultiSpaceMonitor:
     """
     Proactive monitoring system for multi-space activities
     Implements PRD Phase 3 requirements
+
+    Capability-Namespace: space
+
+    Shares the namespace with the capture engine and the enhanced system, and
+    collides with neither: `start_monitoring` here watches for ACTIVITY, while
+    the engine's `start_monitoring_session` holds a CAPTURE open. Two different
+    sessions with two different releases, distinguishable by name, which is the
+    outcome namespacing is supposed to produce rather than the near-miss it
+    would be in a flat vocabulary.
     """
     
     def __init__(self, vision_intelligence=None):
@@ -126,7 +135,16 @@ class MultiSpaceMonitor:
         self.current_space_id = 1
         
     async def start_monitoring(self, callback: Optional[Callable] = None):
-        """Start the proactive monitoring system"""
+        """Start the proactive monitoring system
+
+        Capability: session-start, release=stop_monitoring
+
+        Spawns `_monitor_loop` as a task that runs until cancelled. Without a
+        lease, nothing in the process remembers that task exists once the caller
+        that started it is gone — it would keep polling the workspace forever,
+        cheaply enough that nobody would notice and indefinitely enough that it
+        would still be running tomorrow.
+        """
         if self.monitoring_active:
             logger.warning("Monitoring already active")
             return
@@ -137,7 +155,10 @@ class MultiSpaceMonitor:
         logger.info("Multi-space monitoring started")
         
     async def stop_monitoring(self):
-        """Stop the monitoring system"""
+        """Stop the monitoring system
+
+        Capability: session-end
+        """
         self.monitoring_active = False
         if self.monitor_task:
             self.monitor_task.cancel()
@@ -493,7 +514,10 @@ class MultiSpaceMonitor:
                 
     # Public API
     async def get_activity_summary(self) -> Dict[str, Any]:
-        """Get current activity summary"""
+        """Get current activity summary
+
+        Capability: read-only
+        """
         return {
             "global_activity_level": self.global_activity_level.value,
             "active_spaces": len(self.space_activities),
@@ -518,7 +542,10 @@ class MultiSpaceMonitor:
         }
         
     async def get_space_recommendations(self) -> List[Dict[str, Any]]:
-        """Get intelligent recommendations based on monitoring"""
+        """Get intelligent recommendations based on monitoring
+
+        Capability: read-only
+        """
         recommendations = []
         
         # Check for idle spaces
@@ -553,7 +580,10 @@ class MultiSpaceMonitor:
         return recommendations
         
     def get_pattern_insights(self) -> List[WorkflowPattern]:
-        """Get detected workflow patterns"""
+        """Get detected workflow patterns
+
+        Capability: read-only
+        """
         return list(self.detected_patterns.values())
 
 

--- a/backend/vision/video_stream_capture.py
+++ b/backend/vision/video_stream_capture.py
@@ -353,7 +353,24 @@ elif not MACOS_CAPTURE_AVAILABLE:
 # else: Advanced capture is available, use its VideoFrameDelegate
 
 class VideoStreamCapture:
-    """Main video stream capture manager with memory-safe processing"""
+    """Main video stream capture manager with memory-safe processing
+
+    Capability-Namespace: video
+
+    This class is why `ProviderBindings` exists. Its constructor takes a
+    REQUIRED `vision_analyzer`, so the federation's no-arg fallback raised
+    `TypeError` and the whole video namespace described perfectly and could not
+    be built — the worst available shape, because the model is offered a tool
+    that fails on every call.
+
+    Neither obvious fix was acceptable: naming this class in the federation is
+    the hand-kept table the federation exists to delete, and defaulting the
+    parameter to None would edit a working subsystem to suit its consumer and
+    hand it a half-built object to fail on later. Instead the host binds
+    `vision_analyzer` once at boot and the federation resolves it BY PARAMETER
+    NAME — so the analyzer the HUD already built is the one this gets, rather
+    than a second one constructed in the dark.
+    """
     
     def __init__(self, vision_analyzer, config: Optional[VideoStreamConfig] = None):
         self.vision_analyzer = vision_analyzer
@@ -393,7 +410,16 @@ class VideoStreamCapture:
         logger.info(f"Video Stream Capture initialized with config: {self.config}")
     
     async def start_streaming(self) -> bool:
-        """Start video stream capture"""
+        """Start video stream capture
+
+        Capability: session-start, release=stop_streaming
+
+        THE case the whole session vocabulary was written for. This returns
+        `True` and then holds the display capture open forever, spawning a
+        capture thread and a process thread that outlive every call frame above
+        them. A registry with no word for that reads the `True` as a completed
+        action, and the stream survives the HUD that asked for it.
+        """
         logger.info("[VIDEO] start_streaming called")
         logger.info(f"[VIDEO] Current state - is_capturing: {self.is_capturing}")
 
@@ -882,7 +908,15 @@ class VideoStreamCapture:
                 logger.warning(f"Reduced capture FPS to {self.capture_impl.config.target_fps}")
     
     async def stop_streaming(self):
-        """Stop video streaming"""
+        """Stop video streaming
+
+        Capability: session-end
+
+        Returns None, which the lease book reads as success — a release is
+        judged by whether the call COMPLETED, not by what it handed back, since
+        `is_capturing = False` is a perfectly ordinary way for a stop method to
+        report that it worked.
+        """
         self.is_capturing = False
 
         # Stop advanced capture if using it (v10.6)
@@ -981,7 +1015,14 @@ class VideoStreamCapture:
             self.event_callbacks[event_type].add(callback)
     
     def get_metrics(self) -> Dict[str, Any]:
-        """Get streaming metrics"""
+        """Get streaming metrics
+
+        Capability: read-only
+
+        The honest way to ask "is the camera still on". Read-only and ungated on
+        purpose: an operator checking whether a stream is running must never be
+        the one thing that needs approval.
+        """
         recent_metrics = self.metrics[-10:] if self.metrics else []
 
         # Determine capture method

--- a/tests/system_control/test_capability_federation.py
+++ b/tests/system_control/test_capability_federation.py
@@ -1,0 +1,507 @@
+"""Many subsystems, one vocabulary — and the HUD can finally name them.
+
+`capability_registry` answered "what can this Mac do" for ONE controller. The
+same question over the whole organism had three more answers the HUD could reach
+none of: multi-space intelligence, video multi-space intelligence, and ghost
+touch. Roughly 11,000 lines of working capability whose NAMES were missing.
+
+The mandated scenario is `test_the_three_subsystems_reach_the_hud`: after
+hydration, a `space.`, a `video.` and a `touch.` capability are all nameable by
+the model AND accepted by the Iron Gate's name check — because a capability the
+gate rejects is not reachable no matter how well it was discovered.
+
+THE TESTS TO KEEP
+-------------------
+`test_a_provider_with_a_required_dependency_is_buildable`. `VideoStreamCapture`
+takes a required `vision_analyzer`, so the no-arg fallback raised `TypeError`
+and the entire video namespace described perfectly and constructed never — the
+worst available shape, since the model is offered a tool that fails every call.
+
+`test_a_name_two_providers_claim_is_refused`. Arrival order must never decide
+which subsystem a caller reached. A conflict that resolves silently is a routing
+bug that only manifests as the wrong subsystem doing the right thing.
+
+`test_an_unhydrated_namespace_is_not_an_empty_one`. UNKNOWN is not EMPTY. A
+surface that renders them the same shows an operator a Mac that apparently
+cannot see its own screens.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+from backend.system_control import capability_federation as cf
+from backend.system_control.capability_federation import (
+    CapabilityFederation,
+    ProviderSpec,
+    Readiness,
+    discover,
+    split,
+)
+from backend.system_control.capability_registry import Tier
+
+
+@pytest.fixture(autouse=True)
+def _clean():
+    cf.reset_federation()
+    cf.reset_bindings()
+    yield
+    cf.reset_federation()
+    cf.reset_bindings()
+
+
+# ---------------------------------------------------------------------------
+# Fixture providers, written to a temp tree so discovery is exercised for real.
+# ---------------------------------------------------------------------------
+
+_PROVIDER_A = '''
+class Streamer:
+    """A fake video subsystem.
+
+    Capability-Namespace: fakevideo
+    """
+
+    def __init__(self, vision_analyzer):
+        self.vision_analyzer = vision_analyzer
+        self.running = False
+
+    async def start_streaming(self) -> bool:
+        """Begin capturing.
+
+        Capability: session-start, release=stop_streaming
+        """
+        self.running = True
+        return True
+
+    async def stop_streaming(self):
+        """Stop capturing.
+
+        Capability: session-end
+        """
+        self.running = False
+
+    def get_metrics(self) -> dict:
+        """Streaming metrics.
+
+        Capability: read-only
+        """
+        return {"running": self.running}
+
+    def cleanup(self):
+        """Lifecycle plumbing that is NOT a capability."""
+'''
+
+_PROVIDER_B = '''
+class Toucher:
+    """A fake automation subsystem sharing a namespace.
+
+    Capability-Namespace: faketouch
+    """
+
+    def __init__(self):
+        self.started = False
+
+    async def start(self) -> bool:
+        """Start the toucher.
+
+        Capability: session-start, release=stop_toucher, as=start_toucher
+        """
+        self.started = True
+        return True
+
+    async def stop(self):
+        """Stop the toucher.
+
+        Capability: session-end, as=stop_toucher
+        """
+        self.started = False
+
+    def list_tasks(self) -> list:
+        """Toucher's tasks — the name Watcher also claims.
+
+        Capability: read-only
+        """
+        return []
+
+
+class Watcher:
+    """A second provider in the same namespace.
+
+    Capability-Namespace: faketouch
+    """
+
+    async def start(self) -> bool:
+        """Start watching. Exports as `start` because it declared no alias —
+        which is exactly why it does NOT collide with Toucher's aliased start.
+
+        Capability: session-start, release=stop_watcher
+        """
+        return True
+
+    async def stop_watcher(self):
+        """Stop watching.
+
+        Capability: session-end
+        """
+
+    def list_tasks(self) -> list:
+        """Watcher's tasks — UNALIASED, so it collides with Toucher's.
+
+        Capability: read-only
+        """
+        return []
+'''
+
+_PROVIDER_BROKEN = '''
+class Leaky:
+    """Declares a session it can never release.
+
+    Capability-Namespace: fakeleak
+    """
+
+    async def start_thing(self) -> bool:
+        """No release named at all.
+
+        Capability: session-start
+        """
+        return True
+
+    async def start_other(self) -> bool:
+        """Names a release that is not a session-end.
+
+        Capability: session-start, release=not_an_end
+        """
+        return True
+
+    async def not_an_end(self):
+        """Exists, but was never tagged session-end.
+
+        Capability: read-only
+        """
+'''
+
+
+@pytest.fixture
+def tree(tmp_path: Path, monkeypatch) -> Path:
+    """A real package tree with real annotated modules."""
+    pkg = tmp_path / "fakeprov"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    (pkg / "streamer.py").write_text(_PROVIDER_A)
+    (pkg / "toucher.py").write_text(_PROVIDER_B)
+    (pkg / "leaky.py").write_text(_PROVIDER_BROKEN)
+    import sys
+    sys.path.insert(0, str(tmp_path))
+    yield tmp_path
+    sys.path.remove(str(tmp_path))
+    for mod in list(sys.modules):
+        if mod.startswith("fakeprov"):
+            del sys.modules[mod]
+
+
+@pytest.fixture
+def fed(tree: Path) -> CapabilityFederation:
+    return CapabilityFederation(discover(roots=("fakeprov",), repo_root=tree))
+
+
+class TestTheMandatedScenario:
+    async def test_the_three_subsystems_reach_the_hud(self):
+        """THE scenario, against the REAL annotated classes in this repo.
+
+        Discovery, hydration, naming and the Iron Gate's name check — because a
+        capability the gate rejects is unreachable however well it was found.
+        """
+        from backend.hud.tool_definitions import (
+            ToolCall, derived_tool_names, derived_tool_schemas,
+            validate_tool_call,
+        )
+
+        federation = cf.get_federation()
+        assert {"space", "video", "touch"} <= set(federation.namespaces())
+
+        await federation.warm()
+
+        names = derived_tool_names()
+        schemas = derived_tool_schemas()
+        for want in ("space.analyze_desktop_spaces", "video.start_streaming",
+                     "touch.watch_and_react"):
+            assert want in names, f"{want} is not nameable by the model"
+            assert want in schemas, f"{want} is not in the prompt"
+            ok, why = validate_tool_call(ToolCall(name=want, args={}))
+            assert ok, f"Iron Gate blocked a real capability: {why}"
+
+        # The hand-written nine are not displaced by any of it.
+        assert "take_screenshot" in schemas
+        assert schemas["take_screenshot"]["description"].startswith("Capture")
+
+
+class TestDiscovery:
+    def test_it_finds_providers_without_importing_anything(self, tree):
+        import sys
+        specs = discover(roots=("fakeprov",), repo_root=tree)
+        assert {s.class_name for s in specs} == {"Streamer", "Toucher",
+                                                 "Watcher", "Leaky"}
+        # The whole point of a static scan: nothing ran.
+        assert not any(m.startswith("fakeprov.") for m in sys.modules)
+
+    def test_an_unannotated_class_is_not_a_provider(self, tmp_path):
+        (tmp_path / "plain").mkdir()
+        (tmp_path / "plain" / "__init__.py").write_text("")
+        (tmp_path / "plain" / "m.py").write_text(
+            'class NotAProvider:\n    """No tag here."""\n')
+        assert discover(roots=("plain",), repo_root=tmp_path) == []
+
+    def test_an_unparseable_module_does_not_stop_the_scan(self, tree):
+        (tree / "fakeprov" / "broken.py").write_text(
+            'class X:\n """Capability-Namespace: nope"""\n  def (:\n')
+        specs = discover(roots=("fakeprov",), repo_root=tree)
+        assert {s.class_name for s in specs} >= {"Streamer", "Toucher"}
+
+    def test_a_missing_root_is_skipped_not_fatal(self, tree):
+        assert discover(roots=("nope_not_here",), repo_root=tree) == []
+
+    def test_disabled_discovers_nothing(self, monkeypatch, tree):
+        monkeypatch.setenv("JARVIS_CAPABILITY_FEDERATION_ENABLED", "0")
+        assert cf.federation_enabled() is False
+        assert discover(roots=("fakeprov",), repo_root=tree) == []
+
+    def test_roots_come_from_env_not_from_this_file(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_CAPABILITY_FEDERATION_ROOTS", "a/b, c/d ")
+        assert cf.scan_roots() == ("a/b", "c/d")
+
+
+class TestNamespacingAndCollisions:
+    async def test_only_declared_methods_are_exported(self, fed):
+        await fed.ensure("fakevideo")
+        exported = {split(n)[1] for n in fed.names()}
+        assert {"start_streaming", "stop_streaming", "get_metrics"} <= exported
+        # `public and callable` over-collects on a subsystem: silence means
+        # "not offered", which makes the ratchet honest.
+        assert "cleanup" not in exported
+
+    async def test_an_alias_renames_the_export_not_the_method(self, fed):
+        await fed.ensure("faketouch")
+        assert "faketouch.start_toucher" in fed.names()
+        assert "faketouch.stop_toucher" in fed.names()
+        # The METHOD keeps the name its existing callers use.
+        assert fed.method_for("faketouch.start_toucher") == "start"
+        assert fed.method_for("faketouch.stop_toucher") == "stop"
+
+    async def test_a_name_two_providers_claim_is_refused(self, fed):
+        """Arrival order must never decide which subsystem a caller reached."""
+        await fed.ensure("faketouch")
+        conflicts = fed.conflicts()
+        assert "faketouch.list_tasks" in conflicts
+        assert len(conflicts["faketouch.list_tasks"]) == 2
+        # REFUSED, not resolved: neither provider gets the name.
+        assert "faketouch.list_tasks" not in fed.names()
+        assert fed.get("faketouch.list_tasks") is None
+
+    async def test_an_alias_is_what_prevents_the_collision(self, fed):
+        """The same two classes both define `start`; only one is aliased.
+
+        `Toucher.start` exports as `start_toucher` and `Watcher.start` exports
+        as `start`, so both survive. Their `list_tasks` — neither aliased — does
+        not. The alias is doing the work, at the declaration.
+        """
+        await fed.ensure("faketouch")
+        names = set(fed.names())
+        assert {"faketouch.start_toucher", "faketouch.start"} <= names
+        assert fed.method_for("faketouch.start_toucher") == "start"
+        assert fed.method_for("faketouch.start") == "start"
+        # ...and they resolve to DIFFERENT providers.
+        assert (type(fed.resolve_target("faketouch.start_toucher")).__name__
+                != type(fed.resolve_target("faketouch.start")).__name__)
+
+    async def test_namespaces_do_not_collide_with_each_other(self, fed):
+        await fed.warm()
+        assert "fakevideo.start_streaming" in fed.names()
+        assert "faketouch.start_toucher" in fed.names()
+
+    def test_split_handles_a_bare_name(self):
+        assert split("video.start") == ("video", "start")
+        assert split("lock_screen") == ("", "lock_screen")
+
+
+class TestSessionRules:
+    async def test_a_start_is_never_safe_auto(self, fed):
+        """Duration is itself the risk — one screenshot is not a recording."""
+        await fed.ensure("fakevideo")
+        start = fed.get("fakevideo.start_streaming")
+        assert start.starts_session is True
+        assert start.tier != Tier.SAFE_AUTO.value
+        assert fed.iron_gate_required("fakevideo.start_streaming") is True
+
+    async def test_an_end_is_always_safe_auto(self, fed):
+        """A gate on the release path is a deadlock wearing the costume of caution."""
+        await fed.ensure("fakevideo")
+        end = fed.get("fakevideo.stop_streaming")
+        assert end.ends_session is True
+        assert end.tier == Tier.SAFE_AUTO.value
+        assert fed.iron_gate_required("fakevideo.stop_streaming") is False
+
+    async def test_a_start_with_no_release_is_surfaced(self, fed):
+        await fed.ensure("fakeleak")
+        assert "fakeleak.start_thing" in fed.unreleasable()
+
+    async def test_a_release_the_reaper_cannot_call_is_surfaced(self, fed):
+        """The subtler leak: a release that exists but is gated."""
+        await fed.ensure("fakeleak")
+        broken = fed.broken_releases()
+        assert "fakeleak.start_other" in broken
+        assert "not tagged session-end" in broken["fakeleak.start_other"]
+
+    async def test_the_real_providers_have_neither_defect(self):
+        """A defect a test fails on, rather than a stream nothing can stop."""
+        federation = cf.get_federation()
+        await federation.warm()
+        assert federation.unreleasable() == []
+        assert federation.broken_releases() == {}
+        assert federation.conflicts() == {}
+        assert len(federation.sessions()) >= 5
+
+
+class TestConstruction:
+    async def test_a_provider_with_a_required_dependency_is_buildable(self, fed):
+        """The `TypeError` that made the whole video namespace dead on arrival."""
+        await fed.ensure("fakevideo")
+
+        assert fed.resolve_target("fakevideo.start_streaming") is None
+        why = fed.unbuildable()
+        assert any("vision_analyzer" in v for v in why.values())
+
+        sentinel = object()
+        cf.bind("vision_analyzer", sentinel)
+        inst = fed.resolve_target("fakevideo.start_streaming")
+
+        assert inst is not None
+        assert inst.vision_analyzer is sentinel
+        assert fed.unbuildable() == {}
+
+    async def test_an_instance_is_cached_per_provider(self, fed):
+        cf.bind("vision_analyzer", object())
+        await fed.ensure("fakevideo")
+        assert (fed.resolve_target("fakevideo.start_streaming")
+                is fed.resolve_target("fakevideo.get_metrics"))
+
+    async def test_a_defaulted_parameter_is_left_alone(self, fed):
+        """`cache_size_mb=200` means the engine chose 200, not that it is asking."""
+        cf.bind("config", "SPOOKY")
+        await fed.ensure("fakevideo")
+        cf.bind("vision_analyzer", object())
+        inst = fed.resolve_target("fakevideo.start_streaming")
+        assert inst is not None
+
+    def test_a_binding_may_be_a_factory_or_the_value_itself(self):
+        b = cf.ProviderBindings()
+        b.bind("made", lambda: "built")
+        b.bind("given", "as-is")
+
+        async def analyzer(prompt, image):    # a dependency that IS callable
+            return "x"
+
+        b.bind("analyzer", analyzer)
+        assert b.resolve("made") == (True, "built")
+        assert b.resolve("given") == (True, "as-is")
+        # An async callable is the dependency, not a factory — calling it here
+        # would fire a vision request instead of binding one.
+        assert b.resolve("analyzer") == (True, analyzer)
+
+    def test_bound_to_none_is_not_the_same_as_unbound(self):
+        b = cf.ProviderBindings()
+        b.bind("thing", None)
+        assert b.resolve("thing") == (True, None)
+        assert b.resolve("other") == (False, None)
+
+
+class TestReadiness:
+    async def test_an_unhydrated_namespace_is_not_an_empty_one(self, fed):
+        """UNKNOWN is not EMPTY."""
+        st = fed.stats()["namespaces"]["fakevideo"]
+        assert st["readiness"] == Readiness.UNHYDRATED.value
+        assert fed.get("fakevideo.start_streaming") is None
+
+        await fed.ensure("fakevideo")
+
+        st = fed.stats()["namespaces"]["fakevideo"]
+        assert st["readiness"] == Readiness.READY.value
+        assert st["capabilities"] == 3
+
+    async def test_a_namespace_that_cannot_import_is_degraded_with_a_reason(self, tree):
+        fed = CapabilityFederation([ProviderSpec(
+            namespace="ghost", module="fakeprov.does_not_exist",
+            class_name="Nope")])
+        st = await fed.ensure("ghost")
+        assert st.readiness == Readiness.DEGRADED.value
+        assert "ModuleNotFoundError" in st.detail or "Nope" in st.detail
+
+    async def test_hydration_is_idempotent(self, fed):
+        a = await fed.ensure("fakevideo")
+        b = await fed.ensure("fakevideo")
+        assert a is b
+
+    async def test_concurrent_hydration_happens_once(self, fed):
+        results = await asyncio.gather(*(fed.ensure("fakevideo")
+                                         for _ in range(8)))
+        assert all(r is results[0] for r in results)
+
+    async def test_a_wedged_import_does_not_wedge_the_federation(
+            self, monkeypatch, tree):
+        monkeypatch.setenv("JARVIS_CAPABILITY_HYDRATE_TIMEOUT_S", "1")
+        fed = CapabilityFederation([ProviderSpec(
+            namespace="slow", module="fakeprov.streamer", class_name="Streamer")])
+
+        def _hang(_ns):
+            import time
+            time.sleep(30)
+
+        monkeypatch.setattr(fed, "_hydrate_ns_blocking", _hang)
+        st = await asyncio.wait_for(fed.ensure("slow"), timeout=15)
+        assert st.readiness == Readiness.DEGRADED.value
+        assert "exceeded" in st.detail
+
+    async def test_warm_hydrates_every_namespace(self, fed):
+        result = await fed.warm()
+        assert set(result) == {"fakevideo", "faketouch", "fakeleak"}
+        assert all(v == Readiness.READY.value for v in result.values())
+
+
+class TestTheSchemaSurface:
+    async def test_schemas_carry_the_namespaced_name(self, fed):
+        await fed.ensure("fakevideo")
+        schemas = fed.tool_schemas()
+        assert schemas["fakevideo.get_metrics"]["name"] == "fakevideo.get_metrics"
+        assert "Streaming metrics" in schemas["fakevideo.get_metrics"]["description"]
+
+    async def test_an_unhydrated_namespace_contributes_nothing(self, fed):
+        assert fed.tool_schemas() == {}
+
+    async def test_stats_never_raise_and_report_the_defects(self, fed):
+        await fed.warm()
+        s = fed.stats()
+        for key in ("providers", "namespaces", "capabilities", "conflicts",
+                    "sessions", "unreleasable", "broken_releases",
+                    "unbuildable", "bindings"):
+            assert key in s
+
+
+class TestItNeverRaises:
+    def test_a_hostile_target_degrades_quietly(self, fed):
+        assert fed.get(None) is None            # type: ignore[arg-type]
+        assert fed.get("") is None
+        assert fed.iron_gate_required("nope.nope") is True
+        assert fed.resolve_target("nope.nope") is None
+        assert fed.method_for("nope.nope") == ""
+
+    def test_an_unknown_name_is_gated_not_allowed(self, fed):
+        """The inversion, at the federated layer too."""
+        assert fed.iron_gate_required("never.heard.of.it") is True
+
+    def test_the_singleton_is_process_wide_and_resettable(self):
+        a = cf.get_federation()
+        assert cf.get_federation() is a
+        cf.reset_federation()
+        assert cf.get_federation() is not a

--- a/tests/system_control/test_capability_federation_routing.py
+++ b/tests/system_control/test_capability_federation_routing.py
@@ -1,0 +1,467 @@
+"""The whole path: a HUD tool call reaches a federated subsystem and comes back.
+
+Discovery, hydration and naming are proven next door. This is the part that
+actually runs: `execute_tool` → `CapabilityRouter.route` → the right INSTANCE →
+the right METHOD → a lease that outlives the call and gets reaped.
+
+The mandated scenario is `test_a_gated_session_suspends_then_executes_and_books`:
+`video.start_streaming` is gated (a START is never SAFE_AUTO), so the turn is
+released rather than blocked on a human; the operator answers; the call executes
+against the video provider; and a lease appears that the reaper can discharge.
+
+THE TESTS TO KEEP
+-------------------
+`test_an_alias_is_invoked_by_its_method_not_its_export`. `touch.stop_actuator`
+is exported under an alias and implemented as `stop`. Calling the export name on
+the instance raises `AttributeError` — the collision fix breaking the very calls
+it was added to make possible.
+
+`test_the_reaper_release_is_qualified_into_its_namespace`. A tag says
+`release=stop_streaming` because that is what its author calls it. Routed
+unqualified, that is looked up as a bare macOS capability, misses, and leaves the
+session open — a leak whose only symptom is a line in a log nobody is reading.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, List
+
+import pytest
+
+from backend.system_control import capability_federation as cf
+from backend.system_control import capability_leases as cl
+from backend.system_control import capability_router as cr
+from backend.system_control.capability_federation import CapabilityFederation
+from backend.system_control.capability_leases import LeaseBook
+from backend.system_control.capability_router import (
+    CapabilityRouter,
+    DENIED_PAYLOAD,
+    Outcome,
+)
+
+
+# ---------------------------------------------------------------------------
+# A fake subsystem, hydrated directly rather than through the AST scan (which
+# `test_capability_federation` proves separately). This suite is about routing.
+# ---------------------------------------------------------------------------
+
+
+class FakeStreamer:
+    """A stand-in video subsystem.
+
+    Capability-Namespace: fakevid
+    """
+
+    def __init__(self, vision_analyzer):
+        self.vision_analyzer = vision_analyzer
+        self.running = False
+        self.calls: List[str] = []
+
+    async def start_streaming(self) -> bool:
+        """Begin capturing.
+
+        Capability: session-start, release=stop_streaming
+        """
+        self.calls.append("start_streaming")
+        self.running = True
+        return True
+
+    async def stop_streaming(self):
+        """Stop capturing.
+
+        Capability: session-end
+        """
+        self.calls.append("stop_streaming")
+        self.running = False
+
+    async def stop(self):
+        """A stop exported under an alias, like SilentActuator's.
+
+        Capability: session-end, as=stop_aliased
+        """
+        self.calls.append("stop")
+
+    def get_metrics(self) -> dict:
+        """Metrics.
+
+        Capability: read-only
+        """
+        self.calls.append("get_metrics")
+        return {"running": self.running}
+
+    async def analyze(self, query: str) -> str:
+        """Analyze something.
+
+        Capability: read-only
+
+        Args:
+            query: What to look for
+        """
+        return f"analyzed:{query}"
+
+    async def explodes(self) -> None:
+        """Always fails.
+
+        Capability: read-only
+        """
+        raise RuntimeError("boom")
+
+
+class _Provider:
+    """The minimal `ApprovalProvider` shape the router needs."""
+
+    def __init__(self, rid: str = "req-1") -> None:
+        self.rid = rid
+        self.requests: List[Any] = []
+
+    async def request(self, ctx: Any) -> str:
+        self.requests.append(ctx)
+        return self.rid
+
+
+def _verdict(nonce: str, approved: bool = True) -> Dict[str, Any]:
+    return {"status": "APPROVED" if approved else "DENIED", "nonce": nonce}
+
+
+@pytest.fixture(autouse=True)
+def _clean(monkeypatch):
+    monkeypatch.setenv("JARVIS_CAPABILITY_ROUTER_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_CAPABILITY_LEASES_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_CAPABILITY_LEASE_GRACE_S", "0")
+    cf.reset_federation()
+    cf.reset_bindings()
+    cl.reset_lease_book()
+    cr.reset_capability_router()
+    yield
+    cf.reset_federation()
+    cf.reset_bindings()
+    cl.reset_lease_book()
+    cr.reset_capability_router()
+
+
+@pytest.fixture
+def fed() -> CapabilityFederation:
+    """A federation hydrated with FakeStreamer, no filesystem involved."""
+    from backend.system_control.capability_federation import ProviderSpec
+
+    federation = CapabilityFederation([ProviderSpec(
+        namespace="fakevid", module=__name__, class_name="FakeStreamer")])
+    cf.bind("vision_analyzer", object())
+    return federation
+
+
+@pytest.fixture
+def book() -> LeaseBook:
+    return LeaseBook()
+
+
+@pytest.fixture
+def router(fed: CapabilityFederation, book: LeaseBook) -> CapabilityRouter:
+    return CapabilityRouter(provider=_Provider(), federation=fed, leases=book)
+
+
+async def _hydrated(fed: CapabilityFederation) -> CapabilityFederation:
+    await fed.ensure("fakevid")
+    return fed
+
+
+class TestTheMandatedScenario:
+    async def test_a_gated_session_suspends_then_executes_and_books(
+            self, router, fed, book):
+        """Gate → SUSPEND → operator answers → execute → lease exists."""
+        await _hydrated(fed)
+        cl.set_principal("hud:a")
+
+        routed = await router.route("video_is_not_this", {})
+        assert routed.outcome == Outcome.UNKNOWN_CAPABILITY.value
+
+        routed = await router.route("fakevid.start_streaming", {})
+
+        # The turn is RELEASED, not blocked on a human.
+        assert routed.outcome == Outcome.SUSPENDED.value
+        assert routed.request_id and routed.nonce
+        assert book.active() == [], "booked a session before consent"
+
+        resumed = await router.resume(routed.request_id,
+                                      _verdict(routed.nonce))
+
+        assert resumed.outcome == Outcome.EXECUTED.value
+        target = fed.resolve_target("fakevid.start_streaming")
+        assert target.running is True
+        assert target.calls == ["start_streaming"]
+
+        # THE lease: the session outlived its call, and something knows.
+        active = book.active()
+        assert len(active) == 1
+        assert active[0].capability == "fakevid.start_streaming"
+        assert active[0].release == "fakevid.stop_streaming"
+        assert active[0].owner == "hud:a"
+        assert resumed.lease_id == active[0].lease_id
+        # And the model is TOLD, or it has no reason to ever stop it.
+        assert "SESSION OPEN" in resumed.context_note
+        assert "fakevid.stop_streaming" in resumed.context_note
+
+
+class TestExecutionTargeting:
+    async def test_it_executes_against_the_federated_instance(self, router, fed):
+        await _hydrated(fed)
+        routed = await router.route("fakevid.get_metrics", {})
+        assert routed.outcome == Outcome.EXECUTED.value
+        assert routed.result == {"running": False}
+
+    async def test_an_alias_is_invoked_by_its_method_not_its_export(
+            self, router, fed):
+        """The collision fix must not break the calls it enables."""
+        await _hydrated(fed)
+        assert "fakevid.stop_aliased" in fed.names()
+        assert fed.method_for("fakevid.stop_aliased") == "stop"
+
+        routed = await router.route("fakevid.stop_aliased", {})
+
+        assert routed.outcome == Outcome.EXECUTED.value, routed.detail
+        assert fed.resolve_target("fakevid.stop_aliased").calls == ["stop"]
+
+    async def test_arguments_are_passed_through(self, router, fed):
+        await _hydrated(fed)
+        routed = await router.route("fakevid.analyze", {"query": "spaces"})
+        assert routed.result == "analyzed:spaces"
+
+    async def test_a_bad_argument_says_so_usefully(self, router, fed):
+        """A model inventing an argument deserves better than a bare type name."""
+        await _hydrated(fed)
+        routed = await router.route("fakevid.analyze", {"nope": 1})
+        assert routed.outcome == Outcome.FAILED.value
+        assert "declared parameters" in routed.detail
+
+    async def test_a_raising_capability_is_a_result_not_a_crash(self, router, fed):
+        await _hydrated(fed)
+        routed = await router.route("fakevid.explodes", {})
+        assert routed.outcome == Outcome.FAILED.value
+        assert "RuntimeError" in routed.detail
+
+    async def test_a_bare_name_still_reaches_the_macos_registry(self, book):
+        """Federating must not break the vocabulary that already worked."""
+
+        class _Ctl:
+            async def get_battery(self) -> dict:
+                """Battery.
+
+                Capability: read-only
+                """
+                return {"percent": 88}
+
+        from backend.system_control.capability_registry import CapabilityRegistry
+
+        router = CapabilityRouter(
+            registry=CapabilityRegistry(_Ctl()).hydrate(),
+            target=_Ctl(), leases=book)
+        routed = await router.route("get_battery", {})
+        assert routed.outcome == Outcome.EXECUTED.value
+        assert routed.result == {"percent": 88}
+
+
+class TestHonestUnknowns:
+    async def test_an_unhydrated_namespace_says_so(self, router, fed):
+        """UNHYDRATED and ABSENT get different words, or a model gives up early."""
+        routed = await router.route("fakevid.get_metrics", {})
+        assert routed.outcome == Outcome.UNKNOWN_CAPABILITY.value
+        assert "has not hydrated" in routed.detail
+
+    async def test_an_unknown_namespace_lists_the_known_ones(self, router, fed):
+        await _hydrated(fed)
+        routed = await router.route("nosuchns.thing", {})
+        assert "no namespace 'nosuchns'" in routed.detail
+        assert "fakevid" in routed.detail
+
+    async def test_an_unbuildable_provider_explains_itself(self, book):
+        """Described fine, constructed never — the worst available shape."""
+        from backend.system_control.capability_federation import ProviderSpec
+
+        cf.reset_bindings()      # nothing bound: no `vision_analyzer`
+        fed = CapabilityFederation([ProviderSpec(
+            namespace="fakevid", module=__name__, class_name="FakeStreamer")])
+        await fed.ensure("fakevid")
+        router = CapabilityRouter(provider=_Provider(), federation=fed,
+                                  leases=book)
+
+        routed = await router.route("fakevid.get_metrics", {})
+
+        assert routed.outcome == Outcome.UNKNOWN_CAPABILITY.value
+        assert "vision_analyzer" in routed.detail
+
+
+class TestSessionBookkeeping:
+    async def test_an_explicit_stop_discharges_without_double_calling(
+            self, router, fed, book):
+        await _hydrated(fed)
+        started = await router.resume(
+            *_consent(await router.route("fakevid.start_streaming", {})))
+        assert started.outcome == Outcome.EXECUTED.value
+        target = fed.resolve_target("fakevid.start_streaming")
+
+        stopped = await router.route("fakevid.stop_streaming", {})
+
+        assert stopped.outcome == Outcome.EXECUTED.value
+        assert book.active() == []
+        # Called exactly once — the discharge must not invoke it again.
+        assert target.calls == ["start_streaming", "stop_streaming"]
+
+    async def test_a_start_that_reports_failure_opens_no_lease(
+            self, router, fed, book, monkeypatch):
+        await _hydrated(fed)
+        target = fed.resolve_target("fakevid.start_streaming")
+
+        async def _fails() -> bool:
+            return False
+
+        monkeypatch.setattr(target, "start_streaming", _fails)
+        out = await router.resume(
+            *_consent(await router.route("fakevid.start_streaming", {})))
+
+        assert out.outcome == Outcome.EXECUTED.value
+        assert out.result is False
+        assert book.active() == [], "booked a session that never started"
+
+    async def test_a_denial_executes_nothing_and_books_nothing(
+            self, router, fed, book):
+        await _hydrated(fed)
+        routed = await router.route("fakevid.start_streaming", {})
+
+        denied = await router.resume(routed.request_id,
+                                     _verdict(routed.nonce, approved=False))
+
+        assert denied.outcome == Outcome.DENIED.value
+        assert denied.context_note == DENIED_PAYLOAD
+        assert fed.resolve_target("fakevid.start_streaming").calls == []
+        assert book.active() == []
+
+    async def test_a_read_only_capability_is_never_gated(self, router, fed, book):
+        await _hydrated(fed)
+        routed = await router.route("fakevid.get_metrics", {})
+        assert routed.outcome == Outcome.EXECUTED.value
+        assert routed.lease_id == ""
+
+
+class TestTheReaper:
+    async def test_the_reaper_release_is_qualified_into_its_namespace(
+            self, router, fed, book):
+        """An unqualified release misses, and the session stays open forever."""
+        await _hydrated(fed)
+        cl.set_principal("hud:a")
+        await router.resume(
+            *_consent(await router.route("fakevid.start_streaming", {})))
+        target = fed.resolve_target("fakevid.start_streaming")
+        assert target.running is True
+
+        book.set_releaser(router._release)
+        book.note_departure("hud:a")
+        await book.sweep()
+
+        # The whole point: the reaper actually reached the provider.
+        assert target.running is False
+        assert target.calls == ["start_streaming", "stop_streaming"]
+        assert book.active() == []
+        assert book.orphans() == []
+
+    async def test_an_expired_session_is_reaped_through_the_same_gate(
+            self, router, fed, book):
+        """An END is SAFE_AUTO by RULE, so the reaper needs no bypass."""
+        await _hydrated(fed)
+        routed = await router.route("fakevid.start_streaming", {})
+        out = await router.resume(routed.request_id, _verdict(routed.nonce))
+        book.set_releaser(router._release)
+
+        lease = book.active()[0]
+        lease.opened_at -= lease.ttl_s + 1
+        await book.sweep()
+
+        assert fed.resolve_target("fakevid.start_streaming").running is False
+        assert book.active() == []
+
+    async def test_shutdown_releases_what_is_still_open(self, router, fed, book):
+        await _hydrated(fed)
+        await router.resume(
+            *_consent(await router.route("fakevid.start_streaming", {})))
+        book.set_releaser(router._release)
+
+        n = await book.release_all()
+
+        assert n == 1
+        assert fed.resolve_target("fakevid.start_streaming").running is False
+
+
+class TestTheDisabledPaths:
+    async def test_router_off_executes_without_gating(self, monkeypatch,
+                                                      router, fed):
+        monkeypatch.setenv("JARVIS_CAPABILITY_ROUTER_ENABLED", "0")
+        await _hydrated(fed)
+        routed = await router.route("fakevid.start_streaming", {})
+        assert routed.outcome == Outcome.EXECUTED.value
+
+    async def test_leases_off_still_gates_and_still_executes(
+            self, monkeypatch, router, fed, book):
+        """Off means no bookkeeping — never a crash, and never an open gate."""
+        monkeypatch.setenv("JARVIS_CAPABILITY_LEASES_ENABLED", "0")
+        await _hydrated(fed)
+        routed = await router.route("fakevid.start_streaming", {})
+        assert routed.outcome == Outcome.SUSPENDED.value
+        out = await router.resume(routed.request_id, _verdict(routed.nonce))
+        assert out.outcome == Outcome.EXECUTED.value
+        assert book.active() == []
+
+
+class TestTheHudSeam:
+    async def test_execute_tool_reaches_a_federated_capability(self, fed,
+                                                               monkeypatch, book):
+        """`execute_tool`'s else-branch is the seam this all hangs from."""
+        from backend.hud.tool_definitions import ToolCall, execute_tool
+
+        await _hydrated(fed)
+        router = CapabilityRouter(provider=_Provider(), federation=fed,
+                                  leases=book)
+        monkeypatch.setattr(cr, "_ROUTER", router)
+
+        result = await execute_tool(ToolCall(
+            name="fakevid.analyze", args={"query": "desktops"}, call_id="c1"))
+
+        assert result.success is True
+        assert "analyzed:desktops" in result.output
+
+    async def test_a_suspended_call_is_not_reported_as_an_error(
+            self, fed, monkeypatch, book):
+        """A SUSPENDED call must end the turn cleanly, not look like a failure
+        the model should retry with a reworded name."""
+        from backend.hud.tool_definitions import ToolCall, execute_tool
+
+        await _hydrated(fed)
+        monkeypatch.setattr(cr, "_ROUTER", CapabilityRouter(
+            provider=_Provider(), federation=fed, leases=book))
+
+        result = await execute_tool(ToolCall(
+            name="fakevid.start_streaming", args={}, call_id="c2"))
+
+        assert result.success is False
+        assert "Awaiting operator consent" in result.output
+
+    async def test_the_open_session_note_names_the_stop(self, router, fed, book,
+                                                        monkeypatch):
+        """Four turns later the prompt must still say the camera is on."""
+        from backend.hud import tool_definitions as td
+
+        await _hydrated(fed)
+        monkeypatch.setattr(cl, "_BOOK", book)
+        assert td.open_sessions_note() == ""
+
+        await router.resume(
+            *_consent(await router.route("fakevid.start_streaming", {})))
+
+        note = td.open_sessions_note()
+        assert "fakevid.start_streaming" in note
+        assert "fakevid.stop_streaming" in note
+
+
+def _consent(routed: Any) -> tuple:
+    """(request_id, verdict) for a SUSPENDED call. Fails loudly if it was not."""
+    assert routed.outcome == Outcome.SUSPENDED.value, (
+        f"expected a gated call, got {routed.outcome}: {routed.detail}")
+    return (routed.request_id, _verdict(routed.nonce))

--- a/tests/system_control/test_capability_leases.py
+++ b/tests/system_control/test_capability_leases.py
@@ -1,0 +1,379 @@
+"""What holds a session open, and what closes it when nobody is left.
+
+`video.start_streaming` returns True and then holds the display capture open
+forever. The HUD that asked for it can quit, crash, or be rebuilt; the green
+recording dot stays lit. The mandated scenario is
+`test_the_last_holder_releases_and_the_others_do_not`: two principals hold one
+stream, one leaves, the stream KEEPS RUNNING, the second leaves, the stream
+stops — exactly once.
+
+THE TESTS TO KEEP
+-------------------
+`test_a_failed_release_orphans_rather_than_forgets`. Deleting the record on a
+failed release would make the book report zero open sessions while the camera
+light stays on — the leak PLUS a lie. An orphan is the only honest output when a
+release does not work, and the number an operator can act on is the whole value
+of keeping a book.
+
+`test_a_reconnect_within_grace_never_interrupts`. Reaping the instant a socket
+drops makes every HUD rebuild kill a stream the operator wanted. A one-second
+blip and a quit are indistinguishable at the socket; only time tells them apart.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, List, Tuple
+
+import pytest
+
+from backend.system_control import capability_leases as cl
+from backend.system_control.capability_leases import (
+    LeaseBook,
+    LeaseState,
+    ReapReason,
+)
+
+
+class _Releases:
+    """Records every release call, and can be told to fail."""
+
+    def __init__(self, fail: bool = False, hang: bool = False) -> None:
+        self.calls: List[Tuple[str, Dict[str, Any]]] = []
+        self.fail = fail
+        self.hang = hang
+
+    async def __call__(self, name: str, args: Dict[str, Any]) -> bool:
+        self.calls.append((name, dict(args or {})))
+        if self.hang:
+            await asyncio.sleep(3600)
+        return not self.fail
+
+    @property
+    def names(self) -> List[str]:
+        return [n for n, _ in self.calls]
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    """Deterministic knobs. Every test sets what it depends on, explicitly."""
+    monkeypatch.setenv("JARVIS_CAPABILITY_LEASES_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_CAPABILITY_LEASE_TTL_S", "1800")
+    monkeypatch.setenv("JARVIS_CAPABILITY_LEASE_GRACE_S", "20")
+    monkeypatch.setenv("JARVIS_CAPABILITY_RELEASE_ATTEMPTS", "3")
+    cl.reset_lease_book()
+    yield
+    cl.reset_lease_book()
+
+
+@pytest.fixture
+def rel() -> _Releases:
+    return _Releases()
+
+
+@pytest.fixture
+def book(rel: _Releases) -> LeaseBook:
+    return LeaseBook(releaser=rel)
+
+
+class TestTheMandatedScenario:
+    async def test_the_last_holder_releases_and_the_others_do_not(self, book, rel):
+        """Two holders, one stream. It stops when the SECOND one leaves."""
+        a = book.open("video.start_streaming", "video.stop_streaming", owner="hud:a")
+        b = book.open("video.start_streaming", "video.stop_streaming", owner="hud:b")
+        assert a is not None and b is not None
+        assert book.holders("video.start_streaming") == 2
+
+        await book.close(a.lease_id)
+        # THE assertion: A left, and the stream B is using is still running.
+        assert rel.names == [], "released a stream another principal still holds"
+        assert book.holders("video.start_streaming") == 1
+
+        await book.close(b.lease_id)
+        assert rel.names == ["video.stop_streaming"]
+        # Released exactly once — not once per holder.
+        assert len(rel.calls) == 1
+        assert book.holders("video.start_streaming") == 0
+        assert book.active() == []
+
+
+class TestHonestyAboutFailure:
+    async def test_a_failed_release_orphans_rather_than_forgets(self, monkeypatch):
+        """A release that does not work leaves a NAMED orphan, not a clean book."""
+        monkeypatch.setenv("JARVIS_CAPABILITY_RELEASE_ATTEMPTS", "1")
+        rel = _Releases(fail=True)
+        book = LeaseBook(releaser=rel)
+        lease = book.open("video.start_streaming", "video.stop_streaming")
+
+        ok = await book.close(lease.lease_id)
+
+        assert ok is False
+        assert lease.state == LeaseState.ORPHANED.value
+        # The book must not claim nothing is running.
+        stats = book.stats()
+        assert stats["orphaned"] == 1
+        assert "video.start_streaming" in stats["orphaned_capabilities"]
+
+    async def test_it_retries_before_giving_up(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_CAPABILITY_RELEASE_ATTEMPTS", "3")
+        rel = _Releases(fail=True)
+        book = LeaseBook(releaser=rel)
+        lease = book.open("video.start_streaming", "video.stop_streaming")
+
+        await book.close(lease.lease_id)
+        # Back to OPEN so a sweep tries again — staying RELEASING would hold a
+        # refcount nobody would ever clear.
+        assert lease.state == LeaseState.OPEN.value
+        assert book.holders("video.start_streaming") == 1
+
+        await book.close(lease.lease_id)
+        await book.close(lease.lease_id)
+        assert lease.state == LeaseState.ORPHANED.value
+        assert len(rel.calls) == 3
+
+    async def test_a_hanging_release_is_bounded(self, monkeypatch):
+        """The release is the call most likely to hang — it must not wedge the sweep."""
+        monkeypatch.setenv("JARVIS_CAPABILITY_RELEASE_TIMEOUT_S", "1")
+        monkeypatch.setenv("JARVIS_CAPABILITY_RELEASE_ATTEMPTS", "1")
+        book = LeaseBook(releaser=_Releases(hang=True))
+        lease = book.open("video.start_streaming", "video.stop_streaming")
+
+        await asyncio.wait_for(book.close(lease.lease_id), timeout=10)
+
+        assert lease.state == LeaseState.ORPHANED.value
+        assert "exceeded" in lease.detail
+
+    async def test_no_releaser_is_reported_not_assumed(self):
+        book = LeaseBook(releaser=None)
+        lease = book.open("video.start_streaming", "video.stop_streaming")
+        for _ in range(3):
+            await book.close(lease.lease_id)
+        assert lease.state == LeaseState.ORPHANED.value
+        assert "no releaser" in lease.detail
+
+    def test_a_start_with_no_release_is_refused(self, book):
+        """It cannot be reaped, so recording it would promise what cannot be kept."""
+        assert book.open("video.start_streaming", "") is None
+        assert book.active() == []
+
+
+class TestDeparture:
+    async def test_a_disconnect_does_not_reap_immediately(self, book, rel):
+        book.open("video.start_streaming", "video.stop_streaming", owner="hud:a")
+        book.note_departure("hud:a")
+        await book.sweep()
+        assert rel.names == [], "reaped inside the grace window"
+        assert book.holders("video.start_streaming") == 1
+
+    async def test_a_reconnect_within_grace_never_interrupts(self, book, rel):
+        """A HUD rebuild must not kill the stream the operator asked for."""
+        book.open("video.start_streaming", "video.stop_streaming", owner="hud:a")
+        book.note_departure("hud:a")
+        book.note_arrival("hud:a")
+
+        await book.sweep()
+        await book.sweep()
+
+        assert rel.names == []
+        assert book.holders("video.start_streaming") == 1
+        assert book.stats()["departing"] == []
+
+    async def test_an_elapsed_grace_reaps(self, monkeypatch, rel):
+        monkeypatch.setenv("JARVIS_CAPABILITY_LEASE_GRACE_S", "0")
+        book = LeaseBook(releaser=rel)
+        book.open("video.start_streaming", "video.stop_streaming", owner="hud:a")
+        book.note_departure("hud:a")
+
+        await book.sweep()
+
+        assert rel.names == ["video.stop_streaming"]
+        assert book.stats()["reaped_owner"] == 1
+
+    async def test_one_principal_leaving_leaves_anothers_session_alone(
+            self, monkeypatch, rel):
+        monkeypatch.setenv("JARVIS_CAPABILITY_LEASE_GRACE_S", "0")
+        book = LeaseBook(releaser=rel)
+        book.open("video.start_streaming", "video.stop_streaming", owner="hud:a")
+        book.open("space.start_monitoring", "space.stop_monitoring", owner="hud:b")
+        book.note_departure("hud:a")
+
+        await book.sweep()
+
+        assert rel.names == ["video.stop_streaming"]
+        assert book.holders("space.start_monitoring") == 1
+
+    async def test_opening_a_lease_marks_the_owner_present(self, book, rel):
+        """A principal that is opening sessions is, definitionally, not gone."""
+        book.note_departure("hud:a")
+        book.open("video.start_streaming", "video.stop_streaming", owner="hud:a")
+        assert book.stats()["departing"] == []
+
+
+class TestExpiry:
+    async def test_an_expired_lease_is_reaped(self, monkeypatch, rel):
+        monkeypatch.setenv("JARVIS_CAPABILITY_LEASE_TTL_S", "30")
+        book = LeaseBook(releaser=rel)
+        lease = book.open("video.start_streaming", "video.stop_streaming")
+        # Reach into monotonic age rather than sleeping: the reaper reads a
+        # clock and nothing else, which is exactly what makes it testable.
+        lease.opened_at -= 31
+
+        await book.sweep()
+
+        assert rel.names == ["video.stop_streaming"]
+        assert book.stats()["reaped_expired"] == 1
+
+    async def test_a_ttl_of_zero_never_expires(self, rel):
+        book = LeaseBook(releaser=rel)
+        lease = book.open("video.start_streaming", "video.stop_streaming",
+                          ttl_s=0)
+        lease.opened_at -= 10 ** 6
+        await book.sweep()
+        assert rel.names == []
+
+
+class TestDischarge:
+    def test_an_explicit_stop_records_without_re_calling(self, book, rel):
+        """The release already ran. Calling it again is the bug this prevents."""
+        book.open("video.start_streaming", "video.stop_streaming", owner="hud:a")
+
+        n = book.discharge("video.stop_streaming", owner="hud:a")
+
+        assert n == 1
+        assert rel.names == [], "discharge must not invoke the releaser"
+        assert book.holders("video.start_streaming") == 0
+
+    def test_it_closes_every_holder_because_the_provider_is_shared(self, book):
+        """One principal stopping a singleton stops it for everyone. Say so."""
+        book.open("video.start_streaming", "video.stop_streaming", owner="hud:a")
+        book.open("video.start_streaming", "video.stop_streaming", owner="hud:b")
+
+        assert book.discharge("video.stop_streaming", owner="hud:a") == 2
+        assert book.holders("video.start_streaming") == 0
+
+    async def test_it_skips_a_lease_the_reaper_is_mid_release_on(self, book):
+        """The re-entrancy that would deadlock on a non-reentrant per-cap lock."""
+        lease = book.open("video.start_streaming", "video.stop_streaming")
+        lease.state = LeaseState.RELEASING.value
+
+        assert book.discharge("video.stop_streaming") == 0
+        assert lease.state == LeaseState.RELEASING.value
+
+    def test_discharging_an_unheld_release_is_a_no_op(self, book):
+        assert book.discharge("video.stop_streaming") == 0
+        assert book.discharge("") == 0
+
+
+class TestReentrancy:
+    async def test_a_releaser_that_discharges_does_not_deadlock(self):
+        """The REAL shape: reaper -> release -> router -> discharge, same lock.
+
+        The router's `_execute` discharges on any `session-end` call, and the
+        reaper's release IS such a call. Without `discharge` skipping RELEASING
+        leases this re-enters `_close_lease` and hangs on the capability lock.
+        """
+        book = LeaseBook()
+
+        async def releaser(name: str, args: Dict[str, Any]) -> bool:
+            book.discharge(name)          # what the router does on the way back
+            return True
+
+        book.set_releaser(releaser)
+        lease = book.open("video.start_streaming", "video.stop_streaming")
+
+        await asyncio.wait_for(book.close(lease.lease_id), timeout=5)
+
+        assert lease.state == LeaseState.CLOSED.value
+        assert book.active() == []
+
+
+class TestIdempotenceAndShutdown:
+    async def test_closing_twice_is_a_no_op_that_reports_success(self, book, rel):
+        lease = book.open("video.start_streaming", "video.stop_streaming")
+        assert await book.close(lease.lease_id) is True
+        assert await book.close(lease.lease_id) is True
+        assert len(rel.calls) == 1
+
+    async def test_closing_an_unknown_lease_reports_success(self, book):
+        assert await book.close("nope") is True
+
+    async def test_release_all_closes_everything(self, book, rel):
+        book.open("video.start_streaming", "video.stop_streaming", owner="a")
+        book.open("space.start_monitoring", "space.stop_monitoring", owner="b")
+
+        n = await book.release_all()
+
+        assert n == 2
+        assert sorted(rel.names) == ["space.stop_monitoring", "video.stop_streaming"]
+        assert book.active() == []
+
+    async def test_release_all_leaves_named_orphans_when_it_cannot(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_CAPABILITY_RELEASE_ATTEMPTS", "1")
+        book = LeaseBook(releaser=_Releases(fail=True))
+        book.open("video.start_streaming", "video.stop_streaming")
+
+        await book.release_all()
+
+        assert book.stats()["orphaned_capabilities"] == ["video.start_streaming"]
+
+
+class TestTheDisabledPath:
+    def test_off_means_no_bookkeeping_not_a_crash(self, monkeypatch, book):
+        monkeypatch.setenv("JARVIS_CAPABILITY_LEASES_ENABLED", "0")
+        assert cl.leases_enabled() is False
+        assert book.open("video.start_streaming", "video.stop_streaming") is None
+        assert book.active() == []
+
+
+class TestTheReaperIsIsolated:
+    def test_it_reads_only_a_clock_and_the_book(self):
+        """The Watchdog Isolation Invariant, enforced on the source.
+
+        A reaper that consults the health of what it guards deadlocks WITH it
+        when that thing wedges — which is the state a leaked session is usually
+        in. `sweep` must therefore never reach for an orchestrator, a phase, or
+        any liveness signal.
+        """
+        import ast
+        import inspect
+
+        src = inspect.getsource(LeaseBook.sweep)
+        tree = ast.parse(src.strip())
+        called = {
+            n.func.attr for n in ast.walk(tree)
+            if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+        }
+        forbidden = {"get_orchestrator", "get_governed_loop", "phase",
+                     "is_healthy", "health", "get_status", "peek_blast"}
+        assert not (called & forbidden), f"sweep consults its subject: {called}"
+        # Time is read monotonically — wall-clock would let an NTP step reap a
+        # session that is thirty seconds old.
+        assert "monotonic" in src and "time.time()" not in src
+
+
+class TestTheSingleton:
+    def test_it_is_process_wide_and_resettable(self):
+        cl.reset_lease_book()
+        a = cl.get_lease_book()
+        assert cl.get_lease_book() is a
+        cl.reset_lease_book()
+        assert cl.get_lease_book() is not a
+
+
+class TestThePrincipal:
+    def test_it_defaults_to_unowned_rather_than_guessing(self):
+        assert cl.current_principal() == ""
+
+    async def test_it_is_isolated_per_task(self):
+        """Two clients' sessions must never be attributed to each other."""
+        seen: Dict[str, str] = {}
+
+        async def act(name: str) -> None:
+            cl.set_principal(name)
+            await asyncio.sleep(0)
+            seen[name] = cl.current_principal()
+
+        await asyncio.gather(act("hud:a"), act("hud:b"))
+
+        assert seen == {"hud:a": "hud:a", "hud:b": "hud:b"}
+        # And the caller's own context is untouched by either task.
+        assert cl.current_principal() == ""

--- a/tests/system_control/test_hud_consent_circuit.py
+++ b/tests/system_control/test_hud_consent_circuit.py
@@ -1,0 +1,442 @@
+"""The consent circuit, driven end to end over a real socket.
+
+`SecureConsent.swift` was complete. `main.py`'s `consent_verdict` branch was
+complete. Between them: nothing. The IPC socket was read-only for its whole
+life, `CapabilityRouter._provider` was None, and every gated capability resolved
+to "no approval provider available — failing closed". A gate that always refuses
+is indistinguishable from a gate that works until somebody needs what is behind
+it — and what was behind it was `lock_screen`, `video.start_streaming` and every
+other capability the federation had just made nameable.
+
+The mandated scenario is `test_the_operator_is_asked_and_the_answer_executes`: a
+real `asyncio` server, a real client socket, a gated call that pushes a
+challenge, a verdict echoed back, and the capability running. If this passes,
+the circuit is closed.
+
+THE TESTS TO KEEP
+-------------------
+`test_the_challenge_carries_the_nonce`. The nonce used to be minted AFTER the
+request, so the prompt went out with an empty one, `SecureConsent.Challenge`
+failed closed on it, and the request vanished without the operator ever seeing
+it. A perfectly secure gate that nobody could answer.
+
+`test_no_hud_connected_denies_rather_than_parks`. Zero clients means the
+question was never asked. Parking the call anyway makes an unasked question look
+exactly like a human who is still thinking about it, for the whole TTL.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from backend.hud import consent_bridge as cb
+from backend.hud import ipc_server as ipc
+from backend.system_control import capability_leases as cl
+from backend.system_control import capability_router as cr
+from backend.system_control.capability_registry import CapabilityRegistry
+from backend.system_control.capability_router import CapabilityRouter, Outcome
+
+
+def _can_bind() -> bool:
+    """Whether this environment lets a test open a loopback socket.
+
+    Some sandboxes refuse every `bind()`. Skipping is honest — the alternative
+    is a wall of PermissionErrors that look like the code is broken when the
+    only thing that failed was permission to open a socket at all.
+    """
+    import socket
+    s = socket.socket()
+    try:
+        s.bind(("127.0.0.1", 0))
+        return True
+    except OSError:
+        return False
+    finally:
+        s.close()
+
+
+pytestmark = pytest.mark.skipif(
+    not _can_bind(),
+    reason="sandbox forbids binding a loopback socket; this suite drives a real one")
+
+
+class _Controller:
+    """Two capabilities: one gated, one not."""
+
+    def __init__(self) -> None:
+        self.locked = False
+        self.streaming = False
+
+    async def lock_screen(self) -> bool:
+        """Lock the screen.
+
+        Capability: approval_required
+        """
+        self.locked = True
+        return True
+
+    async def get_battery(self) -> dict:
+        """Battery level.
+
+        Capability: read-only
+        """
+        return {"percent": 91}
+
+    async def start_stream(self) -> bool:
+        """Start a stream.
+
+        Capability: session-start, release=stop_stream
+        """
+        self.streaming = True
+        return True
+
+    async def stop_stream(self):
+        """Stop a stream.
+
+        Capability: session-end
+        """
+        self.streaming = False
+
+
+@pytest.fixture(autouse=True)
+def _clean(monkeypatch):
+    monkeypatch.setenv("JARVIS_HUD_CONSENT_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_CAPABILITY_ROUTER_ENABLED", "true")
+    ipc._CLIENTS.clear()
+    ipc._SERVER_LOOP = None
+    cl.reset_lease_book()
+    cr.reset_capability_router()
+    yield
+    ipc._CLIENTS.clear()
+    ipc._SERVER_LOOP = None
+    cl.reset_lease_book()
+    cr.reset_capability_router()
+
+
+class _Wire:
+    """A real client on the other end of a real IPC server."""
+
+    def __init__(self) -> None:
+        self.server: Optional[asyncio.AbstractServer] = None
+        self.reader: Optional[asyncio.StreamReader] = None
+        self.writer: Optional[asyncio.StreamWriter] = None
+        self.received: List[Dict[str, Any]] = []
+
+    async def start(self, port: int = 0, dispatch=None) -> "_Wire":
+        async def _noop(event_type: str, data: dict) -> None:
+            return None
+
+        self.server = await ipc.start_ipc_server(
+            dispatch=dispatch or _noop, shutdown=asyncio.Event(), port=port)
+        host, self.port = self.server.sockets[0].getsockname()[:2]
+        self.reader, self.writer = await asyncio.open_connection(host, self.port)
+        # The server registers the writer in its accept handler; give the loop a
+        # turn so `connected_clients()` is true before anything publishes.
+        for _ in range(50):
+            if ipc.connected_clients():
+                break
+            await asyncio.sleep(0.01)
+        return self
+
+    async def next_event(self, timeout: float = 5.0) -> Dict[str, Any]:
+        line = await asyncio.wait_for(self.reader.readline(), timeout=timeout)
+        msg = json.loads(line.decode())
+        self.received.append(msg)
+        return msg
+
+    async def send(self, event_type: str, data: Dict[str, Any]) -> None:
+        self.writer.write(
+            (json.dumps({"event_type": event_type, "data": data}) + "\n").encode())
+        await self.writer.drain()
+
+    async def close(self) -> None:
+        if self.writer is not None:
+            self.writer.close()
+            try:
+                await self.writer.wait_closed()
+            except Exception:
+                pass
+        if self.server is not None:
+            self.server.close()
+            await self.server.wait_closed()
+
+
+@pytest.fixture
+async def wire():
+    w = _Wire()
+    try:
+        yield w
+    finally:
+        await w.close()
+
+
+def _router(ctl: _Controller) -> CapabilityRouter:
+    return CapabilityRouter(registry=CapabilityRegistry(ctl).hydrate(),
+                            target=ctl, provider=cb.HUDConsentProvider())
+
+
+class TestTheMandatedScenario:
+    async def test_the_operator_is_asked_and_the_answer_executes(self, wire):
+        """Gate → challenge on the wire → verdict → the capability runs."""
+        await wire.start()
+        ctl = _Controller()
+        router = _router(ctl)
+
+        routed = await router.route("lock_screen", {})
+
+        # 1. The turn was RELEASED, not blocked on a human.
+        assert routed.outcome == Outcome.SUSPENDED.value
+        assert ctl.locked is False
+
+        # 2. The question actually reached the HUD.
+        event = await wire.next_event()
+        assert event["event_type"] == cb.CONSENT_REQUEST_EVENT
+        challenge = event["data"]
+        assert challenge["capability"] == "lock_screen"
+        assert challenge["request_id"] == routed.request_id
+
+        # 3. The HUD echoes the challenge, exactly as SecureConsent.respond does.
+        resumed = await router.resume(challenge["request_id"], {
+            "request_id": challenge["request_id"],
+            "nonce": challenge["nonce"],
+            "approved": True,
+            "status": "APPROVED",
+            "capability": challenge["capability"],
+        })
+
+        assert resumed.outcome == Outcome.EXECUTED.value, resumed.detail
+        assert ctl.locked is True
+
+
+class TestTheChallenge:
+    async def test_the_challenge_carries_the_nonce(self, wire):
+        """Minted BEFORE the ask, or the prompt fails closed on the Swift side."""
+        await wire.start()
+        router = _router(_Controller())
+
+        routed = await router.route("lock_screen", {})
+        challenge = (await wire.next_event())["data"]
+
+        assert challenge["nonce"], "challenge went out with no nonce"
+        assert challenge["nonce"] == routed.nonce
+
+    async def test_it_says_when_approving_opens_a_session(self, wire):
+        """Approving a continuous observer is a different decision. Say so."""
+        await wire.start()
+        router = _router(_Controller())
+
+        await router.route("start_stream", {})
+        challenge = (await wire.next_event())["data"]
+
+        assert challenge["session"] == "start"
+        assert "KEEP RUNNING" in challenge["detail"]
+
+    async def test_the_detail_names_the_arguments(self, wire):
+        await wire.start()
+        router = _router(_Controller())
+        await router.route("lock_screen", {"force": True})
+        challenge = (await wire.next_event())["data"]
+        assert "force" in challenge["detail"]
+
+    async def test_a_provider_refuses_to_ask_without_a_nonce(self):
+        """An unbindable verdict is replayable — better to deny than to ask."""
+        sent: List[Any] = []
+        provider = cb.HUDConsentProvider(
+            publish=lambda e, d: (sent.append((e, d)), 1)[1])
+
+        class _Ctx:
+            op_id, capability, args, nonce, session = "x", "cap", {}, "", ""
+            description = "d"
+
+        assert await provider.request(_Ctx()) == ""
+        assert sent == []
+
+
+class TestFailingClosed:
+    async def test_no_hud_connected_denies_rather_than_parks(self, wire):
+        """An unasked question is not a pending one."""
+        await wire.start()
+        await wire.close()
+        for _ in range(50):
+            if not ipc.connected_clients():
+                break
+            await asyncio.sleep(0.01)
+        router = _router(_Controller())
+
+        routed = await router.route("lock_screen", {})
+
+        assert routed.outcome == Outcome.DENIED.value
+        assert routed.request_id == ""
+        assert router.pending() == {}
+
+    async def test_a_rejection_does_not_execute(self, wire):
+        await wire.start()
+        ctl = _Controller()
+        router = _router(ctl)
+        await router.route("lock_screen", {})
+        challenge = (await wire.next_event())["data"]
+
+        out = await router.resume(challenge["request_id"], {
+            "nonce": challenge["nonce"], "approved": False,
+            "status": "REJECTED"})
+
+        assert out.outcome == Outcome.DENIED.value
+        assert ctl.locked is False
+
+    async def test_a_replayed_verdict_without_the_nonce_is_denied(self, wire):
+        """Anything that can write to the socket must not be able to approve."""
+        await wire.start()
+        ctl = _Controller()
+        router = _router(ctl)
+        await router.route("lock_screen", {})
+        challenge = (await wire.next_event())["data"]
+
+        out = await router.resume(challenge["request_id"],
+                                  {"approved": True, "status": "APPROVED"})
+
+        assert out.outcome == Outcome.DENIED.value
+        assert "nonce" in out.detail
+        assert ctl.locked is False
+
+    async def test_a_wrong_nonce_is_denied(self, wire):
+        await wire.start()
+        ctl = _Controller()
+        router = _router(ctl)
+        await router.route("lock_screen", {})
+        challenge = (await wire.next_event())["data"]
+
+        out = await router.resume(challenge["request_id"], {
+            "nonce": "not-the-one", "status": "APPROVED"})
+
+        assert out.outcome == Outcome.DENIED.value
+        assert ctl.locked is False
+
+    async def test_an_ungated_capability_never_asks(self, wire):
+        await wire.start()
+        router = _router(_Controller())
+
+        routed = await router.route("get_battery", {})
+
+        assert routed.outcome == Outcome.EXECUTED.value
+        with pytest.raises(asyncio.TimeoutError):
+            await wire.next_event(timeout=0.3)
+
+    async def test_disabled_means_deny_never_allow(self, monkeypatch, wire):
+        """There is deliberately no setting that ungates a gated capability."""
+        await wire.start()
+        monkeypatch.setenv("JARVIS_HUD_CONSENT_ENABLED", "0")
+        ctl = _Controller()
+
+        routed = await _router(ctl).route("lock_screen", {})
+
+        assert routed.outcome == Outcome.DENIED.value
+        assert ctl.locked is False
+
+
+class TestThePublishPath:
+    async def test_it_reaches_every_connected_hud(self, wire):
+        await wire.start()
+        host, port = "127.0.0.1", wire.port
+        r2, w2 = await asyncio.open_connection(host, port)
+        for _ in range(50):
+            if ipc.connected_clients() >= 2:
+                break
+            await asyncio.sleep(0.01)
+
+        reached = ipc.publish("ping", {"n": 1})
+
+        assert reached == 2
+        assert (await wire.next_event())["event_type"] == "ping"
+        line = await asyncio.wait_for(r2.readline(), timeout=5)
+        assert json.loads(line.decode())["event_type"] == "ping"
+        w2.close()
+        await w2.wait_closed()
+
+    async def test_publishing_with_nobody_listening_reports_zero(self):
+        assert ipc.publish("ping", {}) == 0
+
+    async def test_a_departed_client_is_dropped(self, wire):
+        await wire.start()
+        assert ipc.connected_clients() == 1
+        await wire.close()
+        for _ in range(50):
+            if not ipc.connected_clients():
+                break
+            await asyncio.sleep(0.01)
+        assert ipc.connected_clients() == 0
+
+    async def test_publish_is_callable_from_another_thread(self, wire):
+        """The router asks from a per-dispatch thread, not the server loop.
+
+        Touching a StreamWriter from a foreign loop is undefined behaviour that
+        usually presents as a silently dropped write — which for a consent
+        request is an operator who is never prompted.
+        """
+        await wire.start()
+        import threading
+
+        result: Dict[str, int] = {}
+
+        def _from_thread() -> None:
+            result["reached"] = ipc.publish("threaded", {"ok": True})
+
+        t = threading.Thread(target=_from_thread)
+        t.start()
+        t.join(timeout=5)
+
+        assert result["reached"] == 1
+        event = await wire.next_event()
+        assert event["event_type"] == "threaded"
+
+
+class TestPrincipalAndLeases:
+    async def test_a_client_id_survives_a_reconnect(self, wire):
+        """A declared identity keeps its stream across a HUD restart."""
+        seen: List[str] = []
+
+        async def _dispatch(event_type: str, data: dict) -> None:
+            seen.append(cl.current_principal())
+
+        await wire.start(dispatch=_dispatch)
+        await wire.send("action", {"client_id": "stable-hud"})
+        for _ in range(100):
+            if seen:
+                break
+            await asyncio.sleep(0.01)
+
+        assert seen and seen[0] == "hud:stable-hud"
+
+    async def test_a_disconnect_starts_a_grace_window_not_a_reap(self, wire,
+                                                                monkeypatch):
+        monkeypatch.setenv("JARVIS_CAPABILITY_LEASE_GRACE_S", "600")
+        await wire.start()
+        book = cl.get_lease_book()
+        book.open("cap.start", "cap.stop", owner="peer:127.0.0.1:1")
+        book.note_departure("peer:127.0.0.1:1")
+
+        await book.sweep()
+
+        assert book.holders("cap.start") == 1
+        assert "peer:127.0.0.1:1" in book.stats()["departing"]
+
+
+class TestInstall:
+    def test_it_wires_the_router_and_is_idempotent(self):
+        router = CapabilityRouter()
+        assert router._provider is None
+
+        assert cb.install(router) is True
+        first = router._provider
+        assert isinstance(first, cb.HUDConsentProvider)
+
+        assert cb.install(router) is True
+        assert router._provider is first
+
+    def test_disabled_installs_nothing(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_HUD_CONSENT_ENABLED", "0")
+        router = CapabilityRouter()
+        assert cb.install(router) is False
+        assert router._provider is None


### PR DESCRIPTION
Three subsystems the HUD could name none of: multi-space intelligence, video multi-space intelligence, and ghost touch. ~11,000 lines of working capability behind a vocabulary derived from a single controller. The capabilities were never missing — their **names** were.

Tool surface **49 → 81** (9 hand-written + 42 macOS + 32 federated across `space`/`video`/`touch`). 5 sessions, 0 conflicts, 0 unreleasable, 0 broken releases.

## Four independently inert layers

1. **`capability_federation.py` had ZERO callers.** `discover()` never ran, no namespace ever hydrated, `derived_tool_schemas` unioned an empty dict forever. Exactly one class in the repo carried the `Capability-Namespace` tag it discovers by.
2. **`CapabilityRouter._execute` was hardwired to `MacOSController`** — a namespaced name would resolve and then execute against the wrong object.
3. **`Session`/`release` were declared with no lease table and no reaper.** The registry's own docstring names the defect and nothing implemented it.
4. **Consent was a half-circuit.** `SecureConsent.swift` complete, `main.py`'s `consent_verdict` branch complete, nothing in between: the IPC socket was read-only for its whole life and `_provider` was None, so every gated capability returned `no approval provider available — failing closed`.

Fixing only the first three would have made the read-only half work and the acting half silently deny.

## What landed

- 5 provider classes annotated by **docstring tag**, so `vision/` and `ghost_hands/` gain no dependency on `system_control`. Discovery stays a static AST scan.
- **`capability_leases.py`**: leases **refcount by capability**, so two holders on one singleton stream release exactly once. A dropped socket starts a **grace window** rather than reaping — a HUD rebuild and a 1s blip are identical at the socket. A failed release goes `ORPHANED` and **stays in the book**; deleting it would be the leak plus a lie. The reaper reads `time.monotonic()` and the book, nothing else (Watchdog Isolation Invariant, AST-enforced by a test).
- **`ProviderBindings`** resolves constructor deps *by parameter name*. Exists because `VideoStreamCapture.__init__(self, vision_analyzer, ...)` is required-arg, so `cls()` raised `TypeError` and the whole video namespace described perfectly and constructed never.
- Router federates resolution + execution (export name → method for aliases), books sessions at the **one** `_execute` seam both entry paths funnel through, and qualifies a release into its own namespace before the reaper routes it.
- **`consent_bridge.py`** + an IPC push path. The nonce is now minted **before** the request: minting it after meant the challenge went out empty, `SecureConsent.Challenge` failed closed on it, and the prompt evaporated. `publish()` returning 0 is a **denial** — an unasked question is not a pending one.
- **`SecureConsent.swift` added to the Xcode target.** It was on disk and in git but absent from `project.pbxproj` — never compiled, for the entire life of the consent design. `BUILD SUCCEEDED`; it compiles for the first time here.

## Bug found by test

`holders()` counts `RELEASING` as holding, so a lease counted **itself** as the reason not to release. The stream would never have been stopped by anyone, ever.

## Also fixed

`ipc_server`'s `port or ...` swallowing an explicit `port=0` (ephemeral); `_principal_of` not reading `data.client_id` (the only place the real Swift client can put one); `_arg_descriptions` truncating wrapped `Args:` lines mid-sentence.

## Testing

183 tests in `tests/system_control` (218 with adjacent suites). **Not live-proven:** the real HUD driving an actual Touch ID prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Federates `space`, `video`, and `touch` capabilities into the HUD with namespaced discovery and routing, adds working consent IPC, and introduces session leases for long‑running operations. Tool surface grows 49 → 81; gated calls now prompt, and sessions are tracked and reaped.

- New Features
  - Discovery via docstring tags in providers; static AST scan, no new deps in `vision/` or `ghost_hands/` (`capability_federation.py`).
  - Router resolves namespaced exports, handles aliases, executes on the right instance, and books leases at a single `_execute` seam.
  - Refcounted session leases with grace window, orphan tracking, and an isolated reaper (`capability_leases.py`).
  - Consent bridge + outbound IPC; nonce minted before challenge; `publish()` with zero subscribers is a denial (`consent_bridge.py`).
  - Constructor deps bound by parameter name so required args (e.g., `VideoStreamCapture(vision_analyzer)`) build correctly.
  - HUD prompt and schemas now expose namespaced tools; includes a short namespace usage note.

- Bug Fixes
  - Router was hardwired to `MacOSController`; namespaced calls now hit the correct provider and method (including aliases).
  - Fixed session accounting: added lease book/reaper and corrected `holders()` so `RELEASING` isn’t counted as holding.
  - IPC was read‑only; backend can push events; also fixed `port=0` handling, client_id propagation, and Args: line wrapping.
  - Consent correctness: nonce minted before request to prevent empty challenges; an unasked question is not “pending”.

<sup>Written for commit c3834300d445db7c2818d545e7335f9c5f368074. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

