### PR TITLE
feat(lifecycle): structured task generation — token, factory, and a total shutdown budget

### DIFF
--- a/backend/core/app_lifecycle.py
+++ b/backend/core/app_lifecycle.py
@@ -1,0 +1,476 @@
+"""Structured lifecycle for long-lived tasks: one token, one factory, one owner.
+
+WHY THIS EXISTS
+---------------
+Measured 2026-08-05: the backend could not shut down. Detection of a dead
+launcher was instantaneous and the process still needed a hard `os._exit`
+every single time, because twenty-plus daemon tasks were still pending when
+`asyncio.Runner.close()` finally cancelled them en masse — CloudSQL cleanup,
+health and leak monitors, GCP VM monitoring, DoubleWord discovery probes,
+learning-DB auto-flush, distributed lock cleanup, agent pool workers, rate
+orchestrator forecasting.
+
+None of those loops was individually wrong. Every one inspected handled
+`asyncio.CancelledError` correctly. **The defect was that nobody owned them.**
+They were created with bare `asyncio.create_task` from twenty different
+modules, no shutdown path knew they existed, and they were left to whatever
+happened to run last.
+
+The same absence of ownership showed from the other end: `FailoverLifecycle`
+was observed STARTING new work while shutdown was already under way. A system
+that can spawn during teardown cannot be torn down — cancel the tasks you know
+about and it grows new ones. This module makes both halves impossible rather
+than discouraged.
+
+THE TWO PRIMITIVES
+------------------
+1. A **cancellation token** — one process-wide, thread-safe flag saying
+   "teardown has begun". Thread-safe because the answer is needed from places
+   that have no event loop: signal handlers, executor threads, the parent
+   watch. `threading.Event` is readable from all of them without coordination.
+
+2. A **managed task factory** — `spawn_managed_task()`. It refuses to create
+   anything once the token is set, registers what it does create, and hands
+   ownership to `CoordinatedShutdownManager` so a phase cancels the tasks
+   belonging to it.
+
+WHY A TOKEN AND NOT JUST CANCELLATION
+--------------------------------------
+Cancellation alone is correct but slow, and slow is what made the hard exit
+routine. A daemon parked in `await asyncio.sleep(300)` does eventually notice
+a `CancelledError` — but only after the loop schedules it, and only if nothing
+else on the loop is ahead of it. Twenty of those, several with network I/O in
+flight, do not unwind inside any sane grace period.
+
+A token turns the wait itself into a race: `sleep_or_shutdown()` waits for the
+delay OR the token, whichever comes first, so a daemon leaves its loop the
+moment shutdown starts rather than when a cancellation reaches it. That is the
+difference between a shutdown measured in seconds and one measured in
+milliseconds, and it is why the migration primitive is a *sleep replacement*
+rather than an instruction to catch a different exception.
+
+Cancellation remains the backstop: the token is cooperative, so anything that
+ignores it is still cancelled by its phase, and anything that ignores THAT is
+still bounded by the phase timeout. Three layers, each one narrower.
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import threading
+import time
+from typing import Any, Awaitable, Callable, Coroutine, Dict, List, Optional, Set
+
+logger = logging.getLogger("jarvis.lifecycle")
+
+APP_LIFECYCLE_SCHEMA_VERSION: str = "app_lifecycle.v1"
+
+#: Total wall-clock budget for the whole shutdown, across every phase. The
+#: process must be gone before the parent watch's grace expires, or the hard
+#: exit does the job and the graceful path was theatre.
+ENV_TOTAL_BUDGET_S: str = "JARVIS_SHUTDOWN_TOTAL_BUDGET_S"
+
+#: Master switch for the spawn ban. The REGISTRATION half never turns off —
+#: a task the manager does not know about is the original defect — but the
+#: refusal can be downgraded to a warning if a subsystem turns out to need a
+#: spawn during teardown and has to be fixed on its own schedule.
+ENV_BLOCK_SPAWN: str = "JARVIS_LIFECYCLE_BLOCK_LATE_SPAWN"
+
+
+def total_budget_s() -> float:
+    """Seconds the entire shutdown may take. NEVER raises.
+
+    Clamped, not validated: a typo in a timing knob must not be able to hand
+    the system an unbounded shutdown, which is the condition being fixed.
+    """
+    try:
+        raw = (os.environ.get(ENV_TOTAL_BUDGET_S, "") or "").strip()
+        return max(0.5, float(raw)) if raw else 5.0
+    except Exception:  # noqa: BLE001
+        return 5.0
+
+
+def _block_late_spawn() -> bool:
+    return (os.environ.get(ENV_BLOCK_SPAWN, "true") or "").strip().lower() not in (
+        "0", "false", "no", "off")
+
+
+class ShutdownInProgress(RuntimeError):
+    """Raised when something tries to start long-lived work during teardown.
+
+    A distinct type on purpose. Callers that legitimately race shutdown — a
+    request handler finishing, a retry deciding whether to try again — should
+    be able to catch exactly this and stop, without swallowing unrelated
+    RuntimeErrors and turning a real bug into a silent no-op.
+    """
+
+
+class AppLifecycle:
+    """Process-wide lifecycle state. Thread-safe. NEVER raises.
+
+    Deliberately not an `asyncio.Event`: the question "are we shutting down?"
+    is asked from signal handlers, executor threads and the parent watch, none
+    of which have a running loop, and an `asyncio.Event` is bound to the loop
+    that created it. `threading.Event` answers from anywhere.
+
+    Waiters that DO have a loop are served by `wait_for_shutdown`, which
+    bridges the threading primitive into async without pinning it to a loop.
+    """
+
+    def __init__(self) -> None:
+        self._event = threading.Event()
+        self._reason: str = ""
+        self._at: float = 0.0
+        self._lock = threading.Lock()
+        # One asyncio.Event per loop that has ever waited, so async waiters
+        # cost a callback rather than a thread. See `_mirror`.
+        self._mirrors: "Dict[int, Any]" = {}
+        self._mirror_loops: "Dict[int, Any]" = {}
+
+    @property
+    def shutdown_requested(self) -> bool:
+        """The token. Cheap enough to read on every loop iteration."""
+        return self._event.is_set()
+
+    @property
+    def reason(self) -> str:
+        return self._reason
+
+    @property
+    def since_s(self) -> float:
+        """Seconds since shutdown was requested, or 0.0 if it has not been."""
+        return (time.monotonic() - self._at) if self._at else 0.0
+
+    def request_shutdown(self, reason: str = "unspecified") -> bool:
+        """Set the token. Idempotent — the FIRST reason is kept.
+
+        The first reason is the true one; anything after it is a consequence.
+        Overwriting would replace "launcher died" with "database closed",
+        which is how a postmortem loses its cause.
+        """
+        with self._lock:
+            if self._event.is_set():
+                return False
+            self._reason = reason
+            self._at = time.monotonic()
+            self._event.set()
+        # Wake async waiters OUTSIDE the lock: `call_soon_threadsafe` touches
+        # another loop's machinery, and holding our lock across that is how a
+        # shutdown path acquires two locks in an order nothing else respects.
+        self._wake_mirrors()
+        logger.warning("[Lifecycle] shutdown requested: %s — long-lived task "
+                       "creation is now refused", reason)
+        return True
+
+    def _mirror(self) -> "asyncio.Event":
+        """An `asyncio.Event` for the CURRENT loop, mirroring the token.
+
+        WHY NOT `run_in_executor(event.wait)`
+        --------------------------------------
+        That was the first implementation and it does not scale. Every waiting
+        daemon parks one thread from the default executor for the whole of its
+        sleep, so twenty daemons sleeping sixty seconds hold twenty threads
+        indefinitely — and the default pool is shared with everything else in
+        the process, so the cost lands on unrelated work. Measured at the time:
+        a nine-test suite took 61 seconds, almost all of it waiting for threads.
+
+        A mirrored `asyncio.Event` costs one object per loop and one callback
+        at shutdown, regardless of how many daemons are waiting.
+
+        Per-loop rather than global because an `asyncio.Event` is bound to the
+        loop that created it — the exact "bound to a different event loop"
+        failure that the IPC dispatch loop was rebuilt to avoid.
+        """
+        loop = asyncio.get_running_loop()
+        key = id(loop)
+        ev = self._mirrors.get(key)
+        if ev is None:
+            ev = asyncio.Event()
+            with self._lock:
+                self._mirrors[key] = ev
+                self._mirror_loops[key] = loop
+            if self._event.is_set():
+                ev.set()          # requested before this loop ever asked
+        return ev
+
+    async def wait_for_shutdown(self, timeout: Optional[float] = None) -> bool:
+        """Await the token from async code. Returns True if it was set.
+
+        Costs no thread: the wait is a plain `asyncio.Event`, woken by a
+        `call_soon_threadsafe` from whoever requests shutdown.
+        """
+        if self._event.is_set():
+            return True
+        try:
+            ev = self._mirror()
+            if timeout is None:
+                await ev.wait()
+                return True
+            await asyncio.wait_for(ev.wait(), timeout=timeout)
+            return True
+        except asyncio.TimeoutError:
+            return False
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001
+            return self._event.is_set()
+
+    def _wake_mirrors(self) -> None:
+        """Set every loop's mirror from whatever thread requested shutdown.
+
+        `call_soon_threadsafe` because the requester is frequently NOT on the
+        loop — a signal handler, the parent watch's kqueue thread, an executor.
+        A loop that has already closed raises, and that is not an error worth
+        propagating: a closed loop has no waiters left to wake.
+        """
+        with self._lock:
+            pairs = list(zip(self._mirrors.values(), self._mirror_loops.values()))
+        for ev, loop in pairs:
+            try:
+                loop.call_soon_threadsafe(ev.set)
+            except Exception:  # noqa: BLE001
+                continue
+
+    def reset(self) -> None:
+        """Testing seam. Never called in production."""
+        with self._lock:
+            self._event.clear()
+            self._reason = ""
+            self._at = 0.0
+            self._mirrors.clear()
+            self._mirror_loops.clear()
+
+
+#: The process-wide instance. A module-level singleton rather than something
+#: passed around, because the twenty subsystems that need to consult it have
+#: no common ancestor to receive it from.
+LIFECYCLE = AppLifecycle()
+
+
+def shutdown_requested() -> bool:
+    """Free function for the hot path in daemon loops. NEVER raises."""
+    return LIFECYCLE.shutdown_requested
+
+
+async def sleep_or_shutdown(delay: float) -> bool:
+    """Sleep, unless shutdown starts first. Returns True if it did.
+
+    THE MIGRATION PRIMITIVE. A daemon written as
+
+        while self._running:
+            await asyncio.sleep(60)
+            do_work()
+
+    waits up to a full minute before it can notice anything, so cancelling it
+    is the only way to stop it and the cost is however long the loop takes to
+    reach a cancellation point. Rewritten as
+
+        while not await sleep_or_shutdown(60):
+            do_work()
+
+    it leaves immediately when the token is set, and the loop condition and
+    the shutdown check become the same expression — there is no window in
+    which it has woken up, seen no cancellation, and started another unit of
+    work that shutdown will then have to wait for.
+
+    Implemented as a race rather than a poll: polling would trade latency
+    against wakeups, and this needs neither.
+    """
+    if LIFECYCLE.shutdown_requested:
+        return True
+    if delay <= 0:
+        return LIFECYCLE.shutdown_requested
+    return await LIFECYCLE.wait_for_shutdown(delay)
+
+
+class ManagedTaskRegistry:
+    """Every long-lived task, and which shutdown phase owns it. NEVER raises."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._by_phase: Dict[int, Set[asyncio.Task]] = {}
+        self._spawned = 0
+        self._refused = 0
+
+    def add(self, task: "asyncio.Task", phase: int) -> None:
+        with self._lock:
+            self._by_phase.setdefault(phase, set()).add(task)
+            self._spawned += 1
+        # Self-removing: a registry that only grows is a leak wearing the
+        # costume of a lifecycle manager.
+        task.add_done_callback(lambda t: self._discard(t, phase))
+
+    def _discard(self, task: "asyncio.Task", phase: int) -> None:
+        with self._lock:
+            bucket = self._by_phase.get(phase)
+            if bucket:
+                bucket.discard(task)
+
+    def refused(self) -> None:
+        with self._lock:
+            self._refused += 1
+
+    def tasks_for(self, phase: int) -> List["asyncio.Task"]:
+        with self._lock:
+            return [t for t in self._by_phase.get(phase, set()) if not t.done()]
+
+    def all_tasks(self) -> List["asyncio.Task"]:
+        with self._lock:
+            return [t for s in self._by_phase.values() for t in s if not t.done()]
+
+    def stats(self) -> Dict[str, Any]:
+        with self._lock:
+            live = {p: len([t for t in s if not t.done()])
+                    for p, s in self._by_phase.items()}
+        return {"schema_version": APP_LIFECYCLE_SCHEMA_VERSION,
+                "spawned": self._spawned, "refused_late_spawn": self._refused,
+                "live_by_phase": live}
+
+
+REGISTRY = ManagedTaskRegistry()
+
+#: Phases that already have a cancel-hook registered with the manager, so the
+#: hook is installed once per phase rather than once per task.
+_HOOKED_PHASES: Set[int] = set()
+_HOOK_LOCK = threading.Lock()
+
+
+def _default_phase() -> int:
+    """CLEANUP, resolved lazily so importing this module stays cheap.
+
+    Daemons import this from all over the codebase; pulling in the whole
+    shutdown stack — and its Trinity IPC dependencies — at import time would
+    make adoption expensive and invite import cycles.
+    """
+    try:
+        from backend.core.coordinated_shutdown import ShutdownPhase
+        return int(ShutdownPhase.CLEANUP)
+    except Exception:  # noqa: BLE001
+        return 4
+
+
+def _ensure_phase_hook(phase: int) -> None:
+    """Register ONE hook per phase that cancels that phase's tasks.
+
+    One hook per phase, not one per task: a hook per task would make the
+    manager's phase timeout meaningless, since twenty hooks each allowed ten
+    seconds is a two-hundred-second phase. Cancelling a phase's tasks together
+    is also semantically right — tasks in the same phase have no ordering
+    relationship with each other, which is what putting them in one phase says.
+    """
+    with _HOOK_LOCK:
+        if phase in _HOOKED_PHASES:
+            return
+        _HOOKED_PHASES.add(phase)
+
+    async def _cancel_phase_tasks() -> None:
+        tasks = REGISTRY.tasks_for(phase)
+        if not tasks:
+            return
+        logger.info("[Lifecycle] phase %s: cancelling %d managed task(s)",
+                    phase, len(tasks))
+        for t in tasks:
+            t.cancel()
+        # Gathered with return_exceptions so one task that raises on the way
+        # out cannot prevent the others from being awaited. The phase timeout
+        # above this bounds the whole thing.
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+    try:
+        from backend.core.coordinated_shutdown import (
+            ShutdownPhase, get_shutdown_manager_sync,
+        )
+        mgr = get_shutdown_manager_sync()
+        mgr.register_hook(
+            name=f"managed_tasks_phase_{phase}",
+            phase=ShutdownPhase(phase),
+            callback=_cancel_phase_tasks,
+            priority=10,          # before hand-written hooks in the same phase
+            timeout=max(1.0, total_budget_s() / 2.0),
+        )
+    except Exception:  # noqa: BLE001
+        # A registry that cannot reach the manager still beats a bare
+        # create_task: the tasks are tracked and `cancel_all` can reach them.
+        logger.debug("[Lifecycle] could not register phase hook", exc_info=True)
+
+
+def spawn_managed_task(
+    coro: "Coroutine[Any, Any, Any]",
+    *,
+    name: Optional[str] = None,
+    phase: Optional[int] = None,
+) -> "asyncio.Task":
+    """Create a long-lived task that shutdown knows about. Replaces create_task.
+
+    Two guarantees, and the second is the one that was missing:
+
+    1. **Refusal during teardown.** Once the token is set this raises
+       `ShutdownInProgress` and the coroutine is closed without ever running.
+       This is the Hydra fix — `FailoverLifecycle` was seen starting recovery
+       work *during* shutdown, and a system that grows new tasks while being
+       torn down cannot be torn down.
+
+    2. **Registration.** The task is filed under a shutdown phase, and that
+       phase cancels it. Nothing has to remember to clean it up, because
+       remembering is precisely what failed twenty times over.
+
+    The coroutine is explicitly closed on refusal. Dropping it would leave an
+    un-awaited coroutine to surface later as a "never awaited" warning during
+    interpreter teardown — a confusing second symptom of a correct refusal.
+    """
+    if LIFECYCLE.shutdown_requested and _block_late_spawn():
+        REGISTRY.refused()
+        label = name or getattr(coro, "__qualname__", repr(coro))
+        try:
+            coro.close()
+        except Exception:  # noqa: BLE001
+            pass
+        raise ShutdownInProgress(
+            f"refusing to spawn '{label}' — shutdown began "
+            f"{LIFECYCLE.since_s:.2f}s ago (reason: {LIFECYCLE.reason}). "
+            f"A system that spawns during teardown cannot be torn down.")
+
+    resolved = _default_phase() if phase is None else int(phase)
+    task = asyncio.get_event_loop().create_task(coro) if name is None \
+        else asyncio.get_event_loop().create_task(coro, name=name)
+    REGISTRY.add(task, resolved)
+    _ensure_phase_hook(resolved)
+    return task
+
+
+async def cancel_all_managed(timeout: Optional[float] = None) -> int:
+    """Cancel every managed task, whatever phase owns it. NEVER raises.
+
+    The escape hatch for callers with no shutdown manager — tests, the legacy
+    brainstem path, an embedded run. Returns how many were still live.
+    """
+    tasks = REGISTRY.all_tasks()
+    if not tasks:
+        return 0
+    for t in tasks:
+        t.cancel()
+    try:
+        await asyncio.wait_for(
+            asyncio.gather(*tasks, return_exceptions=True),
+            timeout=timeout if timeout is not None else total_budget_s())
+    except asyncio.TimeoutError:
+        logger.warning("[Lifecycle] %d managed task(s) did not finish "
+                       "cancelling within budget", len(tasks))
+    except Exception:  # noqa: BLE001
+        pass
+    return len(tasks)
+
+
+def stats() -> Dict[str, Any]:
+    """Observability surface. NEVER raises."""
+    return {
+        "shutdown_requested": LIFECYCLE.shutdown_requested,
+        "reason": LIFECYCLE.reason,
+        "since_s": round(LIFECYCLE.since_s, 3),
+        "total_budget_s": total_budget_s(),
+        "block_late_spawn": _block_late_spawn(),
+        **REGISTRY.stats(),
+    }

