### PR TITLE
fix(hud): prose is not completion — a voice command must actually act

### DIFF
--- a/backend/hud/tool_use_orchestrator.py
+++ b/backend/hud/tool_use_orchestrator.py
@@ -140,6 +140,8 @@ class ToolUseOrchestrator:
 
         conversation = f"Goal: {goal}"
         steps_completed = 0
+        # One corrective re-prompt per goal — see the no-tool-calls branch.
+        nudged = False
 
         for iteration in range(self._max_iter):
             # Timeout check
@@ -186,7 +188,41 @@ class ToolUseOrchestrator:
             # Tool calls
             tool_calls = parsed.get("tool_calls", [])
             if not tool_calls:
-                # Model didn't return tool_calls or done — treat raw text as summary
+                # PROSE IS NOT COMPLETION.
+                #
+                # This branch used to `return success=True` with
+                # steps_completed=0 — so a model that answered "Sure, I'll lock
+                # your screen for you" ended the turn having done NOTHING, and
+                # reported success while doing it. Every capability behind the
+                # tool loop was reachable and none of them fired. That is the
+                # worst available outcome: silent no-op dressed as a result.
+                #
+                # A goal may legitimately be conversational ("what's on my
+                # screen?" answered from a screenshot the model already has),
+                # so prose is not an error either. The distinction is not
+                # knowable from the text — but it IS knowable from whether we
+                # have already asked.
+                #
+                # So: nudge ONCE, naming the failure, then believe the second
+                # answer. No tool name is hardcoded; the correction points at
+                # the tool list already in the prompt, so a capability added
+                # tomorrow is covered by the same sentence.
+                if not nudged and steps_completed == 0:
+                    nudged = True
+                    logger.info(
+                        "[ToolUse] Model answered in prose with no tool call — "
+                        "re-prompting once before accepting it as an answer")
+                    conversation += (
+                        "\n\nYou replied with text and called no tool, and the "
+                        "goal has not been carried out yet. If it needs an "
+                        "action on this Mac, respond ONLY with "
+                        "{\"tool_calls\": [{\"name\": \"...\", \"args\": {...}}]} "
+                        "using a tool from the list above — full name including "
+                        "any dot. If the goal genuinely needs no action, "
+                        "respond with {\"done\": true, \"summary\": \"...\"}."
+                    )
+                    continue
+
                 return CommandResult(
                     success=True, category="composite", steps_completed=steps_completed,
                     steps_total=steps_completed, response_text=raw.strip()[:500],


### PR DESCRIPTION
"Lock my screen" did nothing, **and reported success while doing it.**

The tool loop's no-tool-calls branch returned `success=True` with `steps_completed=0`. A model answering *"Sure, I'll lock your screen for you"* ended the turn having taken **no action**, and the HUD called it a success. All 81 capabilities were reachable; none fired. A silent no-op dressed as a result — which is precisely why it was hard to see.

A goal may legitimately be conversational ("what's on my screen?" answered from a screenshot already in context), so prose isn't an error either. The distinction isn't knowable from the text — but it **is** knowable from whether we've already asked.

**Nudge once, naming the failure, then believe the second answer.**

- No tool name hardcoded — the correction points at the tool list already in the prompt, so a capability annotated tomorrow is covered with no edit here.
- Bounded to one re-prompt per goal, and only before any step has run: cannot loop, cannot re-litigate a turn that already acted.

220 tests pass. The single failure in the combined run is cross-file singleton bleed (`tests/hud` resets the federation); passes **35/35 in isolation**. Pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop treating prose-only answers as successful. The HUD now nudges once to make a tool call or explicitly mark the goal done, so commands like “Lock my screen” actually act.

- **Bug Fixes**
  - When there are no `tool_calls` and `steps_completed == 0`, send a one-time corrective prompt that references the existing tool list.
  - Ask for either a proper `tool_calls` payload or `{"done": true, "summary": "..."}`; accept the second prose reply as final if no action is needed.
  - Guarded by a `nudged` flag and only before any step runs; no loops and no hardcoded tool names.

<sup>Written for commit 2ba46a36b7791fe173ecc99007b0f74c15ba1e75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

