### PR TITLE
fix(hud): one dispatch loop, and my own warm-up was the boot stall

### DIFF
--- a/backend/hud/ipc_server.py
+++ b/backend/hud/ipc_server.py
@@ -44,6 +44,110 @@ _CLIENTS: Set[asyncio.StreamWriter] = set()
 #: undefined behaviour that usually presents as a silently dropped write.
 _SERVER_LOOP: Optional[asyncio.AbstractEventLoop] = None
 
+#: The ONE loop every IPC dispatch runs on.
+#:
+#: Long-lived and deliberately separate from the server loop. Separate,
+#: because a dispatch must not stall when the main loop is busy — that
+#: isolation is the reason the old per-event-loop design existed and it is
+#: worth keeping. Long-lived, because a loop that dies between events takes
+#: every loop-bound object with it: `asyncio.Lock` refuses to cross loops,
+#: `create_task` work is destroyed mid-flight, and subprocess child watchers
+#: are orphaned. All three were measured in one boot.
+_DISPATCH_LOOP: Optional[asyncio.AbstractEventLoop] = None
+_DISPATCH_THREAD: Optional[threading.Thread] = None
+_DISPATCH_LOCK = threading.Lock()
+
+
+def _dispatch_loop() -> asyncio.AbstractEventLoop:
+    """The dispatch loop, started on first use. Thread-safe.
+
+    Lazily created rather than started with the server so that importing this
+    module costs nothing — and so a process that never receives an IPC event
+    never spawns the thread.
+    """
+    global _DISPATCH_LOOP, _DISPATCH_THREAD
+    with _DISPATCH_LOCK:
+        live = (_DISPATCH_LOOP is not None
+                and _DISPATCH_THREAD is not None
+                and _DISPATCH_THREAD.is_alive()
+                and not _DISPATCH_LOOP.is_closed())
+        if live:
+            return _DISPATCH_LOOP
+
+        ready = threading.Event()
+        loop = asyncio.new_event_loop()
+
+        def _serve() -> None:
+            asyncio.set_event_loop(loop)
+            ready.set()
+            try:
+                loop.run_forever()
+            finally:
+                # Drain what is still scheduled before closing, so a shutdown
+                # mid-dispatch does not reproduce in miniature the exact
+                # "Task was destroyed but it is pending" this design removes.
+                try:
+                    pending = asyncio.all_tasks(loop)
+                    for t in pending:
+                        t.cancel()
+                    if pending:
+                        loop.run_until_complete(asyncio.gather(
+                            *pending, return_exceptions=True))
+                except Exception:  # noqa: BLE001
+                    pass
+                loop.close()
+
+        thread = threading.Thread(target=_serve, name="hud-ipc-dispatch",
+                                  daemon=True)
+        thread.start()
+        # Wait for `set_event_loop` before handing the loop out: scheduling
+        # onto a loop that is not yet running is legal but silently queues
+        # until it starts, which is the "unreliable call_soon_threadsafe"
+        # behaviour that produced the old design.
+        ready.wait(timeout=5.0)
+        _DISPATCH_LOOP, _DISPATCH_THREAD = loop, thread
+        logger.info("[IPC] dispatch loop started on '%s' — one loop for every "
+                    "event, so locks and background tasks survive between them",
+                    thread.name)
+        return loop
+
+
+def _report_dispatch_outcome(fut: Any) -> None:
+    """Surface a dispatch that raised. NEVER raises.
+
+    `run_coroutine_threadsafe` returns a `concurrent.futures.Future` nobody
+    awaits, and an unretrieved exception on one of those is silent — the same
+    black hole `TaskHarvester` exists to close, arriving through a different
+    door. This is that door.
+    """
+    try:
+        exc = fut.exception()
+        if exc is None:
+            return
+        from backend.core.ouroboros.telemetry.task_harvester import (
+            get_task_harvester,
+        )
+        get_task_harvester().record(
+            exc, what="HUD IPC dispatch",
+            target_files=("backend/main.py",))
+    except Exception:  # noqa: BLE001
+        logger.debug("[IPC] dispatch outcome unreadable", exc_info=True)
+
+
+def shutdown_dispatch_loop() -> None:
+    """Stop the dispatch loop. Idempotent. NEVER raises."""
+    global _DISPATCH_LOOP, _DISPATCH_THREAD
+    with _DISPATCH_LOCK:
+        loop, thread = _DISPATCH_LOOP, _DISPATCH_THREAD
+        _DISPATCH_LOOP, _DISPATCH_THREAD = None, None
+    try:
+        if loop is not None and not loop.is_closed():
+            loop.call_soon_threadsafe(loop.stop)
+        if thread is not None:
+            thread.join(timeout=5.0)
+    except Exception:  # noqa: BLE001
+        logger.debug("[IPC] dispatch loop shutdown degraded", exc_info=True)
+
 
 def connected_clients() -> int:
     """How many HUDs are listening. NEVER raises."""
