### PR TITLE
fix(hud): the microphone never started, so no voice command was ever heard

### DIFF
--- a/JARVIS-Apple/JARVISHUD/JARVISHUDApp.swift
+++ b/JARVIS-Apple/JARVISHUD/JARVISHUDApp.swift
@@ -184,8 +184,35 @@ class HUDAppDelegate: NSObject, NSApplicationDelegate, AVSpeechSynthesizerDelega
             .receive(on: RunLoop.main)
             .sink { [weak self] status in
                 guard let self else { return }
-                if status == .connected && self.wakeWord.state == .off && !self.isTTSSpeaking {
-                    print("[JARVIS] Cloud connected — starting wake word listener")
+                // THE MICROPHONE NEVER STARTED. This is the only
+                // `wakeWord.start()` in the app, and its `!isTTSSpeaking`
+                // guard made it unreachable:
+                //
+                //   onBackendReady()  connectionStatus = .connected   (fires this
+                //                     sink — but `.receive(on: RunLoop.main)`
+                //                     delivers it on the NEXT runloop turn)
+                //   onBackendReady()  onSpeak("JARVIS Online...")     -> isTTSSpeaking = true
+                //   next turn         guard sees isTTSSpeaking == true -> SKIP
+                //
+                // The greeting always wins that race, because it is emitted
+                // synchronously two lines below the assignment that schedules
+                // this. So the listener was skipped on every single launch and
+                // no voice command could ever be heard — which is exactly what
+                // "JARVIS never got my message" means.
+                //
+                // The guard was correct when `speak()` STOPPED the mic: it kept
+                // a reconnect from rebuilding an audio graph mid-utterance.
+                // That teardown is gone (#70349) — the engine now runs
+                // continuously and SpeechGate mutes the TAP instead — so the
+                // condition it protected against can no longer occur, while its
+                // side effect (never starting) survived. Removing it restores
+                // the invariant the gate assumes: the mic is always ON, and
+                // muting is the gate's job alone.
+                //
+                // `state == .off` is retained and is what makes this idempotent
+                // across reconnects.
+                if status == .connected && self.wakeWord.state == .off {
+                    print("[JARVIS] Backend connected — starting wake word listener")
                     self.wakeWord.start()
                 }
             }


### PR DESCRIPTION
*"I told JARVIS to lock my screen and it didn't get my message."* It **could not have**. The wake-word listener was never started on any launch.

There is exactly **one** `wakeWord.start()` in the app, and its guard made it unreachable:

```
onBackendReady()  connectionStatus = .connected   → schedules this sink, but
                                                    .receive(on: RunLoop.main)
                                                    delivers it NEXT runloop turn
onBackendReady()  onSpeak("JARVIS Online...")     → isTTSSpeaking = true
next turn         guard !isTTSSpeaking            → SKIP
```

The greeting **always** wins that race — it's emitted synchronously two lines below the assignment that schedules the sink.

## My regression

The guard was correct while `speak()` **stopped** the mic: it kept a reconnect from rebuilding an audio graph mid-utterance, and `didFinish → wakeWord.start()` quietly rescued this race on the first utterance. #70349 removed that teardown (engine runs continuously; SpeechGate mutes the **tap**) — and with it the rescuing restart. The condition the guard protected against became impossible; its side effect of never starting did not.

Removing it restores the invariant SpeechGate already assumes: **the mic is always on, muting is the gate's job alone.** `state == .off` is retained and keeps it idempotent across reconnects.

Upstream of everything — lock, unlock, and all 81 capabilities are unreachable by voice until the listener runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the wake-word listener never starting on launch (a race with the greeting TTS), which blocked all voice commands. Removes the `!isTTSSpeaking` guard so the listener starts on backend connect; keeps `state == .off` for idempotent restarts and relies on SpeechGate for muting.

<sup>Written for commit dd7b9a09f68c47730bdfce995c656c8de1aadb65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70365?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

