### PR TITLE
fix(voice): one arbiter for "JARVIS is speaking", so the mic can never stay shut

### DIFF
--- a/JARVIS-Apple/JARVIS-Apple.xcodeproj/project.pbxproj
+++ b/JARVIS-Apple/JARVIS-Apple.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		9675A57D67D07E9D157B8468 /* JARVISPhoneApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 698E4531C1F4FD5A0215C9B1 /* JARVISPhoneApp.swift */; };
 		993234F1A4D7A1BCA27374BB /* BrainstemLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6A777442955E499D4E22D3B /* BrainstemLauncher.swift */; };
 		5EC04E11A2B3C4D5E6F70002 /* SecureConsent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC04E11A2B3C4D5E6F70001 /* SecureConsent.swift */; };
+		5EC04E11A2B3C4D5E6F70004 /* MicSuppression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC04E11A2B3C4D5E6F70003 /* MicSuppression.swift */; };
 		99C3D3109F5801D5ED6F638A /* HapticEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 266CC1C8FBBB302AD623A3D9 /* HapticEngine.swift */; };
 		9FC588C57049591237CF032F /* HUDView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A0A5C4460F31FD5CB53DD10 /* HUDView.swift */; };
 		A0BD7790CE0BF3EDAC6D6372 /* ArcReactorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26744ECD2240E57AF517188D /* ArcReactorView.swift */; };
@@ -62,6 +63,7 @@
 		899F7DC5BF2FA227AA8CEA81 /* LivingBorderWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LivingBorderWindow.swift; sourceTree = "<group>"; };
 		A6A777442955E499D4E22D3B /* BrainstemLauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrainstemLauncher.swift; sourceTree = "<group>"; };
 		5EC04E11A2B3C4D5E6F70001 /* SecureConsent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConsent.swift; sourceTree = "<group>"; };
+		5EC04E11A2B3C4D5E6F70003 /* MicSuppression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicSuppression.swift; sourceTree = "<group>"; };
 		AF2D1789D766C67E4B4A3D2A /* JARVISHUD.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JARVISHUD.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B91850E89902256710524BEA /* LoadingHUDView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingHUDView.swift; sourceTree = "<group>"; };
 		BD8C21EBA8B80C1A39D30C8A /* JARVISPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JARVISPanel.swift; sourceTree = "<group>"; };
@@ -169,6 +171,7 @@
 				A6A777442955E499D4E22D3B /* BrainstemLauncher.swift */,
 				7F97771D9894460348ABB0ED /* ScreenCaptureService.swift */,
 				5EC04E11A2B3C4D5E6F70001 /* SecureConsent.swift */,
+				5EC04E11A2B3C4D5E6F70003 /* MicSuppression.swift */,
 				62C68475EAAD735E3FB66AAE /* WakeWordListener.swift */,
 			);
 			path = Services;
@@ -418,6 +421,7 @@
 				F2372C4356B52F4C5EE16B1C /* LoadingHUDView.swift in Sources */,
 				D3F64926FE39007A1202CB78 /* ScreenCaptureService.swift in Sources */,
 				5EC04E11A2B3C4D5E6F70002 /* SecureConsent.swift in Sources */,
+				5EC04E11A2B3C4D5E6F70004 /* MicSuppression.swift in Sources */,
 				8343F8E9601E5B1F4058448D /* TransparentWindow.swift in Sources */,
 				7E167813DA477376FA50A02A /* WakeWordListener.swift in Sources */,
 			);

--- a/JARVIS-Apple/JARVISHUD/JARVISHUDApp.swift
+++ b/JARVIS-Apple/JARVISHUD/JARVISHUDApp.swift
@@ -216,11 +216,22 @@ class HUDAppDelegate: NSObject, NSApplicationDelegate, AVSpeechSynthesizerDelega
             .replacingOccurrences(of: "# ", with: "")
         if cleaned.count > 400 { cleaned = String(cleaned.prefix(400)) + "..." }
 
-        // Stop the mic BEFORE TTS starts so JARVIS can't hear itself and echo.
-        // isTTSSpeaking flag blocks the connection-status subscription from
-        // accidentally restarting the mic while we're speaking.
+        // v285.0: mute the tap, do not tear the audio graph down.
+        //
+        // This used to call `wakeWord.stop()` — destroying a working
+        // AVAudioEngine on every sentence — and `didFinish` then slept three
+        // seconds before rebuilding, because AVSpeechSynthesizer holds the
+        // output device for ~2-3s and rebuilding early throws -10877. The sleep
+        // was a workaround for a teardown that never needed to happen, and it
+        // left a three-second deaf window after every utterance.
+        //
+        // The claim is taken HERE rather than in `didStart` so the window
+        // between queueing and the first sample is covered too; `didStart`
+        // extends it with a real duration once speaking actually begins.
         isTTSSpeaking = true
-        wakeWord.stop()
+        SpeechGate.shared.claim(.hudSynthesizer,
+                                seconds: Self.estimatedSpeechSeconds(cleaned),
+                                reason: "queued utterance")
 
         let utterance = AVSpeechUtterance(string: cleaned)
         utterance.voice = AVSpeechSynthesisVoice(identifier: "com.apple.voice.compact.en-GB.Daniel")
@@ -231,23 +242,59 @@ class HUDAppDelegate: NSObject, NSApplicationDelegate, AVSpeechSynthesizerDelega
         tts.speak(utterance)
     }
 
-    // Restart the mic once JARVIS finishes speaking — this is the gate that prevents echo.
+    /// Roughly how long this text takes to say, deliberately OVER-estimated.
+    ///
+    /// Under-estimating opens the mic while JARVIS is still talking, which
+    /// feeds the loop this exists to break. Over-estimating costs a fraction of
+    /// a second of not being heard. The asymmetry is why this is not a tight
+    /// fit — and it is only a CEILING regardless: `didFinish` releases the
+    /// claim the instant speech actually ends.
+    ///
+    /// `rate = 0.52` is below AVSpeechUtterance's default, so ~12 chars/second.
+    /// `nonisolated` because it is a pure function of its argument and is
+    /// called from the delegate callbacks, which arrive on an unspecified
+    /// queue. Nothing here touches actor state, so hopping to the MainActor
+    /// just to do arithmetic would be ceremony.
+    nonisolated static func estimatedSpeechSeconds(_ text: String) -> Double {
+        min(1.5 + Double(text.count) / 12.0, 60.0)
+    }
+
+    // The utterance actually began. Extend the claim with a real duration now
+    // that the synthesiser has committed to speaking.
+    nonisolated func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didStart utterance: AVSpeechUtterance) {
+        let seconds = Self.estimatedSpeechSeconds(utterance.speechString)
+        Task { @MainActor in
+            SpeechGate.shared.claim(.hudSynthesizer, seconds: seconds,
+                                    reason: "speaking")
+        }
+    }
+
+    // Speech ended normally. The mic is live again on THIS runloop turn —
+    // nothing was torn down, so there is nothing to rebuild and no 3s wait.
     nonisolated func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didFinish utterance: AVSpeechUtterance) {
         Task { @MainActor [weak self] in
             guard let self else { return }
             self.isTTSSpeaking = false
-            // Only restart if cloud is still connected
-            guard self.appState.pythonBridge.connectionStatus == .connected else { return }
-            // Wait 3s for CoreAudio output hardware to fully release before opening input.
-            // AVSpeechSynthesizer holds the output device for ~2-3s after didFinish fires.
-            // Without this delay, beginListening() throws -10877 repeatedly while the audio
-            // subsystem transitions from output to input mode.
-            try? await Task.sleep(for: .seconds(3.0))
-            // Re-check connection state and TTS flag after the sleep — a new TTS may have started
-            guard !self.isTTSSpeaking,
-                  self.appState.pythonBridge.connectionStatus == .connected else { return }
-            print("[JARVIS Voice] TTS done — resuming mic")
-            self.wakeWord.start()
+            SpeechGate.shared.release(.hudSynthesizer, reason: "didFinish")
+        }
+    }
+
+    // THE CALLBACK THAT WAS MISSING.
+    //
+    // A cancelled utterance never fires `didFinish`. With the old code that
+    // left `isTTSSpeaking == true` and the mic stopped, with nothing left to
+    // restart it: permanent deafness, silent, and reproducible simply by
+    // interrupting JARVIS mid-sentence — which `VoiceManager.speak` does on
+    // purpose whenever a higher-priority utterance arrives.
+    //
+    // The gate's deadline would now expire this claim anyway; implementing the
+    // callback means the mic returns immediately instead of at the deadline.
+    // Both layers, because the one we thought of is not the only one.
+    nonisolated func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didCancel utterance: AVSpeechUtterance) {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            self.isTTSSpeaking = false
+            SpeechGate.shared.release(.hudSynthesizer, reason: "didCancel")
         }
     }
 

--- a/JARVIS-Apple/JARVISHUD/Services/AppState.swift
+++ b/JARVIS-Apple/JARVISHUD/Services/AppState.swift
@@ -664,6 +664,13 @@ final class VoiceManager: NSObject, ObservableObject, AVSpeechSynthesizerDelegat
         utterance.volume = 0.9
 
         isSpeaking = true
