### PR TITLE
fix: Stop the shell from eating quotes out of the code requirement

### DIFF
--- a/backend/voice_unlock/authplugin/install/install.sh
+++ b/backend/voice_unlock/authplugin/install/install.sh
@@ -238,10 +238,33 @@ HELPER_REQ="$(_requirement_of "${DIST}/jarvis-unlock-grant")"
 _jarvis_log "writing broker identity into the plugin Info.plist"
 PLUGIN_PLIST="${DIST}/${JARVIS_BUNDLE_NAME}/Contents/Info.plist"
 
-/usr/libexec/PlistBuddy -c "Delete :JARVISBrokerMachServiceName" "${PLUGIN_PLIST}" >/dev/null 2>&1 || true
-/usr/libexec/PlistBuddy -c "Delete :JARVISBrokerCodeRequirement" "${PLUGIN_PLIST}" >/dev/null 2>&1 || true
-/usr/libexec/PlistBuddy -c "Add :JARVISBrokerMachServiceName string ${CONSUME_SERVICE}" "${PLUGIN_PLIST}"
-/usr/libexec/PlistBuddy -c "Add :JARVISBrokerCodeRequirement string ${BROKER_REQ}" "${PLUGIN_PLIST}"
+# plutil, NOT PlistBuddy.
+#
+# PlistBuddy takes its whole operation as ONE shell word:
+#     PlistBuddy -c "Add :K string ${REQ}"
+# and a requirement contains double quotes -- `cdhash H"732e..."`. The shell
+# consumes them while assembling that word, so the value that lands is
+# `cdhash H732e...`: syntactically present, semantically empty, and unparseable
+# as a requirement. It fails at the lock screen and looks like an unreachable
+# broker.
+#
+# plutil takes the value as its own argv element, so nothing re-parses it.
+plutil -replace JARVISBrokerMachServiceName -string "${CONSUME_SERVICE}" "${PLUGIN_PLIST}" \
+    || _jarvis_die "could not write JARVISBrokerMachServiceName"
+plutil -replace JARVISBrokerCodeRequirement -string "${BROKER_REQ}" "${PLUGIN_PLIST}" \
+    || _jarvis_die "could not write JARVISBrokerCodeRequirement"
+
+# Read it back and compare byte-for-byte. Writing a value is not the same as the
+# value landing, and this specific field is unverifiable at runtime -- it is only
+# exercised inside SecurityAgent at a locked screen, which is the worst possible
+# place to discover it was mangled.
+_written_req="$(plutil -extract JARVISBrokerCodeRequirement raw "${PLUGIN_PLIST}" 2>/dev/null)"
+if [ "${_written_req}" != "${BROKER_REQ}" ]; then
+    _jarvis_warn "wrote:    ${BROKER_REQ}"
+    _jarvis_warn "read back: ${_written_req}"
+    _jarvis_die "the broker requirement did not survive being written to the plugin Info.plist"
+fi
+_jarvis_log "verified: plugin Info.plist carries the broker requirement intact"
 
 # =============================================================================
 # 4. SIGN THE PLUGIN  (Info.plist is inside the signature -- order matters)


### PR DESCRIPTION
Found on the live system immediately after the first real install.

```
cdhash H732e35dae63716b846b4f7247f026d93d40e78c3      ← what installed
cdhash H"732e35dae63716b846b4f7247f026d93d40e78c3"    ← the actual requirement
```

`PlistBuddy` takes its whole operation as **one shell word**:

```bash
PlistBuddy -c "Add :K string ${BROKER_REQ}"
```

and a code signing requirement contains double quotes. The shell consumed them while assembling that word, so the value that landed was unparseable — **syntactically present, semantically empty.** Exactly the failure class this campaign started with.

## Why the self-test passed anyway

The LaunchDaemon plist was unaffected: a heredoc doesn't re-parse quotes. The deposit path reads its requirement from the environment, and the broker reads its own from the heredoc — both intact. The one corrupted field is the only one never exercised until SecurityAgent invokes the mechanism at a locked screen.

## Why this was not dangerous

`setCodeSigningRequirement:` would have failed on the malformed string, the mechanism's `@try`/`@catch` would have yielded, and `builtin:authenticate` would have prompted as normal. **The lock screen was never at risk** — the fail-open invariant did its job.

But voice unlock would have failed forever while reporting itself as an *unreachable broker* — the diagnosis-resistant shape this whole arc exists to eliminate.

## The fix

`plutil`, not `PlistBuddy`: it takes the value as its own argv element, so nothing re-parses it. Structured data stops travelling through a string that gets re-lexed.

Then the write is **read back and compared byte-for-byte**, because writing a value is not the same as the value landing. This field is unverifiable at runtime — only exercised inside SecurityAgent at a locked screen, the worst possible place to discover it was mangled. A mismatch now aborts before the authorization rule is touched.

Verified via `--dry-run`: *"verified: plugin Info.plist carries the broker requirement intact"*.

## Action required

A system installed before this commit carries the corrupted value and must re-run `install.sh`. Re-running derives fresh requirements for all three artifacts and rewrites both plists consistently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes quote loss in the broker code signing requirement when writing the plugin Info.plist by switching to `plutil` and verifying the write. Prevents false “unreachable broker” failures at the lock screen while keeping fail-open behavior.

- **Bug Fixes**
  - Replace `PlistBuddy` writes with `plutil -replace` to preserve quotes in `cdhash H"..."` and avoid shell re-parsing.
  - Read back `JARVISBrokerCodeRequirement` and compare byte-for-byte; abort install if mismatched and log verification on success.

- **Migration**
  - Systems installed before this change must re-run `install.sh` to regenerate requirements and rewrite both plists.

<sup>Written for commit cbae380a125c9e1de87b6311b9988ba4d1c69568. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

