### PR TITLE
fix: Route orphan diagnostics through the durable boot log

### DIFF
--- a/JARVIS-Apple/JARVISHUD/JARVISHUDApp.swift
+++ b/JARVIS-Apple/JARVISHUD/JARVISHUDApp.swift
@@ -420,7 +420,7 @@ class HUDAppDelegate: NSObject, NSApplicationDelegate, AVSpeechSynthesizerDelega
 
         guard !duplicates.isEmpty else { return }
 
-        print("[HUD] found \(duplicates.count) older instance(s) — reaping before startup")
+        BootLogFile.shared.note("[HUD] found \(duplicates.count) older instance(s) — reaping before startup")
 
         // Phased, not a task group. `NSRunningApplication` is not Sendable, and
         // a task group would carry it across an isolation boundary — which Swift
@@ -442,7 +442,7 @@ class HUDAppDelegate: NSObject, NSApplicationDelegate, AVSpeechSynthesizerDelega
             // Named at startup rather than discovered later as "the app is
             // behaving strangely". The instance is still there; the operator
             // should know why things may contend.
-            print("[HUD] ⚠️ an older instance could not be removed — expect contention for ports, mic and socket")
+            BootLogFile.shared.note("[HUD] ⚠️ an older instance could not be removed — expect contention for ports, mic and socket")
         }
     }
 

--- a/JARVIS-Apple/JARVISHUD/Services/BootLogFile.swift
+++ b/JARVIS-Apple/JARVISHUD/Services/BootLogFile.swift
@@ -100,4 +100,21 @@ final class BootLogFile: @unchecked Sendable {
             try? h.write(contentsOf: data)
         }
     }
+
+    /// Say it once, to both audiences.
+    ///
+    /// The live Xcode console is for the developer watching right now; the file
+    /// is for every question asked afterwards. Code that calls only `print()`
+    /// reaches the first and not the second, which is precisely the failure this
+    /// type was built to end — and new code kept reintroducing it, because
+    /// `print` is what comes to hand.
+    ///
+    /// Verified 2026-08-06: `ParentWatch` and `ProcessReaper` shipped with bare
+    /// `print()`, and afterwards there was no way to answer "did the watch arm?"
+    /// for a session that had already happened. One call, both destinations, no
+    /// decision to get wrong at the call site.
+    func note(_ line: String) {
+        print(line)
+        write(line)
+    }
 }

