### PR TITLE
fix: Eradicate the cleartext unlock credential, and measure what replaces it

### DIFF
--- a/backend/api/simple_unlock_handler.py
+++ b/backend/api/simple_unlock_handler.py
@@ -16,6 +16,7 @@ import subprocess
 from typing import Any, Dict, List, Tuple
 
 from backend.core.async_safety import LazyAsyncLock
+from backend.security.credential_eradication import eradicated_path
 
 # Import async pipeline
 from core.async_pipeline import get_async_pipeline
@@ -214,95 +215,26 @@ async def _applescript_unlock_async(context):
         context.metadata["error"] = str(e)
 
 
-def _escape_password_for_applescript(password: str) -> str:
-    """Escape special characters in password for AppleScript"""
-    escaped = password.replace("\\", "\\\\")  # Escape backslashes
-    escaped = escaped.replace('"', '\\"')  # Escape double quotes
-    return escaped
-
-
 async def _perform_direct_unlock(password: str) -> bool:
     """
-    Perform direct screen unlock using SecurePasswordTyper with voice biometric integration
+    ERADICATED. Typed the login password into the lock screen via CGEvent.
 
-    Args:
-        password: The user's Mac password from keychain
+    Removed for two independent reasons:
 
-    Returns:
-        bool: True if unlock succeeded, False otherwise
+    1. It could never work. ``SecurityAgent`` holds SecureEventInput while the
+       lock screen is up, so every synthesised keystroke was discarded. All 47
+       recorded sessions reported 13/13 characters "typed" with the screen still
+       locked.
+    2. It reported success regardless. ``type_password_securely`` returns
+       ``Tuple[bool, Optional[Dict]]``; the result was bound to a single name and
+       truth-tested, and a 2-tuple is always truthy -- so the failure branch was
+       unreachable and the ``except`` around verification returned ``True`` on
+       any error.
+
+    Raises:
+        CleartextCredentialEradicated: Always.
     """
-    caffeinate_process = None
-    try:
-        logger.info("[DIRECT UNLOCK] Starting secure unlock sequence with biometric integration")
-
-        # CRITICAL: Keep screen awake during entire unlock process
-        # This prevents screen from going black while JARVIS processes audio
-        logger.info("[DIRECT UNLOCK] Starting caffeinate to prevent screen sleep...")
-        caffeinate_process = await asyncio.create_subprocess_exec(
-            "caffeinate", "-d", "-u",  # -d = prevent display sleep, -u = wake display
-            stdout=asyncio.subprocess.DEVNULL,
-            stderr=asyncio.subprocess.DEVNULL
-        )
-
-        # Give caffeinate a moment to activate
-        await asyncio.sleep(0.3)
-
-        # Import secure password typer
-        from voice_unlock.secure_password_typer import type_password_securely
-
-        # Type password using secure, native Core Graphics method
-        # This method:
-        # - Uses CGEventCreateKeyboardEvent (native macOS API)
-        # - Never exposes password in logs or process list
-        # - Implements adaptive timing based on system load
-        # - Has AppleScript fallback if Core Graphics fails
-        # - Automatically wakes screen and submits password
-        logger.info(f"[DIRECT UNLOCK] Using SecurePasswordTyper ({len(password)} characters)")
-
-        success = await type_password_securely(
-            password=password,
-            submit=True,  # Automatically press Return
-            randomize_timing=True  # Human-like typing with adaptive timing
-        )
-
-        if success:
-            # Wait for unlock to complete
-            await asyncio.sleep(1.5)
-
-            # Verify unlock by checking screen state
-            try:
-                from voice_unlock.objc.server.screen_lock_detector import is_screen_locked
-
-                is_locked = is_screen_locked()
-
-                if not is_locked:
-                    logger.info("[DIRECT UNLOCK] ✅ Unlock verified successful with biometric authentication")
-                    return True
-                else:
-                    logger.warning("[DIRECT UNLOCK] ⚠️ Screen still locked after attempt")
-                    return False
-            except Exception as verify_error:
-                # If we can't verify, assume success since typing succeeded
-                logger.info(f"[DIRECT UNLOCK] ✅ Unlock completed (verification unavailable: {verify_error})")
-                return True
-        else:
-            logger.error("[DIRECT UNLOCK] ❌ SecurePasswordTyper failed")
-            return False
-
-    except Exception as e:
-        logger.error(f"[DIRECT UNLOCK] ❌ Error during unlock: {e}", exc_info=True)
-        return False
-    finally:
-        # Always terminate caffeinate process to restore normal power management
-        if caffeinate_process:
-            try:
-                caffeinate_process.terminate()
-                await asyncio.sleep(0.1)  # Give it a moment to terminate gracefully
-                if caffeinate_process.returncode is None:
-                    caffeinate_process.kill()  # Force kill if still running
-                logger.info("[DIRECT UNLOCK] Caffeinate process terminated")
-            except Exception as cleanup_error:
-                logger.warning(f"[DIRECT UNLOCK] Failed to cleanup caffeinate: {cleanup_error}")
+    eradicated_path("simple_unlock_handler._perform_direct_unlock")
 
 
 async def handle_unlock_command(command: str, jarvis_instance=None) -> Dict[str, Any]:
@@ -1199,30 +1131,15 @@ async def _try_keychain_unlock(context: Dict[str, Any]) -> Tuple[bool, str]:
                 )
 
     except ImportError:
+        # The former fallback shelled out to `security find-generic-password`
+        # and fed the cleartext login password to _perform_direct_unlock.
+        # Both are eradicated; there is no second way in.
         logger.error("MacOS Keychain integration not available")
