### PR TITLE
fix: Resolve the ML registry in the ECAPA facade accessor

### DIFF
--- a/backend/core/ecapa_facade.py
+++ b/backend/core/ecapa_facade.py
@@ -836,6 +836,41 @@ _facade_instance: Optional[EcapaFacade] = None
 _facade_lock = asyncio.Lock()
 
 
+async def _resolve_ml_registry() -> Any:
+    """Obtain the canonical ML engine registry, or None.
+
+    Reuses the resolution ladder `main.py` already established for this exact
+    module -- async accessor first, then the sync accessor with
+    ``auto_create=True`` -- including its dual-import fallback, because
+    `voice_unlock.ml_engine_registry` is reachable under both the ``backend.``
+    prefixed and bare package names depending on how the process was started.
+
+    Deliberately NOT a seventh way to get a registry. The registry is a
+    singleton with an owner; this asks that owner rather than constructing
+    anything, so no second ECAPA model can be loaded into the process.
+    """
+    try:
+        try:
+            from backend.voice_unlock.ml_engine_registry import get_ml_registry
+        except ImportError:
+            from voice_unlock.ml_engine_registry import get_ml_registry
+        registry = await get_ml_registry()
+        if registry is not None:
+            return registry
+    except Exception as exc:  # noqa: BLE001 — fall through to the sync ladder
+        logger.debug("ECAPA facade: async registry accessor failed: %s", exc)
+
+    try:
+        try:
+            from backend.voice_unlock.ml_engine_registry import get_ml_registry_sync
+        except ImportError:
+            from voice_unlock.ml_engine_registry import get_ml_registry_sync
+        return get_ml_registry_sync(auto_create=True)
+    except Exception as exc:  # noqa: BLE001 — caller reports the failure
+        logger.debug("ECAPA facade: sync registry accessor failed: %s", exc)
+        return None
+
+
 async def get_ecapa_facade(
     registry: Any = None,
     cloud_client: Any = None,
@@ -843,8 +878,40 @@ async def get_ecapa_facade(
 ) -> EcapaFacade:
     """Return the module-level ``EcapaFacade`` singleton.
 
-    On the first call, *registry* is required.  Subsequent calls return the
-    existing instance regardless of arguments.
+    *registry* may be injected (tests, and any caller that already holds one).
+    When it is not, the canonical ML engine registry is resolved here.
+
+    WHY THIS NO LONGER DEMANDS A REGISTRY FROM THE CALLER
+    ----------------------------------------------------
+    It used to raise ``ValueError("registry required for first facade
+    creation")`` when none was passed. Every one of the six call sites in this
+    codebase calls ``get_ecapa_facade()`` with no arguments::
+
+        cloud_ml_router.py:718          parallel_vbi_orchestrator.py:930
+        vbi_debug_tracer.py:555         speaker_verification_service.py:3435
+        speaker_verification_service.py:3979, :4017
+
+    So the first call always raised, the singleton was uncreatable by
+    construction, and the facade was dead code that announced itself as a
+    configuration error. Observed on every boot::
+
+        [INIT] EcapaFacade error: registry required for first facade creation
+            - falling back to local engine
+
+    and downstream, at 13:57:04 on 2026-08-06, an unlock refused because the
+    fallback engine held no voiceprints.
+
+    The requirement WAS the defect. A precondition that no caller in the
+    program can satisfy is not a precondition; it is an unreachable branch
+    wearing a contract. Fixing the six call sites would have spread knowledge of
+    which registry to use across six modules -- the singleton has one owner, and
+    asking that owner belongs here, once.
+
+    Raises:
+        ValueError: only when the registry genuinely cannot be obtained. The
+            message says the registry was unreachable, not that the caller
+            failed to supply one -- blaming callers for something none of them
+            can provide is what made this take eight months to find.
     """
     global _facade_instance
     if _facade_instance is not None:
@@ -853,12 +920,36 @@ async def get_ecapa_facade(
     async with _facade_lock:
         if _facade_instance is not None:
             return _facade_instance
-        if registry is None:
-            raise ValueError("registry required for first facade creation")
+
+        resolved = registry if registry is not None else await _resolve_ml_registry()
+        if resolved is None:
+            raise ValueError(
+                "ECAPA facade unavailable: the ML engine registry could not be "
+                "resolved (get_ml_registry / get_ml_registry_sync both returned "
+                "nothing). This is a registry availability problem, not a missing "
+                "argument."
+            )
+
+        # A registry that cannot answer for this model is not a usable registry,
+        # and finding that out here -- once, at construction -- beats discovering
+        # it later inside a verification, where the failure looks like a voice
+        # that did not match.
+        if not hasattr(resolved, "get_wrapper"):
+            raise ValueError(
+                f"ECAPA facade unavailable: resolved registry "
+                f"{type(resolved).__name__} exposes no get_wrapper(); it cannot "
+                f"supply the 'ecapa_tdnn' wrapper this facade requires."
+            )
+
         _facade_instance = EcapaFacade(
-            registry=registry,
+            registry=resolved,
             cloud_client=cloud_client,
             config=config,
+        )
+        logger.info(
+            "ECAPA facade created (registry=%s, source=%s)",
+            type(resolved).__name__,
+            "injected" if registry is not None else "resolved",
         )
         return _facade_instance
 

--- a/tests/security/test_ecapa_facade_registry.py
+++ b/tests/security/test_ecapa_facade_registry.py
@@ -1,0 +1,146 @@
+"""
+A precondition no caller can satisfy is not a precondition.
+
+`get_ecapa_facade()` raised ``ValueError("registry required for first facade
+creation")`` when called without a registry. Every call site in the codebase
+calls it without one, so the singleton was uncreatable by construction and the
+facade was dead code that announced itself as a configuration error::
+
+    [INIT] EcapaFacade error: registry required for first facade creation
+        - falling back to local engine
+
+Observed on every boot, and downstream on 2026-08-06 at 13:57:04 an unlock
+refused because the fallback engine held no voiceprints.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import re
+from pathlib import Path
+
+import pytest
+
+from backend.core.ecapa_facade import _reset_facade, get_ecapa_facade
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class _Registry:
+    """Minimum contract the facade documents: ``get_wrapper(name)``."""
+
+    def get_wrapper(self, name):  # noqa: D102
+        return object()
+
+
+@pytest.fixture(autouse=True)
+def _clean_singleton():
+    _reset_facade()
+    yield
+    _reset_facade()
+
+
+def test_the_no_argument_call_every_caller_makes_now_works():
+    """
+    The regression, stated exactly as the callers state it.
+
+    Six sites call `get_ecapa_facade()` with no arguments. If this raises, the
+    facade is unreachable in production no matter how correct the rest of it is.
+    """
+    facade = asyncio.run(get_ecapa_facade())
+    assert facade is not None
+
+
+def test_injected_registry_still_wins():
+    """Explicit injection must keep working — tests and any holder rely on it."""
+    reg = _Registry()
+    facade = asyncio.run(get_ecapa_facade(registry=reg))
+    assert facade is not None
+
+
+def test_singleton_is_preserved():
+    """Second call returns the same instance; no second ECAPA model is loaded."""
+    first = asyncio.run(get_ecapa_facade(registry=_Registry()))
+    second = asyncio.run(get_ecapa_facade())
+    assert first is second
+
+
+def test_a_registry_that_cannot_answer_is_rejected_at_construction():
+    """
+    Fail where it is diagnosable.
+
+    A registry with no ``get_wrapper`` cannot supply 'ecapa_tdnn'. Discovering
+    that later, inside a verification, makes a broken registry look like a voice
+    that did not match — which is the failure this whole arc has been about.
+    """
+    class _Useless:
+        pass
+
+    with pytest.raises(ValueError) as excinfo:
+        asyncio.run(get_ecapa_facade(registry=_Useless()))
+
+    assert "get_wrapper" in str(excinfo.value)
+
+
+def test_failure_message_does_not_blame_the_caller():
+    """
+    The old message said "registry required for first facade creation", which
+    reads as "you forgot an argument" — so six call sites were each read as
+    correct and the accessor was never suspected. Any future failure must name
+    registry availability instead.
+    """
+    source = (REPO_ROOT / "backend/core/ecapa_facade.py").read_text()
+    tree = ast.parse(source)
+
+    # Docstrings are exempt: the fix's own documentation quotes the old message
+    # to explain what it replaced, and a guard that cannot tell an explanation
+    # from an executable string would forbid describing the bug it prevents.
+    docstrings = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Module, ast.ClassDef,
+                             ast.FunctionDef, ast.AsyncFunctionDef)):
+            doc = ast.get_docstring(node, clean=False)
+            if doc:
+                docstrings.add(doc)
+
+    live = [
+        n.value for n in ast.walk(tree)
+        if isinstance(n, ast.Constant) and isinstance(n.value, str)
+        and n.value not in docstrings
+        and "registry required for first facade creation" in n.value
+    ]
+    assert not live, (
+        "the caller-blaming message is back as a runtime string; "
+        "it hid this defect for months"
+    )
+
+
+def test_no_call_site_passes_a_registry():
+    """
+    Pins WHY the fix belongs in the accessor.
+
+    If a call site ever starts passing one, that is fine — but if ALL of them
+    did, knowledge of which registry to use would be spread across six modules
+    for a singleton that has exactly one owner. This test documents the shape
+    the fix assumes, and fails loudly if that shape changes.
+    """
+    sites = []
+    for path in REPO_ROOT.joinpath("backend").rglob("*.py"):
+        if "venv" in path.parts or path.name == "ecapa_facade.py":
+            continue
+        try:
+            text = path.read_text()
+        except (OSError, UnicodeDecodeError):
+            continue
+        if "get_ecapa_facade(" not in text:
+            continue
+        for call in re.findall(r"get_ecapa_facade\(([^)]*)\)", text):
+            sites.append((path.name, call.strip()))
+
+    assert sites, "no call sites found — has the facade been removed?"
+    with_registry = [s for s in sites if s[1]]
+    assert not with_registry, (
+        f"a call site now passes arguments: {with_registry}. Re-read this test; "
+        f"the accessor-side resolution may no longer be the right shape."
+    )


### PR DESCRIPTION
```
[INIT] EcapaFacade error: registry required for first facade creation — falling back to local engine
```

On every boot, deterministically. `get_ecapa_facade()` raised when called without a registry — and **every call site in this codebase calls it without one**:

| | |
|---|---|
| `cloud_ml_router.py:718` | `parallel_vbi_orchestrator.py:930` |
| `vbi_debug_tracer.py:555` | `speaker_verification_service.py:3435` |
| `speaker_verification_service.py:3979` | `speaker_verification_service.py:4017` |

Six sites, six no-argument calls. The first call always raised, so the singleton was **uncreatable by construction** and the facade was dead code that announced itself as a configuration error. The ECAPA encoder never loaded, verification fell back to a local engine holding no voiceprints, and on 2026-08-06 at 13:57:04 an unlock refused because of it.

## The requirement was the defect

A precondition no caller in the program can satisfy is not a precondition — it's an unreachable branch wearing a contract. And the message read as *"you forgot an argument"*, so each call site looked correct in isolation and the accessor was never suspected.

The registry it demanded is a singleton with exactly one owner and a canonical accessor `main.py` already uses. So the accessor now resolves it, reusing main.py's established ladder — async `get_ml_registry()`, then `get_ml_registry_sync(auto_create=True)` — including the dual-import fallback, since that module is reachable under both the `backend.`-prefixed and bare package names depending on how the process started.

**Not a seventh way to get a registry:** it *asks the owner* rather than constructing anything, so no second ECAPA model can be loaded into the process.

## Why not fix the six call sites

That would spread knowledge of which registry to use across six modules, for a singleton with one owner. Asking that owner belongs in the accessor, once. Injection still wins where a caller already holds a registry — tests rely on it.

## Fail where it is diagnosable

A resolved registry with no `get_wrapper` is rejected at construction rather than later inside a verification, where a broken registry looks like a voice that did not match. And when the registry genuinely can't be resolved, the error says **the registry was unreachable** — not that the caller failed to supply one.

## Verified

`get_ecapa_facade()` — the exact no-argument call all six sites make — now returns a facade against a really-resolved registry. It previously always raised.

**6 tests**, including one pinning that no call site passes a registry (so the accessor-side fix stays the right shape) and one forbidding the caller-blaming message as a runtime string. That last test **failed first** — it matched the phrase inside the fix's own docstring, where the history is explained. Docstrings are now exempt: a guard that can't tell an explanation from an executable string would forbid describing the bug it prevents.

**103 green** across `tests/security`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ECAPA facade construction by resolving the ML registry inside `get_ecapa_facade()`, so no-argument calls work. ECAPA now loads on boot instead of falling back to the local engine.

- **Bug Fixes**
  - Resolve the canonical registry via `get_ml_registry()` then `get_ml_registry_sync(auto_create=True)` with dual-import fallback (`backend.voice_unlock.ml_engine_registry` / `voice_unlock.ml_engine_registry`).
  - Preserve explicit injection when a registry is provided; still a singleton.
  - Fail fast if the registry lacks `get_wrapper`; error message now names registry availability, not caller arguments.
  - Add tests for no-arg calls, injection, singleton behavior, early rejection, and a guard against reintroducing the caller-blaming message; pin that no call site passes a registry.

<sup>Written for commit ff7b7c45b7a8bf27ec198280749df4eacd79c6fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

