### PR TITLE
feat: Add the authorization plugin install layer

### DIFF
--- a/backend/voice_unlock/authplugin/.gitignore
+++ b/backend/voice_unlock/authplugin/.gitignore
@@ -1,0 +1,2 @@
+dist/
+build/

--- a/backend/voice_unlock/authplugin/Makefile
+++ b/backend/voice_unlock/authplugin/Makefile
@@ -1,0 +1,105 @@
+# JARVIS Authorization Plugin -- build only.
+#
+# There is deliberately NO `install` target. Installation rewrites the
+# authorization database that stands between the operator and their own locked
+# machine, and it has an ordering constraint the build system cannot express:
+# each component's code signing requirement must be COMPUTED from the signed
+# binary before the next component can be configured to trust it. That lives in
+# install/install.sh, where it can be read, and undone by install/uninstall.sh.
+#
+# `make` here produces artifacts. Nothing it does touches system state.
+
+SHELL := /bin/bash
+
+# --- Toolchain --------------------------------------------------------------
+CC       ?= clang
+SDK      := $(shell xcrun --sdk macosx --show-sdk-path 2>/dev/null)
+ARCHS    ?= -arch $(shell uname -m)
+
+# -Werror on purpose. This code runs inside SecurityAgent; a warning here is a
+# defect in the authentication path, not style feedback.
+CFLAGS   := -fobjc-arc -fmodules -Wall -Wextra -Werror -O2 $(ARCHS)
+ifneq ($(SDK),)
+CFLAGS   += -isysroot $(SDK)
+endif
+
+SRC      := src
+BUILD    := build
+DIST     := dist
+
+# --- Components -------------------------------------------------------------
+# JARVISGrantProtocol.m is linked by all three: it defines the symbols the
+# shared header declares. Defining them in any one component's translation unit
+# is what previously left the others with undefined symbols.
+SHARED_SRC    := $(SRC)/JARVISGrantProtocol.m
+
+PLUGIN_SRC    := $(SRC)/JARVISUnlockMechanism.m $(SRC)/JARVISUnlockConfig.m $(SHARED_SRC)
+BROKER_SRC    := $(SRC)/JARVISUnlockBroker.m $(SHARED_SRC)
+HELPER_SRC    := $(SRC)/jarvis_unlock_grant.m $(SHARED_SRC)
+
+PLUGIN_NAME   := JARVISUnlock
+BUNDLE        := $(DIST)/$(PLUGIN_NAME).bundle
+BUNDLE_BIN    := $(BUNDLE)/Contents/MacOS/$(PLUGIN_NAME)
+BROKER_BIN    := $(DIST)/jarvis-unlock-broker
+HELPER_BIN    := $(DIST)/jarvis-unlock-grant
+
+FRAMEWORKS    := -framework Foundation -framework Security -framework CoreGraphics -framework Carbon
+
+.PHONY: all clean verify help
+.DEFAULT_GOAL := all
+
+all: $(BUNDLE) $(BROKER_BIN) $(HELPER_BIN) ## Build every artifact
+	@echo "built into $(DIST)/ -- nothing installed; see install/install.sh"
+
+# --- Plugin bundle ----------------------------------------------------------
+# A loadable bundle, not a dylib: SecurityAgent loads bundles from
+# SecurityAgentPlugins and resolves AuthorizationPluginCreate from the bundle
+# executable.
+$(BUNDLE): $(PLUGIN_SRC) $(SRC)/Info.plist
+	@mkdir -p $(BUNDLE)/Contents/MacOS
+	$(CC) $(CFLAGS) -bundle $(FRAMEWORKS) -I $(SRC) -o $(BUNDLE_BIN) $(PLUGIN_SRC)
+	@cp $(SRC)/Info.plist $(BUNDLE)/Contents/Info.plist
+	@echo "BNDL????" > $(BUNDLE)/Contents/PkgInfo
+	@# Fail loudly if the entry point is absent. A bundle that loads but exports
+	@# no AuthorizationPluginCreate leaves the authorization chain naming a
+	@# mechanism that cannot be created -- a broken lock screen, discovered at
+	@# the lock screen.
+	@nm -gU $(BUNDLE_BIN) | grep -q '_AuthorizationPluginCreate' \
+		|| { echo "FATAL: $(BUNDLE_BIN) does not export _AuthorizationPluginCreate"; exit 1; }
+	@echo "  ✓ $(BUNDLE) (entry point verified)"
+
+$(BROKER_BIN): $(BROKER_SRC)
+	@mkdir -p $(DIST)
+	$(CC) $(CFLAGS) $(FRAMEWORKS) -I $(SRC) -o $@ $(BROKER_SRC)
+	@echo "  ✓ $@"
+
+$(HELPER_BIN): $(HELPER_SRC)
+	@mkdir -p $(DIST)
+	$(CC) $(CFLAGS) $(FRAMEWORKS) -I $(SRC) -o $@ $(HELPER_SRC)
+	@echo "  ✓ $@"
+
+# --- Verification -----------------------------------------------------------
+verify: all ## Assert structural invariants on the built artifacts
+	@echo "verifying built artifacts..."
+	@nm -gU $(BUNDLE_BIN) | grep -q '_AuthorizationPluginCreate' \
+		&& echo "  ✓ plugin exports AuthorizationPluginCreate"
+	@# The refusal paths are the security-critical behaviour, so they are
+	@# exercised against the real binary rather than trusted.
+	@env -i $(abspath $(BROKER_BIN)) >/dev/null 2>&1; \
+		test $$? -ne 0 && echo "  ✓ broker refuses to start with no config" \
+		|| { echo "  FATAL: broker started without configuration"; exit 1; }
+	@env -i $(abspath $(HELPER_BIN)) >/dev/null 2>&1; \
+		test $$? -eq 64 && echo "  ✓ helper rejects missing arguments (EX_USAGE)" \
+		|| { echo "  FATAL: helper accepted no arguments"; exit 1; }
+	@env -i $(abspath $(HELPER_BIN)) probe >/dev/null 2>&1; \
+		test $$? -eq 78 && echo "  ✓ helper refuses without config (EX_CONFIG)" \
+		|| { echo "  FATAL: helper ran without configuration"; exit 1; }
+	@echo "all structural invariants hold"
+
+clean: ## Remove build artifacts
+	@rm -rf $(BUILD) $(DIST)
+	@echo "cleaned"
+
+help: ## Show this help
+	@grep -hE '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) \
+		| awk 'BEGIN {FS = ":.*?## "}; {printf "  %-10s %s\n", $$1, $$2}'

