### PR TITLE
fix: Wait for launchctl bootout before bootstrapping over it

### DIFF
--- a/backend/voice_unlock/authplugin/install/common.sh
+++ b/backend/voice_unlock/authplugin/install/common.sh
@@ -65,3 +65,57 @@ jarvis_authdb_write() {
     [ -f "$plist" ] || _jarvis_die "rule plist not found: $plist"
     security authorizationdb write "$right" < "$plist"
 }
+
+# --- Shared lifecycle helpers ------------------------------------------------
+# Defined here because install.sh and uninstall.sh both need them and a second
+# copy of "how do we put the authorization rule back" is the last thing this
+# system should have.
+
+# Restore the authorization rule from the backup named by the pointer file.
+# Returns 0 on success, 1 if there is no usable backup (caller decides what
+# that means -- uninstall falls back to stripping in place; install aborts).
+jarvis_restore_auth_rule_from_pointer() {
+    local backup
+    [ -f "${JARVIS_AUTHDB_BACKUP_POINTER}" ] || return 1
+
+    backup="$(cat "${JARVIS_AUTHDB_BACKUP_POINTER}" 2>/dev/null || true)"
+    [ -n "${backup}" ] && [ -f "${backup}" ] || return 1
+
+    # Never write a backup we cannot parse. Restoring garbage into the
+    # authorization database is the one way recovery could make things worse
+    # than it found them.
+    plutil -lint "${backup}" >/dev/null 2>&1 || return 1
+
+    jarvis_authdb_write "${JARVIS_AUTH_RIGHT}" "${backup}" >/dev/null 2>&1 || return 1
+    rm -f "${JARVIS_AUTHDB_BACKUP_POINTER}"
+    return 0
+}
+
+# Does the live rule currently name our mechanism?
+jarvis_rule_references_plugin() {
+    jarvis_authdb_read "${JARVIS_AUTH_RIGHT}" 2>/dev/null | grep -q "${JARVIS_PLUGIN_NAME}"
+}
+
+# Wait for a system service to be fully gone.
+#
+# `launchctl bootout` returns before teardown completes, so bootstrapping
+# immediately afterwards races the unload and fails with EIO (5). Polling the
+# actual condition is the fix; a fixed sleep would be a guess that is either too
+# short on a loaded machine or wasted time on an idle one.
+jarvis_wait_for_service_gone() {
+    local label="$1"
+    local timeout="${JARVIS_SERVICE_SETTLE_TIMEOUT_S:-10}"
+    local interval="${JARVIS_SERVICE_POLL_INTERVAL_S:-0.2}"
+    local waited=0
+
+    while launchctl print "system/${label}" >/dev/null 2>&1; do
+        # `bc` is not guaranteed; integer tenths keep this dependency-free so it
+        # still works from a Recovery shell.
+        if [ "${waited}" -ge $(( timeout * 10 )) ]; then
+            return 1
+        fi
+        sleep "${interval}"
+        waited=$(( waited + 2 ))
+    done
+    return 0
+}

--- a/backend/voice_unlock/authplugin/install/install.sh
+++ b/backend/voice_unlock/authplugin/install/install.sh
@@ -345,17 +345,70 @@ else
     rm -f "${DAEMON_TMP}"
     chown -R root:wheel "${JARVIS_PLUGIN_PATH}"
 
+    # A failure from here on can leave the rule pointing at a mechanism whose
+    # broker is down. That is fail-open safe -- the mechanism yields and
+    # builtin:authenticate prompts -- but it is a half-installed system, which is
+    # exactly the wired-but-inert state this project keeps having to dig out of.
+    # So: if we cannot bring the broker up and the rule already names us from an
+    # earlier install, put the stock rule back before dying.
+    _abort_incoherent() {
+        if jarvis_rule_references_plugin; then
+            _jarvis_warn "${JARVIS_AUTH_RIGHT} still names ${JARVIS_PLUGIN_NAME} from an earlier install"
+            if jarvis_restore_auth_rule_from_pointer; then
+                _jarvis_warn "restored the stock authorization rule -- your lock screen is back to default"
+            else
+                _jarvis_warn "COULD NOT restore the rule automatically. Run:"
+                _jarvis_warn "  sudo ${_here}/uninstall.sh"
+            fi
+        fi
+        _jarvis_die "$1"
+    }
+
     _jarvis_log "loading ${JARVIS_BROKER_LABEL}"
     launchctl bootout "system/${JARVIS_BROKER_LABEL}" >/dev/null 2>&1 || true