-        # Fallback to old method
-        result = subprocess.run(
-            [
-                "security",
-                "find-generic-password",
-                "-s",
-                "com.jarvis.voiceunlock",
-                "-a",
-                "unlock_token",
-                "-w",
-            ],
-            capture_output=True,
-            text=True,
+        return (
+            False,
+            "Screen unlock is unavailable: the keystroke-based unlock path has been "
+            "removed. Install the JARVIS Authorization Plugin to unlock without a password.",
         )
-
-        if result.returncode == 0:
-            password = result.stdout.strip()
-            unlock_result = await _perform_direct_unlock(password)
-
-            if unlock_result:
-                return True, f"Screen unlocked by {verified_speaker or 'verified user'}"
-
-        return False, "Password not found in keychain"
 
 
 async def _try_manual_unlock_fallback(context: Dict[str, Any]) -> Tuple[bool, str]:

--- a/backend/macos_keychain_unlock.py
+++ b/backend/macos_keychain_unlock.py
@@ -25,6 +25,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from enum import Enum
 
 from backend.core.async_safety import LazyAsyncLock
+from backend.security.credential_eradication import eradicated_path
 
 logger = logging.getLogger(__name__)
 
@@ -36,13 +37,10 @@ logger = logging.getLogger(__name__)
 class KeychainServiceConfig:
     """Dynamic keychain service configuration"""
 
-    # Service configurations in priority order (highest priority first)
-    # These are discovered dynamically, not hardcoded
-    SERVICES: List[Tuple[str, str, int]] = [
-        ("com.jarvis.voiceunlock", "unlock_token", 0),      # Primary
-        ("jarvis_voice_unlock", "jarvis", 1),               # Alternative
-        ("JARVIS_Screen_Unlock", "jarvis_user", 2),         # Legacy
-    ]
+    # Emptied by the credential eradication sweep. Retained as a named, typed
+    # structure so lookup helpers keep working (and find nothing) rather than
+    # raising AttributeError on a shape that used to exist.
+    SERVICES: List[Tuple[str, str, int]] = []
 
     # Cache configuration
     DEFAULT_CACHE_TTL_SECONDS = 3600.0  # 1 hour
@@ -213,8 +211,10 @@ class MacOSKeychainUnlock:
         self.enable_cache = enable_cache
 
         # Primary service info (for backwards compatibility)
-        self.service_name = "com.jarvis.voiceunlock"
-        self.account_name = "unlock_token"
+        # Credential coordinates deliberately absent: there is no stored login
+        # credential, and naming one here would be a resurrection foothold.
+        self.service_name = ""
+        self.account_name = ""
         self.keychain_item_name = "JARVIS Voice Unlock"
 
         # Cache state
@@ -239,108 +239,40 @@ class MacOSKeychainUnlock:
 
     async def get_password_from_keychain(self, force_refresh: bool = False) -> Optional[str]:
         """
-        Retrieve password from keychain with intelligent caching.
+        ERADICATED. Cleartext login-credential retrieval no longer exists.
 
-        This method:
-        1. Checks cache first (if enabled)
-        2. Falls back to async keychain query if cache miss/expired
-        3. Uses parallel lookup across multiple service names
-        4. Records metrics for monitoring
+        This was the chokepoint every unlock path funnelled through. It fetched
+        the macOS login password in cleartext so it could be typed into the lock
+        screen -- a premise that cannot work, because ``SecurityAgent`` holds
+        SecureEventInput and drops every synthesised keystroke (47/47 recorded
+        sessions typed 13/13 characters into a void with the screen still
+        locked).
 
-        Args:
-            force_refresh: Bypass cache and fetch fresh from keychain
+        The signature is retained so that callers fail loudly at the seam rather
+        than silently taking a different dead-end branch.
 
-        Returns:
-            Password string or None if not found
+        Raises:
+            CleartextCredentialEradicated: Always.
         """
-        start_time = time.time()
-
-        # Check circuit breaker
-        if self._is_circuit_open():
-            logger.warning("Keychain circuit breaker is OPEN - skipping lookup")
-            return None
-
-        # Check cache first (unless force refresh or cache disabled)
-        if self.enable_cache and not force_refresh:
-            async with self._cache_lock:
-                if self._cache and not self._cache.is_expired:
-                    self._cache.touch()
-                    duration_ms = (time.time() - start_time) * 1000
-                    self._metrics.record_lookup(duration_ms, cache_hit=True)
-                    logger.debug(f"Password cache HIT (access #{self._cache.access_count})")
-                    return self._cache.password
-
-        # Cache miss or expired - fetch from keychain
-        logger.debug("Password cache MISS - fetching from keychain...")
-
-        password, service_name = await self._fetch_password_async()
-        duration_ms = (time.time() - start_time) * 1000
-
-        if password:
-            # Update cache
-            if self.enable_cache:
-                async with self._cache_lock:
-                    self._cache = CachedPassword(
-                        password=password,
-                        password_hash=hashlib.sha256(password.encode()).hexdigest(),
-                        service_name=service_name,
-                        account_name=self._get_account_for_service(service_name),
-                        cached_at=time.time(),
-                        ttl_seconds=self.cache_ttl_seconds,
-                    )
-
-            # Update metrics and circuit breaker
-            self._reset_circuit_breaker()
-            self._metrics.last_success_service = service_name
-            self._metrics.last_success_time = time.time()
-            self._metrics.record_lookup(duration_ms, cache_hit=False, parallel=self.enable_parallel_lookup)
-
-            logger.info(f"Password retrieved from keychain ({service_name}) in {duration_ms:.1f}ms")
-            return password
-        else:
-            self._record_failure()
-            self._metrics.failures += 1
-            logger.error(f"Failed to retrieve password from keychain after {duration_ms:.1f}ms")
-            return None
+        eradicated_path("MacOSKeychainUnlock.get_password_from_keychain")
 
     async def get_password_hash(self, force_refresh: bool = False) -> Optional[str]:
         """
-        Get SHA-256 hash of password (for verification without exposing password).
+        ERADICATED. Hashing the credential still required retrieving it.
 
-        Args:
-            force_refresh: Bypass cache
-
-        Returns:
-            SHA-256 hash string or None
+        Raises:
+            CleartextCredentialEradicated: Always.
         """
-        # Check cache for hash
-        if self.enable_cache and not force_refresh:
-            async with self._cache_lock:
-                if self._cache and not self._cache.is_expired:
-                    self._cache.touch()
-                    return self._cache.password_hash
-
-        # Fetch password and compute hash
-        password = await self.get_password_from_keychain(force_refresh=force_refresh)
-        if password:
-            return hashlib.sha256(password.encode()).hexdigest()
-        return None
+        eradicated_path("MacOSKeychainUnlock.get_password_hash")
 
     async def preload_cache(self) -> bool:
         """
-        Preload password into cache (call during service initialization).
+        ERADICATED. There is no credential to preload.
 
-        Returns:
-            True if password was successfully loaded into cache
+        Raises:
+            CleartextCredentialEradicated: Always.
         """
-        logger.info("Preloading keychain password into cache...")
-        password = await self.get_password_from_keychain()
-        success = password is not None
-        if success:
-            logger.info("Keychain cache preloaded successfully")
-        else:
-            logger.warning("Keychain cache preload failed - first unlock will be slower")
-        return success
+        eradicated_path("MacOSKeychainUnlock.preload_cache")
 
     async def invalidate_cache(self) -> None:
         """Invalidate the cached password"""
@@ -354,194 +286,50 @@ class MacOSKeychainUnlock:
 
     async def _fetch_password_async(self) -> Tuple[Optional[str], Optional[str]]:
         """
-        Fetch password using async subprocess (non-blocking).
+        ERADICATED. The keychain fetch machinery has been removed.
 
-        Returns:
-            Tuple of (password, service_name) or (None, None)
+        Previously fanned out ``security find-generic-password`` across the
+        service list in :class:`KeychainServiceConfig`, in parallel or
+        sequentially, and returned the login password in cleartext.
+
+        Raises:
+            CleartextCredentialEradicated: Always.
         """
-        if self.enable_parallel_lookup:
-            return await self._fetch_password_parallel()
-        else:
-            return await self._fetch_password_sequential()
-
-    async def _fetch_password_parallel(self) -> Tuple[Optional[str], Optional[str]]:
-        """
-        Query all keychain services in parallel - first success wins.
-        """
-        async def try_service(service_name: str, account_name: str, priority: int):
-            """Try to get password from a single service"""
-            password = await self._query_keychain_async(service_name, account_name)
-            return (password, service_name, priority) if password else (None, service_name, priority)
-
-        # Create tasks for all services
-        tasks = [
-            asyncio.create_task(try_service(svc, acct, pri))
-            for svc, acct, pri in KeychainServiceConfig.SERVICES
-        ]
-
-        try:
-            # Wait for all with timeout
-            results = await asyncio.wait_for(
-                asyncio.gather(*tasks, return_exceptions=True),
-                timeout=KeychainServiceConfig.PARALLEL_LOOKUP_TIMEOUT_SECONDS
-            )
-
-            # Find successful results and sort by priority
-            successful = []
-            for result in results:
-                if isinstance(result, Exception):
-                    continue
-                password, service_name, priority = result
-                if password:
-                    successful.append((password, service_name, priority))
-
-            if successful:
-                # Return highest priority (lowest number)
-                successful.sort(key=lambda x: x[2])
-                password, service_name, _ = successful[0]
-                return (password, service_name)
-
-            return (None, None)
-
-        except asyncio.TimeoutError:
-            logger.error(f"Parallel keychain lookup timed out")
-            self._metrics.timeouts += 1
-            # Cancel remaining tasks
-            for task in tasks:
-                if not task.done():
-                    task.cancel()
-            await asyncio.gather(*tasks, return_exceptions=True)
-            return (None, None)
-        except asyncio.CancelledError:
-            # Handle external cancellation
-            for task in tasks:
-                if not task.done():
-                    task.cancel()
-            await asyncio.gather(*tasks, return_exceptions=True)
-            raise
-
-    async def _fetch_password_sequential(self) -> Tuple[Optional[str], Optional[str]]:
-        """
-        Query keychain services sequentially (fallback mode).
-        """
-        for service_name, account_name, _ in KeychainServiceConfig.SERVICES:
-            try:
-                password = await asyncio.wait_for(
-                    self._query_keychain_async(service_name, account_name),
-                    timeout=KeychainServiceConfig.QUERY_TIMEOUT_SECONDS
-                )
-                if password:
-                    return (password, service_name)
-            except asyncio.TimeoutError:
-                logger.warning(f"Keychain query timed out for {service_name}")
-                self._metrics.timeouts += 1
-                continue
-            except asyncio.CancelledError:
-                raise
-            except Exception as e:
-                logger.warning(f"Keychain query failed for {service_name}: {e}")
-                continue
-
-        return (None, None)
+        eradicated_path("MacOSKeychainUnlock._fetch_password_async")
 
     async def _query_keychain_async(self, service_name: str, account_name: str) -> Optional[str]:
         """
-        Query keychain using async subprocess (non-blocking).
+        ERADICATED. No code path may shell out to retrieve a login credential.
+
+        Raises:
+            CleartextCredentialEradicated: Always.
         """
-        for attempt in range(KeychainServiceConfig.MAX_RETRIES + 1):
-            try:
-                process = await asyncio.create_subprocess_exec(
-                    "security",
-                    "find-generic-password",
-                    "-s", service_name,
-                    "-a", account_name,
-                    "-w",
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.PIPE,
-                )
+        eradicated_path(
+            f"MacOSKeychainUnlock._query_keychain_async({service_name}/{account_name})"
+        )
 
-                stdout, stderr = await asyncio.wait_for(
-                    process.communicate(),
-                    timeout=KeychainServiceConfig.QUERY_TIMEOUT_SECONDS
-                )
-
-                if process.returncode == 0:
-                    password = stdout.decode().strip()
-                    if password:
-                        logger.debug(f"Found password in keychain (service: {service_name})")
-                        return password
-                elif process.returncode != 44:  # 44 = item not found (not an error)
-                    logger.debug(f"Keychain query returned code {process.returncode}")
-
-            except asyncio.TimeoutError:
-                # v253.1: Kill zombie subprocess on timeout
-                try:
-                    process.kill()
-                    await process.wait()
-                except Exception:
-                    pass
-                logger.warning(f"Keychain query timeout for {service_name} (attempt {attempt + 1})")
-                if attempt < KeychainServiceConfig.MAX_RETRIES:
-                    await asyncio.sleep(
-                        KeychainServiceConfig.RETRY_BACKOFF_BASE_SECONDS * (attempt + 1)
-                    )
-                continue
-            except asyncio.CancelledError:
-                raise
-            except Exception as e:
-                logger.error(f"Keychain query error for {service_name}: {e}")
-                if attempt < KeychainServiceConfig.MAX_RETRIES:
-                    await asyncio.sleep(
-                        KeychainServiceConfig.RETRY_BACKOFF_BASE_SECONDS * (attempt + 1)
-                    )
-                continue
-
-        return None
 
     # =========================================================================
     # STORE PASSWORD
     # =========================================================================
 
     async def store_password_in_keychain(self, password: str) -> bool:
-        """Store password securely in macOS Keychain (one-time setup)"""
-        try:
-            cmd = [
-                "security",
-                "add-generic-password",
-                "-a", self.account_name,
-                "-s", self.service_name,
-                "-w", password,
-                "-T", "/usr/bin/security",
-                "-U",  # Update if exists
-                "-l", self.keychain_item_name,
-            ]
+        """
+        ERADICATED. Wrote the login password into the login keychain.
 
-            process = await asyncio.create_subprocess_exec(
-                *cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
-            )
-            # v253.1: Timeout to prevent infinite stall (was missing unlike query path)
-            try:
-                stdout, stderr = await asyncio.wait_for(
-                    process.communicate(), timeout=10.0,
-                )
-            except asyncio.TimeoutError:
-                process.kill()
-                await process.wait()
-                logger.error("Keychain store timed out after 10s")
-                return False
+        Two distinct defects, both fatal:
 
-            if process.returncode == 0:
-                logger.info(f"Password stored in Keychain as '{self.keychain_item_name}'")
-                # Invalidate cache so next get picks up new password
-                await self.invalidate_cache()
-                return True
-            else:
-                logger.error(f"Failed to store password: {stderr.decode()}")
-                return False
+        * The password was passed as ``-w <password>`` on the argv of a
+          subprocess, so it was visible to any process able to read the process
+          table while the command ran.
+        * ``-T /usr/bin/security`` added the ``security`` binary to the item's
+          ACL, which is why the credential could later be read back in cleartext
+          with no authorisation prompt.
 
-        except Exception as e:
-            logger.error(f"Keychain storage error: {e}")
-            return False
+        Raises:
+            CleartextCredentialEradicated: Always.
+        """
+        eradicated_path("MacOSKeychainUnlock.store_password_in_keychain")
 
     # =========================================================================
     # SCREEN LOCK DETECTION
@@ -588,146 +376,36 @@ class MacOSKeychainUnlock:
 
     async def unlock_screen(self, verified_speaker: Optional[str] = None) -> Dict[str, Any]:
         """
-        Perform screen unlock using cached keychain password.
+        Refuse the keystroke-synthesis unlock; name the mechanism that replaces it.
 
-        Uses intelligent caching for near-instant password retrieval on
-        subsequent unlocks.
+        This returns a structured refusal rather than raising, because it sits on
+        the voice-command response path: the operator needs a spoken explanation,
+        not a traceback. The credential paths beneath it raise; this seam reports.
+
+        Args:
+            verified_speaker: Speaker whose identity was verified upstream.
+
+        Returns:
+            A result dict with ``success=False`` and ``action="eradicated"``.
         """
-        # Check if screen is locked
-        is_locked = await self.check_screen_locked()
-
-        if not is_locked:
-            return {
-                "success": True,
-                "message": f"Screen already unlocked{f' for {verified_speaker}' if verified_speaker else ''}",
-                "action": "none_needed",
-            }
-
-        logger.info(
-            f"Screen locked, attempting unlock{f' for {verified_speaker}' if verified_speaker else ''}..."
+        logger.error(
+            "unlock_screen called on the eradicated keystroke path "
+            "(speaker=%s); SecureEventInput makes this mechanism impossible",
+            verified_speaker or "unverified",
         )
+        return {
+            "success": False,
+            "message": (
+                "Screen unlock by simulated typing is not possible on this version of "
+                "macOS: the lock screen holds SecureEventInput, so synthesised "
+                "keystrokes are discarded. Install the JARVIS Authorization Plugin to "
+                "unlock without a password."
+            ),
+            "action": "eradicated",
+            "replacement": "backend/voice_unlock/authplugin",
+            "verified_speaker": verified_speaker,
+        }
 
-        # Get password (uses cache if available)
-        password = await self.get_password_from_keychain()
-
-        if not password:
-            return {
-                "success": False,
-                "message": "Password not found in Keychain. Run setup first.",
-                "action": "setup_required",
-                "metrics": self._metrics.to_dict(),
-            }
-
-        try:
-            # Use advanced secure password typer
-            from voice_unlock.secure_password_typer import (
-                get_secure_typer,
-                TypingConfig
-            )
-
-            logger.info("Using secure password typer (Core Graphics)")
-            typer = get_secure_typer()
-
-            config = TypingConfig(
-                wake_screen=True,
-                submit_after_typing=True,
-                randomize_timing=True,
-                adaptive_timing=True,
-                detect_system_load=True,
-                clear_memory_after=True,
-                enable_applescript_fallback=True,
-                max_retries=3
-            )
-
-            success, metrics = await typer.type_password_secure(
-                password=password,
-                submit=True,
-                config_override=config
-            )
-
-            logger.info(
-                f"[METRICS] Typing: {metrics.typing_time_ms:.0f}ms, "
-                f"Wake: {metrics.wake_time_ms:.0f}ms, "
-                f"Submit: {metrics.submit_time_ms:.0f}ms, "
-                f"Total: {metrics.total_duration_ms:.0f}ms"
-            )
-
-            if not success:
-                logger.warning(f"Secure typer failed: {metrics.error_message}")
-                # Fallback to AppleScript
-                await self._applescript_fallback(password)
-
-            # Wait for unlock
-            await asyncio.sleep(1.5)
-
-            # Verify unlock
-            still_locked = await self.check_screen_locked()
-
-            if not still_locked:
-                logger.info(
-                    f"Screen unlocked successfully{f' for {verified_speaker}' if verified_speaker else ''}"
-                )
-                return {
-                    "success": True,
-                    "message": f"Screen unlocked{f' for {verified_speaker}' if verified_speaker else ''}",
-                    "action": "unlocked",
-                    "verified_speaker": verified_speaker,
-                    "keychain_metrics": self._metrics.to_dict(),
-                }
-            else:
-                logger.warning("Screen still locked after unlock attempt")
-                return {
-                    "success": False,
-                    "message": "Unlock failed - check password",
-                    "action": "failed",
-                    "keychain_metrics": self._metrics.to_dict(),
-                }
-
-        except Exception as e:
-            logger.error(f"Unlock error: {e}")
-            return {
-                "success": False,
-                "message": f"Unlock error: {str(e)}",
-                "action": "error",
-                "keychain_metrics": self._metrics.to_dict(),
-            }
-
-    async def _applescript_fallback(self, password: str) -> None:
-        """AppleScript fallback for password typing"""
-        # Wake display via caffeinate -u (does NOT inject key events).
-        # Using key code 49 (space) would type a space into the password
-        # field if the lock screen is already visible, corrupting the password.
-        try:
-            proc = await asyncio.create_subprocess_exec(
-                "caffeinate", "-u", "-t", "1",
-                stdout=asyncio.subprocess.DEVNULL,
-                stderr=asyncio.subprocess.DEVNULL,
-            )
-            await asyncio.wait_for(proc.wait(), timeout=3.0)
-        except Exception:
-            pass
-        await asyncio.sleep(0.5)
-
-        type_script = """
-        tell application "System Events"
-            keystroke (system attribute "JARVIS_UNLOCK_PASS")
-            delay 0.1
-            key code 36
-        end tell
-        """
-        env = os.environ.copy()
-        env["JARVIS_UNLOCK_PASS"] = password
-
-        await asyncio.create_subprocess_exec(
-            "osascript", "-e", type_script,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            env=env
-        )
-
-    # =========================================================================
-    # CIRCUIT BREAKER
-    # =========================================================================
 
     def _is_circuit_open(self) -> bool:
         """Check if circuit breaker is open"""
@@ -806,44 +484,17 @@ class MacOSKeychainUnlock:
     # =========================================================================
 
     async def setup_keychain_password(self):
-        """Interactive setup to store password in Keychain"""
-        import getpass
+        """
+        ERADICATED. Prompted for the login password and stored it.
 
-        print("\n" + "=" * 60)
-        print("JARVIS SCREEN UNLOCK SETUP")
-        print("=" * 60)
-        print("\nThis will securely store your login password in macOS Keychain")
-        print("so JARVIS can unlock your screen when you're verified by voice.\n")
+        This was the other half of the vulnerability: eradicating retrieval while
+        leaving the storer intact would let any setup script re-plant the
+        credential.
 
-        username = input(f"macOS username [{self.account_name}]: ").strip() or self.account_name
-        self.account_name = username
-
-        password = getpass.getpass("Enter your macOS login password: ")
-
-        if password:
-            success = await self.store_password_in_keychain(password)
-
-            if success:
-                print("\nSuccess! Password stored in Keychain")
-                print(f"  - Service: {self.service_name}")
-                print(f"  - Account: {self.account_name}")
-                print("  - JARVIS can now unlock your screen\n")
-
-                # Test retrieval
-                test_pwd = await self.get_password_from_keychain()
-                if test_pwd:
-                    print("Verified: Password retrieval working")
-                    print(f"Metrics: {self.get_metrics()}")
-                else:
-                    print("Warning: Could not verify password retrieval")
-
-                return True
-            else:
-                print("\nFailed to store password in Keychain")
-                return False
-        else:
-            print("\nNo password entered")
-            return False
+        Raises:
+            CleartextCredentialEradicated: Always.
+        """
+        eradicated_path("MacOSKeychainUnlock.setup_keychain_password")
 
 
 # =============================================================================
@@ -870,21 +521,33 @@ async def get_keychain_unlock_service() -> MacOSKeychainUnlock:
 
 
 async def get_password_async() -> Optional[str]:
-    """Convenience function to get password from keychain"""
-    service = await get_keychain_unlock_service()
-    return await service.get_password_from_keychain()
+    """
+    ERADICATED. Module-level shortcut to the removed credential fetch.
+
+    Raises:
+        CleartextCredentialEradicated: Always.
+    """
+    eradicated_path("macos_keychain_unlock.get_password_async")
 
 
 async def get_password_hash_async() -> Optional[str]:
-    """Convenience function to get password hash"""
-    service = await get_keychain_unlock_service()
-    return await service.get_password_hash()
+    """
+    ERADICATED. Hashing still required retrieving the credential.
+
+    Raises:
+        CleartextCredentialEradicated: Always.
+    """
+    eradicated_path("macos_keychain_unlock.get_password_hash_async")
 
 
 async def preload_keychain_cache() -> bool:
-    """Preload keychain cache during startup"""
-    service = await get_keychain_unlock_service()
-    return await service.preload_cache()
+    """
+    ERADICATED. Nothing to preload; boot must not warm a credential cache.
+
+    Raises:
+        CleartextCredentialEradicated: Always.
+    """
+    eradicated_path("macos_keychain_unlock.preload_keychain_cache")
 
 
 # =============================================================================
@@ -892,33 +555,20 @@ async def preload_keychain_cache() -> bool:
 # =============================================================================
 
 async def main():
-    """Set up or test Keychain unlock"""
+    """Report that the keychain setup/test CLI has been eradicated."""
     logging.basicConfig(level=logging.INFO)
 
-    unlock_service = MacOSKeychainUnlock()
-
-    # Check if password is already stored
-    password = await unlock_service.get_password_from_keychain()
-
-    if not password:
-        print("\nNo password found in Keychain")
-        setup = input("Would you like to set it up now? (y/n): ").lower()
-
-        if setup == "y":
-            await unlock_service.setup_keychain_password()
-        else:
-            print("Setup cancelled")
-            return
-
-    # Show metrics
-    print("\nKeychain Metrics:")
-    for key, value in unlock_service.get_metrics().items():
-        print(f"  {key}: {value}")
-
-    # Test unlock
-    print("\nTesting screen unlock...")
-    result = await unlock_service.unlock_screen(verified_speaker="Derek")
-    print(f"Result: {result}")
+    print("\n" + "=" * 68)
+    print("JARVIS SCREEN UNLOCK -- KEYCHAIN PATH ERADICATED")
+    print("=" * 68)
+    print(
+        "\nStoring the macOS login password so JARVIS could type it at the lock\n"
+        "screen has been removed. It could never work: SecurityAgent holds\n"
+        "SecureEventInput, so every synthesised keystroke was discarded.\n\n"
+        "The replacement is the JARVIS Authorization Plugin, which satisfies the\n"
+        "system.login.screensaver right directly and needs no password at all:\n\n"
+        "    backend/voice_unlock/authplugin/\n"
+    )
 
 
 if __name__ == "__main__":

--- a/backend/main.py
+++ b/backend/main.py
@@ -775,6 +775,34 @@ try:
 except ImportError:
     pass
 
+# =============================================================================
+# CREDENTIAL SANITISATION — must run immediately after dotenv, before any
+# subsystem reads the environment.
+# =============================================================================
+# A stale `.env` is the one way an eradicated credential can re-enter the
+# process after the keychain item is gone, so the sweep is anchored to the load
+# rather than to a later lifecycle hook. Idempotent; safe if nothing is present.
+#
+# Failure is logged at CRITICAL rather than raised: the credential path is
+# already structurally removed, so an unavailable sanitiser is a visibility
+# problem, not an exposure. Killing boot here would be a worse failure mode.
+try:
+    from backend.security.credential_eradication import sanitize_process_environment
+
+    _sanitized_keys = sanitize_process_environment()
+    if _sanitized_keys:
+        print(
+            f"[SECURITY] Removed {len(_sanitized_keys)} legacy unlock credential "
+            f"key(s) from the environment: {', '.join(sorted(_sanitized_keys))}",
+            flush=True,
+        )
+except Exception as _sanitize_error:  # pragma: no cover - defensive
+    print(
+        f"[SECURITY][CRITICAL] Credential environment sanitisation did not run: "
+        f"{_sanitize_error}",
+        flush=True,
+    )
+
 # Global component storage
 components = {}
 import_times = {}

--- a/backend/security/__init__.py
+++ b/backend/security/__init__.py
@@ -1,0 +1,3 @@
+"""Security primitives that must not depend on any subsystem package."""
+
+from __future__ import annotations

--- a/backend/security/credential_eradication.py
+++ b/backend/security/credential_eradication.py
@@ -1,0 +1,317 @@
+"""
+Cleartext credential eradication -- the single canonical seam.
+
+WHY THIS MODULE EXISTS
+----------------------
+Voice unlock was built on a premise that cannot work on this platform: retrieve
+the macOS login password in cleartext, then synthesise keystrokes into the lock
+screen. Measured evidence (47/47 sessions in ``~/.jarvis/logs/unlock_metrics``,
+every one reporting 13/13 characters typed with ``screen_locked=1`` before and
+after) shows the keystrokes are posted into a ``SecureEventInput`` void. No
+process in the Aqua session can reach the ``SecurityAgent`` password field, so
+no amount of repair to the typing path can succeed.
+
+That makes the stored credential pure liability: it bought nothing and it sat in
+the login keychain without an ACL, readable in cleartext by any process running
+as the user. The replacement is an Authorization Plugin that participates in the
+``system.login.screensaver`` right directly, so no password is ever retrieved,
+held, typed, or stored.
+
+This module is the ONE place that policy is written down. Every former retrieval
+site imports from here and raises, so the vulnerability cannot be reintroduced by
+editing a single call site -- a would-be resurrector has to delete this module,
+which the regression suite forbids.
+
+ON "ZEROING" MEMORY -- AN HONEST NOTE
+-------------------------------------
+CPython ``str`` is immutable and interned; there is no supported way to overwrite
+one in place. Any claim to "zero the password out of memory" for a ``str`` is
+theatre. What this module actually does is drop every *reference* so the object
+becomes unreachable, and zero the buffers it genuinely can (``bytearray`` and
+other writable buffers). The real guarantee is structural rather than hygienic:
+after the sweep there is no code path that puts a login credential in memory at
+all.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from dataclasses import dataclass, field
+from typing import Iterable, Mapping, MutableMapping, NoReturn, Optional, TypeVar
+
+#: Value type of a mapping being sanitised. ``MutableMapping`` is invariant in
+#: its value type, so a plain ``MutableMapping[str, object]`` parameter would
+#: reject ``os.environ`` (a ``MutableMapping[str, str]``). The TypeVar keeps the
+#: helper usable for both the environment and arbitrary config singletons.
+_V = TypeVar("_V")
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "SecurityError",
+    "CleartextCredentialEradicated",
+    "EradicatedCredential",
+    "ERADICATION_NOTICE",
+    "eradicated_credentials",
+    "eradicated_env_keys",
+    "eradicated_path",
+    "sanitize_process_environment",
+    "sanitize_mapping",
+    "zero_buffer",
+]
+
+
+# =============================================================================
+# EXCEPTIONS
+# =============================================================================
+
+
+class SecurityError(Exception):
+    """Base class for zero-trust policy violations raised by this package."""
+
+
+class CleartextCredentialEradicated(SecurityError):
+    """
+    Raised when code attempts a cleartext credential path that has been removed.
+
+    This is deliberately a hard failure rather than a ``None`` return. A soft
+    return would let callers fall through to the next fallback in a cascade and
+    rediscover the same dead end; the raise stops the cascade at the seam and
+    names the replacement.
+    """
+
+    def __init__(self, subject: str, replacement: Optional[str] = None) -> None:
+        message = f"{ERADICATION_NOTICE} (blocked path: {subject})"
+        if replacement:
+            message = f"{message} Use {replacement} instead."
+        super().__init__(message)
+        self.subject = subject
+        self.replacement = replacement
+
+
+ERADICATION_NOTICE = (
+    "Cleartext password retrieval permanently eradicated for zero-trust compliance."
+)
+
+#: Named replacement for every eradicated path, so the error is actionable
+#: rather than merely prohibitive.
+DEFAULT_REPLACEMENT = (
+    "the JARVIS Authorization Plugin grant flow "
+    "(backend/voice_unlock/authplugin, backend/voice_unlock/grant_bridge.py)"
+)
+
+
+# =============================================================================
+# CREDENTIAL REGISTRY
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class EradicatedCredential:
+    """
+    A credential whose cleartext retrieval path has been removed.
+
+    ``service``/``account`` are the keychain coordinates. They live here rather
+    than being spelled out at each call site so the guard, the deletion tooling,
+    and the regression tests all read the same source of truth -- there is no
+    second copy to drift.
+    """
+
+    service: str
+    account: str
+    env_keys: frozenset[str] = field(default_factory=frozenset)
+    reason: str = ""
+
+    @property
+    def coordinates(self) -> tuple[str, str]:
+        return (self.service, self.account)
+
+
+#: The macOS login password formerly used by the keystroke-synthesis unlock path.
+_LOGIN_UNLOCK_CREDENTIAL = EradicatedCredential(
+    service="com.jarvis.voiceunlock",
+    account="unlock_token",
+    env_keys=frozenset({"JARVIS_UNLOCK_PASS", "JARVIS_UNLOCK_PASSWORD"}),
+    reason=(
+        "macOS SecureEventInput makes lock-screen keystroke synthesis impossible; "
+        "the Authorization Plugin grants the right without a password"
+    ),
+)
+
+_BUILTIN_CREDENTIALS: tuple[EradicatedCredential, ...] = (_LOGIN_UNLOCK_CREDENTIAL,)
+
+#: Extension point. Comma-separated ``service:account`` pairs; extends the
+#: builtin registry rather than replacing it, so an operator can widen the sweep
+#: without being able to silently narrow it.
+ENV_EXTRA_CREDENTIALS = "JARVIS_ERADICATED_CREDENTIALS"
+
+#: Extension point for additional environment keys to sweep. Additive, same
+#: rationale as above.
+ENV_EXTRA_ENV_KEYS = "JARVIS_ERADICATED_ENV_KEYS"
+
+#: Environment keys matching this shape are swept even if not enumerated. Scoped
+#: deliberately to unlock/login credentials -- a broad "anything secret-looking"
+#: pattern would strip provider API keys and break the running system.
+_ENV_KEY_PATTERN = re.compile(
+    r"^JARVIS_(?:[A-Z0-9_]*_)?(?:UNLOCK|LOGIN)_(?:PASS|PASSWORD|SECRET|TOKEN)$"
+)
+
+
+def _parse_extra_credentials(raw: Optional[str]) -> tuple[EradicatedCredential, ...]:
+    """Parse ``service:account[,service:account...]`` into descriptors."""
+    if not raw:
+        return ()
+    parsed: list[EradicatedCredential] = []
+    for chunk in raw.split(","):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        service, sep, account = chunk.partition(":")
+        if not sep or not service.strip() or not account.strip():
+            logger.warning(
+                "Ignoring malformed %s entry %r (expected 'service:account')",
+                ENV_EXTRA_CREDENTIALS,
+                chunk,
+            )
+            continue
+        parsed.append(
+            EradicatedCredential(
+                service=service.strip(),
+                account=account.strip(),
+                reason=f"declared via {ENV_EXTRA_CREDENTIALS}",
+            )
+        )
+    return tuple(parsed)
+
+
+def eradicated_credentials(
+    env: Optional[Mapping[str, str]] = None,
+) -> tuple[EradicatedCredential, ...]:
+    """Return the builtin registry plus any operator-declared additions."""
+    source = os.environ if env is None else env
+    return _BUILTIN_CREDENTIALS + _parse_extra_credentials(source.get(ENV_EXTRA_CREDENTIALS))
+
+
+def eradicated_env_keys(env: Optional[Mapping[str, str]] = None) -> frozenset[str]:
+    """
+    Every environment key known to have carried a cleartext login credential.
+
+    Combines the registry's declared keys, operator-declared additions, and any
+    key in ``env`` matching the narrowly-scoped credential shape.
+    """
+    source = os.environ if env is None else env
+
+    keys: set[str] = set()
+    for credential in eradicated_credentials(source):
+        keys.update(credential.env_keys)
+
+    extra = source.get(ENV_EXTRA_ENV_KEYS, "")
+    keys.update(part.strip() for part in extra.split(",") if part.strip())
+
+    keys.update(key for key in source if _ENV_KEY_PATTERN.match(key))
+
+    return frozenset(keys)
+
+
+# =============================================================================
+# THE GUARD
+# =============================================================================
+
+
+def eradicated_path(subject: str, replacement: Optional[str] = DEFAULT_REPLACEMENT) -> NoReturn:
+    """
+    Refuse an eradicated cleartext-credential path.
+
+    Args:
+        subject: Fully-qualified name of the blocked path, e.g.
+            ``"MacOSKeychainUnlock.get_password_from_keychain"``. Appears in the
+            message so the failure names itself without a traceback read.
+        replacement: What the caller should use instead.
+
+    Raises:
+        CleartextCredentialEradicated: Always.
+    """
+    logger.error(
+        "Blocked eradicated cleartext-credential path: %s (replacement: %s)",
+        subject,
+        replacement or "none",
+    )
+    raise CleartextCredentialEradicated(subject, replacement)
+
+
+# =============================================================================
+# MEMORY / ENVIRONMENT SANITISATION
+# =============================================================================
+
+
+def zero_buffer(buffer: object) -> bool:
+    """
+    Overwrite a writable buffer in place.
+
+    Returns True if the buffer was actually zeroed. Immutable objects (``str``,
+    ``bytes``) return False rather than pretending -- see the module docstring.
+    """
+    try:
+        view = memoryview(buffer)  # type: ignore[arg-type]
+    except TypeError:
+        return False
+    if view.readonly:
+        return False
+    try:
+        view[:] = b"\x00" * view.nbytes
+        return True
+    except (TypeError, ValueError):
+        return False
+    finally:
+        view.release()
+
+
+def sanitize_mapping(mapping: MutableMapping[str, _V], keys: Iterable[str]) -> frozenset[str]:
+    """
+    Remove the given keys from a mutable mapping, zeroing writable values.
+
+    Used for both ``os.environ`` and configuration singletons that cached the
+    legacy value. Plain dict operations, per the DRY mandate -- no bespoke
+    framework.
+    """
+    removed: set[str] = set()
+    for key in list(keys):
+        if key not in mapping:
+            continue
+        try:
+            value = mapping[key]
+        except Exception:  # pragma: no cover - exotic mapping
+            value = None
+        zero_buffer(value)
+        try:
+            del mapping[key]
+        except Exception as exc:  # pragma: no cover - exotic mapping
+            logger.warning("Could not delete %s during sanitisation: %s", key, exc)
+            continue
+        removed.add(key)
+    return frozenset(removed)
+
+
+def sanitize_process_environment(
+    env: Optional[MutableMapping[str, str]] = None,
+) -> frozenset[str]:
+    """
+    Pop every eradicated credential key from the process environment.
+
+    Idempotent and safe to call at any point in boot. Returns the keys actually
+    removed so callers can log a real number rather than an assumption.
+    """
+    target: MutableMapping[str, str] = os.environ if env is None else env
+    removed = sanitize_mapping(target, eradicated_env_keys(target))
+    if removed:
+        logger.warning(
+            "Credential sanitisation removed %d legacy env key(s) from the process "
+            "environment: %s",
+            len(removed),
+            ", ".join(sorted(removed)),
+        )
+    else:
+        logger.debug("Credential sanitisation: no legacy env keys present")
+    return removed

--- a/backend/system_control/macos_controller.py
+++ b/backend/system_control/macos_controller.py
@@ -18,6 +18,8 @@ import psutil
 # Import async pipeline for non-blocking operations
 from core.async_pipeline import get_async_pipeline
 
+from backend.security.credential_eradication import eradicated_path
+
 from backend.system_control.capability_registry import (  # noqa: E402
     Effect, capability, os_capability,
 )
@@ -331,52 +333,16 @@ class MacOSController:
             logger.error(f"[Pipeline] Unlock WebSocket error: {e}")
 
     async def _screen_unlock_applescript_async(self, context):
-        """Non-blocking screen unlock via AppleScript (fallback)"""
-        password = context.metadata.get("password")
+        """
+        ERADICATED. Fetched the login password from the keychain and typed it.
 
-        if not password:
-            # Try to retrieve from keychain
-            try:
-                from api.jarvis_voice_api import async_subprocess_run
+        Kept as a named seam so the pipeline stage fails loudly at the point of
+        use rather than silently degrading to another dead end.
 
-                stdout, stderr, returncode = await async_subprocess_run(
-                    [
-                        "security",
-                        "find-generic-password",
-                        "-s",
-                        "com.jarvis.voiceunlock",
-                        "-a",
-                        "unlock_token",
-                        "-w",
-                    ],
-                    timeout=5.0,
-                )
-                if returncode == 0 and stdout:
-                    password = stdout.decode().strip()
-                else:
-                    context.metadata["success"] = False
-                    context.metadata["error"] = "No password available for unlock"
-                    return
-            except Exception as e:
-                context.metadata["success"] = False
-                context.metadata["error"] = f"Failed to retrieve password: {e}"
-                return
-
-        # Use simple_unlock_handler's direct unlock method
-        try:
-            from api.simple_unlock_handler import _perform_direct_unlock
-
-            success = await _perform_direct_unlock(password)
-
-            if success:
-                context.metadata["success"] = True
-                context.metadata["message"] = "Screen unlocked successfully via AppleScript"
-            else:
-                context.metadata["success"] = False
-                context.metadata["error"] = "AppleScript unlock failed"
-        except Exception as e:
-            context.metadata["success"] = False
-            context.metadata["error"] = f"AppleScript unlock error: {e}"
+        Raises:
+            CleartextCredentialEradicated: Always.
+        """
+        eradicated_path("MacOSController._screen_unlock_applescript_async")
 
     async def _check_screen_lock_status_async(self) -> bool:
         """
@@ -1755,59 +1721,23 @@ class MacOSController:
             except Exception as e:
                 logger.warning(f"[UnlockScreen] WebSocket error: {e}")
 
-            # Method 2: Try direct AppleScript unlock (fallback)
+            # The former Method 2 retrieved the login password from the keychain
+            # and typed it. Eradicated: SecureEventInput discards synthesised
+            # keystrokes at the lock screen, so the path could not succeed, and
+            # holding the credential in cleartext bought nothing.
             if not password:
-                # Try to retrieve from keychain
-                try:
-                    from api.jarvis_voice_api import async_subprocess_run
-
-                    stdout, stderr, returncode = await async_subprocess_run(
-                        [
-                            "security",
-                            "find-generic-password",
-                            "-s",
-                            "com.jarvis.voiceunlock",
-                            "-a",
-                            "unlock_token",
-                            "-w",
-                        ],
-                        timeout=5.0,
-                    )
-                    if returncode == 0 and stdout:
-                        password = stdout.decode().strip()
-                    else:
-                        logger.info("[UnlockScreen] No password in keychain")
-                        return (
-                            False,
-                            "Unable to unlock screen. The Voice Unlock daemon is not running. Please run './backend/voice_unlock/enable_screen_unlock.sh' to enable it.",
-                        )
-                except Exception as e:
-                    logger.warning(f"[UnlockScreen] Failed to retrieve password: {e}")
-                    return (
-                        False,
-                        "Unable to unlock screen without password. Please setup Voice Unlock first.",
-                    )
+                logger.info("[UnlockScreen] No unlock grant available")
+                return (
+                    False,
+                    "I can't unlock the screen yet. The JARVIS Authorization Plugin "
+                    "isn't installed, and the old typing method cannot work on this "
+                    "version of macOS.",
+                )
 
             # DYNAMIC DIAGNOSTIC: Intelligently diagnose the issue
             logger.info("[UnlockScreen] Performing dynamic diagnostics...")
 
-            # Build diagnostic report
             diagnostic_issues = []
-
-            # Check keychain password
-            try:
-                result = subprocess.run(
-                    ["security", "find-generic-password", "-s", "com.jarvis.voiceunlock", "-a", "unlock_token", "-w"],
-                    capture_output=True,
-                    text=True,
-                    timeout=2
-                )
-                has_password = (result.returncode == 0)
-            except Exception:
-                has_password = False
-
-            if not has_password:
-                diagnostic_issues.append("Keychain password not configured")
 
             # Check enrollment data
             import json

--- a/backend/voice_unlock/authplugin/install/common.sh
+++ b/backend/voice_unlock/authplugin/install/common.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# JARVIS Authorization Plugin -- shared constants and helpers.
+#
+# Sourced by install.sh and uninstall.sh so both agree on every path, label and
+# right name. There is exactly one definition of each; neither script may
+# introduce a literal of its own.
+#
+# Deliberately POSIX-ish bash with no dependency on the repo, python, or a
+# virtualenv: uninstall must run from a Recovery shell or a bare SSH session on
+# a machine whose screen will not unlock.
+
+set -euo pipefail
+
+# --- Identity ---------------------------------------------------------------
+JARVIS_PLUGIN_NAME="JARVISUnlock"
+JARVIS_BUNDLE_NAME="${JARVIS_PLUGIN_NAME}.bundle"
+JARVIS_MECHANISM="${JARVIS_PLUGIN_NAME}:grant,privileged"
+JARVIS_BROKER_LABEL="com.jarvis.unlockbroker"
+
+# --- Authorization right we participate in ----------------------------------
+# Only the screensaver right. system.login.console is deliberately NEVER
+# touched: a defect there costs you login, not just unlock, and the difference
+# is the difference between "annoying" and "boot from Recovery".
+JARVIS_AUTH_RIGHT="system.login.screensaver"
+
+# --- Filesystem layout ------------------------------------------------------
+JARVIS_PLUGIN_DIR="/Library/Security/SecurityAgentPlugins"
+JARVIS_PLUGIN_PATH="${JARVIS_PLUGIN_DIR}/${JARVIS_BUNDLE_NAME}"
+JARVIS_BROKER_BIN="/usr/local/libexec/jarvis-unlock-broker"
+JARVIS_BROKER_PLIST="/Library/LaunchDaemons/${JARVIS_BROKER_LABEL}.plist"
+JARVIS_STATE_DIR="/Library/Application Support/JARVIS/authplugin"
+JARVIS_AUTHDB_BACKUP_DIR="${JARVIS_STATE_DIR}/authdb-backup"
+# Pointer file naming the backup taken by the most recent install. Uninstall
+# restores from whatever this names, so a reinstall cannot orphan the original.
+JARVIS_AUTHDB_BACKUP_POINTER="${JARVIS_AUTHDB_BACKUP_DIR}/current"
+
+# --- Logging ----------------------------------------------------------------
+_jarvis_log()  { printf '[jarvis-authplugin] %s\n' "$*" >&2; }
+_jarvis_warn() { printf '[jarvis-authplugin][warn] %s\n' "$*" >&2; }
+_jarvis_die()  { printf '[jarvis-authplugin][fatal] %s\n' "$*" >&2; exit 1; }
+
+# --- Guards -----------------------------------------------------------------
+jarvis_require_root() {
+    if [ "$(id -u)" -ne 0 ]; then
+        _jarvis_die "must run as root (try: sudo $0)"
+    fi
+}
+
+jarvis_require_macos() {
+    if [ "$(uname -s)" != "Darwin" ]; then
+        _jarvis_die "macOS only"
+    fi
+}
+
+# Read the current authorization rule for a right to stdout.
+# Returns non-zero if the right cannot be read.
+jarvis_authdb_read() {
+    local right="$1"
+    security authorizationdb read "$right" 2>/dev/null
+}
+
+# Write a rule plist (path) into the authorization database for a right.
+jarvis_authdb_write() {
+    local right="$1" plist="$2"
+    [ -f "$plist" ] || _jarvis_die "rule plist not found: $plist"
+    security authorizationdb write "$right" < "$plist"
+}

--- a/backend/voice_unlock/authplugin/install/probe_screensaver_rule.sh
+++ b/backend/voice_unlock/authplugin/install/probe_screensaver_rule.sh
@@ -1,0 +1,227 @@
+#!/bin/bash
+# JARVIS -- Ephemeral Probe for the system.login.screensaver authorization rule.
+#
+# WHAT THIS MEASURES
+# ------------------
+# Your lock screen currently uses:
+#
+#     class = rule
+#     rule  = ( use-login-window-ui )
+#
+# which means loginwindow owns authentication and there is no mechanism chain an
+# Authorization Plugin could join. Switching the right to a SecurityAgent-
+# evaluated rule is the only way to host a plugin -- but it may sever the
+# loginwindow-native paths for Touch ID and Apple Watch unlock.
+#
+# Nobody should guess at that. This script switches the rule for a bounded
+# window so you can test Touch ID and Watch unlock yourself, then puts it back.
+#
+# WHY IT CANNOT LEAVE YOUR MACHINE MUTATED
+# ----------------------------------------
+# The revert is armed BEFORE the mutation is applied, as a detached background
+# process holding nothing but a sleep and a file path. It survives this script
+# crashing, the terminal closing, the SSH session dropping, and the parent shell
+# being SIGKILLed -- none of those are conditions it observes. It is a dead man's
+# switch, not a cleanup handler, and it is deliberately blind to whether the
+# probe "succeeded": a watchdog that shares state with the thing it guards is not
+# a watchdog.
+#
+# Three independent layers put the rule back:
+#   1. the detached timer          (survives everything short of power loss)
+#   2. an EXIT/INT/TERM trap here  (instant revert on Ctrl-C or normal finish)
+#   3. install/uninstall.sh        (manual recovery from Recovery or SSH)
+#
+# USAGE
+#   sudo ./probe_screensaver_rule.sh                 # 60-second window
+#   sudo JARVIS_PROBE_WINDOW_S=120 ./probe_...sh     # longer window
+
+set -euo pipefail
+
+_here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common.sh
+. "${_here}/common.sh"
+
+jarvis_require_macos
+jarvis_require_root
+
+# --- Tunables (no hardcoded literals in the body) ----------------------------
+PROBE_WINDOW_S="${JARVIS_PROBE_WINDOW_S:-60}"
+# The SecurityAgent-evaluated rule we swap in. Named by the stock rule's own
+# comment as the supported alternative to use-login-window-ui.
+PROBE_RULE_NAME="${JARVIS_PROBE_RULE:-authenticate-session-owner-or-admin}"
+# The marker that proves the live rule is the stock, loginwindow-owned one.
+STOCK_MARKER="${JARVIS_PROBE_STOCK_MARKER:-use-login-window-ui}"
+
+PROBE_LOG="${JARVIS_STATE_DIR}/probe.log"
+
+case "${PROBE_WINDOW_S}" in
+    ''|*[!0-9]*) _jarvis_die "JARVIS_PROBE_WINDOW_S must be a positive integer" ;;
+esac
+[ "${PROBE_WINDOW_S}" -ge 15 ] || _jarvis_die "window must be >= 15s to be testable"
+[ "${PROBE_WINDOW_S}" -le 600 ] || _jarvis_die "window must be <= 600s; this is a probe, not a config change"
+
+# =============================================================================
+# 1. BACK UP THE EXACT LIVE XML
+# =============================================================================
+mkdir -p "${JARVIS_AUTHDB_BACKUP_DIR}"
+chmod 700 "${JARVIS_STATE_DIR}" "${JARVIS_AUTHDB_BACKUP_DIR}" 2>/dev/null || true
+
+_stamp="$(date +%Y%m%d-%H%M%S)"
+BACKUP="${JARVIS_AUTHDB_BACKUP_DIR}/${JARVIS_AUTH_RIGHT}.${_stamp}.probe.plist"
+
+_jarvis_log "reading live ${JARVIS_AUTH_RIGHT}"
+if ! jarvis_authdb_read "${JARVIS_AUTH_RIGHT}" > "${BACKUP}"; then
+    rm -f "${BACKUP}"
+    _jarvis_die "could not read ${JARVIS_AUTH_RIGHT}; refusing to touch anything"
+fi
+
+# =============================================================================
+# 2. PRE-FLIGHT -- abort before any mutation if the backup is not trustworthy
+# =============================================================================
+_jarvis_log "pre-flight: validating backup"
+
+[ -s "${BACKUP}" ] || { rm -f "${BACKUP}"; _jarvis_die "backup is empty; aborting without touching the system"; }
+
+if ! plutil -lint "${BACKUP}" >/dev/null 2>&1; then
+    _jarvis_warn "backup did not parse as a plist: ${BACKUP}"
+    _jarvis_die "aborting without touching the system"
+fi
+
+if ! grep -q "${STOCK_MARKER}" "${BACKUP}"; then
+    _jarvis_warn "live rule does not contain '${STOCK_MARKER}'."
+    _jarvis_warn "current rule:"
+    sed 's/^/    /' "${BACKUP}" >&2
+    _jarvis_warn "the machine is not in the stock configuration this probe knows how to restore."
+    _jarvis_die "aborting without touching the system"
+fi
+
+# Prove the restore path works on this exact file BEFORE relying on it: write the
+# backup back over the identical live value. A no-op if it succeeds, and if it
+# fails we learn that now rather than 60 seconds from now.
+_jarvis_log "pre-flight: verifying the restore path with a no-op write"
+if ! jarvis_authdb_write "${JARVIS_AUTH_RIGHT}" "${BACKUP}" >/dev/null 2>&1; then
+    rm -f "${BACKUP}"
+    _jarvis_die "restore path does not work on this machine; aborting without mutating"
+fi
+
+if ! jarvis_authdb_read "${JARVIS_AUTH_RIGHT}" | grep -q "${STOCK_MARKER}"; then
+    _jarvis_die "no-op restore changed the rule unexpectedly; STOP. Restore by hand from ${BACKUP}"
+fi
+
+_jarvis_log "pre-flight OK; backup at ${BACKUP}"
+printf '%s' "${BACKUP}" > "${JARVIS_AUTHDB_BACKUP_POINTER}"
+
+# =============================================================================
+# 3. ARM THE DEAD MAN'S SWITCH  (before the mutation, on purpose)
+# =============================================================================
+# Holds only a duration and a path. Reads nothing about whether the probe is
+# alive, healthy, or finished -- so nothing the probe does can wedge it.
+mkdir -p "$(dirname "${PROBE_LOG}")"
+nohup bash -c "
+    sleep ${PROBE_WINDOW_S}
+    for attempt in 1 2 3; do
+        if /usr/bin/security authorizationdb write '${JARVIS_AUTH_RIGHT}' < '${BACKUP}' 2>/dev/null; then
+            printf '%s dead-man revert OK (attempt %s)\n' \"\$(date -u +%FT%TZ)\" \"\$attempt\" >> '${PROBE_LOG}'
+            exit 0
+        fi
+        sleep 2
+    done
+    printf '%s DEAD-MAN REVERT FAILED -- restore by hand: security authorizationdb write %s < %s\n' \
+        \"\$(date -u +%FT%TZ)\" '${JARVIS_AUTH_RIGHT}' '${BACKUP}' >> '${PROBE_LOG}'
+" >/dev/null 2>&1 &
+REVERTER_PID=$!
+disown "${REVERTER_PID}" 2>/dev/null || true
+_jarvis_log "dead man's switch armed (pid ${REVERTER_PID}, fires in ${PROBE_WINDOW_S}s)"
+
+# Layer 2: instant revert on Ctrl-C or normal exit. The timer remains the backstop.
+_revert_now() {
+    _jarvis_log "reverting ${JARVIS_AUTH_RIGHT} now"
+    if jarvis_authdb_write "${JARVIS_AUTH_RIGHT}" "${BACKUP}" >/dev/null 2>&1; then
+        _jarvis_log "reverted"
+    else
+        _jarvis_warn "REVERT FAILED. Run by hand:"
+        _jarvis_warn "  sudo security authorizationdb write ${JARVIS_AUTH_RIGHT} < ${BACKUP}"
+        _jarvis_warn "or: sudo ${_here}/uninstall.sh"
+    fi
+}
+trap _revert_now EXIT INT TERM
+
+# =============================================================================
+# 4. MUTATE
+# =============================================================================
+_jarvis_log "switching ${JARVIS_AUTH_RIGHT} -> ${PROBE_RULE_NAME}"
+if ! security authorizationdb write "${JARVIS_AUTH_RIGHT}" "${PROBE_RULE_NAME}"; then
+    _jarvis_die "mutation failed; trap and dead-man switch will restore the stock rule"
+fi
+
+_live_now="$(jarvis_authdb_read "${JARVIS_AUTH_RIGHT}" | tr -d '\n')"
+if printf '%s' "${_live_now}" | grep -q "${STOCK_MARKER}"; then
+    _jarvis_die "rule still reads as stock after the write; probe is not measuring anything"
+fi
+
+# =============================================================================
+# 5. THE MEASUREMENT WINDOW
+# =============================================================================
+cat <<BANNER
+
+================================================================================
+  PROBE ACTIVE -- ${PROBE_WINDOW_S} SECONDS
+================================================================================
+  system.login.screensaver is now: ${PROBE_RULE_NAME}
+  (SecurityAgent-evaluated -- the configuration a plugin would need)
+
+  GO TEST NOW, in this order:
+
+    1. Lock the screen            (Ctrl-Cmd-Q)
+    2. Does TOUCH ID prompt/work?          -> yes / no
+    3. Does APPLE WATCH auto-unlock work?  -> yes / no
+    4. Does your PASSWORD still unlock?    -> yes / no   <- must be yes
+    5. Unlock and come back here
+
+  The rule reverts automatically when the timer fires, even if this window
+  closes, this script dies, or your SSH session drops.
+
+  Revert immediately:  Ctrl-C
+  Revert by hand:      sudo security authorizationdb write \\
+                         ${JARVIS_AUTH_RIGHT} < ${BACKUP}
+  Full recovery:       sudo ${_here}/uninstall.sh
+  Dead-man log:        ${PROBE_LOG}
+================================================================================
+
+BANNER
+
+_remaining="${PROBE_WINDOW_S}"
+while [ "${_remaining}" -gt 0 ]; do
+    printf '\r[jarvis-authplugin] reverting in %3ds (Ctrl-C to revert now) ' "${_remaining}" >&2
+    sleep 1
+    _remaining=$((_remaining - 1))
+done
+printf '\r%*s\r' 60 '' >&2
+
+# EXIT trap performs the revert; step 6 reports what is actually true afterwards.
+trap - EXIT INT TERM
+_revert_now
+
+_jarvis_log "final state of ${JARVIS_AUTH_RIGHT}:"
+if jarvis_authdb_read "${JARVIS_AUTH_RIGHT}" | grep -q "${STOCK_MARKER}"; then
+    _jarvis_log "  STOCK (${STOCK_MARKER}) -- machine is back to how it started"
+    rm -f "${JARVIS_AUTHDB_BACKUP_POINTER}"
+else
+    _jarvis_warn "  NOT STOCK. Restore by hand:"
+    _jarvis_warn "    sudo security authorizationdb write ${JARVIS_AUTH_RIGHT} < ${BACKUP}"
+    exit 1
+fi
+
+cat <<'NEXT'
+
+Report back with the four yes/no answers. They decide the architecture:
+
+  Touch ID + Watch SURVIVE  -> the plugin is viable; build it against
+                               evaluate-mechanisms with no biometric cost.
+  Touch ID or Watch BREAK   -> hosting a plugin costs you native biometrics.
+                               That is a real price, and it is your call
+                               whether voice unlock is worth paying it.
+  PASSWORD fails            -> stop entirely; the SecurityAgent handoff is not
+                               safe on this machine and no plugin gets built.
+
+NEXT

--- a/backend/voice_unlock/authplugin/install/probe_screensaver_rule.sh
+++ b/backend/voice_unlock/authplugin/install/probe_screensaver_rule.sh
@@ -138,7 +138,15 @@ disown "${REVERTER_PID}" 2>/dev/null || true
 _jarvis_log "dead man's switch armed (pid ${REVERTER_PID}, fires in ${PROBE_WINDOW_S}s)"
 
 # Layer 2: instant revert on Ctrl-C or normal exit. The timer remains the backstop.
+#
+# Idempotent. Ctrl-C previously fired the handler once for INT and again for
+# EXIT, reverting twice and printing the whole thing twice -- harmless against
+# the authorization database, but a script that reports two reverts for one
+# revert is lying about what it did.
+_reverted=0
 _revert_now() {
+    [ "${_reverted}" -eq 1 ] && return 0
+    _reverted=1
     _jarvis_log "reverting ${JARVIS_AUTH_RIGHT} now"
     if jarvis_authdb_write "${JARVIS_AUTH_RIGHT}" "${BACKUP}" >/dev/null 2>&1; then
         _jarvis_log "reverted"
@@ -148,7 +156,15 @@ _revert_now() {
         _jarvis_warn "or: sudo ${_here}/uninstall.sh"
     fi
 }
-trap _revert_now EXIT INT TERM
+
+# Ctrl-C means "I am done testing early", NOT "discard what I measured".
+# Previously INT exited straight through the trap and skipped the capture, so
+# the documented escape hatch destroyed the very data the probe exists to
+# collect. It now ends the countdown and falls through to revert + capture.
+_interrupted=0
+_on_interrupt() { _interrupted=1; }
+trap _on_interrupt INT TERM
+trap _revert_now EXIT
 
 # =============================================================================
 # 4. MUTATE
@@ -195,15 +211,19 @@ cat <<BANNER
 BANNER
 
 _remaining="${PROBE_WINDOW_S}"
-while [ "${_remaining}" -gt 0 ]; do
-    printf '\r[jarvis-authplugin] reverting in %3ds (Ctrl-C to revert now) ' "${_remaining}" >&2
-    sleep 1
+while [ "${_remaining}" -gt 0 ] && [ "${_interrupted}" -eq 0 ]; do
+    printf '\r[jarvis-authplugin] reverting in %3ds (Ctrl-C to finish early) ' "${_remaining}" >&2
+    # `|| true`: an interrupted sleep exits non-zero, and `set -e` would tear
+    # the script down before the capture that Ctrl-C is supposed to reach.
+    sleep 1 || true
     _remaining=$((_remaining - 1))
 done
 printf '\r%*s\r' 60 '' >&2
 
-# EXIT trap performs the revert; step 6 reports what is actually true afterwards.
-trap - EXIT INT TERM
+if [ "${_interrupted}" -eq 1 ]; then
+    _jarvis_log "interrupted with ${_remaining}s left -- reverting, then recording what you saw"
+fi
+
 _revert_now
 
 _jarvis_log "final state of ${JARVIS_AUTH_RIGHT}:"

--- a/backend/voice_unlock/authplugin/install/probe_screensaver_rule.sh
+++ b/backend/voice_unlock/authplugin/install/probe_screensaver_rule.sh
@@ -45,7 +45,11 @@ jarvis_require_macos
 jarvis_require_root
 
 # --- Tunables (no hardcoded literals in the body) ----------------------------
-PROBE_WINDOW_S="${JARVIS_PROBE_WINDOW_S:-60}"
+# Default sized to the protocol this script actually prints: lock, wait for
+# Apple Watch to trigger (10-20s on its own), retry Touch ID, test the password,
+# unlock, return to the terminal. A 60s window fit about three of those five
+# steps, so the first run measured nothing.
+PROBE_WINDOW_S="${JARVIS_PROBE_WINDOW_S:-180}"
 # The SecurityAgent-evaluated rule we swap in. Named by the stock rule's own
 # comment as the supported alternative to use-login-window-ui.
 PROBE_RULE_NAME="${JARVIS_PROBE_RULE:-authenticate-session-owner-or-admin}"
@@ -210,6 +214,51 @@ else
     _jarvis_warn "  NOT STOCK. Restore by hand:"
     _jarvis_warn "    sudo security authorizationdb write ${JARVIS_AUTH_RIGHT} < ${BACKUP}"
     exit 1
+fi
+
+# =============================================================================
+# 7. CAPTURE THE MEASUREMENT  (a result that lives only in a terminal is not a
+#    result -- the first run reverted cleanly and recorded nothing)
+# =============================================================================
+PROBE_RESULTS="${JARVIS_STATE_DIR}/probe-results.log"
+
+if [ -t 0 ]; then
+    printf '\n[jarvis-authplugin] recording the measurement (Enter to skip any answer)\n' >&2
+
+    _ask() {  # _ask <prompt> -> echoes normalised answer
+        local reply=""
+        read -r -p "  $1 [y/n/skip]: " reply </dev/tty || reply=""
+        case "${reply}" in
+            [Yy]*) printf 'yes' ;;
+            [Nn]*) printf 'no' ;;
+            *)     printf 'not-tested' ;;
+        esac
+    }
+
+    _locked="$(_ask 'Did you actually LOCK the screen during the window?')"
+    if [ "${_locked}" != "yes" ]; then
+        _jarvis_warn "screen was not locked -- this run measured nothing."
+        _jarvis_warn "re-run and lock the screen inside the window:"
+        _jarvis_warn "  sudo JARVIS_PROBE_WINDOW_S=${PROBE_WINDOW_S} $0"
+    fi
+
+    _touchid="$(_ask 'Did TOUCH ID work?')"
+    _watch="$(_ask 'Did APPLE WATCH auto-unlock work?')"
+    _password="$(_ask 'Did your PASSWORD unlock?')"
+
+    {
+        printf '%s rule=%s window=%ss locked=%s touchid=%s watch=%s password=%s\n' \
+            "$(date -u +%FT%TZ)" "${PROBE_RULE_NAME}" "${PROBE_WINDOW_S}" \
+            "${_locked}" "${_touchid}" "${_watch}" "${_password}"
+    } >> "${PROBE_RESULTS}"
+
+    _jarvis_log "recorded to ${PROBE_RESULTS}"
+
+    if [ "${_password}" = "no" ]; then
+        _jarvis_warn "PASSWORD FAILED under SecurityAgent. Do not build the plugin."
+    fi
+else
+    _jarvis_log "non-interactive; skipping capture. Record answers in ${PROBE_RESULTS}"
 fi
 
 cat <<'NEXT'

