### PR TITLE
fix(hud): resolve the speech voice once, not on every utterance

### DIFF
--- a/JARVIS-Apple/JARVISHUD/JARVISHUDApp.swift
+++ b/JARVIS-Apple/JARVISHUD/JARVISHUDApp.swift
@@ -240,8 +240,7 @@ class HUDAppDelegate: NSObject, NSApplicationDelegate, AVSpeechSynthesizerDelega
                                 reason: "queued utterance")
 
         let utterance = AVSpeechUtterance(string: cleaned)
-        utterance.voice = AVSpeechSynthesisVoice(identifier: "com.apple.voice.compact.en-GB.Daniel")
-            ?? AVSpeechSynthesisVoice(language: "en-GB")
+        utterance.voice = JARVISVoice.daniel
         utterance.rate = 0.52
         utterance.volume = 0.85
 

--- a/JARVIS-Apple/JARVISHUD/Services/AppState.swift
+++ b/JARVIS-Apple/JARVISHUD/Services/AppState.swift
@@ -700,6 +700,38 @@ class PythonBridge: ObservableObject {
     }
 }
 
+// MARK: - JARVISVoice (resolved ONCE, not per utterance)
+
+/// The canonical JARVIS voice, looked up a single time.
+///
+/// `AVSpeechSynthesisVoice(identifier:)` is not a constructor — it is a
+/// SYNCHRONOUS QUERY against the on-device speech-voice catalog, serviced over
+/// XPC. Both synthesisers were calling it (and its `language:` fallback) on
+/// EVERY utterance, from `@MainActor` code. Blocking IPC inside a Swift
+/// Concurrency context is exactly what the runtime reports as:
+///
+///     Potential Structural Swift Concurrency Issue:
+///     unsafeForcedSync called from Swift Concurrent context.
+///
+/// The voice catalog does not change between utterances, so the query was pure
+/// repeated cost — and the diagnostic is the runtime objecting to where that
+/// cost was paid, not to the audio graph.
+///
+/// `static let` resolves lazily, exactly once, under Swift's `swift_once`
+/// guarantee — so the blocking lookup happens a single time at first speech
+/// instead of on every sentence, and never again for the life of the process.
+///
+/// Shared rather than duplicated: two identical lookups in two files was the
+/// literal definition of the thing that drifts.
+enum JARVISVoice {
+    /// Daniel — British English male, the canonical JARVIS voice.
+    /// `nil` is a legal outcome: AVSpeechUtterance then uses the system
+    /// default, which is far better than refusing to speak.
+    static let daniel: AVSpeechSynthesisVoice? =
+        AVSpeechSynthesisVoice(identifier: "com.apple.voice.compact.en-GB.Daniel")
+        ?? AVSpeechSynthesisVoice(language: "en-GB")
+}
+
 // MARK: - VoiceManager (TTS via AVSpeechSynthesizer — Daniel voice)
 
 @MainActor
@@ -726,8 +758,7 @@ final class VoiceManager: NSObject, ObservableObject, AVSpeechSynthesizerDelegat
         currentPriority = priority
         let utterance = AVSpeechUtterance(string: text)
         // Daniel = British English male (JARVIS canonical voice)
-        utterance.voice = AVSpeechSynthesisVoice(identifier: "com.apple.voice.compact.en-GB.Daniel")
-            ?? AVSpeechSynthesisVoice(language: "en-GB")
+        utterance.voice = JARVISVoice.daniel
         utterance.rate = 0.52
         utterance.pitchMultiplier = 1.0
         utterance.volume = 0.9


### PR DESCRIPTION
```
Potential Structural Swift Concurrency Issue: unsafeForcedSync called from Swift Concurrent context.
```

Fires every launch, immediately after `[SpeechGate] mic MUTED by hud_tts` — between `claim` and the utterance starting. That window contains exactly **one** blocking call:

```swift
utterance.voice = AVSpeechSynthesisVoice(identifier: "...Daniel")
                  ?? AVSpeechSynthesisVoice(language: "en-GB")
```

`AVSpeechSynthesisVoice(identifier:)` is **not a constructor** — it's a synchronous query against the on-device voice catalog, serviced over XPC. Both synthesisers ran it (plus the fallback) on **every utterance**, from `@MainActor` code. Blocking IPC inside a Swift Concurrency context is exactly what that diagnostic reports.

The catalog doesn't change between utterances, so the query was pure repeated cost. `static let` resolves it lazily **once** under `swift_once`.

Shared, not duplicated — the identical two-line lookup existed verbatim in two files. `nil` stays legal (system default beats refusing to speak).

**Does not touch** the audio graph, the tap, or SpeechGate — the earlier report's prescription to rewrite those was declined on evidence and remains declined. This is the one blocking call *our* code makes in that window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caches the TTS voice lookup so it’s resolved once at first use, not on every utterance. This removes the “unsafeForcedSync called from Swift Concurrent context” warning and reduces pre-speech latency.

- **Bug Fixes**
  - Introduced `JARVISVoice.daniel` static to cache the `AVSpeechSynthesisVoice` query (lazy, `swift_once`).
  - Replaced duplicated per-utterance lookups in `JARVISHUDApp.swift` and `AppState.swift`.
  - Preserves `nil` fallback to system default; no changes to the audio graph or SpeechGate.

<sup>Written for commit 10dc8d7f43b29aac4a6e22f2f3103ff039d8d074. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

