### PR TITLE
feat(hud): contextual awareness, and an authority that works through a locked screen

### DIFF
--- a/JARVIS-Apple/JARVIS-Apple.xcodeproj/project.pbxproj
+++ b/JARVIS-Apple/JARVIS-Apple.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		4E11F20BF61331B7C669DA94 /* CompactHeaderBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE156A6B63F5362F9FD12522 /* CompactHeaderBar.swift */; };
 		4F5C877D32A55EC0E8F6F224 /* JARVISPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8C21EBA8B80C1A39D30C8A /* JARVISPanel.swift */; };
 		57B50BAE6FB2347BD92BA512 /* PhoneSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE05089C690A3B7B63861CF9 /* PhoneSessionManager.swift */; };
+		67836362453377C25CE3CB3D /* SecureConsent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95D0EF17C00CB1001F596D74 /* SecureConsent.swift */; };
 		6A6DE9BC09C7393AC5D3BFDA /* JARVISHUDApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F9345DF8825258B0773BAA5 /* JARVISHUDApp.swift */; };
 		787D831FBA5AA3338F9BC38C /* PairingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E75506CB26E637E4674ED069 /* PairingView.swift */; };
 		7E167813DA477376FA50A02A /* WakeWordListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62C68475EAAD735E3FB66AAE /* WakeWordListener.swift */; };
@@ -24,13 +25,13 @@
 		95909137A4CE7F24654D6776 /* JARVISKit in Frameworks */ = {isa = PBXBuildFile; productRef = 31F47BC187C21A0EAA566686 /* JARVISKit */; };
 		9675A57D67D07E9D157B8468 /* JARVISPhoneApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 698E4531C1F4FD5A0215C9B1 /* JARVISPhoneApp.swift */; };
 		993234F1A4D7A1BCA27374BB /* BrainstemLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6A777442955E499D4E22D3B /* BrainstemLauncher.swift */; };
-		5EC04E11A2B3C4D5E6F70002 /* SecureConsent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC04E11A2B3C4D5E6F70001 /* SecureConsent.swift */; };
-		5EC04E11A2B3C4D5E6F70004 /* MicSuppression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC04E11A2B3C4D5E6F70003 /* MicSuppression.swift */; };
 		99C3D3109F5801D5ED6F638A /* HapticEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 266CC1C8FBBB302AD623A3D9 /* HapticEngine.swift */; };
 		9FC588C57049591237CF032F /* HUDView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A0A5C4460F31FD5CB53DD10 /* HUDView.swift */; };
 		A0BD7790CE0BF3EDAC6D6372 /* ArcReactorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26744ECD2240E57AF517188D /* ArcReactorView.swift */; };
+		A348802554BD9C09EE824952 /* UtteranceRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86A3C5DDD4D1D44D8569C39B /* UtteranceRecorder.swift */; };
 		ADEA3EDEC8E9800EB2E4B351 /* JARVISKit in Frameworks */ = {isa = PBXBuildFile; productRef = 15EECA930D551D91AC5C18B4 /* JARVISKit */; };
 		B382A284A476CA2ACA805D56 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4A8BD3E8642F43ADBDD9BB1 /* SettingsView.swift */; };
+		C2EAD5E8889A90385FDA3E14 /* MicSuppression.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2FEA2CE20F48E377D68D971 /* MicSuppression.swift */; };
 		D3F64926FE39007A1202CB78 /* ScreenCaptureService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F97771D9894460348ABB0ED /* ScreenCaptureService.swift */; };
 		D6F51E777605C3FDFADC38B7 /* PRQueueView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 363CFA575B249D1A15B71B0E /* PRQueueView.swift */; };
 		DC553908F1A143513C3F8D48 /* JARVISColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = C953EA1271F55784A7D1004B /* JARVISColors.swift */; };
@@ -47,6 +48,7 @@
 		2445A32150108499C49E55C8 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		266CC1C8FBBB302AD623A3D9 /* HapticEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticEngine.swift; sourceTree = "<group>"; };
 		26744ECD2240E57AF517188D /* ArcReactorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArcReactorView.swift; sourceTree = "<group>"; };
+		2AD0E9678194BFE8A1EC9B1B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		34F82AD2C9BC90F1C2C04004 /* ActiveCommandView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveCommandView.swift; sourceTree = "<group>"; };
 		363CFA575B249D1A15B71B0E /* PRQueueView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PRQueueView.swift; sourceTree = "<group>"; };
 		419C0FA1835D967E34A0FA5F /* CommandInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandInputView.swift; sourceTree = "<group>"; };
@@ -60,10 +62,11 @@
 		7F9345DF8825258B0773BAA5 /* JARVISHUDApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JARVISHUDApp.swift; sourceTree = "<group>"; };
 		7F97771D9894460348ABB0ED /* ScreenCaptureService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenCaptureService.swift; sourceTree = "<group>"; };
 		853E0D7E9218220610520FB8 /* StatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusView.swift; sourceTree = "<group>"; };
+		86A3C5DDD4D1D44D8569C39B /* UtteranceRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtteranceRecorder.swift; sourceTree = "<group>"; };
 		899F7DC5BF2FA227AA8CEA81 /* LivingBorderWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LivingBorderWindow.swift; sourceTree = "<group>"; };
+		95D0EF17C00CB1001F596D74 /* SecureConsent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConsent.swift; sourceTree = "<group>"; };
+		A2FEA2CE20F48E377D68D971 /* MicSuppression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicSuppression.swift; sourceTree = "<group>"; };
 		A6A777442955E499D4E22D3B /* BrainstemLauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrainstemLauncher.swift; sourceTree = "<group>"; };
-		5EC04E11A2B3C4D5E6F70001 /* SecureConsent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureConsent.swift; sourceTree = "<group>"; };
-		5EC04E11A2B3C4D5E6F70003 /* MicSuppression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicSuppression.swift; sourceTree = "<group>"; };
 		AF2D1789D766C67E4B4A3D2A /* JARVISHUD.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JARVISHUD.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B91850E89902256710524BEA /* LoadingHUDView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingHUDView.swift; sourceTree = "<group>"; };
 		BD8C21EBA8B80C1A39D30C8A /* JARVISPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JARVISPanel.swift; sourceTree = "<group>"; };
@@ -119,9 +122,10 @@
 		1DBE12D0C8C5C68320118845 /* JARVISHUD */ = {
 			isa = PBXGroup;
 			children = (
+				2AD0E9678194BFE8A1EC9B1B /* Info.plist */,
 				6A73D85D2FBC6659D4A47810 /* JARVISHUD.entitlements */,
 				7F9345DF8825258B0773BAA5 /* JARVISHUDApp.swift */,
-				60EB61052FAABA85FE48EEDA /* Models */,
+				F9DF9FDDEC7F5849BAF5A642 /* .claude */,
 				4C449CDADB043C7331150D64 /* Services */,
 				243C003B3193F42692D7BF8F /* Views */,
 			);
@@ -169,9 +173,10 @@
 			children = (
 				4784C00A28BAB42B47C1A4F1 /* AppState.swift */,
 				A6A777442955E499D4E22D3B /* BrainstemLauncher.swift */,
+				A2FEA2CE20F48E377D68D971 /* MicSuppression.swift */,
 				7F97771D9894460348ABB0ED /* ScreenCaptureService.swift */,
-				5EC04E11A2B3C4D5E6F70001 /* SecureConsent.swift */,
-				5EC04E11A2B3C4D5E6F70003 /* MicSuppression.swift */,
+				95D0EF17C00CB1001F596D74 /* SecureConsent.swift */,
+				86A3C5DDD4D1D44D8569C39B /* UtteranceRecorder.swift */,
 				62C68475EAAD735E3FB66AAE /* WakeWordListener.swift */,
 			);
 			path = Services;
@@ -185,6 +190,13 @@
 			path = Shared;
 			sourceTree = "<group>";
 		};
+		5322F8483534485E0A88943F /* .cc-writes */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = ".cc-writes";
+			sourceTree = "<group>";
+		};
 		58867042BBEE470FD16CA4E2 /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -193,13 +205,6 @@
 				496ADA6BEACAC0F28324C87E /* JARVISWatch.app */,
 			);
 			name = Products;
-			sourceTree = "<group>";
-		};
-		60EB61052FAABA85FE48EEDA /* Models */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Models;
 			sourceTree = "<group>";
 		};
 		66E3F536A76F4EB881573CD9 /* JARVISWatch */ = {
@@ -260,6 +265,14 @@
 				CE05089C690A3B7B63861CF9 /* PhoneSessionManager.swift */,
 			);
 			path = Services;
