### PR TITLE
fix: Give the HUD orphan-protection chain a root

### DIFF
--- a/JARVIS-Apple/JARVIS-Apple.xcodeproj/project.pbxproj
+++ b/JARVIS-Apple/JARVIS-Apple.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		9D8F259F3A4877CC70B36F0C /* BootLogFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 633E90E2380BBC6CB188BB57 /* BootLogFile.swift */; };
 		9FC588C57049591237CF032F /* HUDView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A0A5C4460F31FD5CB53DD10 /* HUDView.swift */; };
 		A0BD7790CE0BF3EDAC6D6372 /* ArcReactorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26744ECD2240E57AF517188D /* ArcReactorView.swift */; };
+		A2C3549A6EDDCEC8A4D1FF98 /* ParentWatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD1B9697A7D560891A59E78 /* ParentWatch.swift */; };
 		A348802554BD9C09EE824952 /* UtteranceRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86A3C5DDD4D1D44D8569C39B /* UtteranceRecorder.swift */; };
 		ADEA3EDEC8E9800EB2E4B351 /* JARVISKit in Frameworks */ = {isa = PBXBuildFile; productRef = 15EECA930D551D91AC5C18B4 /* JARVISKit */; };
 		B382A284A476CA2ACA805D56 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4A8BD3E8642F43ADBDD9BB1 /* SettingsView.swift */; };
@@ -73,6 +74,7 @@
 		B91850E89902256710524BEA /* LoadingHUDView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingHUDView.swift; sourceTree = "<group>"; };
 		BD8C21EBA8B80C1A39D30C8A /* JARVISPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JARVISPanel.swift; sourceTree = "<group>"; };
 		BE156A6B63F5362F9FD12522 /* CompactHeaderBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompactHeaderBar.swift; sourceTree = "<group>"; };
+		BFD1B9697A7D560891A59E78 /* ParentWatch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentWatch.swift; sourceTree = "<group>"; };
 		C953EA1271F55784A7D1004B /* JARVISColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JARVISColors.swift; sourceTree = "<group>"; };
 		CE05089C690A3B7B63861CF9 /* PhoneSessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneSessionManager.swift; sourceTree = "<group>"; };
 		DC9BBC1069F12BD5BEB30913 /* JARVISKit */ = {isa = PBXFileReference; lastKnownFileType = folder; name = JARVISKit; path = JARVISKit; sourceTree = SOURCE_ROOT; };
@@ -176,6 +178,7 @@
 				633E90E2380BBC6CB188BB57 /* BootLogFile.swift */,
 				A6A777442955E499D4E22D3B /* BrainstemLauncher.swift */,
 				A2FEA2CE20F48E377D68D971 /* MicSuppression.swift */,
+				BFD1B9697A7D560891A59E78 /* ParentWatch.swift */,
 				7F97771D9894460348ABB0ED /* ScreenCaptureService.swift */,
 				95D0EF17C00CB1001F596D74 /* SecureConsent.swift */,
 				86A3C5DDD4D1D44D8569C39B /* UtteranceRecorder.swift */,
@@ -421,6 +424,7 @@
 				FBBDB0313A52CEA7D67AFF62 /* LivingBorderWindow.swift in Sources */,
 				F2372C4356B52F4C5EE16B1C /* LoadingHUDView.swift in Sources */,
 				C2EAD5E8889A90385FDA3E14 /* MicSuppression.swift in Sources */,
+				A2C3549A6EDDCEC8A4D1FF98 /* ParentWatch.swift in Sources */,
 				D3F64926FE39007A1202CB78 /* ScreenCaptureService.swift in Sources */,
 				67836362453377C25CE3CB3D /* SecureConsent.swift in Sources */,
 				8343F8E9601E5B1F4058448D /* TransparentWindow.swift in Sources */,

--- a/JARVIS-Apple/JARVISHUD/JARVISHUDApp.swift
+++ b/JARVIS-Apple/JARVISHUD/JARVISHUDApp.swift
@@ -53,6 +53,19 @@ class HUDAppDelegate: NSObject, NSApplicationDelegate, AVSpeechSynthesizerDelega
                 self.appState.pythonBridge.onBackendReady()
             }
             BrainstemLauncher.shared.start()
+
+            // Armed AFTER the brainstem launches, so an orphaning during startup
+            // finds a child that already knows who its parent is and will follow
+            // us out. Arming first would open a window where we can exit while
+            // the child is still unsupervised — trading one orphan for another.
+            //
+            // NSApp.terminate runs the normal shutdown path, so the brainstem is
+            // stopped the way any quit stops it. A bare exit() here would leave
+            // the very orphan this watch exists to prevent.
+            ParentWatch.arm {
+                NSApp.terminate(nil)
+            }
+
             self.appState.boot()
 
             // Living Border setup — the halo is always visible (JARVIS is ambient:

--- a/JARVIS-Apple/JARVISHUD/Services/ParentWatch.swift
+++ b/JARVIS-Apple/JARVISHUD/Services/ParentWatch.swift
@@ -1,0 +1,127 @@
+/// ParentWatch — the HUD leaves when whoever launched it leaves.
+///
+/// WHY THIS EXISTS, GIVEN THE ORPHAN BUG WAS ALREADY FIXED
+/// -------------------------------------------------------
+/// `BrainstemLauncher` declares `JARVIS_PARENT_PID` so the Python brainstem
+/// watches the HUD and exits with it (`brainstem/parent_watch.py`). That fix
+/// rests on an assumption stated in its own comment: *"Xcode's Stop button
+/// SIGKILLs this process."*
+///
+/// Sometimes it does not. Xcode also detaches:
+///
+///     Xcode has killed the LLDB RPC server (pid: N) to allow the debugger
+///     to detach from your process.
+///
+/// Measured on 2026-08-06, twenty-one seconds apart:
+///
+///     80876  ppid 1      (launchd)      ← orphan, previous run, still alive
+///     81007  ppid 81299  (debugserver)  ← the run Xcode was attached to
+///
+/// When the HUD is *detached* rather than killed it is reparented to launchd and
+/// keeps running: holding its ports, its microphone claim, its UDS socket, and
+/// competing with the next instance for all three.
+///
+/// And it takes the existing protection down with it. The brainstem watches the
+/// HUD; the HUD is still alive; so the brainstem correctly stays. Every link in
+/// the chain watches the link above it, and the topmost link watched nothing —
+/// so orphaning the top orphans everything below it, protection intact and
+/// useless. This closes that by giving the chain a root.
+///
+/// WHY NOT SIGNAL HANDLERS, atexit, OR `deinit`
+/// --------------------------------------------
+/// None of them run on SIGKILL, and SIGKILL is one of the two ways this session
+/// ends. A process cannot clean up after its own uncatchable death; something
+/// must observe it from outside. Here the roles invert — we are the observer,
+/// and the thing we observe is our own launcher.
+///
+/// WHY IT IS INERT FOR A NORMALLY-LAUNCHED APP
+/// ------------------------------------------
+/// A double-clicked app is started by launchd and has ppid 1 for its whole life.
+/// Exiting when "the parent dies" would be nonsense there — launchd outlives
+/// everything. So the watch arms only when the parent is something else, which
+/// is precisely the debugger/terminal case where our lifetime really is bounded
+/// by theirs. Same discipline as `JARVIS_PARENT_PID`: refuse to supervise on an
+/// undeclared parent, so a developer is never killed by their own shell.
+
+import Foundation
+
+enum ParentWatch {
+
+    /// pid 1. Any process reparented here has already lost its original parent.
+    private static let launchdPID: pid_t = 1
+
+    private static var source: DispatchSourceProcess?
+
+    /// Set from the Xcode scheme to disable the watch without editing code.
+    /// Present so the behaviour can be turned off during a debugging session
+    /// that deliberately outlives its launcher — never as a default.
+    private static let disableKey = "JARVIS_HUD_PARENT_WATCH_DISABLED"
+
+    /// Begin watching the launching process. Idempotent; safe to call once at
+    /// startup and harmless if called again.
+    ///
+    /// - Parameter onOrphaned: Invoked on the main queue when the parent exits.
+    ///   Given so the caller owns *how* to leave — this type decides only *when*.
+    ///   A watch that called `exit()` itself would skip shutdown work the app
+    ///   legitimately needs to do, which is how "clean up orphans" becomes
+    ///   "corrupt state on every stop".
+    static func arm(onOrphaned: @escaping () -> Void) {
+        guard source == nil else { return }
+
+        if ProcessInfo.processInfo.environment[disableKey] == "1" {
+            print("[ParentWatch] \(disableKey)=1 — not watching; this process can outlive its launcher")
+            return
+        }
+
+        let parent = getppid()
+
+        guard parent != launchdPID else {
+            // Normal launch. There is no parent whose death should end us.
+            print("[ParentWatch] parent is launchd — not arming (normal app launch)")
+            return
+        }
+
+        // Read the parent's identity for the log BEFORE arming. Once it exits
+        // the name is unrecoverable, and "parent 81299 exited" is a much worse
+        // diagnostic than naming debugserver.
+        let parentName = processName(of: parent) ?? "pid \(parent)"
+
+        let src = DispatchSource.makeProcessSource(
+            identifier: parent,
+            eventMask: .exit,
+            queue: .main
+        )
+        src.setEventHandler {
+            print("[ParentWatch] launcher (\(parentName)) exited — leaving rather than orphaning")
+            onOrphaned()
+        }
+        src.resume()
+        source = src
+
+        print("[ParentWatch] watching launcher \(parentName); this process will not outlive it")
+
+        // A DispatchSourceProcess established on an ALREADY-dead pid never
+        // fires. The window is small but real: the parent can die between
+        // getppid() and resume(). Re-check afterwards, because the failure mode
+        // of missing it is exactly the orphan this exists to prevent.
+        if getppid() != parent {
+            print("[ParentWatch] launcher exited while arming — leaving now")
+            onOrphaned()
+        }
+    }
+
+    /// Best-effort name for a pid, for logging only.
+    private static func processName(of pid: pid_t) -> String? {
+        var buffer = [CChar](repeating: 0, count: 4096)
+        // proc_pidpath is in libproc; declared here rather than importing the
+        // whole header to keep this file self-contained.
+        let size = proc_pidpath_shim(pid, &buffer, UInt32(buffer.count))
+        guard size > 0 else { return nil }
+        let path = String(cString: buffer)
+        return (path as NSString).lastPathComponent
+    }
+}
+
+// `proc_pidpath` lives in libproc.dylib and is not surfaced by Foundation.
+@_silgen_name("proc_pidpath")
+private func proc_pidpath_shim(_ pid: pid_t, _ buffer: UnsafeMutablePointer<CChar>, _ size: UInt32) -> Int32