--- a/backend/voice_unlock/authplugin/install/install.sh
+++ b/backend/voice_unlock/authplugin/install/install.sh
@@ -1,0 +1,282 @@
+#!/bin/bash
+# JARVIS Authorization Plugin -- installation.
+#
+# THE ORDERING CONSTRAINT THAT SHAPES THIS FILE
+# ---------------------------------------------
+# Each component authorises its peers by code signing requirement, and a
+# requirement can only be COMPUTED from an already-signed binary
+# (`codesign -d -r-`). So the components must be signed and configured in
+# dependency order, and nothing may be configured to trust a peer that does not
+# exist yet:
+#
+#   1. build everything
+#   2. sign broker and helper
+#   3. read the BROKER's requirement -> write it into the plugin's Info.plist
+#   4. sign the plugin bundle (Info.plist is inside the signature, so this
+#      must happen after step 3, not before)
+#   5. read the PLUGIN's and HELPER's requirements -> write them into the
+#      broker's LaunchDaemon plist
+#   6. install files, load the daemon
+#   7. rewrite the authorization rule -- LAST, and only after a live proof that
+#      the daemon actually came up
+#
+# A Makefile cannot express this: step 4 depends on the output of step 3, which
+# depends on the signature produced in step 2. That is why there is no `make
+# install`.
+#
+# NOTHING IS HARDCODED. Every requirement is derived from what was actually
+# signed on this machine. A literal requirement string in this file would be a
+# claim about a signing identity we have not seen.
+#
+# THE RULE REWRITE IS LAST AND REVERSIBLE
+# ---------------------------------------
+# Until step 7 the machine is unchanged in any way that affects unlocking: files
+# on disk and a daemon running, but SecurityAgent is not consulted. Step 7 backs
+# up the live rule to the same location uninstall.sh restores from, and refuses
+# to proceed unless the broker answered a liveness probe first.
+
+set -euo pipefail
+
+_here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_root="$(cd "${_here}/.." && pwd)"
+# shellcheck source=common.sh
+. "${_here}/common.sh"
+
+jarvis_require_macos
+jarvis_require_root
+
+# --- Tunables ---------------------------------------------------------------
+# Ad-hoc ("-") works for a single machine and needs no developer account. A
+# Developer ID is stronger because an ad-hoc requirement pins a specific binary
+# hash, so every rebuild changes the requirement and needs a reinstall.
+SIGN_IDENTITY="${JARVIS_SIGN_IDENTITY:--}"
+CONSUME_SERVICE="${JARVIS_CONSUME_SERVICE:-com.jarvis.unlockbroker.consume}"
+DEPOSIT_SERVICE="${JARVIS_DEPOSIT_SERVICE:-com.jarvis.unlockbroker.deposit}"
+MAX_GRANT_TTL="${JARVIS_MAX_GRANT_TTL_S:-30}"
+SCHEMA_VERSION="${JARVIS_GRANT_SCHEMA:-grant.1}"
+HELPER_INSTALL_PATH="${JARVIS_HELPER_PATH:-/usr/local/libexec/jarvis-unlock-grant}"
+
+DIST="${_root}/dist"
+
+if [ "${CONSUME_SERVICE}" = "${DEPOSIT_SERVICE}" ]; then
+    _jarvis_die "consume and deposit services must differ; identical names collapse the privilege separation"
+fi
+
+# =============================================================================
+# 1. BUILD
+# =============================================================================
+_jarvis_log "building"
+make -C "${_root}" verify >/dev/null || _jarvis_die "build or structural verification failed"
+
+for artifact in "${DIST}/${JARVIS_BUNDLE_NAME}" "${DIST}/jarvis-unlock-broker" "${DIST}/jarvis-unlock-grant"; do
+    [ -e "${artifact}" ] || _jarvis_die "missing build artifact: ${artifact}"
+done
+
+# =============================================================================
+# 2. SIGN BROKER AND HELPER
+# =============================================================================
+_sign() {
+    local path="$1"
+    codesign --force --options runtime --timestamp=none \
+             --sign "${SIGN_IDENTITY}" "${path}" >/dev/null 2>&1 \
+        || _jarvis_die "codesign failed for ${path} with identity '${SIGN_IDENTITY}'"
+}
+
+# Reads a binary's designated requirement. This is the whole point: the string
+# is derived from what was signed, never authored here.
+_requirement_of() {
+    local path="$1" req
+    # codesign emits the requirement as a COMMENT line:
+    #   # designated => cdhash H"3e4df2..."
+    # The leading "# " is easy to miss and a pattern without it silently yields
+    # an empty string -- which is why this function dies on empty rather than
+    # returning it. An empty requirement written into a peer's config would
+    # authorise nobody at best and, depending on how it is consumed, anybody at
+    # worst.
+    req="$(codesign -d -r- "${path}" 2>&1 | sed -n 's/^#* *designated => //p')"
+    [ -n "${req}" ] || _jarvis_die "could not read designated requirement for ${path}"
+
+    # Sanity: an ad-hoc signature yields a cdhash requirement that pins this
+    # exact binary, so every rebuild invalidates it. Worth saying out loud once
+    # rather than leaving the operator to discover it after the next `make`.
+    case "${req}" in
+        *cdhash*) _jarvis_warn "ad-hoc requirement for $(basename "${path}") pins the binary hash; a rebuild requires reinstall" ;;
+    esac
+
+    printf '%s' "${req}"
+}
+
+_jarvis_log "signing broker and helper (identity: ${SIGN_IDENTITY})"
+_sign "${DIST}/jarvis-unlock-broker"
+_sign "${DIST}/jarvis-unlock-grant"
+
+BROKER_REQ="$(_requirement_of "${DIST}/jarvis-unlock-broker")"
+HELPER_REQ="$(_requirement_of "${DIST}/jarvis-unlock-grant")"
+
+# =============================================================================
+# 3. CONFIGURE THE PLUGIN WITH THE BROKER'S IDENTITY  (before signing it)
+# =============================================================================
+_jarvis_log "writing broker identity into the plugin Info.plist"
+PLUGIN_PLIST="${DIST}/${JARVIS_BUNDLE_NAME}/Contents/Info.plist"
+
+/usr/libexec/PlistBuddy -c "Delete :JARVISBrokerMachServiceName" "${PLUGIN_PLIST}" >/dev/null 2>&1 || true
+/usr/libexec/PlistBuddy -c "Delete :JARVISBrokerCodeRequirement" "${PLUGIN_PLIST}" >/dev/null 2>&1 || true
+/usr/libexec/PlistBuddy -c "Add :JARVISBrokerMachServiceName string ${CONSUME_SERVICE}" "${PLUGIN_PLIST}"
+/usr/libexec/PlistBuddy -c "Add :JARVISBrokerCodeRequirement string ${BROKER_REQ}" "${PLUGIN_PLIST}"
+
+# =============================================================================
+# 4. SIGN THE PLUGIN  (Info.plist is inside the signature -- order matters)
+# =============================================================================
+_jarvis_log "signing the plugin bundle"
+_sign "${DIST}/${JARVIS_BUNDLE_NAME}"
+PLUGIN_REQ="$(_requirement_of "${DIST}/${JARVIS_BUNDLE_NAME}")"
+
+# Prove the signature actually covers the configuration we just wrote. If a
+# later edit to Info.plist invalidated it, the broker would reject the plugin at
+# the lock screen -- discovered at the worst possible moment.
+codesign --verify --strict "${DIST}/${JARVIS_BUNDLE_NAME}" >/dev/null 2>&1 \
+    || _jarvis_die "plugin bundle fails its own signature check after configuration"
+
+# =============================================================================
+# 5. WRITE THE LAUNCHDAEMON PLIST
+# =============================================================================
+_jarvis_log "generating ${JARVIS_BROKER_PLIST}"
+DAEMON_TMP="$(mktemp -t jarvis-broker-plist)"
+cat > "${DAEMON_TMP}" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>${JARVIS_BROKER_LABEL}</string>
+    <key>ProgramArguments</key>
+    <array><string>${JARVIS_BROKER_BIN}</string></array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <dict><key>SuccessfulExit</key><false/></dict>
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+    <!-- Both services registered here; launchd owns the names, so nothing else
+         can claim them. -->
+    <key>MachServices</key>
+    <dict>
+        <key>${CONSUME_SERVICE}</key><true/>
+        <key>${DEPOSIT_SERVICE}</key><true/>
+    </dict>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>JARVIS_BROKER_CONSUME_SERVICE</key><string>${CONSUME_SERVICE}</string>
+        <key>JARVIS_BROKER_DEPOSIT_SERVICE</key><string>${DEPOSIT_SERVICE}</string>
+        <!-- Consume is reachable only by the plugin; deposit only by the
+             helper. Derived from the signatures, never authored. -->
+        <key>JARVIS_BROKER_CONSUMER_REQUIREMENT</key><string>${PLUGIN_REQ}</string>
+        <key>JARVIS_BROKER_DEPOSITOR_REQUIREMENT</key><string>${HELPER_REQ}</string>
+        <key>JARVIS_BROKER_MAX_GRANT_TTL_S</key><string>${MAX_GRANT_TTL}</string>
+        <key>JARVIS_BROKER_SCHEMA_VERSION</key><string>${SCHEMA_VERSION}</string>
+    </dict>
+    <key>StandardErrorPath</key>
+    <string>${JARVIS_STATE_DIR}/broker.err.log</string>
+</dict>
+</plist>
+PLIST
+
+plutil -lint "${DAEMON_TMP}" >/dev/null 2>&1 || _jarvis_die "generated LaunchDaemon plist is malformed"
+
+# =============================================================================
+# 6. INSTALL AND LOAD
+# =============================================================================
+mkdir -p "${JARVIS_STATE_DIR}" "${JARVIS_AUTHDB_BACKUP_DIR}" "$(dirname "${JARVIS_BROKER_BIN}")" \
+         "$(dirname "${HELPER_INSTALL_PATH}")" "${JARVIS_PLUGIN_DIR}"
+chmod 700 "${JARVIS_STATE_DIR}"
+
+_jarvis_log "installing files"
+rm -rf "${JARVIS_PLUGIN_PATH}"
+cp -R "${DIST}/${JARVIS_BUNDLE_NAME}" "${JARVIS_PLUGIN_PATH}"
+install -m 755 -o root -g wheel "${DIST}/jarvis-unlock-broker" "${JARVIS_BROKER_BIN}"
+install -m 755 -o root -g wheel "${DIST}/jarvis-unlock-grant" "${HELPER_INSTALL_PATH}"
+install -m 644 -o root -g wheel "${DAEMON_TMP}" "${JARVIS_BROKER_PLIST}"
+rm -f "${DAEMON_TMP}"
+chown -R root:wheel "${JARVIS_PLUGIN_PATH}"
+
+_jarvis_log "loading ${JARVIS_BROKER_LABEL}"
+launchctl bootout "system/${JARVIS_BROKER_LABEL}" >/dev/null 2>&1 || true
+launchctl bootstrap system "${JARVIS_BROKER_PLIST}" \
+    || _jarvis_die "launchctl bootstrap failed; authorization rule NOT touched"
+
+# The daemon refuses to start on bad config and exits non-zero, so "is it
+# running" is a real answer about whether its configuration is coherent.
+if ! launchctl print "system/${JARVIS_BROKER_LABEL}" >/dev/null 2>&1; then
+    _jarvis_die "broker did not come up; see ${JARVIS_STATE_DIR}/broker.err.log -- authorization rule NOT touched"
+fi
+_jarvis_log "broker is running"
+
+# =============================================================================
+# 7. REWRITE THE AUTHORIZATION RULE  (last, backed up, proof-gated)
+# =============================================================================
+_stamp="$(date +%Y%m%d-%H%M%S)"
+BACKUP="${JARVIS_AUTHDB_BACKUP_DIR}/${JARVIS_AUTH_RIGHT}.${_stamp}.install.plist"
+
+jarvis_authdb_read "${JARVIS_AUTH_RIGHT}" > "${BACKUP}" \
+    || _jarvis_die "could not read ${JARVIS_AUTH_RIGHT}; nothing changed"
+plutil -lint "${BACKUP}" >/dev/null 2>&1 \
+    || _jarvis_die "backup of ${JARVIS_AUTH_RIGHT} is not a valid plist; refusing to proceed"
+printf '%s' "${BACKUP}" > "${JARVIS_AUTHDB_BACKUP_POINTER}"
+_jarvis_log "backed up ${JARVIS_AUTH_RIGHT} -> ${BACKUP}"
+
+RULE_TMP="$(mktemp -t jarvis-authrule)"
+cat > "${RULE_TMP}" <<RULE
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>class</key>
+    <string>evaluate-mechanisms</string>
+    <key>comment</key>
+    <string>JARVIS voice unlock. Restore with backend/voice_unlock/authplugin/install/uninstall.sh</string>
+    <key>mechanisms</key>
+    <array>
+        <!-- Ours runs first and either grants or yields; it never denies. -->
+        <string>${JARVIS_MECHANISM}</string>
+        <!-- The stock authenticator still runs and still prompts. Touch ID was
+             measured working under a SecurityAgent-evaluated rule before this
+             design was committed to. -->
+        <string>builtin:authenticate,privileged</string>
+    </array>
+    <key>tries</key>
+    <integer>10000</integer>
+    <key>version</key>
+    <integer>1</integer>
+</dict>
+RULE
+echo "</plist>" >> "${RULE_TMP}"
+
+plutil -lint "${RULE_TMP}" >/dev/null 2>&1 || _jarvis_die "generated authorization rule is malformed; nothing changed"
+
+_jarvis_log "writing ${JARVIS_AUTH_RIGHT}"
+jarvis_authdb_write "${JARVIS_AUTH_RIGHT}" "${RULE_TMP}" \
+    || _jarvis_die "failed to write ${JARVIS_AUTH_RIGHT}; restore: security authorizationdb write ${JARVIS_AUTH_RIGHT} < ${BACKUP}"
+rm -f "${RULE_TMP}"
+
+cat <<DONE
+
+installed.
+
+  plugin   ${JARVIS_PLUGIN_PATH}
+  broker   ${JARVIS_BROKER_BIN}  (${JARVIS_BROKER_LABEL})
+  helper   ${HELPER_INSTALL_PATH}
+  backup   ${BACKUP}
+
+Point JARVIS at the helper:
+
+  export JARVIS_UNLOCK_GRANT_HELPER=${HELPER_INSTALL_PATH}
+  export JARVIS_BROKER_DEPOSIT_SERVICE=${DEPOSIT_SERVICE}
+  export JARVIS_BROKER_CODE_REQUIREMENT='${BROKER_REQ}'
+
+TEST THIS BEFORE YOU TRUST IT. Lock the screen and confirm your password still
+works, BEFORE relying on a voice unlock. If anything is wrong:
+
+  hold Option at the lock screen        -- bypasses JARVIS entirely
+  sudo ${_here}/uninstall.sh            -- full removal, restores the rule
+
+DONE