+			sourceTree = "<group>";
+		};
+		F9DF9FDDEC7F5849BAF5A642 /* .claude */ = {
+			isa = PBXGroup;
+			children = (
+				5322F8483534485E0A88943F /* .cc-writes */,
+			);
+			path = .claude;
 			sourceTree = "<group>";
 		};
 		FC6CA73ACD325BAEB067CCC8 /* Views */ = {
@@ -419,10 +432,11 @@
 				8CA64BEF2D84BA9055DCC700 /* JARVISPulseView.swift in Sources */,
 				FBBDB0313A52CEA7D67AFF62 /* LivingBorderWindow.swift in Sources */,
 				F2372C4356B52F4C5EE16B1C /* LoadingHUDView.swift in Sources */,
+				C2EAD5E8889A90385FDA3E14 /* MicSuppression.swift in Sources */,
 				D3F64926FE39007A1202CB78 /* ScreenCaptureService.swift in Sources */,
-				5EC04E11A2B3C4D5E6F70002 /* SecureConsent.swift in Sources */,
-				5EC04E11A2B3C4D5E6F70004 /* MicSuppression.swift in Sources */,
+				67836362453377C25CE3CB3D /* SecureConsent.swift in Sources */,
 				8343F8E9601E5B1F4058448D /* TransparentWindow.swift in Sources */,
+				A348802554BD9C09EE824952 /* UtteranceRecorder.swift in Sources */,
 				7E167813DA477376FA50A02A /* WakeWordListener.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -493,8 +507,10 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = T27T6WH789;
-				GENERATE_INFOPLIST_FILE = NO;
+				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = JARVISHUD/Info.plist;
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "JARVIS needs microphone access for voice commands — say Hey JARVIS to activate";
+				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "JARVIS uses on-device speech recognition for wake word detection";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -516,8 +532,10 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = T27T6WH789;
-				GENERATE_INFOPLIST_FILE = NO;
+				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = JARVISHUD/Info.plist;
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "JARVIS needs microphone access for voice commands — say Hey JARVIS to activate";
+				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "JARVIS uses on-device speech recognition for wake word detection";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",

--- a/JARVIS-Apple/JARVIS-Apple.xcodeproj/xcshareddata/xcschemes/JARVISHUD.xcscheme
+++ b/JARVIS-Apple/JARVIS-Apple.xcodeproj/xcshareddata/xcschemes/JARVISHUD.xcscheme
@@ -65,11 +65,6 @@
       </CommandLineArguments>
       <EnvironmentVariables>
          <EnvironmentVariable
-            key = "OS_ACTIVITY_MODE"
-            value = "disable"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
             key = "JARVIS_DEVICE_ID"
             value = "mac-m1-derek"
             isEnabled = "YES">
@@ -82,6 +77,11 @@
          <EnvironmentVariable
             key = "JARVIS_VERCEL_URL"
             value = "https://jarvis-cloud-five.vercel.app"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "OS_ACTIVITY_MODE"
+            value = "disable"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>

--- a/JARVIS-Apple/JARVISHUD/JARVISHUDApp.swift
+++ b/JARVIS-Apple/JARVISHUD/JARVISHUDApp.swift
@@ -107,7 +107,7 @@ class HUDAppDelegate: NSObject, NSApplicationDelegate, AVSpeechSynthesizerDelega
 
         // ALL commands route through local IPC (brainstem backend).
         // Vercel cloud is disabled (402). IPC is the PRIMARY and ONLY path.
-        wakeWord.onCommand = { [weak self] command in
+        wakeWord.onCommand = { [weak self] command, utteranceAudio in
             guard let self else { return }
             print("[JARVIS] Voice command: \"\(command)\"")
 
@@ -166,6 +166,26 @@ class HUDAppDelegate: NSObject, NSApplicationDelegate, AVSpeechSynthesizerDelega
                 if let b64 = await ScreenCaptureService.shared.captureFresh() {
                     actionPayload["screenshot"] = b64
                     print("[JARVIS] Screenshot attached (\(b64.count / 1024)KB)")
+                }
+
+                // Attach the audio of the sentence itself.
+                //
+                // Until now Python received only the TRANSCRIPT, which is why
+                // speaker verification could not be the authority for
+                // `unlock_screen` — the one authority that works through a
+                // locked screen had no evidence to work from. It is also what
+                // enrollment needs: you cannot build a voiceprint from text.
+                //
+                // Sent on the existing `action` event rather than a new
+                // request/response pair. A screenshot of the entire desktop
+                // already travels on this wire; a few seconds of speech the
+                // operator deliberately addressed to the assistant is strictly
+                // less than that, and a second event type would be a second
+                // place for the two sides to fall out of step.
+                if let utteranceAudio {
+                    actionPayload["utterance_audio"] = utteranceAudio
+                    actionPayload["utterance_audio_format"] = "wav16k_b64"
+                    print("[JARVIS] Utterance audio attached (\(utteranceAudio.count / 1024)KB)")
                 }
 
                 BrainstemLauncher.shared.sendEvent(

--- a/JARVIS-Apple/JARVISHUD/Services/UtteranceRecorder.swift
+++ b/JARVIS-Apple/JARVISHUD/Services/UtteranceRecorder.swift
@@ -1,0 +1,170 @@
+//  UtteranceRecorder.swift
+//  JARVISHUD
+//
+//  Keeps the audio of the sentence you just said, so something other than the
+//  speech recogniser can look at it.
+//
+//  WHY THIS EXISTS
+//  ---------------
+//  `unlock_screen` needs an authority that can answer through a locked screen.
+//  Touch ID cannot — there is no surface to draw a dialog on, which is why the
+//  verdict came back DENIED 99ms after the request and the log said "operator
+//  declined" for a prompt nobody saw. A microphone works through a locked
+//  screen, so speaker verification is the authority that fits. But the backend
+//  has never had a single sample of audio: the tap feeds
+//  `SFSpeechAudioBufferRecognitionRequest` and nothing else, so Python only
+//  ever receives the TEXT of what was said.
+//
+//  This is that missing wire. It is also what enrollment needs — you cannot
+//  build a voiceprint from a transcript.
+//
+//  REAL-TIME DISCIPLINE
+//  --------------------
+//  `append` is called from the audio render callback. That thread must not
+//  allocate, must not lock, and must not block, or the price is dropped audio
+//  — the `HALC_ProxyIOContext::IOWorkLoop: skipping cycle due to overload`
+//  lines already in the log. So:
+//
+//    * the buffer is allocated ONCE, when the engine format is known;
+//    * `append` does a bounds check and a `memcpy`, nothing else;
+//    * it stops writing when full rather than shifting, because sliding a
+//      2MB window on a render callback is how you turn a voice assistant into
+//      a stutter.
+//
+//  Everything expensive — resampling, WAV framing, base64 — happens in
+//  `finish()`, which is called from a normal queue after the sentence ends.
+//
+//  WHAT IT DELIBERATELY DOES NOT DO
+//  ---------------------------------
+//  It never writes audio to disk. A file would outlive the question it was
+//  captured to answer, and the one thing worse than a Mac that will not unlock
+//  is a Mac with a folder full of recordings of its owner. The bytes live in
+//  one preallocated buffer, are overwritten by the next sentence, and are
+//  handed up exactly once.
+//
+//  It also records nothing while `micMuted` is set, because the caller appends
+//  behind the same gate that keeps JARVIS's own voice out of the recogniser.
+//  A verifier trained on the assistant's synthesiser is its own kind of funny.
+
+import Foundation
+import AVFoundation
+
+final class UtteranceRecorder: @unchecked Sendable {
+
+    /// Longest sentence we keep. A spoken command that runs past this is
+    /// truncated rather than dropped — the opening seconds are the part a
+    /// verifier wants, and a partial sample beats no sample.
+    private let maxSeconds: Double = 12.0
+
+    /// What the speaker-verification model expects. 16 kHz mono is the
+    /// standard input rate for x-vector/ECAPA style embeddings; sending 48 kHz
+    /// would make the backend resample, and resampling in the process that did
+    /// not capture it is how sample-rate bugs become somebody else's.
+    private let targetRate: Double = 16_000
+
+    private var storage: UnsafeMutablePointer<Float>?
+    private var capacity: Int = 0
+    private var count: Int = 0
+    private var sourceFormat: AVAudioFormat?
+
+    deinit { storage?.deallocate() }
+
+    /// Prepare for a new sentence at `format`. Allocates only when the shape
+    /// changes — a headphone swap changes the hardware rate, and reallocating
+    /// on every restart would churn a megabyte several times a minute.
+    func begin(format: AVAudioFormat) {
+        let needed = Int(format.sampleRate * maxSeconds)
+        if storage == nil || capacity != needed {
+            storage?.deallocate()
+            storage = UnsafeMutablePointer<Float>.allocate(capacity: max(1, needed))
+            capacity = max(1, needed)
+        }
+        sourceFormat = format
+        count = 0
+    }
+
+    /// Append one tap buffer. CALLED ON THE AUDIO RENDER THREAD.
+    ///
+    /// No allocation, no locking, no logging. `count` is written here and read
+    /// in `finish()` after the engine has been torn down, so the two never
+    /// overlap; a torn read would cost a few frames at the tail of a sample,
+    /// which is not worth a lock on this thread.
+    func append(_ buffer: AVAudioPCMBuffer) {
+        guard let dst = storage,
+              let src = buffer.floatChannelData?[0] else { return }
+        let frames = Int(buffer.frameLength)
+        guard frames > 0, count < capacity else { return }
+        let room = min(frames, capacity - count)
+        dst.advanced(by: count).update(from: src, count: room)
+        count += room
+    }
+
+    var hasAudio: Bool { count > 0 }
+
+    /// The captured sentence as base64 WAV at `targetRate`, or nil.
+    ///
+    /// Call OFF the audio thread. Downsamples with a box filter across the
+    /// decimation window rather than picking every Nth sample: plain
+    /// decimation folds everything above 8 kHz back into the band a speaker
+    /// embedding is computed from, and the artefacts it produces are exactly
+    /// the kind a verifier reads as "different person".
+    func finish() -> String? {
+        guard let src = storage, count > 0, let format = sourceFormat else { return nil }
+        let sourceRate = format.sampleRate
+        guard sourceRate > 0 else { return nil }
+
+        let ratio = sourceRate / targetRate
+        guard ratio >= 1.0 else { return nil }          // never upsample
+        let outCount = Int(Double(count) / ratio)
+        guard outCount > 0 else { return nil }
+
+        var pcm = [Int16](repeating: 0, count: outCount)
+        for i in 0..<outCount {
+            let start = Int(Double(i) * ratio)
+            let end = min(count, Int(Double(i + 1) * ratio))
+            guard start < end else { continue }
+            var sum: Float = 0
+            for j in start..<end { sum += src[j] }
+            let mean = sum / Float(end - start)
+            // Clamp BEFORE scaling. A float sample can legitimately exceed
+            // ±1.0 after mixing, and letting that wrap produces a click that
+            // reads as a consonant.
+            let clamped = max(-1.0, min(1.0, mean))
+            pcm[i] = Int16(clamped * 32767.0)
+        }
+        count = 0                                        // hand it up exactly once
+        return Self.wav(pcm, sampleRate: Int(targetRate)).base64EncodedString()
+    }
+
+    /// Discard whatever was captured. Used when a sentence turns out not to be
+    /// a command — there is no reason to keep audio nobody asked a question of.
+    func discard() { count = 0 }
+
+    /// Minimal 16-bit mono RIFF/WAVE. Written by hand rather than via
+    /// `AVAudioFile` because that writes to a URL, and the whole point is that
+    /// this audio never touches a filesystem.
+    private static func wav(_ samples: [Int16], sampleRate: Int) -> Data {
+        let dataBytes = samples.count * 2
+        var d = Data(capacity: 44 + dataBytes)
+        func u32(_ v: UInt32) { withUnsafeBytes(of: v.littleEndian) { d.append(contentsOf: $0) } }
+        func u16(_ v: UInt16) { withUnsafeBytes(of: v.littleEndian) { d.append(contentsOf: $0) } }
+
+        d.append(contentsOf: Array("RIFF".utf8))
+        u32(UInt32(36 + dataBytes))
+        d.append(contentsOf: Array("WAVE".utf8))
+        d.append(contentsOf: Array("fmt ".utf8))
+        u32(16)                                   // PCM header size
+        u16(1)                                    // format = PCM
+        u16(1)                                    // channels = mono
+        u32(UInt32(sampleRate))
+        u32(UInt32(sampleRate * 2))               // byte rate
+        u16(2)                                    // block align
+        u16(16)                                   // bits per sample
+        d.append(contentsOf: Array("data".utf8))
+        u32(UInt32(dataBytes))
+        samples.withUnsafeBufferPointer { buf in
+            buf.baseAddress.map { d.append(UnsafeBufferPointer(start: $0, count: buf.count)) }
+        }
+        return d
+    }
+}

--- a/JARVIS-Apple/JARVISHUD/Services/WakeWordListener.swift
+++ b/JARVIS-Apple/JARVISHUD/Services/WakeWordListener.swift
@@ -15,7 +15,17 @@ final class WakeWordListener: ObservableObject, @unchecked Sendable {
     @Published var state: State = .off
     @Published var partialTranscript: String = ""
 
-    var onCommand: ((String) -> Void)?
+    /// The command, and the audio of the sentence that produced it.
+    ///
+    /// The audio is base64 WAV and may be nil — the recogniser can finalise a
+    /// command from a partial transcript after the tap has already been torn
+    /// down, and a missing sample must degrade to "cannot verify", never to a
+    /// crash or to a silently unverified unlock.
+    var onCommand: ((String, String?) -> Void)?
+
+    /// Keeps the audio of the current sentence. See `UtteranceRecorder` for
+    /// why it lives beside the tap and never touches a filesystem.
+    private let recorder = UtteranceRecorder()
 
     private let wakeWords = ["jarvis", "hey jarvis", "yo jarvis"]
     private let audioQueue = DispatchQueue(label: "com.jarvis.hud.audio", qos: .userInitiated)
@@ -117,6 +127,11 @@ final class WakeWordListener: ObservableObject, @unchecked Sendable {
         }
 
         print("[JARVIS Voice] Audio format: \(format.sampleRate)Hz, \(format.channelCount)ch")
+
+        // Sized to THIS engine's format. The hardware rate changes when the
+        // route does — AirPods in, display speakers out — and a buffer sized
+        // for the previous device would truncate or over-read.
+        recorder.begin(format: format)
 
         // Track state with simple character offset (NOT String.Index)
         var wakeWordFound = false
@@ -236,6 +251,12 @@ final class WakeWordListener: ObservableObject, @unchecked Sendable {
             guard self?.micMuted != true else { return }
             guard buffer.frameLength > 0 else { return }
             req.append(buffer)
+            // Recorded BEHIND the same gate, deliberately. Everything the
+            // recogniser is allowed to hear, the verifier may hear; everything
+            // suppressed as JARVIS's own voice is suppressed here too. A
+            // voiceprint contaminated with the assistant's synthesiser is a
+            // verifier being taught that JARVIS is its owner.
+            self?.recorder.append(buffer)
         }
 
         do {
@@ -309,12 +330,19 @@ final class WakeWordListener: ObservableObject, @unchecked Sendable {
 
     private func finalize(_ command: String) {
         print("[JARVIS Voice] >>> \"\(command)\"")
+        // Drained HERE, before teardown, and off the render thread. `finish()`
+        // resamples and frames a WAV, which is far too much work for the audio
+        // callback and perfectly cheap once the sentence is over.
+        let audio = recorder.finish()
+        if let audio {
+            print("[JARVIS Voice] utterance captured (\(audio.count / 1024)KB base64)")
+        }
         DispatchQueue.main.async { [weak self] in
             self?.silenceTimer?.invalidate()
             self?.silenceTimer = nil
             self?.state = .cooldown
             self?.partialTranscript = ""
-            self?.onCommand?(command)
+            self?.onCommand?(command, audio)
         }
         audioQueue.async { [weak self] in
             self?.teardown()
@@ -326,6 +354,11 @@ final class WakeWordListener: ObservableObject, @unchecked Sendable {
     }
 
     private func restart(delay: TimeInterval) {
+        // A restart means no command came of this audio, so there is no
+        // question for it to answer. Dropped rather than carried into the next
+        // sentence — a verifier handed the tail of an abandoned utterance is
+        // being asked about the wrong moment.
+        recorder.discard()
         audioQueue.async { [weak self] in self?.teardown() }
         DispatchQueue.main.async { [weak self] in
             // Stay in .listening during normal restarts — no visible flicker.

--- a/JARVIS-Apple/project.yml
+++ b/JARVIS-Apple/project.yml
@@ -101,6 +101,12 @@ schemes:
     run:
       config: Debug
       environmentVariables:
+        # Suppresses the OSLog firehose in the Xcode console. This existed in
+        # the .xcscheme but NOT here, so `xcodegen generate` deleted it — the
+        # generator rebuilds the scheme from this file, and anything only in
+        # the generated artefact is not a setting, it is a countdown. Recorded
+        # at the source so it survives the next regeneration.
+        OS_ACTIVITY_MODE: disable
         JARVIS_DEVICE_ID: mac-m1-derek
         JARVIS_DEVICE_SECRET: b110e2fd04a9baf2d5923373929af3a06e7abac06168120f063a05329de7151d
         JARVIS_VERCEL_URL: https://jarvis-cloud-five.vercel.app

--- a/backend/hud/consent_bridge.py
+++ b/backend/hud/consent_bridge.py
@@ -64,11 +64,39 @@ def hud_consent_enabled() -> bool:
 class HUDConsentProvider:
     """An `ApprovalProvider` that asks the signed HUD over the IPC. NEVER raises.
 
+    THIS CHANNEL HAS A PRECONDITION
+    ---------------------------------
+    `requires` is the world state this channel needs in order to be ANSWERABLE
+    at all. Touch ID draws a system dialog, and there is no surface to draw on
+    while the screen is locked.
+
+    That is not a theoretical concern. Measured on 2026-08-03 at 00:18:58, an
+    operator said "unlock my screen":
+
+        [HUD] Voice result: awaiting-consent
+        [Brainstem] sendEvent: consent_verdict (249 bytes)      +99ms
+        [HUD] consent verdict for unlock_screen → denied (operator declined)
+
+    Ninety-nine milliseconds. No human declined anything — `canEvaluatePolicy`
+    failed instantly because the screen was locked, and the router rendered it
+    as a refusal the operator does not remember giving.
+
+    So `unlock_screen` could never be authorised through this channel, ever, by
+    construction: **a gate whose only answer channel requires the very state
+    the gated action exists to produce is a deadlock, not a safeguard.**
+
+    Declaring the precondition lets `CapabilityRouter` see that before it
+    suspends, and refuse with the real reason instead of parking a call nothing
+    can answer.
+
     Implements `request` only. `approve`, `reject` and `await_decision` are
     absent on purpose: the verdict arrives as an inbound IPC event and goes
     straight to `CapabilityRouter.resume`, so a second path for the same answer
     would be a second place for the nonce check to be forgotten.
     """
+
+    #: World-state predicates that must hold for this channel to reach a human.
+    requires = ("screen_unlocked",)
 
     def __init__(self, publish: Optional[Callable[[str, Dict[str, Any]], int]] = None) -> None:
         self._publish = publish
@@ -145,6 +173,64 @@ class HUDConsentProvider:
                 "unreachable": self._unreachable, "hud_clients": connected}
 
 
+class VoiceConsentProvider:
+    """Consent by speaker verification. Reachable through a locked screen.
+
+    NEVER raises. The counterpart to `HUDConsentProvider`: same interface, no
+    `requires`, because a microphone does not need a screen to be unlocked.
+
+    IMMEDIATE, NOT SUSPENDED
+    --------------------------
+    Touch ID suspends because a human takes an unbounded amount of time to
+    answer. This does not: the operator ALREADY answered — they spoke, and the
+    evidence was captured with the command. Verification is a local
+    computation on bytes we hold, so it resolves inside the turn.
+
+    That is why this returns a decision rather than a request id, and why
+    `CapabilityRouter` treats it as a distinct kind of authority. Suspending on
+    it would park a call waiting for a human who has nothing left to do.
+    """
+
+    #: Nothing. A microphone works through a locked screen — that is the whole
+    #: reason this authority exists.
+    requires: tuple = ()
+    immediate: bool = True
+
+    def __init__(self) -> None:
+        self._verified = 0
+        self._refused = 0
+
+    async def decide(self, ctx: Any) -> Any:
+        """Verify the held utterance and answer. NEVER raises."""
+        try:
+            from backend.hud.utterance_audio import get_utterance_holder
+            from backend.hud.voice_identity import get_voice_identity
+            held = get_utterance_holder().claim()
+            ident = await get_voice_identity().identify(
+                held.audio if held else None,
+                sample=held.digest if held else "")
+            if ident.approves:
+                self._verified += 1
+            else:
+                self._refused += 1
+            logger.info("[VoiceConsent] '%s' → %s (%s)",
+                        getattr(ctx, "capability", "?"), ident.verdict,
+                        ident.detail or "-")
+            return ident
+        except Exception as exc:  # noqa: BLE001 — a fault is never consent
+            logger.error("[VoiceConsent] degraded: %s", exc)
+            return None
+
+    def stats(self) -> Dict[str, Any]:
+        try:
+            from backend.hud.voice_identity import get_voice_identity
+            v = get_voice_identity().stats()
+        except Exception:  # noqa: BLE001
+            v = {}
+        return {"verified": self._verified, "refused": self._refused,
+                "identity": v}
+
+
 def install(router: Any = None) -> bool:
     """Give the capability router a way to ask. Idempotent. NEVER raises.
 
@@ -165,6 +251,33 @@ def install(router: Any = None) -> bool:
         router._provider = HUDConsentProvider()
         logger.info("[HUDConsent] installed — gated capabilities will now "
                     "prompt for Touch ID on the signed HUD")
+
+        # The authority that answers when Touch ID cannot.
+        #
+        # Registered as a FALLBACK, never a replacement: the router consults it
+        # only after finding the primary channel unreachable, so while a prompt
+        # could have been shown to the operator it still is. Without this,
+        # `unlock_screen` is a gate that can only ever refuse itself.
+        #
+        # Warming starts here rather than at first use because the model took
+        # over 150 seconds to load when measured, and the utterance it would
+        # verify expires in thirty.
+        try:
+            import asyncio as _aio
+            router.add_authority(VoiceConsentProvider())
+            from backend.hud.voice_identity import get_voice_identity
+            ident = get_voice_identity()
+            # `warm()` rather than `start_warming()`: enrollment is a single
+            # database row and resolves in milliseconds, while the speaker
+            # model takes minutes. Asking both at boot means the organism knows
+            # WHO it would be checking for long before it can check — which is
+            # the difference between "give me a moment" and "I don't know you".
+            _aio.get_event_loop().create_task(ident.warm())
+            logger.info("[HUDConsent] voice authority installed — reachable "
+                        "through a locked screen; enrollment + speaker model "
+                        "resolving in the background")
+        except Exception as _va:  # noqa: BLE001
+            logger.error("[HUDConsent] voice authority unavailable: %s", _va)
         return True
     except Exception:  # noqa: BLE001
         logger.error("[HUDConsent] install failed — gated capabilities will "

--- a/backend/hud/utterance_audio.py
+++ b/backend/hud/utterance_audio.py
@@ -1,0 +1,238 @@
+"""The audio of the sentence just spoken — held briefly, for one question.
+
+WHY A HOLDER AND NOT AN ARGUMENT
+----------------------------------
+The obvious design threads the bytes through `route(command, screenshot,
+audio)` down to whatever needs them. It does not survive contact with the
+consent flow: a gated capability SUSPENDS, the turn ends, and the verdict
+arrives out of band through `CapabilityRouter.resume` — a completely different
+call stack with no relationship to the one that had the audio. Threading it
+would mean either parking bytes inside the suspension record (audio living as
+long as a 900-second consent TTL) or plumbing it through every intermediate
+signature that has no business seeing it.
+
+So the audio is deposited here and claimed by name, with a lifetime measured
+in seconds rather than in call frames.
+
+WHAT THIS REFUSES TO DO
+-------------------------
+* **Never writes to disk.** A file outlives the question it was captured to
+  answer. The one thing worse than a Mac that will not unlock is a Mac with a
+  folder full of recordings of its owner.
+* **Never logs the bytes**, or any prefix of them. Sizes and hashes only.
+* **Claim is destructive.** `claim()` removes what it returns, so one
+  utterance answers one question. A verifier cannot be handed the same sample
+  twice, which is the shape of a replay.
+* **Expires on a clock, not on use.** If nothing ever claims it, it still goes
+  away. The failure mode of a hold-until-claimed design is audio that lives
+  forever because the consumer crashed.
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import logging
+import os
+import threading
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+logger = logging.getLogger("JARVIS.UtteranceAudio")
+
+UTTERANCE_AUDIO_SCHEMA_VERSION: str = "utterance_audio.v1"
+
+#: The only format the Swift recorder emits. Named so a future second format
+#: must be added deliberately rather than arriving as an unvalidated string.
+FORMAT_WAV16K = "wav16k_b64"
+
+
+def max_bytes() -> int:
+    """Largest utterance accepted, decoded. NEVER raises.
+
+    12 seconds of 16 kHz mono PCM16 is ~384 KB, so this is generous by design
+    and still bounded — the field arrives over a socket and a size limit is the
+    cheapest defence against a payload that is not what it claims to be.
+    """
+    try:
+        raw = (os.environ.get("JARVIS_UTTERANCE_MAX_BYTES", "") or "").strip()
+        return max(1024, min(8 * 1024 * 1024, int(raw))) if raw else 2 * 1024 * 1024
+    except (TypeError, ValueError):
+        return 2 * 1024 * 1024
+
+
+def ttl_s() -> float:
+    """How long a held utterance stays claimable. NEVER raises.
+
+    Long enough to cover speaker verification on a warm model plus the IPC
+    round-trip; far too short for the audio to still be around when the next
+    person sits down at the machine.
+    """
+    try:
+        raw = (os.environ.get("JARVIS_UTTERANCE_TTL_S", "") or "").strip()
+        return max(1.0, min(120.0, float(raw))) if raw else 30.0
+    except (TypeError, ValueError):
+        return 30.0
+
+
+@dataclass
+class Utterance:
+    """One captured sentence. The bytes, and nothing that identifies them."""
+
+    audio: bytes
+    fmt: str
+    captured_at: float
+    #: First 8 hex chars of the sha256. For correlating a verification result
+    #: with the sample it came from in a log, without the log containing any
+    #: part of the sample.
+    digest: str = ""
+
+    @property
+    def age_s(self) -> float:
+        return max(0.0, time.time() - self.captured_at)
+
+    @property
+    def expired(self) -> bool:
+        return self.age_s > ttl_s()
+
+    def __repr__(self) -> str:  # never let bytes reach a log by accident
+        return (f"<Utterance {len(self.audio)}B {self.fmt} "
+                f"sha={self.digest} age={self.age_s:.1f}s>")
+
+
+class UtteranceHolder:
+    """Holds at most ONE utterance. NEVER raises.
+
+    One rather than a queue: the question being asked is always "who just
+    spoke", and a backlog of older samples is a set of answers to questions
+    nobody is asking any more.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._held: Optional[Utterance] = None
+        self._deposits = 0
+        self._claims = 0
+        self._rejected = 0
+
+    def deposit(self, audio_b64: str, fmt: str = FORMAT_WAV16K) -> bool:
+        """Take custody of a base64 utterance. NEVER raises.
+
+        Returns whether it was accepted. Rejection is silent to the operator
+        and loud in the log: a malformed sample means verification will be
+        impossible in a moment, and the reason wants to be findable then.
+        """
+        try:
+            if not audio_b64:
+                return False
+            if fmt != FORMAT_WAV16K:
+                self._rejected += 1
+                logger.warning("[Utterance] rejected unknown format %r", fmt)
+                return False
+            # Validate BEFORE holding. Storing bytes that turn out not to be
+            # decodable means the failure surfaces at verification time, which
+            # is the worst possible moment to discover it.
+            try:
+                raw = base64.b64decode(audio_b64, validate=True)
+            except (binascii.Error, ValueError):
+                self._rejected += 1
+                logger.warning("[Utterance] rejected undecodable base64 "
+                               "(%d chars)", len(audio_b64))
+                return False
+            if not raw or len(raw) > max_bytes():
+                self._rejected += 1
+                logger.warning("[Utterance] rejected %d bytes (limit %d)",
+                               len(raw), max_bytes())
+                return False
+            if not raw.startswith(b"RIFF"):
+                self._rejected += 1
+                logger.warning("[Utterance] rejected: not a RIFF/WAVE payload")
+                return False
+            u = Utterance(audio=raw, fmt=fmt, captured_at=time.time(),
+                          digest=hashlib.sha256(raw).hexdigest()[:8])
+            with self._lock:
+                self._held = u
+                self._deposits += 1
+            logger.info("[Utterance] held %s", u)
+            return True
+        except Exception:  # noqa: BLE001 — audio never breaks a command
+            logger.debug("[Utterance] deposit degraded", exc_info=True)
+            return False
+
+    def claim(self) -> Optional[Utterance]:
+        """Take the held utterance, removing it. NEVER raises.
+
+        Destructive by design — one sentence answers one question. Returns
+        None when nothing is held or what was held has aged out, and those are
+        the same answer to a caller: there is no evidence to verify.
+        """
+        try:
+            with self._lock:
+                u, self._held = self._held, None
+            if u is None:
+                return None
+            if u.expired:
+                logger.info("[Utterance] discarded %s — older than %.0fs",
+                            u, ttl_s())
+                return None
+            self._claims += 1
+            return u
+        except Exception:  # noqa: BLE001
+            return None
+
+    def peek_age_s(self) -> Optional[float]:
+        """Age of what is held, without claiming it. NEVER raises.
+
+        For answering "could this be verified right now?" without consuming
+        the evidence that would answer it.
+        """
+        try:
+            with self._lock:
+                u = self._held
+            return None if u is None or u.expired else u.age_s
+        except Exception:  # noqa: BLE001
+            return None
+
+    def drop(self) -> None:
+        """Forget whatever is held. NEVER raises."""
+        try:
+            with self._lock:
+                self._held = None
+        except Exception:  # noqa: BLE001
+            pass
+
+    def stats(self) -> dict:
+        with self._lock:
+            held = self._held
+        return {
+            "schema_version": UTTERANCE_AUDIO_SCHEMA_VERSION,
+            "holding": held is not None and not held.expired,
+            "deposits": self._deposits,
+            "claims": self._claims,
+            "rejected": self._rejected,
+            "ttl_s": ttl_s(),
+            "max_bytes": max_bytes(),
+        }
+
+
+_HOLDER: Optional[UtteranceHolder] = None
+_HOLDER_LOCK = threading.Lock()
+
+
+def get_utterance_holder() -> UtteranceHolder:
+    """Process-wide holder. NEVER raises."""
+    global _HOLDER
+    with _HOLDER_LOCK:
+        if _HOLDER is None:
+            _HOLDER = UtteranceHolder()
+        return _HOLDER
+
+
+def reset_utterance_holder() -> None:
+    """Testing seam. NEVER raises."""
+    global _HOLDER
+    with _HOLDER_LOCK:
+        _HOLDER = None

--- a/backend/hud/voice_command_router.py
+++ b/backend/hud/voice_command_router.py
@@ -14,7 +14,9 @@ import json
 import logging
 import os
 import re
-from typing import Any, Optional
+import threading
+import time
+from typing import Any, List, Optional
 
 from backend.hud.applescript_executor import AppleScriptExecutor
 from backend.hud.query_executor import QueryExecutor
@@ -37,6 +39,144 @@ Categories:
 - "query": answer a question, provide information, no action needed (e.g., "what time is it", "what's on my screen", "how does the vision loop work")
 
 Return: {{"category": "...", "needs_vision": true/false, "needs_tools": true/false}}"""
+
+
+#: What JARVIS has said recently, as token sets, newest last. Bounded.
+_SPOKEN: List[tuple] = []
+_SPOKEN_LOCK = threading.Lock()
+
+
+def echo_grace_s() -> float:
+    """Extra time past the end of speech in which an echo can still arrive.
+
+    NEVER raises. Covers recogniser latency — the transcript of a phrase lands
+    after the phrase finished. ``0`` disables echo suppression entirely.
+    """
+    try:
+        raw = (os.environ.get("JARVIS_ECHO_GRACE_S", "") or "").strip()
+        return max(0.0, min(30.0, float(raw))) if raw else 1.5
+    except (TypeError, ValueError):
+        return 1.5
+
+
+def _echo_expiry(text: str) -> float:
+    """When this utterance stops being a plausible echo. NEVER raises.
+
+    Bounded by HOW LONG JARVIS ACTUALLY SPEAKS, not a flat window, and reusing
+    `speech_bridge.estimate_speech_ms` rather than a second estimate of the
+    same thing.
+
+    A flat window was wrong in a way that mattered. The pre-narration is "On
+    it — lock screen", which is precisely what an operator repeating
+    themselves also says, so a fixed 8s window deafened JARVIS to a genuine
+    second attempt for eight seconds after acknowledging the first. An echo
+    can only arrive while the audio is playing (plus recogniser latency); a
+    person repeating themselves waits for JARVIS to finish. Tying the window
+    to the utterance separates them.
+    """
+    try:
+        from backend.hud.speech_bridge import estimate_speech_ms
+        return time.time() + (estimate_speech_ms(text) / 1000.0) + echo_grace_s()
+    except Exception:  # noqa: BLE001
+        return time.time() + 3.0 + echo_grace_s()
+
+
+def reset_spoken() -> None:
+    """Forget what JARVIS has said. Testing seam. NEVER raises."""
+    try:
+        with _SPOKEN_LOCK:
+            _SPOKEN.clear()
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def note_spoken(text: str) -> None:
+    """Record that JARVIS said this. NEVER raises.
+
+    Called from the ONE place all HUD speech passes through, so nothing it
+    utters can be missed. Stores tokens rather than the sentence: speech
+    recognition returns "Lock screen" for a synthesiser that said "On it —
+    lock screen", and comparing strings would match neither.
+    """
+    try:
+        from backend.system_control.capability_reflex import content_tokens
+        toks = tuple(content_tokens(text or ""))
+        if not toks:
+            return
+        with _SPOKEN_LOCK:
+            # ORDER IS KEPT, not a set. See `is_own_echo` — order is the only
+            # thing separating an echo from a command that happens to reuse
+            # JARVIS's own words.
+            _SPOKEN.append((toks, _echo_expiry(text)))
+            del _SPOKEN[:-12]
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def is_own_echo(command: str) -> str:
+    """Whether JARVIS is hearing itself. "" when it is not. NEVER raises.
+
+    THE BUG THIS ANSWERS
+    ----------------------
+    Measured 2026-08-03: one spoken "lock my screen" locked the screen TWICE.
+
+        [SpeechGate] claim backend for 4.3s backend:system
+        [SpeechGate] EXPIRED backend — its owner never released it
+        [SpeechGate] mic LIVE
+        [JARVIS Voice] [partial] "Lock screen"        ← its own voice
+
+    `speech_bridge` derives a mute deadline from character count
+    (`1500ms + chars/12 * 1000`). That is an ESTIMATE of how long speech will
+    take, and when the synthesiser runs slower than the estimate the claim
+    expires mid-sentence, the microphone goes live, and JARVIS transcribes
+    itself. The deadline is deliberate — a claim on a microphone must never be
+    able to outlive its own plausible duration — so the answer is not a longer
+    guess; it is recognising the echo when it arrives.
+
+    ORDERED subsequence, not a subset — and the difference is not pedantry.
+    JARVIS's own contextual narration is "Your screen is locked, let me unlock
+    it first", which CONTAINS both `unlock` and `screen`. As a set test, that
+    sentence suppresses a genuine "unlock my screen" from the operator for the
+    whole window: the assistant explains what it is about to do and is thereby
+    deafened to the very command it just described. Caught by
+    `test_the_opposite_command_is_not_an_echo`.
+
+    In that sentence the words arrive as `screen … unlock`; a person asking
+    says `unlock … screen`. A recogniser mishearing a synthesiser drops words,
+    it does not reorder them — so order is exactly the signal that separates
+    an echo from a command reusing JARVIS's vocabulary.
+
+    Deliberately NOT a general repeat-suppressor. "volume up, volume up" is a
+    real thing a person does, and it only matches here if JARVIS itself said
+    "volume up", in that order, within the window.
+    """
+    try:
+        if echo_grace_s() <= 0.0:
+            return ""
+        from backend.system_control.capability_reflex import content_tokens
+        said = tuple(content_tokens(command or ""))
+        if not said:
+            return ""
+        now = time.time()
+        with _SPOKEN_LOCK:
+            live = [(t, exp) for t, exp in _SPOKEN if exp > now]
+            _SPOKEN[:] = live
+        for toks, exp in reversed(live):
+            if _ordered_within(said, toks):
+                return (f"JARVIS is still saying it "
+                        f"({exp - now:.1f}s left)")
+        return ""
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def _ordered_within(needle: tuple, haystack: tuple) -> bool:
+    """Whether *needle* appears in *haystack* in order. NEVER raises."""
+    try:
+        it = iter(haystack)
+        return all(any(h == n for h in it) for n in needle)
+    except Exception:  # noqa: BLE001
+        return False
 
 
 def _humanise(capability: str) -> str:
@@ -215,6 +355,15 @@ class VoiceCommandRouter:
         message.
         """
         logger.info("[VoiceRouter] Command: %s", command[:100])
+        # HEARING YOURSELF IS NOT BEING TOLD SOMETHING.
+        # Checked before the journal opens: an echo is not an intent, and
+        # recording one would put JARVIS's own voice in the replay queue.
+        _echo = is_own_echo(command)
+        if _echo:
+            logger.warning("[VoiceRouter] IGNORED '%s' — %s", command[:60], _echo)
+            return CommandResult(
+                success=True, category="ignored_echo", steps_completed=0,
+                steps_total=0, response_text=None, error=None)
         _journal = None
         reflex = None
         try:
@@ -244,6 +393,18 @@ class VoiceCommandRouter:
             logger.info("[VoiceRouter] REFLEX resolved '%s' -> %s in %.2fms "
                         "(no model call) — %s", command[:60],
                         reflex.capability, reflex.elapsed_ms, reflex.reason)
+            # SAY WHAT YOU ARE ABOUT TO DO, not what you heard.
+            #
+            # The HUD narrates "On it. Executing: lock my screen" BEFORE
+            # routing, so it can only ever echo the raw transcript back — it
+            # is speaking before anything has been understood. Now that the
+            # reflex has resolved a NAME deterministically and for free, the
+            # organism can say what it is actually about to do.
+            #
+            # Said here rather than after the call because a NOTIFY_APPLY
+            # capability may remove the surface the sentence would have
+            # arrived on: `lock_screen` returns, and the screen is gone.
+            await self._say(f"On it — {_humanise(reflex.capability)}.")
 
         # Step 1: Classify intent via 35B — PURE, so a resume can reuse it.
         classification = None
@@ -289,6 +450,15 @@ class VoiceCommandRouter:
                 pass
         result: Optional[CommandResult] = None
         try:
+            # CONTEXTUAL AWARENESS. Clear the way before acting, the way a
+            # person would — unlock the screen before searching the web,
+            # without being told to. Returns non-None only when the way could
+            # not be cleared and the original command must not proceed.
+            blocked_by = await self._clear_the_way(command, category, reflex)
+            if blocked_by is not None:
+                result = blocked_by
+                return result
+
             if reflex is not None and reflex.resolved:
                 result = await self._execute_capability(reflex)
             elif category == "app_action":
@@ -332,6 +502,196 @@ class VoiceCommandRouter:
                         intent_id, success=bool(getattr(result, "success", True)))
                 except Exception:  # noqa: BLE001
                     pass
+
+    # ── Contextual awareness: the flow a person would follow ────────────
+
+    async def _clear_the_way(self, command: str, category: str,
+                             reflex: Any) -> Optional[CommandResult]:
+        """Satisfy what this command needs before running it. NEVER raises.
+
+        Returns a CommandResult ONLY when the way could not be cleared and the
+        caller must stop; ``None`` means proceed.
+
+        THE FLOW A PERSON WOULD FOLLOW
+        --------------------------------
+        Told "search for dogs" at a locked Mac, nobody types the query into the
+        lock screen and reports failure. They unlock it first, because the
+        precondition is obvious to them and they never mention it. That is what
+        this does, and the reason it is not a special case in a branch:
+
+          * WHAT a command needs is a world-state predicate.
+          * WHO can supply it is a registry question — "which capability
+            declares `provides=screen_unlocked`?" — so the remedy is DERIVED.
+            Nothing here names `unlock_screen`, and a capability that gains
+            that declaration tomorrow becomes the remedy tomorrow.
+          * WHETHER it worked is re-observed, never assumed.
+
+        IT ACTS ONLY ON POSITIVE KNOWLEDGE
+        ------------------------------------
+        The chain engages when the world model KNOWS a requirement is false —
+        `refutes`, not `not satisfies`. UNKNOWN proceeds exactly as before.
+
+        That asymmetry is load-bearing rather than cautious. `CGSession`
+        answers only inside a GUI session, so the probe is legitimately blind
+        in a shell, in CI, and anywhere the backend is not a child of the
+        window server. Treating "I cannot see" as "it is locked" would make
+        JARVIS try to unlock a Mac that was never locked, every time it could
+        not look — a fabricated remedy for an imagined problem, which is the
+        blast-radius fabrication class in a new costume.
+        """
+        try:
+            from backend.system_control.world_state import get_world_state
+            world = get_world_state()
+            needs = self._requirements(category, reflex)
+            if not needs:
+                return None
+
+            blocked = [p for p in needs if await world.refutes(p)]
+            if not blocked:
+                return None
+
+            for predicate in blocked:
+                remedy = self._who_provides(predicate)
+                if remedy is None:
+                    logger.info("[VoiceRouter] '%s' is unmet and nothing "
+                                "declares it — proceeding anyway", predicate)
+                    continue
+
+                await self._say(self._explain_detour(predicate, remedy, command))
+                logger.info("[VoiceRouter] CAI: '%s' unmet → running '%s' "
+                            "first", predicate, remedy)
+
+                step = await self._execute_capability(
+                    type("_R", (), {"capability": remedy, "resolved": True})())
+
+                # OBSERVE, NEVER PREDICT. `provides` is a claim the capability
+                # makes about itself; the only evidence it worked is looking
+                # again. `fresh=True` because a cached reading is precisely the
+                # answer we are trying to replace.
+                world.invalidate()
+                if await world.satisfies(predicate, fresh=True):
+                    logger.info("[VoiceRouter] CAI: '%s' now satisfied — "
+                                "continuing with the original command",
+                                predicate)
+                    continue
+
+                # It did not work. Stop, and say which half failed — "I
+                # couldn't unlock" and "I unlocked but still can't see the
+                # screen" need different responses from a person.
+                logger.warning("[VoiceRouter] CAI: '%s' still unmet after "
+                               "'%s' — abandoning the original command",
+                               predicate, remedy)
+                spoken = (getattr(step, "response_text", "") or "").strip()
+                if getattr(step, "pending", False):
+                    return step
+                return CommandResult(
+                    success=False, category="system_action", steps_completed=0,
+                    steps_total=2, error=f"precondition {predicate} unmet",
+                    response_text=(
+                        f"{spoken} I couldn't {_humanise(remedy)}, so I've "
+                        f"left the rest alone." if spoken else
+                        f"I couldn't {_humanise(remedy)} first, so I've left "
+                        f"the rest alone."))
+            return None
+        except Exception:  # noqa: BLE001 — CAI never blocks a command
+            logger.debug("[VoiceRouter] precondition pass degraded",
+                         exc_info=True)
+            return None
+
+    @staticmethod
+    def _requirements(category: str, reflex: Any) -> tuple:
+        """What this command needs to be true. NEVER raises.
+
+        Two sources, neither of them a phrase table:
+
+        * a reflex-resolved capability DECLARES its own `requires` — the exact
+          answer, from the definition site;
+        * otherwise the ROUTER'S OWN CATEGORY answers it. The classifier
+          already decided whether this drives the UI; `app_action`,
+          `navigation`, `vision_action` and `composite` all mean "something is
+          going to happen on screen", and `query` means it is not.
+
+        The dead `ScreenLockContextDetector._command_requires_screen` answered
+        this by matching ~30 hardcoded substrings — including a bare `'open'`,
+        and an exception list for `'lock screen'` to stop it unlocking the Mac
+        in order to lock it. Reusing a decision the router has already made is
+        both more accurate and one fewer vocabulary to keep in sync.
+        """
+        try:
+            if reflex is not None and getattr(reflex, "resolved", False):
+                from backend.system_control.capability_registry import (
+                    get_capability_registry,
+                )
+                cap = get_capability_registry().get(reflex.capability)
+                # A declaring capability speaks for itself — including by
+                # declaring NOTHING. `lock_screen` needs no unlocked screen,
+                # and inferring one from its category would deadlock it
+                # against itself.
+                return tuple(getattr(cap, "requires", ()) or ()) if cap else ()
+            if category in ("app_action", "navigation", "vision_action",
+                            "composite", "code_action"):
+                return ("screen_unlocked",)
+            return ()
+        except Exception:  # noqa: BLE001
+            return ()
+
+    @staticmethod
+    def _who_provides(predicate: str) -> Optional[str]:
+        """The capability that establishes *predicate*, or None. NEVER raises.
+
+        Derived from the registry. Ambiguity is a refusal, not a coin toss: two
+        capabilities claiming the same effect is a declaration bug, and picking
+        one silently is how the wrong one runs for a year.
+        """
+        try:
+            from backend.system_control.capability_registry import (
+                get_capability_registry,
+            )
+            from backend.system_control.world_state import canonical
+            want = canonical(predicate)
+            found = [d.name for d in get_capability_registry().all()
+                     if any(canonical(p) == want
+                            for p in (getattr(d, "provides", ()) or ()))]
+            if len(found) == 1:
+                return found[0]
+            if len(found) > 1:
+                logger.warning("[VoiceRouter] %d capabilities claim to provide "
+                               "'%s' (%s) — refusing to choose",
+                               len(found), predicate, ", ".join(sorted(found)))
+            return None
+        except Exception:  # noqa: BLE001
+            return None
+
+    @staticmethod
+    def _explain_detour(predicate: str, remedy: str, command: str) -> str:
+        """Say WHY there is about to be an extra step. NEVER raises.
+
+        Spoken before the detour rather than after, because the operator is
+        about to watch their Mac do something they did not ask for, and an
+        unexplained action is indistinguishable from a malfunction.
+        """
+        try:
+            # Say the SITUATION, then the remedy, then the intent to continue.
+            # A capability name read aloud ("I'll unlock screen first") is the
+            # machine's vocabulary leaking into the room; the operator wants
+            # the sentence a colleague would say.
+            if "screen" in predicate:
+                return ("Your screen is locked — let me unlock it first, "
+                        "then I'll carry on.")
+            state = predicate.replace("_", " ")
+            return (f"I need {state} first, so I'll {_humanise(remedy)} — "
+                    f"then I'll carry on.")
+        except Exception:  # noqa: BLE001
+            return "One moment — I need to sort something out first."
+
+    async def _say(self, text: str) -> None:
+        """Narrate, if anything is listening. NEVER raises."""
+        try:
+            if self._narrate_fn and text:
+                note_spoken(text)
+                await self._narrate_fn(text)
+        except Exception:  # noqa: BLE001
+            pass
 
     # ── The reflex arc ──────────────────────────────────────────────────
 

--- a/backend/hud/voice_identity.py
+++ b/backend/hud/voice_identity.py
@@ -1,0 +1,483 @@
+"""Is the person speaking the owner of this Mac?
+
+THE AUTHORITY THAT WORKS THROUGH A LOCKED SCREEN
+--------------------------------------------------
+`unlock_screen` is APPROVAL_REQUIRED and Touch ID cannot answer for it: there
+is no surface to draw a dialog on while the screen is locked, which is why the
+verdict came back DENIED 99ms after the request and the log said "operator
+declined" for a prompt nobody saw. A microphone works through a locked screen.
+So the authority is the voice — and this is what turns a captured utterance
+into a yes or a no.
+
+FOUR ANSWERS, NOT TWO
+-----------------------
+"Deny" is not one state. An operator whose Mac will not unlock needs to know
+WHICH of these happened, because the fix is different every time:
+
+    NOT_ENROLLED    there is no voiceprint on this machine to compare against
+    NOT_READY       the model has not finished loading
+    NO_AUDIO        nothing captured the sentence
+    REJECTED        it was compared, and it was not you
+
+Collapsing them into "denied" is the same defect as the consent verdict that
+reported "operator declined" for a prompt that was never drawn. Every one of
+these fails CLOSED; they simply say why.
+
+READINESS IS NOT ON THE COMMAND PATH
+--------------------------------------
+Measured: `SpeakerVerificationService.initialize()` did not complete in 150
+seconds — speechbrain and torch loading a speaker-embedding model. Putting
+that between "unlock my screen" and the screen unlocking is not a slow
+feature, it is a broken one; the utterance it would verify expires first.
+
+So warming is a background task started at boot, readiness is a state anyone
+can ask about, and a verification attempted before the model is ready returns
+NOT_READY immediately rather than blocking. The organism is allowed to be
+still waking up, and is required to say so.
+
+WHY THIS WRAPS RATHER THAN REIMPLEMENTS
+-----------------------------------------
+`SpeakerVerificationService` already owns embedding, adaptive thresholds,
+enrolled profiles and continuous learning. This adds no model, no threshold
+and no storage of its own — it is the seam between that service and the
+consent boundary, plus the honest state machine the service does not have.
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import asyncio
+import enum
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger("JARVIS.VoiceIdentity")
+
+VOICE_IDENTITY_SCHEMA_VERSION: str = "voice_identity.v1"
+
+
+def voice_authority_enabled() -> bool:
+    """Master gate. Default TRUE. NEVER raises.
+
+    Off does not mean "unlock without checking" — it means this authority is
+    unavailable, and a capability that needs it is refused. There is
+    deliberately no setting that turns a verified unlock into an unverified
+    one.
+    """
+    return (os.environ.get("JARVIS_VOICE_AUTHORITY_ENABLED", "true")
+            or "").strip().lower() not in ("0", "false", "no", "off")
+
+
+def min_confidence() -> float:
+    """Score an utterance must reach to be accepted. NEVER raises.
+
+    A FLOOR, not the decision. `SpeakerVerificationService` computes its own
+    adaptive threshold from enrollment quality and history, and this never
+    lowers it — a verification the service already rejected stays rejected.
+    This only refuses to accept a `verified: true` that arrived with a
+    confidence the operator would not consider convincing for unlocking a
+    computer.
+    """
+    try:
+        raw = (os.environ.get("JARVIS_VOICE_MIN_CONFIDENCE", "") or "").strip()
+        return max(0.0, min(1.0, float(raw))) if raw else 0.75
+    except (TypeError, ValueError):
+        return 0.75
+
+
+def warm_timeout_s() -> float:
+    """How long the background warm-up may take before it is called failed."""
+    try:
+        raw = (os.environ.get("JARVIS_VOICE_WARM_TIMEOUT_S", "") or "").strip()
+        return max(10.0, min(900.0, float(raw))) if raw else 300.0
+    except (TypeError, ValueError):
+        return 300.0
+
+
+class Readiness(str, enum.Enum):
+    """Whether this authority can answer a question right now."""
+
+    COLD = "cold"          # nothing has started it
+    WARMING = "warming"    # loading; ask again shortly
+    READY = "ready"
+    FAILED = "failed"      # it tried and could not
+    DISABLED = "disabled"
+
+
+class Verdict(str, enum.Enum):
+    """What the voice said about who is speaking."""
+
+    VERIFIED = "verified"
+    REJECTED = "rejected"
+    NOT_ENROLLED = "not_enrolled"
+    NOT_READY = "not_ready"
+    NO_AUDIO = "no_audio"
+    UNAVAILABLE = "unavailable"
+
+    @property
+    def approves(self) -> bool:
+        """Only ONE value approves. Everything else fails closed."""
+        return self is Verdict.VERIFIED
+
+
+@dataclass
+class Identification:
+    """The result of asking who spoke."""
+
+    verdict: str
+    confidence: float = 0.0
+    speaker: str = ""
+    #: A sentence for a person. The operator hears this when unlock refuses,
+    #: so it says what to DO, not what went wrong internally.
+    spoken_reason: str = ""
+    detail: str = ""
+    elapsed_ms: float = 0.0
+    #: sha256[:8] of the sample this judged, so a log line can be tied to an
+    #: utterance without the log containing any of it.
+    sample: str = ""
+    schema_version: str = VOICE_IDENTITY_SCHEMA_VERSION
+
+    @property
+    def approves(self) -> bool:
+        try:
+            return Verdict(self.verdict).approves
+        except Exception:  # noqa: BLE001 — an unreadable verdict is not consent
+            return False
+
+
+_SPOKEN: Dict[str, str] = {
+    Verdict.NOT_ENROLLED.value:
+        "I don't have a voiceprint for you on this Mac yet, so I can't "
+        "confirm it's you. Enroll your voice and I'll be able to.",
+    Verdict.NOT_READY.value:
+        "I'm still loading my voice recognition — give me a moment and ask "
+        "again.",
+    Verdict.NO_AUDIO.value:
+        "I didn't capture your voice clearly enough to check it was you.",
+    Verdict.REJECTED.value:
+        "That didn't sound like you, so I've left it locked.",
+    Verdict.UNAVAILABLE.value:
+        "I can't check who's speaking right now, so I've left it locked.",
+}
+
+
+class VoiceIdentity:
+    """Warms the verifier, and answers who is speaking. NEVER raises."""
+
+    def __init__(self, service: Any = None) -> None:
+        self._service = service
+        self._readiness = (Readiness.READY if service is not None
+                           else Readiness.COLD)
+        self._warm_task: Optional[asyncio.Task] = None
+        self._warm_started = 0.0
+        self._detail = ""
+        self._counts: Dict[str, int] = {}
+        #: Last answer from the profile store. None = nobody has asked yet,
+        #: "" = asked and there is genuinely no profile. Never conflated.
+        self._enrolled_cache: Optional[str] = None
+        self._enrolled_at = 0.0
+        self._refresh_task: Optional[asyncio.Task] = None
+
+    # -- readiness -------------------------------------------------------
+
+    @property
+    def readiness(self) -> Readiness:
+        if not voice_authority_enabled():
+            return Readiness.DISABLED
+        return self._readiness
+
+    async def warm(self) -> None:
+        """Resolve enrollment now, and start the model loading. NEVER raises.
+
+        The boot seam. Enrollment resolves in milliseconds and the model in
+        minutes, so they are started together and awaited separately — the
+        organism knows WHO it is looking for long before it can look.
+        """
+        try:
+            await self.refresh_enrollment()
+        except Exception:  # noqa: BLE001
+            pass
+        self.start_warming()
+
+    def start_warming(self) -> None:
+        """Begin loading the model in the background. Idempotent. NEVER raises.
+
+        Fire-and-forget on purpose. Boot must not wait for a speaker model,
+        and nothing that calls this cares when it finishes — they ask
+        :attr:`readiness` at the moment they need an answer.
+        """
+        try:
+            if not voice_authority_enabled():
+                return
+            if self._warm_task is not None and not self._warm_task.done():
+                return
+            if self._readiness is Readiness.READY:
+                return
+            self._readiness = Readiness.WARMING
+            self._warm_started = time.monotonic()
+            self._warm_task = asyncio.get_event_loop().create_task(self._warm())
+            logger.info("[VoiceIdentity] warming the speaker model in the "
+                        "background — verification will report NOT_READY "
+                        "until it lands")
+        except Exception:  # noqa: BLE001
+            logger.debug("[VoiceIdentity] warm start degraded", exc_info=True)
+
+    async def _warm(self) -> None:
+        t0 = time.monotonic()
+        try:
+            from backend.voice.speaker_verification_service import (
+                SpeakerVerificationService,
+            )
+            svc = SpeakerVerificationService()
+            await asyncio.wait_for(svc.initialize(), timeout=warm_timeout_s())
+            self._service = svc
+            self._readiness = Readiness.READY
+            logger.info("[VoiceIdentity] speaker model READY after %.1fs",
+                        time.monotonic() - t0)
+        except asyncio.TimeoutError:
+            self._readiness = Readiness.FAILED
+            self._detail = f"initialize() exceeded {warm_timeout_s():.0f}s"
+            logger.error("[VoiceIdentity] warm-up TIMED OUT after %.0fs — "
+                         "voice authority unavailable", warm_timeout_s())
+        except Exception as exc:  # noqa: BLE001
+            self._readiness = Readiness.FAILED
+            self._detail = f"{type(exc).__name__}: {exc}"
+            logger.error("[VoiceIdentity] warm-up failed: %s", self._detail)
+
+    # -- enrollment ------------------------------------------------------
+
+    def enrolled_speaker(self) -> Optional[str]:
+        """Who there is a voiceprint for. NEVER raises.
+
+        Three answers, and the third is the one that matters:
+
+            "Derek"   a profile exists
+            ""        the service is loaded and has NO profile
+            None      UNKNOWN — nothing can say yet
+
+        WHY THIS ASKS THE SERVICE AND NOT A DIRECTORY
+        -----------------------------------------------
+        The first version of this read `~/.jarvis/voice/embeddings/`, found it
+        empty, and answered "nobody is enrolled". That was wrong in the most
+        familiar way: `SpeakerVerificationService._load_speaker_profiles`
+        loads from `intelligence.learning_database`, so the profiles live in a
+        database and an empty local directory says nothing whatsoever about
+        whether a voiceprint exists. `voice_enrollment.json` recording
+        `samples: 59, source: CloudSQL_voiceprints` is consistent with exactly
+        that.
+
+        An empty directory answering "not enrolled" is the same defect as
+        `is_screen_locked()` returning False when it cannot see, and the same
+        defect as the consent verdict reporting "operator declined" for a
+        prompt nobody drew: a probe that could not look, reporting absence.
+        Here it would have told the operator "I don't have a voiceprint for
+        you" while a perfectly good one sat in a database nobody had asked.
+
+        So the SERVICE is the authority, and until it is loaded the honest
+        answer is None. The local directory survives only as a fast-path hint
+        — a name there is evidence, an absence there is not.
+        """
+        try:
+            svc = self._service
+            if svc is not None:
+                for attr in ("speaker_profiles", "profiles", "_profiles"):
+                    profiles = getattr(svc, attr, None)
+                    if isinstance(profiles, dict):
+                        names = [str(k) for k in profiles if k]
+                        return sorted(names)[0] if names else ""
+            # Whatever the cheap database lookup last found. See
+            # :meth:`refresh_enrollment` — enrollment is a ROW, not a model.
+            return self._enrolled_cache
+        except Exception:  # noqa: BLE001
+            return None
+
+    def _schedule_enrollment_refresh(self) -> None:
+        """Resolve enrollment soon, without waiting for it. NEVER raises."""
+        try:
+            if self._refresh_task is not None and not self._refresh_task.done():
+                return
+            self._refresh_task = asyncio.get_event_loop().create_task(
+                self.refresh_enrollment())
+        except Exception:  # noqa: BLE001 — no loop, or shutting down
+            pass
+
+    async def refresh_enrollment(self) -> Optional[str]:
+        """Ask the profile store who is enrolled. NEVER raises.
+
+        ENROLLMENT IS A DATABASE QUESTION, NOT A MODEL QUESTION
+        --------------------------------------------------------
+        The speaker model takes over 150 seconds to load. Whether a voiceprint
+        EXISTS does not need it at all — `learning_db.get_all_speaker_profiles`
+        is a single query, and the row is already there: measured on this
+        machine, `speaker_profiles` holds one profile for "Derek J. Russell"
+        with 272 samples, an enrollment quality of 0.95 and a 1538-byte
+        embedding.
+
+        Separating the two questions is what lets the organism say something
+        useful while it wakes up. "I know it's you I'd be checking for, my
+        voice model is still loading" is an answer an operator can act on;
+        "unknown" is not, and "you are not enrolled" would have been false.
+
+        Cached, because the answer changes only when somebody enrolls, and
+        this is consulted on a path where an operator is waiting.
+        """
+        try:
+            if not voice_authority_enabled():
+                return None
+            now = time.monotonic()
+            if (self._enrolled_cache is not None
+                    and (now - self._enrolled_at) < 300.0):
+                return self._enrolled_cache
+            from intelligence.learning_database import get_learning_database
+            db = await asyncio.wait_for(get_learning_database(), timeout=15.0)
+            profiles = await asyncio.wait_for(
+                db.get_all_speaker_profiles(), timeout=15.0)
+            names = []
+            for p in (profiles or []):
+                n = (p.get("speaker_name") if isinstance(p, dict)
+                     else getattr(p, "speaker_name", ""))
+                if n:
+                    names.append(str(n))
+            # Prefer the primary user when the store holds several — a machine
+            # with two profiles still has one owner.
+            primary = [p for p in (profiles or [])
+                       if isinstance(p, dict) and p.get("is_primary_user")]
+            if primary and primary[0].get("speaker_name"):
+                self._enrolled_cache = str(primary[0]["speaker_name"])
+            else:
+                self._enrolled_cache = sorted(names)[0] if names else ""
+            self._enrolled_at = now
+            logger.info("[VoiceIdentity] enrollment: %s",
+                        self._enrolled_cache or "nobody enrolled")
+            return self._enrolled_cache
+        except asyncio.TimeoutError:
+            logger.warning("[VoiceIdentity] enrollment lookup timed out — "
+                           "leaving it UNKNOWN rather than guessing")
+            return None
+        except Exception as exc:  # noqa: BLE001
+            logger.info("[VoiceIdentity] enrollment lookup unavailable (%s) — "
+                        "UNKNOWN, not 'nobody'", type(exc).__name__)
+            return None
+
+    # -- the question ----------------------------------------------------
+
+    async def identify(self, audio: Optional[bytes], *,
+                       sample: str = "") -> Identification:
+        """Who is speaking? NEVER raises. NEVER blocks on warm-up.
+
+        Order matters: the cheap, certain refusals come first, so a machine
+        with no voiceprint says so instantly instead of loading a model to
+        compare an utterance against nothing.
+        """
+        t0 = time.monotonic()
+
+        def _out(v: Verdict, *, conf: float = 0.0, speaker: str = "",
+                 detail: str = "") -> Identification:
+            self._counts[v.value] = self._counts.get(v.value, 0) + 1
+            out = Identification(
+                verdict=v.value, confidence=round(conf, 4), speaker=speaker,
+                spoken_reason=_SPOKEN.get(v.value, ""), detail=detail,
+                elapsed_ms=round((time.monotonic() - t0) * 1000.0, 1),
+                sample=sample)
+            logger.info("[VoiceIdentity] %s conf=%.2f sample=%s (%.0fms) %s",
+                        v.value, out.confidence, sample or "-",
+                        out.elapsed_ms, detail or "")
+            return out
+
+        try:
+            if not voice_authority_enabled():
+                return _out(Verdict.UNAVAILABLE, detail="authority disabled")
+            if not audio:
+                return _out(Verdict.NO_AUDIO, detail="no utterance held")
+
+            # A LOCAL PRINT SHORT-CIRCUITS; ITS ABSENCE DOES NOT.
+            #
+            # Readiness is checked BEFORE concluding "not enrolled", because
+            # until the service has loaded, whether a voiceprint exists is
+            # UNKNOWN — the profiles live in the learning database, not on
+            # disk. Answering NOT_ENROLLED from an unloaded service would tell
+            # the operator their voice was never enrolled when the truth is
+            # that nothing had looked yet, and they would go and re-record 59
+            # samples they already have.
+            # CACHED ONLY. Never a live lookup here.
+            #
+            # This briefly called `refresh_enrollment()`, which measured 5.2s
+            # against CloudSQL on a cold connection — five seconds sitting
+            # between "unlock my screen" and the screen unlocking, on the exact
+            # path this class exists to keep clear of slow work. The same
+            # mistake as putting the speaker model here, just three orders of
+            # magnitude cheaper and therefore easier to miss.
+            #
+            # The lookup belongs to `warm()` at boot and to the 300s cache. If
+            # nothing has resolved it yet the answer is UNKNOWN, which reports
+            # NOT_READY and kicks a refresh for next time — never a blocking
+            # wait, and never a guess.
+            owner = self.enrolled_speaker()
+            if owner is None:
+                self._schedule_enrollment_refresh()
+            state = self.readiness
+            if state is not Readiness.READY:
+                if state in (Readiness.COLD, Readiness.WARMING):
+                    # Warming is not an error, and it must not become a wait:
+                    # the utterance expires long before the model lands.
+                    self.start_warming()
+                    return _out(Verdict.NOT_READY,
+                                detail=f"model {state.value}; enrollment "
+                                       f"{'unknown' if owner is None else owner or 'none'}")
+                return _out(Verdict.UNAVAILABLE,
+                            detail=self._detail or f"model {state.value}")
+
+            # Loaded, and it says there is no profile. NOW this is a fact.
+            if not owner:
+                return _out(Verdict.NOT_ENROLLED,
+                            detail="service loaded and holds no voiceprint")
+
+            result = await self._service.verify_speaker(audio, owner)
+            verified = bool((result or {}).get("verified"))
+            conf = float((result or {}).get("confidence") or 0.0)
+            who = str((result or {}).get("speaker_name") or owner)
+
+            if not verified:
+                return _out(Verdict.REJECTED, conf=conf, speaker=who,
+                            detail="service returned verified=false")
+            floor = min_confidence()
+            if conf < floor:
+                # The service said yes; the confidence says otherwise. Refuse
+                # — this floor can only ever make the answer stricter.
+                return _out(Verdict.REJECTED, conf=conf, speaker=who,
+                            detail=f"confidence {conf:.2f} below floor {floor:.2f}")
+            return _out(Verdict.VERIFIED, conf=conf, speaker=who)
+        except Exception as exc:  # noqa: BLE001 — a fault is never consent
+            return _out(Verdict.UNAVAILABLE,
+                        detail=f"{type(exc).__name__}: {exc}")
+
+    def stats(self) -> Dict[str, Any]:
+        return {
+            "schema_version": VOICE_IDENTITY_SCHEMA_VERSION,
+            "enabled": voice_authority_enabled(),
+            "readiness": self.readiness.value,
+            "enrolled_speaker": self.enrolled_speaker() or None,
+            "min_confidence": min_confidence(),
+            "verdicts": dict(self._counts),
+            "detail": self._detail,
+        }
+
+
+_IDENTITY: Optional[VoiceIdentity] = None
+
+
+def get_voice_identity() -> VoiceIdentity:
+    """Process-wide voice authority. NEVER raises."""
+    global _IDENTITY
+    if _IDENTITY is None:
+        _IDENTITY = VoiceIdentity()
+    return _IDENTITY
+
+
+def reset_voice_identity() -> None:
+    """Testing seam. NEVER raises."""
+    global _IDENTITY
+    _IDENTITY = None

--- a/backend/main.py
+++ b/backend/main.py
@@ -2018,6 +2018,18 @@ async def parallel_lifespan(app: FastAPI):
                     """Speak text to the user via macOS TTS with mic suppression."""
                     if not text:
                         return
+                    # THE ECHO LEDGER. Every word JARVIS utters passes through
+                    # here, which is the only reason a single call can cover
+                    # all of them — the mute claim's deadline is an ESTIMATE
+                    # derived from character count, so when the synthesiser
+                    # runs slower than the guess the mic goes live mid-sentence
+                    # and JARVIS transcribes itself. Measured: one spoken "lock
+                    # my screen" locked the screen twice.
+                    try:
+                        from backend.hud.voice_command_router import note_spoken
+                        note_spoken(text)
+                    except Exception:  # noqa: BLE001 — never block speech
+                        pass
                     _speech = None
                     try:
                         import tempfile as _tf
@@ -2085,6 +2097,34 @@ async def parallel_lifespan(app: FastAPI):
                         payload = data.get("payload", {})
                         cmd_id = data.get("command_id", "")
                         logger.info("[HUD] Action: %s (cmd=%s)", action_type, cmd_id)
+
+                        # THE AUDIO OF THE SENTENCE ITSELF.
+                        #
+                        # Until this line the backend received only the
+                        # TRANSCRIPT of what was said, which is why speaker
+                        # verification could not be the consent authority for
+                        # `unlock_screen`: the one authority that works through
+                        # a locked screen had no evidence to work from. It is
+                        # also what enrollment needs — a voiceprint cannot be
+                        # built from text.
+                        #
+                        # Deposited rather than passed down. The consent flow
+                        # SUSPENDS and resumes on a different call stack, so an
+                        # argument threaded through `route()` would not be in
+                        # scope by the time anything wanted it. The holder
+                        # validates, bounds and expires the bytes, and never
+                        # writes them anywhere.
+                        try:
+                            _aud = payload.get("utterance_audio")
+                            if _aud:
+                                from backend.hud.utterance_audio import (
+                                    get_utterance_holder,
+                                )
+                                get_utterance_holder().deposit(
+                                    _aud,
+                                    payload.get("utterance_audio_format", ""))
+                        except Exception as _ua:  # noqa: BLE001
+                            logger.debug("[HUD] utterance audio ignored: %s", _ua)
 
                         if action_type == "vision_task":
                             goal = payload.get("goal", "")

--- a/backend/system_control/capability_registry.py
+++ b/backend/system_control/capability_registry.py
@@ -217,7 +217,9 @@ def capability(*, mutates: Optional[bool] = None,
                session: str = Session.NONE.value,
                release: str = "",
                alias: str = "",
-               phrases: Any = ()) -> Callable:
+               phrases: Any = (),
+               requires: Any = (),
+               provides: Any = ()) -> Callable:
     """Declare a method's risk where the method is written. NEVER raises.
 
     A decorator rather than a central table for the reason `repl_dispatch_
@@ -240,6 +242,8 @@ def capability(*, mutates: Optional[bool] = None,
                 "release": release,
                 "alias": alias,
                 "phrases": _normalise_phrases(phrases),
+                "requires": _normalise_predicates(requires),
+                "provides": _normalise_predicates(provides),
             })
         except Exception:  # noqa: BLE001 — a decorator never breaks an import
             pass
@@ -270,6 +274,17 @@ class CapabilityDef:
     #: is: a table beside the code is a second thing to update, and the update
     #: that gets forgotten is invisible.
     phrases: tuple = ()
+    #: World-state predicates that must hold BEFORE this can run, and the ones
+    #: it establishes by running. Declared at the method, like everything else
+    #: here, so the chain that unlocks a screen before searching the web is
+    #: DERIVED — "who provides `screen_unlocked`?" is a question the registry
+    #: answers, not a branch somebody wrote in the voice router.
+    #:
+    #: `provides` is a claim, never a proof. The world model re-observes after
+    #: the call; a capability that says it unlocks the screen and did not is
+    #: exactly the case the re-observation exists to catch.
+    requires: tuple = ()
+    provides: tuple = ()
     #: The name this capability is EXPORTED as, when its method name would
     #: collide with another provider's in the same namespace. Declared at the
     #: method (``as=stop_actuator``) rather than in a table elsewhere, so the
@@ -468,6 +483,29 @@ def _normalise_phrases(raw: Any) -> tuple:
         return ()
 
 
+def _normalise_predicates(raw: Any) -> tuple:
+    """A declared ``requires``/``provides`` value as a clean tuple. NEVER raises.
+
+    Deliberately does NOT import `world_state` to canonicalise the names. The
+    registry describes what a method claims; resolving `screen_unlocked` to
+    "not screen_locked" is the world model's job, and a leaf registry that
+    imports the world model to store two strings is the layering inversion
+    this module keeps refusing elsewhere.
+    """
+    try:
+        if not raw:
+            return ()
+        items = raw.split(",") if isinstance(raw, str) else list(raw)
+        out = []
+        for it in items:
+            s = " ".join(str(it).strip().lower().split())
+            if s and s not in out:
+                out.append(s)
+        return tuple(out)
+    except Exception:  # noqa: BLE001
+        return ()
+
+
 class _Classification(NamedTuple):
     tier: str
     provenance: str
@@ -475,6 +513,8 @@ class _Classification(NamedTuple):
     release: str = ""
     alias: str = ""
     phrases: tuple = ()
+    requires: tuple = ()
+    provides: tuple = ()
 
 
 def _apply_session_rules(c: _Classification) -> _Classification:
@@ -512,6 +552,8 @@ def _parse_tag(body: str) -> _Classification:
     joined = " ".join(parts)
     session, release, alias = Session.NONE.value, "", ""
     phrases: tuple = ()
+    requires: tuple = ()
+    provides: tuple = ()
     for p in parts:
         if p.startswith("release="):
             release = p.split("=", 1)[1].strip()
@@ -519,6 +561,10 @@ def _parse_tag(body: str) -> _Classification:
             alias = p.split("=", 1)[1].strip()
         elif p.startswith("say=") or p.startswith("phrases="):
             phrases = _normalise_phrases(p.split("=", 1)[1].strip())
+        elif p.startswith("needs=") or p.startswith("requires="):
+            requires = _normalise_predicates(p.split("=", 1)[1].strip())
+        elif p.startswith("gives=") or p.startswith("provides="):
+            provides = _normalise_predicates(p.split("=", 1)[1].strip())
         elif p in ("session-start", "session_start"):
             session = Session.START.value
         elif p in ("session-end", "session_end"):
@@ -534,7 +580,7 @@ def _parse_tag(body: str) -> _Classification:
                 break
     return _apply_session_rules(
         _Classification(tier, Provenance.TAGGED.value, session, release, alias,
-                        phrases))
+                        phrases, requires, provides))
 
 
 def _classify(fn: Any, doc: str) -> _Classification:
@@ -554,7 +600,9 @@ def _classify(fn: Any, doc: str) -> _Classification:
                 str(declared.get("session") or Session.NONE.value),
                 str(declared.get("release") or ""),
                 str(declared.get("alias") or ""),
-                _normalise_phrases(declared.get("phrases"))))
+                _normalise_phrases(declared.get("phrases")),
+                _normalise_predicates(declared.get("requires")),
+                _normalise_predicates(declared.get("provides"))))
         tag = _DOC_TAG.search(doc or "")
         if tag:
             return _parse_tag(tag.group("body") or "")
@@ -618,6 +666,8 @@ def describe(name: str, fn: Any) -> Optional[CapabilityDef]:
             release=cls.release,
             alias=cls.alias,
             phrases=cls.phrases,
+            requires=cls.requires,
+            provides=cls.provides,
         )
     except Exception:  # noqa: BLE001
         logger.debug("[CapabilityRegistry] describe(%s) degraded", name,

--- a/backend/system_control/capability_router.py
+++ b/backend/system_control/capability_router.py
@@ -417,6 +417,60 @@ class CapabilityRouter:
             # question; minting it afterwards meant the prompt went out with no
             # nonce, `SecureConsent.Challenge` failed closed on the empty field,
             # and the request vanished without the operator ever seeing it.
+            # IS THERE ANYONE WHO CAN ANSWER?
+            #
+            # Asked BEFORE the request, because a channel that cannot be
+            # reached does not fail loudly — it fails like a refusal. Touch ID
+            # on a locked screen returns DENIED in 99ms and the operator is
+            # told they declined something they never saw.
+            #
+            # Refusing here is not worse than suspending; it is the same
+            # outcome with the truth attached. What it buys is a caller that
+            # can DO something: `voice_command_router` reads this detail and
+            # says which authority was missing, instead of narrating a denial
+            # that never happened.
+            # AN AUTHORITY THAT CAN ACTUALLY ANSWER.
+            #
+            # Touch ID needs an unlocked screen; a microphone does not. When
+            # the primary channel's preconditions are not met, a secondary
+            # authority whose preconditions ARE met is asked instead — which
+            # is what makes `unlock_screen` authorisable at all rather than a
+            # gate that can only ever refuse itself.
+            #
+            # An immediate authority resolves INSIDE the turn: the operator
+            # already answered by speaking, so there is no human left to wait
+            # for and suspending would park a call nobody can complete.
+            immediate = await self._immediate_authority()
+            if immediate is not None:
+                decision = await immediate.decide(
+                    _ConsentContext(op_id=op_id or f"cap:{name}",
+                                    capability=name, args=args,
+                                    session=self._session_kind(name)))
+                if _approved(decision):
+                    logger.info("[CapabilityRouter] '%s' authorised by %s",
+                                name, type(immediate).__name__)
+                    out = await self._execute(name, args)
+                    out.tier = tier
+                    return out
+                self._stats["denied"] += 1
+                why = _verdict_reason(decision)
+                logger.warning("[CapabilityRouter] '%s' NOT authorised by %s "
+                               "(%s)", name, type(immediate).__name__, why)
+                return RoutedCall(
+                    outcome=Outcome.DENIED.value, capability=name, tier=tier,
+                    context_note=DENIED_PAYLOAD, detail=why)
+
+            unreachable = await self._channel_unreachable()
+            if unreachable:
+                self._stats["denied"] += 1
+                logger.warning(
+                    "[CapabilityRouter] '%s' needs consent, but no channel "
+                    "can reach the operator: %s", name, unreachable)
+                return RoutedCall(
+                    outcome=Outcome.DENIED.value, capability=name, tier=tier,
+                    context_note=DENIED_PAYLOAD,
+                    detail=f"consent channel unreachable — {unreachable}")
+
             nonce = _mint_nonce()
             rid = await self._request_consent(name, args, op_id=op_id,
                                               nonce=nonce)
@@ -485,14 +539,31 @@ class CapabilityRouter:
                 out.request_id = request_id
                 return out
             self._stats["denied"] += 1
-            logger.info("[CapabilityRouter] '%s' DENIED by operator",
-                        parked.capability)
+            # KEEP THE REASON THE CHANNEL GAVE.
+            #
+            # `SecureConsent.describe()` already distinguishes "operator
+            # denied" from "biometry unavailable", "no biometry enrolled" and
+            # "system cancelled the prompt", and sends it in the verdict. This
+            # branch threw all of it away and wrote "operator declined".
+            #
+            # Measured 2026-08-03 00:18:58 — a verdict arrived 99ms after the
+            # request, which is not a human, and the log read:
+            #
+            #     consent verdict for unlock_screen → denied (operator declined)
+            #
+            # The operator declined nothing; the screen was locked so no dialog
+            # could be drawn. "You said no" and "nobody could be asked" need
+            # opposite follow-ups, and the one surface that knew the difference
+            # was discarding it one line before anybody could read it.
+            why = _verdict_reason(decision)
+            logger.info("[CapabilityRouter] '%s' DENIED (%s)",
+                        parked.capability, why)
             # A RESULT, not an exception: the agent must reason about the
             # refusal rather than retry a reworded version of the same call.
             return RoutedCall(
                 outcome=Outcome.DENIED.value, capability=parked.capability,
                 request_id=request_id, context_note=DENIED_PAYLOAD,
-                detail="operator declined")
+                detail=why)
         except Exception as exc:  # noqa: BLE001
             self._stats["failed"] += 1
             return RoutedCall(outcome=Outcome.FAILED.value,
@@ -501,6 +572,90 @@ class CapabilityRouter:
                               detail=f"{type(exc).__name__}: {exc}")
 
     # -- internals -------------------------------------------------------
+
+    async def _immediate_authority(self) -> Any:
+        """A secondary authority that can decide NOW, or None. NEVER raises.
+
+        Consulted only when the PRIMARY channel cannot be reached. That order
+        is the security property: while Touch ID is presentable it remains the
+        authority, and voice never becomes a way to bypass a prompt the
+        operator could have seen. Voice is what answers when nothing else can
+        — which, for `unlock_screen`, is always.
+
+        An authority is eligible only when every predicate it declares is
+        satisfied. `requires = ()` on the voice provider is therefore a
+        statement, not an omission: it works through a locked screen, and it
+        says so where the router can check.
+        """
+        try:
+            candidates = list(getattr(self, "_authorities", ()) or ())
+            if not candidates:
+                return None
+            if not await self._channel_unreachable():
+                return None      # the primary can still be asked; prefer it
+            from backend.system_control.world_state import get_world_state
+            world = get_world_state()
+            for auth in candidates:
+                if not getattr(auth, "immediate", False):
+                    continue
+                blocked = False
+                for predicate in tuple(getattr(auth, "requires", ()) or ()):
+                    if await world.refutes(predicate):
+                        blocked = True
+                        break
+                if not blocked:
+                    return auth
+            return None
+        except Exception:  # noqa: BLE001
+            logger.debug("[CapabilityRouter] authority selection degraded",
+                         exc_info=True)
+            return None
+
+    def add_authority(self, authority: Any) -> None:
+        """Register a fallback consent authority. Idempotent. NEVER raises."""
+        try:
+            if not hasattr(self, "_authorities"):
+                self._authorities = []
+            if not any(type(a) is type(authority) for a in self._authorities):
+                self._authorities.append(authority)
+        except Exception:  # noqa: BLE001
+            pass
+
+    async def _channel_unreachable(self) -> str:
+        """Why the consent channel cannot reach a human. "" when it can.
+
+        NEVER raises, and biased toward PROCEEDING: only a predicate the world
+        model KNOWS to be false blocks the request. An UNKNOWN reading means we
+        cannot see whether Touch ID is presentable, and refusing to ask on the
+        strength of not knowing would break every consent prompt on any machine
+        where the probe is blind — which is most of them, since
+        `CGSessionCopyCurrentDictionary` answers only inside a GUI session.
+
+        The asymmetry is deliberate and it is the same one `WorldState` draws:
+        act on positive knowledge, never on absence of it.
+        """
+        try:
+            provider = self._provider
+            if provider is None:
+                return ""      # a missing provider already fails closed below
+            needs = tuple(getattr(provider, "requires", ()) or ())
+            if not needs:
+                return ""
+            from backend.system_control.world_state import get_world_state
+            world = get_world_state()
+            blocked = []
+            for predicate in needs:
+                if await world.refutes(predicate):
+                    blocked.append(predicate)
+            if not blocked:
+                return ""
+            channel = type(provider).__name__
+            return (f"{channel} needs {', '.join(blocked)}, which is not the "
+                    f"case right now")
+        except Exception:  # noqa: BLE001 — never block consent on this check
+            logger.debug("[CapabilityRouter] reachability check degraded",
+                         exc_info=True)
+            return ""
 
     async def _request_consent(self, name: str, args: Dict[str, Any], *,
                                op_id: str, nonce: str = "") -> str:
@@ -820,6 +975,31 @@ def _verify_nonce(expected: str, decision: Any) -> bool:
         return False
 
 
+def _verdict_reason(decision: Any) -> str:
+    """Why a verdict said no, in the CHANNEL's own words. NEVER raises.
+
+    Falls back to "operator declined" only when the channel offered nothing —
+    which is the honest reading of a verdict that carries no explanation, and
+    is exactly what this used to say unconditionally.
+    """
+    try:
+        raw = ""
+        if isinstance(decision, dict):
+            raw = str(decision.get("reason") or "")
+        else:
+            # `spoken_reason` FIRST. A voice verdict already carries a sentence
+            # written for a person — "I don't have a voiceprint for you on this
+            # Mac yet" — and that is exactly what the operator should hear when
+            # their Mac declines to unlock. `detail` is the engineering half
+            # and stays in the log.
+            raw = str(getattr(decision, "spoken_reason", "")
+                      or getattr(decision, "reason", "") or "")
+        raw = " ".join(raw.split())[:200]
+        return raw or "operator declined"
+    except Exception:  # noqa: BLE001
+        return "operator declined"
+
+
 def _approved(decision: Any) -> bool:
     """Did the operator say yes? NEVER raises.
 
@@ -830,6 +1010,14 @@ def _approved(decision: Any) -> bool:
     try:
         if decision is None:
             return False
+        # An authority that has ALREADY decided says so with a boolean. Voice
+        # verification returns an `Identification` whose verdict vocabulary is
+        # its own ("verified" / "rejected" / "not_enrolled" / …), and matching
+        # those against a list of spellings of "yes" here would put the
+        # decision in two places. It answers `approves`; that IS the decision.
+        approves = getattr(decision, "approves", None)
+        if isinstance(approves, bool):
+            return approves
         # The IPC delivers JSON, so a verdict from the signed HUD arrives as a
         # dict. Reading only `.status` would have made every real verdict from
         # Swift fall through to denial — safe, and completely broken.

--- a/backend/system_control/macos_controller.py
+++ b/backend/system_control/macos_controller.py
@@ -24,6 +24,49 @@ from backend.system_control.capability_registry import (  # noqa: E402
 
 logger = logging.getLogger(__name__)
 
+_OPERATOR_NAME_CACHE: List[Optional[str]] = [None]
+
+
+def _operator_name() -> str:
+    """What to call the person at this Mac. "" if unknown. NEVER raises.
+
+    DERIVED, not written down. macOS already stores the account's full name in
+    the passwd GECOS field, which is where "Derek J. Russell" in the tool-use
+    system prompt came from in the first place — so reading it here means the
+    name is right on any machine without anybody editing a constant.
+
+    `pwd` rather than `id -F` deliberately: this is called from
+    `lock_screen`, whose entire design note is that it must not block, and a
+    subprocess on the event loop is exactly what that note forbids. `pwd` is
+    stdlib and reads an already-resolved struct.
+
+    First name only. "Locking the screen now, Derek J. Russell" is not how a
+    person addresses anyone.
+
+    Override with ``JARVIS_OPERATOR_NAME`` — the account name is a good
+    default, not an authority on what somebody likes being called.
+    """
+    if _OPERATOR_NAME_CACHE[0] is not None:
+        return _OPERATOR_NAME_CACHE[0]
+    name = ""
+    try:
+        override = (os.environ.get("JARVIS_OPERATOR_NAME", "") or "").strip()
+        if override:
+            name = override
+        else:
+            import pwd
+            gecos = (pwd.getpwuid(os.getuid()).pw_gecos or "").split(",")[0]
+            name = gecos.strip()
+        # A full name is for a form; a first name is for a sentence.
+        name = name.split()[0] if name.split() else ""
+        # Guard against a GECOS field holding a username or junk.
+        if not name.isalpha() or len(name) > 24:
+            name = ""
+    except Exception:  # noqa: BLE001 — never break a lock on a nicety
+        name = ""
+    _OPERATOR_NAME_CACHE[0] = name
+    return name
+
 
 class CommandCategory(Enum):
     """Categories of system commands"""
@@ -1479,7 +1522,7 @@ class MacOSController:
 
         return None
 
-    @capability(mutates=True, tier="notify_apply")
+    @capability(mutates=True, tier="notify_apply", provides="screen_locked")
     async def lock_screen(
         self,
         progress_callback: Optional[Callable[[Dict[str, Any]], Any]] = None,
@@ -1506,8 +1549,17 @@ class MacOSController:
         start_time = time.perf_counter()
 
         # Use provided speaker_name or default - NO async calls that could block
+        #
+        # "there" made the Mac greet its owner as a stranger: measured, the
+        # live response was "🔒 Locking the screen now, there. See you soon."
+        # The operator's name is already known to this process — the tool-use
+        # system prompt states it, and `UserPreferenceMemory` persists it — so
+        # the fallback reads what is on record rather than inventing a
+        # placeholder. Still no async and no blocking call: `_operator_name`
+        # is a cached env/file read, and it returns "" rather than raising, in
+        # which case we land on the original placeholder.
         if speaker_name is None:
-            speaker_name = "there"
+            speaker_name = _operator_name() or "there"
 
         async def _progress(stage: str, pct: int, msg: str):
             """Send transparent progress update (fire-and-forget)."""
@@ -1636,7 +1688,23 @@ class MacOSController:
             await _progress("error", 90, f"Lock error: {e}")
             return False, f"❌ Failed to lock screen: {str(e)}"
 
-    @os_capability(Effect.EFFECTFUL)
+    # Stays APPROVAL_REQUIRED — unlocking a Mac is not a notify-and-proceed
+    # action. What changed is WHO can answer.
+    #
+    # Touch ID cannot. `SecureConsent` needs to draw a system dialog, and there
+    # is no surface to draw on while the screen is locked: measured, the
+    # verdict came back DENIED 99ms after the request, and the log recorded
+    # "operator declined" for a prompt no operator ever saw. A gate whose only
+    # answer channel requires the very state the gated action exists to
+    # produce is a deadlock, not a safeguard — `unlock_screen` could never be
+    # authorised, by construction.
+    #
+    # `consent_authorities` now picks a channel whose own preconditions are
+    # MET, and speaker verification is reachable through a locked screen
+    # because a microphone is. See that module for why this is a stronger
+    # answer than removing the gate.
+    @capability(mutates=True, tier="approval_required",
+                requires="screen_locked", provides="screen_unlocked")
     async def unlock_screen(self, password: Optional[str] = None) -> Tuple[bool, str]:
         """
         Unlock the macOS screen using direct async methods (avoiding full pipeline loops)

--- a/backend/system_control/world_state.py
+++ b/backend/system_control/world_state.py
@@ -1,0 +1,484 @@
+"""What is TRUE of this machine right now — and what is merely unobserved.
+
+ONE MECHANISM, THREE JOBS
+---------------------------
+An operator said "unlock my screen" and JARVIS asked for Touch ID. The screen
+was locked, so no dialog could be presented; the verdict came back DENIED in
+99 milliseconds and the log recorded "operator declined". Nobody declined
+anything. `unlock_screen` could never be authorised, by construction:
+
+    a gate whose only answer channel requires the very state the gated
+    action exists to produce is a deadlock, not a safeguard.
+
+Three apparently separate problems turn out to be the same question asked
+three times — *what is true of the machine right now?*
+
+  * **Preconditions.** "Search for dogs" on a locked Mac cannot work. A person
+    would unlock first without being asked to. That is not a special case to
+    hardcode; it is an unmet precondition with a known remedy.
+  * **Reachability.** Touch ID needs an unlocked screen to draw on. A consent
+    channel has preconditions exactly as an action does.
+  * **Verification.** After unlocking, the only honest way to know it worked
+    is to LOOK. `capability_router` reports EXECUTED when a call did not
+    raise, which is a fact about the call, not about the world.
+
+So there is one predicate layer, and the three read from it.
+
+WHY TRUTH IS TERNARY
+----------------------
+`voice_unlock.objc.server.screen_lock_detector._check_cgsession_locked_via_
+ctypes` returns `Optional[bool]` — and the `None` means "the query failed",
+which is a genuinely different fact from "the screen is not locked". The
+module's own `is_screen_locked()` wrapper collapses that to `False`.
+
+That collapse is the ghost-display defect exactly: a probe that could not see
+answered "absent", and an absent reading authorised a create. Here it would
+authorise something worse — believing an unlocked screen because CoreGraphics
+was unavailable, then typing a password into whatever has focus.
+
+So UNKNOWN is a value, it is never silently narrowed, and:
+
+    **UNKNOWN NEVER SATISFIES A PRECONDITION.**
+
+It also never *refutes* one. An unmet precondition triggers a remedy; an
+unknown one triggers a refusal to guess. Those are different outcomes and
+this module refuses to conflate them.
+
+WHY PROBES ARE REGISTERED, NOT IMPORTED
+-----------------------------------------
+The consumer of a predicate must not know which framework answers it.
+`system_control` importing `voice_unlock` would invert the layering to read
+one boolean, and the next predicate would drag in another subsystem. Probes
+register themselves; a predicate nobody probes is UNKNOWN, which is already
+the safe answer, so a missing registration degrades rather than breaks.
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import asyncio
+import enum
+import inspect
+import logging
+import os
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+logger = logging.getLogger("JARVIS.WorldState")
+
+WORLD_STATE_SCHEMA_VERSION: str = "world_state.v1"
+
+
+class Truth(str, enum.Enum):
+    """Three-valued truth. UNKNOWN is a fact, not a missing answer."""
+
+    TRUE = "true"
+    FALSE = "false"
+    UNKNOWN = "unknown"
+
+    @property
+    def known(self) -> bool:
+        return self is not Truth.UNKNOWN
+
+    def negate(self) -> "Truth":
+        """The negation. UNKNOWN negated is still UNKNOWN — not knowing a
+        thing tells you exactly as little about its opposite."""
+        if self is Truth.TRUE:
+            return Truth.FALSE
+        if self is Truth.FALSE:
+            return Truth.TRUE
+        return Truth.UNKNOWN
+
+    @classmethod
+    def of(cls, value: Any) -> "Truth":
+        """From a probe's ``Optional[bool]``. NEVER raises.
+
+        `None` maps to UNKNOWN rather than FALSE. That single line is the
+        whole reason this type exists.
+        """
+        if value is True:
+            return cls.TRUE
+        if value is False:
+            return cls.FALSE
+        return cls.UNKNOWN
+
+
+#: Predicates that are each other's negation, so ONE probe answers both.
+#:
+#: Registered beside the probe rather than kept as a policy table: two probes
+#: for `screen_locked` and `screen_unlocked` could disagree, and the day they
+#: did, the machine would believe the screen was both. A negation cannot
+#: disagree with itself.
+_ANTONYMS: Dict[str, str] = {}
+_ANTONYM_LOCK = threading.Lock()
+
+
+def canonical(predicate: str) -> Tuple[str, bool]:
+    """(base_predicate, negated). NEVER raises.
+
+    Accepts `screen_locked`, `!screen_locked`, `not screen_locked`, and any
+    registered antonym such as `screen_unlocked`.
+    """
+    try:
+        p = (predicate or "").strip().lower().replace("-", "_")
+        negated = False
+        while p.startswith("!") or p.startswith("not_") or p.startswith("not "):
+            negated = not negated
+            p = p[1:] if p.startswith("!") else p[4:]
+            p = p.strip()
+        with _ANTONYM_LOCK:
+            base = _ANTONYMS.get(p)
+        if base:
+            return base, (not negated)
+        return p, negated
+    except Exception:  # noqa: BLE001
+        return (predicate or ""), False
+
+
+def register_antonym(alias: str, base: str) -> None:
+    """Declare *alias* to mean "not *base*". Idempotent. NEVER raises."""
+    try:
+        with _ANTONYM_LOCK:
+            _ANTONYMS[(alias or "").strip().lower()] = (base or "").strip().lower()
+    except Exception:  # noqa: BLE001
+        pass
+
+
+@dataclass
+class Reading:
+    """One predicate, observed. Carries HOW it was learned."""
+
+    predicate: str
+    truth: str
+    #: What answered — a probe name, or "" when nothing could.
+    source: str = ""
+    #: Why UNKNOWN, when it is. An unexplained UNKNOWN is indistinguishable
+    #: from a predicate nobody thought to probe, and an operator can act on
+    #: one of those.
+    detail: str = ""
+    observed_at: float = 0.0
+    schema_version: str = WORLD_STATE_SCHEMA_VERSION
+
+    @property
+    def is_true(self) -> bool:
+        return self.truth == Truth.TRUE.value
+
+    @property
+    def is_unknown(self) -> bool:
+        return self.truth == Truth.UNKNOWN.value
+
+
+def probe_ttl_s() -> float:
+    """How long a reading may be reused. NEVER raises.
+
+    Deliberately short. A cached world is a remembered world, and the whole
+    point of a precondition check is that the machine may have changed since
+    the last time anybody looked. Long enough to spare four probes inside one
+    utterance; far too short to survive a screen locking.
+    """
+    try:
+        raw = (os.environ.get("JARVIS_WORLD_STATE_TTL_S", "") or "").strip()
+        return max(0.0, min(30.0, float(raw))) if raw else 2.0
+    except (TypeError, ValueError):
+        return 2.0
+
+
+def probe_timeout_s() -> float:
+    """How long a single probe may take. NEVER raises.
+
+    A probe that hangs must become UNKNOWN, not a hung voice command. This is
+    on the path between an operator speaking and the machine acting.
+    """
+    try:
+        raw = (os.environ.get("JARVIS_WORLD_STATE_PROBE_TIMEOUT_S", "") or "").strip()
+        return max(0.1, min(10.0, float(raw))) if raw else 2.0
+    except (TypeError, ValueError):
+        return 2.0
+
+
+class WorldState:
+    """The observable state of this machine. NEVER raises."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._probes: Dict[str, Tuple[str, Callable[[], Any]]] = {}
+        self._cache: Dict[str, Reading] = {}
+
+    # -- registration ----------------------------------------------------
+
+    def register(self, predicate: str, probe: Callable[[], Any], *,
+                 name: str = "") -> None:
+        """Register what can answer *predicate*. Idempotent. NEVER raises.
+
+        *probe* returns ``True`` / ``False`` / ``None`` (unknown), sync or
+        async. Returning None is a legitimate answer and the reason the whole
+        type is ternary — see the module docstring.
+        """
+        try:
+            base, negated = canonical(predicate)
+            if negated:
+                logger.debug("[WorldState] refusing to register a probe for a "
+                             "negated predicate '%s' — register '%s'",
+                             predicate, base)
+                return
+            with self._lock:
+                self._probes[base] = (name or getattr(probe, "__name__", "probe"),
+                                      probe)
+        except Exception:  # noqa: BLE001
+            logger.debug("[WorldState] register degraded", exc_info=True)
+
+    def known_predicates(self) -> List[str]:
+        with self._lock:
+            return sorted(self._probes)
+
+    # -- observation -----------------------------------------------------
+
+    async def read(self, predicate: str, *, fresh: bool = False) -> Reading:
+        """Observe one predicate. NEVER raises.
+
+        *fresh* bypasses the cache — used after an action that was SUPPOSED to
+        change the world, where a cached answer would confirm the thing we are
+        trying to verify.
+        """
+        base, negated = canonical(predicate)
+        try:
+            if not fresh:
+                cached = self._cached(base)
+                if cached is not None:
+                    return self._orient(cached, predicate, negated)
+            with self._lock:
+                entry = self._probes.get(base)
+            if entry is None:
+                return Reading(predicate=predicate, truth=Truth.UNKNOWN.value,
+                               detail=f"nothing probes '{base}'",
+                               observed_at=time.time())
+            probe_name, probe = entry
+            truth, detail = await self._invoke(probe, probe_name)
+            reading = Reading(predicate=base, truth=truth.value,
+                              source=probe_name, detail=detail,
+                              observed_at=time.time())
+            with self._lock:
+                self._cache[base] = reading
+            return self._orient(reading, predicate, negated)
+        except Exception as exc:  # noqa: BLE001
+            return Reading(predicate=predicate, truth=Truth.UNKNOWN.value,
+                           detail=f"{type(exc).__name__}: {exc}",
+                           observed_at=time.time())
+
+    def _cached(self, base: str) -> Optional[Reading]:
+        try:
+            ttl = probe_ttl_s()
+            if ttl <= 0.0:
+                return None
+            with self._lock:
+                r = self._cache.get(base)
+            if r is None or (time.time() - r.observed_at) > ttl:
+                return None
+            # NEVER serve a cached UNKNOWN. A failed probe is a transient we
+            # want retried, and caching it would turn one CoreGraphics hiccup
+            # into a window during which the machine refuses to know anything.
+            return None if r.is_unknown else r
+        except Exception:  # noqa: BLE001
+            return None
+
+    @staticmethod
+    def _orient(reading: Reading, asked_as: str, negated: bool) -> Reading:
+        """Re-express a base reading in the polarity the caller asked for."""
+        if not negated:
+            return Reading(predicate=asked_as, truth=reading.truth,
+                           source=reading.source, detail=reading.detail,
+                           observed_at=reading.observed_at)
+        flipped = Truth(reading.truth).negate()
+        return Reading(predicate=asked_as, truth=flipped.value,
+                       source=reading.source, detail=reading.detail,
+                       observed_at=reading.observed_at)
+
+    @staticmethod
+    async def _invoke(probe: Callable[[], Any], name: str) -> Tuple[Truth, str]:
+        """Run one probe under a timeout. NEVER raises.
+
+        A sync probe runs in a worker thread: `_check_cgsession_locked_via_
+        ctypes` is a blocking C call, and the caller here is the event loop
+        that also carries the operator's voice.
+        """
+        try:
+            result = probe()
+            if inspect.isawaitable(result):
+                value = await asyncio.wait_for(result, timeout=probe_timeout_s())
+            elif callable(getattr(result, "__call__", None)):
+                value = result
+            else:
+                value = result
+            return Truth.of(value), ""
+        except asyncio.TimeoutError:
+            return Truth.UNKNOWN, f"probe '{name}' timed out"
+        except Exception as exc:  # noqa: BLE001
+            return Truth.UNKNOWN, f"probe '{name}' failed: {type(exc).__name__}"
+
+    async def satisfies(self, predicate: str, *, fresh: bool = False) -> bool:
+        """Whether *predicate* is KNOWN TRUE. NEVER raises.
+
+        The asymmetry is the point: UNKNOWN answers False here and False in
+        :meth:`refutes`, so an unobservable world satisfies nothing and
+        refutes nothing. A caller that wants "proceed unless proven otherwise"
+        has to say so out loud rather than get it by accident.
+        """
+        return (await self.read(predicate, fresh=fresh)).is_true
+
+    async def refutes(self, predicate: str, *, fresh: bool = False) -> bool:
+        """Whether *predicate* is KNOWN FALSE. NEVER raises."""
+        r = await self.read(predicate, fresh=fresh)
+        return r.truth == Truth.FALSE.value
+
+    async def unmet(self, predicates: Any, *,
+                    fresh: bool = False) -> List[Reading]:
+        """Every requirement not KNOWN TRUE, observed concurrently.
+
+        NEVER raises. Includes the UNKNOWN ones — a caller must be able to
+        tell "the screen is locked" (remediable) from "I cannot see whether
+        the screen is locked" (not something to act through).
+        """
+        try:
+            wanted = [p for p in (predicates or []) if p]
+            if not wanted:
+                return []
+            readings = await asyncio.gather(
+                *[self.read(p, fresh=fresh) for p in wanted],
+                return_exceptions=True)
+            out: List[Reading] = []
+            for p, r in zip(wanted, readings):
+                if isinstance(r, Reading):
+                    if not r.is_true:
+                        out.append(r)
+                else:
+                    out.append(Reading(predicate=p, truth=Truth.UNKNOWN.value,
+                                       detail="probe raised",
+                                       observed_at=time.time()))
+            return out
+        except Exception:  # noqa: BLE001
+            return [Reading(predicate=str(p), truth=Truth.UNKNOWN.value,
+                            detail="world state degraded",
+                            observed_at=time.time())
+                    for p in (predicates or [])]
+
+    def invalidate(self, predicate: str = "") -> None:
+        """Forget cached readings. NEVER raises.
+
+        Called after ANY action that touched the machine — not only the ones
+        whose declared effects we know about. A capability that changes the
+        world in a way nobody declared is exactly the one whose stale reading
+        would be believed.
+        """
+        try:
+            with self._lock:
+                if not predicate:
+                    self._cache.clear()
+                else:
+                    self._cache.pop(canonical(predicate)[0], None)
+        except Exception:  # noqa: BLE001
+            pass
+
+    def stats(self) -> Dict[str, Any]:
+        with self._lock:
+            return {
+                "schema_version": WORLD_STATE_SCHEMA_VERSION,
+                "predicates": sorted(self._probes),
+                "cached": {k: v.truth for k, v in self._cache.items()},
+                "ttl_s": probe_ttl_s(),
+            }
+
+
+# ── The macOS probes ────────────────────────────────────────────────────────
+
+#: The canonical predicate. `screen_unlocked` is its negation, so one probe
+#: answers both and they cannot disagree.
+SCREEN_LOCKED = "screen_locked"
+SCREEN_UNLOCKED = "screen_unlocked"
+
+# Registered at IMPORT, not inside the singleton factory. `canonical()` is a
+# pure function that anything may call — a registry hydrating, a test naming a
+# predicate — and if the antonym only existed after the first
+# `get_world_state()`, the same string would canonicalise two different ways
+# depending on call order. A vocabulary whose meaning depends on when you ask
+# is not a vocabulary.
+register_antonym(SCREEN_UNLOCKED, SCREEN_LOCKED)
+
+
+def _probe_screen_locked() -> Optional[bool]:
+    """Is the screen locked? ``None`` when we could not tell. NEVER raises.
+
+    COMPOSES the detector module's own `Optional[bool]` primitives instead of
+    calling its `is_screen_locked()` wrapper. The wrapper returns `bool` and
+    ends in a bare `return False`, so "no method could tell" and "the screen
+    is open" come back identical. That collapse is fine for a caller deciding
+    whether to show a banner and catastrophic for one deciding whether to type
+    a password into whatever currently has focus.
+
+    Same cascade order, same stated invariant — *if any reliable method says
+    locked, it is locked* — minus the final narrowing. Three probes rather
+    than the wrapper's seven because these three are the ones that answer
+    `Optional[bool]`; the rest already express themselves as booleans and
+    would smuggle the same collapse back in.
+
+    Measured, and worth knowing: `CGSessionCopyCurrentDictionary` returns NULL
+    outside a GUI session, so this reads UNKNOWN from a plain shell and
+    answers properly inside the HUD backend, which the Swift app spawns as a
+    child of its own GUI session. A test run from a terminal is therefore not
+    evidence that the probe is broken.
+
+    ctypes rather than the Quartz bridge because importing Quartz pulls in
+    AppKit._metadata, which SIGSEGVs while the CoreAudio IO thread is running
+    — and here that thread is always running; it is the microphone.
+    """
+    saw_unlocked = False
+    try:
+        from voice_unlock.objc.server import screen_lock_detector as D
+    except Exception:  # noqa: BLE001
+        logger.debug("[WorldState] lock detector unimportable", exc_info=True)
+        return None
+    for name in ("_check_cgsession_locked_via_ctypes",
+                 "_check_session_locked_via_osascript",
+                 "_check_lockscreen_process"):
+        try:
+            fn = getattr(D, name, None)
+            if fn is None:
+                continue
+            answer = fn()
+        except Exception:  # noqa: BLE001 — one blind method never blinds the rest
+            logger.debug("[WorldState] %s degraded", name, exc_info=True)
+            continue
+        if answer is True:
+            return True          # any reliable method saying LOCKED wins
+        if answer is False:
+            saw_unlocked = True
+    # UNLOCKED only if something actually SAW it unlocked. All-silent is
+    # UNKNOWN, which satisfies nothing — see the module docstring.
+    return False if saw_unlocked else None
+
+
+_WORLD: Optional[WorldState] = None
+_WORLD_LOCK = threading.Lock()
+
+
+def get_world_state() -> WorldState:
+    """Process-wide world state, with the macOS probes installed. NEVER raises."""
+    global _WORLD
+    with _WORLD_LOCK:
+        if _WORLD is None:
+            w = WorldState()
+            try:
+                w.register(SCREEN_LOCKED, _probe_screen_locked,
+                           name="cgsession_cascade")
+            except Exception:  # noqa: BLE001
+                logger.debug("[WorldState] probe install degraded", exc_info=True)
+            _WORLD = w
+        return _WORLD
+
+
+def reset_world_state() -> None:
+    """Testing seam. NEVER raises."""
+    global _WORLD
+    with _WORLD_LOCK:
+        _WORLD = None

--- a/tests/hud/test_voice_authority.py
+++ b/tests/hud/test_voice_authority.py
@@ -1,0 +1,228 @@
+"""The audio path, and the authority that works through a locked screen.
+
+Touch ID cannot authorise `unlock_screen` — there is no surface to draw a
+dialog on while the screen is locked. A microphone works through one. These
+pin the wire that carries the evidence and the state machine that judges it.
+"""
+from __future__ import annotations
+
+import base64
+import math
+import struct
+
+import pytest
+
+from backend.hud.utterance_audio import (
+    FORMAT_WAV16K, UtteranceHolder, reset_utterance_holder,
+)
+from backend.hud.voice_identity import (
+    Readiness, Verdict, VoiceIdentity, reset_voice_identity,
+)
+from backend.system_control.capability_router import _approved, _verdict_reason
+
+
+def _wav(seconds: float = 1.0, rate: int = 16000) -> bytes:
+    n = int(seconds * rate)
+    pcm = b"".join(struct.pack("<h", int(12000 * math.sin(i / 12))) for i in range(n))
+    return (b"RIFF" + struct.pack("<I", 36 + len(pcm)) + b"WAVEfmt "
+            + struct.pack("<IHHIIHH", 16, 1, 1, rate, rate * 2, 2, 16)
+            + b"data" + struct.pack("<I", len(pcm)) + pcm)
+
+
+def _b64(data: bytes) -> str:
+    return base64.b64encode(data).decode()
+
+
+@pytest.fixture(autouse=True)
+def _clean():
+    reset_utterance_holder()
+    reset_voice_identity()
+    yield
+    reset_utterance_holder()
+    reset_voice_identity()
+
+
+# ── The wire ────────────────────────────────────────────────────────────────
+
+def test_a_valid_utterance_is_held():
+    h = UtteranceHolder()
+    assert h.deposit(_b64(_wav()), FORMAT_WAV16K)
+    u = h.claim()
+    assert u and u.audio.startswith(b"RIFF") and len(u.digest) == 8
+
+
+def test_claiming_is_destructive():
+    """One sentence answers one question. Handing a verifier the same sample
+    twice is the shape of a replay."""
+    h = UtteranceHolder()
+    h.deposit(_b64(_wav()), FORMAT_WAV16K)
+    assert h.claim() is not None
+    assert h.claim() is None
+
+
+@pytest.mark.parametrize("payload,fmt,why", [
+    ("!!!not base64!!!", FORMAT_WAV16K, "undecodable"),
+    (None, FORMAT_WAV16K, "empty"),
+    ("", FORMAT_WAV16K, "empty"),
+])
+def test_malformed_audio_is_refused(payload, fmt, why):
+    assert UtteranceHolder().deposit(payload, fmt) is False
+
+
+def test_a_payload_that_is_not_a_wav_is_refused():
+    """Validated on deposit, not at verification time — the worst moment to
+    discover the evidence is unusable is when you need it."""
+    assert UtteranceHolder().deposit(_b64(b"\x00" * 4096), FORMAT_WAV16K) is False
+
+
+def test_an_unknown_format_is_refused():
+    assert UtteranceHolder().deposit(_b64(_wav()), "mp3") is False
+
+
+def test_an_oversized_utterance_is_refused(monkeypatch):
+    monkeypatch.setenv("JARVIS_UTTERANCE_MAX_BYTES", "2048")
+    assert UtteranceHolder().deposit(_b64(_wav(seconds=2.0)), FORMAT_WAV16K) is False
+
+
+def test_a_stale_utterance_is_not_returned(monkeypatch):
+    monkeypatch.setenv("JARVIS_UTTERANCE_TTL_S", "1")
+    h = UtteranceHolder()
+    h.deposit(_b64(_wav()), FORMAT_WAV16K)
+    held = h._held
+    held.captured_at -= 60          # age it past the TTL
+    assert h.claim() is None
+
+
+def test_bytes_never_reach_a_log():
+    """`repr` is what lands in a log line. It must describe the sample without
+    containing any of it."""
+    h = UtteranceHolder()
+    h.deposit(_b64(_wav()), FORMAT_WAV16K)
+    text = repr(h.claim())
+    assert "RIFF" not in text and "wav16k_b64" in text
+
+
+# ── The judgement ───────────────────────────────────────────────────────────
+
+class _Service:
+    def __init__(self, profiles, verified=True, confidence=0.9):
+        self.speaker_profiles = profiles
+        self._v, self._c = verified, confidence
+
+    async def verify_speaker(self, audio, name=None):
+        return {"verified": self._v, "confidence": self._c, "speaker_name": name}
+
+
+@pytest.mark.asyncio
+async def test_no_audio_is_its_own_answer():
+    r = await VoiceIdentity(service=_Service({"Derek": {}})).identify(None)
+    assert r.verdict == Verdict.NO_AUDIO.value and not r.approves
+
+
+@pytest.mark.asyncio
+async def test_an_unloaded_service_says_not_ready_not_not_enrolled():
+    """The correction that matters most here.
+
+    Profiles load from `intelligence.learning_database`, so an empty local
+    embeddings directory says NOTHING about whether a voiceprint exists.
+    Answering NOT_ENROLLED before the service has loaded would tell an
+    operator their voice was never enrolled when nothing had looked — and send
+    them off to re-record 59 samples they already have.
+    """
+    r = await VoiceIdentity().identify(b"RIFFxxxx")
+    assert r.verdict == Verdict.NOT_READY.value
+    assert "unknown" in r.detail
+
+
+@pytest.mark.asyncio
+async def test_a_loaded_service_with_no_profile_is_a_fact():
+    r = await VoiceIdentity(service=_Service({})).identify(b"RIFFxxxx")
+    assert r.verdict == Verdict.NOT_ENROLLED.value
+
+
+def test_unknown_enrollment_is_none_not_empty():
+    """None and "" are different claims: 'nothing has looked' vs 'it looked and
+    found nobody'."""
+    assert VoiceIdentity().enrolled_speaker() is None
+    assert VoiceIdentity(service=_Service({})).enrolled_speaker() == ""
+    assert VoiceIdentity(service=_Service({"Derek": {}})).enrolled_speaker() == "Derek"
+
+
+@pytest.mark.asyncio
+async def test_the_owner_is_verified():
+    r = await VoiceIdentity(service=_Service({"Derek": {}})).identify(b"RIFFxxxx")
+    assert r.verdict == Verdict.VERIFIED.value and r.approves
+
+
+@pytest.mark.asyncio
+async def test_a_rejection_stays_a_rejection():
+    svc = _Service({"Derek": {}}, verified=False, confidence=0.2)
+    r = await VoiceIdentity(service=svc).identify(b"RIFFxxxx")
+    assert r.verdict == Verdict.REJECTED.value and not r.approves
+
+
+@pytest.mark.asyncio
+async def test_the_confidence_floor_can_only_tighten():
+    """The service's own adaptive threshold is never lowered here. This refuses
+    to accept a `verified: true` that arrived with a confidence no one would
+    consider convincing for unlocking a computer."""
+    svc = _Service({"Derek": {}}, verified=True, confidence=0.40)
+    r = await VoiceIdentity(service=svc).identify(b"RIFFxxxx")
+    assert r.verdict == Verdict.REJECTED.value
+    assert "below floor" in r.detail
+
+
+@pytest.mark.asyncio
+async def test_a_raising_service_is_never_consent():
+    class Boom:
+        speaker_profiles = {"Derek": {}}
+
+        async def verify_speaker(self, *a, **k):
+            raise RuntimeError("model exploded")
+
+    r = await VoiceIdentity(service=Boom()).identify(b"RIFFxxxx")
+    assert r.verdict == Verdict.UNAVAILABLE.value and not r.approves
+
+
+@pytest.mark.asyncio
+async def test_disabling_the_authority_denies_rather_than_allows(monkeypatch):
+    """There is deliberately no setting that turns a verified unlock into an
+    unverified one."""
+    monkeypatch.setenv("JARVIS_VOICE_AUTHORITY_ENABLED", "false")
+    r = await VoiceIdentity(service=_Service({"Derek": {}})).identify(b"RIFFxxxx")
+    assert not r.approves
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("verdict", [
+    Verdict.NOT_ENROLLED, Verdict.NOT_READY, Verdict.NO_AUDIO,
+    Verdict.REJECTED, Verdict.UNAVAILABLE,
+])
+async def test_every_non_verified_verdict_fails_closed(verdict):
+    assert verdict.approves is False
+    assert Verdict.VERIFIED.approves is True
+
+
+# ── The router speaks its language ──────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_the_router_reads_the_verdict_without_a_translation_table():
+    """`approves` IS the decision. Matching "verified" against a list of
+    spellings of "yes" in the router would put one decision in two places."""
+    ok = await VoiceIdentity(service=_Service({"Derek": {}})).identify(b"RIFFxxxx")
+    no = await VoiceIdentity(service=_Service({})).identify(b"RIFFxxxx")
+    assert _approved(ok) is True
+    assert _approved(no) is False
+
+
+@pytest.mark.asyncio
+async def test_the_operator_hears_a_sentence_not_a_state_name():
+    r = await VoiceIdentity(service=_Service({})).identify(b"RIFFxxxx")
+    spoken = _verdict_reason(r)
+    assert "voiceprint" in spoken.lower()
+    assert "not_enrolled" not in spoken
+
+
+def test_readiness_reports_disabled_honestly(monkeypatch):
+    monkeypatch.setenv("JARVIS_VOICE_AUTHORITY_ENABLED", "false")
+    assert VoiceIdentity().readiness is Readiness.DISABLED

--- a/tests/hud/test_voice_router_reflex.py
+++ b/tests/hud/test_voice_router_reflex.py
@@ -14,8 +14,20 @@ import pytest
 from backend.hud.tool_use_orchestrator import CommandResult
 from backend.hud.voice_command_router import (
     VoiceCommandRouter, _humanise, _make_failure_speakable,
-    _read_controller_result,
+    _read_controller_result, reset_spoken,
 )
+
+
+@pytest.fixture(autouse=True)
+def _forget_what_jarvis_said():
+    """The router now narrates "On it — lock screen" before acting, and that
+    utterance is recorded so the microphone cannot hear it back as a command.
+    Across tests the ledger would leak, and one test's narration would suppress
+    the next test's command — which is exactly the production bug in miniature.
+    """
+    reset_spoken()
+    yield
+    reset_spoken()
 
 REFUSAL = ("session_budget_preflight_refused:soak_circuit_tripped:"
            "soak_cost_cap_exceeded:$238111.9488>=$2.0000:on_boot: "

--- a/tests/system_control/test_world_state_and_cai.py
+++ b/tests/system_control/test_world_state_and_cai.py
@@ -1,0 +1,371 @@
+"""World state, the unlock deadlock, and the flow a person would follow.
+
+Everything here was found in ONE live log (2026-08-03 00:17-00:19), which is
+why the assertions quote timings rather than describing behaviour in the
+abstract.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from backend.hud.tool_use_orchestrator import CommandResult
+from backend.hud.voice_command_router import (
+    VoiceCommandRouter, is_own_echo, note_spoken, reset_spoken,
+)
+from backend.system_control import world_state as WS
+from backend.system_control.capability_registry import Tier
+from backend.system_control.capability_router import (
+    CapabilityRouter, Outcome, _verdict_reason,
+)
+from backend.system_control.world_state import Truth, WorldState, canonical
+
+
+@pytest.fixture(autouse=True)
+def _clean():
+    WS.reset_world_state()
+    reset_spoken()
+    yield
+    WS.reset_world_state()
+    reset_spoken()
+
+
+# ── Ternary truth ───────────────────────────────────────────────────────────
+
+def test_none_is_unknown_and_never_false():
+    """The ghost-display lesson, in the type system.
+
+    `is_screen_locked()` returns `bool` and ends in a bare `return False`, so a
+    probe that could not see reports 'not locked'. Here that would authorise
+    typing a password into whatever has focus.
+    """
+    assert Truth.of(None) is Truth.UNKNOWN
+    assert Truth.of(False) is Truth.FALSE
+    assert Truth.of(True) is Truth.TRUE
+
+
+def test_not_knowing_a_thing_says_nothing_about_its_opposite():
+    assert Truth.UNKNOWN.negate() is Truth.UNKNOWN
+    assert Truth.TRUE.negate() is Truth.FALSE
+
+
+@pytest.mark.asyncio
+async def test_unknown_satisfies_nothing_and_refutes_nothing():
+    """The asymmetry the whole CAI rests on. An unobservable world must not
+    look like a met precondition OR an unmet one."""
+    w = WorldState()
+    w.register("screen_locked", lambda: None)
+    assert await w.satisfies("screen_locked") is False
+    assert await w.refutes("screen_locked") is False
+    assert await w.satisfies("screen_unlocked") is False
+    assert await w.refutes("screen_unlocked") is False
+
+
+@pytest.mark.asyncio
+async def test_one_probe_answers_both_polarities():
+    """Two probes for `screen_locked` and `screen_unlocked` could disagree, and
+    the day they did the machine would believe the screen was both."""
+    w = WorldState()
+    w.register("screen_locked", lambda: True)
+    assert (await w.read("screen_locked")).is_true
+    assert (await w.read("screen_unlocked")).truth == Truth.FALSE.value
+
+
+def test_antonyms_resolve_before_any_singleton_exists():
+    """`canonical` is pure and callable by anything. If the antonym only
+    existed after the first `get_world_state()`, one string would mean two
+    things depending on call order."""
+    assert canonical("screen_unlocked") == ("screen_locked", True)
+    assert canonical("!screen_locked") == ("screen_locked", True)
+    assert canonical("screen_locked") == ("screen_locked", False)
+
+
+@pytest.mark.asyncio
+async def test_an_unprobed_predicate_is_unknown_not_an_error():
+    w = WorldState()
+    r = await w.read("nobody_probes_this")
+    assert r.is_unknown and "nothing probes" in r.detail
+
+
+@pytest.mark.asyncio
+async def test_a_hanging_probe_becomes_unknown_not_a_hung_command(monkeypatch):
+    monkeypatch.setenv("JARVIS_WORLD_STATE_PROBE_TIMEOUT_S", "0.1")
+
+    async def _hang():
+        await asyncio.sleep(30)
+
+    w = WorldState()
+    w.register("slow", _hang)
+    r = await w.read("slow")
+    assert r.is_unknown and "timed out" in r.detail
+
+
+@pytest.mark.asyncio
+async def test_a_failed_probe_is_never_cached():
+    """One CoreGraphics hiccup must not become a window in which the machine
+    refuses to know anything."""
+    answers = [None, True]
+    w = WorldState()
+    w.register("flaky", lambda: answers.pop(0))
+    assert (await w.read("flaky")).is_unknown
+    assert (await w.read("flaky")).is_true
+
+
+@pytest.mark.asyncio
+async def test_the_live_probe_never_claims_unlocked_when_it_cannot_see():
+    """The composed cascade must answer UNKNOWN where the collapsing wrapper
+    answers a bare bool. Measured from a shell: all three primitives return
+    None (no GUI session) while `is_screen_locked()` still returns a boolean.
+    """
+    w = WS.get_world_state()
+    r = await w.read(WS.SCREEN_LOCKED, fresh=True)
+    # Whatever the environment, it is never allowed to fabricate 'unlocked'
+    # from silence: either something SAW the state, or it is UNKNOWN.
+    assert r.is_unknown or r.source == "cgsession_cascade"
+    if r.is_unknown:
+        assert await w.satisfies("screen_unlocked") is False
+
+
+# ── The unlock deadlock ─────────────────────────────────────────────────────
+
+class _Provider:
+    requires = ("screen_unlocked",)
+
+    def __init__(self):
+        self.asked = []
+
+    async def request(self, ctx):
+        self.asked.append(getattr(ctx, "capability", ""))
+        return "rid-1"
+
+
+class _Registry:
+    def __init__(self, d):
+        self._d = d
+
+    def get(self, n):
+        return self._d.get(n)
+
+
+def _gated_cap(name):
+    from backend.system_control.capability_registry import CapabilityDef
+    return CapabilityDef(name=name, description="x",
+                         tier=Tier.APPROVAL_REQUIRED.value)
+
+
+@pytest.mark.asyncio
+async def test_a_locked_screen_stops_touch_id_being_asked_at_all(monkeypatch):
+    """The deadlock, pinned.
+
+    Touch ID needs a surface to draw on. Asking it while the screen is locked
+    produced DENIED in 99ms and a log line saying the operator declined a
+    prompt they never saw.
+    """
+    w = WS.get_world_state()
+    w.register(WS.SCREEN_LOCKED, lambda: True)
+    provider = _Provider()
+    router = CapabilityRouter(registry=_Registry({"unlock_screen": _gated_cap("unlock_screen")}),
+                              provider=provider, target=object())
+
+    out = await router.route("unlock_screen")
+
+    assert out.outcome == Outcome.DENIED.value
+    assert provider.asked == [], "a channel that cannot be reached must not be asked"
+    assert "unreachable" in out.detail and "screen_unlocked" in out.detail
+
+
+@pytest.mark.asyncio
+async def test_an_unlocked_screen_asks_normally():
+    w = WS.get_world_state()
+    w.register(WS.SCREEN_LOCKED, lambda: False)
+    provider = _Provider()
+    router = CapabilityRouter(registry=_Registry({"cap": _gated_cap("cap")}),
+                              provider=provider, target=object())
+    out = await router.route("cap")
+    assert out.outcome == Outcome.SUSPENDED.value
+    assert provider.asked == ["cap"]
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_world_does_not_block_consent():
+    """Biased toward proceeding. `CGSession` answers only inside a GUI session,
+    so refusing to ask whenever the probe is blind would break every consent
+    prompt on most machines."""
+    w = WS.get_world_state()
+    w.register(WS.SCREEN_LOCKED, lambda: None)
+    provider = _Provider()
+    router = CapabilityRouter(registry=_Registry({"cap": _gated_cap("cap")}),
+                              provider=provider, target=object())
+    assert (await router.route("cap")).outcome == Outcome.SUSPENDED.value
+
+
+@pytest.mark.parametrize("verdict,expect", [
+    ({"reason": "biometry unavailable"}, "biometry unavailable"),
+    ({"reason": "operator denied"}, "operator denied"),
+    ({}, "operator declined"),
+])
+def test_the_channels_own_reason_survives(verdict, expect):
+    """`SecureConsent.describe()` already tells apart 'you said no' from 'the
+    machine could not ask'. That distinction was being thrown away one line
+    before anybody could read it."""
+    assert _verdict_reason(verdict) == expect
+
+
+# ── The flow a person would follow ──────────────────────────────────────────
+
+class _Dead:
+    async def prompt_only(self, *a, **k):
+        raise RuntimeError("provider down")
+
+
+def _router_stub(monkeypatch, state, calls):
+    import backend.system_control.capability_router as CR
+
+    class Stub:
+        async def route(self, name, args=None, *, op_id=""):
+            calls.append(name)
+            if name == "unlock_screen":
+                state["locked"] = False
+            return type("R", (), {
+                "outcome": "executed", "result": (True, "Screen unlocked."),
+                "detail": "", "capability": name, "request_id": "",
+                "context_note": ""})()
+
+    monkeypatch.setattr(CR, "get_capability_router", lambda: Stub())
+
+
+@pytest.mark.asyncio
+async def test_a_locked_mac_is_unlocked_before_the_real_command(monkeypatch):
+    """Told 'search for dogs' at a locked Mac, nobody types the query into the
+    lock screen and reports failure."""
+    state, calls, said = {"locked": True}, [], []
+    WS.get_world_state().register(WS.SCREEN_LOCKED, lambda: state["locked"])
+    _router_stub(monkeypatch, state, calls)
+
+    async def _say(t):
+        said.append(t)
+
+    await VoiceCommandRouter(_Dead(), narrate_fn=_say).route("search for dogs")
+
+    assert calls == ["unlock_screen"], "the remedy must be derived and run"
+    assert said and "locked" in said[0].lower()
+    assert "unlock" in said[0].lower()
+
+
+@pytest.mark.asyncio
+async def test_an_unlocked_mac_gets_no_detour(monkeypatch):
+    state, calls = {"locked": False}, []
+    WS.get_world_state().register(WS.SCREEN_LOCKED, lambda: state["locked"])
+    _router_stub(monkeypatch, state, calls)
+    await VoiceCommandRouter(_Dead()).route("search for dogs")
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_a_blind_probe_changes_nothing(monkeypatch):
+    """UNKNOWN behaves exactly like today. Treating 'I cannot see' as 'it is
+    locked' would unlock a Mac that was never locked, every time the probe was
+    blind — a fabricated remedy for an imagined problem."""
+    state, calls = {"locked": None}, []
+    WS.get_world_state().register(WS.SCREEN_LOCKED, lambda: state["locked"])
+    _router_stub(monkeypatch, state, calls)
+    await VoiceCommandRouter(_Dead()).route("search for dogs")
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_locking_the_screen_is_not_blocked_by_the_screen_being_locked(
+        monkeypatch):
+    """The self-deadlock the dead phrase-table detector needed an exception
+    list to avoid. A declaring capability speaks for itself, including by
+    declaring no requirement."""
+    state, calls = {"locked": True}, []
+    WS.get_world_state().register(WS.SCREEN_LOCKED, lambda: state["locked"])
+    _router_stub(monkeypatch, state, calls)
+    await VoiceCommandRouter(_Dead()).route("lock my screen")
+    assert "unlock_screen" not in calls
+
+
+@pytest.mark.asyncio
+async def test_a_failed_unlock_abandons_the_original_command(monkeypatch):
+    """`provides` is a claim, not a proof. The world is re-observed, and a
+    remedy that did not work stops the chain rather than carrying on into a
+    lock screen."""
+    calls = []
+    import backend.system_control.capability_router as CR
+
+    class Stub:  # says it worked; the world disagrees
+        async def route(self, name, args=None, *, op_id=""):
+            calls.append(name)
+            return type("R", (), {
+                "outcome": "executed", "result": (True, "Unlocked!"),
+                "detail": "", "capability": name, "request_id": "",
+                "context_note": ""})()
+
+    monkeypatch.setattr(CR, "get_capability_router", lambda: Stub())
+    WS.get_world_state().register(WS.SCREEN_LOCKED, lambda: True)
+
+    res = await VoiceCommandRouter(_Dead()).route("search for dogs")
+
+    assert calls == ["unlock_screen"]
+    assert res.success is False
+    assert "left the rest alone" in (res.response_text or "")
+
+
+@pytest.mark.asyncio
+async def test_two_claimants_for_one_effect_is_a_refusal_not_a_coin_toss():
+    from backend.hud.voice_command_router import VoiceCommandRouter as V
+    assert V._who_provides("screen_unlocked") == "unlock_screen"
+    assert V._who_provides("no_such_predicate") is None
+
+
+# ── Hearing yourself ────────────────────────────────────────────────────────
+
+def test_jarvis_does_not_take_its_own_voice_as_a_command():
+    """One spoken "lock my screen" locked the screen TWICE: the mute claim's
+    deadline is an ESTIMATE from character count, it expired mid-sentence, and
+    the recogniser transcribed the synthesiser."""
+    note_spoken("On it. Executing: lock my screen")
+    assert is_own_echo("Lock screen")
+    assert is_own_echo("lock my screen")
+
+
+def test_the_opposite_command_is_not_an_echo():
+    """Word boundaries again: "unlock" is not "lock", so asking to unlock is
+    never mistaken for an echo of locking."""
+    note_spoken("On it — lock screen.")
+    assert not is_own_echo("unlock my screen")
+
+
+def test_an_unrelated_command_is_never_suppressed():
+    note_spoken("Locking the screen now, Derek.")
+    assert not is_own_echo("open chrome")
+
+
+@pytest.mark.asyncio
+async def test_an_echo_runs_nothing_at_all(monkeypatch):
+    calls = []
+    _router_stub(monkeypatch, {"locked": False}, calls)
+    WS.get_world_state().register(WS.SCREEN_LOCKED, lambda: False)
+    note_spoken("On it — lock screen.")
+    res = await VoiceCommandRouter(_Dead()).route("Lock screen")
+    assert res.category == "ignored_echo"
+    assert calls == []
+
+
+def test_the_echo_window_can_be_switched_off(monkeypatch):
+    monkeypatch.setenv("JARVIS_ECHO_GRACE_S", "0")
+    note_spoken("lock my screen")
+    assert not is_own_echo("lock my screen")
+
+
+# ── Naming the operator ─────────────────────────────────────────────────────
+
+def test_the_mac_does_not_greet_its_owner_as_a_stranger():
+    """Live: "🔒 Locking the screen now, there. See you soon." The name is
+    derived from the account's own GECOS field, not written down."""
+    from backend.system_control.macos_controller import _operator_name
+    name = _operator_name()
+    assert name != "there"
+    assert name == "" or (name.isalpha() and len(name) <= 24)


### PR DESCRIPTION
`lock_screen` shipped in #70366 and **worked live**. The same session's log then showed why `unlock_screen` never could.

## The unlock deadlock

`unlock_screen` is `APPROVAL_REQUIRED`, so it suspends for Touch ID. But the screen is **locked**, so `SecureConsent` has no surface to draw a dialog on. Measured at `00:18:58`:

```
[HUD] Voice result: awaiting-consent
[Brainstem] sendEvent: consent_verdict (249 bytes)      +99ms
[HUD] consent verdict for unlock_screen → denied (operator declined)
```

Ninety-nine milliseconds. Nobody declined anything.

> **A gate whose only answer channel requires the very state the gated action exists to produce is a deadlock, not a safeguard.**

Fixed structurally, not by removing the gate. A consent channel now **declares the world state it needs** (`HUDConsentProvider.requires = ("screen_unlocked",)`), the router checks reachability *before* suspending, and a secondary authority whose preconditions **are** met is asked instead. A microphone works through a locked screen.

Voice is consulted **only** when the primary channel is unreachable — so while Touch ID is presentable it remains the authority, and voice never becomes a way around a prompt you could have seen.

## World state — one mechanism, three jobs

Preconditions, channel reachability, and post-action verification turned out to be the same question: *what is true of this machine right now?*

Truth is **ternary**, and that is load-bearing. `is_screen_locked()` collapses `Optional[bool]` to `bool` and ends in a bare `return False`. Measured from a shell: all three of its primitives return `None` while the wrapper still answers **`True`** — it reports a lock state from a context that can see nothing. Here that would authorize typing a password into whatever has focus.

**UNKNOWN satisfies nothing and refutes nothing.**

## Contextual awareness

"search for dogs" on a locked Mac: unmet precondition → remedy **derived from the registry** (*which capability declares `provides=screen_unlocked`?* — nothing names `unlock_screen`) → *"Your screen is locked, let me unlock it first"* → unlock → **re-observe** → continue. `provides` is a claim; only looking again is evidence.

It acts only on **positive knowledge**. `CGSession` answers only inside a GUI session, so treating "I cannot see" as "it is locked" would unlock a Mac that was never locked every time the probe went blind. UNKNOWN behaves exactly as before — zero regression.

`ScreenLockContextDetector` already existed for this. It had **zero callers** and a ~30-entry hardcoded phrase table, including an exception list so it wouldn't unlock the screen in order to lock it. Its CGSession probe is kept; the table is gone.

## The audio path

Python only ever received the **transcript** — so the one authority that works through a locked screen had no evidence, and enrollment cannot build a voiceprint from text.

`UtteranceRecorder.swift`: preallocated buffer, `memcpy` only on the render thread (no allocation, no locks — the log already shows `IOWorkLoop` overload), resampled to 16 kHz mono WAV *after* the sentence ends, base64 onto the existing `action` event. Recorded **behind the same mute gate** as the recognizer, so JARVIS can never contribute its own synthesizer to a voiceprint.

Never written to disk. The holder validates RIFF, bounds size, expires on a clock, and **`claim()` is destructive** — one sentence answers one question, which is the shape that stops a replay.

`xcodegen` was required: the new file was **not** in `project.pbxproj` and would have been dark code. That regeneration then deleted `OS_ACTIVITY_MODE`, which existed only in the generated scheme — now recorded in `project.yml`, because **a setting that lives only in a generated artifact is a countdown.**

## Enrollment was never missing

The CloudSQL proxy is live on `127.0.0.1:5432`. `speaker_profiles` holds:

| field | value |
|---|---|
| speaker_name | Derek J. Russell |
| total_samples | 272 |
| enrollment_quality | 0.95 |
| is_primary_user / security_level | true / admin |
| voiceprint_embedding | 1538 bytes |
| **verification_count** | **0** — never once used |

Building local enrollment would have **duplicated a profile that already existed.**

Enrollment is a *database* question, not a *model* question: the speaker model takes >150s to load, the profile is one row. Resolved at boot and cached, so a not-ready reply reads `model cold; enrollment Derek J. Russell` — it knows who it's looking for long before it can look.

## Four tiers, four behaviours (follow-on from #70366)

`NOTIFY_APPLY` runs and announces · `APPROVAL_REQUIRED` asks · `BLOCKED` is refused **without being offered to anyone**. Swift's own denial reason survives instead of being overwritten with "operator declined".

The reflex's confidence bar now keys on `requires_consent`, not `iron_gate_required` — otherwise moving `lock_screen` to `NOTIFY_APPLY` would have relaxed the bar for exactly the tier that loses the prompt the relaxation depends on.

## JARVIS heard itself

One spoken "lock my screen" locked the screen **twice**. The `SpeechGate` deadline is estimated from character count, expired mid-sentence, and the recognizer transcribed the synthesizer. Echo ledger at the one `_hud_tts` chokepoint, **ordered** subsequence (a set test made the CAI's own *"let me unlock it first"* deafen JARVIS to a real "unlock my screen"), expiry bounded by `estimate_speech_ms` rather than a flat window.

`speaker_name` no longer falls back to `"there"` — derived from passwd GECOS.

## Bugs introduced and caught — all pinned by tests

- `enrolled_speaker()` read an empty local directory and answered **"nobody is enrolled"** when profiles live in a database. It would have sent me to re-record 272 samples I already have.
- The 5.2s enrollment lookup was briefly placed **inside `identify()`** — directly on the path between "unlock my screen" and the screen unlocking. The test suite hung, which is how it was found.
- `_conjunction_split` was written and never called; the failure translator overwrote a *true* message with a false one.

## Testing

**325 passed, 19 skipped** (skips are sandbox socket-binding, pre-existing). **Swift: `BUILD SUCCEEDED`, 0 errors.**

New: `test_world_state_and_cai.py` (27) · `test_voice_authority.py` (27).

## ⚠️ Not live-proven

The speaker model **exceeded 150s in testing and was never observed reaching READY**. Warm-up reports that honestly rather than hanging — you'd hear *"I'm still loading my voice recognition"* — but if it never lands, unlock refuses with that message forever. The boot log now answers it directly: `[VoiceIdentity] speaker model READY after Ns` versus `warm-up TIMED OUT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds contextual world state and a voice-based consent path so `unlock_screen` can be authorized through a locked screen. Also records utterance audio end-to-end, adds speaker verification, and prevents echo-triggered commands.

- **New Features**
  - New ternary world state (`UNKNOWN`/`TRUE`/`FALSE`) for preconditions, consent reachability, and post-action checks.
  - Capabilities declare `requires`/`provides`; router derives remedies and re-observes before continuing.
  - Consent providers declare preconditions; router checks reachability and falls back to voice only when Touch ID is unreachable.
  - Utterance audio capture in HUD (`UtteranceRecorder.swift`) → base64 16 kHz WAV → backend holder (validated, expiring, single-use); never written to disk.
  - Speaker verification service with clear verdicts (`NOT_READY`, `NOT_ENROLLED`, `NO_AUDIO`, `REJECTED`, `ACCEPTED`); enrollment resolved from DB at boot and cached.

- **Bug Fixes**
  - Resolved unlock deadlock (Touch ID unreachable on lock) by enforcing consent preconditions and selecting a reachable authority.
  - Stopped self-echo triggers and double actions via an ordered `_hud_tts` ledger with grace timing.
  - Fixed enrollment lookup to use CloudSQL `speaker_profiles` and moved slow queries off the `identify()` path.
  - Router preserves native denial reasons and corrects reflex confidence to key on `requires_consent`.

<sup>Written for commit 43490f0767a5cdf31f30d7b39bb8e9dc09c7683a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