### PR DESCRIPTION
```
Xcode has killed the LLDB RPC server (pid: 18223) to allow the debugger
to detach from your process.
```

Measured immediately, twenty-one seconds apart:

```
80876  ppid 1      (launchd)      12:04:03   ← orphan, previous run, still alive
81007  ppid 81299  (debugserver)  12:04:24   ← the run Xcode was attached to
```

No crash report today. **Nothing killed the HUD** — Xcode *detached* from it, launchd adopted it, and it kept running: holding its ports, its microphone claim, its UDS socket, and competing with the next instance for all three.

## Why the existing fix didn't cover this

`deed250a92` fixed this message two days ago, and its fix is sound. It declares `JARVIS_PARENT_PID` so the Python brainstem watches the HUD and leaves when the HUD leaves. It rests on an assumption stated in its own comment: *"Xcode's Stop button SIGKILLs this process."*

Sometimes Xcode detaches instead — and when it does, that fix isn't merely absent, it's **actively defeated**. The brainstem watches the HUD; the HUD is still alive; so the brainstem correctly stays. Every link watched the link above it and the topmost link watched nothing, so orphaning the top orphaned the whole chain with its protection intact and useless.

This gives the chain a root rather than adding a second mechanism: the HUD now watches *its* launcher, with the same discipline the brainstem already uses.

## Why not a signal handler

Neither signal handlers nor `atexit` nor `deinit` run on SIGKILL, and SIGKILL is one of the two ways this session ends. A process cannot clean up after its own uncatchable death; something must observe it from outside. The roles simply invert here — we're the observer, and what we observe is our own launcher.

## Inert for a normally-launched app

A double-clicked app is started by launchd and has ppid 1 for its whole life; exiting when "the parent dies" would be nonsense there. The watch arms only when the parent is something else — precisely the debugger/terminal case where our lifetime really is bounded by theirs. Same rule as `JARVIS_PARENT_PID`.

## Two details that would have made it silently wrong

A `DispatchSourceProcess` established on an already-dead pid **never fires**, and the parent can die between `getppid()` and `resume()`. That window is re-checked after arming, because missing it produces exactly the orphan this prevents.

And it calls `NSApp.terminate` rather than `exit()`: the normal shutdown path stops the brainstem the way any quit does. A bare `exit()` would leave behind the very orphan being prevented.

## The file was not in the project

`ParentWatch.swift` had **0 references** in `project.pbxproj` against `BrainstemLauncher`'s 4 — on disk, in git, and never compiled. `project.yml` already sources the whole `JARVISHUD` tree, so `xcodegen generate` picked it up: 4 references, diff exactly 4 insertions, so the project file was already in parity and nothing churned.

Committed with `-f` because `*.xcodeproj` is gitignored while this `pbxproj` is tracked — the ignore rule postdates it, and it's the artifact anyone who doesn't run xcodegen actually builds from.

## Not yet proven

**Not run.** The verification is behavioural and belongs to a real Xcode session: Run, Stop, confirm no `JARVISHUD` survives with ppid 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents orphaned HUD processes when Xcode detaches by making the HUD watch its launcher and quit when the parent exits. Stops leftover instances holding ports, mic, and the UDS socket between runs.

- **Bug Fixes**
  - Added ParentWatch to observe the launcher via DispatchSourceProcess(.exit) and exit the HUD when the parent dies.
  - Arms only when the parent is not launchd (pid 1); no effect for normal app launches.
  - Armed after starting the brainstem to avoid leaving the child unsupervised.
  - Uses NSApp.terminate to run normal shutdown and stop the brainstem.
  - Re-checks ppid after arming to close the race where the parent dies during setup.
  - Included ParentWatch in the project; can be disabled with `JARVIS_HUD_PARENT_WATCH_DISABLED=1` for debugging.

<sup>Written for commit 7fc4c4b0e436806feb718dc6f5651a62945aa764. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

