### PR TITLE
fix(hud): one mouth, and three lies about why something did not happen

### DIFF
--- a/backend/hud/voice_command_router.py
+++ b/backend/hud/voice_command_router.py
@@ -179,6 +179,98 @@ def _ordered_within(needle: tuple, haystack: tuple) -> bool:
         return False
 
 
+#: Capabilities currently executing, name → started-at. Bounded by the number
+#: of things that can be in flight, which is small.
+_IN_FLIGHT: dict = {}
+_IN_FLIGHT_LOCK = threading.Lock()
+
+
+def in_flight_window_s() -> float:
+    """How long a capability counts as still running. NEVER raises.
+
+    A ceiling, not a measurement — the entry is removed when the call
+    finishes. This only stops a crashed or wedged call from blocking its own
+    capability forever.
+    """
+    try:
+        raw = (os.environ.get("JARVIS_IN_FLIGHT_WINDOW_S", "") or "").strip()
+        return max(1.0, min(300.0, float(raw))) if raw else 45.0
+    except (TypeError, ValueError):
+        return 45.0
+
+
+def _claim_in_flight(capability: str) -> bool:
+    """Take the slot for *capability*. False if it is already running.
+
+    NEVER raises.
+
+    THE REPEAT ECHO SUPPRESSION CANNOT SEE
+    ----------------------------------------
+    Measured 2026-08-03: boot held the event loop, so "lock my screen" took
+    31 seconds to produce a sound. Derek did what anyone does when nothing
+    happens — he said it again. Both ran; the screen locked twice.
+
+    `is_own_echo` is blind to this by construction: the repeat arrived at
+    01:40:49 and JARVIS did not speak until 01:41:05, so there was nothing to
+    be an echo OF. They are different problems with different fixes — one is
+    the assistant hearing itself, this is the operator being ignored long
+    enough to ask twice.
+
+    Keyed on the CAPABILITY rather than the words, so "lock my screen" and
+    "Lock screen" coalesce — they resolve to the same act, which is the thing
+    that must not happen twice. Two people asking for two different things
+    still get both.
+    """
+    try:
+        now = time.time()
+        with _IN_FLIGHT_LOCK:
+            started = _IN_FLIGHT.get(capability)
+            if started is not None and (now - started) < in_flight_window_s():
+                return False
+            _IN_FLIGHT[capability] = now
+            # Sweep anything that outlived the ceiling; a wedged call must not
+            # disable its capability for the rest of the session.
+            for k, t in list(_IN_FLIGHT.items()):
+                if (now - t) > in_flight_window_s():
+                    _IN_FLIGHT.pop(k, None)
+        return True
+    except Exception:  # noqa: BLE001 — never block a command on bookkeeping
+        return True
+
+
+def _release_in_flight(capability: str) -> None:
+    """Give the slot back. NEVER raises."""
+    try:
+        with _IN_FLIGHT_LOCK:
+            _IN_FLIGHT.pop(capability, None)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _reads_like_a_sentence(text: str) -> bool:
+    """Whether *text* was written for a person to hear. NEVER raises.
+
+    The test is shape, not vocabulary: a sentence starts with a capital, ends
+    in punctuation, and has several words. `capability_router` details come in
+    both kinds — "I don't have a voiceprint for you on this Mac yet." is meant
+    for the operator's ears, while "consent channel unreachable —
+    HUDConsentProvider needs screen_unlocked" is meant for the log.
+
+    Deciding by shape rather than by matching known phrases is what keeps this
+    correct when a new authority is added: an authority that writes properly
+    for a person is understood without this function learning about it.
+    """
+    try:
+        t = (text or "").strip()
+        if len(t) < 12 or len(t.split()) < 4:
+            return False
+        if not t[0].isupper():
+            return False
+        return t.endswith((".", "!", "?"))
+    except Exception:  # noqa: BLE001
+        return False
+
+
 def _humanise(capability: str) -> str:
     """A capability name as a person would say it. NEVER raises.
 
@@ -728,6 +820,27 @@ class VoiceCommandRouter:
         resolve anything whose signature has a required parameter, so an empty
         call here is a guarantee rather than an omission.
         """
