### PR TITLE
fix(hud): an empty container is not a statement that nothing exists

### DIFF
--- a/backend/hud/voice_command_router.py
+++ b/backend/hud/voice_command_router.py
@@ -49,14 +49,32 @@ _SPOKEN_LOCK = threading.Lock()
 def echo_grace_s() -> float:
     """Extra time past the end of speech in which an echo can still arrive.
 
-    NEVER raises. Covers recogniser latency — the transcript of a phrase lands
-    after the phrase finished. ``0`` disables echo suppression entirely.
+    NEVER raises. ``0`` disables echo suppression entirely.
+
+    WHY 4 SECONDS AND NOT 1.5
+    ---------------------------
+    This was 1.5s, chosen as "recogniser latency", and it was too small by a
+    factor that let a real echo through. Measured 2026-08-03 08:47:47 —
+    JARVIS said "🔒 Locking the screen now, Derek. See you soon." (estimated
+    5.33s of speech), and at 08:47:56 the microphone delivered "See you soon"
+    as a COMMAND. The window had closed 2.17s earlier.
+
+    The gap is not latency, it is the recogniser's own design.
+    `WakeWordListener.commandSilenceTimeout` is 2.5s: it waits for two and a
+    half seconds of silence before deciding an utterance has ended, and only
+    then finalises and dispatches. So a transcript necessarily arrives at
+    least 2.5s AFTER the audio stopped, plus recognition time.
+
+    4s covers that with room, and the cost of being generous is bounded and
+    small: the only thing suppressed is a phrase JARVIS itself said, in that
+    order, within seconds. The cost of being stingy is JARVIS obeying its own
+    voice — which is how "See you soon" became an unlock attempt.
     """
     try:
         raw = (os.environ.get("JARVIS_ECHO_GRACE_S", "") or "").strip()
-        return max(0.0, min(30.0, float(raw))) if raw else 1.5
+        return max(0.0, min(30.0, float(raw))) if raw else 4.0
     except (TypeError, ValueError):
-        return 1.5
+        return 4.0
 
 
 def _echo_expiry(text: str) -> float:

--- a/backend/hud/voice_identity.py
+++ b/backend/hud/voice_identity.py
@@ -294,9 +294,27 @@ class VoiceIdentity:
             if svc is not None:
                 for attr in ("speaker_profiles", "profiles", "_profiles"):
                     profiles = getattr(svc, attr, None)
-                    if isinstance(profiles, dict):
+                    # NON-EMPTY only. An empty dict is NOT a statement that
+                    # nobody is enrolled — it is the state a service is in
+                    # before `_load_speaker_profiles` has succeeded, and that
+                    # load fails routinely: measured 2026-08-03 08:47,
+                    #
+                    #   EcapaFacade error ... falling back to local engine
+                    #   CloudSQL init timed out after 10.0s - SQLite-only mode
+                    #
+                    # left `speaker_profiles == {}` on a live service, and this
+                    # branch reported "I don't have a voiceprint for you on
+                    # this Mac yet" while "Derek J. Russell / 272 samples" sat
+                    # in the local SQLite one query away. Same defect as
+                    # `is_screen_locked` answering False when it could not see:
+                    # an empty container from a FAILED load, read as absence.
+                    #
+                    # A populated dict is authoritative. An empty one means
+                    # "ask something that actually knows".
+                    if isinstance(profiles, dict) and profiles:
                         names = [str(k) for k in profiles if k]
-                        return sorted(names)[0] if names else ""
+                        if names:
+                            return sorted(names)[0]
             # Whatever the cheap database lookup last found. See
             # :meth:`refresh_enrollment` — enrollment is a ROW, not a model.
             return self._enrolled_cache

--- a/tests/hud/test_voice_authority.py
+++ b/tests/hud/test_voice_authority.py
@@ -136,16 +136,26 @@ async def test_an_unloaded_service_says_not_ready_not_not_enrolled():
 
 @pytest.mark.asyncio
 async def test_a_loaded_service_with_no_profile_is_a_fact():
