### PR TITLE
fix: Stop reporting a voice that was never heard as a voice that did not match

### DIFF
--- a/backend/hud/voice_identity.py
+++ b/backend/hud/voice_identity.py
@@ -52,7 +52,7 @@ import logging
 import os
 import time
 from dataclasses import dataclass, field
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
 logger = logging.getLogger("JARVIS.VoiceIdentity")
 
@@ -556,8 +556,34 @@ class VoiceIdentity:
             who = str((result or {}).get("speaker_name") or owner)
 
             if not verified:
+                # `verified=false` is TWO different claims wearing one value:
+                # "I compared you and it was not you", and "I had nothing to
+                # compare you against". Mapping both to REJECTED is the same
+                # collapse the comment above warns about, seventeen lines later.
+                #
+                # Measured 2026-08-06 13:12:23: the ECAPA facade failed to
+                # create, the fallback engine held no voiceprints, and a
+                # comparison that never happened was reported as
+                # "That didn't sound like you, so I've left it locked."
+                #
+                # So ask the verifier whether a comparison was POSSIBLE rather
+                # than inferring it from a zero confidence -- a genuine mismatch
+                # can score zero too, and guessing between them would just move
+                # the ambiguity somewhere harder to see.
+                capable, reason = self._comparison_capability(who)
+                if not capable:
+                    # Still refuses the unlock: an unverifiable voice is not
+                    # consent, and this path can only ever be stricter. What
+                    # changes is that the operator is told the truth, and the
+                    # truth points at repairing enrollment rather than at
+                    # speaking more clearly.
+                    verdict = (Verdict.NOT_ENROLLED
+                               if reason in ("no_profiles_loaded", "speaker_not_loaded")
+                               else Verdict.UNAVAILABLE)
+                    return _out(verdict, conf=conf, speaker=who,
+                                detail=f"comparison not possible: {reason}")
                 return _out(Verdict.REJECTED, conf=conf, speaker=who,
-                            detail="service returned verified=false")
+                            detail="compared against a loaded voiceprint and did not match")
             floor = min_confidence()
             if conf < floor:
                 # The service said yes; the confidence says otherwise. Refuse
@@ -568,6 +594,26 @@ class VoiceIdentity:
         except Exception as exc:  # noqa: BLE001 — a fault is never consent
             return _out(Verdict.UNAVAILABLE,
                         detail=f"{type(exc).__name__}: {exc}")
