### PR TITLE
fix(hud): "lock my screen" did nothing — five root causes

### DIFF
--- a/backend/core/ouroboros/governance/soak_circuit_breaker.py
+++ b/backend/core/ouroboros/governance/soak_circuit_breaker.py
@@ -72,6 +72,26 @@ ENV_ENABLED = "JARVIS_SOAK_CIRCUIT_BREAKER_ENABLED"
 ENV_MAX_COST_USD = "JARVIS_SOAK_MAX_COST_USD"
 ENV_MAX_GCE_RUNTIME_S = "JARVIS_SOAK_MAX_GCE_RUNTIME_S"
 ENV_WARN_PCT = "JARVIS_SOAK_BUDGET_WARN_PCT"
+#: How far back the durable baseline replay reaches. See
+#: :meth:`SoakCircuitBreaker._replay_committed_spend`. ``0`` = all-time.
+ENV_BASELINE_HORIZON_S = "JARVIS_SOAK_BASELINE_HORIZON_S"
+#: The process role that ARMS this breaker. See :func:`process_role`.
+ENV_PROCESS_ROLE = "JARVIS_PROCESS_ROLE"
+
+#: The ``route`` this module stamps on its own WAL rows — and therefore the
+#: rows the baseline replay must never sum. A named constant rather than a
+#: literal in two places precisely because the two places must agree: a writer
+#: and a reader that disagree about this string is the self-amplification loop
+#: rebuilding itself.
+_WAL_SELF_ROUTE = "soak_circuit_breaker"
+
+#: Roles that mean "a human is at the keyboard". See :func:`role_is_attended`.
+#: Not a policy table — a vocabulary. The POLICY is the one line in
+#: `SoakBreakerConfig.from_env` that reads it, and it fails closed.
+ATTENDED_ROLES = frozenset({"hud", "interactive", "repl", "desktop"})
+
+#: The role a soak declares. Named so a launcher can say it out loud.
+ROLE_SOAK = "soak"
 
 _TRUE = {"1", "true", "yes", "on"}
 
@@ -94,6 +114,31 @@ def _env_float(name: str, default: float) -> float:
         return default
 
 
+def process_role() -> str:
+    """What KIND of process this is. ``""`` when nobody has said. NEVER raises.
+
+    Declared, never sniffed. A heuristic ("is stdin a TTY?", "is the module
+    named main?") would answer for a soak launched from a terminal exactly as
+    it answers for the HUD, and the two need opposite answers.
+    """
+    try:
+        return (os.environ.get(ENV_PROCESS_ROLE, "") or "").strip().lower()
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def role_is_attended() -> bool:
+    """Whether a human is at the keyboard of THIS process. NEVER raises.
+
+    Fails closed toward *unattended*. Silence answers False, so a soak that
+    forgets to declare anything stays fully protected — the direction where
+    being wrong costs real money. Only a process that positively names itself
+    as an attended surface is exempt, and the only thing that can name it is
+    its own boot path.
+    """
+    return process_role() in ATTENDED_ROLES
+
+
 @dataclass(frozen=True)
 class SoakBreakerConfig:
     """Immutable per-assessment snapshot of the env-resolved thresholds.
@@ -112,8 +157,35 @@ class SoakBreakerConfig:
         warn = _env_float(ENV_WARN_PCT, 0.8)
         if not (0.0 < warn <= 1.0):
             warn = 0.8
+        # SCOPE. This breaker's whole purpose statement is the first line of
+        # the module docstring: "let an *unattended* graduation soak run
+        # without runaway cloud spend... real money, no human at the
+        # keyboard." Fail-closed refusal of every LLM dispatch is exactly
+        # right for that, and exactly wrong for the attended HUD — where the
+        # human IS at the keyboard, is speaking to the machine, and gets
+        # silence plus a stack trace read aloud.
+        #
+        # The three JARVIS_SOAK_* knobs live in `.env`, which every process in
+        # this repo loads, so the HUD inherited a $2 per-soak cap it had no
+        # way to know was not meant for it. That is a scope error, not a
+        # budget one: an armed soak breaker in an attended process is
+        # measuring the wrong episode against the wrong ceiling.
+        #
+        # Disarming here removes NO protection from the thing this guards.
+        # The attended HUD still has `SessionBudgetAuthority` + `CostGovernor`
+        # on every dispatch, and the real-money risk the breaker exists for —
+        # auto-provisioning a GCE node — is separately held by
+        # `JARVIS_FAILOVER_VM_ORCHESTRATION_HOLD`.
+        enabled = _env_bool(ENV_ENABLED, False)
+        if enabled and role_is_attended():
+            logger.info(
+                "[SoakCB] disarmed for attended role '%s' — the soak breaker "
+                "guards UNATTENDED runs; this process has an operator, a "
+                "session budget authority and a cost governor.",
+                process_role())
+            enabled = False
         return cls(
-            enabled=_env_bool(ENV_ENABLED, False),
+            enabled=enabled,
             max_cost_usd=max(0.0, _env_float(ENV_MAX_COST_USD, 0.0)),
             max_gce_runtime_s=max(0.0, _env_float(ENV_MAX_GCE_RUNTIME_S, 0.0)),
             warn_pct=warn,
@@ -466,6 +538,106 @@ class SoakCircuitBreaker:
 
     # ── Boot reconciliation (mandate 4 — restart durability) ─────────────
 
+    @staticmethod
+    def baseline_horizon_s() -> float:
+        """How far back the durable baseline reaches, in seconds. NEVER raises.
+
+        WHY A HORIZON AT ALL
+        ----------------------
+        The cap this baseline is compared against is a PER-SOAK cap — $2 for
+        one unattended episode. The WAL it was replayed from is ALL-TIME. On
+        this machine that ledger held 685 rows going back a fortnight, so even
+        with the amplification loop closed the honest total ($3.63) still
+        exceeded a $2 episode cap, on boot, permanently, and would have again
+        at every future boot forever. A ceiling that measures one episode
+        against the sum of all episodes is not strict — it is stuck.
+
+        The durable baseline exists for ONE reason, stated in
+        :meth:`reconcile_on_boot`: a soak that already spent $8 of a $10 cap
+        must resume at 80% used rather than 0% after a restart. That is a
+        statement about restarts WITHIN an episode. Spend from a different
+        episode a fortnight ago is not this episode's spend.
+
+        WHERE THE NUMBER COMES FROM
+        -----------------------------
+        Derived from what the operator has already declared about how long an
+        episode lasts, rather than invented: the soak's own GCE runtime
+        ceiling and the battle-test harness's wall-clock cap are both explicit
+        statements of episode length. The widest one wins, floored at an hour
+        so a tiny configured cap cannot shrink the window to nothing.
+        ``JARVIS_SOAK_BASELINE_HORIZON_S`` overrides; ``0`` restores the
+        all-time behaviour for anyone who wants it.
+        """
+        try:
+            explicit = _env_float(ENV_BASELINE_HORIZON_S, -1.0)
+            if explicit >= 0.0:
+                return explicit
+            declared = max(
+                _env_float(ENV_MAX_GCE_RUNTIME_S, 0.0),
+                _env_float("OUROBOROS_BATTLE_MAX_WALL_SECONDS", 0.0),
+            )
+            return max(3600.0, declared)
+        except Exception:  # noqa: BLE001
+            return 3600.0
+
+    def _replay_committed_spend(self, now: Optional[float] = None) -> float:
+        """Sum COMMITTED spend from the durable WAL. NEVER raises.
+
+        Two exclusions, and both are load-bearing.
+
+        **This module's own rows.** :meth:`_durable_append` writes a summary
+        of what this method computed. Summing those makes the reader an input
+        to itself, and a self-referential sum does not drift — it doubles.
+        Excluded by ``route``, so it holds for every row this module has ever
+        written, including the seventeen poisoned ones already on disk (which
+        this makes inert without touching the file: an append-only ledger is
+        not rewritten to fix a reader that was wrong).
+
+        **Rows older than the horizon.** See :meth:`baseline_horizon_s`.
+
+        Everything else is summed fail-CLOSED exactly as before — an
+        un-reconciled in-flight lease still counts against us via its reserve
+        or estimate, because at boot a lease we cannot prove settled is a
+        lease we must assume spent.
+        """
+        try:
+            from backend.core.ouroboros.aegis import flags as _aegis_flags
+            from backend.core.ouroboros.aegis.spend_wal import replay_wal
+            entries = replay_wal(_aegis_flags.wal_path())
+        except Exception:  # noqa: BLE001
+            logger.debug("[SoakCB] WAL replay unavailable", exc_info=True)
+            return 0.0
+
+        horizon = self.baseline_horizon_s()
+        cutoff = ((now if now is not None else time.time()) - horizon
+                  if horizon > 0.0 else float("-inf"))
+        baseline = 0.0
+        counted = skipped_self = skipped_old = 0
+        for e in entries:
+            try:
+                if (getattr(e, "route", None) or "") == _WAL_SELF_ROUTE:
+                    skipped_self += 1
+                    continue
+                if float(getattr(e, "ts", 0.0) or 0.0) < cutoff:
+                    skipped_old += 1
+                    continue
+                val = e.actual_cost_usd
+                if val is None:
+                    val = e.reserve_cost_usd
+                if val is None:
+                    val = e.estimated_cost_usd
+                if val:
+                    baseline += float(val)
+                    counted += 1
+            except Exception:  # noqa: BLE001 — one bad row never blinds the sum
+                continue
+        logger.info(
+            "[SoakCB] baseline replay: $%.4f from %d row(s); skipped %d "
+            "self-written summar%s and %d row(s) older than %.0fs",
+            baseline, counted, skipped_self,
+            "y" if skipped_self == 1 else "ies", skipped_old, horizon)
+        return max(0.0, baseline)
+
     async def reconcile_on_boot(self) -> Dict[str, Any]:
         """Reconstruct spend + active-node runtime from the durable ledger +
         live GCP API BEFORE the loop resumes, then assess (trips immediately
@@ -486,22 +658,7 @@ class SoakCircuitBreaker:
         }
         # 1. Durable LLM-spend baseline from the Aegis spend WAL.
         try:
-            from backend.core.ouroboros.aegis import flags as _aegis_flags
-            from backend.core.ouroboros.aegis.spend_wal import replay_wal
-            entries = replay_wal(_aegis_flags.wal_path())
-            baseline = 0.0
-            for e in entries:
-                # Prefer settled actuals; fall back to reserved/estimated so
-                # an un-reconciled in-flight lease still counts against us
-                # (fail-CLOSED: never under-count spend at boot).
-                val = e.actual_cost_usd
-                if val is None:
-                    val = e.reserve_cost_usd
-                if val is None:
-                    val = e.estimated_cost_usd
-                if val:
-                    baseline += float(val)
-            self._boot_cost_baseline_usd = max(0.0, baseline)
+            self._boot_cost_baseline_usd = self._replay_committed_spend()
             summary["cost_baseline_usd"] = self._boot_cost_baseline_usd
         except Exception:  # noqa: BLE001
             logger.debug("[SoakCB] boot spend replay degraded", exc_info=True)
@@ -585,9 +742,30 @@ class SoakCircuitBreaker:
     def _durable_append(tag: str, detail: Dict[str, Any]) -> None:
         """Durable-DB side — a RECONCILE row on the sealed Aegis spend WAL
         (mandate 3: integrate into the EXISTING logging schema, no new
-        table). The row carries the assessment in ``detail`` and the current
-        spend in ``actual_cost_usd`` so a post-hoc audit reconstructs the
-        trip from the same ledger crash recovery already replays."""
+        table). The row carries the whole assessment in ``detail``, which is
+        what a post-hoc audit reconstructs the trip from.
+
+        AN OBSERVATION IS NOT AN EVENT
+        --------------------------------
+        This row used to carry the observed TOTAL in ``actual_cost_usd``.
+        That field means "money this row spent", and the replay in
+        :meth:`reconcile_on_boot` sums it across every row. So the breaker
+        was writing its own answer into the question, and the next boot read
+        it back as fresh spend on top of the spend it already summarised.
+
+        Measured on this machine's WAL, seventeen consecutive boots:
+
+            3.63 → 7.27 → 14.53 → 29.07 → … → 119055.97 → 238111.95
+
+        Exactly 2ⁿ. A true spend of $3.63 presented as $238,111.95, and every
+        LLM dispatch in the process — including the attended HUD's voice
+        path — refused against it. Nothing overspent; the ledger ate itself.
+
+        So the total goes in ``detail`` (where it already was, in full) and
+        the spend field stays ``None``. A summary row spent nothing.
+        :meth:`_replay_committed_spend` independently refuses to sum rows
+        this method wrote, because one guard on a self-referential loop is
+        one edit away from being none."""
         try:
             from backend.core.ouroboros.aegis import flags as _aegis_flags
             from backend.core.ouroboros.aegis.spend_wal import (
@@ -596,9 +774,11 @@ class SoakCircuitBreaker:
             entry = SpendEntry(
                 kind=SpendEntryKind.RECONCILE,
                 ts=time.time(),
-                op_id=f"soak_circuit_breaker:{tag}",
-                route="soak_circuit_breaker",
-                actual_cost_usd=float(detail.get("cost_used_usd", 0.0) or 0.0),
+                op_id=f"{_WAL_SELF_ROUTE}:{tag}",
+                route=_WAL_SELF_ROUTE,
+                # Deliberately None — see the docstring. The observed total
+                # lives in `detail["cost_used_usd"]`, losslessly.
+                actual_cost_usd=None,
                 detail=str(detail)[:500],
             )
             append_entry_sync(_aegis_flags.wal_path(), entry)

--- a/backend/hud/tool_use_orchestrator.py
+++ b/backend/hud/tool_use_orchestrator.py
@@ -43,6 +43,13 @@ class CommandResult:
     steps_total: int
     response_text: Optional[str]
     error: Optional[str]
+    #: The command was understood and correctly dispatched, and is now waiting
+    #: on somebody — an operator at a Touch ID prompt. Distinct from BOTH
+    #: success and failure, and it needs to be: a gated capability suspends by
+    #: design, and reporting that as `failed` would teach an operator that the
+    #: consent boundary is a malfunction. Nothing that reads `success` breaks
+    #: by ignoring this; the surfaces that narrate to a human read it.
+    pending: bool = False
 
 
 class ToolUseOrchestrator:

--- a/backend/hud/voice_command_router.py
+++ b/backend/hud/voice_command_router.py
@@ -39,6 +39,154 @@ Categories:
 Return: {{"category": "...", "needs_vision": true/false, "needs_tools": true/false}}"""
 
 
