### PR TITLE
diag(hud): name what shutdown is waiting for — 20+ unowned daemon tasks

### DIFF
--- a/brainstem/parent_watch.py
+++ b/brainstem/parent_watch.py
@@ -66,6 +66,47 @@ event loop, the application state, or anything the shutdown it is bounding
 could wedge — for the same reason the wall-clock watchdog in the battle
 harness is forbidden from reading the op-ledger.
 
+WHY THE HARD EXIT FIRES EVERY TIME (MEASURED, NOT YET FIXED)
+--------------------------------------------------------------
+Escalation is meant to be the exception. It is currently the rule: detection
+is instantaneous, and the entire delay is graceful shutdown never finishing.
+The dumps below were taken by this module and are what the finding rests on.
+
+    standalone, SIGTERM by hand                          1s, clean
+    drained pipe, parent SIGKILLed, no brainstem/.env    0s, clean
+    drained pipe, parent SIGKILLed, WITH brainstem/.env  22s, hard exit
+    the real HUD                                         11s, hard exit
+
+`.env` is the discriminator, and the reason is what it turns on. At the hard
+exit there are twenty-plus long-lived daemon tasks still pending — CloudSQL
+cleanup/health/leak monitors, GCP VM monitoring and orphan cleanup, DW
+discovery and heavy-probe loops, learning-DB auto-flush and auto-optimise,
+the distributed lock cleanup, the background agent pool workers, the rate
+orchestrator's forecast and adjustment loops. Without `.env` most of them
+never start, and shutdown is instant.
+
+None of them is individually buggy: the ones inspected handle
+`asyncio.CancelledError` correctly. **The defect is that nobody owns them.**
+They are created ad hoc with `asyncio.create_task` across the codebase, no
+shutdown path knows they exist, and they are left for
+`asyncio.Runner.close()` to cancel en masse after uvicorn has already
+finished. Twenty tasks — several parked on network I/O to CloudSQL, GCP and
+DoubleWord — do not all unwind inside any sane grace period. The logs show
+`FailoverLifecycle` STARTING new work while shutdown is under way, which is
+the same absence of ownership seen from the other end.
+
+The architecture for this already exists and is not wired up:
+`backend/core/coordinated_shutdown.py` provides `CoordinatedShutdownManager`
+with ordered phases, per-hook timeouts, critical/non-critical hooks and
+process-group termination. `backend/main.py`'s lifespan does not call it —
+it hand-rolls 535 sequential lines instead, with roughly twenty awaits that
+have no timeout at all. Fixing this means registering those tasks as hooks,
+not writing a new shutdown system.
+
+Until that lands, this module's hard exit is what keeps a dead launcher from
+leaving a live backend, and every occurrence is recorded with the stacks and
+the task list that explain it.
+
 Python 3.9+, ``from __future__ import annotations``.
 """
 from __future__ import annotations
@@ -102,6 +143,10 @@ EXIT_PARENT_GONE: int = 143
 #: Where this subsystem records what it did, independently of everything else.
 ENV_LOG_PATH: str = "JARVIS_PARENT_WATCH_LOG"
 
+#: Set once stdout/stderr have been pointed at the log file. After that, fd 2
+#: IS the log file, so writing to both would record every line twice.
+_DETACHED: bool = False
+
 
 def _default_log_path() -> str:
     return os.path.join(os.path.expanduser("~/Library/Logs/JARVIS"),
@@ -133,10 +178,13 @@ def _record(message: str) -> None:
     """
     line = f"{time.strftime('%Y-%m-%d %H:%M:%S')} [ParentWatch] {message}\n"
     data = line.encode("utf-8", "replace")
