### PR TITLE
perf(hud): unblock the command path, and end silent failures

### DIFF
--- a/backend/core/ouroboros/governance/hud_governance_boot.py
+++ b/backend/core/ouroboros/governance/hud_governance_boot.py
@@ -94,11 +94,47 @@ async def start_hud_governance(project_root: Path) -> HudGovernanceContext:
             active_brain_set=frozenset(),  # No handshake — gate disabled
             say_fn=_say_fn,
         )
-        await asyncio.wait_for(asyncio.shield(gls.start()), timeout=30.0)
+        # THE SHIELD ABANDONS THE WAIT, NOT THE WORK.
+        #
+        # `wait_for` cancels what it waits on; `shield` prevents that, so on
+        # timeout this stops waiting while `gls.start()` KEEPS RUNNING with
+        # nobody watching it. If it later raised, the traceback went to the
+        # loop's default handler and was lost. If it later SUCCEEDED,
+        # governance was running while the system had already announced
+        # itself DEGRADED — and every boot log says exactly that.
+        #
+        # Keeping the shield is right: a governance service half-started and
+        # then cancelled is worse than one still starting. What was missing is
+        # anyone observing how it ends.
+        from backend.core.ouroboros.telemetry.task_harvester import watch
+        _start = asyncio.ensure_future(gls.start())
+        watch(_start, what="GovernedLoopService.start",
+              target_files=("backend/core/ouroboros/governance/"
+                            "governed_loop_service.py",))
+        await asyncio.wait_for(asyncio.shield(_start), timeout=30.0)
         stack.governed_loop_service = gls
         logger.info("[HUD-Gov] GovernedLoopService started (state=%s)", gls.state.name)
     except Exception as exc:
-        logger.warning("[HUD-Gov] GovernedLoopService failed: %s", exc)
+        # NEVER `%s` A BARE EXCEPTION.
+        #
+        # `str(asyncio.TimeoutError())` is the empty string, so this line
+        # printed "[HUD-Gov] GovernedLoopService failed:" and nothing else, on
+        # every boot, for as long as the timeout has been firing. A message
+        # with no content and a level nobody reads are the same bug in
+        # different clothes — `describe_exception` leads with the TYPE, so a
+        # nameless exception still says what it was.
+        #
+        # The shielded task above outlives this handler, so its real outcome
+        # arrives later through the harvester rather than being inferred here.
+        from backend.core.ouroboros.telemetry.task_harvester import (
+            describe_exception, get_task_harvester,
+        )
+        get_task_harvester().record(
+            exc, what="GovernedLoopService boot",
+            target_files=("backend/core/ouroboros/governance/"
+                          "hud_governance_boot.py",))
+        logger.warning("[HUD-Gov] GovernedLoopService failed: %s",
+                       describe_exception(exc))
         return HudGovernanceContext(stack=stack, gls=None, intake=None)
 
     # Step 3: IntakeLayerService (Zone 6.9)

--- a/backend/core/ouroboros/governance/intake/intake_layer_service.py
+++ b/backend/core/ouroboros/governance/intake/intake_layer_service.py
@@ -922,6 +922,22 @@ class IntakeLayerService:
                         poll_interval_s=_health_poll_s,
                     )
                     self._sensors.append(_health_sensor)
+                # PUBLISH IT, and drain whatever died before it existed.
+                #
+                # `TaskHarvester` and `LoopSentinel` discover health problems
+                # the instant they happen, which is often DURING boot — before
+                # this line runs. They hold those findings; registering here
+                # is what releases them. Without this the one traceback worth
+                # catching (a governance service failing at startup) is the
+                # one guaranteed to be dropped.
+                try:
+                    from backend.core.ouroboros.governance.intake.sensors.runtime_health_sensor import (
+                        register_runtime_health_sensor,
+                    )
+                    register_runtime_health_sensor(_health_sensor)
+                except Exception as _reg:  # noqa: BLE001
+                    logger.debug("[IntakeLayer] health sensor not published: %s",
+                                 _reg)
                 logger.info("[IntakeLayer] RuntimeHealthSensor added (autonomous dependency monitoring)")
             except Exception as exc:
                 logger.debug("[IntakeLayer] RuntimeHealthSensor skipped: %s", exc)

--- a/backend/core/ouroboros/governance/intake/sensors/runtime_health_sensor.py
+++ b/backend/core/ouroboros/governance/intake/sensors/runtime_health_sensor.py
@@ -431,40 +431,7 @@ class RuntimeHealthSensor:
         findings.extend(shims)
 
         # Emit envelopes for new findings
-        emitted = 0
-        for finding in findings:
-            if finding.summary in self._seen_findings:
-                continue
-            self._seen_findings.add(finding.summary)
-
-            try:
-                envelope = make_envelope(
-                    source="runtime_health",
-                    description=finding.summary,
-                    target_files=finding.target_files,
-                    repo=self._repo,
-                    confidence=0.95,  # High — these are factual version comparisons
-                    urgency=finding.severity,
-                    evidence={
-                        "category": finding.category,
-                        "details": finding.details,
-                        "python_version": platform.python_version(),
-                        "sensor": "RuntimeHealthSensor",
-                    },
-                    requires_human_ack=False,  # Fully autonomous — Ouroboros handles upgrades without human gate
-                )
-                result = await self._router.ingest(envelope)
-                if result == "enqueued":
-                    emitted += 1
-                    logger.info(
-                        "[RuntimeHealthSensor] Emitted: %s (%s) -> %s",
-                        finding.category, finding.severity, result,
-                    )
-            except Exception:
-                logger.exception(
-                    "[RuntimeHealthSensor] Failed to emit finding: %s",
-                    finding.summary,
-                )
+        emitted = await self._emit(findings)
 
         if findings:
             logger.info(
@@ -891,3 +858,99 @@ class RuntimeHealthSensor:
             "python_version": platform.python_version(),
             "poll_interval_s": self._poll_interval_s,
         }
+
+
+    async def _emit(self, findings) -> int:
+        """Send findings to the intake router. Returns how many landed.
+
+        NEVER raises. Extracted from `scan_once` so the PUSH path
+        (:meth:`report`) and the POLL path share one emitter — two copies of
+        envelope construction would eventually disagree about what a finding
+        looks like, and the push path is the one carrying tracebacks.
+        """
+        emitted = 0
+        for finding in (findings or []):
+            try:
+                if finding.summary in self._seen_findings:
+                    continue
+                self._seen_findings.add(finding.summary)
+                envelope = make_envelope(
+                    source="runtime_health",
+                    description=finding.summary,
+                    target_files=finding.target_files,
+                    repo=self._repo,
+                    confidence=0.95,
+                    urgency=finding.severity,
+                    evidence={
+                        "category": finding.category,
+                        "details": finding.details,
+                        "python_version": platform.python_version(),
+                        "sensor": "RuntimeHealthSensor",
+                    },
+                    requires_human_ack=False,
+                )
+                result = await self._router.ingest(envelope)
+                if result == "enqueued":
+                    emitted += 1
+                    logger.info(
+                        "[RuntimeHealthSensor] Emitted: %s (%s) -> %s",
+                        finding.category, finding.severity, result,
+                    )
+            except Exception:
+                logger.exception(
+                    "[RuntimeHealthSensor] Failed to emit finding: %s",
+                    getattr(finding, "summary", "?"),
+                )
+        return emitted
+
+    async def report(self, finding) -> int:
+        """PUSH a finding discovered elsewhere. NEVER raises.
+
+        The sensor polls on a 24h interval by default, which is right for
+        package staleness and useless for a background task that just died or
+        an event loop that just stalled for three seconds. Those are known the
+        instant they happen and are stale by the next scan.
+
+        This is an entry point, not a second sensor: it goes through the same
+        `_emit`, the same envelope, the same router, and the same
+        deduplication. `TaskHarvester` and `LoopSentinel` are its callers.
+        """
+        try:
+            return await self._emit([finding])
+        except Exception:  # noqa: BLE001
+            logger.debug("[RuntimeHealthSensor] report degraded", exc_info=True)
+            return 0
+
+
+#: The live sensor, so a component that DISCOVERS a health problem can hand it
+#: over without importing the intake layer or holding a reference through five
+#: constructors. Registration rather than import for the same reason
+#: `world_state` registers probes: the reporter must not know what answers it.
+_LIVE_SENSOR = [None]
+
+
+def register_runtime_health_sensor(sensor) -> None:
+    """Publish the live sensor, and drain anything held for it. NEVER raises.
+
+    The flush is the point. A background task that dies during boot does so
+    while the intake layer is still coming up, so `TaskHarvester` holds those
+    failures until something can receive them — without this call, the one
+    traceback worth catching would be the one dropped.
+    """
+    try:
+        _LIVE_SENSOR[0] = sensor
+        from backend.core.ouroboros.telemetry.task_harvester import (
+            get_task_harvester,
+        )
+        get_task_harvester().flush()
+    except Exception:  # noqa: BLE001
+        logger.debug("[RuntimeHealthSensor] registration degraded",
+                     exc_info=True)
+
+
+def get_runtime_health_sensor():
+    """The live sensor, or None if the intake layer is not up. NEVER raises."""
+    try:
+        return _LIVE_SENSOR[0]
+    except Exception:  # noqa: BLE001
+        return None