--- a/backend/voice_unlock/authplugin/install/uninstall.sh
+++ b/backend/voice_unlock/authplugin/install/uninstall.sh
@@ -1,0 +1,176 @@
+#!/bin/bash
+# JARVIS Authorization Plugin -- complete removal.
+#
+# WRITTEN BEFORE THE PLUGIN IT REMOVES, ON PURPOSE.
+#
+# This script is the recovery path for a machine whose screen will not unlock.
+# Everything about it is shaped by that: it must run from a Recovery Terminal or
+# a bare SSH session, must not depend on the JARVIS repo, python, a virtualenv,
+# or any state the plugin itself wrote beyond a single backup file, and must
+# leave the system in the stock configuration even if it is run twice, run
+# half-way through a failed install, or run when nothing is installed at all.
+#
+#   ssh you@mac 'sudo /path/to/uninstall.sh'
+#
+# ORDER MATTERS. The authorization database is restored FIRST. If the machine is
+# wedged, the rule is what is wedging it -- removing the bundle first would leave
+# a rule pointing at a mechanism that no longer exists, which is a worse state
+# than either the installed or the stock configuration.
+
+set -euo pipefail
+
+_here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common.sh
+. "${_here}/common.sh"
+
+jarvis_require_macos
+jarvis_require_root
+
+_failures=0
+_note_failure() { _jarvis_warn "$1"; _failures=$((_failures + 1)); }
+
+_jarvis_log "starting removal"
+
+# =============================================================================
+# 1. RESTORE THE AUTHORIZATION RULE  (first -- this is what unwedges a machine)
+# =============================================================================
+restore_auth_rule() {
+    if [ ! -f "${JARVIS_AUTHDB_BACKUP_POINTER}" ]; then
+        _jarvis_log "no authdb backup pointer; checking whether the right is stock"
+        _remove_mechanism_in_place
+        return
+    fi
+
+    local backup
+    backup="$(cat "${JARVIS_AUTHDB_BACKUP_POINTER}" 2>/dev/null || true)"
+
+    if [ -z "${backup}" ] || [ ! -f "${backup}" ]; then
+        _jarvis_warn "backup pointer names a missing file: ${backup:-<empty>}"
+        _remove_mechanism_in_place
+        return
+    fi
+
+    # Refuse to write a backup that is not a readable plist: restoring garbage
+    # into the authorization database is the one way this script could make
+    # things worse than it found them.
+    if ! plutil -lint "${backup}" >/dev/null 2>&1; then
+        _jarvis_warn "backup at ${backup} is not a valid plist; refusing to restore it"
+        _remove_mechanism_in_place
+        return
+    fi
+
+    _jarvis_log "restoring ${JARVIS_AUTH_RIGHT} from ${backup}"
+    if jarvis_authdb_write "${JARVIS_AUTH_RIGHT}" "${backup}"; then
+        _jarvis_log "authorization rule restored"
+        rm -f "${JARVIS_AUTHDB_BACKUP_POINTER}"
+    else
+        _note_failure "could not restore ${JARVIS_AUTH_RIGHT} from backup"
+        _remove_mechanism_in_place
+    fi
+}
+
+# Fallback: no usable backup. Strip only our own mechanism from whatever rule is
+# currently live, leaving every other entry untouched. Never invents a rule.
+_remove_mechanism_in_place() {
+    local current
+    if ! current="$(jarvis_authdb_read "${JARVIS_AUTH_RIGHT}")"; then
+        _note_failure "cannot read ${JARVIS_AUTH_RIGHT}; leaving it alone"
+        return
+    fi
+
+    if ! printf '%s' "${current}" | grep -q "${JARVIS_PLUGIN_NAME}"; then
+        _jarvis_log "${JARVIS_AUTH_RIGHT} does not reference ${JARVIS_PLUGIN_NAME}; nothing to strip"
+        return
+    fi
+
+    local scratch
+    scratch="$(mktemp -t jarvis-authdb)" || { _note_failure "mktemp failed"; return; }
+    printf '%s' "${current}" > "${scratch}"
+
+    # Delete every mechanisms[] entry whose value mentions our plugin. Uses
+    # PlistBuddy (present in the base OS and in Recovery) rather than python,
+    # which Recovery does not ship.
+    local idx entry
+    idx=0
+    while entry="$(/usr/libexec/PlistBuddy -c "Print :mechanisms:${idx}" "${scratch}" 2>/dev/null)"; do
+        case "${entry}" in
+            *"${JARVIS_PLUGIN_NAME}"*)
+                /usr/libexec/PlistBuddy -c "Delete :mechanisms:${idx}" "${scratch}" >/dev/null 2>&1 || true
+                # Do not advance: entries shift down after a delete.
+                ;;
+            *)
+                idx=$((idx + 1))
+                ;;
+        esac
+    done
+
+    if jarvis_authdb_write "${JARVIS_AUTH_RIGHT}" "${scratch}"; then
+        _jarvis_log "stripped ${JARVIS_PLUGIN_NAME} from ${JARVIS_AUTH_RIGHT}"
+    else
+        _note_failure "could not write stripped rule for ${JARVIS_AUTH_RIGHT}"
+    fi
+    rm -f "${scratch}"
+}
+
+restore_auth_rule
+
+# =============================================================================
+# 2. STOP AND REMOVE THE GRANT BROKER
+# =============================================================================
+remove_broker() {
+    if launchctl print "system/${JARVIS_BROKER_LABEL}" >/dev/null 2>&1; then
+        _jarvis_log "unloading ${JARVIS_BROKER_LABEL}"
+        launchctl bootout "system/${JARVIS_BROKER_LABEL}" 2>/dev/null \
+            || launchctl unload "${JARVIS_BROKER_PLIST}" 2>/dev/null \
+            || _note_failure "could not unload ${JARVIS_BROKER_LABEL}"
+    else
+        _jarvis_log "${JARVIS_BROKER_LABEL} is not loaded"
+    fi
+
+    for path in "${JARVIS_BROKER_PLIST}" "${JARVIS_BROKER_BIN}"; do
+        if [ -e "${path}" ]; then
+            rm -f "${path}" && _jarvis_log "removed ${path}" \
+                || _note_failure "could not remove ${path}"
+        fi
+    done
+}
+
+remove_broker
+
+# =============================================================================
+# 3. REMOVE THE PLUGIN BUNDLE
+# =============================================================================
+if [ -e "${JARVIS_PLUGIN_PATH}" ]; then
+    rm -rf "${JARVIS_PLUGIN_PATH}" && _jarvis_log "removed ${JARVIS_PLUGIN_PATH}" \
+        || _note_failure "could not remove ${JARVIS_PLUGIN_PATH}"
+else
+    _jarvis_log "${JARVIS_PLUGIN_PATH} not present"
+fi
+
+# =============================================================================
+# 4. VERIFY -- report what is actually true, not what we attempted
+# =============================================================================
+_jarvis_log "verifying"
+
+if [ -e "${JARVIS_PLUGIN_PATH}" ]; then
+    _note_failure "plugin bundle still present at ${JARVIS_PLUGIN_PATH}"
+fi
+if [ -e "${JARVIS_BROKER_PLIST}" ]; then
+    _note_failure "broker plist still present at ${JARVIS_BROKER_PLIST}"
+fi
+if jarvis_authdb_read "${JARVIS_AUTH_RIGHT}" | grep -q "${JARVIS_PLUGIN_NAME}"; then
+    _note_failure "${JARVIS_AUTH_RIGHT} still references ${JARVIS_PLUGIN_NAME}"
+fi
+
+# The state directory is kept: it holds the authdb backups, which are the only
+# record of the pre-install configuration. Removing them would make a future
+# recovery harder, and they contain no secrets.
+_jarvis_log "authdb backups retained at ${JARVIS_AUTHDB_BACKUP_DIR}"
+
+if [ "${_failures}" -ne 0 ]; then
+    _jarvis_warn "removal finished with ${_failures} problem(s) -- see above"
+    _jarvis_warn "the screen unlock right is: $(jarvis_authdb_read "${JARVIS_AUTH_RIGHT}" | tr -d '\n' | cut -c1-200)"
+    exit 1
+fi
+
+_jarvis_log "removal complete; ${JARVIS_AUTH_RIGHT} is stock"

