### PR TITLE
fix(ouroboros): stop guessing whether Oracle is sync or async

### DIFF
--- a/backend/core/ouroboros/governance/governed_loop_service.py
+++ b/backend/core/ouroboros/governance/governed_loop_service.py
@@ -19,6 +19,7 @@ STARTING -> FAILED (on error)
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
 import logging
 import os
@@ -1068,6 +1069,27 @@ def _wrap_subagent_narration(gls: Any, inner: Any) -> Any:
         return SubagentNarrationSink(inner, _emit)
     except Exception:  # noqa: BLE001
         return inner
+
+
+
+async def _maybe_await(value: Any) -> Any:
+    """Await *value* only if it is awaitable. NEVER assumes.
+
+    Oracle has TWO interchangeable implementations and they disagree about
+    async-ness: `oracle.Oracle.get_metrics` is a plain `def` returning a dict,
+    while `oracle_adapter`'s is `async def`. `self._oracle` may be either, so a
+    hardcoded `await` is correct for one and fatal for the other — which is
+    exactly what happened:
+
+        [GovernedLoop] Oracle initialization failed:
+          object dict can't be used in 'await' expression; codebase graph unavailable
+
+    The whole codebase graph was discarded on every boot because a call site
+    guessed which implementation it had. Deleting the `await` would only move
+    the breakage to the other implementation; asking the VALUE whether it is
+    awaitable works for both, and keeps working if a third arrives.
+    """
+    return await value if inspect.isawaitable(value) else value
 
 
 class GovernedLoopService:
@@ -7794,7 +7816,7 @@ class GovernedLoopService:
             if self._oracle is not None:
                 logger.info(
                     "[GovernedLoop] Oracle already injected (%s nodes), skipping re-init",
-                    (await self._oracle.get_metrics()).get("total_nodes", "?"),
+                    (await _maybe_await(self._oracle.get_metrics())).get("total_nodes", "?"),
                 )
             elif TheOracle is None:
                 raise ImportError("TheOracle not available")
@@ -7826,7 +7848,7 @@ class GovernedLoopService:
                 )
             logger.info(
                 "[GovernedLoop] Oracle indexed %s nodes across all repos",
-                (await self._oracle.get_metrics()).get("total_nodes", "?"),
+                (await _maybe_await(self._oracle.get_metrics())).get("total_nodes", "?"),
             )
         except asyncio.CancelledError:
             return
@@ -7917,9 +7939,9 @@ class GovernedLoopService:
                         _consec_skips, _max_consec_skips,
                     )
                 _consec_skips = 0
-                await self._oracle.incremental_update([])
+                await _maybe_await(self._oracle.incremental_update([]))
             except asyncio.CancelledError:
-                await self._oracle.shutdown()
+                await _maybe_await(self._oracle.shutdown())
                 return
             except Exception as exc:
                 logger.warning("[GovernedLoop] Oracle incremental update failed: %s", exc)


### PR DESCRIPTION
```
[GovernedLoop] Oracle initialization failed:
  object dict can't be used in 'await' expression; codebase graph unavailable
```

Every boot discarded the **entire codebase graph** because a call site assumed which of two interchangeable implementations it held:

| implementation | `get_metrics` |
|---|---|
| `oracle.Oracle` | `def` → `Dict[str, Any]` |
| `oracle_adapter` | `async def` → `dict` |

`self._oracle` may be either. `await` on the sync one raises `TypeError`, the generic handler catches it, and `self._oracle = None` — so the Advisor's Oracle-backed blast path (PR-A) silently fell back to the **29.5k-file rglob scan it was built to replace**. A one-word bug that disabled a whole subsystem, quietly enough to survive as a warning nobody chased.

Deleting the `await` would just move the breakage to the other implementation. `_maybe_await` asks the **value** whether it's awaitable — correct for both, and still correct if a third arrives. Applied to **all four** Oracle call sites, not only the logged one: `get_metrics` ×2, `incremental_update`, `shutdown` — the same trap was armed in each.

**Verified:** helper returns 42 from a sync dict, 7 from a coroutine, `None` unchanged; real HUD-mode boot logs **0** "Oracle initialization failed" (was 1/boot).
**Not confirmed:** the "Oracle indexed N nodes" success line — didn't appear inside a 75s window, as indexing this repo takes longer. Success path still unobserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Oracle initialization by safely handling both sync and async implementations with `_maybe_await`. This stops discarding the codebase graph on boot and prevents the slow 29.5k-file scan fallback.

- **Bug Fixes**
  - Added `_maybe_await(value)` using `inspect.isawaitable`.
  - Replaced direct awaits on `get_metrics` (2x), `incremental_update([])`, and `shutdown()` with `_maybe_await`.
  - Works with both `oracle.Oracle` (sync) and `oracle_adapter` (async) without guessing.
  - Verified: no more "Oracle initialization failed" logs; indexing success message may appear after longer runs.

<sup>Written for commit 63c4619fc04ee661791a64d85120dd0a79499b95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

