### PR TITLE
fix: Retry the profile load when it returns empty, not only when it raises

### DIFF
--- a/backend/voice/speaker_verification_service.py
+++ b/backend/voice/speaker_verification_service.py
@@ -5443,12 +5443,35 @@ class SpeakerVerificationService:
             )
 
             if loaded_count == 0 and len(profiles) == 0 and not self.speaker_profiles:
+                # ZERO PROFILES IS A FAULT, NOT AN ANSWER.
+                #
+                # This branch used to log "will require enrollment" and stop.
+                # Only the `except` path below scheduled a retry — so an
+                # exception was recoverable and an empty result was permanent,
+                # which is backwards: an empty result is exactly what a degraded
+                # database returns when it times out without raising.
+                #
+                # Measured 2026-08-06:
+                #
+                #   17:18:40  SQLite-first init timed out (15s)
+                #   17:19:48  No speaker match found. Primary user: None
+                #
+                # 68 seconds apart, with a profile sitting on disk the whole
+                # time — "Derek J. Russell", 768-byte embedding, 272 samples,
+                # is_primary_user=1, in the very file this service opens. The
+                # load ran once during the worst contention window of boot,
+                # came back empty, and nothing ever asked again.
+                #
+                # So schedule the SAME retry an exception would. The mechanism
+                # already exists; it was simply never wired to the failure mode
+                # that actually happens.
                 logger.warning(
-                    "⚠️ No speaker profiles available - voice authentication will require enrollment"
+                    "⚠️ No speaker profiles loaded — scheduling retry. The store "
+                    "may hold profiles this attempt could not reach (a timed-out "
+                    "database returns empty without raising); enrollment is only "
+                    "required if the retries also come back empty."
                 )
-                logger.info("💡 To create a speaker profile, use voice commands like:")
-                logger.info("   - 'Learn my voice as Derek'")
-                logger.info("   - 'Create speaker profile for Derek'")
+                self._schedule_deferred_profile_load()
             elif loaded_count == 0 and len(profiles) > 0:
                 logger.error(
                     f"❌ Found {len(profiles)} profiles in database but failed to load any - check logs above for errors"
@@ -5495,7 +5518,10 @@ class SpeakerVerificationService:
 
             for attempt in range(1, max_retries + 1):
                 delay = min(base_delay * (2 ** (attempt - 1)), max_delay)
-                logger.info(
+                # WARNING, not INFO: the brainstem console filters this
+                # module to WARNING and above, so an INFO-level retry log is
+                # invisible exactly when someone is asking "is it retrying?".
+                logger.warning(
                     f"🔄 [ProfileRetry] Attempt {attempt}/{max_retries} "
                     f"in {delay:.0f}s..."
                 )
@@ -5518,9 +5544,21 @@ class SpeakerVerificationService:
                                 f"{count} profiles loaded on attempt {attempt}"
                             )
                         else:
-                            logger.info(
-                                "✅ [ProfileRetry] Database connected but "
-                                "0 profiles found (enrollment needed)"
+                            # NOT a "✅". The database answering is not the same
+                            # as the answer being right, and this branch cannot
+                            # tell "nobody is enrolled" from "the store did not
+                            # give us what it holds". Retrying forever on a
+                            # genuinely empty store would be wrong, so it stops
+                            # — but it stops SAYING SO, at a level the console
+                            # actually shows, instead of reporting success.
+                            logger.warning(
+                                "⚠️ [ProfileRetry] Database connected but returned "
+                                "0 profiles on attempt %s — giving up. If a "
+                                "voiceprint exists on disk, this is a fault, not "
+                                "an empty store: check "
+                                "~/.jarvis/learning/jarvis_learning.db "
+                                "(select count(*) from speaker_profiles).",
+                                attempt,
                             )
                         return  # Success — stop retrying
                     else:


### PR DESCRIPTION
```
17:18:40  [LearningDB] SQLite-first init timed out (15s)
17:19:48  No speaker match found. Primary user: None, Best confidence: 0.00%
```

68 seconds apart, with the profile sitting on disk the entire time: **"Derek J. Russell", 768-byte embedding, 192 dimensions, 272 samples, `is_primary_user=1`** — in the very file this service opens.

`_load_speaker_profiles()` ran **once**, during the worst contention window of boot, came back empty, and nothing ever asked again.

## The retry existed and was wired to the wrong failure

`_schedule_deferred_profile_load()` — exponential backoff, five attempts — was called **only from the `except` block**. So an exception was recoverable and an **empty result was permanent**.

That's backwards. An empty result is precisely what a degraded database returns when it times out without raising — the failure that actually happens here. The mechanism was already built; it was simply never connected to the mode that occurs.

Zero profiles now schedules the same retry an exception would, and says why: the store may hold profiles this attempt couldn't reach, so enrollment is only required if the retries also come back empty.

## A third fault-as-answer, inside the retry itself

The retry logged `✅ [ProfileRetry] Database connected but 0 profiles found (enrollment needed)` and returned — **reporting success for a zero result**, and stopping.

The database answering is not the same as the answer being right, and that branch can't tell "nobody is enrolled" from "the store didn't give us what it holds". Retrying forever against a genuinely empty store would be wrong, so it still stops — but it stops *saying so*, and names the exact query that settles which one it was.

Same collapse as `verified=false` meaning two things, and as *"retrying with fast_mode"* asserting a transition it never checked. **Third layer, same shape.**

## And it was invisible

Every `ProfileRetry` line was `INFO`. The brainstem console filters this module to `WARNING`+, so *"is it retrying?"* was unanswerable from the log. The attempt line and the give-up line are now `WARNING`.

**106 green** across `tests/security`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries speaker profile loading when the database returns zero profiles, not only on exceptions, to avoid permanent empty state after startup contention. Elevates retry logs to WARNING for visibility and clarifies behavior when zero profiles persist.

- **Bug Fixes**
  - Treat zero profiles as a retryable fault; schedule `_schedule_deferred_profile_load()` with backoff.
  - In the retry path, stop reporting success on zero profiles; log a WARNING and stop cleanly.
  - Raise retry attempt and give-up logs to WARNING so console filtering shows them.

<sup>Written for commit e5c31e1a13c323c50b084ae90da9dbdd7ce2aa22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

