### PR TITLE
fix(boot): the starver was `import`, and the loop was waiting on a lock

### DIFF
--- a/backend/core/async_offload.py
+++ b/backend/core/async_offload.py
@@ -1,0 +1,325 @@
+"""
+Blocking work does not belong on the event loop — including ``import``.
+
+Measured 2026-08-06 from ``~/Library/Logs/JARVIS/loop-stalls.log``, five
+StallSampler dumps taken while the loop was provably wedged::
+
+    dump 2 — 12.38s  main thread in ``importlib._bootstrap._lock_unlock_module``
+                     networkx/algorithms/regular.py <module>
+                     <- oracle.py:73 <- governed_loop_service.py:89
+                     <- hud_governance_boot.py:76 <- main.py parallel_lifespan
+
+    dump 1 —  2.34s  main thread in ``_get_module_lock.__enter__``
+                     <- semantic_guardian.py:1608 <module>
+
+    dump 4 —  2.06s  main thread in ``_path_stat`` under ``find_spec``
+                     <- module_discovery.py:255
+
+The loop was not *doing* that work. In dump 2 it was **waiting on a module
+lock another thread already held** — the boot deliberately pushes heavy init
+onto background threads ("Debug tasks deferred to background for fast
+startup"), and one of those threads was midway through the scipy/sklearn
+graph. Dump 1 caught four threads inside an import simultaneously.
+
+So two optimizations were fighting each other over CPython's per-module import
+locks: "defer heavy init to a thread" and "lazy-import inside the coroutine."
+The loop lost. A module-lock wait runs no bytecode, holds the GIL region in C,
+and cannot be interrupted — ``async def`` around it buys nothing, and the loop
+is simply gone for the duration. Availability measured 34%, worst stall 16.33s.
+
+Everything downstream followed from that, not from its own defect:
+
+    [LearningDB] SQLite-first init timed out (15s) — the local path alone did
+    not finish. Cloud SQL was NOT the blocker; look at event-loop starvation.
+    [CapabilityRouter] 'unlock_screen' NOT authorised (I'm still loading my
+    voice recognition — give me a moment and ask again.)
+    [HUD] dropped a reply that waited 14.1s for the voice
+
+This module is the one seam that keeps that work off the loop.
+
+WHY A DEDICATED EXECUTOR AND NOT ``asyncio.to_thread``
+------------------------------------------------------
+``to_thread`` is already the house idiom (200+ call sites) and stays correct
+for ordinary blocking calls. It is the wrong tool for *imports*, twice over:
+
+1. It runs on asyncio's default executor, shared with every other blocking
+   call in the process and sized for short work. A 12s import parked there
+   starves unrelated callers.
+2. It does not address the actual cost. Moving an import to *some* thread
+   still leaves N threads racing for the same module locks. Funnelling every
+   deferred import through **one** worker serializes the graph, so the lock
+   contention that turned ~2s of work into a 12.38s wedge cannot form. The
+   imports are not slower for being serialized — they were already serialized
+   by the locks, just with the loop thread queued in among them.
+
+Imports and ordinary blocking calls get separate pools for the same reason: a
+long import must not delay a short secret fetch, and neither may borrow the
+default executor the rest of the codebase depends on.
+
+FAIL-OPEN, ALWAYS
+-----------------
+Every failure path here degrades to doing the work inline — exactly the
+behaviour that existed before this module. A helper whose job is to protect
+boot must never be the reason boot fails.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import atexit
+import importlib
+import logging
+import os
+import sys
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Callable, Optional, Tuple, TypeVar
+
+logger = logging.getLogger(__name__)
+
+_T = TypeVar("_T")
+
+# ── Environment surface (no hardcoded policy) ────────────────────────────────
+ENV_ENABLED = "JARVIS_ASYNC_OFFLOAD_ENABLED"
+ENV_IMPORT_WORKERS = "JARVIS_OFFLOAD_IMPORT_WORKERS"
+ENV_CALL_WORKERS = "JARVIS_OFFLOAD_CALL_WORKERS"
+ENV_SLOW_MS = "JARVIS_OFFLOAD_SLOW_MS"
+
+_DEFAULT_IMPORT_WORKERS = 1     # serialization is the point — see module docstring
+_DEFAULT_CALL_WORKERS = 4
+_DEFAULT_SLOW_MS = 250.0
+
+_POOL_LOCK = threading.Lock()
+_IMPORT_POOL: Optional[ThreadPoolExecutor] = None
+_CALL_POOL: Optional[ThreadPoolExecutor] = None
+
+# Set on threads owned by this module. A worker that re-enters must do the work
+# inline: with a single import worker, re-dispatching onto our own pool and
+# waiting for it is a self-deadlock.
+_local = threading.local()
+
+
+def _flag(env: os._Environ | dict, name: str, default: bool = True) -> bool:
+    """Only an explicit disabling value turns a protection off."""
+    raw = str(env.get(name, "")).strip().lower()
+    if not raw:
+        return default
+    return raw not in ("0", "false", "no", "off")
+
+
+def _positive_int(name: str, default: int) -> int:
+    """A malformed knob must not size a pool at zero and hang every caller."""
+    try:
+        value = int(str(os.environ.get(name, "")).strip())
+    except (TypeError, ValueError):
+        return default
+    return value if value > 0 else default
+
+
+def _slow_threshold_ms() -> float:
+    try:
+        value = float(str(os.environ.get(ENV_SLOW_MS, "")).strip())
+    except (TypeError, ValueError):
+        return _DEFAULT_SLOW_MS
+    return value if value > 0 else _DEFAULT_SLOW_MS
+
+
+def offload_enabled() -> bool:
+    """Master switch. Off ⇒ every call here degrades to inline execution."""
+    return _flag(os.environ, ENV_ENABLED, default=True)
+
+
+# ── Pools ────────────────────────────────────────────────────────────────────
+def _mark_owned() -> None:
+    _local.owned = True
+
+
+def _on_offload_thread() -> bool:
+    return getattr(_local, "owned", False)
+
+
+def _get_pool(kind: str) -> Optional[ThreadPoolExecutor]:
+    """
+    Lazily build a pool. Returns None if one cannot be created, which routes the
+    caller to the inline path rather than raising.
+    """
+    global _IMPORT_POOL, _CALL_POOL
+
+    existing = _IMPORT_POOL if kind == "import" else _CALL_POOL
+    if existing is not None:
+        return existing
+
+    with _POOL_LOCK:
+        existing = _IMPORT_POOL if kind == "import" else _CALL_POOL
+        if existing is not None:
+            return existing
+        try:
+            if kind == "import":
+                pool = ThreadPoolExecutor(
+                    max_workers=_positive_int(ENV_IMPORT_WORKERS, _DEFAULT_IMPORT_WORKERS),
+                    thread_name_prefix="jarvis-import",
+                    initializer=_mark_owned,
+                )
+                _IMPORT_POOL = pool
+            else:
+                pool = ThreadPoolExecutor(
+                    max_workers=_positive_int(ENV_CALL_WORKERS, _DEFAULT_CALL_WORKERS),
+                    thread_name_prefix="jarvis-offload",
+                    initializer=_mark_owned,
+                )
+                _CALL_POOL = pool
+            return pool
+        except Exception as exc:  # noqa: BLE001 - thread exhaustion, RLIMIT
+            logger.warning(
+                "[AsyncOffload] could not create %s pool (%s) — running inline; "
+                "the loop may stall on this work",
+                kind, exc,
+            )
+            return None
+
+
+def _shutdown_pools(wait: bool = False) -> None:
+    global _IMPORT_POOL, _CALL_POOL
+    with _POOL_LOCK:
+        pools = [p for p in (_IMPORT_POOL, _CALL_POOL) if p is not None]
+        _IMPORT_POOL = None
+        _CALL_POOL = None
+    for pool in pools:
+        try:
+            pool.shutdown(wait=wait)
+        except Exception:  # noqa: BLE001 - interpreter teardown
+            pass
+
+
+def _reset_after_fork() -> None:
+    """
+    A forked child inherits pool objects whose worker threads did not survive.
+    Submitting to one blocks forever. Drop them; the next call rebuilds.
+    """
+    global _IMPORT_POOL, _CALL_POOL
+    _IMPORT_POOL = None
+    _CALL_POOL = None
+    try:
+        _local.owned = False
+    except Exception:  # noqa: BLE001
+        pass
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_reset_after_fork)
+
+atexit.register(_shutdown_pools, False)
+
+
+# ── Import ───────────────────────────────────────────────────────────────────
+def _extract(module: Any, names: Tuple[str, ...]) -> Any:
+    """Mirror ``from X import a, b`` — module, one attribute, or a tuple."""
+    if not names:
+        return module
+    if len(names) == 1:
+        return getattr(module, names[0])
+    return tuple(getattr(module, n) for n in names)
+
+
+def _already_usable(dotted: str) -> Any:
+    """
+    Fast path for a module that is fully imported.
+
+    A module present in ``sys.modules`` may still be *mid-initialization* in
+    another thread, in which case its namespace is incomplete and returning it
+    hands out a half-built module. ``__spec__._initializing`` is exactly the
+    flag the import system uses to answer that, and is why a plain
+    ``sys.modules`` check is not sufficient.
+    """
+    module = sys.modules.get(dotted)
+    if module is None:
+        return None
+    spec = getattr(module, "__spec__", None)
+    if spec is not None and getattr(spec, "_initializing", False):
+        return None
+    return module
+
+
+def _timed_import(dotted: str) -> Any:
+    started = time.perf_counter()
+    module = importlib.import_module(dotted)
+    elapsed_ms = (time.perf_counter() - started) * 1000.0
+    if elapsed_ms >= _slow_threshold_ms():
+        logger.warning(
+            "[AsyncOffload] import %s took %.0fms off-loop — "
+            "the loop stayed responsive for it",
+            dotted, elapsed_ms,
+        )
+    return module
+
+
+async def import_off_loop(dotted: str, *names: str) -> Any:
+    """
+    ``from <dotted> import <names>`` without blocking the event loop.
+
+    Returns the module when no names are given, the attribute for one name, or
+    a tuple for several — so a call site converts without changing its shape.
+
+    Resolution order, cheapest first:
+      1. already imported and fully initialized → return inline, no thread hop
+      2. offload disabled, no pool, or already on an offload thread → inline
+      3. otherwise → the serialized import worker, awaited
+    """
+    ready = _already_usable(dotted)
+    if ready is not None:
+        return _extract(ready, names)
+
+    if not offload_enabled() or _on_offload_thread():
+        return _extract(_timed_import(dotted), names)
+
+    pool = _get_pool("import")
+    if pool is None:
+        return _extract(_timed_import(dotted), names)
+
+    loop = asyncio.get_running_loop()
+    try:
+        module = await loop.run_in_executor(pool, _timed_import, dotted)
+    except RuntimeError:
+        # Pool shut down underneath us (interpreter teardown, fork). The work
+        # still has to happen; correctness outranks the loop here.
+        module = _timed_import(dotted)
+    return _extract(module, names)
+
+
+# ── Arbitrary blocking calls ─────────────────────────────────────────────────
+async def call_off_loop(fn: Callable[..., _T], *args: Any, **kwargs: Any) -> _T:
+    """
+    Run a blocking synchronous callable without blocking the event loop.
+
+    For constructors and clients that do real I/O in ``__init__`` — the
+    measured case being ``SecretManagerServiceClient()``, which reaches
+    ``google.auth`` and shells out to ``gcloud`` via ``subprocess.check_output``
+    with no timeout (dump 3, 4.40s on the loop).
+
+    Uses a pool separate from asyncio's default executor so this can never
+    contend with the 200+ ``to_thread`` call sites already in the codebase.
+    """
+    if not offload_enabled() or _on_offload_thread():
+        return fn(*args, **kwargs)
+
+    pool = _get_pool("call")
+    if pool is None:
+        return fn(*args, **kwargs)
+
+    loop = asyncio.get_running_loop()
+    try:
+        return await loop.run_in_executor(pool, lambda: fn(*args, **kwargs))
+    except RuntimeError:
+        return fn(*args, **kwargs)
+
+
+__all__ = [
+    "ENV_ENABLED",
+    "ENV_IMPORT_WORKERS",
+    "ENV_CALL_WORKERS",
+    "ENV_SLOW_MS",
+    "call_off_loop",
+    "import_off_loop",
+    "offload_enabled",
+]

--- a/backend/core/ouroboros/governance/hud_governance_boot.py
+++ b/backend/core/ouroboros/governance/hud_governance_boot.py
@@ -9,6 +9,8 @@ If governance fails, HUD still serves API and CU tasks.
 import asyncio
 import logging
 import os
+
+from backend.core.async_offload import import_off_loop
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional
@@ -52,9 +54,12 @@ async def start_hud_governance(project_root: Path) -> HudGovernanceContext:
 
     # Step 1: GovernanceStack
     try:
-        from backend.core.ouroboros.governance.integration import (
-            GovernanceConfig,
-            create_governance_stack,
+        # Off-loop: this graph reaches semantic_guardian, whose module body was
+        # caught holding the loop for 2.34s on an import lock (stall dump 1).
+        GovernanceConfig, create_governance_stack = await import_off_loop(
+            "backend.core.ouroboros.governance.integration",
+            "GovernanceConfig",
+            "create_governance_stack",
         )
         _gov_config = GovernanceConfig.from_env_and_args(None)
         stack = await asyncio.wait_for(
@@ -73,9 +78,14 @@ async def start_hud_governance(project_root: Path) -> HudGovernanceContext:
 
     # Step 2: GovernedLoopService (Zone 6.8)
     try:
-        from backend.core.ouroboros.governance.governed_loop_service import (
-            GovernedLoopConfig,
-            GovernedLoopService,
+        # Off-loop: the worst measured stall in the process. This import pulls
+        # governed_loop_service:89 -> oracle.py:73 -> networkx, and blocked the
+        # loop for 12.38s waiting on a module lock a background thread already
+        # held (stall dump 2).
+        GovernedLoopConfig, GovernedLoopService = await import_off_loop(
+            "backend.core.ouroboros.governance.governed_loop_service",
+            "GovernedLoopConfig",
+            "GovernedLoopService",
         )
         _loop_config = GovernedLoopConfig.from_env(project_root=project_root)
 

--- a/backend/intelligence/cloud_database_adapter.py
+++ b/backend/intelligence/cloud_database_adapter.py
@@ -1417,7 +1417,13 @@ async def get_database_adapter() -> CloudDatabaseAdapter:
     # ── Initialise adapter (with timeout safety net) ──────────────────
     _init_timeout = float(os.getenv("JARVIS_DB_ADAPTER_INIT_TIMEOUT", "15.0"))
 
-    _adapter = CloudDatabaseAdapter()
+    # Off-loop: __init__ reaches secret_manager.get_db_password(), which builds a
+    # SecretManagerServiceClient; google.auth resolves the project by shelling out
+    # to `gcloud` via subprocess.check_output with no timeout. That held the loop
+    # for 4.40s (stall dump 3, 2026-08-06).
+    from backend.core.async_offload import call_off_loop
+
+    _adapter = await call_off_loop(CloudDatabaseAdapter)
 
     if _force_sqlite:
         # Bypass Cloud SQL entirely — direct SQLite init

--- a/backend/main.py
+++ b/backend/main.py
@@ -2795,8 +2795,11 @@ async def parallel_lifespan(app: FastAPI):
         # ── HUD Governance Boot (Sub-project E) ──────────────────────────
         if HUD_MODE and os.environ.get("JARVIS_HUD_GOVERNANCE_ENABLED", "1").strip().lower() not in ("0", "false", "no"):
             try:
-                from backend.core.ouroboros.governance.hud_governance_boot import (
-                    start_hud_governance,
+                from backend.core.async_offload import import_off_loop
+
+                start_hud_governance = await import_off_loop(
+                    "backend.core.ouroboros.governance.hud_governance_boot",
+                    "start_hud_governance",
                 )
                 app.state.hud_gov_ctx = await start_hud_governance(
                     project_root=Path.cwd(),

--- a/tests/hud/test_async_offload.py
+++ b/tests/hud/test_async_offload.py
@@ -1,0 +1,311 @@
+"""
+The loop must stay responsive while heavy boot work happens.
+
+These tests are written against the measured failure, not against the helper's
+API. From ``~/Library/Logs/JARVIS/loop-stalls.log`` on 2026-08-06, the main
+thread was found inside ``importlib._bootstrap._lock_unlock_module`` for 12.38s
+while a background thread held the module lock — availability 34%, worst stall
+16.33s, and every downstream symptom ("still loading my voice recognition",
+"dropped a reply that waited 14.1s") followed from it.
+
+So the load-bearing assertion is a *liveness* one: a heartbeat coroutine keeps
+ticking while the offloaded work runs. A test that only checked the return
+value would pass against the very code that caused the stall.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import threading
+import time
+import types
+
+import pytest
+
+from backend.core import async_offload
+from backend.core.async_offload import (
+    ENV_ENABLED,
+    ENV_IMPORT_WORKERS,
+    call_off_loop,
+    import_off_loop,
+    offload_enabled,
+)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_pools():
+    """Each test gets its own pools so worker counts don't leak between them."""
+    async_offload._reset_after_fork()
+    yield
+    async_offload._shutdown_pools(wait=False)
+    async_offload._reset_after_fork()
+
+
+# ── Liveness: the actual defect ──────────────────────────────────────────────
+async def _heartbeat(stop: asyncio.Event, ticks: list) -> None:
+    while not stop.is_set():
+        ticks.append(time.perf_counter())
+        await asyncio.sleep(0.01)
+
+
+@pytest.mark.asyncio
+async def test_loop_keeps_ticking_during_a_slow_blocking_call():
+    """
+    The regression, stated directly.
+
+    A 0.5s blocking call is a miniature of the 12.38s import. If it runs on the
+    loop thread the heartbeat records no ticks for its whole duration, which is
+    precisely what "JARVIS could not respond to anything during that window"
+    meant.
+    """
+    stop = asyncio.Event()
+    ticks: list = []
+    beat = asyncio.create_task(_heartbeat(stop, ticks))
+    await asyncio.sleep(0.02)
+
+    before = len(ticks)
+    await call_off_loop(time.sleep, 0.5)
+    during = len(ticks) - before
+
+    stop.set()
+    await beat
+
+    # ~50 ticks are possible; anything above a handful proves the loop ran.
+    assert during >= 10, (
+        f"loop only ticked {during} times across a 0.5s offloaded call — "
+        "the work is still on the loop thread"
+    )
+
+
+@pytest.mark.asyncio
+async def test_blocking_call_on_the_loop_would_fail_this_same_assertion():
+    """
+    Pins the test's own sensitivity.
+
+    If this control ever passes, the liveness test above has stopped measuring
+    anything and both must be re-read.
+    """
+    stop = asyncio.Event()
+    ticks: list = []
+    beat = asyncio.create_task(_heartbeat(stop, ticks))
+    await asyncio.sleep(0.02)
+
+    before = len(ticks)
+    time.sleep(0.5)                      # deliberately ON the loop
+    during = len(ticks) - before
+
+    stop.set()
+    await beat
+
+    assert during < 10, (
+        "a synchronous sleep on the loop produced heartbeats — the harness is "
+        "not measuring loop occupancy"
+    )
+
+
+@pytest.mark.asyncio
+async def test_import_runs_off_the_loop_thread():
+    """The import must not execute on the thread running the loop."""
+    loop_thread = threading.get_ident()
+    seen: dict = {}
+
+    name = "_jarvis_offload_probe_thread"
+    module = types.ModuleType(name)
+
+    real_import = async_offload.importlib.import_module
+
+    def _record(dotted):
+        if dotted == name:
+            seen["thread"] = threading.get_ident()
+            sys.modules[name] = module
+            return module
+        return real_import(dotted)
+
+    async_offload.importlib.import_module = _record
+    try:
+        got = await import_off_loop(name)
+    finally:
+        async_offload.importlib.import_module = real_import
+        sys.modules.pop(name, None)
+
+    assert got is module
+    assert seen["thread"] != loop_thread, "import ran on the event loop thread"
+
+
+# ── Shape parity with `from X import a, b` ───────────────────────────────────
+@pytest.mark.asyncio
+async def test_returns_module_attribute_or_tuple():
+    """A call site converts without changing shape, or conversions introduce bugs."""
+    mod = await import_off_loop("json")
+    assert mod.__name__ == "json"
+
+    dumps = await import_off_loop("json", "dumps")
+    assert dumps({"a": 1}) == '{"a": 1}'
+
+    dumps2, loads = await import_off_loop("json", "dumps", "loads")
+    assert loads(dumps2({"a": 1})) == {"a": 1}
+
+
+@pytest.mark.asyncio
+async def test_missing_attribute_still_raises_attributeerror():
+    """Failure modes must not change shape either."""
+    with pytest.raises(AttributeError):
+        await import_off_loop("json", "no_such_symbol")
+
+
+@pytest.mark.asyncio
+async def test_import_error_propagates():
+    with pytest.raises(ImportError):
+        await import_off_loop("jarvis_module_that_does_not_exist_xyz")
+
+
+# ── The half-built module trap ───────────────────────────────────────────────
+def test_module_mid_initialization_is_not_served_from_the_fast_path():
+    """
+    ``sys.modules`` membership is not proof a module is usable.
+
+    A module being imported by another thread is already in ``sys.modules`` with
+    a partially populated namespace — returning it hands out missing attributes.
+    ``__spec__._initializing`` is the flag the import system itself uses, and is
+    why a plain ``in sys.modules`` check would be wrong here. This is the exact
+    concurrent-import state the stall dumps captured.
+    """
+    name = "_jarvis_offload_probe_initializing"
+    module = types.ModuleType(name)
+    spec = types.SimpleNamespace(_initializing=True)
+    module.__spec__ = spec
+    sys.modules[name] = module
+    try:
+        assert async_offload._already_usable(name) is None, \
+            "a half-initialized module was served from the fast path"
+        spec._initializing = False
+        assert async_offload._already_usable(name) is module
+    finally:
+        sys.modules.pop(name, None)
+
+
+@pytest.mark.asyncio
+async def test_already_imported_module_skips_the_thread_hop():
+    """The common case must cost nothing — no dispatch for a resolved module."""
+    await import_off_loop("json")
+    calls: list = []
+    real = async_offload.importlib.import_module
+    async_offload.importlib.import_module = lambda d: (calls.append(d), real(d))[1]
+    try:
+        got = await import_off_loop("json", "dumps")
+    finally:
+        async_offload.importlib.import_module = real
+    assert got is not None
+    assert calls == [], "an already-imported module was re-dispatched to a thread"
+
+
+# ── Fail-open: this helper may never be the reason boot fails ────────────────
+@pytest.mark.asyncio
+async def test_disabled_master_switch_still_imports(monkeypatch):
+    monkeypatch.setenv(ENV_ENABLED, "false")
+    assert offload_enabled() is False
+    dumps = await import_off_loop("json", "dumps")
+    assert dumps({"a": 1}) == '{"a": 1}'
+
+
+@pytest.mark.asyncio
+async def test_unavailable_pool_degrades_to_inline(monkeypatch):
+    """No threads left is a reason to be slow, never a reason to fail."""
+    monkeypatch.setattr(async_offload, "_get_pool", lambda kind: None)
+    dumps = await import_off_loop("json", "dumps")
+    assert dumps({"a": 1}) == '{"a": 1}'
+    assert await call_off_loop(lambda: 7) == 7
+
+
+@pytest.mark.parametrize("value", ["0", "-4", "", "not-a-number", "abc"])
+def test_malformed_worker_count_never_sizes_a_pool_at_zero(monkeypatch, value):
+    """
+    A zero-worker pool accepts submissions and never runs them.
+
+    That converts a stall into a permanent hang, so a malformed knob must fall
+    back to the default rather than be honoured.
+    """
+    monkeypatch.setenv(ENV_IMPORT_WORKERS, value)
+    assert async_offload._positive_int(ENV_IMPORT_WORKERS, 1) == 1
+
+
+@pytest.mark.asyncio
+async def test_reentrant_call_from_an_offload_thread_runs_inline():
+    """
+    With a single import worker, a worker that re-dispatched onto its own pool
+    and waited would deadlock. Re-entrancy must resolve inline.
+    """
+    async_offload._local.owned = True
+    try:
+        assert async_offload._on_offload_thread() is True
+        dumps = await import_off_loop("json", "dumps")
+        assert dumps({"a": 1}) == '{"a": 1}'
+        assert await call_off_loop(lambda: 11) == 11
+    finally:
+        async_offload._local.owned = False
+
+
+@pytest.mark.asyncio
+async def test_call_off_loop_propagates_exceptions():
+    """Offloading must not swallow a failure — that would hide the next defect."""
+    def _boom():
+        raise ValueError("propagated")
+
+    with pytest.raises(ValueError, match="propagated"):
+        await call_off_loop(_boom)
+
+
+@pytest.mark.asyncio
+async def test_call_off_loop_forwards_arguments():
+    assert await call_off_loop(lambda a, b=0: a + b, 3, b=4) == 7
+
+
+def test_fork_reset_drops_inherited_pools():
+    """
+    A forked child inherits pool objects whose worker threads did not survive;
+    submitting to one blocks forever. The reset must clear both.
+    """
+    async_offload._get_pool("import")
+    async_offload._get_pool("call")
+    assert async_offload._IMPORT_POOL is not None
+    assert async_offload._CALL_POOL is not None
+
+    async_offload._reset_after_fork()
+
+    assert async_offload._IMPORT_POOL is None
+    assert async_offload._CALL_POOL is None
+
+
+# ── Wiring: an unused seam fixes nothing ─────────────────────────────────────
+def test_measured_stall_sites_actually_use_the_seam():
+    """
+    Guards the wired-but-inert trap.
+
+    Each path below is a stack the StallSampler caught holding the loop. If a
+    later edit reverts one to a plain import, the stall returns silently and
+    every test above still passes.
+    """
+    import ast
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[2]
+    sites = {
+        "backend/core/ouroboros/governance/hud_governance_boot.py": 2,  # dumps 1 + 2
+        "backend/main.py": 1,
+        "backend/intelligence/cloud_database_adapter.py": 1,            # dump 3
+    }
+
+    for rel, expected in sites.items():
+        tree = ast.parse((root / rel).read_text())
+        used = sum(
+            1
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id in ("import_off_loop", "call_off_loop")
+        )
+        assert used >= expected, (
+            f"{rel} calls the offload seam {used}x, expected >= {expected} — "
+            "a measured stall site was reverted to blocking-on-the-loop"
+        )