-    try:
-        os.write(2, data)          # stderr, for when anyone is still reading
-    except Exception:  # noqa: BLE001
-        pass
+    if not _DETACHED:
+        # Skipped once detached: fd 2 has been dup2'd onto the log file, so
+        # this write and the one below would be the same line, twice.
+        try:
+            os.write(2, data)      # stderr, for when anyone is still reading
+        except Exception:  # noqa: BLE001
+            pass
     try:
         path = (os.environ.get(ENV_LOG_PATH, "") or "").strip() or _default_log_path()
         os.makedirs(os.path.dirname(path), exist_ok=True)
@@ -147,6 +195,145 @@ def _record(message: str) -> None:
             os.close(fd)
     except Exception:  # noqa: BLE001
         pass
+
+
+def _dump_stacks() -> None:
+    """Record every thread's stack at the moment of the hard exit. NEVER raises.
+
+    A hard exit that says only "shutdown did not finish" reports a symptom and
+    destroys the evidence in the same instant. This is the one moment the
+    answer is still in memory, and it is the last moment anybody can ask.
+
+    `faulthandler.dump_traceback` is used rather than `traceback` because it
+    writes to a raw file descriptor from C, taking no Python-level lock and
+    allocating nothing. It is designed to work in exactly the state that makes
+    this necessary — a process too wedged to run ordinary Python reliably.
+    Using `traceback.format_stack` here would mean acquiring the very locks
+    the wedge may be holding, which is how a diagnostic becomes the hang.
+    """
+    try:
+        import faulthandler
+        path = (os.environ.get(ENV_LOG_PATH, "") or "").strip() or _default_log_path()
+        _record("--- thread stacks at hard exit (what shutdown was waiting on) ---")
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+        try:
+            faulthandler.dump_traceback(file=fd, all_threads=True)
+        finally:
+            os.close(fd)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _dump_pending_tasks(limit: int = 40) -> None:
+    """Name the asyncio tasks that were still alive at the hard exit.
+
+    Thread stacks are not enough. The measured wedge was the MAIN thread
+    sitting in `asyncio.runners._cancel_all_tasks`, which cancels every
+    remaining task and then waits for all of them to finish — so the thread
+    stack says "waiting for tasks" and stops exactly where the interesting
+    part begins. A coroutine that swallows `CancelledError`, or that is
+    blocked somewhere cancellation cannot reach, holds the process open
+    forever and appears in no thread dump.
+
+    Found by walking the garbage collector rather than `asyncio.all_tasks()`,
+    which must be called from the loop's own thread — the thread that is, by
+    construction, the one that is stuck. This costs a full heap scan, which
+    would be indefensible anywhere except here: the process is already leaving,
+    and this is the last instant the answer exists.
+    """
+    try:
+        import asyncio
+        import gc
+        alive = []
+        for obj in gc.get_objects():
+            try:
+                if isinstance(obj, asyncio.Task) and not obj.done():
+                    alive.append(obj)
+            except Exception:  # noqa: BLE001
+                continue
+        if not alive:
+            _record("no pending asyncio tasks — the wedge is not task cancellation")
+            return
+        _record(f"--- {len(alive)} pending asyncio task(s) at hard exit "
+                f"(these are what _cancel_all_tasks was waiting for) ---")
+        for t in alive[:limit]:
+            try:
+                coro = t.get_coro()
+                name = getattr(coro, "__qualname__", None) or repr(coro)
+                where = ""
+                frame = getattr(coro, "cr_frame", None)
+                if frame is not None:
+                    where = (f" at {os.path.basename(frame.f_code.co_filename)}"
+                             f":{frame.f_lineno}")
+                _record(f"    cancelling={t.cancelled()} name={t.get_name()} "
+                        f"coro={name}{where}")
+            except Exception:  # noqa: BLE001
+                continue
+        if len(alive) > limit:
+            _record(f"    ... and {len(alive) - limit} more")
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _detach_dead_output() -> bool:
+    """Point stdout/stderr somewhere that cannot block. NEVER raises.
+
+    WHAT THIS IS, AND WHAT IT IS NOT
+    ----------------------------------
+    It is NOT the fix for the slow shutdown. That was measured and disproved:
+    a faithful repro — a parent that DRAINS the pipe exactly as
+    `readabilityHandler` does, then is SIGKILLed — shuts the backend down in
+    **0 seconds** with or without this. The real cause is elsewhere and is
+    recorded in the module docstring.
+
+    What it does fix is a real and separately measured failure: a pipe that is
+    NOT being drained. A 64KB buffer fills, the child blocks in `write()`, and
+    everything downstream of that write stops:
+
+        undrained pipe, reader killed   17s, never completed, 17 tasks pending
+        file sink, reader killed         1s, clean
+
+    That is not hypothetical. A HUD that is alive but has stopped reading — a
+    beachball, a suspended debugger, a paused process under Instruments — puts
+    the backend in exactly that state, and no watch fires because nobody has
+    died. Severing the connection when the reader is known dead removes one
+    version of it cheaply.
+
+    The general form of the defect is worth stating plainly: **a process's
+    ability to make progress must not depend on a consumer of its logs.** The
+    complete answer is for the launcher to hand the child a FILE rather than a
+    pipe, so no reader can ever apply backpressure. That is a Swift-side
+    change, and it is the honest fix for the class.
+
+    By the time this runs the watch has already established that the reader is
+    dead — that is the entire reason it fired — so this severs a connection to
+    a corpse and loses no output that was still going anywhere. The
+    replacement is the watch's own log file rather than `/dev/null`, because
+    what arrives now is shutdown's account of itself.
+    """
+    try:
+        path = (os.environ.get(ENV_LOG_PATH, "") or "").strip() or _default_log_path()
+        try:
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+        except Exception:  # noqa: BLE001
+            # Anywhere that accepts writes beats a pipe nobody is reading.
+            fd = os.open(os.devnull, os.O_WRONLY)
+        try:
+            # dup2 onto the raw descriptors, so every writer is covered at once
+            # — `sys.stdout`, `sys.stderr`, C extensions, and any handler that
+            # captured `sys.__stderr__` at import time and would otherwise keep
+            # its own reference to the dead pipe.
+            os.dup2(fd, 1)
+            os.dup2(fd, 2)
+        finally:
+            if fd > 2:
+                os.close(fd)
+        global _DETACHED
+        _DETACHED = True
+        return True
+    except Exception:  # noqa: BLE001
+        return False
 
 
 def _enabled() -> bool:
