### PR TITLE
fix: An absent scoring engine is not a missing voiceprint

### DIFF
--- a/backend/voice/speaker_verification_service.py
+++ b/backend/voice/speaker_verification_service.py
@@ -6065,6 +6065,19 @@ class SpeakerVerificationService:
         if not self.initialized:
             return (False, "not_initialized")
 
+        # An absent scoring engine is a FAULT, and it must not be reported as a
+        # missing voiceprint. Measured 2026-08-06 22:11:30: one profile was
+        # loaded, `speechbrain_engine` was None, verification crashed, and the
+        # operator was told "I don't have a voiceprint for you on this Mac yet"
+        # — advice that would have him re-enrol a voice that was already there.
+        #
+        # Checked BEFORE the profile check on purpose: with no engine, whether a
+        # profile exists is not the reason the answer is no.
+        if getattr(self, "speechbrain_engine", None) is None and not getattr(
+            self, "_use_registry_encoder", False
+        ):
+            return (False, "no_scoring_engine")
+
         profiles = getattr(self, "speaker_profiles", None) or {}
         if not profiles:
             # The enrollment STORE may well hold a voiceprint; this says the
@@ -6335,6 +6348,40 @@ class SpeakerVerificationService:
                     logger.info(f"  ✅ Pre-extracted embedding via {'registry/cloud' if self._use_registry_encoder else 'local'}")
                 else:
                     logger.warning(f"  ⚠️ Pre-extraction failed, will use local fallback")
+
+                # THE "LOCAL FALLBACK" IS THIS ENGINE, AND IT MAY NOT EXIST.
+                #
+                # Measured 2026-08-06 22:11:30::
+                #
+                #     ⚠️ Pre-extraction failed, will use local fallback
+                #     ERROR Speaker verification error:
+                #         'NoneType' object has no attribute 'verify_speaker'
+                #     NOT authorised (I don't have a voiceprint for you...)
+                #
+                # and 66 seconds earlier the service had already said::
+                #
+                #     SpeechBrain engine not initialized — cannot detect dimension
+                #
+                # The line above promises a fallback to `speechbrain_engine`, then
+                # this line calls a method on it. When it is None the promise was
+                # a claim the code never checked — and the crash was caught
+                # upstream and reported as "I don't have a voiceprint", which is
+                # false: the voiceprint was loaded (1 profile) and the ENGINE was
+                # missing. A fault wearing a refusal's clothes, for the fourth
+                # time in this chain.
+                #
+                # Raising a typed error rather than returning a verdict: the
+                # caller's handler turns exceptions into UNAVAILABLE, which is
+                # what an absent engine actually is. Returning `verified=False`
+                # here would re-create the exact conflation being removed.
+                if self.speechbrain_engine is None:
+                    raise RuntimeError(
+                        "speaker verification engine unavailable: speechbrain_engine "
+                        "is None, so neither the registry/cloud extraction nor the "
+                        "local fallback can score this utterance. The enrolled "
+                        "voiceprint is NOT the problem — this is an engine "
+                        "initialisation failure."
+                    )
 
                 is_verified, confidence = await self.speechbrain_engine.verify_speaker(
                     audio_data, known_embedding, threshold=adaptive_threshold,


### PR DESCRIPTION
```
22:11:30  ⚠️ Pre-extraction failed, will use local fallback
22:11:30  ERROR Speaker verification error: 'NoneType' object has no attribute 'verify_speaker'
22:11:30  NOT authorised (I don't have a voiceprint for you on this Mac yet...)
```

66 seconds earlier the same service had already said: `SpeechBrain engine not initialized`.

## The fallback that did not exist

"will use local fallback" refers to `self.speechbrain_engine`. The very next statement calls `.verify_speaker` on it. When it's None, the log printed a promise the code never checked — then crashed keeping it.

That crash was caught upstream and reported as *"I don't have a voiceprint for you on this Mac yet"* — which is **false**. The log two lines up says `1 profiles loaded`. The **engine** was missing. The advice sent the operator to re-enrol a voice that was already there.

**Fourth occurrence of this shape in this chain**, now at the deepest layer: `verified=false` meaning two things; "retrying with fast_mode" asserting an unchecked transition; ProfileRetry reporting a zero result as success; and now a crash presented as an enrolment problem.

## Raised, not returned

An absent engine raises a typed `RuntimeError`. The caller's handler turns exceptions into UNAVAILABLE — which is what an absent engine actually is. Returning `verified=False` would recreate the exact conflation being removed. The message names the engine and explicitly clears the voiceprint of blame.

## The capability probe now knows

`verification_capability()` reports `no_scoring_engine`, checked **before** the profile check: with no engine, whether a profile exists isn't the reason the answer is no. Only when the registry/cloud encoder is also unavailable, since that path doesn't need speechbrain.

Verified end to end: `(False, 'no_scoring_engine')` → verdict UNAVAILABLE → operator hears *"I can't check who's speaking right now, so I've left it locked"* instead of being told to enrol.

Still fails closed. 106 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes speaker verification to treat a missing scoring engine as an availability fault instead of a missing voiceprint, and prevents a None dereference crash. Users now get a clear “can’t check right now” message while the system still fails closed.

- **Bug Fixes**
  - `verification_capability()` now checks for an absent `speechbrain_engine` before profile checks and returns `(False, "no_scoring_engine")` when no registry/cloud encoder is available.
  - `verify_speaker()` raises a typed `RuntimeError` if `speechbrain_engine` is `None` before attempting the local fallback; the caller maps this to UNAVAILABLE, avoiding false “no voiceprint” messages.

<sup>Written for commit 1456dd79aa9229ca6beac1aee6bd40a0e96fcd82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

