### PR TITLE
fix: The initialiser that actually runs never loaded the voiceprints

### DIFF
--- a/backend/voice/speaker_verification_service.py
+++ b/backend/voice/speaker_verification_service.py
@@ -3994,6 +3994,44 @@ class SpeakerVerificationService:
         except Exception as e:
             logger.warning(f"⚠️ [INIT] EcapaFacade error: {e} - falling back to local engine")
 
+        # LOAD THE VOICEPRINTS. This path never did.
+        #
+        # There are two initialisers. `initialize_fast()` calls
+        # `_load_speaker_profiles()`; this one -- the one `voice_identity.py`
+        # actually invokes -- did not. So the service declared itself ready with
+        # an empty profile table and every verification compared against
+        # nothing:
+        #
+        #     ✅ Speaker Verification Service ready (0 profiles loaded)
+        #     ⚠️ No speaker match found. Primary user: None, Best confidence: 0.00%
+        #     'unlock_screen' NOT authorised (I don't have a voiceprint...)
+        #
+        # measured 2026-08-06 21:19:24. Deterministic, every boot, for as long
+        # as this path has existed.
+        #
+        # It is why nothing upstream helped. The profile was on disk the whole
+        # time ("Derek J. Russell", 768-byte embedding, 272 samples,
+        # is_primary_user=1). Local-first SQLite did not help because the query
+        # never ran. The retry-on-empty did not fire because the function
+        # containing it was never called. The 15s database timeout was real but
+        # irrelevant to THIS symptom. Four fixes upstream of a call that was
+        # simply absent.
+        #
+        # Awaited, not backgrounded: `self.initialized = True` immediately
+        # follows, and a service that announces readiness while its profiles are
+        # still loading is how "ready (0 profiles)" becomes true again by a
+        # different route. If the load fails it schedules its own retry
+        # (5342e1b8e5) rather than raising -- readiness with zero profiles is
+        # then honest and recoverable rather than silent and permanent.
+        try:
+            await self._load_speaker_profiles()
+        except Exception as e:  # noqa: BLE001 — never block readiness on this
+            logger.warning(
+                "⚠️ [INIT] Speaker profile load failed (%s: %s) — the service will "
+                "report 0 profiles and retry in the background",
+                type(e).__name__, e,
+            )
+
         self.initialized = True
         # WARNING, not INFO. This module is filtered to WARNING+ in the
         # brainstem console, so the ONE line that answers "did the


### PR DESCRIPTION
```
21:19:24  ✅ Speaker Verification Service ready (0 profiles loaded)
21:19:27  ⚠️ No speaker match found. Primary user: None, Best confidence: 0.00%
21:19:27  'unlock_screen' NOT authorised (I don't have a voiceprint...)
```

**Zero.** Measured at last, because the count was raised to WARNING in `b133b0c80e` — and the "Speaker profile loading complete" line **never appeared at all**, which is what named the cause.

There are two initialisers:

| | |
|---|---|
| `SpeakerVerificationService.initialize_fast()` line 3405 | loads profiles ✓ |
| `SpeakerVerificationService.initialize()` line 3933 | **did not** ✗ |

`voice_identity.py:297` calls `initialize()`. So the service completed startup, set `self.initialized = True`, announced itself ready, and **never read the profile table**. Every verification compared an utterance against an empty dict. Deterministic, every boot, for as long as this path has existed.

## Why nothing upstream helped

The profile was on disk the entire time — "Derek J. Russell", 768-byte 192-dimension embedding, 272 samples, `is_primary_user=1`.

- local-first SQLite didn't help: **the query never ran**
- retry-on-empty never fired: **the function containing that branch was never called**
- the 15s database timeout was real, and irrelevant to *this* symptom
- the ECAPA registry and lifecycle fixes were real, and also not this

Four fixes upstream of a call that was simply absent. Each found a genuine defect; none could have produced a loaded profile, because nothing was asking for one. That's the cost of debugging a chain whose decisive number was unreadable — and why the symptom kept returning looking identical.

## Awaited, not backgrounded

`self.initialized = True` immediately follows. A service that announces readiness while its profiles are still loading reproduces "ready (0 profiles)" by a different route. On failure it doesn't raise — `_load_speaker_profiles` schedules its own retry, so readiness-with-zero stays honest and recoverable rather than silent and permanent.

106 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure `SpeakerVerificationService.initialize()` actually loads voiceprints on startup, fixing the persistent “ready (0 profiles)” state and failed speaker matches. We now await `_load_speaker_profiles()` during init; on failure we warn and retry in the background without blocking readiness.

- **Bug Fixes**
  - Call and await `_load_speaker_profiles()` from `initialize()` (the path used by `voice_identity.py`).
  - On error: log a warning and rely on the existing background retry, so readiness is not blocked.
  - Restores normal verification by loading profiles at boot.

<sup>Written for commit 6733a46c4a9990771609fe287e79f03b1297bc87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

