### PR TITLE
fix(hud): stop poisoning the chosen Python, and knock on the door we opened

### DIFF
--- a/JARVIS-Apple/JARVISHUD/Services/AppState.swift
+++ b/JARVIS-Apple/JARVISHUD/Services/AppState.swift
@@ -586,7 +586,16 @@ class PythonBridge: ObservableObject {
         // Set JARVIS_HUD_FORCE_CLOUD=1 to fall back to the cloud path.
         let forceCloud = (env["JARVIS_HUD_FORCE_CLOUD"] ?? "") == "1"
         if !forceCloud {
-            let localURL = env["JARVIS_LOCAL_BACKEND_URL"] ?? "http://localhost:8010"
+            // Derived from the launcher's own port — ONE source of truth.
+            // This was hardcoded 8010 while BrainstemLauncher binds its spawned
+            // backend on 8011 ("separate port from supervisor's 8010"), so the
+            // HUD spawned a healthy backend and then knocked on the wrong door
+            // forever: every /api/stream/token went to 8010, connection
+            // refused. Two hardcoded ports for one conversation is how they
+            // drift; the env override remains for pointing at an external
+            // supervisor on 8010.
+            let localURL = env["JARVIS_LOCAL_BACKEND_URL"]
+                ?? "http://localhost:\(BrainstemLauncher.shared.httpPort)"
             let id = env["JARVIS_DEVICE_ID"] ?? "mac-local"
             // The default was the literal string "local", and the comment above
             // called a placeholder secret "fine". It was not: the secret is

--- a/JARVIS-Apple/JARVISHUD/Services/BrainstemLauncher.swift
+++ b/JARVIS-Apple/JARVISHUD/Services/BrainstemLauncher.swift
@@ -199,11 +199,17 @@ final class BrainstemLauncher {
             }
         }
 
-        // Ensure PYTHONPATH includes the repo root AND Homebrew site-packages.
-        // Xcode's subprocess environment may not include Homebrew's default paths.
-        let sitePackages = "/opt/homebrew/lib/python3.12/site-packages"
+        // PYTHONPATH carries the REPO only — never another interpreter's
+        // site-packages. This used to inject a hardcoded
+        // `/opt/homebrew/lib/python3.12/site-packages`, and PYTHONPATH entries
+        // precede an interpreter's own site-packages: whichever Python the
+        // probe selected then imported python3.12's compiled numpy
+        // (`_multiarray_umath.cpython-312-darwin.so`) into a 3.11 process and
+        // the backend died with exit code 1 at startup. An interpreter that
+        // passed the probe has its own packages; poisoning it with a different
+        // ABI's is how a healthy Python is made to fail anyway.
         let existingPythonPath = env["PYTHONPATH"] ?? ""
-        let pathParts = [repoRoot, sitePackages, existingPythonPath].filter { !$0.isEmpty }
+        let pathParts = [repoRoot, existingPythonPath].filter { !$0.isEmpty }
         env["PYTHONPATH"] = pathParts.joined(separator: ":")
 
         // Ensure PATH includes Homebrew so Python 3.12 can find its packages/tools


### PR DESCRIPTION
Console showed the probe working (pyenv 3.11 selected, brainstem spawned) — then `Process exited with code 1` and endless `Connection refused` on 8010. Two hardcodings:

1. **PYTHONPATH injected `/opt/homebrew/lib/python3.12/site-packages`.** PYTHONPATH precedes an interpreter's own site-packages, so the probe-selected 3.11 imported python3.12's compiled numpy (`_multiarray_umath.cpython-312-darwin.so`) and died. An interpreter that *passed the probe* has its own packages; injecting a different ABI's makes a healthy Python fail anyway. Repo path only now.
2. **Port mismatch:** HUD hardcoded `localhost:8010`; the spawned backend binds **8011**. Healthy backend, wrong door, forever. Local URL now derives from `BrainstemLauncher.httpPort` — one source of truth; `JARVIS_LOCAL_BACKEND_URL` still overrides for an external supervisor.

Verified: clean-PYTHONPATH backend runs past 40s (was exit 1), zero cpython-312 errors, IPC 8742 bound. BUILD SUCCEEDED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes backend launch failures by removing cross-ABI `PYTHONPATH` injection and aligning the HUD with the spawned backend’s port. The HUD now connects to the correct local backend and the Python process no longer crashes at startup.

- **Bug Fixes**
  - Remove hardcoded `/opt/homebrew/lib/python3.12/site-packages` from `PYTHONPATH`; include only the repo root and any existing `PYTHONPATH`.
  - Build the local backend URL from `BrainstemLauncher.httpPort` instead of hardcoding `localhost:8010`; `JARVIS_LOCAL_BACKEND_URL` still overrides.

<sup>Written for commit e0e281b30d8de23685c44cafd07a3c36f7adcb1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