--- a/backend/voice_unlock/authplugin/src/JARVISGrantProtocol.h
+++ b/backend/voice_unlock/authplugin/src/JARVISGrantProtocol.h
@@ -1,0 +1,132 @@
+/**
+ * JARVISGrantProtocol.h
+ * The contract between the Authorization Plugin and the grant broker.
+ *
+ * Shared by both sides so the wire shape has exactly one definition. The plugin
+ * links this header; the broker links this header; there is no second copy to
+ * drift.
+ *
+ * WHAT A GRANT IS, AND WHAT IT IS NOT
+ * -----------------------------------
+ * A grant is an assertion by the JARVIS backend that a human it has already
+ * authenticated -- by voice, and by whatever else the backend layers on -- asked
+ * for the screen to be unlocked, just now. It is NOT a credential. It carries no
+ * password, no key material, and nothing that could unlock anything if it
+ * leaked. The worst a stolen grant can do is unlock a screen once, within its
+ * TTL, on the machine that issued it.
+ *
+ * That property is the whole point of this design. The system it replaces kept
+ * the user's actual login password in cleartext.
+ */
+
+#ifndef JARVIS_GRANT_PROTOCOL_H
+#define JARVIS_GRANT_PROTOCOL_H
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Schema version of the grant payload. Bumped on any breaking field change so
+/// a stale plugin and a fresh broker refuse each other loudly rather than
+/// misinterpreting each other's dictionaries.
+extern NSString *const JARVISGrantSchemaVersion;
+
+#pragma mark - Verdict
+
+/**
+ * What the broker says when the plugin asks.
+ *
+ * Deliberately NOT a BOOL. "no grant available" and "the broker is unreachable"
+ * must be distinguishable in the plugin's logs, because they mean completely
+ * different things operationally -- one is the normal resting state on every
+ * manual unlock, the other means the daemon died. Collapsing them into `false`
+ * is how a broken daemon hides behind a working one.
+ *
+ * Every value other than Granted yields to the native password UI. There is no
+ * verdict that denies the user their own machine: the plugin's only power is to
+ * let someone in early, never to keep them out.
+ */
+typedef NS_ENUM(NSInteger, JARVISGrantVerdict) {
+    /// A valid, unexpired, single-use grant existed and has been consumed.
+    JARVISGrantVerdictGranted = 0,
+    /// The broker answered, and there is no grant. The overwhelmingly common case.
+    JARVISGrantVerdictNoGrant = 1,
+    /// A grant existed but had aged past its TTL. Reported separately from
+    /// NoGrant so a chronically-too-short TTL is visible as itself.
+    JARVISGrantVerdictExpired = 2,
+    /// The broker rejected US -- our code signature did not satisfy its
+    /// requirement. Should be impossible in a correct install; if it is ever
+    /// seen, something is impersonating one side of this channel.
+    JARVISGrantVerdictRejected = 3,
+    /// No answer inside the deadline. The dead man's switch of the auth path.
+    JARVISGrantVerdictTimedOut = 4,
+    /// Broker unreachable: not running, not registered, or refusing connections.
+    JARVISGrantVerdictUnavailable = 5,
+    /// The operator physically held the panic key. Not even asked.
+    JARVISGrantVerdictPanicBypass = 6,
+};
+
+/// Human-readable name for a verdict, for logs. Never returns nil.
+extern NSString *JARVISGrantVerdictName(JARVISGrantVerdict verdict);
+
+#pragma mark - Wire protocol
+
+/**
+ * The XPC interface the broker vends.
+ *
+ * One method. The narrowness is intentional: the attack surface of an XPC
+ * service is its interface, and this one cannot be asked to do anything except
+ * answer a yes/no about a grant that the caller cannot influence.
+ *
+ * Note what is absent -- there is no `depositGrant:` here. Deposits arrive on a
+ * separate, separately-validated interface, so that a compromised plugin (which
+ * runs inside SecurityAgent and is the more exposed side) cannot mint the very
+ * grants it consumes.
+ */
+@protocol JARVISGrantConsumer <NSObject>
+
+/**
+ * Atomically consume any valid grant.
+ *
+ * Consumption is single-use and happens broker-side under a lock: two
+ * simultaneous unlock attempts cannot both be satisfied by one grant, and a
+ * replayed request finds nothing.
+ *
+ * @param schemaVersion Caller's schema. Mismatch yields Rejected rather than a
+ *                      best-effort interpretation of an unknown payload.
+ * @param reply         Verdict plus a correlation id for cross-log stitching.
+ */
+- (void)consumeGrantWithSchemaVersion:(NSString *)schemaVersion
+                                reply:(void (^)(JARVISGrantVerdict verdict,
+                                                NSString *_Nullable correlationId))reply;
+
+@end
+
+/**
+ * The interface JARVIS itself uses to deposit a grant. Separate from
+ * JARVISGrantConsumer on purpose -- see above.
+ */
+@protocol JARVISGrantDepositor <NSObject>
+
+/**
+ * Deposit a single-use grant.
+ *
+ * @param schemaVersion Caller's schema version.
+ * @param ttlSeconds    Requested lifetime. The broker clamps this to its own
+ *                      configured ceiling; a caller cannot mint an immortal
+ *                      grant by asking for one.
+ * @param reason        Short operator-facing string for the audit log, e.g.
+ *                      "voice: unlock my screen". Never contains credentials.
+ * @param reply         Whether the deposit was accepted, and the grant id.
+ */
+- (void)depositGrantWithSchemaVersion:(NSString *)schemaVersion
+                           ttlSeconds:(NSTimeInterval)ttlSeconds
+                               reason:(NSString *)reason
+                                reply:(void (^)(BOOL accepted,
+                                                NSString *_Nullable grantId))reply;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif /* JARVIS_GRANT_PROTOCOL_H */