-    launchctl bootstrap system "${JARVIS_BROKER_PLIST}" \
-        || _jarvis_die "launchctl bootstrap failed; authorization rule NOT touched"
+
+    # bootout is asynchronous: it returns before teardown finishes, and
+    # bootstrapping into a label that is still unloading fails with
+    # "Bootstrap failed: 5: Input/output error". Wait for the actual condition.
+    if ! jarvis_wait_for_service_gone "${JARVIS_BROKER_LABEL}"; then
+        _abort_incoherent "${JARVIS_BROKER_LABEL} did not unload; refusing to bootstrap over it"
+    fi
+
+    # Bounded retries. launchctl can still transiently refuse while the previous
+    # instance's Mach ports are reclaimed, and one more attempt is cheaper than
+    # sending the operator back to the shell.
+    _bootstrap_attempts="${JARVIS_BOOTSTRAP_ATTEMPTS:-3}"
+    _attempt=1
+    _bootstrap_err=""
+    while : ; do
+        if _bootstrap_err="$(launchctl bootstrap system "${JARVIS_BROKER_PLIST}" 2>&1)"; then
+            break
+        fi
+        if [ "${_attempt}" -ge "${_bootstrap_attempts}" ]; then
+            _jarvis_warn "launchctl: ${_bootstrap_err}"
+            _abort_incoherent "launchctl bootstrap failed after ${_attempt} attempt(s)"
+        fi
+        _jarvis_log "bootstrap attempt ${_attempt} failed (${_bootstrap_err}); retrying"
+        _attempt=$(( _attempt + 1 ))
+        sleep 1
+    done
 
     # The daemon refuses to start on bad config and exits non-zero, so "is it
     # running" is a real answer about whether its configuration is coherent.
+    #
+    # `launchctl print` succeeding only means the job is REGISTERED. A job that
+    # execs and immediately exits 1 is still registered, so the process itself
+    # has to be confirmed -- otherwise "broker is running" would be a claim about
+    # launchd's bookkeeping rather than about a broker.
     if ! launchctl print "system/${JARVIS_BROKER_LABEL}" >/dev/null 2>&1; then
-        _jarvis_die "broker did not come up; see ${JARVIS_STATE_DIR}/broker.err.log -- authorization rule NOT touched"
+        _abort_incoherent "broker job did not register; see ${JARVIS_STATE_DIR}/broker.err.log"
     fi
-    _jarvis_log "broker is running"
+    if ! pgrep -qf "${JARVIS_BROKER_BIN}" 2>/dev/null; then
+        _jarvis_warn "the job registered but no broker process is alive -- it started and exited"
+        _jarvis_warn "see ${JARVIS_STATE_DIR}/broker.err.log"
+        _abort_incoherent "broker is not running"
+    fi
+    _jarvis_log "broker is running (pid $(pgrep -f "${JARVIS_BROKER_BIN}" | head -1))"
 
     # =========================================================================
     # 6b. THE FIRST INTEGRATION TEST THIS SYSTEM HAS EVER HAD

--- a/backend/voice_unlock/authplugin/install/uninstall.sh
+++ b/backend/voice_unlock/authplugin/install/uninstall.sh
@@ -35,38 +35,22 @@ _jarvis_log "starting removal"
 # 1. RESTORE THE AUTHORIZATION RULE  (first -- this is what unwedges a machine)
 # =============================================================================
 restore_auth_rule() {
-    if [ ! -f "${JARVIS_AUTHDB_BACKUP_POINTER}" ]; then
-        _jarvis_log "no authdb backup pointer; checking whether the right is stock"
-        _remove_mechanism_in_place
+    # The backup-pointer restore lives in common.sh because install.sh needs the
+    # identical operation when it has to abandon a half-finished install. Two
+    # copies of "how do we put the authorization rule back" is the last thing
+    # this system should have -- they would drift, and the one that drifted would
+    # be discovered by someone whose screen will not unlock.
+    #
+    # Every path this function can take is a REPAIR, so it degrades rather than
+    # aborting: a failed restore falls through to stripping our mechanism out of
+    # whatever rule is live.
+    if jarvis_restore_auth_rule_from_pointer; then
+        _jarvis_log "authorization rule restored from backup"
         return
     fi
 
-    local backup
-    backup="$(cat "${JARVIS_AUTHDB_BACKUP_POINTER}" 2>/dev/null || true)"
-
-    if [ -z "${backup}" ] || [ ! -f "${backup}" ]; then
-        _jarvis_warn "backup pointer names a missing file: ${backup:-<empty>}"
-        _remove_mechanism_in_place
-        return
-    fi
-
-    # Refuse to write a backup that is not a readable plist: restoring garbage
-    # into the authorization database is the one way this script could make
-    # things worse than it found them.
-    if ! plutil -lint "${backup}" >/dev/null 2>&1; then
-        _jarvis_warn "backup at ${backup} is not a valid plist; refusing to restore it"
-        _remove_mechanism_in_place
-        return
-    fi
-
-    _jarvis_log "restoring ${JARVIS_AUTH_RIGHT} from ${backup}"
-    if jarvis_authdb_write "${JARVIS_AUTH_RIGHT}" "${backup}"; then
-        _jarvis_log "authorization rule restored"
-        rm -f "${JARVIS_AUTHDB_BACKUP_POINTER}"
-    else
-        _note_failure "could not restore ${JARVIS_AUTH_RIGHT} from backup"
-        _remove_mechanism_in_place
-    fi
+    _jarvis_warn "no usable backup (absent pointer, missing file, or unparseable plist)"
+    _remove_mechanism_in_place
 }
 
 # Fallback: no usable backup. Strip only our own mechanism from whatever rule is