--- a/backend/core/ouroboros/telemetry/task_harvester.py
+++ b/backend/core/ouroboros/telemetry/task_harvester.py
@@ -1,0 +1,314 @@
+"""Nothing dies quietly.
+
+WHAT THIS EXISTS TO STOP
+--------------------------
+Every boot logged this, and it was the whole message::
+
+    [HUD-Gov] GovernedLoopService failed:
+    [HUD] Ouroboros governance DEGRADED — partial pipeline
+
+Nothing after the colon. The cause turned out to be two defects sharing one
+line in `hud_governance_boot`::
+
+    await asyncio.wait_for(asyncio.shield(gls.start()), timeout=30.0)
+    ...
+    logger.warning("[HUD-Gov] GovernedLoopService failed: %s", exc)
+
+1. ``str(asyncio.TimeoutError())`` is the EMPTY STRING. Formatting an
+   exception with ``%s`` prints its message, and that class has none — so a
+   thirty-second timeout rendered as silence. Any exception can do this;
+   `KeyError` prints a bare key, `StopIteration` prints nothing.
+
+2. ``asyncio.shield`` means the timeout abandons the WAIT, not the WORK.
+   `gls.start()` carried on running with nobody awaiting it. If it later
+   raised, that exception went to the loop's default handler and the
+   traceback was lost; if it later SUCCEEDED, governance was running while
+   the system had already declared itself DEGRADED. Both are worse than a
+   crash, because a crash tells you something.
+
+An un-awaited task is a black hole with a schedule. This makes one impossible
+to open silently: attach a done-callback, extract the FULL traceback, log it
+at a level somebody reads, and route it to the organism that can act on it.
+
+WHY IT BUFFERS
+----------------
+The failure this was written for happens DURING boot — which is exactly when
+`RuntimeHealthSensor` may not exist yet, because the intake layer is still
+coming up. A harvester that simply looked the sensor up would drop the one
+traceback it was built to catch.
+
+So findings are held in a small ring until a sensor registers, then flushed.
+Bounded, because a boot that fails a hundred times has one problem, not a
+hundred, and the first few tell you which.
+
+DRY
+-----
+No logging framework and no new envelope. It formats with `traceback`, logs
+through `logging`, and hands the finding to `RuntimeHealthSensor.report`,
+which emits through the SAME `make_envelope` + `router.ingest` path a polled
+finding uses. The only thing added is the entry point.
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import threading
+import time
+import traceback
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger("Ouroboros.TaskHarvester")
+
+TASK_HARVESTER_SCHEMA_VERSION: str = "task_harvester.v1"
+
+
+def harvester_enabled() -> bool:
+    """Master gate. Default TRUE. NEVER raises.
+
+    Off means background tasks die the way they did before — silently. There
+    is no reason to want that, so this is a rollback switch rather than a
+    posture.
+    """
+    return (os.environ.get("JARVIS_TASK_HARVESTER_ENABLED", "true")
+            or "").strip().lower() not in ("0", "false", "no", "off")
+
+
+def _buffer_size() -> int:
+    try:
+        raw = (os.environ.get("JARVIS_TASK_HARVESTER_BUFFER", "") or "").strip()
+        return max(1, min(200, int(raw))) if raw else 25
+    except (TypeError, ValueError):
+        return 25
+
+
+def describe_exception(exc: BaseException) -> str:
+    """A one-line description that is NEVER empty. NEVER raises.
+
+    `%s` on an exception prints its message, and plenty of exception classes
+    have none — `asyncio.TimeoutError` is the one that cost us this bug, but
+    `StopIteration`, `CancelledError` and any bare `raise SomeError` behave
+    identically. Leading with the TYPE means a nameless exception still says
+    what it was.
+    """
+    try:
+        name = type(exc).__name__
+        message = str(exc).strip()
+        return f"{name}: {message}" if message else name
+    except Exception:  # noqa: BLE001
+        return "unprintable exception"
+
+
+def format_traceback(exc: BaseException, limit: int = 40) -> str:
+    """The full traceback as text. NEVER raises."""
+    try:
+        return "".join(traceback.format_exception(
+            type(exc), exc, exc.__traceback__, limit=limit)).strip()
+    except Exception:  # noqa: BLE001
+        return describe_exception(exc)
+
+
+@dataclass
+class TaskFailure:
+    """One background task that died, and everything known about it."""
+
+    what: str
+    summary: str
+    traceback_text: str = ""
+    severity: str = "high"
+    at: float = field(default_factory=time.time)
+    target_files: tuple = ()
+
+    def as_finding(self) -> Any:
+        """A `HealthFinding` for the runtime-health sensor. NEVER raises."""
+        from backend.core.ouroboros.governance.intake.sensors.runtime_health_sensor import (
+            HealthFinding,
+        )
+        return HealthFinding(
+            category="background_task_failure",
+            severity=self.severity,
+            summary=f"{self.what} failed: {self.summary}",
+            details={
+                "what": self.what,
+                "traceback": self.traceback_text[:4000],
+                "detected_at": self.at,
+                "schema_version": TASK_HARVESTER_SCHEMA_VERSION,
+            },
+            target_files=self.target_files or ("backend/main.py",),
+        )
+
+
+class TaskHarvester:
+    """Collects what background tasks take with them. NEVER raises."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._pending: List[TaskFailure] = []
+        self._harvested = 0
+        self._routed = 0
+        self._watched = 0
+
+    # -- the entry point -------------------------------------------------
+
+    def watch(self, task: Any, *, what: str,
+              target_files: tuple = ()) -> Any:
+        """Make *task* unable to fail silently. Returns it. NEVER raises.
+
+        Wraps rather than replaces: the caller keeps the task and may still
+        await it. A task that is awaited AND watched reports once, because
+        `add_done_callback` fires exactly once per task.
+        """
+        try:
+            if not harvester_enabled() or task is None:
+                return task
+            self._watched += 1
+            task.add_done_callback(
+                lambda t: self._on_done(t, what, target_files))
+        except Exception:  # noqa: BLE001 — never break the thing being watched
+            logger.debug("[TaskHarvester] could not watch '%s'", what,
+                         exc_info=True)
+        return task
+
+    def _on_done(self, task: Any, what: str, target_files: tuple) -> None:
+        try:
+            if task.cancelled():
+                # Cancellation is a decision somebody made, not a failure.
+                logger.info("[TaskHarvester] '%s' was cancelled", what)
+                return
+            exc = task.exception()
+            if exc is None:
+                logger.info("[TaskHarvester] '%s' completed", what)
+                return
+            self.record(exc, what=what, target_files=target_files)
+        except asyncio.CancelledError:
+            return
+        except Exception:  # noqa: BLE001
+            logger.debug("[TaskHarvester] done-callback degraded", exc_info=True)
+
+    def record(self, exc: BaseException, *, what: str,
+               target_files: tuple = ()) -> TaskFailure:
+        """Log a failure fully and route it. NEVER raises.
+
+        Public so a caller that already caught an exception can hand it over
+        without re-raising into a task — `hud_governance_boot` does exactly
+        that with its timeout.
+        """
+        failure = TaskFailure(
+            what=what, summary=describe_exception(exc),
+            traceback_text=format_traceback(exc), target_files=target_files)
+        try:
+            self._harvested += 1
+            # ERROR with the traceback attached. The whole defect was a
+            # WARNING that printed nothing; a level nobody reads and a message
+            # with no content are the same bug wearing different clothes.
+            logger.error("[TaskHarvester] %s failed: %s\n%s",
+                         what, failure.summary, failure.traceback_text)
+            self._route(failure)
+        except Exception:  # noqa: BLE001
+            pass
+        return failure
+
+    # -- routing ---------------------------------------------------------
+
+    def _route(self, failure: TaskFailure) -> None:
+        """Hand the failure to O+V, or hold it until O+V exists. NEVER raises."""
+        try:
+            from backend.core.ouroboros.governance.intake.sensors.runtime_health_sensor import (
+                get_runtime_health_sensor,
+            )
+            sensor = get_runtime_health_sensor()
+        except Exception:  # noqa: BLE001
+            sensor = None
+        if sensor is None:
+            with self._lock:
+                self._pending.append(failure)
+                del self._pending[:-_buffer_size()]
+            logger.info("[TaskHarvester] no intake sensor yet — holding '%s' "
+                        "(%d pending)", failure.what, len(self._pending))
+            return
+        self._deliver(sensor, failure)
+
+    def _deliver(self, sensor: Any, failure: TaskFailure) -> None:
+        try:
+            report = getattr(sensor, "report", None)
+            if report is None:
+                return
+            result = report(failure.as_finding())
+            if asyncio.iscoroutine(result):
+                # `report` is async and this may be a done-callback on a
+                # closing loop. Scheduling is best-effort by design: the
+                # traceback is already in the log, so a failure to route
+                # costs O+V an opportunity, never the evidence.
+                try:
+                    asyncio.get_event_loop().create_task(result)
+                except RuntimeError:
+                    result.close()
+                    return
+            self._routed += 1
+            logger.info("[TaskHarvester] routed '%s' to O+V intake",
+                        failure.what)
+        except Exception:  # noqa: BLE001
+            logger.debug("[TaskHarvester] routing degraded", exc_info=True)
+
+    def flush(self) -> int:
+        """Deliver everything held while the sensor was absent. NEVER raises.
+
+        Called when a sensor registers. This is the whole reason for the
+        buffer: the failure worth catching happens during boot, and during
+        boot the intake layer may not exist yet.
+        """
+        try:
+            from backend.core.ouroboros.governance.intake.sensors.runtime_health_sensor import (
+                get_runtime_health_sensor,
+            )
+            sensor = get_runtime_health_sensor()
+            if sensor is None:
+                return 0
+            with self._lock:
+                held, self._pending = list(self._pending), []
+            for f in held:
+                self._deliver(sensor, f)
+            if held:
+                logger.info("[TaskHarvester] flushed %d held failure(s) into "
+                            "O+V intake", len(held))
+            return len(held)
+        except Exception:  # noqa: BLE001
+            return 0
+
+    def stats(self) -> Dict[str, Any]:
+        with self._lock:
+            pending = len(self._pending)
+        return {
+            "schema_version": TASK_HARVESTER_SCHEMA_VERSION,
+            "enabled": harvester_enabled(),
+            "watched": self._watched,
+            "harvested": self._harvested,
+            "routed": self._routed,
+            "pending": pending,
+        }
+
+
+_HARVESTER: Optional[TaskHarvester] = None
+
+
+def get_task_harvester() -> TaskHarvester:
+    """Process-wide harvester. NEVER raises."""
+    global _HARVESTER
+    if _HARVESTER is None:
+        _HARVESTER = TaskHarvester()
+    return _HARVESTER
+
+
+def watch(task: Any, *, what: str, target_files: tuple = ()) -> Any:
+    """Convenience: make one task unable to fail silently. NEVER raises."""
+    return get_task_harvester().watch(task, what=what,
+                                      target_files=target_files)
+
+
+def reset_task_harvester() -> None:
+    """Testing seam. NEVER raises."""
+    global _HARVESTER
+    _HARVESTER = None

