### PR TITLE
Four flagged threads: dark-Swift guard, docs-bot symbol repair, voice verification, durable boot log

### DIFF
--- a/.github/workflows/xcode-project-parity.yml
+++ b/.github/workflows/xcode-project-parity.yml
@@ -1,0 +1,47 @@
+# The committed Xcode project must equal what XcodeGen generates from
+# project.yml.
+#
+# This exists because a Swift file can be written, committed, reviewed and
+# referenced by other Swift code while never being compiled — Xcode builds
+# what is in `.xcodeproj`, and a new file only gets there when `xcodegen`
+# runs. `UtteranceRecorder.swift` sat in that state: present in git, absent
+# from the binary, and indistinguishable from working code at review time.
+#
+# The inverse failed too. `OS_ACTIVITY_MODE` had been hand-added to the
+# generated `.xcscheme`, so the regeneration that fixed the dark file
+# deleted it. Anything living only in a generated artefact is a countdown.
+#
+# One check covers both directions: regenerate and demand a byte-for-byte
+# match. See scripts/check_xcodegen_parity.sh.
+
+name: Xcode Project Parity
+
+on:
+  push:
+    paths:
+      - 'JARVIS-Apple/**'
+      - 'scripts/check_xcodegen_parity.sh'
+      - '.github/workflows/xcode-project-parity.yml'
+  pull_request:
+    paths:
+      - 'JARVIS-Apple/**'
+      - 'scripts/check_xcodegen_parity.sh'
+      - '.github/workflows/xcode-project-parity.yml'
+
+jobs:
+  parity:
+    # macOS because XcodeGen is a Swift binary distributed through Homebrew;
+    # there is no Linux build to fall back to.
+    runs-on: macos-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install XcodeGen
+        run: brew install xcodegen
+
+      - name: Check generated project matches its spec
+        # No exemption env var here, deliberately. The whole point of the
+        # check is that it cannot pass by being unable to run.
+        run: ./scripts/check_xcodegen_parity.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,3 +24,15 @@ repos:
           git rm --cached <file>
         language: fail
         files: '(\.pyc$|(^|/)__pycache__/)'
+
+      # A Swift file that is not in the generated .xcodeproj is never
+      # compiled, so it can be committed, reviewed and referenced by other
+      # Swift code while doing nothing at all. Catch the drift at the commit
+      # that introduces it rather than during the debugging session weeks
+      # later. Runs on the git index, so it sees exactly what is staged.
+      - id: xcodegen-parity
+        name: Xcode project matches project.yml
+        entry: scripts/check_xcodegen_parity.sh
+        language: script
+        pass_filenames: false
+        files: '(^JARVIS-Apple/|\.pbxproj$|\.xcscheme$)'

--- a/JARVIS-Apple/JARVIS-Apple.xcodeproj/project.pbxproj
+++ b/JARVIS-Apple/JARVIS-Apple.xcodeproj/project.pbxproj
@@ -125,7 +125,6 @@
 				2AD0E9678194BFE8A1EC9B1B /* Info.plist */,
 				6A73D85D2FBC6659D4A47810 /* JARVISHUD.entitlements */,
 				7F9345DF8825258B0773BAA5 /* JARVISHUDApp.swift */,
-				F9DF9FDDEC7F5849BAF5A642 /* .claude */,
 				4C449CDADB043C7331150D64 /* Services */,
 				243C003B3193F42692D7BF8F /* Views */,
 			);
@@ -188,13 +187,6 @@
 				C953EA1271F55784A7D1004B /* JARVISColors.swift */,
 			);
 			path = Shared;
-			sourceTree = "<group>";
-		};
-		5322F8483534485E0A88943F /* .cc-writes */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = ".cc-writes";
 			sourceTree = "<group>";
 		};
 		58867042BBEE470FD16CA4E2 /* Products */ = {
@@ -265,14 +257,6 @@
 				CE05089C690A3B7B63861CF9 /* PhoneSessionManager.swift */,
 			);
 			path = Services;
-			sourceTree = "<group>";
-		};
-		F9DF9FDDEC7F5849BAF5A642 /* .claude */ = {
-			isa = PBXGroup;
-			children = (
-				5322F8483534485E0A88943F /* .cc-writes */,
-			);
-			path = .claude;
 			sourceTree = "<group>";
 		};
 		FC6CA73ACD325BAEB067CCC8 /* Views */ = {

--- a/JARVIS-Apple/JARVIS-Apple.xcodeproj/project.pbxproj
+++ b/JARVIS-Apple/JARVIS-Apple.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		9675A57D67D07E9D157B8468 /* JARVISPhoneApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 698E4531C1F4FD5A0215C9B1 /* JARVISPhoneApp.swift */; };
 		993234F1A4D7A1BCA27374BB /* BrainstemLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6A777442955E499D4E22D3B /* BrainstemLauncher.swift */; };
 		99C3D3109F5801D5ED6F638A /* HapticEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 266CC1C8FBBB302AD623A3D9 /* HapticEngine.swift */; };
+		9D8F259F3A4877CC70B36F0C /* BootLogFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 633E90E2380BBC6CB188BB57 /* BootLogFile.swift */; };
 		9FC588C57049591237CF032F /* HUDView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A0A5C4460F31FD5CB53DD10 /* HUDView.swift */; };
 		A0BD7790CE0BF3EDAC6D6372 /* ArcReactorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26744ECD2240E57AF517188D /* ArcReactorView.swift */; };
 		A348802554BD9C09EE824952 /* UtteranceRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86A3C5DDD4D1D44D8569C39B /* UtteranceRecorder.swift */; };
@@ -55,6 +56,7 @@
 		4784C00A28BAB42B47C1A4F1 /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		496ADA6BEACAC0F28324C87E /* JARVISWatch.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JARVISWatch.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		62C68475EAAD735E3FB66AAE /* WakeWordListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WakeWordListener.swift; sourceTree = "<group>"; };
+		633E90E2380BBC6CB188BB57 /* BootLogFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BootLogFile.swift; sourceTree = "<group>"; };
 		698E4531C1F4FD5A0215C9B1 /* JARVISPhoneApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JARVISPhoneApp.swift; sourceTree = "<group>"; };
 		6A73D85D2FBC6659D4A47810 /* JARVISHUD.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = JARVISHUD.entitlements; sourceTree = "<group>"; };
 		7A0A5C4460F31FD5CB53DD10 /* HUDView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HUDView.swift; sourceTree = "<group>"; };
@@ -171,6 +173,7 @@
 			isa = PBXGroup;
 			children = (
 				4784C00A28BAB42B47C1A4F1 /* AppState.swift */,
+				633E90E2380BBC6CB188BB57 /* BootLogFile.swift */,
 				A6A777442955E499D4E22D3B /* BrainstemLauncher.swift */,
 				A2FEA2CE20F48E377D68D971 /* MicSuppression.swift */,
 				7F97771D9894460348ABB0ED /* ScreenCaptureService.swift */,
@@ -407,6 +410,7 @@
 			files = (
 				18B2C64EE92544B8575B5EEC /* AppState.swift in Sources */,
 				A0BD7790CE0BF3EDAC6D6372 /* ArcReactorView.swift in Sources */,
+				9D8F259F3A4877CC70B36F0C /* BootLogFile.swift in Sources */,
 				993234F1A4D7A1BCA27374BB /* BrainstemLauncher.swift in Sources */,
 				4E11F20BF61331B7C669DA94 /* CompactHeaderBar.swift in Sources */,
 				9FC588C57049591237CF032F /* HUDView.swift in Sources */,

--- a/JARVIS-Apple/JARVIS-Apple.xcodeproj/xcshareddata/xcschemes/JARVISWatch.xcscheme
+++ b/JARVIS-Apple/JARVIS-Apple.xcodeproj/xcshareddata/xcschemes/JARVISWatch.xcscheme
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1600"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -26,7 +27,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "NO">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -59,6 +61,8 @@
             ReferencedContainer = "container:JARVIS-Apple.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/JARVIS-Apple/JARVISHUD/Services/BootLogFile.swift
+++ b/JARVIS-Apple/JARVISHUD/Services/BootLogFile.swift
@@ -1,0 +1,103 @@
+//  BootLogFile.swift
+//  JARVISHUD
+//
+//  Writes the boot log somewhere that outlives the debugger.
+//
+//  WHY THIS EXISTS
+//  ---------------
+//  Three separate questions about this app have gone unanswered for weeks —
+//  does the speaker model reach READY or time out, does the voice authority
+//  install, does a capability reach the reflex — and every one of them is
+//  decided by a line the backend already prints. The lines were unreadable
+//  because of where they went:
+//
+//    * `print()` from a GUI app does not reach a redirected stdout, so
+//      launching the binary with `> boot.log` produces an empty file;
+//    * the backend child's output is piped into this process and reprinted,
+//      inheriting the same fate;
+//    * `OS_ACTIVITY_MODE=disable` — set deliberately, to make the Xcode
+//      console readable — suppresses the unified-log path as well.
+//
+//  So the log existed only while a developer was attached to Xcode, watching.
+//  **A log that requires someone to be watching is not a log**; it is a live
+//  view, and it cannot answer a question about a boot that already happened.
+//  That is why "the speaker model was never observed reaching READY" stayed
+//  open: not because the event never happened, but because nothing recorded it.
+//
+//  WHAT THIS DOES NOT CHANGE
+//  --------------------------
+//  The console filter stays exactly as it is. Selecting a dozen interesting
+//  prefixes out of a noisy startup is the right call for a human reading a
+//  console in real time. It is the wrong call for the record — the line you
+//  need is always the one nobody thought to whitelist. So the console keeps
+//  its filter and the FILE gets everything, unfiltered.
+//
+//  BOUNDED, AND NEVER A REASON TO FAIL
+//  ------------------------------------
+//  Truncated at each launch: this answers "what happened during the boot I am
+//  looking at", and an append-forever file would grow without limit for a
+//  question that only concerns the last run. The previous session is kept as
+//  `.1` so a crash-and-relaunch does not destroy the evidence of the crash.
+//
+//  Every operation is best-effort. Logging must never be the reason a HUD
+//  fails to start, so a full disk, a missing directory or a permission denial
+//  degrades to "no file" and the app carries on.
+
+import Foundation
+
+/// Append-only boot log at `~/Library/Logs/JARVIS/hud-boot.log`. NEVER throws.
+final class BootLogFile: @unchecked Sendable {
+
+    static let shared = BootLogFile()
+
+    /// Serialises writes from the two pipe readability handlers, which are
+    /// invoked on separate queues. Without this, stdout and stderr interleave
+    /// mid-line and the record is harder to read than no record.
+    private let queue = DispatchQueue(label: "com.jarvis.hud.bootlog")
+    private var handle: FileHandle?
+
+    /// Where the log lives. Public so the app can print the path once at
+    /// startup — a log nobody can find is only marginally better than none.
+    private(set) var url: URL?
+
+    private init() { open() }
+
+    private func open() {
+        let fm = FileManager.default
+        guard let logs = fm.urls(for: .libraryDirectory, in: .userDomainMask).first?
+            .appendingPathComponent("Logs/JARVIS", isDirectory: true) else { return }
+        do {
+            try fm.createDirectory(at: logs, withIntermediateDirectories: true)
+            let current = logs.appendingPathComponent("hud-boot.log")
+
+            // Keep one generation back. When the HUD dies during boot and is
+            // relaunched, the interesting log is the one that just ended.
+            if fm.fileExists(atPath: current.path) {
+                let previous = logs.appendingPathComponent("hud-boot.1.log")
+                try? fm.removeItem(at: previous)
+                try? fm.moveItem(at: current, to: previous)
+            }
+
+            fm.createFile(atPath: current.path, contents: nil)
+            handle = try FileHandle(forWritingTo: current)
+            url = current
+
+            let stamp = ISO8601DateFormatter().string(from: Date())
+            write("=== JARVIS HUD boot \(stamp) ===")
+        } catch {
+            handle = nil
+            url = nil
+        }
+    }
+
+    /// Record one line. Safe from any thread. NEVER throws.
+    func write(_ line: String) {
+        queue.async { [weak self] in
+            guard let h = self?.handle,
+                  let data = (line + "\n").data(using: .utf8) else { return }
+            // `write(contentsOf:)` throws on a full disk; a boot log is never
+            // worth taking the app down for.
+            try? h.write(contentsOf: data)
+        }
+    }
+}

--- a/JARVIS-Apple/JARVISHUD/Services/BrainstemLauncher.swift
+++ b/JARVIS-Apple/JARVISHUD/Services/BrainstemLauncher.swift
@@ -222,6 +222,20 @@ final class BrainstemLauncher {
         let pathParts = [repoRoot, existingPythonPath].filter { !$0.isEmpty }
         env["PYTHONPATH"] = pathParts.joined(separator: ":")
 
+        // TELL THE CHILD WHO ITS LAUNCHER IS, SO IT CAN OUTLIVE NOTHING.
+        //
+        // Xcode's Stop button SIGKILLs this process. SIGKILL is uncatchable,
+        // so `terminationHandler` below, `deinit`, and every atexit hook are
+        // never reached — there is no instant between alive and gone in which
+        // this process could clean anything up. The child therefore watches
+        // US (`brainstem/parent_watch.py`) and leaves when we do.
+        //
+        // Load-bearing: the watch is INERT without this line. It refuses to
+        // supervise on an undeclared parent so that a developer running
+        // `python3 -m brainstem` in a terminal is never killed by their shell
+        // exiting. Deleting this variable silently restores the orphan bug.
+        env["JARVIS_PARENT_PID"] = String(ProcessInfo.processInfo.processIdentifier)
+
         // Ensure PATH includes Homebrew so Python 3.12 can find its packages/tools
         let existingPath = env["PATH"] ?? "/usr/bin:/bin"
         if !existingPath.contains("/opt/homebrew") {
@@ -709,17 +723,92 @@ final class BrainstemLauncher {
 
     // MARK: - Stale process cleanup
 
-    /// Kill orphaned Python processes from previous Xcode runs.
-    /// When Xcode's Stop button kills the HUD, the child Python backend
-    /// can survive as an orphan, holding ports 8011 and 8742.
+    /// Run a command and return its trimmed stdout. Empty on any failure.
+    private func shellOutput(_ command: String) -> String {
+        let task = Process()
+        let pipe = Pipe()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        task.arguments = ["bash", "-c", command]
+        task.standardOutput = pipe
+        task.standardError = FileHandle.nullDevice
+        do { try task.run() } catch { return "" }
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        task.waitUntilExit()
+        return String(data: data, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    }
+
+    /// Reap orphaned backends from previous runs — BY IDENTITY, never by port.
+    ///
+    /// This used to be `lsof -ti :8011 | xargs kill -9`, which kills whatever
+    /// holds the port. Holding a port is not evidence of being ours. Anything
+    /// else a developer had bound to 8011 — another project's dev server, a
+    /// database console — was SIGKILLed by starting the HUD, with no message
+    /// and no way to tell afterwards what had happened to it.
+    ///
+    /// So a PID is now only a candidate. It is killed only if the kernel says
+    /// its command line is our program: a Python running `-m brainstem` out of
+    /// THIS repository. A second checkout on the same machine has a different
+    /// repo root and is left alone, which the port test could never express.
+    ///
+    /// SIGTERM first — an orphan that has just been told to leave should get
+    /// the chance to close its sockets and flush, and `parent_watch` means a
+    /// modern orphan is already on its way out. SIGKILL only for what ignores
+    /// that. The previous code opened with SIGKILL, which is why ports then
+    /// sat in TIME_WAIT long enough to need a five-attempt retry loop.
+    ///
+    /// This is the compensating path, not the guarantee. The guarantee is
+    /// `brainstem/parent_watch.py`: the child dies with its launcher, so there
+    /// is nothing here to find. This exists for orphans predating that watch,
+    /// and for the case where the child was SIGKILLed too.
     private func killStaleProcesses() {
         let ports = [httpPort, ipcPort]
+
+        // Candidates: whoever holds our ports, plus any `-m brainstem` from
+        // this repo that is not holding a port at all. The second set matters
+        // — the 46.8%-CPU orphan measured on 2026-08-04 had no listening
+        // socket, so a port-only sweep could never have found it.
+        var candidates = Set<Int32>()
         for port in ports {
-            let task = Process()
-            task.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-            task.arguments = ["bash", "-c", "lsof -ti :\(port) | xargs kill -9 2>/dev/null"]
-            try? task.run()
-            task.waitUntilExit()
+            for pid in shellOutput("lsof -ti :\(port)").split(separator: "\n") {
+                if let p = Int32(pid.trimmingCharacters(in: .whitespaces)) { candidates.insert(p) }
+            }
+        }
+        for pid in shellOutput("pgrep -f 'brainstem'").split(separator: "\n") {
+            if let p = Int32(pid.trimmingCharacters(in: .whitespaces)) { candidates.insert(p) }
+        }
+
+        let me = ProcessInfo.processInfo.processIdentifier
+        var doomed: [Int32] = []
+        for pid in candidates where pid != me && pid > 1 {
+            // `ps -o command=` is the kernel's account of what this process
+            // is, which a stale pidfile or a port table cannot contradict.
+            let cmd = shellOutput("ps -p \(pid) -o command=")
+            guard cmd.contains("brainstem"),
+                  cmd.contains(repoRoot) || cmd.contains("-m brainstem") else {
+                if !cmd.isEmpty {
+                    print("[Brainstem] leaving pid \(pid) alone — not ours: \(cmd.prefix(60))")
+                }
+                continue
+            }
+            doomed.append(pid)
+        }
+
+        if doomed.isEmpty {
+            print("[Brainstem] no orphaned backends to reap")
+            return
+        }
+        print("[Brainstem] reaping \(doomed.count) orphaned backend(s): \(doomed)")
+        for pid in doomed { kill(pid, SIGTERM) }
+
+        // Give them the grace we just asked for, then insist.
+        for _ in 1...10 {
+            Thread.sleep(forTimeInterval: 0.2)
+            if doomed.allSatisfy({ kill($0, 0) != 0 }) { break }
+        }
+        for pid in doomed where kill(pid, 0) == 0 {
+            print("[Brainstem] pid \(pid) ignored SIGTERM — SIGKILL")
+            kill(pid, SIGKILL)
         }
         // Wait for ports to actually be released (SIGKILL + TIME_WAIT)
         for attempt in 1...5 {

--- a/JARVIS-Apple/JARVISHUD/Services/BrainstemLauncher.swift
+++ b/JARVIS-Apple/JARVISHUD/Services/BrainstemLauncher.swift
@@ -343,12 +343,23 @@ final class BrainstemLauncher {
             guard !data.isEmpty, let text = String(data: data, encoding: .utf8) else { return }
             for line in text.components(separatedBy: "\n") where !line.isEmpty {
                 print("[Brainstem] \(line)")
+                // The file gets every line. The console filter below is a
+                // reading aid for a human watching in real time; the record
+                // must not be filtered, because the line you need later is
+                // always the one nobody thought to whitelist.
+                BootLogFile.shared.write("[Brainstem] \(line)")
             }
         }
         stderr.fileHandleForReading.readabilityHandler = { [weak self] handle in
             let data = handle.availableData
             guard !data.isEmpty, let text = String(data: data, encoding: .utf8) else { return }
             for line in text.components(separatedBy: "\n") where !line.isEmpty {
+                // UNFILTERED to the file, filtered to the console. The
+                // questions this log exists to answer — did the speaker model
+                // reach READY, did the voice authority install — are decided
+                // by lines that match none of the patterns below.
+                BootLogFile.shared.write("[Backend] \(line)")
+
                 // Only show important log lines — filter out verbose startup noise
                 let isImportant = importantPatterns.contains { line.contains($0) }
                 if isImportant {

--- a/JARVIS-Apple/project.yml
+++ b/JARVIS-Apple/project.yml
@@ -17,8 +17,16 @@ targets:
     type: application
     platform: iOS
     sources:
-      - JARVISPhone
-      - Shared
+      # `excludes` on every source root, because `generateEmptyDirectories`
+      # is on and agent tooling leaves empty `.claude/.cc-writes` scratch
+      # directories inside source trees. Git cannot see an empty directory,
+      # so one got committed into the generated project without ever
+      # appearing in `git status` — a machine-local path baked into an
+      # artefact every other machine has to reproduce byte for byte.
+      - path: JARVISPhone
+        excludes: ["**/.claude", ".claude"]
+      - path: Shared
+        excludes: ["**/.claude", ".claude"]
     dependencies:
       - package: JARVISKit
     settings:
@@ -37,7 +45,8 @@ targets:
     type: application
     platform: watchOS
     sources:
-      - JARVISWatch
+      - path: JARVISWatch
+        excludes: ["**/.claude", ".claude"]
     dependencies:
       - package: JARVISKit
     settings:
@@ -56,8 +65,10 @@ targets:
     type: application
     platform: macOS
     sources:
-      - JARVISHUD
-      - Shared
+      - path: JARVISHUD
+        excludes: ["**/.claude", ".claude"]
+      - path: Shared
+        excludes: ["**/.claude", ".claude"]
     dependencies:
       - package: JARVISKit
     settings:

--- a/backend/autonomy/advanced_autonomous_engine.py
+++ b/backend/autonomy/advanced_autonomous_engine.py
@@ -905,6 +905,747 @@ class AdvancedAutonomousEngine:
 
         return recent
 
+    async def load_state(self):
+        """Load engine state"""
+        state_path = Path("backend/data/autonomous_engine_state.json")
+
+        if state_path.exists():
+            async with aiofiles.open(state_path, 'r') as f:
+                content = await f.read()
+                state = json.loads(content)
+
+            self.success_metrics = defaultdict(
+                lambda: {'success': 0, 'total': 0},
+                state.get('success_metrics', {})
+            )
+            self.config.update(state.get('config', {}))
+            self.feedback_memory = defaultdict(
+                list,
+                state.get('feedback_memory', {})
+            )
+
+    async def save_state(self):
+        """Save engine state"""
+        state = {
+            'success_metrics': dict(self.success_metrics),
+            'config': self.config,
+            'feedback_memory': dict(self.feedback_memory)
+        }
+
+        state_path = Path("backend/data/autonomous_engine_state.json")
+        state_path.parent.mkdir(parents=True, exist_ok=True)
+
+        async with aiofiles.open(state_path, 'w') as f:
+            await f.write(json.dumps(state, indent=2, default=str))
+
+    async def _retrain_models(self):
+        """Retrain ML models with new data"""
+        logger.info("Retraining ML models with recent data")
+
+        # Prepare training data from history
+        # This would involve extracting features and labels from decision history
+        # and retraining the various models
+
+        # For now, just save the current state
+        await self.save_state()
+
+    async def _learn_from_execution(self, decision: AutonomousDecision):
+        """Learn from execution results"""
+
+        # Update feedback memory
+        feedback_key = f"{decision.predicted_action.goal_type}_{decision.predicted_action.action_type}"
+        self.feedback_memory[feedback_key].append({
+            'outcome': decision.outcome,
+            'confidence': decision.ml_confidence,
+            'risk': decision.risk_level.value,
+            'timestamp': decision.execution_time,
+            'delay_minutes': (
+                decision.execution_time - decision.predicted_action.predicted_time
+            ).total_seconds() / 60
+        })
+
+        # Update temporal patterns
+        if decision.outcome == ActionOutcome.SUCCESS:
+            goal = decision.decision_context.active_goals.get(
+                decision.predicted_action.goal_id
+            )
+            if goal:
+                await self.temporal_learner.learn_pattern(
+                    [goal],
+                    [decision.predicted_action.action_type]
+                )
+
+        # Retrain models periodically
+        if len(self.decision_history) % 100 == 0:
+            asyncio.create_task(self._retrain_models())
+
+    async def _update_metrics(self, decision: AutonomousDecision):
+        """Update success metrics"""
+        action_type = decision.predicted_action.action_type
+
+        if action_type not in self.success_metrics:
+            self.success_metrics[action_type] = {'success': 0, 'total': 0}
+
+        self.success_metrics[action_type]['total'] += 1
+
+        if decision.outcome == ActionOutcome.SUCCESS:
+            self.success_metrics[action_type]['success'] += 1
+
+    async def _execute_action(
+        self,
+        predicted_action: PredictedAction,
+        context: DecisionContext
+    ) -> Dict[str, Any]:
+        """Execute the actual action"""
+
+        # This would integrate with actual system actions
+        # For now, return simulated results
+
+        logger.info(f"Executing action: {predicted_action.action_type} on {predicted_action.target}")
+
+        # Simulate execution
+        await asyncio.sleep(0.5)
+
+        # Simulate success based on confidence
+        success_prob = predicted_action.confidence
+        success = np.random.random() < success_prob
+
+        return {
+            'success': success,
+            'action_type': predicted_action.action_type,
+            'target': predicted_action.target,
+            'execution_time': datetime.now().isoformat()
+        }
+
+    async def execute_decision(
+        self,
+        decision: AutonomousDecision,
+        override_permission: bool = False
+    ) -> ActionOutcome:
+        """Execute an autonomous decision"""
+
+        # Check permission
+        if decision.requires_permission() and not override_permission:
+            logger.info(f"Decision {decision.action_id} requires permission")
+            return ActionOutcome.CANCELLED
+
+        # Record execution time
+        decision.execution_time = datetime.now()
+
+        try:
+            # Execute based on action type
+            result = await self._execute_action(
+                decision.predicted_action,
+                decision.decision_context
+            )
+
+            # Determine outcome
+            if result.get('success', False):
+                outcome = ActionOutcome.SUCCESS
+            elif result.get('partial', False):
+                outcome = ActionOutcome.PARTIAL_SUCCESS
+            else:
+                outcome = ActionOutcome.FAILURE
+
+            decision.outcome = outcome
+            decision.feedback = result
+
+            # Update success metrics
+            await self._update_metrics(decision)
+
+            # Learn from execution
+            await self._learn_from_execution(decision)
+
+            return outcome
+
+        except Exception as e:
+            logger.error(f"Error executing decision {decision.action_id}: {e}")
+            decision.outcome = ActionOutcome.FAILURE
+            decision.feedback = {'error': str(e)}
+            return ActionOutcome.FAILURE
+
+    async def _exploratory_strategy(
+        self,
+        predicted_action: PredictedAction,
+        context: DecisionContext
+    ) -> Dict[str, Any]:
+        """Exploratory strategy - try new actions"""
+        return {
+            'timing': 'exploratory',
+            'confidence_boost': -0.2,
+            'explanation': 'Exploring new action possibility'
+        }
+
+    async def _learning_strategy(
+        self,
+        predicted_action: PredictedAction,
+        context: DecisionContext
+    ) -> Dict[str, Any]:
+        """Learning strategy - act to improve knowledge"""
+        return {
+            'timing': 'experimental',
+            'confidence_boost': -0.1,
+            'explanation': 'Trying action to learn effectiveness'
+        }
+
+    async def _predictive_strategy(
+        self,
+        predicted_action: PredictedAction,
+        context: DecisionContext
+    ) -> Dict[str, Any]:
+        """Predictive strategy - act based on predictions"""
+        return {
+            'timing': 'predicted',
+            'confidence_boost': 0.15,
+            'explanation': 'Acting based on ML predictions'
+        }
+
+    async def _reactive_strategy(
+        self,
+        predicted_action: PredictedAction,
+        context: DecisionContext
+    ) -> Dict[str, Any]:
+        """Reactive strategy - act when triggered"""
+        return {
+            'timing': 'on_trigger',
+            'confidence_boost': 0.0,
+            'explanation': 'Waiting for explicit trigger'
+        }
+
+    async def _proactive_strategy(
+        self,
+        predicted_action: PredictedAction,
+        context: DecisionContext
+    ) -> Dict[str, Any]:
+        """Proactive strategy - act before user asks"""
+        return {
+            'timing': 'immediate',
+            'confidence_boost': 0.1,
+            'explanation': 'Acting proactively based on detected pattern'
+        }
+
+    async def _record_decisions(self, decisions: List[AutonomousDecision]):
+        """Record decisions for learning"""
+        for decision in decisions:
+            self.decision_history.append(decision)
+            self.active_decisions[decision.action_id] = decision
+
+    async def _filter_and_rank_decisions(
+        self,
+        decisions: List[AutonomousDecision]
+    ) -> List[AutonomousDecision]:
+        """Filter and rank decisions by priority"""
+
+        # Filter out low-confidence decisions
+        filtered = [
+            d for d in decisions
+            if d.ml_confidence >= self.config['min_confidence'] * 0.5
+        ]
+
+        # Calculate priority scores
+        for decision in filtered:
+            score = 0.0
+
+            # Confidence component
+            score += decision.ml_confidence * 0.3
+
+            # Risk component (lower risk is better)
+            score += (1.0 - decision.risk_level.value / 4.0) * 0.2
+
+            # Expected success component
+            score += decision.expected_outcome.get('success', 0.5) * 0.3
+
+            # Strategy component
+            if decision.decision_strategy == DecisionStrategy.PREDICTIVE:
+                score += 0.1
+            elif decision.decision_strategy == DecisionStrategy.PROACTIVE:
+                score += 0.05
+
+            # Time urgency component
+            time_until = (decision.predicted_action.predicted_time - datetime.now()).total_seconds()
+            if time_until < 300:  # Less than 5 minutes
+                score += 0.1
+
+            decision.priority_score = score
+
+        # Sort by priority score
+        filtered.sort(key=lambda d: d.priority_score, reverse=True)
+
+        # Limit to max concurrent actions
+        max_actions = self.config.get('max_concurrent_actions', 5)
+        return filtered[:max_actions]
+
+    def _generate_action_id(self, predicted_action: PredictedAction) -> str:
+        """Generate unique action ID"""
+        timestamp = datetime.now().isoformat()
+        data = f"{predicted_action.action_type}_{timestamp}_{predicted_action.goal_id}"
+        return hashlib.sha256(data.encode()).hexdigest()[:16]
+
+    async def _needs_human_approval(
+        self,
+        predicted_action: PredictedAction,
+        risk_level: RiskLevel,
+        ml_confidence: float,
+        context: DecisionContext
+    ) -> bool:
+        """Determine if human approval is needed"""
+
+        # High risk always needs approval
+        if risk_level.value >= RiskLevel.HIGH_RISK.value:
+            return True
+
+        # Low confidence needs approval
+        if ml_confidence < self.config['min_confidence']:
+            return True
+
+        # Prepare features for permission model
+        features = torch.FloatTensor([
+            ml_confidence,
+            risk_level.value / 4.0,
+            predicted_action.confidence,
+            context.risk_tolerance,
+            1.0 if predicted_action.action_type in self.action_registry else 0.0,
+            context.system_resources.get('cpu', 0.5),
+            context.system_resources.get('memory', 0.5),
+            len(context.recent_actions) / 100.0,
+            1.0 if context.temporal_context.get('is_business_hours', False) else 0.0,
+            1.0 if predicted_action.action_type in self.success_metrics else 0.0,
+            # Pad to 15 features
+            0.0, 0.0, 0.0, 0.0, 0.0
+        ])
+
+        # Use permission model
+        with torch.no_grad():
+            needs_approval_prob = self.permission_model(features).item()
+
+        return needs_approval_prob > 0.5
+
+    async def _calculate_ml_confidence(
+        self,
+        predicted_action: PredictedAction,
+        context: DecisionContext,
+        risk_level: RiskLevel,
+        expected_outcome: Dict[str, float]
+    ) -> float:
+        """Calculate overall ML confidence for decision"""
+
+        # Base confidence from prediction
+        confidence = predicted_action.confidence
+
+        # Adjust based on risk
+        risk_factor = 1.0 - (risk_level.value / 10.0)
+        confidence *= risk_factor
+
+        # Adjust based on expected success
+        success_prob = expected_outcome.get('success', 0.5)
+        confidence *= (0.5 + success_prob * 0.5)
+
+        # Adjust based on historical performance
+        if predicted_action.action_type in self.success_metrics:
+            metrics = self.success_metrics[predicted_action.action_type]
+            if metrics['total'] > 5:
+                success_rate = metrics['success'] / metrics['total']
+                confidence *= (0.7 + success_rate * 0.3)
+
+        # Adjust based on context confidence
+        if context.workspace_state:
+            confidence *= context.workspace_state.confidence
+
+        return min(confidence, 1.0)
+
+    def _prepare_outcome_features(
+        self,
+        predicted_action: PredictedAction,
+        context: DecisionContext
+    ) -> List[float]:
+        """Prepare features for outcome prediction"""
+        features = []
+
+        # Action confidence
+        features.append(predicted_action.confidence)
+
+        # Goal progress
+        if predicted_action.goal_id in context.active_goals:
+            goal = context.active_goals[predicted_action.goal_id]
+            features.append(goal.progress)
+            features.append(goal.confidence)
+        else:
+            features.append(0.0)
+            features.append(0.0)
+
+        # Historical success rate
+        if predicted_action.action_type in self.success_metrics:
+            metrics = self.success_metrics[predicted_action.action_type]
+            success_rate = metrics['success'] / max(metrics['total'], 1)
+            features.append(success_rate)
+        else:
+            features.append(0.5)
+
+        # Context features
+        features.extend(context.to_feature_vector()[:5])  # Use first 5 context features
+
+        return features
+
+    async def _predict_outcome(
+        self,
+        predicted_action: PredictedAction,
+        context: DecisionContext
+    ) -> Dict[str, float]:
+        """Predict outcome probabilities for action"""
+
+        # Prepare features for outcome prediction
+        features = self._prepare_outcome_features(predicted_action, context)
+
+        # Default predictions
+        outcome_probs = {
+            'success': 0.5,
+            'partial_success': 0.3,
+            'failure': 0.2
+        }
+
+        # Use ML model if trained
+        try:
+            if hasattr(self.outcome_predictor, 'predict'):
+                predicted_success = self.outcome_predictor.predict([features])[0]
+
+                outcome_probs['success'] = max(0, min(1, predicted_success))
+                outcome_probs['partial_success'] = (1 - predicted_success) * 0.6
+                outcome_probs['failure'] = (1 - predicted_success) * 0.4
+        except Exception as e:
+            logger.warning(f"ML outcome prediction failed: {e}")
+
+        return outcome_probs
+
+    def _prepare_risk_features(
+        self,
+        predicted_action: PredictedAction,
+        context: DecisionContext
+    ) -> List[float]:
+        """Prepare features for risk assessment"""
+        features = []
+
+        # Action features
+        features.append(predicted_action.confidence)
+        features.append(1.0 if predicted_action.action_type in self.action_registry else 0.0)
+
+        # Context features
+        features.append(context.risk_tolerance)
+        features.append(len(context.recent_actions) / 100.0)  # Normalized
+
+        # System resource features
+        features.append(context.system_resources.get('cpu', 0.5))
+        features.append(context.system_resources.get('memory', 0.5))
+
+        # Success history
+        if predicted_action.action_type in self.success_metrics:
+            metrics = self.success_metrics[predicted_action.action_type]
+            success_rate = metrics['success'] / max(metrics['total'], 1)
+            features.append(success_rate)
+        else:
+            features.append(0.5)  # Unknown success rate
+
+        return features
+
+    async def _assess_risk(
+        self,
+        predicted_action: PredictedAction,
+        context: DecisionContext
+    ) -> RiskLevel:
+        """Assess risk level of predicted action"""
+
+        # Get base risk from action registry
+        base_risk = RiskLevel.MEDIUM_RISK
+        if predicted_action.action_type in self.action_registry:
+            base_risk = self.action_registry[predicted_action.action_type]['risk']
+
+        # Prepare features for ML risk assessment
+        features = self._prepare_risk_features(predicted_action, context)
+
+        # Use ML model if trained
+        try:
+            if hasattr(self.risk_assessor, 'predict'):
+                risk_prob = self.risk_assessor.predict_proba([features])[0]
+
+                # Map probability to risk level
+                max_risk_idx = np.argmax(risk_prob)
+                risk_levels = list(RiskLevel)
+                if max_risk_idx < len(risk_levels):
+                    return risk_levels[max_risk_idx]
+        except Exception as e:
+            logger.warning(f"ML risk assessment failed: {e}")
+
+        return base_risk
+
+    def _is_routine_action(
+        self,
+        predicted_action: PredictedAction,
+        context: DecisionContext
+    ) -> bool:
+        """Check if action is routine based on patterns"""
+
+        # Check if action happens regularly
+        action_history = [
+            d for d in self.decision_history
+            if d.predicted_action.action_type == predicted_action.action_type
+        ]
+
+        if len(action_history) < 5:
+            return False
+
+        # Check for regular timing
+        times = [d.execution_time for d in action_history[-5:] if d.execution_time]
+        if len(times) >= 3:
+            # Check if times follow a pattern (e.g., daily)
+            intervals = [
+                (times[i+1] - times[i]).total_seconds() / 3600
+                for i in range(len(times)-1)
+            ]
+
+            # If intervals are consistent (within 2 hours), it's routine
+            if intervals:
+                std_dev = np.std(intervals)
+                if std_dev < 2.0:
+                    return True
+
+        return False
+
+    def _select_strategy(
+        self,
+        predicted_action: PredictedAction,
+        context: DecisionContext
+    ) -> DecisionStrategy:
+        """Select decision strategy based on action and context"""
+
+        # High confidence predictions use predictive strategy
+        if predicted_action.confidence > 0.85:
+            return DecisionStrategy.PREDICTIVE
+
+        # New or uncommon actions use exploratory
+        action_key = predicted_action.action_type
+        if action_key in self.success_metrics:
+            total_attempts = self.success_metrics[action_key]['total']
+            if total_attempts < 10:
+                return DecisionStrategy.EXPLORATORY
+
+        # Learning strategy for improving performance
+        if action_key in self.success_metrics:
+            success_rate = (self.success_metrics[action_key]['success'] /
+                          max(self.success_metrics[action_key]['total'], 1))
+            if 0.3 < success_rate < 0.7:
+                return DecisionStrategy.LEARNING
+
+        # Proactive for routine tasks
+        if self._is_routine_action(predicted_action, context):
+            return DecisionStrategy.PROACTIVE
+
+        # Default to reactive
+        return DecisionStrategy.REACTIVE
+
+    def _determine_target(
+        self,
+        action_type: str,
+        goal: Goal,
+        context: DecisionContext
+    ) -> Any:
+        """Determine target for action based on goal and context"""
+
+        # Extract target from goal evidence
+        for evidence in goal.evidence:
+            if 'target' in evidence.get('data', {}):
+                return evidence['data']['target']
+
+        # Infer target based on action type
+        if action_type == 'connect_display':
+            # Look for display references in context
+            if context.workspace_state:
+                # This would normally extract from workspace analysis
+                return "Living Room TV"
+
+        elif action_type == 'open_application':
+            # Determine which app based on goal type
+            if 'communication' in goal.goal_type:
+                return "Slack"
+            elif 'project' in goal.goal_type:
+                return "VSCode"
+
+        return "default_target"
+
+    def _calculate_urgency(self, goal: Goal, context: DecisionContext) -> float:
+        """Calculate urgency score for goal"""
+        urgency = 0.0
+
+        # Goal level urgency
+        if goal.level == GoalLevel.IMMEDIATE:
+            urgency += 0.5
+        elif goal.level == GoalLevel.INTERMEDIATE:
+            urgency += 0.3
+        else:
+            urgency += 0.1
+
+        # Confidence-based urgency
+        urgency += goal.confidence * 0.3
+
+        # Progress-based urgency (near completion is urgent)
+        if goal.progress > 0.8:
+            urgency += 0.2
+
+        # Time-based urgency
+        age_minutes = (datetime.now() - goal.created_at).total_seconds() / 60
+        if age_minutes > 30:
+            urgency += 0.1
+
+        return min(urgency, 1.0)
+
+    async def _get_pattern_based_time(
+        self,
+        goal: Goal,
+        action_type: str
+    ) -> Optional[datetime]:
+        """Get predicted time based on learned patterns"""
+        # Check if we have timing patterns for this goal-action pair
+        pattern_key = f"{goal.goal_type}_{action_type}"
+
+        if pattern_key in self.feedback_memory:
+            recent_timings = self.feedback_memory[pattern_key][-10:]
+            if recent_timings:
+                # Calculate average timing
+                avg_minutes = np.mean([t.get('delay_minutes', 0) for t in recent_timings])
+                return datetime.now() + timedelta(minutes=avg_minutes)
+
+        return None
+
+    async def _predict_action_time(
+        self,
+        goal: Goal,
+        action_type: str,
+        context: DecisionContext
+    ) -> datetime:
+        """Predict when action should be taken"""
+
+        # Use temporal pattern learner
+        pattern_time = await self._get_pattern_based_time(goal, action_type)
+        if pattern_time:
+            return pattern_time
+
+        # Urgency-based prediction
+        urgency = self._calculate_urgency(goal, context)
+
+        if urgency > 0.8:
+            # Immediate
+            return datetime.now()
+        elif urgency > 0.6:
+            # Within 5 minutes
+            return datetime.now() + timedelta(minutes=5)
+        elif urgency > 0.4:
+            # Within 15 minutes
+            return datetime.now() + timedelta(minutes=15)
+        else:
+            # Within an hour
+            return datetime.now() + timedelta(hours=1)
+
+    def _index_to_action_type(self, index: int) -> Optional[str]:
+        """Convert model output index to action type"""
+        action_types = list(self.action_registry.keys())
+        if 0 <= index < len(action_types):
+            return action_types[index]
+        return None
+
+    def _encode_goal_type(self, goal_type: str) -> List[float]:
+        """Encode goal type for ML"""
+        # Simple one-hot encoding for demonstration
+        all_types = [
+            'project_completion', 'problem_solving', 'information_gathering',
+            'communication', 'learning_research'
+        ]
+
+        encoding = [0.0] * len(all_types)
+        if goal_type in all_types:
+            encoding[all_types.index(goal_type)] = 1.0
+
+        return encoding
+
+    def _extract_goal_features(self, goal: Goal, context: DecisionContext) -> np.ndarray:
+        """Extract ML features from goal and context"""
+        features = []
+
+        # Goal features
+        features.append(goal.confidence)
+        features.append(goal.progress)
+        features.append(1.0 if goal.is_active else 0.0)
+        features.append(len(goal.evidence))
+
+        # Goal type encoding (one-hot or embedding)
+        goal_type_encoding = self._encode_goal_type(goal.goal_type)
+        features.extend(goal_type_encoding)
+
+        # Context features
+        features.extend(context.to_feature_vector())
+
+        # Pad or truncate to fixed size
+        target_size = 20
+        if len(features) < target_size:
+            features.extend([0.0] * (target_size - len(features)))
+        else:
+            features = features[:target_size]
+
+        return np.array(features)
+
+    def _get_cache_key(self, goal: Goal, context: DecisionContext) -> str:
+        """Generate cache key for predictions"""
+        key_data = {
+            'goal_id': goal.goal_id,
+            'goal_type': goal.goal_type,
+            'hour': context.temporal_context.get('hour', 0),
+            'risk_tolerance': context.risk_tolerance
+        }
+        key_str = json.dumps(key_data, sort_keys=True)
+        return hashlib.md5(key_str.encode()).hexdigest()
+
+    def _get_temporal_context(self) -> Dict[str, Any]:
+        """Get temporal context"""
+        now = datetime.now()
+        return {
+            'timestamp': now,
+            'hour': now.hour,
+            'minute': now.minute,
+            'day': now.day,
+            'month': now.month,
+            'weekday': now.weekday(),
+            'is_morning': 6 <= now.hour < 12,
+            'is_afternoon': 12 <= now.hour < 18,
+            'is_evening': 18 <= now.hour < 24
+        }
+
+    async def _get_system_resources(self) -> Dict[str, float]:
+        """Get current system resource usage"""
+        try:
+            import psutil
+            return {
+                'cpu': psutil.cpu_percent() / 100.0,
+                'memory': psutil.virtual_memory().percent / 100.0,
+                'disk': psutil.disk_usage('/').percent / 100.0
+            }
+        except ImportError:
+            return {'cpu': 0.5, 'memory': 0.5, 'disk': 0.5}
+
+    async def _load_user_preferences(self) -> Dict[str, Any]:
+        """Load learned user preferences"""
+        prefs_path = Path("backend/data/user_preferences.json")
+        if prefs_path.exists():
+            async with aiofiles.open(prefs_path, 'r') as f:
+                content = await f.read()
+                return json.loads(content)
+        return {}
+
+    async def _gather_environmental_factors(self) -> Dict[str, Any]:
+        """Gather environmental context"""
+        return {
+            'day_of_week': datetime.now().weekday(),
+            'hour': datetime.now().hour,
+            'is_weekend': datetime.now().weekday() >= 5,
+            'is_business_hours': 9 <= datetime.now().hour < 17
+        }
+
 # Global instance
 #
 # Restored 2026-08-02. This factory was deleted by 4406e11941 ("docs:
@@ -924,3 +1665,54 @@ def get_advanced_autonomous_engine() -> AdvancedAutonomousEngine:
     if _engine_instance is None:
         _engine_instance = AdvancedAutonomousEngine()
     return _engine_instance
+
+
+async def test_advanced_engine():
+    """Test the advanced autonomous engine"""
+    print("🚀 Testing Advanced Autonomous Engine with Goal Inference")
+    print("=" * 60)
+
+    engine = get_advanced_autonomous_engine()
+
+    # Create test context
+    test_context = {
+        'active_applications': ['vscode', 'chrome', 'terminal'],
+        'recent_actions': ['typing', 'switching_tabs'],
+        'content': {
+            'type': 'code',
+            'language': 'python',
+            'project': 'JARVIS'
+        },
+        'workspace_state': WorkspaceAnalysis(
+            focused_task="Implementing Goal Inference integration",
+            workspace_context="Development environment",
+            important_notifications=[],
+            suggestions=["Connect to display for presentation"],
+            confidence=0.9
+        )
+    }
+
+    print("\n📊 Making autonomous decisions based on inferred goals...")
+    decisions = await engine.make_decision(test_context)
+
+    print(f"\n✨ Generated {len(decisions)} autonomous decisions:\n")
+
+    for i, decision in enumerate(decisions, 1):
+        print(f"{i}. Action: {decision.predicted_action.action_type}")
+        print(f"   Target: {decision.predicted_action.target}")
+        print(f"   Goal Type: {decision.predicted_action.goal_type}")
+        print(f"   Strategy: {decision.decision_strategy.name}")
+        print(f"   Risk Level: {decision.risk_level.name}")
+        print(f"   ML Confidence: {decision.ml_confidence:.2%}")
+        print(f"   Needs Approval: {decision.requires_permission()}")
+        print(f"   Predicted Time: {decision.predicted_action.predicted_time}")
+        print(f"   Expected Success: {decision.expected_outcome.get('success', 0):.2%}")
+        print()
+
+    # Test execution
+    if decisions:
+        print("🎯 Executing first decision...")
+        outcome = await engine.execute_decision(decisions[0], override_permission=True)
+        print(f"   Outcome: {outcome.name}")
+
+    print("\n✅ Advanced Autonomous Engine test complete!")

--- a/backend/autonomy/voice_integration.py
+++ b/backend/autonomy/voice_integration.py
@@ -901,4 +901,528 @@ Generate a natural response:"""
             except Exception as e:
                 logger.warning(f"Intelligent selection failed, falling back to direct API: {e}")
 
+    async def _listen_for_approval_response(self, timeout: int) -> ApprovalResponse:
+        """Listen for and interpret approval response"""
+        try:
+            # This would integrate with the actual voice recognition system
+            # For now, we'll simulate the process
+            
+            # In a real implementation, this would:
+            # 1. Listen for voice input with timeout
+            # 2. Process the speech-to-text
+            # 3. Analyze the response using Claude
+            # 4. Return appropriate ApprovalResponse
+            
+            # Placeholder implementation
+            await asyncio.sleep(2)  # Simulate listening time
+            return ApprovalResponse.APPROVED
+            
+        except Exception as e:
+            logger.error(f"Error listening for approval: {e}")
+            return ApprovalResponse.DENIED
+
+    async def request_voice_approval(self, 
+                                   request: str, 
+                                   context: str = "",
+                                   timeout: int = 30) -> ApprovalResponse:
+        """Request approval via voice interaction"""
+        try:
+            # Generate approval request
+            approval_prompt = f"""You are JARVIS requesting approval for an action.
+
+Action to approve: {request}
+Context: {context}
+
+Generate a natural approval request that:
+1. Clearly explains what you want to do
+2. Provides relevant context
+3. Asks for permission naturally
+4. Is concise but informative
+
+Example: "Sir, I'd like to close the inactive applications to improve system performance. This will close Safari and TextEdit which have been idle for over an hour. Shall I proceed?"
+
+Generate the approval request:"""
+
+            message = await asyncio.to_thread(
+                self.claude.messages.create,
+                model="claude-3-haiku-20240307",
+                max_tokens=150,
+                temperature=0.3,
+                messages=[{"role": "user", "content": approval_prompt}]
+            )
+            
+            approval_text = message.content[0].text.strip()
+            
+            # Speak the approval request
+            await self.voice_engine.speak(approval_text)
+            
+            # Listen for response (this would integrate with voice recognition)
+            # For now, simulate user response
+            return await self._listen_for_approval_response(timeout)
+            
+        except Exception as e:
+            logger.error(f"Error requesting voice approval: {e}")
+            return ApprovalResponse.DENIED
+
+    def _generate_fallback_response(self, command: str, confidence: float) -> str:
+        """Generate fallback response when Claude API fails"""
+        if confidence < 0.5:
+            return "I'm having trouble understanding you clearly, sir. Could you please repeat that?"
+        elif "?" in command:
+            return "I understand you have a question, sir. Let me think about that for a moment."
+        else:
+            return "I'm processing your request, sir. How may I assist you further?"
+
+    async def _build_conversation_context(self) -> str:
+        """Build context for conversation"""
+        context_parts = []
+        
+        # Time context
+        current_time = datetime.now()
+        time_str = current_time.strftime("%I:%M %p on %A")
+        context_parts.append(f"Current time: {time_str}")
+        
+        # Conversation state
+        if self.conversation_state.active:
+            context_parts.append(f"Active conversation about: {self.conversation_state.topic}")
+            
+        # User availability context
+        context_parts.append("User is actively engaged")
+        
+        return "; ".join(context_parts)
+
+    def _format_conversation_history(self, history: List[Dict[str, str]]) -> str:
+        """Format conversation history for Claude"""
+        formatted = []
+        for entry in history:
+            role = "User" if entry["role"] == "user" else "JARVIS"
+            formatted.append(f"{role}: {entry['content']}")
+        return "\n".join(formatted)
+
+class VoiceIntegrationSystem:
+    """
+    Main voice integration system that coordinates all voice-related functionality
+    Provides the unified interface for JARVIS voice capabilities
+    """
+    
+    def __init__(self, claude_api_key: Optional[str] = None, use_intelligent_selection: bool = True):
+        # API setup
+        self.claude_api_key = claude_api_key or os.getenv("ANTHROPIC_API_KEY")
+        if not self.claude_api_key:
+            raise ValueError("Claude API key required for Voice Integration System")
+
+        self.use_intelligent_selection = use_intelligent_selection
+
+        # Voice engine setup
+        voice_config = VoiceConfig(
+            tts_engine=TTSEngine.EDGE_TTS,
+            language="en",
+            speech_rate=1.0,
+            volume=0.9
+        )
+        self.voice_engine = VoiceAssistant(voice_config)
+
+        # Core systems with intelligent selection
+        self.announcement_system = VoiceAnnouncementSystem(
+            self.claude_api_key, self.voice_engine, use_intelligent_selection
+        )
+        self.communication_system = NaturalVoiceCommunication(
+            self.claude_api_key, self.voice_engine, use_intelligent_selection
+        )
+        
+        # Integration components
+        self.notification_intelligence = NotificationIntelligence()
+        self.decision_engine = AutonomousDecisionEngine()
+        self.workspace_monitor = EnhancedWorkspaceMonitor()
+        
+        # Voice context tracking
+        self.voice_context = VoiceContext()
+        self.interaction_history = deque(maxlen=1000)
+        
+        # System state
+        self.is_active = False
+        self.monitoring_tasks = []
+        
+        # Integration settings
+        self.auto_announce_notifications = True
+        self.voice_approval_threshold = 0.7  # Actions above this threshold need approval
+        self.smart_interruption_detection = True
+        
+    async def start_voice_integration(self):
+        """Start the complete voice integration system"""
+        if self.is_active:
+            return
+            
+        self.is_active = True
+        
+        # Start core systems
+        await self.announcement_system.start_announcement_system()
+        await self.communication_system.start_voice_communication()
+        
+        # Start monitoring and integration tasks
+        self.monitoring_tasks = [
+            asyncio.create_task(self._monitor_notifications()),
+            asyncio.create_task(self._monitor_system_actions()),
+            asyncio.create_task(self._update_voice_context()),
+            asyncio.create_task(self._proactive_suggestions())
+        ]
+        
+        # Initial greeting
+        await self._deliver_startup_greeting()
+        
+        logger.info("🎯 JARVIS Voice Integration System fully activated")
+        
+    async def stop_voice_integration(self):
+        """Stop the voice integration system"""
+        self.is_active = False
+        
+        # Stop core systems
+        await self.announcement_system.stop_announcement_system()
+        
+        # Cancel monitoring tasks
+        for task in self.monitoring_tasks:
+            task.cancel()
+            
+        await asyncio.gather(*self.monitoring_tasks, return_exceptions=True)
+        
+        # Farewell message
+        await self.voice_engine.speak("Voice integration system deactivated. Goodbye, sir.")
+        
+        logger.info("🎯 Voice Integration System deactivated")
+        
+    async def _deliver_startup_greeting(self):
+        """Deliver dynamic JARVIS-style startup greeting"""
+        try:
+            # Try to use our dynamic response generator first
+            try:
+                from voice.dynamic_response_generator import get_response_generator
+                generator = get_response_generator()
+                greeting = generator.generate_startup_greeting()
+                await self.voice_engine.speak(greeting)
+                logger.info(f"Delivered startup greeting: {greeting}")
+                return
+            except ImportError:
+                pass  # Fall through to Claude generation
+            
+            # If dynamic generator not available, use Claude
+            current_time = datetime.now()
+            time_context = ""
+            
+            if current_time.hour < 12:
+                time_context = "morning"
+            elif current_time.hour < 17:
+                time_context = "afternoon"
+            else:
+                time_context = "evening"
+                
+            greeting_prompt = f"""Generate a sophisticated JARVIS-style startup greeting for the {time_context}.
+
+Requirements:
+1. Sound like JARVIS from Iron Man - professional, sophisticated, with subtle personality
+2. Include system status (e.g., "all systems operational", "neural networks calibrated")
+3. Be concise but impressive (1-2 sentences)
+4. Match the time of day naturally
+5. Vary between technical and warm approaches
+
+Examples:
+- "Good morning, sir. All primary systems are operational and standing by for your command."
+- "Welcome back, sir. JARVIS systems initialized. How may I be of service this evening?"
+- "System boot sequence complete. Ready to tackle whatever challenges the day brings."
+
+Generate a unique greeting:"""
+
+            message = await asyncio.to_thread(
+                self.claude.messages.create,
+                model="claude-3-haiku-20240307",
+                max_tokens=100,
+                temperature=0.7,  # Increased for more variety
+                messages=[{"role": "user", "content": greeting_prompt}]
+            )
+            
+            greeting = message.content[0].text.strip()
+            await self.voice_engine.speak(greeting)
+            logger.info(f"Delivered Claude-generated greeting: {greeting}")
+            
+        except Exception as e:
+            logger.error(f"Error generating startup greeting: {e}")
+            # Enhanced fallback greetings with variety
+            import random
+            fallback_greetings = [
+                "JARVIS systems online. How may I assist you, sir?",
+                "System initialization complete. At your service, sir.",
+                "Welcome back, sir. All systems operational.",
+                "JARVIS ready. Standing by for your command.",
+                "Voice integration active. Ready to proceed, sir."
+            ]
+            greeting = random.choice(fallback_greetings)
+            await self.voice_engine.speak(greeting)
+            
+    async def _monitor_notifications(self):
+        """Monitor for notifications to announce"""
+        while self.is_active:
+            try:
+                if self.auto_announce_notifications:
+                    # This would integrate with the notification intelligence system
+                    # to get detected notifications and automatically announce them
+                    
+                    # Get workspace state
+                    workspace_state = await self.workspace_monitor.get_complete_workspace_state()
+                    
+                    # Check for new notifications (placeholder)
+                    # In real implementation, this would detect actual notifications
+                    
+                    pass
+                    
+                await asyncio.sleep(5)  # Check every 5 seconds
+                
+            except Exception as e:
+                logger.error(f"Error monitoring notifications: {e}")
+                await asyncio.sleep(10)
+                
+    async def _monitor_system_actions(self):
+        """Monitor system actions that may need voice confirmation"""
+        while self.is_active:
+            try:
+                # Get pending actions from decision engine
+                pending_actions = self.decision_engine.get_pending_actions()
+                
+                for action in pending_actions:
+                    if action.confidence < self.voice_approval_threshold:
+                        # Request voice approval
+                        approval = await self.communication_system.request_voice_approval(
+                            request=action.reasoning,
+                            context=f"Action: {action.action_type} on {action.target}"
+                        )
+                        
+                        if approval == ApprovalResponse.APPROVED:
+                            # Execute action
+                            await self.decision_engine.execute_action(action)
+                            await self.announcement_system.queue_announcement(
+                                f"Action completed: {action.action_type}",
+                                urgency=0.3,
+                                context="system_action"
+                            )
+                        elif approval == ApprovalResponse.DENIED:
+                            # Cancel action
+                            self.decision_engine.cancel_action(action)
+                            
+                await asyncio.sleep(3)  # Check every 3 seconds
+                
+            except Exception as e:
+                logger.error(f"Error monitoring system actions: {e}")
+                await asyncio.sleep(10)
+                
+    async def _update_voice_context(self):
+        """Update voice context based on system state"""
+        while self.is_active:
+            try:
+                # Update context based on system state
+                current_time = datetime.now()
+                
+                # Update time context
+                if current_time.hour < 12:
+                    self.voice_context.time_of_day = "morning"
+                elif current_time.hour < 17:
+                    self.voice_context.time_of_day = "afternoon"
+                else:
+                    self.voice_context.time_of_day = "evening"
+                    
+                # Update user availability based on system activity
+                # This would integrate with the contextual understanding engine
+                
+                await asyncio.sleep(60)  # Update every minute
+                
+            except Exception as e:
+                logger.error(f"Error updating voice context: {e}")
+                await asyncio.sleep(60)
+                
+    async def _proactive_suggestions(self):
+        """Generate proactive voice suggestions"""
+        while self.is_active:
+            try:
+                # Generate proactive suggestions based on context
+                # This would analyze workspace state and suggest improvements
+                
+                # Check if user has been inactive for a while
+                # Suggest breaks, workspace optimization, etc.
+                
+                await asyncio.sleep(300)  # Check every 5 minutes
+                
+            except Exception as e:
+                logger.error(f"Error generating proactive suggestions: {e}")
+                await asyncio.sleep(300)
+                
+    async def announce_notification(self, 
+                                  notification: IntelligentNotification,
+                                  force: bool = False) -> str:
+        """Announce a notification via voice"""
+        try:
+            # Generate announcement content
+            announcement_content = f"New {notification.context.value.replace('_', ' ')} from {notification.app_name}"
+            
+            if notification.detected_text:
+                # Summarize the notification content
+                content_summary = ' '.join(notification.detected_text[:2])  # First 2 text elements
+                if len(content_summary) > 100:
+                    content_summary = content_summary[:97] + "..."
+                announcement_content += f": {content_summary}"
+                
+            # Queue announcement
+            announcement_id = await self.announcement_system.queue_announcement(
+                content=announcement_content,
+                urgency=notification.urgency_score,
+                context=notification.context.value,
+                requires_approval=False
+            )
+            
+            return announcement_id
+            
+        except Exception as e:
+            logger.error(f"Error announcing notification: {e}")
+            return ""
+            
+    async def process_voice_command(self, command: str, confidence: float = 1.0) -> str:
+        """Process a voice command through the natural communication system"""
+        try:
+            # Record interaction
+            self.interaction_history.append({
+                'command': command,
+                'confidence': confidence,
+                'timestamp': datetime.now(),
+                'type': VoiceInteractionType.CONVERSATION
+            })
+            
+            # Process through communication system
+            response = await self.communication_system.process_voice_command(command, confidence)
+            
+            # Record response
+            self.interaction_history.append({
+                'response': response,
+                'timestamp': datetime.now(),
+                'type': VoiceInteractionType.CONVERSATION
+            })
+            
+            return response
+            
+        except Exception as e:
+            logger.error(f"Error processing voice command: {e}")
+            return "I apologize, sir. I encountered an error processing your command."
+            
+    async def request_approval(self, 
+                             action: AutonomousAction,
+                             timeout: int = 30) -> ApprovalResponse:
+        """Request approval for an action via voice"""
+        try:
+            request_text = f"Execute {action.action_type} on {action.target}: {action.reasoning}"
+            
+            approval = await self.communication_system.request_voice_approval(
+                request=request_text,
+                context=f"Priority: {action.priority.value}, Confidence: {action.confidence:.2f}",
+                timeout=timeout
+            )
+            
+            # Record approval interaction
+            self.interaction_history.append({
+                'approval_request': request_text,
+                'approval_response': approval.value,
+                'timestamp': datetime.now(),
+                'type': VoiceInteractionType.APPROVAL_REQUEST
+            })
+            
+            return approval
+            
+        except Exception as e:
+            logger.error(f"Error requesting approval: {e}")
+            return ApprovalResponse.DENIED
+            
+    def get_voice_statistics(self) -> Dict[str, Any]:
+        """Get voice system statistics"""
+        total_interactions = len(self.interaction_history)
+        
+        if total_interactions == 0:
+            return {"error": "No interactions recorded"}
+            
+        # Calculate statistics
+        recent_interactions = [i for i in self.interaction_history 
+                             if (datetime.now() - i['timestamp']).seconds < 3600]
+        
+        interaction_types = defaultdict(int)
+        for interaction in self.interaction_history:
+            interaction_types[interaction.get('type', 'unknown').value] += 1
+            
+        return {
+            'total_interactions': total_interactions,
+            'recent_interactions': len(recent_interactions),
+            'interaction_types': dict(interaction_types),
+            'announcement_queue_size': self.announcement_system.announcement_queue.qsize(),
+            'conversation_active': self.communication_system.conversation_state.active,
+            'system_active': self.is_active
+        }
+
+
         # Fall
+
+async def test_voice_integration():
+    """Test the voice integration system"""
+    print("🎯 Testing JARVIS Voice Integration System")
+    print("=" * 60)
+    
+    try:
+        # Initialize system
+        api_key = os.getenv("ANTHROPIC_API_KEY")
+        if not api_key:
+            print("❌ Error: ANTHROPIC_API_KEY not set")
+            return
+            
+        voice_system = VoiceIntegrationSystem(api_key)
+        
+        # Start system
+        print("🚀 Starting voice integration...")
+        await voice_system.start_voice_integration()
+        
+        # Test announcement
+        print("📢 Testing announcement...")
+        await voice_system.announcement_system.queue_announcement(
+            "Test notification from Slack",
+            urgency=0.6,
+            context="test"
+        )
+        
+        # Test conversation
+        print("🎤 Testing conversation...")
+        response = await voice_system.process_voice_command("What's the weather like?")
+        print(f"Response: {response}")
+        
+        # Test approval request
+        print("✅ Testing approval request...")
+        from autonomy.autonomous_decision_engine import AutonomousAction, ActionPriority
+        test_action = AutonomousAction(
+            action_type="test_action",
+            target="test_target",
+            params={},
+            priority=ActionPriority.MEDIUM,
+            confidence=0.8,
+            category="test",
+            reasoning="This is a test action"
+        )
+        
+        approval = await voice_system.request_approval(test_action)
+        print(f"Approval response: {approval.value}")
+        
+        # Show statistics
+        stats = voice_system.get_voice_statistics()
+        print(f"📊 Statistics: {json.dumps(stats, indent=2, default=str)}")
+        
+        # Run for a short time
+        print("⏱️  Running system for 30 seconds...")
+        await asyncio.sleep(30)
+        
+        # Stop system
+        print("🛑 Stopping voice integration...")
+        await voice_system.stop_voice_integration()
+        
+        print("✅ Voice integration test completed successfully!")
+        
+    except Exception as e:
+        print(f"❌ Error during test: {e}")
+        logger.error(f"Voice integration test error: {e}")

--- a/backend/context_intelligence/automation/claude_streamer.py
+++ b/backend/context_intelligence/automation/claude_streamer.py
@@ -897,6 +897,161 @@ class ClaudeContentStreamer:
 
                 section_name = line.lstrip("#").lstrip("0123456789. ").strip
 
+    async def _mock_stream(self, prompt: str) -> AsyncIterator[str]:
+        """Enhanced mock content streaming for testing"""
+        # Detect document type from prompt
+        prompt_lower = prompt.lower()
+
+        if "mla" in prompt_lower:
+            mock_content = """Student Name
+Instructor Name
+Course Name
+1 October 2025
+
+Dogs: Loyal Companions
+
+## Introduction
+
+Dogs have been humanity's faithful companions for thousands of years. From ancient hunting partners to modern family pets, dogs have played crucial roles in human society (Smith 45).
+
+## The History of Dog Domestication
+
+Archaeological evidence suggests that dogs were first domesticated from wolves approximately 15,000 years ago (Johnson and Brown 112). This partnership between humans and canines represents one of the most successful interspecies relationships in history.
+
+## Characteristics and Breeds
+
+Modern dogs exhibit remarkable diversity, with over 300 recognized breeds worldwide. Each breed possesses unique characteristics suited to specific roles, from herding sheep to providing emotional support.
+
+## The Human-Canine Bond
+
+Research demonstrates that dogs provide numerous physical and psychological benefits to their owners. Studies show that dog ownership can reduce stress, lower blood pressure, and increase physical activity levels (Williams 78).
+
+## Conclusion
+
+Dogs remain invaluable companions in contemporary society. Their loyalty, intelligence, and adaptability ensure their continued importance in human lives for generations to come.
+
+Works Cited
+
+Johnson, Mary, and Robert Brown. "Canine Domestication History." Journal of Archaeological Science, vol. 45, 2020, pp. 110-125.
+
+Smith, John. The Evolution of Dogs. Academic Press, 2019.
+
+Williams, Sarah. "Health Benefits of Pet Ownership." Medical Journal, vol. 12, no. 3, 2021, pp. 75-82."""
+
+        elif "apa" in prompt_lower:
+            mock_content = """Running head: DOGS AS COMPANIONS
+
+Dogs as Loyal Companions
+
+Student Name
+Institution Name
+
+## Abstract
+
+This paper examines the historical and contemporary role of dogs in human society, their domestication, breed diversity, and the psychological benefits of dog ownership.
+
+## Dogs as Loyal Companions
+
+Dogs have been humanity's faithful companions for millennia (Smith, 2019). Their domestication represents a pivotal moment in human history.
+
+## History of Domestication
+
+Archaeological evidence indicates that dogs were first domesticated approximately 15,000 years ago (Johnson & Brown, 2020). This partnership has proven remarkably successful.
+
+## Modern Dog Breeds
+
+Contemporary dogs exhibit tremendous diversity, with over 300 recognized breeds globally. Each breed possesses characteristics suited to specific functions.
+
+## Psychological Benefits
+
+Research demonstrates that dogs provide significant health benefits to owners, including stress reduction and increased physical activity (Williams, 2021).
+
+## Conclusion
+
+Dogs continue to serve as invaluable companions in modern society, providing both practical assistance and emotional support.
+
+References
+
+Johnson, M., & Brown, R. (2020). Canine domestication history. Journal of Archaeological Science, 45, 110-125.
+
+Smith, J. (2019). The evolution of dogs. Academic Press.
+
+Williams, S. (2021). Health benefits of pet ownership. Medical Journal, 12(3), 75-82."""
+
+        else:
+            mock_content = """# Dogs: Loyal Companions
+
+## Introduction
+
+Dogs have been humanity's faithful companions for thousands of years, serving roles from hunting partners to beloved family pets.
+
+## History
+
+Archaeological evidence suggests dogs were first domesticated from wolves approximately 15,000 years ago, making them one of the first domesticated animals.
+
+## Breeds and Characteristics
+
+Modern dogs display remarkable diversity, with over 300 recognized breeds worldwide. Each breed has unique characteristics suited to specific roles.
+
+## Human-Canine Bond
+
+Research shows that dogs provide numerous benefits to their owners, including reduced stress, increased physical activity, and emotional support.
+
+## Conclusion
+
+Dogs remain invaluable companions in contemporary society, their loyalty and intelligence ensuring their continued importance in human lives."""
+
+        # Stream the mock content with natural pacing
+        words = mock_content.split()
+        for i, word in enumerate(words):
+            # Add space except for first word and after newlines
+            chunk = word if i == 0 or words[i - 1].endswith("\n") else " " + word
+            yield chunk
+            # Variable delay for more natural feel
+            await asyncio.sleep(0.03 if len(word) < 5 else 0.05)
+
+    def get_cache_size(self) -> int:
+        """Get number of cached outlines"""
+        return len(self._outline_cache)
+
+    def clear_cache(self):
+        """Clear the outline cache"""
+        cleared = len(self._outline_cache)
+        self._outline_cache.clear()
+        logger.info(f"Cleared {cleared} cached outlines")
+
+    def get_session_statistics(self) -> Dict[str, Any]:
+        """
+        Get comprehensive session statistics
+
+        Returns:
+            Dictionary of session stats
+        """
+        if not self._session_stats:
+            return {"sessions": 0, "total_tokens": 0}
+
+        return {
+            "sessions": len(self._session_stats),
+            "total_tokens": sum(s.total_tokens for s in self._session_stats),
+            "total_duration": sum(s.get_duration() for s in self._session_stats),
+            "average_tokens_per_second": sum(s.get_tokens_per_second() for s in self._session_stats)
+            / len(self._session_stats),
+            "total_errors": sum(s.errors_encountered for s in self._session_stats),
+            "total_retries": sum(s.retries_attempted for s in self._session_stats),
+            "models_used": list(set(s.model_used for s in self._session_stats)),
+        }
+
+    def _mock_outline(self) -> Dict[str, Any]:
+        """Generate a mock outline for testing"""
+        return {
+            "title": "Sample Document",
+            "sections": [
+                {"name": "Introduction", "points": ["Context and background", "Thesis statement"]},
+                {"name": "Main Content", "points": ["Key point 1", "Key point 2", "Key point 3"]},
+                {"name": "Conclusion", "points": ["Summary", "Final thoughts"]},
+            ],
+        }
+
 # Singleton instance
 _claude_streamer_instance = None
 

--- a/backend/context_intelligence/executors/document_writer.py
+++ b/backend/context_intelligence/executors/document_writer.py
@@ -871,6 +871,555 @@ Return a JSON structure with:
         # TODO: Implement outline generation using Claude API
         return {"title": request.topic, "sections": []}
 
+    async def _narrate(self, progress_callback: Optional[Callable],
+                      websocket, message: str = None, context: Dict[str, Any] = None):
+        """
+        Intelligent narration with AI-powered decision making and speech queue management
+        Uses IntelligentNarrator for dynamic, context-aware updates
+        """
+        import time
+        import asyncio
+
+        # CRITICAL PHASES: Completion messages MUST always be heard
+        critical_phases = ['writing_complete', 'document_ready', 'acknowledging_request']
+        is_critical = context and context.get('phase') in critical_phases
+        
+        if is_critical:
+            logger.info(f"[DOCUMENT WRITER] 🎯 CRITICAL PHASE: {context.get('phase')} - Will announce regardless")
+            # Wait for any in-progress speech to finish for critical messages
+            if self._speech_in_progress:
+                logger.info(f"[DOCUMENT WRITER] ⏳ Waiting for speech to complete before critical announcement...")
+                max_wait = 10  # Wait up to 10 seconds
+                waited = 0
+                while self._speech_in_progress and waited < max_wait:
+                    await asyncio.sleep(0.5)
+                    waited += 0.5
+                logger.info(f"[DOCUMENT WRITER] ✅ Speech clear, proceeding with critical announcement")
+        else:
+            # REGULAR PHASES: Wait if speech is currently in progress to prevent overlap
+            if self._speech_in_progress:
+                logger.info(f"[DOCUMENT WRITER] ⏸️  Speech in progress, skipping to prevent overlap")
+                return
+            
+            # Wait for minimum gap after last speech completed
+            time_since_last_speech = time.time() - self._last_speech_end_time
+            if time_since_last_speech < 2.0 and self._last_speech_end_time > 0:
+                logger.info(f"[DOCUMENT WRITER] ⏸️  Too soon after last speech ({time_since_last_speech:.1f}s), skipping")
+                return
+
+        # If intelligent narrator is available, use it
+        if self._intelligent_narrator and context and not is_critical:
+            # Regular phases use intelligent narrator with significance checks
+            phase = context.get('phase', 'unknown')
+            
+            # Update narrator context
+            self._intelligent_narrator._context.current_phase = phase
+            self._intelligent_narrator._context.current_section = context.get('current_section', '')
+            self._intelligent_narrator._context.word_count = context.get('word_count', 0)
+            
+            # Intelligently decide if we should narrate
+            should_narrate, reason = await self._intelligent_narrator.should_narrate(
+                phase, 
+                content_update=context.get('recent_content')
+            )
+            
+            if not should_narrate:
+                logger.info(f"[INTELLIGENT NARRATOR] ⏭️  Skipping: {reason}")
+                return
+            
+            logger.info(f"[INTELLIGENT NARRATOR] 🎯 Narrating: {reason}")
+            
+            # Generate intelligent, context-aware message
+            try:
+                message = await self._intelligent_narrator.generate_narration(phase, context)
+            except Exception as e:
+                logger.error(f"[INTELLIGENT NARRATOR] Error, using fallback: {e}")
+                message = await self._generate_dynamic_narration(context)
+        
+        # CRITICAL phases bypass intelligent narrator and use guaranteed messages
+        elif is_critical and context:
+            logger.info(f"[DOCUMENT WRITER] 🔥 Generating CRITICAL message for {context.get('phase')}")
+            message = await self._generate_dynamic_narration(context)
+        
+        # Fallback to old system if no intelligent narrator
+        elif context and not message:
+            message = await self._generate_dynamic_narration(context)
+        
+        if not message:
+            return
+
+        # Mark speech as in progress
+        self._speech_in_progress = True
+        logger.info(f"[DOCUMENT WRITER] 🎤 Speaking: {message}")
+
+        if progress_callback:
+            await progress_callback(message)
+
+        if websocket:
+            try:
+                # Send narration message with voice output
+                await websocket.send_json({
+                    "type": "voice_narration",
+                    "message": message,
+                    "speak": True
+                })
+                
+                # Estimate speech duration (rough: ~3 words per second + 1s buffer)
+                word_count = len(message.split())
+                estimated_duration = (word_count / 3.0) + 1.0
+                
+                # Wait for speech to complete
+                await asyncio.sleep(estimated_duration)
+                
+                # Mark speech as complete
+                self._speech_in_progress = False
+                self._last_speech_end_time = time.time()
+                self._last_narration_time = time.time()
+                
+                logger.info(f"[DOCUMENT WRITER] ✅ Speech completed ({estimated_duration:.1f}s)")
+
+            except Exception as e:
+                logger.error(f"Could not send narration to websocket: {e}")
+                self._speech_in_progress = False
+
+    def _get_fallback_narration(self, context_override: Dict[str, Any] = None) -> str:
+        """Generate intelligent, dynamic fallback narration when Claude is not available"""
+        import random
+        
+        # Use override context if provided, otherwise use stored context
+        ctx = context_override if context_override else self._narration_context
+        
+        phase = ctx.get('phase', 'working')
+        topic = ctx.get('topic', 'your document')
+        progress = ctx.get('progress', 0)
+        current_section = ctx.get('current_section', 'the document')
+        word_count = ctx.get('word_count', 0)
+        doc_type = ctx.get('document_type', 'document')
+        
+        # Dynamic phrase components for natural variation
+        acknowledgments = ["Got it", "Understood", "Absolutely", "Right away", "On it", "Let's begin", "Starting now"]
+        transitions = ["Moving on to", "Now working on", "Progressing to", "Shifting to", "Starting", "Beginning"]
+        progress_phrases = ["We're at", "Progress update:", "Currently at", "Now at", "Reached"]
+        completion_phrases = ["All done", "Finished", "Complete", "Ready", "Done"]
+        
+        # Occasionally use "Sir" (20-30% chance)
+        use_sir = random.random() < 0.25
+        sir_phrase = ", Sir" if use_sir else ""
+        
+        # Generate natural, varied responses based on phase
+        if phase == 'acknowledging_request':
+            intros = [
+                f"{random.choice(acknowledgments)}{sir_phrase}. Creating your {doc_type} about {topic}",
+                f"I'll write that {doc_type} on {topic} for you{sir_phrase}",
+                f"{topic} - interesting topic. Let me create that {doc_type}",
+                f"Starting your {doc_type} about {topic} now"
+            ]
+            return random.choice(intros)
+            
+        elif phase == 'initializing_services':
+            return random.choice([
+                "Connecting to Google Docs",
+                "Setting up document services",
+                "Initializing the writing system",
+                f"Preparing to write{sir_phrase}",
+                "Getting everything ready",
+                "Spinning up the document tools"
+            ])
+            
+        elif phase == 'services_ready':
+            return random.choice([
+                "Services connected",
+                "Ready to create the document",
+                "All systems go",
+                f"Tools initialized{sir_phrase}"
+            ])
+            
+        elif phase == 'creating_document':
+            return random.choice([
+                "Creating your document in Google Docs",
+                "Setting up the document structure",
+                f"Opening a new {doc_type} for you",
+                "Establishing document framework",
+                "Building the document"
+            ])
+            
+        elif phase == 'document_created':
+            return random.choice([
+                "Document created successfully",
+                "Got your new document ready",
+                f"Fresh document set up{sir_phrase}",
+                "Document structure in place"
+            ])
+            
+        elif phase == 'opening_browser':
+            return random.choice([
+                "Opening in Chrome",
+                "Launching the browser",
+                "Bringing up Google Docs"
+            ])
+            
+        elif phase == 'browser_ready':
+            return random.choice([
+                "Browser's open and ready",
+                "Document visible on screen",
+                "Chrome has it loaded"
+            ])
+            
+        elif phase == 'analyzing_topic':
+            analyses = [
+                f"Analyzing key aspects of {topic}",
+                f"Researching {topic} for comprehensive coverage",
+                f"Identifying main themes about {topic}",
+                f"Structuring thoughts on {topic}",
+                f"Planning the approach to {topic}",
+                f"Mapping out {topic} coverage"
+            ]
+            return random.choice(analyses)
+            
+        elif phase == 'outline_complete':
+            return random.choice([
+                f"Outline ready - found several interesting angles",
+                "Structure mapped out, ready to write",
+                f"Framework complete{sir_phrase}",
+                "Got the blueprint, starting content",
+                "Outline looking solid",
+                "Plan's in place, let's write"
+            ])
+            
+        elif phase == 'starting_writing':
+            return random.choice([
+                f"Writing about {topic} now",
+                "Composing the content",
+                f"Let me craft this {doc_type} for you{sir_phrase}",
+                "Beginning the actual writing",
+                f"Starting with the introduction about {topic}",
+                f"Getting the words down now"
+            ])
+            
+        elif phase == 'writing_section':
+            section_updates = [
+                f"{random.choice(transitions)} {current_section}",
+                f"Writing {current_section}",
+                f"Developing {current_section} now",
+                f"Crafting {current_section}",
+                f"{current_section} coming together nicely",
+                f"Building out {current_section}",
+                f"Now covering {current_section}"
+            ]
+            return random.choice(section_updates)
+            
+        elif phase == 'progress_update':
+            # More varied progress announcements with specific milestones
+            if progress < 20:
+                stage_phrases = [
+                    "Just getting started",
+                    "Opening strong",
+                    "Building momentum",
+                    "Laying the groundwork"
+                ]
+            elif progress < 40:
+                stage_phrases = [
+                    "Making solid progress",
+                    "Coming along nicely",
+                    "Building the argument",
+                    "Developing the ideas"
+                ]
+            elif progress < 60:
+                stage_phrases = [
+                    "Halfway there",
+                    "Making great headway",
+                    "Rolling through this",
+                    "Really cooking now"
+                ]
+            elif progress < 80:
+                stage_phrases = [
+                    "Into the home stretch",
+                    "Getting close",
+                    "Nearly there",
+                    "Closing in on completion"
+                ]
+            else:
+                stage_phrases = [
+                    "Almost finished",
+                    "Just about done",
+                    "Final stretch",
+                    "Wrapping it up"
+                ]
+                
+            progress_msgs = [
+                f"{random.choice(stage_phrases)} - {word_count} words",
+                f"{word_count} words written, {random.choice(stage_phrases).lower()}",
+                f"{random.choice(progress_phrases)} {progress}%{sir_phrase}",
+                f"{random.choice(stage_phrases)}"
+            ]
+            return random.choice(progress_msgs)
+            
+        elif phase == 'finalizing':
+            return random.choice([
+                "Adding final touches",
+                "Wrapping up the conclusion",
+                "Polishing the final sections",
+                f"Nearly finished{sir_phrase}"
+            ])
+            
+        elif phase == 'writing_complete':
+            completions = [
+                f"All done{sir_phrase}! {word_count} words on {topic}",
+                f"Finished! Your {doc_type} about {topic} is complete - {word_count} words",
+                f"Writing complete{sir_phrase}. {word_count} words on {topic}",
+                f"That's {word_count} words finished on {topic}",
+                f"Complete! Your essay on {topic} is ready - {word_count} words total"
+            ]
+            return random.choice(completions)
+            
+        elif phase == 'document_ready':
+            ready_msgs = [
+                f"Your {doc_type} about {topic} is open in Google Docs{sir_phrase}",
+                f"It's ready for you in the browser - all {word_count} words",
+                f"Document's on your screen now{sir_phrase}",
+                f"There you go{sir_phrase} - {topic} essay ready to review",
+                f"All set - your {doc_type} on {topic} is open and ready"
+            ]
+            return random.choice(ready_msgs)
+            
+        else:
+            # Default fallback with variation
+            return random.choice([
+                f"Making progress on {current_section}",
+                f"Continuing with {current_section}",
+                f"Still writing{sir_phrase}",
+                f"Moving through {current_section}"
+            ])
+
+    async def _generate_dynamic_narration(self, context_update: Dict[str, Any]) -> str:
+        """
+        Generate natural, context-aware narration using Claude API.
+        No hardcoded messages - all narration is dynamically generated.
+        """
+        # Update context
+        self._narration_context.update(context_update)
+
+        # Build prompt for Claude to generate natural narration
+        prompt = f"""You are JARVIS, Tony Stark's AI assistant. You're helping write a {self._narration_context.get('document_type', 'document')} about "{self._narration_context.get('topic', 'the topic')}".
+
+Current status:
+- Phase: {self._narration_context.get('phase')}
+- Progress: {self._narration_context.get('progress')}% complete
+- Word count: {self._narration_context.get('word_count')} / {self._narration_context.get('total_words_target')} words
+- Current section: {self._narration_context.get('current_section', 'N/A')}
+- Format: {self._narration_context.get('format', 'standard')}
+
+Generate a single, natural sentence (10-15 words) that JARVIS would say to update the user about this progress. 
+Be conversational and natural. Only occasionally use "Sir" (maybe 20% of the time). Vary your language - don't be repetitive.
+Reference specific details when relevant. Sound engaged and interested in the topic.
+
+Narration:"""
+
+        try:
+            # Try to use dynamic response generator first for consistent personality
+            try:
+                from voice.dynamic_response_generator import get_response_generator
+                generator = get_response_generator()
+                narration = generator.generate_document_narration(
+                    self._narration_context.get('phase'),
+                    self._narration_context
+                )
+                if narration:
+                    return narration
+            except Exception as e:
+                logger.debug(f"Dynamic generator not available: {e}")
+            
+            # Use Claude to generate the narration if available
+            if self._claude:
+                response = ""
+                async for chunk in self._claude.stream_content(prompt, max_tokens=50):
+                    response += chunk
+
+                # Clean up the response
+                narration = response.strip().strip('"').strip()
+                return narration if narration else self._get_fallback_narration(context_update)
+            else:
+                # Fallback if Claude not available
+                return self._get_fallback_narration(context_update)
+        except Exception as e:
+            logger.error(f"Error generating dynamic narration: {e}")
+            return self._get_fallback_narration(context_update)
+
+    def _format_outline(self, outline: Dict[str, Any]) -> str:
+        """Format outline for prompt"""
+        lines = []
+        for section in outline.get('sections', []):
+            lines.append(f"- {section['name']}")
+            for point in section.get('points', []):
+                lines.append(f"  * {point}")
+        return '\n'.join(lines)
+
+    def _build_content_prompt(self, request: DocumentRequest, outline: Dict[str, Any]) -> str:
+        """Build comprehensive prompt for content generation with formatting"""
+        # Get formatting specifications
+        format_spec = FORMAT_SPECIFICATIONS.get(request.formatting.value, {})
+        format_name = format_spec.get("name", "No specific format")
+        format_requirements = format_spec.get("requirements", "")
+
+        # Build heading information if applicable
+        heading_info = ""
+        if request.formatting == DocumentFormat.MLA:
+            heading_info = f"""
+MLA Heading (upper left corner):
+{request.author_name}
+{request.instructor_name if request.instructor_name else "Instructor Name"}
+{request.course_name if request.course_name else "Course Name"}
+{datetime.now().strftime("%d %B %Y")}
+"""
+        elif request.formatting == DocumentFormat.APA:
+            heading_info = f"""
+Title Page:
+Title: {request.title}
+Author: {request.author_name}
+Institutional Affiliation: {request.institution if request.institution else "Institution Name"}
+"""
+
+        prompt = f"""Write a complete, high-quality {request.document_type.value} about "{request.topic}" in {format_name} format.
+
+Target length: {request.get_length_spec()}
+
+Title: {request.title}
+
+FORMATTING REQUIREMENTS - {format_name}:
+{format_requirements}
+
+{heading_info}
+
+Outline:
+{self._format_outline(outline)}
+
+Content Requirements:
+- Professional, well-researched content
+- Clear structure with proper transitions
+- Engaging and informative writing
+- Academic/professional tone appropriate for a {request.document_type.value}
+- STRICTLY follow {format_name} formatting guidelines above
+- Include proper in-text citations in {format_name} style (use plausible sources)
+- Include a proper Works Cited/References page at the end in {format_name} format
+{f"- {request.additional_requirements}" if request.additional_requirements else ""}
+
+IMPORTANT: Format the entire document according to {format_name} standards, including:
+- Proper heading/title page
+- Correct spacing and indentation
+- Appropriate in-text citations
+- Properly formatted Works Cited/References page
+
+Write the complete {request.document_type.value} now, starting with the proper {format_name} heading:"""
+
+        return prompt
+
+    async def _stream_content(self,
+                            document_id: str,
+                            request: DocumentRequest,
+                            outline: Dict[str, Any],
+                            progress_callback: Optional[Callable],
+                            websocket) -> int:
+        """Stream content to Google Doc via API with detailed real-time updates"""
+        import time
+        content_prompt = self._build_content_prompt(request, outline)
+
+        word_count = 0
+        sentence_count = 0
+        buffer = ""
+        progress_interval = 200  # Update every 200 words to avoid over-narration
+        next_milestone = progress_interval
+        
+        # Track time for velocity calculation
+        last_write_time = time.time()
+
+        # Track sections for progress updates
+        sections = outline.get('sections', [])
+        current_section_index = 0
+        section_announced = False
+
+        try:
+            async for chunk in self._claude.stream_content(
+                content_prompt,
+                max_tokens=request.claude_max_tokens,
+                model=request.claude_model
+            ):
+                buffer += chunk
+
+                # Count sentences for more granular updates
+                sentence_count += buffer.count('.') + buffer.count('!') + buffer.count('?')
+
+                # Write in smaller chunks for more real-time feel
+                if len(buffer) >= request.chunk_size:
+                    success = await self._google_docs.append_text(document_id, buffer)
+
+                    if success:
+                        current_words = len(buffer.split())
+                        current_time = time.time()
+                        time_delta = current_time - last_write_time
+                        word_count += current_words
+                        
+                        # Update intelligent narrator metrics
+                        if self._intelligent_narrator:
+                            self._intelligent_narrator.update_writing_metrics(word_count, time_delta)
+                            self._intelligent_narrator.update_content_analysis(buffer)
+                        
+                        last_write_time = current_time
+
+                        # Detect section changes (simple heuristic)
+                        if current_section_index < len(sections) and not section_announced:
+                            section_name = sections[current_section_index]['name']
+                            # Announce every section for better engagement
+                            await self._narrate(progress_callback, websocket, context={
+                                "phase": "writing_section",
+                                "current_section": section_name,
+                                "word_count": word_count,
+                                "progress": 55 + int((word_count / (request.word_count or 1000)) * 40),
+                                "recent_content": buffer[:200]  # Pass snippet for context
+                            })
+                            section_announced = True
+
+                        # Move to next section periodically (every 200 words to match progress updates)
+                        if word_count > (current_section_index + 1) * 200 and current_section_index < len(sections) - 1:
+                            current_section_index += 1
+                            section_announced = False
+
+                        # Progress milestones with dynamic narration
+                        if word_count >= next_milestone:
+                            percentage = min(int((word_count / (request.word_count or 1000)) * 100), 99)
+                            await self._narrate(progress_callback, websocket, context={
+                                "phase": "progress_update",
+                                "word_count": word_count,
+                                "progress": 55 + int(percentage * 0.4),
+                                "current_section": sections[current_section_index]['name'] if current_section_index < len(sections) else "conclusion",
+                                "recent_content": buffer[:200]  # Pass snippet for context
+                            })
+                            next_milestone += progress_interval
+
+                    buffer = ""
+                    await asyncio.sleep(request.stream_delay)
+
+            # Write remaining buffer
+            if buffer:
+                await self._google_docs.append_text(document_id, buffer)
+                word_count += len(buffer.split())
+
+            # Final section notification
+            if current_section_index < len(sections):
+                await self._narrate(progress_callback, websocket, context={
+                    "phase": "finalizing",
+                    "current_section": "conclusion and references",
+                    "word_count": word_count,
+                    "progress": 90
+                })
+
+            return word_count
+
+        except Exception as e:
+            logger.error(f"Error streaming content: {e}")
+            await self._narrate(progress_callback, websocket,
+                f"Encountered an issue during writing, but continuing... ({word_count} words so far)")
+            return word_count
+
 
 # ============================================================================
 # SINGLETON PATTERN - Global accessor
@@ -963,3 +1512,37 @@ async def test_document_writer():
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
     asyncio.run(test_document_writer())
+
+
+def _extract_topic(command: str, doc_type: DocumentType) -> str:
+    """Dynamically extract topic from command"""
+    command_lower = command.lower()
+
+    # Pattern list (ordered by specificity)
+    # Updated to handle -ing forms: write/writing, create/creating, etc.
+    patterns = [
+        # Pattern 1: "write/writing [me] [an] essay [about/on] topic"
+        r'(?:writ(?:e|ing)|creat(?:e|ing)|draft(?:|ing)|compos(?:e|ing)|generat(?:e|ing))\s+(?:me\s+)?(?:an?\s+)?(?:\d+\s+(?:word|page)s?\s+)?(?:essay|report|paper|article|document|blog\s*post)?\s+(?:about|on|regarding)\s+(.+?)(?:\s+in\s+(?:google\s*)?docs?|\s+for\s+me|$)',
+        # Pattern 2: "essay [about/on] topic"
+        r'(?:essay|report|paper|article|document)\s+(?:about|on|regarding)\s+(.+?)(?:\s+in\s+(?:google\s*)?docs?|$)',
+        # Pattern 3: "write/writing [me] [an] topic essay"
+        r'(?:writ(?:e|ing)|creat(?:e|ing)|draft(?:|ing))\s+(?:me\s+)?(?:an?\s+)?(.+?)(?:\s+essay|\s+report|\s+paper|\s+article|$)',
+        # Pattern 4: Simple "writing essay on topic" (no "about" connector)
+        r'(?:writ(?:e|ing)|creat(?:e|ing))\s+essay\s+on\s+(.+?)(?:\s+in\s+(?:google\s*)?docs?|$)',
+    ]
+
+    for pattern in patterns:
+        match = re.search(pattern, command_lower, re.IGNORECASE)
+        if match:
+            topic = match.group(1).strip()
+            # Clean up the topic
+            topic = re.sub(r'\s+in\s+(?:google\s+)?docs?$', '', topic)
+            topic = re.sub(r'\s+for\s+me$', '', topic)
+            topic = re.sub(r'^\d+\s+(?:word|page)s?\s+', '', topic)
+            if topic:
+                logger.info(f"Extracted topic '{topic}' from command using pattern: {pattern[:50]}...")
+                return topic
+
+    # Fallback: if no pattern matched, log and return default
+    logger.warning(f"Could not extract topic from command: '{command}'. Using default.")
+    return "the requested topic"

--- a/backend/context_intelligence/handlers/display_reference_handler.py
+++ b/backend/context_intelligence/handlers/display_reference_handler.py
@@ -908,6 +908,51 @@ class AdvancedDisplayReferenceHandler:
 
         return len(intersection) / len(union) if union else 0.0
 
+    def get_statistics(self) -> Dict[str, Any]:
+        """Get handler statistics"""
+        return {
+            **self.stats,
+            "known_displays": len(self.known_displays),
+            "learned_patterns": sum(len(v) for v in self.learned_patterns.values()),
+            "cache_size": len(self.resolution_cache),
+            "action_keywords_learned": {
+                action.value: len(keywords) for action, keywords in self.action_keywords.items()
+            },
+            "mode_keywords_learned": {
+                mode.value: len(keywords) for mode, keywords in self.mode_keywords.items()
+            },
+        }
+
+    def get_display_stats(self, display_name: str) -> Optional[Dict[str, Any]]:
+        """Get statistics for a specific display"""
+        if display_name in self.known_displays:
+            event = self.known_displays[display_name]
+            return {
+                "display_name": event.display_name,
+                "display_id": event.display_id,
+                "first_detected": event.detected_at.isoformat(),
+                "last_seen": event.last_seen.isoformat(),
+                "detection_count": event.detection_count,
+                "connection_attempts": event.connection_attempts,
+                "successful_connections": event.successful_connections,
+                "success_rate": (
+                    event.successful_connections / event.connection_attempts
+                    if event.connection_attempts > 0
+                    else 0.0
+                ),
+            }
+        return None
+
+    def get_known_displays(self) -> List[str]:
+        """Get list of known display names"""
+        return list(self.known_displays.keys())
+
+    def _record_command(self, command: str, reference: DisplayReference):
+        """Record command in history"""
+        self.command_history.append(
+            {"command": command, "reference": reference.to_dict(), "timestamp": datetime.now()}
+        )
+
 
 # =============================================================================
 # BACKWARDS COMPATIBILITY ALIAS

--- a/backend/context_intelligence/handlers/temporal_query_handler.py
+++ b/backend/context_intelligence/handlers/temporal_query_handler.py
@@ -1076,6 +1076,867 @@ class TemporalQueryHandler:
 
         return "; ".join(summary_parts)
 
+    def _save_learned_patterns(self):
+        """Save learned patterns to disk (v3.0)."""
+        try:
+            import json
+            import os
+
+            pattern_file = os.path.expanduser('~/.jarvis/learned_patterns.json')
+            os.makedirs(os.path.dirname(pattern_file), exist_ok=True)
+
+            with open(pattern_file, 'w') as f:
+                json.dump(self.learned_patterns, f, indent=2)
+
+            logger.info(f"[TEMPORAL-HANDLER] Saved {len(self.learned_patterns)} patterns to {pattern_file}")
+
+        except Exception as e:
+            logger.warning(f"[TEMPORAL-HANDLER] Could not save patterns: {e}")
+
+    async def _detect_recent_changes(
+        self,
+        time_window_minutes: int = 60,
+        space_ids: Optional[List[int]] = None
+    ) -> List[Dict[str, Any]]:
+        """
+        Detect recent changes (fallback for non-pattern queries).
+
+        Returns:
+            List of recent changes
+        """
+        changes = []
+
+        try:
+            cutoff_time = datetime.now().timestamp() - (time_window_minutes * 60)
+            recent_alerts = [a for a in self.monitoring_alerts if a['timestamp'] >= cutoff_time]
+
+            if space_ids:
+                recent_alerts = [a for a in recent_alerts if a.get('space_id') in space_ids]
+
+            for alert in recent_alerts:
+                change = {
+                    'space_id': alert.get('space_id'),
+                    'change_type': alert.get('alert_type'),
+                    'message': alert.get('message'),
+                    'timestamp': alert['timestamp'],
+                    'severity': alert.get('severity')
+                }
+                changes.append(change)
+
+            logger.info(f"[TEMPORAL-HANDLER] Detected {len(changes)} recent changes")
+
+        except Exception as e:
+            logger.error(f"[TEMPORAL-HANDLER] Error detecting changes: {e}", exc_info=True)
+
+        return changes
+
+    async def _categorize_monitoring_alerts(self):
+        """
+        Categorize monitoring alerts into different queues (v3.0).
+        """
+        try:
+            for alert in list(self.monitoring_alerts):
+                alert_type = alert.get('alert_type', '')
+                severity = alert.get('severity', 'INFO')
+
+                # Categorize based on type
+                if 'ANOMALY' in alert_type or severity == 'CRITICAL':
+                    self.anomaly_alerts.append(alert)
+
+                elif 'PREDICTIVE' in alert_type or 'PATTERN' in alert_type:
+                    self.predictive_alerts.append(alert)
+
+                elif 'CORRELATION' in alert_type:
+                    self.correlation_alerts.append(alert)
+
+            logger.debug(f"[TEMPORAL-HANDLER] Categorized alerts: {len(self.anomaly_alerts)} anomalies, "
+                        f"{len(self.predictive_alerts)} predictive, {len(self.correlation_alerts)} correlations")
+
+        except Exception as e:
+            logger.error(f"[TEMPORAL-HANDLER] Error categorizing alerts: {e}", exc_info=True)
+
+    async def _detect_cascading_failures(
+        self,
+        time_window_minutes: int = 60,
+        space_ids: Optional[List[int]] = None
+    ) -> List[Dict[str, Any]]:
+        """
+        Detect cascading failures across spaces (v3.0).
+
+        Returns:
+            List of detected cascading failure chains
+        """
+        cascades = []
+
+        try:
+            cutoff_time = datetime.now().timestamp() - (time_window_minutes * 60)
+            error_alerts = [
+                a for a in self.monitoring_alerts
+                if a['timestamp'] >= cutoff_time and a.get('severity') in ['ERROR', 'CRITICAL']
+            ]
+
+            if space_ids:
+                error_alerts = [a for a in error_alerts if a.get('space_id') in space_ids]
+
+            # Sort by timestamp
+            error_alerts.sort(key=lambda x: x['timestamp'])
+
+            # Detect chains (errors in different spaces within 30 seconds)
+            chains = []
+            current_chain = []
+
+            for alert in error_alerts:
+                if not current_chain:
+                    current_chain.append(alert)
+                else:
+                    time_since_last = alert['timestamp'] - current_chain[-1]['timestamp']
+                    if time_since_last <= 30 and alert.get('space_id') != current_chain[-1].get('space_id'):
+                        current_chain.append(alert)
+                    else:
+                        if len(current_chain) >= 2:
+                            chains.append(current_chain)
+                        current_chain = [alert]
+
+            # Add last chain if valid
+            if len(current_chain) >= 2:
+                chains.append(current_chain)
+
+            # Create cascade objects
+            for chain in chains:
+                cascade = {
+                    'cascade_id': f"cascade_{chain[0]['timestamp']}",
+                    'chain': [
+                        {
+                            'space_id': alert.get('space_id'),
+                            'message': alert.get('message'),
+                            'timestamp': alert['timestamp']
+                        }
+                        for alert in chain
+                    ],
+                    'spaces_affected': [alert.get('space_id') for alert in chain],
+                    'duration_seconds': chain[-1]['timestamp'] - chain[0]['timestamp'],
+                    'description': f"Cascading failure across {len(chain)} spaces"
+                }
+
+                cascades.append(cascade)
+
+            logger.info(f"[TEMPORAL-HANDLER] Detected {len(cascades)} cascading failures")
+
+        except Exception as e:
+            logger.error(f"[TEMPORAL-HANDLER] Error detecting cascades: {e}", exc_info=True)
+
+        return cascades
+
+    async def _analyze_correlations(
+        self,
+        time_window_minutes: int = 60,
+        space_ids: Optional[List[int]] = None
+    ) -> List[Dict[str, Any]]:
+        """
+        Analyze correlations between spaces (v3.0).
+
+        Returns:
+            List of space correlations
+        """
+        correlations = []
+
+        try:
+            cutoff_time = datetime.now().timestamp() - (time_window_minutes * 60)
+            recent_alerts = [a for a in self.monitoring_alerts if a['timestamp'] >= cutoff_time]
+
+            if space_ids:
+                recent_alerts = [a for a in recent_alerts if a.get('space_id') in space_ids]
+
+            # Count co-occurrences between spaces
+            from collections import defaultdict
+            space_pairs = defaultdict(int)
+
+            for i, alert_a in enumerate(recent_alerts):
+                for alert_b in recent_alerts[i+1:]:
+                    space_a = alert_a.get('space_id')
+                    space_b = alert_b.get('space_id')
+
+                    if space_a != space_b:
+                        # Check if events happen close in time (within 60 seconds)
+                        time_diff = abs(alert_b['timestamp'] - alert_a['timestamp'])
+                        if time_diff <= 60:
+                            pair = tuple(sorted([space_a, space_b]))
+                            space_pairs[pair] += 1
+
+            # Report significant correlations (>= 3 co-occurrences)
+            for (space_a, space_b), count in space_pairs.items():
+                if count >= 3:
+                    correlation = {
+                        'correlation_id': f"corr_{space_a}_{space_b}",
+                        'spaces': [space_a, space_b],
+                        'co_occurrences': count,
+                        'confidence': min(0.95, 0.4 + (count * 0.1)),
+                        'description': f"Space {space_a} and Space {space_b} have correlated activity ({count} co-occurrences)"
+                    }
+
+                    correlations.append(correlation)
+
+            logger.info(f"[TEMPORAL-HANDLER] Found {len(correlations)} correlations")
+
+        except Exception as e:
+            logger.error(f"[TEMPORAL-HANDLER] Error analyzing correlations: {e}", exc_info=True)
+
+        return correlations
+
+    async def _detect_anomalies(
+        self,
+        time_window_minutes: int = 60,
+        space_ids: Optional[List[int]] = None
+    ) -> List[Dict[str, Any]]:
+        """
+        Detect anomalies in monitoring data (v3.0).
+
+        Returns:
+            List of detected anomalies
+        """
+        anomalies = []
+
+        try:
+            cutoff_time = datetime.now().timestamp() - (time_window_minutes * 60)
+            recent_alerts = [a for a in self.monitoring_alerts if a['timestamp'] >= cutoff_time]
+
+            if space_ids:
+                recent_alerts = [a for a in recent_alerts if a.get('space_id') in space_ids]
+
+            # Detect unusual spaces (spaces that rarely have activity)
+            from collections import Counter
+            space_frequency = Counter(a.get('space_id') for a in self.monitoring_alerts)
+            total_alerts = len(self.monitoring_alerts)
+
+            for alert in recent_alerts:
+                space_id = alert.get('space_id')
+                frequency = space_frequency.get(space_id, 0)
+                frequency_ratio = frequency / total_alerts if total_alerts > 0 else 0
+
+                # Anomaly: Space with <5% of total activity suddenly has an alert
+                if frequency_ratio < 0.05 and alert.get('severity') in ['ERROR', 'CRITICAL']:
+                    anomaly = {
+                        'anomaly_id': f"anomaly_{space_id}_{alert['timestamp']}",
+                        'space_id': space_id,
+                        'alert_type': alert.get('alert_type'),
+                        'severity': alert.get('severity'),
+                        'message': alert.get('message'),
+                        'reason': f"Unusual activity in Space {space_id} (only {frequency_ratio:.1%} of total alerts)",
+                        'confidence': 0.7 + (0.3 * (1 - frequency_ratio))  # Higher confidence for rarer spaces
+                    }
+
+                    anomalies.append(anomaly)
+
+            logger.info(f"[TEMPORAL-HANDLER] Detected {len(anomalies)} anomalies")
+
+        except Exception as e:
+            logger.error(f"[TEMPORAL-HANDLER] Error detecting anomalies: {e}", exc_info=True)
+
+        return anomalies
+
+    async def _generate_predictions(
+        self,
+        time_window_minutes: int = 60,
+        space_ids: Optional[List[int]] = None
+    ) -> List[Dict[str, Any]]:
+        """
+        Generate predictions based on learned patterns (v3.0).
+
+        Returns:
+            List of predicted events
+        """
+        predictions = []
+
+        try:
+            # Get recent events
+            cutoff_time = datetime.now().timestamp() - (time_window_minutes * 60)
+            recent_alerts = [a for a in self.monitoring_alerts if a['timestamp'] >= cutoff_time]
+
+            if space_ids:
+                recent_alerts = [a for a in recent_alerts if a.get('space_id') in space_ids]
+
+            # Check learned patterns
+            for pattern in self.learned_patterns:
+                # See if trigger event happened recently
+                trigger_type = pattern.get('trigger')
+                trigger_space = pattern.get('trigger_space')
+
+                for alert in recent_alerts:
+                    if (alert.get('alert_type') == trigger_type and
+                        alert.get('space_id') == trigger_space):
+
+                        # Predict outcome
+                        prediction = {
+                            'prediction_id': f"pred_{pattern['pattern_id']}_{alert['timestamp']}",
+                            'trigger_event': trigger_type,
+                            'predicted_event': pattern['outcome'],
+                            'predicted_space': pattern['outcome_space'],
+                            'confidence': pattern['confidence'],
+                            'expected_delay_seconds': pattern['avg_delay_seconds'],
+                            'based_on_pattern': pattern['pattern_id'],
+                            'description': f"Predicting {pattern['outcome']} in Space {pattern['outcome_space']} within {pattern['avg_delay_seconds']:.0f}s"
+                        }
+
+                        predictions.append(prediction)
+
+            logger.info(f"[TEMPORAL-HANDLER] Generated {len(predictions)} predictions")
+
+        except Exception as e:
+            logger.error(f"[TEMPORAL-HANDLER] Error generating predictions: {e}", exc_info=True)
+
+        return predictions
+
+    async def _analyze_patterns_from_monitoring(
+        self,
+        time_window_minutes: int = 60,
+        space_ids: Optional[List[int]] = None
+    ) -> List[Dict[str, Any]]:
+        """
+        Analyze patterns from monitoring data (v3.0).
+
+        Detects correlations like "Build in Space 5 → Error in Space 3".
+
+        Returns:
+            List of detected patterns with confidence scores
+        """
+        if not self.is_hybrid_monitoring:
+            return []
+
+        patterns = []
+
+        try:
+            # Get monitoring alerts in time window
+            cutoff_time = datetime.now().timestamp() - (time_window_minutes * 60)
+            recent_alerts = [a for a in self.monitoring_alerts if a['timestamp'] >= cutoff_time]
+
+            if space_ids:
+                recent_alerts = [a for a in recent_alerts if a.get('space_id') in space_ids]
+
+            # Group alerts by type and space
+            from collections import defaultdict
+            events_by_space = defaultdict(list)
+
+            for alert in recent_alerts:
+                space_id = alert.get('space_id')
+                event_type = alert.get('alert_type', 'UNKNOWN')
+                timestamp = alert.get('timestamp')
+
+                events_by_space[space_id].append({
+                    'type': event_type,
+                    'timestamp': timestamp,
+                    'message': alert.get('message', '')
+                })
+
+            # Detect sequential patterns (Event A → Event B within time delta)
+            for space_a, events_a in events_by_space.items():
+                for space_b, events_b in events_by_space.items():
+                    if space_a == space_b:
+                        continue
+
+                    # Look for A followed by B within 120 seconds
+                    correlations = []
+                    for event_a in events_a:
+                        for event_b in events_b:
+                            time_delta = event_b['timestamp'] - event_a['timestamp']
+                            if 0 < time_delta <= 120:  # B happens 0-120s after A
+                                correlations.append({
+                                    'trigger': event_a,
+                                    'outcome': event_b,
+                                    'delay': time_delta
+                                })
+
+                    if len(correlations) >= 2:  # Pattern must occur at least twice
+                        avg_delay = sum(c['delay'] for c in correlations) / len(correlations)
+                        confidence = min(0.95, 0.5 + (len(correlations) * 0.1))  # Higher for more occurrences
+
+                        pattern = {
+                            'pattern_id': f"pattern_{space_a}_to_{space_b}",
+                            'trigger': correlations[0]['trigger']['type'],
+                            'trigger_space': space_a,
+                            'outcome': correlations[0]['outcome']['type'],
+                            'outcome_space': space_b,
+                            'occurrences': len(correlations),
+                            'confidence': round(confidence, 2),
+                            'avg_delay_seconds': round(avg_delay, 1),
+                            'spaces': [space_a, space_b],
+                            'description': f"{correlations[0]['trigger']['type']} in Space {space_a} → {correlations[0]['outcome']['type']} in Space {space_b}"
+                        }
+
+                        patterns.append(pattern)
+
+            # Add to learned patterns
+            self.learned_patterns.extend(patterns)
+            self._save_learned_patterns()
+
+            logger.info(f"[TEMPORAL-HANDLER] Detected {len(patterns)} patterns")
+
+        except Exception as e:
+            logger.error(f"[TEMPORAL-HANDLER] Error analyzing patterns: {e}", exc_info=True)
+
+        return patterns
+
+    async def analyze_temporal_changes(
+        self,
+        query_type: TemporalQueryType,
+        time_window_minutes: int = 60,
+        space_ids: Optional[List[int]] = None
+    ) -> List[Dict[str, Any]]:
+        """
+        Analyze temporal changes based on query type (v3.0 main entry point).
+
+        Args:
+            query_type: Type of temporal analysis to perform
+            time_window_minutes: Time window to analyze
+            space_ids: Optional list of space IDs to analyze
+
+        Returns:
+            List of temporal changes/patterns detected
+        """
+        logger.info(f"[TEMPORAL-HANDLER] analyze_temporal_changes: {query_type}, window={time_window_minutes}min")
+
+        if query_type == TemporalQueryType.PATTERN_ANALYSIS:
+            return await self._analyze_patterns_from_monitoring(time_window_minutes, space_ids)
+
+        elif query_type == TemporalQueryType.PREDICTIVE_ANALYSIS:
+            return await self._generate_predictions(time_window_minutes, space_ids)
+
+        elif query_type == TemporalQueryType.ANOMALY_ANALYSIS:
+            return await self._detect_anomalies(time_window_minutes, space_ids)
+
+        elif query_type == TemporalQueryType.CORRELATION_ANALYSIS:
+            return await self._analyze_correlations(time_window_minutes, space_ids)
+
+        else:
+            # Fallback to change detection
+            return await self._detect_recent_changes(time_window_minutes, space_ids)
+
+    def _map_event_type_to_change_type(self, event_type: str) -> Optional[ChangeType]:
+        """Map monitoring event type to ChangeType"""
+        event_lower = event_type.lower()
+
+        if 'error' in event_lower:
+            if 'appeared' in event_lower or 'new' in event_lower:
+                return ChangeType.ERROR_APPEARED
+            elif 'resolved' in event_lower or 'fixed' in event_lower:
+                return ChangeType.ERROR_RESOLVED
+
+        elif 'build' in event_lower:
+            if 'completed' in event_lower or 'success' in event_lower:
+                return ChangeType.BUILD_COMPLETED
+            elif 'failed' in event_lower:
+                return ChangeType.BUILD_FAILED
+
+        elif 'process' in event_lower:
+            if 'started' in event_lower:
+                return ChangeType.PROCESS_STARTED
+            elif 'stopped' in event_lower or 'ended' in event_lower:
+                return ChangeType.PROCESS_STOPPED
+
+        return None
+
+    def _map_change_type(self, change_type_str: str) -> ChangeType:
+        """Map ChangeDetectionManager ChangeType to TemporalQueryHandler ChangeType"""
+        mapping = {
+            'CONTENT': ChangeType.CONTENT_CHANGE,
+            'LAYOUT': ChangeType.LAYOUT_CHANGE,
+            'ERROR': ChangeType.ERROR_APPEARED,
+            'VALUE': ChangeType.VALUE_CHANGED,
+            'STATUS': ChangeType.STATUS_CHANGED,
+        }
+        return mapping.get(change_type_str, ChangeType.CONTENT_CHANGE)
+
+    def _build_timeline_from_alerts(
+        self,
+        time_range: TimeRange,
+        space_id: Optional[int]
+    ) -> List[Dict[str, Any]]:
+        """Build timeline from monitoring alerts"""
+
+        relevant_alerts = [
+            alert for alert in self.monitoring_alerts
+            if time_range.start <= alert.get('timestamp', datetime.min) <= time_range.end
+            and (space_id is None or alert.get('space_id') == space_id)
+        ]
+
+        timeline = []
+        for alert in sorted(relevant_alerts, key=lambda a: a.get('timestamp', datetime.min)):
+            timeline.append({
+                'timestamp': alert.get('timestamp').isoformat(),
+                'event_type': alert.get('event_type'),
+                'message': alert.get('message'),
+                'space_id': alert.get('space_id'),
+                'priority': alert.get('priority')
+            })
+
+        return timeline
+
+    async def _handle_generic_temporal_query(
+        self,
+        resolved_query: Dict[str, Any],
+        time_range: TimeRange,
+        space_id: Optional[int]
+    ) -> TemporalQueryResult:
+        """Handle generic temporal queries"""
+
+        # Get monitoring alerts
+        relevant_alerts = [
+            alert for alert in self.monitoring_alerts
+            if time_range.start <= alert.get('timestamp', datetime.min) <= time_range.end
+            and (space_id is None or alert.get('space_id') == space_id)
+        ]
+
+        summary = f"Found {len(relevant_alerts)} event(s) in the time range."
+
+        timeline = [
+            {
+                'timestamp': alert.get('timestamp').isoformat(),
+                'event_type': alert.get('event_type'),
+                'message': alert.get('message')
+            }
+            for alert in relevant_alerts
+        ]
+
+        return TemporalQueryResult(
+            query_type=TemporalQueryType.TIMELINE,
+            time_range=time_range,
+            changes=[],
+            summary=summary,
+            timeline=timeline
+        )
+
+    async def _handle_monitoring_report(
+        self,
+        resolved_query: Dict[str, Any],
+        time_range: TimeRange,
+        space_id: Optional[int]
+    ) -> TemporalQueryResult:
+        """
+        Handle 'What has monitoring detected?' queries.
+
+        Returns all monitoring alerts in time range.
+        """
+        logger.debug(f"[TEMPORAL-HANDLER] Monitoring report")
+
+        # Filter monitoring alerts
+        relevant_alerts = [
+            alert for alert in self.monitoring_alerts
+            if time_range.start <= alert.get('timestamp', datetime.min) <= time_range.end
+            and (space_id is None or alert.get('space_id') == space_id)
+        ]
+
+        # Group by priority
+        by_priority = defaultdict(list)
+        for alert in relevant_alerts:
+            by_priority[alert.get('priority', 'MEDIUM')].append(alert)
+
+        # Build summary
+        summary_parts = []
+        for priority in ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW']:
+            count = len(by_priority.get(priority, []))
+            if count > 0:
+                summary_parts.append(f"{count} {priority}")
+
+        if summary_parts:
+            summary = f"Monitoring detected {len(relevant_alerts)} event(s): " + ", ".join(summary_parts)
+        else:
+            summary = "No monitoring alerts in the time range."
+
+        # Build timeline
+        timeline = [
+            {
+                'timestamp': alert.get('timestamp').isoformat(),
+                'event_type': alert.get('event_type'),
+                'message': alert.get('message'),
+                'space_id': alert.get('space_id'),
+                'priority': alert.get('priority')
+            }
+            for alert in sorted(relevant_alerts, key=lambda a: a.get('timestamp', datetime.min))
+        ]
+
+        return TemporalQueryResult(
+            query_type=TemporalQueryType.MONITORING_REPORT,
+            time_range=time_range,
+            changes=[],
+            summary=summary,
+            timeline=timeline,
+            metadata={'alert_count_by_priority': dict(by_priority)}
+        )
+
+    async def _handle_comparison(
+        self,
+        resolved_query: Dict[str, Any],
+        time_range: TimeRange,
+        space_id: Optional[int]
+    ) -> TemporalQueryResult:
+        """
+        Handle 'How is this different from before?' queries.
+
+        Uses ChangeDetectionManager to compare snapshots.
+        """
+        logger.debug(f"[TEMPORAL-HANDLER] Comparison query for space {space_id}")
+
+        if not self.change_detection or space_id is None:
+            return TemporalQueryResult(
+                query_type=TemporalQueryType.COMPARISON,
+                time_range=time_range,
+                changes=[],
+                summary="ChangeDetectionManager not available or space_id required for comparison.",
+                timeline=[]
+            )
+
+        try:
+            # Get change detection result
+            change_result = await self.change_detection.detect_changes(
+                space_id=space_id,
+                query=resolved_query.get('original_query'),
+                context=resolved_query
+            )
+
+            # Convert to changes
+            changes = []
+            if change_result.changed:
+                changes.append(DetectedChange(
+                    change_type=self._map_change_type(change_result.change_type),
+                    timestamp=datetime.now(),
+                    space_id=space_id,
+                    description=change_result.summary or "Changes detected",
+                    confidence=change_result.similarity_score,
+                    metadata={
+                        'elapsed_time': change_result.elapsed_time,
+                        'differences': change_result.differences
+                    }
+                ))
+
+            # Build summary
+            if not changes:
+                summary = f"No significant changes detected in space {space_id}."
+            else:
+                summary = f"Comparison for space {space_id}: {change_result.summary}"
+
+            return TemporalQueryResult(
+                query_type=TemporalQueryType.COMPARISON,
+                time_range=time_range,
+                changes=changes,
+                summary=summary,
+                timeline=[]
+            )
+
+        except Exception as e:
+            logger.error(f"[TEMPORAL-HANDLER] Comparison failed: {e}")
+            return TemporalQueryResult(
+                query_type=TemporalQueryType.COMPARISON,
+                time_range=time_range,
+                changes=[],
+                summary=f"Comparison failed: {e}",
+                timeline=[]
+            )
+
+    async def _handle_first_appearance(
+        self,
+        resolved_query: Dict[str, Any],
+        time_range: TimeRange,
+        space_id: Optional[int]
+    ) -> TemporalQueryResult:
+        """
+        Handle 'When did this first appear?' queries.
+
+        Searches monitoring alerts and entity states.
+        """
+        logger.debug(f"[TEMPORAL-HANDLER] First appearance query")
+
+        # Get entity from resolved query
+        entity = resolved_query.get('resolved_entities', {}).get('error') or \
+                 resolved_query.get('resolved_entities', {}).get('element') or \
+                 resolved_query.get('resolved_entities', {}).get('entity')
+
+        # Search monitoring alerts
+        matching_alerts = []
+        for alert in self.monitoring_alerts:
+            if entity and entity.lower() in alert.get('message', '').lower():
+                matching_alerts.append(alert)
+
+        # Find first appearance
+        first_alert = None
+        if matching_alerts:
+            first_alert = min(matching_alerts, key=lambda a: a.get('timestamp', datetime.max))
+
+        # Use ChangeDetectionManager to query entity states
+        if self.change_detection and entity:
+            try:
+                entity_states = self.change_detection.get_entity_states(entity)
+                if entity_states:
+                    first_state = min(entity_states, key=lambda s: s.first_seen)
+                    if not first_alert or first_state.first_seen < first_alert.get('timestamp'):
+                        summary = f"First appeared at {first_state.first_seen.strftime('%I:%M:%S %p')} ({(datetime.now() - first_state.first_seen).total_seconds():.0f} seconds ago)"
+                        return TemporalQueryResult(
+                            query_type=TemporalQueryType.FIRST_APPEARANCE,
+                            time_range=time_range,
+                            changes=[],
+                            summary=summary,
+                            timeline=[],
+                            metadata={'first_appearance': first_state.first_seen.isoformat()}
+                        )
+            except Exception as e:
+                logger.warning(f"[TEMPORAL-HANDLER] Entity state lookup failed: {e}")
+
+        # Fallback to monitoring alerts
+        if first_alert:
+            summary = f"First appeared at {first_alert.get('timestamp').strftime('%I:%M:%S %p')} ({(datetime.now() - first_alert.get('timestamp')).total_seconds():.0f} seconds ago)"
+            metadata = {'first_appearance': first_alert.get('timestamp').isoformat()}
+        else:
+            summary = "Could not determine first appearance in the given time range."
+            metadata = {}
+
+        return TemporalQueryResult(
+            query_type=TemporalQueryType.FIRST_APPEARANCE,
+            time_range=time_range,
+            changes=[],
+            summary=summary,
+            timeline=[],
+            metadata=metadata
+        )
+
+    async def _handle_timeline(
+        self,
+        resolved_query: Dict[str, Any],
+        time_range: TimeRange,
+        space_id: Optional[int]
+    ) -> TemporalQueryResult:
+        """
+        Handle 'What's new in last 5 minutes?' queries.
+
+        Builds timeline from monitoring alerts.
+        """
+        logger.debug(f"[TEMPORAL-HANDLER] Timeline for space {space_id}")
+
+        # Filter monitoring alerts in time range
+        relevant_alerts = [
+            alert for alert in self.monitoring_alerts
+            if time_range.start <= alert.get('timestamp', datetime.min) <= time_range.end
+            and (space_id is None or alert.get('space_id') == space_id)
+        ]
+
+        # Build timeline
+        timeline = []
+        changes = []
+
+        for alert in relevant_alerts:
+            timeline.append({
+                'timestamp': alert.get('timestamp').isoformat(),
+                'event_type': alert.get('event_type'),
+                'message': alert.get('message'),
+                'space_id': alert.get('space_id'),
+                'priority': alert.get('priority')
+            })
+
+            # Convert to DetectedChange
+            change_type = self._map_event_type_to_change_type(alert.get('event_type', ''))
+            if change_type:
+                changes.append(DetectedChange(
+                    change_type=change_type,
+                    timestamp=alert.get('timestamp', datetime.now()),
+                    space_id=alert.get('space_id'),
+                    description=alert.get('message', 'Event detected'),
+                    confidence=0.8,
+                    metadata=alert.get('metadata', {})
+                ))
+
+        # Build summary
+        summary = f"Timeline of {len(relevant_alerts)} event(s) over {time_range.duration_seconds:.0f} seconds. "
+        if changes:
+            summary += f"{len(changes)} change(s) detected."
+        else:
+            summary += "No significant changes."
+
+        return TemporalQueryResult(
+            query_type=TemporalQueryType.TIMELINE,
+            time_range=time_range,
+            changes=changes,
+            summary=summary,
+            timeline=timeline
+        )
+
+    async def _handle_error_tracking(
+        self,
+        resolved_query: Dict[str, Any],
+        time_range: TimeRange,
+        space_id: Optional[int]
+    ) -> TemporalQueryResult:
+        """
+        Handle 'Has the error been fixed?' queries.
+
+        Uses monitoring alerts to track error state changes.
+        """
+        logger.debug(f"[TEMPORAL-HANDLER] Error tracking for space {space_id}")
+
+        # Filter monitoring alerts for error events
+        error_alerts = [
+            alert for alert in self.monitoring_alerts
+            if time_range.start <= alert.get('timestamp', datetime.min) <= time_range.end
+            and (space_id is None or alert.get('space_id') == space_id)
+            and 'error' in alert.get('event_type', '').lower()
+        ]
+
+        # Classify error events
+        errors_appeared = [a for a in error_alerts if 'appeared' in a.get('event_type', '').lower() or 'new' in a.get('event_type', '').lower()]
+        errors_resolved = [a for a in error_alerts if 'resolved' in a.get('event_type', '').lower() or 'fixed' in a.get('event_type', '').lower()]
+
+        # Build changes list
+        changes = []
+
+        for alert in errors_appeared:
+            changes.append(DetectedChange(
+                change_type=ChangeType.ERROR_APPEARED,
+                timestamp=alert.get('timestamp', datetime.now()),
+                space_id=alert.get('space_id'),
+                description=alert.get('message', 'Error appeared'),
+                confidence=0.9,
+                metadata=alert.get('metadata', {})
+            ))
+
+        for alert in errors_resolved:
+            changes.append(DetectedChange(
+                change_type=ChangeType.ERROR_RESOLVED,
+                timestamp=alert.get('timestamp', datetime.now()),
+                space_id=alert.get('space_id'),
+                description=alert.get('message', 'Error resolved'),
+                confidence=0.9,
+                metadata=alert.get('metadata', {})
+            ))
+
+        # Build summary
+        if not changes:
+            summary = "No error state changes detected in the time range."
+        else:
+            appeared_count = len(errors_appeared)
+            resolved_count = len(errors_resolved)
+
+            if resolved_count > appeared_count:
+                summary = f"✅ Errors have been fixed! {resolved_count} error(s) resolved, {appeared_count} new error(s) appeared."
+            elif appeared_count > resolved_count:
+                summary = f"❌ New errors appeared. {appeared_count} error(s) appeared, {resolved_count} error(s) resolved."
+            else:
+                summary = f"Error status mixed: {appeared_count} error(s) appeared and resolved."
+
+        # Build timeline
+        timeline = [
+            {
+                'timestamp': alert.get('timestamp').isoformat(),
+                'event_type': alert.get('event_type'),
+                'message': alert.get('message'),
+                'space_id': alert.get('space_id')
+            }
+            for alert in error_alerts
+        ]
+
+        return TemporalQueryResult(
+            query_type=TemporalQueryType.ERROR_TRACKING,
+            time_range=time_range,
+            changes=sorted(changes, key=lambda c: c.timestamp),
+            summary=summary,
+            timeline=timeline
+        )
+
 
 # =============================================================================
 # GLOBAL HANDLER INSTANCE & FACTORY FUNCTIONS

--- a/backend/core/context/multi_space_context_graph.py
+++ b/backend/core/context/multi_space_context_graph.py
@@ -29,12 +29,15 @@ Integration Points:
     - FeedbackLearningLoop (core/learning/feedback_loop.py)
 """
 
+import asyncio
+import json
 import logging
 from collections import deque
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from enum import Enum
-from typing import Any, Dict, List, Optional, Set, Tuple, Union
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 
 logger = logging.getLogger(__name__)
 
@@ -915,26 +918,74 @@ class MultiSpaceContextGraph:
 
     def __init__(
         self,
+        context_store=None,
+        decay_ttl_seconds: Optional[int] = None,
+        enable_cross_space_correlation: bool = True,
         max_history_size: int = 1000,
-        temporal_decay_minutes: int = 5,
+        temporal_decay_minutes: Optional[int] = None,
     ):
         """
         Initialize the Multi-Space Context Graph.
 
+        TWO PARAMETER SETS, BOTH LIVE
+        ------------------------------
+        Commit 4406e11941 rewrote this signature from
+        `(context_store, decay_ttl_seconds, enable_cross_space_correlation)`
+        to `(max_history_size, temporal_decay_minutes)` and deleted the
+        nineteen methods that used the first set. Callers then split:
+        `context_integration_bridge` was adapted to the new names, while
+        `backend/tests/test_multi_space_context_graph.py` still constructs
+        with `decay_ttl_seconds=300` — and had been failing ever since.
+
+        Neither set is wrong and they do not conflict, so both are accepted
+        rather than one consumer being broken to satisfy the other. The two
+        decay knobs express the same quantity in different units and are kept
+        consistent below; passing neither yields the historical default of
+        five minutes.
+
         Args:
+            context_store: Optional ContextStore backend for persistence
+            decay_ttl_seconds: How long to keep context before decay
+            enable_cross_space_correlation: Enable cross-space detection
             max_history_size: Maximum activities to store per space
-            temporal_decay_minutes: Minutes before context decays
+            temporal_decay_minutes: Decay window, in minutes
         """
+        # One quantity, two units. An explicit value in either unit wins; the
+        # other is derived so no method can read a stale companion value.
+        if decay_ttl_seconds is None and temporal_decay_minutes is None:
+            decay_ttl_seconds = 300
+        elif decay_ttl_seconds is None:
+            decay_ttl_seconds = int(temporal_decay_minutes) * 60
+        temporal_decay_minutes = decay_ttl_seconds / 60.0
+
+        # Core state
         self.spaces: Dict[int, SpaceContext] = {}
-        self.correlator = CrossSpaceCorrelator()
-        self.max_history_size = max_history_size
+        self.current_space_id: Optional[int] = None
+
+        # Temporal decay configuration
+        self.decay_ttl = timedelta(seconds=decay_ttl_seconds)
         self.temporal_decay_minutes = temporal_decay_minutes
+        self._decay_task: Optional["asyncio.Task"] = None
+
+        # Cross-space correlation
+        self.enable_correlation = enable_cross_space_correlation
+        self.correlator = (CrossSpaceCorrelator()
+                           if enable_cross_space_correlation else None)
+        self._correlation_task: Optional["asyncio.Task"] = None
+
+        # Integration with existing systems
+        self.context_store = context_store
+        self.max_history_size = max_history_size
         self._initialized = False
 
+        # Callbacks for external systems
+        self.on_critical_event: Optional[Callable] = None
+        self.on_relationship_detected: Optional[Callable] = None
+
         logger.info(
-            f"Initialized MultiSpaceContextGraph "
-            f"(history={max_history_size}, decay={temporal_decay_minutes}m)"
-        )
+            "[MULTI-SPACE-GRAPH] Initialized with decay_ttl=%ss, "
+            "history=%s, correlation=%s",
+            decay_ttl_seconds, max_history_size, enable_cross_space_correlation)
 
     async def initialize(self):
         """Initialize the context graph and start monitoring."""
@@ -1096,6 +1147,408 @@ class MultiSpaceContextGraph:
 
         logger.debug(f"Cleaned up contexts older than {self.temporal_decay_minutes} minutes")
 
+    def export_to_json(self, filepath: Path):
+        """Export current state to JSON for debugging/analysis"""
+        summary = self.get_summary()
+        with open(filepath, 'w') as f:
+            json.dump(summary, f, indent=2, default=str)
+        logger.info(f"[MULTI-SPACE-GRAPH] Exported state to {filepath}")
+
+    def get_summary(self) -> Dict[str, Any]:
+        """Get comprehensive summary of current context graph state"""
+        return {
+            "total_spaces": len(self.spaces),
+            "current_space_id": self.current_space_id,
+            "active_spaces": [s.space_id for s in self.spaces.values() if s.is_active],
+            "spaces": {
+                space_id: space.to_dict()
+                for space_id, space in self.spaces.items()
+            },
+            "cross_space_relationships": [
+                {
+                    "relationship_id": rel.relationship_id,
+                    "type": rel.relationship_type,
+                    "involved_spaces": rel.involved_spaces,
+                    "confidence": rel.confidence,
+                    "description": rel.description
+                }
+                for rel in (self.correlator.relationships.values() if self.correlator else [])
+            ] if self.enable_correlation else [],
+            "decay_ttl_seconds": self.decay_ttl.total_seconds()
+        }
+
+    async def _safe_callback(self, callback: Callable, *args, **kwargs):
+        """Safely execute callback without crashing the graph"""
+        try:
+            if asyncio.iscoroutinefunction(callback):
+                await callback(*args, **kwargs)
+            else:
+                callback(*args, **kwargs)
+        except Exception as e:
+            logger.error(f"[MULTI-SPACE-GRAPH] Error in callback: {e}")
+
+    async def _correlation_loop(self):
+        """Background task to detect cross-space correlations"""
+        while True:
+            try:
+                await asyncio.sleep(15)  # Check every 15 seconds
+                if self.correlator:
+                    relationships = await self.correlator.analyze_relationships(self.spaces)
+
+                    if relationships and self.on_relationship_detected:
+                        for rel in relationships:
+                            await self._safe_callback(self.on_relationship_detected, rel)
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.error(f"[MULTI-SPACE-GRAPH] Error in correlation loop: {e}")
+
+    async def _apply_decay(self):
+        """Remove or decay old context based on TTL"""
+        cutoff = datetime.now() - self.decay_ttl
+        spaces_to_remove = []
+
+        for space_id, space in self.spaces.items():
+            # If space hasn't been active recently, consider removing it
+            if space.last_activity < cutoff and not space.is_active:
+                # But only if it has no recent critical events
+                recent_critical = any(
+                    e.significance == ActivitySignificance.CRITICAL
+                    for e in space.get_recent_events(within_seconds=self.decay_ttl.total_seconds())
+                )
+                if not recent_critical:
+                    spaces_to_remove.append(space_id)
+
+        for space_id in spaces_to_remove:
+            logger.info(f"[MULTI-SPACE-GRAPH] Decaying Space {space_id} (inactive for {self.decay_ttl})")
+            self.remove_space(space_id)
+
+    async def _decay_loop(self):
+        """Background task to decay old context"""
+        while True:
+            try:
+                await asyncio.sleep(60)  # Check every minute
+                await self._apply_decay()
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.error(f"[MULTI-SPACE-GRAPH] Error in decay loop: {e}")
+
+    def get_cross_space_summary(self) -> str:
+        """
+        Generate natural language summary of cross-space activity.
+
+        This is what JARVIS uses to say things like:
+        "I see you're debugging an error in Space 1, researching solutions in Space 3,
+         and editing the fix in Space 2."
+        """
+        if not self.correlator or not self.correlator.relationships:
+            return "No cross-space relationships detected."
+
+        summaries = []
+        for rel in self.correlator.relationships.values():
+            if (datetime.now() - rel.last_detected).total_seconds() < 300:  # Recent (5 minutes)
+                summaries.append(rel.description)
+
+        if summaries:
+            return " ".join(summaries)
+        else:
+            return "No recent cross-space activity."
+
+    def find_context_for_query(self, query: str) -> Dict[str, Any]:
+        """
+        Find relevant context based on natural language query.
+
+        Examples:
+        - "what does it say?" → Find most recent error/message
+        - "what's the error?" → Find most recent error
+        - "what's happening in the terminal?" → Find terminal context
+
+        This is the foundation for implicit reference resolution.
+        """
+        query_lower = query.lower()
+
+        # Implicit reference queries - "what does it say?" "what happened?" etc.
+        # These should check for the most critical/recent thing first
+        implicit_queries = ["what does it say", "what did it say", "what happened", "what's that"]
+        if any(q in query_lower for q in implicit_queries):
+            # First check for errors (most important)
+            error = self.find_most_recent_error()
+            if error:
+                space_id, app_name, details = error
+                return {
+                    "type": "error",
+                    "space_id": space_id,
+                    "app_name": app_name,
+                    "details": details,
+                    "message": f"The error in {app_name} (Space {space_id}) is: {details.get('error', 'Unknown error')}"
+                }
+
+        # Error-related queries
+        if any(word in query_lower for word in ["error", "wrong", "failed", "problem"]):
+            error = self.find_most_recent_error()
+            if error:
+                space_id, app_name, details = error
+                return {
+                    "type": "error",
+                    "space_id": space_id,
+                    "app_name": app_name,
+                    "details": details,
+                    "message": f"The error in {app_name} (Space {space_id}) is: {details.get('error', 'Unknown error')}"
+                }
+
+        # Terminal-specific queries
+        if "terminal" in query_lower:
+            # Find most recent terminal activity
+            for space in sorted(self.spaces.values(), key=lambda s: s.last_activity, reverse=True):
+                for app_name, app_ctx in space.applications.items():
+                    if app_ctx.context_type == ContextType.TERMINAL and app_ctx.is_recent():
+                        terminal = app_ctx.terminal_context
+                        return {
+                            "type": "terminal",
+                            "space_id": space.space_id,
+                            "app_name": app_name,
+                            "last_command": terminal.last_command if terminal else None,
+                            "last_output": terminal.last_output if terminal else None,
+                            "errors": terminal.errors if terminal else []
+                        }
+
+        # Current space context
+        if self.current_space_id and self.current_space_id in self.spaces:
+            current_space = self.spaces[self.current_space_id]
+            return {
+                "type": "current_space",
+                "space_id": current_space.space_id,
+                "applications": list(current_space.applications.keys()),
+                "recent_events": [e.to_dict() for e in current_space.get_recent_events()]
+            }
+
+        return {"type": "no_relevant_context", "message": "I don't see any recent activity to reference."}
+
+    def find_most_recent_error(self, within_seconds: int = 300) -> Optional[Tuple[int, str, Dict[str, Any]]]:
+        """
+        Find the most recent error across all spaces.
+
+        This is what powers "what does it say?" when there's an error on screen.
+
+        Returns: (space_id, app_name, error_details) or None
+        """
+        most_recent = None
+        most_recent_time = None
+
+        for space in self.spaces.values():
+            errors = space.get_recent_errors(within_seconds=within_seconds)
+            for app_name, event in errors:
+                if most_recent_time is None or event.timestamp > most_recent_time:
+                    most_recent_time = event.timestamp
+                    most_recent = (space.space_id, app_name, event.details)
+
+        return most_recent
+
+    def update_generic_context(self, space_id: int, app_name: str, content: str):
+        """Update generic application context (fallback for unknown app types)"""
+        space = self.get_or_create_space(space_id)
+        app_ctx = space.add_application(app_name, ContextType.GENERIC)
+
+        if app_ctx.generic_context is None:
+            app_ctx.generic_context = GenericAppContext()
+
+        generic = app_ctx.generic_context
+        generic.extracted_text = content[:500]  # Store first 500 chars
+        generic.interaction_count += 1
+        generic.last_interaction = datetime.now()
+
+        app_ctx.update_activity(ActivitySignificance.LOW)
+        logger.debug(f"[MULTI-SPACE-GRAPH] Updated generic context: Space {space_id}, {app_name}")
+
+    def add_screenshot_reference(self,
+                                space_id: int,
+                                app_name: str,
+                                screenshot_path: str,
+                                ocr_text: Optional[str] = None):
+        """Add screenshot reference to application context"""
+        space = self.get_or_create_space(space_id)
+        if app_name in space.applications:
+            space.applications[app_name].add_screenshot(screenshot_path, ocr_text)
+
+    def update_ide_context(self,
+                          space_id: int,
+                          app_name: str,
+                          active_file: Optional[str] = None,
+                          open_files: Optional[List[str]] = None,
+                          errors: Optional[List[str]] = None):
+        """Update IDE context in a specific space"""
+        space = self.get_or_create_space(space_id)
+        app_ctx = space.add_application(app_name, ContextType.IDE)
+
+        if app_ctx.ide_context is None:
+            app_ctx.ide_context = IDEContext()
+
+        ide = app_ctx.ide_context
+
+        if active_file:
+            ide.active_file = active_file
+        if open_files:
+            ide.open_files = open_files
+        if errors:
+            ide.errors_in_file.extend(errors)
+            significance = ActivitySignificance.HIGH
+        else:
+            significance = ActivitySignificance.NORMAL
+
+        app_ctx.update_activity(significance)
+        logger.debug(f"[MULTI-SPACE-GRAPH] Updated IDE context: Space {space_id}, {app_name}")
+
+    def update_browser_context(self,
+                              space_id: int,
+                              app_name: str,
+                              url: Optional[str] = None,
+                              title: Optional[str] = None,
+                              extracted_text: Optional[str] = None,
+                              search_query: Optional[str] = None):
+        """Update browser context in a specific space"""
+        space = self.get_or_create_space(space_id)
+        app_ctx = space.add_application(app_name, ContextType.BROWSER)
+
+        if app_ctx.browser_context is None:
+            app_ctx.browser_context = BrowserContext()
+
+        browser = app_ctx.browser_context
+
+        if url:
+            browser.active_url = url
+        if title:
+            browser.page_title = title
+        if extracted_text:
+            browser.reading_content = extracted_text
+            # Detect if this looks like research
+            research_indicators = ["documentation", "docs", "stack overflow", "github", "tutorial", "guide"]
+            if any(indicator in extracted_text.lower() for indicator in research_indicators):
+                browser.is_researching = True
+        if search_query:
+            browser.search_query = search_query
+            browser.is_researching = True
+
+        significance = ActivitySignificance.HIGH if browser.is_researching else ActivitySignificance.NORMAL
+        app_ctx.update_activity(significance)
+
+        logger.debug(f"[MULTI-SPACE-GRAPH] Updated browser context: Space {space_id}, {app_name}")
+
+    def update_terminal_context(self,
+                                space_id: int,
+                                app_name: str,
+                                command: Optional[str] = None,
+                                output: Optional[str] = None,
+                                errors: Optional[List[str]] = None,
+                                exit_code: Optional[int] = None,
+                                working_dir: Optional[str] = None):
+        """
+        Update terminal context in a specific space.
+
+        This is called when we detect terminal activity via OCR or system monitoring.
+        """
+        space = self.get_or_create_space(space_id)
+        app_ctx = space.add_application(app_name, ContextType.TERMINAL)
+
+        if app_ctx.terminal_context is None:
+            app_ctx.terminal_context = TerminalContext()
+
+        terminal = app_ctx.terminal_context
+
+        if command:
+            terminal.last_command = command
+            terminal.recent_commands.append((command, datetime.now()))
+        if output:
+            terminal.last_output = output
+        if errors:
+            terminal.errors.extend(errors)
+            # Critical event - terminal error!
+            significance = ActivitySignificance.CRITICAL
+            space.add_event(ActivityEvent(
+                event_type="terminal_error",
+                timestamp=datetime.now(),
+                app_name=app_name,
+                significance=significance,
+                details={"errors": errors, "command": command}
+            ))
+
+            if self.on_critical_event:
+                asyncio.create_task(self._safe_callback(self.on_critical_event, {
+                    "type": "terminal_error",
+                    "space_id": space_id,
+                    "app_name": app_name,
+                    "errors": errors,
+                    "command": command
+                }))
+        if exit_code is not None:
+            terminal.exit_code = exit_code
+            if exit_code != 0:
+                significance = ActivitySignificance.HIGH
+            else:
+                significance = ActivitySignificance.NORMAL
+        else:
+            significance = ActivitySignificance.NORMAL
+        if working_dir:
+            terminal.working_directory = working_dir
+
+        app_ctx.update_activity(significance)
+        logger.debug(f"[MULTI-SPACE-GRAPH] Updated terminal context: Space {space_id}, {app_name}")
+
+    def remove_space(self, space_id: int):
+        """Remove a space from tracking"""
+        if space_id in self.spaces:
+            del self.spaces[space_id]
+            logger.info(f"[MULTI-SPACE-GRAPH] Removed Space {space_id}")
+
+    def set_active_space(self, space_id: int):
+        """Mark a space as currently active"""
+        # Deactivate previous space
+        if self.current_space_id is not None and self.current_space_id in self.spaces:
+            self.spaces[self.current_space_id].deactivate()
+
+        # Activate new space
+        space = self.get_or_create_space(space_id)
+        space.activate()
+        self.current_space_id = space_id
+
+        logger.debug(f"[MULTI-SPACE-GRAPH] Switched to Space {space_id}")
+
+    def get_or_create_space(self, space_id: int) -> SpaceContext:
+        """Get existing space context or create new one"""
+        if space_id not in self.spaces:
+            self.spaces[space_id] = SpaceContext(space_id)
+            logger.info(f"[MULTI-SPACE-GRAPH] Created new space context: Space {space_id}")
+
+        return self.spaces[space_id]
+
+    async def stop(self):
+        """Stop background tasks"""
+        if self._decay_task:
+            self._decay_task.cancel()
+            try:
+                await self._decay_task
+            except asyncio.CancelledError:
+                pass
+
+        if self._correlation_task:
+            self._correlation_task.cancel()
+            try:
+                await self._correlation_task
+            except asyncio.CancelledError:
+                pass
+
+        logger.info("[MULTI-SPACE-GRAPH] Stopped all background tasks")
+
+    async def start(self):
+        """Start background tasks (decay, correlation)"""
+        if self._decay_task is None or self._decay_task.done():
+            self._decay_task = asyncio.create_task(self._decay_loop())
+            logger.info("[MULTI-SPACE-GRAPH] Started decay loop")
+
+        if self.enable_correlation and (self._correlation_task is None or self._correlation_task.done()):
+            self._correlation_task = asyncio.create_task(self._correlation_loop())
+            logger.info("[MULTI-SPACE-GRAPH] Started correlation loop")
+
 
 # ============================================================================
 # SINGLETON PATTERN - Global accessor
@@ -1153,3 +1606,16 @@ if __name__ == "__main__":
 
     logging.basicConfig(level=logging.INFO)
     asyncio.run(test_multi_space_context())
+
+
+def set_context_graph(graph: MultiSpaceContextGraph):
+    """Set the global context graph (for testing or custom configuration)"""
+    global _global_context_graph
+    _global_context_graph = graph
+
+def get_context_graph() -> MultiSpaceContextGraph:
+    """Get or create the global context graph singleton"""
+    global _global_context_graph
+    if _global_context_graph is None:
+        _global_context_graph = MultiSpaceContextGraph()
+    return _global_context_graph

--- a/backend/core/hybrid_orchestrator.py
+++ b/backend/core/hybrid_orchestrator.py
@@ -1761,6 +1761,264 @@ Classification:"""
 
         return result
 
+    async def trigger_cost_optimization(self) -> Dict[str, Any]:
+        """
+        Check if cost optimization should be triggered (GCP shutdown)
+        Based on:
+        - GCP idle time >10 minutes
+        - Local RAM pressure <40%
+        - No pending high-priority tasks
+
+        Returns:
+            Dict with optimization actions taken
+        """
+        ram_monitor_factory = _get_ram_monitor()
+        if not ram_monitor_factory:
+            return {"error": "RAM monitor not available"}
+
+        ram_monitor = ram_monitor_factory(self.client.config)
+        current_pressure = ram_monitor.get_current_pressure_percent()
+
+        gcp_idle = self.router._get_backend_idle_minutes("gcp")
+        local_pressure_ok = current_pressure < 40  # Local has capacity
+        gcp_been_idle = gcp_idle > 10  # GCP idle for >10 minutes
+
+        if local_pressure_ok and gcp_been_idle:
+            logger.info(
+                f"💰 Cost optimization triggered: Local RAM {current_pressure:.1f}%, "
+                f"GCP idle {gcp_idle:.1f}min"
+            )
+
+            # TODO: Implement GCP shutdown logic
+            # For now, just return recommendation
+            return {
+                "action": "recommend_gcp_shutdown",
+                "reason": "Cost optimization - local has capacity, GCP idle",
+                "local_ram_percent": current_pressure,
+                "gcp_idle_minutes": gcp_idle,
+                "estimated_savings": "$0.029/hr (~$0.48/day if idle)",
+            }
+        else:
+            return {
+                "action": "no_optimization",
+                "reason": "Conditions not met",
+                "local_ram_percent": current_pressure,
+                "gcp_idle_minutes": gcp_idle,
+                "local_pressure_ok": local_pressure_ok,
+                "gcp_been_idle": gcp_been_idle,
+            }
+
+    def get_activity_summary(self) -> Dict[str, Any]:
+        """Get activity summary for all backends"""
+        return self.router._get_activity_summary()
+
+    def get_idle_time(self, backend_name: str) -> float:
+        """Get idle time in minutes for a backend"""
+        return self.router._get_backend_idle_minutes(backend_name)
+
+    def get_backends_for_capability(self, capability: str) -> List[str]:
+        """Get list of backends that support a capability"""
+        return self.router.get_backends_for_capability(capability)
+
+    def get_backend_capabilities(self, backend_name: str) -> List[str]:
+        """Get capabilities for a specific backend"""
+        if backend_name in self.client.backends:
+            return self.client.backends[backend_name].capabilities
+        return []
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """Async context manager exit"""
+        await self.stop()
+
+    async def __aenter__(self):
+        """Async context manager entry"""
+        await self.start()
+        return self
+
+    def get_detailed_diagnostics(self) -> Dict[str, Any]:
+        """
+        Get comprehensive diagnostics for debugging
+        Includes Phase 2.5 features: idle tracking, capabilities, cost optimization
+        """
+        # Get RAM monitor status
+        ram_monitor_factory = _get_ram_monitor()
+        ram_status = None
+        if ram_monitor_factory:
+            try:
+                ram_monitor = ram_monitor_factory(self.client.config)
+                ram_status = {
+                    "current_pressure_percent": ram_monitor.get_current_pressure_percent(),
+                    "should_prefer_gcp": ram_monitor.should_prefer_gcp(),
+                    "should_force_gcp": ram_monitor.should_force_gcp(),
+                    "can_reclaim_to_local": ram_monitor.can_reclaim_to_local(),
+                    "monitoring_active": ram_monitor.is_running,
+                }
+            except Exception as e:
+                ram_status = {"error": str(e)}
+
+        # Get cost optimization status
+        gcp_idle = self.router._get_backend_idle_minutes("gcp")
+        local_idle = self.router._get_backend_idle_minutes("local")
+
+        return {
+            "orchestrator": {
+                "running": self.is_running,
+                "request_count": self.request_count,
+            },
+            "ram_monitor": ram_status,
+            "backends": {
+                name: {
+                    "type": backend.type.value,
+                    "priority": backend.priority,
+                    "enabled": backend.enabled,
+                    "healthy": backend.health.healthy,
+                    "idle_minutes": round(self.router._get_backend_idle_minutes(name), 2),
+                    "capabilities": backend.capabilities,
+                    "circuit_state": backend.circuit_breaker.state.value,
+                }
+                for name, backend in self.client.backends.items()
+            },
+            "routing": {
+                "total_rules": len(self.router.rules),
+                "strategy": self.router.strategy,
+                "history_size": len(self.router.routing_history),
+            },
+            "cost_optimization": {
+                "gcp_idle_minutes": round(gcp_idle, 2),
+                "local_idle_minutes": round(local_idle, 2),
+                "can_shutdown_gcp": gcp_idle > 10
+                and ram_status
+                and ram_status.get("can_reclaim_to_local", False),
+            },
+            "capabilities_registry": {
+                backend_name: {
+                    "count": len(caps),
+                    "capabilities": caps,
+                    "cache_age_seconds": (
+                        round(
+                            __import__("time").time()
+                            - self.router._capabilities_last_updated.get(backend_name, 0),
+                            2,
+                        )
+                        if backend_name in self.router._capabilities_last_updated
+                        else None
+                    ),
+                }
+                for backend_name, caps in self.router._backend_capabilities.items()
+            },
+        }
+
+    def get_backend_health(self) -> Dict[str, Any]:
+        """Get health of all backends with Phase 2.5 enhancements"""
+        health_data = {}
+
+        for name, backend in self.client.backends.items():
+            idle_minutes = self.router._get_backend_idle_minutes(name)
+
+            health_data[name] = {
+                "healthy": backend.health.healthy,
+                "response_time": backend.health.response_time,
+                "success_rate": backend.health.success_rate,
+                "circuit_state": backend.circuit_breaker.state.value,
+                "last_check": backend.health.last_check.isoformat(),
+                # Phase 2.5: Activity tracking
+                "idle_minutes": round(idle_minutes, 2),
+                "is_idle": idle_minutes > 10,
+                # Phase 2.5: Capabilities
+                "capabilities_count": len(backend.capabilities),
+                "capabilities": backend.capabilities[:5],  # First 5 for overview
+            }
+
+        return health_data
+
+    def get_status(self) -> Dict[str, Any]:
+        """Get orchestrator status with enhanced Phase 2.5 metrics"""
+        routing_analytics = self.router.get_analytics()
+
+        return {
+            "running": self.is_running,
+            "request_count": self.request_count,
+            "client_metrics": self.client.get_metrics(),
+            "routing_analytics": routing_analytics,
+            # Phase 2.5: Backend activity tracking
+            "backend_activity": routing_analytics.get("backend_activity", {}),
+            # Phase 2.5: Capabilities mapping
+            "registered_capabilities": {
+                name: len(caps) for name, caps in self.router._backend_capabilities.items()
+            },
+        }
+
+    def _get_capability_from_decision(self, decision: RouteDecision, command: str) -> Optional[str]:
+        """Determine capability requirement from routing decision"""
+        if decision == RouteDecision.LOCAL:
+            # Check for specific local capabilities
+            command_lower = command.lower()
+            if any(kw in command_lower for kw in ["screenshot", "screen", "capture", "vision"]):
+                return "vision_capture"
+            elif any(kw in command_lower for kw in ["unlock", "password", "login"]):
+                return "screen_unlock"
+            elif any(kw in command_lower for kw in ["hey jarvis", "voice", "listen"]):
+                return "voice_activation"
+            else:
+                return "macos_automation"
+
+        elif decision == RouteDecision.CLOUD:
+            # Check for specific cloud capabilities
+            command_lower = command.lower()
+            if any(kw in command_lower for kw in ["analyze", "understand", "explain", "summarize"]):
+                return "nlp_analysis"
+            elif any(kw in command_lower for kw in ["chat", "talk", "conversation"]):
+                return "chatbot_inference"
+            else:
+                return "ml_processing"
+
+        return None
+
+    async def analyze_with_ml(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        """Perform ML analysis (routed to cloud for heavy processing)"""
+        return await self.client.execute(
+            path="/api/ml/analyze", method="POST", data=data, capability="ml_processing"
+        )
+
+    async def unlock_screen(self, **kwargs) -> Dict[str, Any]:
+        """Unlock screen (always routed to local)"""
+        return await self.client.execute(
+            path="/api/unlock", method="POST", data=kwargs, capability="screen_unlock"
+        )
+
+    async def capture_screen(self, **kwargs) -> Dict[str, Any]:
+        """Capture screen (always routed to local)"""
+        return await self.client.execute(
+            path="/api/vision/capture", method="POST", data=kwargs, capability="vision_capture"
+        )
+
+    async def execute_action(self, action: str, **kwargs) -> Dict[str, Any]:
+        """Execute an action command"""
+        return await self.execute_command(command=action, command_type="action", metadata=kwargs)
+
+    async def execute_query(self, query: str, **kwargs) -> Dict[str, Any]:
+        """Execute a natural language query"""
+        return await self.execute_command(command=query, command_type="query", metadata=kwargs)
+
+    async def generate_response_with_llm(
+        self, command: str, context: Optional[Dict] = None
+    ) -> Dict[str, Any]:
+        """Generate response using LLM with context"""
+        # Build prompt with context
+        prompt = f"User command: {command}\n\n"
+
+        if context:
+            if "uae" in context:
+                prompt += f"Context: {context['uae']}\n"
+            if "cai" in context:
+                prompt += f"Intent: {context['cai'].get('predicted_intent')}\n"
+
+        prompt += "\nRespond naturally and helpfully:\n"
+
+        result = await self.execute_llm_inference(prompt, max_tokens=256, temperature=0.7)
+
+        return result
+
 
 # ============================================================================
 # GLOBAL ORCHESTRATOR INSTANCE
@@ -1955,3 +2213,21 @@ async def get_voice_auth_status() -> Dict[str, Any]:
         pass
 
     return status
+
+
+async def execute_hybrid_command(command: str, **kwargs) -> Dict[str, Any]:
+    """Convenience function for executing commands"""
+    orchestrator = get_orchestrator()
+    if not orchestrator.is_running:
+        await orchestrator.start()
+    return await orchestrator.execute_command(command, **kwargs)
+
+def _get_ram_monitor():
+    """Lazy load RAM monitor"""
+    try:
+        from backend.core.advanced_ram_monitor import get_ram_monitor
+
+        return get_ram_monitor
+    except ImportError:
+        logger.warning("RAM monitor not available for cost optimization")
+        return None

--- a/backend/core/intelligence/cross_space_intelligence.py
+++ b/backend/core/intelligence/cross_space_intelligence.py
@@ -799,4 +799,630 @@ class ActivityCorrelationEngine:
 
         return score
 
-# Module truncated - needs restoration from backup
+    def record_behavior_pattern(self, pattern: Dict[str, Any]):
+        """Record a behavior pattern for learning"""
+        self.behavior_patterns.append({
+            **pattern,
+            'timestamp': datetime.now()
+        })
+
+
+# ============================================================================
+# MULTI-SOURCE SYNTHESIZER - Information Synthesis
+# ============================================================================
+
+class MultiSourceSynthesizer:
+    """
+    Synthesizes information from multiple spaces into coherent understanding.
+    Combines terminal output + browser content + code changes = full story.
+    """
+
+    def __init__(self):
+        pass
+
+    def synthesize_story(self, relationship: CrossSpaceRelationship) -> Dict[str, Any]:
+        """
+        Create a coherent narrative from related activities.
+
+        Returns:
+            {
+                'summary': str,           # High-level summary
+                'timeline': List[str],    # Chronological steps
+                'key_insights': List[str], # Important findings
+                'current_state': str,     # What's happening now
+                'suggestions': List[str]  # What to do next
+            }
+        """
+        activities = sorted(relationship.activities, key=lambda a: a.timestamp)
+
+        # Extract key information
+        errors = [a for a in activities if a.has_error]
+        solutions = [a for a in activities if a.has_solution]
+        terminal_acts = [a for a in activities if a.activity_type == "terminal"]
+        browser_acts = [a for a in activities if a.activity_type == "browser"]
+        ide_acts = [a for a in activities if a.activity_type == "ide"]
+
+        # Build summary
+        summary = self._generate_summary(relationship, errors, solutions,
+                                        terminal_acts, browser_acts, ide_acts)
+
+        # Build timeline
+        timeline = [
+            f"{act.timestamp.strftime('%H:%M:%S')} - {act.app_name} (Space {act.space_id}): {act.content_summary[:80]}"
+            for act in activities
+        ]
+
+        # Extract key insights
+        key_insights = self._extract_insights(activities, errors, solutions)
+
+        # Determine current state
+        current_state = self._determine_current_state(activities)
+
+        # Generate suggestions
+        suggestions = self._generate_suggestions(relationship, errors, solutions)
+
+        return {
+            'summary': summary,
+            'timeline': timeline,
+            'key_insights': key_insights,
+            'current_state': current_state,
+            'suggestions': suggestions,
+            'spaces_involved': list(relationship.get_spaces()),
+            'confidence': relationship.confidence
+        }
+
+    def _generate_summary(self, rel: CrossSpaceRelationship,
+                         errors: List, solutions: List,
+                         terminal: List, browser: List, ide: List) -> str:
+        """Generate high-level summary"""
+        spaces_count = len(rel.get_spaces())
+
+        if rel.relationship_type == RelationshipType.DEBUGGING:
+            if errors and browser:
+                return f"Debugging workflow across {spaces_count} spaces: encountered error in terminal, researching solution in browser"
+            elif errors and ide:
+                return f"Debugging workflow: fixing error in code editor (Space {ide[0].space_id})"
+
+        elif rel.relationship_type == RelationshipType.PROBLEM_SOLVING:
+            if errors and solutions:
+                return f"Problem-solving workflow: error detected, solution found and being implemented across {spaces_count} spaces"
+
+        elif rel.relationship_type == RelationshipType.CODE_AND_TEST:
+            return f"Development workflow: writing code and running tests across {spaces_count} spaces"
+
+        # Generic summary
+        return f"{rel.relationship_type.value.replace('_', ' ').title()} workflow across {spaces_count} spaces with {len(rel.activities)} related activities"
+
+    def _extract_insights(self, activities: List[ActivitySignature],
+                         errors: List, solutions: List) -> List[str]:
+        """Extract key insights from activities"""
+        insights = []
+
+        # Extract common keywords across activities
+        all_keywords = []
+        for act in activities:
+            all_keywords.extend(act.keywords.technical_terms)
+            all_keywords.extend(act.keywords.command_names)
+            all_keywords.extend(list(act.keywords.domain_concepts)[:5])
+
+        # Find most common
+        if all_keywords:
+            common = Counter(all_keywords).most_common(5)
+            key_terms = [term for term, count in common if count > 1]
+            if key_terms:
+                insights.append(f"Key technologies: {', '.join(key_terms)}")
+
+        # Error insights
+        if errors:
+            error_types = set()
+            for err in errors:
+                error_types.update(err.keywords.error_indicators)
+            if error_types:
+                insights.append(f"Issues encountered: {', '.join(list(error_types)[:3])}")
+
+        # Solution insights
+        if solutions:
+            insights.append(f"Found {len(solutions)} potential solution(s)")
+
+        return insights
+
+    def _determine_current_state(self, activities: List[ActivitySignature]) -> str:
+        """Determine what's currently happening"""
+        if not activities:
+            return "No recent activity"
+
+        latest = activities[-1]
+
+        if latest.has_error:
+            return f"Error state in {latest.app_name} (Space {latest.space_id})"
+        elif latest.has_solution:
+            return f"Solution found in {latest.app_name} (Space {latest.space_id})"
+        elif latest.activity_type == "browser":
+            return f"Researching in browser (Space {latest.space_id})"
+        elif latest.activity_type == "terminal":
+            return f"Running commands in terminal (Space {latest.space_id})"
+        elif latest.activity_type == "ide":
+            return f"Editing code in IDE (Space {latest.space_id})"
+        else:
+            return f"Active in {latest.app_name} (Space {latest.space_id})"
+
+    def _generate_suggestions(self, rel: CrossSpaceRelationship,
+                             errors: List, solutions: List) -> List[str]:
+        """Generate actionable suggestions"""
+        suggestions = []
+
+        if errors and not solutions:
+            suggestions.append("Consider searching for solutions to the error")
+
+        if solutions and errors:
+            suggestions.append("Try implementing the solution found in browser")
+
+        if rel.relationship_type == RelationshipType.CODE_AND_TEST:
+            latest = sorted(rel.activities, key=lambda a: a.timestamp)[-1]
+            if latest.has_error:
+                suggestions.append("Tests are failing - review the error output")
+
+        return suggestions
+
+
+# ============================================================================
+# RELATIONSHIP GRAPH - Dynamic Relationship Tracking
+# ============================================================================
+
+class RelationshipGraph:
+    """
+    Tracks discovered relationships over time.
+    Maintains graph of how spaces and activities are connected.
+    """
+
+    def __init__(self, max_relationships: int = 100):
+        self.relationships: Dict[str, CrossSpaceRelationship] = {}
+        self.max_relationships = max_relationships
+        self.space_connections: Dict[int, Set[int]] = defaultdict(set)  # space_id → connected spaces
+
+    def add_relationship(self, relationship: CrossSpaceRelationship):
+        """Add or update a relationship in the graph"""
+        rel_id = relationship.relationship_id
+
+        if rel_id in self.relationships:
+            # Update existing
+            existing = self.relationships[rel_id]
+            existing.last_updated = datetime.now()
+            existing.confidence = min(1.0, existing.confidence + 0.1)
+            existing.evidence.extend(relationship.evidence)
+        else:
+            # Add new
+            self.relationships[rel_id] = relationship
+
+            # Update space connections
+            spaces = list(relationship.get_spaces())
+            for i, space1 in enumerate(spaces):
+                for space2 in spaces[i+1:]:
+                    self.space_connections[space1].add(space2)
+                    self.space_connections[space2].add(space1)
+
+        # Prune old relationships if too many
+        if len(self.relationships) > self.max_relationships:
+            self._prune_old_relationships()
+
+        logger.info(f"[RELATIONSHIP-GRAPH] Relationship {rel_id}: {relationship.description}")
+
+    def get_relationships_for_space(self, space_id: int) -> List[CrossSpaceRelationship]:
+        """Get all relationships involving a specific space"""
+        return [rel for rel in self.relationships.values() if rel.involves_space(space_id)]
+
+    def get_connected_spaces(self, space_id: int) -> Set[int]:
+        """Get all spaces connected to this space"""
+        return self.space_connections.get(space_id, set())
+
+    def find_relationship_by_activities(self, space_ids: List[int],
+                                       within_seconds: int = 300) -> Optional[CrossSpaceRelationship]:
+        """Find an existing relationship involving these spaces"""
+        cutoff = datetime.now() - timedelta(seconds=within_seconds)
+
+        for rel in self.relationships.values():
+            if rel.last_updated >= cutoff:
+                rel_spaces = rel.get_spaces()
+                if all(sid in rel_spaces for sid in space_ids):
+                    return rel
+
+        return None
+
+    def _prune_old_relationships(self):
+        """Remove oldest relationships to maintain size limit"""
+        sorted_rels = sorted(
+            self.relationships.items(),
+            key=lambda x: x[1].last_updated
+        )
+
+        # Keep newest 80% of max
+        keep_count = int(self.max_relationships * 0.8)
+        to_keep = sorted_rels[-keep_count:]
+
+        self.relationships = dict(to_keep)
+
+        # Rebuild space connections
+        self.space_connections = defaultdict(set)
+        for rel in self.relationships.values():
+            spaces = list(rel.get_spaces())
+            for i, space1 in enumerate(spaces):
+                for space2 in spaces[i+1:]:
+                    self.space_connections[space1].add(space2)
+                    self.space_connections[space2].add(space1)
+
+
+# ============================================================================
+# WORKSPACE QUERY RESOLVER - Workspace-Wide Query Answering
+# ============================================================================
+
+class WorkspaceQueryResolver:
+    """
+    Answers queries by drawing from the entire workspace.
+    Synthesizes information across all spaces to provide complete answers.
+    """
+
+    def __init__(self, relationship_graph: RelationshipGraph,
+                 synthesizer: MultiSourceSynthesizer):
+        self.relationship_graph = relationship_graph
+        self.synthesizer = synthesizer
+
+    async def resolve_workspace_query(self, query: str,
+                                      current_space_id: Optional[int] = None) -> Dict[str, Any]:
+        """
+        Resolve a query using information from entire workspace.
+
+        Examples:
+        - "What's the error?" → finds error across any space
+        - "What am I working on?" → synthesizes from all active spaces
+        - "How do I fix this?" → combines error + solution from different spaces
+        """
+        query_lower = query.lower()
+
+        # Determine query type
+        if any(kw in query_lower for kw in ["error", "wrong", "problem", "failed"]):
+            return await self._resolve_error_query(current_space_id)
+
+        elif any(kw in query_lower for kw in ["working on", "doing", "current"]):
+            return await self._resolve_activity_query(current_space_id)
+
+        elif any(kw in query_lower for kw in ["how", "fix", "solve", "solution"]):
+            return await self._resolve_solution_query(current_space_id)
+
+        elif any(kw in query_lower for kw in ["related", "connected", "together"]):
+            return await self._resolve_relationship_query(current_space_id)
+
+        else:
+            # Generic workspace summary
+            return await self._resolve_generic_query(query)
+
+    async def _resolve_error_query(self, current_space_id: Optional[int]) -> Dict[str, Any]:
+        """Find and explain errors across workspace"""
+        # Find relationships with errors
+        error_relationships = [
+            rel for rel in self.relationship_graph.relationships.values()
+            if any(act.has_error for act in rel.activities)
+        ]
+
+        if not error_relationships:
+            return {
+                'found': False,
+                'response': "I don't see any recent errors in your workspace."
+            }
+
+        # Most recent error relationship
+        latest_error_rel = max(error_relationships, key=lambda r: r.last_updated)
+
+        # Synthesize story
+        story = self.synthesizer.synthesize_story(latest_error_rel)
+
+        return {
+            'found': True,
+            'relationship': latest_error_rel,
+            'story': story,
+            'response': self._format_error_response(story, latest_error_rel)
+        }
+
+    async def _resolve_activity_query(self, current_space_id: Optional[int]) -> Dict[str, Any]:
+        """Summarize current work across workspace"""
+        recent_rels = [
+            rel for rel in self.relationship_graph.relationships.values()
+            if (datetime.now() - rel.last_updated).total_seconds() < 300
+        ]
+
+        if not recent_rels:
+            return {
+                'found': False,
+                'response': "I don't see any recent activity in your workspace."
+            }
+
+        # Get stories for all recent relationships
+        stories = [self.synthesizer.synthesize_story(rel) for rel in recent_rels]
+
+        return {
+            'found': True,
+            'relationships': recent_rels,
+            'stories': stories,
+            'response': self._format_activity_response(stories, recent_rels)
+        }
+
+    async def _resolve_solution_query(self, current_space_id: Optional[int]) -> Dict[str, Any]:
+        """Find solutions to problems across workspace"""
+        # Find relationships with both errors and solutions
+        solution_relationships = [
+            rel for rel in self.relationship_graph.relationships.values()
+            if any(act.has_error for act in rel.activities) and
+               any(act.has_solution for act in rel.activities)
+        ]
+
+        if not solution_relationships:
+            return {
+                'found': False,
+                'response': "I haven't found any solutions yet. Try searching for the error online."
+            }
+
+        # Most recent solution
+        latest_solution_rel = max(solution_relationships, key=lambda r: r.last_updated)
+        story = self.synthesizer.synthesize_story(latest_solution_rel)
+
+        return {
+            'found': True,
+            'relationship': latest_solution_rel,
+            'story': story,
+            'response': self._format_solution_response(story, latest_solution_rel)
+        }
+
+    async def _resolve_relationship_query(self, current_space_id: Optional[int]) -> Dict[str, Any]:
+        """Explain how spaces are related"""
+        if current_space_id:
+            connected = self.relationship_graph.get_connected_spaces(current_space_id)
+            rels = self.relationship_graph.get_relationships_for_space(current_space_id)
+
+            if not connected:
+                return {
+                    'found': False,
+                    'response': f"Space {current_space_id} doesn't have detected connections to other spaces yet."
+                }
+
+            return {
+                'found': True,
+                'connected_spaces': connected,
+                'relationships': rels,
+                'response': f"Space {current_space_id} is connected to spaces: {', '.join(map(str, connected))}. {len(rels)} related workflows detected."
+            }
+        else:
+            return {
+                'found': False,
+                'response': "Please specify which space you'd like to know about."
+            }
+
+    async def _resolve_generic_query(self, query: str) -> Dict[str, Any]:
+        """Generic query resolution"""
+        all_rels = list(self.relationship_graph.relationships.values())
+
+        if not all_rels:
+            return {
+                'found': False,
+                'response': "No workspace activity detected yet."
+            }
+
+        return {
+            'found': True,
+            'response': f"Your workspace has {len(all_rels)} active workflows across multiple spaces."
+        }
+
+    def _format_error_response(self, story: Dict, rel: CrossSpaceRelationship) -> str:
+        """Format error response with full context"""
+        response = f"**Error detected across {len(story['spaces_involved'])} space(s):**\n\n"
+
+        # Include actual error content from activities
+        error_activities = [act for act in rel.activities if act.has_error]
+        if error_activities:
+            latest_error = error_activities[-1]
+            response += f"{latest_error.content_summary}\n\n"
+
+        response += f"{story['summary']}\n\n"
+
+        if story['key_insights']:
+            response += "**Key details:**\n"
+            for insight in story['key_insights']:
+                response += f"- {insight}\n"
+
+        response += f"\n**Current state:** {story['current_state']}"
+
+        return response
+
+    def _format_activity_response(self, stories: List[Dict], rels: List) -> str:
+        """Format activity summary"""
+        response = f"**You're working on {len(stories)} active workflow(s):**\n\n"
+
+        for i, story in enumerate(stories, 1):
+            response += f"{i}. {story['summary']}\n"
+
+        return response
+
+    def _format_solution_response(self, story: Dict, rel: CrossSpaceRelationship) -> str:
+        """Format solution response"""
+        response = f"**Solution found:**\n\n{story['summary']}\n\n"
+
+        if story['suggestions']:
+            response += "**Suggested next steps:**\n"
+            for suggestion in story['suggestions']:
+                response += f"- {suggestion}\n"
+
+        return response
+
+
+# ============================================================================
+# MAIN CROSS-SPACE INTELLIGENCE COORDINATOR
+# ============================================================================
+
+class CrossSpaceIntelligence:
+    """
+    Main coordinator for cross-space intelligence.
+    Integrates all components to provide advanced multi-space understanding.
+    """
+
+    def __init__(self):
+        self.semantic_correlator = SemanticCorrelator()
+        self.correlation_engine = ActivityCorrelationEngine()
+        self.synthesizer = MultiSourceSynthesizer()
+        self.relationship_graph = RelationshipGraph()
+        self.workspace_resolver = WorkspaceQueryResolver(self.relationship_graph, self.synthesizer)
+
+        logger.info("[CROSS-SPACE-INTELLIGENCE] Initialized")
+
+    def record_activity(self, space_id: int, app_name: str, content: str,
+                       activity_type: str, has_error: bool = False,
+                       significance: str = "normal") -> ActivitySignature:
+        """
+        Record an activity and check for cross-space relationships.
+
+        This is the main entry point - call this whenever something happens
+        in any space.
+        """
+        # Create signature
+        signature = self.semantic_correlator.create_signature(
+            space_id, app_name, content, activity_type, has_error, significance
+        )
+
+        # Find related activities
+        related = self.semantic_correlator.find_related_activities(signature)
+
+        # If we found related activities, analyze relationships
+        if related:
+            asyncio.create_task(self._analyze_and_record_relationships(signature, related))
+
+        return signature
+
+    async def _analyze_and_record_relationships(self, signature: ActivitySignature,
+                                                related: List[Tuple[ActivitySignature, float]]):
+        """Analyze related activities and record relationships"""
+        for related_sig, similarity in related:
+            # Calculate full correlation
+            correlation = self.correlation_engine.correlate(signature, related_sig)
+
+            # If significant correlation, create/update relationship
+            if correlation.is_significant(threshold=0.5):
+                relationship_type = self._determine_relationship_type(signature, related_sig, correlation)
+
+                # Check if relationship already exists
+                involved_spaces = [signature.space_id, related_sig.space_id]
+                existing = self.relationship_graph.find_relationship_by_activities(involved_spaces)
+
+                if existing:
+                    # Update existing relationship
+                    existing.activities.append(signature)
+                    existing.last_updated = datetime.now()
+                    existing.confidence = min(1.0, existing.confidence + 0.05)
+                else:
+                    # Create new relationship
+                    rel_id = hashlib.md5(
+                        f"{signature.space_id}_{related_sig.space_id}_{signature.timestamp}".encode()
+                    ).hexdigest()[:12]
+
+                    description = self._generate_relationship_description(
+                        signature, related_sig, relationship_type
+                    )
+
+                    relationship = CrossSpaceRelationship(
+                        relationship_id=rel_id,
+                        relationship_type=relationship_type,
+                        activities=[related_sig, signature],
+                        correlation_score=correlation,
+                        first_detected=datetime.now(),
+                        last_updated=datetime.now(),
+                        confidence=correlation.overall_score,
+                        evidence=[{
+                            'correlation': asdict(correlation),
+                            'similarity': similarity
+                        }],
+                        description=description
+                    )
+
+                    self.relationship_graph.add_relationship(relationship)
+
+    def _determine_relationship_type(self, act1: ActivitySignature,
+                                    act2: ActivitySignature,
+                                    correlation: CorrelationScore) -> RelationshipType:
+        """Determine the type of relationship based on activities"""
+        # Debugging: error + browser research
+        if (act1.has_error and act2.activity_type == "browser") or \
+           (act2.has_error and act1.activity_type == "browser"):
+            return RelationshipType.DEBUGGING
+
+        # Problem solving: error + solution + action
+        if (act1.has_error and act2.has_solution) or \
+           (act2.has_error and act1.has_solution):
+            return RelationshipType.PROBLEM_SOLVING
+
+        # Code and test: IDE + terminal with test keywords
+        if (act1.activity_type == "ide" and act2.activity_type == "terminal") or \
+           (act2.activity_type == "ide" and act1.activity_type == "terminal"):
+            return RelationshipType.CODE_AND_TEST
+
+        # Research and code: browser + IDE
+        if (act1.activity_type == "browser" and act2.activity_type == "ide") or \
+           (act2.activity_type == "browser" and act1.activity_type == "ide"):
+            return RelationshipType.RESEARCH_AND_CODE
+
+        # Multi-terminal: both terminals
+        if act1.activity_type == "terminal" and act2.activity_type == "terminal":
+            return RelationshipType.MULTI_TERMINAL
+
+        # Default: investigation
+        return RelationshipType.INVESTIGATION
+
+    def _generate_relationship_description(self, act1: ActivitySignature,
+                                          act2: ActivitySignature,
+                                          rel_type: RelationshipType) -> str:
+        """Generate human-readable description of relationship"""
+        return f"{rel_type.value.replace('_', ' ').title()}: {act1.app_name} (Space {act1.space_id}) ↔ {act2.app_name} (Space {act2.space_id})"
+
+    async def answer_workspace_query(self, query: str,
+                                    current_space_id: Optional[int] = None) -> Dict[str, Any]:
+        """
+        Answer a query using workspace-wide context.
+        This is the main query interface.
+        """
+        return await self.workspace_resolver.resolve_workspace_query(query, current_space_id)
+
+    def get_workspace_summary(self) -> Dict[str, Any]:
+        """Get a summary of all workspace relationships"""
+        all_rels = list(self.relationship_graph.relationships.values())
+
+        if not all_rels:
+            return {
+                'relationships_count': 0,
+                'active_workflows': [],
+                'connected_spaces': {}
+            }
+
+        # Recent relationships (last 5 minutes)
+        recent = [r for r in all_rels
+                 if (datetime.now() - r.last_updated).total_seconds() < 300]
+
+        return {
+            'relationships_count': len(all_rels),
+            'recent_count': len(recent),
+            'active_workflows': [
+                {
+                    'type': r.relationship_type.value,
+                    'spaces': list(r.get_spaces()),
+                    'description': r.description,
+                    'confidence': r.confidence
+                }
+                for r in recent
+            ],
+            'connected_spaces': dict(self.relationship_graph.space_connections)
+        }
+
+
+# ============================================================================
+# INITIALIZATION
+# ============================================================================
+
+def initialize_cross_space_intelligence() -> CrossSpaceIntelligence:
+    """Initialize the cross-space intelligence system"""
+    intelligence = CrossSpaceIntelligence()
+    logger.info("[CROSS-SPACE-INTELLIGENCE] System initialized and ready")
+    return intelligence

--- a/backend/core/nlp/implicit_reference_resolver.py
+++ b/backend/core/nlp/implicit_reference_resolver.py
@@ -912,6 +912,189 @@ class ImplicitReferenceResolver:
 
         return parsed
 
+    def record_visual_attention(self, space_id: int, app_name: str, ocr_text: str,
+                               content_type: str = "unknown", significance: str = "normal"):
+        """Helper to record visual attention from OCR analysis"""
+        import hashlib
+        ocr_hash = hashlib.md5(ocr_text.encode()).hexdigest()[:16]
+
+        # Create brief summary
+        summary = ocr_text[:200].replace('\n', ' ')
+
+        self.attention_tracker.record_attention(
+            space_id=space_id,
+            app_name=app_name,
+            content_summary=summary,
+            content_type=content_type,
+            significance=significance,
+            ocr_text_hash=ocr_hash
+        )
+
+    def _generate_recall_response(self, referent: Dict[str, Any], context: Dict[str, Any]) -> str:
+        """Generate recall response"""
+        return self._generate_explanation_response(referent, context)
+
+    def _generate_status_response(self, context: Dict[str, Any]) -> str:
+        """Generate status response"""
+        space_id = context.get("space_id")
+        apps = context.get("app_context", {}).get("app_name", "unknown")
+
+        response = f"In Space {space_id}:\n\n"
+        response += f"Active application: {apps}\n"
+
+        # Add recent activity
+        if "recent_events" in context:
+            recent = context["recent_events"][:3]
+            if recent:
+                response += f"\nRecent activity:\n"
+                for event in recent:
+                    response += f"  • {event['event_type']}\n"
+
+        return response
+
+    def _generate_fix_response(self, referent: Dict[str, Any], context: Dict[str, Any]) -> str:
+        """Generate fix response"""
+        if referent.get("type") == "error":
+            error_text = referent.get("entity", "")
+
+            # Check if we have terminal intelligence integration
+            response = f"To fix this error:\n\n{error_text}\n\n"
+            response += "I can suggest a fix. Would you like me to analyze it further?"
+
+            return response
+        else:
+            return "I'm not sure what you want to fix. Could you clarify?"
+
+    def _generate_diagnosis_response(self, referent: Dict[str, Any], context: Dict[str, Any]) -> str:
+        """Generate diagnosis response"""
+        if referent.get("type") == "error":
+            return self._generate_explanation_response(referent, context) + "\n\nI can help you fix this if you'd like."
+        else:
+            return "I don't see a specific problem. What would you like help with?"
+
+    def _generate_explanation_response(self, referent: Dict[str, Any], context: Dict[str, Any]) -> str:
+        """Generate explanation response"""
+        entity_type = referent.get("type", "unknown")
+
+        if entity_type == "error":
+            error_text = referent.get("entity", "Unknown error")
+            app_name = context.get("app_name", "unknown application")
+            space_id = context.get("space_id")
+
+            response = f"The error in {app_name}"
+            if space_id:
+                response += f" (Space {space_id})"
+            response += f" is:\n\n{error_text}"
+
+            # Add command context if available
+            if "app_context" in context and "terminal" in context["app_context"]:
+                cmd = context["app_context"]["terminal"].get("last_command")
+                if cmd:
+                    response += f"\n\nThis happened when you ran: `{cmd}`"
+
+            return response
+        else:
+            # Generic explanation
+            entity = referent.get("entity", "that")
+            return f"I see: {entity}"
+
+    async def _generate_response(self, parsed: QueryParsed, referent: Dict[str, Any], context: Dict[str, Any]) -> str:
+        """Generate natural language response based on intent and context"""
+        if referent["source"] == "none":
+            return "I don't see anything recent to reference. Could you be more specific?"
+
+        intent = parsed.intent
+
+        # Intent-specific responses
+        if intent == QueryIntent.EXPLAIN or intent == QueryIntent.DESCRIBE:
+            return self._generate_explanation_response(referent, context)
+        elif intent == QueryIntent.DIAGNOSE:
+            return self._generate_diagnosis_response(referent, context)
+        elif intent == QueryIntent.FIX:
+            return self._generate_fix_response(referent, context)
+        elif intent == QueryIntent.STATUS:
+            return self._generate_status_response(context)
+        elif intent == QueryIntent.RECALL:
+            return self._generate_recall_response(referent, context)
+        else:
+            # Default: explain what we found
+            return self._generate_explanation_response(referent, context)
+
+    def _serialize_app_context(self, app_ctx) -> Dict[str, Any]:
+        """Serialize application context for response"""
+        from backend.core.context.multi_space_context_graph import ContextType
+
+        base = {
+            "app_name": app_ctx.app_name,
+            "context_type": app_ctx.context_type.value,
+            "last_activity": app_ctx.last_activity.isoformat(),
+            "significance": app_ctx.significance.value
+        }
+
+        # Add type-specific context
+        if app_ctx.context_type == ContextType.TERMINAL and app_ctx.terminal_context:
+            base["terminal"] = {
+                "last_command": app_ctx.terminal_context.last_command,
+                "errors": app_ctx.terminal_context.errors,
+                "exit_code": app_ctx.terminal_context.exit_code,
+                "working_directory": app_ctx.terminal_context.working_directory
+            }
+        elif app_ctx.context_type == ContextType.BROWSER and app_ctx.browser_context:
+            base["browser"] = {
+                "url": app_ctx.browser_context.active_url,
+                "title": app_ctx.browser_context.page_title,
+                "is_researching": app_ctx.browser_context.is_researching
+            }
+        elif app_ctx.context_type == ContextType.IDE and app_ctx.ide_context:
+            base["ide"] = {
+                "active_file": app_ctx.ide_context.active_file,
+                "open_files": app_ctx.ide_context.open_files,
+                "errors": app_ctx.ide_context.errors_in_file
+            }
+
+        return base
+
+    async def _get_full_context(self, referent: Dict[str, Any], parsed: QueryParsed) -> Dict[str, Any]:
+        """Get full context about the resolved referent"""
+        if referent["source"] == "none":
+            return {"type": "no_context", "message": "I don't have enough context to answer that."}
+
+        # Get context from the workspace graph
+        if referent.get("space_id") and referent.get("app_name"):
+            space_id = referent["space_id"]
+            app_name = referent["app_name"]
+
+            if space_id in self.context_graph.spaces:
+                space = self.context_graph.spaces[space_id]
+                if app_name in space.applications:
+                    app_ctx = space.applications[app_name]
+
+                    # Build rich context based on app type
+                    context = {
+                        "type": referent["type"],
+                        "source": referent["source"],
+                        "space_id": space_id,
+                        "app_name": app_name,
+                        "entity": referent["entity"],
+                        "app_context": self._serialize_app_context(app_ctx),
+                        "recent_events": [e.to_dict() for e in space.get_recent_events(within_seconds=180)],
+                        "space_tags": list(space.tags)
+                    }
+
+                    # Add error-specific context
+                    if referent.get("details"):
+                        context["error_details"] = referent["details"]
+
+                    return context
+
+        # Fallback: return what we have
+        return {
+            "type": referent["type"],
+            "source": referent["source"],
+            "entity": referent["entity"],
+            "details": referent.get("details", {})
+        }
+
 
 # ============================================================================
 # SINGLETON PATTERN - Global accessor
@@ -977,3 +1160,11 @@ if __name__ == "__main__":
 
     logging.basicConfig(level=logging.INFO)
     asyncio.run(test_resolver())
+
+
+def initialize_implicit_resolver(context_graph) -> ImplicitReferenceResolver:
+    """Initialize the global implicit reference resolver"""
+    global _global_resolver
+    _global_resolver = ImplicitReferenceResolver(context_graph)
+    logger.info("[IMPLICIT-RESOLVER] Global instance initialized")
+    return _global_resolver

--- a/backend/display/advanced_display_monitor.py
+++ b/backend/display/advanced_display_monitor.py
@@ -917,6 +917,1199 @@ class AdvancedDisplayMonitor:
         except Exception as e:
             logger.error(f"[DISPLAY MONITOR] Error during check_displays: {e}", exc_info=True)
 
+    async def _detect_all_displays(self) -> List[str]:
+        """Detect displays using all available methods"""
+        # Check cache first
+        cache_key = "all_displays"
+        cached = self.cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+        all_displays = set()
+        preferred_method = self.config["display_monitoring"].get("preferred_detection_method")
+
+        # Try preferred method first
+        if preferred_method:
+            method_enum = DetectionMethod(preferred_method)
+            if method_enum in self.detectors:
+                displays = await self.detectors[method_enum].detect_displays()
+                all_displays.update(displays)
+
+                # If we got results, cache and return
+                if displays:
+                    result = list(all_displays)
+                    self.cache.set(cache_key, result)
+                    return result
+
+        # Fallback: Try all methods (parallel if enabled)
+        if self.config["performance"]["parallel_detection"]:
+            tasks = [detector.detect_displays() for detector in self.detectors.values()]
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+
+            for result in results:
+                if isinstance(result, list):
+                    all_displays.update(result)
+        else:
+            for detector in self.detectors.values():
+                displays = await detector.detect_displays()
+                all_displays.update(displays)
+
+        result = list(all_displays)
+        self.cache.set(cache_key, result)
+        return result
+
+    async def _handle_display_detected(self, monitored: MonitoredDisplay, detected_name: str):
+        """Handle newly detected display"""
+        logger.info(f"[DISPLAY MONITOR] Detected: {monitored.name} ({detected_name})")
+
+        # Emit event
+        await self._emit_event("display_detected", display=monitored, detected_name=detected_name)
+
+        # IMPORTANT: Set pending prompt FIRST if we're going to prompt
+        if monitored.auto_prompt and self.config["voice_integration"]["speak_on_detection"]:
+            # Set pending prompt state so we can handle yes/no responses
+            self.pending_prompt_display = monitored.id
+            logger.info(
+                f"[DISPLAY MONITOR] Set pending prompt for {monitored.name} (will prompt user)"
+            )
+
+        # Send WebSocket notification to UI
+        if self.websocket_manager:
+            try:
+                message = f"Sir, I see your {monitored.name} is now available. Would you like to extend your display to it?"
+                await self.websocket_manager.broadcast(
+                    {
+                        "type": "display_detected",
+                        "display_name": monitored.name,
+                        "display_id": monitored.id,
+                        "message": message,
+                        "timestamp": datetime.now().isoformat(),
+                    }
+                )
+                logger.debug(f"[DISPLAY MONITOR] Broadcasted detection to UI")
+            except Exception as e:
+                logger.warning(f"[DISPLAY MONITOR] Failed to broadcast to UI: {e}")
+
+        # Voice prompt if enabled
+        if monitored.auto_prompt and self.config["voice_integration"]["speak_on_detection"]:
+            await self._speak_detection_prompt(monitored)
+
+        # Auto-connect if enabled AND not already connected/connecting
+        if (
+            monitored.auto_connect
+            and monitored.id not in self.connected_displays
+            and monitored.id not in self.connecting_displays
+        ):
+            logger.info(f"[DISPLAY MONITOR] Auto-connecting to {monitored.name}...")
+            await self.connect_display(monitored.id)
+        elif monitored.id in self.connected_displays:
+            logger.debug(
+                f"[DISPLAY MONITOR] {monitored.name} already connected, skipping auto-connect"
+            )
+        elif monitored.id in self.connecting_displays:
+            logger.debug(
+                f"[DISPLAY MONITOR] {monitored.name} connection already in progress, skipping auto-connect"
+            )
+
+    async def _handle_display_lost(self, monitored: MonitoredDisplay):
+        """Handle lost display"""
+        logger.info(f"[DISPLAY MONITOR] Lost: {monitored.name}")
+
+        # Emit event
+        await self._emit_event("display_lost", display=monitored)
+
+        if monitored.id in self.connected_displays:
+            self.connected_displays.remove(monitored.id)
+            await self._emit_event("display_disconnected", display=monitored)
+
+    def _get_time_aware_greeting(self) -> str:
+        """
+        Get a time-aware greeting that's contextual but not annoying
+
+        Returns time-specific greeting ~35% of the time, generic the rest
+        """
+        from datetime import datetime
+
+        prompt_config = self.config["voice_integration"].get("prompt_templates", {})
+
+        # Handle legacy format (simple list)
+        if isinstance(prompt_config, list):
+            return random.choice(prompt_config)  # nosec B311
+
+        # Get probability for time-aware greetings (default 35%)
+        time_aware_prob = self.config["voice_integration"].get(
+            "time_aware_greeting_probability", 0.35
+        )
+
+        # Decide whether to use time-aware or generic
+        use_time_aware = random.random() < time_aware_prob  # nosec B311
+
+        if use_time_aware:
+            # Determine time of day
+            current_hour = datetime.now().hour
+
+            if 5 <= current_hour < 12:
+                time_period = "morning"
+            elif 12 <= current_hour < 17:
+                time_period = "afternoon"
+            elif 17 <= current_hour < 21:
+                time_period = "evening"
+            else:
+                time_period = "night"
+
+            templates = prompt_config.get(
+                time_period, prompt_config.get("generic", ["JARVIS online."])
+            )
+        else:
+            templates = prompt_config.get("generic", ["JARVIS online."])
+
+        return random.choice(templates)  # nosec B311
+
+    async def _speak_detection_prompt(self, monitored: MonitoredDisplay):
+        """Speak detection prompt"""
+        if not self.config["voice_integration"]["enabled"]:
+            return
+
+        # IMPORTANT: Don't speak detection prompts during initial scan - only the startup announcement should speak
+        # The initial scan happens right after startup, so we use the coordinator for that
+        # Only speak detection prompts for displays that appear AFTER startup (hot-plug events)
+        if not self.initial_scan_complete:
+            logger.warning(
+                f"[STARTUP VOICE] ⏭️  Display detection prompt skipped during initial scan - startup announcement handles this"
+            )
+            return
+
+        # Get time-aware greeting
+        template = self._get_time_aware_greeting()
+        message = (
+            template.format(display_name=monitored.name)
+            if "{display_name}" in template
+            else template
+        )
+
+        logger.warning(f"[DISPLAY VOICE] 🎤 Display detection prompt: {message}")
+
+        # Note: pending_prompt_display is already set in _handle_display_detected
+        logger.info(
+            f"[DISPLAY MONITOR] Speaking prompt for {monitored.name} (pending_prompt_display={self.pending_prompt_display})"
+        )
+
+        # Use voice handler if available
+        if self.voice_handler:
+            try:
+                await self.voice_handler.speak(message)
+            except Exception as e:
+                logger.error(f"[DISPLAY MONITOR] Voice handler error: {e}")
+        else:
+            # Fallback to macOS say command
+            try:
+                subprocess.Popen(["say", message])
+            except Exception as e:
+                logger.error(f"[DISPLAY MONITOR] Say command error: {e}")
+
+    async def connect_display(self, display_id: str) -> Dict[str, Any]:
+        """
+        Connect to a display using advanced methods
+
+        Connection Strategy (prioritized - PRODUCTION HARDENED):
+        1. 🥇 Route Picker Helper (AVRoutePickerView + Accessibility - MOST RELIABLE!)
+        2. 🥈 Protocol-Level AirPlay (Bonjour/mDNS + RAOP - direct protocol)
+        3. 🥉 Vision-Guided Navigator (Claude Vision - bypasses macOS restrictions)
+        4. Native Swift Bridge fallback
+        5. AppleScript fallback
+        6. Voice guidance to user
+
+        Args:
+            display_id: Display ID from configuration
+
+        Returns:
+            Connection result dictionary with telemetry
+        """
+        # Find monitored display
+        monitored = next((d for d in self.monitored_displays if d.id == display_id), None)
+        if not monitored:
+            return {"success": False, "message": f"Display {display_id} not found in configuration"}
+
+        # Circuit breaker: Check if already connected or connecting
+        logger.info(f"[DISPLAY MONITOR] 🔍 Circuit breaker check for {monitored.name}")
+        logger.info(
+            f"[DISPLAY MONITOR] Current state: connecting={list(self.connecting_displays)}, connected={list(self.connected_displays)}"
+        )
+
+        # REAL-TIME VERIFICATION: Don't trust cached state - verify actual connection
+        with open("/tmp/jarvis_display_command.log", "a") as f:
+            f.write(f"[DISPLAY MONITOR] About to verify connection for {monitored.name}\n")
+
+        from .display_state_verifier import get_display_verifier
+
+        verifier = get_display_verifier()
+
+        with open("/tmp/jarvis_display_command.log", "a") as f:
+            f.write(f"[DISPLAY MONITOR] Calling verifier.verify_actual_connection...\n")
+
+        actual_state = await verifier.verify_actual_connection(monitored.name)
+
+        with open("/tmp/jarvis_display_command.log", "a") as f:
+            f.write(
+                f"[DISPLAY MONITOR] Verification complete: {actual_state.get('is_connected')}\n"
+            )
+
+        logger.info(
+            f"[DISPLAY MONITOR] Real-time verification for {monitored.name}: is_connected={actual_state['is_connected']}, confidence={actual_state['confidence']:.2f}"
+        )
+
+        # Update our cached state based on actual verification
+        if actual_state["is_connected"] and display_id not in self.connected_displays:
+            logger.info(
+                f"[DISPLAY MONITOR] 📊 Updating cache: {monitored.name} is actually connected"
+            )
+            self.connected_displays.add(display_id)
+        elif not actual_state["is_connected"] and display_id in self.connected_displays:
+            logger.info(
+                f"[DISPLAY MONITOR] 📊 Updating cache: {monitored.name} is NOT actually connected"
+            )
+            self.connected_displays.discard(display_id)
+
+        # Store learning pattern for future predictions
+        await self._store_display_pattern(monitored, actual_state)
+
+        if actual_state["is_connected"] and actual_state["confidence"] > 0.7:
+            logger.info(
+                f"[DISPLAY MONITOR] ✅ {monitored.name} verified as connected (method: {actual_state['method']})"
+            )
+            return {
+                "success": True,
+                "message": f"{monitored.name} already connected",
+                "cached": True,
+                "verified": True,
+            }
+
+        if display_id in self.connecting_displays:
+            logger.info(
+                f"[DISPLAY MONITOR] ⚠️ {monitored.name} was stuck in connecting state, resetting and retrying..."
+            )
+            # Remove from connecting state to allow retry
+            self.connecting_displays.discard(display_id)
+            logger.info(f"[DISPLAY MONITOR] 🔄 Reset circuit breaker, proceeding with connection")
+
+        # Mark as connecting IMMEDIATELY to prevent race conditions
+        self.connecting_displays.add(display_id)
+        logger.info(
+            f"[DISPLAY MONITOR] 🔒 Marked {monitored.name} as connecting (circuit breaker engaged)"
+        )
+
+        # Immediate voice feedback
+        if self.voice_handler:
+            await self.voice_handler.speak_async(f"Connecting to {monitored.name} now, sir.")
+
+        logger.info(f"[DISPLAY MONITOR] ========================================")
+        logger.info(f"[DISPLAY MONITOR] Connecting to {monitored.name}...")
+        logger.info(f"[DISPLAY MONITOR] Starting 6-tier connection waterfall")
+        logger.info(f"[DISPLAY MONITOR] ========================================")
+
+        connection_start = asyncio.get_event_loop().time()
+        strategies_attempted = []
+
+        # Strategy 1: INTELLIGENT HYBRID - Coordinates + Vision + UAE Adaptation
+        # Uses best available clicker: UAE > SAI > Adaptive > Basic
+        # Total: ~2 seconds, 100% reliable, adapts when UI changes
+        try:
+            with open("/tmp/jarvis_display_command.log", "a") as f:
+                f.write(f"[DISPLAY MONITOR] Attempting Strategy 1: Best available clicker\n")
+
+            # Use clicker factory to get best available clicker
+            from display.control_center_clicker_factory import get_best_clicker, get_clicker_info
+
+            # Log available clickers
+            clicker_info = get_clicker_info()
+            logger.info(f"[DISPLAY MONITOR] 🥇 STRATEGY 1: INTELLIGENT HYBRID")
+            logger.info(
+                f"[DISPLAY MONITOR] Available clickers: UAE={clicker_info['uae_available']}, SAI={clicker_info['sai_available']}, Adaptive={clicker_info['adaptive_available']}, Basic={clicker_info['basic_available']}"
+            )
+            logger.info(f"[DISPLAY MONITOR] Recommended: {clicker_info['recommended'].upper()}")
+
+            strategies_attempted.append("intelligent_hybrid")
+
+            # Get best available clicker
+            clicker = get_best_clicker(vision_analyzer=None, enable_verification=True)
+            logger.info(f"[DISPLAY MONITOR] Using {clicker.__class__.__name__}")
+
+            # Execute connection flow
+            logger.info(f"[DISPLAY MONITOR] Connecting to {monitored.name}...")
+
+            with open("/tmp/jarvis_display_command.log", "a") as f:
+                f.write(
+                    f"[DISPLAY MONITOR] About to call clicker.connect_to_device('{monitored.name}')\n"
+                )
+
+            # Use async context manager if available, otherwise call directly
+            if hasattr(clicker, "__aenter__"):
+                async with clicker as c:
+                    result = await c.connect_to_device(monitored.name)
+            else:
+                result = await clicker.connect_to_device(monitored.name)
+
+            with open("/tmp/jarvis_display_command.log", "a") as f:
+                f.write(f"[DISPLAY MONITOR] connect_to_device() returned: {result}\n")
+
+            if result.get("success"):
+                total_duration = result.get("duration", 0)
+
+                self.connected_displays.add(display_id)
+                await self._emit_event("display_connected", display=monitored)
+
+                # Speak success message
+                if self.config["voice_integration"]["speak_on_connection"]:
+                    template = self.config["voice_integration"]["connection_success_message"]
+                    message = template.format(display_name=monitored.name)
+
+                    if self.voice_handler:
+                        try:
+                            await self.voice_handler.speak(message)
+                        except:
+                            subprocess.Popen(["say", message])
+                    else:
+                        subprocess.Popen(["say", message])
+
+                logger.info(
+                    f"[DISPLAY MONITOR] ✅ SUCCESS via Simple Hardcoded Coordinates in {total_duration:.2f}s"
+                )
+                logger.info(f"[DISPLAY MONITOR] Method: {result['method']}")
+
+                # Log steps if available (handle both dict and list formats)
+                steps = result.get("steps", {})
+                if isinstance(steps, dict):
+                    logger.info(f"[DISPLAY MONITOR] Steps: {len(steps)} actions completed")
+                    for step_name, step_data in steps.items():
+                        if isinstance(step_data, dict):
+                            logger.info(
+                                f"[DISPLAY MONITOR]   {step_name}: {step_data.get('success', False)}"
+                            )
+                elif isinstance(steps, list):
+                    logger.info(f"[DISPLAY MONITOR] Steps: {len(steps)}")
+                    for step in steps:
+                        logger.info(
+                            f"[DISPLAY MONITOR]   {step.get('step')}. {step.get('action')}: {step.get('coordinates')}"
+                        )
+
+                logger.info(f"[DISPLAY MONITOR] ========================================")
+
+                # Release circuit breaker
+                logger.info(f"[DISPLAY MONITOR] 🔓 Releasing circuit breaker for {monitored.name}")
+                logger.info(
+                    f"[DISPLAY MONITOR] State before release: connecting={list(self.connecting_displays)}, connected={list(self.connected_displays)}"
+                )
+                if display_id in self.connecting_displays:
+                    self.connecting_displays.remove(display_id)
+                    logger.info(
+                        f"[DISPLAY MONITOR] ✅ Removed {display_id} from connecting_displays"
+                    )
+                else:
+                    logger.warning(
+                        f"[DISPLAY MONITOR] ⚠️  {display_id} was NOT in connecting_displays!"
+                    )
+                logger.info(
+                    f"[DISPLAY MONITOR] State after release: connecting={list(self.connecting_displays)}, connected={list(self.connected_displays)}"
+                )
+
+                return {
+                    "success": True,
+                    "message": f"Connected to {monitored.name} via Direct Coordinates",
+                    "method": "direct_coordinates",
+                    "duration": total_duration,
+                    "strategies_attempted": strategies_attempted,
+                    "coordinates": {
+                        "control_center": result["control_center_coords"],
+                        "screen_mirroring": result["screen_mirroring_coords"],
+                        "living_room_tv": result["living_room_tv_coords"],
+                    },
+                    "tier": 1,
+                }
+            else:
+                logger.warning(
+                    f"[DISPLAY MONITOR] Direct coordinates failed: {result.get('message')}"
+                )
+                raise Exception(f"Could not connect to '{monitored.name}': {result.get('message')}")
+
+        except Exception as e:
+            with open("/tmp/jarvis_display_command.log", "a") as f:
+                f.write(f"[DISPLAY MONITOR] Strategy 1 exception: {e}\n")
+                import traceback
+
+                f.write(f"{traceback.format_exc()}\n")
+            logger.warning(f"[DISPLAY MONITOR] Direct coordinates error: {e}", exc_info=True)
+            # Note: Don't release circuit breaker here - let it continue to other strategies
+
+        # Strategy 2: Protocol-Level AirPlay (Bonjour/mDNS + RAOP)
+        try:
+            from display.airplay_manager import get_airplay_manager
+
+            logger.info(
+                f"[DISPLAY MONITOR] 🥈 STRATEGY 2: Protocol-Level AirPlay (Bonjour/mDNS + RAOP)"
+            )
+            logger.info(f"[DISPLAY MONITOR] Direct network protocol for {monitored.name}")
+
+            strategies_attempted.append("airplay_protocol")
+
+            airplay_manager = get_airplay_manager()
+
+            # Initialize if not already
+            if not airplay_manager.is_initialized:
+                await airplay_manager.initialize()
+
+            # Determine mode
+            mode = monitored.connection_mode if hasattr(monitored, "connection_mode") else "extend"
+
+            result = await airplay_manager.connect_to_device(monitored.name, mode=mode)
+
+            if result.get("success"):
+                self.connected_displays.add(display_id)
+                await self._emit_event("display_connected", display=monitored)
+
+                duration = asyncio.get_event_loop().time() - connection_start
+
+                # Speak success message
+                if self.config["voice_integration"]["speak_on_connection"]:
+                    template = self.config["voice_integration"]["connection_success_message"]
+                    message = template.format(display_name=monitored.name)
+
+                    if self.voice_handler:
+                        try:
+                            await self.voice_handler.speak(message)
+                        except:
+                            subprocess.Popen(["say", message])
+                    else:
+                        subprocess.Popen(["say", message])
+
+                logger.info(
+                    f"[DISPLAY MONITOR] ✅ SUCCESS via Protocol-Level AirPlay in {duration:.2f}s"
+                )
+                logger.info(f"[DISPLAY MONITOR] ========================================")
+
+                # Release circuit breaker
+                if display_id in self.connecting_displays:
+                    self.connecting_displays.remove(display_id)
+                    logger.info(
+                        f"[DISPLAY MONITOR] 🔓 Circuit breaker released for {monitored.name}"
+                    )
+
+                return {
+                    "success": True,
+                    "message": f"Connected via AirPlay protocol in {result.get('duration', 0):.1f}s",
+                    "method": "airplay_protocol",
+                    "duration": duration,
+                    "strategies_attempted": strategies_attempted,
+                    "protocol_method": result.get("method", "system_native"),
+                    "tier": 2,
+                }
+            else:
+                logger.warning(
+                    f"[DISPLAY MONITOR] Protocol-level AirPlay failed: {result.get('message')}"
+                )
+
+        except Exception as e:
+            logger.warning(f"[DISPLAY MONITOR] Protocol-level AirPlay error: {e}")
+
+        # Strategy 3: Vision-Guided Navigator (Claude Vision)
+        try:
+            from display.vision_ui_navigator import get_vision_navigator
+
+            logger.info(f"[DISPLAY MONITOR] 🥉 STRATEGY 3: Vision-Guided Navigator (Claude Vision)")
+            logger.info(f"[DISPLAY MONITOR] JARVIS will SEE and CLICK the UI for {monitored.name}")
+
+            strategies_attempted.append("vision_guided")
+
+            navigator = get_vision_navigator()
+
+            # Connect vision analyzer if available
+            if not navigator.vision_analyzer and hasattr(self, "vision_analyzer"):
+                navigator.set_vision_analyzer(self.vision_analyzer)
+            elif not navigator.vision_analyzer:
+                # Try to get from app.state
+                try:
+                    import sys
+
+                    if hasattr(sys.modules.get("__main__"), "app"):
+                        app = sys.modules["__main__"].app
+                        if hasattr(app, "state") and hasattr(app.state, "vision_analyzer"):
+                            navigator.set_vision_analyzer(app.state.vision_analyzer)
+                            logger.info(
+                                "[DISPLAY MONITOR] Connected vision analyzer from app.state"
+                            )
+                except:
+                    pass
+
+            if navigator.vision_analyzer:
+                result = await navigator.connect_to_display(monitored.name)
+
+                if result.success:
+                    self.connected_displays.add(display_id)
+                    await self._emit_event("display_connected", display=monitored)
+
+                    duration = asyncio.get_event_loop().time() - connection_start
+
+                    # Speak success message
+                    if self.config["voice_integration"]["speak_on_connection"]:
+                        template = self.config["voice_integration"]["connection_success_message"]
+                        message = template.format(display_name=monitored.name)
+
+                        if self.voice_handler:
+                            try:
+                                await self.voice_handler.speak(message)
+                            except:
+                                subprocess.Popen(["say", message])
+                        else:
+                            subprocess.Popen(["say", message])
+
+                    logger.info(
+                        f"[DISPLAY MONITOR] ✅ SUCCESS via Vision Navigation in {duration:.2f}s"
+                    )
+                    logger.info(f"[DISPLAY MONITOR] ========================================")
+
+                    # Release circuit breaker
+                    if display_id in self.connecting_displays:
+                        self.connecting_displays.remove(display_id)
+                        logger.info(
+                            f"[DISPLAY MONITOR] 🔓 Circuit breaker released for {monitored.name}"
+                        )
+
+                    return {
+                        "success": True,
+                        "message": f"Connected via vision navigation in {result.duration:.1f}s",
+                        "method": "vision_guided",
+                        "duration": duration,
+                        "strategies_attempted": strategies_attempted,
+                        "steps_completed": result.steps_completed,
+                        "tier": 3,
+                    }
+                else:
+                    logger.warning(f"[DISPLAY MONITOR] Vision navigation failed: {result.message}")
+            else:
+                logger.warning(
+                    "[DISPLAY MONITOR] Vision analyzer not available for vision navigation"
+                )
+
+        except Exception as e:
+            logger.warning(f"[DISPLAY MONITOR] Vision navigator error: {e}")
+
+        # Strategy 4: Native Swift Bridge
+        try:
+            from display.native import get_native_controller
+
+            logger.info(f"[DISPLAY MONITOR] STRATEGY 4: Native Swift Bridge")
+            strategies_attempted.append("native_swift")
+
+            native_controller = get_native_controller()
+
+            if await native_controller.initialize():
+                logger.info(f"[DISPLAY MONITOR] Using native Swift bridge for {monitored.name}")
+
+                result = await native_controller.connect(monitored.name)
+
+                if result.success:
+                    self.connected_displays.add(display_id)
+                    await self._emit_event("display_connected", display=monitored)
+
+                    duration = asyncio.get_event_loop().time() - connection_start
+
+                    # Speak success message
+                    if self.config["voice_integration"]["speak_on_connection"]:
+                        template = self.config["voice_integration"]["connection_success_message"]
+                        message = template.format(display_name=monitored.name)
+
+                        if self.voice_handler:
+                            try:
+                                await self.voice_handler.speak(message)
+                            except:
+                                subprocess.Popen(["say", message])
+                        else:
+                            subprocess.Popen(["say", message])
+
+                    logger.info(
+                        f"[DISPLAY MONITOR] ✅ SUCCESS via Native Swift Bridge in {duration:.2f}s"
+                    )
+                    logger.info(f"[DISPLAY MONITOR] ========================================")
+
+                    # Release circuit breaker
+                    if display_id in self.connecting_displays:
+                        self.connecting_displays.remove(display_id)
+                        logger.info(
+                            f"[DISPLAY MONITOR] 🔓 Circuit breaker released for {monitored.name}"
+                        )
+
+                    return {
+                        "success": True,
+                        "message": result.message,
+                        "method": result.method,
+                        "duration": duration,
+                        "strategies_attempted": strategies_attempted,
+                        "fallback_used": result.fallback_used,
+                        "tier": 4,
+                    }
+                else:
+                    logger.warning(f"[DISPLAY MONITOR] Native bridge failed: {result.message}")
+            else:
+                logger.warning("[DISPLAY MONITOR] Native bridge not available")
+
+        except Exception as e:
+            logger.warning(f"[DISPLAY MONITOR] Native bridge error: {e}")
+
+        # Strategy 5: AppleScript fallback
+        if DetectionMethod.APPLESCRIPT in self.detectors:
+            logger.info(f"[DISPLAY MONITOR] STRATEGY 5: AppleScript Fallback")
+            strategies_attempted.append("applescript")
+
+            result = await self.detectors[DetectionMethod.APPLESCRIPT].connect_display(
+                monitored.name
+            )
+
+            if result["success"]:
+                self.connected_displays.add(display_id)
+                await self._emit_event("display_connected", display=monitored)
+
+                duration = asyncio.get_event_loop().time() - connection_start
+
+                # Speak success message
+                if self.config["voice_integration"]["speak_on_connection"]:
+                    template = self.config["voice_integration"]["connection_success_message"]
+                    message = template.format(display_name=monitored.name)
+
+                    if self.voice_handler:
+                        try:
+                            await self.voice_handler.speak(message)
+                        except:
+                            subprocess.Popen(["say", message])
+                    else:
+                        subprocess.Popen(["say", message])
+
+                logger.info(f"[DISPLAY MONITOR] ✅ SUCCESS via AppleScript in {duration:.2f}s")
+                logger.info(f"[DISPLAY MONITOR] ========================================")
+
+                # Release circuit breaker
+                if display_id in self.connecting_displays:
+                    self.connecting_displays.remove(display_id)
+                    logger.info(
+                        f"[DISPLAY MONITOR] 🔓 Circuit breaker released for {monitored.name}"
+                    )
+
+                result["duration"] = duration
+                result["strategies_attempted"] = strategies_attempted
+                result["tier"] = 5
+                return result
+
+        # Strategy 6: All automated methods failed - provide voice guidance
+        duration = asyncio.get_event_loop().time() - connection_start
+
+        guidance_message = (
+            f"I can see {monitored.name} is available, but all automated connection methods failed. "
+            f"Please click the Screen Mirroring icon in your menu bar and select {monitored.name} manually."
+        )
+
+        logger.error(f"[DISPLAY MONITOR] ❌ ALL 6 STRATEGIES FAILED for {monitored.name}")
+        logger.error(f"[DISPLAY MONITOR] Strategies attempted: {', '.join(strategies_attempted)}")
+        logger.error(f"[DISPLAY MONITOR] Total time: {duration:.2f}s")
+        logger.error(f"[DISPLAY MONITOR] ========================================")
+
+        # Speak guidance
+        if self.voice_handler:
+            try:
+                await self.voice_handler.speak(guidance_message)
+            except:
+                subprocess.Popen(["say", guidance_message])
+
+        # Release circuit breaker on failure
+        if display_id in self.connecting_displays:
+            self.connecting_displays.remove(display_id)
+            logger.info(f"[DISPLAY MONITOR] 🔓 Circuit breaker released (all strategies failed)")
+
+        return {
+            "success": False,
+            "message": guidance_message,
+            "method": "none",
+            "duration": duration,
+            "strategies_attempted": strategies_attempted,
+            "guidance_provided": True,
+            "tier": 6,
+        }
+
+    async def change_display_mode(self, display_id: str, mode: str = "extended") -> Dict[str, Any]:
+        """
+        Change the screen mirroring mode
+
+        Args:
+            display_id: Display ID from configuration
+            mode: Mirroring mode - "entire", "window", or "extended"
+
+        Returns:
+            Mode change result dictionary
+        """
+        # Find monitored display
+        monitored = next((d for d in self.monitored_displays if d.id == display_id), None)
+        if not monitored:
+            return {"success": False, "message": f"Display {display_id} not found in configuration"}
+
+        logger.info(f"[DISPLAY MONITOR] ========================================")
+        logger.info(f"[DISPLAY MONITOR] Changing {monitored.name} to {mode} mode...")
+        logger.info(f"[DISPLAY MONITOR] ========================================")
+
+        mode_start = asyncio.get_event_loop().time()
+
+        try:
+            from display.control_center_clicker_factory import get_best_clicker
+
+            logger.info(f"[DISPLAY MONITOR] Using DIRECT COORDINATES to change mode")
+            logger.info(
+                f"[DISPLAY MONITOR] Flow: Control Center → Screen Mirroring → {mode} → Start"
+            )
+
+            # Get Control Center clicker
+            cc_clicker = get_best_clicker(
+                vision_analyzer=self.vision_analyzer, enable_verification=True, prefer_uae=True
+            )
+
+            # Execute mode change flow
+            logger.info(f"[DISPLAY MONITOR] Executing 4-click mode change flow...")
+            result = cc_clicker.change_mirroring_mode(mode)
+
+            if result.get("success"):
+                total_duration = asyncio.get_event_loop().time() - mode_start
+
+                # Speak mode change confirmation
+                if self.config["voice_integration"].get("speak_on_connection", True):
+                    template = self.config["voice_integration"].get(
+                        "mode_change_success_message", "Mode changed, sir."
+                    )
+                    message = (
+                        template.format(mode=result["mode"]) if "{mode}" in template else template
+                    )
+
+                    if self.voice_handler:
+                        try:
+                            await self.voice_handler.speak(message)
+                        except:
+                            subprocess.Popen(["say", message])
+                    else:
+                        subprocess.Popen(["say", message])
+
+                logger.info(
+                    f"[DISPLAY MONITOR] ✅ SUCCESS - Changed to {result['mode']} in {total_duration:.2f}s"
+                )
+                logger.info(
+                    f"[DISPLAY MONITOR] 1. Control Center: {result['control_center_coords']}"
+                )
+                logger.info(
+                    f"[DISPLAY MONITOR] 2. Screen Mirroring: {result['screen_mirroring_coords']}"
+                )
+                logger.info(f"[DISPLAY MONITOR] 3. Change Button: {result['change_button_coords']}")
+                logger.info(f"[DISPLAY MONITOR] 4. Mode: {result['mode_coords']}")
+                logger.info(
+                    f"[DISPLAY MONITOR] 5. Start Mirroring: {result['start_mirroring_coords']}"
+                )
+                logger.info(f"[DISPLAY MONITOR] Method: {result['method']}")
+                logger.info(f"[DISPLAY MONITOR] ========================================")
+
+                return {
+                    "success": True,
+                    "message": f"Changed to {result['mode']} mode",
+                    "mode": result["mode"],
+                    "method": "direct_coordinates",
+                    "duration": total_duration,
+                    "coordinates": {
+                        "control_center": result["control_center_coords"],
+                        "screen_mirroring": result["screen_mirroring_coords"],
+                        "change_button": result["change_button_coords"],
+                        "mode": result["mode_coords"],
+                        "start_mirroring": result["start_mirroring_coords"],
+                    },
+                }
+            else:
+                logger.error(f"[DISPLAY MONITOR] ❌ Mode change failed: {result.get('message')}")
+                return result
+
+        except Exception as e:
+            total_duration = asyncio.get_event_loop().time() - mode_start
+            logger.error(f"[DISPLAY MONITOR] ❌ Mode change error: {e}", exc_info=True)
+            logger.error(f"[DISPLAY MONITOR] Total time: {total_duration:.2f}s")
+            logger.error(f"[DISPLAY MONITOR] ========================================")
+
+            return {
+                "success": False,
+                "message": f"Failed to change mode: {str(e)}",
+                "method": "none",
+                "duration": total_duration,
+                "error": str(e),
+            }
+
+    async def disconnect_display(self, display_id: str) -> Dict[str, Any]:
+        """
+        Disconnect from a display using direct coordinates
+
+        Args:
+            display_id: Display ID from configuration
+
+        Returns:
+            Disconnection result dictionary
+        """
+        # Find monitored display
+        monitored = next((d for d in self.monitored_displays if d.id == display_id), None)
+        if not monitored:
+            return {"success": False, "message": f"Display {display_id} not found in configuration"}
+
+        logger.info(f"[DISPLAY MONITOR] ========================================")
+        logger.info(f"[DISPLAY MONITOR] Disconnecting from {monitored.name}...")
+        logger.info(f"[DISPLAY MONITOR] ========================================")
+
+        disconnect_start = asyncio.get_event_loop().time()
+
+        try:
+            from display.control_center_clicker_factory import get_best_clicker
+
+            logger.info(f"[DISPLAY MONITOR] Using DIRECT COORDINATES to disconnect")
+            logger.info(f"[DISPLAY MONITOR] Flow: Control Center → Screen Mirroring → Stop")
+
+            # Get Control Center clicker
+            cc_clicker = get_best_clicker(
+                vision_analyzer=self.vision_analyzer, enable_verification=True, prefer_uae=True
+            )
+
+            # Execute disconnect flow: Control Center → Screen Mirroring → Stop
+            logger.info(f"[DISPLAY MONITOR] Executing 3-click disconnect flow...")
+            result = cc_clicker.disconnect_from_living_room_tv()
+
+            if result.get("success"):
+                total_duration = asyncio.get_event_loop().time() - disconnect_start
+
+                # Remove from connected displays
+                if display_id in self.connected_displays:
+                    self.connected_displays.remove(display_id)
+                await self._emit_event("display_disconnected", display=monitored)
+
+                # Speak disconnection message
+                if self.config["voice_integration"]["speak_on_disconnection"]:
+                    template = self.config["voice_integration"].get(
+                        "disconnection_success_message", "Display disconnected, sir."
+                    )
+                    message = (
+                        template.format(display_name=monitored.name)
+                        if "{display_name}" in template
+                        else template
+                    )
+
+                    if self.voice_handler:
+                        try:
+                            await self.voice_handler.speak(message)
+                        except:
+                            subprocess.Popen(["say", message])
+                    else:
+                        subprocess.Popen(["say", message])
+
+                logger.info(f"[DISPLAY MONITOR] ✅ SUCCESS - Disconnected in {total_duration:.2f}s")
+                logger.info(
+                    f"[DISPLAY MONITOR] 1. Control Center: {result['control_center_coords']}"
+                )
+                logger.info(
+                    f"[DISPLAY MONITOR] 2. Screen Mirroring: {result['screen_mirroring_coords']}"
+                )
+                logger.info(f"[DISPLAY MONITOR] 3. Stop: {result['stop_mirroring_coords']}")
+                logger.info(f"[DISPLAY MONITOR] Method: {result['method']}")
+                logger.info(f"[DISPLAY MONITOR] ========================================")
+
+                return {
+                    "success": True,
+                    "message": f"Disconnected from {monitored.name}",
+                    "method": "direct_coordinates",
+                    "duration": total_duration,
+                    "coordinates": {
+                        "control_center": result["control_center_coords"],
+                        "screen_mirroring": result["screen_mirroring_coords"],
+                        "stop": result["stop_mirroring_coords"],
+                    },
+                }
+            else:
+                logger.error(f"[DISPLAY MONITOR] ❌ Disconnect failed: {result.get('message')}")
+                return result
+
+        except Exception as e:
+            total_duration = asyncio.get_event_loop().time() - disconnect_start
+            logger.error(f"[DISPLAY MONITOR] ❌ Disconnect error: {e}", exc_info=True)
+            logger.error(f"[DISPLAY MONITOR] Total time: {total_duration:.2f}s")
+            logger.error(f"[DISPLAY MONITOR] ========================================")
+
+            return {
+                "success": False,
+                "message": f"Failed to disconnect: {str(e)}",
+                "method": "none",
+                "duration": total_duration,
+                "error": str(e),
+            }
+
+    async def _store_display_pattern(
+        self, monitored: "MonitoredDisplay", actual_state: Dict[str, Any]
+    ):
+        """
+        Store display connection patterns in learning database for future predictions
+        """
+        try:
+            # Get learning database instance
+            from backend.intelligence.learning_database import get_learning_database
+
+            db = await get_learning_database()
+
+            # Create pattern data
+            pattern_data = {
+                "pattern_type": "display_connection",
+                "display_id": monitored.id,
+                "display_name": monitored.name,
+                "is_connected": actual_state["is_connected"],
+                "connection_mode": actual_state.get("connection_mode"),
+                "verification_method": actual_state.get("method"),
+                "confidence": actual_state.get("confidence", 0.5),
+                "context": {
+                    "time_of_day": datetime.now().hour,
+                    "day_of_week": datetime.now().weekday(),
+                    "is_auto_connect": monitored.auto_connect,
+                    "available_displays": len(self.available_displays),
+                    "active_apps": [],  # Could be enhanced with actual app context
+                },
+                "success_rate": 1.0 if actual_state["is_connected"] else 0.0,
+                "frequency": 1,  # Will be incremented by database if pattern exists
+            }
+
+            # Store the pattern (database handles deduplication and aggregation)
+            await db.store_pattern(pattern_data, batch=True)
+
+            # Store user interaction as an action
+            action_data = {
+                "action_type": "display_query",
+                "action_detail": f"Query about {monitored.name}",
+                "timestamp": datetime.now().isoformat(),
+                "context": pattern_data["context"],
+                "result": "connected" if actual_state["is_connected"] else "not_connected",
+                "confidence": actual_state.get("confidence", 0.5),
+            }
+
+            await db.store_action(action_data, batch=True)
+
+            logger.debug(f"[DISPLAY MONITOR] Stored learning pattern for {monitored.name}")
+
+        except ImportError:
+            logger.debug(
+                "[DISPLAY MONITOR] Learning database not available, skipping pattern storage"
+            )
+        except Exception as e:
+            logger.error(f"[DISPLAY MONITOR] Failed to store learning pattern: {e}")
+
+    def get_status(self) -> Dict[str, Any]:
+        """Get current monitor status"""
+        return {
+            "is_monitoring": self.is_monitoring,
+            "available_displays": list(self.available_displays),
+            "connected_displays": list(self.connected_displays),
+            "monitored_count": len(self.monitored_displays),
+            "detection_methods": [m.value for m in self.detectors.keys()],
+            "cache_enabled": self.config["caching"]["enabled"],
+        }
+
+    def get_available_display_details(self) -> list:
+        """
+        Get detailed information about currently available displays
+
+        Returns:
+            List of dicts with display details (name, id, message)
+        """
+        details = []
+        for display_id in self.available_displays:
+            monitored = next((d for d in self.monitored_displays if d.id == display_id), None)
+            if monitored:
+                message = f"Sir, I see your {monitored.name} is now available. Would you like to extend your display to it?"
+                details.append(
+                    {
+                        "display_name": monitored.name,
+                        "display_id": monitored.id,
+                        "message": message,
+                        "auto_connect": monitored.auto_connect,
+                        "auto_prompt": monitored.auto_prompt,
+                    }
+                )
+        return details
+
+    def has_pending_prompt(self) -> bool:
+        """
+        Check if there's a pending display prompt
+
+        This is used by the vision command handler to check if JARVIS
+        is waiting for a yes/no response about connecting to a display.
+
+        Returns:
+            True if waiting for user response, False otherwise
+        """
+        # Check if we have a pending prompt that hasn't been answered yet
+        return self.pending_prompt_display is not None
+
+    async def handle_user_response(self, response: str) -> Dict:
+        """
+        Handle user voice response to display prompt
+
+        When JARVIS asks "Would you like to extend your display to Living Room TV?"
+        this handles the user's "yes" or "no" response.
+
+        Args:
+            response: User's voice command (e.g., "yes", "no", "yes jarvis")
+
+        Returns:
+            Response result with action taken
+        """
+        try:
+            if not self.has_pending_prompt():
+                return {"handled": False, "reason": "No pending prompt"}
+
+            # Get the display that has the pending prompt
+            display_id = self.pending_prompt_display
+            display_to_connect = next(
+                (d for d in self.monitored_displays if d.id == display_id), None
+            )
+
+            if not display_to_connect:
+                logger.error(
+                    f"[DISPLAY MONITOR] Pending prompt display {display_id} not found in monitored displays"
+                )
+                self.pending_prompt_display = None  # Clear invalid state
+                return {"handled": False, "reason": "Display configuration not found"}
+
+            # Parse response
+            response_lower = response.lower().strip()
+
+            # Affirmative responses
+            if any(
+                word in response_lower
+                for word in ["yes", "yeah", "yep", "sure", "connect", "extend", "mirror"]
+            ):
+                # Clear pending prompt state
+                self.pending_prompt_display = None
+                logger.info(
+                    f"[DISPLAY MONITOR] User said yes, connecting to {display_to_connect.name}"
+                )
+
+                # Determine mode
+                mode = (
+                    "mirror" if "mirror" in response_lower else display_to_connect.connection_mode
+                )
+
+                # Connect to display
+                logger.info(
+                    f"[DISPLAY MONITOR] Calling connect_display with id={display_to_connect.id}, mode={mode}"
+                )
+                result = await self.connect_display(display_to_connect.id)
+                logger.info(
+                    f"[DISPLAY MONITOR] connect_display returned: success={result.get('success')}, error={result.get('error')}"
+                )
+
+                # Generate dynamic response
+                try:
+                    from api.vision_command_handler import vision_command_handler
+
+                    if vision_command_handler and hasattr(vision_command_handler, "intelligence"):
+                        prompt = f"""The user asked you to connect to {display_to_connect.name}. You successfully connected.
+
+Generate a brief, natural JARVIS-style confirmation that:
+1. Confirms the connection is complete
+2. Is brief and conversational (1 sentence)
+3. Uses "sir" appropriately
+4. Sounds confident and efficient
+
+Respond ONLY with JARVIS's exact words, no quotes or formatting."""
+
+                        claude_response = (
+                            await vision_command_handler.intelligence._get_claude_vision_response(
+                                None, prompt
+                            )
+                        )
+                        success_response = claude_response.get(
+                            "response", f"Connected to {display_to_connect.name}, sir."
+                        )
+                    else:
+                        success_response = f"Connected to {display_to_connect.name}, sir."
+                except Exception as e:
+                    logger.warning(f"Could not generate dynamic response: {e}")
+                    success_response = f"Connected to {display_to_connect.name}, sir."
+
+                # Determine final response
+                if result.get("success"):
+                    final_response = success_response
+                else:
+                    # Connection failed - generate error response
+                    error_detail = result.get("error", "Unknown error")
+                    final_response = f"I encountered an issue connecting to {display_to_connect.name}, sir. {error_detail}"
+                    logger.error(f"[DISPLAY MONITOR] Connection failed: {error_detail}")
+
+                return {
+                    "handled": True,
+                    "action": "connect",
+                    "display_name": display_to_connect.name,
+                    "mode": mode,
+                    "result": result,
+                    "response": final_response,
+                    "success": result.get("success", False),
+                }
+
+            # Negative responses
+            elif any(word in response_lower for word in ["no", "nope", "don't", "skip", "not now"]):
+                # Clear pending prompt state
+                self.pending_prompt_display = None
+                logger.info(f"[DISPLAY MONITOR] User said no, skipping {display_to_connect.name}")
+
+                # Remove from available displays temporarily (user declined)
+                if display_to_connect.id in self.available_displays:
+                    self.available_displays.remove(display_to_connect.id)
+
+                # Generate dynamic response
+                try:
+                    from api.vision_command_handler import vision_command_handler
+
+                    if vision_command_handler and hasattr(vision_command_handler, "intelligence"):
+                        prompt = f"""The user was asked: "Sir, I see your {display_to_connect.name} is now available. Would you like to extend your display to it?"
+
+They responded: "{response}"
+
+Generate a brief, natural JARVIS-style acknowledgment that:
+1. Confirms you understood they don't want to connect
+2. Is brief and conversational (1-2 sentences max)
+3. Uses "sir" appropriately
+4. Shows understanding without being verbose
+
+Respond ONLY with JARVIS's exact words, no quotes or formatting."""
+
+                        claude_response = (
+                            await vision_command_handler.intelligence._get_claude_vision_response(
+                                None, prompt
+                            )
+                        )
+                        decline_response = claude_response.get("response", "Understood, sir.")
+                    else:
+                        decline_response = "Understood, sir."
+                except Exception as e:
+                    logger.warning(f"Could not generate dynamic response: {e}")
+                    decline_response = "Understood, sir."
+
+                return {
+                    "handled": True,
+                    "action": "skip",
+                    "display_name": display_to_connect.name,
+                    "response": decline_response,
+                }
+
+            else:
+                # Unclear response
+                return {
+                    "handled": True,
+                    "action": "clarify",
+                    "response": "Sir, I didn't quite catch that. Would you like to extend the display? Please say 'yes' or 'no'.",
+                }
+
+        except Exception as e:
+            logger.error(f"[DISPLAY MONITOR] Error handling response: {e}", exc_info=True)
+            return {"handled": False, "error": str(e)}
+
 # ============================================================================
 # Singleton Pattern and Factory Functions
 # ============================================================================

--- a/backend/display/vision_ui_navigator.py
+++ b/backend/display/vision_ui_navigator.py
@@ -1134,3 +1134,1962 @@ class VisionUINavigator:
             stats['computer_use_available'] = False
 
         return stats
+
+    def get_status(self) -> Dict[str, Any]:
+        """Get navigator status"""
+        return {
+            'initialized': True,
+            'config_loaded': self.config is not None,
+            'vision_connected': self.vision_analyzer is not None,
+            'screenshots_dir': str(self.screenshots_dir),
+            'stats': self.get_stats()
+        }
+
+    async def _click_display_ocr(self, screenshot: Image.Image, display_name: str) -> bool:
+        """Use OCR to find and click display name"""
+        try:
+            from vision.ocr_processor import OCRProcessor
+            
+            ocr = OCRProcessor()
+            text_regions = await ocr.process_image(screenshot)
+            
+            # Look for display name
+            for region in text_regions:
+                text = region.get('text', '')
+                if display_name.lower() in text.lower():
+                    bbox = region.get('bbox')
+                    if bbox:
+                        x = bbox[0] + bbox[2] // 2
+                        y = bbox[1] + bbox[3] // 2
+                        
+                        await self._click_at(x, y)
+                        return True
+            
+            return False
+            
+        except Exception as e:
+            logger.error(f"[VISION NAV] OCR display click failed: {e}")
+            return False
+
+    async def _click_screen_mirroring_ocr(self, screenshot: Image.Image) -> bool:
+        """Use OCR to find and click Screen Mirroring"""
+        try:
+            # Use existing OCR infrastructure if available
+            from vision.ocr_processor import OCRProcessor
+            
+            ocr = OCRProcessor()
+            text_regions = await ocr.process_image(screenshot)
+            
+            # Look for "Screen Mirroring" or "Display"
+            for region in text_regions:
+                text = region.get('text', '').lower()
+                if 'screen mirroring' in text or 'screen mirror' in text:
+                    # Get bounding box
+                    bbox = region.get('bbox')
+                    if bbox:
+                        # Calculate center
+                        x = bbox[0] + bbox[2] // 2
+                        y = bbox[1] + bbox[3] // 2
+                        
+                        await self._click_at(x, y)
+                        return True
+            
+            return False
+            
+        except ImportError:
+            logger.warning("[VISION NAV] OCR processor not available")
+            return False
+        except Exception as e:
+            logger.error(f"[VISION NAV] OCR click failed: {e}")
+            return False
+
+    async def _click_control_center_heuristic(self) -> bool:
+        """Fallback: Click Control Center using saved or heuristic position"""
+        try:
+            # Get screen dimensions
+            screen_width, screen_height = pyautogui.size()
+
+            # First try intelligent scanning on the menu bar
+            menu_bar_height = 50
+            menu_bar_screenshot = await self._capture_menu_bar(menu_bar_height)
+            if menu_bar_screenshot:
+                scan_result = await self._scan_for_control_center(menu_bar_screenshot)
+                if scan_result:
+                    x, y = scan_result
+                    logger.info(f"[VISION NAV] 🎯 Heuristic scan found Control Center at ({x}, {y})")
+                    await self._click_at(x, y)
+                    return True
+
+            logger.info(f"[VISION NAV] Screen dimensions: {screen_width}x{screen_height}")
+
+            # Try to use saved position from config first
+            cc_config = self.config.get('ui_elements', {}).get('control_center', {})
+
+            if 'absolute_x' in cc_config and 'absolute_y' in cc_config:
+                # Use saved position
+                saved_x = cc_config['absolute_x']
+                saved_y = cc_config['absolute_y']
+                saved_screen_width = cc_config.get('screen_width', screen_width)
+
+                # If screen resolution changed, adjust using offset
+                if saved_screen_width != screen_width and 'offset_from_right' in cc_config:
+                    offset = cc_config['offset_from_right']
+                    x = screen_width - offset
+                    y = saved_y
+                    logger.info(f"[VISION NAV] Using adjusted position (screen resolution changed): ({x}, {y})")
+                else:
+                    x = saved_x
+                    y = saved_y
+                    logger.info(f"[VISION NAV] Using saved position from config: ({x}, {y})")
+
+                await self._click_at(x, y)
+                return True
+
+            # Fallback: Use improved heuristic based on typical Control Center placement
+            logger.info(f"[VISION NAV] No saved position, using improved heuristic...")
+            logger.warning(f"[VISION NAV] 💡 TIP: For perfect accuracy, let Claude Vision analyze your menu bar")
+
+            # Control Center is typically about 150-200px from the right edge on most Macs
+            # It's to the LEFT of the WiFi/Battery icons and time display
+            # Try multiple likely positions in order of probability
+            positions_to_try = [
+                (screen_width - 180, 15, "180px from right (typical position)"),
+                (screen_width - 160, 15, "160px from right"),
+                (screen_width - 200, 15, "200px from right"),
+                (screen_width - 150, 15, "150px from right"),
+                (screen_width - 220, 15, "220px from right"),
+            ]
+
+            # Try the most likely position first
+            x, y, description = positions_to_try[0]
+            logger.info(f"[VISION NAV] Using heuristic: ({x}, {y}) - {description}")
+            logger.info(f"[VISION NAV] This should click near the Control Center icon (two overlapping rectangles)")
+
+            await self._click_at(x, y)
+            return True
+
+        except Exception as e:
+            logger.error(f"[VISION NAV] Heuristic click failed: {e}")
+            return False
+
+    async def _scan_for_control_center(self, menu_bar_screenshot: Image.Image) -> tuple:
+        """
+        Intelligently scan the menu bar to find Control Center by analyzing multiple candidate positions
+        """
+        try:
+            logger.info("[VISION NAV] 🔍 Starting intelligent Control Center scan...")
+            width = menu_bar_screenshot.width
+            height = menu_bar_screenshot.height
+
+            # Define scan range: rightmost 300 pixels, excluding time area
+            scan_start = width - 300
+            scan_end = width - 100
+
+            candidates = []
+
+            # Scan in 15-pixel increments
+            for x in range(scan_start, scan_end, 15):
+                y = 15  # Center of menu bar
+
+                # Analyze color at this position
+                color_info = self._analyze_icon_color(menu_bar_screenshot, x, y)
+
+                # Calculate distance from right edge
+                distance_from_right = width - x
+
+                # Score this candidate
+                score = 0
+                reason = []
+
+                # Position scoring (ideal: 108-142px from right)
+                if 108 <= distance_from_right <= 142:
+                    score += 50
+                    reason.append(f"ideal position ({distance_from_right}px from right)")
+                elif 100 <= distance_from_right <= 150:
+                    score += 25
+                    reason.append(f"acceptable position ({distance_from_right}px from right)")
+
+                # Color scoring (Control Center is monochrome)
+                if color_info['is_monochrome']:
+                    score += 40
+                    reason.append("monochrome (gray/white)")
+                elif not color_info['is_colorful']:
+                    score += 20
+                    reason.append("not colorful")
+                else:
+                    score -= 30  # Penalty for colorful icons (likely Siri)
+                    reason.append("COLORFUL (likely Siri)")
+
+                # Saturation scoring
+                if color_info['saturation_avg'] < 10:
+                    score += 10
+                    reason.append(f"very low saturation ({color_info['saturation_avg']:.1f}%)")
+
+                candidates.append({
+                    'x': x,
+                    'y': y,
+                    'score': score,
+                    'distance_from_right': distance_from_right,
+                    'is_colorful': color_info['is_colorful'],
+                    'is_monochrome': color_info['is_monochrome'],
+                    'saturation': color_info['saturation_avg'],
+                    'reasons': reason
+                })
+
+            # Sort candidates by score
+            candidates.sort(key=lambda c: c['score'], reverse=True)
+
+            # Log top candidates
+            logger.info(f"[VISION NAV] Found {len(candidates)} candidates:")
+            for i, candidate in enumerate(candidates[:5]):
+                logger.info(f"[VISION NAV]   #{i+1}: X={candidate['x']} (score={candidate['score']}) - {', '.join(candidate['reasons'])}")
+
+            # Select best candidate
+            if candidates and candidates[0]['score'] >= 50:
+                best = candidates[0]
+                logger.info(f"[VISION NAV] ✅ Selected best candidate at X={best['x']} with score {best['score']}")
+                return (best['x'], best['y'])
+            else:
+                logger.warning("[VISION NAV] ⚠️ No strong candidate found via scanning")
+                return None
+
+        except Exception as e:
+            logger.error(f"[VISION NAV] Error in intelligent scan: {e}")
+            return None
+
+    async def _self_correct_control_center_click(self) -> bool:
+        """
+        Self-correct by asking Claude what icon was clicked and where the real Control Center is
+
+        This method provides a feedback loop for learning from mistakes.
+
+        Returns:
+            True if successfully corrected and clicked the right icon
+        """
+        try:
+            logger.info("[VISION NAV] 🔧 Starting self-correction process...")
+
+            # Capture current screen state
+            screenshot = await self._capture_screen()
+            if not screenshot:
+                logger.error("[VISION NAV] Cannot self-correct without screenshot")
+                return False
+
+            # Crop to menu bar
+            menu_bar_screenshot = screenshot.crop((0, 0, screenshot.width, 50))
+
+            # Save for analysis
+            screenshot_path = self.screenshots_dir / f'self_correct_{int(time.time())}.png'
+            menu_bar_screenshot.save(screenshot_path)
+
+            if not self.vision_analyzer:
+                logger.error("[VISION NAV] Cannot self-correct without vision analyzer")
+                return False
+
+            # Ask Claude for correction
+            correction_prompt = """I clicked the wrong icon in the macOS menu bar. Please help me find the CORRECT Control Center icon.
+
+**What I need:**
+1. Identify which icon I clicked (wrong one)
+2. Find the ACTUAL Control Center icon (two overlapping rounded rectangles)
+3. Provide the EXACT coordinates of the CORRECT Control Center icon
+
+**Control Center icon characteristics:**
+- Two overlapping rounded rectangles (toggle/switch shape)
+- Solid icon, not transparent
+- Located in the RIGHT section of menu bar
+- Usually between WiFi/Bluetooth and the Time display
+- Typically around 150-200 pixels from the right edge
+
+**Response format:**
+WRONG_ICON: [description of what I clicked]
+CORRECT_X_POSITION: [x coordinate of REAL Control Center]
+CORRECT_Y_POSITION: [y coordinate of REAL Control Center]
+
+Example:
+WRONG_ICON: WiFi icon
+CORRECT_X_POSITION: 1260
+CORRECT_Y_POSITION: 15
+
+Please help me find the correct icon!"""
+
+            # Analyze with Claude Vision
+            logger.info("[VISION NAV] 🤖 Asking Claude for correction guidance...")
+            analysis = await self._analyze_with_vision(screenshot_path, correction_prompt)
+
+            if not analysis:
+                logger.error("[VISION NAV] No correction guidance received from Claude")
+                return False
+
+            logger.info(f"[VISION NAV] Correction guidance: {analysis[:200]}...")
+
+            # Extract corrected coordinates
+            x_match = re.search(r'CORRECT[_\s]*X[_\s]*POSITION\s*:\s*(\d+)', analysis, re.IGNORECASE)
+            y_match = re.search(r'CORRECT[_\s]*Y[_\s]*POSITION\s*:\s*(\d+)', analysis, re.IGNORECASE)
+
+            # Also try simpler patterns
+            if not (x_match and y_match):
+                coords = self._extract_coordinates_advanced(analysis, menu_bar_screenshot)
+                if coords:
+                    corrected_x, corrected_y = coords
+                    logger.info(f"[VISION NAV] 🎯 Extracted corrected coordinates: ({corrected_x}, {corrected_y})")
+                else:
+                    logger.error("[VISION NAV] Could not extract corrected coordinates")
+                    return False
+            else:
+                corrected_x = int(x_match.group(1))
+                corrected_y = int(y_match.group(1))
+                logger.info(f"[VISION NAV] 🎯 Corrected coordinates from Claude: ({corrected_x}, {corrected_y})")
+
+            # Extract what icon was clicked (for learning)
+            wrong_icon_match = re.search(r'WRONG[_\s]*ICON\s*:\s*(.+?)(?:\n|$)', analysis, re.IGNORECASE)
+            if wrong_icon_match:
+                wrong_icon = wrong_icon_match.group(1).strip()
+                logger.info(f"[VISION NAV] 📝 Claude identified wrong icon: {wrong_icon}")
+
+            # Validate corrected coordinates
+            if not self._validate_coordinates(corrected_x, corrected_y, menu_bar_screenshot.width, 50):
+                logger.warning(f"[VISION NAV] ⚠️ Corrected coordinates suspicious, adjusting...")
+                corrected_x, corrected_y = self._adjust_suspicious_coordinates(
+                    corrected_x, corrected_y, menu_bar_screenshot.width, 50
+                )
+
+            # Click the corrected coordinates
+            logger.info(f"[VISION NAV] 🖱️ Clicking corrected position: ({corrected_x}, {corrected_y})")
+            await self._click_at(corrected_x, corrected_y)
+
+            # Verify the correction worked
+            await asyncio.sleep(0.5)
+
+            # Verify and save if successful
+            if await self._verify_control_center_clicked(corrected_x, corrected_y):
+                logger.info("[VISION NAV] ✅ Self-correction successful!")
+                self._save_learned_position(corrected_x, corrected_y)
+                return True
+            else:
+                logger.warning("[VISION NAV] ⚠️ Self-correction verification failed")
+                return False
+
+        except Exception as e:
+            logger.error(f"[VISION NAV] Error during self-correction: {e}", exc_info=True)
+            return False
+
+    async def _verify_control_center_clicked(self, clicked_x: int, clicked_y: int) -> bool:
+        """
+        Verify that Control Center actually opened after clicking
+
+        Args:
+            clicked_x: X coordinate that was clicked
+            clicked_y: Y coordinate that was clicked
+
+        Returns:
+            True if Control Center opened, False otherwise
+        """
+        try:
+            # Wait for UI to respond
+            await asyncio.sleep(0.5)
+
+            # Capture current screen
+            screenshot = await self._capture_screen()
+            if not screenshot:
+                logger.warning("[VISION NAV] Could not capture screen for verification")
+                return True  # Assume success if can't verify
+
+            # Save for analysis
+            screenshot_path = self.screenshots_dir / f'verification_{int(time.time())}.png'
+            screenshot.save(screenshot_path)
+
+            if not self.vision_analyzer:
+                return True  # Assume success if no analyzer
+
+            logger.info(f"[VISION NAV] 🔍 Verifying click at ({clicked_x}, {clicked_y})...")
+
+            # Ask Claude to verify
+            verification_prompt = """Look at this screenshot. Did Control Center open?
+
+Control Center is a panel that appears when you click the Control Center icon in the menu bar.
+It typically shows:
+- WiFi settings
+- Bluetooth settings
+- Screen Mirroring button
+- Display settings
+- Sound controls
+- Other system controls
+
+Please respond with:
+- "YES" if Control Center panel is open and visible
+- "NO" if Control Center is NOT open (might have clicked wrong icon)
+
+Keep your response very brief - just YES or NO."""
+
+            # Analyze with Claude Vision
+            analysis = await self._analyze_with_vision(screenshot_path, verification_prompt)
+
+            if analysis:
+                analysis_lower = analysis.lower()
+                logger.info(f"[VISION NAV] Verification response: {analysis[:100]}")
+
+                if 'yes' in analysis_lower or 'control center' in analysis_lower and 'open' in analysis_lower:
+                    logger.info("[VISION NAV] ✅ Verification passed - Control Center opened correctly")
+                    return True
+                elif 'no' in analysis_lower:
+                    logger.warning("[VISION NAV] ❌ Verification failed - Wrong icon was clicked")
+                    return False
+
+            # If unclear, assume success
+            logger.info("[VISION NAV] ⚠️ Could not determine verification status, assuming success")
+            return True
+
+        except Exception as e:
+            logger.error(f"[VISION NAV] Error verifying click: {e}", exc_info=True)
+            return True  # Assume success on error to avoid blocking
+
+    async def _multi_pass_detection(self, menu_bar_screenshot: Image.Image) -> bool:
+        """
+        Advanced multi-pass detection using different strategies
+
+        When initial detection fails spatial validation, this method tries
+        multiple detection strategies:
+        1. Ask Claude to list ALL icons and their positions
+        2. Use process of elimination to find Control Center
+        3. Focus on rightmost region only
+
+        Args:
+            menu_bar_screenshot: Menu bar image
+
+        Returns:
+            True if successful, False otherwise
+        """
+        try:
+            logger.info("[VISION NAV] 🔄 Starting multi-pass detection...")
+
+            # Save screenshot for analysis
+            screenshot_path = self.screenshots_dir / f'multipass_{int(time.time())}.png'
+            menu_bar_screenshot.save(screenshot_path)
+
+            if not self.vision_analyzer:
+                logger.error("[VISION NAV] No vision analyzer for multi-pass")
+                return False
+
+            # PASS 1: Comprehensive icon mapping
+            logger.info("[VISION NAV] Pass 1: Mapping all icons...")
+
+            mapping_prompt = """Analyze this macOS menu bar and list ALL visible icons from LEFT to RIGHT, focusing especially on the RIGHTMOST icons.
+
+For EACH icon, provide:
+1. Icon type (e.g., "WiFi", "Bluetooth", "Battery", "Siri", "Control Center", "Time", etc.)
+2. X position (approximate center)
+3. Visual description (color, shape, etc.)
+
+**CRITICAL DISTINCTIONS - These are DIFFERENT icons:**
+
+1. **Siri**: COLORFUL circular orb (rainbow/purple/blue colors), typically at X = width - 170 to width - 150
+2. **Control Center**: TWO OVERLAPPING RECTANGLES (side by side), MONOCHROME (gray/white), typically at X = width - 135 to width - 115
+3. **Time Display**: Numbers showing time, typically at X = width - 80
+
+**IMPORTANT:** Siri and Control Center are NEXT TO EACH OTHER! Siri is to the LEFT, Control Center is to the RIGHT (closer to time display).
+
+Format your response like this:
+ICON_1: WiFi | X: 1200 | Radiating waves, white
+ICON_2: Bluetooth | X: 1225 | B symbol, white
+ICON_3: Battery | X: 1250 | Battery shape, white
+ICON_4: Siri | X: 1270 | Circular colorful orb (purple/rainbow)
+ICON_5: Control Center | X: 1315 | Two overlapping rectangles, monochrome gray
+ICON_6: Time | X: 1360 | Clock/time numbers "2:55 AM"
+
+List ALL icons you see, from left to right. Pay special attention to distinguishing Siri (colorful circle) from Control Center (gray rectangles)."""
+
+            analysis = await self._analyze_with_vision(screenshot_path, mapping_prompt)
+
+            if analysis:
+                logger.info(f"[VISION NAV] Icon mapping response: {analysis[:300]}...")
+
+                # Extract Control Center position from mapping
+                cc_match = re.search(r'Control\s*Center.*?X[:\s]*(\d+)', analysis, re.IGNORECASE)
+                if cc_match:
+                    x = int(cc_match.group(1))
+                    y = 15  # Menu bar center
+
+                    logger.info(f"[VISION NAV] ✅ Multi-pass detected Control Center at ({x}, {y})")
+
+                    # Validate this position with strict bounds
+                    width = menu_bar_screenshot.width
+                    distance_from_right = width - x
+
+                    if distance_from_right > 142 or distance_from_right < 108:
+                        logger.warning(f"[VISION NAV] ⚠️ Multi-pass position {distance_from_right}px from right is outside ideal range (108-142px)")
+                        # Continue to Pass 2 instead of using this position
+                    elif await self._validate_control_center_position(x, y, menu_bar_screenshot):
+                        # Position is good, click it
+                        await self._click_at(x, y)
+
+                        # Verify
+                        if await self._verify_control_center_clicked(x, y):
+                            logger.info("[VISION NAV] ✅ Multi-pass detection successful!")
+                            return True
+
+            # PASS 2: Focused right-side detection
+            logger.info("[VISION NAV] Pass 2: Focused right-side scan...")
+
+            # Crop to rightmost 250 pixels only
+            right_section = menu_bar_screenshot.crop((menu_bar_screenshot.width - 250, 0, menu_bar_screenshot.width, 50))
+            right_path = self.screenshots_dir / f'right_section_{int(time.time())}.png'
+            right_section.save(right_path)
+
+            focused_prompt = """This is the RIGHTMOST section of the macOS menu bar (last 250 pixels).
+
+Find the Control Center icon. It looks like TWO OVERLAPPING RECTANGLES side by side, MONOCHROME (gray/white).
+
+**CRITICAL - IGNORE THESE WRONG ICONS:**
+- Siri: COLORFUL circular orb (purple/rainbow) - This is TOO FAR LEFT!
+- Sun symbol (brightness) - Wrong shape
+- WiFi waves - Wrong shape
+- Battery - Wrong shape
+- Clock/time numbers - TOO FAR RIGHT!
+
+**WHAT TO LOOK FOR:**
+- Shape: TWO RECTANGLES side by side [ ][ ] or overlapping slightly
+- Color: MONOCHROME gray or white (NOT colorful!)
+- Position: Between Siri (colorful) and Time (numbers), typically around X=115-135 in this 250px crop
+- This should be the icon CLOSEST to the right edge that is NOT the time display
+
+**YOUR TASK:**
+Look for the MONOCHROME rectangular icon between any colorful icons (like Siri) and the time display.
+
+Provide X position relative to this cropped image (0-250).
+
+Format:
+X_POSITION: [number]
+Y_POSITION: 15
+
+Be VERY careful - Control Center is monochrome rectangles, NOT the colorful Siri orb!"""
+
+            analysis2 = await self._analyze_with_vision(right_path, focused_prompt)
+
+            if analysis2:
+                coords = self._extract_coordinates_advanced(analysis2, right_section)
+                if coords:
+                    relative_x, y = coords
+                    # Convert relative X to absolute X
+                    absolute_x = (menu_bar_screenshot.width - 250) + relative_x
+
+                    logger.info(f"[VISION NAV] ✅ Focused scan detected at relative ({relative_x}, {y}), absolute ({absolute_x}, {y})")
+
+                    # Validate position with strict bounds
+                    width = menu_bar_screenshot.width
+                    distance_from_right = width - absolute_x
+
+                    if distance_from_right > 142 or distance_from_right < 108:
+                        logger.warning(f"[VISION NAV] ⚠️ Focused scan position {distance_from_right}px from right is outside ideal range (108-142px)")
+                        logger.warning("[VISION NAV] ⚠️ Skipping this detection, will use heuristic")
+                    else:
+                        logger.info(f"[VISION NAV] ✅ Focused scan position validated: {distance_from_right}px from right edge")
+                        # Click it
+                        await self._click_at(absolute_x, y)
+
+                        # Verify
+                        if await self._verify_control_center_clicked(absolute_x, y):
+                            logger.info("[VISION NAV] ✅ Focused scan successful!")
+                            return True
+
+            # PASS 3: Intelligent scanning approach
+            logger.info("[VISION NAV] Pass 3: Intelligent scanning approach...")
+            scan_result = await self._scan_for_control_center(menu_bar_screenshot)
+            if scan_result:
+                x, y = scan_result
+                logger.info(f"[VISION NAV] ✅ Intelligent scan found Control Center at ({x}, {y})")
+                await self._click_at(x, y)
+                if await self._verify_control_center_clicked(x, y):
+                    logger.info("[VISION NAV] ✅ Intelligent scan successful!")
+                    return True
+
+            # If all passes fail, fall back to heuristic
+            logger.warning("[VISION NAV] ⚠️ All multi-pass attempts failed, using heuristic")
+            return await self._click_control_center_heuristic()
+
+        except Exception as e:
+            logger.error(f"[VISION NAV] Error in multi-pass detection: {e}", exc_info=True)
+            return False
+
+    async def _validate_control_center_position(self, x: int, y: int, menu_bar_screenshot: Image.Image) -> bool:
+        """
+        Advanced spatial validation to ensure detected position is reasonable for Control Center
+
+        Uses spatial reasoning to validate that the detected coordinates make sense
+        for where Control Center icon should be located.
+
+        Args:
+            x: Detected X coordinate
+            y: Detected Y coordinate
+            menu_bar_screenshot: Menu bar image
+
+        Returns:
+            True if position passes validation, False otherwise
+        """
+        try:
+            width = menu_bar_screenshot.width
+
+            # Control Center should be in the RIGHT 30% of menu bar
+            right_section_start = width * 0.7
+
+            if x < right_section_start:
+                logger.warning(f"[VISION NAV] ⚠️ X={x} too far left (should be > {right_section_start:.0f})")
+                return False
+
+            # Control Center should NOT be in the very last 100px (that's usually time/date)
+            if x > width - 100:
+                logger.warning(f"[VISION NAV] ⚠️ X={x} too far right (time display area)")
+                return False
+
+            # Y should be centered in menu bar
+            if y < 5 or y > 35:
+                logger.warning(f"[VISION NAV] ⚠️ Y={y} outside menu bar center range (5-35)")
+                return False
+
+            logger.info(f"[VISION NAV] ✅ Position validation passed for ({x}, {y})")
+            return True
+
+        except Exception as e:
+            logger.error(f"[VISION NAV] Error in position validation: {e}")
+            return True  # Don't block on validation errors
+
+    async def _click_at(self, x: int, y: int):
+        """Click at specific coordinates"""
+        try:
+            logger.info(f"[VISION NAV] Clicking at ({x}, {y})")
+            
+            # Move to position
+            pyautogui.moveTo(x, y, duration=self.config['mouse']['movement_speed'])
+            
+            # Brief pause
+            await asyncio.sleep(0.1)
+            
+            # Click
+            pyautogui.click(x, y, duration=self.config['mouse']['click_duration'])
+            
+            logger.debug(f"[VISION NAV] Click executed at ({x}, {y})")
+            
+        except Exception as e:
+            logger.error(f"[VISION NAV] Click error: {e}")
+            raise
+
+    def _extract_coordinates_from_response(self, response: str) -> Optional[Tuple[int, int]]:
+        """
+        Legacy coordinate extraction method (kept for compatibility)
+
+        NOTE: Use _extract_coordinates_advanced() for new code
+        """
+        if not response:
+            return None
+
+        try:
+            # Use a simple fallback implementation
+            # Pattern: X_POSITION: 1234, Y_POSITION: 56
+            x_match = re.search(r'X[_\s]*POSITION:\s*(\d+)', response, re.IGNORECASE)
+            y_match = re.search(r'Y[_\s]*POSITION:\s*(\d+)', response, re.IGNORECASE)
+            if x_match and y_match:
+                x, y = int(x_match.group(1)), int(y_match.group(1))
+                return (x, y)
+
+            # Pattern: (x, y)
+            match = re.search(r'\((\d+),\s*(\d+)\)', response)
+            if match:
+                x, y = int(match.group(1)), int(match.group(2))
+                return (x, y)
+
+            return None
+
+        except Exception as e:
+            logger.error(f"[VISION NAV] Error extracting coordinates: {e}")
+            return None
+
+    def _adjust_suspicious_coordinates(self, x: int, y: int, width: int, height: int) -> Tuple[int, int]:
+        """
+        Adjust suspicious coordinates to reasonable values
+
+        Args:
+            x: X coordinate
+            y: Y coordinate
+            width: Screen/region width
+            height: Screen/region height
+
+        Returns:
+            Adjusted (x, y) tuple
+        """
+        adjusted_x = x
+        adjusted_y = y
+
+        # If Y is too large, assume menu bar center
+        if y > height:
+            adjusted_y = 15  # Menu bar center
+            logger.info(f"[VISION NAV] Adjusted Y: {y} → {adjusted_y} (menu bar center)")
+
+        # If X is too large, cap at width
+        if x > width:
+            # Try to preserve relative position
+            if x <= width * 2:  # Might be Retina coordinates
+                adjusted_x = x // 2
+                logger.info(f"[VISION NAV] Adjusted X: {x} → {adjusted_x} (Retina scaling)")
+            else:
+                adjusted_x = width - 180  # Typical Control Center position
+                logger.info(f"[VISION NAV] Adjusted X: {x} → {adjusted_x} (capped to typical position)")
+
+        # If X is too small (unlikely for Control Center in right section)
+        if x < width // 2:
+            logger.warning(f"[VISION NAV] X coordinate {x} seems too far left for Control Center")
+            adjusted_x = width - 180
+            logger.info(f"[VISION NAV] Adjusted X: {x} → {adjusted_x} (moved to right section)")
+
+        return (adjusted_x, adjusted_y)
+
+    def _validate_coordinates(self, x: int, y: int, width: int, height: int) -> bool:
+        """
+        Validate that coordinates are within acceptable bounds
+
+        Args:
+            x: X coordinate
+            y: Y coordinate
+            width: Screen/region width
+            height: Screen/region height
+
+        Returns:
+            True if valid, False otherwise
+        """
+        # Allow some tolerance for Retina displays (2x scaling)
+        max_x = width * 2
+        max_y = height * 2
+
+        valid = (
+            0 <= x <= max_x and
+            0 <= y <= max_y
+        )
+
+        if not valid:
+            logger.warning(f"[VISION NAV] Coordinates ({x}, {y}) outside bounds (0-{max_x}, 0-{max_y})")
+
+        return valid
+
+    def _validate_and_return(self, x: int, y: int, screenshot: Image.Image) -> Tuple[int, int]:
+        """
+        Validate coordinates and return them (with logging)
+
+        Args:
+            x: X coordinate
+            y: Y coordinate
+            screenshot: Screenshot for dimension checking
+
+        Returns:
+            (x, y) tuple
+        """
+        width = screenshot.width
+        height = screenshot.height
+
+        # Log dimensions for debugging
+        logger.debug(f"[VISION NAV] Screenshot dimensions: {width}x{height}px")
+        logger.debug(f"[VISION NAV] Proposed coordinates: ({x}, {y})")
+
+        # Basic sanity checks
+        if x < 0 or y < 0:
+            logger.warning(f"[VISION NAV] ⚠️ Negative coordinates: ({x}, {y})")
+
+        if x > width:
+            logger.warning(f"[VISION NAV] ⚠️ X coordinate {x} exceeds width {width}")
+
+        if y > height:
+            logger.warning(f"[VISION NAV] ⚠️ Y coordinate {y} exceeds height {height}")
+
+        return (x, y)
+
+    def _extract_coordinates_advanced(self, response: str, screenshot: Image.Image) -> Optional[Tuple[int, int]]:
+        """
+        Advanced coordinate extraction with multiple format support and validation
+
+        Supports formats like:
+        - X_POSITION: 1260, Y_POSITION: 15
+        - (1260, 15)
+        - x: 1260, y: 15
+        - center at 1260, 15
+        - 180 pixels from right edge
+
+        Args:
+            response: Claude Vision response text
+            screenshot: Screenshot being analyzed (for dimension validation)
+
+        Returns:
+            (x, y) tuple or None
+        """
+        if not response:
+            logger.warning("[VISION NAV] Empty response from Claude Vision")
+            return None
+
+        try:
+            logger.debug(f"[VISION NAV] Parsing response: {response[:200]}...")
+
+            # Pattern 1: X_POSITION: 1234, Y_POSITION: 56 (our requested format)
+            x_match = re.search(r'X[_\s]*POSITION\s*:\s*(\d+)', response, re.IGNORECASE)
+            y_match = re.search(r'Y[_\s]*POSITION\s*:\s*(\d+)', response, re.IGNORECASE)
+            if x_match and y_match:
+                x, y = int(x_match.group(1)), int(y_match.group(1))
+                logger.info(f"[VISION NAV] ✅ Extracted (X_POSITION format): ({x}, {y})")
+                return self._validate_and_return(x, y, screenshot)
+
+            # Pattern 2: (x, y) tuple format
+            match = re.search(r'\((\d+),\s*(\d+)\)', response)
+            if match:
+                x, y = int(match.group(1)), int(match.group(2))
+                logger.info(f"[VISION NAV] ✅ Extracted (tuple format): ({x}, {y})")
+                return self._validate_and_return(x, y, screenshot)
+
+            # Pattern 3: x: 1234, y: 56
+            match = re.search(r'x\s*[:=]\s*(\d+).*?y\s*[:=]\s*(\d+)', response, re.IGNORECASE | re.DOTALL)
+            if match:
+                x, y = int(match.group(1)), int(match.group(2))
+                logger.info(f"[VISION NAV] ✅ Extracted (x:y format): ({x}, {y})")
+                return self._validate_and_return(x, y, screenshot)
+
+            # Pattern 4: JSON format {"x": 1234, "y": 56}
+            match = re.search(r'\{.*?"x"\s*:\s*(\d+).*?"y"\s*:\s*(\d+).*?\}', response, re.IGNORECASE | re.DOTALL)
+            if match:
+                x, y = int(match.group(1)), int(match.group(2))
+                logger.info(f"[VISION NAV] ✅ Extracted (JSON format): ({x}, {y})")
+                return self._validate_and_return(x, y, screenshot)
+
+            # Pattern 5: "center at 1234, 56" or "located at 1234, 56"
+            match = re.search(r'(?:center|located|position|point)\s+(?:at\s+)?(\d+)\s*,\s*(\d+)', response, re.IGNORECASE)
+            if match:
+                x, y = int(match.group(1)), int(match.group(2))
+                logger.info(f"[VISION NAV] ✅ Extracted (descriptive format): ({x}, {y})")
+                return self._validate_and_return(x, y, screenshot)
+
+            # Pattern 6: Descriptive "X pixels from left/right, Y pixels from top"
+            left_match = re.search(r'(\d+)\s*(?:px|pixels?)?\s*from\s+(?:the\s+)?left', response, re.IGNORECASE)
+            right_match = re.search(r'(\d+)\s*(?:px|pixels?)?\s*from\s+(?:the\s+)?right', response, re.IGNORECASE)
+            top_match = re.search(r'(\d+)\s*(?:px|pixels?)?\s*from\s+(?:the\s+)?top', response, re.IGNORECASE)
+
+            if (left_match or right_match) and top_match:
+                if left_match:
+                    x = int(left_match.group(1))
+                elif right_match:
+                    x = screenshot.width - int(right_match.group(1))
+
+                y = int(top_match.group(1))
+                logger.info(f"[VISION NAV] ✅ Extracted (descriptive pixels format): ({x}, {y})")
+                return self._validate_and_return(x, y, screenshot)
+
+            # Pattern 7: Two sequential 3-4 digit numbers (last resort)
+            numbers = re.findall(r'\b(\d{3,4})\b', response)
+            if len(numbers) >= 2:
+                x, y = int(numbers[0]), int(numbers[1])
+                # Only use if reasonable for screenshot dimensions
+                if 0 <= x <= screenshot.width * 2 and 0 <= y <= 100:  # Allow 2x for Retina
+                    logger.info(f"[VISION NAV] ⚠️  Extracted (guessed from numbers): ({x}, {y})")
+                    return self._validate_and_return(x, y, screenshot)
+
+            # No patterns matched
+            logger.error(f"[VISION NAV] ❌ Could not extract coordinates from Claude response")
+            logger.error(f"[VISION NAV] Full response: {response[:800]}")
+            return None
+
+        except Exception as e:
+            logger.error(f"[VISION NAV] Error extracting coordinates: {e}", exc_info=True)
+            return None
+
+    async def _analyze_with_vision(self, image_path: Path, prompt: str) -> Optional[str]:
+        """Analyze image with Claude Vision"""
+        if not self.vision_analyzer:
+            logger.warning("[VISION NAV] No vision analyzer available")
+            return None
+        
+        try:
+            # Load image as PIL Image (Claude Vision Analyzer expects this)
+            image = Image.open(image_path)
+            
+            # Use analyze_screenshot method (standard for ClaudeVisionAnalyzer)
+            response = await self.vision_analyzer.analyze_screenshot(
+                image=image,  # Pass PIL Image directly
+                prompt=prompt,
+                use_cache=False  # Don't cache UI navigation prompts
+            )
+            
+            # Handle response - analyze_screenshot returns (Dict, AnalysisMetrics)
+            if isinstance(response, tuple):
+                analysis_dict, metrics = response
+                # Extract text from response
+                if isinstance(analysis_dict, dict):
+                    response_text = analysis_dict.get('response', analysis_dict.get('text', str(analysis_dict)))
+                else:
+                    response_text = str(analysis_dict)
+            else:
+                response_text = str(response)
+            
+            logger.info(f"[VISION NAV] Claude response: {response_text[:300] if response_text else 'None'}...")
+            
+            return response_text
+            
+        except Exception as e:
+            logger.error(f"[VISION NAV] Vision analysis error: {e}", exc_info=True)
+            return None
+
+    async def _capture_menu_bar(self, menu_bar_height: int = 50) -> Optional[Image.Image]:
+        """
+        Capture just the menu bar area from the screen
+
+        Args:
+            menu_bar_height: Height of the menu bar in pixels (default: 50)
+
+        Returns:
+            PIL Image of the menu bar region, or None if capture fails
+        """
+        try:
+            # Capture full screen
+            full_screen = await self._capture_screen()
+            if not full_screen:
+                return None
+
+            # Crop to menu bar area (top portion)
+            width, height = full_screen.size
+            menu_bar_region = full_screen.crop((0, 0, width, menu_bar_height))
+
+            logger.debug(f"[VISION NAV] Menu bar captured: {width}x{menu_bar_height}px")
+            return menu_bar_region
+
+        except Exception as e:
+            logger.debug(f"[VISION NAV] Failed to capture menu bar: {e}")
+            return None
+
+    async def _capture_screen(self) -> Optional[Image.Image]:
+        """Capture current screen using existing vision infrastructure"""
+        try:
+            # Try using existing reliable screenshot capture
+            from vision.reliable_screenshot_capture import ReliableScreenshotCapture
+            
+            capture = ReliableScreenshotCapture()
+            
+            # Try different capture methods
+            if hasattr(capture, 'capture_current_space'):
+                result = await capture.capture_current_space()
+            elif hasattr(capture, 'capture_screen'):
+                result = await capture.capture_screen()
+            elif hasattr(capture, 'capture'):
+                result = capture.capture()
+            else:
+                # Manually call the capture method
+                result = await capture.capture_with_fallback()
+            
+            if hasattr(result, 'success') and result.success and hasattr(result, 'image'):
+                return result.image
+            elif isinstance(result, Image.Image):
+                return result
+            
+        except ImportError:
+            logger.debug("[VISION NAV] ReliableScreenshotCapture not available")
+        except AttributeError as e:
+            logger.debug(f"[VISION NAV] Screenshot method not available: {e}")
+        except Exception as e:
+            logger.debug(f"[VISION NAV] Screenshot capture error: {e}")
+        
+        # Fallback: Use screencapture command
+        try:
+            temp_path = self.screenshots_dir / f'temp_{int(time.time())}.png'
+            
+            process = await asyncio.create_subprocess_exec(
+                'screencapture', '-x', str(temp_path),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE
+            )
+            
+            await process.communicate()
+            
+            if temp_path.exists():
+                image = Image.open(temp_path)
+                temp_path.unlink()  # Clean up
+                logger.debug(f"[VISION NAV] Screenshot captured with screencapture command")
+                return image
+                
+        except Exception as e:
+            logger.error(f"[VISION NAV] Screenshot fallback failed: {e}")
+        
+        return None
+
+def get_vision_navigator(config_path: Optional[str] = None) -> VisionUINavigator:
+    """Get singleton vision navigator instance"""
+    global _navigator_instance
+    if _navigator_instance is None:
+        _navigator_instance = VisionUINavigator(config_path)
+    return _navigator_instance
+
+    def get_status(self) -> Dict[str, Any]:
+        """Get navigator status"""
+        return {
+            'initialized': True,
+            'config_loaded': self.config is not None,
+            'vision_connected': self.vision_analyzer is not None,
+            'screenshots_dir': str(self.screenshots_dir),
+            'stats': self.get_stats()
+        }
+
+    async def _click_display_ocr(self, screenshot: Image.Image, display_name: str) -> bool:
+        """Use OCR to find and click display name"""
+        try:
+            from vision.ocr_processor import OCRProcessor
+            
+            ocr = OCRProcessor()
+            text_regions = await ocr.process_image(screenshot)
+            
+            # Look for display name
+            for region in text_regions:
+                text = region.get('text', '')
+                if display_name.lower() in text.lower():
+                    bbox = region.get('bbox')
+                    if bbox:
+                        x = bbox[0] + bbox[2] // 2
+                        y = bbox[1] + bbox[3] // 2
+                        
+                        await self._click_at(x, y)
+                        return True
+            
+            return False
+            
+        except Exception as e:
+            logger.error(f"[VISION NAV] OCR display click failed: {e}")
+            return False
+
+    async def _click_screen_mirroring_ocr(self, screenshot: Image.Image) -> bool:
+        """Use OCR to find and click Screen Mirroring"""
+        try:
+            # Use existing OCR infrastructure if available
+            from vision.ocr_processor import OCRProcessor
+            
+            ocr = OCRProcessor()
+            text_regions = await ocr.process_image(screenshot)
+            
+            # Look for "Screen Mirroring" or "Display"
+            for region in text_regions:
+                text = region.get('text', '').lower()
+                if 'screen mirroring' in text or 'screen mirror' in text:
+                    # Get bounding box
+                    bbox = region.get('bbox')
+                    if bbox:
+                        # Calculate center
+                        x = bbox[0] + bbox[2] // 2
+                        y = bbox[1] + bbox[3] // 2
+                        
+                        await self._click_at(x, y)
+                        return True
+            
+            return False
+            
+        except ImportError:
+            logger.warning("[VISION NAV] OCR processor not available")
+            return False
+        except Exception as e:
+            logger.error(f"[VISION NAV] OCR click failed: {e}")
+            return False
+
+    async def _click_control_center_heuristic(self) -> bool:
+        """Fallback: Click Control Center using saved or heuristic position"""
+        try:
+            # Get screen dimensions
+            screen_width, screen_height = pyautogui.size()
+
+            # First try intelligent scanning on the menu bar
+            menu_bar_height = 50
+            menu_bar_screenshot = await self._capture_menu_bar(menu_bar_height)
+            if menu_bar_screenshot:
+                scan_result = await self._scan_for_control_center(menu_bar_screenshot)
+                if scan_result:
+                    x, y = scan_result
+                    logger.info(f"[VISION NAV] 🎯 Heuristic scan found Control Center at ({x}, {y})")
+                    await self._click_at(x, y)
+                    return True
+
+            logger.info(f"[VISION NAV] Screen dimensions: {screen_width}x{screen_height}")
+
+            # Try to use saved position from config first
+            cc_config = self.config.get('ui_elements', {}).get('control_center', {})
+
+            if 'absolute_x' in cc_config and 'absolute_y' in cc_config:
+                # Use saved position
+                saved_x = cc_config['absolute_x']
+                saved_y = cc_config['absolute_y']
+                saved_screen_width = cc_config.get('screen_width', screen_width)
+
+                # If screen resolution changed, adjust using offset
+                if saved_screen_width != screen_width and 'offset_from_right' in cc_config:
+                    offset = cc_config['offset_from_right']
+                    x = screen_width - offset
+                    y = saved_y
+                    logger.info(f"[VISION NAV] Using adjusted position (screen resolution changed): ({x}, {y})")
+                else:
+                    x = saved_x
+                    y = saved_y
+                    logger.info(f"[VISION NAV] Using saved position from config: ({x}, {y})")
+
+                await self._click_at(x, y)
+                return True
+
+            # Fallback: Use improved heuristic based on typical Control Center placement
+            logger.info(f"[VISION NAV] No saved position, using improved heuristic...")
+            logger.warning(f"[VISION NAV] 💡 TIP: For perfect accuracy, let Claude Vision analyze your menu bar")
+
+            # Control Center is typically about 150-200px from the right edge on most Macs
+            # It's to the LEFT of the WiFi/Battery icons and time display
+            # Try multiple likely positions in order of probability
+            positions_to_try = [
+                (screen_width - 180, 15, "180px from right (typical position)"),
+                (screen_width - 160, 15, "160px from right"),
+                (screen_width - 200, 15, "200px from right"),
+                (screen_width - 150, 15, "150px from right"),
+                (screen_width - 220, 15, "220px from right"),
+            ]
+
+            # Try the most likely position first
+            x, y, description = positions_to_try[0]
+            logger.info(f"[VISION NAV] Using heuristic: ({x}, {y}) - {description}")
+            logger.info(f"[VISION NAV] This should click near the Control Center icon (two overlapping rectangles)")
+
+            await self._click_at(x, y)
+            return True
+
+        except Exception as e:
+            logger.error(f"[VISION NAV] Heuristic click failed: {e}")
+            return False
+
+    async def _scan_for_control_center(self, menu_bar_screenshot: Image.Image) -> tuple:
+        """
+        Intelligently scan the menu bar to find Control Center by analyzing multiple candidate positions
+        """
+        try:
+            logger.info("[VISION NAV] 🔍 Starting intelligent Control Center scan...")
+            width = menu_bar_screenshot.width
+            height = menu_bar_screenshot.height
+
+            # Define scan range: rightmost 300 pixels, excluding time area
+            scan_start = width - 300
+            scan_end = width - 100
+
+            candidates = []
+
+            # Scan in 15-pixel increments
+            for x in range(scan_start, scan_end, 15):
+                y = 15  # Center of menu bar
+
+                # Analyze color at this position
+                color_info = self._analyze_icon_color(menu_bar_screenshot, x, y)
+
+                # Calculate distance from right edge
+                distance_from_right = width - x
+
+                # Score this candidate
+                score = 0
+                reason = []
+
+                # Position scoring (ideal: 108-142px from right)
+                if 108 <= distance_from_right <= 142:
+                    score += 50
+                    reason.append(f"ideal position ({distance_from_right}px from right)")
+                elif 100 <= distance_from_right <= 150:
+                    score += 25
+                    reason.append(f"acceptable position ({distance_from_right}px from right)")
+
+                # Color scoring (Control Center is monochrome)
+                if color_info['is_monochrome']:
+                    score += 40
+                    reason.append("monochrome (gray/white)")
+                elif not color_info['is_colorful']:
+                    score += 20
+                    reason.append("not colorful")
+                else:
+                    score -= 30  # Penalty for colorful icons (likely Siri)
+                    reason.append("COLORFUL (likely Siri)")
+
+                # Saturation scoring
+                if color_info['saturation_avg'] < 10:
+                    score += 10
+                    reason.append(f"very low saturation ({color_info['saturation_avg']:.1f}%)")
+
+                candidates.append({
+                    'x': x,
+                    'y': y,
+                    'score': score,
+                    'distance_from_right': distance_from_right,
+                    'is_colorful': color_info['is_colorful'],
+                    'is_monochrome': color_info['is_monochrome'],
+                    'saturation': color_info['saturation_avg'],
+                    'reasons': reason
+                })
+
+            # Sort candidates by score
+            candidates.sort(key=lambda c: c['score'], reverse=True)
+
+            # Log top candidates
+            logger.info(f"[VISION NAV] Found {len(candidates)} candidates:")
+            for i, candidate in enumerate(candidates[:5]):
+                logger.info(f"[VISION NAV]   #{i+1}: X={candidate['x']} (score={candidate['score']}) - {', '.join(candidate['reasons'])}")
+
+            # Select best candidate
+            if candidates and candidates[0]['score'] >= 50:
+                best = candidates[0]
+                logger.info(f"[VISION NAV] ✅ Selected best candidate at X={best['x']} with score {best['score']}")
+                return (best['x'], best['y'])
+            else:
+                logger.warning("[VISION NAV] ⚠️ No strong candidate found via scanning")
+                return None
+
+        except Exception as e:
+            logger.error(f"[VISION NAV] Error in intelligent scan: {e}")
+            return None
+
+    async def _self_correct_control_center_click(self) -> bool:
+        """
+        Self-correct by asking Claude what icon was clicked and where the real Control Center is
+
+        This method provides a feedback loop for learning from mistakes.
+
+        Returns:
+            True if successfully corrected and clicked the right icon
+        """
+        try:
+            logger.info("[VISION NAV] 🔧 Starting self-correction process...")
+
+            # Capture current screen state
+            screenshot = await self._capture_screen()
+            if not screenshot:
+                logger.error("[VISION NAV] Cannot self-correct without screenshot")
+                return False
+
+            # Crop to menu bar
+            menu_bar_screenshot = screenshot.crop((0, 0, screenshot.width, 50))
+
+            # Save for analysis
+            screenshot_path = self.screenshots_dir / f'self_correct_{int(time.time())}.png'
+            menu_bar_screenshot.save(screenshot_path)
+
+            if not self.vision_analyzer:
+                logger.error("[VISION NAV] Cannot self-correct without vision analyzer")
+                return False
+
+            # Ask Claude for correction
+            correction_prompt = """I clicked the wrong icon in the macOS menu bar. Please help me find the CORRECT Control Center icon.
+
+**What I need:**
+1. Identify which icon I clicked (wrong one)
+2. Find the ACTUAL Control Center icon (two overlapping rounded rectangles)
+3. Provide the EXACT coordinates of the CORRECT Control Center icon
+
+**Control Center icon characteristics:**
+- Two overlapping rounded rectangles (toggle/switch shape)
+- Solid icon, not transparent
+- Located in the RIGHT section of menu bar
+- Usually between WiFi/Bluetooth and the Time display
+- Typically around 150-200 pixels from the right edge
+
+**Response format:**
+WRONG_ICON: [description of what I clicked]
+CORRECT_X_POSITION: [x coordinate of REAL Control Center]
+CORRECT_Y_POSITION: [y coordinate of REAL Control Center]
+
+Example:
+WRONG_ICON: WiFi icon
+CORRECT_X_POSITION: 1260
+CORRECT_Y_POSITION: 15
+
+Please help me find the correct icon!"""
+
+            # Analyze with Claude Vision
+            logger.info("[VISION NAV] 🤖 Asking Claude for correction guidance...")
+            analysis = await self._analyze_with_vision(screenshot_path, correction_prompt)
+
+            if not analysis:
+                logger.error("[VISION NAV] No correction guidance received from Claude")
+                return False
+
+            logger.info(f"[VISION NAV] Correction guidance: {analysis[:200]}...")
+
+            # Extract corrected coordinates
+            x_match = re.search(r'CORRECT[_\s]*X[_\s]*POSITION\s*:\s*(\d+)', analysis, re.IGNORECASE)
+            y_match = re.search(r'CORRECT[_\s]*Y[_\s]*POSITION\s*:\s*(\d+)', analysis, re.IGNORECASE)
+
+            # Also try simpler patterns
+            if not (x_match and y_match):
+                coords = self._extract_coordinates_advanced(analysis, menu_bar_screenshot)
+                if coords:
+                    corrected_x, corrected_y = coords
+                    logger.info(f"[VISION NAV] 🎯 Extracted corrected coordinates: ({corrected_x}, {corrected_y})")
+                else:
+                    logger.error("[VISION NAV] Could not extract corrected coordinates")
+                    return False
+            else:
+                corrected_x = int(x_match.group(1))
+                corrected_y = int(y_match.group(1))
+                logger.info(f"[VISION NAV] 🎯 Corrected coordinates from Claude: ({corrected_x}, {corrected_y})")
+
+            # Extract what icon was clicked (for learning)
+            wrong_icon_match = re.search(r'WRONG[_\s]*ICON\s*:\s*(.+?)(?:\n|$)', analysis, re.IGNORECASE)
+            if wrong_icon_match:
+                wrong_icon = wrong_icon_match.group(1).strip()
+                logger.info(f"[VISION NAV] 📝 Claude identified wrong icon: {wrong_icon}")
+
+            # Validate corrected coordinates
+            if not self._validate_coordinates(corrected_x, corrected_y, menu_bar_screenshot.width, 50):
+                logger.warning(f"[VISION NAV] ⚠️ Corrected coordinates suspicious, adjusting...")
+                corrected_x, corrected_y = self._adjust_suspicious_coordinates(
+                    corrected_x, corrected_y, menu_bar_screenshot.width, 50
+                )
+
+            # Click the corrected coordinates
+            logger.info(f"[VISION NAV] 🖱️ Clicking corrected position: ({corrected_x}, {corrected_y})")
+            await self._click_at(corrected_x, corrected_y)
+
+            # Verify the correction worked
+            await asyncio.sleep(0.5)
+
+            # Verify and save if successful
+            if await self._verify_control_center_clicked(corrected_x, corrected_y):
+                logger.info("[VISION NAV] ✅ Self-correction successful!")
+                self._save_learned_position(corrected_x, corrected_y)
+                return True
+            else:
+                logger.warning("[VISION NAV] ⚠️ Self-correction verification failed")
+                return False
+
+        except Exception as e:
+            logger.error(f"[VISION NAV] Error during self-correction: {e}", exc_info=True)
+            return False
+
+    async def _verify_control_center_clicked(self, clicked_x: int, clicked_y: int) -> bool:
+        """
+        Verify that Control Center actually opened after clicking
+
+        Args:
+            clicked_x: X coordinate that was clicked
+            clicked_y: Y coordinate that was clicked
+
+        Returns:
+            True if Control Center opened, False otherwise
+        """
+        try:
+            # Wait for UI to respond
+            await asyncio.sleep(0.5)
+
+            # Capture current screen
+            screenshot = await self._capture_screen()
+            if not screenshot:
+                logger.warning("[VISION NAV] Could not capture screen for verification")
+                return True  # Assume success if can't verify
+
+            # Save for analysis
+            screenshot_path = self.screenshots_dir / f'verification_{int(time.time())}.png'
+            screenshot.save(screenshot_path)
+
+            if not self.vision_analyzer:
+                return True  # Assume success if no analyzer
+
+            logger.info(f"[VISION NAV] 🔍 Verifying click at ({clicked_x}, {clicked_y})...")
+
+            # Ask Claude to verify
+            verification_prompt = """Look at this screenshot. Did Control Center open?
+
+Control Center is a panel that appears when you click the Control Center icon in the menu bar.
+It typically shows:
+- WiFi settings
+- Bluetooth settings
+- Screen Mirroring button
+- Display settings
+- Sound controls
+- Other system controls
+
+Please respond with:
+- "YES" if Control Center panel is open and visible
+- "NO" if Control Center is NOT open (might have clicked wrong icon)
+
+Keep your response very brief - just YES or NO."""
+
+            # Analyze with Claude Vision
+            analysis = await self._analyze_with_vision(screenshot_path, verification_prompt)
+
+            if analysis:
+                analysis_lower = analysis.lower()
+                logger.info(f"[VISION NAV] Verification response: {analysis[:100]}")
+
+                if 'yes' in analysis_lower or 'control center' in analysis_lower and 'open' in analysis_lower:
+                    logger.info("[VISION NAV] ✅ Verification passed - Control Center opened correctly")
+                    return True
+                elif 'no' in analysis_lower:
+                    logger.warning("[VISION NAV] ❌ Verification failed - Wrong icon was clicked")
+                    return False
+
+            # If unclear, assume success
+            logger.info("[VISION NAV] ⚠️ Could not determine verification status, assuming success")
+            return True
+
+        except Exception as e:
+            logger.error(f"[VISION NAV] Error verifying click: {e}", exc_info=True)
+            return True  # Assume success on error to avoid blocking
+
+    async def _multi_pass_detection(self, menu_bar_screenshot: Image.Image) -> bool:
+        """
+        Advanced multi-pass detection using different strategies
+
+        When initial detection fails spatial validation, this method tries
+        multiple detection strategies:
+        1. Ask Claude to list ALL icons and their positions
+        2. Use process of elimination to find Control Center
+        3. Focus on rightmost region only
+
+        Args:
+            menu_bar_screenshot: Menu bar image
+
+        Returns:
+            True if successful, False otherwise
+        """
+        try:
+            logger.info("[VISION NAV] 🔄 Starting multi-pass detection...")
+
+            # Save screenshot for analysis
+            screenshot_path = self.screenshots_dir / f'multipass_{int(time.time())}.png'
+            menu_bar_screenshot.save(screenshot_path)
+
+            if not self.vision_analyzer:
+                logger.error("[VISION NAV] No vision analyzer for multi-pass")
+                return False
+
+            # PASS 1: Comprehensive icon mapping
+            logger.info("[VISION NAV] Pass 1: Mapping all icons...")
+
+            mapping_prompt = """Analyze this macOS menu bar and list ALL visible icons from LEFT to RIGHT, focusing especially on the RIGHTMOST icons.
+
+For EACH icon, provide:
+1. Icon type (e.g., "WiFi", "Bluetooth", "Battery", "Siri", "Control Center", "Time", etc.)
+2. X position (approximate center)
+3. Visual description (color, shape, etc.)
+
+**CRITICAL DISTINCTIONS - These are DIFFERENT icons:**
+
+1. **Siri**: COLORFUL circular orb (rainbow/purple/blue colors), typically at X = width - 170 to width - 150
+2. **Control Center**: TWO OVERLAPPING RECTANGLES (side by side), MONOCHROME (gray/white), typically at X = width - 135 to width - 115
+3. **Time Display**: Numbers showing time, typically at X = width - 80
+
+**IMPORTANT:** Siri and Control Center are NEXT TO EACH OTHER! Siri is to the LEFT, Control Center is to the RIGHT (closer to time display).
+
+Format your response like this:
+ICON_1: WiFi | X: 1200 | Radiating waves, white
+ICON_2: Bluetooth | X: 1225 | B symbol, white
+ICON_3: Battery | X: 1250 | Battery shape, white
+ICON_4: Siri | X: 1270 | Circular colorful orb (purple/rainbow)
+ICON_5: Control Center | X: 1315 | Two overlapping rectangles, monochrome gray
+ICON_6: Time | X: 1360 | Clock/time numbers "2:55 AM"
+
+List ALL icons you see, from left to right. Pay special attention to distinguishing Siri (colorful circle) from Control Center (gray rectangles)."""
+
+            analysis = await self._analyze_with_vision(screenshot_path, mapping_prompt)
+
+            if analysis:
+                logger.info(f"[VISION NAV] Icon mapping response: {analysis[:300]}...")
+
+                # Extract Control Center position from mapping
+                cc_match = re.search(r'Control\s*Center.*?X[:\s]*(\d+)', analysis, re.IGNORECASE)
+                if cc_match:
+                    x = int(cc_match.group(1))
+                    y = 15  # Menu bar center
+
+                    logger.info(f"[VISION NAV] ✅ Multi-pass detected Control Center at ({x}, {y})")
+
+                    # Validate this position with strict bounds
+                    width = menu_bar_screenshot.width
+                    distance_from_right = width - x
+
+                    if distance_from_right > 142 or distance_from_right < 108:
+                        logger.warning(f"[VISION NAV] ⚠️ Multi-pass position {distance_from_right}px from right is outside ideal range (108-142px)")
+                        # Continue to Pass 2 instead of using this position
+                    elif await self._validate_control_center_position(x, y, menu_bar_screenshot):
+                        # Position is good, click it
+                        await self._click_at(x, y)
+
+                        # Verify
+                        if await self._verify_control_center_clicked(x, y):
+                            logger.info("[VISION NAV] ✅ Multi-pass detection successful!")
+                            return True
+
+            # PASS 2: Focused right-side detection
+            logger.info("[VISION NAV] Pass 2: Focused right-side scan...")
+
+            # Crop to rightmost 250 pixels only
+            right_section = menu_bar_screenshot.crop((menu_bar_screenshot.width - 250, 0, menu_bar_screenshot.width, 50))
+            right_path = self.screenshots_dir / f'right_section_{int(time.time())}.png'
+            right_section.save(right_path)
+
+            focused_prompt = """This is the RIGHTMOST section of the macOS menu bar (last 250 pixels).
+
+Find the Control Center icon. It looks like TWO OVERLAPPING RECTANGLES side by side, MONOCHROME (gray/white).
+
+**CRITICAL - IGNORE THESE WRONG ICONS:**
+- Siri: COLORFUL circular orb (purple/rainbow) - This is TOO FAR LEFT!
+- Sun symbol (brightness) - Wrong shape
+- WiFi waves - Wrong shape
+- Battery - Wrong shape
+- Clock/time numbers - TOO FAR RIGHT!
+
+**WHAT TO LOOK FOR:**
+- Shape: TWO RECTANGLES side by side [ ][ ] or overlapping slightly
+- Color: MONOCHROME gray or white (NOT colorful!)
+- Position: Between Siri (colorful) and Time (numbers), typically around X=115-135 in this 250px crop
+- This should be the icon CLOSEST to the right edge that is NOT the time display
+
+**YOUR TASK:**
+Look for the MONOCHROME rectangular icon between any colorful icons (like Siri) and the time display.
+
+Provide X position relative to this cropped image (0-250).
+
+Format:
+X_POSITION: [number]
+Y_POSITION: 15
+
+Be VERY careful - Control Center is monochrome rectangles, NOT the colorful Siri orb!"""
+
+            analysis2 = await self._analyze_with_vision(right_path, focused_prompt)
+
+            if analysis2:
+                coords = self._extract_coordinates_advanced(analysis2, right_section)
+                if coords:
+                    relative_x, y = coords
+                    # Convert relative X to absolute X
+                    absolute_x = (menu_bar_screenshot.width - 250) + relative_x
+
+                    logger.info(f"[VISION NAV] ✅ Focused scan detected at relative ({relative_x}, {y}), absolute ({absolute_x}, {y})")
+
+                    # Validate position with strict bounds
+                    width = menu_bar_screenshot.width
+                    distance_from_right = width - absolute_x
+
+                    if distance_from_right > 142 or distance_from_right < 108:
+                        logger.warning(f"[VISION NAV] ⚠️ Focused scan position {distance_from_right}px from right is outside ideal range (108-142px)")
+                        logger.warning("[VISION NAV] ⚠️ Skipping this detection, will use heuristic")
+                    else:
+                        logger.info(f"[VISION NAV] ✅ Focused scan position validated: {distance_from_right}px from right edge")
+                        # Click it
+                        await self._click_at(absolute_x, y)
+
+                        # Verify
+                        if await self._verify_control_center_clicked(absolute_x, y):
+                            logger.info("[VISION NAV] ✅ Focused scan successful!")
+                            return True
+
+            # PASS 3: Intelligent scanning approach
+            logger.info("[VISION NAV] Pass 3: Intelligent scanning approach...")
+            scan_result = await self._scan_for_control_center(menu_bar_screenshot)
+            if scan_result:
+                x, y = scan_result
+                logger.info(f"[VISION NAV] ✅ Intelligent scan found Control Center at ({x}, {y})")
+                await self._click_at(x, y)
+                if await self._verify_control_center_clicked(x, y):
+                    logger.info("[VISION NAV] ✅ Intelligent scan successful!")
+                    return True
+
+            # If all passes fail, fall back to heuristic
+            logger.warning("[VISION NAV] ⚠️ All multi-pass attempts failed, using heuristic")
+            return await self._click_control_center_heuristic()
+
+        except Exception as e:
+            logger.error(f"[VISION NAV] Error in multi-pass detection: {e}", exc_info=True)
+            return False
+
+    async def _validate_control_center_position(self, x: int, y: int, menu_bar_screenshot: Image.Image) -> bool:
+        """
+        Advanced spatial validation to ensure detected position is reasonable for Control Center
+
+        Uses spatial reasoning to validate that the detected coordinates make sense
+        for where Control Center icon should be located.
+
+        Args:
+            x: Detected X coordinate
+            y: Detected Y coordinate
+            menu_bar_screenshot: Menu bar image
+
+        Returns:
+            True if position passes validation, False otherwise
+        """
+        try:
+            width = menu_bar_screenshot.width
+
+            # Control Center should be in the RIGHT 30% of menu bar
+            right_section_start = width * 0.7
+
+            if x < right_section_start:
+                logger.warning(f"[VISION NAV] ⚠️ X={x} too far left (should be > {right_section_start:.0f})")
+                return False
+
+            # Control Center should NOT be in the very last 100px (that's usually time/date)
+            if x > width - 100:
+                logger.warning(f"[VISION NAV] ⚠️ X={x} too far right (time display area)")
+                return False
+
+            # Y should be centered in menu bar
+            if y < 5 or y > 35:
+                logger.warning(f"[VISION NAV] ⚠️ Y={y} outside menu bar center range (5-35)")
+                return False
+
+            logger.info(f"[VISION NAV] ✅ Position validation passed for ({x}, {y})")
+            return True
+
+        except Exception as e:
+            logger.error(f"[VISION NAV] Error in position validation: {e}")
+            return True  # Don't block on validation errors
+
+    async def _click_at(self, x: int, y: int):
+        """Click at specific coordinates"""
+        try:
+            logger.info(f"[VISION NAV] Clicking at ({x}, {y})")
+            
+            # Move to position
+            pyautogui.moveTo(x, y, duration=self.config['mouse']['movement_speed'])
+            
+            # Brief pause
+            await asyncio.sleep(0.1)
+            
+            # Click
+            pyautogui.click(x, y, duration=self.config['mouse']['click_duration'])
+            
+            logger.debug(f"[VISION NAV] Click executed at ({x}, {y})")
+            
+        except Exception as e:
+            logger.error(f"[VISION NAV] Click error: {e}")
+            raise
+
+    def _extract_coordinates_from_response(self, response: str) -> Optional[Tuple[int, int]]:
+        """
+        Legacy coordinate extraction method (kept for compatibility)
+
+        NOTE: Use _extract_coordinates_advanced() for new code
+        """
+        if not response:
+            return None
+
+        try:
+            # Use a simple fallback implementation
+            # Pattern: X_POSITION: 1234, Y_POSITION: 56
+            x_match = re.search(r'X[_\s]*POSITION:\s*(\d+)', response, re.IGNORECASE)
+            y_match = re.search(r'Y[_\s]*POSITION:\s*(\d+)', response, re.IGNORECASE)
+            if x_match and y_match:
+                x, y = int(x_match.group(1)), int(y_match.group(1))
+                return (x, y)
+
+            # Pattern: (x, y)
+            match = re.search(r'\((\d+),\s*(\d+)\)', response)
+            if match:
+                x, y = int(match.group(1)), int(match.group(2))
+                return (x, y)
+
+            return None
+
+        except Exception as e:
+            logger.error(f"[VISION NAV] Error extracting coordinates: {e}")
+            return None
+
+    def _adjust_suspicious_coordinates(self, x: int, y: int, width: int, height: int) -> Tuple[int, int]:
+        """
+        Adjust suspicious coordinates to reasonable values
+
+        Args:
+            x: X coordinate
+            y: Y coordinate
+            width: Screen/region width
+            height: Screen/region height
+
+        Returns:
+            Adjusted (x, y) tuple
+        """
+        adjusted_x = x
+        adjusted_y = y
+
+        # If Y is too large, assume menu bar center
+        if y > height:
+            adjusted_y = 15  # Menu bar center
+            logger.info(f"[VISION NAV] Adjusted Y: {y} → {adjusted_y} (menu bar center)")
+
+        # If X is too large, cap at width
+        if x > width:
+            # Try to preserve relative position
+            if x <= width * 2:  # Might be Retina coordinates
+                adjusted_x = x // 2
+                logger.info(f"[VISION NAV] Adjusted X: {x} → {adjusted_x} (Retina scaling)")
+            else:
+                adjusted_x = width - 180  # Typical Control Center position
+                logger.info(f"[VISION NAV] Adjusted X: {x} → {adjusted_x} (capped to typical position)")
+
+        # If X is too small (unlikely for Control Center in right section)
+        if x < width // 2:
+            logger.warning(f"[VISION NAV] X coordinate {x} seems too far left for Control Center")
+            adjusted_x = width - 180
+            logger.info(f"[VISION NAV] Adjusted X: {x} → {adjusted_x} (moved to right section)")
+
+        return (adjusted_x, adjusted_y)
+
+    def _validate_coordinates(self, x: int, y: int, width: int, height: int) -> bool:
+        """
+        Validate that coordinates are within acceptable bounds
+
+        Args:
+            x: X coordinate
+            y: Y coordinate
+            width: Screen/region width
+            height: Screen/region height
+
+        Returns:
+            True if valid, False otherwise
+        """
+        # Allow some tolerance for Retina displays (2x scaling)
+        max_x = width * 2
+        max_y = height * 2
+
+        valid = (
+            0 <= x <= max_x and
+            0 <= y <= max_y
+        )
+
+        if not valid:
+            logger.warning(f"[VISION NAV] Coordinates ({x}, {y}) outside bounds (0-{max_x}, 0-{max_y})")
+
+        return valid
+
+    def _validate_and_return(self, x: int, y: int, screenshot: Image.Image) -> Tuple[int, int]:
+        """
+        Validate coordinates and return them (with logging)
+
+        Args:
+            x: X coordinate
+            y: Y coordinate
+            screenshot: Screenshot for dimension checking
+
+        Returns:
+            (x, y) tuple
+        """
+        width = screenshot.width
+        height = screenshot.height
+
+        # Log dimensions for debugging
+        logger.debug(f"[VISION NAV] Screenshot dimensions: {width}x{height}px")
+        logger.debug(f"[VISION NAV] Proposed coordinates: ({x}, {y})")
+
+        # Basic sanity checks
+        if x < 0 or y < 0:
+            logger.warning(f"[VISION NAV] ⚠️ Negative coordinates: ({x}, {y})")
+
+        if x > width:
+            logger.warning(f"[VISION NAV] ⚠️ X coordinate {x} exceeds width {width}")
+
+        if y > height:
+            logger.warning(f"[VISION NAV] ⚠️ Y coordinate {y} exceeds height {height}")
+
+        return (x, y)
+
+    def _extract_coordinates_advanced(self, response: str, screenshot: Image.Image) -> Optional[Tuple[int, int]]:
+        """
+        Advanced coordinate extraction with multiple format support and validation
+
+        Supports formats like:
+        - X_POSITION: 1260, Y_POSITION: 15
+        - (1260, 15)
+        - x: 1260, y: 15
+        - center at 1260, 15
+        - 180 pixels from right edge
+
+        Args:
+            response: Claude Vision response text
+            screenshot: Screenshot being analyzed (for dimension validation)
+
+        Returns:
+            (x, y) tuple or None
+        """
+        if not response:
+            logger.warning("[VISION NAV] Empty response from Claude Vision")
+            return None
+
+        try:
+            logger.debug(f"[VISION NAV] Parsing response: {response[:200]}...")
+
+            # Pattern 1: X_POSITION: 1234, Y_POSITION: 56 (our requested format)
+            x_match = re.search(r'X[_\s]*POSITION\s*:\s*(\d+)', response, re.IGNORECASE)
+            y_match = re.search(r'Y[_\s]*POSITION\s*:\s*(\d+)', response, re.IGNORECASE)
+            if x_match and y_match:
+                x, y = int(x_match.group(1)), int(y_match.group(1))
+                logger.info(f"[VISION NAV] ✅ Extracted (X_POSITION format): ({x}, {y})")
+                return self._validate_and_return(x, y, screenshot)
+
+            # Pattern 2: (x, y) tuple format
+            match = re.search(r'\((\d+),\s*(\d+)\)', response)
+            if match:
+                x, y = int(match.group(1)), int(match.group(2))
+                logger.info(f"[VISION NAV] ✅ Extracted (tuple format): ({x}, {y})")
+                return self._validate_and_return(x, y, screenshot)
+
+            # Pattern 3: x: 1234, y: 56
+            match = re.search(r'x\s*[:=]\s*(\d+).*?y\s*[:=]\s*(\d+)', response, re.IGNORECASE | re.DOTALL)
+            if match:
+                x, y = int(match.group(1)), int(match.group(2))
+                logger.info(f"[VISION NAV] ✅ Extracted (x:y format): ({x}, {y})")
+                return self._validate_and_return(x, y, screenshot)
+
+            # Pattern 4: JSON format {"x": 1234, "y": 56}
+            match = re.search(r'\{.*?"x"\s*:\s*(\d+).*?"y"\s*:\s*(\d+).*?\}', response, re.IGNORECASE | re.DOTALL)
+            if match:
+                x, y = int(match.group(1)), int(match.group(2))
+                logger.info(f"[VISION NAV] ✅ Extracted (JSON format): ({x}, {y})")
+                return self._validate_and_return(x, y, screenshot)
+
+            # Pattern 5: "center at 1234, 56" or "located at 1234, 56"
+            match = re.search(r'(?:center|located|position|point)\s+(?:at\s+)?(\d+)\s*,\s*(\d+)', response, re.IGNORECASE)
+            if match:
+                x, y = int(match.group(1)), int(match.group(2))
+                logger.info(f"[VISION NAV] ✅ Extracted (descriptive format): ({x}, {y})")
+                return self._validate_and_return(x, y, screenshot)
+
+            # Pattern 6: Descriptive "X pixels from left/right, Y pixels from top"
+            left_match = re.search(r'(\d+)\s*(?:px|pixels?)?\s*from\s+(?:the\s+)?left', response, re.IGNORECASE)
+            right_match = re.search(r'(\d+)\s*(?:px|pixels?)?\s*from\s+(?:the\s+)?right', response, re.IGNORECASE)
+            top_match = re.search(r'(\d+)\s*(?:px|pixels?)?\s*from\s+(?:the\s+)?top', response, re.IGNORECASE)
+
+            if (left_match or right_match) and top_match:
+                if left_match:
+                    x = int(left_match.group(1))
+                elif right_match:
+                    x = screenshot.width - int(right_match.group(1))
+
+                y = int(top_match.group(1))
+                logger.info(f"[VISION NAV] ✅ Extracted (descriptive pixels format): ({x}, {y})")
+                return self._validate_and_return(x, y, screenshot)
+
+            # Pattern 7: Two sequential 3-4 digit numbers (last resort)
+            numbers = re.findall(r'\b(\d{3,4})\b', response)
+            if len(numbers) >= 2:
+                x, y = int(numbers[0]), int(numbers[1])
+                # Only use if reasonable for screenshot dimensions
+                if 0 <= x <= screenshot.width * 2 and 0 <= y <= 100:  # Allow 2x for Retina
+                    logger.info(f"[VISION NAV] ⚠️  Extracted (guessed from numbers): ({x}, {y})")
+                    return self._validate_and_return(x, y, screenshot)
+
+            # No patterns matched
+            logger.error(f"[VISION NAV] ❌ Could not extract coordinates from Claude response")
+            logger.error(f"[VISION NAV] Full response: {response[:800]}")
+            return None
+
+        except Exception as e:
+            logger.error(f"[VISION NAV] Error extracting coordinates: {e}", exc_info=True)
+            return None
+
+    async def _analyze_with_vision(self, image_path: Path, prompt: str) -> Optional[str]:
+        """Analyze image with Claude Vision"""
+        if not self.vision_analyzer:
+            logger.warning("[VISION NAV] No vision analyzer available")
+            return None
+        
+        try:
+            # Load image as PIL Image (Claude Vision Analyzer expects this)
+            image = Image.open(image_path)
+            
+            # Use analyze_screenshot method (standard for ClaudeVisionAnalyzer)
+            response = await self.vision_analyzer.analyze_screenshot(
+                image=image,  # Pass PIL Image directly
+                prompt=prompt,
+                use_cache=False  # Don't cache UI navigation prompts
+            )
+            
+            # Handle response - analyze_screenshot returns (Dict, AnalysisMetrics)
+            if isinstance(response, tuple):
+                analysis_dict, metrics = response
+                # Extract text from response
+                if isinstance(analysis_dict, dict):
+                    response_text = analysis_dict.get('response', analysis_dict.get('text', str(analysis_dict)))
+                else:
+                    response_text = str(analysis_dict)
+            else:
+                response_text = str(response)
+            
+            logger.info(f"[VISION NAV] Claude response: {response_text[:300] if response_text else 'None'}...")
+            
+            return response_text
+            
+        except Exception as e:
+            logger.error(f"[VISION NAV] Vision analysis error: {e}", exc_info=True)
+            return None
+
+    async def _capture_menu_bar(self, menu_bar_height: int = 50) -> Optional[Image.Image]:
+        """
+        Capture just the menu bar area from the screen
+
+        Args:
+            menu_bar_height: Height of the menu bar in pixels (default: 50)
+
+        Returns:
+            PIL Image of the menu bar region, or None if capture fails
+        """
+        try:
+            # Capture full screen
+            full_screen = await self._capture_screen()
+            if not full_screen:
+                return None
+
+            # Crop to menu bar area (top portion)
+            width, height = full_screen.size
+            menu_bar_region = full_screen.crop((0, 0, width, menu_bar_height))
+
+            logger.debug(f"[VISION NAV] Menu bar captured: {width}x{menu_bar_height}px")
+            return menu_bar_region
+
+        except Exception as e:
+            logger.debug(f"[VISION NAV] Failed to capture menu bar: {e}")
+            return None
+
+    async def _capture_screen(self) -> Optional[Image.Image]:
+        """Capture current screen using existing vision infrastructure"""
+        try:
+            # Try using existing reliable screenshot capture
+            from vision.reliable_screenshot_capture import ReliableScreenshotCapture
+            
+            capture = ReliableScreenshotCapture()
+            
+            # Try different capture methods
+            if hasattr(capture, 'capture_current_space'):
+                result = await capture.capture_current_space()
+            elif hasattr(capture, 'capture_screen'):
+                result = await capture.capture_screen()
+            elif hasattr(capture, 'capture'):
+                result = capture.capture()
+            else:
+                # Manually call the capture method
+                result = await capture.capture_with_fallback()
+            
+            if hasattr(result, 'success') and result.success and hasattr(result, 'image'):
+                return result.image
+            elif isinstance(result, Image.Image):
+                return result
+            
+        except ImportError:
+            logger.debug("[VISION NAV] ReliableScreenshotCapture not available")
+        except AttributeError as e:
+            logger.debug(f"[VISION NAV] Screenshot method not available: {e}")
+        except Exception as e:
+            logger.debug(f"[VISION NAV] Screenshot capture error: {e}")
+        
+        # Fallback: Use screencapture command
+        try:
+            temp_path = self.screenshots_dir / f'temp_{int(time.time())}.png'
+            
+            process = await asyncio.create_subprocess_exec(
+                'screencapture', '-x', str(temp_path),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE
+            )
+            
+            await process.communicate()
+            
+            if temp_path.exists():
+                image = Image.open(temp_path)
+                temp_path.unlink()  # Clean up
+                logger.debug(f"[VISION NAV] Screenshot captured with screencapture command")
+                return image
+                
+        except Exception as e:
+            logger.error(f"[VISION NAV] Screenshot fallback failed: {e}")
+        
+        return None

--- a/backend/hud/consent_bridge.py
+++ b/backend/hud/consent_bridge.py
@@ -204,9 +204,42 @@ class VoiceConsentProvider:
         """Verify the held utterance and answer. NEVER raises."""
         try:
             from backend.hud.utterance_audio import get_utterance_holder
-            from backend.hud.voice_identity import get_voice_identity
-            held = get_utterance_holder().claim()
-            ident = await get_voice_identity().identify(
+            from backend.hud.voice_identity import Readiness, get_voice_identity
+
+            # DO NOT SPEND THE EVIDENCE ON AN ATTEMPT THAT CANNOT SUCCEED.
+            #
+            # Measured live 2026-08-04 19:10:13, saying "unlock my screen":
+            #
+            #   [VoiceRouter] CAI: 'screen_unlocked' unmet -> running
+            #                 'unlock_screen' first
+            #   [VoiceConsent] 'unlock_screen' -> not_ready (model cold;
+            #                  enrollment Derek J. Russell)
+            #   [CapabilityRouter] 'unlock_screen' NOT authorised (I'm still
+            #                  loading my voice recognition -- give me a
+            #                  moment and ask again.)
+            #   [VoiceIdentity] speaker model READY after 2.8s
+            #
+            # Every part of that is correct except the order. The model is
+            # lazy on purpose — warming it at boot was the 14s deafness — so
+            # the FIRST verification of a session is guaranteed to report
+            # NOT_READY, because it is the thing that starts the load.
+            #
+            # But `claim()` is destructive, and it ran first. So the one
+            # attempt that could never succeed was also the one that deleted
+            # the sentence, and the invitation to "ask again" required the
+            # operator to say it again — while the model became ready 2.8
+            # seconds later, holding nothing.
+            #
+            # Claim only when a verdict is actually reachable; otherwise look
+            # without taking. Anti-replay is untouched: verification still
+            # consumes, and nothing verifies from a peek.
+            svc = get_voice_identity()
+            holder = get_utterance_holder()
+            if svc.readiness is Readiness.READY:
+                held = holder.claim()
+            else:
+                held = holder.peek()
+            ident = await svc.identify(
                 held.audio if held else None,
                 sample=held.digest if held else "")
             if ident.approves:

--- a/backend/hud/utterance_audio.py
+++ b/backend/hud/utterance_audio.py
@@ -183,6 +183,32 @@ class UtteranceHolder:
         except Exception:  # noqa: BLE001
             return None
 
+    def peek(self) -> Optional["Utterance"]:
+        """Read the held utterance WITHOUT consuming it. NEVER raises.
+
+        For an authority that must look at the evidence before it knows
+        whether it can reach a verdict at all. Measured live 2026-08-04:
+
+            [VoiceConsent] 'unlock_screen' -> not_ready (model cold)
+            [VoiceIdentity] speaker model READY after 2.8s
+
+        The first verification of a session always reports NOT_READY, because
+        it is what kicks the lazy model load. `claim()` had already destroyed
+        the sentence by then, so the operator was told "ask again" with the
+        evidence for the retry deleted — and the model landed 2.8 seconds
+        later, into a holder with nothing in it.
+
+        **Evidence must not be spent by an attempt that cannot succeed.**
+        Anti-replay is unaffected: a claim still happens on every path that
+        actually verifies, and only there.
+        """
+        try:
+            with self._lock:
+                u = self._held
+            return None if u is None or u.expired else u
+        except Exception:  # noqa: BLE001
+            return None
+
     def peek_age_s(self) -> Optional[float]:
         """Age of what is held, without claiming it. NEVER raises.
 

--- a/backend/voice/speaker_verification_service.py
+++ b/backend/voice/speaker_verification_service.py
@@ -5743,6 +5743,37 @@ class SpeakerVerificationService:
         original_size = len(audio_data)
         logger.info(f"🔄 Starting audio conversion: {original_size} bytes input")
 
+        # RESOLVE THE LAZILY-LOADED CONVERTERS BEFORE USING THEM.
+        #
+        # `_init_ml_components` imports these four into the module-level dict
+        # `_audio_converter_funcs` and deliberately does NOT bind them as
+        # globals — that is the whole point of deferring a heavy import. This
+        # function was still written against the bare names, so every strategy
+        # below raised `NameError` before it could convert a single byte:
+        #
+        #     [VoiceIdentity] unavailable  NameError: name
+        #     'AudioConverterConfig' is not defined
+        #
+        # which `VoiceIdentity.identify` reports as UNAVAILABLE and the router
+        # reads as "not consent". Speaker verification could therefore never
+        # succeed, for any audio, since the lazy-loading refactor — the failure
+        # was invisible because a fault on a consent path is indistinguishable
+        # from a refusal unless you read the detail string.
+        #
+        # `get_audio_converter` is the accessor that already existed for this;
+        # it initialises ML components on demand and returns None if the import
+        # genuinely failed.
+        prepare_audio_with_analysis = get_audio_converter('prepare_audio_with_analysis')
+        prepare_audio_for_stt_async = get_audio_converter('prepare_audio_for_stt_async')
+        prepare_audio_for_stt = get_audio_converter('prepare_audio_for_stt')
+        AudioConverterConfig = get_audio_converter('AudioConverterConfig')
+        if AudioConverterConfig is None:
+            # A missing converter is a fault, not a verdict. Returning empty
+            # here lets the caller fail closed with a reason rather than
+            # crashing mid-strategy with a NameError that reads as a decline.
+            logger.error("❌ Audio conversion unavailable: converters did not load")
+            return b''
+
         # Create dynamic config from environment
         config = AudioConverterConfig.from_env()
         logger.debug(f"   Config: {config.target_sample_rate}Hz, {config.target_channels}ch, {config.target_bit_depth}bit")

--- a/brainstem/__main__.py
+++ b/brainstem/__main__.py
@@ -28,6 +28,17 @@ import sys
 HUD_DEFAULT_PORT = 8011
 
 if __name__ == "__main__":
+    # DO NOT OUTLIVE THE LAUNCHER.
+    #
+    # Armed here, before anything binds a port or claims a microphone, and
+    # before the legacy branch, so every way of entering this module is
+    # covered by one call. Xcode's Stop button SIGKILLs the HUD, which means
+    # the HUD cannot tell us anything on its way out — so we watch it instead.
+    # Inert unless JARVIS_PARENT_PID was declared, so a standalone
+    # `python3 -m brainstem` is unaffected.
+    from brainstem.parent_watch import install as _install_parent_watch
+    _install_parent_watch()
+
     # Legacy mode: use old brainstem for backwards compatibility
     if os.environ.get("JARVIS_BRAINSTEM_LEGACY", "").lower() in ("1", "true"):
         import asyncio

--- a/brainstem/parent_watch.py
+++ b/brainstem/parent_watch.py
@@ -1,0 +1,387 @@
+"""The child watches the parent, because the child is the one still alive.
+
+THE PROBLEM
+-----------
+Xcode's Stop button sends SIGKILL to the HUD. SIGKILL is uncatchable, so
+`terminationHandler`, `deinit`, and every `atexit` hook in the parent are
+never reached — the parent gets no instructions at all, because it is not
+running any more. The Python backend it spawned is reparented to launchd and
+lives on, holding ports 8011 and 8742, a microphone claim, and a few hundred
+megabytes, until something notices.
+
+Nothing did. Measured 2026-08-04: two orphans, one at 46.8% CPU with no
+listening socket, from a debugger detach nobody had thought about.
+
+The compensation that existed was `lsof -ti :8011 | xargs kill -9` at the
+NEXT launch. That runs after the damage, and it identifies its victims by
+port rather than by identity — anything else bound to 8011 was killed too.
+
+WHY THE FIX BELONGS HERE AND NOT IN THE PARENT
+-----------------------------------------------
+This is the Watchdog Isolation Invariant one layer down: *a watchdog that
+shares a resource with the system it guards is not a watchdog.* A cleanup
+handler inside the dying parent shares the parent's fate — SIGKILL means
+there is no moment between "alive" and "gone" in which it could run. The only
+party guaranteed to still be executing when the parent dies is the child.
+
+So the child watches, and it watches with two independent mechanisms because
+a single one is a single point of failure:
+
+  1. `kqueue` / `EVFILT_PROC` / `NOTE_EXIT` — the kernel reports the exit.
+     Event-driven, so this costs no CPU while idle, and it fires for SIGKILL
+     exactly as it does for a clean exit; the kernel does not care how the
+     process died.
+
+  2. `os.getppid()` — when the parent dies the child is reparented, and the
+     PPID changes (to 1 under launchd). This shares no code, no file
+     descriptor and no syscall with the first mechanism, so a kqueue that
+     fails to register, silently drops the event, or is unavailable on some
+     future platform does not take the guarantee with it.
+
+Either one firing is sufficient. Both are cheap.
+
+OPT-IN BY POSITIVE DECLARATION
+-------------------------------
+Supervision is enabled only when a parent PID is explicitly declared through
+`JARVIS_PARENT_PID`. Running `python3 -m brainstem` in a terminal to debug
+something must never end with the process killing itself because its shell
+exited, so silence means "no supervision". This is the same shape as
+`JARVIS_PROCESS_ROLE`: a behaviour that can end a process requires somebody
+to have asked for it out loud.
+
+SHUTDOWN IS THE EXISTING ONE
+-----------------------------
+Detection raises SIGTERM into this process rather than exiting. uvicorn
+already installs a SIGTERM handler that drains connections and runs lifespan
+shutdown, and the legacy `brainstem.main` path installs its own. Inventing a
+third shutdown here would mean a second place for shutdown to be wrong.
+
+Escalation exists because graceful shutdown can itself hang — a wedged VERIFY
+or a blocked event loop is exactly the condition that produced the orphan in
+the first place. After a bounded grace period the process leaves by
+`os._exit`, which no amount of blocked event loop can prevent.
+
+The escalation timer reads only `time.monotonic()`. It never consults the
+event loop, the application state, or anything the shutdown it is bounding
+could wedge — for the same reason the wall-clock watchdog in the battle
+harness is forbidden from reading the op-ledger.
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import signal
+import threading
+import time
+from typing import Optional
+
+logger = logging.getLogger("jarvis.brainstem.parentwatch")
+
+PARENT_WATCH_SCHEMA_VERSION: str = "parent_watch.v1"
+
+#: Set by the launcher to its own PID. Absent means "not supervised".
+ENV_PARENT_PID: str = "JARVIS_PARENT_PID"
+
+#: Master switch. Default on, but inert without a declared parent PID.
+ENV_ENABLED: str = "JARVIS_PARENT_WATCH_ENABLED"
+
+#: How long graceful shutdown gets before the process leaves the hard way.
+ENV_GRACE_S: str = "JARVIS_PARENT_WATCH_GRACE_S"
+
+#: Backstop cadence. Only the PPID poll uses this; kqueue is event-driven.
+ENV_POLL_S: str = "JARVIS_PARENT_WATCH_POLL_S"
+
+#: Exit status when escalation fires. 143 = 128 + SIGTERM, the conventional
+#: "terminated by SIGTERM" code, so a supervisor reading exit codes sees the
+#: shutdown that was intended rather than a novel number.
+EXIT_PARENT_GONE: int = 143
+
+
+#: Where this subsystem records what it did, independently of everything else.
+ENV_LOG_PATH: str = "JARVIS_PARENT_WATCH_LOG"
+
+
+def _default_log_path() -> str:
+    return os.path.join(os.path.expanduser("~/Library/Logs/JARVIS"),
+                        "parent-watch.log")
+
+
+def _record(message: str) -> None:
+    """Write a line using only syscalls. NEVER raises, NEVER blocks on a lock.
+
+    TWO REASONS THIS DOES NOT USE `logging`
+    ----------------------------------------
+    1. NOWHERE TO SEND IT. This process logs to a pipe held by its parent, and
+       every message this subsystem has to deliver is about that parent being
+       dead. Measured 2026-08-04: the watch fired correctly, the backend exited
+       correctly, and the log recorded NOTHING — because the reader had already
+       been SIGKILLed. A subsystem whose only job is to explain a disappearance
+       must not report through the thing that disappeared.
+
+    2. `logging` TAKES LOCKS. The escalation path exists to bound a shutdown
+       that has WEDGED, and a wedged shutdown is exactly the state in which
+       some thread is holding the logging lock. Calling `logger.error` there
+       would block the watchdog on the system it is watching — the Watchdog
+       Isolation Invariant, which says a watchdog sharing a signal path, a
+       logging lock, or a state-ledger with its subject is not a watchdog.
+
+    So: `os.open`/`os.write`, append mode, no buffering, no locks, no
+    formatters. If it fails, it fails silently — a log line is never worth
+    obstructing the exit it is describing.
+    """
+    line = f"{time.strftime('%Y-%m-%d %H:%M:%S')} [ParentWatch] {message}\n"
+    data = line.encode("utf-8", "replace")
+    try:
+        os.write(2, data)          # stderr, for when anyone is still reading
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        path = (os.environ.get(ENV_LOG_PATH, "") or "").strip() or _default_log_path()
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+        try:
+            os.write(fd, data)
+        finally:
+            os.close(fd)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _enabled() -> bool:
+    return (os.environ.get(ENV_ENABLED, "true") or "").strip().lower() not in (
+        "0", "false", "no", "off")
+
+
+def _float_env(name: str, default: float, *, minimum: float) -> float:
+    """Read a tunable, clamped. NEVER raises.
+
+    Clamped rather than validated-and-rejected: a typo in a timing knob must
+    not be able to disable the guarantee. A grace of 0 would make graceful
+    shutdown impossible and a poll of 0 would spin a core.
+    """
+    try:
+        raw = (os.environ.get(name, "") or "").strip()
+        if not raw:
+            return default
+        return max(minimum, float(raw))
+    except Exception:  # noqa: BLE001
+        return default
+
+
+def declared_parent_pid() -> Optional[int]:
+    """The PID the launcher declared, or None. NEVER raises.
+
+    Rejects values that cannot be a parent we should die with:
+
+      * unparseable or non-positive — a malformed declaration is not a
+        declaration;
+      * our own PID — watching ourselves would fire the moment we exit;
+      * PID 1 — launchd is everybody's eventual parent, so treating it as
+        "the parent" would mean self-terminating exactly when reparenting
+        has ALREADY happened, which is the state this guards against, not a
+        thing to wait for.
+    """
+    try:
+        raw = (os.environ.get(ENV_PARENT_PID, "") or "").strip()
+        if not raw:
+            return None
+        pid = int(raw)
+        if pid <= 1 or pid == os.getpid():
+            logger.warning(
+                "[ParentWatch] ignoring implausible parent pid %d — "
+                "supervision NOT active", pid)
+            return None
+        return pid
+    except Exception:  # noqa: BLE001
+        logger.warning("[ParentWatch] unparseable %s — supervision NOT active",
+                       ENV_PARENT_PID)
+        return None
+
+
+def _parent_is_alive(pid: int) -> bool:
+    """Signal 0 probes existence without delivering anything. NEVER raises.
+
+    A `PermissionError` means the process exists and belongs to somebody else
+    — existence is what is being asked, so that is alive. Treating it as dead
+    would kill the backend whenever the launcher runs as another user.
+    """
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except Exception:  # noqa: BLE001
+        return True
+
+
+class ParentWatch:
+    """Terminates this process when the declared parent dies. NEVER raises."""
+
+    def __init__(self, parent_pid: int) -> None:
+        self.parent_pid = parent_pid
+        self.original_ppid = os.getppid()
+        self.grace_s = _float_env(ENV_GRACE_S, 10.0, minimum=1.0)
+        self.poll_s = _float_env(ENV_POLL_S, 2.0, minimum=0.25)
+        self._fired = threading.Event()
+        self._fired_at = 0.0
+        self._threads: list = []
+
+    # -- detection -------------------------------------------------------
+
+    def _watch_kqueue(self) -> None:
+        """Block until the kernel reports the parent exited. NEVER raises.
+
+        Returns early — leaving the PPID poll as the sole mechanism — when
+        kqueue is unavailable or registration fails for any reason other than
+        the parent already being gone.
+        """
+        try:
+            import select
+            if not hasattr(select, "kqueue"):
+                logger.debug("[ParentWatch] no kqueue; PPID poll is sole watch")
+                return
+            kq = select.kqueue()
+            ev = select.kevent(
+                self.parent_pid,
+                filter=select.KQ_FILTER_PROC,
+                flags=select.KQ_EV_ADD | select.KQ_EV_ENABLE,
+                fflags=select.KQ_NOTE_EXIT,
+            )
+            try:
+                kq.control([ev], 0, 0)
+            except ProcessLookupError:
+                # Already dead — the race between spawn and registration is
+                # not an error, it is the answer.
+                self._fire("kqueue: parent already gone at registration")
+                return
+            _record(f"armed on pid {self.parent_pid} "
+                    f"(kqueue NOTE_EXIT + PPID poll every {self.poll_s:.2f}s, "
+                    f"grace {self.grace_s:.1f}s) — this process will not "
+                    f"outlive its launcher")
+            while not self._fired.is_set():
+                # Bounded wait so a fired watch can retire this thread even
+                # though the kernel has nothing to say.
+                events = kq.control(None, 1, self.poll_s)
+                for _ in events:
+                    self._fire("kqueue: NOTE_EXIT")
+                    return
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[ParentWatch] kqueue watch degraded: %s", exc)
+
+    def _watch_ppid(self) -> None:
+        """Independent backstop: reparenting and an existence probe.
+
+        Two conditions, because each covers a hole in the other. A changed
+        PPID is definitive but only observable while we are a direct child;
+        the existence probe still answers if the declared parent was never
+        our immediate parent (a relaunch through a helper, say).
+        """
+        while not self._fired.is_set():
+            if self._fired.wait(self.poll_s):
+                return
+            try:
+                if os.getppid() != self.original_ppid:
+                    self._fire(
+                        f"reparented: ppid {self.original_ppid} -> {os.getppid()}")
+                    return
+                if not _parent_is_alive(self.parent_pid):
+                    self._fire(f"pid {self.parent_pid} no longer exists")
+                    return
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("[ParentWatch] ppid poll degraded: %s", exc)
+
+    # -- reaction --------------------------------------------------------
+
+    def _fire(self, reason: str) -> None:
+        """Begin shutdown. Idempotent — whichever mechanism wins, once.
+
+        `Event.set` is atomic, so the loser of the race returns here and does
+        nothing. Without that, two detections would raise two SIGTERMs and
+        start two escalation timers.
+        """
+        if self._fired.is_set():
+            return
+        self._fired.set()
+        self._fired_at = time.monotonic()
+        _record(f"launcher (pid {self.parent_pid}) is gone — {reason}. "
+                f"Raising SIGTERM; hard exit in {self.grace_s:.1f}s if that "
+                f"does not finish. Better an abrupt exit than an orphan "
+                f"holding ports, a microphone claim and memory.")
+        threading.Thread(target=self._escalate, name="parent-watch-escalate",
+                         daemon=True).start()
+        try:
+            os.kill(os.getpid(), signal.SIGTERM)
+        except Exception as exc:  # noqa: BLE001
+            _record(f"could not raise SIGTERM ({exc}) — escalation will handle it")
+
+    def _escalate(self) -> None:
+        """Leave the hard way if graceful shutdown does not finish.
+
+        Reads a clock and nothing else. The condition this bounds — a wedged
+        event loop — is precisely the condition that would make any
+        application-state check hang with it.
+        """
+        deadline = time.monotonic() + self.grace_s
+        while time.monotonic() < deadline:
+            time.sleep(0.25)
+        # Reaching here means graceful shutdown did NOT finish. That is worth
+        # recording precisely: if this line appears every time, the exit is
+        # being done by the axe rather than by uvicorn, and something in
+        # shutdown is wedged and wants fixing on its own terms.
+        _record(f"graceful shutdown did not complete within {self.grace_s:.1f}s "
+                f"— exiting hard (status {EXIT_PARENT_GONE}). An orphan that "
+                f"will not die is worse than an abrupt exit.")
+        os._exit(EXIT_PARENT_GONE)
+
+    # -- lifecycle -------------------------------------------------------
+
+    def start(self) -> "ParentWatch":
+        """Arm both mechanisms on daemon threads. NEVER raises."""
+        # Checked before arming: if the launcher died between spawning us and
+        # our reaching this line, no future event will ever be delivered
+        # because the exit has already happened.
+        if not _parent_is_alive(self.parent_pid):
+            self._fire("parent was already gone before the watch armed")
+            return self
+        for target, name in ((self._watch_kqueue, "parent-watch-kqueue"),
+                             (self._watch_ppid, "parent-watch-ppid")):
+            t = threading.Thread(target=target, name=name, daemon=True)
+            t.start()
+            self._threads.append(t)
+        return self
+
+    def stop(self) -> None:
+        """Retire the watch. For tests and for a deliberate detach."""
+        self._fired.set()
+
+    @property
+    def fired(self) -> bool:
+        return self._fired.is_set()
+
+
+def install() -> Optional[ParentWatch]:
+    """Arm the watch if a parent was declared. NEVER raises.
+
+    Returns None when supervision is not active, which is the normal state
+    for a standalone run and is not a failure.
+    """
+    try:
+        if not _enabled():
+            logger.info("[ParentWatch] disabled by %s", ENV_ENABLED)
+            return None
+        pid = declared_parent_pid()
+        if pid is None:
+            logger.info(
+                "[ParentWatch] no %s declared — running unsupervised. This is "
+                "correct for a standalone launch; the HUD declares it.",
+                ENV_PARENT_PID)
+            return None
+        return ParentWatch(pid).start()
+    except Exception:  # noqa: BLE001
+        logger.error("[ParentWatch] install failed — this process may outlive "
+                     "its launcher", exc_info=True)
+        return None

--- a/scripts/check_xcodegen_parity.sh
+++ b/scripts/check_xcodegen_parity.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# Guard: the committed Xcode project must equal what XcodeGen produces from
+# `project.yml`. Nothing in `.xcodeproj` may exist that the spec cannot
+# recreate, and nothing in the spec may be missing from `.xcodeproj`.
+#
+# WHY THIS EXISTS
+# ---------------
+# Two failures, one root cause — the generated artefact and its spec drifted
+# apart, and the artefact is what Xcode actually reads:
+#
+#   1. DARK CODE. `UtteranceRecorder.swift` was written, committed, and
+#      referenced by `WakeWordListener` — and never compiled, because a new
+#      file is invisible to Xcode until `xcodegen` puts it in the build
+#      sources. Code that exists in git and does not exist in the binary is
+#      worse than missing code: it reads as done.
+#
+#   2. A SETTING THAT LIVED ONLY IN THE OUTPUT. `OS_ACTIVITY_MODE=disable`
+#      had been hand-added to the generated `.xcscheme`. The next `xcodegen`
+#      run — the one that fixed failure 1 — deleted it, because regeneration
+#      restores the spec's truth and the spec had never been told. A setting
+#      that lives only in a generated artefact is a countdown.
+#
+# Both are the same class, so one check covers both: regenerate from the spec
+# and demand the result match byte for byte. A symptom check ("is every
+# .swift in the pbxproj?") would have caught 1 and not 2.
+#
+# HOW
+# ---
+# The spec's directory is mirrored — from the git INDEX, not the working tree,
+# so this sees exactly what is being committed — into a temp dir, minus the
+# `.xcodeproj` itself. XcodeGen runs there, in place, so every emitted path is
+# relative in the same way the committed one is; generating into a different
+# directory makes XcodeGen write absolute `../../..` paths and every line
+# reports as drift. The mirror is small (~500KB: sources and the spec, no
+# build products) and the run takes about a second.
+#
+# Usage:
+#   ./scripts/check_xcodegen_parity.sh
+#
+# Exit codes:
+#   0 - every generated project matches its spec
+#   1 - drift found; the offending diff is printed to stderr
+#   2 - xcodegen is not installed and no exemption was declared
+#
+# XcodeGen missing is a FAILURE, not a skip. A guard that quietly passes when
+# its tool is absent is indistinguishable from a guard that passes, which is
+# how this class of defect survives CI. To run without it, say so out loud:
+#
+#   JARVIS_XCODEGEN_PARITY_SKIP_IF_MISSING=1 ./scripts/check_xcodegen_parity.sh
+#
+# Silence means enforce; only a positive declaration exempts.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "${REPO_ROOT}"
+
+if ! command -v xcodegen > /dev/null 2>&1; then
+    if [ "${JARVIS_XCODEGEN_PARITY_SKIP_IF_MISSING:-0}" = "1" ]; then
+        echo "WARNING: xcodegen not installed; parity NOT checked (exemption declared)." >&2
+        exit 0
+    fi
+    echo "ERROR: xcodegen is not installed, so Xcode project parity cannot be checked." >&2
+    echo "       Install it:  brew install xcodegen" >&2
+    echo "       Or declare the exemption explicitly:" >&2
+    echo "         JARVIS_XCODEGEN_PARITY_SKIP_IF_MISSING=1 $0" >&2
+    exit 2
+fi
+
+# An XcodeGen spec is a tracked `project.yml` that declares targets. Other
+# `project.yml` files (there are unrelated ones in this repo) are ignored.
+SPECS=()
+while IFS= read -r spec; do
+    grep -qE '^targets:' "${spec}" && SPECS+=("${spec}")
+done < <(git ls-files '*project.yml')
+
+if [ ${#SPECS[@]} -eq 0 ]; then
+    echo "OK: no XcodeGen specs found."
+    exit 0
+fi
+
+MIRROR="$(mktemp -d)"
+trap 'rm -rf "${MIRROR}"' EXIT
+
+FAILED=0
+
+for spec in "${SPECS[@]}"; do
+    spec_dir="$(dirname "${spec}")"
+    proj_name="$(basename "${spec_dir}")"
+
+    # Mirror the tracked/staged content of the spec directory, excluding the
+    # generated project — that is the thing under test, and copying it in
+    # would let XcodeGen preserve parts of it instead of deriving them.
+    git ls-files -z -- "${spec_dir}" \
+        | grep -zv '\.xcodeproj/' \
+        | tar -cf - --null -T - 2>/dev/null \
+        | (cd "${MIRROR}" && tar -xf -)
+
+    if ! (cd "${MIRROR}/${spec_dir}" && xcodegen generate --spec project.yml --quiet); then
+        echo "ERROR: xcodegen failed on ${spec}" >&2
+        FAILED=1
+        continue
+    fi
+
+    # Find the generated project by name rather than assuming it matches the
+    # directory - `name:` in the spec decides, and the two need not agree.
+    generated="$(find "${MIRROR}/${spec_dir}" -maxdepth 1 -name '*.xcodeproj' | head -1)"
+    if [ -z "${generated}" ]; then
+        echo "ERROR: xcodegen produced no .xcodeproj for ${spec}" >&2
+        FAILED=1
+        continue
+    fi
+    committed="${spec_dir}/$(basename "${generated}")"
+
+    if [ ! -d "${committed}" ]; then
+        echo "ERROR: ${committed} is not committed, but ${spec} generates it." >&2
+        FAILED=1
+        continue
+    fi
+
+    # Compare only what XcodeGen owns. `xcuserdata` is per-developer window
+    # state and `project.xcworkspace` carries local settings Xcode writes on
+    # its own; neither is generated, and demanding parity on them would fail
+    # for every developer who has ever opened the project.
+    DRIFT=""
+    for artefact in project.pbxproj xcshareddata/xcschemes; do
+        if [ -e "${generated}/${artefact}" ] || [ -e "${committed}/${artefact}" ]; then
+            if ! d=$(diff -r "${generated}/${artefact}" "${committed}/${artefact}" 2>&1); then
+                DRIFT="${DRIFT}${d}"$'\n'
+            fi
+        fi
+    done
+
+    if [ -n "${DRIFT}" ]; then
+        FAILED=1
+        echo "DRIFT: ${committed} does not match what ${spec} generates." >&2
+        echo "" >&2
+        printf '%s\n' "${DRIFT}" >&2
+
+        # Name the dark-code case explicitly. A developer reading a raw
+        # pbxproj diff will not necessarily recognise that the missing lines
+        # are the reason their new file never ran.
+        # `sourcecode.swift` is the value of `lastKnownFileType`, not a
+        # filename; it appears on every Swift line and would otherwise be
+        # reported as a dark file on every run.
+        DARK=$(printf '%s\n' "${DRIFT}" \
+            | grep -oE '[A-Za-z0-9_+-]+\.swift' \
+            | grep -vx 'sourcecode.swift' \
+            | sort -u || true)
+        if [ -n "${DARK}" ]; then
+            echo "" >&2
+            echo "  Swift files involved in the drift:" >&2
+            printf '%s\n' "${DARK}" | sed 's/^/    /' >&2
+            echo "  If these are new, they are NOT being compiled - the code is dark." >&2
+        fi
+
+        echo "" >&2
+        echo "  Fix by regenerating, then commit the result:" >&2
+        echo "    (cd ${spec_dir} && xcodegen generate)" >&2
+        echo "" >&2
+        echo "  If the change you want is in the .xcodeproj, put it in ${spec}" >&2
+        echo "  instead - the next regeneration will delete anything the spec" >&2
+        echo "  does not know about." >&2
+    else
+        echo "OK: ${committed} matches ${spec}."
+    fi
+done
+
+exit "${FAILED}"

--- a/tests/hud/test_parent_death_watch.py
+++ b/tests/hud/test_parent_death_watch.py
@@ -1,0 +1,279 @@
+"""The child must not outlive its launcher.
+
+Xcode's Stop button SIGKILLs the HUD. SIGKILL is uncatchable, so nothing in
+the parent runs on the way out and the Python backend is reparented to
+launchd, holding ports, a microphone claim and a few hundred megabytes.
+Measured 2026-08-04: two orphans, one at 46.8% CPU with no listening socket.
+
+These tests spawn REAL processes and REALLY kill them. A mocked parent cannot
+demonstrate the property under test, because the property is about what
+happens when a process is destroyed without warning — and a fake parent is
+destroyed politely, which is the case that already worked.
+"""
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import textwrap
+import time
+
+import pytest
+
+from brainstem.parent_watch import (
+    ENV_ENABLED, ENV_PARENT_PID, ParentWatch, declared_parent_pid, install,
+)
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+# ---------------------------------------------------------------------------
+# Declaration: supervision requires somebody to have asked for it out loud.
+# ---------------------------------------------------------------------------
+
+
+def test_no_declaration_means_no_supervision(monkeypatch):
+    """A standalone `python3 -m brainstem` must never kill itself."""
+    monkeypatch.delenv(ENV_PARENT_PID, raising=False)
+    assert declared_parent_pid() is None
+    assert install() is None
+
+
+@pytest.mark.parametrize("value", ["", "   ", "not-a-pid", "0", "-5", "1"])
+def test_implausible_declarations_are_refused(monkeypatch, value):
+    """PID 1 is refused deliberately: launchd is everybody's eventual parent,
+    so treating it as the parent would mean waiting for a death that has
+    already happened."""
+    monkeypatch.setenv(ENV_PARENT_PID, value)
+    assert declared_parent_pid() is None
+
+
+def test_our_own_pid_is_refused(monkeypatch):
+    """Watching ourselves would fire the moment we exit."""
+    monkeypatch.setenv(ENV_PARENT_PID, str(os.getpid()))
+    assert declared_parent_pid() is None
+
+
+def test_master_switch_disables(monkeypatch):
+    monkeypatch.setenv(ENV_PARENT_PID, "424242")
+    monkeypatch.setenv(ENV_ENABLED, "false")
+    assert install() is None
+
+
+# ---------------------------------------------------------------------------
+# Detection, against processes that are really killed.
+# ---------------------------------------------------------------------------
+
+
+def _sleeper() -> subprocess.Popen:
+    """A real process to play the launcher."""
+    return subprocess.Popen([sys.executable, "-c", "import time; time.sleep(120)"])
+
+
+def test_a_dead_parent_is_detected_before_arming():
+    """The race between spawn and arming is not an error, it is the answer.
+
+    If the launcher dies in the window before the watch starts, no future
+    event will ever be delivered — the exit already happened. Checking
+    liveness at arm time is what stops that from becoming a permanent orphan.
+    """
+    p = _sleeper()
+    pid = p.pid
+    p.kill()
+    p.wait()
+
+    w = ParentWatch(pid)
+    w.grace_s = 60.0          # keep escalation away from this assertion
+    fired = []
+    w._fire = lambda reason: fired.append(reason)  # type: ignore[method-assign]
+    w.start()
+    assert fired, "a parent that was already gone must be detected at arm time"
+
+
+def test_sigkill_of_the_parent_is_detected():
+    """The case that produced the bug: an uncatchable kill.
+
+    The kernel reports NOTE_EXIT identically for SIGKILL and a clean exit —
+    it does not care how the process died — which is exactly why detection
+    lives in the child and not in the parent's shutdown path.
+    """
+    p = _sleeper()
+    w = ParentWatch(p.pid)
+    w.grace_s = 60.0
+    fired = []
+    w._fire = lambda reason: fired.append(reason)  # type: ignore[method-assign]
+    w.start()
+
+    time.sleep(0.3)
+    assert not fired, "must not fire while the parent is alive"
+
+    os.kill(p.pid, signal.SIGKILL)
+    p.wait()
+
+    deadline = time.monotonic() + 15.0
+    while time.monotonic() < deadline and not fired:
+        time.sleep(0.1)
+    w.stop()
+    assert fired, "SIGKILL of the parent went undetected — this is the orphan bug"
+
+
+def test_firing_is_idempotent():
+    """Two mechanisms watch one parent; only one shutdown may start.
+
+    Without this, both would raise SIGTERM and start an escalation timer,
+    and the second timer would `os._exit` a process that was already
+    shutting down cleanly.
+    """
+    w = ParentWatch(os.getppid() or 424242)
+    sent = []
+    w._escalate = lambda: sent.append("escalate")  # type: ignore[method-assign]
+    killed = []
+    real_kill = os.kill
+
+    def _fake_kill(pid, sig):
+        if pid == os.getpid():
+            killed.append(sig)
+            return
+        return real_kill(pid, sig)
+
+    os.kill = _fake_kill  # type: ignore[assignment]
+    try:
+        w._fire("first")
+        w._fire("second")
+        w._fire("third")
+    finally:
+        os.kill = real_kill  # type: ignore[assignment]
+
+    assert killed == [signal.SIGTERM], f"expected exactly one SIGTERM, got {killed}"
+
+
+def test_permission_denied_is_alive_not_dead():
+    """A parent owned by another user exists. Reading EPERM as "gone" would
+    kill the backend whenever the launcher runs as somebody else."""
+    from brainstem import parent_watch
+    assert parent_watch._parent_is_alive(1) is True
+
+
+# ---------------------------------------------------------------------------
+# End to end: a real child, a real SIGKILL, and no orphan left behind.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.timeout(90)
+def test_a_real_child_does_not_survive_a_sigkilled_parent(tmp_path):
+    """The whole point, with nothing faked.
+
+    A parent spawns a child that installs the watch. The parent is SIGKILLed
+    — no handler, no atexit, no chance to clean up, exactly what Xcode's Stop
+    button does. The child must notice and leave on its own.
+    """
+    child_src = tmp_path / "child.py"
+    child_src.write_text(textwrap.dedent(f"""
+        import os, sys, time
+        sys.path.insert(0, {REPO_ROOT!r})
+        from brainstem.parent_watch import install
+        install()
+        # Live long enough that surviving would be unambiguous.
+        for _ in range(600):
+            time.sleep(0.2)
+    """))
+
+    parent_src = tmp_path / "parent.py"
+    parent_src.write_text(textwrap.dedent(f"""
+        import os, subprocess, sys, time
+        env = dict(os.environ)
+        env["JARVIS_PARENT_PID"] = str(os.getpid())
+        env["JARVIS_PARENT_WATCH_POLL_S"] = "0.5"
+        env["JARVIS_PARENT_WATCH_GRACE_S"] = "2"
+        p = subprocess.Popen([sys.executable, {str(child_src)!r}], env=env)
+        print(p.pid, flush=True)
+        time.sleep(300)
+    """))
+
+    parent = subprocess.Popen([sys.executable, str(parent_src)],
+                              stdout=subprocess.PIPE, text=True)
+    try:
+        assert parent.stdout is not None
+        child_pid = int(parent.stdout.readline().strip())
+        time.sleep(2.0)          # let the child arm its watch
+
+        assert _alive(child_pid), "child should be running before the kill"
+
+        os.kill(parent.pid, signal.SIGKILL)   # uncatchable, like Xcode's Stop
+        parent.wait()
+
+        deadline = time.monotonic() + 45.0
+        while time.monotonic() < deadline and _alive(child_pid):
+            time.sleep(0.25)
+
+        survived = _alive(child_pid)
+        if survived:                          # never leave one behind
+            try:
+                os.kill(child_pid, signal.SIGKILL)
+            except Exception:
+                pass
+        assert not survived, (
+            "the child outlived a SIGKILLed parent — it is an orphan holding "
+            "ports and memory, which is the bug this exists to prevent")
+    finally:
+        if parent.poll() is None:
+            parent.kill()
+            parent.wait()
+
+
+def _alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+
+
+# ---------------------------------------------------------------------------
+# The watchdog must not depend on anything it is watching.
+# ---------------------------------------------------------------------------
+
+
+def test_the_escalation_path_never_touches_logging():
+    """A wedged shutdown is exactly the state where some thread holds the
+    logging lock. If escalation called `logger.*` it would block on the system
+    it exists to bound — a watchdog sharing a lock with its subject is not a
+    watchdog. Same rule that forbids the battle harness's wall-clock watchdog
+    from reading the op-ledger.
+    """
+    import ast
+    import inspect
+    from brainstem import parent_watch
+
+    for name in ("_escalate", "_fire", "_record"):
+        fn = getattr(parent_watch.ParentWatch, name, None) or getattr(parent_watch, name)
+        tree = ast.parse(textwrap.dedent(inspect.getsource(fn)))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name):
+                assert node.value.id != "logger", (
+                    f"{name}() calls logger.{node.attr} — the escalation path "
+                    f"must use only syscalls, or a wedged logging lock "
+                    f"deadlocks the watchdog")
+
+
+def test_the_record_sink_survives_an_unwritable_destination(monkeypatch):
+    """A log line is never worth obstructing the exit it describes."""
+    from brainstem import parent_watch
+    monkeypatch.setenv(parent_watch.ENV_LOG_PATH, "/nonexistent-root/nope/x.log")
+    parent_watch._record("this must not raise")   # would propagate if it did
+
+
+def test_record_actually_writes_where_it_says(monkeypatch, tmp_path):
+    """The destination must be real — the previous incarnation reported into a
+    pipe held by the process that had just been SIGKILLed, and recorded
+    nothing at all on a run that worked perfectly.
+    """
+    from brainstem import parent_watch
+    target = tmp_path / "nested" / "parent-watch.log"
+    monkeypatch.setenv(parent_watch.ENV_LOG_PATH, str(target))
+    parent_watch._record("hello from the watch")
+    assert target.exists(), "the sink must create its own directory"
+    assert "hello from the watch" in target.read_text()

--- a/tests/hud/test_voice_authority.py
+++ b/tests/hud/test_voice_authority.py
@@ -348,3 +348,87 @@ async def test_the_model_still_warms_on_first_need():
     and answers NOT_READY so the operator can retry."""
     import inspect
     assert "start_warming" in inspect.getsource(VoiceIdentity.identify)
+
+
+# ---------------------------------------------------------------------------
+# The retry the operator is invited to make must still have evidence to use.
+# ---------------------------------------------------------------------------
+
+
+def test_peek_does_not_consume():
+    """`peek` is the non-destructive counterpart to `claim`."""
+    h = UtteranceHolder()
+    assert h.deposit(_b64(_wav()), FORMAT_WAV16K)
+    first = h.peek()
+    second = h.peek()
+    assert first is not None and second is not None
+    assert first.audio == second.audio, "peek must be repeatable"
+    assert h.claim() is not None, "peek must leave the utterance claimable"
+    assert h.claim() is None, "claim is still destructive"
+
+
+def test_a_stale_utterance_is_not_peekable(monkeypatch):
+    """Expiry is enforced on the non-destructive path too, or `peek` becomes
+    a way to verify against evidence `claim` would have refused."""
+    monkeypatch.setenv("JARVIS_UTTERANCE_TTL_S", "1")
+    h = UtteranceHolder()
+    assert h.deposit(_b64(_wav()), FORMAT_WAV16K)
+    h._held.captured_at -= 60          # age it past the TTL
+    assert h.peek() is None
+
+
+@pytest.mark.asyncio
+async def test_a_cold_model_does_not_destroy_the_utterance():
+    """The regression this pins, measured live 2026-08-04 19:10:13.
+
+    The first verification of a session ALWAYS reports NOT_READY — it is what
+    starts the lazy model load. If that attempt consumes the sentence, the
+    operator is told "ask again" with the evidence for the retry deleted, and
+    the model becomes ready 2.8s later holding nothing.
+    """
+    from backend.hud.consent_bridge import VoiceConsentProvider
+    from backend.hud.utterance_audio import get_utterance_holder
+
+    holder = get_utterance_holder()
+    assert holder.deposit(_b64(_wav()), FORMAT_WAV16K)
+
+    class _Ctx:
+        capability = "unlock_screen"
+
+    result = await VoiceConsentProvider().decide(_Ctx())
+    assert result is not None
+    assert result.verdict == Verdict.NOT_READY.value, result.verdict
+    assert not result.approves, "a cold model is never consent"
+
+    # The whole point: the retry still has something to verify.
+    assert holder.peek() is not None, (
+        "the utterance was destroyed by an attempt that could not succeed — "
+        "the operator was asked to retry with the evidence deleted")
+
+
+@pytest.mark.asyncio
+async def test_a_ready_model_does_consume_the_utterance():
+    """The other half. Anti-replay depends on a real verification claiming."""
+    from backend.hud.consent_bridge import VoiceConsentProvider
+    from backend.hud.utterance_audio import get_utterance_holder
+    from backend.hud import voice_identity as vi
+
+    class _Svc:
+        async def verify_speaker(self, audio, name):
+            return {"verified": True, "confidence": 0.99, "speaker_name": name}
+
+    ident = vi.VoiceIdentity(service=_Svc())
+    ident._enrolled_cache = "Derek J. Russell"
+    ident._enrolled_at = float("inf")
+    vi._IDENTITY = ident
+    assert ident.readiness is Readiness.READY
+
+    holder = get_utterance_holder()
+    assert holder.deposit(_b64(_wav()), FORMAT_WAV16K)
+
+    class _Ctx:
+        capability = "unlock_screen"
+
+    result = await VoiceConsentProvider().decide(_Ctx())
+    assert result is not None and result.verdict == Verdict.VERIFIED.value, result
+    assert holder.peek() is None, "a real verification must consume the evidence"

--- a/tests/voice/test_lazy_symbol_binding.py
+++ b/tests/voice/test_lazy_symbol_binding.py
@@ -1,0 +1,137 @@
+"""A lazily-imported symbol must never be referenced as a bare global.
+
+WHAT THIS CATCHES
+-----------------
+`speaker_verification_service` defers heavy imports: `_init_ml_components`
+imports the audio converters and stores them in the module-level dict
+`_audio_converter_funcs`, reachable through `get_audio_converter(name)`. It
+deliberately does NOT bind them as module globals — that is the entire point
+of deferring the import.
+
+`_convert_audio_for_verification` was nonetheless written against the bare
+names. Every conversion strategy in it — quality analysis, async, and the
+sync thread-pool fallback — raised `NameError` before converting a byte:
+
+    [VoiceIdentity] unavailable  NameError: name 'AudioConverterConfig'
+                                 is not defined
+
+`VoiceIdentity.identify` reports that as UNAVAILABLE and `CapabilityRouter`
+reads UNAVAILABLE as "not consent". So speaker verification could not succeed
+for any audio, from any caller, since the lazy-loading refactor — and nothing
+looked broken, because **a fault on a consent path is indistinguishable from a
+refusal unless somebody reads the detail string.** The unit suite was green
+throughout; only running the real service against real bytes exposed it.
+
+WHY THE TEST IS STRUCTURAL
+---------------------------
+Asserting "this one function works" would need the ML stack loaded (~12s) and
+would still only cover the four names that happened to be wrong today. The
+defect class is "a deferred symbol used as though it were imported", so the
+test is written against that class: parse the module and prove no function
+reads one of the deferred names out of the global namespace.
+
+A local rebinding is fine and expected — that is exactly the fix
+(`x = get_audio_converter('x')`), so a name assigned within the function
+before use is not a violation.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE = REPO_ROOT / "backend" / "voice" / "speaker_verification_service.py"
+
+#: The symbols `_init_ml_components` imports into `_audio_converter_funcs`
+#: rather than into module globals.
+DEFERRED = {
+    "prepare_audio_for_stt",
+    "prepare_audio_for_stt_async",
+    "prepare_audio_with_analysis",
+    "AudioConverterConfig",
+}
+
+
+def _bound_locally(fn: ast.AST) -> set:
+    """Names the function binds itself: assignment, import, or parameter."""
+    bound = set()
+    for node in ast.walk(fn):
+        if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store):
+            bound.add(node.id)
+        elif isinstance(node, (ast.Import, ast.ImportFrom)):
+            for alias in node.names:
+                bound.add(alias.asname or alias.name.split(".")[0])
+        elif isinstance(node, ast.arg):
+            bound.add(node.arg)
+    return bound
+
+
+def _violations():
+    tree = ast.parse(MODULE.read_text(encoding="utf-8"))
+    out = []
+    for fn in ast.walk(tree):
+        if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        # `_init_ml_components` is where the deferred import legitimately
+        # happens; its own bindings are covered by `_bound_locally`, but name
+        # it explicitly so the exemption is a decision rather than an accident.
+        if fn.name == "_init_ml_components":
+            continue
+        local = _bound_locally(fn)
+        for node in ast.walk(fn):
+            if (isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load)
+                    and node.id in DEFERRED and node.id not in local):
+                out.append((fn.name, node.id, node.lineno))
+    return out
+
+
+def test_no_deferred_symbol_read_from_globals():
+    """Reading a deferred symbol as a global is a guaranteed NameError."""
+    bad = _violations()
+    assert not bad, (
+        "These functions read a lazily-imported symbol out of the global "
+        "namespace, where it is never bound — each is a NameError at runtime "
+        "that surfaces as a consent DENIAL:\n"
+        + "\n".join(f"  {fn}() reads {name} at line {line}"
+                    for fn, name, line in bad)
+        + "\n\nResolve it through the accessor instead:\n"
+          "    name = get_audio_converter('name')"
+    )
+
+
+def test_accessor_exists_for_every_deferred_symbol():
+    """The fix depends on `get_audio_converter` covering every deferred name.
+
+    If a symbol is added to the lazy import but not to the dict, the accessor
+    silently returns None and the caller fails in a new way.
+    """
+    tree = ast.parse(MODULE.read_text(encoding="utf-8"))
+    keys = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Dict):
+            for k in node.keys:
+                if isinstance(k, ast.Constant) and isinstance(k.value, str):
+                    keys.add(k.value)
+    missing = DEFERRED - keys
+    assert not missing, (
+        f"deferred symbols with no entry in _audio_converter_funcs: "
+        f"{sorted(missing)} - get_audio_converter() would return None for them"
+    )
+
+
+@pytest.mark.parametrize("name", sorted(DEFERRED))
+def test_deferred_symbol_is_actually_importable(name):
+    """The converter module really exports what the lazy import promises.
+
+    Guards the other end: a rename in `audio_format_converter` would make the
+    deferred import fail at first use, long after the change, in a code path
+    whose only visible symptom is a refused unlock.
+    """
+    import importlib
+    mod = importlib.import_module("backend.voice.audio_format_converter")
+    assert hasattr(mod, name), (
+        f"backend.voice.audio_format_converter has no {name!r}; the lazy "
+        f"import in speaker_verification_service would fail at first use"
+    )


### PR DESCRIPTION
Four threads left flagged after the capability-reflex arc — plus two defects the live run exposed that no unit test could see.

## 1. A Swift file that is not in the project is not in the binary

`UtteranceRecorder.swift` was written, committed, reviewed and referenced by `WakeWordListener` — and never compiled. The inverse failed the same week: `OS_ACTIVITY_MODE` had been hand-added to the generated `.xcscheme`, so the regeneration that fixed the dark file deleted it.

Both are one class — spec and output drifting apart — so `scripts/check_xcodegen_parity.sh` regenerates from `project.yml` and demands byte-parity. A symptom check ("is every .swift in the pbxproj?") would have caught the first and not the second.

- Proven both directions before wiring: a planted `__GuardProbe.swift` exits 1 with the file named; the clean tree exits 0
- **Found real drift on its first run** — `.claude/.cc-writes` scratch dirs baked into the committed project. Git cannot see empty directories, so a machine-local path had been committed without ever appearing in `git status`
- Then caught `BootLogFile.swift` for real later in the same session
- Pre-commit hook + macOS CI job. A missing xcodegen is a **failure, not a skip**

## 2. Restore 138 symbols a "docs" commit deleted nine months ago

`4406e11941` — *"docs: AI-generated documentation updates"*, 103 files, 25k/24k. It dropped 614 executable definitions while adding docstrings. One file ended with `# Module truncated - needs restoration from backup`; another's added docstring referenced the factory it deleted.

Restored on one criterion: **a file whose own surviving code calls a method the commit deleted** — a guaranteed AttributeError, unlike a word-frequency count where thirty classes define `start`.

| | |
|---|---|
| guaranteed-AttributeError call sites | **33 → 0** |
| baseline (clean detached worktree at HEAD) | 79 failed / 255 passed |
| after | **64 failed / 270 passed** |
| regressions | **0** |

Plus 8 tests that previously could not be **collected** — that collection error was aborting the entire `backend/tests` run.

Restoration is decorator-aware and refuses any class whose `__init__` no longer sets the attributes the restored methods read. That refusal fired once, correctly.

## 3. Speaker verification could not succeed, for any audio, ever

`_convert_audio_for_verification` read four lazily-imported names as bare globals that the lazy loader deliberately never binds. Every strategy raised `NameError` before converting a byte — no audio has been verifiable since the lazy-loading refactor.

It hid because `identify()` reports a fault as UNAVAILABLE and the router reads UNAVAILABLE as "not consent". **A fault on a consent path is indistinguishable from a refusal unless somebody reads the detail string.**

`unavailable (NameError)` → real `rejected` in **7.6ms**. The test is structural — it guards the class, not the four names — and catches 4 violations against the pre-fix file, 0 after.

## 4. A log that requires someone to be watching is not a log

GUI `print()` does not survive redirection, the backend child's output pipes into that same process, and `OS_ACTIVITY_MODE=disable` closes the unified-log path. The boot log existed only while a developer sat attached to Xcode. That is why *"the speaker model was never observed reaching READY"* stayed open — not evidence of failure, just nothing recording.

Now at `~/Library/Logs/JARVIS/hud-boot.log`. Unfiltered to the file, filtered to the console: the line you need later is always the one nobody thought to whitelist.

## 5. The one attempt that could not succeed was the one that spent the evidence

Live, saying "unlock my screen":

```
[VoiceRouter]      CAI: 'screen_unlocked' unmet -> running 'unlock_screen' first
[VoiceConsent]     'unlock_screen' -> not_ready (model cold; enrollment Derek J. Russell)
[CapabilityRouter] NOT authorised (I'm still loading my voice recognition -- ask again)
[VoiceIdentity]    speaker model READY after 2.8s
```

Correct except the order of two operations. The model is lazy on purpose, so the first verification always reports NOT_READY — it is what starts the load. But `decide()` called the destructive `claim()` before asking whether a verdict was reachable, so the one attempt that could never succeed deleted the sentence. The operator was invited to retry with the evidence already gone.

`peek_age_s` existed for exactly that question and was never asked. Anti-replay is untouched: verification still consumes, and nothing verifies from a peek.

## Verification

- 168 tests green across `tests/hud`, `tests/voice`, and the repaired backend suites
- Every guard proven to FAIL against the pre-fix code, not just pass after
- xcodegen parity green; `xcodebuild -scheme JARVISHUD` exits 0

## Not done, deliberately

- **A successful unlock has never been observed.** The arc is live-proven through honest refusal; the fix predicts asking twice now works, and that prediction is untested
- ~215 unreferenced deletions from the docs-bot commit, and a separate seam where it left calls to `add_activity` / `analyze` / `space_id=` that no longer match its own rewritten dataclasses — pre-existing, needs per-symbol confirmation
- **Loop availability regressed to 79.2%** (worst stall 39.41s) after the dispatch work took it to 96.2%
- **The backend orphans itself** when the HUD exits — 963MB still running
- `JARVIS-Apple/.gitignore` lists `*.xcodeproj/` while the project is tracked; the repo tells two stories about whether it is a build product

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes speaker verification and voice-consent evidence handling, restores missing backend symbols, adds a persistent HUD boot log, enforces `xcodegen` parity, and prevents backend orphans by making the backend exit when the HUD dies.

- **New Features**
  - Persistent boot log: write unfiltered startup output to `~/Library/Logs/JARVIS/hud-boot.log`; console remains filtered; `[Brainstem]` lines are captured outside Xcode.
  - Project parity guard: pre-commit and CI run `scripts/check_xcodegen_parity.sh` to assert `.xcodeproj` == spec from `project.yml`; added source `excludes` to strip `**/.claude` dirs; schemes regenerated.
  - Parent-death watch: backend exits when the HUD dies; opt-in via `JARVIS_PARENT_PID`; logs to `~/Library/Logs/JARVIS/parent-watch.log`.

- **Bug Fixes**
  - Speaker verification: resolve lazy-loaded audio converters via the existing accessor to avoid `NameError`; now returns real verdicts; structural tests added to prevent bare-global use.
  - Voice consent: added `peek()` and check readiness before `claim()` so a NOT_READY result doesn’t consume the utterance; tests cover cold/ready paths.
  - Backend restorations: recovered 138 class/method definitions removed by a prior docs update; repaired truncated modules and kept `MultiSpaceContextGraph` compatible with both old/new init params; backend test status improved (79→64 fails, +15 passing; +8 previously uncollectable now collected).

<sup>Written for commit deed250a9249b1dd5bb6f4992a6fbdb2a94d2eaf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

