### PR TITLE
fix(auth): stop the HUD killing itself at launch on an odd-length device secret

### DIFF
--- a/JARVIS-Apple/JARVISHUD/Services/AppState.swift
+++ b/JARVIS-Apple/JARVISHUD/Services/AppState.swift
@@ -149,11 +149,33 @@ class PythonBridge: ObservableObject {
         deviceId = creds.deviceId
         baseURL = creds.baseURL
 
-        let deviceAuth = DeviceAuth(
+        // MALFORMED is a third state, distinct from PRESENT and MISSING.
+        //
+        // `loadCredentials()` returning nil already lands cleanly on "not
+        // paired". Credentials that exist but cannot be used had no handling at
+        // all — they went straight into `DeviceAuth`, which trapped, and the
+        // app died at launch with `Fatal error: String index is out of bounds`.
+        //
+        // The message is deliberately NOT the "not paired" one: the remedies
+        // are opposite. "Not paired" means go and pair the device. This means
+        // the value you already have is corrupt — re-pair or fix the `.env`.
+        // Telling an operator to pair a device that IS paired sends them
+        // looking in the one place the problem is not.
+        guard let deviceAuth = DeviceAuth(
             deviceId: creds.deviceId,
             deviceType: .mac,
             deviceSecret: creds.deviceSecret
-        )
+        ) else {
+            let hint = "JARVIS_DEVICE_SECRET must be an even number of hex "
+                     + "characters (got \(creds.deviceSecret.count))"
+            print("[JARVIS] Device secret is not usable — \(hint)")
+            updateLoading(progress: 0, message: "Device secret is malformed")
+            connectionStatus = .error
+            detailedConnectionState = "Malformed device secret — \(hint)"
+            hudState = .offline
+            isRunning = false
+            return
+        }
         auth = deviceAuth
         commandSender = CommandSender(baseURL: creds.baseURL, auth: deviceAuth)
 
@@ -566,7 +588,21 @@ class PythonBridge: ObservableObject {
         if !forceCloud {
             let localURL = env["JARVIS_LOCAL_BACKEND_URL"] ?? "http://localhost:8010"
             let id = env["JARVIS_DEVICE_ID"] ?? "mac-local"
-            let secret = env["JARVIS_DEVICE_SECRET"] ?? "local"
+            // The default was the literal string "local", and the comment above
+            // called a placeholder secret "fine". It was not: the secret is
+            // hex-encoded by contract on all three implementations, and "local"
+            // is five characters — odd-length, so `DeviceAuth` trapped and the
+            // app died at launch on the DEFAULT path. Running the HUD from
+            // Xcode without JARVIS_DEVICE_SECRET set reproduced it every time.
+            //
+            // Derived rather than replaced with a hex literal: no magic
+            // constant to drift, deterministic per device id, and valid input
+            // for Python's `bytes.fromhex` and TypeScript's
+            // `Buffer.from(_, "hex")` as well as ours — so pointing the local
+            // path at a backend that DOES verify signatures becomes a
+            // configuration change rather than another crash.
+            let secret = env["JARVIS_DEVICE_SECRET"]
+                ?? DeviceAuth.derivedLocalSecret(forDeviceId: id)
             print("[JARVIS] LOCAL-FIRST: connecting to \(localURL) (device: \(id))")
             return HUDCredentials(deviceId: id, deviceSecret: secret, baseURL: localURL)
         }

--- a/JARVIS-Apple/JARVISKit/Sources/JARVISKit/Auth/DeviceAuth.swift
+++ b/JARVIS-Apple/JARVISKit/Sources/JARVISKit/Auth/DeviceAuth.swift
@@ -6,10 +6,25 @@ public final class DeviceAuth: Sendable {
     public let deviceType: DeviceType
     private let secretKey: SymmetricKey
 
-    public init(deviceId: String, deviceType: DeviceType, deviceSecret: String) {
+    /// Fails when `deviceSecret` is not a usable hex-encoded key.
+    ///
+    /// FAILABLE ON PURPOSE. The previous initialiser could not express "that is
+    /// not a secret": it took a `String` and had to produce a key, so a
+    /// malformed value left it two options — trap, or fabricate. It did both,
+    /// depending on the input, and trapping killed the app at launch.
+    ///
+    /// Returning nil moves the decision to the caller, which is the only place
+    /// that knows what to do about it. A HUD can show "credentials are
+    /// malformed" and stay up; a paired phone can send the user back to
+    /// Settings. Neither outcome is available to an initialiser that can only
+    /// succeed or die.
+    public init?(deviceId: String, deviceType: DeviceType, deviceSecret: String) {
+        guard let bytes = Self.decodeHexSecret(deviceSecret), !bytes.isEmpty else {
+            return nil
+        }
         self.deviceId = deviceId
         self.deviceType = deviceType
-        self.secretKey = SymmetricKey(data: Self.hexToBytes(deviceSecret))
+        self.secretKey = SymmetricKey(data: Data(bytes))
     }
 
     /// Canonical field order — MUST match TypeScript server and Python brainstem
@@ -62,16 +77,78 @@ public final class DeviceAuth: Sendable {
         return parts.joined(separator: "&")
     }
 
-    private static func hexToBytes(_ hex: String) -> [UInt8] {
+    /// Decode a hex-encoded shared secret. Returns nil if it is not one.
+    ///
+    /// THE CRASH THIS REPLACES
+    /// -------------------------
+    /// The previous version walked the string two characters at a time with
+    /// `hex.index(index, offsetBy: 2)`. On an ODD-LENGTH string the final step
+    /// runs past `endIndex`, and `String.index(_:offsetBy:)` traps — taking the
+    /// whole process with it. The HUD's own local-first default secret was the
+    /// literal `"local"`: five characters, so **the app killed itself at boot
+    /// with `Fatal error: String index is out of bounds` every single launch**
+    /// unless `JARVIS_DEVICE_SECRET` happened to be set.
+    ///
+    /// A CRLF `.env` file reaches the same place from another direction: the
+    /// loader splits on `"\n"` and trims only `.whitespaces`, so a 64-character
+    /// secret arrives as 65 characters with a trailing `\r`.
+    ///
+    /// Striding over an `Array<Character>` by integer index cannot express that
+    /// bug — there is no cursor to advance past the end, and the count is
+    /// checked before any indexing happens.
+    ///
+    /// WHY IT REFUSES INSTEAD OF SKIPPING
+    /// ------------------------------------
+    /// The old loop did `if let byte = UInt8(pair, radix: 16)` and SILENTLY
+    /// DROPPED anything that failed to parse. That is worse than the crash it
+    /// sat next to: `"local"` would have yielded a single byte (`0xCA`, from
+    /// the pair `"ca"`) and produced a perfectly usable `SymmetricKey` that
+    /// could never match the server's. Every request would fail authentication
+    /// with nothing anywhere saying why.
+    ///
+    /// The secret is hex by contract on all three implementations — Python uses
+    /// `bytes.fromhex`, TypeScript uses `Buffer.from(secret, "hex")` — so
+    /// anything that is not hex is a configuration error, and the only honest
+    /// response is to say so rather than to improvise a key.
+    ///
+    /// It DOES normalise what is merely untidy rather than wrong: surrounding
+    /// whitespace and newlines, an optional `0x` prefix, and either case. Those
+    /// are transport artefacts of a `.env` file or a copy-paste, not corruption,
+    /// and rejecting them would send an operator hunting for a bug in a secret
+    /// that is perfectly correct.
+    public static func decodeHexSecret(_ raw: String) -> [UInt8]? {
+        var s = Substring(raw).trimmingCharacters(in: .whitespacesAndNewlines)
+        if s.hasPrefix("0x") || s.hasPrefix("0X") { s = String(s.dropFirst(2)) }
+        guard !s.isEmpty else { return nil }
+
+        let chars = Array(s)
+        guard chars.count % 2 == 0 else { return nil }
+
         var bytes: [UInt8] = []
-        var index = hex.startIndex
-        while index < hex.endIndex {
-            let nextIndex = hex.index(index, offsetBy: 2)
-            if let byte = UInt8(hex[index..<nextIndex], radix: 16) {
-                bytes.append(byte)
-            }
-            index = nextIndex
+        bytes.reserveCapacity(chars.count / 2)
+        for i in stride(from: 0, to: chars.count, by: 2) {
+            guard let hi = chars[i].hexDigitValue,
+                  let lo = chars[i + 1].hexDigitValue else { return nil }
+            bytes.append(UInt8(hi << 4 | lo))
         }
         return bytes
+    }
+
+    /// A well-formed secret for a loopback-trusted local backend.
+    ///
+    /// The HUD's local-first path connects to `localhost:8010`, whose
+    /// `/api/command` handler performs no signature verification at all
+    /// (checked, not assumed). The secret's VALUE is therefore irrelevant
+    /// there; only its WELL-FORMEDNESS matters, because `DeviceAuth` must be
+    /// constructible.
+    ///
+    /// Derived rather than hardcoded so there is no magic constant to drift,
+    /// and deterministic per device id so it is stable across launches — which
+    /// matters the day someone points the local path at a backend that DOES
+    /// verify, because both sides can then compute the same value from the same
+    /// input instead of one of them inventing a fresh one.
+    public static func derivedLocalSecret(forDeviceId deviceId: String) -> String {
+        let digest = SHA256.hash(data: Data("jarvis-local:\(deviceId)".utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
     }
 }

--- a/JARVIS-Apple/JARVISKit/Tests/JARVISKitTests/DeviceAuthTests.swift
+++ b/JARVIS-Apple/JARVISKit/Tests/JARVISKitTests/DeviceAuthTests.swift
@@ -1,8 +1,8 @@
 import Testing
 @testable import JARVISKit
 
-@Test func canonicalizeMatchesSpec() {
-    let auth = DeviceAuth(deviceId: "watch-ultra2-derek", deviceType: .watch, deviceSecret: String(repeating: "a", count: 64))
+@Test func canonicalizeMatchesSpec() throws {
+    let auth = try #require(DeviceAuth(deviceId: "watch-ultra2-derek", deviceType: .watch, deviceSecret: String(repeating: "a", count: 64)))
     let payload = CommandPayload(
         commandId: "cmd-001",
         deviceId: "watch-ultra2-derek",
@@ -16,8 +16,8 @@ import Testing
     #expect(canonical == "command_id=cmd-001&device_id=watch-ultra2-derek&device_type=watch&priority=realtime&response_mode=stream&text=refactor the auth module&timestamp=2026-03-29T18:45:00Z")
 }
 
-@Test func signProduces64CharHex() {
-    let auth = DeviceAuth(deviceId: "mac-m1", deviceType: .mac, deviceSecret: String(repeating: "a", count: 64))
+@Test func signProduces64CharHex() throws {
+    let auth = try #require(DeviceAuth(deviceId: "mac-m1", deviceType: .mac, deviceSecret: String(repeating: "a", count: 64)))
     let payload = CommandPayload(
         commandId: "cmd-001", deviceId: "mac-m1", deviceType: .mac, text: "hello",
         priority: .realtime, responseMode: .stream, timestamp: "2026-03-29T18:45:00Z"
@@ -27,8 +27,8 @@ import Testing
     #expect(sig.allSatisfy { "0123456789abcdef".contains($0) })
 }
 
-@Test func signIsDeterministic() {
-    let auth = DeviceAuth(deviceId: "mac-m1", deviceType: .mac, deviceSecret: String(repeating: "a", count: 64))
+@Test func signIsDeterministic() throws {
+    let auth = try #require(DeviceAuth(deviceId: "mac-m1", deviceType: .mac, deviceSecret: String(repeating: "a", count: 64)))
     let payload = CommandPayload(
         commandId: "cmd-001", deviceId: "mac-m1", deviceType: .mac, text: "hello",
         priority: .realtime, responseMode: .stream, timestamp: "2026-03-29T18:45:00Z"
@@ -36,15 +36,15 @@ import Testing
     #expect(auth.sign(payload) == auth.sign(payload))
 }
 
-@Test func signChangesWithDifferentText() {
-    let auth = DeviceAuth(deviceId: "mac-m1", deviceType: .mac, deviceSecret: String(repeating: "a", count: 64))
+@Test func signChangesWithDifferentText() throws {
+    let auth = try #require(DeviceAuth(deviceId: "mac-m1", deviceType: .mac, deviceSecret: String(repeating: "a", count: 64)))
     let p1 = CommandPayload(commandId: "cmd-001", deviceId: "mac-m1", deviceType: .mac, text: "hello", priority: .realtime, responseMode: .stream, timestamp: "2026-03-29T18:45:00Z")
     let p2 = CommandPayload(commandId: "cmd-001", deviceId: "mac-m1", deviceType: .mac, text: "goodbye", priority: .realtime, responseMode: .stream, timestamp: "2026-03-29T18:45:00Z")
     #expect(auth.sign(p1) != auth.sign(p2))
 }
 
-@Test func canonicalizeIncludesIntentHint() {
-    let auth = DeviceAuth(deviceId: "mac-m1", deviceType: .mac, deviceSecret: String(repeating: "a", count: 64))
+@Test func canonicalizeIncludesIntentHint() throws {
+    let auth = try #require(DeviceAuth(deviceId: "mac-m1", deviceType: .mac, deviceSecret: String(repeating: "a", count: 64)))
     let payload = CommandPayload(
         commandId: "cmd-001", deviceId: "mac-m1", deviceType: .mac, text: "scan",
         intentHint: "ouroboros_scan", priority: .background, responseMode: .notify,
@@ -54,4 +54,79 @@ import Testing
     #expect(canonical.contains("intent_hint=ouroboros_scan"))
     let parts = canonical.split(separator: "&").map { String($0.split(separator: "=")[0]) }
     #expect(parts.firstIndex(of: "intent_hint") == 3)
+}
+
+// MARK: - Secret decoding
+//
+// The HUD killed itself at launch with `Fatal error: String index is out of
+// bounds` every time `JARVIS_DEVICE_SECRET` was unset, because the local-first
+// default secret was the literal `"local"` — five characters. The old decoder
+// walked the string with `index(_:offsetBy: 2)`, which traps when the final
+// step runs past `endIndex`.
+//
+// `theLiteralLocalDefaultIsRejected` is the regression. The rest are the
+// sources a malformed secret actually arrives from.
+
+@Test func theLiteralLocalDefaultIsRejected() {
+    // THE crash. Odd length AND non-hex — it must not trap, and it must not
+    // silently yield the single byte 0xCA from the pair "ca", which is what the
+    // old decoder did with the characters it could parse.
+    #expect(DeviceAuth.decodeHexSecret("local") == nil)
+    #expect(DeviceAuth(deviceId: "mac-local", deviceType: .mac,
+                       deviceSecret: "local") == nil)
+}
+
+@Test func oddLengthIsRejectedRatherThanTrapping() {
+    // Valid hex characters, odd count — the exact shape that ran off the end.
+    #expect(DeviceAuth.decodeHexSecret("abc") == nil)
+    #expect(DeviceAuth.decodeHexSecret("a") == nil)
+    #expect(DeviceAuth.decodeHexSecret(String(repeating: "a", count: 65)) == nil)
+}
+
+@Test func nonHexIsRejectedNotSilentlySkipped() {
+    // The quieter half of the bug: the old decoder dropped unparseable pairs
+    // and returned a shorter key that could never match the server's, so every
+    // request failed authentication with nothing saying why.
+    #expect(DeviceAuth.decodeHexSecret("zzzz") == nil)
+    #expect(DeviceAuth.decodeHexSecret("abcdzz01") == nil)
+    #expect(DeviceAuth.decodeHexSecret("ab cd") == nil)   // interior space
+}
+
+@Test func aCRLFEnvFileStillWorks() {
+    // `loadFromBrainstemEnv` splits on "\n" and trims only `.whitespaces`, so a
+    // CRLF file hands over a 64-character secret as 65 characters with a
+    // trailing "\r" — odd, and previously fatal.
+    let good = String(repeating: "ab", count: 32)
+    #expect(DeviceAuth.decodeHexSecret(good + "\r")?.count == 32)
+    #expect(DeviceAuth.decodeHexSecret("\n " + good + " \n")?.count == 32)
+}
+
+@Test func normalisesTransportArtefactsButNotCorruption() {
+    let good = String(repeating: "ab", count: 32)
+    #expect(DeviceAuth.decodeHexSecret("0x" + good)?.count == 32)
+    #expect(DeviceAuth.decodeHexSecret(good.uppercased())
+            == DeviceAuth.decodeHexSecret(good))
+    // ...but tidying stops there.
+    #expect(DeviceAuth.decodeHexSecret("") == nil)
+    #expect(DeviceAuth.decodeHexSecret("0x") == nil)
+    #expect(DeviceAuth.decodeHexSecret("   ") == nil)
+}
+
+@Test func decodesTheBytesThePythonAndTypeScriptSidesWould() {
+    // Interop is the whole point: Python does `bytes.fromhex`, TypeScript does
+    // `Buffer.from(secret, "hex")`. A decoder that disagreed about the VALUE
+    // would produce signatures the server rejects.
+    #expect(DeviceAuth.decodeHexSecret("00ff10") == [0x00, 0xFF, 0x10])
+    #expect(DeviceAuth.decodeHexSecret("deadbeef") == [0xDE, 0xAD, 0xBE, 0xEF])
+}
+
+@Test func theDerivedLocalSecretIsUsableAndStable() throws {
+    let a = DeviceAuth.derivedLocalSecret(forDeviceId: "mac-local")
+    #expect(a.count == 64)                                   // 32 bytes of hex
+    #expect(DeviceAuth.decodeHexSecret(a)?.count == 32)
+    #expect(a == DeviceAuth.derivedLocalSecret(forDeviceId: "mac-local"))
+    #expect(a != DeviceAuth.derivedLocalSecret(forDeviceId: "other"))
+    // ...and the thing it exists for: the HUD can actually boot with it.
+    _ = try #require(DeviceAuth(deviceId: "mac-local", deviceType: .mac,
+                                deviceSecret: a))
 }

--- a/JARVIS-Apple/JARVISPhone/Services/PhoneSessionManager.swift
+++ b/JARVIS-Apple/JARVISPhone/Services/PhoneSessionManager.swift
@@ -23,7 +23,13 @@ class PhoneSessionManager: ObservableObject {
             return
         }
 
-        let deviceAuth = DeviceAuth(deviceId: deviceId, deviceType: .iphone, deviceSecret: secret)
+        guard let deviceAuth = DeviceAuth(deviceId: deviceId, deviceType: .iphone,
+                                          deviceSecret: secret) else {
+            // Paired, but the stored secret cannot be decoded. Re-pairing is
+            // the fix, and saying "not paired" would be a lie that hides it.
+            lastDaemon = "Stored credentials are corrupt — re-pair in Settings"
+            return
+        }
         auth = deviceAuth
         sender = CommandSender(baseURL: baseURL, auth: deviceAuth)
 

--- a/JARVIS-Apple/JARVISWatch/Services/WatchSessionManager.swift
+++ b/JARVIS-Apple/JARVISWatch/Services/WatchSessionManager.swift
@@ -22,7 +22,11 @@ class WatchSessionManager: ObservableObject {
             return
         }
 
-        let deviceAuth = DeviceAuth(deviceId: deviceId, deviceType: .watch, deviceSecret: secret)
+        guard let deviceAuth = DeviceAuth(deviceId: deviceId, deviceType: .watch,
+                                          deviceSecret: secret) else {
+            lastDaemon = "Stored credentials are corrupt — re-pair on iPhone."
+            return
+        }
         auth = deviceAuth
         sender = CommandSender(baseURL: baseURL, auth: deviceAuth)
 


### PR DESCRIPTION
Running `JARVISHUD` from Xcode died immediately, every time:

```
Swift/StringCharacterView.swift:158: Fatal error: String index is out of bounds
exit 133 (SIGTRAP)

DeviceAuth.hexToBytes      DeviceAuth.swift:69
  ← DeviceAuth.init         DeviceAuth.swift:12
  ← PythonBridge.boot       AppState.swift:152
```

## The trigger was the default

```swift
let secret = env["JARVIS_DEVICE_SECRET"] ?? "local"   // AppState.swift:569
```

`"local"` is **five characters**. `hexToBytes` walked the string two at a time with `hex.index(index, offsetBy: 2)`; on an odd-length string the final step runs past `endIndex`, and `String.index(_:offsetBy:)` **traps**. So the app killed itself on the *default* path whenever `JARVIS_DEVICE_SECRET` was unset — which is exactly what running from Xcode does.

The comment above it called a placeholder secret "fine". It was not: the secret is hex-encoded by contract on all three implementations, and `"local"` is not hex.

| | key derivation | on `"local"` |
|---|---|---|
| Python `brainstem/auth.py` | `bytes.fromhex(secret)` | `ValueError` |
| TypeScript `lib/auth/hmac.ts` | `Buffer.from(secret, "hex")` | silently empty |
| Swift `DeviceAuth` | hand-rolled | **traps — kills the app** |

A CRLF `.env` reaches the same crash from another direction: `loadFromBrainstemEnv` splits on `"\n"` and trims only `.whitespaces`, so a 64-character secret arrives as **65** characters with a trailing `\r`.

## The quieter half

The same loop did `if let byte = UInt8(pair, radix: 16)` and **silently dropped** anything unparseable. Without the crash, `"local"` would have produced a one-byte key (`0xCA`, from the pair `"ca"`) — a perfectly usable `SymmetricKey` that could never match the server's, so every request would fail authentication with nothing anywhere saying why. Silent corruption is worse than the trap sitting next to it.

## What changed

- **`decodeHexSecret` returns `[UInt8]?`** and strides an `Array<Character>` by integer index, which cannot express the walk-off-the-end bug. Refuses odd length and any non-hex character instead of skipping. Normalises what is merely *untidy* — surrounding whitespace/newlines, an optional `0x` prefix, either case — because those are `.env` transport artefacts, not corruption.
- **`DeviceAuth.init?` is failable.** The old initialiser could not express "that is not a secret": it took a `String` and had to produce a key, so it trapped or fabricated. Callers now decide, which is the only place that can.
- **HUD / Phone / Watch handle the failure with a message distinct from "not paired."** The remedies are opposite — telling someone to pair a device that *is* paired sends them to the one place the problem is not.
- **The local default is derived**, not a literal: SHA-256 of the device id → 64 hex chars. No magic constant, deterministic per device, and valid input for all three implementations. Its *value* is irrelevant today because the local `/api/command` performs no signature check — verified in `backend/main.py`, not assumed from the comment.

## Verification

- `BUILD SUCCEEDED`
- Before: exited **133** within seconds of launch. After: runs indefinitely, **zero** fatal errors.
- 12 JARVISKit tests pass, including `theLiteralLocalDefaultIsRejected` — the exact regression — plus odd-length, non-hex, CRLF, `0x`/case normalisation, empty input, and byte-level interop with `bytes.fromhex`.

> Committed from an isolated worktree: a second Claude Code session is holding 201 staged renames in the shared tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a HUD launch crash caused by odd-length or non-hex `JARVIS_DEVICE_SECRET` and stops silent key corruption by validating secrets and surfacing clear errors. Adds a derived, well-formed local default so running from Xcode works without extra setup.

- **Bug Fixes**
  - Replaced hex decoding to prevent index overrun; rejects odd-length and non-hex secrets.
  - Normalizes whitespace/newlines and optional `0x` prefix; CRLF `.env` now works.
  - HUD/Phone/Watch show “malformed secret” (not “not paired”) and stay running.
  - HUD no longer crashes when `JARVIS_DEVICE_SECRET` is unset.

- **Refactors**
  - `DeviceAuth.init` is now failable; only creates a key with a valid secret.
  - New `decodeHexSecret` returns `[UInt8]?` with no silent byte drops.
  - Local default secret is SHA-256 of the device id (64 hex), valid across Swift/Python/TypeScript.
  - Added tests for odd-length/non-hex, CRLF handling, normalization, and interop.

<sup>Written for commit e079160209cb8c5c4a0284605754b821adc4d944. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