--- a/backend/hud/loop_sentinel.py
+++ b/backend/hud/loop_sentinel.py
@@ -1,0 +1,237 @@
+"""Is the event loop actually running, or only appearing to?
+
+WHY THIS AND NOT MORE REASONING
+---------------------------------
+An operator said "lock my screen" and waited. The IPC event was received at
+01:40:34 and the router did not begin until 01:40:49 — fifteen seconds during
+which JARVIS was, from the room, simply not there. `Application startup
+complete` landed 79 seconds after boot began.
+
+The obvious diagnosis is "heavy initialisation blocks the loop", and it may
+well be right. But `await slow_thing()` does NOT starve a loop — it yields,
+and a 79-second boot can be perfectly responsive throughout. Only a
+SYNCHRONOUS call that never yields starves anything. Those two produce
+identical-looking logs and need opposite fixes, and the difference is not
+visible in a wall-clock timeline.
+
+`telemetry/loop_sink` already measures this, but only where somebody wrapped a
+call site — it can prove a suspect guilty and can never find one. What is
+missing is a witness that watches the loop ITSELF.
+
+HOW IT WORKS
+--------------
+Sleep for a known interval, then measure how much longer than that it actually
+took. `asyncio.sleep(0.25)` returning after 3.1 seconds means the loop could
+not get back to this task for 2.85 seconds, and that is starvation by
+definition — no instrumentation of the culprit required, because the
+measurement is of the loop rather than of any particular call.
+
+The lag is attributed to a WINDOW rather than a function on purpose. Naming
+the guilty callable requires `loop.set_debug(True)`, whose own overhead
+changes the thing being measured; this says "between 01:40:34 and 01:40:49 the
+loop was gone", which is exactly the fact needed to go and look.
+
+WHAT IT COSTS
+---------------
+One task, one timer, and a subtraction, at 4 Hz. It is cheaper than the log
+line it emits, and it only emits when something is actually wrong.
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger("JARVIS.LoopSentinel")
+
+LOOP_SENTINEL_SCHEMA_VERSION: str = "loop_sentinel.v1"
+
+
+def sentinel_enabled() -> bool:
+    """Master gate. Default TRUE. NEVER raises.
+
+    On by default because the cost is a subtraction every 250ms and the thing
+    it detects is invisible without it — an assistant that is not there is
+    indistinguishable, in a log, from an assistant that is merely busy.
+    """
+    return (os.environ.get("JARVIS_LOOP_SENTINEL_ENABLED", "true")
+            or "").strip().lower() not in ("0", "false", "no", "off")
+
+
+def _env_float(name: str, default: float, lo: float, hi: float) -> float:
+    try:
+        raw = (os.environ.get(name, "") or "").strip()
+        return max(lo, min(hi, float(raw))) if raw else default
+    except (TypeError, ValueError):
+        return default
+
+
+def probe_interval_s() -> float:
+    """How often to check. NEVER raises."""
+    return _env_float("JARVIS_LOOP_SENTINEL_INTERVAL_S", 0.25, 0.05, 5.0)
+
+
+def stall_threshold_s() -> float:
+    """Lag above which the loop is considered to have stalled. NEVER raises.
+
+    250ms is the point at which a person notices an assistant is not
+    responding. Below that it is a busy machine; above it, JARVIS is absent.
+    """
+    return _env_float("JARVIS_LOOP_SENTINEL_STALL_S", 0.25, 0.05, 10.0)
+
+
+@dataclass
+class Stall:
+    """One window during which the loop could not run this task."""
+
+    started_at: float
+    lag_s: float
+    #: Wall-clock, so a stall can be matched against a log line by eye.
+    started_wall: str = ""
+
+    def __str__(self) -> str:
+        return f"{self.started_wall} for {self.lag_s:.2f}s"
+
+
+@dataclass
+class LoopHealth:
+    """What the sentinel has seen. Bounded."""
+
+    probes: int = 0
+    stalls: int = 0
+    worst_lag_s: float = 0.0
+    total_stalled_s: float = 0.0
+    recent: List[Stall] = field(default_factory=list)
+    started_at: float = 0.0
+
+    @property
+    def availability(self) -> float:
+        """Fraction of wall-clock the loop was responsive. NEVER raises."""
+        try:
+            elapsed = max(1e-6, time.monotonic() - self.started_at)
+            return max(0.0, min(1.0, 1.0 - (self.total_stalled_s / elapsed)))
+        except Exception:  # noqa: BLE001
+            return 1.0
+
+
+class LoopSentinel:
+    """Watches the event loop from inside it. NEVER raises."""
+
+    def __init__(self) -> None:
+        self._task: Optional[asyncio.Task] = None
+        self._health = LoopHealth()
+        self._max_recent = 20
+
+    def start(self) -> None:
+        """Begin watching. Idempotent. NEVER raises.
+
+        Started as EARLY as possible — the interesting stalls are the ones
+        during boot, and a witness that arrives after the event has nothing to
+        report.
+        """
+        try:
+            if not sentinel_enabled():
+                return
+            if self._task is not None and not self._task.done():
+                return
+            self._health = LoopHealth(started_at=time.monotonic())
+            self._task = asyncio.get_event_loop().create_task(self._watch())
+            logger.info("[LoopSentinel] watching — will report any window "
+                        "longer than %.0fms in which the loop cannot run",
+                        stall_threshold_s() * 1000.0)
+        except Exception:  # noqa: BLE001
+            logger.debug("[LoopSentinel] start degraded", exc_info=True)
+
+    async def stop(self) -> None:
+        """Stop watching. NEVER raises."""
+        try:
+            t, self._task = self._task, None
+            if t is not None and not t.done():
+                t.cancel()
+                try:
+                    await t
+                except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                    pass
+        except Exception:  # noqa: BLE001
+            pass
+
+    async def _watch(self) -> None:
+        interval = probe_interval_s()
+        while True:
+            try:
+                threshold = stall_threshold_s()
+                before = time.monotonic()
+                await asyncio.sleep(interval)
+                # Everything past the interval is time the loop owed this task
+                # and could not pay. No attribution, no instrumentation — the
+                # measurement IS the starvation.
+                lag = (time.monotonic() - before) - interval
+                self._health.probes += 1
+                if lag >= threshold:
+                    self._record(before, lag)
+            except asyncio.CancelledError:
+                return
+            except Exception:  # noqa: BLE001 — a witness never dies of a fault
+                logger.debug("[LoopSentinel] probe degraded", exc_info=True)
+                try:
+                    await asyncio.sleep(interval)
+                except asyncio.CancelledError:
+                    return
+
+    def _record(self, started: float, lag: float) -> None:
+        try:
+            h = self._health
+            h.stalls += 1
+            h.total_stalled_s += lag
+            h.worst_lag_s = max(h.worst_lag_s, lag)
+            stall = Stall(started_at=started, lag_s=lag,
+                          started_wall=time.strftime("%H:%M:%S"))
+            h.recent.append(stall)
+            del h.recent[:-self._max_recent]
+            # WARNING, not DEBUG. This is the operator's assistant being
+            # absent; it belongs at the level somebody reads.
+            logger.warning(
+                "[LoopSentinel] EVENT LOOP STALLED %.2fs at %s — JARVIS could "
+                "not respond to anything during that window (stall #%d, worst "
+                "%.2fs, availability %.1f%%)",
+                lag, stall.started_wall, h.stalls, h.worst_lag_s,
+                h.availability * 100.0)
+        except Exception:  # noqa: BLE001
+            pass
+
+    def health(self) -> Dict[str, Any]:
+        """What the loop has been doing. NEVER raises."""
+        h = self._health
+        return {
+            "schema_version": LOOP_SENTINEL_SCHEMA_VERSION,
+            "enabled": sentinel_enabled(),
+            "watching": self._task is not None and not self._task.done(),
+            "probes": h.probes,
+            "stalls": h.stalls,
+            "worst_lag_s": round(h.worst_lag_s, 3),
+            "total_stalled_s": round(h.total_stalled_s, 3),
+            "availability": round(h.availability, 4),
+            "recent": [str(s) for s in h.recent],
+        }
+
+
+_SENTINEL: Optional[LoopSentinel] = None
+
+
+def get_loop_sentinel() -> LoopSentinel:
+    """Process-wide sentinel. NEVER raises."""
+    global _SENTINEL
+    if _SENTINEL is None:
+        _SENTINEL = LoopSentinel()
+    return _SENTINEL
+
+
+def reset_loop_sentinel() -> None:
+    """Testing seam. NEVER raises."""
+    global _SENTINEL
+    _SENTINEL = None

--- a/backend/hud/loop_sentinel.py
+++ b/backend/hud/loop_sentinel.py
@@ -76,6 +76,16 @@ def probe_interval_s() -> float:
     return _env_float("JARVIS_LOOP_SENTINEL_INTERVAL_S", 0.25, 0.05, 5.0)
 
 
+def report_stalls_to_ouroboros() -> bool:
+    """Whether a stall becomes an O+V signal. Default TRUE. NEVER raises.
+
+    Off leaves the sentinel a pure observer — it still logs, it just stops
+    asking the organism to do anything about it.
+    """
+    return (os.environ.get("JARVIS_LOOP_SENTINEL_REPORT_ENABLED", "true")
+            or "").strip().lower() not in ("0", "false", "no", "off")
+
+
 def stall_threshold_s() -> float:
     """Lag above which the loop is considered to have stalled. NEVER raises.
 
