### PR TITLE
fix: Stall dumps must survive the console filter

### DIFF
--- a/backend/hud/stall_sampler.py
+++ b/backend/hud/stall_sampler.py
@@ -60,6 +60,7 @@ STALL_SAMPLER_SCHEMA_VERSION: str = "stall_sampler.v1"
 
 #: Master switch. Default TRUE — it costs one float read per interval while
 #: the loop is healthy, and the thing it catches is otherwise uncatchable.
+ENV_DUMP_PATH = "JARVIS_STALL_DUMP_PATH"
 ENV_ENABLED: str = "JARVIS_STALL_SAMPLER_ENABLED"
 
 #: How stale the heartbeat must be before the loop counts as wedged NOW.
@@ -102,6 +103,34 @@ def min_gap_s() -> float:
 
 def max_dumps() -> int:
     return int(_f(ENV_MAX_DUMPS, 8.0, 1.0))
+
+
+
+def _now_iso() -> str:
+    """Timestamp for a dump header. NEVER raises."""
+    try:
+        from datetime import datetime
+        return datetime.now().isoformat(timespec="seconds")
+    except Exception:  # noqa: BLE001
+        return "unknown-time"
+
+
+def _dump_path():
+    """Where stall stacks are written so they outlive the process.
+
+    Env-overridable; defaults alongside the other JARVIS logs so an operator
+    looking for "what was the loop stuck on" finds it where the boot log lives.
+    Returns None if a path cannot be resolved, and the caller falls back to
+    stderr rather than losing the dump.
+    """
+    try:
+        from pathlib import Path as _Path
+        raw = (os.environ.get(ENV_DUMP_PATH, "") or "").strip()
+        if raw:
+            return _Path(raw).expanduser()
+        return _Path.home() / "Library" / "Logs" / "JARVIS" / "loop-stalls.log"
+    except Exception:  # noqa: BLE001
+        return None
 
 
 class StallSampler:
@@ -198,17 +227,63 @@ class StallSampler:
             "stacks (dump %d/%d). The frames below are what the loop is "
             "stuck on, not what it ran afterwards.",
             stale_for, self._dumps, max_dumps())
+        # WRITE THE FRAMES WHERE THEY CAN BE READ AFTERWARDS.
+        #
+        # `dump_all_threads()` defaults to sys.stderr, and the brainstem console
+        # filters the backend's output to a whitelist of prefixes. A raw
+        # faulthandler traceback matches none of them, so the stacks this
+        # sampler exists to capture have been discarded at the console for every
+        # run — the message "the frames below are what the loop is stuck on"
+        # was followed by nothing the operator could see.
+        #
+        # That is why loop starvation is the one defect still open after the
+        # rest of this chain was fixed: the instrument built to name the starver
+        # was writing to a stream nobody reads. Same lesson as BootLogFile on
+        # the Swift side, and as the four other observability findings in this
+        # arc — a measurement that cannot be recovered is not a measurement.
+        #
+        # The dump goes to a file that outlives the process. stderr is kept as
+        # well: a developer watching live should not lose what they had.
+        dump_target = None
+        try:
+            path = _dump_path()
+            if path is not None:
+                path.parent.mkdir(parents=True, exist_ok=True)
+                dump_target = path.open("a", encoding="utf-8")
+                dump_target.write(
+                    f"\n===== STALL DUMP {self._dumps}/{max_dumps()} — "
+                    f"loop wedged {stale_for:.2f}s — "
+                    f"{_now_iso()} =====\n"
+                )
+                dump_target.flush()
+                logger.warning("[StallSampler] frames -> %s", path)
+        except Exception:  # noqa: BLE001 — a witness never dies of a fault
+            dump_target = None
+
         try:
             from backend.core.ouroboros.battle_test.oob_diagnostics import (
                 dump_all_threads,
             )
-            if dump_all_threads():
+            # The file first: it is the copy that survives. stderr second, for
+            # whoever is attached right now.
+            wrote = False
+            if dump_target is not None:
+                wrote = bool(dump_all_threads(file=dump_target))
+            if dump_all_threads() or wrote:
                 return
         except Exception:  # noqa: BLE001
             logger.debug("[StallSampler] oob dump unavailable", exc_info=True)
-        # Fallback: straight to stderr. Less convenient than the log file the
-        # oob module maintains, and infinitely better than nothing at the one
-        # moment the answer exists.
+        finally:
+            if dump_target is not None:
+                try:
+                    dump_target.flush()
+                    dump_target.close()
+                except Exception:  # noqa: BLE001
+                    pass
+
+        # Fallback: faulthandler direct. Writes from the C signal handler, so it
+        # still works on a thread blocked inside a C call running no bytecode —
+        # which is precisely the case being investigated.
         try:
             import faulthandler
             faulthandler.dump_traceback(all_threads=True)


### PR DESCRIPTION
```
[StallSampler] LOOP WEDGED for 2.30s RIGHT NOW — capturing stacks (dump 1/8).
The frames below are what the loop is stuck on, not what it ran afterwards.
```

Followed, in every log this session, by **nothing**.

`dump_all_threads()` defaults to `sys.stderr`, and the brainstem console filters the backend's output to a whitelist of prefixes. A raw faulthandler traceback matches none of them, so the stacks were discarded at the console on every run. **Eight dumps per boot, none readable.**

That's why loop starvation is the last defect standing after the rest of this chain was fixed. Not because it's hard — because the measurement that would name it has never been recoverable. Availability measured 33–77%, worst stall 14.70s, and the one artifact saying *what* held the loop went to a stream the operator doesn't see.

**Fifth instance of this shape in this arc:** BootLogFile on the Swift side, the LOCAL-FIRST promotion at INFO, ProfileRetry at INFO, the speaker profile count at INFO, and now this. A measurement that cannot be recovered is not a measurement.

## What changed

Dumps are written to a file that outlives the process — default `~/Library/Logs/JARVIS/loop-stalls.log`, beside the boot log an operator already checks, overridable via `JARVIS_STALL_DUMP_PATH`. Each carries a header naming its index, stall duration, and wall-clock time, so a stack can be tied to the `LoopSentinel` line reporting the same window.

**stderr is still written** — a developer attached right now shouldn't lose what they had. The file is the copy that survives; stderr is the live view.

The faulthandler fallback is retained unchanged: it writes from the C signal handler, so it still produces frames for a thread blocked inside a C call running no bytecode — precisely the case being investigated, and the reason this sampler uses faulthandler rather than `traceback` at all.

Path resolution and file opening cannot take the sampler down; any failure degrades to the previous stderr-only behaviour. A witness never dies of a fault.

## This diagnoses, it does not cure

**No starvation is fixed here, and none is claimed.** Every previous attempt to name a starver from inside this system was wrong — `loop_sink.sink_async` measured wall-clock and sent a full day of work after `posture_observer`, which was already off-loop and innocent.

The next fix should come from reading real frames, not another inference.

Verified: dumps land in the file with a timestamped header and live frames.

106 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
