### PR TITLE
fix(voice): the recorder kept the room and threw away the sentence

### DIFF
--- a/JARVIS-Apple/JARVISHUD/Services/UtteranceRecorder.swift
+++ b/JARVIS-Apple/JARVISHUD/Services/UtteranceRecorder.swift
@@ -64,7 +64,11 @@ final class UtteranceRecorder: @unchecked Sendable {
 
     private var storage: UnsafeMutablePointer<Float>?
     private var capacity: Int = 0
-    private var count: Int = 0
+    /// Where the next frame goes. Wraps; never shifts.
+    private var head: Int = 0
+    /// Frames written since `begin`, monotonic. Distinguishes a buffer that is
+    /// partly filled from one that has wrapped, without a second flag.
+    private var written: Int = 0
     private var sourceFormat: AVAudioFormat?
 
     deinit { storage?.deallocate() }
@@ -80,26 +84,59 @@ final class UtteranceRecorder: @unchecked Sendable {
             capacity = max(1, needed)
         }
         sourceFormat = format
-        count = 0
+        head = 0
+        written = 0
     }
 
     /// Append one tap buffer. CALLED ON THE AUDIO RENDER THREAD.
     ///
-    /// No allocation, no locking, no logging. `count` is written here and read
-    /// in `finish()` after the engine has been torn down, so the two never
-    /// overlap; a torn read would cost a few frames at the tail of a sample,
-    /// which is not worth a lock on this thread.
+    /// KEEPS THE MOST RECENT `maxSeconds`, NOT THE FIRST.
+    ///
+    /// This used to stop writing once full, which sounds conservative and is
+    /// the opposite of what a verifier needs. `begin()` runs when the audio
+    /// ENGINE starts, so the buffer filled with whatever the room was doing
+    /// while nobody was talking, and by the time an actual command arrived
+    /// there was no space left for it. Measured live 2026-08-05, saying
+    /// "unlock my screen":
+    ///
+    ///     [JARVIS Voice] utterance captured (345KB base64)
+    ///     ⚠️ AUDIO DEBUG: Audio appears to be silent!
+    ///     ⚠️ No speaker match found. Best confidence: 0.00%
+    ///     'unlock_screen' NOT authorised (That didn't sound like you)
+    ///
+    /// Three hundred kilobytes of room tone, faithfully captured, and the
+    /// sentence the operator actually said discarded for lack of room. The
+    /// verifier did its job correctly on the evidence it was given.
+    ///
+    /// The original objection to a moving window was that "sliding a 2MB
+    /// window on a render callback" stutters — and that is true of SHIFTING,
+    /// which memmoves the whole buffer on every callback. A ring does not
+    /// shift. It writes at an index and wraps, so this is still two memcpys
+    /// at worst, no allocation, no lock, and O(frames) rather than O(capacity).
+    ///
+    /// `written` is monotonic and only ever grows, so `finish()` can tell a
+    /// partially-filled buffer from a wrapped one without a second flag.
     func append(_ buffer: AVAudioPCMBuffer) {
         guard let dst = storage,
               let src = buffer.floatChannelData?[0] else { return }
         let frames = Int(buffer.frameLength)
-        guard frames > 0, count < capacity else { return }
-        let room = min(frames, capacity - count)
-        dst.advanced(by: count).update(from: src, count: room)
-        count += room
+        guard frames > 0, capacity > 0 else { return }
+
+        // A single buffer longer than the whole window: keep only its tail,
+        // which is the part nearest the end of the sentence.
+        let take = min(frames, capacity)
+        let offset = frames - take
+
+        let first = min(take, capacity - head)
+        dst.advanced(by: head).update(from: src.advanced(by: offset), count: first)
+        if take > first {
+            dst.update(from: src.advanced(by: offset + first), count: take - first)
+        }
+        head = (head + take) % capacity
+        written += take
     }
 
-    var hasAudio: Bool { count > 0 }
+    var hasAudio: Bool { written > 0 }
 
     /// The captured sentence as base64 WAV at `targetRate`, or nil.
     ///