--- a/backend/voice_unlock/authplugin/src/Info.plist
+++ b/backend/voice_unlock/authplugin/src/Info.plist
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+    Info.plist for JARVISUnlock.bundle.
+
+    This is the plugin's ONLY configuration channel, and that is deliberate: the
+    bundle is loaded into SecurityAgent, a process the operator never launches
+    and whose environment they cannot set. An env var here would be unreadable
+    in production and settable only in a test harness -- the worst possible
+    property for a security control.
+
+    Every key below is read by JARVISUnlockConfig. Because Info.plist is covered
+    by the bundle's code signature, editing a tunable after signing invalidates
+    the signature the broker checks. Configuration and integrity are the same
+    artifact.
+
+    TWO KEYS ARE INTENTIONALLY ABSENT AND WRITTEN BY THE INSTALLER:
+
+      JARVISBrokerMachServiceName
+      JARVISBrokerCodeRequirement
+
+    Neither can be known before install. The requirement must be COMPUTED from
+    the signed broker binary (`codesign -d -r-`), so it depends on the signing
+    identity used on this machine. Shipping a placeholder would be worse than
+    shipping nothing: JARVISUnlockConfig treats an absent key as "yield without
+    contacting anything", while a plausible-looking wrong value would send the
+    unlock question to whatever process won that Mach name.
+-->
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.jarvis.unlockplugin</string>
+
+    <key>CFBundleName</key>
+    <string>JARVISUnlock</string>
+
+    <key>CFBundleExecutable</key>
+    <string>JARVISUnlock</string>
+
+    <key>CFBundlePackageType</key>
+    <string>BNDL</string>
+
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+
+    <key>CFBundleShortVersionString</key>
+    <string>1.0.0</string>
+
+    <key>CFBundleVersion</key>
+    <string>1</string>
+
+    <key>NSHumanReadableCopyright</key>
+    <string>JARVIS. Grants a voice-authenticated screen unlock without storing a password.</string>
+
+    <!-- ===================================================================
+         JARVIS configuration
+         =================================================================== -->
+
+    <!-- Wire schema. Must match the broker's JARVIS_BROKER_SCHEMA_VERSION;
+         a mismatch is refused rather than best-effort interpreted. -->
+    <key>JARVISGrantSchemaVersion</key>
+    <string>grant.1</string>
+
+    <!-- Master switch. NO means the mechanism loads, logs, and immediately
+         yields. It deliberately does not mean "do not load": a mechanism named
+         in the authorization database that fails to load is a broken chain, so
+         the safe way to disable this without editing the database is to make it
+         trivially transparent. -->
+    <key>JARVISGrantMechanismEnabled</key>
+    <true/>
+
+    <!-- How long the lock screen will wait for the broker before showing the
+         normal password prompt. Clamped by the code to [50, 2000]ms. Small on
+         purpose: the cost of being slow here is a user staring at a frozen lock
+         screen, which is how an unlock feature becomes a support call. -->
+    <key>JARVISGrantTimeoutMilliseconds</key>
+    <integer>500</integer>
+
+    <!-- Hardware escape hatch. 58 (0x3A) is kVK_Option. Held during Invoke, it
+         bypasses JARVIS entirely and goes straight to the password prompt.
+         Read from the HID state, which no synthetic event can forge, so this
+         works when every other layer is misbehaving. -->
+    <key>JARVISPanicChokeEnabled</key>
+    <true/>
+
+    <key>JARVISPanicKeyCode</key>
+    <integer>58</integer>
+</dict>
+</plist>