--- a/JARVIS-Apple/JARVISHUD/Services/ParentWatch.swift
+++ b/JARVIS-Apple/JARVISHUD/Services/ParentWatch.swift
@@ -81,7 +81,7 @@ enum ParentWatch {
         guard source == nil else { return }
 
         if ProcessInfo.processInfo.environment[disableKey] == "1" {
-            print("[ParentWatch] \(disableKey)=1 — not watching; this process can outlive its launcher")
+            BootLogFile.shared.note("[ParentWatch] \(disableKey)=1 — not watching; this process can outlive its launcher")
             return
         }
 
@@ -89,7 +89,7 @@ enum ParentWatch {
 
         guard parent != launchdPID else {
             // Normal launch. There is no parent whose death should end us.
-            print("[ParentWatch] parent is launchd — not arming (normal app launch)")
+            BootLogFile.shared.note("[ParentWatch] parent is launchd — not arming (normal app launch)")
             return
         }
 
@@ -109,21 +109,21 @@ enum ParentWatch {
         // premise ever stops holding it traps here rather than racing silently.
         src.setEventHandler {
             MainActor.assumeIsolated {
-                print("[ParentWatch] launcher (\(parentName)) exited — leaving rather than orphaning")
+                BootLogFile.shared.note("[ParentWatch] launcher (\(parentName)) exited — leaving rather than orphaning")
                 onOrphaned()
             }
         }
         src.resume()
         source = src
 
-        print("[ParentWatch] watching launcher \(parentName); this process will not outlive it")
+        BootLogFile.shared.note("[ParentWatch] watching launcher \(parentName); this process will not outlive it")
 
         // A DispatchSourceProcess established on an ALREADY-dead pid never
         // fires. The window is small but real: the parent can die between
         // getppid() and resume(). Re-check afterwards, because the failure mode
         // of missing it is exactly the orphan this exists to prevent.
         if getppid() != parent {
-            print("[ParentWatch] launcher exited while arming — leaving now")
+            BootLogFile.shared.note("[ParentWatch] launcher exited while arming — leaving now")
             onOrphaned()
         }
     }

--- a/JARVIS-Apple/JARVISHUD/Services/ProcessReaper.swift
+++ b/JARVIS-Apple/JARVISHUD/Services/ProcessReaper.swift
@@ -137,18 +137,18 @@ enum ProcessReaper {
 
         // Phase 2 — one shared grace window. Polling, so a process that leaves
         // immediately does not cost the worst case.
-        pending = await waitForExit(targets, pending: pending, outcomes: &outcomes, as: .exitedGracefully)
+        pending = await waitForExit(targets, pending: pending, label: label, outcomes: &outcomes, as: .exitedGracefully)
         guard !pending.isEmpty else { return outcomes }
 
         // Phase 3 — insist, only on what ignored the request.
         for index in pending {
-            print("[Reaper] \(label) pid \(targets[index].pid) ignored the request after \(graceSeconds)s — forcing")
+            BootLogFile.shared.note("[Reaper] \(label) pid \(targets[index].pid) ignored the request after \(graceSeconds)s — forcing")
             targets[index].force()
         }
 
         // Phase 4 — force is not instantaneous either, and claiming success
         // without looking is the defect this type exists to remove.
-        pending = await waitForExit(targets, pending: pending, outcomes: &outcomes, as: .forced)
+        pending = await waitForExit(targets, pending: pending, label: label, outcomes: &outcomes, as: .forced)
 
         // Deliberately loud. A process that survives force is wedged in the
         // kernel (uninterruptible I/O, or a debugger holding it), and the next
@@ -156,7 +156,7 @@ enum ProcessReaper {
         // UDS socket. Silence here is what produced the 12:04 duplicate.
         for index in pending {
             outcomes[index] = .survived
-            print("[Reaper] ⚠️ \(label) pid \(targets[index].pid) SURVIVED force — it will contend with this instance")
+            BootLogFile.shared.note("[Reaper] ⚠️ \(label) pid \(targets[index].pid) SURVIVED force — it will contend with this instance")
         }
         return outcomes
     }
@@ -166,6 +166,7 @@ enum ProcessReaper {
     private static func waitForExit(
         _ targets: [Target],
         pending: [Int],
+        label: String,
         outcomes: inout [Outcome],
         as outcome: Outcome
     ) async -> [Int] {
@@ -177,6 +178,14 @@ enum ProcessReaper {
             remaining = remaining.filter { index in
                 if isAlive(targets[index].pid) { return true }
                 outcomes[index] = outcome
+                // Success is recorded, not assumed.
+                //
+                // The first version logged only escalation and survival, so a
+                // reap that WORKED left no trace -- and "no trace" is exactly
+                // what the old forceTerminate() left when it FAILED. A record
+                // that only exists on failure cannot distinguish the two, which
+                // is the whole defect this type was written to remove.
+                BootLogFile.shared.note("[Reaper] \(label) pid \(targets[index].pid) \(outcome)")
                 return false
             }
         }


### PR DESCRIPTION
## First: there is no code defect

The reported errors are Xcode showing a **cached issue set** from a build predating `9f40c991a1`.

| Xcode says | On disk |
|---|---|
| line 60 `enum ParentWatch {`, no `@MainActor` | line 59 **is** `@MainActor` |
| line 120 `String(cString:)` | `String(decoding:as:)` at line 149 |

A clean `xcodebuild` of the current tree returns **BUILD SUCCEEDED, zero errors, zero warnings**. The fix is to let Xcode rebuild, not to change code that's already correct.

Investigating it exposed a real defect instead.

## A log that requires someone watching is not a log

Asked *"did ParentWatch arm?"*, there was no way to find out. `log show` returned nothing and the app's stdout was empty — because **a GUI app's `print()` doesn't survive redirection**, which is the exact lesson `BootLogFile.swift` was written to end and states in its own header.

`ParentWatch` and `ProcessReaper` shipped with bare `print()`. They are the two files whose entire purpose is making orphaned processes visible, and their evidence evaporated the moment nobody was attached to Xcode. Every diagnostic in both now goes through `BootLogFile`, which survives the debugger.

## One call, both destinations

Rather than a `print` + `write` pair at each site — the shape that decays, because someone eventually writes only the print — `BootLogFile` gains `note()`: the live console for whoever is watching now, the file for every question asked afterwards. No decision left to get wrong at the call site.

## Success is recorded, not assumed

`ProcessReaper` logged only escalation and survival, so a reap that **worked** left no trace. "No trace" is precisely what the old `forceTerminate()` left when it **failed** — a record that exists only on failure cannot distinguish the two, which is the defect the type was written to remove. Every outcome is now recorded.

Pre-existing `print()` calls elsewhere in `JARVISHUDApp` are left alone: same flaw, but converting them wholesale is unrelated churn.

## Verified

**BUILD SUCCEEDED** (xcodebuild, Debug, arm64).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes orphan-process diagnostics through the durable boot log so they persist outside Xcode. Adds a single-call logger and records successful reaps for clear post-mortem traces.

- **New Features**
  - `BootLogFile.note(_:)` logs to both the console and the persistent boot log.

- **Bug Fixes**
  - Replaced `print()` in `ParentWatch` and `ProcessReaper` with `BootLogFile` logging.
  - `ProcessReaper` now logs successful exits, not just escalation/survival.
  - Startup duplicate-instance messages in `JARVISHUDApp` now use `BootLogFile`.

<sup>Written for commit ef33721d0f71bce3267ba5b18fdd6e1216ea5648. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