@@ -109,9 +146,50 @@ final class UtteranceRecorder: @unchecked Sendable {
     /// embedding is computed from, and the artefacts it produces are exactly
     /// the kind a verifier reads as "different person".
     func finish() -> String? {
-        guard let src = storage, count > 0, let format = sourceFormat else { return nil }
+        guard let src = storage, written > 0, let format = sourceFormat else { return nil }
         let sourceRate = format.sampleRate
         guard sourceRate > 0 else { return nil }
+
+        // Unwrap the ring into chronological order before anything else looks
+        // at it. `written < capacity` means it never wrapped, so the frames sit
+        // at 0..<written already; otherwise the oldest frame is under `head`.
+        //
+        // Done here rather than in `append` on purpose: this runs once per
+        // sentence on a normal queue, whereas append runs on the render thread
+        // hundreds of times a second. The expensive half belongs where it can
+        // afford to be.
+        let count = min(written, capacity)
+        var linear = [Float](repeating: 0, count: count)
+        linear.withUnsafeMutableBufferPointer { dst in
+            guard let base = dst.baseAddress else { return }
+            if written < capacity {
+                base.update(from: src, count: count)
+            } else {
+                let tail = capacity - head          // oldest slice, at the top
+                base.update(from: src.advanced(by: head), count: tail)
+                base.advanced(by: tail).update(from: src, count: head)
+            }
+        }
+        let encoded = linear.withUnsafeBufferPointer { buf -> String? in
+            guard let src = buf.baseAddress else { return nil }
+            return Self.encode(src, count: count, sourceRate: sourceRate,
+                               targetRate: targetRate)
+        }
+        // Hand it up exactly once. Reset AFTER the copy, not before — the
+        // anti-replay guarantee is that the same sentence cannot be claimed
+        // twice, not that it can be lost between the copy and the reset.
+        head = 0
+        written = 0
+        return encoded
+    }
+
+    /// Resample to `targetRate` and frame as base64 WAV. Pure; no state.
+    ///
+    /// Split out of `finish()` so the ring-unwrapping and the signal work are
+    /// separable — the unwrap is where a subtle ordering bug would hide, and it
+    /// is much easier to reason about when it is not tangled with resampling.
+    private static func encode(_ src: UnsafePointer<Float>, count: Int,
+                               sourceRate: Double, targetRate: Double) -> String? {
 
         let ratio = sourceRate / targetRate
         guard ratio >= 1.0 else { return nil }          // never upsample
@@ -132,13 +210,15 @@ final class UtteranceRecorder: @unchecked Sendable {
             let clamped = max(-1.0, min(1.0, mean))
             pcm[i] = Int16(clamped * 32767.0)
         }
-        count = 0                                        // hand it up exactly once
         return Self.wav(pcm, sampleRate: Int(targetRate)).base64EncodedString()
     }
 
     /// Discard whatever was captured. Used when a sentence turns out not to be
     /// a command — there is no reason to keep audio nobody asked a question of.
-    func discard() { count = 0 }
+    func discard() {
+        head = 0
+        written = 0
+    }
 
     /// Minimal 16-bit mono RIFF/WAVE. Written by hand rather than via
     /// `AVAudioFile` because that writes to a URL, and the whole point is that

--- a/backend/main.py
+++ b/backend/main.py
@@ -2126,7 +2126,70 @@ async def parallel_lifespan(app: FastAPI):
                             stdout=asyncio.subprocess.DEVNULL,
                             stderr=asyncio.subprocess.DEVNULL,
                         )
