### PR TITLE
fix(hud): do not open a cloud relay to discover the HUD is on local IPC

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1953,6 +1953,15 @@ async def parallel_lifespan(app: FastAPI):
         # =================================================================
         # v351.0: HUD MODE — IPC server + SSE consumer for Swift HUD
         # =================================================================
+        class _SkipCloudRelay(Exception):
+            """Not an error — the cloud relay was deliberately not started.
+
+            A typed sentinel rather than a bare flag check wrapped around the
+            whole block: the existing `except Exception` already logs and
+            degrades gracefully, so raising through it keeps ONE exit path
+            instead of duplicating the teardown logic under an `if`.
+            """
+
         _hud_ipc_server = None
         _hud_shutdown = None
         if HUD_MODE:
@@ -2370,8 +2379,34 @@ async def parallel_lifespan(app: FastAPI):
                 logger.error("[HUD] capability federation wiring failed: %s", _fe,
                              exc_info=True)
 
-            # Optional: SSE consumer for Vercel cloud relay
+            # Optional: SSE consumer for Vercel cloud relay.
+            #
+            # v287.0: NOT started in HUD mode by default. The HUD reaches this
+            # backend over the local IPC socket; the cloud relay is a SECOND
+            # transport for the same conversation, and it was being opened
+            # every boot only to be torn down seconds later:
+            #
+            #   [SSE] Requesting stream token from https://...vercel.app
+            #   [SSE] Vercel deployment disabled (402) — stopping SSE consumer.
+            #         HUD operates via local IPC.
+            #
+            # The consumer's own shutdown message states the conclusion — the
+            # HUD operates via local IPC — so opening it at all was work done
+            # to discover something already known. This is the Python mirror of
+            # the loopback gate added to the Swift side: one transport per
+            # conversation, chosen up front rather than discovered by failure.
+            #
+            # Opt back in with JARVIS_HUD_CLOUD_RELAY=1 for a genuinely
+            # cloud-relayed HUD (phone/watch pairing, remote command).
+            _cloud_relay = (os.environ.get("JARVIS_HUD_CLOUD_RELAY", "0")
+                            or "").strip().lower() in ("1", "true", "yes")
+            if not _cloud_relay:
+                logger.info(
+                    "[HUD] Cloud SSE relay disabled (local IPC is the "
+                    "transport). Set JARVIS_HUD_CLOUD_RELAY=1 to enable.")
             try:
+                if not _cloud_relay:
+                    raise _SkipCloudRelay()
                 from brainstem.config import BrainstemConfig
                 from brainstem.sse_consumer import SSEConsumer
                 from brainstem.auth import BrainstemAuth

--- a/requirements.txt
+++ b/requirements.txt
@@ -319,3 +319,4 @@ google-cloud-monitoring>=2.0.0
 
 discord.py>=2.3  # Slice 156 — interactive Discord control gateway (bot)
 pyobjc-framework-libdispatch  # advanced video capture (macos_video_capture_advanced) — dispatch_queue_create
+langgraph  # autonomy.langgraph_engine — falls back to sequential execution when absent


### PR DESCRIPTION
Every boot:

```
[HUD] SSE consumer started (Vercel cloud relay)
[SSE] Requesting stream token from https://...vercel.app
[SSE] Vercel deployment disabled (402) — stopping SSE consumer. HUD operates via local IPC.
```

The consumer's own shutdown message states the conclusion. Opening it was work done to discover something already known — plus a network round trip and a 402 every start.

Python mirror of the loopback gate just added to Swift (#70355): **one transport per conversation, chosen up front rather than discovered by failure.** `JARVIS_HUD_CLOUD_RELAY=1` opts back in for a genuinely cloud-relayed HUD.

Implemented as a typed `_SkipCloudRelay` sentinel raised into the existing `except`, keeping one exit path instead of duplicating teardown under an `if`. Also pins `langgraph`.

**Verified:** backend boots, gate line present, **0** Vercel 402s, **0** SSE consumer starts (each was 1/boot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip starting the Vercel cloud SSE relay in HUD mode and use local IPC by default. This removes the boot-time 402s and the extra network round trip; opt in with JARVIS_HUD_CLOUD_RELAY=1.

- **Bug Fixes**
  - Choose one transport upfront in HUD mode; raise a `_SkipCloudRelay` sentinel to reuse existing teardown path.
  - Log a clear notice when the cloud relay is disabled and how to enable it.

- **Dependencies**
  - Add `langgraph` to `requirements.txt` (used by `autonomy.langgraph_engine`).

<sup>Written for commit 5fd3cb38a8f9d5d67fe748faffd9192df9f0f337. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