@@ -139,27 +243,74 @@ async def start_ipc_server(
                 if port is None else int(port))
 
     def _dispatch_in_thread(event_type: str, data: dict, principal: str) -> None:
-        """Run async dispatch in a fresh event loop on a daemon thread.
+        """Hand the event to the dedicated dispatch loop. NEVER raises.
 
-        macOS subprocess contexts make call_soon_threadsafe unreliable,
-        so each dispatch gets its own short-lived loop.
+        WHAT THIS USED TO DO, AND WHY IT COST SO MUCH
+        -----------------------------------------------
+        This created `asyncio.new_event_loop()` per EVENT, ran the dispatch on
+        it, and closed it — with the note that "macOS subprocess contexts make
+        call_soon_threadsafe unreliable".
 
-        The principal is stamped INSIDE this function rather than passed down
-        through dispatch: a new thread starts with an empty context, so setting
-        the contextvar here is what makes it visible to everything the dispatch
-        awaits — and scoping it to this thread is what stops two clients'
-        sessions from being attributed to each other.
+        That diagnosis was almost certainly a symptom of something else. A
+        main loop blocked for 34 seconds by the synchronous invariant audit
+        (see `event_channel`) makes `call_soon_threadsafe` look exactly
+        "unreliable": the callback is queued correctly and simply never runs,
+        because nothing is running the loop. The workaround outlived its
+        cause.
+
+        And a loop that is created and destroyed per event breaks every
+        loop-bound primitive in the process. Measured 2026-08-03 08:47:
+
+          * `<asyncio.locks.Lock object ...> is bound to a different event
+            loop` — three times. The TTS mutex that makes JARVIS speak with
+            ONE voice binds to the first dispatch's loop and is unusable from
+            the second.
+          * `Task was destroyed but it is pending!` — every
+            `asyncio.create_task` scheduled during a dispatch dies the instant
+            `run_until_complete` returns and the loop closes. That includes
+            the fire-and-forget acknowledgement TTS, which is the whole reason
+            commands stopped waiting 15 seconds.
+          * `Loop <...closed=True> that handles pid 24496 is closed` — the
+            child watcher for a subprocess spawned during dispatch, orphaned
+            when its loop went away.
+
+        ONE LOOP, LONG-LIVED
+        ----------------------
+        The isolation the old design bought is real and worth keeping: a
+        dispatch must not stall because the MAIN loop is busy. So this keeps a
+        dedicated loop on a dedicated thread — created once, never closed
+        between events. Isolation from the main loop, and a stable identity for
+        anything loop-bound.
+
+        Events still run concurrently: `run_coroutine_threadsafe` schedules
+        each as its own task on that loop, exactly as before, minus the
+        teardown.
+
+        The principal is set INSIDE the coroutine rather than here. The
+        contextvar must be visible to what the dispatch awaits, and that now
+        runs on the dispatch loop's thread rather than this one — setting it
+        here would stamp the reader thread and leave the actual work
+        unattributed.
         """
+        async def _run() -> None:
+            try:
+                from backend.system_control.capability_leases import (
+                    set_principal,
+                )
+                set_principal(principal)
+            except Exception:  # noqa: BLE001 — an unowned lease still has a TTL
+                pass
+            await dispatch(event_type, data)
+
         try:
-            from backend.system_control.capability_leases import set_principal
-            set_principal(principal)
-        except Exception:  # noqa: BLE001 — an unowned lease still has a TTL
-            pass
-        loop = asyncio.new_event_loop()
-        try:
-            loop.run_until_complete(dispatch(event_type, data))
-        finally:
-            loop.close()
+            loop = _dispatch_loop()
+            fut = asyncio.run_coroutine_threadsafe(_run(), loop)
+            # Observed, never awaited: blocking this reader thread on the
+            # dispatch would serialise the socket behind the slowest command.
+            fut.add_done_callback(_report_dispatch_outcome)
+        except Exception:  # noqa: BLE001 — a bad event never kills the reader
+            logger.exception("[IPC] could not schedule dispatch for %r",
+                             event_type)
 
     def _note(present: bool, principal: str) -> None:
         """Tell the lease book this principal came or went. NEVER raises."""

--- a/backend/hud/voice_identity.py
+++ b/backend/hud/voice_identity.py
@@ -199,17 +199,43 @@ class VoiceIdentity:
         return self._readiness
 
     async def warm(self) -> None:
-        """Resolve enrollment now, and start the model loading. NEVER raises.
+        """Resolve enrollment at boot. Does NOT load the model. NEVER raises.
 
-        The boot seam. Enrollment resolves in milliseconds and the model in
-        minutes, so they are started together and awaited separately — the
-        organism knows WHO it is looking for long before it can look.
+        WHY THE MODEL IS NOT WARMED HERE ANY MORE
+        -------------------------------------------
+        It was, and it was the boot starvation. Measured from an OS thread
+        that cannot itself be starved:
+
+            worst loop round-trip lag : 13.82s
+            VERDICT                   : WARM-UP STARVES THE LOOP
+
+        which matches the 14.33s stall in the live boot log almost exactly.
+        `SpeakerVerificationService.initialize()` is `async def`, but its body
+        loads torch and speechbrain without ever yielding — so awaiting it
+        stops the loop for fourteen seconds, during which JARVIS cannot hear,
+        answer, or dispatch anything. I built the sentinel to catch that class
+        of defect and then introduced one with it.
+
+        The obvious fix does not work. `initialize()` creates
+        `asyncio.Lock` and `asyncio.Queue` on whatever loop is running, so
+        pushing it into a worker thread's loop would bind them there and break
+        the moment `verify_speaker` is called from the main loop — precisely
+        the "bound to a different event loop" failure just removed from
+        `ipc_server`. The stall cannot be moved off the loop; it can only be
+        moved off the BOOT PATH.
+
+        So enrollment — one cheap database read, and the only part needed to
+        answer "who would I be checking for" — resolves here. The model loads
+        lazily on the first verification that actually needs it, via
+        `start_warming` inside `identify`, which already reports NOT_READY and
+        invites a retry. The cost is one "give me a moment" on the first
+        unlock of a session. The alternative was fourteen seconds of deafness
+        during every boot, for a capability that may never be used.
         """
         try:
             await self.refresh_enrollment()
         except Exception:  # noqa: BLE001
             pass