--- a/backend/voice_unlock/authplugin/src/JARVISUnlockConfig.h
+++ b/backend/voice_unlock/authplugin/src/JARVISUnlockConfig.h
@@ -1,0 +1,106 @@
+/**
+ * JARVISUnlockConfig.h
+ * Every tunable in the plugin, resolved once, from the bundle's Info.plist.
+ *
+ * WHY INFO.PLIST AND NOT ENVIRONMENT VARIABLES
+ * --------------------------------------------
+ * The rest of JARVIS is env-var driven, and copying that here would be cargo
+ * culting rather than DRY. This code runs inside SecurityAgent, a process the
+ * operator does not launch and whose environment they cannot set. An env var
+ * would be unreadable in production and settable only in a test harness, which
+ * is the worst possible property for a security control: configuration that
+ * exists for tests and is inert in the field.
+ *
+ * Info.plist is the macOS-native configuration channel for a bundle. It is
+ * readable from inside SecurityAgent, it is covered by the bundle's code
+ * signature -- so tampering with a tunable invalidates the signature that the
+ * broker checks -- and it is inspectable with `plutil` during an incident.
+ *
+ * Defaults are the fallback if a key is absent or malformed, never a silent
+ * substitute for a key that is present and out of range: those are clamped and
+ * logged, because a value the operator wrote and the code ignored is a lie.
+ */
+
+#ifndef JARVIS_UNLOCK_CONFIG_H
+#define JARVIS_UNLOCK_CONFIG_H
+
+#import <Foundation/Foundation.h>
+#import <CoreGraphics/CoreGraphics.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface JARVISUnlockConfig : NSObject
+
+/// Resolved once per plugin load from the bundle containing this code.
++ (instancetype)sharedConfig;
+
+/**
+ * How long the mechanism will wait for the broker before yielding to the
+ * native password UI.
+ *
+ * This is the dead man's switch of the authentication path. It is small by
+ * design and clamped hard: the cost of being too slow is a user staring at a
+ * frozen lock screen, which is the failure mode that turns an unlock feature
+ * into a support call. Key: JARVISGrantTimeoutMilliseconds. Default 500ms.
+ * Clamped to [50, 2000].
+ */
+@property (nonatomic, readonly) NSTimeInterval grantTimeoutSeconds;
+
+/**
+ * Mach service name of the grant broker.
+ *
+ * Key: JARVISBrokerMachServiceName. No default -- if this is absent the plugin
+ * refuses to look anything up and yields immediately. A missing service name
+ * must not fall back to a guessed one; guessing which Mach service to hand an
+ * unlock question to is how you get answered by the wrong process.
+ */
+@property (nonatomic, readonly, nullable) NSString *brokerMachServiceName;
+
+/**
+ * Code signing requirement the broker must satisfy for the plugin to trust its
+ * answer. Key: JARVISBrokerCodeRequirement.
+ *
+ * Validation is mutual. The broker checking the plugin is the obvious half; the
+ * plugin checking the broker is the half people forget, and it is the half that
+ * matters here, because the plugin is asking "should I let this person in" and
+ * a spoofed answer is an unlock.
+ */
+@property (nonatomic, readonly, nullable) NSString *brokerCodeRequirement;
+
+/**
+ * Virtual keycode which, held during Invoke, bypasses JARVIS entirely.
+ *
+ * Key: JARVISPanicKeyCode. Default kVK_Option (0x3A). The escape hatch for a
+ * misbehaving daemon that a user needs to get past without a terminal -- hold
+ * the key, get the stock password prompt, no matter what any software thinks.
+ */
+@property (nonatomic, readonly) CGKeyCode panicKeyCode;
+
+/// Whether the panic choke is consulted at all. Key: JARVISPanicChokeEnabled.
+/// Default YES. Present so it can be disabled in automated tests, never in the
+/// shipped Info.plist.
+@property (nonatomic, readonly) BOOL panicChokeEnabled;
+
+/**
+ * Master switch. Key: JARVISGrantMechanismEnabled. Default YES.
+ *
+ * Disabled means the mechanism loads, logs, and immediately yields -- the
+ * cheapest possible no-op. It deliberately does NOT mean "do not load": a
+ * mechanism named in the authorization database that fails to load is a broken
+ * chain, and the safe way to turn this off without editing the database is to
+ * make it trivially transparent.
+ */
+@property (nonatomic, readonly) BOOL mechanismEnabled;
+
+/// Schema version this build speaks. Read from the bundle so the plugin and
+/// broker versions are visible in `plutil` output during an incident.
+@property (nonatomic, readonly) NSString *schemaVersion;
+
+/// Snapshot of the resolved values, for a single log line at load.
+- (NSString *)describeResolved;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif /* JARVIS_UNLOCK_CONFIG_H */

