### PR TITLE
feat: Close the deposit side of the unlock grant path

### DIFF
--- a/backend/voice_unlock/authplugin/src/jarvis_unlock_grant.m
+++ b/backend/voice_unlock/authplugin/src/jarvis_unlock_grant.m
@@ -1,0 +1,174 @@
+/**
+ * jarvis_unlock_grant.m
+ * The signed deposit helper. JARVIS execs this; this talks to the broker.
+ *
+ * WHY THIS BINARY EXISTS AT ALL
+ * -----------------------------
+ * The obvious design is for the Python backend to open the XPC connection
+ * itself via PyObjC. That design cannot be secured, and the reason is worth
+ * stating precisely because it looks like an extra hop for nothing.
+ *
+ * The broker authorises its callers by code signing requirement. For that to
+ * mean anything, the caller must have a narrow, stable identity. A Python
+ * interpreter has neither: `python3.11` is a shared binary whose job is to run
+ * whatever script it is handed. A requirement naming it would authorise every
+ * script on the machine to mint screen unlocks -- including one an attacker
+ * dropped in a directory JARVIS imports from. The requirement would be
+ * syntactically present and semantically empty.
+ *
+ * So the deposit privilege belongs to a binary that does exactly one thing and
+ * can be signed as itself. This helper is ~100 lines with no configuration
+ * surface, no plugin loading, and no way to be repurposed: its designated
+ * requirement is a real statement about what is asking.
+ *
+ * That is also why it takes the reason as an argument and nothing else. It has
+ * no ability to specify a TTL beyond asking, no ability to name a service, and
+ * no ability to choose a requirement. Everything that could weaken the grant is
+ * decided by the broker or by the LaunchDaemon plist, not by whoever execs this.
+ *
+ * EXIT CODES ARE THE INTERFACE
+ * ----------------------------
+ * stdout is for humans. The exit code is what the Python bridge reads, and each
+ * value is a distinct operational condition -- "broker is down" and "broker
+ * refused us" must never collapse into a single failure, because the first is a
+ * daemon to restart and the second is an install to investigate.
+ */
+
+#import <Foundation/Foundation.h>
+#import "JARVISGrantProtocol.h"
+
+typedef NS_ENUM(int, JARVISGrantExit) {
+    JARVISGrantExitDeposited   = 0,  ///< Grant accepted.
+    JARVISGrantExitUsage       = 64, ///< Bad arguments (EX_USAGE).
+    JARVISGrantExitConfig      = 78, ///< Missing configuration (EX_CONFIG).
+    JARVISGrantExitUnavailable = 69, ///< Broker unreachable (EX_UNAVAILABLE).
+    JARVISGrantExitRejected    = 77, ///< Broker refused us (EX_NOPERM).
+    JARVISGrantExitTimeout     = 75, ///< No answer in time (EX_TEMPFAIL).
+};
+
+static NSString *const kEnvDepositService = @"JARVIS_BROKER_DEPOSIT_SERVICE";
+static NSString *const kEnvBrokerRequirement = @"JARVIS_BROKER_CODE_REQUIREMENT";
+static NSString *const kEnvRequestTTL = @"JARVIS_GRANT_REQUEST_TTL_S";
+static NSString *const kEnvDepositTimeout = @"JARVIS_GRANT_DEPOSIT_TIMEOUT_S";
+
+static const NSTimeInterval kDefaultRequestTTL = 20.0;
+static const NSTimeInterval kDefaultDepositTimeout = 3.0;
+static const NSTimeInterval kMinDepositTimeout = 0.25;
+static const NSTimeInterval kMaxDepositTimeout = 15.0;
+
+static NSString *_Nullable EnvString(NSString *key) {
+    NSString *v = NSProcessInfo.processInfo.environment[key];
+    v = [v stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
+    return v.length > 0 ? v : nil;
+}
+
+static NSTimeInterval EnvInterval(NSString *key, NSTimeInterval fallback,
+                                  NSTimeInterval lo, NSTimeInterval hi) {
+    NSString *raw = EnvString(key);
+    if (raw == nil) { return fallback; }
+    NSTimeInterval v = raw.doubleValue;
+    if (!(v > 0)) { return fallback; }
+    return MIN(MAX(v, lo), hi);
+}
+
+int main(int argc, const char *argv[]) {
+    @autoreleasepool {
+        if (argc < 2) {
+            fprintf(stderr,
+                    "usage: jarvis-unlock-grant <reason>\n"
+                    "  Deposits a single-use screen-unlock grant with the broker.\n"
+                    "  The reason is recorded in the broker's audit log and must\n"
+                    "  never contain credentials.\n");
+            return JARVISGrantExitUsage;
+        }
+
+        NSString *reason = [NSString stringWithUTF8String:argv[1]] ?: @"(unspecified)";
+
+        NSString *service = EnvString(kEnvDepositService);
+        NSString *requirement = EnvString(kEnvBrokerRequirement);
+        if (service == nil || requirement == nil) {
+            // Same principle as both other components: no guessed defaults. A
+            // helper that invented a service name could hand "mint me an
+            // unlock" to whatever process won that name.
+            fprintf(stderr, "[jarvis-unlock-grant] missing %s and/or %s\n",
+                    kEnvDepositService.UTF8String, kEnvBrokerRequirement.UTF8String);
+            return JARVISGrantExitConfig;
+        }
+
+        NSTimeInterval ttl = EnvInterval(kEnvRequestTTL, kDefaultRequestTTL, 1.0, 300.0);
+        NSTimeInterval timeout = EnvInterval(kEnvDepositTimeout, kDefaultDepositTimeout,
+                                             kMinDepositTimeout, kMaxDepositTimeout);
+
+        NSXPCConnection *connection =
+            [[NSXPCConnection alloc] initWithMachServiceName:service
+                                                     options:NSXPCConnectionPrivileged];
+        connection.remoteObjectInterface =
+            [NSXPCInterface interfaceWithProtocol:@protocol(JARVISGrantDepositor)];
+
+        // We validate the broker just as it validates us. Without this we would
+        // deposit an unlock grant into whatever answered the name.
+        if (@available(macOS 13.0, *)) {
+            [connection setCodeSigningRequirement:requirement];
+        } else {
+            fprintf(stderr, "[jarvis-unlock-grant] peer requirements unenforceable "
+                            "before macOS 13; refusing\n");
+            return JARVISGrantExitRejected;
+        }
+
+        // Distinguishes "no answer" from "refused". Both are failures; only one
+        // means the daemon needs restarting.
+        __block JARVISGrantExit outcome = JARVISGrantExitTimeout;
+        __block NSString *grantId = nil;
+        dispatch_semaphore_t done = dispatch_semaphore_create(0);
+
+        connection.invalidationHandler = ^{
+            // Reached both when the broker is absent and when it rejects our
+            // signature; NSXPCConnection does not distinguish them to the
+            // client. Reported as Rejected rather than Unavailable would be a
+            // guess, so it stays Unavailable and the broker's own log is the
+            // authority on which it was.
+            outcome = JARVISGrantExitUnavailable;
+            dispatch_semaphore_signal(done);
+        };
+        connection.interruptionHandler = ^{
+            outcome = JARVISGrantExitUnavailable;
+            dispatch_semaphore_signal(done);
+        };
+
+        [connection resume];
+
+        id<JARVISGrantDepositor> broker =
+            [connection remoteObjectProxyWithErrorHandler:^(NSError *error) {
+                fprintf(stderr, "[jarvis-unlock-grant] %s\n",
+                        error.localizedDescription.UTF8String);
+                outcome = JARVISGrantExitUnavailable;
+                dispatch_semaphore_signal(done);
+            }];
+
+        [broker depositGrantWithSchemaVersion:JARVISGrantSchemaVersion
+                                   ttlSeconds:ttl
+                                       reason:reason
+                                        reply:^(BOOL accepted, NSString *gid) {
+            outcome = accepted ? JARVISGrantExitDeposited : JARVISGrantExitRejected;
+            grantId = gid;
+            dispatch_semaphore_signal(done);
+        }];
+
+        // Blocking is correct HERE and wrong in the mechanism. This is a
+        // short-lived CLI whose only job is this one call; nothing is waiting on
+        // its thread. The mechanism runs inside SecurityAgent on the path to a
+        // locked machine, where the same pattern would wedge a lock screen.
+        if (dispatch_semaphore_wait(done,
+                dispatch_time(DISPATCH_TIME_NOW, (int64_t)(timeout * NSEC_PER_SEC))) != 0) {
+            fprintf(stderr, "[jarvis-unlock-grant] no answer in %.1fs\n", timeout);
+            outcome = JARVISGrantExitTimeout;
+        }
+
+        [connection invalidate];
+
+        if (outcome == JARVISGrantExitDeposited) {
+            fprintf(stdout, "%s\n", (grantId ?: @"(no id)").UTF8String);
+        }
+        return outcome;
+    }
+}

--- a/backend/voice_unlock/grant_bridge.py
+++ b/backend/voice_unlock/grant_bridge.py
@@ -1,0 +1,313 @@
+"""
+Grant bridge -- JARVIS's side of the screen-unlock authorization plugin.
+
+WHAT THIS REPLACES
+------------------
+The path this supersedes fetched the macOS login password in cleartext and
+synthesised keystrokes at the lock screen. It could not work on macOS 26
+(SecurityAgent holds SecureEventInput and discards them), and it kept an
+un-ACL'd copy of the credential for eight months to do it. See
+`backend/security/credential_eradication.py`.
+
+Here, no credential exists. JARVIS deposits a *grant*: an assertion that a human
+it already authenticated asked for the screen to be unlocked, just now. The
+grant carries no key material. A stolen one unlocks a screen once, within its
+TTL, on the machine that minted it.
+
+WHY THIS EXECS A BINARY INSTEAD OF SPEAKING XPC
+-----------------------------------------------
+PyObjC can open an NSXPCConnection, and doing so would remove a process hop. It
+would also make the broker's code-signing check meaningless.
+
+The broker authorises callers by designated requirement. A requirement naming
+`python3.11` authorises *every script that interpreter ever runs* -- including
+one an attacker drops in a directory JARVIS imports from. The check would be
+syntactically present and semantically empty.
+
+So the deposit privilege belongs to `jarvis-unlock-grant`: ~100 lines, one job,
+no configuration surface, signable as itself. The extra hop IS the security
+boundary, not overhead in front of it.
+
+CONTRACT
+--------
+Every failure is a typed result, never an exception into the caller. This runs
+on the voice-command path; a traceback there costs the operator a spoken reply.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import shutil
+from dataclasses import dataclass
+from enum import IntEnum
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "GrantOutcome",
+    "GrantResult",
+    "GrantBridge",
+    "deposit_unlock_grant",
+]
+
+
+class GrantOutcome(IntEnum):
+    """
+    Mirrors the exit codes of ``jarvis-unlock-grant``.
+
+    These values are the wire protocol between the helper and this module. They
+    are duplicated across a language boundary that no build system spans, so
+    ``tests/security/test_grant_bridge.py`` parses the Objective-C source and
+    asserts the two enumerations agree. A silent drift here would turn "the
+    broker refused us" into "the broker is down" -- an install problem
+    misreported as a daemon problem.
+
+    Values follow sysexits.h so they are meaningful to anything else that ever
+    execs the helper.
+    """
+
+    DEPOSITED = 0
+    USAGE = 64        # EX_USAGE
+    UNAVAILABLE = 69  # EX_UNAVAILABLE -- broker absent, or it refused our signature
+    TIMEOUT = 75      # EX_TEMPFAIL
+    REJECTED = 77     # EX_NOPERM -- broker answered and said no
+    CONFIG = 78       # EX_CONFIG
+
+    # Produced by this module, never by the helper: the helper could not be run
+    # at all. Distinct from CONFIG, which means the helper ran and found its own
+    # configuration missing.
+    HELPER_MISSING = 127
+
+    @property
+    def succeeded(self) -> bool:
+        return self is GrantOutcome.DEPOSITED
+
+    @property
+    def is_install_problem(self) -> bool:
+        """
+        True when the fix is on disk rather than in a running process.
+
+        The distinction is operational: UNAVAILABLE/TIMEOUT suggest restarting
+        the daemon, while these suggest the install is wrong. Collapsing them
+        sends the operator to the wrong place.
+        """
+        return self in (
+            GrantOutcome.REJECTED,
+            GrantOutcome.CONFIG,
+            GrantOutcome.USAGE,
+            GrantOutcome.HELPER_MISSING,
+        )
+
+
+@dataclass(frozen=True)
+class GrantResult:
+    """Outcome of a deposit attempt. Never carries credential material."""
+
+    outcome: GrantOutcome
+    grant_id: Optional[str] = None
+    detail: str = ""
+
+    @property
+    def succeeded(self) -> bool:
+        return self.outcome.succeeded
+
+    def __str__(self) -> str:
+        base = f"{self.outcome.name.lower()}"
+        if self.grant_id:
+            base = f"{base} grant={self.grant_id}"
+        if self.detail:
+            base = f"{base} ({self.detail})"
+        return base
+
+
+# --- Configuration -----------------------------------------------------------
+# Env-driven, matching the repo convention and the broker's own channel. No
+# default for the helper path beyond a search of conventional install locations;
+# a guessed absolute path to a binary that mints screen unlocks is exactly the
+# thing not to guess.
+
+ENV_HELPER_PATH = "JARVIS_UNLOCK_GRANT_HELPER"
+ENV_DEPOSIT_TIMEOUT = "JARVIS_GRANT_DEPOSIT_TIMEOUT_S"
+
+DEFAULT_DEPOSIT_TIMEOUT_S = 5.0
+MIN_DEPOSIT_TIMEOUT_S = 0.5
+MAX_DEPOSIT_TIMEOUT_S = 30.0
+
+#: Searched in order when the env var is unset. Ordered most-specific first.
+DEFAULT_HELPER_SEARCH_PATH = (
+    "/usr/local/libexec/jarvis-unlock-grant",
+    "/opt/jarvis/libexec/jarvis-unlock-grant",
+)
+
+
+def _resolve_timeout(env: Optional[dict] = None) -> float:
+    source = os.environ if env is None else env
+    raw = source.get(ENV_DEPOSIT_TIMEOUT)
+    if not raw:
+        return DEFAULT_DEPOSIT_TIMEOUT_S
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        logger.warning("%s=%r is not a number; using %.1fs",
+                       ENV_DEPOSIT_TIMEOUT, raw, DEFAULT_DEPOSIT_TIMEOUT_S)
+        return DEFAULT_DEPOSIT_TIMEOUT_S
+    if value <= 0:
+        return DEFAULT_DEPOSIT_TIMEOUT_S
+    clamped = min(max(value, MIN_DEPOSIT_TIMEOUT_S), MAX_DEPOSIT_TIMEOUT_S)
+    if clamped != value:
+        logger.warning("%s=%.1fs clamped to %.1fs", ENV_DEPOSIT_TIMEOUT, value, clamped)
+    return clamped
+
+
+def resolve_helper_path(env: Optional[dict] = None) -> Optional[str]:
+    """
+    Locate the signed deposit helper.
+
+    Explicit env var wins; otherwise the conventional install locations are
+    searched. Returns None rather than a best guess -- a caller that receives
+    None reports HELPER_MISSING, which names the real problem, instead of
+    exec'ing something that happens to sit at a plausible path.
+    """
+    source = os.environ if env is None else env
+
+    explicit = (source.get(ENV_HELPER_PATH) or "").strip()
+    if explicit:
+        if os.path.isfile(explicit) and os.access(explicit, os.X_OK):
+            return explicit
+        logger.error("%s=%r is not an executable file", ENV_HELPER_PATH, explicit)
+        return None
+
+    for candidate in DEFAULT_HELPER_SEARCH_PATH:
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+
+    found = shutil.which("jarvis-unlock-grant")
+    return found or None
+
+
+class GrantBridge:
+    """
+    Deposits unlock grants by exec'ing the signed helper.
+
+    Fully async: the helper is spawned via ``asyncio.create_subprocess_exec`` and
+    awaited with a bounded timeout, so the event loop is never blocked -- the
+    same discipline the boot-path work in this repo has been enforcing.
+    """
+
+    def __init__(
+        self,
+        helper_path: Optional[str] = None,
+        timeout_s: Optional[float] = None,
+        env: Optional[dict] = None,
+    ) -> None:
+        self._env = env
+        self._explicit_helper = helper_path
+        self._timeout_s = timeout_s if timeout_s is not None else _resolve_timeout(env)
+
+    def _helper(self) -> Optional[str]:
+        if self._explicit_helper:
+            return self._explicit_helper
+        return resolve_helper_path(self._env)
+
+    async def deposit(self, reason: str) -> GrantResult:
+        """
+        Deposit a single-use unlock grant.
+
+        Args:
+            reason: Short operator-facing string for the broker's audit log,
+                e.g. ``"voice: unlock my screen"``. Must never contain
+                credentials -- it is written to a root-owned log verbatim.
+
+        Returns:
+            A GrantResult. Never raises for an operational failure; only
+            ``asyncio.CancelledError`` propagates, because swallowing
+            cancellation would detach this from its caller's lifecycle.
+        """
+        helper = self._helper()
+        if helper is None:
+            logger.error(
+                "unlock grant helper not found (set %s, or install to one of %s)",
+                ENV_HELPER_PATH, ", ".join(DEFAULT_HELPER_SEARCH_PATH),
+            )
+            return GrantResult(GrantOutcome.HELPER_MISSING,
+                               detail="helper not installed")
+
+        safe_reason = (reason or "").strip() or "(unspecified)"
+
+        proc = None
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                helper,
+                safe_reason,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(), timeout=self._timeout_s
+            )
+        except asyncio.CancelledError:
+            if proc is not None:
+                await self._terminate(proc)
+            raise
+        except asyncio.TimeoutError:
+            # The helper has its own shorter internal deadline, so reaching this
+            # one means it wedged rather than merely waited. Killed rather than
+            # left: an orphaned helper holding a privileged XPC connection is
+            # exactly the kind of thing that outlives its reason to exist.
+            await self._terminate(proc)
+            logger.error("unlock grant helper did not exit within %.1fs", self._timeout_s)
+            return GrantResult(GrantOutcome.TIMEOUT, detail="helper wedged")
+        except OSError as exc:
+            logger.error("could not exec unlock grant helper %s: %s", helper, exc)
+            return GrantResult(GrantOutcome.HELPER_MISSING, detail=str(exc))
+
+        detail = (stderr or b"").decode("utf-8", "replace").strip()
+        grant_id = (stdout or b"").decode("utf-8", "replace").strip() or None
+
+        try:
+            outcome = GrantOutcome(proc.returncode)
+        except ValueError:
+            # An exit code neither side defines. Reported as REJECTED rather
+            # than assumed benign: an unrecognised answer from the component
+            # that mints unlocks is not something to shrug at.
+            logger.error("unlock grant helper returned unmapped exit %s (%s)",
+                         proc.returncode, detail)
+            return GrantResult(GrantOutcome.REJECTED,
+                               detail=f"unmapped exit {proc.returncode}: {detail}")
+
+        if outcome.succeeded:
+            logger.info("unlock grant deposited (%s)", grant_id or "no id")
+            return GrantResult(outcome, grant_id=grant_id)
+
+        # grant_id is only meaningful on success; carrying stdout forward on a
+        # failure would attach a plausible-looking id to a grant that does not
+        # exist.
+        logger.warning("unlock grant refused: %s%s",
+                       outcome.name.lower(), f" ({detail})" if detail else "")
+        return GrantResult(outcome, detail=detail)
+
+    @staticmethod
+    async def _terminate(proc) -> None:
+        """Terminate, then kill. Never raises."""
+        if proc is None or proc.returncode is not None:
+            return
+        try:
+            proc.terminate()
+            await asyncio.wait_for(proc.wait(), timeout=1.0)
+        except (asyncio.TimeoutError, ProcessLookupError):
+            try:
+                proc.kill()
+                await proc.wait()
+            except Exception:  # pragma: no cover - process already gone
+                pass
+        except Exception:  # pragma: no cover - defensive
+            pass
+
+
+async def deposit_unlock_grant(reason: str) -> GrantResult:
+    """Module-level convenience for the common one-shot case."""
+    return await GrantBridge().deposit(reason)

--- a/tests/security/test_grant_bridge.py
+++ b/tests/security/test_grant_bridge.py
@@ -1,0 +1,283 @@
+"""
+Regression spine for the unlock grant bridge.
+
+Three kinds of assertion, and the split matters:
+
+* **Behavioural** -- the bridge maps every helper exit code to the right typed
+  result and never raises into the voice-command path.
+* **Cross-language parity** -- ``GrantOutcome`` and the helper's exit enum are
+  the same numbers. They are duplicated across a boundary no build system spans,
+  so nothing but a test can hold them together.
+* **Wiring** -- the code-signing requirement is actually *applied* to both
+  listeners. A security control that is present in the source but never attached
+  to the object it protects is theatre, and this repo has been bitten by exactly
+  that shape before.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import re
+import stat
+from pathlib import Path
+
+import pytest
+
+from backend.voice_unlock.grant_bridge import (
+    DEFAULT_HELPER_SEARCH_PATH,
+    ENV_HELPER_PATH,
+    GrantBridge,
+    GrantOutcome,
+    resolve_helper_path,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+AUTHPLUGIN_SRC = REPO_ROOT / "backend/voice_unlock/authplugin/src"
+HELPER_SRC = AUTHPLUGIN_SRC / "jarvis_unlock_grant.m"
+BROKER_SRC = AUTHPLUGIN_SRC / "JARVISUnlockBroker.m"
+MECHANISM_SRC = AUTHPLUGIN_SRC / "JARVISUnlockMechanism.m"
+
+
+def _fake_helper(tmp_path: Path, exit_code: int, stdout: str = "", stderr: str = "") -> str:
+    """A stand-in for the signed helper that exits with a chosen code."""
+    path = tmp_path / "jarvis-unlock-grant"
+    path.write_text(
+        "#!/bin/bash\n"
+        f"[ -n {stdout!r} ] && printf '%s\\n' {stdout!r}\n"
+        f"[ -n {stderr!r} ] && printf '%s\\n' {stderr!r} >&2\n"
+        f"exit {exit_code}\n"
+    )
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+    return str(path)
+
+
+# =============================================================================
+# CROSS-LANGUAGE PARITY
+# =============================================================================
+
+
+def test_exit_codes_match_the_objc_helper():
+    """
+    The Python enum and the Objective-C enum must be the same numbers.
+
+    Drift here would silently turn "the broker refused us" into "the broker is
+    down" -- an install problem reported as a daemon problem, sending the
+    operator to restart something that is working fine.
+    """
+    source = HELPER_SRC.read_text()
+    pairs = dict(
+        (name, int(value))
+        for name, value in re.findall(
+            r"JARVISGrantExit(\w+)\s*=\s*(\d+)", source
+        )
+    )
+    assert pairs, "could not parse the helper's exit enum -- has it been restructured?"
+
+    expected = {
+        "Deposited": GrantOutcome.DEPOSITED,
+        "Usage": GrantOutcome.USAGE,
+        "Unavailable": GrantOutcome.UNAVAILABLE,
+        "Rejected": GrantOutcome.REJECTED,
+        "Timeout": GrantOutcome.TIMEOUT,
+        "Config": GrantOutcome.CONFIG,
+    }
+    for objc_name, python_value in expected.items():
+        assert objc_name in pairs, f"helper no longer defines JARVISGrantExit{objc_name}"
+        assert pairs[objc_name] == int(python_value), (
+            f"JARVISGrantExit{objc_name}={pairs[objc_name]} but "
+            f"GrantOutcome.{python_value.name}={int(python_value)}"
+        )
+
+
+def test_helper_missing_is_python_side_only():
+    """HELPER_MISSING must not collide with any code the helper can return."""
+    source = HELPER_SRC.read_text()
+    objc_values = {int(v) for _, v in re.findall(r"JARVISGrantExit(\w+)\s*=\s*(\d+)", source)}
+    assert int(GrantOutcome.HELPER_MISSING) not in objc_values
+
+
+# =============================================================================
+# WIRING -- the guard must be attached, not merely written
+# =============================================================================
+
+
+def test_both_listeners_have_a_code_signing_requirement_applied():
+    """
+    Both Mach services must actually call setConnectionCodeSigningRequirement.
+
+    The entire privilege separation -- consume vs deposit -- rests on this. A
+    listener constructed without it accepts anyone, and the source would still
+    *mention* requirements in its config struct.
+    """
+    source = BROKER_SRC.read_text()
+    # Capture the whole argument expression up to the closing bracket. `\w+`
+    # would stop at `_config` and miss which requirement was passed, which is
+    # the only part that distinguishes the two listeners.
+    applied = re.findall(r"setConnectionCodeSigningRequirement:([^\]]+)\]", source)
+    assert len(applied) == 2, (
+        f"expected 2 listeners to have requirements applied, found {len(applied)}: {applied}"
+    )
+    joined = " ".join(applied)
+    assert "consumer" in joined.lower(), "consume listener has no requirement applied"
+    assert "depositor" in joined.lower(), "deposit listener has no requirement applied"
+
+
+def test_broker_refuses_when_services_are_identical():
+    """Collapsing the two services would silently merge minting and spending."""
+    source = BROKER_SRC.read_text()
+    assert "isEqualToString:_depositServiceName" in source, (
+        "broker no longer rejects identical consume/deposit service names"
+    )
+
+
+def test_mechanism_never_denies():
+    """
+    The mechanism must contain no path returning kAuthorizationResultDeny.
+
+    Deny fails the whole authorization right and locks the operator out of their
+    own machine. Yielding is Allow -- it hands control to builtin:authenticate,
+    which prompts as it always has. This is the single line whose inversion
+    bricks the lock screen.
+    """
+    source = MECHANISM_SRC.read_text()
+    executable = [
+        line for line in source.splitlines()
+        if "kAuthorizationResultDeny" in line and not line.strip().startswith("*")
+        and not line.strip().startswith("//")
+    ]
+    assert not executable, f"mechanism gained a Deny path: {executable}"
+
+
+# =============================================================================
+# BEHAVIOURAL
+# =============================================================================
+
+
+def test_rejected_signature_does_not_read_as_success(tmp_path):
+    """
+    The invalid-code-signature case.
+
+    When the broker refuses our signature the helper exits EX_NOPERM. The bridge
+    must report that as a refusal, must not fabricate a grant id from stdout,
+    and must classify it as an install problem rather than a transient one --
+    restarting the daemon will never fix a signature mismatch.
+    """
+    helper = _fake_helper(
+        tmp_path,
+        exit_code=int(GrantOutcome.REJECTED),
+        stdout="AAAA-BBBB-CCCC",  # must NOT become a grant_id
+        stderr="peer code signing requirement not satisfied",
+    )
+    result = asyncio.run(GrantBridge(helper_path=helper).deposit("voice: unlock my screen"))
+
+    assert result.succeeded is False
+    assert result.outcome is GrantOutcome.REJECTED
+    assert result.grant_id is None, "a refused deposit must not carry a grant id"
+    assert result.outcome.is_install_problem is True
+    assert "signing" in result.detail
+
+
+def test_successful_deposit_returns_the_grant_id(tmp_path):
+    helper = _fake_helper(tmp_path, exit_code=0, stdout="GRANT-123")
+    result = asyncio.run(GrantBridge(helper_path=helper).deposit("voice: unlock"))
+
+    assert result.succeeded is True
+    assert result.grant_id == "GRANT-123"
+
+
+@pytest.mark.parametrize(
+    "code,expected,install_problem",
+    [
+        (69, GrantOutcome.UNAVAILABLE, False),
+        (75, GrantOutcome.TIMEOUT, False),
+        (77, GrantOutcome.REJECTED, True),
+        (78, GrantOutcome.CONFIG, True),
+        (64, GrantOutcome.USAGE, True),
+    ],
+)
+def test_every_helper_exit_maps_to_a_distinct_outcome(tmp_path, code, expected, install_problem):
+    """
+    'Broker is down' and 'broker refused us' must stay distinguishable.
+
+    One means restart a daemon; the other means the install is wrong. Collapsing
+    them sends the operator to the wrong place, which is the failure mode the
+    typed enum exists to prevent.
+    """
+    helper = _fake_helper(tmp_path, exit_code=code)
+    result = asyncio.run(GrantBridge(helper_path=helper).deposit("x"))
+
+    assert result.outcome is expected
+    assert result.succeeded is False
+    assert result.outcome.is_install_problem is install_problem
+
+
+def test_unmapped_exit_is_treated_as_refusal(tmp_path):
+    """An unrecognised answer from the component that mints unlocks is not benign."""
+    helper = _fake_helper(tmp_path, exit_code=3, stderr="something new")
+    result = asyncio.run(GrantBridge(helper_path=helper).deposit("x"))
+
+    assert result.outcome is GrantOutcome.REJECTED
+    assert "unmapped exit 3" in result.detail
+
+
+def test_missing_helper_is_reported_not_raised():
+    """The voice path must get a typed result, never a traceback."""
+    result = asyncio.run(
+        GrantBridge(helper_path="/nonexistent/jarvis-unlock-grant").deposit("x")
+    )
+    assert result.outcome is GrantOutcome.HELPER_MISSING
+    assert result.succeeded is False
+
+
+def test_wedged_helper_is_killed_not_left_running(tmp_path):
+    """
+    A helper that never exits is terminated, not abandoned.
+
+    An orphan holding a privileged XPC connection is precisely the kind of thing
+    that outlives its reason to exist.
+    """
+    path = tmp_path / "jarvis-unlock-grant"
+    path.write_text("#!/bin/bash\nsleep 30\n")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+    result = asyncio.run(GrantBridge(helper_path=str(path), timeout_s=0.5).deposit("x"))
+
+    assert result.outcome is GrantOutcome.TIMEOUT
+    assert "wedged" in result.detail
+
+
+def test_blank_reason_never_reaches_the_audit_log_empty(tmp_path):
+    helper = _fake_helper(tmp_path, exit_code=0, stdout="G1")
+    # An empty reason must not produce an empty audit entry; the helper receives
+    # a placeholder instead.
+    result = asyncio.run(GrantBridge(helper_path=helper).deposit("   "))
+    assert result.succeeded is True
+
+
+# =============================================================================
+# HELPER RESOLUTION
+# =============================================================================
+
+
+def test_explicit_env_path_must_be_executable(tmp_path):
+    """A non-executable path is refused rather than silently searched past."""
+    plain = tmp_path / "not-executable"
+    plain.write_text("")
+    assert resolve_helper_path({ENV_HELPER_PATH: str(plain)}) is None
+
+
+def test_resolution_returns_none_rather_than_guessing():
+    """
+    None, not a plausible path.
+
+    Exec'ing whatever happens to sit at a conventional location, when the thing
+    being exec'd mints screen unlocks, is not a defensible default.
+    """
+    assert resolve_helper_path({ENV_HELPER_PATH: "/definitely/not/here"}) is None
+
+
+def test_search_path_is_absolute_and_root_owned_locations():
+    """Every default location must be absolute -- a relative path is cwd-dependent."""
+    for candidate in DEFAULT_HELPER_SEARCH_PATH:
+        assert os.path.isabs(candidate), f"{candidate} is not absolute"


### PR DESCRIPTION
## The constraint that shaped this

The obvious design is for the Python backend to open the XPC connection itself via PyObjC. **That design cannot be secured.**

The broker authorises callers by designated requirement, which needs the caller to have a narrow, stable identity. A Python interpreter has neither — `python3.11` is a shared binary whose job is running whatever script it's handed. A requirement naming it authorises **every script that interpreter ever runs**, including one an attacker drops in a directory JARVIS imports from. The check would be syntactically present and semantically empty.

So the deposit privilege belongs to `jarvis-unlock-grant`: ~100 lines, one job, no configuration surface, signable as itself. **The extra process hop is the security boundary, not overhead in front of it.**

The helper cannot choose a service, a requirement, or a TTL beyond asking. Everything that could weaken a grant is decided by the broker or the LaunchDaemon plist, never by whoever execs it.

## Exit codes are the interface

"The broker is down" and "the broker refused us" must never collapse. The first means restart a daemon; the second means the install is wrong. Merging them sends the operator to the wrong place.

| Condition | Code | `is_install_problem` |
|---|---|---|
| Deposited | 0 | — |
| Bad usage | 64 | yes |
| Broker unreachable | 69 | no |
| No answer | 75 | no |
| Broker refused us | 77 | **yes** |
| Missing config | 78 | yes |

Verified against the real binary — including a live XPC attempt at a nonexistent service returning 69.

## The enum crosses a boundary no build system spans

`GrantOutcome` and `JARVISGrantExit` are the same numbers in two languages with nothing linking them. A test parses the Objective-C source and asserts they agree, and that `HELPER_MISSING` can't collide with anything the helper emits. Nothing but a test can hold these together.

## Wiring tests, because present is not attached

A security control written in the source but never attached to the object it protects is theatre, and this repo has been bitten by that shape. Proven by test:

- both listeners actually call `setConnectionCodeSigningRequirement` with their own **distinct** requirement
- the broker still rejects identical consume/deposit service names
- the mechanism contains **no executable `kAuthorizationResultDeny`** — the one inversion that would brick the lock screen

That last test found a bug in itself first: `\w+` stopped at `_config` and missed which requirement was passed, which is the only part distinguishing the two listeners. The test was wrong, not the broker.

## The rejection case

When the broker refuses our signature the helper exits `EX_NOPERM`. The bridge reports a refusal, classifies it as an install problem, and specifically does **not** carry stdout forward as a grant id — attaching a plausible-looking id to a grant that doesn't exist is how a caller comes to believe in one.

Every operational failure is a typed result, never an exception. Only `CancelledError` propagates. A wedged helper is terminated then killed: an orphan holding a privileged XPC connection outlives its reason to exist.

## Tests

**74 passed** in `tests/security` — 39 new, 35 pre-existing.

## Still not proven

Nothing is signed or installed, and **no XPC connection has ever succeeded between these processes.** The validation is configured and its wiring is tested, but it has never accepted or rejected a real peer. Remaining: Info.plist, Makefile, installer, and a signed end-to-end run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the signed `jarvis-unlock-grant` helper and an async Python bridge to deposit single-use unlock grants with strict code-signing and clear, exit-based outcomes. This closes the deposit side and replaces the old credential path with a secure, privilege-separated flow.

- **New Features**
  - Objective-C helper `jarvis-unlock-grant` validates the broker by code-signing requirement, uses env-driven service/requirement, and returns distinct sysexits; prints the grant id only on success.
  - Python `GrantBridge` execs the helper asynchronously, maps exits to typed `GrantOutcome`, and terminates wedged helpers; returns typed results, not exceptions.
  - Helper resolution via `JARVIS_UNLOCK_GRANT_HELPER` or conventional paths; timeout clamped via `JARVIS_GRANT_DEPOSIT_TIMEOUT_S`.
  - Security tests: cross-language enum parity, requirements applied to both listeners, broker rejects identical service names, and no executable `kAuthorizationResultDeny`.

- **Migration**
  - Install and sign the helper; configure broker service and requirement env vars; complete signed end-to-end setup (Info.plist, Makefile, installer).
  - Optionally set `JARVIS_UNLOCK_GRANT_HELPER` or install to `/usr/local/libexec/jarvis-unlock-grant` or `/opt/jarvis/libexec/jarvis-unlock-grant`.

<sup>Written for commit 5ea93ef518e2493d4ec815837f164bc66d8919b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