-                        await asyncio.wait_for(play.communicate(), timeout=15)
+
+                        # HOLD THE MUTE FOR AS LONG AS SOUND IS ACTUALLY
+                        # COMING OUT — NOT FOR AS LONG AS WE GUESSED.
+                        #
+                        # The claim above was opened BEFORE `say` had rendered
+                        # a single sample, with a deadline estimated from the
+                        # character count. It has to cover render AND playback,
+                        # and on a loop measured at 41-65% availability it does
+                        # not. Live, 2026-08-05:
+                        #
+                        #   [SpeechGate] EXPIRED backend — its owner never
+                        #                released it
+                        #   [SpeechGate] mic LIVE
+                        #   [JARVIS Voice] >>> "Executing lock my screen"
+                        #   [JARVIS Voice] >>> "See you soon"
+                        #
+                        # Those are JARVIS's OWN WORDS, transcribed and
+                        # executed as commands. `lock_screen` ran five times
+                        # from one request, and the session never reached
+                        # "unlock" because the feedback loop consumed it.
+                        #
+                        # An estimate cannot fix this — any margin large enough
+                        # to be safe leaves the microphone dead after short
+                        # replies, and any margin small enough to feel
+                        # responsive reopens it mid-sentence. So this stops
+                        # predicting: `afplay` either exists or it does not,
+                        # and while it exists the mute is renewed. The claim
+                        # cannot outlive the sound (the `finally` releases it)
+                        # and cannot die before it (this renews it), whatever
+                        # the loop is doing.
+                        _hold_ms = 2500.0
+
+                        async def _hold_mute_while_playing() -> None:
+                            """Renew the claim while the player is alive.
+
+                            `_speech` is None when the manager lookup above
+                            failed. There is then no claim to renew, and
+                            speaking unsuppressed is already the documented
+                            fallback for that case — it must not become a
+                            crash on the audio path.
+                            """
+                            if _speech is None:
+                                return
+                            try:
+                                while play.returncode is None:
+                                    await asyncio.sleep(_hold_ms / 3000.0)
+                                    if play.returncode is not None:
+                                        return
+                                    await _speech.start_speaking(
+                                        text, source=SpeechSource.SYSTEM,
+                                        estimated_duration_ms=_hold_ms)
+                            except asyncio.CancelledError:
+                                raise
+                            except Exception:  # noqa: BLE001
+                                # A failed renewal must never stop playback;
+                                # the deadline and the manager's own watchdog
+                                # remain underneath it.
+                                return
+
+                        _holder = asyncio.ensure_future(_hold_mute_while_playing())
+                        try:
+                            await asyncio.wait_for(play.communicate(), timeout=15)
+                        finally:
+                            _holder.cancel()
                         try:
                             os.unlink(tmp_path)
                         except OSError:

--- a/scripts/check_utterance_ring.sh
+++ b/scripts/check_utterance_ring.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# The utterance recorder must keep the MOST RECENT window of audio, in order.
+#
+# It used to stop writing once full, and `begin()` runs when the audio ENGINE
+# starts — so the buffer filled with whatever the room was doing while nobody
+# was talking, and the command the operator actually spoke arrived to find no
+# space left. Measured live 2026-08-05: 345KB of audio delivered, "Audio
+# appears to be silent", 0.00% confidence, unlock refused.
+#
+# There is no XCTest target for the HUD app, so this compiles the REAL source
+# file together with a harness and exercises it. Testing a copy of the logic
+# would prove nothing about the file that ships.
+#
+# Usage:  ./scripts/check_utterance_ring.sh
+# Exit:   0 all checks pass · 1 a check failed · 2 toolchain missing
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SRC="${ROOT}/JARVIS-Apple/JARVISHUD/Services/UtteranceRecorder.swift"
+HARNESS="${ROOT}/scripts/swift_checks/utterance_ring/main.swift"
+
+if ! command -v swiftc > /dev/null 2>&1; then
+    echo "ERROR: swiftc not found — cannot verify the utterance ring." >&2
+    exit 2
+fi
+[ -f "${SRC}" ] || { echo "ERROR: missing ${SRC}" >&2; exit 2; }
+
+OUT="$(mktemp -d)"
+trap 'rm -rf "${OUT}"' EXIT
+swiftc -o "${OUT}/run" "${HARNESS}" "${SRC}"
+"${OUT}/run"

