### PR TITLE
fix(capability): never offer a credential parameter to the model

### DIFF
--- a/backend/system_control/capability_registry.py
+++ b/backend/system_control/capability_registry.py
@@ -107,6 +107,38 @@ _EXCLUDED_PARAMS = frozenset({"self", "cls", "progress_callback", "callback",
                               "on_progress", "loop", "session", "ctx",
                               "context", "_internal"})
 
+#: Parameters a language model must NEVER be offered, because the only values
+#: it can supply are invented or stolen.
+#:
+#: `unlock_screen(password=None)` was reaching the model with `password` as a
+#: fillable string. A model asked to unlock a Mac will either hallucinate a
+#: password — a guaranteed failed auth attempt — or, on a screen carrying
+#: injected text, be induced to echo a REAL one into a tool call that is then
+#: written to the conversation log and the intent journal in plaintext.
+#:
+#: The authority for these values is never the model. `unlock_screen` already
+#: defaults to None and reads the macOS Keychain; every capability that takes a
+#: secret has the same shape, because a secret a caller must pass in is a
+#: secret that has already leaked.
+#:
+#: Matched by SUBSTRING on a normalised name, so `password`, `db_password`,
+#: `apiKey` and `auth_token` are all covered without a list of spellings to
+#: keep — the same reason this module derives its vocabulary instead of
+#: declaring it. Silence is not the default here: this is a DENY list applied
+#: on top of a schema that is otherwise complete.
+_SECRET_PARAM_MARKERS = ("password", "passwd", "secret", "token", "apikey",
+                         "api_key", "credential", "passphrase", "private_key")
+
+
+def _is_secret_param(name: str) -> bool:
+    """Whether a parameter carries a credential. NEVER raises."""
+    try:
+        n = (name or "").strip().lower().replace("-", "_")
+        flat = n.replace("_", "")
+        return any(m.replace("_", "") in flat for m in _SECRET_PARAM_MARKERS)
+    except Exception:  # noqa: BLE001
+        return True   # unreadable name -> withhold, never offer
+
 _DOC_TAG = re.compile(r"^\s*Capability:\s*(?P<body>.+)$",
                       re.IGNORECASE | re.MULTILINE)
 _ARGS_BLOCK = re.compile(
@@ -436,6 +468,10 @@ def describe(name: str, fn: Any) -> Optional[CapabilityDef]:
             descs = _arg_descriptions(doc)
             for pname, p in sig.parameters.items():
                 if pname in _EXCLUDED_PARAMS:
+                    continue
+                if _is_secret_param(pname):
+                    # Withheld from the schema, NOT from the call: the method
+                    # keeps its default and sources the value from the Keychain.
                     continue
                 if p.kind in (inspect.Parameter.VAR_POSITIONAL,
                               inspect.Parameter.VAR_KEYWORD):


### PR DESCRIPTION
`unlock_screen` needed **no wiring** — already derived, gated `approval_required`, provenance `declared`, live in the 81-tool surface. What checking for it exposed was worse than a missing capability:

```
unlock_screen params exposed : ['password']
```

The tool schema handed the model a **fillable `password` field**. A model asked to unlock a Mac either hallucinates one (guaranteed failed auth against the operator's own account) or — on a screen carrying injected text — is induced to echo a **real** password into a tool call, which is then written to the conversation log and intent journal **in plaintext**.

The model is never the authority for these values. `unlock_screen` already defaults to `None` and reads the **macOS Keychain**.

Withheld from the **schema**, not the **call**: the method keeps its default and still sources the Keychain. Nothing about unlocking changes except that the model can no longer be asked for the secret.

Extends the existing `_EXCLUDED_PARAMS` mechanism rather than adding a second one — same idea, same place. **Substring match on a normalised name**, so `password`, `db_password`, `apiKey`, `auth_token`, `passphrase` are covered with no spelling list to maintain; `level`/`app_name` unaffected.

**Verified live:** `unlock_screen` now exposes `[]`, still registered and gated. 68 registry/router tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented credential-like parameters from appearing in capability schemas so the model is never asked for secrets. Calls still use secure defaults (e.g., Keychain for `unlock_screen`), so behavior is unchanged while removing plaintext secret risk in logs.

- **Bug Fixes**
  - Withhold any param whose normalized name includes markers like password, token, apikey, credential, or passphrase (substring match).
  - Applied at schema generation only; functions keep defaults and source secrets securely at call time.
  - Verified `unlock_screen` exposes no params; registry/router tests pass.

<sup>Written for commit e0a1b042f2fe7b0519d753e1342da765e9b61047. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

