### PR TITLE
perf(governance): take the 34-second invariant audit off the event loop

### DIFF
--- a/backend/core/ouroboros/governance/event_channel.py
+++ b/backend/core/ouroboros/governance/event_channel.py
@@ -486,13 +486,14 @@ class EventChannelServer:
                     assert_loopback_only as _assert_loopback_id,
                 )
                 from backend.core.ouroboros.governance.invariant_drift_auditor import (  # noqa: E501
+                    capture_snapshot_async as _id_capture_async,
                     invariant_drift_auditor_enabled as _id_enabled,
                 )
                 from backend.core.ouroboros.governance.invariant_drift_observability import (  # noqa: E501
                     register_invariant_drift_routes,
                 )
                 from backend.core.ouroboros.governance.invariant_drift_store import (  # noqa: E501
-                    install_boot_snapshot,
+                    install_boot_snapshot_async,
                 )
                 from backend.core.ouroboros.governance.invariant_drift_observer import (  # noqa: E501
                     get_default_observer as _id_get_observer,
@@ -514,9 +515,54 @@ class EventChannelServer:
                         ),
                         cors_headers=_id_helper._cors_headers,
                     )
-                    # Boot snapshot — best-effort, idempotent
+                    # Boot snapshot — best-effort, idempotent, OFF-LOOP.
+                    #
+                    # THE 34-SECOND STOP-THE-WORLD.
+                    #
+                    # This was `install_boot_snapshot()`, called synchronously
+                    # from inside `async def start()`. Measured on this repo:
+                    #
+                    #     validate_all() BLOCKED the caller for 34.43 SECONDS
+                    #
+                    # `capture_snapshot` -> `_capture_shipped_invariants` ->
+                    # `validate_all`, and one of those invariants `rglob`s the
+                    # whole governance tree, reading and `ast.parse`-ing every
+                    # file. None of it yields. An `await` whose body never
+                    # yields does not merely take a long time — it stops the
+                    # event loop dead, and everything the organism owes an
+                    # operator stops with it.
+                    #
+                    # That single call accounts for the observed boot
+                    # pathology: an IPC action received at 01:40:34 and not
+                    # routed until 01:40:49; `LearningDB` "timing out" after
+                    # 15s when it was merely starved of the loop; the
+                    # enrollment lookup doing the same; and
+                    # `GovernedLoopService` blowing its 30s budget, because
+                    # 34s > 30s all on its own.
+                    #
+                    # BOTH halves are needed and neither is sufficient:
+                    #
+                    #   * `capture_snapshot_async` routes the AST work through
+                    #     the canonical PROCESS pool. A thread would not do —
+                    #     `ast.parse` holds the GIL, so `to_thread` alone
+                    #     frees the file-I/O half and leaves the parsing half
+                    #     still blocking the loop.
+                    #   * passing that snapshot into `install_boot_snapshot_
+                    #     async` makes it skip its own sync capture (see
+                    #     `current = snapshot if snapshot is not None else
+                    #     capture_snapshot()`), leaving only the sub-
+                    #     millisecond disk write on the thread hop.
+                    #
+                    # Nothing here weakens the audit: the same invariants are
+                    # checked over the same files with the same fail-closed
+                    # semantics. Only the thread it happens on changed.
+                    #
+                    # Both async entry points already existed and had no
+                    # caller — `install_boot_snapshot_async`'s own docstring
+                    # names this exact scenario as the reason it was written.
                     try:
-                        install_boot_snapshot()
+                        _snap = await _id_capture_async()
+                        await install_boot_snapshot_async(snapshot=_snap)
                     except Exception as boot_exc:  # noqa: BLE001
                         logger.warning(
                             "[EventChannel] invariant-drift boot "


### PR DESCRIPTION
## The hang and the starvation were the same call

```
EventChannelServer.start()      ← async def
  install_boot_snapshot()       ← synchronous
    capture_snapshot()
      validate_all()            ← rglob + read_text + ast.parse, whole tree
```

**Measured: `validate_all()` blocked the caller for 34.43 seconds.** For four invariants.

An `await` whose body never yields doesn't take a long time — it stops the loop dead. That one call explains what looked like five separate defects in the `2026-08-03` boot log:

- an IPC action received at `01:40:34`, not routed until `01:40:49`
- `LearningDB` *"Initialization timed out (15s)"* — not slow, **starved of the loop**
- the enrollment lookup timing out identically, at the same moment
- `GovernedLoopService` blowing its 30s budget — **34s > 30s on its own**, which is the empty `failed:` fixed in #70379
- the governance test-suite hang: `pytest-timeout` uses the **thread** method, which cannot interrupt a C-level read/parse loop, so the timeout hung beside the test it was meant to kill

## The fix already existed and had no caller

`install_boot_snapshot_async`'s own docstring names this exact scenario:

> *"cheap insurance for the rare case where `capture_snapshot` happens to call into a slow path (e.g. `shipped_code_invariants.validate_all` reading cold source files at boot)"*

Both async entry points were built and never adopted — the same wired-but-inert shape as the reflex arc, the consent bridge and the CAI detector before them.

**Both halves are needed:**

- `capture_snapshot_async` routes AST work through the canonical **process** pool. A thread won't do — `ast.parse` holds the GIL, so `to_thread` alone frees the file-I/O half and leaves parsing still blocking the loop.
- passing that snapshot into `install_boot_snapshot_async` makes it skip its own sync capture (`current = snapshot if snapshot is not None else capture_snapshot()`), leaving a sub-millisecond disk write.

Nothing weakened: same invariants, same files, same fail-closed semantics. Only the thread changed.

## Measured with the sentinel from #70379

| | before | after |
|---|---|---|
| loop during audit | **DEAD 34.43s** | alive, **96.2% available** |
| worst stall | 34.43s | **0.52s** |
| heartbeats served | **0** | **589** |
| wall-clock | 34.4s | 59.6s |

**Wall-clock got worse.** The process pool costs startup and IPC marshalling. That's a real regression and the right trade: 59s during which JARVIS answers beats 34s during which it is absent. Being present comes before being quick.

## The deeper cause — measured, not fixed here

Moving work off the loop doesn't make it fast, and 34s for four invariants isn't repo size. Instrumenting `read_text` across one audit:

| where the audit read | files | MB |
|---|---|---|
| **governance (the target)** | **2776** | **70.3** |
| site-packages | 662 | 0.1 |
| repo, outside governance | 26 | 1.8 |

Governance is **1242 unique files / 29.1 MB**. The audit read **2.4× more than exists**. One full pass costs ~6.1s; it's doing roughly two and a half, because validators like `_validate_v1_methods_routed_through_helper` ignore the tree handed to them and `rglob` the whole package themselves. **20 files in `governance/` do their own full-tree scan.**

That defeats Slice 11C's grouping optimisation, whose docstring claims *"the legacy O(N_invariants) parse path is gone"* — gone for target files, alive for whole-tree validators. The fix is a shared per-cycle source/AST cache; none exists today (`ast_compile_helper` is a parse helper, not a store). Left for its own change rather than bolted onto this one.

## Verification

**285 tests pass** across the five invariant-drift suites (5m23s — slow because they exercise the audit repeatedly, which is now itself evidence).

Two failures confirmed **pre-existing** against a clean worktree at `026e54df98`, not caused by this work:

- `test_l3_telemetry::test_worktree_lifespan_measured_create_to_reap` — asserts a mocked 3.5s lifespan, gets `0.0`
- `test_organism_bus_host` — 2 failures, sandbox `PermissionError` on socket bind, same class as the skipped consent-circuit suite

## ⚠️ Not live-proven

This has not run against a live HUD boot. The next boot is the proof: the sentinel from #70379 should be near-silent where it would previously have screamed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move the invariant-drift boot audit off the event loop to prevent the 34s stop-the-world stall and keep boot-time services responsive.

- **Bug Fixes**
  - Replaced sync `install_boot_snapshot()` in `EventChannelServer.start` with `_id_capture_async()` + `install_boot_snapshot_async(snapshot=...)`, sending parse work to the process pool (avoids GIL-bound `ast.parse` blocking the loop).
  - Results: loop stayed responsive (~96% availability, worst stall 0.52s, heartbeats served), with a small wall-clock increase due to pool startup.

<sup>Written for commit 4b27ec9a90476f194e45683eb479c6671b8ea894. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70380?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