--- a/scripts/swift_checks/utterance_ring/main.swift
+++ b/scripts/swift_checks/utterance_ring/main.swift
@@ -1,0 +1,97 @@
+// Exercises the REAL UtteranceRecorder.swift, compiled in alongside this.
+//
+// The property that matters: after more audio than the window has been
+// appended, `finish()` must yield the MOST RECENT `maxSeconds` in
+// chronological order. A wrapping bug reorders the sentence, which produces
+// audio that is present but garbled — and fails verification with exactly the
+// symptom being fixed, so it would look like no progress at all.
+import AVFoundation
+import Foundation
+
+func buffer(_ values: [Float], rate: Double) -> AVAudioPCMBuffer {
+    let fmt = AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: rate,
+                            channels: 1, interleaved: false)!
+    let b = AVAudioPCMBuffer(pcmFormat: fmt, frameCapacity: AVAudioFrameCount(values.count))!
+    b.frameLength = AVAudioFrameCount(values.count)
+    for (i, v) in values.enumerated() { b.floatChannelData![0][i] = v }
+    return b
+}
+
+func decodeWavMonoInt16(_ b64: String) -> [Int16] {
+    guard let d = Data(base64Encoded: b64), d.count > 44 else { return [] }
+    let body = d.subdata(in: 44..<d.count)
+    return body.withUnsafeBytes { raw in
+        Array(UnsafeBufferPointer(start: raw.baseAddress!.assumingMemoryBound(to: Int16.self),
+                                  count: body.count / 2))
+    }
+}
+
+var failures = 0
+func check(_ cond: Bool, _ what: String) {
+    print("\(cond ? "PASS" : "FAIL")  \(what)")
+    if !cond { failures += 1 }
+}
+
+// 16 kHz so no resampling happens and samples survive one-for-one.
+let rate = 16000.0
+let maxSeconds = 12.0
+let cap = Int(rate * maxSeconds)
+
+// ---- 1. Under-filled: order preserved, nothing invented -------------------
+do {
+    let r = UtteranceRecorder()
+    let fmt = AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: rate,
+                            channels: 1, interleaved: false)!
+    r.begin(format: fmt)
+    r.append(buffer([0.1, 0.2, 0.3, 0.4], rate: rate))
+    let out = decodeWavMonoInt16(r.finish() ?? "")
+    check(out.count == 4, "under-filled keeps every frame (got \(out.count))")
+    check(out.count == 4 && out[0] < out[1] && out[1] < out[2] && out[2] < out[3],
+          "under-filled preserves ascending order")
+}
+
+// ---- 2. Wrapped: keeps the LAST window, in order --------------------------
+do {
+    let r = UtteranceRecorder()
+    let fmt = AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: rate,
+                            channels: 1, interleaved: false)!
+    r.begin(format: fmt)
+    // 1.5 windows of a strictly increasing ramp, in realistic tap-sized chunks.
+    let total = cap + cap / 2
+    var next = 0
+    let chunk = 4096
+    while next < total {
+        let n = min(chunk, total - next)
+        let vals = (0..<n).map { Float(next + $0) / Float(total) }
+        r.append(buffer(vals, rate: rate))
+        next += n
+    }
+    let out = decodeWavMonoInt16(r.finish() ?? "")
+    check(out.count == cap, "wrapped yields exactly one window (\(out.count) vs \(cap))")
+
+    var monotonic = true
+    for i in 1..<out.count where out[i] < out[i - 1] { monotonic = false; break }
+    check(monotonic, "wrapped output is in CHRONOLOGICAL order (no torn seam)")
+
+    // The window must be the RECENT half, not the opening half — this is the
+    // whole defect: room tone kept, the command discarded.
+    let firstKept = Float(total - cap) / Float(total)
+    let expected = Int16(max(-1.0, min(1.0, firstKept)) * 32767.0)
+    check(abs(Int(out[0]) - Int(expected)) < 400,
+          "window starts at the RECENT end (got \(out[0]), expected ~\(expected))")
+    check(out.last! > 32000, "window ends at the newest sample (got \(out.last!))")
+}
+
+// ---- 3. Claimed exactly once ---------------------------------------------
+do {
+    let r = UtteranceRecorder()
+    let fmt = AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: rate,
+                            channels: 1, interleaved: false)!
+    r.begin(format: fmt)
+    r.append(buffer([0.5, 0.6], rate: rate))
+    check(r.finish() != nil, "first finish returns audio")
+    check(r.finish() == nil, "second finish returns nil — handed up exactly once")
+}
+
+print(failures == 0 ? "\nALL RING CHECKS PASSED" : "\n\(failures) CHECK(S) FAILED")
+exit(failures == 0 ? 0 : 1)