--- a/backend/core/coordinated_shutdown.py
+++ b/backend/core/coordinated_shutdown.py
@@ -98,6 +98,21 @@ def _env_float(key: str, default: float) -> float:
         return default
 
 
+def _shutdown_total_budget_s() -> float:
+    """Wall-clock ceiling for the entire shutdown, all phases together.
+
+    Read through `app_lifecycle` so the manager and the task factory cannot
+    disagree about how long the system has — two copies of one deadline is how
+    a budget silently stops being one. Falls back to a local default if that
+    import is unavailable, because shutdown must not depend on it.
+    """
+    try:
+        from backend.core.app_lifecycle import total_budget_s
+        return total_budget_s()
+    except Exception:  # noqa: BLE001
+        return _env_float("JARVIS_SHUTDOWN_TOTAL_BUDGET_S", 5.0)
+
+
 def _env_int(key: str, default: int) -> int:
     try:
         return int(os.getenv(key, str(default)))
@@ -774,13 +789,41 @@ class CoordinatedShutdownManager:
             last_successful_phase = ShutdownPhase.ANNOUNCE
             processes_terminated = 0
 
+            # TOTAL BUDGET, not just per-phase.
+            #
+            # Every phase was already bounded by `wait_for`, and the process
+            # still needed a hard `os._exit` every time — because six phases
+            # each allowed their own generous timeout is a shutdown whose
+            # worst case is the SUM, and the sum exceeded the window the
+            # parent watch gives before it takes the axe. A per-step bound
+            # says nothing about the whole.
+            #
+            # So phases now draw down one shared budget: each is allowed the
+            # smaller of its own timeout and whatever is actually left. The
+            # last phases get squeezed rather than the process being killed
+            # mid-sentence, which is the right trade — TERMINATE and VERIFY
+            # are the cheap ones, and being squeezed is visible in the log
+            # whereas a hard exit erases the reason.
+            _budget_s = _shutdown_total_budget_s()
+            _budget_deadline = start_time + _budget_s
+            logger.info("[ShutdownManager] total shutdown budget: %.1fs", _budget_s)
+
             for phase in phases:
                 self._current_phase = phase
