### PR TITLE
fix(hud): pick a Python that works, not one whose file exists

### DIFF
--- a/JARVIS-Apple/JARVISHUD/Services/BrainstemLauncher.swift
+++ b/JARVIS-Apple/JARVISHUD/Services/BrainstemLauncher.swift
@@ -30,6 +30,38 @@ final class BrainstemLauncher {
     private let ipcQueue = DispatchQueue(label: "com.jarvis.brainstem.ipc", qos: .userInitiated)
 
     /// The repo root, derived from the known brainstem .env path.
+    /// Can this interpreter actually import what the brainstem needs?
+    ///
+    /// Bounded on purpose: a hung probe would stall the HUD's startup, and an
+    /// interpreter that cannot answer in a few seconds is not one to launch a
+    /// backend with. A timeout counts as FAILURE — the candidate has to earn
+    /// selection, not merely avoid disproving itself.
+    private static func probeSucceeds(executable: String, arguments: [String],
+                                      environment: [String: String],
+                                      cwd: String,
+                                      timeout: TimeInterval = 12) -> Bool {
+        let p = Process()
+        p.executableURL = URL(fileURLWithPath: executable)
+        p.arguments = arguments
+        p.environment = environment
+        p.currentDirectoryURL = URL(fileURLWithPath: cwd)
+        // Discarded rather than piped: an unread pipe that fills would block
+        // the child forever, which is the deadlock a health check must not add.
+        p.standardOutput = FileHandle.nullDevice
+        p.standardError = FileHandle.nullDevice
+        do { try p.run() } catch { return false }
+
+        let deadline = Date().addingTimeInterval(timeout)
+        while p.isRunning && Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.05)
+        }
+        if p.isRunning {
+            p.terminate()
+            return false
+        }
+        return p.terminationStatus == 0
+    }
+
     private let repoRoot: String = {
         // Same path the HUD uses to find brainstem/.env
         let home = NSHomeDirectory()
@@ -125,19 +157,61 @@ final class BrainstemLauncher {
         // Priority: venv/bin/python3.12 > /opt/homebrew/bin/python3.12 > /usr/bin/env python3
         let venvPython = "\(repoRoot)/venv/bin/python3.12"
         let brewPython = "/opt/homebrew/bin/python3.12"
-        let python: String
-        let pythonArgs: [String]
 
-        if FileManager.default.fileExists(atPath: venvPython) {
-            python = venvPython
-            pythonArgs = ["-m", "brainstem"]
-        } else if FileManager.default.fileExists(atPath: brewPython) {
-            python = brewPython
-            pythonArgs = ["-m", "brainstem"]
-        } else {
-            python = "/usr/bin/env"
-            pythonArgs = ["python3", "-m", "brainstem"]
+        // v286.0: CHOOSE AN INTERPRETER THAT WORKS, NOT ONE THAT EXISTS.
+        //
+        // This used to take the first candidate whose FILE was present. That is
+        // the wrong predicate, and it failed in the field: `venv/` inside this
+        // repo had 5,980 files whose originals were replaced by iCloud
+        // duplicate-renames (`auto.py` -> `auto 2.py`), so
+        // `uvicorn/protocols/http/` had no `__init__.py` and uvicorn could not
+        // start. The venv binary existed, was selected, and every launch died
+        // with `Could not import module "uvicorn.protocols.http.auto"` — while
+        // a perfectly healthy pyenv interpreter sat two candidates further down
+        // the list, never reached.
+        //
+        // So each candidate is PROBED with the exact import whose absence
+        // killed the brainstem — a test of the failure actually hit rather than
+        // a guess at what "healthy" means. Bounded, so a wedged interpreter
+        // cannot hang startup, and every rejection is logged BY REASON: a
+        // launcher that silently picks the third choice is undebuggable.
+        let candidates: [(String, [String])] = [
+            (venvPython, ["-m", "brainstem"]),
+            (brewPython, ["-m", "brainstem"]),
+            ("/usr/bin/env", ["python3", "-m", "brainstem"]),
+        ]
+        var chosen: (String, [String])?
+        for (path, args) in candidates {
+            if path != "/usr/bin/env",
+               !FileManager.default.fileExists(atPath: path) {
+                print("[Brainstem] skip \(path) — not present")
+                continue
+            }
+            let probeArgs = Array(args.dropLast(2))
+                + ["-c", "import uvicorn.protocols.http.auto"]
+            if Self.probeSucceeds(executable: path, arguments: probeArgs,
+                                  environment: env, cwd: repoRoot) {
+                chosen = (path, args)
+                break
+            }
+            print("[Brainstem] reject \(path) — cannot import "
+                  + "uvicorn.protocols.http.auto (broken or incomplete install)")
         }
+
+        guard let picked = chosen else {
+            print("""
+            [Brainstem] FATAL: no usable Python interpreter.
+              Tried: \(candidates.map(\.0).joined(separator: ", "))
+              Each failed to `import uvicorn.protocols.http.auto`.
+              If `\(repoRoot)/venv` was touched by iCloud, files may have been
+              renamed (`auto.py` -> `auto 2.py`); rebuild the venv or remove it
+              so a healthy system interpreter is used instead.
+            """)
+            return
+        }
+        let python = picked.0
+        let pythonArgs = picked.1
+        print("[Brainstem] interpreter: \(python) (probe passed)")
 
         proc.executableURL = URL(fileURLWithPath: python)
         proc.arguments = pythonArgs


### PR DESCRIPTION
The HUD launched cleanly and the backend died instantly:

```
uvicorn.importer.ImportFromStringError: Could not import module "uvicorn.protocols.http.auto"
```

**Not uvicorn's fault.** The in-repo `venv/` had been mangled by iCloud duplicate-renaming:

```
uvicorn/protocols/http/auto.py      →  auto 2.py
uvicorn/protocols/http/__init__.py  →  __init__ 2.py    (so it wasn't a package at all)
```

Measured across the venv: **7,986 renamed files, 5,980 with the original gone** — torch (1,115), transformers (1,890), scipy, numpy, sklearn, pydantic, anthropic, and `pip` itself. Same damage that forced this repo to `.nosync`; the venv was already wrecked before the move.

## The bug

`BrainstemLauncher` selected `venv/bin/python3.12` **because the file existed**. Existence is not health.

| interpreter | uvicorn | mangled files |
|---|---|---|
| pyenv 3.11.10 (outside the repo) | **OK** | **0** |
| `venv/bin/python3.12` (in-repo) | broken | 5,980 originals gone |

The healthy interpreter — the one all 257 repo tests already run under — sat two candidates further down the list and was never reached.

## The fix

Each candidate is now **probed** with the exact import whose absence killed the brainstem, rather than tested for mere presence. That makes it a test of the failure actually hit instead of a guess at what "healthy" means, and it covers the whole family: a half-installed venv, a wrong interpreter, a missing dependency, a Python that cannot import its own server.

- **Bounded** — a wedged interpreter must not hang HUD startup, and a timeout counts as **failure**: a candidate has to earn selection, not merely avoid disproving itself.
- Probe output goes to `nullDevice`, not a `Pipe` — an unread pipe that fills would block the child forever, the exact deadlock a health check must not introduce.
- Every rejection is logged **by reason**, and total failure prints what was tried and what to do. A launcher that silently picks the third choice is one nobody can debug.

## Verification

`BUILD SUCCEEDED`. With the corrupt venv removed, `python3 -m brainstem` now boots and binds the HUD IPC port (8742); previously it exited immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pick a Python interpreter that actually works by probing `import uvicorn.protocols.http.auto` for each candidate, instead of trusting file existence. Fixes HUD crashes when a mangled in-repo `venv` is selected and ensures `python3 -m brainstem` starts reliably.

- **Bug Fixes**
  - Added a bounded probe with a timeout; output goes to `nullDevice` to avoid hangs.
  - Try candidates in order and pick the first that passes: `venv/bin/python3.12`, `/opt/homebrew/bin/python3.12`, `/usr/bin/env python3`.
  - Log each rejection with the reason; if all fail, print what was tried and guidance to rebuild/remove `venv`.

<sup>Written for commit 322488df598f48415a1e04a396a54bb8d4e79ff0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

