### PR TITLE
perf(boot): 239 lines of synchronous filesystem work inside an async def

### DIFF
--- a/backend/core/resilience/file_watch_guard.py
+++ b/backend/core/resilience/file_watch_guard.py
@@ -736,6 +736,56 @@ class FileWatchGuard:
         logger.info("[FileWatchGuard] Stopped")
 
     async def _start_watchdog(self) -> None:
+        """Start the observer WITHOUT holding the event loop.
+
+        The body of this used to run here, and it is 239 lines of pure
+        synchronous filesystem work — resolving roots, walking exclusions,
+        calling ``observer.schedule()`` per root and finally
+        ``observer.start()``. There is not a single ``await`` in it. It was
+        ``async`` in name only, so every millisecond of it ran ON the loop.
+
+        Caught in the act by ``stall_sampler``, which dumps stacks from a
+        thread WHILE the loop is wedged rather than after it recovers. This
+        chain appeared in 5 of 8 boot dumps on 2026-08-05:
+
+            intake_layer_service.start
+              -> _build_components
+                -> fs_event_bridge.start
+                  -> file_watch_guard.start
+                    -> _start_watchdog        <- the loop stopped here
+
+        which matches the boot stalls the sentinel had been reporting for
+        weeks without ever being able to name them (6.71s, 8.05s, 7.66s,
+        availability 41-65%).
+
+        Offloaded through ``cooperative_fs_io.offload`` — the substrate that
+        exists for exactly this and that the posture collectors already use.
+        No new threading mechanism, no second policy. Threads rather than a
+        process pool deliberately: this is filesystem and syscall work, which
+        RELEASES the GIL, so a thread genuinely frees the loop here. That is
+        the opposite of the posture case, where a wholesale thread offload was
+        measured and rejected because pure-Python work carries the GIL with it.
+
+        Fails soft to the direct call: a substrate fault must not stop a
+        watcher from starting. That degrades to the old behaviour — a blocked
+        loop — which is strictly better than no file watching at all.
+        """
+        try:
+            from backend.core.ouroboros.governance.cooperative_fs_io import (
+                offload,
+                is_offload_error,
+            )
+        except Exception:  # noqa: BLE001 — substrate unavailable
+            return self._start_watchdog_blocking()
+        result = await offload(self._start_watchdog_blocking, cpu_bound=False)
+        if is_offload_error(result):
+            # The collector raised inside the worker. Re-run inline so the
+            # exception surfaces to the caller exactly as it always has,
+            # rather than being swallowed into a silently watcher-less boot.
+            return self._start_watchdog_blocking()
+        return result
+
+    def _start_watchdog_blocking(self) -> None:
         """Start the watchdog observer.
 
         Backend selection:

--- a/backend/hud/loop_sentinel.py
+++ b/backend/hud/loop_sentinel.py
@@ -177,6 +177,11 @@ class LoopSentinel:
     def __init__(self) -> None:
         self._task: Optional[asyncio.Task] = None
         self._health = LoopHealth()
+        #: Last time the probe woke, published for off-loop readers. Starts at
+        #: 0.0 so a sampler can tell "never ticked" from "ticked long ago" —
+        #: before `start()`, a stale heartbeat means nothing has begun, not
+        #: that the loop is wedged.
+        self._last_tick: float = 0.0
         self._max_recent = 20
         #: One report per run. Forty stalls are one defect restated.
         self._reported = False
@@ -222,10 +227,26 @@ class LoopSentinel:
                 threshold = stall_threshold_s()
                 before = time.monotonic()
                 await asyncio.sleep(interval)
+                # HEARTBEAT, published for readers OFF this loop.
+                #
+                # This task can only notice a stall AFTER it ends — it is the
+                # thing being starved, so while the loop is dead it is not
+                # running to observe anything. That is fine for measuring, and
+                # useless for catching the culprit in the act: by the time
+                # `_record` runs, whatever held the loop has already let go.
+                #
+                # A single float write, which is atomic under CPython, so a
+                # sampler thread can read it without a lock and without any
+                # chance of blocking the loop to ask. `stall_sampler` watches
+                # this timestamp go stale and dumps the stacks WHILE the loop
+                # is still wedged — the same separation that makes the parent
+                # watch work: the observer must not share the fate of the
+                # observed.
+                self._last_tick = time.monotonic()
                 # Everything past the interval is time the loop owed this task
                 # and could not pay. No attribution, no instrumentation — the
                 # measurement IS the starvation.
-                lag = (time.monotonic() - before) - interval
+                lag = self._last_tick - before - interval
                 self._health.probes += 1
                 if lag >= threshold:
                     self._record(before, lag)

--- a/backend/hud/stall_sampler.py
+++ b/backend/hud/stall_sampler.py
@@ -1,0 +1,245 @@
+"""Catch the event loop being blocked, while it is still blocked.
+
+WHY THIS EXISTS
+---------------
+`LoopSentinel` reports the stalls perfectly — 6.71s, 8.05s, 7.66s during a
+single boot on 2026-08-05, availability 41-65%. What it cannot report is WHO,
+and for a structural reason rather than an oversight: it is a task ON the loop
+it measures. While the loop is dead it is not running, so by the time it wakes
+to record the lag, whatever held the loop has already let go. It is the
+victim, and the victim never sees the culprit.
+
+Every attempt to name that culprit from inside the loop has the same flaw, and
+one of them cost most of a day: `loop_sink.sink_async` measures wall-clock and
+was read as blocking time, which pointed an investigation at
+`posture_observer` — a subsystem that was already off-loop and entirely
+innocent.
+
+So this samples from a THREAD. When the heartbeat the sentinel publishes goes
+stale, the loop is wedged AT THIS INSTANT, and the stacks are dumped while it
+is still wedged. That is the difference between "something blocked the loop
+for eight seconds" and "here is the function that did it".
+
+The separation is the same one that makes the parent watch work, and the same
+one the battle harness's wall-clock watchdog is forbidden from breaking: an
+observer that shares a resource with the thing it observes is not an observer.
+This thread reads one float and calls `faulthandler`; it takes no lock the
+loop can hold, allocates nothing the loop can starve, and asks the application
+for nothing.
+
+WHY faulthandler AND NOT traceback
+------------------------------------
+`faulthandler.dump_traceback` writes from C, walking interpreter state without
+executing Python and without taking the logging lock. A thread blocked inside
+a C call — a lock acquire, a `read()`, a futex wait — runs no bytecode, so
+anything Python-level is deferred until it moves, which is exactly never in
+the case being investigated. Reused from `oob_diagnostics.dump_all_threads`
+rather than reimplemented; that module already solved this for the `/` freeze.
+
+BOUNDED, BECAUSE A DIAGNOSTIC MUST NOT BECOME THE INCIDENT
+------------------------------------------------------------
+Boot produces many stalls in a short window. Dumping every one would write
+megabytes and add its own I/O to a machine already under memory pressure. So:
+a minimum gap between dumps, a hard cap per process, and each dump is one
+write. When the cap is reached it says so once and stops — silence would look
+like health.
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from typing import Optional
+
+logger = logging.getLogger("jarvis.stallsampler")
+
+STALL_SAMPLER_SCHEMA_VERSION: str = "stall_sampler.v1"
+
+#: Master switch. Default TRUE — it costs one float read per interval while
+#: the loop is healthy, and the thing it catches is otherwise uncatchable.
+ENV_ENABLED: str = "JARVIS_STALL_SAMPLER_ENABLED"
+
+#: How stale the heartbeat must be before the loop counts as wedged NOW.
+#: Deliberately larger than the sentinel's own stall threshold: this is for
+#: the pathological windows worth a stack dump, not every scheduling hiccup.
+ENV_TRIGGER_S: str = "JARVIS_STALL_SAMPLER_TRIGGER_S"
+
+#: Minimum gap between dumps, so one long stall yields one dump.
+ENV_MIN_GAP_S: str = "JARVIS_STALL_SAMPLER_MIN_GAP_S"
+
+#: Hard cap per process.
+ENV_MAX_DUMPS: str = "JARVIS_STALL_SAMPLER_MAX_DUMPS"
+
+
+def _enabled() -> bool:
+    return (os.environ.get(ENV_ENABLED, "true") or "").strip().lower() not in (
+        "0", "false", "no", "off")
+
+
+def _f(name: str, default: float, minimum: float) -> float:
+    """Read a knob, clamped. NEVER raises.
+
+    Clamped rather than rejected: a typo in a diagnostic's timing must not be
+    able to turn it into a spin loop on a machine that is already struggling.
+    """
+    try:
+        raw = (os.environ.get(name, "") or "").strip()
+        return max(minimum, float(raw)) if raw else default
+    except Exception:  # noqa: BLE001
+        return default
+
+
+def trigger_s() -> float:
+    return _f(ENV_TRIGGER_S, 2.0, 0.25)
+
+
+def min_gap_s() -> float:
+    return _f(ENV_MIN_GAP_S, 10.0, 1.0)
+
+
+def max_dumps() -> int:
+    return int(_f(ENV_MAX_DUMPS, 8.0, 1.0))
+
+
+class StallSampler:
+    """Dumps every thread's stack while the loop is unresponsive. NEVER raises."""
+
+    def __init__(self) -> None:
+        self._thread: Optional[threading.Thread] = None
+        self._stop = threading.Event()
+        self._dumps = 0
+        self._last_dump = 0.0
+        self._capped_announced = False
+
+    # -- lifecycle -------------------------------------------------------
+
+    def start(self) -> bool:
+        """Arm the sampler on a daemon thread. Idempotent. NEVER raises."""
+        try:
+            if not _enabled():
+                logger.info("[StallSampler] disabled by %s", ENV_ENABLED)
+                return False
+            if self._thread is not None and self._thread.is_alive():
+                return True
+            self._stop.clear()
+            self._thread = threading.Thread(
+                target=self._run, name="loop-stall-sampler", daemon=True)
+            self._thread.start()
+            logger.info(
+                "[StallSampler] armed — a loop wedged for more than %.1fs will "
+                "have its stacks captured WHILE wedged (max %d dumps, %.0fs "
+                "apart). The sentinel says a stall happened; this says what "
+                "was running.",
+                trigger_s(), max_dumps(), min_gap_s())
+            return True
+        except Exception:  # noqa: BLE001
+            logger.debug("[StallSampler] start degraded", exc_info=True)
+            return False
+
+    def stop(self) -> None:
+        self._stop.set()
+
+    # -- the watch -------------------------------------------------------
+
+    def _heartbeat(self) -> float:
+        """The sentinel's last tick, or 0.0 if it is not running.
+
+        Read without a lock on purpose. A float read is atomic under CPython,
+        and taking a lock the loop might hold would let this thread block on
+        exactly the condition it exists to observe.
+        """
+        try:
+            from backend.hud import loop_sentinel as ls
+            s = ls._SENTINEL
+            return float(getattr(s, "_last_tick", 0.0)) if s is not None else 0.0
+        except Exception:  # noqa: BLE001
+            return 0.0
+
+    def _run(self) -> None:
+        # Sample considerably faster than the trigger so a stall is caught
+        # near its beginning rather than near its end — a dump taken as the
+        # loop recovers shows the recovery, not the cause.
+        while not self._stop.is_set():
+            interval = max(0.1, trigger_s() / 4.0)
+            if self._stop.wait(interval):
+                return
+            try:
+                beat = self._heartbeat()
+                if beat <= 0.0:
+                    continue          # sentinel not started; nothing to judge
+                stale_for = time.monotonic() - beat
+                if stale_for < trigger_s():
+                    continue
+                now = time.monotonic()
+                if now - self._last_dump < min_gap_s():
+                    continue          # same stall, already captured
+                if self._dumps >= max_dumps():
+                    if not self._capped_announced:
+                        self._capped_announced = True
+                        logger.warning(
+                            "[StallSampler] dump cap (%d) reached — further "
+                            "stalls will NOT be captured. Raise %s if the "
+                            "culprit has not shown up yet.",
+                            max_dumps(), ENV_MAX_DUMPS)
+                    continue
+                self._last_dump = now
+                self._dumps += 1
+                self._capture(stale_for)
+            except Exception:  # noqa: BLE001 — a witness never dies of a fault
+                logger.debug("[StallSampler] sample degraded", exc_info=True)
+
+    def _capture(self, stale_for: float) -> None:
+        """One dump, through the module that already does this correctly."""
+        logger.warning(
+            "[StallSampler] LOOP WEDGED for %.2fs RIGHT NOW — capturing "
+            "stacks (dump %d/%d). The frames below are what the loop is "
+            "stuck on, not what it ran afterwards.",
+            stale_for, self._dumps, max_dumps())
+        try:
+            from backend.core.ouroboros.battle_test.oob_diagnostics import (
+                dump_all_threads,
+            )
+            if dump_all_threads():
+                return
+        except Exception:  # noqa: BLE001
+            logger.debug("[StallSampler] oob dump unavailable", exc_info=True)
+        # Fallback: straight to stderr. Less convenient than the log file the
+        # oob module maintains, and infinitely better than nothing at the one
+        # moment the answer exists.
+        try:
+            import faulthandler
+            faulthandler.dump_traceback(all_threads=True)
+        except Exception:  # noqa: BLE001
+            pass
+
+    def stats(self) -> dict:
+        return {
+            "schema_version": STALL_SAMPLER_SCHEMA_VERSION,
+            "enabled": _enabled(),
+            "running": bool(self._thread and self._thread.is_alive()),
+            "dumps": self._dumps,
+            "max_dumps": max_dumps(),
+            "trigger_s": trigger_s(),
+        }
+
+
+_SAMPLER: Optional[StallSampler] = None
+
+
+def get_stall_sampler() -> StallSampler:
+    """Process-wide sampler. NEVER raises."""
+    global _SAMPLER
+    if _SAMPLER is None:
+        _SAMPLER = StallSampler()
+    return _SAMPLER
+
+
+def reset_stall_sampler() -> None:
+    """Testing seam."""
+    global _SAMPLER
+    if _SAMPLER is not None:
+        _SAMPLER.stop()
+    _SAMPLER = None

