### PR TITLE
fix(hud): discover Python interpreters instead of naming three of them

### DIFF
--- a/JARVIS-Apple/JARVISHUD/Services/BrainstemLauncher.swift
+++ b/JARVIS-Apple/JARVISHUD/Services/BrainstemLauncher.swift
@@ -30,6 +30,76 @@ final class BrainstemLauncher {
     private let ipcQueue = DispatchQueue(label: "com.jarvis.brainstem.ipc", qos: .userInitiated)
 
     /// The repo root, derived from the known brainstem .env path.
+    /// Every Python on this machine that might run the brainstem, best first.
+    ///
+    /// NOT a hardcoded list. The previous version named three paths and leaned
+    /// on `/usr/bin/env python3` for everything else — and that is a PATH
+    /// LOOKUP, not an interpreter. A GUI app inherits Xcode's PATH, which has
+    /// no pyenv on it, so `env python3` resolved to Homebrew's python3.14 (no
+    /// uvicorn) while the only healthy interpreter on the machine —
+    /// `~/.pyenv/versions/3.11.10/bin/python3`, the one every repo test already
+    /// runs under — appeared in no candidate at all. Every candidate was
+    /// correctly rejected; the list was simply wrong.
+    ///
+    /// Sources are ENUMERATED rather than named, so a Python installed
+    /// tomorrow is found tomorrow:
+    ///   0. `JARVIS_PYTHON` — an explicit operator override always wins
+    ///   1. the repo's own venv
+    ///   2. every pyenv version, newest first, plus the shim
+    ///   3. every Homebrew `python3.N`, newest first
+    ///   4. `/usr/local/bin` (Intel Homebrew / python.org)
+    ///   5. the system Python, and finally a PATH lookup
+    ///
+    /// Ordering is by LIKELIHOOD OF BEING RIGHT, not by preference: a project
+    /// venv is the intended environment, pyenv is what this repo's tooling
+    /// actually uses, and the system Python is a last resort. Correctness does
+    /// not depend on the order — `probeSucceeds` decides — but a good order
+    /// means the first probe usually wins, and each probe costs a subprocess.
+    private static func discoverPythons(repoRoot: String,
+                                        environment: [String: String]) -> [String] {
+        let fm = FileManager.default
+        var out: [String] = []
+        func add(_ path: String) {
+            // Resolve so a shim, a symlink and a real binary are not probed
+            // three times as if they were three different interpreters.
+            let real = (try? fm.destinationOfSymbolicLink(atPath: path)) ?? path
+            let key = real.hasPrefix("/") ? real : path
+            if !out.contains(path) && !out.contains(key) { out.append(path) }
+        }
+        /// Newest-first: `python3.14` should be tried before `python3.9`, and a
+        /// plain lexical sort puts 3.9 above 3.14.
+        func versionedChildren(of dir: String, prefix: String) -> [String] {
+            guard let names = try? fm.contentsOfDirectory(atPath: dir) else { return [] }
+            return names
+                .filter { $0.hasPrefix(prefix) && !$0.hasSuffix("-config") }
+                .sorted { a, b in
+                    a.compare(b, options: .numeric) == .orderedDescending
+                }
+                .map { dir + "/" + $0 }
+        }
+
+        if let explicit = environment["JARVIS_PYTHON"], !explicit.isEmpty {
+            add(explicit)
+        }
+        add("\(repoRoot)/venv/bin/python3")
+        for p in versionedChildren(of: "\(repoRoot)/venv/bin", prefix: "python3.") { add(p) }
+
+        let home = NSHomeDirectory()
+        let pyenvRoot = environment["PYENV_ROOT"] ?? "\(home)/.pyenv"
+        for v in versionedChildren(of: "\(pyenvRoot)/versions", prefix: "3.") {
+            add("\(v)/bin/python3")
+        }
+        add("\(pyenvRoot)/shims/python3")
+
+        for dir in ["/opt/homebrew/bin", "/usr/local/bin"] {
+            for p in versionedChildren(of: dir, prefix: "python3.") { add(p) }
+            add("\(dir)/python3")
+        }
+        add("/usr/bin/python3")
+
+        return out.filter { fm.isExecutableFile(atPath: $0) }
+    }
+
     /// Can this interpreter actually import what the brainstem needs?
     ///
     /// Bounded on purpose: a hung probe would stall the HUD's startup, and an
@@ -155,8 +225,6 @@ final class BrainstemLauncher {
         // doesn't have them, causing "ModuleNotFoundError: No module named 'uvicorn'".
         //
         // Priority: venv/bin/python3.12 > /opt/homebrew/bin/python3.12 > /usr/bin/env python3
-        let venvPython = "\(repoRoot)/venv/bin/python3.12"
-        let brewPython = "/opt/homebrew/bin/python3.12"
 
         // v286.0: CHOOSE AN INTERPRETER THAT WORKS, NOT ONE THAT EXISTS.
         //
@@ -175,11 +243,13 @@ final class BrainstemLauncher {
         // a guess at what "healthy" means. Bounded, so a wedged interpreter
         // cannot hang startup, and every rejection is logged BY REASON: a
         // launcher that silently picks the third choice is undebuggable.
-        let candidates: [(String, [String])] = [
-            (venvPython, ["-m", "brainstem"]),
-            (brewPython, ["-m", "brainstem"]),
-            ("/usr/bin/env", ["python3", "-m", "brainstem"]),
-        ]
+        var discovered = Self.discoverPythons(repoRoot: repoRoot, environment: env)
+        // A PATH lookup last, never first: it is not an interpreter, it is
+        // whatever this process's PATH happens to resolve — the very
+        // indirection that hid the working Python behind a broken one.
+        var candidates: [(String, [String])] = discovered.map { ($0, ["-m", "brainstem"]) }
+        candidates.append(("/usr/bin/env", ["python3", "-m", "brainstem"]))
+        print("[Brainstem] \(discovered.count) candidate interpreter(s) discovered")
         var chosen: (String, [String])?
         for (path, args) in candidates {
             if path != "/usr/bin/env",


### PR DESCRIPTION
The probe from #70351 worked exactly as designed — and still failed, because it was handed the wrong list:

```
[Brainstem] skip   .../venv/bin/python3.12 — not present
[Brainstem] reject /opt/homebrew/bin/python3.12 — cannot import uvicorn...
[Brainstem] reject /usr/bin/env             — cannot import uvicorn...
[Brainstem] FATAL: no usable Python interpreter.
```

Every rejection was **correct**. The list was the defect.

`/usr/bin/env python3` is not an interpreter — it is a **PATH lookup**. A GUI app inherits Xcode's PATH, which has no pyenv on it:

| context | `python3` resolves to | uvicorn |
|---|---|---|
| a login shell | `~/.pyenv/shims/python3` → 3.11.10 | **OK** |
| the app | `/opt/homebrew/opt/python@3.14/bin/python3.14` | missing |

The only healthy interpreter on the machine — `~/.pyenv/versions/3.11.10/bin/python3`, the one every repo test already runs under — appeared in **no candidate at all**.

## Fix

Candidates are **enumerated, not named**: `JARVIS_PYTHON` override → repo venv → every pyenv version (newest first) + shim → every Homebrew/`/usr/local` `python3.N` → system Python → PATH lookup **last**, never first, since that indirection is what hid the working Python behind a broken one.

- versions sort **numerically**, so `python3.14` precedes `python3.9`
- symlinks resolved, so a shim and its target aren't probed as two interpreters
- order is by likelihood, not preference — `probeSucceeds` still decides

Verified in a clean `PATH=/usr/bin:/bin`: the first candidate probed passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Discover Python interpreters at runtime and probe them in a sensible order instead of relying on three hardcoded paths. Fixes HUD startup failures when `/usr/bin/env python3` resolves to a Python without `uvicorn`.

- **Bug Fixes**
  - Enumerate candidates from: `JARVIS_PYTHON`, repo venv, all `pyenv` versions (newest first) + shim, Homebrew and `/usr/local` `python3.N`, system Python; add PATH lookup via `/usr/bin/env` last.
  - Sort versions numerically and resolve symlinks to dedupe; keep only executable paths.
  - Keep probe-based selection; ordering favors likely-good interpreters so a working one is picked quickly.

<sup>Written for commit 0588823ac64f380159fd21dce18a2bd61aebe5fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

