### PR TITLE
fix: Make the DB init timeout say which mode actually timed out

### DIFF
--- a/backend/intelligence/learning_database.py
+++ b/backend/intelligence/learning_database.py
@@ -9327,7 +9327,18 @@ async def get_learning_database(
     # when the account is in good standing.
     if not fast_mode:
         if local_first_enabled():
-            logger.info(
+            # WARNING, not INFO, and the reason is not severity.
+            #
+            # This line was INFO. The brainstem console filters this module to
+            # WARNING and above, so the one line that says WHICH database is
+            # authoritative for boot never reached the operator — and on
+            # 2026-08-06 its absence was read as evidence the promotion had not
+            # fired, when nothing in the log could have shown either way.
+            #
+            # A decision that changes which store a boot depends on has to be
+            # visible at the level the operator actually sees, or it is not
+            # auditable. This fires once per process.
+            logger.warning(
                 "[LearningDB] LOCAL-FIRST — SQLite is authoritative for startup; "
                 "Cloud SQL deferred to background (set "
                 "JARVIS_LEARNING_DB_LOCAL_FIRST=false to restore cloud-first init)"
@@ -9425,11 +9436,38 @@ async def get_learning_database(
                 timeout=_init_timeout,
             )
         except asyncio.TimeoutError:
-            logger.warning(
-                "[LearningDB v265.1] Initialization timed out (%.0fs) "
-                "— retrying with fast_mode (SQLite-first)",
-                _init_timeout,
-            )
+            # SAY WHICH MODE ACTUALLY TIMED OUT.
+            #
+            # This message used to read "— retrying with fast_mode
+            # (SQLite-first)" unconditionally, which is a claim about the FIRST
+            # attempt that it never checked. When fast_mode was already true the
+            # line asserted a transition that did not happen.
+            #
+            # On 2026-08-06 that cost a wrong diagnosis: the log was read as
+            # proof that cloud-first init was still running, when the honest
+            # reading is that SQLite-first may have timed out on its own. Those
+            # point at completely different causes — an unreachable Cloud SQL,
+            # versus a starved event loop making 15s of wall clock worth far
+            # less than 15s of progress (that run: 30-46% loop availability,
+            # 14.05s worst stall).
+            #
+            # A diagnostic that names the wrong subsystem is worse than none:
+            # it spends the next hour of work.
+            if fast_mode:
+                logger.warning(
+                    "[LearningDB] SQLite-first init timed out (%.0fs) — the local "
+                    "path alone did not finish. Cloud SQL was NOT the blocker; "
+                    "look at event-loop starvation (LoopSentinel/StallSampler) "
+                    "or raise JARVIS_LEARNING_DB_INIT_TIMEOUT.",
+                    _init_timeout,
+                )
+            else:
+                logger.warning(
+                    "[LearningDB] Cloud-first init timed out (%.0fs) — retrying "
+                    "with fast_mode (SQLite-first). Set "
+                    "JARVIS_LEARNING_DB_LOCAL_FIRST=true to skip this attempt.",
+                    _init_timeout,
+                )
             # Discard partial state and retry with fast_mode
             try:
                 if _db_instance:


### PR DESCRIPTION
Two diagnostic defects, both found by a diagnosis they made wrong.

## The message claimed a transition it never verified

```
[LearningDB v265.1] Initialization timed out (15s) — retrying with fast_mode (SQLite-first)
```

Emitted **unconditionally** on timeout, regardless of whether `fast_mode` was already true. It's a claim about the *first* attempt that the code never inspects.

I read it on 2026-08-06 as proof that cloud-first init was still running — which is what the sentence says. The honest reading is that it cannot distinguish that from **SQLite-first timing out on its own**, and those point at opposite causes: an unreachable Cloud SQL, versus a starved event loop making 15s of wall clock worth far less than 15s of progress. That run measured **30–46% loop availability with a 14.05s worst stall**, so the second reading is at least as likely.

A diagnostic that names the wrong subsystem is worse than none — it doesn't merely fail to help, it spends the next hour of work.

The two cases now say different things, and the SQLite-first case points explicitly at loop starvation rather than the cloud.

## The decision was logged where nobody could see it

The LOCAL-FIRST promotion logged at `INFO`. The brainstem console filters this module to `WARNING` and above, so the one line stating **which database is authoritative for boot** never reached the operator — and its absence from the log was then read as evidence the promotion hadn't fired, when nothing in that log could have shown either way.

Now `WARNING`, and not for severity: a decision that changes which store a boot depends on has to be visible at the level the operator actually sees, or it isn't auditable. Fires once per process.

Same lesson as `BootLogFile` on the Swift side, from the other direction — there the log went to a stream nobody could read, here to a level nobody could see. Both make a recorded fact unrecoverable, and I wrote this one three commits after fixing that one.

## What is still unknown

Whether local-first fired on the 13:54 run is **genuinely undetermined** — the evidence to decide it did not exist. The next run will say so plainly in one line either way, which is the point.

13 tests still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DB initialization logs to be accurate and visible. Timeout messages now state which mode actually timed out, and the local-first decision is logged at WARNING so operators can see it.

- **Bug Fixes**
  - Timeout logging now distinguishes Cloud-first vs SQLite-first. If SQLite-first times out, it points to event-loop starvation and suggests raising JARVIS_LEARNING_DB_INIT_TIMEOUT; if Cloud-first times out, we retry with fast_mode and note JARVIS_LEARNING_DB_LOCAL_FIRST=true to skip Cloud-first.
  - Elevated the LOCAL-FIRST promotion log from INFO to WARNING so it appears on the operator console; fires once per process.

<sup>Written for commit 9ed4e42e14b77bb7863cc5043ec3483a09958596. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