--- a/backend/voice_unlock/authplugin/src/JARVISUnlockConfig.m
+++ b/backend/voice_unlock/authplugin/src/JARVISUnlockConfig.m
@@ -1,0 +1,155 @@
+/**
+ * JARVISUnlockConfig.m
+ */
+
+#import "JARVISUnlockConfig.h"
+#import "JARVISGrantProtocol.h"
+#import <Carbon/Carbon.h>
+#import <os/log.h>
+
+NSString *const JARVISGrantSchemaVersion = @"grant.1";
+
+NSString *JARVISGrantVerdictName(JARVISGrantVerdict verdict) {
+    switch (verdict) {
+        case JARVISGrantVerdictGranted:      return @"granted";
+        case JARVISGrantVerdictNoGrant:      return @"no_grant";
+        case JARVISGrantVerdictExpired:      return @"expired";
+        case JARVISGrantVerdictRejected:     return @"rejected";
+        case JARVISGrantVerdictTimedOut:     return @"timed_out";
+        case JARVISGrantVerdictUnavailable:  return @"unavailable";
+        case JARVISGrantVerdictPanicBypass:  return @"panic_bypass";
+    }
+    // Not a default: case, so the compiler still warns when the enum grows.
+    return [NSString stringWithFormat:@"unknown(%ld)", (long)verdict];
+}
+
+#pragma mark - Defaults and bounds
+
+// Named constants rather than literals at the point of use: the bound and the
+// value it bounds are defined adjacently and cannot drift apart.
+static const NSTimeInterval kDefaultGrantTimeoutSeconds = 0.500;
+static const NSTimeInterval kMinGrantTimeoutSeconds     = 0.050;
+static const NSTimeInterval kMaxGrantTimeoutSeconds     = 2.000;
+
+static NSString *const kKeyTimeoutMs        = @"JARVISGrantTimeoutMilliseconds";
+static NSString *const kKeyMachService      = @"JARVISBrokerMachServiceName";
+static NSString *const kKeyCodeRequirement  = @"JARVISBrokerCodeRequirement";
+static NSString *const kKeyPanicKeyCode     = @"JARVISPanicKeyCode";
+static NSString *const kKeyPanicEnabled     = @"JARVISPanicChokeEnabled";
+static NSString *const kKeyMechanismEnabled = @"JARVISGrantMechanismEnabled";
+static NSString *const kKeySchemaVersion    = @"JARVISGrantSchemaVersion";
+
+@interface JARVISUnlockConfig ()
+@property (nonatomic, readwrite) NSTimeInterval grantTimeoutSeconds;
+@property (nonatomic, readwrite, nullable) NSString *brokerMachServiceName;
+@property (nonatomic, readwrite, nullable) NSString *brokerCodeRequirement;
+@property (nonatomic, readwrite) CGKeyCode panicKeyCode;
+@property (nonatomic, readwrite) BOOL panicChokeEnabled;
+@property (nonatomic, readwrite) BOOL mechanismEnabled;
+@property (nonatomic, readwrite) NSString *schemaVersion;
+@end
+
+@implementation JARVISUnlockConfig
+
++ (instancetype)sharedConfig {
+    static JARVISUnlockConfig *shared = nil;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        shared = [[JARVISUnlockConfig alloc] initFromBundle];
+    });
+    return shared;
+}
+
+/// Reads a BOOL that may legitimately be absent. Absent -> fallback; present but
+/// not a boolean -> fallback, loudly. A misspelled type must not read as NO.
+static BOOL JARVISBoolValue(id raw, BOOL fallback, NSString *key, os_log_t log) {
+    if (raw == nil) { return fallback; }
+    if ([raw isKindOfClass:[NSNumber class]]) { return [raw boolValue]; }
+    os_log_error(log, "config: %{public}@ is not a boolean; using default %d",
+                 key, fallback);
+    return fallback;
+}
+
+- (instancetype)initFromBundle {
+    self = [super init];
+    if (!self) { return nil; }
+
+    os_log_t log = os_log_create("com.jarvis.unlockplugin", "config");
+
+    // The bundle containing THIS class, not mainBundle -- mainBundle inside
+    // SecurityAgent is SecurityAgent, whose Info.plist is Apple's.
+    NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+    NSDictionary *info = bundle.infoDictionary ?: @{};
+
+    // --- timeout: clamp rather than reject, and say so when clamping ---
+    id rawTimeout = info[kKeyTimeoutMs];
+    NSTimeInterval timeout = kDefaultGrantTimeoutSeconds;
+    if ([rawTimeout isKindOfClass:[NSNumber class]]) {
+        NSTimeInterval requested = [rawTimeout doubleValue] / 1000.0;
+        timeout = MIN(MAX(requested, kMinGrantTimeoutSeconds), kMaxGrantTimeoutSeconds);
+        if (fabs(timeout - requested) > DBL_EPSILON) {
+            os_log_error(log,
+                         "config: %{public}@=%.0fms clamped to %.0fms; "
+                         "a value outside [%.0f, %.0f] would make the lock screen "
+                         "either untestable or visibly frozen",
+                         kKeyTimeoutMs, requested * 1000.0, timeout * 1000.0,
+                         kMinGrantTimeoutSeconds * 1000.0, kMaxGrantTimeoutSeconds * 1000.0);
+        }
+    } else if (rawTimeout != nil) {
+        os_log_error(log, "config: %{public}@ is not a number; using %.0fms",
+                     kKeyTimeoutMs, kDefaultGrantTimeoutSeconds * 1000.0);
+    }
+    _grantTimeoutSeconds = timeout;
+
+    // --- broker identity: no defaults, deliberately ---
+    id rawService = info[kKeyMachService];
+    _brokerMachServiceName = [rawService isKindOfClass:[NSString class]] && [rawService length] > 0
+        ? rawService : nil;
+    if (_brokerMachServiceName == nil) {
+        os_log_error(log,
+                     "config: %{public}@ missing; the mechanism will yield without "
+                     "contacting anything. Guessing a Mach service name would risk "
+                     "asking the wrong process whether to unlock this screen.",
+                     kKeyMachService);
+    }
+
+    id rawRequirement = info[kKeyCodeRequirement];
+    _brokerCodeRequirement = [rawRequirement isKindOfClass:[NSString class]] && [rawRequirement length] > 0
+        ? rawRequirement : nil;
+    if (_brokerCodeRequirement == nil) {
+        os_log_error(log,
+                     "config: %{public}@ missing; the mechanism will yield rather than "
+                     "trust an unverified broker.",
+                     kKeyCodeRequirement);
+    }
+
+    // --- panic choke ---
+    id rawPanicKey = info[kKeyPanicKeyCode];
+    _panicKeyCode = [rawPanicKey isKindOfClass:[NSNumber class]]
+        ? (CGKeyCode)[rawPanicKey unsignedIntegerValue]
+        : (CGKeyCode)kVK_Option;
+    _panicChokeEnabled = JARVISBoolValue(info[kKeyPanicEnabled], YES, kKeyPanicEnabled, log);
+
+    // --- master switch ---
+    _mechanismEnabled = JARVISBoolValue(info[kKeyMechanismEnabled], YES, kKeyMechanismEnabled, log);
+
+    id rawSchema = info[kKeySchemaVersion];
+    _schemaVersion = [rawSchema isKindOfClass:[NSString class]] && [rawSchema length] > 0
+        ? rawSchema : JARVISGrantSchemaVersion;
+
+    return self;
+}
+
+- (NSString *)describeResolved {
+    return [NSString stringWithFormat:
+            @"enabled=%d timeout=%.0fms service=%@ requirement=%@ panic=%d key=0x%02X schema=%@",
+            _mechanismEnabled,
+            _grantTimeoutSeconds * 1000.0,
+            _brokerMachServiceName ?: @"<missing>",
+            _brokerCodeRequirement ? @"<set>" : @"<missing>",
+            _panicChokeEnabled,
+            (unsigned)_panicKeyCode,
+            _schemaVersion];
+}
+
+@end

