### PR TITLE
fix: One INSERT was writing two different voice_samples schemas

### DIFF
--- a/backend/intelligence/learning_database.py
+++ b/backend/intelligence/learning_database.py
@@ -8104,25 +8104,102 @@ class JARVISLearningDatabase:
                         await conn.commit()
 
             # Local SQLite storage
-            # v259.0: Use RETURNING for PostgreSQL, lastrowid for SQLite
-            _vs_sql = """
-                INSERT INTO voice_samples (
-                    speaker_name, audio_data, embedding,
-                    verification_confidence, verification_result,
-                    command, transcription, environment_type,
-                    quality_score, metadata
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """
+            #
+            # TWO DATABASES, TWO `voice_samples` SCHEMAS, ONE INSERT
+            # ------------------------------------------------------
+            # The CloudSQL block above writes the CLOUD schema
+            # (speaker_name, embedding, verification_confidence, ...) and is
+            # correct for it. This block used to reuse that identical column
+            # list against LOCAL SQLite, whose `voice_samples` is a different
+            # table entirely -- created by this very module at the
+            # `CREATE TABLE IF NOT EXISTS voice_samples` above:
+            #
+            #     speaker_id INTEGER NOT NULL, audio_hash TEXT NOT NULL,
+            #     audio_data, audio_fingerprint, mfcc_features,
+            #     duration_ms REAL NOT NULL, transcription, pitch_*, energy_mean,
+            #     recording_timestamp TIMESTAMP NOT NULL, quality_score,
+            #     background_noise, used_for_training
+            #
+            # Measured 2026-08-06 23:22:24::
+            #
+            #     Failed to store voice sample:
+            #         table voice_samples has no column named speaker_name
+            #
+            # Not a missing migration: the canonical CREATE in this file has
+            # never had `speaker_name` or `embedding`, and the live database
+            # matches it exactly. The writer contradicted the schema its own
+            # module defines. Migrating the table to match the cloud would
+            # rewrite a table that is correct and populated; the INSERT is what
+            # was wrong.
+            #
+            # The local schema keys on speaker_id with a foreign key into
+            # speaker_profiles, so the name is resolved to an id here using the
+            # same lookup the rest of this module uses.
+            speaker_row = None
+            if not self._is_cloud_db:
+                async with self.db.execute(
+                    "SELECT speaker_id FROM speaker_profiles WHERE speaker_name = ?",
+                    (speaker_name,),
+                ) as _sid_cursor:
+                    speaker_row = await _sid_cursor.fetchone()
+
+            if not self._is_cloud_db and speaker_row is None:
+                # A sample with no owner cannot satisfy the foreign key, and
+                # inventing a profile here would create an unenrolled speaker as
+                # a side effect of storing telemetry.
+                logger.warning(
+                    "Voice sample not stored: no speaker_profiles row for %r "
+                    "(the local schema keys samples by speaker_id)",
+                    speaker_name,
+                )
+                return -1
+
+            _speaker_id = speaker_row[0] if speaker_row else None
+
+            # audio_hash and duration_ms are NOT NULL in the local schema.
+            # Derived from the payload rather than defaulted, so a sample is
+            # addressable by content and its duration is real.
+            _audio_hash = hashlib.sha256(audio_data or b"").hexdigest()
+            _duration_ms = float((metadata or {}).get("duration_ms") or 0.0)
+
+            # `self.db` is not always SQLite: `_is_cloud_db` means this handle
+            # speaks the CLOUD schema, and the local column list would be just
+            # as wrong there as the cloud list was here. Each branch writes the
+            # schema its own connection actually has -- that is the whole defect
+            # being fixed, and hardcoding one shape for both would recreate it
+            # pointing the other way.
             if self._is_cloud_db:
-                _vs_sql += " RETURNING sample_id"
-            async with self.db.execute(
-                _vs_sql,
-                (
+                _vs_sql = """
+                    INSERT INTO voice_samples (
+                        speaker_name, audio_data, embedding,
+                        verification_confidence, verification_result,
+                        command, transcription, environment_type,
+                        quality_score, metadata
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING sample_id
+                """
+                _vs_params = (
                     speaker_name, audio_data, embedding_bytes,
                     confidence, verified, command, transcription,
                     environment_type, quality_score,
-                    json.dumps(metadata) if metadata else None
+                    json.dumps(metadata) if metadata else None,
                 )
+            else:
+                _vs_sql = """
+                    INSERT INTO voice_samples (
+                        speaker_id, audio_hash, audio_data, duration_ms,
+                        transcription, recording_timestamp, quality_score,
+                        used_for_training
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """
+                _vs_params = (
+                    _speaker_id, _audio_hash, audio_data, _duration_ms,
+                    transcription, datetime.now().isoformat(),
+                    quality_score, 1 if verified else 0,
+                )
+
+            async with self.db.execute(
+                _vs_sql,
+                _vs_params
             ) as cursor:
                 await self.db.commit()
                 if self._is_cloud_db:


### PR DESCRIPTION
```
Failed to store voice sample: table voice_samples has no column named speaker_name
```

## Schema audit

Live `~/.jarvis/learning/jarvis_learning.db`:

```
voice_samples: sample_id speaker_id audio_hash audio_data audio_fingerprint
               mfcc_features duration_ms transcription pitch_mean pitch_std
               energy_mean recording_timestamp quality_score background_noise
               used_for_training
```

| expected by code | reality |
|---|---|
| `speaker_name` | **absent** — the column is `speaker_id` |
| `embedding_json` | **absent from every table in this database** |

`store_voice_sample` has two storage blocks. The CloudSQL block writes the **cloud** schema and is correct for it. The local block then reused that **identical column list** against SQLite — whose `voice_samples` is a different table, one this very module creates 4,700 lines earlier, keyed on `speaker_id` with a foreign key into `speaker_profiles`.

## Not a missing migration

The canonical `CREATE TABLE IF NOT EXISTS voice_samples` in this file has **never** had `speaker_name` or `embedding`, and the live database matches it exactly. The writer contradicted the schema its own module defines.

Migrating the table would have been the wrong fix: it would rewrite a table that is correct and populated, to satisfy the statement that was the actual error. **The schema was right; the INSERT was not.**

## Each branch writes the schema its connection has

`self.db` isn't always SQLite — `_is_cloud_db` means the handle speaks the cloud schema, where the local column list would be exactly as wrong as the cloud list was locally. Hardcoding one shape for both *is* the defect; doing it in the other direction would just re-point it.

`speaker_name` resolves to `speaker_id` via the same lookup the rest of the module uses. A name with no profile row returns `-1` rather than inserting — it can't satisfy the foreign key, and auto-creating a profile would enrol an unknown speaker as a side effect of storing telemetry.

`audio_hash` and `duration_ms` are NOT NULL and are derived from the payload, so a sample is addressable by content rather than a placeholder.

## Verified against the real database

Against a copy of the live `jarvis_learning.db`: the new INSERT is **accepted**; the old statement still fails with the **exact error from the log**.

## Still open, and separate

`embedding_json` is queried by `voice_profile_learning_engine.py:283` and created in `metrics_database.py:2177` — a **different database**. That's the learning engine reading the wrong store, not a missing column. Not touched here.

106 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes voice sample storage by using the correct INSERT for each database schema (CloudSQL vs local SQLite). Prevents “no column named speaker_name” errors and reliably stores samples.

- **Bug Fixes**
  - Use schema-specific INSERTs: CloudSQL writes `speaker_name`/`embedding`; SQLite writes `speaker_id`, `audio_hash`, `duration_ms`, etc.
  - Resolve `speaker_name` to `speaker_id` via `speaker_profiles`; if missing, skip insert and return `-1` with a warning.
  - Compute `audio_hash` (sha256 of `audio_data`) and set `duration_ms` from metadata; record timestamp and derive `used_for_training` from verification.
  - Keep CloudSQL `RETURNING sample_id`; commit handling unchanged.
  - Verified against a copy of the live SQLite DB: new INSERT succeeds; old one reproduces the original error.

<sup>Written for commit d8e99d18095d134dbc95a420f2f4b72e66b84ac0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70420?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