--- a/backend/main.py
+++ b/backend/main.py
@@ -1986,6 +1986,20 @@ async def parallel_lifespan(app: FastAPI):
         except Exception as _ls:  # noqa: BLE001 — a witness never blocks a boot
             logger.debug("[HUD] loop sentinel unavailable: %s", _ls)
 
+        # The sentinel says a stall HAPPENED. This says what was RUNNING.
+        #
+        # Started immediately after it, and deliberately here rather than
+        # later: the stalls worth catching (6.71s, 8.05s, 7.66s on
+        # 2026-08-05) all occur DURING boot, so a sampler armed after boot
+        # completes would arrive after the evidence. It runs on its own
+        # thread precisely because the loop is the thing being observed —
+        # anything scheduled on the loop cannot witness the loop being dead.
+        try:
+            from backend.hud.stall_sampler import get_stall_sampler
+            get_stall_sampler().start()
+        except Exception as _ss:  # noqa: BLE001 — a witness never blocks a boot
+            logger.debug("[HUD] stall sampler unavailable: %s", _ss)
+
         # =================================================================
         # v351.0: HUD MODE — IPC server + SSE consumer for Swift HUD
         # =================================================================


### PR DESCRIPTION
`LoopSentinel` has reported these stalls for weeks — 6.71s, 8.05s, 7.66s in one boot, availability 41–65% — and could never say what caused them.