-                phase_timeout = self._phase_timeouts[phase]
+                _remaining = _budget_deadline - time.time()
+                if _remaining <= 0:
+                    all_errors.append(
+                        f"budget exhausted before phase {phase.name}")
+                    logger.warning(
+                        "[ShutdownManager] %.1fs budget exhausted — skipping "
+                        "%s and everything after it", _budget_s, phase.name)
+                    break
+                phase_timeout = min(self._phase_timeouts[phase], _remaining)
 
                 logger.info(
                     f"[ShutdownManager] Executing phase {phase.name} "
-                    f"(timeout={phase_timeout}s)"
+                    f"(timeout={phase_timeout:.2f}s, "
+                    f"{_remaining:.2f}s of budget left)"
                 )
 
                 try:

--- a/backend/core/distributed_lock_manager.py
+++ b/backend/core/distributed_lock_manager.py
@@ -128,6 +128,7 @@ from uuid import uuid4
 
 import aiofiles
 import aiofiles.os
+from backend.core.app_lifecycle import spawn_managed_task  # managed: dies with its shutdown phase
 
 logger = logging.getLogger(__name__)
 
@@ -984,7 +985,7 @@ class DistributedLockManager:
 
             # Start cleanup task
             if self.config.cleanup_enabled:
-                self._cleanup_task = asyncio.create_task(
+                self._cleanup_task = spawn_managed_task(
                     self._cleanup_loop(),
                     name="lock_cleanup_loop"
                 )

--- a/backend/core/gcp_vm_manager.py
+++ b/backend/core/gcp_vm_manager.py
@@ -120,6 +120,7 @@ except ImportError:
     pass
 
 from backend.core.async_safety import LazyAsyncLock, create_safe_task
+from backend.core.app_lifecycle import spawn_managed_task  # managed: dies with its shutdown phase
 
 # Log severity bridge for criticality-aware logging
 try:
@@ -3226,14 +3227,14 @@ class GCPVMManager:
 
                 # Start monitoring if enabled
                 if self.config.enable_monitoring:
-                    self.monitoring_task = asyncio.create_task(
+                    self.monitoring_task = spawn_managed_task(
                         self._monitoring_loop(),
                         name="gcp_vm_monitoring"
                     )
                     logger.info("✅ VM monitoring started")
 
                 # v235.3: Start periodic orphan cleanup (runs every 30min)
-                self._orphan_cleanup_task = asyncio.create_task(
+                self._orphan_cleanup_task = spawn_managed_task(
                     self._periodic_orphan_cleanup(),
                     name="gcp_orphan_cleanup"
                 )

--- a/backend/core/intelligent_rate_orchestrator.py
+++ b/backend/core/intelligent_rate_orchestrator.py
@@ -68,6 +68,7 @@ import json
 from functools import wraps
 from contextlib import asynccontextmanager
 import threading
+from backend.core.app_lifecycle import spawn_managed_task  # managed: dies with its shutdown phase
 
 logger = logging.getLogger(__name__)
 
@@ -1018,13 +1019,13 @@ class IntelligentRateOrchestrator:
         self._running = True
         
         # Start throttle adjustment loop
-        self._adjustment_task = asyncio.create_task(
+        self._adjustment_task = spawn_managed_task(
             self._adjustment_loop(),
             name="rate_orchestrator_adjustment"
         )
         
         # Start forecast update loop
-        self._forecast_task = asyncio.create_task(
+        self._forecast_task = spawn_managed_task(
             self._forecast_loop(),
             name="rate_orchestrator_forecast"
         )

--- a/backend/core/ouroboros/governance/dw_discovery_runner.py
+++ b/backend/core/ouroboros/governance/dw_discovery_runner.py
@@ -827,6 +827,7 @@ import threading
 from backend.core.ouroboros.governance.dw_catalog_client import (
     _refresh_interval_s as _refresh_interval_s_internal,
 )
+from backend.core.app_lifecycle import spawn_managed_task  # managed: dies with its shutdown phase
 
 
 _BOOT_DISCOVERY_LOCK = asyncio.Lock()
@@ -1260,7 +1261,7 @@ async def boot_discovery_once(
         # Spawn the refresh loop. We DON'T await; it runs forever
         # until cancellation. Capture in module-level for shutdown.
         try:
-            _REFRESH_TASK = asyncio.create_task(
+            _REFRESH_TASK = spawn_managed_task(
                 _discovery_refresh_loop(
                     session=session,
                     base_url=base_url,
@@ -1289,7 +1290,7 @@ async def boot_discovery_once(
                 heavy_probe_enabled,
             )
             if heavy_probe_enabled():
-                _HEAVY_PROBE_TASK = asyncio.create_task(
+                _HEAVY_PROBE_TASK = spawn_managed_task(
                     _heavy_probe_loop(
                         session=session,
                         base_url=base_url,

--- a/backend/intelligence/cloud_sql_connection_manager.py
+++ b/backend/intelligence/cloud_sql_connection_manager.py
@@ -157,6 +157,7 @@ from typing import Tuple
 import json
 from pathlib import Path
 import random
+from backend.core.app_lifecycle import spawn_managed_task  # managed: dies with its shutdown phase
 
 
 # v260.4: Safe env var parsing helper — prevents ValueError from killing coroutines
@@ -5254,15 +5255,15 @@ class CloudSQLConnectionManager:
                     pass
 
         # Start new tasks
-        self._cleanup_task = asyncio.create_task(
+        self._cleanup_task = spawn_managed_task(
             self._cleanup_loop(),
             name="cloudsql_cleanup"
         )
-        self._leak_monitor_task = asyncio.create_task(
+        self._leak_monitor_task = spawn_managed_task(
             self._leak_monitor_loop(),
             name="cloudsql_leak_monitor"
         )
-        self._health_check_task = asyncio.create_task(
+        self._health_check_task = spawn_managed_task(
             self._health_check_loop(),
             name="cloudsql_health_check"
         )

--- a/backend/main.py
+++ b/backend/main.py
@@ -2667,6 +2667,56 @@ async def parallel_lifespan(app: FastAPI):
 
         yield
 
+        # ── SHUTDOWN BEGINS HERE (this is the LIVE lifespan) ─────────────
+        #
+        # `selected_lifespan = parallel_lifespan if PARALLEL_STARTUP_ENABLED
+        # else lifespan`, and `JARVIS_PARALLEL_STARTUP` defaults to true — so
+        # this function is the one that runs, and the other `lifespan()` below
+        # is dead in every normal boot. Anything added there for shutdown is
+        # never executed, which is worth stating out loud because it has now
+        # happened once.
+        #
+        # Two things, in this order, before any resource is closed:
+        #
+        #   1. Set the cancellation token. Until it is set, daemons parked in
+        #      `await asyncio.sleep(300)` cannot learn anything has changed,
+        #      and subsystems keep SPAWNING — `FailoverLifecycle` was observed
+        #      starting new recovery work mid-shutdown. A population that grows
+        #      while being torn down cannot be torn down.
+        #
+        #   2. Run the coordinated phases. `spawn_managed_task` files every
+        #      long-lived task under a phase and registers one hook per phase
+        #      to cancel them, but a hook is a promise until something executes
+        #      the phases. The manager enforces a single wall-clock budget
+        #      across all of them (JARVIS_SHUTDOWN_TOTAL_BUDGET_S, default 5s)
+        #      so this cannot itself become where shutdown hangs.
+        #
+        # Daemons first, resources second: a health-check loop still running
+        # while its connection pool closes is how a clean shutdown becomes an
+        # exception storm.
+        try:
+            from backend.core.app_lifecycle import LIFECYCLE
+            LIFECYCLE.request_shutdown("lifespan shutdown")
+        except Exception as _lc:  # noqa: BLE001 — never block shutdown on this
+            logger.debug("[Lifecycle] token not set: %s", _lc)
+
+        try:
+            from backend.core.coordinated_shutdown import (
+                ShutdownReason, get_shutdown_manager,
+            )
+            _mgr = await get_shutdown_manager()
+            _sd = await _mgr.initiate_shutdown(reason=ShutdownReason.SIGNAL_RECEIVED)
+            logger.info("[Shutdown] coordinated phases done in %.2fs "
+                        "(hooks=%d failed=%d)", _sd.elapsed_seconds,
+                        _sd.hooks_executed, _sd.hooks_failed)
+        except Exception as _cs:  # noqa: BLE001
+            logger.warning("[Shutdown] coordinated phases degraded: %s", _cs)
+            try:
+                from backend.core.app_lifecycle import cancel_all_managed
+                await cancel_all_managed()
+            except Exception:  # noqa: BLE001
+                pass
+
         # =====================================================================
         # v4.0: Run deferred debug tasks in background AFTER server is serving
         # =====================================================================
@@ -5038,6 +5088,65 @@ async def lifespan(app: FastAPI):  # type: ignore[misc]
             app.state.hud_gov_ctx = None
 
     yield
+
+    # ── SET THE CANCELLATION TOKEN FIRST ─────────────────────────────
+    #
+    # Before a single subsystem is asked to stop. Everything below this line
+    # takes time, and until the token is set two things keep happening that
+    # make shutdown impossible to finish:
+    #
+    #   * daemons parked in `await asyncio.sleep(300)` have no way to learn
+    #     that anything has changed, so they can only be stopped by a
+    #     cancellation that has to reach them one at a time;
+    #   * subsystems keep SPAWNING. `FailoverLifecycle` was observed starting
+    #     new recovery work while shutdown was already under way, and a system
+    #     that grows new tasks while being torn down cannot be torn down.
+    #
+    # Setting it here makes `sleep_or_shutdown` return immediately everywhere
+    # and makes `spawn_managed_task` refuse, so the population being shut down
+    # stops changing while we shut it down. See backend/core/app_lifecycle.py.
+    try:
+        from backend.core.app_lifecycle import LIFECYCLE
+        LIFECYCLE.request_shutdown("lifespan shutdown")
+    except Exception as _lc:  # noqa: BLE001 — never block shutdown on this
+        logger.debug("[Lifecycle] token not set: %s", _lc)
+
+    # ── RUN THE COORDINATED SHUTDOWN PHASES ──────────────────────────
+    #
+    # This call is what makes the registry real. `spawn_managed_task` files
+    # every long-lived task under a shutdown phase and registers ONE hook per
+    # phase to cancel them — but a hook is only a promise until something
+    # executes the phases, and nothing did. Registering with a manager nobody
+    # invokes produces exactly the state it was meant to fix: tasks that
+    # believe they are managed, and are not.
+    #
+    # Runs BEFORE the resource teardown below, deliberately. Those daemons
+    # hold the connections the next few hundred lines are trying to close; a
+    # health-check loop that is still running while its pool is closed is how
+    # a clean shutdown turns into an exception storm.
+    #
+    # The manager enforces a single wall-clock budget across all phases
+    # (JARVIS_SHUTDOWN_TOTAL_BUDGET_S, default 5s), so this cannot become the
+    # new place shutdown hangs — the thing it exists to prevent.
+    try:
+        from backend.core.coordinated_shutdown import (
+            ShutdownReason, get_shutdown_manager,
+        )
+        _mgr = await get_shutdown_manager()
+        _sd = await _mgr.initiate_shutdown(reason=ShutdownReason.SIGNAL_RECEIVED)
+        logger.info("[Shutdown] coordinated phases done in %.2fs "
+                    "(hooks=%d failed=%d)", _sd.elapsed_seconds,
+                    _sd.hooks_executed, _sd.hooks_failed)
+    except Exception as _cs:  # noqa: BLE001
+        logger.warning("[Shutdown] coordinated phases degraded: %s", _cs)
+        # Fall back to cancelling managed tasks directly. The manager is the
+        # preferred owner, but an unmanaged daemon is the original defect and
+        # must not survive because orchestration was unavailable.
+        try:
+            from backend.core.app_lifecycle import cancel_all_managed
+            await cancel_all_managed()
+        except Exception:  # noqa: BLE001
+            pass
 
     # ── HUD Governance Shutdown (Sub-project E) ──────────────────────
     _gov_ctx = getattr(app.state, "hud_gov_ctx", None)

--- a/brainstem/parent_watch.py
+++ b/brainstem/parent_watch.py
@@ -497,6 +497,15 @@ class ParentWatch:
         # BEFORE the SIGTERM, not after. Shutdown begins the instant the signal
         # is delivered, and it is shutdown's own logging that blocks on the
         # dead pipe — redirecting afterwards would race the thing it prevents.
+        # The token, before anything else. This thread learns the launcher is
+        # gone microseconds before SIGTERM is delivered, and that head start is
+        # exactly the window in which a subsystem would otherwise spawn one
+        # more recovery task for shutdown to wait on.
+        try:
+            from backend.core.app_lifecycle import LIFECYCLE
+            LIFECYCLE.request_shutdown(f"launcher gone: {reason}")
+        except Exception:  # noqa: BLE001 — the watch never depends on the app
+            pass
         detached = _detach_dead_output()
         _record(f"launcher (pid {self.parent_pid}) is gone — {reason}. "
                 f"Raising SIGTERM; hard exit in {self.grace_s:.1f}s if that "

--- a/tests/core/test_app_lifecycle_hydra.py
+++ b/tests/core/test_app_lifecycle_hydra.py
@@ -1,0 +1,217 @@
+"""The Hydra: a system that spawns during teardown cannot be torn down.
+
+`FailoverLifecycle` was observed STARTING new recovery work while shutdown was
+already under way — measured 2026-08-05, in the log of a backend that then
+needed a hard `os._exit`. Cancelling the tasks you know about is useless
+against something that grows new ones behind you.
+
+These pin the two halves of the fix: the token refuses late spawns, and the
+registry hands every task it did create to a shutdown phase that cancels it.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from backend.core.app_lifecycle import (
+    LIFECYCLE, REGISTRY, ShutdownInProgress, cancel_all_managed,
+    shutdown_requested, sleep_or_shutdown, spawn_managed_task, stats,
+    total_budget_s,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean():
+    LIFECYCLE.reset()
+    yield
+    LIFECYCLE.reset()
+
+
+# ---------------------------------------------------------------------------
+# The token
+# ---------------------------------------------------------------------------
+
+
+def test_the_token_is_readable_without_an_event_loop():
+    """Signal handlers, executor threads and the parent watch all ask this
+    question, and none of them has a loop. An asyncio.Event could not answer."""
+    assert shutdown_requested() is False
+    LIFECYCLE.request_shutdown("test")
+    assert shutdown_requested() is True
+
+
+def test_the_first_reason_is_the_one_kept():
+    """Anything after the first is a consequence, not a cause. Overwriting
+    would replace 'launcher died' with 'database closed'."""
+    assert LIFECYCLE.request_shutdown("launcher died") is True
+    assert LIFECYCLE.request_shutdown("database closed") is False
+    assert LIFECYCLE.reason == "launcher died"
+
+
+@pytest.mark.asyncio
+async def test_sleep_or_shutdown_returns_early():
+    """The migration primitive. A daemon parked in `asyncio.sleep(60)` cannot
+    notice anything for a minute; this makes the wait a race."""
+    async def _fire():
+        await asyncio.sleep(0.05)
+        LIFECYCLE.request_shutdown("early")
+
+    asyncio.ensure_future(_fire())
+    t0 = time.monotonic()
+    hit = await sleep_or_shutdown(10.0)
+    elapsed = time.monotonic() - t0
+
+    assert hit is True, "must report that shutdown, not the delay, ended the wait"
+    assert elapsed < 2.0, f"waited {elapsed:.2f}s of a 10s sleep — did not race"
+
+
+@pytest.mark.asyncio
+async def test_sleep_or_shutdown_sleeps_when_nothing_happens():
+    """It must still be a sleep. A primitive that returns immediately would
+    turn every daemon loop into a busy-wait."""
+    t0 = time.monotonic()
+    hit = await sleep_or_shutdown(0.3)
+    assert hit is False
+    assert time.monotonic() - t0 >= 0.25
+
+
+# ---------------------------------------------------------------------------
+# The factory
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_managed_task_is_registered_and_cancellable():
+    async def _daemon():
+        while not await sleep_or_shutdown(60):
+            pass
+
+    task = spawn_managed_task(_daemon(), name="test-daemon")
+    await asyncio.sleep(0.05)
+    assert task in REGISTRY.all_tasks()
+
+    cancelled = await cancel_all_managed(timeout=2.0)
+    assert cancelled >= 1
+    assert task.done()
+
+
+@pytest.mark.asyncio
+async def test_a_finished_task_leaves_the_registry():
+    """A registry that only grows is a leak wearing the costume of a
+    lifecycle manager."""
+    async def _brief():
+        return 1
+
+    t = spawn_managed_task(_brief(), name="brief")
+    await t
+    await asyncio.sleep(0)          # let the done-callback run
+    assert t not in REGISTRY.all_tasks()
+
+
+@pytest.mark.asyncio
+async def test_the_hydra_is_refused():
+    """THE MANDATED CASE. A subsystem tries to spawn recovery work after
+    shutdown has begun; the factory must refuse it."""
+    LIFECYCLE.request_shutdown("phase 1 started")
+
+    async def _recovery():
+        await asyncio.sleep(300)
+
+    coro = _recovery()
+    with pytest.raises(ShutdownInProgress) as exc:
+        spawn_managed_task(coro, name="failover-recovery")
+
+    assert "failover-recovery" in str(exc.value)
+    assert "phase 1 started" in str(exc.value)
+    assert REGISTRY.stats()["refused_late_spawn"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_a_refused_coroutine_is_closed_not_leaked():
+    """Dropping it would surface later as a 'never awaited' warning during
+    interpreter teardown — a confusing second symptom of a correct refusal."""
+    LIFECYCLE.request_shutdown("teardown")
+
+    async def _never_runs():
+        raise AssertionError("the refused coroutine must never execute")
+
+    coro = _never_runs()
+    with pytest.raises(ShutdownInProgress):
+        spawn_managed_task(coro, name="doomed")
+
+    # A closed coroutine cannot be started again; awaiting it raises.
+    with pytest.raises(RuntimeError):
+        await coro
+
+
+# ---------------------------------------------------------------------------
+# The whole point: a clean, fast close under an active Hydra.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_hydra_under_shutdown_closes_cleanly_in_under_a_second():
+    """A mock FailoverLifecycle that respawns on every cycle — the exact
+    behaviour observed in the real log — must not be able to keep the loop
+    alive, and teardown must finish well inside the budget.
+    """
+    spawn_attempts = {"blocked": 0, "allowed": 0}
+
+    async def _recovery_worker(depth: int):
+        """A head that grows another.
+
+        Deliberately does NOT consult the token — it sleeps on plain
+        `asyncio.sleep` and keeps spawning. That is faithful to the observed
+        bug: `FailoverLifecycle` knows nothing about any of this, and the
+        factory has to hold the line on its behalf. A cooperative Hydra would
+        stop itself and prove nothing about the guard.
+        """
+        while True:
+            await asyncio.sleep(0.05)
+            try:
+                spawn_managed_task(_recovery_worker(depth + 1),
+                                   name=f"hydra-{depth + 1}")
+                spawn_attempts["allowed"] += 1
+            except ShutdownInProgress:
+                spawn_attempts["blocked"] += 1
+                raise
+
+    # Let it grow while healthy, so there is a real population to tear down.
+    spawn_managed_task(_recovery_worker(0), name="hydra-0")
+    await asyncio.sleep(0.3)
+    assert spawn_attempts["allowed"] > 0, "the Hydra never grew; test is vacuous"
+    assert len(REGISTRY.all_tasks()) > 1
+
+    t0 = time.monotonic()
+    LIFECYCLE.request_shutdown("phase 1")
+
+    # The window that matters. Shutdown is not instantaneous — phases run,
+    # hooks execute, connections drain — and it is DURING that window that the
+    # observed Hydra kept spawning. Cancelling in the same breath as requesting
+    # would mean the guard was never asked anything, and the test would pass
+    # because nothing had time to misbehave.
+    await asyncio.sleep(0.15)
+
+    await cancel_all_managed(timeout=total_budget_s())
+    elapsed = time.monotonic() - t0
+
+    assert elapsed < 1.0, (
+        f"teardown took {elapsed:.2f}s under an active Hydra — the mandate is "
+        f"a clean close in under a second")
+    assert not REGISTRY.all_tasks(), (
+        f"{len(REGISTRY.all_tasks())} managed task(s) survived teardown")
+    assert spawn_attempts["blocked"] > 0, (
+        "no spawn was refused — the Hydra was never actually blocked, so this "
+        "passed for the wrong reason")
+
+
+@pytest.mark.asyncio
+async def test_stats_expose_the_state():
+    """Absolute observability: whether the ban is armed must be inspectable,
+    not inferred from behaviour."""
+    s = stats()
+    assert s["shutdown_requested"] is False
+    assert s["block_late_spawn"] is True
+    assert s["total_budget_s"] > 0


### PR DESCRIPTION
Implements the mandated architecture. **It does not yet move the measured shutdown time** — that is stated up front rather than buried, because the remaining blocker is upstream of everything here.

## The token
`AppLifecycle.shutdown_requested` — a process-wide `threading.Event`, thread-safe because the question is asked from signal handlers, executor threads and the parent watch, none of which have a loop. An `asyncio.Event` is bound to its creating loop: the same "bound to a different event loop" failure the IPC dispatch loop was rebuilt to avoid.

Async waiters get a **per-loop mirror** woken by `call_soon_threadsafe`. My first implementation used `run_in_executor(event.wait)` and does not scale — every waiting daemon parks a thread from the *shared* default pool for its whole sleep. Twenty daemons × sixty seconds = twenty threads held, with the cost landing on unrelated work. **The test suite went 61s → 1.5s on that one change.**

`sleep_or_shutdown(delay)` is the migration primitive: the loop condition and the shutdown check become one expression, so there is no window where a daemon wakes, sees no cancellation, and starts another unit of work.

## The factory
`spawn_managed_task()` refuses once the token is set (typed `ShutdownInProgress`, and it **closes** the coroutine so a correct refusal doesn't also emit a "never awaited" warning), and files what it creates under a shutdown phase.

**One cancel-hook per phase, not per task** — twenty hooks each allowed ten seconds is a two-hundred-second phase, and tasks within a phase have no ordering relationship by definition.

Three layers, each narrower: the token is cooperative → anything ignoring it is cancelled by its phase → anything ignoring that is bounded by the phase timeout.

## Strict total budget
Phases were *already* individually bounded by `wait_for`, and the process still needed a hard exit every time — six phases with their own generous timeouts is a shutdown whose worst case is the **sum**. Phases now draw down one shared budget (`JARVIS_SHUTDOWN_TOTAL_BUDGET_S`, default 5s) and get squeezed rather than the process being killed mid-sentence. The manager reads it through `app_lifecycle` so the two cannot disagree.

## Migrated (10)
Every one observed pending at a real hard exit: the three CloudSQL loops, both DW discovery loops, both GCP loops, the distributed lock cleanup, and both rate-orchestrator loops. Located by **AST, not regex** — my first attempt used a regex that disallowed nested parens and matched nothing, because every one of these calls passes a coroutine.

## The Hydra test
A mock recovery worker that deliberately does **not** consult the token — faithful to `FailoverLifecycle`, which knows nothing about any of this — keeps spawning during teardown. The factory refuses it, teardown finishes in **under 1s**, no managed task survives.

The test asserts a refusal *actually occurred*, so it cannot pass by nothing having had time to misbehave. That assertion caught two versions of this test that passed vacuously. Verified both directions: with `JARVIS_LIFECYCLE_BLOCK_LATE_SPAWN=false` it fails.

## What this does NOT fix yet

The repro still takes **21s** (from 22s).

The wiring is correct and in the right place — `selected_lifespan = parallel_lifespan if PARALLEL_STARTUP_ENABLED else lifespan`, and that env var defaults to true. I first wired the dead `lifespan()` and measured no change: the **third** wired-but-inert instance found today.

But **nothing after `yield` executes at all** — not the token, not the phases, not the budget, and none of it appears even in the watch log that survives the stdout detach. **uvicorn's serve loop is not completing, so lifespan shutdown is never reached.** That blocker is upstream of this entire PR and is not yet diagnosed.

This is the foundation the fix needs, not the fix.

## Notes
- 5 tests in `tests/hud` fail identically with these changes stashed — pre-existing, unrelated.
- `scripts/repro_shutdown_wedge.py` (merged in #70387) reproduces in ~2 min with no Xcode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a structured task lifecycle: a process-wide shutdown token, a managed task factory, and a single total shutdown budget to stop late spawns and let phases cancel tasks fast. Migrates 10 background loops and wires token + phases into app shutdown; this lays the groundwork for fixing the upstream lifespan hang.

- **New Features**
  - `AppLifecycle`: process-wide shutdown token (`threading.Event`) with per-loop async mirrors and `sleep_or_shutdown(delay)` for cooperative exits.
  - `spawn_managed_task()`: refuses spawns after shutdown (raises `ShutdownInProgress` and closes the coroutine), registers tasks by phase, installs one cancel hook per phase, and exposes `cancel_all_managed()`.
  - Coordinated shutdown now enforces a shared total budget via `JARVIS_SHUTDOWN_TOTAL_BUDGET_S`; per-phase timeouts are clamped to remaining budget (manager reads from lifecycle to stay in sync).
  - Shutdown wiring: `main` sets the token then runs phases (fallbacks to `cancel_all_managed` on errors); `parent_watch` sets the token before sending SIGTERM to stop late spawns.
  - Migration applied to 10 long-lived loops (CloudSQL, DW discovery, GCP monitoring/cleanup, distributed lock cleanup, rate orchestrator) using `spawn_managed_task`.

- **Migration**
  - Use `spawn_managed_task(...)` instead of `asyncio.create_task(...)` for long-lived/background tasks.
  - Replace long sleeps in daemon loops with `await sleep_or_shutdown(delay)`.
  - Config knobs: `JARVIS_SHUTDOWN_TOTAL_BUDGET_S` (default 5s) and `JARVIS_LIFECYCLE_BLOCK_LATE_SPAWN` (to temporarily allow late spawns if needed).

<sup>Written for commit c9368aaef86c69d32fc258497affaf79020dfa9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70388?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

