### PR TITLE
fix: Make the speaker-profile count visible

### DIFF
--- a/backend/voice/speaker_verification_service.py
+++ b/backend/voice/speaker_verification_service.py
@@ -3486,7 +3486,14 @@ class SpeakerVerificationService:
         ecapa_status = "ECAPA ready" if self._use_registry_encoder else (
             "cloud ECAPA (SLIM)" if _slim_skip_speechbrain else "SpeechBrain fallback"
         )
-        logger.info(
+        # WARNING, not INFO. This module is filtered to WARNING+ in the
+        # brainstem console, so the ONE line that answers "did the
+        # voiceprint load?" has been invisible for this entire
+        # investigation. Four separate fixes were made without ever
+        # being able to read whether the profile count was 0 or 1 --
+        # which is not debugging, it is guessing with extra steps.
+        # A readiness line nobody can see is not a readiness line.
+        logger.warning(
             f"✅ Speaker Verification Service ready - {len(self.speaker_profiles)} profiles loaded ({ecapa_status})"
         )
 
@@ -3988,7 +3995,14 @@ class SpeakerVerificationService:
             logger.warning(f"⚠️ [INIT] EcapaFacade error: {e} - falling back to local engine")
 
         self.initialized = True
-        logger.info(
+        # WARNING, not INFO. This module is filtered to WARNING+ in the
+        # brainstem console, so the ONE line that answers "did the
+        # voiceprint load?" has been invisible for this entire
+        # investigation. Four separate fixes were made without ever
+        # being able to read whether the profile count was 0 or 1 --
+        # which is not debugging, it is guessing with extra steps.
+        # A readiness line nobody can see is not a readiness line.
+        logger.warning(
             f"✅ Speaker Verification Service ready ({len(self.speaker_profiles)} profiles loaded)"
         )
         if self._use_registry_encoder:
@@ -5438,7 +5452,8 @@ class SpeakerVerificationService:
                     await self._auto_create_owner_profile_from_macos()
 
             # Summary
-            logger.info(
+            # WARNING for the same reason: this is the decisive count.
+            logger.warning(
                 f"✅ Speaker profile loading complete: {loaded_count} loaded, {skipped_count} skipped"
             )
 


### PR DESCRIPTION
Unlock still refuses with `Primary user: None`. The retry added in `5342e1b8e5` logged nothing. Neither did the readiness line, nor the profile-load summary.

**None of that is evidence they didn't run** — it's evidence this module's INFO is filtered out of the brainstem console. The three lines that answer *"did the voiceprint load?"* have been invisible for this entire investigation.

Four consecutive fixes were made to this chain — registry resolution, lifecycle start, local-first SQLite, retry-on-empty — **without once being able to read whether the count was 0 or 1.** That is not debugging; it's guessing with extra steps, and it's why the same symptom keeps returning looking identical.

All three are now WARNING. Not for severity: a readiness line nobody can see is not a readiness line.

This is the **fourth** time in this arc the fix was "the fact existed and was unreadable" — BootLogFile on the Swift side, the LOCAL-FIRST promotion, the ProfileRetry attempts, now this. The recurring defect isn't any one of them; it's that observability keeps being added at a level the operator's console discards.

106 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promoted the three speaker verification readiness/profile-count logs from INFO to WARNING so the brainstem console (WARNING+) shows them. This makes the voiceprint load status and profile counts visible to diagnose “Primary user: None” failures in `backend/voice/speaker_verification_service.py`.

<sup>Written for commit 9920ea2c40514af1fd3d2ee6e49572a29833e6f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