### PR DESCRIPTION
First run with recoverable stall dumps. Five captures — and the loop thread is in the same place in three of them.

```
dump 2 — 12.38s  importlib._bootstrap._lock_unlock_module
                 networkx/algorithms/regular.py <module>
                 <- oracle.py:73 <- governed_loop_service.py:89
                 <- hud_governance_boot.py:76 <- main.py parallel_lifespan
dump 1 —  2.34s  _get_module_lock.__enter__ <- semantic_guardian.py:1608
dump 4 —  2.06s  _path_stat under find_spec <- module_discovery.py:255
dump 3 —  4.40s  subprocess.communicate <- google.auth get_project_id
                 <- SecretManagerServiceClient() <- get_db_password
                 <- CloudDatabaseAdapter.__init__
```

**The loop was not doing that work.** In dump 2 it was *waiting on a module lock another thread already held.* Boot deliberately pushes heavy init onto background threads (`Debug tasks deferred to background for fast startup`), and one of those was midway through the scipy/sklearn graph. Dump 1 caught **four threads inside an import at once**.

Two optimizations were fighting over CPython's per-module import locks: "defer heavy init to a thread" and "lazy-import inside the coroutine." The loop lost. A module-lock wait runs no bytecode, blocks in C, and cannot be interrupted — `async def` around it buys nothing.