+def _humanise(capability: str) -> str:
+    """A capability name as a person would say it. NEVER raises.
+
+    `video.start_streaming` → "start streaming". Derived from the name rather
+    than looked up, for the same reason the reflex derives its lexicon: a
+    table of spoken forms is a table that goes stale the first time somebody
+    adds a capability without reading this file.
+    """
+    try:
+        bare = str(capability or "").split(".")[-1]
+        return " ".join(bare.replace("_", " ").split()) or "that"
+    except Exception:  # noqa: BLE001
+        return "that"
+
+
+def _read_controller_result(result: Any, human: str) -> tuple:
+    """(succeeded, what to say) from whatever a capability returned.
+
+    NEVER raises. `MacOSController` methods answer `(bool, str)` and the
+    string is already a sentence written for a person — "🔒 Locking the screen
+    now, Derek. See you soon." Synthesising our own narration on top of that
+    would be a second voice for the same event, and the two would eventually
+    disagree about what happened.
+    """
+    try:
+        if isinstance(result, tuple) and len(result) == 2:
+            ok, msg = result
+            text = str(msg or "").strip()
+            if isinstance(ok, bool):
+                return ok, (text or (f"Done — {human}." if ok
+                                     else f"I couldn't {human}."))
+        if isinstance(result, str) and result.strip():
+            return True, result.strip()[:400]
+        if result is False:
+            return False, f"I couldn't {human}."
+        return True, f"Done — {human}."
+    except Exception:  # noqa: BLE001
+        return True, f"Done — {human}."
+
+
+def _why_the_model_could_not_answer(detail: str) -> str:
+    """Turn a provider fault into a sentence. NEVER raises.
+
+    The operator asked for their screen to be locked and JARVIS said, out
+    loud, through a speech synthesiser:
+
+        "Model error: session_budget_preflight_refused:soak_circuit_tripped:
+         soak_cost_cap_exceeded:$238111.9488>=$2.0000:on_boot: provider=
+         doubleword est=$0.1000 > session_remaining=$0.0000"
+
+    Absolute observability means every autonomous decision is VISIBLE, and a
+    diagnostic read aloud to a person is not visibility — it is the log
+    escaping onto the one surface that cannot skim. The full string stays in
+    `error` for the log; this is what gets spoken.
+
+    Classified by SHAPE rather than by matching a provider's exact wording, so
+    a reworded refusal from a new provider still lands in the right sentence.
+    """
+    try:
+        d = (detail or "").lower()
+        if "budget" in d or "cost_cap" in d or "circuit" in d or "spend" in d:
+            return ("I've hit my own spending limit, so I can't think that "
+                    "one through right now.")
+        if ("403" in d or "entitlement" in d or "unauthor" in d
+                or "api key" in d or "credential" in d):
+            return "I'm not authorised to reach my language model right now."
+        if "timeout" in d or "timed out" in d:
+            return "My language model took too long to answer."
+        if ("connect" in d or "unreachable" in d or "network" in d
+                or "outage" in d or "502" in d or "503" in d):
+            return "I can't reach my language model right now."
+        return "My language model isn't answering right now."
+    except Exception:  # noqa: BLE001
+        return "My language model isn't answering right now."
+
+
+def _near_miss_offer(reflex: Any) -> str:
+    """What the reflex ALMOST understood, phrased as an offer. "" if nothing.
+
+    NEVER raises. When the cortex is unreachable, "I don't know" and "I think
+    you meant lock screen but I wasn't sure enough to act" are very different
+    answers, and the second one lets the operator fix it in one word. The
+    reflex still does not act on it — this only says what it saw.
+    """
+    try:
+        if reflex is None or getattr(reflex, "resolved", False):
+            return ""
+        cap = str(getattr(reflex, "capability", "") or "")
+        outcome = str(getattr(reflex, "outcome", "") or "")
+        if not cap:
+            return ""
+        if outcome in ("low_confidence", "ambiguous"):
+            return f" Did you mean {_humanise(cap)}?"
+        if outcome == "needs_args":
+            return (f" I can {_humanise(cap)}, but I need you to tell me "
+                    f"what to run it on.")
+        return ""
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def _make_failure_speakable(result: Any, reflex: Any) -> Any:
+    """Rewrite a failed result's spoken half. NEVER raises.
+
+    Applied HERE rather than inside `ToolUseOrchestrator` on purpose: the
+    orchestrator has other callers and its `error` string is a diagnostic that
+    logs and tests depend on. Only this path ends at a speech synthesiser, so
+    only this path translates. `error` is left exactly as it was.
+    """
+    try:
+        if result is None or getattr(result, "success", False):
+            return result
+        if getattr(result, "pending", False):
+            return result
+        # NEVER touch a result the reflex produced. Measured: the capability
+        # path answered "I couldn't ask anyone to approve lock screen, so I
+        # didn't do it" — true, specific, and actionable — and this function
+        # saw the word "provider" in `no approval provider available` and
+        # replaced it with "My language model isn't answering right now",
+        # which is a plain falsehood; no model was involved in that failure at
+        # all. A translator that can overwrite a true sentence with a false
+        # one is worse than the diagnostic it was written to replace.
+        #
+        # The gate is the PATH, not a better keyword list: the capability path
+        # already writes sentences for people, so it needs no translation, and
+        # anything this function did to one could only be damage.
+        if reflex is not None and getattr(reflex, "resolved", False):
+            return result
+        detail = str(getattr(result, "error", "")
+                     or getattr(result, "response_text", "") or "")
+        # Only rewrite when the failure was the MODEL being unavailable. A
+        # genuine task failure ("couldn't find Chrome") is already a sentence
+        # a person can act on, and replacing it would lose the only useful
+        # thing in it.
+        markers = ("model error", "preflight", "provider", "circuit", "budget",
+                   "timeout", "connect", "unauthor", "403", "502", "503",
+                   "entitlement", "outage")
+        if not any(m in detail.lower() for m in markers):
+            return result
+        result.response_text = (_why_the_model_could_not_answer(detail)
+                                + _near_miss_offer(reflex))
+        logger.warning("[VoiceRouter] model path unavailable — spoken: %s "
+                       "| detail: %s", result.response_text, detail[:200])
+        return result
+    except Exception:  # noqa: BLE001
+        return result
+
+
 class VoiceCommandRouter:
     """Routes voice commands through Ouroboros for intelligent execution."""
 