+        // v285.0: the SECOND synthesiser in this app, and until now it
+        // suppressed NOTHING — `HUDAppDelegate` guarded its own utterances
+        // while this one spoke straight into a live microphone. One claim per
+        // speaker is the only arrangement where that cannot happen again.
+        SpeechGate.shared.claim(.voiceManager,
+                                seconds: min(1.5 + Double(text.count) / 12.0, 60.0),
+                                reason: "VoiceManager.speak")
         synthesizer.speak(utterance)
     }
 
@@ -673,6 +680,18 @@ final class VoiceManager: NSObject, ObservableObject, AVSpeechSynthesizerDelegat
     nonisolated func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didFinish utterance: AVSpeechUtterance) {
         Task { @MainActor [weak self] in
             self?.isSpeaking = false
+            SpeechGate.shared.release(.voiceManager, reason: "didFinish")
+        }
+    }
+
+    // `speak` calls `stopSpeaking(at: .immediate)` whenever a higher-priority
+    // utterance arrives, so cancellation is not an edge case here — it is a
+    // designed, routine event. Without this callback every interruption leaked
+    // a claim, and the mic stayed shut until the gate's deadline expired it.
+    nonisolated func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didCancel utterance: AVSpeechUtterance) {
+        Task { @MainActor [weak self] in
+            self?.isSpeaking = false
+            SpeechGate.shared.release(.voiceManager, reason: "didCancel")
         }
     }
 

--- a/JARVIS-Apple/JARVISHUD/Services/BrainstemLauncher.swift
+++ b/JARVIS-Apple/JARVISHUD/Services/BrainstemLauncher.swift
@@ -350,6 +350,15 @@ final class BrainstemLauncher {
                 }
             case .failed(let error):
                 print("[Brainstem] IPC connection failed: \(error) — retries left: \(retriesLeft - 1)")
+                // THE STRUCTURAL CRASH-SAFETY. If the backend dies mid-utterance
+                // its "stopped speaking" message never arrives — and with the
+                // old `/tmp/jarvis_speaking` lockfile the flag survived the
+                // process, leaving the mic deaf until somebody deleted the file
+                // by hand. A socket cannot lie about this: the connection
+                // dropping IS the notification, so the claim goes with it.
+                Task { @MainActor in
+                    SpeechGate.shared.release(.backend, reason: "IPC connection lost")
+                }
                 conn.cancel()
                 self.ipcQueue.asyncAfter(deadline: .now() + 1.0) { [weak self] in
                     Task { @MainActor in
@@ -367,7 +376,9 @@ final class BrainstemLauncher {
                     }
                 }
             case .cancelled:
-                break
+                Task { @MainActor in
+                    SpeechGate.shared.release(.backend, reason: "IPC cancelled")
+                }
             default:
                 break
             }
@@ -483,6 +494,31 @@ final class BrainstemLauncher {
                     return
                 }
                 SecureConsent.shared.request(challenge)
+            }
+
+        case "speech_state":
+            // The backend is speaking (or has stopped). Values are lifted to
+            // Sendable scalars before the actor hop, same as the consent case.
+            let speaking = (data["speaking"] as? Bool) ?? false
+            let deadlineMs = (data["deadline_ms"] as? Double) ?? 0
+            let nowMs = (data["now_ms"] as? Double) ?? 0
+            let source = (data["source"] as? String) ?? "backend"
+
+            Task { @MainActor in
+                if speaking && deadlineMs > nowMs {
+                    // The deadline is trusted for its DURATION, never for its
+                    // absolute value — the two processes do not share a clock,
+                    // and a backend running five minutes fast must not be able
+                    // to mute this microphone for five minutes.
+                    SpeechGate.shared.claim(.backend,
+                                            untilEpochMs: deadlineMs,
+                                            nowEpochMs: nowMs,
+                                            reason: "backend:\(source)")
+                } else {
+                    // Covers "stopped" AND a stale frame that arrived after its
+                    // own deadline — both mean the backend is not speaking now.
+                    SpeechGate.shared.release(.backend, reason: "backend idle")
+                }
             }
 
         default:

--- a/JARVIS-Apple/JARVISHUD/Services/MicSuppression.swift
+++ b/JARVIS-Apple/JARVISHUD/Services/MicSuppression.swift
@@ -3,128 +3,278 @@
 //
 //  Stop JARVIS hearing itself — without ever being able to go permanently deaf.
 //
-//  WHAT IS THERE NOW, AND WHY IT IS FRAGILE
-//  ------------------------------------------
-//  `HUDAppDelegate.speak` currently does:
+//  FOUR THINGS SPEAK, AND THEY EACH INVENTED THEIR OWN SIGNAL
+//  -----------------------------------------------------------
+//  1. `HUDAppDelegate.tts`            — tore the audio graph down, slept 3s
+//  2. `AppState.VoiceManager`         — suppressed NOTHING at all
+//  3. Python `_hud_tts`               — wrote `/tmp/jarvis_speaking`
+//  4. Backend `realtime_voice_*`      — told UnifiedSpeechStateManager, which
+//                                       had no way to reach this process
 //
-//      isTTSSpeaking = true
-//      wakeWord.stop()                    // tears the whole audio graph down
-//      ...
-//      didFinish -> try? await Task.sleep(for: .seconds(3.0))   // then rebuild
+//  Three mechanisms, one of which was absent, for one question. This file is
+//  the single arbiter they all report to.
 //
-//  Three problems, in increasing order of severity:
+//  WHY REFCOUNTED CLAIMS AND NOT A BOOLEAN
+//  -----------------------------------------
+//  A boolean loses. The delegate finishes utterance A and sets `speaking =
+//  false` while utterance B — queued on the other synthesiser — is still
+//  playing, and the mic opens into JARVIS's own voice. Each source instead
+//  holds a NAMED CLAIM; the mic is muted while any claim is live and opens when
+//  the last one ends. Exactly the reason a file descriptor is not closed by
+//  whichever holder happens to exit first.
 //
-//  1. A three-second deaf window after EVERY utterance, imposed because
-//     AVSpeechSynthesizer holds the output device for ~2-3s and rebuilding the
-//     input graph too early throws -10877. The delay is a workaround for a
-//     teardown that did not need to happen.
+//  WHY EVERY CLAIM HAS A DEADLINE
+//  --------------------------------
+//  This is the property that matters most, and the one every previous attempt
+//  lacked.
 //
-//  2. Tearing down and rebuilding a working AVAudioEngine on every sentence is
-//     the most failure-prone thing in the loop, and the -10877 in the existing
-//     comment is that failure already happening.
+//  `didCancel` WAS NEVER IMPLEMENTED. A cancelled utterance never fires
+//  `didFinish`, so `isTTSSpeaking` stayed true and the mic never came back:
+//  permanent deafness, silent, with no file to blame. The lockfile had the same
+//  shape from the other direction — SIGKILL Python and `finally:` never runs,
+//  so `/tmp/jarvis_speaking` outlives the process that meant it.
 //
-//  3. `didCancel` IS NOT IMPLEMENTED. A cancelled utterance never fires
-//     `didFinish`, so `isTTSSpeaking` stays true and the mic is never
-//     restarted. PERMANENT DEAFNESS, with no lockfile in sight — the exact
-//     orphaned-state failure a `/tmp/jarvis_speaking` file would have caused,
-//     already present in memory.
+//  Implementing `didCancel` fixes the case we thought of. A deadline fixes the
+//  cases we did not: a delegate callback that never arrives, a socket that dies
+//  mid-utterance, a synthesiser wedged in the audio server. A claim states when
+//  it stops being true, and the gate believes the clock over every one of its
+//  informants. Deafness stops being a bug to avoid and becomes a state the
+//  design cannot represent.
 //
-//  THE FIX: MUTE THE TAP, DO NOT DESTROY THE GRAPH
-//  -------------------------------------------------
-//  The engine keeps running; the tap simply drops buffers while JARVIS speaks.
-//  Nothing to rebuild, so no -10877, no three-second wait, and the mic is live
-//  again on the same runloop turn the utterance ends.
+//  MUTE THE TAP, DO NOT DESTROY THE GRAPH
+//  ----------------------------------------
+//  The old path called `wakeWord.stop()` — tearing down a working
+//  AVAudioEngine on every sentence — and then slept three seconds before
+//  rebuilding, because AVSpeechSynthesizer holds the output device for ~2-3s
+//  and rebuilding early throws -10877. The delay was a workaround for a
+//  teardown that did not need to happen.
 //
-//  Crash-safety comes free and structurally: the mute is a field on a live
-//  object. If the process dies, the object dies with it. There is no state on
-//  disk that can outlive the thing it describes — which is the whole reason
-//  not to use a lockfile, stated as a property rather than a preference.
+//  Here the engine keeps running and the tap simply drops buffers. Nothing is
+//  rebuilt, so there is no -10877 and no three-second deaf window, and the mic
+//  is live again on the same runloop turn the utterance ends.
+//
+//  Crash-safety comes free and structurally: claims live on an object inside
+//  this process. If the process dies they die with it. Nothing on disk can
+//  outlive the thing it describes — the property the lockfile could never have,
+//  stated as a consequence rather than a promise.
 
