### PR TITLE
fix: Verify instance reaping instead of assuming it worked

### DIFF
--- a/JARVIS-Apple/JARVIS-Apple.xcodeproj/project.pbxproj
+++ b/JARVIS-Apple/JARVIS-Apple.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		ADEA3EDEC8E9800EB2E4B351 /* JARVISKit in Frameworks */ = {isa = PBXBuildFile; productRef = 15EECA930D551D91AC5C18B4 /* JARVISKit */; };
 		B382A284A476CA2ACA805D56 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4A8BD3E8642F43ADBDD9BB1 /* SettingsView.swift */; };
 		C2EAD5E8889A90385FDA3E14 /* MicSuppression.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2FEA2CE20F48E377D68D971 /* MicSuppression.swift */; };
+		C8DADA0477E42685A38F3582 /* ProcessReaper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 853D4634AFC6AE6D5E4CC20A /* ProcessReaper.swift */; };
 		D3F64926FE39007A1202CB78 /* ScreenCaptureService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F97771D9894460348ABB0ED /* ScreenCaptureService.swift */; };
 		D6F51E777605C3FDFADC38B7 /* PRQueueView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 363CFA575B249D1A15B71B0E /* PRQueueView.swift */; };
 		DC553908F1A143513C3F8D48 /* JARVISColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = C953EA1271F55784A7D1004B /* JARVISColors.swift */; };
@@ -64,6 +65,7 @@
 		7F2D54D7706047B14362D0D6 /* TransparentWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransparentWindow.swift; sourceTree = "<group>"; };
 		7F9345DF8825258B0773BAA5 /* JARVISHUDApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JARVISHUDApp.swift; sourceTree = "<group>"; };
 		7F97771D9894460348ABB0ED /* ScreenCaptureService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenCaptureService.swift; sourceTree = "<group>"; };
+		853D4634AFC6AE6D5E4CC20A /* ProcessReaper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessReaper.swift; sourceTree = "<group>"; };
 		853E0D7E9218220610520FB8 /* StatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusView.swift; sourceTree = "<group>"; };
 		86A3C5DDD4D1D44D8569C39B /* UtteranceRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtteranceRecorder.swift; sourceTree = "<group>"; };
 		899F7DC5BF2FA227AA8CEA81 /* LivingBorderWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LivingBorderWindow.swift; sourceTree = "<group>"; };
@@ -179,6 +181,7 @@
 				A6A777442955E499D4E22D3B /* BrainstemLauncher.swift */,
 				A2FEA2CE20F48E377D68D971 /* MicSuppression.swift */,
 				BFD1B9697A7D560891A59E78 /* ParentWatch.swift */,
+				853D4634AFC6AE6D5E4CC20A /* ProcessReaper.swift */,
 				7F97771D9894460348ABB0ED /* ScreenCaptureService.swift */,
 				95D0EF17C00CB1001F596D74 /* SecureConsent.swift */,
 				86A3C5DDD4D1D44D8569C39B /* UtteranceRecorder.swift */,
@@ -425,6 +428,7 @@
 				F2372C4356B52F4C5EE16B1C /* LoadingHUDView.swift in Sources */,
 				C2EAD5E8889A90385FDA3E14 /* MicSuppression.swift in Sources */,
 				A2C3549A6EDDCEC8A4D1FF98 /* ParentWatch.swift in Sources */,
+				C8DADA0477E42685A38F3582 /* ProcessReaper.swift in Sources */,
 				D3F64926FE39007A1202CB78 /* ScreenCaptureService.swift in Sources */,
 				67836362453377C25CE3CB3D /* SecureConsent.swift in Sources */,
 				8343F8E9601E5B1F4058448D /* TransparentWindow.swift in Sources */,

