### PR TITLE
fix: Warm the voice authority at boot, not on first unlock

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -2567,6 +2567,45 @@ async def parallel_lifespan(app: FastAPI):
                 except Exception as _ce:  # noqa: BLE001
                     logger.error("[HUD] consent bridge install failed: %s", _ce)
 
+                # START WARMING THE VOICE AUTHORITY NOW, NOT ON FIRST USE.
+                #
+                # `VoiceIdentity.start_warming()` had exactly two callers, both
+                # on REQUEST paths: inside `identify()` and inside the
+                # enrollment handler. Nothing warmed it at boot — `main.py` did
+                # not reference voice_identity at all.
+                #
+                # So the speaker model began loading only when someone asked for
+                # an unlock, which makes the first unlock after every boot a
+                # guaranteed NOT_READY:
+                #
+                #   21:30:20  backend starts
+                #   21:31:25  'unlock_screen' NOT authorised
+                #             (I'm still loading my voice recognition...)
+                #   21:31:33  same
+                #   21:31:40  ✅ Speaker Verification Service ready (1 profiles)
+                #
+                # measured 2026-08-06. The operator is told to "give me a moment
+                # and ask again" for a load their request had just started.
+                #
+                # This is the same defect 532801531c fixed for the model import
+                # ("the model now loads at boot, not when you ask it to unlock")
+                # — that moved the import; the WARM stayed lazy, so the symptom
+                # survived at a different layer.
+                #
+                # `start_warming()` is idempotent and non-blocking by contract:
+                # it spawns a background task and returns. Boot is not delayed,
+                # and the request-path callers remain as the safety net for any
+                # path that reaches identify() before this ran.
+                try:
+                    from backend.hud.voice_identity import get_voice_identity
+                    get_voice_identity().start_warming()
+                    logger.warning(
+                        "[HUD] voice authority warming started at boot — the "
+                        "first unlock no longer pays for the model load"
+                    )
+                except Exception as _ve:  # noqa: BLE001 — never block boot on a warm
+                    logger.error("[HUD] voice authority warm failed to start: %s", _ve)
+
                 # Tell the HUD when JARVIS is speaking, so it can mute its own
                 # microphone. `UnifiedSpeechStateManager` has always known;
                 # its `register_websocket_broadcaster` had zero callers, so


### PR DESCRIPTION
```
21:30:20  backend starts
21:31:25  'unlock_screen' NOT authorised (I'm still loading my voice recognition...)
21:31:33  same
21:31:40  ✅ Speaker Verification Service ready (1 profiles loaded)
```

Measured 2026-08-06. **The operator was told to wait for a load their own request had just started.**

`VoiceIdentity.start_warming()` had exactly two callers, both on **request paths** — inside `identify()` and inside the enrollment handler. `main.py` didn't reference `voice_identity` at all. So the speaker model began loading when someone first asked for an unlock, making the **first unlock after every boot a guaranteed NOT_READY**. Not a race, not a slow machine: structurally certain.

## The same defect, one layer over

`532801531c` fixed this once already — *"the model now loads at boot, not when you ask it to unlock"*. That moved the module **import** to boot. The **warm** stayed lazy, so the symptom survived at a different layer and reappeared identical, right down to the sentence the operator hears.

Fixing the import made the load fast. It couldn't make it *early*, because nothing was starting it.

## Why at the consent-bridge install

That's where the voice authority becomes the thing that answers `unlock_screen`. Warming earlier would warm a model for an authority not yet installed; later is another window where a request pays the load.

`start_warming()` is idempotent and non-blocking **by contract** — spawns a task and returns — so boot isn't delayed, and the two request-path callers remain the safety net for any path reaching `identify()` first. Verified against the contract rather than assumed: it returns early if disabled, if a warm is already running, or if already READY, and never raises.

## Now honest, and soon unnecessary

`NOT_READY` was already truthful after `d11c0a173b` — the service really was still loading. This removes the reason it was still loading when asked.

106 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Warm the voice authority at boot so the first unlock doesn’t wait for the speaker model and no longer returns NOT_READY. We now call `get_voice_identity().start_warming()` during consent-bridge install; it’s idempotent and non-blocking, so boot isn’t slowed and request-path warm calls remain as a fallback.

<sup>Written for commit 77638efb9065cb3757bbac699c29813a3537c7a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