+import Foundation
 import AVFoundation
+
+/// Who is holding the microphone shut. Named rather than counted so a log can
+/// say WHICH source is keeping the mic closed — "muted" with no owner is the
+/// state nobody can debug.
+enum SpeechClaimant: String, CaseIterable {
+    case hudSynthesizer      = "hud_tts"        // HUDAppDelegate.tts
+    case voiceManager        = "voice_manager"  // AppState.VoiceManager
+    case backend             = "backend"        // Python, over the IPC socket
+    case manual              = "manual"         // operator / test override
+}
+
+/// One source's claim on the microphone, and when it stops being true.
+private struct SpeechClaim {
+    let claimant: SpeechClaimant
+    /// Monotonic. `Date()` would let an NTP step or a daylight-saving change
+    /// extend a mute by an hour, and the operator would simply be unheard.
+    let deadline: ContinuousClock.Instant
+    let reason: String
+
+    func isLive(_ now: ContinuousClock.Instant) -> Bool { now < deadline }
+}
+
+/// The single arbiter of "is JARVIS speaking, and therefore is our mic shut".
+///
+/// MainActor-isolated: every mutation arrives from a delegate hop or the IPC
+/// reader, and serialising them here means the refcount cannot be corrupted by
+/// two synthesisers finishing at once. The AUDIO THREAD never touches this —
+/// it reads a single `Bool` that this class publishes (see
+/// `WakeWordListener.micMuted`), because blocking a render callback on a lock
+/// owned by the main thread is a priority inversion that produces drop-outs.
+@MainActor
+final class SpeechGate {
+
+    static let shared = SpeechGate()
+
+    /// Set when the mute state changes. `WakeWordListener` installs this.
+    var onMuteChange: ((Bool) -> Void)?
+
+    private var claims: [SpeechClaimant: SpeechClaim] = [:]
+    private var sweepTask: Task<Void, Never>?
+    private var lastPublished = false
+
+    /// How long a claim may last when its source did not say. A source that
+    /// cannot estimate its own duration gets a bounded default rather than an
+    /// open one — there is no such thing as "until further notice" here.
+    private let defaultClaimSeconds: Double = 15.0
+
+    /// Absolute ceiling on any claim, however it was requested. Mirrors
+    /// `SpeechStateConfig.MAX_SPEAKING_DURATION_MS` on the Python side: the
+    /// backend already decided no single utterance runs past 60s, and a mute
+    /// derived from one must not outlive it.
+    private let maxClaimSeconds: Double = 60.0
+
+    /// How often expired claims are swept. The sweep is what turns a deadline
+    /// from a fact into an effect; without it a claim would expire and the mic
+    /// would stay shut until the next unrelated event happened to re-evaluate.
+    private let sweepInterval: Duration = .milliseconds(250)
+
+    private init() {}
+
+    // MARK: - Claims
+
+    /// Hold the mic shut for `seconds`, or until `release` — whichever is first.
+    ///
+    /// Re-claiming for the same claimant EXTENDS rather than stacks. Two
+    /// `didStart` callbacks from one synthesiser are one speaker, and counting
+    /// them would need two releases to open a mic that one cancel should open.
+    func claim(_ who: SpeechClaimant,
+               seconds: Double? = nil,
+               reason: String = "") {
+        let bounded = min(max(seconds ?? defaultClaimSeconds, 0.1), maxClaimSeconds)
+        claims[who] = SpeechClaim(
+            claimant: who,
+            deadline: ContinuousClock.now.advanced(by: .seconds(bounded)),
+            reason: reason)
+        print("[SpeechGate] claim \(who.rawValue) for \(String(format: "%.1f", bounded))s \(reason)")
+        startSweeping()
+        publish()
+    }
+
+    /// Hold the mic shut until an ABSOLUTE wall-clock instant.
+    ///
+    /// What the backend sends, because only it knows how long its own utterance
+    /// plus echo cooldown will run. Converted to monotonic ON ARRIVAL: the two
+    /// processes do not share a clock, so a wall-clock deadline is trusted for
+    /// its DURATION from now, never for its absolute value. A backend whose
+    /// clock is five minutes fast must not mute this mic for five minutes.
+    func claim(_ who: SpeechClaimant,
+               untilEpochMs deadlineMs: Double,
+               nowEpochMs: Double,
+               reason: String = "") {
+        let remaining = (deadlineMs - nowEpochMs) / 1000.0
+        guard remaining > 0 else {
+            release(who, reason: "deadline already passed on arrival")
+            return
+        }
+        claim(who, seconds: remaining, reason: reason)
+    }
+
+    /// Drop one source's claim. Idempotent — releasing what was never claimed
+    /// is a no-op, so a `didCancel` that arrives after `didFinish` is harmless.
+    func release(_ who: SpeechClaimant, reason: String = "") {
+        guard claims.removeValue(forKey: who) != nil else { return }
+        print("[SpeechGate] release \(who.rawValue) \(reason)")
+        publish()
+    }
+
+    /// Drop every claim. For teardown and for the operator's escape hatch.
+    func releaseAll(reason: String = "") {
+        guard !claims.isEmpty else { return }
+        claims.removeAll()
+        print("[SpeechGate] release ALL \(reason)")
+        publish()
+    }
+
+    // MARK: - Reconciliation
+
+    /// Assert a claim from the synthesiser itself rather than from our
+    /// bookkeeping.
+    ///
+    /// `AVSpeechSynthesizer.isSpeaking` is the authority for a local
+    /// synthesiser, and a dropped delegate callback is the one failure this
+    /// class cannot otherwise see. Deriving the claim from the synthesiser
+    /// costs one sweep of staleness instead of a permanently shut mic. Called
+    /// on every sweep and on every mic restart.
+    func reconcile(_ who: SpeechClaimant, isSpeaking: Bool) {
+        if isSpeaking {
+            // Re-arm on a short lease. If the synthesiser stops and the
+            // callback is lost, the claim dies within one lease rather than
+            // living until the 60s ceiling.
+            claim(who, seconds: 2.0, reason: "(reconciled from synthesizer)")
+        } else {
+            release(who, reason: "(reconciled: synthesizer idle)")
+        }
+    }
+
+    // MARK: - State
+
+    var isMuted: Bool {
+        let now = ContinuousClock.now
+        return claims.values.contains { $0.isLive(now) }
+    }
+
+    /// Who is currently holding it shut. For the status menu and for logs.
+    var holders: [String] {
+        let now = ContinuousClock.now
+        return claims.values.filter { $0.isLive(now) }
+            .map(\.claimant.rawValue).sorted()
+    }
+
+    // MARK: - Sweep
+
+    private func startSweeping() {
+        guard sweepTask == nil else { return }
+        sweepTask = Task { [weak self] in
+            while !Task.isCancelled {
+                let interval = await MainActor.run { self?.sweepInterval ?? .milliseconds(250) }
+                try? await Task.sleep(for: interval)
+                guard let self else { return }
+                let stop = await MainActor.run { () -> Bool in
+                    self.expire()
+                    self.publish()
+                    if self.claims.isEmpty {
+                        self.sweepTask = nil
+                        return true
+                    }
+                    return false
+                }
+                if stop { return }
+            }
+        }
+    }
+
+    /// Drop claims whose deadline has passed. The whole safety net: this runs
+    /// on a clock and consults nothing else, so a wedged synthesiser or a dead
+    /// socket cannot keep the microphone shut by failing to answer.
+    private func expire() {
+        let now = ContinuousClock.now
+        for (who, claim) in claims where !claim.isLive(now) {
+            claims.removeValue(forKey: who)
+            print("[SpeechGate] EXPIRED \(who.rawValue) — its owner never released it")
+        }
+    }
+
+    private func publish() {
+        let muted = isMuted
+        guard muted != lastPublished else { return }
+        lastPublished = muted
+        print("[SpeechGate] mic \(muted ? "MUTED" : "LIVE")\(muted ? " by \(holders.joined(separator: "+"))" : "")")
+        onMuteChange?(muted)
+    }
+}
+
+// MARK: - WakeWordListener integration
 
 extension WakeWordListener {
 
-    /// Drop input while JARVIS is speaking, without stopping the engine.
+    /// Bind this listener to the gate. Called once at start-up.
     ///
-    /// Read from the tap closure, which runs on a REAL-TIME AUDIO THREAD.
-    /// Deliberately a plain flag and not a lock: blocking a render callback on
-    /// a mutex owned by the main thread is a priority inversion that produces
-    /// audio glitches and, under load, drop-outs. The worst case here is that
-    /// one 4096-frame buffer (~85 ms) slips through on the transition — far
-    /// cheaper than stalling the audio thread, and inaudible as an echo.
-    func setMuted(_ muted: Bool) {
-        micMuted = muted
+    /// The gate pushes; the listener does not poll. A poll would put a
+    /// filesystem or lock access on the audio path, which is what the old
+    /// `FileManager.fileExists(atPath: "/tmp/jarvis_speaking")` did on EVERY
+    /// recognition callback — a synchronous `stat` several times a second, and
+    /// at the wrong layer besides: it dropped RESULTS while still feeding
+    /// JARVIS's own voice into the recogniser, so the transcript accumulated
+    /// what JARVIS said and acted on it the moment the flag cleared.
+    @MainActor
+    func bindToSpeechGate() {
+        SpeechGate.shared.onMuteChange = { [weak self] muted in
+            self?.setMuted(muted)
+        }
+        // Assert the CURRENT truth immediately, not just future changes. A
+        // listener that only subscribed would start unmuted and stay that way
+        // until the next transition — opening the mic in the middle of an
+        // utterance already in progress.
+        setMuted(SpeechGate.shared.isMuted)
     }
-
-    var isMicMuted: Bool { micMuted }
 }
-
-// MARK: - Wiring notes (apply inside WakeWordListener.swift)
-//
-//  1. Add the storage. `nonisolated(unsafe)` is the honest annotation: it IS
-//     read off-actor from the audio thread, and the race is benign by the
-//     argument above.
-//
-//         nonisolated(unsafe) fileprivate var micMuted = false
-//
-//  2. Gate the EXISTING tap — one line, no restructuring:
-//
-//         inputNode.installTap(onBus: 0, bufferSize: 4096, format: format) { buffer, _ in
-//             guard !self.micMuted else { return }          // <-- ADD
-//             guard buffer.frameLength > 0 else { return }
-//             req.append(buffer)
-//         }
-//
-//     Dropping the buffer rather than pausing the node keeps the recognition
-//     request alive: `SFSpeechAudioBufferRecognitionRequest` treats a gap as
-//     silence, which is exactly what it was.
-//
-//  3. Unmute in `beginListening()` as well as on didFinish. A restart for any
-//     other reason must never inherit a stale mute — the one way this design
-//     could reproduce the bug it replaces.
-
-// MARK: - Delegate lifecycle (apply inside HUDAppDelegate)
-//
-//  REPLACE the teardown-and-sleep with lifecycle-bound muting. The mute now
-//  begins when the utterance ACTUALLY starts speaking rather than when we
-//  queue it, closing a window where the synthesiser is still warming up and
-//  the mic is already deaf.
-//
-//      // in speak(...): remove `wakeWord.stop()` and keep only
-//      isTTSSpeaking = true
-//      tts.speak(utterance)
-//
-//      nonisolated func speechSynthesizer(_ s: AVSpeechSynthesizer,
-//                                         didStart utterance: AVSpeechUtterance) {
-//          Task { @MainActor [weak self] in self?.wakeWord.setMuted(true) }
-//      }
-//
-//      nonisolated func speechSynthesizer(_ s: AVSpeechSynthesizer,
-//                                         didFinish utterance: AVSpeechUtterance) {
-//          Task { @MainActor [weak self] in
-//              guard let self else { return }
-//              self.isTTSSpeaking = false
-//              self.wakeWord.setMuted(false)      // no 3s sleep: nothing was torn down
-//          }
-//      }
-//
-//      // THE MISSING ONE. Without this a cancelled utterance leaves the mic
-//      // muted forever, which is the deafness this file exists to prevent.
-//      nonisolated func speechSynthesizer(_ s: AVSpeechSynthesizer,
-//                                         didCancel utterance: AVSpeechUtterance) {
-//          Task { @MainActor [weak self] in
-//              guard let self else { return }
-//              self.isTTSSpeaking = false
-//              self.wakeWord.setMuted(false)
-//          }
-//      }
-//
-//  A belt-and-braces reconciliation, because a delegate callback that never
-//  arrives is the one failure this cannot see: on any mic restart, and on
-//  connection-status changes, assert the truth from the synthesiser itself —
-//
-//      wakeWord.setMuted(tts.isSpeaking)
-//
-//  `AVSpeechSynthesizer.isSpeaking` is the authority. Deriving the mute from
-//  it rather than from our own bookkeeping means a dropped callback costs one
-//  cycle of staleness instead of permanent silence.

--- a/JARVIS-Apple/JARVISHUD/Services/WakeWordListener.swift
+++ b/JARVIS-Apple/JARVISHUD/Services/WakeWordListener.swift
@@ -30,6 +30,31 @@ final class WakeWordListener: ObservableObject, @unchecked Sendable {
     // cancelled-task callback from racing with the newly-started task and killing it.
     private var listenerGeneration = 0
 
+    /// True while JARVIS is speaking. Read from the audio tap on a REAL-TIME
+    /// THREAD, written from the MainActor by `SpeechGate`.
+    ///
+    /// `nonisolated(unsafe)` is the honest annotation rather than a suppression:
+    /// it IS read off-actor, and the race is benign because the value is a
+    /// single word and the cost of reading a stale one is that a single
+    /// 4096-frame buffer (~85ms) slips through on the transition. A lock here
+    /// would let the main thread stall a render callback, which is a priority
+    /// inversion that costs audio drop-outs — far worse than one buffer of
+    /// echo, which is inaudible.
+    nonisolated(unsafe) private var micMuted = false
+
+    /// Drop input while JARVIS is speaking, without stopping the engine.
+    ///
+    /// Lives HERE rather than in `MicSuppression.swift` so the flag can stay
+    /// `private` to the file that owns the tap reading it. An extension in
+    /// another file would force the storage to `internal`, widening a
+    /// real-time-thread variable's blast radius to the whole module for no gain
+    /// — every legitimate writer goes through `SpeechGate` anyway.
+    func setMuted(_ muted: Bool) {
+        micMuted = muted
+    }
+
+    var isMicMuted: Bool { micMuted }
+
     // MARK: - Lifecycle
 
     func start() {
@@ -100,12 +125,12 @@ final class WakeWordListener: ObservableObject, @unchecked Sendable {
         recognitionTask = recognizer.recognitionTask(with: req) { [weak self] result, error in
             guard let self, self.listenerGeneration == generation else { return }
 
-            // Mic suppression: if the Python backend is speaking via TTS,
-            // ignore all audio to prevent voice feedback loops (JARVIS hearing
-            // its own speech and treating it as a new command).
-            if FileManager.default.fileExists(atPath: "/tmp/jarvis_speaking") {
-                return
-            }
+            // Mic suppression moved to the TAP (see installTap below), where
+            // dropping a buffer actually keeps JARVIS's voice out of the
+            // recogniser. It used to `stat` /tmp/jarvis_speaking right here —
+            // a synchronous filesystem call several times a second, describing
+            // only ONE of the four things that can speak, and read at a layer
+            // where the audio had already been transcribed.
 
             if let result {
                 let fullText = result.bestTranscription.formattedString
@@ -194,7 +219,21 @@ final class WakeWordListener: ObservableObject, @unchecked Sendable {
 
         // 4096 frames ≈ 85ms at 48kHz — large enough to prevent HALC I/O overload.
         // Guard against zero-byte buffers produced during audio hardware warmup.
-        inputNode.installTap(onBus: 0, bufferSize: 4096, format: format) { buffer, _ in
+        inputNode.installTap(onBus: 0, bufferSize: 4096, format: format) { [weak self] buffer, _ in
+            // THE GATE. Dropping the buffer here is what actually stops JARVIS
+            // hearing itself: the audio never reaches the recogniser at all.
+            //
+            // The previous check lived in the recognition RESULT callback and
+            // only skipped handling — the recogniser still received every
+            // sample of JARVIS's own voice, accumulated it into the running
+            // transcript, and delivered the lot as a command the moment
+            // suppression lifted. Suppressing the symptom one layer above the
+            // cause.
+            //
+            // Dropping rather than pausing the node keeps the recognition
+            // request alive: `SFSpeechAudioBufferRecognitionRequest` treats a
+            // gap as silence, which is exactly what it was.
+            guard self?.micMuted != true else { return }
             guard buffer.frameLength > 0 else { return }
             req.append(buffer)
         }
@@ -205,6 +244,15 @@ final class WakeWordListener: ObservableObject, @unchecked Sendable {
             audioEngine = engine
             request = req
             DispatchQueue.main.async { self.state = .listening }
+            // Re-assert the mute from the GATE on every restart. A restart that
+            // inherited a stale `micMuted` would be silently deaf, and one that
+            // blindly cleared it would open the mic mid-sentence. Neither is a
+            // guess here — the gate is asked.
+            //
+            // `Task { @MainActor }` rather than `DispatchQueue.main.async`
+            // because `bindToSpeechGate` is MainActor-isolated, and a GCD
+            // closure is not: Swift 6 rejects the hop, correctly.
+            Task { @MainActor in self.bindToSpeechGate() }
             print("[JARVIS Voice] Listening...")
         } catch {
             // self.audioEngine was never assigned, so teardown() won't clean up the local engine.

--- a/backend/core/unified_speech_state.py
+++ b/backend/core/unified_speech_state.py
@@ -230,6 +230,10 @@ class UnifiedSpeechStateManager:
         self._listeners: Set[weakref.ref] = set()
         self._websocket_broadcasters: List[Callable] = []
         self._last_broadcast_time: float = 0
+        #: The last event actually broadcast. Kept so the throttle can tell a
+        #: repeat from a transition — dropping a transition silently strands
+        #: every consumer in the previous state.
+        self._last_broadcast_event: str = ""
         self._config = SpeechStateConfig()
         
         # Thread-safe state access
@@ -631,13 +635,29 @@ class UnifiedSpeechStateManager:
             self._websocket_broadcasters.remove(broadcaster)
     
     async def _broadcast_state_change(self, event: str) -> None:
-        """Broadcast state change to all registered listeners."""
+        """Broadcast state change to all registered listeners.
+
+        v285.0: the throttle no longer drops a CHANGE of event.
+
+        It used to return early whenever two broadcasts fell inside
+        ``MIN_BROADCAST_INTERVAL_MS`` (50ms) regardless of what they said. A
+        short utterance — "Done." — starts and stops well inside that window, so
+        the ``speech_ended`` broadcast was silently discarded while
+        ``speech_started`` had already gone out. Any consumer gating a
+        microphone on those events is then muted with nothing left to unmute it.
+
+        Throttling REPEATS of the same event is still right and still happens:
+        those are heartbeats and a listener loses nothing by missing one. A
+        transition is not a repeat — it is the entire message.
+        """
         now = time.time() * 1000
-        
-        # Throttle broadcasts
-        if now - self._last_broadcast_time < self._config.MIN_BROADCAST_INTERVAL_MS:
+
+        if (event == self._last_broadcast_event
+                and now - self._last_broadcast_time
+                < self._config.MIN_BROADCAST_INTERVAL_MS):
             return
         self._last_broadcast_time = now
+        self._last_broadcast_event = event
         
         with self._state_lock:
             state_dict = self._state.to_dict()

--- a/backend/hud/speech_bridge.py
+++ b/backend/hud/speech_bridge.py
@@ -1,0 +1,285 @@
+"""Tell the HUD when JARVIS is speaking — over the socket, not a lockfile.
+
+There is already a complete authority on this. `UnifiedSpeechStateManager`
+tracks who is speaking, from which of seven sources, with a length-scaled echo
+cooldown, a text-similarity check that catches an echo the gate missed, an
+`AudioBus` mic gate, and a 60-second watchdog that resets `is_speaking` if a
+`stop` never arrives. It has been right for a long time.
+
+The HUD — which owns the actual microphone — was not connected to any of it.
+`main.py::_hud_tts` skipped the manager entirely and touched
+`/tmp/jarvis_speaking`, and `WakeWordListener` read that file. Meanwhile the
+manager's own `register_websocket_broadcaster` had ZERO callers, so the
+broadcast surface built for precisely this was dark.
+
+This module is the missing wire, and deliberately nothing else: no second
+notion of "speaking", no parallel cooldown, no new watchdog. It subscribes to
+the authority and forwards to the transport.
+
+WHY THE SOCKET AND NOT THE FILE
+---------------------------------
+A lockfile records a FACT with no LIVENESS. If Python is SIGKILLed mid-utterance
+the file survives, and `finally:` does not run — the HUD stays deaf until
+somebody notices and deletes it by hand. That is not a hypothetical; it is the
+same orphaned-state class as a leaked capability lease and an abandoned virtual
+display.
+
+The IPC socket has the property the file cannot: when the process dies the
+connection drops, and the HUD is told. Crash-safety stops being a cleanup
+routine somebody has to remember and becomes a consequence of the transport.
+The channel already exists — `ipc_server.publish` was built to carry consent
+challenges — so this adds a message type, not a mechanism.
+
+EVERY FRAME CARRIES A DEADLINE
+--------------------------------
+A mute is a claim on the operator's microphone, and no claim on a microphone
+should be able to outlive its own plausible duration. Each `speaking` frame
+therefore says WHEN it stops being true, computed from the estimated utterance
+length plus the manager's own cooldown. If the socket dies, if a broadcast is
+dropped, if this process is killed between start and stop — the HUD's claim
+expires on its own clock and the mic comes back.
+
+Belt and braces with the same rule as elsewhere in this codebase: the reaper
+must not depend on the thing it guards.
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Any, Callable, Dict, Optional
+
+logger = logging.getLogger("JARVIS.HUDSpeechBridge")
+
+SPEECH_BRIDGE_SCHEMA_VERSION: str = "hud_speech_bridge.v1"
+
+#: The event the Swift side listens for. Must match the string
+#: `BrainstemLauncher.dispatchInbound` switches on — a mismatch is silent on
+#: both sides, so it is a named constant rather than a literal at the one place
+#: that sends it.
+SPEECH_STATE_EVENT: str = "speech_state"
+
+
+def speech_bridge_enabled() -> bool:
+    """Master gate. Default TRUE. NEVER raises.
+
+    Off means the HUD is not told, which means it does not mute — the mic stays
+    live and JARVIS may hear itself. That is the LOUD failure, and it is the
+    right one: the alternative default would be a silently deaf microphone.
+    """
+    return (os.environ.get("JARVIS_HUD_SPEECH_BRIDGE_ENABLED", "true")
+            or "").strip().lower() not in ("0", "false", "no", "off")
+
+
+def speaking_grace_ms() -> float:
+    """Extra head-room added to every deadline. Clamped. NEVER raises.
+
+    Covers the gap between "this process believes speech ended" and "the last
+    sample has actually left the speaker". Too small and the tail of an
+    utterance re-enters the mic; too large and the operator is briefly unheard
+    after JARVIS finishes. The manager's own cooldown already models the echo
+    tail, so this only absorbs scheduling jitter.
+    """
+    try:
+        return max(0.0, min(float(os.environ.get(
+            "JARVIS_HUD_SPEECH_GRACE_MS", "400")), 5000.0))
+    except (TypeError, ValueError):
+        return 400.0
+
+
+def max_claim_ms() -> float:
+    """The longest a single mute claim may last. Clamped. NEVER raises.
+
+    The ceiling that makes permanent deafness impossible rather than unlikely.
+    Mirrors `SpeechStateConfig.MAX_SPEAKING_DURATION_MS` — the manager already
+    decided no single utterance runs past 60s, and a mute derived from it must
+    not outlive the thing it was derived from.
+    """
+    try:
+        return max(1000.0, min(float(os.environ.get(
+            "JARVIS_HUD_SPEECH_MAX_CLAIM_MS", "60000")), 300000.0))
+    except (TypeError, ValueError):
+        return 60000.0
+
+
+def estimate_speech_ms(text: str) -> float:
+    """How long this utterance will plausibly take to say. NEVER raises.
+
+    Deliberately an OVER-estimate. Under-estimating unmutes while JARVIS is
+    still talking, which feeds the loop this exists to break; over-estimating
+    costs a fraction of a second of not being heard. The asymmetry is the whole
+    reason this is not a tight fit.
+
+    ~12 characters/second is a slow-ish conversational rate, which is what the
+    HUD's own utterances use (`rate = 0.52`, below AVSpeechUtterance's default).
+    """
+    try:
+        chars = len(text or "")
+        return min(1500.0 + (chars / 12.0) * 1000.0, max_claim_ms())
+    except Exception:  # noqa: BLE001
+        return 5000.0
+
+
+def build_frame(message: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Turn one manager broadcast into a HUD frame. NEVER raises.
+
+    Returns None for anything that is not a speech-state change, so an
+    unrelated broadcaster message can never mute a microphone.
+
+    The frame is FLAT and absolute: a boolean and a wall-clock deadline. The
+    HUD is not asked to re-derive anything from durations or to track cooldown
+    itself — two clocks agreeing on a rule is how they eventually disagree.
+    """
+    try:
+        if not isinstance(message, dict):
+            return None
+        if message.get("type") != "speech_state_change":
+            return None
+        state = message.get("state")
+        # `or {}` here used to turn a MISSING state into an empty one, which
+        # then read as "not speaking" and produced a perfectly well-formed
+        # unmute frame from a message that said nothing at all. Unmuting is the
+        # safe direction, but fabricating a conclusion from absent data is how a
+        # gate stops being trustworthy in the other direction later.
+        if not isinstance(state, dict) or "is_speaking" not in state:
+            return None
+
+        speaking = bool(state.get("is_speaking"))
+        now_ms = time.time() * 1000.0
+
+        if speaking:
+            text = str(state.get("current_text") or "")
+            # Prefer the manager's own numbers where it has them; only
+            # estimate what it does not track.
+            started = state.get("speech_started_at")
+            base = float(started) if isinstance(started, (int, float)) else now_ms
+            deadline = base + estimate_speech_ms(text) + speaking_grace_ms()
+        else:
+            # NOT simply "unmute now". The manager keeps a cooldown after speech
+            # ends precisely because the room is still ringing; honouring it is
+            # what stops the tail of JARVIS's own sentence being transcribed as
+            # a command.
+            cooldown_until = state.get("cooldown_until")
+            deadline = (float(cooldown_until)
+                        if isinstance(cooldown_until, (int, float))
+                        and float(cooldown_until) > now_ms
+                        else now_ms)
+
+        # Hard ceiling, applied last so no arithmetic above can escape it.
+        deadline = min(deadline, now_ms + max_claim_ms())
+
+        return {
+            "schema_version": SPEECH_BRIDGE_SCHEMA_VERSION,
+            "speaking": speaking,
+            # Absolute, milliseconds since epoch. The HUD converts once, on
+            # arrival, against its own monotonic clock — see SpeechGate.
+            "deadline_ms": deadline,
+            "now_ms": now_ms,
+            "source": str(state.get("current_source") or "unknown"),
+            "in_cooldown": bool(state.get("in_cooldown")),
+            "event": str(message.get("event") or ""),
+        }
+    except Exception:  # noqa: BLE001
+        logger.debug("[SpeechBridge] frame build degraded", exc_info=True)
+        return None
+
+
+class HUDSpeechBroadcaster:
+    """Forwards manager broadcasts to the HUD. NEVER raises.
+
+    A callable, because that is the shape `register_websocket_broadcaster`
+    accepts. Stateful only for counters — the authority is the manager and this
+    holds no opinion of its own about whether JARVIS is speaking.
+    """
+
+    def __init__(self, publish: Optional[Callable[[str, Dict[str, Any]], int]] = None) -> None:
+        self._publish = publish
+        self._sent = 0
+        self._unreached = 0
+        self._last: Dict[str, Any] = {}
+
+    def _publisher(self) -> Optional[Callable[[str, Dict[str, Any]], int]]:
+        if self._publish is None:
+            try:
+                from backend.hud.ipc_server import publish
+                self._publish = publish
+            except Exception:  # noqa: BLE001
+                logger.debug("[SpeechBridge] no IPC publisher", exc_info=True)
+        return self._publish
+
+    def __call__(self, message: Dict[str, Any]) -> None:
+        """Called by the manager on every state change. NEVER raises."""
+        try:
+            if not speech_bridge_enabled():
+                return
+            frame = build_frame(message)
+            if frame is None:
+                return
+            publish = self._publisher()
+            if publish is None:
+                return
+            reached = publish(SPEECH_STATE_EVENT, frame)
+            self._last = frame
+            if reached > 0:
+                self._sent += 1
+            else:
+                self._unreached += 1
+                # NOT an error. No HUD connected means no microphone of ours is
+                # listening, so there is nothing to mute and nothing to warn
+                # about. Counted so the difference is visible.
+                logger.debug("[SpeechBridge] no HUD connected for %s",
+                             frame.get("event"))
+        except Exception:  # noqa: BLE001
+            logger.debug("[SpeechBridge] broadcast degraded", exc_info=True)
+
+    def stats(self) -> Dict[str, Any]:
+        return {"schema_version": SPEECH_BRIDGE_SCHEMA_VERSION,
+                "enabled": speech_bridge_enabled(), "sent": self._sent,
+                "unreached": self._unreached, "last": dict(self._last)}
+
+
+_BROADCASTER: Optional[HUDSpeechBroadcaster] = None
+
+
+async def install() -> bool:
+    """Subscribe the HUD to the speech authority. Idempotent. NEVER raises.
+
+    Called once from the HUD boot. Without it the manager keeps tracking speech
+    perfectly and the HUD keeps never hearing about it — which is the state this
+    module was written to end, and which looked exactly like working software
+    because both halves were individually fine.
+    """
+    global _BROADCASTER
+    try:
+        if not speech_bridge_enabled():
+            logger.info("[SpeechBridge] disabled — the HUD will NOT mute its "
+                        "microphone while JARVIS speaks")
+            return False
+        if _BROADCASTER is not None:
+            return True
+        from backend.core.unified_speech_state import get_speech_state_manager
+
+        manager = await get_speech_state_manager()
+        broadcaster = HUDSpeechBroadcaster()
+        manager.register_websocket_broadcaster(broadcaster)
+        _BROADCASTER = broadcaster
+        logger.info("[SpeechBridge] installed — HUD mic now follows "
+                    "UnifiedSpeechStateManager over the IPC socket")
+        return True
+    except Exception as exc:  # noqa: BLE001
+        logger.error("[SpeechBridge] install failed (%s) — the HUD will not "
+                     "mute while JARVIS speaks", exc, exc_info=True)
+        return False
+
+
+def get_broadcaster() -> Optional[HUDSpeechBroadcaster]:
+    """Testing / observability seam. NEVER raises."""
+    return _BROADCASTER
+
+
+def reset() -> None:
+    """Testing seam. NEVER raises."""
+    global _BROADCASTER
+    _BROADCASTER = None

--- a/backend/main.py
+++ b/backend/main.py
@@ -1971,22 +1971,48 @@ async def parallel_lifespan(app: FastAPI):
                 _hud_shutdown = asyncio.Event()
 
                 # TTS helper — uses macOS `say -v Daniel` for voice feedback.
-                # CRITICAL: Creates /tmp/jarvis_speaking flag file BEFORE speaking
-                # and removes it AFTER. The Swift HUD's WakeWordListener checks
-                # this flag to suppress the mic during Python-side TTS, preventing
-                # the voice feedback loop (mic picking up JARVIS's own speech).
-                _SPEAKING_FLAG = "/tmp/jarvis_speaking"
+                #
+                # v285.0: mic suppression now goes through
+                # `UnifiedSpeechStateManager`, the authority that already owns
+                # this question — it tracks seven speech sources, scales an echo
+                # cooldown by utterance length, catches an echo the gate missed
+                # by text similarity, gates `AudioBus`, and resets itself after
+                # 60s if a stop never arrives.
+                #
+                # It previously wrote `/tmp/jarvis_speaking` and the Swift HUD
+                # stat'd that file. Two problems the manager does not have:
+                # a lockfile records a FACT with no LIVENESS, so a SIGKILL here
+                # (which skips `finally:`) left the HUD deaf until somebody
+                # deleted the file by hand; and the flag described only THIS
+                # source, while three other things in the system also speak.
                 _TTS_VOICE = os.environ.get("JARVIS_TTS_VOICE", "Daniel")
 
                 async def _hud_tts(text: str) -> None:
                     """Speak text to the user via macOS TTS with mic suppression."""
                     if not text:
                         return
+                    _speech = None
                     try:
                         import tempfile as _tf
-                        # Signal Swift HUD to mute mic
-                        with open(_SPEAKING_FLAG, "w") as f:
-                            f.write("1")
+                        from backend.core.unified_speech_state import (
+                            SpeechSource, get_speech_state_manager,
+                        )
+
+                        # Announce BEFORE any audio plays. The manager
+                        # broadcasts, `hud.speech_bridge` forwards over the IPC
+                        # socket, and the HUD mutes its tap — all before `say`
+                        # has produced a sample.
+                        try:
+                            _speech = await get_speech_state_manager()
+                            await _speech.start_speaking(
+                                text, source=SpeechSource.SYSTEM)
+                        except Exception as _sp_err:  # noqa: BLE001
+                            # Speak anyway. A missing mute risks an echo; a
+                            # refusal to speak because bookkeeping failed is a
+                            # mute button on the whole assistant.
+                            logger.warning("[HUD] speech-state start failed "
+                                           "(%s) — speaking unsuppressed",
+                                           _sp_err)
 
                         with _tf.NamedTemporaryFile(suffix=".aiff", delete=False) as tmp:
                             tmp_path = tmp.name
@@ -2009,11 +2035,20 @@ async def parallel_lifespan(app: FastAPI):
                     except Exception as tts_err:
                         logger.debug("[HUD] TTS failed: %s", tts_err)
                     finally:
-                        # Remove flag — allow mic to resume
-                        try:
-                            os.unlink(_SPEAKING_FLAG)
-                        except OSError:
-                            pass
+                        # Best effort, and NOT the only thing standing between
+                        # the operator and a deaf microphone: every frame this
+                        # sends carries its own deadline, and the manager has
+                        # its own 60s watchdog. `finally:` is the fast path, not
+                        # the guarantee — which is the difference between this
+                        # and the lockfile it replaced.
+                        if _speech is not None:
+                            try:
+                                await _speech.stop_speaking()
+                            except Exception as _sp_err:  # noqa: BLE001
+                                logger.warning(
+                                    "[HUD] speech-state stop failed (%s) — the "
+                                    "HUD mic will un-mute on its own deadline",
+                                    _sp_err)
 
                 # Dispatch IPC events through the same command processor
                 async def _hud_dispatch(event_type: str, data: dict) -> None:
@@ -2077,11 +2112,19 @@ async def parallel_lifespan(app: FastAPI):
                                         )
 
                                     # --- TTS: Voice narration (gated by JARVIS_HUD_TTS) ---
-                                    # OFF by default — causes voice feedback loop until the
-                                    # Swift HUD is rebuilt with the /tmp/jarvis_speaking
-                                    # mic-suppression check in WakeWordListener.swift.
-                                    # Enable with: JARVIS_HUD_TTS=1 after rebuilding Swift.
-                                    _tts_enabled = os.environ.get("JARVIS_HUD_TTS", "0").lower() in ("1", "true", "yes")
+                                    # v285.0: ON by default. It was off because
+                                    # the feedback loop was unsolved — the mic
+                                    # heard JARVIS and treated it as a command.
+                                    #
+                                    # The loop is now closed at the layer that
+                                    # matters: `SpeechGate` in the HUD drops
+                                    # audio buffers AT THE TAP while any of the
+                                    # four speech sources holds a claim, and
+                                    # every claim carries a deadline so a lost
+                                    # callback or a dead socket cannot leave the
+                                    # microphone shut. Turn off with
+                                    # JARVIS_HUD_TTS=0.
+                                    _tts_enabled = os.environ.get("JARVIS_HUD_TTS", "1").lower() in ("1", "true", "yes")
                                     if _tts_enabled:
                                         if _is_messaging and _msg_contact_match:
                                             _contact_name = _msg_contact_match.group(1)
@@ -2204,6 +2247,17 @@ async def parallel_lifespan(app: FastAPI):
                     _install_consent()
                 except Exception as _ce:  # noqa: BLE001
                     logger.error("[HUD] consent bridge install failed: %s", _ce)
+
+                # Tell the HUD when JARVIS is speaking, so it can mute its own
+                # microphone. `UnifiedSpeechStateManager` has always known;
+                # its `register_websocket_broadcaster` had zero callers, so
+                # nothing ever carried the answer to the process that owns the
+                # microphone. This is that wire.
+                try:
+                    from backend.hud.speech_bridge import install as _install_speech
+                    await _install_speech()
+                except Exception as _se:  # noqa: BLE001
+                    logger.error("[HUD] speech bridge install failed: %s", _se)
             except Exception as e:
                 logger.error("[HUD] IPC server failed to start: %s", e)
 

--- a/tests/hud/test_speech_bridge.py
+++ b/tests/hud/test_speech_bridge.py
@@ -1,0 +1,270 @@
+"""Telling the HUD when JARVIS is speaking — so it can shut its own microphone.
+
+`UnifiedSpeechStateManager` has tracked this correctly for a long time: seven
+sources, a length-scaled echo cooldown, a text-similarity check for an echo that
+slipped the gate, an `AudioBus` mic gate, and a 60s watchdog. Its
+`register_websocket_broadcaster` had **zero callers**, so none of it ever
+reached the process that owns the microphone. The HUD instead read
+`/tmp/jarvis_speaking`, a file with no liveness, describing one of four
+speakers, stat'd in the recognition callback — one layer above the audio it was
+supposed to suppress.
+
+The mandated scenario is `test_a_start_mutes_and_a_stop_unmutes`: the manager
+speaks, the HUD gets a frame that says so, and the frame carries a deadline.
+
+THE TESTS TO KEEP
+-------------------
+`test_every_frame_carries_a_bounded_deadline`. A mute is a claim on the
+operator's microphone. If the process is killed between start and stop, the
+deadline is the only thing that gives it back — the property the lockfile could
+never have, because `finally:` does not run on SIGKILL.
+
+`test_a_stop_is_never_throttled_away`. The manager dropped any broadcast inside
+50ms of the previous one, regardless of what it said. A short utterance starts
+and stops well inside that window, so `speech_ended` was discarded while
+`speech_started` had gone out — muted, with nothing left to unmute.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any, Dict, List, Tuple
+
+import pytest
+
+from backend.hud import speech_bridge as sb
+
+
+@pytest.fixture(autouse=True)
+def _env(monkeypatch):
+    monkeypatch.setenv("JARVIS_HUD_SPEECH_BRIDGE_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_HUD_SPEECH_GRACE_MS", "400")
+    monkeypatch.setenv("JARVIS_HUD_SPEECH_MAX_CLAIM_MS", "60000")
+    sb.reset()
+    yield
+    sb.reset()
+
+
+class _Publisher:
+    """Stands in for `ipc_server.publish`, recording every frame."""
+
+    def __init__(self, reached: int = 1) -> None:
+        self.frames: List[Tuple[str, Dict[str, Any]]] = []
+        self.reached = reached
+
+    def __call__(self, event: str, data: Dict[str, Any]) -> int:
+        self.frames.append((event, dict(data)))
+        return self.reached
+
+    @property
+    def last(self) -> Dict[str, Any]:
+        return self.frames[-1][1]
+
+
+def _message(event: str, *, speaking: bool, text: str = "",
+             cooldown_until: float = 0.0,
+             started_at: float = 0.0) -> Dict[str, Any]:
+    """The exact shape `UnifiedSpeechStateManager._broadcast_state_change` emits."""
+    return {
+        "type": "speech_state_change",
+        "event": event,
+        "state": {
+            "is_speaking": speaking,
+            "speech_started_at": started_at or (time.time() * 1000),
+            "speech_ended_at": None if speaking else time.time() * 1000,
+            "current_text": text,
+            "current_source": "system",
+            "cooldown_until": cooldown_until,
+            "in_cooldown": cooldown_until > time.time() * 1000,
+            "cooldown_remaining_ms": 0,
+            "recent_texts_count": 1,
+        },
+        "timestamp": time.time() * 1000,
+    }
+
+
+class TestTheMandatedScenario:
+    def test_a_start_mutes_and_a_stop_unmutes(self):
+        pub = _Publisher()
+        bridge = sb.HUDSpeechBroadcaster(publish=pub)
+
+        bridge(_message("speech_started", speaking=True, text="On it."))
+        bridge(_message("speech_ended", speaking=False))
+
+        assert len(pub.frames) == 2
+        assert all(e == sb.SPEECH_STATE_EVENT for e, _ in pub.frames)
+        assert pub.frames[0][1]["speaking"] is True
+        assert pub.frames[1][1]["speaking"] is False
+
+
+class TestTheDeadline:
+    def test_every_frame_carries_a_bounded_deadline(self):
+        """The only thing that returns the mic if this process is SIGKILLed."""
+        pub = _Publisher()
+        bridge = sb.HUDSpeechBroadcaster(publish=pub)
+
+        bridge(_message("speech_started", speaking=True, text="hello there"))
+
+        frame = pub.last
+        now = frame["now_ms"]
+        assert frame["deadline_ms"] > now
+        assert frame["deadline_ms"] <= now + sb.max_claim_ms()
+
+    def test_a_longer_utterance_gets_a_longer_deadline(self):
+        pub = _Publisher()
+        bridge = sb.HUDSpeechBroadcaster(publish=pub)
+
+        bridge(_message("speech_started", speaking=True, text="hi"))
+        short = pub.last["deadline_ms"] - pub.last["now_ms"]
+        bridge(_message("speech_started", speaking=True, text="x" * 600))
+        long = pub.last["deadline_ms"] - pub.last["now_ms"]
+
+        assert long > short
+
+    def test_the_ceiling_is_absolute(self, monkeypatch):
+        """No arithmetic may escape the cap — an unbounded mute is deafness."""
+        monkeypatch.setenv("JARVIS_HUD_SPEECH_MAX_CLAIM_MS", "5000")
+        pub = _Publisher()
+        bridge = sb.HUDSpeechBroadcaster(publish=pub)
+
+        bridge(_message("speech_started", speaking=True, text="x" * 100000))
+
+        frame = pub.last
+        assert frame["deadline_ms"] - frame["now_ms"] <= 5000 + 1
+
+    def test_a_stop_honours_the_cooldown_rather_than_unmuting_instantly(self):
+        """The room is still ringing; the manager already models that."""
+        pub = _Publisher()
+        bridge = sb.HUDSpeechBroadcaster(publish=pub)
+        cooldown = time.time() * 1000 + 1500
+
+        bridge(_message("speech_ended", speaking=False, cooldown_until=cooldown))
+
+        frame = pub.last
+        assert frame["speaking"] is False
+        assert frame["deadline_ms"] > frame["now_ms"], (
+            "unmuted instantly, so the tail of JARVIS's own sentence can be "
+            "transcribed as a command")
+
+    def test_an_elapsed_cooldown_unmutes_now(self):
+        pub = _Publisher()
+        bridge = sb.HUDSpeechBroadcaster(publish=pub)
+        stale = time.time() * 1000 - 10_000
+
+        bridge(_message("speech_ended", speaking=False, cooldown_until=stale))
+
+        frame = pub.last
+        assert frame["deadline_ms"] <= frame["now_ms"] + 1
+
+
+class TestFrameBuilding:
+    def test_it_ignores_messages_that_are_not_speech_state(self):
+        """An unrelated broadcaster message must never mute a microphone."""
+        assert sb.build_frame({"type": "something_else", "state": {}}) is None
+        assert sb.build_frame({}) is None
+        assert sb.build_frame(None) is None          # type: ignore[arg-type]
+        assert sb.build_frame({"type": "speech_state_change"}) is None
+
+    def test_a_malformed_state_does_not_raise(self):
+        assert sb.build_frame(
+            {"type": "speech_state_change", "state": "not-a-dict"}) is None
+
+    def test_the_frame_is_flat_and_absolute(self):
+        """The HUD re-derives nothing: two clocks agreeing on a rule is how
+        they eventually disagree."""
+        frame = sb.build_frame(
+            _message("speech_started", speaking=True, text="hi"))
+        assert set(frame) >= {"speaking", "deadline_ms", "now_ms", "source"}
+        assert isinstance(frame["speaking"], bool)
+        assert isinstance(frame["deadline_ms"], float)
+
+    def test_the_estimate_is_an_over_estimate(self):
+        """Under-estimating unmutes mid-sentence and feeds the loop."""
+        # ~12 chars/sec, plus a floor. 120 chars must exceed 10s of speech.
+        assert sb.estimate_speech_ms("x" * 120) >= 10_000
+        assert sb.estimate_speech_ms("") >= 1000
+        assert sb.estimate_speech_ms("x" * 10**7) <= sb.max_claim_ms()
+
+
+class TestFailingSafe:
+    def test_no_hud_connected_is_not_an_error(self):
+        """No HUD means no microphone of ours is listening."""
+        pub = _Publisher(reached=0)
+        bridge = sb.HUDSpeechBroadcaster(publish=pub)
+
+        bridge(_message("speech_started", speaking=True, text="hi"))
+
+        assert bridge.stats()["unreached"] == 1
+        assert bridge.stats()["sent"] == 0
+
+    def test_a_raising_publisher_never_escapes(self):
+        def _boom(event, data):
+            raise RuntimeError("socket exploded")
+
+        bridge = sb.HUDSpeechBroadcaster(publish=_boom)
+        bridge(_message("speech_started", speaking=True, text="hi"))  # no raise
+
+    def test_disabled_publishes_nothing(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_HUD_SPEECH_BRIDGE_ENABLED", "0")
+        pub = _Publisher()
+        sb.HUDSpeechBroadcaster(publish=pub)(
+            _message("speech_started", speaking=True, text="hi"))
+        assert pub.frames == []
+
+    def test_knobs_are_clamped(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_HUD_SPEECH_MAX_CLAIM_MS", "not-a-number")
+        assert sb.max_claim_ms() == 60000.0
+        monkeypatch.setenv("JARVIS_HUD_SPEECH_GRACE_MS", "999999")
+        assert sb.speaking_grace_ms() == 5000.0
+
+
+class TestAgainstTheRealManager:
+    """Drives the actual `UnifiedSpeechStateManager`, not a stand-in."""
+
+    async def test_install_subscribes_to_the_authority(self, monkeypatch):
+        from backend.core.unified_speech_state import (
+            SpeechSource, get_speech_state_manager,
+        )
+
+        pub = _Publisher()
+        monkeypatch.setattr(sb, "_BROADCASTER", None)
+        manager = await get_speech_state_manager()
+        before = len(manager._websocket_broadcasters)
+
+        assert await sb.install() is True
+        sb.get_broadcaster()._publish = pub
+
+        assert len(manager._websocket_broadcasters) == before + 1
+
+        await manager.start_speaking("Opening Safari.",
+                                     source=SpeechSource.SYSTEM)
+        assert pub.frames, "the authority spoke and the HUD was not told"
+        assert pub.last["speaking"] is True
+
+        await manager.stop_speaking()
+        manager._websocket_broadcasters.remove(sb.get_broadcaster())
+
+    async def test_a_stop_is_never_throttled_away(self):
+        """A short utterance starts and stops inside the 50ms throttle window.
+
+        The throttle used to drop it outright, leaving a consumer muted with
+        nothing left to unmute it. Only REPEATS may be throttled; a transition
+        is the entire message.
+        """
+        from backend.core.unified_speech_state import (
+            SpeechSource, get_speech_state_manager,
+        )
+
+        seen: List[str] = []
+        manager = await get_speech_state_manager()
+        manager.register_websocket_broadcaster(
+            lambda m: seen.append(m.get("event", "")))
+        try:
+            await manager.start_speaking("Done.", source=SpeechSource.SYSTEM)
+            await manager.stop_speaking()          # well inside 50ms
+            assert "speech_started" in seen
+            assert "speech_ended" in seen, (
+                "the terminal event was throttled away — the mic would stay "
+                "muted forever")
+        finally:
+            manager._websocket_broadcasters.clear()


### PR DESCRIPTION
`MicSuppression.swift` has been on disk since `378497d8a0` and **never compiled**. It could not: it was a design document in Swift syntax whose `extension WakeWordListener` referenced a `micMuted` that did not exist. This implements it, finds the parts of it that were already stale, and closes the loop it described.

## Four things speak; they each invented their own signal

| Source | Suppression |
|---|---|
| `HUDAppDelegate.tts` | tore the audio graph down, then slept 3s |
| `AppState.VoiceManager` | **nothing at all** |
| Python `_hud_tts` | wrote `/tmp/jarvis_speaking` |
| Backend `realtime_voice_*` | told `UnifiedSpeechStateManager`, which had no way to reach the process owning the microphone |

Three mechanisms, one of them absent, for one question.

## The authority already existed and nothing carried it

`UnifiedSpeechStateManager` tracks seven speech sources with a length-scaled echo cooldown, a text-similarity check for an echo the gate missed, an `AudioBus` mic gate, and a 60s watchdog. Its `register_websocket_broadcaster` had **zero callers**, so the broadcast surface built for exactly this was dark. This adds the wire (`hud/speech_bridge.py`) — not a second notion of "speaking", no parallel cooldown, no new watchdog.

## The suppression that existed was at the wrong layer

`WakeWordListener` stat'd `/tmp/jarvis_speaking` in the recognition **result** callback. Audio still reached `req.append(buffer)`, so the recogniser kept transcribing JARVIS's own voice into the running transcript and delivered the lot as a command the moment the flag cleared. It suppressed the symptom one layer above the cause — and did a synchronous filesystem `stat` several times a second to do it.

The gate is now the **tap**: the buffer is dropped, so the audio never reaches the recogniser at all. Dropping rather than pausing keeps the request alive — `SFSpeechAudioBufferRecognitionRequest` treats a gap as silence, which is exactly what it was.

## Why deafness is now unrepresentable

**`didCancel` was never implemented.** A cancelled utterance never fires `didFinish`, so `isTTSSpeaking` stayed true and the mic never came back — reproducible by interrupting JARVIS mid-sentence, which `VoiceManager.speak` does *deliberately* on every higher-priority utterance. The lockfile had the same shape from the other side: SIGKILL Python and `finally:` never runs, so the flag outlives the process that meant it.

Implementing `didCancel` fixes the case we thought of. Every claim also carries a **deadline**, which fixes the ones we did not: a lost callback, a dead socket, a synthesiser wedged in the audio server.

- Claims are **refcounted per named source** — a boolean loses when one synthesiser finishes while the other is still talking.
- The backend's claim is **dropped when the IPC connection drops** — crash-safety as a property of the transport rather than a cleanup routine somebody has to remember.
- Deadlines are trusted for their **duration**, never their absolute value: the two processes do not share a clock, and a backend running fast must not be able to mute the mic for five minutes.

Also removes the 3-second deaf window after every utterance, and the engine teardown/rebuild that produced the `-10877` class.

## Also fixed

- `_broadcast_state_change` threw away **any** broadcast within 50ms of the previous one. A short utterance — "Done." — starts and stops inside that window, so `speech_ended` was silently discarded while `speech_started` had gone out: muted, with nothing left to unmute. Repeats are still throttled; a transition is the entire message.
- `build_frame` used `message.get("state") or {}`, turning a **missing** state into a well-formed unmute frame derived from no data.
- `JARVIS_HUD_TTS` now defaults **ON**. It was off because this loop was unsolved.

## Testing

`BUILD SUCCEEDED`, Swift 6 clean, and **no dark Swift files remain** in the HUD target. 16 new tests; 221 green across the touched suites.

**Not live-proven:** the real HUD speaking and listening on the same machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies mic suppression behind a single arbiter so the mic never stays muted and JARVIS can’t hear itself. Moves gating to the audio tap, bridges backend speech state to the HUD over IPC, and removes the fragile lockfile path.

- **New Features**
  - Added `SpeechGate`: refcounted, deadline-backed claims per source (HUD TTS, VoiceManager, backend). Mutes at the audio tap; mic re-opens when the last claim ends.
  - Bridged `UnifiedSpeechStateManager` to the HUD via `backend/hud/speech_bridge.py`; each IPC frame carries a deadline. IPC drop auto-releases the backend claim.
  - HUD and VoiceManager now claim/release on `didStart`/`didFinish`/`didCancel`. No engine teardown or 3s sleep; mic resumes immediately after speech.
  - `JARVIS_HUD_TTS` now defaults on (set to 0 to disable).

- **Bug Fixes**
  - Fixed permanent deafness: implemented `didCancel` and added deadlines so lost callbacks or crashes can’t leave the mic shut.
  - Moved suppression from recognition result handling to the tap, preventing self-transcription and echo loops.
  - Broadcast throttle no longer drops transitions; only repeats are throttled. `build_frame` ignores malformed/missing state.
  - Compiled and integrated `MicSuppression.swift`. Added tests for the speech bridge and end-to-end speech state.

<sup>Written for commit 4619997eeb2264d39642af41dfe0e876061bb76f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

