### PR TITLE
chore(hud): quiet Apple subsystem logging so JARVIS output is findable

### DIFF
--- a/JARVIS-Apple/JARVIS-Apple.xcodeproj/xcshareddata/xcschemes/JARVISHUD.xcscheme
+++ b/JARVIS-Apple/JARVIS-Apple.xcodeproj/xcshareddata/xcschemes/JARVISHUD.xcscheme
@@ -65,6 +65,11 @@
       </CommandLineArguments>
       <EnvironmentVariables>
          <EnvironmentVariable
+            key = "OS_ACTIVITY_MODE"
+            value = "disable"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
             key = "JARVIS_DEVICE_ID"
             value = "mac-m1-derek"
             isEnabled = "YES">


### PR DESCRIPTION
Two lines appear every launch, neither from this codebase:

```
AddInstanceForFactory: No factory registered for id <CFUUID …> F8BB1C28-BAE8-11D6-9C31-00039315CD46
Unable to obtain a task name port right for pid 404: (os/kern) failure (0x5)
```

- **First:** CoreAudio/HAL logging a factory-lookup miss in Apple's own registry. That UUID is an Apple constant, emitted by any process touching `AVAudioEngine`/`AVSpeechSynthesizer`, *before our code runs*.
- **Second:** a Mach task-port permission denial (`KERN_FAILURE`) for **pid 404 — a system process, not ours**. SIP refusing a task port is the sandbox working.

No line of our code is wrong in either case, so there is nothing to repair. The honest fix is to stop them drowning the console.

`OS_ACTIVITY_MODE=disable` on the **LaunchAction** is Apple's documented switch for this — scoped to this scheme's Run action only.

**Safe for a checked reason, not an assumed one:** JARVIS logs exclusively via `print()` to stdout (32 lines in `BrainstemLauncher` alone) and uses `os_log` **nowhere** — verified. So `[Brainstem]`, `[JARVIS]`, `[SpeechGate]` and piped `[Backend]` output are unaffected; only Apple's chatter goes.

This is more than tidiness: console noise is precisely why the `[Brainstem]` diagnostics were hard to find for several rounds of debugging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Silences Apple subsystem console chatter during HUD runs so JARVIS logs are easy to find. Adds `OS_ACTIVITY_MODE=disable` to the `JARVISHUD` Xcode scheme’s Run action, suppressing Apple `os_log` noise while leaving our `print()` stdout logs unchanged.

<sup>Written for commit afb26d98c1e45de7e3a6336c64eebf92e9c3a61b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