+        capability = str(getattr(reflex, "capability", "") or "")
+        if not _claim_in_flight(capability):
+            logger.warning("[VoiceRouter] COALESCED '%s' — the same action is "
+                           "already running; not starting a second one",
+                           capability)
+            return CommandResult(
+                success=True, category="system_action", steps_completed=0,
+                steps_total=0, error=None,
+                response_text=f"Already {_humanise(capability)} — one moment.")
+        try:
+            return await self._route_capability(reflex, capability)
+        finally:
+            # Released on EVERY path, including the suspended one. A slot that
+            # leaks disables its own capability until the ceiling sweeps it,
+            # which would turn a crash into "JARVIS will not lock my screen
+            # any more" — a worse failure than the double-lock it prevents.
+            _release_in_flight(capability)
+
+    async def _route_capability(self, reflex: Any,
+                                capability: str) -> CommandResult:
+        """Route one already-claimed capability. NEVER raises."""
         try:
             from backend.system_control.capability_router import (
                 Outcome, get_capability_router,
@@ -768,19 +881,36 @@ class VoiceCommandRouter:
                               f"Check the prompt on screen.")
 
         if outcome == Outcome.DENIED.value:
-            # Two very different situations wearing one outcome, and an
-            # operator needs opposite follow-ups: they said no, or nothing
-            # could ask them. The router already writes the distinction into
-            # `detail`; dropping it here would make a disconnected HUD look
-            # like a refusal the operator does not remember giving.
-            unasked = "no approval provider" in (routed.detail or "").lower()
+            # PREFER THE REASON THE AUTHORITY GAVE.
+            #
+            # DENIED covers many situations and only one of them is "you said
+            # no". Measured 2026-08-03 01:41:27 — the voice authority answered
+            # "I don't have a voiceprint for you on this Mac yet", and this
+            # branch recognised only the no-provider case, fell through, and
+            # said:
+            #
+            #     "You declined unlock screen, so I left it alone."
+            #
+            # Derek declined nothing. The true reason was already a finished
+            # sentence in `routed.detail` and was overwritten with a
+            # fabrication about the operator's own behaviour — the same defect
+            # as the consent verdict reporting "operator declined" for a
+            # prompt nobody drew, one layer up and in my own code.
+            #
+            # So: if the authority wrote a sentence, that IS the answer.
+            # Matching keywords to pick a canned line is what produced the lie,
+            # and a longer keyword list would only postpone the next one.
+            detail = (routed.detail or "").strip()
+            if _reads_like_a_sentence(detail):
+                spoken = detail
+            elif "no approval provider" in detail.lower():
+                spoken = (f"I couldn't ask anyone to approve {human}, so I "
+                          f"didn't do it.")
+            else:
+                spoken = f"I couldn't {human}: {detail or 'it was refused'}."
             return CommandResult(
                 success=False, category="system_action", steps_completed=0,
-                steps_total=1, error=routed.detail or "denied",
-                response_text=(
-                    f"I couldn't ask anyone to approve {human}, so I didn't "
-                    f"do it." if unasked
-                    else f"You declined {human}, so I left it alone."))
+                steps_total=1, error=detail or "denied", response_text=spoken)
 
         if outcome == Outcome.EXPIRED.value:
             return CommandResult(

--- a/backend/hud/voice_identity.py
+++ b/backend/hud/voice_identity.py
@@ -88,6 +88,15 @@ def min_confidence() -> float:
         return 0.75
 
 
+def _enrollment_timeout_s() -> float:
+    """How long the profile lookup may take. NEVER raises."""
+    try:
+        raw = (os.environ.get("JARVIS_ENROLLMENT_TIMEOUT_S", "") or "").strip()
+        return max(5.0, min(180.0, float(raw))) if raw else 60.0
+    except (TypeError, ValueError):
+        return 60.0
+
+
 def warm_timeout_s() -> float:
     """How long the background warm-up may take before it is called failed."""
     try:
@@ -331,10 +340,27 @@ class VoiceIdentity:
             if (self._enrolled_cache is not None
                     and (now - self._enrolled_at) < 300.0):
                 return self._enrolled_cache
+            # PATIENT, because nothing is waiting on this.
+            #
+            # Measured 2026-08-03 01:40:34 — this timed out at 15s and left
+            # enrollment UNKNOWN for the whole session, while `LearningDB`
+            # itself logged "Initialization timed out (15s) — retrying with
+            # fast_mode (SQLite-first)" and fell back to a local database that
+            # holds no profiles. Two 15s ceilings racing the same cold
+            # CloudSQL connect, both losing.
+            #
+            # A cold connect measured 5.2s idle and rather more during boot,
+            # when it competes with everything else waking up. This runs in
+            # the background and has no operator waiting on it — the ONLY cost
+            # of waiting longer is that enrollment stays UNKNOWN a little
+            # longer, and UNKNOWN is already handled honestly. The cost of
+            # giving up early is a whole session that cannot verify anybody.
+            timeout = _enrollment_timeout_s()
             from intelligence.learning_database import get_learning_database
-            db = await asyncio.wait_for(get_learning_database(), timeout=15.0)
+            db = await asyncio.wait_for(get_learning_database(),
+                                        timeout=timeout)
             profiles = await asyncio.wait_for(
-                db.get_all_speaker_profiles(), timeout=15.0)
+                db.get_all_speaker_profiles(), timeout=timeout)
             names = []
             for p in (profiles or []):
                 n = (p.get("speaker_name") if isinstance(p, dict)
@@ -430,10 +456,28 @@ class VoiceIdentity:
                 return _out(Verdict.UNAVAILABLE,
                             detail=self._detail or f"model {state.value}")
 
-            # Loaded, and it says there is no profile. NOW this is a fact.
-            if not owner:
+            # UNKNOWN IS NOT "NOBODY". Checked as `is None`, never `not owner`.
+            #
+            # Measured 2026-08-03 01:41:27, with 272 samples sitting in
+            # CloudSQL: the enrollment lookup timed out, returned None, and
+            # `if not owner` treated that identically to "" — so JARVIS told
+            # its owner "I don't have a voiceprint for you on this Mac yet"
+            # and suggested he enroll a voice he enrolled last October.
+            #
+            # Three states were designed precisely so this could not happen,
+            # and then two of them were collapsed by one falsy check. `None`
+            # and `""` are different claims and the operator acts on them
+            # differently: one is "wait", the other is "enroll".
+            if owner is None:
+                self._schedule_enrollment_refresh()
+                return _out(Verdict.NOT_READY,
+                            detail="enrollment UNKNOWN — the profile store "
+                                   "could not be reached; NOT a statement "
+                                   "that nobody is enrolled")
+            if owner == "":
                 return _out(Verdict.NOT_ENROLLED,
-                            detail="service loaded and holds no voiceprint")
+                            detail="profile store reachable and holds no "
+                                   "voiceprint")
 
             result = await self._service.verify_speaker(audio, owner)
             verified = bool((result or {}).get("verified"))