@@ -68,6 +216,7 @@ class VoiceCommandRouter:
         """
         logger.info("[VoiceRouter] Command: %s", command[:100])
         _journal = None
+        reflex = None
         try:
             from backend.hud.intent_journal import (
                 NodeKind, get_intent_journal,
@@ -79,8 +228,31 @@ class VoiceCommandRouter:
         except Exception:  # noqa: BLE001 — a journal never blocks a command
             _journal = None
 
+        # Step 0: THE REFLEX. Deterministic, ~0.1ms, zero LLM, zero I/O.
+        #
+        # This runs BEFORE classification rather than as its fallback, and the
+        # order is the whole point. As a fallback it would only ever run after
+        # a model call had already been attempted — so a sentence naming a
+        # capability outright would still cost two round-trips when the model
+        # is up, and would still be at the mercy of the model being up at all.
+        #
+        # It fires only when it is certain, and every uncertain outcome falls
+        # through to exactly the path that ran before, so nothing it declines
+        # is lost. See `capability_reflex` for the four separate refusals.
+        reflex = self._reflex(command)
+        if reflex is not None and reflex.resolved:
+            logger.info("[VoiceRouter] REFLEX resolved '%s' -> %s in %.2fms "
+                        "(no model call) — %s", command[:60],
+                        reflex.capability, reflex.elapsed_ms, reflex.reason)
+
         # Step 1: Classify intent via 35B — PURE, so a resume can reuse it.
         classification = None
+        if reflex is not None and reflex.resolved:
+            # Skip the classifier entirely. Asking a model to categorise a
+            # sentence we have already resolved to a named capability is a
+            # round-trip whose answer we would discard.
+            classification = {"category": "system_action",
+                              "needs_vision": False, "needs_tools": False}
         if _journal is not None and intent_id:
             try:
                 _v = _journal.resume_plan(intent_id).for_node("classify")
@@ -117,7 +289,9 @@ class VoiceCommandRouter:
                 pass
         result: Optional[CommandResult] = None
         try:
-            if category == "app_action":
+            if reflex is not None and reflex.resolved:
+                result = await self._execute_capability(reflex)
+            elif category == "app_action":
                 result = await self._execute_app_action(command)
             elif category == "navigation":
                 result = await self._execute_navigation(command)
@@ -131,7 +305,7 @@ class VoiceCommandRouter:
                 # composite or unknown -> tool-use loop (397B)
                 result = await self._tool_orchestrator.execute(
                     command, screenshot_b64)
-            return result
+            return _make_failure_speakable(result, reflex)
         except Exception as exc:  # noqa: BLE001 — record, then propagate
             if _journal is not None and intent_id:
                 try:
@@ -158,6 +332,106 @@ class VoiceCommandRouter:
                         intent_id, success=bool(getattr(result, "success", True)))
                 except Exception:  # noqa: BLE001
                     pass
+
+    # ── The reflex arc ──────────────────────────────────────────────────
+
+    def _reflex(self, command: str) -> Optional[Any]:
+        """Resolve the sentence to a named capability, or None. NEVER raises.
+
+        Wrapped rather than called inline so that a fault in the reflex costs
+        the model round-trip it was meant to save, and nothing else. A reflex
+        that can take the voice path down with it is worse than no reflex.
+        """
+        try:
+            from backend.system_control.capability_reflex import (
+                get_capability_reflex,
+            )
+            out = get_capability_reflex().resolve(command)
+            if not out.resolved:
+                logger.debug("[VoiceRouter] reflex declined (%s): %s",
+                             out.outcome, out.reason)
+            return out
+        except Exception:  # noqa: BLE001
+            logger.debug("[VoiceRouter] reflex unavailable", exc_info=True)
+            return None
+
+    async def _execute_capability(self, reflex: Any) -> CommandResult:
+        """Run a reflex-resolved capability through the consent boundary.
+
+        Goes through `CapabilityRouter.route`, never around it. The reflex
+        decided WHICH capability; the registry still decides whether it needs
+        the Iron Gate, the router still mints the nonce and suspends, and the
+        operator still sees the Touch ID prompt. Arriving at the gate without
+        a model does not mean arriving past it.
+
+        Called with NO arguments, always — `capability_reflex` refuses to
+        resolve anything whose signature has a required parameter, so an empty
+        call here is a guarantee rather than an omission.
+        """
+        try:
+            from backend.system_control.capability_router import (
+                Outcome, get_capability_router,
+            )
+            routed = await get_capability_router().route(
+                reflex.capability, {}, op_id=f"reflex:{reflex.capability}")
+        except Exception as exc:  # noqa: BLE001
+            logger.error("[VoiceRouter] capability route failed: %s", exc)
+            return CommandResult(
+                success=False, category="system_action", steps_completed=0,
+                steps_total=1, error=str(exc),
+                response_text=f"I couldn't run {_humanise(reflex.capability)}.")
+
+        human = _humanise(reflex.capability)
+        outcome = routed.outcome
+
+        if outcome == Outcome.EXECUTED.value:
+            # HONOUR THE RETURN VALUE. `_execute` reports EXECUTED when the
+            # call did not RAISE — but `lock_screen` answers
+            # `(False, "Unable to lock screen (all methods failed)")` without
+            # raising anything. Reading only the router's outcome would report
+            # a locked screen to an operator looking at an unlocked one, which
+            # is the one failure mode worse than not acting.
+            ok, spoken = _read_controller_result(routed.result, human)
+            return CommandResult(
+                success=ok, category="system_action",
+                steps_completed=1 if ok else 0, steps_total=1,
+                response_text=spoken, error=None if ok else spoken)
+
+        if outcome == Outcome.SUSPENDED.value:
+            logger.info("[VoiceRouter] '%s' awaiting operator consent "
+                        "(request=%s)", reflex.capability,
+                        (routed.request_id or "")[:12])
+            return CommandResult(
+                success=False, pending=True, category="system_action",
+                steps_completed=0, steps_total=1, error=None,
+                response_text=f"I need your approval to {human}. "
+                              f"Check the prompt on screen.")
+
+        if outcome == Outcome.DENIED.value:
+            # Two very different situations wearing one outcome, and an
+            # operator needs opposite follow-ups: they said no, or nothing
+            # could ask them. The router already writes the distinction into
+            # `detail`; dropping it here would make a disconnected HUD look
+            # like a refusal the operator does not remember giving.
+            unasked = "no approval provider" in (routed.detail or "").lower()
+            return CommandResult(
+                success=False, category="system_action", steps_completed=0,
+                steps_total=1, error=routed.detail or "denied",
+                response_text=(
+                    f"I couldn't ask anyone to approve {human}, so I didn't "
+                    f"do it." if unasked
+                    else f"You declined {human}, so I left it alone."))
+
+        if outcome == Outcome.EXPIRED.value:
+            return CommandResult(
+                success=False, category="system_action", steps_completed=0,
+                steps_total=1, error=routed.detail or "expired",
+                response_text=f"The approval for {human} timed out.")
+
+        return CommandResult(
+            success=False, category="system_action", steps_completed=0,
+            steps_total=1, error=routed.detail or outcome,
+            response_text=f"I couldn't {human}: {routed.detail or outcome}.")
 
     async def _classify(self, command: str) -> dict:
         """Classify intent via Doubleword 35B."""

--- a/backend/main.py
+++ b/backend/main.py
@@ -1599,6 +1599,24 @@ PARALLEL_STARTUP_ENABLED = os.getenv("JARVIS_PARALLEL_STARTUP", "true").lower() 
 # Adds: IPC server on 8742, optional SSE consumer for Vercel cloud relay.
 HUD_MODE = os.getenv("JARVIS_MODE", "").lower() == "hud"
 
+# DECLARE THE ROLE. Set before anything that gates on it is constructed.
+#
+# `.env` carries `JARVIS_SOAK_CIRCUIT_BREAKER_ENABLED=true` with a $2 cap,
+# and `.env` is loaded by every process in this repo — so the attended HUD
+# inherited an UNATTENDED soak's fail-closed budget breaker. Measured
+# consequence: an operator said "lock my screen", every LLM dispatch was
+# refused against a cap that was never meant for this process, and the
+# machine answered by reading the refusal string aloud.
+#
+# `soak_circuit_breaker.role_is_attended` fails closed — silence means
+# unattended and fully armed — so this line is the ONLY thing that exempts
+# this process, and a soak that never runs it stays protected. Nothing is
+# weakened: SessionBudgetAuthority and CostGovernor still gate every
+# dispatch here, and the real-money risk the breaker guards (auto-spinning
+# a GCE node) is separately held by JARVIS_FAILOVER_VM_ORCHESTRATION_HOLD.
+if HUD_MODE and not os.environ.get("JARVIS_PROCESS_ROLE"):
+    os.environ["JARVIS_PROCESS_ROLE"] = "hud"
+
 # v351.0: When BOTH supervisor (8010) and HUD (8011) run simultaneously,
 # hardware singletons must have a single owner to avoid contention:
 #
@@ -2151,7 +2169,10 @@ async def parallel_lifespan(app: FastAPI):
 
                                     logger.info(
                                         "[HUD] Voice result: %s (category=%s, steps=%d/%d)",
-                                        "success" if result.success else "failed",
+                                        "success" if result.success
+                                        else ("awaiting-consent"
+                                              if getattr(result, "pending", False)
+                                              else "failed"),
                                         result.category, result.steps_completed, result.steps_total,
                                     )
                                     if result.response_text:
@@ -2168,6 +2189,16 @@ async def parallel_lifespan(app: FastAPI):
                                                 await _hud_tts(result.response_text[:200])
                                             else:
                                                 await _hud_tts(f"Done. Completed {result.steps_completed} steps.")
+                                        elif getattr(result, "pending", False):
+                                            # Understood, dispatched, and now
+                                            # waiting on the operator at a Touch
+                                            # ID prompt. Not a failure, and
+                                            # saying "action incomplete" here
+                                            # would teach them the consent
+                                            # boundary is a malfunction. The
+                                            # verdict handler speaks the ending.
+                                            if result.response_text:
+                                                await _hud_tts(result.response_text[:200])
                                         else:
                                             if _is_messaging and _msg_contact_match:
                                                 _cn = _msg_contact_match.group(1)
@@ -2175,6 +2206,18 @@ async def parallel_lifespan(app: FastAPI):
                                                     f"I had trouble sending that message to {_cn}. "
                                                     f"Got through {result.steps_completed} of {result.steps_total} steps."
                                                 )
+                                            elif result.response_text:
+                                                # PREFER THE REASON. This branch
+                                                # used to speak only the step
+                                                # count, so "Action incomplete.
+                                                # Finished 0 of 1 steps" was the
+                                                # entire explanation an operator
+                                                # got for a provider outage — a
+                                                # sentence that says something
+                                                # went wrong and nothing about
+                                                # what, when the router had
+                                                # already worked out what.
+                                                await _hud_tts(result.response_text[:200])
                                             else:
                                                 await _hud_tts(
                                                     f"Action incomplete. Finished {result.steps_completed} of {result.steps_total} steps."
@@ -2235,6 +2278,43 @@ async def parallel_lifespan(app: FastAPI):
                                 "[HUD] consent verdict for %s → %s (%s)",
                                 data.get("capability") or "?",
                                 routed.outcome, routed.detail or "-")
+
+                            # SAY WHAT HAPPENED.
+                            #
+                            # A suspended call resolves OUT OF BAND: the turn
+                            # that asked for it ended cleanly the moment it
+                            # suspended (see `capability_router` on why it must
+                            # never await a human), so by the time the operator
+                            # touches the sensor there is nobody left holding a
+                            # response to speak. Without this the whole circuit
+                            # completes in silence — Touch ID, execution and all
+                            # — and from where the operator stands that is
+                            # indistinguishable from having been ignored.
+                            try:
+                                from backend.hud.voice_command_router import (
+                                    _humanise, _read_controller_result,
+                                )
+                                from backend.system_control.capability_router import (
+                                    Outcome as _CapOutcome,
+                                )
+                                _cap = _humanise(
+                                    routed.capability
+                                    or str(data.get("capability") or ""))
+                                if routed.outcome == _CapOutcome.EXECUTED.value:
+                                    _ok, _say = _read_controller_result(
+                                        routed.result, _cap)
+                                elif routed.outcome == _CapOutcome.DENIED.value:
+                                    _say = f"Alright, I won't {_cap}."
+                                elif routed.outcome == _CapOutcome.EXPIRED.value:
+                                    _say = (f"That approval to {_cap} expired, "
+                                            f"so I left it alone.")
+                                else:
+                                    _say = f"I couldn't {_cap}."
+                                if _say:
+                                    await _hud_tts(_say[:200])
+                            except Exception as _cs:  # noqa: BLE001
+                                logger.debug(
+                                    "[HUD] consent narration degraded: %s", _cs)
                         except Exception as _cv:  # noqa: BLE001
                             logger.error("[HUD] consent verdict failed: %s", _cv)
                     else:

--- a/backend/system_control/capability_reflex.py
+++ b/backend/system_control/capability_reflex.py
@@ -1,0 +1,697 @@
+"""Resolve a spoken sentence to a capability WITHOUT a model.
+
+THE DEFECT THIS EXISTS TO DELETE
+---------------------------------
+An operator said "lock my screen" to a Mac that has had `lock_screen` all
+along, in a registry that already derives it, behind a router that already
+knows how to gate and call it. Nothing happened. The measured chain::
+
+    VoiceCommandRouter.route
+      → _classify(...)                 → LLM call   → REFUSED
+      → except: fall back to "composite"
+      → ToolUseOrchestrator.execute    → LLM call   → REFUSED
+      → CommandResult(success=False, steps_completed=0)
+
+Two model round-trips stood between a sentence and a system call, and the
+FALLBACK for the first was the second — the classifier's failure path routed
+to the strictly more model-dependent branch. So one provider fault took the
+whole organism from "fully capable" to "cannot lock a screen", and the four
+faults visible in that single boot log (session-budget refusal, DW 403
+entitlement denial, DW streaming outage, J-Prime unreachable) were each
+independently sufficient to cause it.
+
+That is a reflex routed through the cortex. A spinal reflex does not consult
+the brain, and the reason is not speed — it is that the brain is the part that
+can be unavailable.
+
+WHY THIS IS NOT A PHRASE TABLE
+--------------------------------
+`intent_classifier.py` already has a function it calls a "reflex arc". It is
+~180 lines of hand-written phrase tuples, it resolves to a CATEGORY rather
+than a capability (it can say "lock screen" is `system`; it cannot name
+`lock_screen` or call it), and it is not wired to the HUD at all. A fourth
+hand-kept vocabulary would be the exact defect `capability_registry` was
+written to delete, in a new costume.
+
+So the lexicon is DERIVED from the same reflection the tool schemas come from.
+`lock_screen` is speakable because its NAME is {lock, screen} and the operator
+said both words — not because anybody wrote "lock screen" down. A capability
+annotated tomorrow is speakable tomorrow, and one that is renamed changes what
+it answers to in the same commit.
+
+THE FOUR REFUSALS
+-------------------
+A reflex that fires when it is unsure is worse than no reflex, because the
+thing on the other side is somebody's screen locking mid-sentence. This
+declines in four separate ways, and every one of them hands the sentence to
+the model rather than guessing:
+
+* **Partial name coverage.** Every token of the capability's name must be
+  present as a WHOLE WORD. This is what keeps `lock` out of `unlock`: "unlock
+  my screen" tokenises to {unlock, screen} and contains no `lock` token at
+  all, so `lock_screen` scores zero rather than 0.5. Substring matching here
+  would invert the operator's intent on the single most dangerous pair on the
+  surface.
+
+* **Ambiguity.** The winner must beat the runner-up by a margin. Two plausible
+  readings is not a close call to be settled by rounding; it is a question.
+
+* **Arguments.** A capability with a required parameter needs a value pulled
+  out of a sentence, and pulling values out of sentences is what a model is
+  genuinely better at. `lock_screen()` is a complete call. `open_app(app_name)`
+  is not, and the reflex never invents one.
+
+* **Shape.** Negations, interrogatives and conjunctions are refused outright.
+  "don't lock my screen", "how do I lock my screen" and "lock my screen and
+  open Chrome" all contain a perfect match for `lock_screen` and none of them
+  is a request to lock the screen right now.
+
+CONFIDENCE IS NOT ONE NUMBER
+------------------------------
+The bar depends on what happens if the reflex is WRONG, which is not the same
+question for every capability.
+
+A gated capability (anything above `SAFE_AUTO`) suspends into a Touch ID
+prompt that names it. A misread there is shown to the operator, in the system
+dialog, before a single thing happens — the consent boundary IS the
+confirmation. An ungated capability just runs. So ungated calls need the top
+bar and gated ones can accept a little less, which is the opposite of the
+instinct to make dangerous things need more certainty, and is right for the
+same reason a seatbelt does not make you drive slower: the mitigation is
+already downstream.
+
+Session starts are exempted back up to the top bar. Duration is its own risk
+class — `Session` says so, and a continuous observer opened by a misheard
+sentence is not made acceptable by having been consented to once.
+
+WHAT THIS DOES NOT DO
+-----------------------
+It does not execute anything. It resolves a name and hands it to
+`CapabilityRouter`, which still applies the registry's tier, the Iron Gate,
+consent, the nonce challenge and the lease book. The reflex is a faster way to
+ARRIVE at the gate, never a way around it. There is deliberately no setting
+that makes a gated capability ungated.
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import enum
+import logging
+import os
+import re
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+logger = logging.getLogger("JARVIS.CapabilityReflex")
+
+CAPABILITY_REFLEX_SCHEMA_VERSION: str = "capability_reflex.v1"
+
+
+# ── Config (env-resolved at READ time, per the module convention) ───────────
+
+def reflex_enabled() -> bool:
+    """Master gate. Default TRUE. NEVER raises.
+
+    Off means every sentence goes to the model exactly as before — which is
+    the behaviour that produced the outage this module answers, so `off` is a
+    rollback switch rather than a supported posture.
+    """
+    return (os.environ.get("JARVIS_CAPABILITY_REFLEX_ENABLED", "true")
+            or "").strip().lower() not in ("0", "false", "no", "off")
+
+
+def _env_float(name: str, default: float, lo: float, hi: float) -> float:
+    """A clamped float from env. NEVER raises."""
+    try:
+        raw = (os.environ.get(name, "") or "").strip()
+        return max(lo, min(hi, float(raw))) if raw else default
+    except (TypeError, ValueError):
+        return default
+
+
+def certain_threshold() -> float:
+    """Score an UNGATED capability must reach to fire. NEVER raises."""
+    return _env_float("JARVIS_REFLEX_CERTAIN_SCORE", 0.85, 0.5, 1.0)
+
+
+def gated_threshold() -> float:
+    """Score a GATED capability must reach — see the module docstring."""
+    return _env_float("JARVIS_REFLEX_GATED_SCORE", 0.70, 0.5, 1.0)
+
+
+def ambiguity_margin() -> float:
+    """How far the winner must beat the runner-up. NEVER raises."""
+    return _env_float("JARVIS_REFLEX_MARGIN", 0.15, 0.0, 1.0)
+
+
+def lexicon_ttl_s() -> float:
+    """How long a derived lexicon is reused. NEVER raises.
+
+    Short, because a federated namespace finishing its 8.4 s hydration should
+    become speakable within seconds rather than at the next restart — the same
+    reason `derived_tool_names` reads per call instead of snapshotting.
+    """
+    return _env_float("JARVIS_REFLEX_LEXICON_TTL_S", 30.0, 1.0, 3600.0)
+
+
+# ── Linguistic constants ────────────────────────────────────────────────────
+#
+# These ARE hardcoded, and the distinction from a phrase table matters. A
+# phrase table encodes WHAT THE MACHINE CAN DO, which is exactly the knowledge
+# that goes stale the moment a capability is added — that is derived, below,
+# and never written here. These encode HOW ENGLISH WORKS, which does not
+# change when somebody annotates a method. The one is a duplicate of the
+# codebase; the other is a property of the language it is being spoken in.
+
+#: Function words carrying no capability signal. Applied to BOTH sides — the
+#: utterance AND the derived name/description tokens — because stripping
+#: "get" from what the operator said while keeping it in `get_battery` would
+#: make the capability permanently unreachable by its own name.
+_FILLER = frozenset("""
+a an the my mine your yours our its it this that these those please just now
+right away then some any all for to of on in at with from up down out off
+i you we he she they me us him her them am is are was were be been being do
+does did done have has had will would shall should can could may might must
+jarvis hey ok okay computer thanks thank kindly again also very really quite
+""".split())
+
+#: Refusal triggers. Each is a shape whose presence means the sentence is not
+#: a bare imperative, however well its content words match.
+_NEGATIONS = frozenset("""
+not no never dont don t cant cannot can wont won shouldnt stop cancel without
+undo nevermind
+""".split())
+
+#: Interrogative CONTENT words. Deliberately excludes modal politeness — "can
+#: you lock my screen" is an imperative wearing a question mark, while "how do
+#: I lock my screen" is a request for instructions and must never lock it.
+_INTERROGATIVES = frozenset(
+    "what whats how why when where who whom whose which".split())
+
+#: Multi-step joiners. Their presence alongside unexplained content words says
+#: the sentence contains more than one act, which is a plan, not a reflex.
+_CONJUNCTIONS = frozenset("and then after before while also plus".split())
+
+_WORD = re.compile(r"[a-z0-9]+")
+
+
+def _extra_filler() -> frozenset:
+    """Operator-supplied filler, e.g. a nickname the wake word misses."""
+    try:
+        raw = os.environ.get("JARVIS_REFLEX_EXTRA_FILLER", "") or ""
+        return frozenset(t for t in _WORD.findall(raw.lower()) if t)
+    except Exception:  # noqa: BLE001
+        return frozenset()
+
+
+def tokenize(text: str) -> List[str]:
+    """Whole-word tokens, lowercased. NEVER raises.
+
+    Word boundaries rather than substrings, and that is the load-bearing
+    property of this whole module: `"lock" in "unlock my screen"` is True and
+    `"lock" in ["unlock", "my", "screen"]` is False. The first would have
+    locked a screen the operator asked to unlock.
+    """
+    try:
+        return _WORD.findall((text or "").lower())
+    except Exception:  # noqa: BLE001
+        return []
+
+
+def content_tokens(text: str) -> List[str]:
+    """Tokens that carry capability signal, in order. NEVER raises."""
+    filler = _FILLER | _extra_filler()
+    return [t for t in tokenize(text) if t not in filler]
+
+
+# ── The derived lexicon ─────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class Signature:
+    """One capability's speakable shape, derived from its own definition."""
+
+    name: str
+    #: Content tokens of the EXPORT name — `video.start_streaming` becomes
+    #: {start, streaming}. The namespace is dropped: an operator says "start
+    #: streaming", never "video dot start streaming".
+    name_tokens: Tuple[str, ...]
+    #: Content tokens of the docstring summary. Support only, never sufficient
+    #: on its own — a description is prose and prose overlaps by accident.
+    desc_tokens: frozenset
+    #: Explicitly declared spellings. Empty for almost everything.
+    phrases: Tuple[str, ...]
+    tier: str
+    #: Whether a HUMAN is asked before this runs — `requires_consent`, NOT
+    #: `iron_gate_required`.
+    #:
+    #: The whole reason the confidence bar can be lower here is that the
+    #: operator SEES a system dialog naming the capability, so a misread is
+    #: caught before anything happens. `iron_gate_required` is True for
+    #: NOTIFY_APPLY as well, and a NOTIFY_APPLY capability shows nobody
+    #: anything — it runs and reports. Keying on it would have quietly relaxed
+    #: the bar for exactly the tier that lost the safeguard the relaxation was
+    #: justified by.
+    gated: bool
+    starts_session: bool
+    no_args: bool
+    required_args: Tuple[str, ...]
+
+    @property
+    def speakable(self) -> bool:
+        """Whether this can be reached by voice at all. NEVER raises.
+
+        A capability whose name is entirely function words has no signature to
+        match, and one that needs arguments cannot be completed by a reflex.
+        Both are simply not offered here; neither is an error, and both remain
+        fully reachable through the model.
+        """
+        return bool(self.name_tokens or self.phrases)
+
+
+def _signature_for(cap: Any) -> Optional[Signature]:
+    """Derive one Signature from a CapabilityDef. None if unusable. NEVER raises."""
+    try:
+        export = str(getattr(cap, "export_name", "")
+                     or getattr(cap, "name", "") or "")
+        if not export:
+            return None
+        # Split on BOTH separators so a namespaced export contributes its verb
+        # rather than its namespace.
+        bare = export.split(".")[-1]
+        name_tokens = tuple(content_tokens(bare.replace("_", " ")))
+        desc = str(getattr(cap, "description", "") or "")
+        tier = str(getattr(cap, "tier", "") or "")
+        return Signature(
+            name=export,
+            name_tokens=name_tokens,
+            desc_tokens=frozenset(content_tokens(desc)),
+            phrases=tuple(getattr(cap, "phrases", ()) or ()),
+            tier=tier,
+            # Fall back to `iron_gate_required` only for a federated def that
+            # predates `requires_consent`, and to True if it has neither: an
+            # unknown consent posture is never the permissive answer.
+            gated=bool(getattr(cap, "requires_consent",
+                               getattr(cap, "iron_gate_required", True))),
+            starts_session=bool(getattr(cap, "starts_session", False)),
+            no_args=bool(getattr(cap, "callable_with_no_args", False)),
+            required_args=tuple(getattr(cap, "required_parameters", ()) or ()),
+        )
+    except Exception:  # noqa: BLE001
+        return None
+
+
+class Lexicon:
+    """Every speakable capability, derived and briefly cached. NEVER raises.
+
+    Cached because a sentence is scored against the whole surface and the
+    surface is stable between utterances; re-derived on a TTL rather than
+    pinned at import because the surface GROWS — a federated namespace that
+    finishes hydrating mid-session must become speakable without a restart.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._sigs: List[Signature] = []
+        self._built_at = 0.0
+        self._degraded = ""
+
+    def _derive(self) -> List[Signature]:
+        out: List[Signature] = []
+        seen = set()
+        try:
+            from backend.system_control.capability_registry import (
+                get_capability_registry,
+            )
+            for cap in get_capability_registry().all():
+                s = _signature_for(cap)
+                if s is not None and s.speakable and s.name not in seen:
+                    seen.add(s.name)
+                    out.append(s)
+        except Exception as exc:  # noqa: BLE001
+            self._degraded = f"registry: {type(exc).__name__}"
+            logger.debug("[Reflex] registry lexicon degraded", exc_info=True)
+        try:
+            from backend.system_control.capability_federation import (
+                federation_enabled, get_federation,
+            )
+            if federation_enabled():
+                fed = get_federation()
+                for name in fed.names():
+                    cap = fed.get(name)
+                    s = _signature_for(cap) if cap is not None else None
+                    if s is not None and s.speakable and s.name not in seen:
+                        seen.add(s.name)
+                        out.append(s)
+        except Exception as exc:  # noqa: BLE001
+            self._degraded = f"federation: {type(exc).__name__}"
+            logger.debug("[Reflex] federated lexicon degraded", exc_info=True)
+        return out
+
+    def signatures(self) -> List[Signature]:
+        """The current surface. NEVER raises."""
+        try:
+            now = time.monotonic()
+            with self._lock:
+                fresh = self._sigs and (now - self._built_at) < lexicon_ttl_s()
+                if fresh:
+                    return list(self._sigs)
+            built = self._derive()
+            with self._lock:
+                self._sigs = built
+                self._built_at = now
+            return list(built)
+        except Exception:  # noqa: BLE001
+            return []
+
+    def invalidate(self) -> None:
+        """Force a re-derive. NEVER raises."""
+        try:
+            with self._lock:
+                self._built_at = 0.0
+        except Exception:  # noqa: BLE001
+            pass
+
+    def stats(self) -> Dict[str, Any]:
+        sigs = self.signatures()
+        return {
+            "schema_version": CAPABILITY_REFLEX_SCHEMA_VERSION,
+            "enabled": reflex_enabled(),
+            "speakable": len(sigs),
+            "gated": sum(1 for s in sigs if s.gated),
+            "callable_with_no_args": sum(1 for s in sigs if s.no_args),
+            "degraded_reason": self._degraded,
+        }
+
+
+# ── Scoring ─────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class Candidate:
+    """One capability's fit against one sentence, with its arithmetic shown."""
+
+    name: str
+    score: float
+    coverage: float
+    explained: float
+    ordered: bool
+    phrase_hit: bool
+    signature: Optional[Signature] = None
+
+    def why(self) -> str:
+        return (f"{self.name} score={self.score:.2f} "
+                f"(coverage={self.coverage:.2f} explained={self.explained:.2f}"
+                f"{' ordered' if self.ordered else ''}"
+                f"{' phrase' if self.phrase_hit else ''})")
+
+
+#: Weights. They sum to 1.0 so a score is readable as a fraction.
+#:
+#: `explained` carries real weight rather than being a tie-break because it is
+#: the term that distinguishes a capability that accounts for the WHOLE
+#: sentence from one that happens to appear inside it. Given "lock my screen",
+#: a hypothetical `screen` capability has perfect name coverage too — it is
+#: `explained` that says `lock_screen` accounts for everything said and
+#: `screen` accounts for half.
+_W_COVERAGE, _W_EXPLAINED, _W_ORDERED = 0.55, 0.35, 0.10
+
+
+def _ordered_subsequence(needles: Sequence[str], haystack: Sequence[str]) -> bool:
+    """Whether *needles* appear in *haystack* in order. NEVER raises."""
+    try:
+        it = iter(haystack)
+        return all(any(h == n for h in it) for n in needles)
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def score_candidate(sig: Signature, said: Sequence[str],
+                    normalised: str) -> Optional[Candidate]:
+    """Score one capability against one sentence. None if it does not qualify.
+
+    NEVER raises. The qualification gate is absolute: EVERY token of the
+    capability's name must have been said, or one of its declared phrases must
+    appear verbatim. Nothing partial is scored at all — a capability that half
+    matches does not compete, it is absent.
+    """
+    try:
+        said_set = set(said)
+        phrase_hit = any(p and p in normalised for p in sig.phrases)
+        n = sig.name_tokens
+        coverage = (sum(1 for t in n if t in said_set) / len(n)) if n else 0.0
+        if coverage < 1.0 and not phrase_hit:
+            return None
+        matched = sum(1 for t in said if t in set(n))
+        explained = (matched / len(said)) if said else 0.0
+        if phrase_hit:
+            # A declared phrase is a direct statement about this sentence, so
+            # it satisfies both structural terms on its own.
+            coverage = max(coverage, 1.0)
+            explained = max(explained, 1.0)
+        ordered = bool(n) and _ordered_subsequence(n, said)
+        score = (_W_COVERAGE * coverage
+                 + _W_EXPLAINED * min(1.0, explained)
+                 + _W_ORDERED * (1.0 if ordered else 0.0))
+        return Candidate(name=sig.name, score=round(min(1.0, score), 4),
+                         coverage=round(coverage, 4),
+                         explained=round(min(1.0, explained), 4),
+                         ordered=ordered, phrase_hit=phrase_hit, signature=sig)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+# ── The resolution ──────────────────────────────────────────────────────────
+
+
+class Outcome(str, enum.Enum):
+    """What the reflex concluded. Every non-RESOLVED value means "ask the model"."""
+
+    RESOLVED = "resolved"
+    AMBIGUOUS = "ambiguous"            # more than one plausible reading
+    NEEDS_ARGS = "needs_args"          # matched, but cannot be called complete
+    LOW_CONFIDENCE = "low_confidence"  # matched, not well enough
+    NOT_IMPERATIVE = "not_imperative"  # a question, a negation, or a plan
+    UNRECOGNIZED = "unrecognized"      # nothing named matches
+    DISABLED = "disabled"
+
+
+@dataclass
+class Reflex:
+    """The reflex's answer, with enough detail to explain itself out loud."""
+
+    outcome: str
+    capability: str = ""
+    score: float = 0.0
+    margin: float = 0.0
+    tier: str = ""
+    gated: bool = False
+    #: Why, in one sentence, phrased for a log and for a person.
+    reason: str = ""
+    #: The top few, scored — so `/observability` can show near misses.
+    candidates: List[Candidate] = field(default_factory=list)
+    elapsed_ms: float = 0.0
+    schema_version: str = CAPABILITY_REFLEX_SCHEMA_VERSION
+
+    @property
+    def resolved(self) -> bool:
+        return self.outcome == Outcome.RESOLVED.value
+
+    @property
+    def runner_up(self) -> str:
+        return self.candidates[1].name if len(self.candidates) > 1 else ""
+
+
+class CapabilityReflex:
+    """Sentence → capability name, deterministically. NEVER raises."""
+
+    def __init__(self, lexicon: Optional[Lexicon] = None) -> None:
+        self._lex = lexicon if lexicon is not None else Lexicon()
+        self._counts: Dict[str, int] = {}
+
+    def lexicon(self) -> Lexicon:
+        return self._lex
+
+    def resolve(self, utterance: str) -> Reflex:
+        """Resolve a sentence. Sub-millisecond, zero LLM, zero I/O.
+
+        NEVER raises — a reflex that can throw is a reflex that can take the
+        voice path down with it, which is the failure it exists to prevent.
+        """
+        t0 = time.monotonic()
+        try:
+            out = self._resolve(utterance or "")
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[Reflex] resolve degraded", exc_info=True)
+            out = Reflex(outcome=Outcome.UNRECOGNIZED.value,
+                         reason=f"reflex degraded: {type(exc).__name__}")
+        out.elapsed_ms = round((time.monotonic() - t0) * 1000.0, 3)
+        try:
+            self._counts[out.outcome] = self._counts.get(out.outcome, 0) + 1
+        except Exception:  # noqa: BLE001
+            pass
+        return out
+
+    def _resolve(self, utterance: str) -> Reflex:
+        if not reflex_enabled():
+            return Reflex(outcome=Outcome.DISABLED.value,
+                          reason="reflex disabled by env")
+
+        raw = tokenize(utterance)
+        if not raw:
+            return Reflex(outcome=Outcome.UNRECOGNIZED.value,
+                          reason="nothing was said")
+
+        # SHAPE FIRST, before any scoring. "don't lock my screen" contains a
+        # perfect match for `lock_screen`, and scoring it first would mean the
+        # only thing standing between the operator and the opposite of what
+        # they asked for is a subtraction at the end.
+        shape = self._non_imperative_reason(raw)
+        if shape:
+            return Reflex(outcome=Outcome.NOT_IMPERATIVE.value, reason=shape)
+
+        said = content_tokens(utterance)
+        if not said:
+            return Reflex(outcome=Outcome.UNRECOGNIZED.value,
+                          reason="no content words after filler")
+        normalised = " ".join(raw)
+
+        scored = [c for c in (score_candidate(s, said, normalised)
+                              for s in self._lex.signatures()) if c is not None]
+        if not scored:
+            return Reflex(outcome=Outcome.UNRECOGNIZED.value,
+                          reason="no capability's full name was said")
+        scored.sort(key=lambda c: (-c.score, c.name))
+        top = scored[:5]
+        best = scored[0]
+        margin = best.score - (scored[1].score if len(scored) > 1 else 0.0)
+        sig = best.signature
+
+        def _no(outcome: Outcome, reason: str) -> Reflex:
+            return Reflex(outcome=outcome.value, capability=best.name,
+                          score=best.score, margin=round(margin, 4),
+                          tier=(sig.tier if sig else ""),
+                          gated=bool(sig and sig.gated),
+                          reason=reason, candidates=top)
+
+        # A sentence that reads two ways is a question, not a rounding error.
+        if len(scored) > 1 and margin < ambiguity_margin():
+            return _no(Outcome.AMBIGUOUS,
+                       f"'{best.name}' and '{scored[1].name}' both fit "
+                       f"(margin {margin:.2f} < {ambiguity_margin():.2f})")
+
+        if sig is None:
+            return _no(Outcome.UNRECOGNIZED, "candidate lost its signature")
+
+        # "lock my screen and open Chrome" matches `lock_screen` perfectly and
+        # is not a request to lock the screen — it is a request to do that AND
+        # something else, and a reflex that serves the first half silently
+        # drops the second. Checked here rather than with the other shape
+        # refusals because it is the only one that needs to know which tokens
+        # the winning capability already accounts for.
+        if self._conjunction_split(raw, sig):
+            return _no(Outcome.NOT_IMPERATIVE,
+                       f"'{best.name}' fits, but the sentence joins it to "
+                       f"another act — a plan belongs to the model, which can "
+                       f"carry out both halves")
+
+        # Never invent an argument. See the module docstring.
+        if not sig.no_args:
+            return _no(Outcome.NEEDS_ARGS,
+                       f"'{best.name}' requires "
+                       f"{', '.join(sig.required_args) or 'arguments'} — a "
+                       f"value has to be read out of the sentence, which is "
+                       f"the model's job")
+
+        # The bar depends on whether a human will see this before it happens.
+        # A session start is pushed back up to the top bar regardless: duration
+        # is its own risk class, and one consent does not cover forever.
+        needs = (gated_threshold() if (sig.gated and not sig.starts_session)
+                 else certain_threshold())
+        if best.score < needs:
+            kind = ("gated" if sig.gated else "ungated")
+            if sig.starts_session:
+                kind = "session-opening"
+            return _no(Outcome.LOW_CONFIDENCE,
+                       f"'{best.name}' scored {best.score:.2f}, below the "
+                       f"{needs:.2f} a {kind} capability needs")
+
+        return Reflex(
+            outcome=Outcome.RESOLVED.value, capability=best.name,
+            score=best.score, margin=round(margin, 4), tier=sig.tier,
+            gated=sig.gated, candidates=top,
+            reason=(f"{best.why()}; "
+                    + ("gated — the operator sees a consent prompt naming it"
+                       if sig.gated else "ungated — executes directly")))
+
+    @staticmethod
+    def _non_imperative_reason(raw: Sequence[str]) -> str:
+        """Why this sentence is not a bare command. "" when it is. NEVER raises.
+
+        Reads RAW tokens, not content tokens: every marker here is a function
+        word, so filtering filler first would delete the entire signal.
+        """
+        try:
+            toks = list(raw)
+            hit = next((t for t in toks if t in _NEGATIONS), "")
+            if hit:
+                return (f"'{hit}' — a negation or a cancellation, not a "
+                        f"command to carry out")
+            # Only a LEADING interrogative. "lock the screen, which is faster"
+            # is still an instruction; "which screen do I lock" is not.
+            for t in toks[:2]:
+                if t in _INTERROGATIVES:
+                    return f"'{t}' — a question about a capability, not a request to run it"
+            return ""
+        except Exception:  # noqa: BLE001
+            return ""
+
+    def _conjunction_split(self, raw: Sequence[str], sig: Signature) -> bool:
+        """Whether the sentence contains an act beyond this capability."""
+        try:
+            rest = [t for t in raw if t not in set(sig.name_tokens)]
+            if not any(t in _CONJUNCTIONS for t in rest):
+                return False
+            filler = _FILLER | _extra_filler()
+            leftover = [t for t in rest
+                        if t not in filler and t not in _CONJUNCTIONS]
+            return bool(leftover)
+        except Exception:  # noqa: BLE001
+            return False
+
+    def stats(self) -> Dict[str, Any]:
+        out: Dict[str, Any] = {
+            "schema_version": CAPABILITY_REFLEX_SCHEMA_VERSION,
+            "outcomes": dict(self._counts),
+            "certain_score": certain_threshold(),
+            "gated_score": gated_threshold(),
+            "margin": ambiguity_margin(),
+        }
+        try:
+            out["lexicon"] = self._lex.stats()
+        except Exception:  # noqa: BLE001
+            pass
+        return out
+
+
+_REFLEX: Optional[CapabilityReflex] = None
+_REFLEX_LOCK = threading.Lock()
+
+
+def get_capability_reflex() -> CapabilityReflex:
+    """Process-wide reflex. NEVER raises."""
+    global _REFLEX
+    with _REFLEX_LOCK:
+        if _REFLEX is None:
+            _REFLEX = CapabilityReflex()
+        return _REFLEX
+
+
+def reset_capability_reflex() -> None:
+    """Testing seam. NEVER raises."""
+    global _REFLEX
+    with _REFLEX_LOCK:
+        _REFLEX = None

