### PR TITLE
perf(boot): stop eagerly probing engines that already probe themselves

### DIFF
--- a/backend/core/parallel_initializer.py
+++ b/backend/core/parallel_initializer.py
@@ -2221,25 +2221,71 @@ class ParallelInitializer:
             # Get the global AI Manager (singleton)
             ai_manager = get_ai_manager()
 
-            # Discover available optimization engines
+            # DISCOVERY IS ALREADY LAZY. BOOT WAS DEFEATING IT.
+            #
+            # `discover_engines()` probes each optimization engine by IMPORTING
+            # it — `import torch`, `import onnxruntime`, and for the JIT probe
+            # it builds and traces a small `nn.Module`. Caught by
+            # `stall_sampler` as the worst remaining boot blocker at 14.24s,
+            # inside an `async def` with nothing to yield to.
+            #
+            # It did not need to happen here at all:
+            #
+            #   * it caches — `if self._discovered: return self._engine_cache`
+            #   * it is ALREADY called on demand, from the router's own routing
+            #     methods (ai_loader.py:966 and :1166)
+            #
+            # So the eager call bought nothing except fourteen seconds of a
+            # deaf assistant. The models were never the problem — this method's
+            # own docstring says registrations use Ghost Proxies for instant
+            # startup with background loading, and that was already true. Only
+            # the CAPABILITY PROBE was eager.
+            #
+            # The router is published to app.state immediately, which is what
+            # callers actually need; discovery warms behind it.
             router = get_optimization_router()
-            engines = router.discover_engines()
-
-            # Count available engines
-            available_engines = [
-                (e.name, c.speedup_factor)
-                for e, c in engines.items()
-                if c.available
-            ]
-
-            logger.info(f"   Optimization Router: {len(available_engines)} engines available")
-            for name, speedup in available_engines[:4]:  # Show top 4
-                logger.info(f"      {name}: {speedup}x speedup")
-
-            # Store in app state for global access
             self.app.state.ai_manager = ai_manager
             self.app.state.optimization_router = router
             self.app.state.ai_loader_ready = True
+
+            async def _warm_engines() -> None:
+                """Probe the engines off the loop, after boot is serving.
+
+                Through `cooperative_fs_io.offload` rather than a process pool:
+                these are module imports, dominated by reading and mapping
+                shared objects, and that work releases the GIL. Measured on
+                this codebase today — the same treatment took the speaker
+                model's import stall from ~14s to 3.1s. A process pool would
+                be actively wrong here: it would have to re-import torch in
+                the child anyway, and on 16GB of unified memory a second
+                interpreter holding a second copy is how a boot becomes a swap
+                storm.
+                """
+                try:
+                    from backend.core.ouroboros.governance.cooperative_fs_io import (
+                        offload,
+                    )
+                    found = await offload(router.discover_engines, cpu_bound=False)
+                except Exception:  # noqa: BLE001 — substrate unavailable
+                    found = router.discover_engines()
+                try:
+                    available = [(e.name, c.speedup_factor)
+                                 for e, c in (found or {}).items() if c.available]
+                    logger.info("   Optimization Router: %d engines available "
+                                "(discovered off the boot path)", len(available))
+                    for name, speedup in available[:4]:
+                        logger.info("      %s: %sx speedup", name, speedup)
+                except Exception:  # noqa: BLE001
+                    pass
+
+            # Owned by a shutdown phase rather than orphaned: an import that
+            # outlives the process it was warming is the exact class of
+            # unmanaged task that made shutdown unkillable.
+            try:
+                from backend.core.app_lifecycle import spawn_managed_task
+                spawn_managed_task(_warm_engines(), name="ai_engine_discovery")
+            except Exception:  # noqa: BLE001
+                asyncio.get_event_loop().create_task(_warm_engines())
 
             logger.info("   ✅ AI Loader ready - Ghost Proxy pattern enabled")
             logger.info("   All ML models will now use non-blocking background loading")