--- a/backend/main.py
+++ b/backend/main.py
@@ -2013,11 +2013,53 @@ async def parallel_lifespan(app: FastAPI):
                 # deleted the file by hand; and the flag described only THIS
                 # source, while three other things in the system also speak.
                 _TTS_VOICE = os.environ.get("JARVIS_TTS_VOICE", "Daniel")
+                # How long a reply may wait for the voice before it stops
+                # being worth saying. Bounded because the queue drains at
+                # speaking speed while commands arrive at speaking speed — a
+                # backlog never catches up, it only gets older.
+                try:
+                    _TTS_MAX_QUEUE_S = max(1.0, min(60.0, float(
+                        os.environ.get("JARVIS_TTS_MAX_QUEUE_S", "") or 12.0)))
+                except (TypeError, ValueError):
+                    _TTS_MAX_QUEUE_S = 12.0
+
+                # ONE MOUTH.
+                #
+                # `say` writes an aiff and `afplay` plays it, and NOTHING
+                # serialised the pair. Two responses arriving 0.65s apart
+                # produced two concurrent `afplay` processes — measured
+                # 2026-08-03 01:41:27, "You declined unlock screen" and
+                # "Locking the screen now, Derek" playing over each other.
+                # From the room that is not a race condition, it is two
+                # JARVISes talking at once.
+                #
+                # A lock rather than a queue-with-worker because the ordering
+                # that matters is already the order the results arrived in,
+                # and a second scheduling layer would be a second place for an
+                # utterance to get lost.
+                _tts_mouth = asyncio.Lock()
 
                 async def _hud_tts(text: str) -> None:
                     """Speak text to the user via macOS TTS with mic suppression."""
                     if not text:
                         return
