### PR TITLE
fix(hud): a deliberate skip is not a failure

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -2427,6 +2427,17 @@ async def parallel_lifespan(app: FastAPI):
                     name="hud_sse_consumer",
                 )
                 logger.info("[HUD] SSE consumer started (Vercel cloud relay)")
+            except _SkipCloudRelay:
+                # A DELIBERATE skip, not a failure. Reusing the generic handler
+                # for it made the log say "[HUD] SSE consumer failed:" with an
+                # empty reason directly under the line explaining the relay was
+                # switched off on purpose — two lines contradicting each other,
+                # and the alarming one last.
+                #
+                # The "one exit path" this sentinel was meant to preserve is not
+                # worth a log that cries wolf: an operator scanning for real
+                # faults must never have to learn which warnings to ignore.
+                pass
             except (ImportError, ValueError) as e:
                 logger.info("[HUD] SSE consumer not available (local-only mode): %s", e)
             except Exception as e:


### PR DESCRIPTION
My own regression from #70356:

```
[HUD] Cloud SSE relay disabled (local IPC is the transport). ...
[HUD] SSE consumer failed:
```

Two adjacent lines contradicting each other, alarming one last, with an **empty reason** — because the "exception" was the `_SkipCloudRelay` sentinel I raised on purpose and then let fall into the generic `except Exception`.

The "one exit path" that sentinel preserved is not worth a log that cries wolf. An operator scanning for real faults must never have to learn which warnings to ignore — a warning meaning *working as designed* trains people to skim past the ones that aren't.

Caught explicitly. **Verified:** relay-disabled line present, **0** "SSE consumer failed" (was 1/boot), backend healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop logging a false "SSE consumer failed" when the cloud relay is intentionally disabled. `_SkipCloudRelay` is now handled as an expected path so operators only see the relay-disabled info.

- **Bug Fixes**
  - Catch `_SkipCloudRelay` explicitly to suppress the erroneous failure log.
  - Verified: relay-disabled line remains; no "SSE consumer failed" on boot.

<sup>Written for commit 3ef4265b04ef535bb71732f4aba9804eed54c9c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70359?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