@@ -126,6 +136,8 @@ class LoopSentinel:
         self._task: Optional[asyncio.Task] = None
         self._health = LoopHealth()
         self._max_recent = 20
+        #: One report per run. Forty stalls are one defect restated.
+        self._reported = False
 
     def start(self) -> None:
         """Begin watching. Idempotent. NEVER raises.
@@ -140,6 +152,7 @@ class LoopSentinel:
             if self._task is not None and not self._task.done():
                 return
             self._health = LoopHealth(started_at=time.monotonic())
+            self._reported = False
             self._task = asyncio.get_event_loop().create_task(self._watch())
             logger.info("[LoopSentinel] watching — will report any window "
                         "longer than %.0fms in which the loop cannot run",
@@ -201,8 +214,72 @@ class LoopSentinel:
                 "%.2fs, availability %.1f%%)",
                 lag, stall.started_wall, h.stalls, h.worst_lag_s,
                 h.availability * 100.0)
+            self._tell_ouroboros(stall)
         except Exception:  # noqa: BLE001
             pass
+
+    def _tell_ouroboros(self, stall: Stall) -> None:
+        """Hand the stall to the organism that can fix it. NEVER raises.
+
+        This is what turns a witness into a self-healing loop: the sentinel
+        measures the starvation, O+V reads the measurement, and the 11-phase
+        pipeline proposes, validates and gates a patch to the code that caused
+        it. A log line only informs whoever is reading; a `RuntimeHealth`
+        finding is something the system can act on while nobody is.
+
+        Reported ONCE per run, not per stall. A boot that stalls forty times
+        has one defect, and forty envelopes would drown the intake queue in
+        restatements of a single fact — the summary carries the count.
+        """
+        try:
+            if not report_stalls_to_ouroboros() or self._reported:
+                return
+            self._reported = True
+            from backend.core.ouroboros.governance.intake.sensors.runtime_health_sensor import (
+                HealthFinding, get_runtime_health_sensor,
+            )
+            sensor = get_runtime_health_sensor()
+            finding = HealthFinding(
+                category="event_loop_starvation",
+                severity="high",
+                summary=(f"Event loop stalled {stall.lag_s:.2f}s — the HUD "
+                         f"could not respond to voice, IPC or timers during "
+                         f"that window"),
+                details={
+                    "first_stall_at": stall.started_wall,
+                    "lag_s": round(stall.lag_s, 3),
+                    "threshold_s": stall_threshold_s(),
+                    "note": ("A synchronous call is blocking the event loop. "
+                             "An awaited coroutine cannot cause this — only a "
+                             "call that never yields."),
+                    "health": self.health(),
+                    "schema_version": LOOP_SENTINEL_SCHEMA_VERSION,
+                },
+                target_files=("backend/main.py",),
+            )
+            if sensor is None:
+                # The interesting stalls happen during boot, BEFORE the intake
+                # layer exists. `TaskHarvester` already owns a buffer that
+                # flushes on sensor registration, so this rides it rather than
+                # keeping a second queue of its own.
+                from backend.core.ouroboros.telemetry.task_harvester import (
+                    TaskFailure, get_task_harvester,
+                )
+                held = TaskFailure(
+                    what="event loop", summary=finding.summary,
+                    traceback_text="", severity="high",
+                    target_files=finding.target_files)
+                held.as_finding = lambda f=finding: f     # keep OUR finding
+                get_task_harvester()._pending.append(held)
+                logger.info("[LoopSentinel] intake not up yet — stall held "
+                            "for O+V until it is")
+                return
+            result = sensor.report(finding)
+            if asyncio.iscoroutine(result):
+                asyncio.get_event_loop().create_task(result)
+        except Exception:  # noqa: BLE001 — a witness never breaks on reporting
+            logger.debug("[LoopSentinel] could not reach O+V intake",
+                         exc_info=True)
 
     def health(self) -> Dict[str, Any]:
         """What the loop has been doing. NEVER raises."""

--- a/backend/hud/voiceprint_hydration.py
+++ b/backend/hud/voiceprint_hydration.py
@@ -1,0 +1,289 @@
+"""Turn a stored voiceprint back into a vector, without guessing.
+
+THE MISMATCH THIS EXISTS FOR
+------------------------------
+The same speaker profile is stored in two places and the blobs are different
+sizes::
+
+    CloudSQL   voiceprint_embedding   1538 bytes
+    local      voiceprint_embedding    768 bytes
+
+768 is 192 float32s, which is ECAPA-TDNN's native embedding width. 1538 is
+192 float64s plus two bytes of something — almost certainly the same vector at
+double precision with a small header. Almost certainly. That word is the
+problem.
+
+A cosine similarity does not fail loudly on a misread buffer. Decode 768 bytes
+of float32 as float64 and you get 96 finite-looking numbers that are pure
+noise; the comparison still runs, still returns a number, and that number
+means the operator's Mac says "that didn't sound like you" — a statement about
+a person, produced by a type error. The failure is silent, plausible, and
+blames the human.
+
+So nothing here is assumed. The blob is INSPECTED: a length that divides
+cleanly by a known width for a known dimension is decoded that way, and a
+length that does not is REFUSED. Refusing to hydrate is a bad afternoon;
+hydrating wrongly is an accusation.
+
+WHY UPCASTING IS SAFE AND DOWNCASTING IS NOT
+----------------------------------------------
+float32 → float64 is exact: every float32 has an exact float64
+representation, so widening cannot move a vector. The reverse rounds, and
+rounding a normalised embedding perturbs the cosine at the fourth decimal —
+which is inside the margin that separates "you" from "not you" on a
+borderline sample. So this widens toward whatever the model wants and never
+narrows.
+
+WHY IT NORMALISES NOTHING
+---------------------------
+Cosine similarity is scale-invariant, and the verification service owns its
+own preprocessing. A helper that quietly L2-normalised would be a second
+opinion about the maths, and the two would diverge the first time the service
+changed. This decodes bytes into the requested dtype and stops.
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Tuple
+
+logger = logging.getLogger("JARVIS.VoiceprintHydration")
+
+VOICEPRINT_HYDRATION_SCHEMA_VERSION: str = "voiceprint_hydration.v1"
+
+#: Embedding widths this codebase actually produces, smallest first.
+#:
+#: 192 is ECAPA-TDNN's output and the one measured in the local profile (768 =
+#: 192 x 4). The others are here because a speaker-embedding stack that swaps
+#: models is normal and a blob that matches none of these must be refused
+#: rather than reinterpreted — the list exists to make "unknown" detectable,
+#: not to make every length acceptable.
+KNOWN_DIMENSIONS: Tuple[int, ...] = (192, 256, 384, 512)
+
+#: (numpy dtype name, bytes per element).
+#:
+#: float16 is deliberately ABSENT. Nobody stores half-precision speaker
+#: embeddings, and including it made 768 bytes ambiguous between 192xfloat32
+#: and 384xfloat16 — an ambiguity invented entirely by offering a reading
+#: nothing produces.
+_CANDIDATE_DTYPES: Tuple[Tuple[str, int], ...] = (
+    ("float32", 4),
+    ("float64", 8),
+)
+
+#: Header bytes tolerated when the caller has NOT told us the dimension.
+#:
+#: Zero. This was 16, and a 16-byte tolerance is not a tolerance — it is a
+#: licence: 777 bytes of nothing hydrated cleanly as "192 float32 with a
+#: 9-byte header", which is exactly the confident reinterpretation this module
+#: exists to refuse. Caught by `test_a_length_matching_nothing_is_refused`.
+#:
+#: With a declared dimension a header is fine, because the arithmetic is then
+#: pinned from both ends. Without one, only an exact multiple is a vector.
+_MAX_HEADER_BYTES_UNGUIDED = 0
+
+#: Header bytes tolerated when the caller HAS declared the dimension.
+#: CloudSQL's 1538 is 1536 + 2, so a small prefix is real.
+_MAX_HEADER_BYTES_GUIDED = 16
+
+
+@dataclass
+class Hydrated:
+    """A decoded voiceprint, and the evidence for how it was read."""
+
+    vector: Any                    # numpy.ndarray
+    dimension: int
+    source_dtype: str
+    output_dtype: str
+    header_bytes: int = 0
+    #: What was rejected on the way to this answer, for a log line that
+    #: explains itself when the guess is wrong.
+    considered: Tuple[str, ...] = ()
+
+    @property
+    def shape(self) -> tuple:
+        try:
+            return tuple(self.vector.shape)
+        except Exception:  # noqa: BLE001
+            return ()
+
+    def __str__(self) -> str:
+        return (f"{self.dimension}-d {self.source_dtype}"
+                f"{f' (+{self.header_bytes}B header)' if self.header_bytes else ''}"
+                f" -> {self.output_dtype}")
+
+
+class UnreadableVoiceprint(ValueError):
+    """The blob is not a vector of any shape this code knows.
+
+    A distinct type because the CALLER must be able to tell "I could not read
+    your voiceprint" from "that was not your voice". Both refuse the unlock;
+    only one of them is about the operator.
+    """
+
+
+def default_output_dtype() -> str:
+    """The dtype the verification model wants. NEVER raises.
+
+    Torch defaults to float32 and ECAPA is trained there, so that is the
+    default — but it is a knob rather than a constant, because the correct
+    answer belongs to whatever model is loaded and this module must not be the
+    thing that has to change when it is swapped.
+    """
+    return (os.environ.get("JARVIS_VOICEPRINT_DTYPE", "") or "float32").strip()
+
+
+def hydrate(blob: Any, *, dtype: str = "",
+            expect_dimension: int = 0) -> Hydrated:
+    """Decode a stored voiceprint. Raises :class:`UnreadableVoiceprint`.
+
+    The ONLY function here that raises, deliberately: every other failure in
+    this codebase degrades, and a silently-degraded voiceprint is a wrong
+    answer about a person. A caller that cannot hydrate must refuse to verify,
+    and a return value of None would let that be forgotten.
+    """
+    import numpy as np
+
+    want = (dtype or default_output_dtype()).strip()
+    raw = _as_bytes(blob)
+    if not raw:
+        raise UnreadableVoiceprint("voiceprint blob is empty")
+
+    guided = bool(expect_dimension)
+    max_header = (_MAX_HEADER_BYTES_GUIDED if guided
+                  else _MAX_HEADER_BYTES_UNGUIDED)
+    dims = (expect_dimension,) if guided else KNOWN_DIMENSIONS
+
+    # AMBIGUITY IS REFUSED, NOT BROKEN BY PRECEDENCE.
+    #
+    # 1538 bytes is 384 float32 + 2 AND 192 float64 + 2. Length cannot tell
+    # those apart, and picking one by candidate order would be a coin toss
+    # that silently produces a wrong vector half the time. The profile schema
+    # already records `embedding_dimension` — so the answer is to ASK, and to
+    # refuse until somebody does.
+    if not guided:
+        exact = [(n, d) for n, w in _CANDIDATE_DTYPES
+                 for d in KNOWN_DIMENSIONS if d * w == len(raw)]
+        if len(exact) > 1:
+            raise UnreadableVoiceprint(
+                f"{len(raw)} bytes is ambiguous — it reads as "
+                + " or ".join(f"{d}-d {n}" for n, d in exact)
+                + "; pass expect_dimension (the profile's "
+                  "`embedding_dimension` column) rather than letting this "
+                  "guess which one your model was trained on")
+
+    considered = []
+    for name, width in _CANDIDATE_DTYPES:
+        for dim in dims:
+            need = dim * width
+            header = len(raw) - need
+            if header < 0 or header > max_header:
+                considered.append(f"{dim}x{name}={need}B")
+                continue
+            try:
+                # Read from the END. A header sits at the front, so the vector
+                # is the trailing `need` bytes — slicing from the front would
+                # shift every element by the header width and produce a
+                # perfectly finite, entirely wrong vector.
+                vec = np.frombuffer(raw[len(raw) - need:], dtype=name)
+                if vec.size != dim or not np.isfinite(vec).all():
+                    considered.append(f"{dim}x{name}:non-finite")
+                    continue
+                # `frombuffer` returns a READ-ONLY view onto the original
+                # buffer. Handing that to a model that writes in place is a
+                # memory-corruption bug that surfaces somewhere else entirely,
+                # so `astype` (which copies) is load-bearing, not cosmetic.
+                out = vec.astype(want, copy=True)
+                h = Hydrated(vector=out, dimension=dim, source_dtype=name,
+                             output_dtype=want, header_bytes=max(0, header),
+                             considered=tuple(considered))
+                logger.info("[VoiceprintHydration] %dB -> %s", len(raw), h)
+                return h
+            except UnreadableVoiceprint:
+                raise
+            except Exception as exc:  # noqa: BLE001
+                considered.append(f"{dim}x{name}:{type(exc).__name__}")
+                continue
+
+    raise UnreadableVoiceprint(
+        f"{len(raw)} bytes matches no known embedding shape "
+        f"(tried {', '.join(considered) or 'nothing'}); refusing to "
+        f"reinterpret — a misread vector produces a confident wrong answer "
+        f"about who is speaking")
+
+
+def _as_bytes(blob: Any) -> bytes:
+    """Whatever the driver handed back, as bytes. NEVER raises.
+
+    psycopg2 returns `memoryview` for bytea and sqlite3 returns `bytes`, so
+    the same profile arrives as two types depending on which store answered —
+    which is exactly the seam this module exists to make invisible.
+    """
+    try:
+        if blob is None:
+            return b""
+        if isinstance(blob, (bytes, bytearray)):
+            return bytes(blob)
+        if isinstance(blob, memoryview):
+            return blob.tobytes()
+        if isinstance(blob, str):
+            # Some rows round-trip through text; try hex, then base64.
+            import base64
+            import binascii
+            t = blob.strip()
+            try:
+                return bytes.fromhex(t[2:] if t.startswith("\\x") else t)
+            except (ValueError, binascii.Error):
+                pass
+            try:
+                return base64.b64decode(t, validate=True)
+            except (ValueError, binascii.Error):
+                return b""
+        return bytes(blob)
+    except Exception:  # noqa: BLE001
+        return b""
+
+
+def describe(blob: Any) -> Dict[str, Any]:
+    """What a blob looks like, without committing to reading it. NEVER raises.
+
+    For diagnostics and for the log line that has to explain a mismatch
+    between two stores holding "the same" profile.
+    """
+    raw = _as_bytes(blob)
+    out: Dict[str, Any] = {
+        "schema_version": VOICEPRINT_HYDRATION_SCHEMA_VERSION,
+        "bytes": len(raw),
+        "readable": False,
+        "candidates": [],
+    }
+    for name, width in _CANDIDATE_DTYPES:
+        for dim in KNOWN_DIMENSIONS:
+            header = len(raw) - dim * width
+            if 0 <= header <= _MAX_HEADER_BYTES_GUIDED:
+                out["candidates"].append(
+                    f"{dim}-d {name}" + (f" +{header}B" if header else ""))
+    # `readable` means readable WITHOUT being told the dimension — i.e. an
+    # exact multiple. A blob that only resolves once somebody declares the
+    # dimension is a candidate, not an answer.
+    out["exact"] = [c for c in out["candidates"] if "+" not in c]
+    out["readable"] = len(out.get("exact") or []) == 1
+    return out
+
+
+def hydrate_or_none(blob: Any, *, dtype: str = "",
+                    expect_dimension: int = 0) -> Optional[Hydrated]:
+    """:func:`hydrate`, for callers that genuinely cannot raise. NEVER raises.
+
+    Separate rather than a flag so the raising form stays the default. A
+    caller reaching for this is saying "I will handle None", and that sentence
+    should be visible at the call site.
+    """
+    try:
+        return hydrate(blob, dtype=dtype, expect_dimension=expect_dimension)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[VoiceprintHydration] refused: %s", exc)
+        return None