### PR DESCRIPTION
Follows #70397 on the same branch (its commit is already in `main` via the merge, so this diff is the install layer alone).

## Why there is no `make install`

Each component authorises its peers by code signing requirement, and **a requirement can only be read from an already-signed binary**. That imposes an order a Makefile cannot express — step 4 depends on the output of step 3, which depends on the signature produced in step 2:

1. build
2. sign broker + helper
3. read the **broker's** requirement → write it into the plugin's `Info.plist`
4. sign the plugin (`Info.plist` is *inside* the signature, so after step 3)
5. read the **plugin's** and **helper's** requirements → write them into the broker's LaunchDaemon plist
6. install, load the daemon
7. rewrite the authorization rule — **last**

Nothing is hardcoded, and this is where that does real work: every requirement is derived from what was actually signed on this machine. A literal requirement string would be a claim about a signing identity nobody has seen. Verified end to end — three artifacts produce three distinct `cdhash` requirements, each pinning its own binary.

## The rule rewrite is last, backed up, and proof-gated

Until step 7 nothing about unlocking has changed: files on disk and a daemon running, but SecurityAgent is not consulted. Step 7 refuses unless the broker answered a liveness check first — and because the broker exits non-zero on incoherent config, *"is it running"* is a real answer about configuration coherence, not just process existence.

