### PR TITLE
fix(hud): stop polling a blocking property four times a second

### DIFF
--- a/JARVIS-Apple/JARVISHUD/Services/BrainstemLauncher.swift
+++ b/JARVIS-Apple/JARVISHUD/Services/BrainstemLauncher.swift
@@ -259,7 +259,7 @@ final class BrainstemLauncher {
         // a guess at what "healthy" means. Bounded, so a wedged interpreter
         // cannot hang startup, and every rejection is logged BY REASON: a
         // launcher that silently picks the third choice is undebuggable.
-        var discovered = Self.discoverPythons(repoRoot: repoRoot, environment: env)
+        let discovered = Self.discoverPythons(repoRoot: repoRoot, environment: env)
         // A PATH lookup last, never first: it is not an interpreter, it is
         // whatever this process's PATH happens to resolve — the very
         // indirection that hid the working Python behind a broken one.

--- a/JARVIS-Apple/JARVISHUD/Services/MicSuppression.swift
+++ b/JARVIS-Apple/JARVISHUD/Services/MicSuppression.swift
@@ -77,6 +77,11 @@ private struct SpeechClaim {
     /// Monotonic. `Date()` would let an NTP step or a daylight-saving change
     /// extend a mute by an hour, and the operator would simply be unheard.
     let deadline: ContinuousClock.Instant
+    /// When this claim was taken. Distinct from `deadline`, which moves every
+    /// time the claim is extended — age must be measured from the ORIGINAL
+    /// grab, or an extending claim looks perpetually new and never qualifies
+    /// as stale.
+    let opened: ContinuousClock.Instant
     let reason: String
 
     func isLive(_ now: ContinuousClock.Instant) -> Bool { now < deadline }
@@ -141,9 +146,14 @@ final class SpeechGate {
                seconds: Double? = nil,
                reason: String = "") {
         let bounded = min(max(seconds ?? defaultClaimSeconds, 0.1), maxClaimSeconds)
+        // Preserve the ORIGINAL grab time across extensions: `claim()` is
+        // called again on didStart and on every reconcile, and resetting
+        // `opened` each time would mean a stuck claim never ages.
+        let firstSeen = claims[who]?.opened ?? ContinuousClock.now
         claims[who] = SpeechClaim(
             claimant: who,
             deadline: ContinuousClock.now.advanced(by: .seconds(bounded)),
+            opened: firstSeen,
             reason: reason)
         print("[SpeechGate] claim \(who.rawValue) for \(String(format: "%.1f", bounded))s \(reason)")
         startSweeping()
@@ -238,9 +248,7 @@ final class SpeechGate {
                 guard let self else { return }
                 let stop = await MainActor.run { () -> Bool in
                     self.expire()
-                    for (who, probe) in self.reconcilers {
-                        self.reconcile(who, isSpeaking: probe())
-                    }
+                    self.reconcileStaleClaimsOnly()
                     self.publish()
                     if self.claims.isEmpty {
                         self.sweepTask = nil
@@ -250,6 +258,39 @@ final class SpeechGate {
                 }
                 if stop { return }
             }
+        }
+    }
+
+    /// Consult the synthesisers ONLY where a dropped callback is plausible.
+    ///
+    /// HANG RISK, self-inflicted. The first version probed every registered
+    /// reconciler on every 250ms sweep. `AVSpeechSynthesizer.isSpeaking` is not
+    /// a stored property — reading it performs a SYNCHRONOUS THREAD HOP
+    /// (`-[_NSThreadPerformInfo wait]` in the trace), so a user-interactive
+    /// sweep blocked on a default-QoS thread four times a second, forever, and
+    /// Xcode correctly flagged the priority inversion.
+    ///
+    /// The probe is an ANOMALY DETECTOR: it exists to catch a `didFinish` that
+    /// never arrived. So it should run only when an anomaly is actually
+    /// possible, and the conditions are precise:
+    ///
+    ///   * NO live claim -> nothing could have been dropped. Skip entirely.
+    ///     This is the common case, and it now costs zero blocking calls.
+    ///   * A claim YOUNGER than the grace period -> a normal utterance still
+    ///     in flight. Its callback has not had time to be late yet.
+    ///
+    /// What remains is exactly the suspicious case: a claim old enough that a
+    /// well-behaved synthesiser should already have released it. The cost of
+    /// the blocking read is then paid once per sweep per genuinely-stuck claim
+    /// rather than continuously, and the recovery window is unchanged.
+    private func reconcileStaleClaimsOnly() {
+        guard !reconcilers.isEmpty, !claims.isEmpty else { return }
+        let now = ContinuousClock.now
+        for (who, probe) in reconcilers {
+            guard let claim = claims[who], claim.isLive(now) else { continue }
+            // Old enough that `didFinish` is overdue, not merely pending.
+            guard now >= claim.opened.advanced(by: .seconds(1.5)) else { continue }
+            reconcile(who, isSpeaking: probe())
         }
     }
 


### PR DESCRIPTION
Self-inflicted, from #70354. Xcode named it precisely:

```
Hang Risk — User-interactive thread waiting on a Default-QoS thread
  #0 -[_NSThreadPerformInfo wait]
  #6 closure in applicationDidFinishLaunching  JARVISHUDApp.swift:49
  #9 SpeechGate.startSweeping()                MicSuppression.swift:242
```

`AVSpeechSynthesizer.isSpeaking` is **not a stored property** — reading it performs a synchronous thread hop. My reconciler probed every claimant on **every 250ms sweep**, so a user-interactive sweep blocked on a default-QoS thread 4×/second forever. Same defect class as the per-utterance voice lookup fixed in #70358 — created by me one PR earlier.

The probe is an **anomaly detector** (catch a `didFinish` that never arrived), so it should run only when an anomaly is possible:

- **no live claim** → nothing could have been dropped; skip. Common case now costs **zero** blocking calls.
- **claim younger than 1.5s** → normal utterance in flight; callback isn't late yet.

Leaving exactly the suspicious case. Recovery window unchanged; the blocking read is rare instead of continuous.

Needed a new `SpeechClaim.opened` distinct from `deadline` — `claim()` is re-entered on didStart and every reconcile, so measuring age from the (moving) deadline would make a stuck claim look perpetually new. Preserved across extensions.

Also `var discovered` → `let`. **BUILD SUCCEEDED, no warnings.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop polling `AVSpeechSynthesizer.isSpeaking` every 250ms to remove the QoS inversion and hang risk. We now only probe when a claim might be stale, keeping the recovery window the same while making the blocking read rare.

- **Bug Fixes**
  - Reconcile only when there’s a live claim older than 1.5s; skip otherwise.
  - Added `SpeechClaim.opened` (preserved across extensions) to measure true claim age.
  - Minor: `var discovered` → `let` in `BrainstemLauncher.swift`.

<sup>Written for commit d7f9e815d72831398332b905b785090964dc5efa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70360?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

