### PR TITLE
fix: Dimension adaptation was fabricating confidence scores

### DIFF
--- a/backend/voice/engines/speechbrain_engine.py
+++ b/backend/voice/engines/speechbrain_engine.py
@@ -3411,6 +3411,45 @@ __all__ = ["EncoderDecoderASR"]
                 embedding2[:common_dim]
             )
 
+    @staticmethod
+    def _as_host_vector(embedding) -> "Optional[np.ndarray]":
+        """Coerce an embedding to a flat float32 numpy vector in host memory.
+
+        dtype and device are REPRESENTATION differences, not semantic ones: the
+        same voiceprint stored as float64 in SQLite and produced as float32 by
+        the encoder is the same vector twice. Casting is the correct response;
+        refusing would reject a valid comparison over a storage detail.
+
+        A torch tensor is detached and moved to CPU first — cosine similarity
+        here is numpy arithmetic, and a tensor still on an accelerator raises
+        rather than converting. `.detach()` because an embedding carrying a grad
+        graph into a comparison is a memory leak in a loop that runs per unlock.
+
+        Returns None when the input cannot be coerced at all, so the caller
+        refuses rather than scoring something it does not understand.
+        """
+        try:
+            if embedding is None:
+                return None
+
+            # torch tensors: detach, host, numpy. Guarded by duck-typing so this
+            # module does not require torch to be importable to run.
+            if hasattr(embedding, "detach") and hasattr(embedding, "cpu"):
+                embedding = embedding.detach().cpu().numpy()
+
+            vec = np.asarray(embedding)
+            if vec.size == 0:
+                return None
+
+            # float32 is the encoder's native precision; float64 profiles cast
+            # down losslessly for a direction-only measure like cosine.
+            return vec.flatten().astype(np.float32, copy=False)
+        except Exception as exc:  # noqa: BLE001 — never raise into a verdict
+            logger.error(
+                "❌ Embedding coercion failed (%s: %s)", type(exc).__name__, exc
+            )
+            return None
+
     def _compute_cosine_similarity(self, embedding1: np.ndarray, embedding2: np.ndarray) -> float:
         """Compute cosine similarity between two embeddings.
 
@@ -3424,18 +3463,45 @@ __all__ = ["EncoderDecoderASR"]
             Cosine similarity score (0.0-1.0, higher is more similar)
         """
         try:
-            # Flatten embeddings in case they have extra dimensions
-            emb1 = embedding1.flatten()
-            emb2 = embedding2.flatten()
-
-            # Handle dimension mismatch
-            if emb1.shape[0] != emb2.shape[0]:
-                logger.warning(
-                    f"⚠️  Embedding dimension mismatch: {emb1.shape[0]} vs {emb2.shape[0]}"
+            # ---- Omni-Validator: align what is alignable, refuse what is not ----
+            #
+            # dtype and device are REPRESENTATION differences. A float64 profile
+            # from SQLite compared against a float32 tensor from the encoder is
+            # the same vector twice, and casting is lossless in the direction
+            # that matters. A torch tensor on any device is brought to host
+            # memory as numpy, because numpy is what this function's arithmetic
+            # is written against.
+            emb1 = self._as_host_vector(embedding1)
+            emb2 = self._as_host_vector(embedding2)
+            if emb1 is None or emb2 is None:
+                logger.error(
+                    "❌ Cosine similarity: embedding could not be coerced to a "
+                    "host vector — refusing to score"
                 )
-                logger.info("   Applying dimension adaptation...")
-                emb1, emb2 = self._adapt_embedding_dimensions(emb1, emb2)
-                logger.info(f"   Adapted to common dimension: {emb1.shape[0]}")
+                return 0.0
+
+            # SHAPE IS NOT A REPRESENTATION DIFFERENCE. IT IS A DIFFERENT VECTOR.
+            #
+            # This used to call `_adapt_embedding_dimensions()` — padding or
+            # truncating until the arithmetic ran — and return a score. That is
+            # worse than crashing: a 192D ECAPA voiceprint compared against a
+            # differently-shaped vector is not a weak match, it is NOT A
+            # COMPARISON, and adaptation turns that into a plausible-looking
+            # confidence number in the one place that decides whether someone is
+            # you. Both false accepts and false rejects become invisible.
+            #
+            # Same defect class as every other one in this chain: a fault
+            # presented as a verdict. Here it is at the arithmetic.
+            if emb1.shape[0] != emb2.shape[0]:
+                logger.error(
+                    "❌ ShapeMismatchError: %dD vs %dD — these are different "
+                    "vectors, not a weak match. Refusing to fabricate a "
+                    "similarity score; returning 0.0. A stored ECAPA voiceprint "
+                    "is 192D, so a mismatch means the live embedding came from "
+                    "the wrong encoder, not that the speaker is wrong.",
+                    emb1.shape[0], emb2.shape[0],
+                )
+                return 0.0
 
             # Compute cosine similarity
             dot_product = np.dot(emb1, emb2)

--- a/backend/voice/speaker_verification_service.py
+++ b/backend/voice/speaker_verification_service.py
@@ -6073,9 +6073,8 @@ class SpeakerVerificationService:
                 model_path="speechbrain/asr-wav2vec2-commonvoice-en",
             )
             self.speechbrain_engine = _SpeechBrainEngine(model_config)