+                    # STALE SPEECH IS WORSE THAN SILENCE. An utterance that
+                    # waited out the whole queue is describing something the
+                    # operator has stopped caring about, and saying it anyway
+                    # is how an assistant ends up narrating its own backlog.
+                    _queued_at = time.monotonic()
+                    async with _tts_mouth:
+                        _waited = time.monotonic() - _queued_at
+                        if _waited > _TTS_MAX_QUEUE_S:
+                            logger.info(
+                                "[HUD] dropped a reply that waited %.1fs for "
+                                "the voice — it is no longer about anything: "
+                                "%s", _waited, text[:60])
+                            return
+                        await _hud_tts_locked(text)
+
+                async def _hud_tts_locked(text: str) -> None:
+                    """The actual speaking. Only ever called holding the lock."""
                     # THE ECHO LEDGER. Every word JARVIS utters passes through
                     # here, which is the only reason a single call can cover
                     # all of them — the mute claim's deadline is an ESTIMATE

--- a/tests/hud/test_voice_authority.py
+++ b/tests/hud/test_voice_authority.py
@@ -226,3 +226,40 @@ async def test_the_operator_hears_a_sentence_not_a_state_name():
 def test_readiness_reports_disabled_honestly(monkeypatch):
     monkeypatch.setenv("JARVIS_VOICE_AUTHORITY_ENABLED", "false")
     assert VoiceIdentity().readiness is Readiness.DISABLED
+
+
+# ── The 2026-08-03 01:41 log, defect by defect ──────────────────────────────
+
+@pytest.mark.asyncio
+async def test_unknown_enrollment_is_never_reported_as_not_enrolled():
+    """Measured 01:41:27, with 272 samples sitting in CloudSQL.
+
+    The enrollment lookup timed out and returned None, `if not owner` treated
+    that identically to "", and JARVIS told its owner "I don't have a
+    voiceprint for you on this Mac yet" — suggesting he enroll a voice he
+    enrolled last October. Three states were designed so this could not
+    happen, then two were collapsed by one falsy check.
+    """
+    # The measured shape: the ECAPA facade came up ("falling back to local
+    # engine") so the service is present and answers verifications, but it
+    # exposes no loaded profile dict, and the database lookup behind it timed
+    # out — so enrollment is genuinely UNKNOWN.
+    class _NoProfilesLoaded:
+        async def verify_speaker(self, audio, name=None):
+            return {"verified": True, "confidence": 0.9}
+
+    vi = VoiceIdentity(service=_NoProfilesLoaded())
+    vi._enrolled_cache = None                     # the lookup timed out
+    r = await vi.identify(b"RIFFxxxx")
+    assert r.verdict == Verdict.NOT_READY.value
+    assert "UNKNOWN" in r.detail
+    assert "voiceprint" not in r.spoken_reason.lower()
+
+
+@pytest.mark.asyncio
+async def test_a_reachable_store_with_no_profile_still_says_not_enrolled():
+    """The other side of the same coin — "" must keep meaning nobody."""
+    vi = VoiceIdentity(service=_Service({}))
+    vi._enrolled_cache = ""
+    r = await vi.identify(b"RIFFxxxx")
+    assert r.verdict == Verdict.NOT_ENROLLED.value