--- a/backend/voice_unlock/authplugin/src/JARVISUnlockMechanism.m
+++ b/backend/voice_unlock/authplugin/src/JARVISUnlockMechanism.m
@@ -1,0 +1,351 @@
+/**
+ * JARVISUnlockMechanism.m
+ * The Authorization Plugin that lets a voice-authenticated unlock satisfy
+ * system.login.screensaver without a password existing anywhere.
+ *
+ * THE ONE INVARIANT
+ * -----------------
+ * This code runs inside SecurityAgent, on the path between a human and their
+ * own locked machine. It may make that path FASTER. It may never make it
+ * SLOWER, and it may never make it IMPOSSIBLE.
+ *
+ * Everything below follows from that. There is no code path that returns
+ * kAuthorizationResultDeny. There is no code path that blocks the invoking
+ * thread. There is no error -- unreachable broker, malformed config, spoofed
+ * signature, panicking Objective-C runtime -- that produces anything except
+ * "yield to the native password UI". The plugin's only power is to let someone
+ * in early. It cannot keep anyone out.
+ *
+ * WHY IT DOES NOT BLOCK
+ * ---------------------
+ * MechanismInvoke returns noErr immediately, and SetResult is called later from
+ * whichever of two racers arrives first: the broker's XPC reply, or a
+ * dispatch_after deadline. SecurityAgent's thread is never held for even the
+ * 500ms budget.
+ *
+ * A semaphore-and-wait would have been three lines shorter and is the shape
+ * most examples use. It is also how you wedge a lock screen: SecurityAgent
+ * would sit inside our frame for the whole timeout, and any bug that lost the
+ * reply would hold it forever. The AuthorizationPlugin API is asynchronous
+ * precisely so that a mechanism cannot do this, and taking the synchronous
+ * shortcut would discard the guarantee the API exists to provide.
+ *
+ * The deadline is armed BEFORE the request is sent, for the same reason the
+ * probe arms its dead man's switch before mutating the rule: there must be no
+ * window in which the operation is in flight and nothing is scheduled to end it.
+ */
+
+#import <Foundation/Foundation.h>
+#import <Security/AuthorizationPlugin.h>
+#import <Security/AuthSession.h>
+#import <CoreGraphics/CoreGraphics.h>
+#import <os/log.h>
+#import <stdatomic.h>
+
+#import "JARVISGrantProtocol.h"
+#import "JARVISUnlockConfig.h"
+
+#pragma mark - Plugin / mechanism state
+
+typedef struct {
+    const AuthorizationCallbacks *callbacks;
+    os_log_t log;
+} JARVISPlugin;
+
+typedef struct {
+    JARVISPlugin *plugin;
+    AuthorizationEngineRef engine;
+    /// Guarantees exactly one SetResult per invocation, whichever racer wins.
+    atomic_flag resultDelivered;
+} JARVISMechanism;
+
+#pragma mark - Result delivery
+
+/**
+ * Deliver the verdict, exactly once.
+ *
+ * The timeout and the XPC reply race by design, and both call this. The atomic
+ * flag is what makes that safe: a second SetResult on the same engine is
+ * undefined behaviour in an API whose failure mode is a stuck lock screen.
+ */
+static void JARVISDeliver(JARVISMechanism *mech,
+                          AuthorizationResult result,
+                          JARVISGrantVerdict verdict,
+                          NSTimeInterval elapsed) {
+    if (atomic_flag_test_and_set(&mech->resultDelivered)) {
+        // Lost the race. The winner already answered; say so at debug level
+        // rather than dropping it silently, because a persistent stream of
+        // these means the timeout is mistuned.
+        os_log_debug(mech->plugin->log,
+                     "verdict %{public}@ arrived after the result was delivered (%.0fms)",
+                     JARVISGrantVerdictName(verdict), elapsed * 1000.0);
+        return;
+    }
+
+    os_log(mech->plugin->log,
+           "verdict=%{public}@ result=%{public}s elapsed=%.0fms",
+           JARVISGrantVerdictName(verdict),
+           result == kAuthorizationResultAllow ? "allow" : "yield",
+           elapsed * 1000.0);
+
+    OSStatus status = mech->plugin->callbacks->SetResult(mech->engine, result);
+    if (status != errAuthorizationSuccess) {
+        os_log_error(mech->plugin->log, "SetResult failed: %d", (int)status);
+    }
+}
+
+/**
+ * Yield to the native password UI.
+ *
+ * kAuthorizationResultAllow, not Deny. In an evaluate-mechanisms chain, Allow
+ * means "this mechanism is satisfied, continue" -- the later builtin:authenticate
+ * then does the real work and prompts as it always has. Deny would fail the
+ * whole right and lock the user out of their own machine, which is the outcome
+ * this plugin exists to never cause.
+ *
+ * That distinction is the single most load-bearing line in this file.
+ */
+static void JARVISYield(JARVISMechanism *mech, JARVISGrantVerdict why, NSTimeInterval elapsed) {
+    JARVISDeliver(mech, kAuthorizationResultAllow, why, elapsed);
+}
+
+#pragma mark - Hardware panic choke
+
+/**
+ * Is the operator physically holding the panic key right now?
+ *
+ * Read from kCGEventSourceStateHIDSystemState -- the hardware state, not the
+ * combined state a synthetic event could forge. Nothing in software can hold
+ * this key down on the operator's behalf, which is exactly the property wanted:
+ * an escape hatch that outranks every other layer here, usable by someone
+ * standing at a locked machine with no terminal and no idea what went wrong.
+ *
+ * Fails toward bypass. If this cannot be determined, assume the human wants out.
+ */
+static BOOL JARVISPanicHeld(JARVISUnlockConfig *config, os_log_t log) {
+    if (!config.panicChokeEnabled) { return NO; }
+
+    @try {
+        if (CGEventSourceKeyState(kCGEventSourceStateHIDSystemState, config.panicKeyCode)) {
+            os_log(log, "panic choke: key 0x%02X held; bypassing JARVIS entirely",
+                   (unsigned)config.panicKeyCode);
+            return YES;
+        }
+        return NO;
+    } @catch (NSException *e) {
+        os_log_error(log, "panic choke probe threw (%{public}@); assuming bypass",
+                     e.name);
+        return YES;
+    }
+}
+
+#pragma mark - Broker query
+
+/**
+ * Ask the broker whether a grant exists, without ever waiting for the answer.
+ *
+ * Returns immediately. Exactly one of two things will later call JARVISDeliver:
+ * the reply block, or the deadline armed here before the request goes out.
+ */
+static void JARVISAskBroker(JARVISMechanism *mech, JARVISUnlockConfig *config) {
+    os_log_t log = mech->plugin->log;
+    NSDate *started = [NSDate date];
+
+    // Arm the deadline FIRST. If anything below throws, misbehaves, or simply
+    // never calls back, this still fires and the user still gets their prompt.
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW,
+                                 (int64_t)(config.grantTimeoutSeconds * NSEC_PER_SEC)),
+                   dispatch_get_global_queue(QOS_CLASS_USER_INTERACTIVE, 0), ^{
+        JARVISYield(mech, JARVISGrantVerdictTimedOut,
+                    -[started timeIntervalSinceNow]);
+    });
+
+    NSString *service = config.brokerMachServiceName;
+    NSString *requirement = config.brokerCodeRequirement;
+    if (service == nil || requirement == nil) {
+        // Config already logged the specifics at load. Yield now rather than
+        // making the user wait out a timeout for a decision already made.
+        JARVISYield(mech, JARVISGrantVerdictUnavailable, -[started timeIntervalSinceNow]);
+        return;
+    }
+
+    NSXPCConnection *connection =
+        [[NSXPCConnection alloc] initWithMachServiceName:service
+                                                 options:NSXPCConnectionPrivileged];
+    connection.remoteObjectInterface =
+        [NSXPCInterface interfaceWithProtocol:@protocol(JARVISGrantConsumer)];
+
+    // Mutual validation. The broker checks us; we check the broker. A plugin
+    // that trusted whatever answered its Mach lookup would take "unlock this
+    // screen" from any process that won the name.
+    //
+    // Availability-guarded rather than assumed: if the OS cannot enforce the
+    // requirement, we do not proceed with an unverified peer. Yielding costs
+    // the user one password entry; trusting an unchecked broker costs them the
+    // machine.
+    if (@available(macOS 13.0, *)) {
+        [connection setCodeSigningRequirement:requirement];
+    } else {
+        os_log_error(log,
+                     "code signing requirements unsupported on this OS; "
+                     "refusing to trust an unverified broker");
+        JARVISYield(mech, JARVISGrantVerdictRejected, -[started timeIntervalSinceNow]);
+        [connection invalidate];
+        return;
+    }
+
+    // Both handlers yield. An interrupted or invalidated connection is
+    // indistinguishable from a dead broker from here, and both mean "prompt".
+    connection.interruptionHandler = ^{
+        JARVISYield(mech, JARVISGrantVerdictUnavailable, -[started timeIntervalSinceNow]);
+    };
+    connection.invalidationHandler = ^{
+        JARVISYield(mech, JARVISGrantVerdictUnavailable, -[started timeIntervalSinceNow]);
+    };
+
+    [connection resume];
+
+    id<JARVISGrantConsumer> broker =
+        [connection remoteObjectProxyWithErrorHandler:^(NSError *error) {
+            os_log_error(log, "broker proxy error: %{public}@", error.localizedDescription);
+            JARVISYield(mech, JARVISGrantVerdictUnavailable, -[started timeIntervalSinceNow]);
+        }];
+
+    [broker consumeGrantWithSchemaVersion:config.schemaVersion
+                                    reply:^(JARVISGrantVerdict verdict,
+                                            NSString *correlationId) {
+        NSTimeInterval elapsed = -[started timeIntervalSinceNow];
+        if (correlationId.length > 0) {
+            os_log_debug(log, "broker correlation=%{public}@", correlationId);
+        }
+        if (verdict == JARVISGrantVerdictGranted) {
+            JARVISDeliver(mech, kAuthorizationResultAllow, verdict, elapsed);
+        } else {
+            JARVISYield(mech, verdict, elapsed);
+        }
+        [connection invalidate];
+    }];
+}
+
+#pragma mark - AuthorizationPlugin interface
+
+static OSStatus JARVISMechanismCreate(AuthorizationPluginRef inPlugin,
+                                      AuthorizationEngineRef inEngine,
+                                      AuthorizationMechanismId mechanismId,
+                                      AuthorizationMechanismRef *outMechanism) {
+    if (inPlugin == NULL || outMechanism == NULL) { return errAuthorizationInternal; }
+
+    JARVISPlugin *plugin = (JARVISPlugin *)inPlugin;
+    JARVISMechanism *mech = calloc(1, sizeof(JARVISMechanism));
+    if (mech == NULL) { return errAuthorizationInternal; }
+
+    mech->plugin = plugin;
+    mech->engine = inEngine;
+    atomic_flag_clear(&mech->resultDelivered);
+
+    os_log_debug(plugin->log, "mechanism created: %{public}s",
+                 mechanismId ? mechanismId : "(unnamed)");
+
+    *outMechanism = (AuthorizationMechanismRef)mech;
+    return errAuthorizationSuccess;
+}
+
+static OSStatus JARVISMechanismInvoke(AuthorizationMechanismRef inMechanism) {
+    JARVISMechanism *mech = (JARVISMechanism *)inMechanism;
+    if (mech == NULL) { return errAuthorizationInternal; }
+
+    // Every invocation starts fresh: the same mechanism object is reused across
+    // retries, and a flag left set from a previous attempt would swallow this
+    // attempt's result and hang the chain.
+    atomic_flag_clear(&mech->resultDelivered);
+
+    @autoreleasepool {
+        @try {
+            JARVISUnlockConfig *config = [JARVISUnlockConfig sharedConfig];
+
+            if (!config.mechanismEnabled) {
+                JARVISYield(mech, JARVISGrantVerdictUnavailable, 0);
+                return errAuthorizationSuccess;
+            }
+
+            // Checked before anything else, and before any IPC: the panic key
+            // must work when the broker is the thing that is broken.
+            if (JARVISPanicHeld(config, mech->plugin->log)) {
+                JARVISYield(mech, JARVISGrantVerdictPanicBypass, 0);
+                return errAuthorizationSuccess;
+            }
+
+            JARVISAskBroker(mech, config);
+        } @catch (NSException *e) {
+            // An exception escaping into SecurityAgent is how a lock screen
+            // dies. Nothing gets past this frame.
+            os_log_error(mech->plugin->log,
+                         "unhandled exception in Invoke (%{public}@); yielding",
+                         e.name);
+            JARVISYield(mech, JARVISGrantVerdictUnavailable, 0);
+        }
+    }
+
+    // Returns immediately in every path above. SetResult happens later, from
+    // whichever racer wins.
+    return errAuthorizationSuccess;
+}
+
+static OSStatus JARVISMechanismDeactivate(AuthorizationMechanismRef inMechanism) {
+    JARVISMechanism *mech = (JARVISMechanism *)inMechanism;
+    if (mech == NULL) { return errAuthorizationInternal; }
+    return mech->plugin->callbacks->DidDeactivate(mech->engine);
+}
+
+static OSStatus JARVISMechanismDestroy(AuthorizationMechanismRef inMechanism) {
+    if (inMechanism != NULL) { free(inMechanism); }
+    return errAuthorizationSuccess;
+}
+
+static OSStatus JARVISPluginDestroy(AuthorizationPluginRef inPlugin) {
+    if (inPlugin != NULL) { free(inPlugin); }
+    return errAuthorizationSuccess;
+}
+
+static AuthorizationPluginInterface gInterface = {
+    kAuthorizationPluginInterfaceVersion,
+    &JARVISPluginDestroy,
+    &JARVISMechanismCreate,
+    &JARVISMechanismInvoke,
+    &JARVISMechanismDeactivate,
+    &JARVISMechanismDestroy,
+};
+
+/**
+ * SecurityAgent's entry point into this bundle.
+ *
+ * A failure here means the mechanism cannot load, which means the authorization
+ * chain names something that does not exist -- so this returns an error only for
+ * conditions under which we genuinely cannot function, and never for anything
+ * we could instead survive and log.
+ */
+OSStatus AuthorizationPluginCreate(const AuthorizationCallbacks *callbacks,
+                                   AuthorizationPluginRef *outPlugin,
+                                   const AuthorizationPluginInterface **outPluginInterface) {
+    if (callbacks == NULL || outPlugin == NULL || outPluginInterface == NULL) {
+        return errAuthorizationInternal;
+    }
+    if (callbacks->version < kAuthorizationCallbacksVersion) {
+        return errAuthorizationInternal;
+    }
+
+    JARVISPlugin *plugin = calloc(1, sizeof(JARVISPlugin));
+    if (plugin == NULL) { return errAuthorizationInternal; }
+
+    plugin->callbacks = callbacks;
+    plugin->log = os_log_create("com.jarvis.unlockplugin", "mechanism");
+
+    // One line, at load, naming every resolved tunable. During an incident the
+    // first question is always "what did it actually think its config was".
+    os_log(plugin->log, "loaded: %{public}@",
+           [[JARVISUnlockConfig sharedConfig] describeResolved]);
+
+    *outPlugin = (AuthorizationPluginRef)plugin;
+    *outPluginInterface = &gInterface;
+    return errAuthorizationSuccess;
+}

--- a/backend/voice_unlock/secure_password_typer.py
+++ b/backend/voice_unlock/secure_password_typer.py
@@ -44,6 +44,8 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from enum import IntEnum
 from typing import Optional, Dict, List, Tuple, Any
+
+from backend.security.credential_eradication import eradicated_path
 from weakref import WeakValueDictionary
 
 try:
@@ -505,6 +507,10 @@ class SecurePasswordTyper:
         Returns:
             Tuple of (success: bool, metrics: TypingMetrics)
         """
+        # ERADICATED: no code path may type a login credential. The
+        # machinery below is unreachable and retained only so the module
+        # stays importable for its metrics dataclasses.
+        eradicated_path("SecurePasswordTyper.type_password_secure")
         # Use config override or instance config
         config = config_override or self.config
         submit = submit if submit is not None else config.submit_after_typing
@@ -877,71 +883,19 @@ class SecurePasswordTyper:
         except Exception as e:
             logger.error(f"❌ Failed to release shift: {e}")
 
-    async def _fallback_applescript(self, password: str, submit: bool, metrics: TypingMetrics) -> Tuple[bool, TypingMetrics]:
-        """Fallback to AppleScript if Core Graphics fails"""
-        try:
-            logger.info("🔄 Using AppleScript fallback for password typing")
-            metrics.fallback_used = True
-            
-            # Wake screen via caffeinate -u (no key events injected).
-            # key code 49 (space) would type into the password field if
-            # the lock screen is already visible, corrupting the password.
-            try:
-                proc = await asyncio.create_subprocess_exec(
-                    "caffeinate", "-u", "-t", "1",
-                    stdout=asyncio.subprocess.DEVNULL,
-                    stderr=asyncio.subprocess.DEVNULL,
-                )
-                await asyncio.wait_for(proc.wait(), timeout=3.0)
-            except Exception:
-                pass
-            await asyncio.sleep(0.5)
-            
-            # Type password using AppleScript with environment variable for security
-            type_script = """
-            tell application "System Events"
-                keystroke (system attribute "JARVIS_UNLOCK_PASS")
-            end tell
-            """
-            
-            env = os.environ.copy()
-            env["JARVIS_UNLOCK_PASS"] = password
-            
-            proc = await asyncio.create_subprocess_exec(
-                "osascript", "-e", type_script,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-                env=env
-            )
-            await proc.communicate()
-            
-            # Clear from environment
-            if "JARVIS_UNLOCK_PASS" in env:
-                del env["JARVIS_UNLOCK_PASS"]
-            
-            # Submit if requested
-            if submit:
-                await asyncio.sleep(0.1)
-                submit_script = """
-                tell application "System Events"
-                    key code 36
-                end tell
-                """
-                proc = await asyncio.create_subprocess_exec(
-                    "osascript", "-e", submit_script,
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.PIPE
-                )
-                await proc.communicate()
-            
-            metrics.success = True
-            logger.info("✅ AppleScript fallback succeeded")
-            return True, metrics
-            
-        except Exception as e:
-            logger.error(f"❌ AppleScript fallback failed: {e}")
-            metrics.error_message = f"Fallback failed: {str(e)}"
-            return False, metrics
+    async def _fallback_applescript(self, *args, **kwargs):
+        """
+        ERADICATED. Injected the login password into a child process
+        environment (``JARVIS_UNLOCK_PASS``) for an osascript keystroke.
+    
+        A child's environment is readable by same-user processes, so this
+        traded an argv leak for an environment leak -- and the keystrokes
+        were discarded by SecureEventInput regardless.
+    
+        Raises:
+            CleartextCredentialEradicated: Always.
+        """
+        eradicated_path("SecurePasswordTyper._fallback_applescript")
     
     async def _type_password_characters(self, password: str, config: TypingConfig, metrics: TypingMetrics) -> bool:
         """