-    r = await VoiceIdentity(service=_Service({})).identify(b"RIFFxxxx")
+    vi = VoiceIdentity(service=_Service({}))
+    vi._enrolled_cache = ""               # the store answered, and found none
+    r = await vi.identify(b"RIFFxxxx")
     assert r.verdict == Verdict.NOT_ENROLLED.value
 
 
 def test_unknown_enrollment_is_none_not_empty():
     """None and "" are different claims: 'nothing has looked' vs 'it looked and
-    found nobody'."""
+    found nobody'.
+
+    A service with an EMPTY profiles dict is ALSO None — it has not looked
+    either; its load failed. Only a populated dict, or a completed database
+    lookup, is a statement about the world."""
     assert VoiceIdentity().enrolled_speaker() is None
-    assert VoiceIdentity(service=_Service({})).enrolled_speaker() == ""
+    assert VoiceIdentity(service=_Service({})).enrolled_speaker() is None
     assert VoiceIdentity(service=_Service({"Derek": {}})).enrolled_speaker() == "Derek"
+
+    settled = VoiceIdentity(service=_Service({}))
+    settled._enrolled_cache = ""          # the store answered: genuinely nobody
+    assert settled.enrolled_speaker() == ""
 
 
 @pytest.mark.asyncio
@@ -217,7 +227,9 @@ async def test_the_router_reads_the_verdict_without_a_translation_table():
 
 @pytest.mark.asyncio
 async def test_the_operator_hears_a_sentence_not_a_state_name():
-    r = await VoiceIdentity(service=_Service({})).identify(b"RIFFxxxx")
+    vi = VoiceIdentity(service=_Service({}))
+    vi._enrolled_cache = ""               # the store answered: nobody enrolled
+    r = await vi.identify(b"RIFFxxxx")
     spoken = _verdict_reason(r)
     assert "voiceprint" in spoken.lower()
     assert "not_enrolled" not in spoken
@@ -263,3 +275,43 @@ async def test_a_reachable_store_with_no_profile_still_says_not_enrolled():
     vi._enrolled_cache = ""
     r = await vi.identify(b"RIFFxxxx")
     assert r.verdict == Verdict.NOT_ENROLLED.value
+
+
+def test_an_empty_profile_dict_is_not_a_statement_that_nobody_is_enrolled():
+    """Live 2026-08-03 08:47. `EcapaFacade error ... falling back to local
+    engine` + `CloudSQL init timed out after 10.0s` left a LIVE service whose
+    `speaker_profiles` was `{}` — and this reported "I don't have a voiceprint
+    for you on this Mac yet" while "Derek J. Russell / 272 samples" sat in the
+    local SQLite one query away.
+
+    Third instance of one defect: an empty container produced by a FAILED
+    load, read as a positive statement of absence.
+    """
+    class FailedLoad:
+        speaker_profiles = {}
+        async def verify_speaker(self, a, n=None):
+            return {"verified": True, "confidence": 0.9}
+
+    vi = VoiceIdentity(service=FailedLoad())
+    assert vi.enrolled_speaker() is None, "empty != nobody"
+
+    class Loaded:
+        speaker_profiles = {"Derek J. Russell": {}}
+        async def verify_speaker(self, a, n=None):
+            return {"verified": True, "confidence": 0.9}
+
+    assert VoiceIdentity(service=Loaded()).enrolled_speaker() == "Derek J. Russell"
+
+
+@pytest.mark.asyncio
+async def test_an_unloaded_service_says_not_ready_so_a_retry_can_succeed():
+    """NOT_ENROLLED is terminal advice ("go enroll"); NOT_READY invites the
+    retry that actually works once the database answers."""
+    class FailedLoad:
+        speaker_profiles = {}
+        async def verify_speaker(self, a, n=None):
+            return {"verified": True, "confidence": 0.9}
+
+    r = await VoiceIdentity(service=FailedLoad()).identify(b"RIFFxxxx")
+    assert r.verdict == Verdict.NOT_READY.value
+    assert "UNKNOWN" in r.detail

--- a/tests/hud/test_voice_router_reflex.py
+++ b/tests/hud/test_voice_router_reflex.py
@@ -16,7 +16,7 @@ import pytest
 from backend.hud.tool_use_orchestrator import CommandResult
 from backend.hud.voice_command_router import (
     VoiceCommandRouter, _humanise, _make_failure_speakable,
-    _read_controller_result, reset_spoken,
+    _read_controller_result, is_own_echo, note_spoken, reset_spoken,
 )
 
 
@@ -306,3 +306,26 @@ async def test_the_slot_is_released_so_a_capability_still_works_after(monkeypatc
     await r.route("lock my screen")
     await r.route("lock my screen")
     assert calls == ["lock_screen", "lock_screen"], "the slot leaked"
+
+
+def test_the_echo_window_outlives_the_recognisers_silence_timeout():
+    """Live 2026-08-03: JARVIS said "...See you soon." at 08:47:47 and the mic
+    delivered "See you soon" as a COMMAND at 08:47:56. The old 1.5s grace
+    closed the window 2.17s early.
+
+    `WakeWordListener.commandSilenceTimeout` is 2.5s — a transcript CANNOT
+    arrive sooner than 2.5s after the audio stops, by design."""
+    from backend.hud.speech_bridge import estimate_speech_ms
+    from backend.hud.voice_command_router import echo_grace_s
+
+    spoken = "🔒 Locking the screen now, Derek. See you soon."
+    window = estimate_speech_ms(spoken) / 1000.0 + echo_grace_s()
+    assert window >= 9.0, f"window {window:.2f}s still misses the measured echo"
+    assert echo_grace_s() > 2.5, "must outlast the recogniser's silence timeout"
+
+
+def test_that_exact_echo_is_now_suppressed():
+    reset_spoken()
+    note_spoken("🔒 Locking the screen now, Derek. See you soon.")
+    assert is_own_echo("See you soon")
+    assert not is_own_echo("unlock my screen")


### PR DESCRIPTION
Live boot `2026-08-03 08:46–08:48`. Two defects — one of them the **third appearance of a single mistake**.

## First, what worked

| | before | now |
|---|---|---|
| IPC receive → route | **15,000 ms** | **37 ms** |
| `GovernedLoopService failed:` | *(blank)* | **`TimeoutError`** |
| greeting | "there" | **"Derek"** |

Every instrument reported for real: `[LoopSentinel]` named its stalls, `[TaskHarvester]` caught the timeout the empty log line had been hiding, and **the CAI chain executed live** — `CAI: 'screen_unlocked' still unmet after 'unlock_screen' — abandoning`.

## "I don't have a voiceprint for you" — while it sat one query away

```
[CapabilityRouter] 'unlock_screen' NOT authorised by VoiceConsentProvider
  (I don't have a voiceprint for you on this Mac yet...)
```

…and simultaneously, in the same database: `[('Derek J. Russell', 272)]`.

The boot log says why:

```
EcapaFacade error: registry required for first facade creation — falling back to local engine
CloudSQL init timed out after 10.0s - using SQLite-only mode
```

A **live** service object existed whose `speaker_profiles` was `{}` — the load had failed — and `enrolled_speaker()` read that empty dict as an authoritative *"nobody is enrolled"*.

**The same defect, a third time:**

1. `is_screen_locked()` returning `False` when it could not see
2. `enrolled_speaker()` reading an empty embeddings **directory** as "nobody"
3. this — an empty profiles **dict** from a failed load, read as absence

Each time: a container that is empty *because a lookup failed*, treated as a positive statement about the world. Only a **populated** dict is authoritative now; an empty one falls through to the database, which answers in milliseconds from local SQLite.

Verified end to end:

```
BEFORE any lookup ->  None              (UNKNOWN, not 'nobody')
first verdict     ->  not_ready
after DB lookup   ->  'Derek J. Russell'
second verdict    ->  verified conf=0.93
```

`NOT_READY` rather than `NOT_ENROLLED` matters: the first invites a retry that now succeeds; the second is terminal advice to go and enroll a voice that has been enrolled since October.

## JARVIS obeyed its own voice

```
08:47:47  Response: "🔒 Locking the screen now, Derek. See you soon."
08:47:56  >>> "See you soon"   → dispatched as a COMMAND → unlock attempt
```

The echo ledger expired **2.17s too early**. The old 1.5s grace modelled the gap as "recogniser latency", which is the wrong model: `WakeWordListener.commandSilenceTimeout` is **2.5s**, so a transcript *cannot* arrive sooner than 2.5s after audio stops — by design — plus recognition time.

Grace is now 4s, covering the measured 9s echo against a 5.33s utterance. Being generous costs only the suppression of a phrase JARVIS itself said, in that order, within seconds. Being stingy costs JARVIS acting on itself.

## Testing

**125 passed.** Both defects pinned with tests quoting the timestamps they came from. Two older tests updated — they encoded the behaviour this corrects.

## ⚠️ Still open

- **Loop still starved**: worst stall **14.33s**, availability 33.8%. `[LoopSink]` names the next culprits — `posture_observer.run_one_cycle blocked_ms=6234`, `commit_ratios 1332`, `recent_summaries_scan 2478`.
- **`VLA failed: <asyncio.locks.Lock> is bound to a different event loop`** — three times, origin unknown.
- DW is now **402 Account balance too low**, not 403 — a billing problem, not a code one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two defects in HUD voice handling: we now treat an empty `speaker_profiles` as unknown (not “nobody”), and we extend echo suppression so JARVIS doesn’t act on its own voice.

- **Bug Fixes**
  - Voice identity: `enrolled_speaker()` only trusts a non-empty profile dict; an empty dict means “not ready” and falls back to the DB/cache. This returns NOT_READY instead of NOT_ENROLLED until a lookup completes, then verifies the enrolled user.
  - Echo suppression: increased default `echo_grace_s()` from 1.5s to 4.0s (still overridable via `JARVIS_ECHO_GRACE_S`) to outlast the recognizer’s 2.5s silence timeout and prevent self-triggered commands. Tests updated to pin both behaviors.

<sup>Written for commit c2f1b61f471116d8a0e10b008a48fba374e4bb54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