--- a/backend/system_control/capability_registry.py
+++ b/backend/system_control/capability_registry.py
@@ -216,7 +216,8 @@ def capability(*, mutates: Optional[bool] = None,
                description: str = "",
                session: str = Session.NONE.value,
                release: str = "",
-               alias: str = "") -> Callable:
+               alias: str = "",
+               phrases: Any = ()) -> Callable:
     """Declare a method's risk where the method is written. NEVER raises.
 
     A decorator rather than a central table for the reason `repl_dispatch_
@@ -238,6 +239,7 @@ def capability(*, mutates: Optional[bool] = None,
                 "session": session,
                 "release": release,
                 "alias": alias,
+                "phrases": _normalise_phrases(phrases),
             })
         except Exception:  # noqa: BLE001 — a decorator never breaks an import
             pass
@@ -251,7 +253,7 @@ class CapabilityDef:
 
     name: str
     description: str
-    parameters: Dict[str, Dict[str, str]] = field(default_factory=dict)
+    parameters: Dict[str, Dict[str, Any]] = field(default_factory=dict)
     tier: str = _DEFAULT_TIER.value
     provenance: str = Provenance.DEFAULTED.value
     is_async: bool = True
@@ -261,6 +263,13 @@ class CapabilityDef:
     #: THIS, so a start whose release is unnamed cannot be cleaned up — which
     #: `Session.START` refuses to be, at hydrate time rather than at 3am.
     release: str = ""
+    #: How an operator might SAY this, when the method name is not how anyone
+    #: says it. Optional and usually empty — `lock_screen` needs none, because
+    #: its name already IS the phrase. Declared at the method (``say=...``)
+    #: rather than in a lookup table elsewhere, for the same reason `alias`
+    #: is: a table beside the code is a second thing to update, and the update
+    #: that gets forgotten is invisible.
+    phrases: tuple = ()
     #: The name this capability is EXPORTED as, when its method name would
     #: collide with another provider's in the same namespace. Declared at the
     #: method (``as=stop_actuator``) rather than in a table elsewhere, so the
@@ -284,16 +293,89 @@ class CapabilityDef:
 
     @property
     def iron_gate_required(self) -> bool:
-        """The only question most callers ask.
+        """Whether this is GOVERNED at all — i.e. not plain SAFE_AUTO.
 
         Anything above SAFE_AUTO goes through the gate. A defaulted capability
         answers True — the point of the inversion.
+
+        This is NOT the same question as "must a human be asked", and the two
+        were conflated for as long as there was only one of them. See
+        :attr:`requires_consent`.
         """
         return self.tier != Tier.SAFE_AUTO.value
 
     @property