-        self.start_warming()
 
     def start_warming(self) -> None:
         """Begin loading the model in the background. Idempotent. NEVER raises.

--- a/backend/main.py
+++ b/backend/main.py
@@ -2772,6 +2772,16 @@ async def parallel_lifespan(app: FastAPI):
                     _hud_shutdown.set()
                 _hud_ipc_server.close()
                 await _hud_ipc_server.wait_closed()
+                # Stop the dispatch loop AFTER the socket, so nothing new
+                # arrives while it is draining. It cancels and gathers what is
+                # still in flight rather than closing underneath it — a
+                # shutdown that orphaned tasks would reproduce, in miniature,
+                # the exact defect the long-lived loop removes.
+                try:
+                    from backend.hud.ipc_server import shutdown_dispatch_loop
+                    shutdown_dispatch_loop()
+                except Exception as _dl:  # noqa: BLE001
+                    logger.debug("[HUD] dispatch loop shutdown: %s", _dl)
                 logger.info("[HUD] IPC server shutdown complete")
             except Exception as e:
                 logger.debug(f"[HUD] IPC shutdown error (non-critical): {e}")

--- a/tests/hud/test_dispatch_loop.py
+++ b/tests/hud/test_dispatch_loop.py
@@ -1,0 +1,157 @@
+"""One loop for every IPC event, not one loop per event.
+
+`ipc_server` created `asyncio.new_event_loop()` per event and closed it. The
+note said "macOS subprocess contexts make call_soon_threadsafe unreliable" —
+almost certainly a symptom of the main loop being blocked for 34s by the
+synchronous invariant audit, which makes a correctly-queued callback simply
+never run.
+
+The workaround outlived its cause and broke three things, all measured in one
+boot on 2026-08-03 08:47:
+
+    <asyncio.locks.Lock object ...> is bound to a different event loop   (x3)
+    Task was destroyed but it is pending!
+    Loop <...closed=True> that handles pid 24496 is closed
+"""
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import pytest
+
+import backend.hud.ipc_server as IPC
+
+
+@pytest.fixture(autouse=True)
+def _clean():
+    IPC.shutdown_dispatch_loop()
+    yield
+    IPC.shutdown_dispatch_loop()
+
+
+def _run(coro):
+    loop = IPC._dispatch_loop()
+    return asyncio.run_coroutine_threadsafe(coro, loop).result(timeout=20)
+
+
+# ── The three measured failures ─────────────────────────────────────────────
+
+def test_a_lock_survives_between_dispatches():
+    """THE TTS MUTEX. It is what makes JARVIS speak with one voice, and under
+    per-event loops it bound to the first dispatch and refused every one
+    after — so two replies played over each other."""
+    holder = {}
+
+    async def dispatch(n):
+        if "mutex" not in holder:
+            holder["mutex"] = asyncio.Lock()
+        async with holder["mutex"]:      # raised on the 2nd event, before
+            await asyncio.sleep(0.01)
+        return n
+
+    assert [_run(dispatch(i)) for i in range(3)] == [0, 1, 2]
+
+
+def test_a_background_task_survives_the_dispatch_that_started_it():
+    """The fire-and-forget acknowledgement. Under per-event loops it was
+    destroyed the instant `run_until_complete` returned — so the fix that took
+    command latency from 15s to 37ms was silently killing its own audio."""
+    done = []
+
+    async def dispatch():
+        async def later():
+            await asyncio.sleep(0.2)
+            done.append(True)
+        asyncio.create_task(later())
+
+    _run(dispatch())
+    import time
+    time.sleep(0.6)
+    assert done == [True], "the background task was destroyed with its loop"
+
+
+def test_every_dispatch_shares_one_loop():
+    ids = {id(IPC._dispatch_loop()) for _ in range(5)}
+    assert len(ids) == 1
+
+
+def test_the_loop_is_not_the_callers_loop():
+    """Isolation is the one thing the old design got right: a dispatch must
+    not stall because the MAIN loop is busy. That is kept."""
+    async def outer():
+        here = id(asyncio.get_running_loop())
+        there = id(IPC._dispatch_loop())
+        return here, there
+
+    here, there = asyncio.run(outer())
+    assert here != there
+
+
+def test_it_runs_off_the_calling_thread():
+    async def dispatch():
+        return threading.current_thread().name
+
+    assert _run(dispatch()) != threading.current_thread().name
+
+
+# ── Lifecycle ───────────────────────────────────────────────────────────────
+
+def test_the_loop_is_recreated_after_shutdown():
+    """A HUD that reconnects after a shutdown must not find a dead loop."""
+    first = id(IPC._dispatch_loop())
+    IPC.shutdown_dispatch_loop()
+    second = id(IPC._dispatch_loop())
+    assert second and second != first
+
+
+def test_shutdown_is_idempotent():
+    IPC._dispatch_loop()
+    IPC.shutdown_dispatch_loop()
+    IPC.shutdown_dispatch_loop()          # must not raise
+
+
+def test_shutdown_without_a_loop_is_fine():
+    IPC.shutdown_dispatch_loop()
+
+
+def test_a_dispatch_that_raises_is_reported_not_swallowed():
+    """`run_coroutine_threadsafe` returns a future nobody awaits, and an
+    unretrieved exception on one of those is silent — the same black hole
+    `TaskHarvester` exists to close, arriving through a different door."""
+    from backend.core.ouroboros.telemetry import task_harvester as TH
+    TH.reset_task_harvester()
+    h = TH.get_task_harvester()
+    before = h.stats()["harvested"]
+
+    async def boom():
+        raise RuntimeError("dispatch exploded")
+
+    fut = asyncio.run_coroutine_threadsafe(boom(), IPC._dispatch_loop())
+    fut.add_done_callback(IPC._report_dispatch_outcome)
+    with pytest.raises(RuntimeError):
+        fut.result(timeout=10)
+    import time
+    time.sleep(0.2)
+    assert h.stats()["harvested"] > before
+
+
+def test_concurrency_is_preserved():
+    """Per-event loops ran events in parallel threads. One loop must still run
+    them concurrently, or a slow command would serialise the socket."""
+    order = []
+
+    async def slow():
+        await asyncio.sleep(0.3)
+        order.append("slow")
+
+    async def quick():
+        await asyncio.sleep(0.05)
+        order.append("quick")
+
+    loop = IPC._dispatch_loop()
+    a = asyncio.run_coroutine_threadsafe(slow(), loop)
+    b = asyncio.run_coroutine_threadsafe(quick(), loop)
+    b.result(timeout=10)
+    a.result(timeout=10)
+    assert order == ["quick", "slow"], "the slow event blocked the quick one"

--- a/tests/hud/test_voice_authority.py
+++ b/tests/hud/test_voice_authority.py
@@ -315,3 +315,36 @@ async def test_an_unloaded_service_says_not_ready_so_a_retry_can_succeed():
     r = await VoiceIdentity(service=FailedLoad()).identify(b"RIFFxxxx")
     assert r.verdict == Verdict.NOT_READY.value
     assert "UNKNOWN" in r.detail
+
+
+@pytest.mark.asyncio
+async def test_boot_warm_does_not_load_the_model():
+    """Measured from an unstarvable OS thread: awaiting
+    `SpeakerVerificationService.initialize()` produced a 13.82s loop
+    round-trip lag, matching the 14.33s stall in the live boot log. It is
+    `async def` whose body never yields.
+
+    It cannot be pushed to a worker loop either — it creates `asyncio.Lock`
+    and `asyncio.Queue`, which would then be bound to a dying thread's loop.
+    So boot resolves ENROLLMENT only; the model loads lazily on first need.
+    """
+    import ast
+    import inspect
+    # Parse it, and strip the docstring — this docstring EXPLAINS why
+    # start_warming is absent, so a substring check reads its own prose as
+    # evidence against itself.
+    fn = ast.parse(inspect.getsource(VoiceIdentity.warm).lstrip()).body[0]
+    body = [n for n in fn.body
+            if not (isinstance(n, ast.Expr) and isinstance(n.value, ast.Constant))]
+    called = {n.func.attr for n in ast.walk(ast.Module(body=body, type_ignores=[]))
+              if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)}
+    assert "refresh_enrollment" in called
+    assert "start_warming" not in called, "boot must not load the speaker model"
+
+
+@pytest.mark.asyncio
+async def test_the_model_still_warms_on_first_need():
+    """Lazily, not never. The first verification that needs it kicks the load
+    and answers NOT_READY so the operator can retry."""
+    import inspect
+    assert "start_warming" in inspect.getsource(VoiceIdentity.identify)


### PR DESCRIPTION
Two commits, both chasing the same live boot log. The second one is a defect I introduced.

## `ipc_server` was creating a new event loop per IPC event

```python
loop = asyncio.new_event_loop()
loop.run_until_complete(dispatch(event_type, data))
loop.close()
```

Its note: *"macOS subprocess contexts make `call_soon_threadsafe` unreliable."* That was almost certainly a **symptom of the 34-second invariant audit** — a main loop blocked that long makes a correctly-queued callback simply never run. The workaround outlived its cause, and broke three things visible in one boot:

- **`<asyncio.locks.Lock ...> is bound to a different event loop` ×3** — the TTS mutex binds to the first dispatch's loop and is dead by the second. *The "two JARVISes talking at once" fix was being defeated by the transport underneath it.*
- **`Task was destroyed but it is pending!`** — every `create_task` dies when the loop closes. **That includes the fire-and-forget acknowledgement**, so the change that took latency from 15s → 37ms was silently killing its own audio.
- **`Loop <...closed=True> that handles pid 24496 is closed`** — orphaned subprocess child watcher.

Now **one long-lived loop on a dedicated thread**: keeps the isolation the old design was right to want (a dispatch must not stall because the main loop is busy), gains a stable identity for anything loop-bound. Concurrency preserved and pinned. `_report_dispatch_outcome` routes a raising dispatch into `TaskHarvester` — `run_coroutine_threadsafe` returns a future nobody awaits, and an unretrieved exception on one of those is silent.

## My warm-up was the 14-second stall

```
worst loop round-trip lag : 13.82s
VERDICT: *** WARM-UP STARVES THE LOOP ***
```

Matching `EVENT LOOP STALLED 14.33s` in the live log almost exactly. `SpeakerVerificationService.initialize()` is `async def` but its body loads torch and speechbrain **without ever yielding**. I added that await, at boot, **in the same change that introduced the LoopSentinel** — the instrument built to catch this shipped alongside a new instance of it.

**The first two measurements failed, and that was the clue.** Both put the watcher *on the loop it was measuring*, so when the loop starved the watcher couldn't reach its own exit condition — the runs timed out with no data. The third used a plain OS thread pinging via `call_soon_threadsafe` and answered in seconds. Same principle the harness wall-clock cap already documents: *a watchdog that shares a resource with the system it guards is not a watchdog.*

**The obvious fix doesn't work.** `initialize()` creates `asyncio.Lock` and `asyncio.Queue` on whatever loop is running; pushing it to a worker thread's loop would bind them there and break `verify_speaker` on the main loop — precisely the bug removed in the first commit. The stall can't be moved off the loop, only off the **boot path**.

So boot resolves **enrollment only** (one cheap DB read — the part that answers *who* would be checked). The model loads lazily on first need through the `NOT_READY` retry path that already exists.

> Cost: one *"give me a moment"* on the first unlock of a session.
> Previously: fourteen seconds of deafness on **every** boot, for a capability that may never be used.

## A correction

I reported the posture observer as a starvation source on the strength of `[LoopSink] posture_observer.run_one_cycle blocked_ms=6234`. **That was a misreading** — most posture signals already route through the unified `cooperative_fs_io.offload` gateway, and `blocked_ms` on a `kind=async` callsite measures **await latency, not on-loop blocking**. A contended thread pool produces that number with the loop entirely free. Nothing was changed there.

## Testing

**137 passed**, 10 new for the dispatch loop — including one asserting a background task survives the dispatch that started it, and one that concurrency wasn't traded away.

## ⚠️ Not live-proven

Neither fix has run against a live HUD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes HUD boot stalls and IPC reliability. IPC now uses one long‑lived dispatch loop on its own thread, and speaker model warm‑up is deferred to avoid a 14s boot pause.

- **Bug Fixes**
  - Replaced per-event `asyncio` loop with a single dedicated loop and thread; events run as tasks via `run_coroutine_threadsafe`, preserving concurrency and background tasks.
  - Routed dispatch exceptions to `TaskHarvester` and added a clean shutdown that cancels/gathers in‑flight work after closing the IPC server.
  - Moved speaker model warm‑up out of boot: `VoiceIdentity.warm()` only refreshes enrollment; the model loads on first verification (returns NOT_READY once, then proceeds).
  - Set the principal inside the dispatched coroutine to ensure context is applied on the dispatch loop.
  - Added tests for loop lifecycle, concurrency, exception reporting, and lazy model warm‑up.

<sup>Written for commit 72d43f2b19712b5499f8c07bd2c51b8af5f29fff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