Availability 34%, worst stall 16.33s.

## Everything downstream was this

> `[LearningDB] SQLite-first init timed out (15s) — the local path alone did not finish. Cloud SQL was NOT the blocker; look at event-loop starvation.`

That message was written last session as a guess. **It was right.** The local SQLite path didn't finish because the loop was wedged in an import — which is why the voiceprint wasn't loaded, which is why:

```
[CapabilityRouter] 'unlock_screen' NOT authorised (I'm still loading my voice recognition…)
[HUD] dropped a reply that waited 14.1s for the voice
```

One root cause, three symptoms — including the dropped acknowledgments that made the operator repeat commands.

## The fix

`backend/core/async_offload.py` — one seam, two entry points.

`import_off_loop()` runs deferred imports on a dedicated **serialized** worker. Not `asyncio.to_thread`, for two reasons: it runs on asyncio's default executor, shared with 200+ call sites and sized for short work, so a 12s import parked there starves unrelated callers; and it doesn't address the actual cost, since moving an import to *some* thread still leaves N threads racing for the same locks. Funnelling every deferred import through one worker serializes the graph so the contention can't form. Nothing gets slower — the imports were already serialized by the locks, just with the loop queued in among them.

`call_off_loop()` covers blocking constructors, on its own pool so a long import can't delay a short secret fetch and neither borrows the default executor.

