### PR TITLE
fix(voice): load the speaker model at boot, not when you ask it to unlock

### DIFF
--- a/backend/hud/consent_bridge.py
+++ b/backend/hud/consent_bridge.py
@@ -306,6 +306,33 @@ def install(router: Any = None) -> bool:
             # WHO it would be checking for long before it can check — which is
             # the difference between "give me a moment" and "I don't know you".
             _aio.get_event_loop().create_task(ident.warm())
+
+            # AND LOAD THE MODEL NOW, NOT AT THE FIRST UNLOCK.
+            #
+            # Measured live 2026-08-05 11:10:14, saying "unlock my screen":
+            #
+            #   [CapabilityRouter] 'unlock_screen' NOT authorised by
+            #       VoiceConsentProvider (I'm still loading my voice
+            #       recognition — give me a moment and ask again.)
+            #   ...4s later: [INIT] EcapaFacade ... falling back to local engine
+            #
+            # The model only STARTED loading because the operator asked. So the
+            # first unlock of every session is guaranteed to fail, and the
+            # operator is told to repeat themselves for a reason that has
+            # nothing to do with them.
+            #
+            # Warming was made lazy because it stalled the boot for fourteen
+            # seconds. That stall was the ML module import, and `_warm` now
+            # runs that import in a worker thread — so starting here costs the
+            # loop almost nothing, and the model is ready long before anyone
+            # can finish booting the HUD and speak to it.
+            #
+            # Fire-and-forget on purpose: nothing here waits for it. Readiness
+            # is a state anyone can query, and a boot that blocks on a speaker
+            # model is the defect this replaces.
+            ident.start_warming()
+            logger.info("[HUDConsent] speaker model warming at BOOT — the "
+                        "first unlock should no longer be told to ask again")
             logger.info("[HUDConsent] voice authority installed — reachable "
                         "through a locked screen; enrollment + speaker model "
                         "resolving in the background")

--- a/backend/hud/voice_identity.py
+++ b/backend/hud/voice_identity.py
@@ -264,8 +264,35 @@ class VoiceIdentity:
         t0 = time.monotonic()
         try:
             from backend.voice.speaker_verification_service import (
-                SpeakerVerificationService,
+                SpeakerVerificationService, _init_ml_components,
             )
+
+            # THE 14 SECONDS, TAKEN OFF THE LOOP.
+            #
+            # `_init_ml_components` says it in its own docstring: "moves 12+
+            # seconds of import time from startup to first request". That
+            # import is what stalled the boot when warm-up lived on the boot
+            # path, and it is why warming was made lazy — at the cost of the
+            # first unlock of every session failing with NOT_READY, which is
+            # exactly what the operator hits when they say "unlock my screen"
+            # and are told to ask again.
+            #
+            # But it is a MODULE IMPORT. It creates no asyncio primitives and
+            # has no loop affinity, so it never needed to be on the loop at
+            # all. Running it in a worker thread gets the cost off the event
+            # loop without moving `initialize()` — which DOES create an
+            # `asyncio.Lock` and an `asyncio.Queue`, and must therefore stay on
+            # the loop that will later call `verify_speaker`, or those objects
+            # end up bound to a thread's loop and fail the moment they are used.
+            #
+            # That split is the whole fix: the heavy half is loop-independent,
+            # the loop-bound half is cheap once the imports are cached.
+            loop = asyncio.get_event_loop()
+            _t_imp = time.monotonic()
+            await loop.run_in_executor(None, _init_ml_components)
+            logger.info("[VoiceIdentity] ML imports resolved off-loop in %.1fs",
+                        time.monotonic() - _t_imp)
+
             svc = SpeakerVerificationService()
             await asyncio.wait_for(svc.initialize(), timeout=warm_timeout_s())
             self._service = svc


### PR DESCRIPTION
From your live run, 11:10:14, saying **"unlock my screen"**:

```
[CapabilityRouter] 'unlock_screen' NOT authorised by VoiceConsentProvider
    (I'm still loading my voice recognition — give me a moment and ask again.)
...four seconds later:
[INIT] EcapaFacade error ... falling back to local engine
```

The model only **started** loading because you asked. So the first unlock of every session was guaranteed to fail, and you were told to repeat yourself for a reason that had nothing to do with you.

## Why it was lazy, and why that reason no longer holds

Warming used to happen at boot and was removed because it stalled the event loop for **fourteen seconds** — JARVIS couldn't hear, answer or dispatch during its own startup. The trade was deliberate: one "give me a moment" per session instead of fourteen seconds of deafness every boot.

But that fourteen seconds was a **module import**. `_init_ml_components` says so in its own docstring: *"moves 12+ seconds of import time from startup to first request"*. It creates no asyncio primitives and has no loop affinity — it never needed to be on the loop.

`initialize()` is genuinely different: it creates an `asyncio.Lock` and `asyncio.Queue` that `verify_speaker` later uses from the main loop. Running *that* off-loop would bind them to a worker's loop and fail at first use — the same "bound to a different event loop" defect the IPC dispatch loop was rebuilt to remove.

So the split follows the line that actually matters: heavy half → thread, loop-bound half stays and is cheap once imports are cached.

## Measured, with a heartbeat on the same loop

| | |
|---|---|
| readiness | cold → **READY in 16.7s** |
| worst loop gap | **3.10s** (was ~14s) |
| gaps over 0.5s | 2 of 234 ticks — `[0.66s, 3.10s]` |

**Not zero.** The residual 3.1s is `EcapaFacade.ensure_ready()` inside `initialize()`, which loads the encoder on the loop. Moving that too means surgery on the verification path I just repaired, and it is **not** done here — it's named rather than rounded away. For context, the same boot already shows 6.3s, 8.1s and 13.1s stalls from unrelated subsystems.

The model is ready ~17s into boot. You reach the HUD and speak ~70s in.

158 HUD tests green.

## Also confirmed working in that same run

- **"lock my screen" succeeded live** — `Voice result: success (steps=1/1)` → *"🔒 Locking the screen now, Derek."* Utterance captured (500KB), forwarded, executed.
- **Identity-based reaping ran correctly** — `[Brainstem] no orphaned backends to reap`, instead of the old `kill -9` on whatever held the port.

## NOT fixed here (diagnosed, not addressed)

**The acknowledgment was generated and then dropped.** `[HUD] dropped a reply that waited 16.2s for the voice — it is no longer about anything: On it — unlock screen.`

`_hud_tts` serializes every utterance through a single `_tts_mouth` lock and discards anything that waited longer than `JARVIS_TTS_MAX_QUEUE_S` (12s). The ack waited 16.2s behind the lock. That is *correct* behaviour applied to a starved loop — and the loop was at 41–65% availability with a 13.1s worst stall during that run.

Fixing "say it right away" properly means either priority for short acks over long replies, or fixing the loop starvation underneath. Both deserve their own change; the "one mouth" invariant was built deliberately and I won't undercut it blind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Load the speaker verification model at boot to prevent the first unlock from failing and asking the user to repeat. Heavy ML imports now run off the event loop, so startup stays responsive.

- **Bug Fixes**
  - Start warm-up during consent install via `ident.start_warming()` in `backend/hud/consent_bridge.py`.
  - Run `_init_ml_components` in a worker thread in `backend/hud/voice_identity.py`; keep `SpeakerVerificationService.initialize()` on the main loop to avoid cross-loop issues.
  - Removes the first-unlock “still loading” failure; readiness is reached during boot instead of on first request.
  - Added logs for off-loop import timing and boot warm start.

<sup>Written for commit 532801531c769d8f8392c98b317e215a3250b13e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70389?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