--- a/tests/hud/test_voice_router_reflex.py
+++ b/tests/hud/test_voice_router_reflex.py
@@ -9,6 +9,8 @@ answered by reading the refusal string aloud through a speech synthesiser.
 """
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from backend.hud.tool_use_orchestrator import CommandResult
@@ -249,3 +251,58 @@ def test_controller_results_speak_for_themselves():
         True, "🔒 Locking now.")
     ok, say = _read_controller_result(None, "lock screen")
     assert ok and "lock screen" in say
+
+
+# ── The 2026-08-03 01:41 log ────────────────────────────────────────────────
+
+def test_a_real_reason_is_never_replaced_with_you_declined():
+    """Measured 01:41:27. The voice authority answered "I don't have a
+    voiceprint for you on this Mac yet"; the DENIED branch recognised only the
+    no-provider case and said "You declined unlock screen, so I left it
+    alone." Derek declined nothing — the truth was discarded and replaced with
+    a fabrication about the operator's own behaviour."""
+    from backend.hud.voice_command_router import _reads_like_a_sentence
+    authority = ("I don't have a voiceprint for you on this Mac yet, so I "
+                 "can't confirm it's you.")
+    assert _reads_like_a_sentence(authority)
+    assert not _reads_like_a_sentence(
+        "consent channel unreachable — HUDConsentProvider needs screen_unlocked")
+
+
+@pytest.mark.asyncio
+async def test_the_same_action_does_not_run_twice_concurrently(monkeypatch):
+    """Boot held the loop for 31s, so Derek said it again and the screen
+    locked TWICE. Echo suppression is blind to this: the repeat arrived before
+    JARVIS had spoken, so there was nothing to be an echo of."""
+    import backend.system_control.capability_router as CR
+    calls = []
+
+    class Slow:
+        async def route(self, name, args=None, *, op_id=""):
+            calls.append(name)
+            await asyncio.sleep(0.3)
+            return _Routed("executed", result=(True, "Locked."))
+
+    monkeypatch.setattr(CR, "get_capability_router", lambda: Slow())
+    r = VoiceCommandRouter(DeadCortex())
+    await asyncio.gather(r.route("lock my screen"), r.route("Lock screen"))
+    assert calls == ["lock_screen"], f"ran twice: {calls}"
+
+
+@pytest.mark.asyncio
+async def test_the_slot_is_released_so_a_capability_still_works_after(monkeypatch):
+    """A leaked slot would turn one crash into "JARVIS will not lock my screen
+    any more" — worse than the double-lock it prevents."""
+    import backend.system_control.capability_router as CR
+    calls = []
+
+    class Boom:
+        async def route(self, name, args=None, *, op_id=""):
+            calls.append(name)
+            raise RuntimeError("router exploded")
+
+    monkeypatch.setattr(CR, "get_capability_router", lambda: Boom())
+    r = VoiceCommandRouter(DeadCortex())
+    await r.route("lock my screen")
+    await r.route("lock my screen")
+    assert calls == ["lock_screen", "lock_screen"], "the slot leaked"


### PR DESCRIPTION
Live log `2026-08-03 01:39–01:41`. Five defects — **three of them shipped in #70367.**

## Two JARVISes talking at once

`_hud_tts` runs `say` then `afplay`, and nothing serialized the pair. Two responses 0.65s apart:

```
01:41:27,191  Response: You declined unlock screen, so I left it alone.
01:41:27,841  Response: 🔒 Locking the screen now, Derek. See you soon.
```

Two concurrent `afplay` processes. From the room that isn't a race condition — it's two voices. Now one lock, and a reply that waited out the queue is **dropped rather than narrated late**: the queue drains at speaking speed while commands arrive at speaking speed, so a backlog never catches up, it only gets older.

## "You declined unlock screen" — nobody declined

The voice authority answered *"I don't have a voiceprint for you on this Mac yet."* The `DENIED` branch recognized only the no-provider case, fell through, and **replaced a true sentence with a fabrication about the operator's own behaviour.**

This is the same defect fixed one layer up in #70367 (`operator declined` for a prompt nobody drew), reintroduced in my own code. It now prefers the authority's own words, chosen by **shape** rather than a keyword list — the keyword list is what produced the lie, and a longer one only postpones the next.

## UNKNOWN collapsed into "nobody"

```
01:40:34  enrollment lookup timed out — leaving it UNKNOWN
01:41:27  I don't have a voiceprint for you on this Mac yet
```

The lookup returned `None` and `if not owner` treated it identically to `""`. JARVIS told its owner to enroll a voice with **272 samples sitting in CloudSQL**. Three states were designed so this couldn't happen, then two were collapsed by one falsy check.

Root cause of the timeout: **two 15s ceilings racing the same cold connect, both losing** — mine, and `LearningDB`'s own, which logged `Initialization timed out (15s) — retrying with fast_mode (SQLite-first)` and fell back to a database holding no profiles. Mine is now 60s; nothing waits on it, and giving up early costs a whole session that cannot verify anybody.

## The screen locked twice, and it was not an echo

Boot held the loop for 31s, so the operator said it again. The repeat arrived at `01:40:49`; JARVIS did not speak until `01:41:05` — **there was nothing to be an echo of**, so `is_own_echo` is blind to it by construction.

An identical capability already in flight now coalesces, keyed on the **capability** rather than the words, so "lock my screen" and "Lock screen" collapse into one act. The slot releases in a `finally` on every path including `SUSPENDED` — a leaked slot would turn one crash into "JARVIS will not lock my screen any more", worse than the double-lock it prevents.

## Testing

**330 passed, 19 skipped.** New regressions quote the log timestamps they came from.

## ⚠️ Not fixed — and it is the cause, not a symptom

The **15–31s command latency**. `Application startup complete` landed **79 seconds** after boot began, and an action received at `01:40:34` wasn't dispatched until `01:40:49`. Boot is starving the event loop; that queues commands, makes the operator repeat himself, and stacks the replies that then overlap. The next change addresses it directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes HUD speech single-threaded, prevents duplicate actions, and fixes misleading denial messages. Also corrects voice enrollment state handling and drops stale replies so speech stays relevant.

- Bug Fixes
  - Serialize TTS with one async lock; drop replies that waited beyond `JARVIS_TTS_MAX_QUEUE_S` (default 12s) instead of narrating the backlog.
  - Coalesce identical capabilities already in flight (keyed by capability) and always release the slot, preventing double-exec and leaks.
  - For DENIED outcomes, prefer the authority’s full-sentence `detail` (shape-based) instead of canned “you declined”; keep a clear line for “no approval provider”.
  - Treat enrollment UNKNOWN (`None`) distinctly from NOT_ENROLLED (`""`); extend profile lookup timeouts to 60s to avoid cold-start misreports.
  - Added targeted tests covering these regressions.

- Migration
  - No breaking changes. Optional envs: `JARVIS_TTS_MAX_QUEUE_S` (1–60, default 12), `JARVIS_IN_FLIGHT_WINDOW_S` (1–300, default 45), `JARVIS_ENROLLMENT_TIMEOUT_S` (5–180, default 60).

<sup>Written for commit ea19f7bd88812bfb9cb3c31701a9308871203f2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

