### PR TITLE
fix: Start the ECAPA lifecycle — nothing ever did

### DIFF
--- a/backend/core/ecapa_facade.py
+++ b/backend/core/ecapa_facade.py
@@ -76,10 +76,24 @@ class _FileFence:
                     pass
                 self._lock_fd = None
 
+            # The PID here comes from the lock FILE's contents, which the
+            # current holder may never have rewritten -- the file persists
+            # across runs while the flock does not. Presenting it as the
+            # holder's identity is a claim this code cannot support, and on
+            # 2026-08-06 it produced a months-dead PID (20415, from May) and a
+            # confident diagnosis of a "stale lock" that did not exist. flock is
+            # advisory and the kernel drops it when a process dies, so a stale
+            # FILE blocks nothing; only a live holder can fail this call.
+            #
+            # So: report the contents as what they are -- a hint, possibly from a
+            # previous run -- and name the fact we actually know.
             existing_info = self._read_lock_info()
+            recorded_pid = existing_info.get("pid", "?")
             raise DualAuthorityError(
-                f"Another process (PID {existing_info.get('pid', '?')}) "
-                f"already owns the ECAPA facade lock at {self._lock_path}"
+                f"Another LIVE process currently holds the ECAPA facade lock at "
+                f"{self._lock_path}. The file records pid={recorded_pid}, but "
+                f"that metadata may be from an earlier run and is not proof of "
+                f"which process holds it — use `lsof {self._lock_path}` for that."
             ) from exc
 
         # Write our ownership metadata into the lock file.
@@ -946,15 +960,74 @@ async def get_ecapa_facade(
             cloud_client=cloud_client,
             config=config,
         )
+
+        # START THE LIFECYCLE. Nobody else does.
+        #
+        # `start()` is documented "Non-blocking and idempotent" and has ZERO
+        # call sites in this codebase. Every caller does:
+        #
+        #     facade = await get_ecapa_facade()
+        #     await facade.ensure_ready(...)        # or extract_embedding(...)
+        #
+        # But `ensure_ready()` only waits on `_ready_event`, and that event is
+        # set by a state transition that only `start()` initiates. With nothing
+        # driving the machine it stays UNINITIALIZED forever, every
+        # `ensure_ready()` burns its full timeout and returns False, and the
+        # operator is told "I'm still loading my voice recognition" — for a load
+        # that was never begun.
+        #
+        # Observed 2026-08-06 14:24:14, ninety seconds after boot, on an unlock
+        # that then refused.
+        #
+        # This belongs here for the same reason registry resolution does: the
+        # singleton has one owner, and six callers each remembering a two-phase
+        # construction protocol is six chances to forget it. Idempotent by
+        # contract, so a caller that also starts it loses nothing.
+        try:
+            await _facade_instance.start()
+        except Exception as exc:  # noqa: BLE001 — see below
+            # `start()` acquires a cross-process fence and raises
+            # DualAuthorityError when another process already owns ECAPA. That
+            # is a real condition, not a bug, and it must not take down the
+            # caller: the facade is returned unstarted, `ensure_ready()` reports
+            # not-ready, and the voice layer says so honestly. Failing soft here
+            # keeps a second JARVIS process from breaking the first one's caller.
+            logger.warning(
+                "ECAPA facade created but could not start (%s: %s) — it will "
+                "report not-ready until this resolves",
+                type(exc).__name__,
+                exc,
+            )
+
         logger.info(
-            "ECAPA facade created (registry=%s, source=%s)",
+            "ECAPA facade created (registry=%s, source=%s, state=%s)",
             type(resolved).__name__,
             "injected" if registry is not None else "resolved",
+            getattr(getattr(_facade_instance, "_state", None), "value", "unknown"),
         )
         return _facade_instance
 
 
 def _reset_facade() -> None:
-    """Reset the singleton for testing.  Not for production use."""
+    """Reset the singleton for testing.  Not for production use.
+
+    Releases the process fence before dropping the reference.
+
+    It used to only clear the global. The fence's file descriptor stayed open,
+    so the flock stayed held for the life of the process -- and since ``start()``
+    acquires it, the NEXT facade could never start. Two consecutive resets in
+    one process produced a facade permanently stuck in UNINITIALIZED, reporting
+    a lock "held by another process" that was in fact held by this one.
+
+    Found by exactly that: two tests in one file, the second unable to start
+    because the first had leaked the lock. Production never resets the
+    singleton, which is why a process-wide leak in the reset path went unseen --
+    the shape of a bug that only bites the thing trying to verify it.
+    """
     global _facade_instance