+    def requires_consent(self) -> bool:
+        """Whether a HUMAN must say yes before this runs.
+
+        WHY THIS IS SEPARATE FROM `iron_gate_required`
+        ------------------------------------------------
+        The registry declares four tiers, mirroring `risk_engine.RiskTier` by
+        value. The router asked exactly one question — `iron_gate_required` —
+        and that question is False only for SAFE_AUTO. So NOTIFY_APPLY and
+        APPROVAL_REQUIRED produced byte-identical behaviour, and a four-word
+        vocabulary described two behaviours.
+
+        A word that cannot change what happens is not a word. Worse, it is a
+        word an author will reach for believing it means something: declaring
+        a capability NOTIFY_APPLY looked like "apply it and tell me" and
+        delivered "block until Touch ID", which is what APPROVAL_REQUIRED was
+        already for.
+
+        The tiers now mean what the rest of the codebase has always meant by
+        them (CLAUDE.md: "Green/Yellow auto-apply, Orange blocks for human"):
+
+            SAFE_AUTO          run it
+            NOTIFY_APPLY       run it, and SAY SO
+            APPROVAL_REQUIRED  ask first
+            BLOCKED            refuse, and do not even ask
+
+        BLOCKED answering True here would be a bug in the safe direction and
+        is still wrong: a blocked capability must never reach an operator as a
+        prompt, because a prompt is an invitation to approve it. See
+        :attr:`blocked`, which the router checks first.
+        """
+        return self.tier in (Tier.APPROVAL_REQUIRED.value, Tier.BLOCKED.value)
+
+    @property
+    def notifies(self) -> bool:
+        """Runs without asking, but never silently. NEVER raises."""
+        return self.tier == Tier.NOTIFY_APPLY.value
+
+    @property
+    def blocked(self) -> bool:
+        """Refused outright. Not a question to put to anyone. NEVER raises."""
+        return self.tier == Tier.BLOCKED.value
+
+    @property
     def classified(self) -> bool:
         return self.provenance != Provenance.DEFAULTED.value
+
+    @property
+    def required_parameters(self) -> List[str]:
+        """Parameters with no default — the call cannot be made without them.
+
+        NEVER raises. Note what is NOT here: a withheld credential parameter
+        was dropped from `parameters` entirely, so it cannot appear as
+        "required" and cause a caller to go looking for a password. The method
+        sources it from the Keychain, which is the only correct answer.
+        """
+        try:
+            return sorted(n for n, p in (self.parameters or {}).items()
+                          if bool(p.get("required")))
+        except Exception:  # noqa: BLE001
+            return []
+
+    @property
+    def callable_with_no_args(self) -> bool:
+        """Whether ``fn()`` is a complete call. NEVER raises.
+
+        The deterministic reflex's licence to fire. A capability that needs an
+        argument needs something extracted from a sentence, and extracting a
+        value from a sentence is exactly the job that belongs to a model — so
+        the reflex declines rather than guessing.
+        """
+        return not self.required_parameters
 
     def to_tool_schema(self) -> Dict[str, Any]:
         """The exact shape `TOOL_SCHEMAS` already uses. NEVER raises."""
@@ -365,12 +447,34 @@ def _summary(doc: str, fallback: str) -> str:
     return fallback
 
 
+def _normalise_phrases(raw: Any) -> tuple:
+    """A declared ``phrases``/``say=`` value as a clean tuple. NEVER raises.
+
+    Accepts a string (``"lock the mac|lock it down"``) or any iterable of
+    strings, because a decorator author and a docstring tag author naturally
+    reach for different shapes and neither should have to care.
+    """
+    try:
+        if not raw:
+            return ()
+        items = raw.split("|") if isinstance(raw, str) else list(raw)
+        out = []
+        for it in items:
+            s = " ".join(str(it).strip().lower().split())
+            if s and s not in out:
+                out.append(s)
+        return tuple(out)
+    except Exception:  # noqa: BLE001
+        return ()
+
+
 class _Classification(NamedTuple):
     tier: str
     provenance: str
     session: str = Session.NONE.value
     release: str = ""
     alias: str = ""
+    phrases: tuple = ()
 
 
 def _apply_session_rules(c: _Classification) -> _Classification:
@@ -407,11 +511,14 @@ def _parse_tag(body: str) -> _Classification:
     parts = [p.strip() for p in (body or "").lower().split(",") if p.strip()]
     joined = " ".join(parts)
     session, release, alias = Session.NONE.value, "", ""
+    phrases: tuple = ()
     for p in parts:
         if p.startswith("release="):
             release = p.split("=", 1)[1].strip()
         elif p.startswith("as=") or p.startswith("alias="):
             alias = p.split("=", 1)[1].strip()
+        elif p.startswith("say=") or p.startswith("phrases="):
+            phrases = _normalise_phrases(p.split("=", 1)[1].strip())
         elif p in ("session-start", "session_start"):
             session = Session.START.value
         elif p in ("session-end", "session_end"):
@@ -426,7 +533,8 @@ def _parse_tag(body: str) -> _Classification:
                 tier = t.value
                 break
     return _apply_session_rules(
-        _Classification(tier, Provenance.TAGGED.value, session, release, alias))
+        _Classification(tier, Provenance.TAGGED.value, session, release, alias,
+                        phrases))
 
 
 def _classify(fn: Any, doc: str) -> _Classification:
@@ -445,7 +553,8 @@ def _classify(fn: Any, doc: str) -> _Classification:
                 Provenance.DECLARED.value,
                 str(declared.get("session") or Session.NONE.value),
                 str(declared.get("release") or ""),
-                str(declared.get("alias") or "")))
+                str(declared.get("alias") or ""),
+                _normalise_phrases(declared.get("phrases"))))
         tag = _DOC_TAG.search(doc or "")
         if tag:
             return _parse_tag(tag.group("body") or "")
@@ -459,7 +568,7 @@ def describe(name: str, fn: Any) -> Optional[CapabilityDef]:
     try:
         doc = inspect.getdoc(fn) or ""
         cls = _classify(fn, doc)
-        params: Dict[str, Dict[str, str]] = {}
+        params: Dict[str, Dict[str, Any]] = {}
         try:
             sig = inspect.signature(fn)
         except (TypeError, ValueError):
@@ -485,6 +594,16 @@ def describe(name: str, fn: Any) -> Optional[CapabilityDef]:
                 params[pname] = {
                     "type": _json_type(p.annotation),
                     "description": descs.get(pname, f"{pname} parameter"),
+                    # Whether the method genuinely cannot be called without
+                    # it. Recorded rather than inferred by a consumer, because
+                    # the ONE place that already holds the signature is here —
+                    # and a consumer that re-introspects to find out is the
+                    # second vocabulary this module exists to delete.
+                    #
+                    # The deterministic reflex arc reads this to decide it may
+                    # not fire: a capability it cannot call COMPLETELY is one
+                    # it must hand to a model rather than call with a guess.
+                    "required": p.default is inspect.Parameter.empty,
                 }
         declared = getattr(fn, "__capability__", None) or {}
         return CapabilityDef(
@@ -498,6 +617,7 @@ def describe(name: str, fn: Any) -> Optional[CapabilityDef]:
             session=cls.session,
             release=cls.release,
             alias=cls.alias,
+            phrases=cls.phrases,
         )
     except Exception:  # noqa: BLE001
         logger.debug("[CapabilityRegistry] describe(%s) degraded", name,

--- a/backend/system_control/capability_router.py
+++ b/backend/system_control/capability_router.py
@@ -64,6 +64,72 @@ SUSPENDED_NOTE: str = "[SYSTEM: Awaiting operator consent]"
 EXPIRED_PAYLOAD: str = "[SYSTEM: OPERATOR_CONSENT_TIMED_OUT]"
 
 
+#: Tier names, mirrored by VALUE rather than imported — the same layering rule
+#: `capability_registry.Tier` states: a leaf router that imports the governance
+#: risk engine drags the whole pipeline into any process that wants to call a
+#: Mac capability.
+_T_SAFE_AUTO = "safe_auto"
+_T_NOTIFY_APPLY = "notify_apply"
+_T_APPROVAL_REQUIRED = "approval_required"
+_T_BLOCKED = "blocked"
+
+
+def risk_floor_enabled() -> bool:
+    """Whether the operator's standing risk floor is composed in. Default TRUE.
+
+    NEVER raises. Off means a capability is judged purely at its declared tier
+    — which is the behaviour before the floor was wired, and is strictly more
+    permissive, so this is a rollback switch rather than a hardening one.
+    """
+    return (os.environ.get("JARVIS_CAPABILITY_RISK_FLOOR_ENABLED", "true")
+            or "").strip().lower() not in ("0", "false", "no", "off")
+
+
+def _effective_tier(cap: Any, name: str) -> tuple:
+    """(tier, floor_that_raised_it_or_"") for one capability. NEVER raises.
+
+    Fails toward the DECLARED tier on any fault. That is deliberate and it is
+    the safe direction here: the declared tier is what the author of the method
+    chose, and a floor subsystem that cannot answer must not be able to make a
+    capability MORE permissive than its own declaration by failing.
+    """
+    declared = str(getattr(cap, "tier", "") or _T_APPROVAL_REQUIRED)
+    if not risk_floor_enabled():
+        return declared, ""
+    try:
+        from backend.core.ouroboros.governance.risk_tier_floor import (
+            apply_floor_to_name,
+        )
+        effective, applied = apply_floor_to_name(declared)
+        return (str(effective or declared), str(applied or ""))
+    except Exception:  # noqa: BLE001
+        logger.debug("[CapabilityRouter] risk floor unavailable for '%s'",
+                     name, exc_info=True)
+        return declared, ""
+
+
+def _floor_note(floored: str) -> str:
+    """" (raised to X by the operator's risk floor)" or "". NEVER raises."""
+    return f" (raised to {floored} by the operator's risk floor)" if floored else ""
+
+
+def _redact(args: Dict[str, Any]) -> str:
+    """Arguments, safe to log. NEVER raises.
+
+    The registry withholds credential-shaped PARAMETERS from the schema, so a
+    model cannot be offered one — but a caller can still pass a key this
+    module has never seen, and a NOTIFY_APPLY call logs its arguments by
+    design. Matched on the same substring rule the registry uses, so the two
+    cannot drift into disagreeing about what a secret looks like.
+    """
+    try:
+        from backend.system_control.capability_registry import _is_secret_param
+        return str({k: ("***" if _is_secret_param(str(k)) else v)
+                    for k, v in (args or {}).items()})[:300]
+    except Exception:  # noqa: BLE001
+        return "<unprintable>"
+
+
 def router_enabled() -> bool:
     """Master gate. Default TRUE. NEVER raises."""
     return (os.environ.get("JARVIS_CAPABILITY_ROUTER_ENABLED", "true")
@@ -110,6 +176,14 @@ class RoutedCall:
     #: without telling the model why is a turn the model will simply repeat.
     context_note: str = ""
     detail: str = ""
+    #: The tier this call was actually judged at — which is not always the one
+    #: the capability declares, because the operator's standing risk floor can
+    #: raise it. Surfaced so "why did that ask me?" has an answer.
+    tier: str = ""
+    #: Set when the call RAN WITHOUT ASKING and the operator was told instead.
+    #: Distinct from `EXECUTED` alone: a SAFE_AUTO call and a NOTIFY_APPLY call
+    #: both execute, and only one of them owes anybody an explanation.
+    notified: bool = False
     #: Set when this call OPENED a session. Surfaced rather than kept internal
     #: because a model that started a stream and was never told it holds
     #: something open has no reason to ever stop it.
@@ -287,8 +361,54 @@ class CapabilityRouter:
                     outcome=Outcome.UNKNOWN_CAPABILITY.value, capability=name,
                     context_note=f"[SYSTEM: UNKNOWN_CAPABILITY {name}]",
                     detail=self._why_unknown(name))
-            if not cap.iron_gate_required:
+
+            # THE EFFECTIVE TIER, not the declared one.
+            #
+            # `risk_tier_floor` is the operator's standing posture — paranoia
+            # mode, a minimum tier, quiet hours in a declared timezone — and it
+            # already existed, fully tested, consumed only by the Ouroboros
+            # risk engine. Composing it here rather than re-deriving a second
+            # notion of "how careful are we being right now" is the same DRY
+            # rule the registry applies to vocabularies.
+            #
+            # It matters most precisely because NOTIFY_APPLY now really does
+            # run without asking: the operator keeps a way to take that back
+            # globally, at 2am or before a demo, without editing a decorator.
+            # The floor only ever RAISES — `apply_floor_to_name` returns the
+            # input untouched when the floor is weaker.
+            tier, floored = _effective_tier(cap, name)
+
+            if tier == _T_BLOCKED:
+                # Never asked, never run. A prompt is an invitation to approve,
+                # and a blocked capability is not a question.
+                self._stats["denied"] += 1
+                logger.warning("[CapabilityRouter] '%s' is BLOCKED — refused "
+                               "without asking anyone", name)
+                return RoutedCall(
+                    outcome=Outcome.DENIED.value, capability=name,
+                    context_note=DENIED_PAYLOAD,
+                    detail=f"capability is BLOCKED{_floor_note(floored)}")
+
+            if tier == _T_SAFE_AUTO:
                 return await self._execute(name, args)
+
+            if tier == _T_NOTIFY_APPLY:
+                # RUN IT, AND SAY SO. The distinction from SAFE_AUTO is not
+                # whether it happens — it is whether the operator finds out.
+                # The notice is emitted BEFORE the call, because a capability
+                # that locks a screen, kills a window or starts a stream can
+                # take away the surface the notice would have arrived on.
+                logger.warning("[CapabilityRouter] NOTIFY_APPLY '%s' args=%s "
+                               "— running WITHOUT consent%s", name,
+                               _redact(args), _floor_note(floored))
+                out = await self._execute(name, args)
+                out.notified = True
+                out.tier = tier
+                out.context_note = (
+                    f"[SYSTEM: APPLIED WITHOUT CONSENT — '{name}' is "
+                    f"NOTIFY_APPLY; the operator was told, not asked]\n"
+                    f"{out.context_note}")[:2400]
+                return out
 
             # GATED. Request consent and RETURN — do not await the human.
             #
@@ -316,7 +436,8 @@ class CapabilityRouter:
             return RoutedCall(
                 outcome=Outcome.SUSPENDED.value, capability=name,
                 request_id=rid, nonce=nonce, context_note=SUSPENDED_NOTE,
-                detail="operator consent required")
+                tier=tier,
+                detail=f"operator consent required{_floor_note(floored)}")
         except Exception as exc:  # noqa: BLE001 — a router never kills a turn
             self._stats["failed"] += 1
             logger.debug("[CapabilityRouter] route degraded", exc_info=True)