**Fast path:** a module already imported *and fully initialized* returns inline, no thread hop. `sys.modules` membership alone isn't sufficient — a module being imported by another thread is already there with a half-populated namespace, so `__spec__._initializing` is checked, the same flag the import system uses. That's the exact concurrent state these dumps captured.

**Fail-open everywhere:** master switch off, no pool (thread exhaustion), pool shut down mid-flight, re-entry from an offload thread (a self-deadlock on a single worker), fork — all degrade to inline execution. A helper whose job is to protect boot must never be why boot fails. Malformed worker counts fall back to the default rather than sizing a pool at zero, which would convert a stall into a permanent hang.

Wired at the four measured sites only. Not a codebase-wide sweep.

## Tests

20 new, asserting **liveness** rather than return values — a heartbeat coroutine must keep ticking across the offloaded work. A test checking only the returned object passes against the very code that caused the stall. A control test runs the same blocking call *on* the loop and asserts the heartbeat stops, so if the harness ever stops measuring occupancy both fail together.

An AST test pins the four call sites: revert one to a plain import and the stall returns silently while every other test still passes.

**284 green** (`tests/security` + `tests/hud`).

## Not claimed

**Unverified live.** The next boot's `loop-stalls.log` is the proof, and the remaining stall class (`module_discovery`'s `find_spec` storm) is untouched.