--- a/backend/core/resilience/file_watch_guard.py
+++ b/backend/core/resilience/file_watch_guard.py
@@ -736,6 +736,56 @@ class FileWatchGuard:
         logger.info("[FileWatchGuard] Stopped")
 
     async def _start_watchdog(self) -> None:
+        """Start the observer WITHOUT holding the event loop.
+
+        The body of this used to run here, and it is 239 lines of pure
+        synchronous filesystem work — resolving roots, walking exclusions,
+        calling ``observer.schedule()`` per root and finally
+        ``observer.start()``. There is not a single ``await`` in it. It was
+        ``async`` in name only, so every millisecond of it ran ON the loop.
+
+        Caught in the act by ``stall_sampler``, which dumps stacks from a
+        thread WHILE the loop is wedged rather than after it recovers. This
+        chain appeared in 5 of 8 boot dumps on 2026-08-05:
+
+            intake_layer_service.start
+              -> _build_components
+                -> fs_event_bridge.start
+                  -> file_watch_guard.start
+                    -> _start_watchdog        <- the loop stopped here
+
+        which matches the boot stalls the sentinel had been reporting for
+        weeks without ever being able to name them (6.71s, 8.05s, 7.66s,
+        availability 41-65%).
+
+        Offloaded through ``cooperative_fs_io.offload`` — the substrate that
+        exists for exactly this and that the posture collectors already use.
+        No new threading mechanism, no second policy. Threads rather than a
+        process pool deliberately: this is filesystem and syscall work, which
+        RELEASES the GIL, so a thread genuinely frees the loop here. That is
+        the opposite of the posture case, where a wholesale thread offload was
+        measured and rejected because pure-Python work carries the GIL with it.
+
+        Fails soft to the direct call: a substrate fault must not stop a
+        watcher from starting. That degrades to the old behaviour — a blocked
+        loop — which is strictly better than no file watching at all.
+        """
+        try:
+            from backend.core.ouroboros.governance.cooperative_fs_io import (
+                offload,
+                is_offload_error,
+            )
+        except Exception:  # noqa: BLE001 — substrate unavailable
+            return self._start_watchdog_blocking()
+        result = await offload(self._start_watchdog_blocking, cpu_bound=False)
+        if is_offload_error(result):
+            # The collector raised inside the worker. Re-run inline so the
+            # exception surfaces to the caller exactly as it always has,
+            # rather than being swallowed into a silently watcher-less boot.
+            return self._start_watchdog_blocking()
+        return result
+
+    def _start_watchdog_blocking(self) -> None:
         """Start the watchdog observer.
 
         Backend selection:

--- a/backend/hud/loop_sentinel.py
+++ b/backend/hud/loop_sentinel.py
@@ -177,6 +177,11 @@ class LoopSentinel:
     def __init__(self) -> None:
         self._task: Optional[asyncio.Task] = None
         self._health = LoopHealth()
+        #: Last time the probe woke, published for off-loop readers. Starts at
+        #: 0.0 so a sampler can tell "never ticked" from "ticked long ago" —
+        #: before `start()`, a stale heartbeat means nothing has begun, not
+        #: that the loop is wedged.
+        self._last_tick: float = 0.0
         self._max_recent = 20
         #: One report per run. Forty stalls are one defect restated.
         self._reported = False
@@ -222,10 +227,26 @@ class LoopSentinel:
                 threshold = stall_threshold_s()
                 before = time.monotonic()
                 await asyncio.sleep(interval)
+                # HEARTBEAT, published for readers OFF this loop.
+                #
+                # This task can only notice a stall AFTER it ends — it is the
+                # thing being starved, so while the loop is dead it is not
+                # running to observe anything. That is fine for measuring, and
+                # useless for catching the culprit in the act: by the time
+                # `_record` runs, whatever held the loop has already let go.
+                #
+                # A single float write, which is atomic under CPython, so a
+                # sampler thread can read it without a lock and without any
+                # chance of blocking the loop to ask. `stall_sampler` watches
+                # this timestamp go stale and dumps the stacks WHILE the loop
+                # is still wedged — the same separation that makes the parent
+                # watch work: the observer must not share the fate of the
+                # observed.
+                self._last_tick = time.monotonic()
                 # Everything past the interval is time the loop owed this task
                 # and could not pay. No attribution, no instrumentation — the
                 # measurement IS the starvation.
-                lag = (time.monotonic() - before) - interval
+                lag = self._last_tick - before - interval
                 self._health.probes += 1
                 if lag >= threshold:
                     self._record(before, lag)

--- a/backend/hud/stall_sampler.py
+++ b/backend/hud/stall_sampler.py
@@ -1,0 +1,245 @@
+"""Catch the event loop being blocked, while it is still blocked.
+
+WHY THIS EXISTS
+---------------
+`LoopSentinel` reports the stalls perfectly — 6.71s, 8.05s, 7.66s during a
+single boot on 2026-08-05, availability 41-65%. What it cannot report is WHO,
+and for a structural reason rather than an oversight: it is a task ON the loop
+it measures. While the loop is dead it is not running, so by the time it wakes
+to record the lag, whatever held the loop has already let go. It is the
+victim, and the victim never sees the culprit.
+
+Every attempt to name that culprit from inside the loop has the same flaw, and
+one of them cost most of a day: `loop_sink.sink_async` measures wall-clock and
+was read as blocking time, which pointed an investigation at
+`posture_observer` — a subsystem that was already off-loop and entirely
+innocent.
+
+So this samples from a THREAD. When the heartbeat the sentinel publishes goes
+stale, the loop is wedged AT THIS INSTANT, and the stacks are dumped while it
+is still wedged. That is the difference between "something blocked the loop
+for eight seconds" and "here is the function that did it".
+
+The separation is the same one that makes the parent watch work, and the same
+one the battle harness's wall-clock watchdog is forbidden from breaking: an
+observer that shares a resource with the thing it observes is not an observer.
+This thread reads one float and calls `faulthandler`; it takes no lock the
+loop can hold, allocates nothing the loop can starve, and asks the application
+for nothing.
+
+WHY faulthandler AND NOT traceback
+------------------------------------
+`faulthandler.dump_traceback` writes from C, walking interpreter state without
+executing Python and without taking the logging lock. A thread blocked inside
+a C call — a lock acquire, a `read()`, a futex wait — runs no bytecode, so
+anything Python-level is deferred until it moves, which is exactly never in
+the case being investigated. Reused from `oob_diagnostics.dump_all_threads`
+rather than reimplemented; that module already solved this for the `/` freeze.
+
+BOUNDED, BECAUSE A DIAGNOSTIC MUST NOT BECOME THE INCIDENT
+------------------------------------------------------------
+Boot produces many stalls in a short window. Dumping every one would write
+megabytes and add its own I/O to a machine already under memory pressure. So:
+a minimum gap between dumps, a hard cap per process, and each dump is one
+write. When the cap is reached it says so once and stops — silence would look
+like health.
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from typing import Optional
+
+logger = logging.getLogger("jarvis.stallsampler")
+
+STALL_SAMPLER_SCHEMA_VERSION: str = "stall_sampler.v1"
+
+#: Master switch. Default TRUE — it costs one float read per interval while
+#: the loop is healthy, and the thing it catches is otherwise uncatchable.
+ENV_ENABLED: str = "JARVIS_STALL_SAMPLER_ENABLED"
+
+#: How stale the heartbeat must be before the loop counts as wedged NOW.
+#: Deliberately larger than the sentinel's own stall threshold: this is for
+#: the pathological windows worth a stack dump, not every scheduling hiccup.
+ENV_TRIGGER_S: str = "JARVIS_STALL_SAMPLER_TRIGGER_S"
+
+#: Minimum gap between dumps, so one long stall yields one dump.
+ENV_MIN_GAP_S: str = "JARVIS_STALL_SAMPLER_MIN_GAP_S"
+
+#: Hard cap per process.
+ENV_MAX_DUMPS: str = "JARVIS_STALL_SAMPLER_MAX_DUMPS"
+
+
+def _enabled() -> bool:
+    return (os.environ.get(ENV_ENABLED, "true") or "").strip().lower() not in (
+        "0", "false", "no", "off")
+
+
+def _f(name: str, default: float, minimum: float) -> float:
+    """Read a knob, clamped. NEVER raises.
+
+    Clamped rather than rejected: a typo in a diagnostic's timing must not be
+    able to turn it into a spin loop on a machine that is already struggling.
+    """
+    try:
+        raw = (os.environ.get(name, "") or "").strip()
+        return max(minimum, float(raw)) if raw else default
+    except Exception:  # noqa: BLE001
+        return default
+
+
+def trigger_s() -> float:
+    return _f(ENV_TRIGGER_S, 2.0, 0.25)
+
+
+def min_gap_s() -> float:
+    return _f(ENV_MIN_GAP_S, 10.0, 1.0)
+
+
+def max_dumps() -> int:
+    return int(_f(ENV_MAX_DUMPS, 8.0, 1.0))
+
+
+class StallSampler:
+    """Dumps every thread's stack while the loop is unresponsive. NEVER raises."""
+
+    def __init__(self) -> None:
+        self._thread: Optional[threading.Thread] = None
+        self._stop = threading.Event()
+        self._dumps = 0
+        self._last_dump = 0.0
+        self._capped_announced = False
+
+    # -- lifecycle -------------------------------------------------------
+
+    def start(self) -> bool:
+        """Arm the sampler on a daemon thread. Idempotent. NEVER raises."""
+        try:
+            if not _enabled():
+                logger.info("[StallSampler] disabled by %s", ENV_ENABLED)
+                return False
+            if self._thread is not None and self._thread.is_alive():
+                return True
+            self._stop.clear()
+            self._thread = threading.Thread(
+                target=self._run, name="loop-stall-sampler", daemon=True)
+            self._thread.start()
+            logger.info(
+                "[StallSampler] armed — a loop wedged for more than %.1fs will "
+                "have its stacks captured WHILE wedged (max %d dumps, %.0fs "
+                "apart). The sentinel says a stall happened; this says what "
+                "was running.",
+                trigger_s(), max_dumps(), min_gap_s())
+            return True
+        except Exception:  # noqa: BLE001
+            logger.debug("[StallSampler] start degraded", exc_info=True)
+            return False
+
+    def stop(self) -> None:
+        self._stop.set()
+
+    # -- the watch -------------------------------------------------------
+
+    def _heartbeat(self) -> float:
+        """The sentinel's last tick, or 0.0 if it is not running.
+
+        Read without a lock on purpose. A float read is atomic under CPython,
+        and taking a lock the loop might hold would let this thread block on
+        exactly the condition it exists to observe.
+        """
+        try:
+            from backend.hud import loop_sentinel as ls
+            s = ls._SENTINEL
+            return float(getattr(s, "_last_tick", 0.0)) if s is not None else 0.0
+        except Exception:  # noqa: BLE001
+            return 0.0
+
+    def _run(self) -> None:
+        # Sample considerably faster than the trigger so a stall is caught
+        # near its beginning rather than near its end — a dump taken as the
+        # loop recovers shows the recovery, not the cause.
+        while not self._stop.is_set():
+            interval = max(0.1, trigger_s() / 4.0)
+            if self._stop.wait(interval):
+                return
+            try:
+                beat = self._heartbeat()
+                if beat <= 0.0:
+                    continue          # sentinel not started; nothing to judge
+                stale_for = time.monotonic() - beat
+                if stale_for < trigger_s():
+                    continue
+                now = time.monotonic()
+                if now - self._last_dump < min_gap_s():
+                    continue          # same stall, already captured
+                if self._dumps >= max_dumps():
+                    if not self._capped_announced:
+                        self._capped_announced = True
+                        logger.warning(
+                            "[StallSampler] dump cap (%d) reached — further "
+                            "stalls will NOT be captured. Raise %s if the "
+                            "culprit has not shown up yet.",
+                            max_dumps(), ENV_MAX_DUMPS)
+                    continue
+                self._last_dump = now
+                self._dumps += 1
+                self._capture(stale_for)
+            except Exception:  # noqa: BLE001 — a witness never dies of a fault
+                logger.debug("[StallSampler] sample degraded", exc_info=True)
+
+    def _capture(self, stale_for: float) -> None:
+        """One dump, through the module that already does this correctly."""
+        logger.warning(
+            "[StallSampler] LOOP WEDGED for %.2fs RIGHT NOW — capturing "
+            "stacks (dump %d/%d). The frames below are what the loop is "
+            "stuck on, not what it ran afterwards.",
+            stale_for, self._dumps, max_dumps())
+        try:
+            from backend.core.ouroboros.battle_test.oob_diagnostics import (
+                dump_all_threads,
+            )
+            if dump_all_threads():
+                return
+        except Exception:  # noqa: BLE001
+            logger.debug("[StallSampler] oob dump unavailable", exc_info=True)
+        # Fallback: straight to stderr. Less convenient than the log file the
+        # oob module maintains, and infinitely better than nothing at the one
+        # moment the answer exists.
+        try:
+            import faulthandler
+            faulthandler.dump_traceback(all_threads=True)
+        except Exception:  # noqa: BLE001
+            pass
+
+    def stats(self) -> dict:
+        return {
+            "schema_version": STALL_SAMPLER_SCHEMA_VERSION,
+            "enabled": _enabled(),
+            "running": bool(self._thread and self._thread.is_alive()),
+            "dumps": self._dumps,
+            "max_dumps": max_dumps(),
+            "trigger_s": trigger_s(),
+        }
+
+
+_SAMPLER: Optional[StallSampler] = None
+
+
+def get_stall_sampler() -> StallSampler:
+    """Process-wide sampler. NEVER raises."""
+    global _SAMPLER
+    if _SAMPLER is None:
+        _SAMPLER = StallSampler()
+    return _SAMPLER
+
+
+def reset_stall_sampler() -> None:
+    """Testing seam."""
+    global _SAMPLER
+    if _SAMPLER is not None:
+        _SAMPLER.stop()
+    _SAMPLER = None