+
+    def _comparison_capability(self, speaker: str) -> Tuple[bool, str]:
+        """
+        Ask the verifier whether it could have compared anything.
+
+        Fails toward "a comparison happened" ONLY when the verifier cannot be
+        asked at all. That direction is deliberate: claiming a fault we cannot
+        evidence would let a genuine mismatch be reported as a broken verifier,
+        which is the same dishonesty in the other direction. A service too old
+        to answer keeps the previous behaviour rather than acquiring a new
+        excuse.
+        """
+        probe = getattr(self._service, "verification_capability", None)
+        if not callable(probe):
+            return (True, "capability_probe_unavailable")
+        try:
+            capable, reason = probe(speaker)
+            return (bool(capable), str(reason))
+        except Exception as exc:  # noqa: BLE001 — the probe must never decide by throwing
+            return (True, f"capability_probe_failed:{type(exc).__name__}")
 
     def stats(self) -> Dict[str, Any]:
         return {

--- a/backend/voice/speaker_verification_service.py
+++ b/backend/voice/speaker_verification_service.py
@@ -5939,6 +5939,54 @@ class SpeakerVerificationService:
                 logger.warning("   ⚠️ Returning original audio data (may not be PCM!)")
                 return audio_data
 
+    def verification_capability(self, speaker_name: Optional[str] = None) -> Tuple[bool, str]:
+        """
+        Could a comparison happen at all right now? If not, why not.
+
+        WHY THIS EXISTS
+        ---------------
+        Measured 2026-08-06 13:12:23, on a real unlock attempt::
+
+            EcapaFacade error: registry required for first facade creation
+                - falling back to local engine
+            No speaker match found. Primary user: None, Best confidence: 0.00%
+            'unlock_screen' NOT authorised (That didn't sound like you...)
+
+        ``Best confidence: 0.00%`` is not a low score. It is the absence of a
+        score: nothing was compared, because the fallback engine held no
+        voiceprints. The operator was told his voice did not match, when the
+        truth was that his voice was never checked.
+
+        A FAULT ON A CONSENT PATH IS INDISTINGUISHABLE FROM A REFUSAL unless
+        something makes it distinguishable, and only the verifier knows which
+        one happened. ``verified: False`` cannot carry that distinction --
+        it is the same value for "I compared you and it was not you" and for
+        "I had nothing to compare you against".
+
+        The two demand opposite responses from the operator: speak again, or
+        repair enrollment. Reporting the second as the first sends them to do
+        the one thing that cannot help.
+
+        Returns:
+            ``(can_compare, reason)``. ``reason`` is a stable machine token,
+            never a sentence -- the caller owns the wording.
+        """
+        if not self.initialized:
+            return (False, "not_initialized")
+
+        profiles = getattr(self, "speaker_profiles", None) or {}
+        if not profiles:
+            # The enrollment STORE may well hold a voiceprint; this says the
+            # running verifier does not have one loaded. Distinct claims, and
+            # conflating them is how "enroll your voice" gets said to someone
+            # who enrolled months ago.
+            return (False, "no_profiles_loaded")
+
+        if speaker_name and speaker_name not in profiles:
+            return (False, "speaker_not_loaded")
+
+        return (True, "ready")
+
     async def verify_speaker(self, audio_data: bytes, speaker_name: Optional[str] = None) -> dict:
         """
         Verify speaker from audio with adaptive learning

--- a/tests/security/test_voice_identity_fault_vs_refusal.py
+++ b/tests/security/test_voice_identity_fault_vs_refusal.py
@@ -1,0 +1,135 @@
+"""
+A fault on the consent path must not be reported as a refusal.
+
+Measured 2026-08-06 13:12:23, on a real unlock attempt::
+
+    EcapaFacade error: registry required for first facade creation
+        - falling back to local engine
+    No speaker match found. Primary user: None, Best confidence: 0.00%
+    'unlock_screen' NOT authorised (That didn't sound like you, so I've left it locked.)
+
+``Best confidence: 0.00%`` is not a low score -- it is the absence of a score.
+Nothing was compared, because the fallback engine held no voiceprints. The
+operator was told his voice did not match, when his voice was never checked.
+
+The two outcomes demand opposite responses: speak again, or repair enrollment.
+These tests pin the distinction so it cannot collapse back into one value, which
+is what `voice_identity.py` already warns about seventeen lines above the site
+where it happened again.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.hud.voice_identity import Verdict, VoiceIdentity
+
+
+class _Service:
+    """Stands in for SpeakerVerificationService's capability probe."""
+
+    def __init__(self, capable: bool, reason: str):
+        self._capable = capable
+        self._reason = reason
+
+    def verification_capability(self, speaker_name=None):
+        return (self._capable, self._reason)
+
+
+def test_no_loaded_voiceprint_is_not_enrolled_not_rejected():
+    """
+    The exact 2026-08-06 failure.
+
+    The engine held no profiles, so no comparison occurred. Saying "that didn't
+    sound like you" sends the operator to speak more clearly -- the one action
+    that cannot possibly help.
+    """
+    identity = VoiceIdentity(service=_Service(False, "no_profiles_loaded"))
+
+    capable, reason = identity._comparison_capability("Derek J. Russell")
+
+    assert capable is False
+    assert reason == "no_profiles_loaded"
+
+
+def test_a_real_comparison_still_reports_rejection():
+    """
+    The fix must not turn every refusal into a fault.
+
+    If a voiceprint IS loaded and the audio does not match, that is a genuine
+    REJECTED -- and reporting it as "I can't check who's speaking" would be the
+    same dishonesty pointing the other way.
+    """
+    identity = VoiceIdentity(service=_Service(True, "ready"))
+
+    capable, reason = identity._comparison_capability("Derek J. Russell")
+
+    assert capable is True
+    assert reason == "ready"
+
+
+def test_probe_absent_preserves_previous_behaviour():
+    """
+    A service too old to answer must not acquire a new excuse.
+
+    Failing toward "a comparison happened" is deliberate: claiming a fault we
+    cannot evidence would let a genuine mismatch masquerade as a broken
+    verifier.
+    """
+    class _Old:
+        pass
+
+    identity = VoiceIdentity(service=_Old())
+    capable, reason = identity._comparison_capability("Derek J. Russell")
+
+    assert capable is True
+    assert reason == "capability_probe_unavailable"
+
+
+def test_probe_that_throws_does_not_decide():
+    """A probe must never determine consent by raising."""
+
+    class _Exploding:
+        def verification_capability(self, speaker_name=None):
+            raise RuntimeError("boom")
+
+    identity = VoiceIdentity(service=_Exploding())
+    capable, reason = identity._comparison_capability("Derek J. Russell")
+
+    assert capable is True
+    assert reason.startswith("capability_probe_failed:RuntimeError")
+
+
+@pytest.mark.parametrize(
+    "verdict",
+    [Verdict.NOT_ENROLLED, Verdict.UNAVAILABLE, Verdict.REJECTED,
+     Verdict.NOT_READY, Verdict.NO_AUDIO],
+)
+def test_every_negative_verdict_still_fails_closed(verdict):
+    """
+    Honesty must not have cost strictness.
+
+    Distinguishing a fault from a refusal changes only what the operator is
+    TOLD. Exactly one verdict approves; an unverifiable voice is not consent.
+    """
+    assert verdict.approves is False
+    assert Verdict.VERIFIED.approves is True
+
+
+def test_each_negative_verdict_says_something_different():
+    """
+    Distinct verdicts with identical wording would be the collapse in prose
+    rather than in code -- the operator would still not know which happened.
+    """
+    from backend.hud.voice_identity import _SPOKEN
+
+    spoken = [_SPOKEN[v.value] for v in
+              (Verdict.NOT_ENROLLED, Verdict.NOT_READY,
+               Verdict.NO_AUDIO, Verdict.REJECTED, Verdict.UNAVAILABLE)]
+
+    assert len(set(spoken)) == len(spoken), "two verdicts share a sentence"
+    # The one that misfired on 2026-08-06 must remain specifically about
+    # sounding wrong, so that hearing it is evidence a comparison happened.
+    assert "sound like you" in _SPOKEN[Verdict.REJECTED.value]
+    assert "sound like you" not in _SPOKEN[Verdict.NOT_ENROLLED.value]
+    assert "sound like you" not in _SPOKEN[Verdict.UNAVAILABLE.value]


### PR DESCRIPTION
Live unlock attempt, 2026-08-06 13:12:23:

```
EcapaFacade error: registry required for first facade creation — falling back to local engine
No speaker match found. Primary user: None, Best confidence: 0.00%
'unlock_screen' NOT authorised (That didn't sound like you, so I've left it locked.)
```

**`Best confidence: 0.00%` is not a low score — it is the absence of a score.** The ECAPA facade failed to create, the fallback engine held no voiceprints, and nothing was ever compared. `Primary user: None` says the same thing again.

The operator was told his voice did not match. **His voice was not checked.**

Lock worked in the same session (`Voice result: success (steps=1/1)`) because lock takes no consent. Unlock is `APPROVAL_REQUIRED`, so it went through the voice authority and died there — the Authorization Plugin was never consulted. This failed upstream of it.

## The collapse, seventeen lines below a comment warning about it

`voice_identity.py` already has four honest verdicts — `NOT_ENROLLED`, `NOT_READY`, `NO_AUDIO`, `UNAVAILABLE` — each with its own spoken sentence, and a comment explaining that a previous bug collapsed three enrollment states into one falsy check. Seventeen lines further down:

```python
if not verified:
    return _out(Verdict.REJECTED, ...)
```

`verified=False` is **two claims wearing one value**: *"I compared you and it was not you"* and *"I had nothing to compare you against"*. Mapping both to `REJECTED` made three of those four verdicts unreachable from the live path.

The distinction decides what the operator does next: speak again, or repair enrollment. Reporting the second as the first sends them to do the one thing that cannot help — on a machine whose voiceprint was enrolled months ago.

## Ask, do not infer

`SpeakerVerificationService.verification_capability()` answers whether a comparison was *possible*, with a stable machine token (`not_initialized`, `no_profiles_loaded`, `speaker_not_loaded`, `ready`). The caller owns the wording; the service owns the fact, because only the verifier knows which happened.

Deliberately **not** inferred from `confidence == 0.0` — a genuine mismatch can also score zero, and guessing would move the ambiguity somewhere harder to see.

## Fails toward "a comparison happened"

If the probe is absent or throws, previous behaviour is kept. Claiming a fault we cannot evidence would let a real mismatch masquerade as a broken verifier — the same dishonesty pointing the other way.

## Honesty did not cost strictness

Every negative verdict still refuses the unlock; exactly one value approves. What changed is only what the operator is told.

**10 tests**, including one asserting the five negative verdicts do not share a sentence — identical wording would be the same collapse in prose rather than code. **84 green** across `tests/security`.

## Still broken, and not addressed here

The reason there were no profiles: `registry required for first facade creation`. That is a separate defect in facade construction. This change makes it **visible** rather than fixing it — the operator will now hear *"I don't have a voiceprint for you on this Mac yet"* instead of being told he sounded wrong. That is the next piece of work, and it is now diagnosable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes unlock voice verification to distinguish “no comparison possible” from “mismatch,” returning accurate verdicts and messages instead of `REJECTED` when the verifier has no loaded voiceprints or isn’t initialized.

- **Bug Fixes**
  - Added `verification_capability()` to `SpeakerVerificationService` to report comparison readiness (`ready`, `not_initialized`, `no_profiles_loaded`, `speaker_not_loaded`).
  - Updated `voice_identity.py` to use capability and map faults to `NOT_ENROLLED` or `UNAVAILABLE`; only real mismatches return `REJECTED`.
  - Fail-safe: if the probe is missing or throws, assume a comparison happened to avoid masking true mismatches.
  - Ensured each negative verdict has unique wording; approval logic unchanged.
  - Added tests to pin fault vs refusal behavior and sentence uniqueness.

<sup>Written for commit 0d4823c520d8e4cf0a031d2894730205464c22cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70407?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

