### PR TITLE
fix: Make local SQLite authoritative for startup instead of Cloud SQL

### DIFF
--- a/backend/intelligence/learning_database.py
+++ b/backend/intelligence/learning_database.py
@@ -9250,6 +9250,23 @@ async def _singleton_instance_has_healthy_connection(db_instance: "JARVISLearnin
             return True
 
 
+def local_first_enabled(env=None) -> bool:
+    """Is local SQLite authoritative for startup? Default TRUE. NEVER raises.
+
+    Extracted so the decision can be tested without standing up a database.
+    Buried inline it was reachable only through a 9000-line init path, which is
+    how a load-bearing default goes unverified.
+
+    "Local-first" is an ORDERING, not an exclusion: fast_mode still initialises
+    Cloud SQL in the background and still syncs. What it refuses is blocking a
+    boot on a remote database for data already on local disk.
+    """
+    import os as _os
+    source = _os.environ if env is None else env
+    raw = source.get("JARVIS_LEARNING_DB_LOCAL_FIRST", "true")
+    return (raw or "").strip().lower() not in ("0", "false", "no", "off")
+
+
 async def get_learning_database(
     config: Optional[Dict] = None,
     fast_mode: bool = False,
@@ -9274,6 +9291,48 @@ async def get_learning_database(
     the gate state is unknown, the call cannot block indefinitely.
     """
     global _db_instance
+
+    # ── LOCAL-FIRST: an operator declaration, checked before any inference ──
+    #
+    # Measured 2026-08-06 13:11:08, on a real unlock attempt:
+    #
+    #   [LearningDB v265.1] Initialization timed out (15s)
+    #       — retrying with fast_mode (SQLite-first)
+    #
+    # and downstream of it:
+    #
+    #   No speaker match found. Primary user: None, Best confidence: 0.00%
+    #   'unlock_screen' NOT authorised (That didn't sound like you...)
+    #
+    # The voiceprint was never missing. `~/.jarvis/learning/jarvis_learning.db`
+    # holds "Derek J. Russell", a 768-byte 192-dimension embedding from 272
+    # samples, is_primary_user=1 — at exactly the path this class opens. It did
+    # not load because init spent its whole budget reaching for Cloud SQL and
+    # timed out before the profile query ran.
+    #
+    # WHY THIS IS NOT A FOURTH INFERENCE
+    # The three promotions below are all guesses about whether Cloud SQL is
+    # reachable — gate state, startup memory mode, gate import failure. Every
+    # one of them said "go standard" on the run above, and every one was wrong,
+    # because a gate reporting READY is a claim about a proxy, not about whether
+    # a query will return inside 15 seconds. Adding a fourth guess would be
+    # more of what already failed. This is an operator STATEMENT, and it is
+    # checked first so no inference can overrule it.
+    #
+    # WHY IT DEFAULTS ON
+    # fast_mode is "SQLite-first, Cloud SQL deferred to background" — an
+    # ORDERING, not an exclusion. Cloud SQL still initialises and still syncs.
+    # What stops is blocking a boot on a remote database for data that is
+    # already on the local disk, which is not a defensible thing to do even
+    # when the account is in good standing.
+    if not fast_mode:
+        if local_first_enabled():
+            logger.info(
+                "[LearningDB] LOCAL-FIRST — SQLite is authoritative for startup; "
+                "Cloud SQL deferred to background (set "
+                "JARVIS_LEARNING_DB_LOCAL_FIRST=false to restore cloud-first init)"
+            )
+            fast_mode = True
 
     # ── v265.1→v286.0: Gate-aware + mode-aware fast_mode promotion ────
     # v283.3: Added UNKNOWN and CHECKING to the gate promotion set.

--- a/tests/security/test_learning_db_local_first.py
+++ b/tests/security/test_learning_db_local_first.py
@@ -1,0 +1,101 @@
+"""
+The voiceprint is on local disk. Startup must not block on a remote database.
+
+Measured 2026-08-06, on a real unlock attempt::
+
+    13:11:08  [LearningDB v265.1] Initialization timed out (15s)
+                  — retrying with fast_mode (SQLite-first)
+    13:12:23  No speaker match found. Primary user: None, Best confidence: 0.00%
+    13:12:23  'unlock_screen' NOT authorised (That didn't sound like you...)
+
+The profile was never missing. ``~/.jarvis/learning/jarvis_learning.db`` holds
+"Derek J. Russell" — a 768-byte, 192-dimension embedding built from 272 samples,
+``is_primary_user=1`` — at exactly the path the service opens. It did not load
+because init spent its entire budget reaching for Cloud SQL first.
+
+Three fast_mode promotions already existed, and every one of them is an
+INFERENCE about whether Cloud SQL is reachable. All three said "go standard" on
+that run, because a readiness gate reporting READY is a claim about a proxy, not
+a promise that a query returns inside fifteen seconds. These tests pin the
+operator declaration that outranks them.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from backend.intelligence.learning_database import local_first_enabled
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LEARNING_DB_SRC = REPO_ROOT / "backend/intelligence/learning_database.py"
+
+
+def test_local_first_is_the_default():
+    """
+    Default ON.
+
+    fast_mode is "SQLite-first, Cloud SQL deferred to background" — an ordering,
+    not an exclusion. Cloud SQL still initialises and still syncs. Blocking a
+    boot on a remote database for data already on local disk is not defensible
+    even when the account is in good standing.
+    """
+    assert local_first_enabled({}) is True
+
+
+@pytest.mark.parametrize("value", ["false", "FALSE", "0", "no", "off", " off "])
+def test_operator_can_restore_cloud_first(value):
+    """The declaration is reversible without a code change."""
+    assert local_first_enabled({"JARVIS_LEARNING_DB_LOCAL_FIRST": value}) is False
+
+
+@pytest.mark.parametrize("value", ["true", "1", "yes", "", "anything-else"])
+def test_anything_not_explicitly_disabling_keeps_local_first(value):
+    """
+    A malformed value must not silently restore cloud-first.
+
+    The failure mode of guessing wrong here is a fifteen-second boot stall and
+    an unlock that reports the wrong reason, so ambiguity resolves toward local.
+    """
+    assert local_first_enabled({"JARVIS_LEARNING_DB_LOCAL_FIRST": value}) is True
+
+
+def test_declaration_is_checked_before_every_inference():
+    """
+    Ordering is the whole point.
+
+    Three inferential promotions already existed and all three were wrong on the
+    measured run. If the operator declaration were evaluated after them it would
+    be unreachable whenever an inference had already decided — which is exactly
+    the state that produced the 15s timeout.
+    """
+    source = LEARNING_DB_SRC.read_text()
+    tree = ast.parse(source)
+
+    fn = next(
+        n for n in ast.walk(tree)
+        if isinstance(n, ast.AsyncFunctionDef) and n.name == "get_learning_database"
+    )
+
+    declaration_line = None
+    inference_lines = []
+    for node in ast.walk(fn):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) \
+                and node.func.id == "local_first_enabled":
+            declaration_line = node.lineno
+        # The inferences are identified by what they read, not by line text.
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            if node.value == "JARVIS_STARTUP_MEMORY_MODE":
+                inference_lines.append(node.lineno)
+        if isinstance(node, ast.Attribute) and node.attr == "state":
+            inference_lines.append(node.lineno)
+
+    assert declaration_line is not None, \
+        "get_learning_database no longer consults local_first_enabled"
+    assert inference_lines, "inferential promotions vanished — re-read this test"
+    assert declaration_line < min(inference_lines), (
+        f"operator declaration at line {declaration_line} is evaluated AFTER an "
+        f"inference at line {min(inference_lines)}; an inference can now overrule it"
+    )


### PR DESCRIPTION
Answering *"does the voiceprint load under Xcode?"* — **it does not, and it isn't missing.**

`~/.jarvis/learning/jarvis_learning.db` holds:

```
speaker_name          Derek J. Russell
voiceprint_embedding  768 bytes (dimension 192)
total_samples         272
is_primary_user       1
created_at            2025-12-05
```

at exactly the path `JARVISLearningDatabase` opens (`db_dir = ~/.jarvis/learning`). **A comparison is possible from local SQLite alone** — nothing in that row needs the cloud.

## What actually happens

```
13:11:08  [LearningDB v265.1] Initialization timed out (15s) — retrying with fast_mode (SQLite-first)
13:11:36  SQLite init did not complete within 10.0s (event loop contention)
13:12:23  No speaker match found. Primary user: None, Best confidence: 0.00%
```

`_load_speaker_profiles()` reads through `get_learning_database()`. Init spent its whole budget reaching for Cloud SQL, timed out, and the profile query never ran — so `speaker_profiles` stayed empty and the voice authority had nothing to compare against.

## Three inferences, all wrong — so not a fourth

fast_mode promotion already existed three times over: startup memory mode, `ReadinessGate` state, and gate-import failure. Every one is a **guess** about whether Cloud SQL is reachable, and all three said "go standard" on the measured run — because a gate reporting `READY` is a claim about a proxy, not a promise that a query returns inside fifteen seconds.

A fourth guess would be more of what already failed. This adds an operator **declaration** (`JARVIS_LEARNING_DB_LOCAL_FIRST`, default true) evaluated **before** all three. A test pins that ordering by AST, because a declaration evaluated after an inference is unreachable exactly when it matters.

## An ordering, not an exclusion

`fast_mode` is *"SQLite-first, Cloud SQL deferred to background"*. Cloud SQL still initialises and still syncs. What stops is blocking a boot on a remote database for data already on local disk — not defensible even when the account is in good standing, and simply wrong while it isn't.

Malformed values resolve toward local: the cost of guessing wrong is a 15s boot stall and an unlock that reports the wrong reason.

The helper is extracted rather than inline so the default is testable without standing up a database — buried in a 9000-line init path it was reachable only by booting, which is how a load-bearing default goes unverified.

**13 tests. 97 green** across `tests/security`.

## What this does not fix

The 10s SQLite timeout was attributed to *"event loop contention"*, and that run showed **33.8% loop availability with a 14.70s worst stall**. Removing the 15s cloud reach should widen the window materially, but if the loop is starved badly enough the local read can still miss. That's the same starvation the `stall_sampler` work has been chasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make local SQLite authoritative at startup to prevent boot stalls and missing voice profiles, deferring Cloud SQL init and sync to the background. Adds an env flag to control ordering with a safe default.

- **Bug Fixes**
  - Force `fast_mode` when `local_first_enabled()` is true (default) so startup reads from local `jarvis_learning.db`.
  - Cloud SQL no longer blocks boot; it still initializes and syncs in the background.
  - Added `local_first_enabled(env)` to read `JARVIS_LEARNING_DB_LOCAL_FIRST` with robust parsing.
  - Tests verify default ON, reversibility, and AST-pinned ordering so the declaration runs before any inference.

- **Migration**
  - To restore cloud-first: set `JARVIS_LEARNING_DB_LOCAL_FIRST` to `false`, `0`, `no`, or `off`.

<sup>Written for commit 56eb1fdc65e8c49fbf3e15cc155ae44431414bd3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70408?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