The biometric rejection is a **separate defect and survives this fix** — once the loop was calm the verdict became `That didn't sound like you`, with `no such column: embedding_json` and `no such column: speaker_name` still live. That's the next thread, not this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops event-loop starvation at boot by offloading imports and other blocking work to dedicated threads. Serializes deferred imports to avoid CPython module-lock contention and keeps the HUD responsive.

- **Bug Fixes**
  - Added `backend/core/async_offload.py` with `import_off_loop()` (single serialized worker) and `call_off_loop()` (separate pool).
  - Fast path returns modules only when fully initialized (checks `__spec__._initializing`); no thread hop for hot imports.
  - Fail-open behavior for disabled switch, no pool, shutdown, reentry, and fork; env knobs: `JARVIS_ASYNC_OFFLOAD_ENABLED`, `JARVIS_OFFLOAD_IMPORT_WORKERS`, `JARVIS_OFFLOAD_CALL_WORKERS`, `JARVIS_OFFLOAD_SLOW_MS`.
  - Wired at measured stall sites: `hud_governance_boot` (imports touching `semantic_guardian`/`networkx`), `main` (HUD boot), and `CloudDatabaseAdapter` init (avoids `google.auth` → `gcloud` subprocess on the loop).
  - Added liveness tests to ensure the loop keeps ticking during offloaded work; AST test guards these call sites.

<sup>Written for commit f9afe1c1107e4a30e7ed021fabf111bde398b0e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70425?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