--- a/backend/system_control/macos_controller.py
+++ b/backend/system_control/macos_controller.py
@@ -19,7 +19,7 @@ import psutil
 from core.async_pipeline import get_async_pipeline
 
 from backend.system_control.capability_registry import (  # noqa: E402
-    Effect, os_capability,
+    Effect, capability, os_capability,
 )
 
 logger = logging.getLogger(__name__)
@@ -1479,7 +1479,7 @@ class MacOSController:
 
         return None
 
-    @os_capability(Effect.EFFECTFUL)
+    @capability(mutates=True, tier="notify_apply")
     async def lock_screen(
         self,
         progress_callback: Optional[Callable[[Dict[str, Any]], Any]] = None,

--- a/tests/governance/test_soak_circuit_breaker.py
+++ b/tests/governance/test_soak_circuit_breaker.py
@@ -9,6 +9,7 @@ the Aegis spend WAL + live GCP node runtime.
 from __future__ import annotations
 
 import asyncio
+import time
 
 import pytest
 
@@ -218,8 +219,18 @@ def test_boot_reconcile_rebuilds_cost_baseline(tmp_path, monkeypatch):
         SpendEntry, SpendEntryKind, append_entry_sync,
     )
     # Seed durable spend that already blew the $1.00 cap.
+    #
+    # `ts` is NOW rather than the 1.0 it used to be. The baseline replay is
+    # bounded to an episode horizon (see `baseline_horizon_s`), because a
+    # per-soak cap compared against an all-time ledger trips on boot forever —
+    # measured: $3.63 of real all-time spend against a $2 episode cap, on a
+    # machine that had done nothing wrong. A restart-durability test is about
+    # a restart WITHIN an episode, so a timestamp from 1970 was never the
+    # scenario this describes; it only happened to work while the replay was
+    # unbounded. The horizon's own semantics are pinned in
+    # `test_soak_ledger_amplification.py`.
     append_entry_sync(AF.wal_path(), SpendEntry(
-        kind=SpendEntryKind.RECONCILE, ts=1.0, op_id="o1",
+        kind=SpendEntryKind.RECONCILE, ts=time.time(), op_id="o1",
         route="immediate", actual_cost_usd=1.40,
     ))
     b = SCB.get_soak_breaker()

--- a/tests/governance/test_soak_ledger_amplification.py
+++ b/tests/governance/test_soak_ledger_amplification.py
@@ -1,0 +1,187 @@
+"""Regression spine for the soak breaker's self-amplifying spend ledger.
+
+WHAT HAPPENED
+---------------
+`SoakCircuitBreaker._durable_append` wrote the total it had just computed into
+`SpendEntry.actual_cost_usd`, on the same WAL that `reconcile_on_boot` sums
+across every row. So the reader was an input to itself, and a self-referential
+sum does not drift — it doubles. Measured on the real ledger, seventeen
+consecutive boots:
+
+    3.63 → 7.27 → 14.53 → 29.07 → … → 119055.97 → 238111.95
+
+A true spend of $3.63 was presented to a $2 cap as $238,111.95, every LLM
+dispatch in the process was refused against it, and the attended HUD answered
+a spoken command by reading the refusal string aloud.
+
+The test that matters is `test_a_trip_does_not_raise_the_baseline_it_measured`:
+it fails on the old code at the FIRST doubling, not the seventeenth.
+"""
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+from backend.core.ouroboros.aegis.spend_wal import (
+    SpendEntry, SpendEntryKind, append_entry_sync,
+)
+from backend.core.ouroboros.governance.soak_circuit_breaker import (
+    SoakBreakerConfig, SoakCircuitBreaker, _WAL_SELF_ROUTE, role_is_attended,
+)
+
+
+@pytest.fixture()
+def wal(tmp_path, monkeypatch):
+    """An isolated WAL. NEVER the repo's real ledger."""
+    p = tmp_path / "spend.jsonl"
+    monkeypatch.setenv("JARVIS_AEGIS_WAL_PATH", str(p))
+    return p
+
+
+def _spend(wal, usd, *, route="standard", op="op"):
+    append_entry_sync(wal, SpendEntry(
+        kind=SpendEntryKind.ADMIT, ts=time.time(), op_id=op,
+        route=route, actual_cost_usd=usd))
+
+
+# ── The amplification loop ──────────────────────────────────────────────────
+
+def test_a_trip_does_not_raise_the_baseline_it_measured(wal):
+    """The whole defect, in one assertion.
+
+    Observe a total, write the observation down, observe again. The second
+    number must equal the first. On the old code it was exactly double.
+    """
+    _spend(wal, 3.6333)
+    b = SoakCircuitBreaker()
+
+    first = b._replay_committed_spend()
+    assert first == pytest.approx(3.6333)
+
+    b._durable_append("soak_trip", {"cost_used_usd": first,
+                                    "event": "soak_circuit_tripped"})
+    second = b._replay_committed_spend()
+
+    assert second == pytest.approx(first), (
+        f"the breaker's own trip row was summed as spend: "
+        f"{first} became {second}")
+
+
+def test_seventeen_boots_do_not_move_the_number(wal):
+    """The observed shape: 2**17 growth. Bounded now by construction."""
+    _spend(wal, 3.6333)
+    b = SoakCircuitBreaker()
+    for _ in range(17):
+        total = b._replay_committed_spend()
+        b._durable_append("soak_trip", {"cost_used_usd": total})
+    assert b._replay_committed_spend() == pytest.approx(3.6333)
+
+
+def test_the_summary_row_carries_no_spend_but_keeps_the_audit(wal):
+    """Both halves of the fix, separately.
+
+    The total must still be reconstructable — the row exists for post-hoc
+    audit — it just must not live in the field that means "money this row
+    spent".
+    """
+    SoakCircuitBreaker()._durable_append(
+        "soak_trip", {"cost_used_usd": 41.5, "event": "soak_circuit_tripped"})
+    row = json.loads(wal.read_text().strip().splitlines()[-1])
+    assert row["actual_cost_usd"] is None
+    assert row["route"] == _WAL_SELF_ROUTE
+    assert "41.5" in row["detail"]          # audit intact
+
+
+def test_the_reader_refuses_self_rows_even_if_a_writer_regresses(wal):
+    """Belt and braces. If some future edit puts a total back in the spend
+    field, the replay must still not sum it — one guard on a self-referential
+    loop is one edit away from being none."""
+    append_entry_sync(wal, SpendEntry(
+        kind=SpendEntryKind.RECONCILE, ts=time.time(),
+        op_id=f"{_WAL_SELF_ROUTE}:soak_trip", route=_WAL_SELF_ROUTE,
+        actual_cost_usd=999999.0, detail="a regressed writer"))
+    _spend(wal, 1.25)
+    assert SoakCircuitBreaker()._replay_committed_spend() == pytest.approx(1.25)
+
+
+def test_a_genuine_reconcile_row_is_still_counted(wal):
+    """The exclusion is by ROUTE, not by kind. RECONCILE rows from real lease
+    settlement are spend and must keep counting — 54 of the 71 on the real
+    ledger were exactly that."""
+    append_entry_sync(wal, SpendEntry(
+        kind=SpendEntryKind.RECONCILE, ts=time.time(), op_id="lease-42",
+        route="standard", actual_cost_usd=2.5))
+    assert SoakCircuitBreaker()._replay_committed_spend() == pytest.approx(2.5)
+
+
+# ── The horizon ─────────────────────────────────────────────────────────────
+
+def test_spend_from_a_previous_episode_is_not_this_episode_s(wal, monkeypatch):
+    monkeypatch.setenv("JARVIS_SOAK_BASELINE_HORIZON_S", "3600")
+    now = time.time()
+    append_entry_sync(wal, SpendEntry(
+        kind=SpendEntryKind.ADMIT, ts=now - 86400 * 14, op_id="ancient",
+        route="standard", actual_cost_usd=50.0))
+    _spend(wal, 0.75)
+    assert SoakCircuitBreaker()._replay_committed_spend(now) == pytest.approx(0.75)
+
+
+def test_the_horizon_can_be_switched_off(wal, monkeypatch):
+    monkeypatch.setenv("JARVIS_SOAK_BASELINE_HORIZON_S", "0")
+    now = time.time()
+    append_entry_sync(wal, SpendEntry(
+        kind=SpendEntryKind.ADMIT, ts=now - 86400 * 14, op_id="ancient",
+        route="standard", actual_cost_usd=50.0))
+    assert SoakCircuitBreaker()._replay_committed_spend(now) == pytest.approx(50.0)
+
+
+def test_the_horizon_is_derived_from_declared_episode_length(monkeypatch):
+    monkeypatch.delenv("JARVIS_SOAK_BASELINE_HORIZON_S", raising=False)
+    monkeypatch.setenv("OUROBOROS_BATTLE_MAX_WALL_SECONDS", "9000")
+    assert SoakCircuitBreaker.baseline_horizon_s() == 9000.0
+    monkeypatch.delenv("OUROBOROS_BATTLE_MAX_WALL_SECONDS")
+    monkeypatch.setenv("JARVIS_SOAK_MAX_GCE_RUNTIME_S", "60")
+    assert SoakCircuitBreaker.baseline_horizon_s() == 3600.0   # floored
+
+
+def test_an_in_flight_lease_still_counts_fail_closed(wal):
+    """Unchanged behaviour, pinned: a lease we cannot prove settled is a lease
+    we must assume spent."""
+    append_entry_sync(wal, SpendEntry(
+        kind=SpendEntryKind.ADMIT, ts=time.time(), op_id="inflight",
+        route="standard", reserve_cost_usd=0.30))
+    assert SoakCircuitBreaker()._replay_committed_spend() == pytest.approx(0.30)
+
+
+# ── Role scoping ────────────────────────────────────────────────────────────
+
+def test_silence_means_unattended_and_fully_armed(monkeypatch):
+    """The direction where being wrong costs real money."""
+    monkeypatch.delenv("JARVIS_PROCESS_ROLE", raising=False)
+    monkeypatch.setenv("JARVIS_SOAK_CIRCUIT_BREAKER_ENABLED", "true")
+    assert not role_is_attended()
+    assert SoakBreakerConfig.from_env().enabled
+
+
+def test_a_soak_that_declares_itself_stays_armed(monkeypatch):
+    monkeypatch.setenv("JARVIS_PROCESS_ROLE", "soak")
+    monkeypatch.setenv("JARVIS_SOAK_CIRCUIT_BREAKER_ENABLED", "true")
+    assert SoakBreakerConfig.from_env().enabled
+
+
+def test_the_attended_hud_is_not_governed_by_a_soak_cap(monkeypatch):
+    """`.env` arms this for every process in the repo. The HUD has an operator
+    at the keyboard, which is the exact condition the breaker's own purpose
+    statement excludes."""
+    monkeypatch.setenv("JARVIS_PROCESS_ROLE", "hud")
+    monkeypatch.setenv("JARVIS_SOAK_CIRCUIT_BREAKER_ENABLED", "true")
+    assert role_is_attended()
+    assert not SoakBreakerConfig.from_env().enabled
+
+
+def test_an_unknown_role_is_treated_as_unattended(monkeypatch):
+    monkeypatch.setenv("JARVIS_PROCESS_ROLE", "something-nobody-defined")
+    monkeypatch.setenv("JARVIS_SOAK_CIRCUIT_BREAKER_ENABLED", "true")
+    assert SoakBreakerConfig.from_env().enabled

