### PR TITLE
fix(hud): wire the unwired reconciler, back off IPC retries, add libdispatch

### DIFF
--- a/JARVIS-Apple/JARVISHUD/JARVISHUDApp.swift
+++ b/JARVIS-Apple/JARVISHUD/JARVISHUDApp.swift
@@ -42,6 +42,12 @@ class HUDAppDelegate: NSObject, NSApplicationDelegate, AVSpeechSynthesizerDelega
             // Auto-start the Python brainstem — full backend in HUD mode.
             // The onReady callback fires when IPC connects (backend fully booted),
             // telling the HUD to announce "JARVIS Online" to the user.
+            // `AVSpeechSynthesizer.isSpeaking` is the authority for this synth;
+            // a dropped delegate callback now costs one 250ms sweep, not the
+            // whole estimated deadline.
+            SpeechGate.shared.registerReconciler(.hudSynthesizer) { [weak self] in
+                self?.tts.isSpeaking ?? false
+            }
             BrainstemLauncher.shared.onReady = { [weak self] in
                 guard let self = self else { return }
                 self.appState.pythonBridge.onBackendReady()

--- a/JARVIS-Apple/JARVISHUD/Services/AppState.swift
+++ b/JARVIS-Apple/JARVISHUD/Services/AppState.swift
@@ -692,6 +692,9 @@ final class VoiceManager: NSObject, ObservableObject, AVSpeechSynthesizerDelegat
     override init() {
         super.init()
         synthesizer.delegate = self
+        SpeechGate.shared.registerReconciler(.voiceManager) { [weak self] in
+            self?.synthesizer.isSpeaking ?? false
+        }
     }
 
     func speak(_ text: String, priority: SpeechPriority = .normal) {

--- a/JARVIS-Apple/JARVISHUD/Services/BrainstemLauncher.swift
+++ b/JARVIS-Apple/JARVISHUD/Services/BrainstemLauncher.swift
@@ -29,6 +29,13 @@ final class BrainstemLauncher {
     var onReady: (() -> Void)?
     private let ipcQueue = DispatchQueue(label: "com.jarvis.brainstem.ipc", qos: .userInitiated)
 
+    /// IPC reconnect delay: 1s → 2s → 4s → 8s, reset on a successful connect.
+    /// A fixed 1s retry against a backend that takes minutes to boot is log
+    /// spam and socket churn for no information gain. `nonisolated(unsafe)`
+    /// because the NWConnection state handler runs off-actor; the race is a
+    /// benign double-read of a Double.
+    nonisolated(unsafe) private var reconnectDelay: Double = 1.0
+
     /// The repo root, derived from the known brainstem .env path.
     /// Every Python on this machine that might run the brainstem, best first.
     ///
@@ -478,6 +485,7 @@ final class BrainstemLauncher {
             guard let self = self else { return }
             switch state {
             case .ready:
+                self.reconnectDelay = 1.0
                 print("[Brainstem] IPC connected to localhost:\(self.ipcPort)")
                 Task { @MainActor in
                     self.connection = conn
@@ -510,7 +518,9 @@ final class BrainstemLauncher {
                     SpeechGate.shared.release(.backend, reason: "IPC connection lost")
                 }
                 conn.cancel()
-                self.ipcQueue.asyncAfter(deadline: .now() + 1.0) { [weak self] in
+                let delay = self.reconnectDelay
+                self.reconnectDelay = min(delay * 2.0, 8.0)
+                self.ipcQueue.asyncAfter(deadline: .now() + delay) { [weak self] in
                     Task { @MainActor in
                         self?.connectToBrainstem(retriesLeft: retriesLeft - 1)
                     }
@@ -520,7 +530,9 @@ final class BrainstemLauncher {
                 // during brainstem boot. Cancel and retry after a delay.
                 print("[Brainstem] IPC connection waiting: \(error) — retries left: \(retriesLeft - 1)")
                 conn.cancel()
-                self.ipcQueue.asyncAfter(deadline: .now() + 1.0) { [weak self] in
+                let delay = self.reconnectDelay
+                self.reconnectDelay = min(delay * 2.0, 8.0)
+                self.ipcQueue.asyncAfter(deadline: .now() + delay) { [weak self] in
                     Task { @MainActor in
                         self?.connectToBrainstem(retriesLeft: retriesLeft - 1)
                     }

--- a/JARVIS-Apple/JARVISHUD/Services/MicSuppression.swift
+++ b/JARVIS-Apple/JARVISHUD/Services/MicSuppression.swift
@@ -99,6 +99,16 @@ final class SpeechGate {
     var onMuteChange: ((Bool) -> Void)?
 
     private var claims: [SpeechClaimant: SpeechClaim] = [:]
+    /// Per-claimant "is it actually speaking right now?" probes. The design
+    /// doc always specified this belt-and-braces; the method existed with ZERO
+    /// callers — so a dropped `didFinish` cost the whole estimated deadline
+    /// (observed: ~4.2s of dead mic) instead of one sweep.
+    private var reconcilers: [SpeechClaimant: () -> Bool] = [:]
+
+    /// Let the gate ask the synthesiser itself, every sweep.
+    func registerReconciler(_ who: SpeechClaimant, isSpeaking: @escaping () -> Bool) {
+        reconcilers[who] = isSpeaking
+    }
     private var sweepTask: Task<Void, Never>?
     private var lastPublished = false
 
@@ -187,11 +197,18 @@ final class SpeechGate {
     /// on every sweep and on every mic restart.
     func reconcile(_ who: SpeechClaimant, isSpeaking: Bool) {
         if isSpeaking {
-            // Re-arm on a short lease. If the synthesiser stops and the
-            // callback is lost, the claim dies within one lease rather than
-            // living until the 60s ceiling.
-            claim(who, seconds: 2.0, reason: "(reconciled from synthesizer)")
-        } else {
+            // Extend ONLY when the claim is about to lapse — re-claiming every
+            // 250ms sweep would spam the log and reset deadlines pointlessly.
+            let needsExtend: Bool = {
+                guard let c = claims[who] else { return true }
+                return ContinuousClock.now.advanced(by: .seconds(1.0)) >= c.deadline
+            }()
+            if needsExtend {
+                claim(who, seconds: 2.0, reason: "(reconciled from synthesizer)")
+            }
+        } else if claims[who] != nil {
+            // The synthesiser says idle but a claim is live: the callback was
+            // dropped. Release NOW — one sweep of staleness, not the deadline.
             release(who, reason: "(reconciled: synthesizer idle)")
         }
     }
@@ -221,6 +238,9 @@ final class SpeechGate {
                 guard let self else { return }
                 let stop = await MainActor.run { () -> Bool in
                     self.expire()
+                    for (who, probe) in self.reconcilers {
+                        self.reconcile(who, isSpeaking: probe())
+                    }
                     self.publish()
                     if self.claims.isEmpty {
                         self.sweepTask = nil

--- a/requirements.txt
+++ b/requirements.txt
@@ -318,3 +318,4 @@ google-cloud-monitoring>=2.0.0
 # Requires-Python: >=3.12
 
 discord.py>=2.3  # Slice 156 — interactive Discord control gateway (bot)
+pyobjc-framework-libdispatch  # advanced video capture (macos_video_capture_advanced) — dispatch_queue_create


### PR DESCRIPTION
Triage of a field report — implemented what the code confirmed, declined what it contradicted.

## Real, fixed
1. **`SpeechGate.reconcile` had zero callers** — a dropped `didFinish` cost the whole estimated deadline (~4.2s dead mic) instead of one sweep. Both synthesisers now register `isSpeaking` probes; the 250ms sweep consults them. Lost callback → one sweep of staleness.
2. **IPC reconnect backoff** 1s→2s→4s→8s, reset on `.ready`.
3. **`pyobjc-framework-libdispatch` missing** from the pyenv interpreter — installed + pinned in requirements.txt, import verified.

## Declined, with evidence
- **Volume-fade instead of buffer-drop:** `inputNode` is not a mixer; node volume applies at mix-in *downstream*, while the tap observes the node's output *before* that — muting volume would keep feeding JARVIS's own voice to the recogniser at full level. That reintroduces the wrong-layer bug removed in #70349. Also: nothing in the suppression path pauses the engine or removes the tap; `frameLength > 0` already guards warm-up buffers, and `unsafeForcedSync` appears nowhere in the codebase (`rg`: 0 hits).
- **`~/.jarvis/ipc.port` file:** liveness-free state on disk is the `/tmp/jarvis_speaking` class removed in #70349 — SIGKILL leaves a stale file. Port coordination is already live and single-sourced: launcher passes `JARVIS_HUD_PORT` down, HUD derives its URL from the same property (#70353). `localhost:8011` is no longer hardcoded in the HUD (`grep`: 0 hits). Full SSE-over-IPC multiplexing would break the cloud/external-supervisor modes that share those endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dead mic staleness by wiring the speech reconciler and reduces IPC reconnect churn with exponential backoff; also adds the missing `pyobjc-framework-libdispatch` dependency.

- **Bug Fixes**
  - Wired speech reconciliation: both synthesizers now register isSpeaking probes; 250ms sweep reconciles and only extends near lapse, releasing immediately when idle (dropped callbacks now cost one sweep, not seconds).
  - IPC reconnect backoff: 1s → 2s → 4s → 8s with reset on ready, reducing log spam and socket churn during long boots.

- **Dependencies**
  - Added `pyobjc-framework-libdispatch` to `requirements.txt` for advanced macOS video capture.

<sup>Written for commit 29228cf8b30003b442a1b3ff907d360c08e1fecf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70354?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