@@ -307,10 +494,15 @@ class ParentWatch:
             return
         self._fired.set()
         self._fired_at = time.monotonic()
+        # BEFORE the SIGTERM, not after. Shutdown begins the instant the signal
+        # is delivered, and it is shutdown's own logging that blocks on the
+        # dead pipe — redirecting afterwards would race the thing it prevents.
+        detached = _detach_dead_output()
         _record(f"launcher (pid {self.parent_pid}) is gone — {reason}. "
                 f"Raising SIGTERM; hard exit in {self.grace_s:.1f}s if that "
                 f"does not finish. Better an abrupt exit than an orphan "
-                f"holding ports, a microphone claim and memory.")
+                f"holding ports, a microphone claim and memory. "
+                f"stdout/stderr detached from the dead reader: {detached}")
         threading.Thread(target=self._escalate, name="parent-watch-escalate",
                          daemon=True).start()
         try:
@@ -335,6 +527,8 @@ class ParentWatch:
         _record(f"graceful shutdown did not complete within {self.grace_s:.1f}s "
                 f"— exiting hard (status {EXIT_PARENT_GONE}). An orphan that "
                 f"will not die is worse than an abrupt exit.")
+        _dump_stacks()
+        _dump_pending_tasks()
         os._exit(EXIT_PARENT_GONE)
 
     # -- lifecycle -------------------------------------------------------

