### PR TITLE
fix(voice): JARVIS was transcribing its own voice and executing it as commands

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -2126,7 +2126,70 @@ async def parallel_lifespan(app: FastAPI):
                             stdout=asyncio.subprocess.DEVNULL,
                             stderr=asyncio.subprocess.DEVNULL,
                         )
-                        await asyncio.wait_for(play.communicate(), timeout=15)
+
+                        # HOLD THE MUTE FOR AS LONG AS SOUND IS ACTUALLY
+                        # COMING OUT — NOT FOR AS LONG AS WE GUESSED.
+                        #
+                        # The claim above was opened BEFORE `say` had rendered
+                        # a single sample, with a deadline estimated from the
+                        # character count. It has to cover render AND playback,
+                        # and on a loop measured at 41-65% availability it does
+                        # not. Live, 2026-08-05:
+                        #
+                        #   [SpeechGate] EXPIRED backend — its owner never
+                        #                released it
+                        #   [SpeechGate] mic LIVE
+                        #   [JARVIS Voice] >>> "Executing lock my screen"
+                        #   [JARVIS Voice] >>> "See you soon"
+                        #
+                        # Those are JARVIS's OWN WORDS, transcribed and
+                        # executed as commands. `lock_screen` ran five times
+                        # from one request, and the session never reached
+                        # "unlock" because the feedback loop consumed it.
+                        #
+                        # An estimate cannot fix this — any margin large enough
+                        # to be safe leaves the microphone dead after short
+                        # replies, and any margin small enough to feel
+                        # responsive reopens it mid-sentence. So this stops
+                        # predicting: `afplay` either exists or it does not,
+                        # and while it exists the mute is renewed. The claim
+                        # cannot outlive the sound (the `finally` releases it)
+                        # and cannot die before it (this renews it), whatever
+                        # the loop is doing.
+                        _hold_ms = 2500.0
+
+                        async def _hold_mute_while_playing() -> None:
+                            """Renew the claim while the player is alive.
+
+                            `_speech` is None when the manager lookup above
+                            failed. There is then no claim to renew, and
+                            speaking unsuppressed is already the documented
+                            fallback for that case — it must not become a
+                            crash on the audio path.
+                            """
+                            if _speech is None:
+                                return
+                            try:
+                                while play.returncode is None:
+                                    await asyncio.sleep(_hold_ms / 3000.0)
+                                    if play.returncode is not None:
+                                        return
+                                    await _speech.start_speaking(
+                                        text, source=SpeechSource.SYSTEM,
+                                        estimated_duration_ms=_hold_ms)
+                            except asyncio.CancelledError:
+                                raise
+                            except Exception:  # noqa: BLE001
+                                # A failed renewal must never stop playback;
+                                # the deadline and the manager's own watchdog
+                                # remain underneath it.
+                                return
+
+                        _holder = asyncio.ensure_future(_hold_mute_while_playing())
+                        try:
+                            await asyncio.wait_for(play.communicate(), timeout=15)
+                        finally:
+                            _holder.cancel()
                         try:
                             os.unlink(tmp_path)
                         except OSError:


### PR DESCRIPTION
From your run. JARVIS says *"🔒 Locking the screen now, Derek. See you soon."* — then:

```
[SpeechGate] EXPIRED backend — its owner never released it
[SpeechGate] mic LIVE
[JARVIS Voice] >>> "Executing lock my screen"
[JARVIS Voice] >>> "See you soon"
[JARVIS Voice] >>> "Just locking the screen now see you soon"
[JARVIS Voice] >>> "Completed zero step"
```

Those are **JARVIS's own words**, recognised as speech and dispatched as commands. `lock_screen` executed **five times** from one request, and the session never reached "unlock my screen" at all — the feedback loop consumed it. Each echo produced another reply, which was spoken, which was heard.

That is the "it keeps repeating itself" you described, and it is also why unlock never got a chance.

## Why the mute opened mid-sentence

```
start_speaking(text)         claim opens, deadline ESTIMATED from character count
say -v … -o tmp_path text    render to a file — not a sample of audio yet
afplay tmp_path              the audio finally plays
finally: stop_speaking       release, delivered by the event loop
```

The deadline is guessed from the text **before rendering begins**, yet it must cover render *and* playback. At 41–65% loop availability with a 7.8s worst stall, playback outlives the guess: the claim expires, the mic opens, the recogniser hears the tail.

`SpeechGate` already has the right mechanism — a reconciler that asks the synthesiser whether it is *really* still speaking, swept every 250ms. `hud_tts` and `voice_manager` both have one. **`backend` does not**, so its claims can only expire.

## The obvious fix would have made it worse

Registering a `.backend` reconciler probing `tts.isSpeaking` reports **idle** — the backend speaks through its own `say`/`afplay` subprocesses, not the HUD's `AVSpeechSynthesizer`. It would have released the mute *while sound was still playing*. I nearly shipped that; checking who actually produces the audio is what caught it.

## So stop predicting

`afplay` either exists or it doesn't. While it exists the claim is renewed; when it exits the existing `finally` releases it. **The mute cannot outlive the sound, and cannot die before it** — whatever the loop is doing.

No estimate can do this job: a margin large enough to be safe leaves the mic dead after every short reply; one small enough to feel responsive reopens it mid-sentence. `estimated_duration_ms` was already a parameter of `start_speaking` and had never been passed — it's now used as a short *renewal*, not a prediction of the whole utterance.

Same principle as the parent watch: observe the thing, don't forecast it.

Failure modes are tightenings, not new single points of failure — a failed renewal returns quietly (the deadline and the manager's 60s watchdog remain underneath), and `_speech is None` returns immediately, since speaking unsuppressed is already the documented fallback there.

158 HUD tests green.

## Not fixed here, visible in the same log

Every command burned **ten futile Venom iterations** against `402 Account balance too low`, then answered *"Completed 0 steps (max iterations reached)"* — which was spoken, and heard. The provider layer already declines to retry 4xx; the iteration is the **tool loop** treating a terminal billing failure as a per-iteration one. That deserves its own change rather than a rushed one.

You will also want credits on the DoubleWord account — that 402 is real, and it is degrading every classification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the assistant from hearing and executing its own TTS by keeping the mic muted for the entire playback. Replaces guess-based timeouts with a renewal loop tied to the actual `afplay` process so the mute ends only when audio ends.

- **Bug Fixes**
  - Renew `SpeechGate` while `afplay` is alive; cancel the holder task when playback exits.
  - Use short `estimated_duration_ms` renewals instead of predicting the full utterance to avoid mid-sentence mic opens.
  - Fail-safe behavior: if `_speech` is missing or a renewal fails, playback continues and existing watchdogs handle expiry.

<sup>Written for commit 65bf345b16d7d5c532ea0bf0efaf61b951703002. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