### PR DESCRIPTION
From your run, saying **"unlock my screen"**:

```
[JARVIS Voice] utterance captured (345KB base64)
⚠️ AUDIO DEBUG: Audio appears to be silent!
⚠️ No speaker match found. Best confidence: 0.00%
'unlock_screen' NOT authorised (That didn't sound like you, so I've left it locked.)
```

345KB of audio arrived and it was **silent**. The verifier was right on the evidence it had; the evidence was wrong.

`append` stopped writing once full, and `begin()` runs when the audio **engine** starts — not when anyone speaks. The window filled with whatever the room was doing while nobody was talking, and by the time a command arrived there was no space left. It captured twelve seconds of nothing and discarded the sentence it exists to capture.

**This is the third distinct reason unlock has failed, and each hid the next:** the model wasn't loaded (#70389) → JARVIS was transcribing its own voice (#70390) → only with those cleared did the request get far enough to be refused on its audio.

## A ring, not a window that slides

The original objection to a moving window was that *"sliding a 2MB window on a render callback is how you turn a voice assistant into a stutter."* True — of **shifting**, which memmoves the whole buffer every callback. A ring doesn't shift: it writes at an index and wraps. Two memcpys at worst, no allocation, no lock, O(frames) instead of O(capacity). The real-time discipline the file was written with is preserved exactly.

`written` is monotonic, so `finish()` distinguishes a partly-filled buffer from a wrapped one without a second flag. The unwrap into chronological order happens in `finish()`, on a normal queue, once per sentence — never on the render thread, which still only bounds-checks and copies.

## Verified against the real file, both directions

No XCTest target exists for the HUD app, so `scripts/check_utterance_ring.sh` compiles the **actual shipping source** alongside a harness. Testing a copy of the logic would prove nothing about the file that ships.

| | |
|---|---|
| after the fix | **8/8 pass** |
| before the fix | window starts at sample **0** (room tone), ends at **21844/32767** — newest audio absent |

That second row is the defect, reproduced by the test.

The checks pin: under-filled keeps every frame in order; wrapped yields exactly one window, chronologically, starting at the **recent** end; and `finish()` still hands the sentence up exactly once — so the anti-replay guarantee from #70386 is intact.

## Not proven

That an unlock now **succeeds**. This removes the reason the audio was empty; whether the voiceprint then matches is what the next log will say.

`Primary user: None` in the same run suggests the profile lookup on the verification path has its own problem, separate from this one — worth watching for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two voice issues: the recorder now keeps the most recent speech instead of room noise, and TTS playback no longer re-opens the mic mid-sentence causing self-echo commands.

- **Bug Fixes**
  - UtteranceRecorder: switch to a ring buffer that always retains the latest frames; unwraps once in finish; render thread remains O(frames).
  - Backend TTS: renew the SpeechGate claim while `afplay` is running (using short `estimated_duration_ms`) so the mute holds for actual playback duration and prevents self-transcription; falls back safely if the manager is unavailable.

- **Verification**
  - Added `scripts/check_utterance_ring.sh` and a Swift harness to compile the real source and verify under-filled and wrapped cases.
  - Confirms chronological output of the most recent window and single handoff behavior.

<sup>Written for commit bbb303a96daf0ddc19ae922ba9ddcd060eb59505. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