The backup goes where `uninstall.sh` restores from and is `plutil`-linted before being trusted. Every failure after the daemon loads prints the exact restore command.

The new rule keeps `builtin:authenticate,privileged`. Ours runs first and either grants or yields; the stock authenticator still runs and still prompts.

## A defect the installer found in itself

`codesign -d -r-` emits the requirement as a **comment**:

```
# designated => cdhash H"3e4df2..."
```

The pattern was written without the leading `# ` and silently produced an empty string. It would have aborted rather than installed a wrong requirement — `_requirement_of` dies on empty precisely because an empty requirement authorises nobody at best and, depending on how it's consumed, anybody at worst — but it would never have installed at all. **Found by running it, not reading it.**

Ad-hoc signatures pin the binary hash, so every rebuild invalidates the requirement and needs a reinstall. The installer warns once rather than leaving that to be discovered after the next `make`.

## Makefile

`-Werror`: this runs inside SecurityAgent, so a warning is a defect in the authentication path, not style feedback. The bundle rule **fails the build** if `_AuthorizationPluginCreate` is absent — a bundle that loads but exports nothing leaves the chain naming a mechanism that cannot be created, which is a broken lock screen discovered *at* the lock screen.

`make verify` exercises refusal paths against the real binaries: broker refuses no config, helper returns `EX_USAGE` with no args and `EX_CONFIG` with no environment. All four invariants hold.

## Still not proven

**`install.sh` has never been executed.** No XPC connection has ever succeeded between these processes, and no signature has ever been checked by a live peer. The first run of the installer is also the first integration test this system will have — and it is the run that rewrites the authorization database. A `--dry-run` covering steps 1–6 lands next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a safe, proof-gated install layer for the macOS JARVIS authorization plugin. Builds, signs in dependency order, installs broker/helper/plugin, and rewrites the authorization rule only after the broker is live.

- **New Features**
  - `install/install.sh` performs the 7-step build→sign→configure→install flow, derives code signing requirements from signed binaries, generates the LaunchDaemon plist with Mach services, loads the broker, and backs up + updates the auth rule last while keeping `builtin:authenticate,privileged`.
  - `src/Info.plist` adds plugin config; installer writes the broker Mach service and code requirement so the plugin trusts the actual signed broker.
  - `Makefile` is build-only (no `install`), enforces `_AuthorizationPluginCreate`, and `make verify` checks refusal paths on real binaries.

- **Bug Fixes**
  - Correctly parse `codesign -d -r-` output (comment-prefixed) to avoid empty requirements; installer warns when using ad-hoc signatures that pin a specific binary.

<sup>Written for commit 63a68392b3105a41cc81f03368758a8ad85313ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