+    if _facade_instance is not None:
+        try:
+            _facade_instance._fence.release()
+        except Exception as exc:  # noqa: BLE001 — reset must never raise
+            logger.debug("ECAPA fence release during reset failed: %s", exc)
     _facade_instance = None

--- a/tests/security/test_ecapa_facade_registry.py
+++ b/tests/security/test_ecapa_facade_registry.py
@@ -144,3 +144,107 @@ def test_no_call_site_passes_a_registry():
         f"a call site now passes arguments: {with_registry}. Re-read this test; "
         f"the accessor-side resolution may no longer be the right shape."
     )
+
+
+# =============================================================================
+# LIFECYCLE — construction is not enough; something must START it
+# =============================================================================
+
+
+def test_the_accessor_starts_the_lifecycle():
+    """
+    `start()` had ZERO call sites.
+
+    It is documented "Non-blocking and idempotent", and every caller does
+    `get_ecapa_facade()` then `ensure_ready()`. But `ensure_ready()` only waits
+    on an event that a state transition sets, and only `start()` initiates that
+    transition. With nothing driving the machine it stayed UNINITIALIZED
+    forever, every `ensure_ready()` burned its full timeout, and the operator
+    was told "I'm still loading my voice recognition" — for a load never begun.
+
+    Observed 2026-08-06 14:24:14, ninety seconds after boot, on an unlock that
+    then refused.
+
+    STRUCTURAL, BECAUSE THE OUTCOME IS NOT OURS TO ASSERT
+    -----------------------------------------------------
+    An earlier version asserted the resulting STATE. That is undecidable here:
+    the facade takes a machine-global `flock`, so on any machine where another
+    JARVIS process is running — a battle test, a daemon, a second HUD — the
+    correct outcome is DualAuthorityError and an unstarted facade. Measured
+    exactly that on 2026-08-06 with `ouroboros_battle_test.py` live.
+
+    A test that fails when the system is behaving correctly trains people to
+    ignore it. What IS ours to assert is that the accessor calls `start()` at
+    all — the thing that was missing.
+    """
+    source = (REPO_ROOT / "backend/core/ecapa_facade.py").read_text()
+    tree = ast.parse(source)
+
+    fn = next(
+        n for n in ast.walk(tree)
+        if isinstance(n, ast.AsyncFunctionDef) and n.name == "get_ecapa_facade"
+    )
+    starts = [
+        n for n in ast.walk(fn)
+        if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+        and n.func.attr == "start"
+    ]
+    assert starts, (
+        "get_ecapa_facade() no longer calls start(); the state machine will "
+        "never leave UNINITIALIZED and every ensure_ready() will time out"
+    )
+
+
+def test_start_failure_does_not_break_the_caller():
+    """
+    The cross-process fence can legitimately refuse — another JARVIS process may
+    own ECAPA. That must not raise into a voice command: the facade is returned
+    unstarted, ensure_ready() reports not-ready, and the voice layer says so.
+    A second process must not break the first one's callers.
+    """
+    class _Exploding(_Registry):
+        pass
+
+    import backend.core.ecapa_facade as mod
+
+    original = mod.EcapaFacade.start
+
+    async def _boom(self):
+        raise RuntimeError("fence held elsewhere")
+
+    mod.EcapaFacade.start = _boom
+    try:
+        facade = asyncio.run(get_ecapa_facade(registry=_Exploding()))
+        assert facade is not None, "a failed start must still yield a facade"
+    finally:
+        mod.EcapaFacade.start = original
+
+
+def test_lock_error_does_not_present_stale_file_contents_as_the_holder():
+    """
+    The fence's error used to read the lock FILE and name its pid as the holder.
+
+    The file persists across runs; the flock does not. On 2026-08-06 that
+    surfaced a months-dead pid (20415, from May) and produced a confident
+    diagnosis of a stale lock that did not exist — flock is advisory and the
+    kernel drops it when a process dies, so a stale file blocks nothing.
+    """
+    source = (REPO_ROOT / "backend/core/ecapa_facade.py").read_text()
+    tree = ast.parse(source)
+    docstrings = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Module, ast.ClassDef,
+                             ast.FunctionDef, ast.AsyncFunctionDef)):
+            doc = ast.get_docstring(node, clean=False)
+            if doc:
+                docstrings.add(doc)
+
+    claims = [
+        n.value for n in ast.walk(tree)
+        if isinstance(n, ast.Constant) and isinstance(n.value, str)
+        and n.value not in docstrings
+        and "Another process (PID" in n.value
+    ]
+    assert not claims, (
+        "the lock error again asserts a holder identity it cannot know"
+    )