--- a/JARVIS-Apple/JARVISHUD/JARVISHUDApp.swift
+++ b/JARVIS-Apple/JARVISHUD/JARVISHUDApp.swift
@@ -32,7 +32,11 @@ class HUDAppDelegate: NSObject, NSApplicationDelegate, AVSpeechSynthesizerDelega
         Task { @MainActor in
             for w in NSApp.windows { w.orderOut(nil) }
             NSApp.setActivationPolicy(.accessory)
-            self.terminateOlderInstancesIfNeeded()
+            // Awaited: everything below claims ports, the microphone and the UDS
+            // socket, and a stale instance still holds all three until it is
+            // actually gone. The previous fire-and-forget call let startup race
+            // a process it had merely asked to leave.
+            await self.terminateOlderInstancesIfNeeded()
             self.setupMenuBar()
             self.setupVoice()
             // Request Screen Recording permission early, then start persistent stream.
@@ -387,17 +391,58 @@ class HUDAppDelegate: NSObject, NSApplicationDelegate, AVSpeechSynthesizerDelega
 
     // MARK: - Menu Bar
 
-    private func terminateOlderInstancesIfNeeded() {
+    /// Remove HUD instances left over from previous runs, and PROVE they are gone.
+    ///
+    /// The previous implementation called `forceTerminate()` and returned. That
+    /// method's `Bool` was discarded, nothing waited, and nothing verified — so
+    /// on 2026-08-06 this ran at 12:04:24 against orphan pid 80876, failed, and
+    /// said nothing. A request is not an outcome.
+    ///
+    /// Graceful `terminate()` first, deliberately. `forceTerminate()` is
+    /// uncatchable, so the target never runs its shutdown and its Python
+    /// brainstem child is orphaned at the instant we kill its parent — reaping
+    /// one orphan by creating another. `terminate()` routes through AppKit's
+    /// normal quit path, and the target takes its own children with it.
+    ///
+    /// Async because it now actually waits. Startup must not race a dying
+    /// instance for the ports, microphone and socket it has not released yet,
+    /// and the wait must not block the main thread while it happens.
+    private func terminateOlderInstancesIfNeeded() async {
         guard let bundleIdentifier = Bundle.main.bundleIdentifier else { return }
 
         let currentPID = ProcessInfo.processInfo.processIdentifier
+
+        // Identity, not ports — the same principle BrainstemLauncher's reaper
+        // documents. A bundle identifier says "this is another copy of us";
+        // holding a port says only "something is here".
         let duplicates = NSRunningApplication.runningApplications(withBundleIdentifier: bundleIdentifier)
             .filter { $0.processIdentifier != currentPID }
 
         guard !duplicates.isEmpty else { return }
 
-        for app in duplicates {
-            app.forceTerminate()
+        print("[HUD] found \(duplicates.count) older instance(s) — reaping before startup")
+
+        // Phased, not a task group. `NSRunningApplication` is not Sendable, and
+        // a task group would carry it across an isolation boundary — which Swift
+        // 6's region checker rejects, and rightly. `reapAll` asks all of them at
+        // once and shares a single grace window, so N stale instances still cost
+        // one wait rather than N.
+        let outcomes = await ProcessReaper.reapAll(
+            duplicates.map { app in
+                ProcessReaper.Target(
+                    pid: app.processIdentifier,
+                    requestExit: { app.terminate() },
+                    force: { app.forceTerminate() }
+                )
+            },
+            label: "HUD instance"
+        )
+
+        if outcomes.contains(.survived) {
+            // Named at startup rather than discovered later as "the app is
+            // behaving strangely". The instance is still there; the operator
+            // should know why things may contend.
+            print("[HUD] ⚠️ an older instance could not be removed — expect contention for ports, mic and socket")
         }
     }
 

--- a/JARVIS-Apple/JARVISHUD/Services/ProcessReaper.swift
+++ b/JARVIS-Apple/JARVISHUD/Services/ProcessReaper.swift
@@ -1,0 +1,185 @@
+/// ProcessReaper — ask a process to leave, then confirm that it did.
+///
+/// WHY THIS EXISTS
+/// ---------------
+/// `terminateOlderInstancesIfNeeded()` called `NSRunningApplication.forceTerminate()`
+/// and moved on. That method returns `Bool` and the result was discarded, nothing
+/// waited, and nothing verified — so when it failed it failed *silently*.
+///
+/// Measured 2026-08-06: a new HUD started at 12:04:24 while pid 80876 from the
+/// previous run was still alive, and was still alive minutes later. The code
+/// written to prevent exactly that had already run and reported nothing, because
+/// there was nothing in it capable of reporting.
+///
+/// A request is not an outcome. Every reap here is verified against the kernel
+/// (`kill(pid, 0)`), and a reap that could not be completed says so.
+///
+/// GRACE BEFORE FORCE, AND WHY IT IS NOT POLITENESS
+/// ------------------------------------------------
+/// The old code opened with force. `forceTerminate` is uncatchable, so the HUD
+/// being killed never runs its shutdown — and its Python brainstem child is
+/// therefore orphaned at the moment we kill its parent. Reaping one orphan by
+/// creating another is not a reap.
+///
+/// SIGTERM first gives the target the chance to take its own children with it.
+/// This is the same discipline `BrainstemLauncher.killStaleProcesses()` already
+/// documents: *"an orphan that has just been told to leave should get the chance
+/// to close its sockets and flush... SIGKILL only for what ignores that."*
+/// That reaper still has its own copy of the escalation loop; adopting this type
+/// there means making a synchronous startup path async, which is a larger change
+/// than this fix should carry. Named here so it is a known follow-up rather than
+/// an unremarked divergence.
+///
+/// ASYNC, NOT `Thread.sleep`
+/// -------------------------
+/// Waiting is done with `Task.sleep`, so the grace period does not block the
+/// thread that is waiting. The caller is app startup on the main actor; blocking
+/// it for the full grace window would freeze the UI of the instance that is
+/// trying to come up.
+
+import Foundation
+
+@MainActor
+enum ProcessReaper {
+
+    /// What happened to one process.
+    enum Outcome {
+        /// Gone after being asked politely.
+        case exitedGracefully
+        /// Ignored the request; required force.
+        case forced
+        /// Still alive after everything. The caller must decide what that means.
+        case survived
+        /// Already gone before we started.
+        case alreadyGone
+    }
+
+    /// Total grace before escalating to force, in seconds.
+    /// Env-overridable so a slow machine can be given more without a rebuild.
+    private static var graceSeconds: Double {
+        if let raw = ProcessInfo.processInfo.environment["JARVIS_REAP_GRACE_S"],
+           let value = Double(raw), value > 0, value <= 30 {
+            return value
+        }
+        return 2.0
+    }
+
+    /// How often to re-ask the kernel whether the process is gone.
+    private static var pollSeconds: Double {
+        if let raw = ProcessInfo.processInfo.environment["JARVIS_REAP_POLL_S"],
+           let value = Double(raw), value > 0, value <= 1 {
+            return value
+        }
+        return 0.1
+    }
+
+    /// Is this pid still alive, according to the kernel?
+    ///
+    /// `kill(pid, 0)` sends no signal; it only performs the existence and
+    /// permission check. This is the authority — an `NSRunningApplication` handle
+    /// can go stale, and a `Bool` returned by a termination request describes
+    /// only whether the request was accepted.
+    static func isAlive(_ pid: pid_t) -> Bool {
+        guard pid > 1 else { return false }
+        return kill(pid, 0) == 0
+    }
+
+    /// One process to reap, and how to ask it.
+    ///
+    /// `requestExit`/`force` are closures rather than a fixed signal pair so an
+    /// `NSRunningApplication` caller can route through AppKit's quit path, which
+    /// lets the target run its shutdown and take its own children with it.
+    /// A signal-only reaper could not express that.
+    struct Target {
+        let pid: pid_t
+        let requestExit: () -> Void
+        let force: () -> Void
+
+        /// Signal-based target, for a bare pid with no app handle.
+        static func signals(_ pid: pid_t) -> Target {
+            Target(pid: pid,
+                   requestExit: { kill(pid, SIGTERM) },
+                   force: { kill(pid, SIGKILL) })
+        }
+    }
+
+    /// Reap a set of processes in PHASES: ask all, wait once, force the
+    /// survivors, wait once, report.
+    ///
+    /// Phased rather than one concurrent task per process, for two reasons.
+    ///
+    /// The practical one: N stale instances would otherwise cost N grace periods
+    /// in series if reaped in a loop, and startup is waiting on all of them. One
+    /// shared wait covers every target at once.
+    ///
+    /// The structural one: a task group would have to carry `NSRunningApplication`
+    /// — which is not `Sendable` — across an isolation boundary. Swift 6's
+    /// region-based isolation checker rejects that outright, and the honest
+    /// response is to stop crossing the boundary rather than to annotate the
+    /// crossing away. Everything here stays on the main actor, so there is no
+    /// region to cross and no unsafe opt-out to justify.
+    ///
+    /// - Returns: Outcome per target, in the order given, verified against the
+    ///   kernel rather than inferred from whether a request was accepted.
+    @discardableResult
+    static func reapAll(_ targets: [Target], label: String) async -> [Outcome] {
+        guard !targets.isEmpty else { return [] }
+
+        var outcomes = [Outcome](repeating: .alreadyGone, count: targets.count)
+        var pending: [Int] = []
+
+        // Phase 1 — ask everyone at once.
+        for (index, target) in targets.enumerated() where isAlive(target.pid) {
+            target.requestExit()
+            pending.append(index)
+        }
+        guard !pending.isEmpty else { return outcomes }
+
+        // Phase 2 — one shared grace window. Polling, so a process that leaves
+        // immediately does not cost the worst case.
+        pending = await waitForExit(targets, pending: pending, outcomes: &outcomes, as: .exitedGracefully)
+        guard !pending.isEmpty else { return outcomes }
+
+        // Phase 3 — insist, only on what ignored the request.
+        for index in pending {
+            print("[Reaper] \(label) pid \(targets[index].pid) ignored the request after \(graceSeconds)s — forcing")
+            targets[index].force()
+        }
+
+        // Phase 4 — force is not instantaneous either, and claiming success
+        // without looking is the defect this type exists to remove.
+        pending = await waitForExit(targets, pending: pending, outcomes: &outcomes, as: .forced)
+
+        // Deliberately loud. A process that survives force is wedged in the
+        // kernel (uninterruptible I/O, or a debugger holding it), and the next
+        // instance is about to contend with it for ports, the microphone and the
+        // UDS socket. Silence here is what produced the 12:04 duplicate.
+        for index in pending {
+            outcomes[index] = .survived
+            print("[Reaper] ⚠️ \(label) pid \(targets[index].pid) SURVIVED force — it will contend with this instance")
+        }
+        return outcomes
+    }
+
+    /// Poll until every pending target is gone or the grace window expires.
+    /// Returns the indices still alive.
+    private static func waitForExit(
+        _ targets: [Target],
+        pending: [Int],
+        outcomes: inout [Outcome],
+        as outcome: Outcome
+    ) async -> [Int] {
+        var remaining = pending
+        let deadline = Date().addingTimeInterval(graceSeconds)
+
+        while !remaining.isEmpty && Date() < deadline {
+            try? await Task.sleep(nanoseconds: UInt64(pollSeconds * 1_000_000_000))
+            remaining = remaining.filter { index in
+                if isAlive(targets[index].pid) { return true }
+                outcomes[index] = outcome
+                return false
+            }
+        }
+        return remaining
+    }
+}


### PR DESCRIPTION
`terminateOlderInstancesIfNeeded()` called `NSRunningApplication.forceTerminate()` and returned. That method returns `Bool`; **the result was discarded, nothing waited, and nothing verified.**

Measured 2026-08-06: a new HUD started at 12:04:24 while pid 80876 from the previous run was still alive — and it was still alive minutes later. The code written to prevent exactly that had already run and reported nothing, because there was nothing in it capable of reporting.

Same shape as the 47 typing sessions that counted their own calls as successes.

## Two defects, the second worse

**1. No verification.** A failed reap was indistinguishable from a successful one. Every outcome is now checked against the kernel via `kill(pid, 0)` — the authority. An `NSRunningApplication` handle can go stale, and a `Bool` from a termination request describes only whether the *request* was accepted.

**2. Force first.** `forceTerminate()` is uncatchable, so the target never runs its shutdown and its Python brainstem child is **orphaned at the instant we kill its parent**. Reaping one orphan by creating another is not a reap. Graceful `terminate()` now goes first, routing through AppKit's quit path so the target takes its own children with it — the discipline `BrainstemLauncher.killStaleProcesses()` already documents.

Startup now **awaits** the reap. Everything after it claims ports, the microphone and the UDS socket, all of which a stale instance holds until it's actually gone.

## Phased, not a task group — and the build is why

The first version used `withTaskGroup` so N stale instances wouldn't cost N grace periods in series. It **typechecked in isolation and failed the real build**:

```
error: pattern that the region-based isolation checker does not understand how to check
```

`NSRunningApplication` isn't `Sendable`, and a task group carries it across an isolation boundary. The honest response is to stop crossing the boundary, not to annotate the crossing away with an unsafe opt-out.

So `reapAll` works in phases — ask all, wait once, force the survivors, wait once, report. Everything stays on the main actor, there's no region to cross, and N targets still share a single grace window. The structural constraint and the performance goal wanted the same shape.

**Worth recording:** `swiftc -typecheck` on the file alone passed. Only the full target build caught this. Per-file typechecking is not a build.

## Verified

**BUILD SUCCEEDED** (xcodebuild, Debug, arm64) — which also means `ParentWatch.swift` from the previous commit now genuinely compiles into the app rather than merely parsing.

## Follow-up, named rather than left

`BrainstemLauncher.killStaleProcesses()` still has its own copy of the escalation loop, and uses `Thread.sleep` — blocking the caller for up to 2s. Adopting `ProcessReaper` there means making a synchronous startup path async, a larger change than this fix should carry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Verified and awaited reaping of stale HUD instances at startup to prevent duplicate processes contending for ports, mic, and UDS socket. Introduces a `ProcessReaper` that prefers graceful `terminate()` and confirms outcomes via the kernel before forcing.

- **Bug Fixes**
  - Startup now awaits instance reaping and verifies results using kill(pid, 0).
  - Switch to `terminate()` before `forceTerminate()` to avoid orphaning child processes.
  - Reap in phases on the main actor: ask all, share one grace window, then force survivors; avoids non-Sendable crossings.
  - Grace/poll intervals are tunable via `JARVIS_REAP_GRACE_S` and `JARVIS_REAP_POLL_S`; survivors are clearly logged.

<sup>Written for commit c46d3777192a39c2ec8d7d5aace9084952227db4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