Not an oversight. It is a task **on** the loop it measures, so while the loop is dead it isn't running; by the time it wakes to record the lag, whatever held the loop has let go. **The victim never sees the culprit.**

## Sample from a thread

`LoopSentinel` now publishes its heartbeat (one float, atomic under CPython). `stall_sampler` watches that go stale from its own thread and dumps every stack **while the loop is still wedged**. Same separation that makes the parent watch work.

The dump is `oob_diagnostics.dump_all_threads` — already written, already faulthandler-based for exactly the reason that matters (writes from the C signal handler, so it works on a thread blocked inside a C call running no bytecode). Not reimplemented. Bounded: min gap, hard cap, and it announces the cap once — silence would look like health.

## What it caught, in 5 of 8 boot dumps

```
intake_layer_service.start
  -> _build_components
    -> fs_event_bridge.start
      -> file_watch_guard.start
        -> _start_watchdog          <- the loop stopped here
```

`_start_watchdog` is **239 lines with zero awaits** — resolving roots, walking exclusions, `observer.schedule()` per root, `observer.start()`. `async` in name only, so all of it ran on the loop.

**I verified it was the main thread before touching it: 10 main-thread blocks, 0 worker blocks.** That check mattered — `capability_federation._hydrate_ns_blocking` appears in the same dumps and is **already correctly offloaded** via `_to_thread`; it shows up because the dump captures every thread. Reading it as a culprit would have repeated this morning's mistake.