--- a/backend/main.py
+++ b/backend/main.py
@@ -1986,6 +1986,20 @@ async def parallel_lifespan(app: FastAPI):
         except Exception as _ls:  # noqa: BLE001 — a witness never blocks a boot
             logger.debug("[HUD] loop sentinel unavailable: %s", _ls)
 
+        # The sentinel says a stall HAPPENED. This says what was RUNNING.
+        #
+        # Started immediately after it, and deliberately here rather than
+        # later: the stalls worth catching (6.71s, 8.05s, 7.66s on
+        # 2026-08-05) all occur DURING boot, so a sampler armed after boot
+        # completes would arrive after the evidence. It runs on its own
+        # thread precisely because the loop is the thing being observed —
+        # anything scheduled on the loop cannot witness the loop being dead.
+        try:
+            from backend.hud.stall_sampler import get_stall_sampler
+            get_stall_sampler().start()
+        except Exception as _ss:  # noqa: BLE001 — a witness never blocks a boot
+            logger.debug("[HUD] stall sampler unavailable: %s", _ss)
+
         # =================================================================
         # v351.0: HUD MODE — IPC server + SSE consumer for Swift HUD
         # =================================================================

--- a/tests/core/test_boot_no_eager_engine_probe.py
+++ b/tests/core/test_boot_no_eager_engine_probe.py
@@ -1,0 +1,114 @@
+"""Boot must not probe the optimization engines on the event loop.
+
+`OptimizationRouter.discover_engines()` probes each engine by IMPORTING it —
+`import torch`, `import onnxruntime`, and for the JIT probe it builds and
+traces a small `nn.Module`. Captured by `stall_sampler` as the worst remaining
+boot blocker at 14.24s, running inside an `async def` with nothing to yield to.
+
+It never needed to be there:
+
+  * it caches (``if self._discovered: return self._engine_cache``)
+  * it is ALREADY called on demand from the router's own routing methods
+
+so the eager call bought nothing. The models were never the issue — Ghost
+Proxies already made registration instant. Only the CAPABILITY PROBE was eager.
+
+STRUCTURAL, NOT TIMED, ON PURPOSE
+-----------------------------------
+The obvious test — "assert boot is faster" — cannot be written honestly here.
+Measured on this machine, two runs of IDENTICAL code produced 120s/58.16s
+stalled and 68s/27.93s stalled: a 2x spread, because the machine is at HIGH
+memory pressure and every run competes with whatever else is resident. A
+timing assertion would pass or fail on load, not on code, and would eventually
+be "fixed" by loosening the threshold until it asserted nothing.
+
+So this asserts the STRUCTURE that makes the stall impossible: no synchronous
+`discover_engines()` on the boot path. That claim is decidable from the source
+and stays true regardless of what the machine is doing.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+INITIALIZER = REPO / "backend" / "core" / "parallel_initializer.py"
+
+
+def _init_ai_loader_node() -> ast.AsyncFunctionDef:
+    tree = ast.parse(INITIALIZER.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "_init_ai_loader":
+            return node
+    raise AssertionError("_init_ai_loader not found — has it been renamed?")
+
+
+def _calls_in(node: ast.AST) -> list:
+    """(func_name, lineno) for every call, excluding nested function bodies.
+
+    Nested functions are excluded deliberately: the fix moves the probe into a
+    coroutine that is scheduled, not awaited, so a call appearing THERE is the
+    correct outcome rather than a violation.
+    """
+    out = []
+    nested = {n for fn in ast.walk(node)
+              if isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)) and fn is not node
+              for n in ast.walk(fn)}
+    for n in ast.walk(node):
+        if n in nested or not isinstance(n, ast.Call):
+            continue
+        f = n.func
+        name = getattr(f, "attr", None) or getattr(f, "id", None)
+        if name:
+            out.append((name, n.lineno))
+    return out
+
+
+def test_boot_does_not_probe_engines_synchronously():
+    """The 14.24s blocker, asserted out of existence."""
+    calls = _calls_in(_init_ai_loader_node())
+    offenders = [(n, ln) for n, ln in calls if n == "discover_engines"]
+    assert not offenders, (
+        "_init_ai_loader calls discover_engines() directly on the boot path at "
+        f"line(s) {[ln for _, ln in offenders]}. That probe imports torch and "
+        "onnxruntime and traces an nn.Module — 14.24s on the event loop, with "
+        "nothing to yield to. It caches and is already called on demand; the "
+        "eager call buys nothing."
+    )
+
+
+def test_the_router_is_still_published_immediately():
+    """Deferring the probe must not defer the ROUTER. Callers read
+    `app.state.optimization_router`; making them wait for a torch import would
+    trade one stall for a different one."""
+    body = INITIALIZER.read_text(encoding="utf-8")
+    node = _init_ai_loader_node()
+    seg = "\n".join(body.split("\n")[node.lineno - 1:node.end_lineno])
+    assert "optimization_router" in seg, "the router is no longer published"
+    assert "ai_loader_ready" in seg, "readiness flag is no longer set"
+
+
+def test_the_deferred_probe_is_owned_by_shutdown():
+    """An import warming a process it outlives is the unmanaged-task class that
+    made shutdown unkillable. The deferred probe must go through the managed
+    factory, not a bare create_task."""
+    node = _init_ai_loader_node()
+    body = INITIALIZER.read_text(encoding="utf-8")
+    seg = "\n".join(body.split("\n")[node.lineno - 1:node.end_lineno])
+    assert "spawn_managed_task" in seg, (
+        "the deferred engine probe is not registered with a shutdown phase")
+
+
+def test_discover_engines_still_caches():
+    """The whole argument for deferring rests on this. If the probe stopped
+    caching, deferring it would move a repeated cost rather than remove one."""
+    ai_loader = REPO / "backend" / "core" / "ai_loader.py"
+    tree = ast.parse(ai_loader.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "discover_engines":
+            seg = ast.dump(node)
+            assert "_discovered" in seg and "_engine_cache" in seg, (
+                "discover_engines no longer short-circuits on a cache — the "
+                "premise for deferring it no longer holds")
+            return
+    raise AssertionError("discover_engines not found")


### PR DESCRIPTION
`stall_sampler` named `_init_ai_loader` as the worst remaining boot blocker at 14.24s. **The cause is not what the mandate assumed, and the lazy proxy already exists.**

## It does not load models

Its own docstring: registrations use Ghost Proxies *"for instant startup with background loading."* That was already true.

What blocked was the **capability probe** — `router.discover_engines()` checks each engine by **importing** it: `import torch`, `import onnxruntime`, and for the JIT probe it builds and traces an `nn.Module`. Synchronously, inside an `async def`, with nothing to yield to.

And it never needed to be on the boot path:

- it **caches** — `if self._discovered: return self._engine_cache`
- it is **already called on demand** from the router's own routing methods (`ai_loader.py:966`, `:1166`)

The eager call bought nothing. So the fix is a **deletion**: publish the router to `app.state` immediately (what callers actually need) and let the probe warm behind it.

## Sidestepping the GIL trap — with today's evidence

The warm goes through `cooperative_fs_io.offload`, **not** a process pool. These are module imports, dominated by reading and mapping shared objects, and that work **releases the GIL** — measured on this codebase today, the same treatment took the speaker model's import stall from ~14s to 3.1s.

A process pool would be actively wrong here: it would re-import torch in the child anyway, and on 16GB of unified memory a second interpreter holding a second copy is how a boot becomes a swap storm. Your OOM concern was right; the answer is not to cross that boundary at all.

Spawned via `spawn_managed_task`, so an import warming a process it might outlive is owned by a shutdown phase.

## The timing claim is not established — and neither was my last one

Two runs of **identical code**, same machine, minutes apart:

| | boot | stalled | worst |
|---|---|---|---|
| run 1 | 120s | 58.16s | 17.94s |
| run 2 | 68s | 27.93s | 8.45s |

A **2× spread**. The machine is at HIGH memory pressure; every run competes with whatever else is resident. Single-run before/after comparisons cannot establish an effect of this size.

**This applies retroactively.** The "125s → 89s" I claimed for the file-watch fix in #70393 is *also* within this variance and should not be read as measured. The structural arguments stand on their own — 239 lines of synchronous filesystem work in an `async def`, and an eager call to a self-caching lazy function, are defects whether or not a stopwatch agrees on the day — but the numbers were over-claimed and are corrected here.

Establishing magnitude honestly needs n≥5 per arm under controlled load. That is a measurement exercise, not a code change.

## Tests are structural for the same reason

"Assert boot is faster" would pass or fail on machine load rather than on code, and would eventually be repaired by loosening the threshold until it asserted nothing. These assert what is decidable from source: no synchronous `discover_engines()` on the boot path, the router still published immediately, the deferred probe owned by shutdown, and — the premise of the whole change — that `discover_engines` still caches.

4 tests. Pre-existing `test_intent_journal` failures are state-dependent (a poisoned soak ledger reading $238,111.94) and present with this change stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes eager engine capability probing from boot and moves heavy watchdog setup off the event loop to reduce startup stalls and keep the app responsive. Adds a stall sampler that captures thread stacks while the loop is wedged for actionable diagnostics.

- **New Features**
  - `stall_sampler`: thread watches `LoopSentinel` heartbeat and dumps stacks via `oob_diagnostics`/`faulthandler` when the loop is stalled; rate-limited and capped; started during boot.
  - `LoopSentinel` now publishes a `_last_tick` heartbeat for off-loop readers.

- **Refactors**
  - Stop calling `discover_engines()` during boot; publish the router to `app.state` immediately and warm the capability probe via `cooperative_fs_io.offload` in a `spawn_managed_task` (fallback to inline).
  - Offload file watcher startup (`_start_watchdog_blocking`) via `cooperative_fs_io.offload` to avoid blocking the event loop (fallback to inline).
  - Add structural tests to ensure no synchronous engine discovery on boot, the router is published immediately, the deferred probe is managed, and discovery still caches.

<sup>Written for commit 225d5e2feb2915b5ab5156a7900289451113e8c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