--- a/backend/main.py
+++ b/backend/main.py
@@ -1969,6 +1969,24 @@ async def parallel_lifespan(app: FastAPI):
         create_safe_task(_init_agent_runtime_background(), name="agent_runtime_init")
 
         # =================================================================
+        # THE WITNESS. Started before anything heavy, because the stalls worth
+        # knowing about are the ones during boot and a witness that arrives
+        # afterwards has nothing to report.
+        #
+        # `await slow_thing()` does not starve a loop — it yields, and a
+        # 79-second boot can be responsive the whole way through. Only a
+        # SYNCHRONOUS call that never yields starves anything, and the two
+        # produce identical-looking timelines while needing opposite fixes.
+        # This measures the loop itself rather than any suspect, so the next
+        # boot log states which it was instead of inviting us to theorise.
+        # =================================================================
+        try:
+            from backend.hud.loop_sentinel import get_loop_sentinel
+            get_loop_sentinel().start()
+        except Exception as _ls:  # noqa: BLE001 — a witness never blocks a boot
+            logger.debug("[HUD] loop sentinel unavailable: %s", _ls)
+
+        # =================================================================
         # v351.0: HUD MODE — IPC server + SSE consumer for Swift HUD
         # =================================================================
         class _SkipCloudRelay(Exception):
@@ -2235,12 +2253,37 @@ async def parallel_lifespan(app: FastAPI):
                                     # JARVIS_HUD_TTS=0.
                                     _tts_enabled = os.environ.get("JARVIS_HUD_TTS", "1").lower() in ("1", "true", "yes")
                                     if _tts_enabled:
+                                        # AN ACKNOWLEDGEMENT MUST NOT GATE THE ACT.
+                                        #
+                                        # This was `await _hud_tts(...)`, and
+                                        # `_hud_tts` awaits `say` to synthesise a
+                                        # file and then `afplay` to play it TO
+                                        # COMPLETION. So the dispatch stopped and
+                                        # waited for "On it" to finish being
+                                        # spoken before it began doing anything —
+                                        # measured 2026-08-03, an action received
+                                        # at 01:40:34 was not routed until
+                                        # 01:40:49.
+                                        #
+                                        # The entire purpose of saying "On it" is
+                                        # to reassure the operator WHILE the work
+                                        # happens. Awaiting it inverts that: the
+                                        # reassurance becomes the delay it was
+                                        # meant to cover, on every command.
+                                        #
+                                        # Fire-and-forget is safe here precisely
+                                        # because `_hud_tts` now holds a single
+                                        # mouth-lock: the acknowledgement and the
+                                        # result cannot overlap, they queue, and
+                                        # the order they queue in is the order
+                                        # they were decided in.
                                         if _is_messaging and _msg_contact_match:
                                             _contact_name = _msg_contact_match.group(1)
                                             _app_name = app_context or "the messaging app"
-                                            await _hud_tts(f"Sending your message to {_contact_name} on {_app_name}.")
+                                            _ack = f"Sending your message to {_contact_name} on {_app_name}."
                                         else:
-                                            await _hud_tts(f"On it. Executing: {goal[:60]}")
+                                            _ack = f"On it. Executing: {goal[:60]}"
+                                        asyncio.create_task(_hud_tts(_ack))
 
                                     # Route through Ouroboros — classifier decides execution path
                                     logger.info("[HUD] VoiceRouter executing: %s", goal[:80])

--- a/tests/governance/test_task_harvester.py
+++ b/tests/governance/test_task_harvester.py
@@ -1,0 +1,221 @@
+"""Nothing dies quietly.
+
+Every boot logged this, and it was the whole message::
+
+    [HUD-Gov] GovernedLoopService failed:
+    [HUD] Ouroboros governance DEGRADED — partial pipeline
+
+Two defects shared one line: `str(asyncio.TimeoutError())` is the empty
+string, and `asyncio.shield` left the real work running with nobody watching
+how it ended.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from backend.core.ouroboros.governance.intake.sensors import (
+    runtime_health_sensor as R,
+)
+from backend.core.ouroboros.telemetry import task_harvester as TH
+from backend.core.ouroboros.telemetry.task_harvester import (
+    TaskHarvester, describe_exception, format_traceback,
+)
+
+
+class _Sensor:
+    def __init__(self):
+        self.got = []
+
+    async def report(self, finding):
+        self.got.append(finding)
+        return 1
+
+
+@pytest.fixture(autouse=True)
+def _clean():
+    TH.reset_task_harvester()
+    R._LIVE_SENSOR[0] = None
+    yield
+    TH.reset_task_harvester()
+    R._LIVE_SENSOR[0] = None
+
+
+# ── The empty message ───────────────────────────────────────────────────────
+
+def test_a_timeout_no_longer_renders_as_nothing():
+    """THE BUG. `%s` prints an exception's MESSAGE, and this class has none —
+    so a 30-second timeout printed as silence on every single boot."""
+    assert str(asyncio.TimeoutError()) == ""
+    assert describe_exception(asyncio.TimeoutError()) == "TimeoutError"
+
+
+@pytest.mark.parametrize("exc,expect", [
+    (asyncio.TimeoutError(), "TimeoutError"),
+    (StopIteration(), "StopIteration"),
+    (RuntimeError("boom"), "RuntimeError: boom"),
+    (KeyError("k"), "KeyError: 'k'"),
+])
+def test_no_exception_can_describe_itself_as_nothing(exc, expect):
+    """Not just TimeoutError. Any class without a message does this, so the
+    fix leads with the TYPE rather than special-casing one culprit."""
+    assert describe_exception(exc) == expect
+    assert describe_exception(exc).strip()
+
+
+def test_the_full_traceback_is_kept_not_just_the_message():
+    try:
+        raise ValueError("deep")
+    except ValueError as e:
+        text = format_traceback(e)
+    assert "ValueError: deep" in text and "line" in text
+
+
+# ── The black hole ──────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_a_task_that_dies_unobserved_is_still_reported():
+    """`shield` abandons the WAIT, not the WORK. The shielded task carried on
+    and its exception went to the loop's default handler, where the traceback
+    was lost."""
+    h = TaskHarvester()
+
+    async def boom():
+        raise RuntimeError("governance exploded")
+
+    t = asyncio.ensure_future(boom())
+    h.watch(t, what="GovernedLoopService.start")
+    with pytest.raises(RuntimeError):
+        await t
+    await asyncio.sleep(0)
+
+    assert h.stats()["harvested"] == 1
+
+
+@pytest.mark.asyncio
+async def test_a_task_that_succeeds_reports_nothing():
+    h = TaskHarvester()
+
+    async def fine():
+        return 42
+
+    t = asyncio.ensure_future(fine())
+    h.watch(t, what="ok")
+    assert await t == 42
+    await asyncio.sleep(0)
+    assert h.stats()["harvested"] == 0
+
+
+@pytest.mark.asyncio
+async def test_cancellation_is_a_decision_not_a_failure():
+    h = TaskHarvester()
+    t = asyncio.ensure_future(asyncio.sleep(5))
+    h.watch(t, what="cancelled")
+    t.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await t
+    await asyncio.sleep(0)
+    assert h.stats()["harvested"] == 0
+
+
+@pytest.mark.asyncio
+async def test_watching_never_breaks_the_thing_it_watches():
+    h = TaskHarvester()
+    assert h.watch(None, what="nothing") is None
+    assert h.watch("not a task", what="junk") == "not a task"
+
+
+# ── Holding what died before anyone could listen ────────────────────────────
+
+@pytest.mark.asyncio
+async def test_a_failure_during_boot_is_held_until_intake_exists():
+    """THE EDGE CASE THAT MATTERS.
+
+    The failure worth catching is a governance service dying at startup —
+    which happens while the intake layer is still coming up. A harvester that
+    merely looked the sensor up would drop the one traceback it was built for.
+    """
+    h = TaskHarvester()
+    TH._HARVESTER = h
+
+    h.record(RuntimeError("died during boot"), what="EarlyService")
+    assert h.stats()["pending"] == 1, "it should be held, not dropped"
+    assert h.stats()["routed"] == 0
+
+    sensor = _Sensor()
+    R.register_runtime_health_sensor(sensor)     # intake finally comes up
+    await asyncio.sleep(0.05)
+
+    assert len(sensor.got) == 1
+    assert "died during boot" in sensor.got[0].summary
+    assert h.stats()["pending"] == 0
+
+
+@pytest.mark.asyncio
+async def test_the_finding_carries_the_traceback_for_o_plus_v():
+    """O+V is being asked to FIX this. A summary without a traceback is a
+    complaint; with one it is a bug report."""
+    h = TaskHarvester()
+    TH._HARVESTER = h
+    try:
+        raise ValueError("the actual cause")
+    except ValueError as e:
+        h.record(e, what="Thing")
+
+    sensor = _Sensor()
+    R.register_runtime_health_sensor(sensor)
+    await asyncio.sleep(0.05)
+
+    finding = sensor.got[0]
+    assert finding.category == "background_task_failure"
+    assert "the actual cause" in finding.details["traceback"]
+    assert finding.severity == "high"
+
+
+@pytest.mark.asyncio
+async def test_the_buffer_is_bounded(monkeypatch):
+    """A boot that fails a hundred times has one problem, not a hundred."""
+    monkeypatch.setenv("JARVIS_TASK_HARVESTER_BUFFER", "5")
+    h = TaskHarvester()
+    TH._HARVESTER = h
+    for i in range(50):
+        h.record(RuntimeError(f"fail {i}"), what=f"svc{i}")
+    assert h.stats()["pending"] == 5
+
+
+@pytest.mark.asyncio
+async def test_it_routes_straight_through_once_intake_is_up():
+    h = TaskHarvester()
+    TH._HARVESTER = h
+    sensor = _Sensor()
+    R.register_runtime_health_sensor(sensor)
+
+    h.record(RuntimeError("later failure"), what="LateService")
+    await asyncio.sleep(0.05)
+
+    assert len(sensor.got) == 1
+    assert h.stats()["pending"] == 0
+
+
+def test_it_can_be_switched_off(monkeypatch):
+    monkeypatch.setenv("JARVIS_TASK_HARVESTER_ENABLED", "false")
+    h = TaskHarvester()
+    t = object()
+    assert h.watch(t, what="x") is t
+    assert h.stats()["watched"] == 0
+
+
+# ── The sensor's push entry point ───────────────────────────────────────────
+
+def test_report_and_scan_share_one_emitter():
+    """Two copies of envelope construction would eventually disagree about
+    what a finding looks like, and the push path is the one carrying
+    tracebacks."""
+    import inspect
+    assert "_emit" in inspect.getsource(R.RuntimeHealthSensor.scan_once)
+    assert "_emit" in inspect.getsource(R.RuntimeHealthSensor.report)
+
+
+def test_an_absent_sensor_answers_none_rather_than_raising():
+    assert R.get_runtime_health_sensor() is None

--- a/tests/hud/test_loop_sentinel.py
+++ b/tests/hud/test_loop_sentinel.py
@@ -1,0 +1,165 @@
+"""Was JARVIS there, or only appearing to be?
+
+An operator said "lock my screen" at 01:40:34 and the router did not begin
+until 01:40:49. Fifteen seconds in which the assistant was, from the room,
+absent. These pin the witness that can tell the two shapes of that apart:
+
+  * a SLOW boot that yields — the loop stays responsive, commands still land
+  * a BLOCKED loop — nothing runs at all
+
+They produce identical wall-clock timelines and need opposite fixes.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from backend.hud.loop_sentinel import (
+    LoopSentinel, get_loop_sentinel, reset_loop_sentinel,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean(monkeypatch):
+    monkeypatch.setenv("JARVIS_LOOP_SENTINEL_INTERVAL_S", "0.05")
+    monkeypatch.setenv("JARVIS_LOOP_SENTINEL_STALL_S", "0.20")
+    reset_loop_sentinel()
+    yield
+    reset_loop_sentinel()
+
+
+# ── The mandate: heavy init must not stop Tier 0 ────────────────────────────
+
+@pytest.mark.asyncio
+async def test_a_slow_dependency_does_not_stop_the_loop():
+    """THE ASSERTION THAT MATTERS.
+
+    A `LearningDB` that takes ten seconds to initialise must not cost the
+    operator a single millisecond, PROVIDED it yields. This is the proof that
+    a slow boot and a starved boot are different things: the dependency here
+    is twenty times slower than the stall threshold and the loop never
+    notices.
+    """
+    s = LoopSentinel()
+    s.start()
+
+    async def slow_learning_db():
+        await asyncio.sleep(1.0)          # stands in for the measured 15s+
+        return "ready"
+
+    boot = asyncio.create_task(slow_learning_db())
+
+    # Tier 0 work, interleaved with the heavy boot.
+    latencies = []
+    for _ in range(20):
+        t0 = time.monotonic()
+        await asyncio.sleep(0)            # one full trip through the loop
+        latencies.append(time.monotonic() - t0)
+
+    assert await boot == "ready"
+    await s.stop()
+
+    assert max(latencies) < 0.20, f"Tier 0 was delayed: {max(latencies):.3f}s"
+    assert s.health()["stalls"] == 0, (
+        "an awaiting dependency was reported as starvation — the sentinel "
+        "cannot tell slow from blocked, which is its whole job")
+
+
+@pytest.mark.asyncio
+async def test_a_synchronous_call_IS_caught():
+    """The other half. `time.sleep` on the loop is what starvation looks like,
+    and it must be impossible to mistake for a slow await."""
+    s = LoopSentinel()
+    s.start()
+    await asyncio.sleep(0.15)
+    time.sleep(0.6)                       # a blocking call, on the loop
+    await asyncio.sleep(0.15)
+    await s.stop()
+
+    h = s.health()
+    assert h["stalls"] >= 1, "a blocking call went unnoticed"
+    assert h["worst_lag_s"] >= 0.4
+
+
+@pytest.mark.asyncio
+async def test_a_capability_still_resolves_while_a_dependency_boots():
+    """End to end, in the shape of the actual failure.
+
+    A PURE, deterministic capability resolution must complete instantly while
+    a heavy dependency is mid-initialisation — that is the whole promise of
+    the reflex arc, and the property the 15s gap violated.
+    """
+    from backend.system_control.capability_reflex import get_capability_reflex
+
+    rx = get_capability_reflex()
+    rx.resolve("warm the lexicon")        # pay any one-time import first
+
+    booting = asyncio.create_task(asyncio.sleep(0.8))
+
+    t0 = time.monotonic()
+    out = rx.resolve("lock my screen")
+    elapsed = time.monotonic() - t0
+
+    assert out.resolved and out.capability == "lock_screen"
+    assert elapsed < 0.05, f"resolution took {elapsed:.3f}s during boot"
+    assert not booting.done(), "the dependency finished early; test is vacuous"
+    await booting
+
+
+# ── The witness itself ──────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_availability_reflects_time_spent_absent():
+    s = LoopSentinel()
+    s.start()
+    await asyncio.sleep(0.1)
+    time.sleep(0.5)
+    await asyncio.sleep(0.1)
+    await s.stop()
+    h = s.health()
+    assert 0.0 <= h["availability"] <= 1.0
+    assert h["availability"] < 1.0, "a half-second absence left no trace"
+
+
+@pytest.mark.asyncio
+async def test_stalls_are_reported_with_a_wall_clock_time():
+    """The point is to go and LOOK at the log around that moment, so a lag
+    number without a timestamp is a fact nobody can use."""
+    s = LoopSentinel()
+    s.start()
+    await asyncio.sleep(0.1)
+    time.sleep(0.5)
+    await asyncio.sleep(0.1)
+    await s.stop()
+    recent = s.health()["recent"]
+    assert recent and ":" in recent[0] and "for" in recent[0]
+
+
+@pytest.mark.asyncio
+async def test_it_can_be_switched_off(monkeypatch):
+    monkeypatch.setenv("JARVIS_LOOP_SENTINEL_ENABLED", "false")
+    s = LoopSentinel()
+    s.start()
+    assert s.health()["watching"] is False
+
+
+@pytest.mark.asyncio
+async def test_starting_twice_watches_once():
+    s = LoopSentinel()
+    s.start()
+    first = s._task
+    s.start()
+    assert s._task is first
+    await s.stop()
+
+
+@pytest.mark.asyncio
+async def test_stopping_when_never_started_is_fine():
+    await LoopSentinel().stop()
+
+
+@pytest.mark.asyncio
+async def test_the_singleton_is_shared():
+    assert get_loop_sentinel() is get_loop_sentinel()

--- a/tests/hud/test_voiceprint_hydration.py
+++ b/tests/hud/test_voiceprint_hydration.py
@@ -1,0 +1,216 @@
+"""Decoding a voiceprint, without guessing what it is.
+
+The same profile is stored twice at different sizes — 768 bytes locally, 1538
+in CloudSQL. A cosine similarity does not fail loudly on a misread buffer: it
+returns a plausible number, and that number becomes "that didn't sound like
+you". A statement about a person, produced by a type error.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from backend.hud.voiceprint_hydration import (
+    KNOWN_DIMENSIONS, UnreadableVoiceprint, describe, hydrate,
+    hydrate_or_none,
+)
+
+
+def _blob(dim: int = 192, dtype: str = "float32", header: int = 0) -> bytes:
+    v = np.linspace(-1.0, 1.0, dim).astype(dtype)
+    return (b"\x00" * header) + v.tobytes()
+
+
+# ── The mandate ─────────────────────────────────────────────────────────────
+
+def test_a_768_byte_float32_blob_hydrates_to_the_expected_shape_and_dtype():
+    """THE ASSERTION ASKED FOR.
+
+    768 bytes is 192 float32s — ECAPA-TDNN's native width, and exactly what
+    the local SQLite profile holds.
+    """
+    raw = _blob(192, "float32")
+    assert len(raw) == 768
+
+    h = hydrate(raw, dtype="float32")
+
+    assert h.dimension == 192
+    assert h.source_dtype == "float32"
+    assert h.shape == (192,)
+    assert h.vector.dtype == np.float32
+    assert np.isfinite(h.vector).all()
+
+
+def test_the_values_survive_the_round_trip_exactly():
+    """Shape and dtype are not enough — a vector can be the right shape and
+    still be nonsense."""
+    v = np.linspace(-1.0, 1.0, 192).astype("float32")
+    h = hydrate(v.tobytes(), dtype="float32")
+    assert np.array_equal(h.vector, v)
+
+
+def test_the_result_is_writable_and_owns_its_memory():
+    """`np.frombuffer` returns a READ-ONLY view onto the source buffer.
+    Handing that to a model that writes in place is a corruption bug that
+    surfaces somewhere else entirely, so the copy is load-bearing."""
+    raw = _blob()
+    h = hydrate(raw)
+    assert h.vector.flags.writeable
+    assert h.vector.base is None or h.vector.flags.owndata
+    h.vector[0] = 42.0                      # must not raise, must not corrupt
+    assert hydrate(raw).vector[0] != 42.0
+
+
+def test_upcasting_to_float64_is_exact():
+    """float32 -> float64 is lossless; every float32 has an exact float64
+    representation, so widening cannot move a vector."""
+    v = np.linspace(-1.0, 1.0, 192).astype("float32")
+    h = hydrate(v.tobytes(), dtype="float64")
+    assert h.vector.dtype == np.float64
+    assert np.array_equal(h.vector, v.astype("float64"))
+
+
+# ── Refusing, rather than reinterpreting ────────────────────────────────────
+
+def test_a_length_matching_nothing_is_refused_not_guessed():
+    """The whole point. A misread buffer produces a confident wrong answer
+    about who is speaking, so an unrecognisable length must raise."""
+    with pytest.raises(UnreadableVoiceprint) as e:
+        hydrate(b"\x01" * 777)
+    assert "refusing to reinterpret" in str(e.value)
+
+
+def test_an_empty_blob_is_refused():
+    with pytest.raises(UnreadableVoiceprint):
+        hydrate(b"")
+    with pytest.raises(UnreadableVoiceprint):
+        hydrate(None)
+
+
+def test_a_blob_of_non_finite_values_is_refused():
+    """NaNs in an embedding make every cosine NaN, which compares False
+    against every threshold — a silent, total verification failure."""
+    v = np.full(192, np.nan, dtype="float32")
+    with pytest.raises(UnreadableVoiceprint):
+        hydrate(v.tobytes())
+
+
+def test_the_narrower_reading_wins_when_a_length_is_ambiguous():
+    """768 bytes is 192 float32 AND 96 float64. A writer producing 768 bytes
+    for a 192-d model was writing float32, so that is the reading."""
+    h = hydrate(_blob(192, "float32"))
+    assert (h.dimension, h.source_dtype) == (192, "float32")
+
+
+def test_a_small_header_is_tolerated_when_the_dimension_is_declared():
+    """CloudSQL's 1538 is 1536 + 2 — a real header, not corruption. It is
+    only readable once the dimension is declared, because 1538 also reads as
+    384 float32 + 2."""
+    h = hydrate(_blob(192, "float64", header=2), dtype="float64",
+                expect_dimension=192)
+    assert h.dimension == 192 and h.source_dtype == "float64"
+    assert h.header_bytes == 2
+
+
+def test_the_vector_is_read_from_the_END_when_a_header_is_present():
+    """A header sits at the FRONT. Slicing from the front would shift every
+    element by the header width and produce a finite, entirely wrong vector."""
+    v = np.linspace(-1.0, 1.0, 192).astype("float64")
+    h = hydrate(b"\xde\xad" + v.tobytes(), dtype="float64",
+                expect_dimension=192)
+    assert np.array_equal(h.vector, v)
+
+
+def test_a_large_remainder_is_not_called_a_header():
+    with pytest.raises(UnreadableVoiceprint):
+        hydrate(_blob(192, "float32", header=64), expect_dimension=192)
+
+
+def test_an_ambiguous_length_is_refused_rather_than_settled_by_precedence():
+    """1538 bytes reads as 384 float32 + 2 AND 192 float64 + 2. Picking one by
+    candidate order is a coin toss that produces a wrong vector half the time;
+    the profile schema records `embedding_dimension` precisely so nobody has
+    to guess."""
+    # 1536 bytes exactly: 384 float32 OR 192 float64. Refused by name.
+    with pytest.raises(UnreadableVoiceprint) as e:
+        hydrate(_blob(192, "float64"))
+    assert "ambiguous" in str(e.value)
+
+    # 1538 (CloudSQL's actual size) is not an exact multiple of anything, so
+    # unguided it is simply unreadable — a different refusal, same discipline.
+    raw = _blob(192, "float64", header=2)
+    with pytest.raises(UnreadableVoiceprint):
+        hydrate(raw)
+    assert hydrate(raw, dtype="float64", expect_dimension=192).dimension == 192
+
+
+# ── Whatever the driver hands back ──────────────────────────────────────────
+
+def test_a_memoryview_from_psycopg2_reads_the_same_as_sqlite_bytes():
+    """psycopg2 returns memoryview for bytea, sqlite3 returns bytes — the same
+    profile arrives as two types depending on which store answered."""
+    raw = _blob()
+    assert np.array_equal(hydrate(raw).vector,
+                          hydrate(memoryview(raw)).vector)
+    assert np.array_equal(hydrate(raw).vector,
+                          hydrate(bytearray(raw)).vector)
+
+
+def test_a_hex_encoded_blob_is_understood():
+    raw = _blob()
+    assert np.array_equal(hydrate("\\x" + raw.hex()).vector, hydrate(raw).vector)
+
+
+# ── Diagnostics ─────────────────────────────────────────────────────────────
+
+def test_describe_reports_shape_without_committing_to_a_reading():
+    d = describe(_blob(192, "float32"))
+    assert d["bytes"] == 768 and d["readable"]
+    assert any("192-d float32" in c for c in d["candidates"])
+
+
+def test_describe_says_so_when_nothing_fits():
+    assert describe(b"\x00" * 777)["readable"] is False
+
+
+def test_the_non_raising_form_returns_none_rather_than_a_wrong_vector():
+    assert hydrate_or_none(b"\x00" * 777) is None
+    assert hydrate_or_none(_blob()) is not None
+
+
+@pytest.mark.parametrize("dim", KNOWN_DIMENSIONS)
+def test_every_declared_dimension_round_trips(dim):
+    """Declared, because some widths collide: 384 float32 and 192 float64 are
+    both 1536 bytes. The dimension comes from the profile row, not a guess."""
+    h = hydrate(_blob(dim, "float32"), expect_dimension=dim)
+    assert h.dimension == dim and h.shape == (dim,)
+
+
+# ── The real profile on this machine ────────────────────────────────────────
+
+def test_the_actual_local_voiceprint_hydrates():
+    """Not a fixture. The 768-byte blob measured in
+    ~/.jarvis/learning/jarvis_learning.db for "Derek J. Russell"."""
+    import pathlib
+    import sqlite3
+
+    p = pathlib.Path.home() / ".jarvis/learning/jarvis_learning.db"
+    if not p.exists():
+        pytest.skip("no local learning database on this machine")
+    con = sqlite3.connect(str(p))
+    con.row_factory = sqlite3.Row
+    try:
+        row = con.execute(
+            "select voiceprint_embedding from speaker_profiles limit 1"
+        ).fetchone()
+    except sqlite3.Error:
+        pytest.skip("no speaker_profiles table")
+    finally:
+        con.close()
+    if row is None or row["voiceprint_embedding"] is None:
+        pytest.skip("no stored voiceprint")
+
+    h = hydrate(row["voiceprint_embedding"])
+    assert h.dimension in KNOWN_DIMENSIONS
+    assert np.isfinite(h.vector).all()
+    assert h.vector.flags.writeable


### PR DESCRIPTION
Two commits: the measured cause of the command latency, and the end of silent failures.

## The acknowledgement WAS the delay

```python
await _hud_tts(f"On it. Executing: {goal[:60]}")   # blocks until afplay FINISHES
result = await voice_router.route(...)
```

`_hud_tts` awaits `say` to synthesize a file, then `afplay` to play it **to completion**. Every command stopped and waited for its own acknowledgement to finish being *spoken* before it started being *done* — measured `01:40:34` received, `01:40:49` routed. The mouth-lock added last round made it worse, since the acknowledgement then also queued behind any utterance already speaking.

The entire point of "On it" is to reassure *while* the work happens. Awaiting it turns the reassurance into the delay it was meant to cover. Now `create_task` — safe precisely **because** of that lock: acknowledgement and result cannot overlap, they queue, in the order they were decided.

## A witness, before a refactor

The remaining hypothesis is that heavy init starves the loop. It may be true. But **`await slow_thing()` does not starve a loop** — it yields, and a 79-second boot can be responsive throughout. Only a *synchronous* call that never yields starves anything, and the two produce identical wall-clock timelines while needing opposite fixes.

Backgrounding an already-yielding dependency costs nothing and fixes nothing. So rather than refactor boot on a guess, `hud/loop_sentinel.py` watches the **loop itself**: sleep a known interval at 4 Hz, measure the overshoot. `sleep(0.25)` returning after 3.1s means the loop couldn't reach that task for 2.85s — starvation by definition, no instrumentation of the culprit required. Starts before anything heavy; logs at WARNING with a wall-clock timestamp.

`telemetry/loop_sink` exists but is opt-in per call site: it can convict a suspect, never find one.

## The blank `failed:` — two bugs on one line

```python
await asyncio.wait_for(asyncio.shield(gls.start()), timeout=30.0)
logger.warning("[HUD-Gov] GovernedLoopService failed: %s", exc)
```

**`str(asyncio.TimeoutError())` is the empty string.** `%s` prints an exception's *message* and that class has none — so a 30-second timeout rendered as silence, on every boot. Not a special case: `StopIteration`, `CancelledError`, and any bare `raise SomeError` behave identically.

**`asyncio.shield` abandons the wait, not the work.** `gls.start()` carried on unobserved — if it later raised, the traceback went to the loop's default handler; if it later *succeeded*, governance was running while the system had already announced itself DEGRADED. Both are worse than a crash, because a crash tells you something.

The shield stays (a governance service half-started then cancelled is worse than one still starting). What was missing is anyone observing how it ends.

## TaskHarvester — and why it buffers

`add_done_callback` extracts the full traceback, logs at ERROR, and routes a `HealthFinding` into O+V intake. `describe_exception` leads with the **type**, so a nameless exception still says what it was.

**It buffers, and that is the point.** The failure worth catching happens *during* boot — exactly when `RuntimeHealthSensor` doesn't exist yet. A harvester that merely looked the sensor up would drop the one traceback it was built for. Findings are held in a bounded ring and flushed when `register_runtime_health_sensor` publishes.

DRY: no logging framework, no new envelope. `report()` is a push entry point through the same `_emit` → `make_envelope` → `router.ingest` path polling uses; `scan_once` was refactored onto that emitter so the two cannot drift.

A loop stall now arrives as an `event_loop_starvation` finding — **once per run**, because a boot that stalls forty times has one defect.

## Precision-aware hydration — my own tests caught two real flaws

768 bytes local vs 1538 in CloudSQL. A cosine similarity does not fail loudly on a misread buffer: it returns a plausible number, and that number becomes *"that didn't sound like you"* — a statement about a person, produced by a type error.

- **A 16-byte header tolerance is not a tolerance, it's a licence.** 777 bytes of nothing hydrated cleanly as "192 float32 + 9-byte header" — the exact reinterpretation the module exists to refuse. Unguided, only an exact multiple is now a vector.
- **1536 bytes is genuinely ambiguous** — 384×float32 *or* 192×float64. Breaking the tie by candidate order is a coin toss producing a wrong vector half the time. Now refused, naming both readings; the schema already records `embedding_dimension`, so the answer is to ask.

Reads the vector from the **end** (a header sits at the front; slicing from the front shifts every element into a finite, entirely wrong vector), and `astype(copy=True)` because `np.frombuffer` returns a **read-only view** — handing that to a model that writes in place is a corruption bug surfacing somewhere else entirely.

## Testing

**378 passed, 19 skipped.** 17 harvester · 22 hydration (including the **real 768-byte blob** from this machine) · 9 sentinel, of which `test_a_slow_dependency_does_not_stop_the_loop` and `test_a_synchronous_call_IS_caught` together prove the witness can tell slow from blocked.

`hud_governance_boot.py` and `intake_layer_service.py` have no direct tests; both verified to import cleanly with the intended edits present.

## ⚠️ Not live-proven

Neither the acknowledgement fix nor the sentinel has run against a live boot. The next boot log settles it: `EVENT LOOP STALLED …` means starvation is real and the tiered-boot refactor is justified; silence plus fast commands means it was the awaited acknowledgement all along.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run the HUD TTS acknowledgement in the background so commands start immediately. Add a loop sentinel and task harvester to surface event‑loop stalls and background startup failures, plus safe voiceprint hydration to prevent misreads.

- **New Features**
  - Event loop sentinel: watches the asyncio loop at ~4 Hz, logs/warns on stalls, and reports a single `event_loop_starvation` finding per run; started early in `backend/main.py`.
  - Task harvester: observes shielded/async tasks, logs full tracebacks, buffers failures during boot, and flushes to runtime‑health intake when published; exposes `watch()`/`record()`.
  - Precision‑aware voiceprint hydration: refuses ambiguous/malformed blobs (e.g., 1536 B is 192×f64 or 384×f32), reads vectors from the end, widens dtype, and returns writable arrays.

- **Bug Fixes**
  - Unblocked HUD command path by using `asyncio.create_task(_hud_tts(...))` instead of awaiting the acknowledgement.
  - Eliminated blank “failed:” logs and silent governance outcomes: keep `asyncio.shield`, attach a watcher, describe exceptions by type, and route findings via runtime health.
  - Runtime health intake: added `report()` with a shared emitter, and publish the sensor during intake build to flush buffered findings.

<sup>Written for commit 6b44aee1a93b241bc0b2cb254af4af8bcc8d3f8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

