### PR TITLE
fix(hud): stop the SSE loop chasing an endpoint that does not exist

### DIFF
--- a/JARVIS-Apple/JARVISHUD/Services/AppState.swift
+++ b/JARVIS-Apple/JARVISHUD/Services/AppState.swift
@@ -183,6 +183,27 @@ class PythonBridge: ObservableObject {
         detailedConnectionState = "Authenticating with cloud..."
 
         // Enter SSE reconnect loop (runs forever with exponential backoff)
+        // SPLIT-BRAIN, ENDED. A loopback backend is reached over the IPC
+        // socket, not over SSE — `BrainstemLauncher` connects 8742 and calls
+        // `onBackendReady()`, which is what actually sets `.connected`.
+        //
+        // The cloud SSE loop was running anyway, against
+        // `POST /api/stream/token` — an endpoint that does not exist in this
+        // backend AT ALL (0 hits in backend/main.py). So it 404'd forever:
+        // first as `Connection refused` while the backend booted, then as a
+        // real 404 once it was up, retrying without end. Two transports for one
+        // conversation, one of them aimed at nothing.
+        //
+        // Detected by LOOPBACK, not by port number: any host that resolves to
+        // this machine is served by the brainstem we spawned. The cloud path is
+        // untouched — JARVIS_HUD_FORCE_CLOUD=1 still gets full SSE.
+        let host = URL(string: creds.baseURL)?.host?.lowercased() ?? ""
+        let isLoopback = ["localhost", "127.0.0.1", "::1", "[::1]"].contains(host)
+        if isLoopback {
+            print("[JARVIS] LOCAL mode — IPC (\(BrainstemLauncher.shared.ipcPortNumber)) is the transport; not starting the cloud SSE loop")
+            detailedConnectionState = "Waiting for local backend IPC..."
+            return
+        }
         await connectLoop(deviceAuth: deviceAuth, config: creds)
     }
 

--- a/JARVIS-Apple/JARVISHUD/Services/BrainstemLauncher.swift
+++ b/JARVIS-Apple/JARVISHUD/Services/BrainstemLauncher.swift
@@ -21,6 +21,9 @@ final class BrainstemLauncher {
     /// TCP connection to the brainstem IPC server.
     private var connection: NWConnection?
     private let ipcPort: UInt16 = 8742
+    /// Read-only accessor so other components can NAME the transport they
+    /// are deferring to, without a second copy of the number.
+    var ipcPortNumber: UInt16 { ipcPort }
     /// HTTP port for the backend in HUD mode (separate from supervisor's 8010).
     let httpPort: UInt16 = 8011
 


### PR DESCRIPTION
Console showed the backend **fully up** — Uvicorn on 8011, IPC connected on 8742, 81 capabilities federated, "JARVIS Online" spoken — while the HUD retried forever:

```
POST /api/stream/token HTTP/1.1" 404 Not Found
```

**`/api/stream/token` does not exist in `backend/main.py` at all** (0 hits). The HUD was running the *cloud* SSE loop against a *loopback* backend that never served that route: `Connection refused` while it booted, then a real 404 once it was up, forever.

Two transports for one conversation, one aimed at nothing. The real transport was already live — `BrainstemLauncher` connects 8742 and calls `onBackendReady()`, which is what sets `.connected`.

Local mode now skips the SSE loop. Detected by **loopback**, not port number, so nothing new is hardcoded. Cloud path untouched: `JARVIS_HUD_FORCE_CLOUD=1` still gets full SSE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops infinite SSE retries in local mode by skipping the cloud SSE loop when the backend is loopback. The HUD now uses IPC for local runs, fixing 404s to `/api/stream/token` and reducing log noise.

- **Bug Fixes**
  - Detect loopback hosts (`localhost`, `127.0.0.1`, `::1`) and do not start the SSE reconnect loop.
  - Show “Waiting for local backend IPC...” while connecting locally.
  - Add read-only `ipcPortNumber` in `BrainstemLauncher` for consistent logging.
  - Cloud behavior unchanged; set `JARVIS_HUD_FORCE_CLOUD=1` to force SSE.

<sup>Written for commit a9e358869d1880c6083d1323d398dc68d11d3480. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