### PR DESCRIPTION
Live failure on reinstall:

```
[jarvis-authplugin] loading com.jarvis.unlockbroker
Bootstrap failed: 5: Input/output error
[jarvis-authplugin][fatal] launchctl bootstrap failed; authorization rule NOT touched
```

`launchctl bootout` returns **before teardown completes**. Bootstrapping into a label that's still unloading fails with EIO.

The guard held — the rule was untouched — but the machine was left with the broker **down** while the rule from the previous install still named the mechanism. Fail-open safe (the mechanism yields, `builtin:authenticate` prompts, the password works), but a half-installed system: precisely the wired-but-inert state this project keeps digging out of.

## Wait on the condition, not the clock

`jarvis_wait_for_service_gone` polls until launchctl no longer knows the label, bounded by `JARVIS_SERVICE_SETTLE_TIMEOUT_S`. A fixed sleep would be a guess — too short on a loaded machine, wasted time on an idle one. Integer tenths rather than `bc`, so it still works from a Recovery shell.

Bootstrap then retries a bounded number of times, since launchctl can transiently refuse while the previous instance's Mach ports are reclaimed. The actual launchctl error is now reported rather than swallowed into a generic failure.

## "Registered" is not "running"

`launchctl print` succeeding only means the job is **registered**. A job that execs and immediately exits 1 — exactly what this broker does on incoherent config — is still registered. The check now confirms a live process, so *"broker is running"* is a claim about a broker rather than about launchd's bookkeeping.

## A failed install must not leave a half-installed system

If the broker can't be brought up **and** the rule already names our mechanism from an earlier install, the stock rule is restored before dying. The installer's contract is to leave the system coherent, and a rule pointing at a mechanism with no broker behind it isn't coherent — it merely happens to be harmless.

## One restore, not two

That restore is the same operation `uninstall.sh` performs, so it moved to `common.sh` and both call it. Two copies of *"how do we put the authorization rule back"* would drift, and the copy that drifted would be found by someone whose screen won't unlock. `uninstall.sh` keeps its in-place mechanism-strip as the fallback for when no usable backup exists.

## Verified

`--dry-run` passes end to end; both scripts parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a reinstall race by waiting for `launchctl bootout` to fully finish before `bootstrap`, adding safe retries, and restoring the stock authorization rule if the broker can’t start to avoid a half-installed system.

- **Bug Fixes**
  - Added `jarvis_wait_for_service_gone` to poll until `launchctl` no longer knows the label, avoiding EIO 5 when bootstrapping over an unloading job (bounded by `JARVIS_SERVICE_SETTLE_TIMEOUT_S`; integer polling, no `bc`).
  - Added bounded bootstrap retries (`JARVIS_BOOTSTRAP_ATTEMPTS`, default 3) and now surface the actual `launchctl` error.
  - Validate the broker is truly running by checking for a live process (`pgrep`) instead of relying on `launchctl print` registration.
  - On install failure, if the rule already names our mechanism, restore the stock rule from the backup pointer and abort cleanly.

- **Refactors**
  - Moved rule-restore logic into `common.sh` as `jarvis_restore_auth_rule_from_pointer`; both `install.sh` and `uninstall.sh` call it. `uninstall.sh` keeps its fallback to strip the mechanism in place when no usable backup exists.

<sup>Written for commit 092acfcb9d474c8d6a21cd2cbf32620d1adc62b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