--- a/tests/hud/test_voice_router_reflex.py
+++ b/tests/hud/test_voice_router_reflex.py
@@ -1,0 +1,239 @@
+"""The voice path must act, and must tell the truth about it.
+
+Reconstructs the exact failure from the boot log of 2026-08-02 22:51:54: the
+operator said "lock my screen", the classifier's model call was refused, its
+fallback was the MORE model-dependent branch, that was refused too, and JARVIS
+answered by reading the refusal string aloud through a speech synthesiser.
+
+`DeadCortex` below is that outage. Every test in this file runs with it.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.hud.tool_use_orchestrator import CommandResult
+from backend.hud.voice_command_router import (
+    VoiceCommandRouter, _humanise, _make_failure_speakable,
+    _read_controller_result,
+)
+
+REFUSAL = ("session_budget_preflight_refused:soak_circuit_tripped:"
+           "soak_cost_cap_exceeded:$238111.9488>=$2.0000:on_boot: "
+           "provider=doubleword est=$0.1000 > session_remaining=$0.0000")
+
+
+class DeadCortex:
+    """Every model dispatch refused — the measured outage."""
+
+    def __init__(self):
+        self.calls = 0
+
+    async def prompt_only(self, *a, **k):
+        self.calls += 1
+        raise RuntimeError(REFUSAL)
+
+
+class _Routed:
+    def __init__(self, outcome, result=None, detail="", capability="lock_screen"):
+        self.outcome = outcome
+        self.result = result
+        self.detail = detail
+        self.capability = capability
+        self.request_id = "rid-1234567890"
+        self.context_note = ""
+
+
+@pytest.fixture()
+def router():
+    return VoiceCommandRouter(DeadCortex())
+
+
+def _fake_router(monkeypatch, routed):
+    """Intercept at the capability boundary — nothing may touch the real Mac."""
+    import backend.system_control.capability_router as CR
+    calls = []
+
+    class Stub:
+        async def route(self, name, args=None, *, op_id=""):
+            calls.append((name, dict(args or {})))
+            return routed
+
+    monkeypatch.setattr(CR, "get_capability_router", lambda: Stub())
+    return calls
+
+
+# ── The reflex fires without the cortex ─────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_lock_my_screen_reaches_the_capability_with_the_model_dead(
+        router, monkeypatch):
+    calls = _fake_router(monkeypatch, _Routed(
+        "executed", result=(True, "🔒 Locking the screen now, Derek.")))
+
+    res = await router.route("lock my screen")
+
+    assert calls == [("lock_screen", {})], "the capability was never reached"
+    assert res.success and res.category == "system_action"
+    assert res.response_text == "🔒 Locking the screen now, Derek."
+
+
+@pytest.mark.asyncio
+async def test_no_model_call_is_made_at_all(router, monkeypatch):
+    """Not merely 'it works when the model is down' — it does not ASK.
+
+    Two round-trips for a sentence that names a capability outright is the
+    cost this exists to delete, and it is a cost paid when the model is UP.
+    """
+    _fake_router(monkeypatch, _Routed("executed", result=(True, "ok")))
+    await router.route("lock my screen")
+    assert router._dw.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_the_capability_is_called_with_no_invented_arguments(
+        router, monkeypatch):
+    calls = _fake_router(monkeypatch, _Routed("executed", result=(True, "ok")))
+    await router.route("lock my screen")
+    assert calls[0][1] == {}
+
+
+# ── It does not lie about what happened ─────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_a_capability_that_failed_without_raising_is_not_a_success(
+        router, monkeypatch):
+    """`lock_screen` answers `(False, "Unable to lock screen")` WITHOUT
+    raising, so the router reports EXECUTED. Reading only that outcome would
+    announce a locked screen to somebody looking at an unlocked one."""
+    _fake_router(monkeypatch, _Routed(
+        "executed", result=(False, "❌ Unable to lock screen (all methods failed).")))
+
+    res = await router.route("lock my screen")
+
+    assert res.success is False
+    assert "Unable to lock screen" in res.response_text
+
+
+@pytest.mark.asyncio
+async def test_awaiting_consent_is_neither_success_nor_failure(
+        router, monkeypatch):
+    _fake_router(monkeypatch, _Routed("suspended", detail="operator consent required"))
+
+    res = await router.route("lock my screen")
+
+    assert res.pending is True and res.success is False
+    assert "approval" in res.response_text.lower()
+
+
+@pytest.mark.asyncio
+async def test_nobody_to_ask_is_not_reported_as_a_refusal(router, monkeypatch):
+    """The operator needs opposite follow-ups for 'you said no' and 'nothing
+    could ask you'."""
+    _fake_router(monkeypatch, _Routed(
+        "denied", detail="no approval provider available — failing closed"))
+
+    res = await router.route("lock my screen")
+
+    assert "couldn't ask anyone" in res.response_text
+    assert "declined" not in res.response_text
+
+
+@pytest.mark.asyncio
+async def test_an_operator_refusal_says_so(router, monkeypatch):
+    _fake_router(monkeypatch, _Routed("denied", detail="operator declined"))
+    res = await router.route("lock my screen")
+    assert "declined" in res.response_text
+
+
+# ── The model path still speaks like a person ───────────────────────────────
+
+@pytest.mark.asyncio
+async def test_an_unreflexive_command_still_goes_to_the_model(router):
+    res = await router.route("open chrome and check my email")
+    assert router._dw.calls > 0
+    assert res.success is False
+
+
+@pytest.mark.asyncio
+async def test_a_provider_refusal_is_never_read_aloud_verbatim(router):
+    res = await router.route("open chrome and check my email")
+    for leak in ("session_budget_preflight_refused", "$238111", "doubleword",
+                 "soak_circuit_tripped", "Traceback"):
+        assert leak not in (res.response_text or ""), (
+            f"a diagnostic reached the speech synthesiser: {leak}")
+    assert "spending limit" in res.response_text
+    # The diagnostic is KEPT — for the log, which can be read at leisure.
+    assert "session_budget_preflight_refused" in (res.error or "")
+
+
+def test_the_translator_never_overwrites_a_truthful_message():
+    """A real bug found while building this.
+
+    The capability path answered "I couldn't ask anyone to approve lock
+    screen, so I didn't do it" — true and actionable — and the translator saw
+    the word "provider" inside `no approval provider available` and replaced
+    it with "My language model isn't answering right now", which is false; no
+    model was involved. A translator that can turn a true sentence into a
+    false one is worse than the diagnostic it replaced.
+    """
+    honest = "I couldn't ask anyone to approve lock screen, so I didn't do it."
+    res = CommandResult(success=False, category="system_action",
+                        steps_completed=0, steps_total=1,
+                        response_text=honest,
+                        error="no approval provider available — failing closed")
+
+    class Resolved:
+        resolved = True
+        outcome = "resolved"
+        capability = "lock_screen"
+
+    assert _make_failure_speakable(res, Resolved()).response_text == honest
+
+
+def test_a_real_task_failure_keeps_its_own_words():
+    res = CommandResult(success=False, category="app_action", steps_completed=0,
+                        steps_total=1, response_text="Couldn't open Chrome.",
+                        error="Couldn't open Chrome.")
+    assert _make_failure_speakable(res, None).response_text == "Couldn't open Chrome."
+
+
+@pytest.mark.parametrize("detail,expect", [
+    ("Model error: 403 entitlement denied", "authorised"),
+    ("Model error: read timeout after 120s", "too long"),
+    ("Model error: cannot connect to host", "can't reach"),
+    (REFUSAL, "spending limit"),
+])
+def test_provider_faults_are_classified_by_shape(detail, expect):
+    res = CommandResult(success=False, category="composite", steps_completed=0,
+                        steps_total=0, response_text=detail, error=detail)
+    assert expect in _make_failure_speakable(res, None).response_text
+
+
+def test_a_near_miss_is_offered_rather_than_acted_on():
+    class NearMiss:
+        resolved = False
+        outcome = "low_confidence"
+        capability = "lock_screen"
+
+    res = CommandResult(success=False, category="composite", steps_completed=0,
+                        steps_total=0, response_text=REFUSAL, error=REFUSAL)
+    spoken = _make_failure_speakable(res, NearMiss()).response_text
+    assert "Did you mean lock screen?" in spoken
+
+
+# ── Small pieces ────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("name,said", [
+    ("lock_screen", "lock screen"),
+    ("video.start_streaming", "start streaming"),
+    ("", "that"),
+])
+def test_humanise_is_derived_not_looked_up(name, said):
+    assert _humanise(name) == said
+
+
+def test_controller_results_speak_for_themselves():
+    assert _read_controller_result((True, "🔒 Locking now."), "lock screen") == (
+        True, "🔒 Locking now.")
+    ok, say = _read_controller_result(None, "lock screen")
+    assert ok and "lock screen" in say

--- a/tests/system_control/test_capability_reflex.py
+++ b/tests/system_control/test_capability_reflex.py
@@ -1,0 +1,227 @@
+"""Regression spine for the deterministic capability reflex.
+
+The defect this guards: an operator said "lock my screen" to a Mac that has
+`lock_screen`, and nothing happened, because the only path from a sentence to
+a capability ran through two model calls and the model was refusing.
+
+The tests that matter most here are the REFUSALS. A reflex that fires is easy
+to test and easy to get right; a reflex that fires when it should not is how a
+screen locks in the middle of a sentence.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.system_control.capability_reflex import (
+    CapabilityReflex, Lexicon, Outcome, Signature, content_tokens,
+    score_candidate, tokenize,
+)
+
+
+def _sig(name, *, tokens=None, desc="", gated=True, no_args=True,
+         session=False, phrases=(), required=()):
+    return Signature(
+        name=name,
+        name_tokens=tuple(tokens if tokens is not None
+                          else content_tokens(name.split(".")[-1].replace("_", " "))),
+        desc_tokens=frozenset(content_tokens(desc)),
+        phrases=tuple(phrases),
+        tier="approval_required" if gated else "safe_auto",
+        gated=gated, starts_session=session, no_args=no_args,
+        required_args=tuple(required),
+    )
+
+
+class _FixedLexicon(Lexicon):
+    def __init__(self, sigs):
+        super().__init__()
+        self._fixed = list(sigs)
+
+    def signatures(self):
+        return list(self._fixed)
+
+
+def _reflex(*sigs):
+    return CapabilityReflex(lexicon=_FixedLexicon(sigs))
+
+
+LOCK = _sig("lock_screen")
+UNLOCK = _sig("unlock_screen")
+SHOT = _sig("take_screenshot", gated=False)
+OPEN_APP = _sig("open_app", no_args=False, required=("app_name",))
+STREAM = _sig("video.start_streaming", session=True)
+
+
+# ── The whole point ─────────────────────────────────────────────────────────
+
+def test_the_sentence_that_did_nothing_now_resolves():
+    out = _reflex(LOCK, UNLOCK, SHOT).resolve("lock my screen")
+    assert out.outcome == Outcome.RESOLVED.value
+    assert out.capability == "lock_screen"
+
+
+@pytest.mark.parametrize("said", [
+    "lock my screen", "lock the screen", "please lock my screen",
+    "jarvis lock my screen", "lock my screen now", "screen lock",
+])
+def test_phrasings_of_the_same_request(said):
+    assert _reflex(LOCK, UNLOCK).resolve(said).capability == "lock_screen"
+
+
+def test_the_reflex_costs_no_model_call_and_no_io():
+    # The property that makes it useful during an outage. If this ever needs a
+    # collaborator, it has stopped being a reflex.
+    out = _reflex(LOCK).resolve("lock my screen")
+    assert out.resolved and out.elapsed_ms < 50.0
+
+
+# ── Refusal: the lock/unlock collision ──────────────────────────────────────
+
+@pytest.mark.parametrize("said,expected", [
+    ("lock my screen", "lock_screen"),
+    ("unlock my screen", "unlock_screen"),
+    ("unlock the screen", "unlock_screen"),
+])
+def test_lock_is_not_a_substring_of_unlock(said, expected):
+    """The single most dangerous pair on the surface.
+
+    `"lock" in "unlock my screen"` is True. Substring matching here would
+    lock a screen the operator asked to unlock — inverting the request, on the
+    one capability where that is most visible.
+    """
+    assert _reflex(LOCK, UNLOCK).resolve(said).capability == expected
+
+
+def test_unlock_utterance_does_not_even_score_lock():
+    said = content_tokens("unlock my screen")
+    assert score_candidate(LOCK, said, "unlock my screen") is None
+    assert "lock" not in tokenize("unlock my screen")
+
+
+# ── Refusal: shape ──────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("said", [
+    "don't lock my screen",
+    "do not lock my screen",
+    "never lock my screen",
+    "cancel lock screen",
+])
+def test_a_negation_is_not_a_command(said):
+    out = _reflex(LOCK).resolve(said)
+    assert out.outcome == Outcome.NOT_IMPERATIVE.value
+
+
+@pytest.mark.parametrize("said", [
+    "how do I lock my screen",
+    "what happens when you lock my screen",
+    "why would you lock my screen",
+])
+def test_a_question_about_a_capability_does_not_run_it(said):
+    assert _reflex(LOCK).resolve(said).outcome == Outcome.NOT_IMPERATIVE.value
+
+
+def test_modal_politeness_is_not_a_question():
+    """"can you lock my screen" is an imperative wearing a question mark."""
+    assert _reflex(LOCK).resolve("could you lock my screen").resolved
+
+
+def test_a_conjunction_means_a_plan_not_a_reflex():
+    out = _reflex(LOCK, SHOT).resolve("lock my screen and open chrome")
+    assert out.outcome == Outcome.NOT_IMPERATIVE.value
+    # It still says what it saw, so the caller can explain itself.
+    assert out.capability == "lock_screen"
+
+
+# ── Refusal: arguments ──────────────────────────────────────────────────────
+
+def test_a_capability_needing_an_argument_is_never_guessed():
+    out = _reflex(OPEN_APP).resolve("open app")
+    assert out.outcome == Outcome.NEEDS_ARGS.value
+    assert "app_name" in out.reason
+
+
+# ── Refusal: ambiguity ──────────────────────────────────────────────────────
+
+def test_two_readings_is_a_question_not_a_rounding_error():
+    a = _sig("mute_audio", tokens=("mute", "audio"))
+    b = _sig("mute_audio_output", tokens=("mute", "audio"))  # same signature
+    out = _reflex(a, b).resolve("mute audio")
+    assert out.outcome == Outcome.AMBIGUOUS.value
+
+
+def test_the_more_specific_capability_wins_when_it_explains_more():
+    """Given "lock my screen", a bare `screen` capability also has full name
+    coverage. `explained` is what breaks the tie honestly."""
+    bare = _sig("screen", tokens=("screen",))
+    out = _reflex(LOCK, bare).resolve("lock my screen")
+    assert out.capability == "lock_screen"
+
+
+# ── Confidence depends on what happens if it is wrong ───────────────────────
+
+def test_a_session_start_is_held_to_the_top_bar():
+    """Duration is its own risk class. One consent does not cover forever."""
+    sig = STREAM
+    assert sig.starts_session and sig.gated
+    out = _reflex(sig).resolve("start streaming the video feed for me")
+    # Whatever it decides, it must not have used the LOWER gated bar.
+    if not out.resolved:
+        assert out.outcome == Outcome.LOW_CONFIDENCE.value
+
+
+def test_an_ungated_capability_needs_the_top_bar(monkeypatch):
+    monkeypatch.setenv("JARVIS_REFLEX_CERTAIN_SCORE", "0.99")
+    monkeypatch.setenv("JARVIS_REFLEX_GATED_SCORE", "0.10")
+    ungated = _sig("take_screenshot", gated=False)
+    out = _reflex(ungated).resolve("take screenshot of the browser window")
+    assert out.outcome == Outcome.LOW_CONFIDENCE.value
+
+
+# ── Derivation, not declaration ─────────────────────────────────────────────
+
+def test_a_capability_renamed_answers_to_its_new_name():
+    """The property a phrase table cannot have."""
+    renamed = _sig("hibernate_display", tokens=("hibernate", "display"))
+    rx = _reflex(renamed)
+    assert rx.resolve("hibernate the display").capability == "hibernate_display"
+    assert not rx.resolve("lock my screen").resolved
+
+
+def test_a_declared_phrase_reaches_a_badly_named_capability():
+    odd = _sig("do_the_thing_v2", tokens=("do", "thing", "v2"),
+               phrases=("secure my mac",))
+    assert _reflex(odd).resolve("secure my mac").capability == "do_the_thing_v2"
+
+
+def test_a_namespaced_capability_is_spoken_without_its_namespace():
+    assert STREAM.name_tokens == ("start", "streaming")
+
+
+def test_nothing_named_means_unrecognized_not_a_guess():
+    out = _reflex(LOCK, UNLOCK).resolve("play some jazz")
+    assert out.outcome == Outcome.UNRECOGNIZED.value
+    assert out.capability == ""
+
+
+def test_the_reflex_never_raises():
+    rx = _reflex(LOCK)
+    for junk in ["", "   ", "!!!", "\x00", "a" * 5000, "lock " * 400]:
+        assert rx.resolve(junk) is not None
+
+
+def test_disabled_falls_through_to_the_model(monkeypatch):
+    monkeypatch.setenv("JARVIS_CAPABILITY_REFLEX_ENABLED", "false")
+    assert _reflex(LOCK).resolve("lock my screen").outcome == Outcome.DISABLED.value
+
+
+# ── The live surface ────────────────────────────────────────────────────────
+
+def test_the_real_registry_can_be_spoken_to():
+    """Not a mock. If the derivation breaks, the reflex is decorative."""
+    rx = CapabilityReflex()
+    names = {s.name for s in rx.lexicon().signatures()}
+    if not names:                      # controller unimportable on this box
+        pytest.skip("capability registry degraded in this environment")
+    assert "lock_screen" in names
+    assert rx.resolve("lock my screen").capability == "lock_screen"
+    assert rx.resolve("unlock my screen").capability == "unlock_screen"

--- a/tests/system_control/test_capability_tiers.py
+++ b/tests/system_control/test_capability_tiers.py
@@ -1,0 +1,241 @@
+"""Four declared tiers must produce four behaviours.
+
+`capability_registry` declares SAFE_AUTO / NOTIFY_APPLY / APPROVAL_REQUIRED /
+BLOCKED, mirroring `risk_engine.RiskTier`. The router asked exactly one
+question — `iron_gate_required`, which is False only for SAFE_AUTO — so
+NOTIFY_APPLY and APPROVAL_REQUIRED were byte-identical, and BLOCKED was
+presented to the operator as a prompt they could approve.
+
+A word that cannot change what happens is not a word; worse, it is a word an
+author will reach for believing it means something.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.system_control.capability_registry import (
+    CapabilityDef, Tier,
+)
+from backend.system_control.capability_router import (
+    CapabilityRouter, Outcome,
+)
+
+
+def _cap(name, tier, **kw):
+    return CapabilityDef(name=name, description=f"{name} does a thing",
+                         tier=tier, **kw)
+
+
+class _Target:
+    def __init__(self):
+        self.ran = []
+
+    async def safe(self):
+        self.ran.append("safe")
+        return (True, "read something")
+
+    async def notify(self):
+        self.ran.append("notify")
+        return (True, "🔒 Locking the screen now, Derek.")
+
+    async def approve(self):
+        self.ran.append("approve")
+        return (True, "did the guarded thing")
+
+    async def forbidden(self):
+        self.ran.append("forbidden")
+        return (True, "should never happen")
+
+
+class _Registry:
+    def __init__(self, defs):
+        self._d = {d.name: d for d in defs}
+
+    def get(self, name):
+        return self._d.get(name)
+
+
+class _Provider:
+    """Records that somebody was ASKED. That is the whole assertion."""
+
+    def __init__(self):
+        self.asked = []
+
+    async def request(self, ctx):
+        self.asked.append(getattr(ctx, "capability", ""))
+        return "rid-1"
+
+
+@pytest.fixture()
+def rig(monkeypatch):
+    monkeypatch.delenv("JARVIS_MIN_RISK_TIER", raising=False)
+    monkeypatch.delenv("JARVIS_PARANOIA_MODE", raising=False)
+    monkeypatch.delenv("JARVIS_AUTO_APPLY_QUIET_HOURS", raising=False)
+    target, provider = _Target(), _Provider()
+    reg = _Registry([
+        _cap("safe", Tier.SAFE_AUTO.value),
+        _cap("notify", Tier.NOTIFY_APPLY.value),
+        _cap("approve", Tier.APPROVAL_REQUIRED.value),
+        _cap("forbidden", Tier.BLOCKED.value),
+    ])
+    return (CapabilityRouter(registry=reg, provider=provider, target=target),
+            target, provider)
+
+
+# ── The four behaviours ─────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_safe_auto_just_runs(rig):
+    router, target, provider = rig
+    out = await router.route("safe")
+    assert out.outcome == Outcome.EXECUTED.value
+    assert target.ran == ["safe"] and provider.asked == []
+    assert out.notified is False
+
+
+@pytest.mark.asyncio
+async def test_notify_apply_runs_without_asking(rig):
+    """The behaviour that did not exist. Before this, declaring NOTIFY_APPLY
+    got you APPROVAL_REQUIRED and a Touch ID prompt."""
+    router, target, provider = rig
+    out = await router.route("notify")
+    assert out.outcome == Outcome.EXECUTED.value
+    assert target.ran == ["notify"]
+    assert provider.asked == [], "NOTIFY_APPLY must not ask anybody"
+
+
+@pytest.mark.asyncio
+async def test_notify_apply_is_never_silent(rig):
+    """Running without asking is only acceptable because it is announced.
+    `notified` is what every narrating surface reads."""
+    router, _, _ = rig
+    out = await router.route("notify")
+    assert out.notified is True
+    assert out.tier == Tier.NOTIFY_APPLY.value
+    assert "WITHOUT CONSENT" in out.context_note
+
+
+@pytest.mark.asyncio
+async def test_approval_required_still_suspends(rig):
+    router, target, provider = rig
+    out = await router.route("approve")
+    assert out.outcome == Outcome.SUSPENDED.value
+    assert provider.asked == ["approve"]
+    assert target.ran == [], "it must not run before the human answers"
+
+
+@pytest.mark.asyncio
+async def test_blocked_is_refused_without_asking_anyone(rig):
+    """A prompt is an invitation to approve. BLOCKED is not a question.
+
+    Before this, BLOCKED fell into the consent path — so the one tier that
+    means 'never' was rendered to the operator as something they could say
+    yes to.
+    """
+    router, target, provider = rig
+    out = await router.route("forbidden")
+    assert out.outcome == Outcome.DENIED.value
+    assert provider.asked == [], "BLOCKED must never reach an operator"
+    assert target.ran == []
+    assert "BLOCKED" in out.detail
+
+
+# ── The operator's standing floor ───────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_paranoia_mode_takes_notify_apply_back(rig, monkeypatch):
+    """The counterweight to NOTIFY_APPLY actually applying.
+
+    The operator can revoke it globally — at 2am, before a demo — without
+    editing a decorator, using the floor module that already existed.
+    """
+    router, target, provider = rig
+    monkeypatch.setenv("JARVIS_MIN_RISK_TIER", "approval_required")
+    out = await router.route("notify")
+    assert out.outcome == Outcome.SUSPENDED.value
+    assert provider.asked == ["notify"] and target.ran == []
+    assert "risk floor" in out.detail
+
+
+@pytest.mark.asyncio
+async def test_the_floor_only_ever_raises(rig, monkeypatch):
+    """A floor BELOW the declared tier changes nothing — it is a floor, not a
+    ceiling, and it must never make a capability more permissive."""
+    router, _, provider = rig
+    monkeypatch.setenv("JARVIS_MIN_RISK_TIER", "safe_auto")
+    assert (await router.route("approve")).outcome == Outcome.SUSPENDED.value
+    assert provider.asked == ["approve"]
+
+
+@pytest.mark.asyncio
+async def test_a_broken_floor_falls_back_to_the_declared_tier(rig, monkeypatch):
+    """Fail toward what the method's author chose. A floor subsystem that
+    cannot answer must not be able to make anything MORE permissive."""
+    import backend.system_control.capability_router as CR
+
+    def _boom(*a, **k):
+        raise RuntimeError("floor is down")
+
+    monkeypatch.setattr(
+        "backend.core.ouroboros.governance.risk_tier_floor.apply_floor_to_name",
+        _boom)
+    router, target, provider = rig
+    assert (await router.route("approve")).outcome == Outcome.SUSPENDED.value
+    assert (await router.route("notify")).outcome == Outcome.EXECUTED.value
+
+
+@pytest.mark.asyncio
+async def test_the_floor_can_be_rolled_back(rig, monkeypatch):
+    monkeypatch.setenv("JARVIS_CAPABILITY_RISK_FLOOR_ENABLED", "false")
+    monkeypatch.setenv("JARVIS_MIN_RISK_TIER", "approval_required")
+    router, target, _ = rig
+    assert (await router.route("notify")).outcome == Outcome.EXECUTED.value
+
+
+# ── The registry's own vocabulary ───────────────────────────────────────────
+
+@pytest.mark.parametrize("tier,governed,consent,notifies,blocked", [
+    (Tier.SAFE_AUTO.value, False, False, False, False),
+    (Tier.NOTIFY_APPLY.value, True, False, True, False),
+    (Tier.APPROVAL_REQUIRED.value, True, True, False, False),
+    (Tier.BLOCKED.value, True, True, False, True),
+])
+def test_the_four_tiers_answer_four_different_ways(
+        tier, governed, consent, notifies, blocked):
+    d = _cap("x", tier)
+    assert d.iron_gate_required is governed
+    assert d.requires_consent is consent
+    assert d.notifies is notifies
+    assert d.blocked is blocked
+
+
+def test_governed_and_needs_consent_are_not_the_same_question():
+    """The conflation itself, pinned. Both were one property for as long as
+    there was only one of them."""
+    n = _cap("x", Tier.NOTIFY_APPLY.value)
+    assert n.iron_gate_required and not n.requires_consent
+
+
+def test_an_unclassified_capability_still_needs_consent():
+    """The registry's inversion survives the split: silence means
+    APPROVAL_REQUIRED, which means a human is asked."""
+    assert CapabilityDef(name="mystery", description="").requires_consent
+
+
+# ── The live capability ─────────────────────────────────────────────────────
+
+def test_lock_screen_is_instant_and_unlock_screen_is_not():
+    """The operator's deliberate choice, pinned so a refactor cannot quietly
+    reverse it — in either direction."""
+    from backend.system_control.capability_registry import (
+        get_capability_registry,
+    )
+    reg = get_capability_registry()
+    lock = reg.get("lock_screen")
+    if lock is None:
+        pytest.skip("controller unimportable in this environment")
+    assert lock.tier == Tier.NOTIFY_APPLY.value
+    assert lock.requires_consent is False, "locking must not wait for Touch ID"
+    assert lock.notifies is True, "and must never happen silently"
+    # Unlocking is the opposite decision and must stay that way.
+    assert reg.get("unlock_screen").requires_consent is True