### PR DESCRIPTION
```
'unlock_screen' NOT authorised (I'm still loading my voice recognition — give me a moment and ask again.)
```

Ninety seconds after boot, on 2026-08-06 14:24:14. **Asking again never helped, because nothing was loading.**

`EcapaFacade.start()` — documented *"Non-blocking and idempotent"* — had **zero call sites**. Every caller does:

```python
facade = await get_ecapa_facade()
await facade.ensure_ready(...)
```

but `ensure_ready()` only waits on `_ready_event`, and that event is set by a state transition only `start()` initiates. With nothing driving the machine the facade sat in `UNINITIALIZED`, every `ensure_ready()` burned its full timeout, and the voice layer honestly reported `NOT_READY` forever.

Same shape as the registry defect one layer up — and **hidden by it**: while the facade couldn't be constructed, nobody could notice it was also never started.

The accessor now starts it, for the same reason it resolves the registry: the singleton has one owner, and six callers each remembering a two-phase construction protocol is six chances to forget it.

## Fail soft on the fence

`start()` takes a machine-global flock and raises `DualAuthorityError` when another JARVIS process owns ECAPA. That's a real condition, not a bug — the facade is returned unstarted, `ensure_ready()` reports not-ready, and the voice layer says so. A second process must not break the first one's callers.

**Verified live in both directions:** with `ouroboros_battle_test.py --headless` running it fails soft and reports honestly; with nothing else running it reaches `PROBING`, where it previously stayed `UNINITIALIZED`.

## Two diagnostics that misled me while fixing this

**The fence error named a dead PID as the holder.** It read the lock *file* and reported its pid — but the file persists across runs while the flock does not. It surfaced a months-dead pid (20415, from May) and I announced a stale-lock root cause **that did not exist**; flock is advisory and the kernel drops it when a process dies, so a stale file blocks nothing. It now reports what's actually known and points at `lsof`.

**`_reset_facade()` leaked the fence.** It cleared the global without releasing the lock, leaving the fd open and the flock held for the life of the process — so the *next* facade could never start, reporting a lock "held by another process" that was held by this one. Production never resets the singleton, which is why a process-wide leak in the reset path went unseen: the shape of a bug that only bites the thing trying to verify it.

## The test is structural because the outcome is not ours to assert

It first asserted the resulting **state**, and failed — correctly — on a machine where a battle test held the fence. A test that fails when the system is behaving correctly trains people to ignore it. What *is* ours to assert is that the accessor calls `start()` at all, decidable from source in any environment.

**106 green** across `tests/security`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically start the ECAPA lifecycle in `get_ecapa_facade()` so voice unlock no longer stays in `UNINITIALIZED`/`NOT_READY`. Improves lock handling and ensures test resets release the fence; secondary processes now fail soft without breaking callers.

- **Bug Fixes**
  - Call `start()` in `get_ecapa_facade()`; idempotent, non-blocking, and returns the facade even if start fails (e.g., `DualAuthorityError`) with a warning.
  - Fix lock error message to avoid asserting a PID from stale file metadata; advise using `lsof` to find the live holder.
  - Release the cross-process fence in `_reset_facade()` to prevent leaked locks between tests.
  - Add structural tests to verify the accessor starts the lifecycle and that start failures don’t raise into callers.

<sup>Written for commit caf9e5d6f359a2a645ee079f4205c516f8fb0a01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