## The fix

Async entry point stays (no caller changes); the body becomes `_start_watchdog_blocking`, awaited through `cooperative_fs_io.offload` — the substrate that exists for this and that the posture collectors already use.

**Threads, not a process pool, deliberately.** Filesystem and syscall work *releases* the GIL, so a thread genuinely frees the loop. That is the opposite of the posture case, where a wholesale thread offload was measured and rejected because pure-Python work carries the GIL with it. Same substrate, opposite verdict — the difference is what the work actually does.

Fails soft to the direct call: a blocked loop beats a boot with no file watching.

## Measured, boot phase only, same machine

| | BEFORE | AFTER |
|---|---|---|
| boot duration | 125s | **89s** |
| total stalled | 84.05s | **45.85s** |
| worst stall | 64.53s | **14.24s** |
| loop lost | 67.2% | **51.5%** |

**Not solved.** 51.5% is still bad — and the next blocker is already named by the same instrument: `parallel_initializer._init_ai_loader`. That is the entire point of building the sampler instead of guessing again.

166 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Offloaded synchronous file watcher startup off the event loop and added a stall sampler that captures stacks while the loop is blocked. Boot got faster and less stalled (125s→89s; worst stall 64.53s→14.24s).

- **New Features**
  - `LoopSentinel` now exposes a heartbeat timestamp for off-loop readers.
  - New `stall_sampler` thread watches the heartbeat and dumps stacks via `oob_diagnostics.dump_all_threads`; bounded by env knobs and started during boot.

- **Refactors**
  - Moved `file_watch_guard._start_watchdog` work to `_start_watchdog_blocking` and offloaded via `cooperative_fs_io.offload` (thread); falls back to inline on failure.

<sup>Written for commit aa9ecc87065fc306079ac93f310d61b4fb3ffb1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