### PR DESCRIPTION
## What happened

An operator said **"lock my screen"** to a Mac that has had `lock_screen` all along — derived by `capability_registry`, gateable and callable by `capability_router` — and nothing happened.

Five independent root causes. **Fixing any one alone still leaves it broken.**

## 1. The spend ledger ate itself

`SoakCircuitBreaker._durable_append` wrote the total it had just computed into `SpendEntry.actual_cost_usd` — on the same WAL `reconcile_on_boot` sums. **An observer writing into the field it aggregates does not drift, it doubles.**

The real ledger, seventeen boots:

```
3.63 → 7.27 → 14.53 → 29.07 → … → 119055.97 → 238111.95     exactly 2¹⁷
```

True spend: **$3.6333**. Presented to a $2 cap as $238,111.95, and every LLM dispatch in the process refused against it.

Fixed at **both** ends — the writer keeps the total in `detail` (audit lossless, `actual_cost_usd=None`), the reader skips rows stamped with its own route. One guard on a self-referential loop is one edit away from being none. The 17 poisoned rows on disk become inert; an append-only ledger is not rewritten to fix a reader that was wrong.

## 2. A per-episode cap measured against an all-time ledger

Even at the honest $3.63, replay summed a fortnight against a **$2 per-soak** cap → tripped on boot forever. **A fix for (1) alone looks correct and leaves the HUD equally dead.** Added an episode horizon derived from already-declared episode length.

## 3. A soak breaker governing an attended process

`.env` carries `JARVIS_SOAK_CIRCUIT_BREAKER_ENABLED=true`, and every process here loads `.env` — so the *attended* HUD inherited an *unattended* soak's fail-closed breaker. New `JARVIS_PROCESS_ROLE`, **failing closed toward armed**: silence means unattended; only a positive declaration exempts. A soak that never declares stays fully protected.

## 4. No path from a sentence to a capability without a model

`_classify` needed an LLM, and its except-branch fell back to `"composite"` → the tool loop → **a second model call**. *The fallback was strictly more model-dependent than the thing that failed.* Each of the four faults in that one boot log — budget refusal, DW 403, DW streaming outage, J-Prime down — was independently sufficient for total paralysis.

**The reflexes were routed through the cortex, and the cortex is the part that can be unavailable.**

`backend/system_control/capability_reflex.py` derives its lexicon from the same reflection the tool schemas come from, so a capability annotated tomorrow is speakable tomorrow. Not a phrase table. Four refusals instead of guessing:

- **partial name coverage** — matching is on **word boundaries**: `"lock" in "unlock my screen"` is `True`, and substring matching would invert the request on the most dangerous pair on the surface
- **ambiguity** — two readings is a question, not a rounding error
- **required arguments** — never invents one; pulling a value out of a sentence is the model's job
- **shape** — negation / leading interrogative / conjunction, checked *before* scoring, because `"don't lock my screen"` contains a perfect match

It resolves a **name** and hands it to `CapabilityRouter`. Tier, Iron Gate, consent, nonce and lease book all still apply — a faster way to *arrive* at the gate, never a way around it.

## 5. Four declared tiers that meant two things

`iron_gate_required` is `tier != SAFE_AUTO`, and it was the **only** question the router asked. So `NOTIFY_APPLY` and `APPROVAL_REQUIRED` were byte-identical, and **`BLOCKED` — the tier that means *never* — was rendered to the operator as a prompt they could approve.**

Split the question rather than loosening the gate: `iron_gate_required` keeps its meaning; new `requires_consent` covers `{approval_required, blocked}`. Both pre-existing `iron_gate_required("lock_screen") is True` assertions stay green — non-breaking by construction.

| tier | behaviour |
|---|---|
| `SAFE_AUTO` | run it |
| `NOTIFY_APPLY` | run it, and say so |
| `APPROVAL_REQUIRED` | ask first |
| `BLOCKED` | refuse, and don't even ask |

Composed the **existing** `risk_tier_floor` (paranoia mode / `JARVIS_MIN_RISK_TIER` / quiet hours) so an auto-applying tier can be revoked globally without editing a decorator. It only ever raises, and **fails toward the declared tier** — a broken floor must never make anything more permissive.

`lock_screen` → `notify_apply` (instant, announced). `unlock_screen` stays `approval_required`.

## Honesty at the voice surface

JARVIS read a provider diagnostic **aloud, through a speech synthesiser**:

> "Model error: session_budget_preflight_refused:soak_circuit_tripped:soak_cost_cap_exceeded:$238111.9488>=$2.0000:on_boot…"

Provider faults are now classified **by shape** into a sentence; the diagnostic stays in `error` for the log. `main.py`'s failure branch spoke only a step count and discarded `response_text`, so the explanation would never have been heard. Awaiting-consent is now distinct from failure, and a consent verdict resolving out of band is spoken — that circuit used to complete in total silence.

## Bugs introduced and caught while building — all pinned by tests

- the reflex's conjunction guard was **written and never called** (the wired-but-inert trap, inside the fix for a wired-but-inert defect)
- the failure translator **overwrote a true message with a false one** — it saw "provider" in `no approval provider available` and said "My language model isn't answering", when no model was involved
- the reflex's confidence bar keyed on `iron_gate_required`, which would have **silently relaxed it for exactly the tier that loses the consent prompt the relaxation is justified by**

## Testing

**304 passed, 19 skipped** (skips are sandbox socket-binding, pre-existing).

New: `test_capability_reflex.py` (33) · `test_voice_router_reflex.py` (20) · `test_capability_tiers.py` (16) · `test_soak_ledger_amplification.py` (13).

The amplification test **fails on the old code at the first doubling**, not the seventeenth. Verified the old path reproduces `3.63 → 7.27 → 14.53 → 29.07 → 58.13 → 116.27 → 232.53` exactly.

One existing test changed: `test_boot_reconcile_rebuilds_cost_baseline` seeded `ts=1.0` (1970) — it only worked while replay was unbounded, and a restart-durability test is about a restart *within* an episode. Updated to `time.time()` with the rationale in-line.

Perf: **0.12 ms** cached resolve, 1.66 ms after TTL re-derive, ~1.15 s one-time `macos_controller` import already paid at HUD boot.

## ⚠️ Not live-proven

Verified in-process against the real registry and the real poisoned WAL. **The Touch ID leg has never been exercised live on this Mac** — `unlock_screen` and every other `approval_required` capability still depend on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes voice commands like “lock my screen” by removing LLM dependency from routing, repairing a self-amplifying spend ledger, and enforcing correct capability tier behavior. The HUD now acts immediately when safe, asks when needed, refuses when blocked, and explains failures clearly.

- **Bug Fixes**
  - Stopped spend ledger doubling: writer no longer stores totals in `actual_cost_usd`; reader skips its own WAL rows. Added per-episode replay horizon via `JARVIS_SOAK_BASELINE_HORIZON_S` so a per-soak cap isn’t compared to all-time spend.
  - Prevented unattended soak breaker from governing the attended HUD with `JARVIS_PROCESS_ROLE`; defaults fail-closed, only an explicit attended role exempts.
  - Corrected tier semantics in the router: `safe_auto` runs, `notify_apply` runs and announces, `approval_required` asks, `blocked` refuses. Split “iron gate” vs “consent” and composed the risk floor (toggle with `JARVIS_CAPABILITY_RISK_FLOOR_ENABLED`).
  - Voice path now tells the truth: translates provider errors into clear sentences, preserves diagnostics in logs, and distinguishes consent-waiting from failure.

- **New Features**
  - Added deterministic capability reflex (`backend/system_control/capability_reflex.py`) to resolve sentences to capability names without a model. Handles word-boundary matching, ambiguity, required args, and negation/conjunction up front.
  - Updated voice router to use the reflex and improved humanized responses; `CommandResult.pending` signals consent in progress.
  - Registry and router updates: optional `phrases` on `@capability`, and `lock_screen` set to tier `notify_apply` for instant, announced execution.

<sup>Written for commit 6f9a27caf60b04943c099e81f3c66dbbe550f8d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