@@ -1297,6 +1251,10 @@ async def type_password_with_display_awareness(
     Returns:
         Tuple of (success, metrics_dict, display_context)
     """
+    # ERADICATED: no code path may type a login credential. The
+    # machinery below is unreachable and retained only so the module
+    # stays importable for its metrics dataclasses.
+    eradicated_path("secure_password_typer.type_password_with_display_awareness")
     start_time = time.time()
     display_context_dict = None
     typing_config_dict = None
@@ -1526,113 +1484,19 @@ async def _store_display_tracking_data(
         # Don't let DB errors affect the unlock flow
 
 
-async def _type_password_applescript_sai(
-    password: str,
-    submit: bool,
-    config,  # TypingConfig from SAI
-    attempt_id: Optional[int]
-) -> Tuple[bool, Optional[Dict[str, Any]]]:
+async def _type_password_applescript_sai(self, *args, **kwargs):
     """
-    Type password using AppleScript with SAI-recommended timing.
-    Most reliable for mirrored/TV displays.
+    ERADICATED. Injected the login password into a child process
+    environment (``JARVIS_UNLOCK_PASS``) for an osascript keystroke.
+
+    A child's environment is readable by same-user processes, so this
+    traded an argv leak for an environment leak -- and the keystrokes
+    were discarded by SecureEventInput regardless.
+
+    Raises:
+        CleartextCredentialEradicated: Always.
     """
-    metrics = TypingMetrics()
-    metrics.characters_typed = len(password)
-    metrics.fallback_used = True
-
-    try:
-        logger.info(f"🔐 [APPLESCRIPT-SAI] Starting secure input (strategy: AppleScript)")
-
-        # Wake screen via caffeinate -u (no key events injected).
-        # key code 49 (space) would type into the password field if
-        # the lock screen is already visible, corrupting the password.
-        try:
-            proc = await asyncio.create_subprocess_exec(
-                "caffeinate", "-u", "-t", "1",
-                stdout=asyncio.subprocess.DEVNULL,
-                stderr=asyncio.subprocess.DEVNULL,
-            )
-            await asyncio.wait_for(proc.wait(), timeout=3.0)
-        except Exception:
-            pass
-
-        # SAI-recommended wake delay (longer for TV)
-        await asyncio.sleep(config.wake_delay_ms / 1000.0)
-        logger.info(f"🔐 [APPLESCRIPT-SAI] Wake delay: {config.wake_delay_ms}ms")
-
-        # Type password character by character for reliability
-        # Using keystroke with character-level control
-        type_script = """
-        tell application "System Events"
-            keystroke (system attribute "JARVIS_UNLOCK_PASS")
-        end tell
-        """
-
-        env = os.environ.copy()
-        env["JARVIS_UNLOCK_PASS"] = password
-
-        typing_start = time.time()
-
-        proc = await asyncio.create_subprocess_exec(
-            "osascript", "-e", type_script,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            env=env
-        )
-        stdout, stderr = await proc.communicate()
-
-        metrics.typing_time_ms = (time.time() - typing_start) * 1000
-
-        # Clear from environment
-        if "JARVIS_UNLOCK_PASS" in env:
-            del env["JARVIS_UNLOCK_PASS"]
-
-        if proc.returncode != 0:
-            logger.error(f"❌ [APPLESCRIPT-SAI] AppleScript failed: {stderr.decode()}")
-            metrics.error_message = stderr.decode()
-            return False, metrics.to_dict()
-
-        # Submit if requested
-        if submit:
-            await asyncio.sleep(config.submit_delay_ms / 1000.0)
-            submit_script = """
-            tell application "System Events"
-                key code 36
-            end tell
-            """
-            proc = await asyncio.create_subprocess_exec(
-                "osascript", "-e", submit_script,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE
-            )
-            await proc.communicate()
-            logger.info("🔐 [APPLESCRIPT-SAI] Return key pressed")
-
-        # Verify unlock
-        await asyncio.sleep(2.0)  # Longer delay for TV display
-
-        try:
-            from voice_unlock.objc.server.screen_lock_detector import is_screen_locked
-
-            if is_screen_locked():
-                metrics.success = False
-                metrics.error_message = "Password incorrect - screen still locked"
-                logger.error("❌ [APPLESCRIPT-SAI] Screen still locked after AppleScript typing")
-                return False, metrics.to_dict()
-            else:
-                metrics.success = True
-                logger.info("✅ [APPLESCRIPT-SAI] Screen unlocked successfully!")
-                return True, metrics.to_dict()
-
-        except Exception as e:
-            logger.warning(f"⚠️ Could not verify unlock status: {e}")
-            metrics.success = True  # Assume success if can't verify
-            return True, metrics.to_dict()
-
-    except Exception as e:
-        logger.error(f"❌ [APPLESCRIPT-SAI] Error: {e}", exc_info=True)
-        metrics.error_message = str(e)
-        return False, metrics.to_dict()
+    eradicated_path("SecurePasswordTyper._type_password_applescript_sai")
 
 
 async def _type_password_cg_sai(
@@ -1735,6 +1599,10 @@ async def type_password_securely(
         ...     print("Password typed securely")
         ...     print(f"Collected {len(metrics['character_metrics'])} character metrics")
     """
+    # ERADICATED: no code path may type a login credential. The
+    # machinery below is unreachable and retained only so the module
+    # stays importable for its metrics dataclasses.
+    eradicated_path("secure_password_typer.type_password_securely")
     typer = get_secure_typer()
 
     # Create config with randomize_timing setting

--- a/tests/security/test_credential_eradication.py
+++ b/tests/security/test_credential_eradication.py
@@ -1,0 +1,261 @@
+"""
+Regression spine for the cleartext-credential eradication sweep.
+
+Two kinds of assertion live here, and the distinction is load-bearing:
+
+* **Behavioural** -- calling a former retrieval path raises rather than
+  returning ``None``. A soft return would let a caller fall through to the next
+  branch of a cascade and rediscover the same dead end.
+* **Structural** -- the eradicated call shapes are absent from the live unlock
+  modules' ASTs. This is what actually prevents resurrection. Deleting code does
+  not stop it being rewritten; a test that fails when it comes back does.
+
+The structural checks parse source rather than importing, so they stay fast and
+do not depend on the heavyweight import graphs of ``main``/``macos_controller``.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from backend.security.credential_eradication import (
+    CleartextCredentialEradicated,
+    SecurityError,
+    eradicated_credentials,
+    eradicated_env_keys,
+    eradicated_path,
+    sanitize_mapping,
+    sanitize_process_environment,
+    zero_buffer,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+#: Modules that formerly sat on the live "unlock my screen" path. These are the
+#: files the sweep gutted; the structural guard is scoped to them so it stays
+#: decidable and does not police ad-hoc debug scripts.
+LIVE_UNLOCK_MODULES = (
+    "backend/macos_keychain_unlock.py",
+    "backend/api/simple_unlock_handler.py",
+    "backend/system_control/macos_controller.py",
+    "backend/voice_unlock/secure_password_typer.py",
+)
+
+
+def _module_sources():
+    for rel in LIVE_UNLOCK_MODULES:
+        path = REPO_ROOT / rel
+        assert path.exists(), f"guarded module vanished: {rel}"
+        yield rel, path.read_text()
+
+
+def _string_constants(tree: ast.AST):
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            yield node.value
+
+
+# =============================================================================
+# BEHAVIOURAL — the old fetchers refuse instead of fetching
+# =============================================================================
+
+
+def test_eradicated_path_raises_security_error():
+    with pytest.raises(CleartextCredentialEradicated) as excinfo:
+        eradicated_path("probe.subject")
+
+    assert isinstance(excinfo.value, SecurityError)
+    assert "zero-trust compliance" in str(excinfo.value)
+    assert "probe.subject" in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    "method_name",
+    [
+        "get_password_from_keychain",
+        "get_password_hash",
+        "preload_cache",
+        "_fetch_password_async",
+        "_query_keychain_async",
+    ],
+)
+def test_keychain_service_methods_raise(method_name, monkeypatch):
+    """
+    The former fetchers must raise -- and must not shell out on the way.
+
+    Both halves matter. A version that raised *after* running
+    ``security find-generic-password`` would still have put the credential in a
+    subprocess pipe, so the subprocess spawner is booby-trapped here.
+    """
+    from backend import macos_keychain_unlock
+
+    def _explode(*args, **kwargs):
+        raise AssertionError(
+            "eradicated path attempted to spawn a subprocess before raising"
+        )
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _explode)
+
+    service = macos_keychain_unlock.MacOSKeychainUnlock()
+    method = getattr(service, method_name)
+    args = ("svc", "acct") if method_name == "_query_keychain_async" else ()
+
+    with pytest.raises(CleartextCredentialEradicated):
+        asyncio.run(method(*args))
+
+
+@pytest.mark.parametrize(
+    "func_name",
+    ["get_password_async", "get_password_hash_async", "preload_keychain_cache"],
+)
+def test_module_level_helpers_raise(func_name):
+    from backend import macos_keychain_unlock
+
+    with pytest.raises(CleartextCredentialEradicated):
+        asyncio.run(getattr(macos_keychain_unlock, func_name)())
+
+
+def test_unlock_screen_reports_rather_than_raises():
+    """
+    ``unlock_screen`` sits on the spoken-response path, so it reports.
+
+    The operator needs a sentence they can hear, not a traceback. The credential
+    paths beneath it raise; this one seam degrades deliberately.
+    """
+    from backend import macos_keychain_unlock
+
+    service = macos_keychain_unlock.MacOSKeychainUnlock()
+    result = asyncio.run(service.unlock_screen(verified_speaker="Derek J. Russell"))
+
+    assert result["success"] is False
+    assert result["action"] == "eradicated"
+    assert "SecureEventInput" in result["message"]
+
+
+# =============================================================================
+# STRUCTURAL — the shapes cannot come back
+# =============================================================================
+
+
+def test_no_live_module_references_the_eradicated_keychain_item():
+    """No live unlock module may name the eradicated credential coordinates."""
+    service, account = eradicated_credentials()[0].coordinates
+
+    for rel, source in _module_sources():
+        tree = ast.parse(source)
+        constants = set(_string_constants(tree))
+        assert service not in constants, f"{rel} still references keychain service {service!r}"
+        assert account not in constants, f"{rel} still references keychain account {account!r}"
+
+
+def test_no_live_module_invokes_find_generic_password():
+    for rel, source in _module_sources():
+        tree = ast.parse(source)
+        assert "find-generic-password" not in set(_string_constants(tree)), (
+            f"{rel} reintroduced a `security find-generic-password` invocation"
+        )
+
+
+def test_no_live_module_injects_credentials_into_a_child_environment():
+    """
+    ``JARVIS_UNLOCK_PASS`` must not appear as a runtime string.
+
+    Docstrings are exempt on purpose -- the gutted functions explain what they
+    used to do, and that explanation is the point. Only executable string
+    constants are policed.
+    """
+    for rel, source in _module_sources():
+        tree = ast.parse(source)
+        docstrings = set()
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+                doc = ast.get_docstring(node, clean=False)
+                if doc:
+                    docstrings.add(doc)
+
+        live = [
+            value
+            for value in _string_constants(tree)
+            if value not in docstrings and "JARVIS_UNLOCK_PASS" in value
+        ]
+        assert not live, f"{rel} reintroduced JARVIS_UNLOCK_PASS as a runtime string"
+
+
+# =============================================================================
+# ENVIRONMENT SWEEP
+# =============================================================================
+
+
+def test_sanitize_removes_legacy_keys_and_reports_them():
+    env = {
+        "JARVIS_UNLOCK_PASS": "hunter2",
+        "JARVIS_UNLOCK_PASSWORD": "hunter2",
+        "ANTHROPIC_API_KEY": "sk-keep-me",
+        "PATH": "/usr/bin",
+    }
+
+    removed = sanitize_process_environment(env)
+
+    assert removed == frozenset({"JARVIS_UNLOCK_PASS", "JARVIS_UNLOCK_PASSWORD"})
+    assert "JARVIS_UNLOCK_PASS" not in env
+    assert env["ANTHROPIC_API_KEY"] == "sk-keep-me", "sweep must not strip provider keys"
+    assert env["PATH"] == "/usr/bin"
+
+
+def test_sanitize_is_idempotent():
+    env = {"JARVIS_UNLOCK_PASS": "hunter2"}
+
+    assert sanitize_process_environment(env) == frozenset({"JARVIS_UNLOCK_PASS"})
+    assert sanitize_process_environment(env) == frozenset()
+
+
+def test_pattern_catches_unenumerated_credential_shapes():
+    env = {"JARVIS_VOICE_UNLOCK_SECRET": "x", "JARVIS_TTS_MAX_QUEUE_S": "12"}
+
+    assert "JARVIS_VOICE_UNLOCK_SECRET" in eradicated_env_keys(env)
+    assert "JARVIS_TTS_MAX_QUEUE_S" not in eradicated_env_keys(env)
+
+
+def test_operator_declared_keys_extend_rather_than_replace():
+    env = {"JARVIS_ERADICATED_ENV_KEYS": "CUSTOM_LEGACY_SECRET"}
+    keys = eradicated_env_keys(env)
+
+    assert "CUSTOM_LEGACY_SECRET" in keys
+    assert "JARVIS_UNLOCK_PASS" in keys, "builtin registry must survive an extension"
+
+
+def test_sanitize_mapping_clears_config_singletons():
+    singleton = {"JARVIS_UNLOCK_PASS": bytearray(b"hunter2"), "keep": "yes"}
+
+    removed = sanitize_mapping(singleton, ["JARVIS_UNLOCK_PASS"])
+
+    assert removed == frozenset({"JARVIS_UNLOCK_PASS"})
+    assert singleton == {"keep": "yes"}
+
+
+# =============================================================================
+# HONESTY — zeroing claims must match what CPython can actually do
+# =============================================================================
+
+
+def test_zero_buffer_zeroes_writable_buffers():
+    buf = bytearray(b"hunter2")
+
+    assert zero_buffer(buf) is True
+    assert bytes(buf) == b"\x00" * 7
+
+
+def test_zero_buffer_reports_false_for_immutable_strings():
+    """
+    A ``str`` cannot be overwritten in place, and this must not pretend it can.
+
+    The guarantee the sweep offers is structural (no code path loads a
+    credential), not hygienic. A ``zero_buffer`` that returned True for ``str``
+    would be exactly the kind of security theatre the sweep exists to remove.
+    """
+    assert zero_buffer("hunter2") is False
+    assert zero_buffer(b"hunter2") is False


### PR DESCRIPTION
## What this is

JARVIS stopped being able to unlock the screen when macOS 26.1 landed on 2025-11-18. Every recorded attempt carries its kernel — `Darwin 25.1.0` — and all 47 password-typing sessions report **13/13 characters typed with `screen_locked=1` before and after**. 611 character records ÷ 47 sessions = exactly 13.0, zero deviations.

`CGEventPost` returns `void`, so no error is possible: every keystroke landed in the counter and none in the field. Accessibility is granted for all five interpreters on this machine, so permission is eliminated as a cause. `SecurityAgent` holds SecureEventInput and discards the events. Typing the password cannot work on macOS 26, and no repair to that code brings it back.

## The credential was pure liability

The macOS login password sat in the login keychain in **cleartext, un-ACL'd**, readable by any process running as the user with no authorization prompt, for eight months — while the only thing consuming it couldn't work.

Both halves are gone. The **storer** was the worse of the two: it passed the password as `-w <password>` on a subprocess argv (visible in the process table), and `-T /usr/bin/security` is what put the `security` binary on the item's ACL — the reason it could be read back without a prompt. Eradicating the reader alone would have let any setup script re-plant it.

`backend/security/credential_eradication.py` is the single definition of the policy; every gutted site imports it, so resurrection requires deleting the module rather than editing one call site.

A second defect surfaced during removal: `_perform_direct_unlock` bound `type_password_securely`'s `Tuple[bool, Optional[Dict]]` to one name and truth-tested it. **A 2-tuple is always truthy** — the failure branch was unreachable and the `except` returned `True` on any error. It reported success unconditionally.

## Measured, not assumed

`system.login.screensaver` is `class=rule / use-login-window-ui` — no mechanism chain to join. Hosting a plugin means replacing the rule, which risked Touch ID and Apple Watch unlock.

**Probe result, 2026-08-05, macOS 26.5.2:** under `authenticate-session-owner-or-admin`, **Touch ID works, password works.** No biometric cost. Apple Watch untested.

The probe arms a detached dead man's switch *before* mutating, verified by SIGKILLing the parent and confirming the timer still fires. Three independent restore layers. Pre-flight exercises the restore path before touching anything.

## Contents

| Commit | |
|---|---|
| `03726c2c2d` | credential eradication + 20 tests |
| `d20002074a` | probe + uninstaller (written first) |
| `ba139e47c5` | 60s window couldn't fit its own protocol |
| `1057c9ed63` | Ctrl-C reverted and discarded the measurement |
| `0e6eb83115` | Authorization Plugin mechanism |

## Honest status

The mechanism **compiles clean** (`-Wall -Wextra`, `_AuthorizationPluginCreate` exported). It is **not signed, not installed, and has never run inside SecurityAgent.** Compiling is not working. The broker, Python bridge, Makefile, Info.plist and installer are still to come.

Nothing on this machine is mutated by this PR: stock rule intact, `SecurityAgentPlugins` empty, no JARVIS LaunchDaemons.

## Tests

20 passed in 0.82s. Behavioural (fetchers raise, with `create_subprocess_exec` booby-trapped to prove they raise *before* shelling out) plus AST guards that fail if the shapes return. One test asserts `zero_buffer` returns **False** for `str` — CPython can't overwrite an immutable string, and claiming otherwise would be the theatre this PR removes.

No regressions: `test_close_apps` fails identically at clean HEAD in a throwaway worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed all cleartext macOS login password storage and usage, and added a safe path toward a passwordless Authorization Plugin unlock. Measured the screensaver rule handoff; Touch ID and the password still work.

- **New Features**
  - Credential eradication across the codebase via `backend/security/credential_eradication.py`; former fetch/type paths now hard-fail through `eradicated_path`.
  - Early environment sweep in `backend/main.py` (`sanitize_process_environment`) to purge stale `.env` secrets before any subsystem loads.
  - Probe tool `backend/voice_unlock/authplugin/install/probe_screensaver_rule.sh` safely switches `system.login.screensaver` to `authenticate-session-owner-or-admin` with an armed timed revert; results logged. Touch ID and password work; Apple Watch untested.
  - Recovery `backend/voice_unlock/authplugin/install/uninstall.sh` restores stock auth rule first and removes plugin artifacts; shared constants in `common.sh`.
  - Authorization Plugin skeleton (`JARVISUnlockMechanism.m`, `JARVISUnlockConfig.*`, `JARVISGrantProtocol.h`) compiles clean; config via Info.plist; not signed or installed.
  - Tests (`tests/security/test_credential_eradication.py`) enforce behavioral raises and structural deletion to prevent resurrection.

- **Bug Fixes**
  - `_perform_direct_unlock` no longer reports success on errors caused by truth-testing a 2-tuple; the path is eradicated and callers now fail safely.
  - Removed AppleScript/keychain fallbacks and emptied `KeychainServiceConfig.SERVICES`; prevents silent reintroduction of the credential.

<sup>Written for commit 0e6eb831158e491e550642e7dfa5d6b6a8dcf98a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