--- a/scripts/repro_shutdown_wedge.py
+++ b/scripts/repro_shutdown_wedge.py
@@ -1,0 +1,89 @@
+"""Faithful repro: a parent that DRAINS the pipe, exactly like the HUD.
+
+The first attempt spawned the child with `stdout=PIPE` and never read it, so
+the 64KB buffer filled during boot and the child was already blocked in
+write() before anything was killed. That is a real failure mode but it is NOT
+the HUD's: `BrainstemLauncher` attaches a `readabilityHandler` to both pipes
+and drains them continuously, right up until the instant it is SIGKILLed.
+
+So this drains in a background thread, lets the child boot fully, and only
+then kills the reader — which is the actual sequence on the machine.
+
+  MODE=drain   drain the pipe, then SIGKILL the parent   (faithful to the HUD)
+  MODE=file    stdout to a file, then SIGKILL the parent (control)
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+MODE = sys.argv[1] if len(sys.argv) > 1 else "drain"
+
+env = dict(os.environ)
+env["PYTHONPATH"] = f"{REPO}/backend:{REPO}"
+env["JARVIS_PROCESS_ROLE"] = "hud"
+# The HUD loads brainstem/.env before spawning; without it a different set of
+# subsystems starts, which is the last untested difference from the real case.
+try:
+    for line in open(f"{REPO}/brainstem/.env"):
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        k, v = line.split("=", 1)
+        env[k.strip()] = v.strip().strip('"').strip("'")
+except Exception as e:
+    print("no .env:", e)
+env["JARVIS_PARENT_PID"] = str(os.getpid())
+env["JARVIS_PARENT_WATCH_GRACE_S"] = "20"
+env["JARVIS_PARENT_WATCH_LOG"] = os.path.join(
+    os.environ.get("REPRO_OUT_DIR", tempfile.gettempdir()), f"watch-{MODE}.log")
+
+OUT = os.environ.get("REPRO_OUT_DIR", tempfile.mkdtemp(prefix="shutdown-wedge-"))
+mirror = open(os.path.join(OUT, f"child-{MODE}.log"), "w")
+
+if MODE == "file":
+    p = subprocess.Popen([sys.executable, "-u", "-m", "brainstem"],
+                         cwd=REPO, env=env, stdout=mirror,
+                         stderr=subprocess.STDOUT)
+else:
+    p = subprocess.Popen([sys.executable, "-u", "-m", "brainstem"],
+                         cwd=REPO, env=env, stdout=subprocess.PIPE,
+                         stderr=subprocess.STDOUT)
+
+    def _drain() -> None:
+        """What `readabilityHandler` does: read continuously, forever."""
+        assert p.stdout is not None
+        for line in p.stdout:
+            mirror.write(line.decode("utf-8", "replace"))
+            mirror.flush()
+
+    threading.Thread(target=_drain, daemon=True).start()
+
+print(f"child={p.pid} mode={MODE}", flush=True)
+
+# Boot fully. With the pipe drained this now actually completes.
+deadline = time.time() + 150
+booted = False
+while time.time() < deadline:
+    time.sleep(2)
+    try:
+        if "Application startup complete" in open(os.path.join(OUT, f"child-{MODE}.log")).read():
+            booted = True
+            break
+    except Exception:
+        pass
+print(f"booted={booted}", flush=True)
+if p.poll() is not None:
+    print(f"child died during boot rc={p.returncode}", flush=True)
+    raise SystemExit(1)
+
+time.sleep(3)
+print("killing self (SIGKILL) — the drain stops at this instant", flush=True)
+sys.stdout.flush()
+mirror.flush()
+os.kill(os.getpid(), 9)


### PR DESCRIPTION
The hard exit added in #70386 was firing on **every** run: detection instant, then ten seconds of graceful shutdown getting nowhere. A watchdog that always has to use the axe is reporting a defect, not preventing one. This finds and names it. **It does not fix it** — see below.

## The instrument

At the hard exit — the last instant the answer exists, and the one this process was about to destroy — the watch now records every thread stack and every pending asyncio task.

- Stacks via `faulthandler.dump_traceback`: raw fd, from C, no Python lock, no allocation. `traceback.format_stack` would acquire the locks the wedge may be holding, which is how a diagnostic becomes the hang.
- Tasks via a GC walk, because `asyncio.all_tasks()` must be called from the loop's own thread — which is, by construction, the stuck one. A full heap scan is indefensible anywhere except here.

## What it found

| scenario | result |
|---|---|
| standalone, SIGTERM by hand | 1s, clean |
| drained pipe, parent SIGKILLed, no `brainstem/.env` | 0s, clean |
| drained pipe, parent SIGKILLed, **with** `.env` | **22s, hard exit** |
| the real HUD | **11s, hard exit** |

Twenty-plus long-lived daemon tasks still pending at exit: CloudSQL cleanup/health/leak monitors, GCP VM monitoring and orphan cleanup, DW discovery and heavy-probe loops, learning-DB auto-flush and auto-optimise, distributed lock cleanup, background agent pool workers, rate orchestrator forecast/adjustment. `.env` is the discriminator because it is what turns those subsystems on.

**None of them is individually buggy** — the ones inspected handle `CancelledError` correctly. The defect is that **nobody owns them**. Created ad hoc with `create_task` across the codebase; no shutdown path knows they exist; left for `asyncio.Runner.close()` to cancel en masse *after* uvicorn has already finished. Twenty tasks, several parked on network I/O, do not unwind inside any sane grace. The logs show `FailoverLifecycle` **starting new work during shutdown** — the same missing ownership from the other end.

## The fix already exists and is unwired

`backend/core/coordinated_shutdown.py` provides `CoordinatedShutdownManager`: ordered phases, per-hook timeouts, critical/non-critical hooks, process-group termination. `backend/main.py`'s lifespan **never calls it** — it hand-rolls 535 sequential lines with ~20 awaits that have no timeout at all.

So the remedy is registration, not a new subsystem. **That migration is deliberately not in this PR** — it touches ~20 subsystems and deserves its own change with its own verification.

## Two corrections to my own work in #70386

- `_detach_dead_output` was committed **claiming it fixed this hang. It does not.** A faithful repro — a parent that DRAINS the pipe as `readabilityHandler` does, then is SIGKILLed — exits in 0s with or without it. My first repro never drained, so the child was already blocked mid-boot on a full 64KB buffer: that was my harness, not the bug. The function keeps its place only on the separate measured failure it does fix (17s vs 1s on an undrained pipe — a beachballed or suspended HUD).
- `_record` wrote every line twice after the detach, because fd 2 had been `dup2`'d onto the file it was also writing directly.

## Repro

`scripts/repro_shutdown_wedge.py` reproduces the wedge in ~2 minutes with no Xcode and no HUD, so the migration can be measured instead of guessed. No hardcoded paths.

158 HUD tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds diagnostics to name exactly what shutdown is waiting for in HUD exits. On hard exit we capture thread stacks and pending `asyncio` tasks, revealing 20+ unowned daemon tasks; behavior is unchanged.

- **New Features**
  - Record all thread stacks via `faulthandler.dump_traceback` at hard exit.
  - Log pending `asyncio.Task`s (via GC walk) to identify long-lived daemon tasks.
  - Detach stdout/stderr to the watch log before sending SIGTERM to avoid blocked shutdown logs.
  - Add `scripts/repro_shutdown_wedge.py` to reproduce the shutdown wedge with drained pipes and optional `.env`.

- **Bug Fixes**
  - Prevent double logging after detachment by not writing to fd 2 when it points at the log.
  - Clarify `_detach_dead_output` behavior and ensure it never raises; minor resilience in log path handling.

<sup>Written for commit 2a624975d1f4bb47114b0d21446ac025d3c69122. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