-            logger.warning(
-                "✅ SpeechBrain engine constructed (weights load lazily on first use)"
-            )
+            logger.warning("✅ SpeechBrain engine constructed — pre-warming encoder")
+            self._schedule_encoder_prewarm()
         except Exception as exc:  # noqa: BLE001
             # LOUD, with a traceback. A construction failure was previously
             # indistinguishable from "nobody built one", and both presented
@@ -6087,6 +6086,82 @@ class SpeakerVerificationService:
                 "will report no_scoring_engine, NOT a missing voiceprint",
                 type(exc).__name__, exc, exc_info=True,
             )
+
+    def _schedule_encoder_prewarm(self) -> None:
+        """Pre-load the ECAPA speaker encoder in the background, off the unlock path.
+
+        WHY A DAEMON AND NOT A LAZY LOAD
+        --------------------------------
+        `ensure_speaker_encoder_ready()` loads on first use — and first use is an
+        unlock, on a loop measured at 33-55% availability. Paying a model load
+        there is how "unlock my screen" turns into a timeout the operator reads
+        as a refusal.
+
+        DRY: this does NOT reimplement fetching. `ensure_speaker_encoder_ready()`
+        already owns the download, the cache, the loading lock, and the
+        deliberate CPU pinning (MPS lacks the FFT ops ECAPA needs). This only
+        decides WHEN it happens. A second fetcher would be a second opinion
+        about which model and which device, which is exactly the divergence that
+        left `initialize()` without an engine.
+
+        NEVER WEDGES BOOT
+        -----------------
+        Bounded by a timeout, so a partitioned network or a HuggingFace
+        `filelock` held by another JARVIS process degrades to a warning and a
+        lazy load later, rather than a boot that never finishes. Fire-and-forget:
+        nothing awaits this, and the unlock path still calls
+        `ensure_speaker_encoder_ready()` itself — the daemon makes that call fast,
+        it does not replace it.
+
+        The loader's blocking work already runs off-loop inside the engine, so
+        this task never holds the event loop for the download.
+        """
+        if getattr(self, "_encoder_prewarm_task", None) is not None:
+            return
+
+        engine = getattr(self, "speechbrain_engine", None)
+        if engine is None or not hasattr(engine, "ensure_speaker_encoder_ready"):
+            return
+
+        try:
+            timeout_s = float(
+                os.environ.get("JARVIS_ENCODER_PREWARM_TIMEOUT_S", "180") or 180
+            )
+        except (TypeError, ValueError):
+            timeout_s = 180.0
+
+        async def _prewarm() -> None:
+            import time as _t
+            started = _t.monotonic()
+            try:
+                await asyncio.wait_for(
+                    engine.ensure_speaker_encoder_ready(), timeout=timeout_s
+                )
+                logger.warning(
+                    "✅ [EncoderPrewarm] speaker encoder ready in %.1fs — the first "
+                    "unlock will not pay for the model load",
+                    _t.monotonic() - started,
+                )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "⚠️ [EncoderPrewarm] encoder not ready within %.0fs — falling "
+                    "back to lazy load on first use. Common causes: a partitioned "
+                    "network, or a HuggingFace filelock held by another process.",
+                    timeout_s,
+                )
+            except Exception as exc:  # noqa: BLE001 — a warm must never break boot
+                logger.warning(
+                    "⚠️ [EncoderPrewarm] pre-warm failed (%s: %s) — lazy load "
+                    "remains available",
+                    type(exc).__name__, exc,
+                )
+
+        try:
+            self._encoder_prewarm_task = asyncio.get_running_loop().create_task(_prewarm())
+        except RuntimeError:
+            # No running loop (sync construction path). The lazy load still
+            # works; a pre-warm that cannot be scheduled is not a failure.
+            logger.debug("[EncoderPrewarm] no running loop — skipping pre-warm")
 
     def verification_capability(self, speaker_name: Optional[str] = None) -> Tuple[bool, str]:
         """


### PR DESCRIPTION
## The shape gate found something worse than a crash

`_compute_cosine_similarity` **didn't crash** on mismatched embeddings. It called `_adapt_embedding_dimensions()` — padding or truncating until the arithmetic ran — and returned a score:

```
⚠️  Embedding dimension mismatch: {a} vs {b}
   Applying dimension adaptation...
```

A 192D ECAPA voiceprint compared against a differently-shaped vector is not a weak match. **It is not a comparison.** Adaptation turned that into a plausible-looking confidence number in the one place that decides whether someone is the owner of this machine — making both false accepts and false rejects invisible.

**The predicted PyTorch `RuntimeError` would have been the safer outcome.** A crash is loud. This was silent, and it produced a verdict.

Same defect class as the rest of this chain — a fault presented as a verdict — now found at the arithmetic itself.

## The Omni-Validator: align what is alignable, refuse what is not

`dtype` and `device` are **representation** differences. A float64 profile from SQLite and a float32 tensor from the encoder are the same vector twice; casting is correct, and refusing over a storage detail would reject a valid comparison. Torch tensors are detached (a grad graph entering a per-unlock comparison is a leak) and moved to host memory, because this function's arithmetic is numpy.

**Shape is not a representation difference.** A mismatch now logs `ShapeMismatchError` and returns `0.0`, naming what it means: the live embedding came from the wrong encoder, *not* that the speaker is wrong. That distinction sends the operator to the right problem.

| case | result |
|---|---|
| 192D float64 vs float32 | scores 1.0 |
| (1,192) vs (192,) | scores 1.0 |
| 192D vs 512D | **refuses, 0.0** |
| None / empty | **refuses, 0.0** |

## The pre-warm daemon triggers, it does not reimplement

`ensure_speaker_encoder_ready()` already owns the download, cache, loading lock, and the deliberate CPU pinning (MPS lacks the FFT ops ECAPA needs). The daemon only decides **when**. A second fetcher would be a second opinion about which model and which device — exactly the divergence that left `initialize()` without an engine.

First use is an unlock, on a loop at 33–55% availability. Paying a model load there is how "unlock my screen" becomes a timeout read as a refusal.

Bounded by `JARVIS_ENCODER_PREWARM_TIMEOUT_S` (default 180s), so a partitioned network or a HuggingFace `filelock` held by another process degrades to a warning and a lazy load — not a boot that never finishes. The unlock path still calls `ensure_speaker_encoder_ready()` itself: the daemon makes that call fast, it doesn't replace it.

106 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops fabricating similarity scores by rejecting shape-mismatched embeddings, and prewarms the ECAPA encoder in the background to avoid first-unlock latency.

- **Bug Fixes**
  - Reject embedding shape mismatches; return 0.0 and log an error (no padding/truncation).
  - Add `_as_host_vector` to coerce inputs: detach torch tensors, move to CPU, flatten, cast to float32; refuse on None/empty/uncoercible.
  - Normalize dtype/device so valid comparisons (e.g., float64 vs float32, (1,192) vs (192,)) score correctly.

- **New Features**
  - Background encoder prewarm using `ensure_speaker_encoder_ready()` with `JARVIS_ENCODER_PREWARM_TIMEOUT_S` (default 180s).
  - Non-blocking and safe: on timeout/failure, falls back to lazy load; unlock path still calls the readiness check.

<sup>Written for commit 9dc30ee10e94e312100e8b94d2d03f7764a6f246. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

