### PR TITLE
fix(voice): three copies of "LPC" that peak-picked rumble, and wrote it down

### DIFF
--- a/backend/intelligence/learning_database.py
+++ b/backend/intelligence/learning_database.py
@@ -70,7 +70,58 @@ except Exception:
     RobustFileLock = None  # type: ignore[assignment]
     ROBUST_FILE_LOCK_AVAILABLE = False
 
+# Biological bounds for the acoustic columns. Imported at module scope
+# deliberately: `biological_bounds` depends on nothing beyond the standard
+# library — no numpy, no torch, no scipy — so it adds no module-lock contention
+# to a boot path that PR #70425 had to rescue from exactly that.
+try:  # pragma: no cover - depends on which root is on sys.path
+    from backend.voice.biological_bounds import default_validator as _voice_bounds
+except ImportError:  # pragma: no cover
+    try:
+        from voice.biological_bounds import default_validator as _voice_bounds
+    except ImportError:
+        _voice_bounds = None  # type: ignore[assignment]
+
 logger = logging.getLogger(__name__)
+
+#: Columns of ``speaker_profiles`` that describe the voice itself. Only these
+#: are bounds-checked on read; identifiers, counters, blobs and timestamps are
+#: not measurements and have no physiological range.
+_ACOUSTIC_COLUMNS = (
+    "pitch_mean_hz", "pitch_std_hz", "pitch_range_hz", "pitch_min_hz", "pitch_max_hz",
+    "formant_f1_hz", "formant_f2_hz", "formant_f3_hz", "formant_f4_hz",
+    "spectral_centroid_hz", "spectral_rolloff_hz",
+    "speaking_rate_wpm", "speech_rate_wpm", "average_pitch_hz", "pause_ratio",
+    "jitter_percent", "shimmer_percent", "harmonic_to_noise_ratio_db",
+)
+
+
+def _sanitize_profile_acoustics(profile: Dict[str, Any]) -> List[str]:
+    """
+    NULL out every stored acoustic value that no human voice can produce.
+
+    Mutates ``profile`` in place and returns a description of each value
+    dropped, empty when the profile is clean.
+
+    Absent columns are left alone — a profile that never recorded a formant is
+    incomplete, not corrupt, and only a value that is *present* and impossible
+    means something wrote a fabrication. Returning NULL rather than deleting the
+    key matters: downstream readers use ``.get()`` and treat NULL as "abstain",
+    while a missing key would take a different branch in several of them.
+    """
+    if _voice_bounds is None:  # bounds module unavailable — do not guess
+        return []
+    validator = _voice_bounds()
+    dropped: List[str] = []
+    for column in _ACOUSTIC_COLUMNS:
+        if column not in profile or profile[column] is None:
+            continue
+        violation = validator.check(column, profile[column])
+        if violation is None:
+            continue
+        profile[column] = None
+        dropped.append(violation.describe())
+    return dropped
 
 # Canonicalize module identity so `intelligence.learning_database` and
 # `backend.intelligence.learning_database` share one singleton state.
@@ -7876,6 +7927,40 @@ class JARVISLearningDatabase:
                 if not has_embedding:
                     logger.debug(f"⏭️  Skipping profile '{profile['speaker_name']}' - no embedding (incomplete enrollment)")
                     continue
+
+                # THE READ GATE. Acoustic columns are validated against the
+                # biological bounds on their way OUT of the store, and anything
+                # impossible is returned as NULL.
+                #
+                # This sits here, at the one seam every stored profile crosses
+                # to reach the verifier, because the poison already on disk was
+                # written by four different code paths over months and a gate on
+                # any one writer would leave the other three. It is a read-side
+                # complement to the extractor gates, not a substitute: the
+                # extractors stop new fabrications being created, this stops
+                # existing ones being reasoned from, and the boot-time
+                # sanitiser (`voice_profile_sanitizer`) removes them for good.
+                #
+                # Measured on this machine 2026-08-06: formant_f1_hz = 42.9,
+                # formant_f2_hz = 80.03, speaking_rate_wpm = 420.0, all read
+                # back and compared against the operator's live voice.
+                dropped = _sanitize_profile_acoustics(profile)
+                if dropped:
+                    logger.warning(
+                        "🧪 Profile '%s': %d stored acoustic value(s) are "
+                        "biologically impossible and were read as NULL — %s. "
+                        "Re-enrolment will replace them.",
+                        profile.get('speaker_name'), len(dropped),
+                        "; ".join(dropped),
+                    )
+                    # Recompute: a profile whose only "acoustic features" were
+                    # the impossible ones has none, and must not be logged as
+                    # enhanced.
+                    has_acoustic = any([
+                        profile.get("pitch_mean_hz"),
+                        profile.get("formant_f1_hz"),
+                        profile.get("spectral_centroid_hz"),
+                    ])
 
                 if has_acoustic:
                     logger.debug(f"✅ Profile '{profile['speaker_name']}' has enhanced acoustic features")

--- a/backend/quick_voice_enhancement.py
+++ b/backend/quick_voice_enhancement.py
@@ -67,6 +67,7 @@ import asyncio
 import io
 import json
 import logging
+import math
 import sys
 import time
 from dataclasses import dataclass, field
@@ -82,7 +83,9 @@ import soundfile as sf
 sys.path.insert(0, str(Path(__file__).parent))
 
 from intelligence.learning_database import get_learning_database
+from voice.biological_bounds import UNMEASURED, MeasuredAggregator, default_validator
 from voice.engines.speechbrain_engine import SpeechBrainEngine
+from voice.formant_estimation import estimate_formants
 from voice.stt_config import ModelConfig, STTEngine
 
 # Configure logging with colors
@@ -91,6 +94,14 @@ logging.basicConfig(
     format="%(message)s",
 )
 logger = logging.getLogger(__name__)
+
+_VALIDATOR = default_validator()
+
+# Reductions that skip samples nothing measured. Shared with enroll_voice via
+# biological_bounds rather than reimplemented here — the two enrolment paths
+# writing to the same columns with different ideas of how to average them is
+# how the columns disagreed in the first place.
+_agg = MeasuredAggregator(_VALIDATOR)
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -705,39 +716,31 @@ class AdvancedVoiceAnalyzer:
             return {'mean': 150.0, 'std': 20.0, 'range': 50.0, 'median': 150.0}
 
     def _analyze_formants_lpc(self, audio: np.ndarray) -> List[float]:
-        """Formant estimation using Linear Predictive Coding (simplified)"""
-        # Use spectral peaks as formant estimates
-        fft = np.fft.rfft(audio)
-        magnitude = np.abs(fft)
-        freqs = np.fft.rfftfreq(len(audio), 1 / self.sample_rate)
+        """
+        Formant estimation by linear prediction.
 
-        # Apply pre-emphasis
-        emphasized = np.append(audio[0], audio[1:] - 0.97 * audio[:-1])
-        fft_emph = np.fft.rfft(emphasized)
-        magnitude_emph = np.abs(fft_emph)
+        THIS FUNCTION WROTE THE PROFILE ON THIS MACHINE. Despite the name it
+        contained no linear prediction at all — it peak-picked the magnitude
+        spectrum and took ``peaks[:4]``, the four LOWEST peaks by frequency,
+        which in a desk recording are DC offset, mains hum and low harmonics.
+        The four values it stored for the operator were 42.9, 80.0, 102.8 and
+        107.4 Hz: an ascending run of rumble, every one of them below the F1 of
+        any human being.
 
-        # Find peaks in formant regions
-        from scipy.signal import find_peaks
+        It failed three further ways, all now gone:
 
-        peaks, properties = find_peaks(
-            magnitude_emph,
-            height=np.max(magnitude_emph) * 0.15,
-            distance=30
-        )
+          * ``[500, 1500, 2500, 3500]`` on fewer than four peaks — the textbook
+            male average, written into a specific speaker's profile;
+          * ``formants[-1] + 1000.0`` padding, inventing a resonance from the
+            previous invented resonance;
+          * silence about all of it, so the profile looked complete.
 
-        if len(peaks) >= 4:
-            # Take first 4 peaks as F1-F4
-            peak_freqs = freqs[peaks[:4]]
-            formants = [float(f) for f in peak_freqs]
-        else:
-            # Default formants (male voice)
-            formants = [500.0, 1500.0, 2500.0, 3500.0]
-
-        # Ensure we have exactly 4 formants
-        while len(formants) < 4:
-            formants.append(formants[-1] + 1000.0 if formants else 500.0)
-
-        return formants[:4]
+        It is the third copy of this same defect (with ``enroll_voice`` and
+        ``advanced_feature_extraction``); all three now call one estimator that
+        fits an all-pole model to voiced frames and reports UNMEASURED for any
+        formant it cannot resolve.
+        """
+        return estimate_formants(audio, self.sample_rate, n_formants=4)
 
     def _analyze_spectral_features(self, audio: np.ndarray) -> Dict[str, float]:
         """Comprehensive spectral feature extraction"""
@@ -771,10 +774,21 @@ class AdvancedVoiceAnalyzer:
         zero_crossings = np.sum(np.abs(np.diff(np.sign(audio)))) / 2
         zcr = zero_crossings / len(audio)
 
-        # Estimate speech rate (words per minute)
+        # Estimate speech rate (words per minute).
+        #
+        # With no transcription this used to yield 0.0 — a speaker who said
+        # nothing, stored as one who speaks at zero words per minute and then
+        # differenced against the live speaker. With a short clip it yields an
+        # arbitrarily high figure; 7 words over 1.0 s is exactly the 420 wpm in
+        # this machine's profile. Neither is a measurement of how fast this
+        # person speaks, so neither is reported as one.
         duration_seconds = len(audio) / self.sample_rate
         word_count = len(transcription.split()) if transcription else 0
-        speech_rate = (word_count / duration_seconds) * 60 if duration_seconds > 0 else 0.0
+        if word_count == 0 or duration_seconds <= 0:
+            speech_rate = UNMEASURED
+        else:
+            speech_rate = _VALIDATOR.coerce(
+                'speaking_rate_wpm', (word_count / duration_seconds) * 60)
 
         # Pause ratio (estimate from energy)
         frame_size = self.sample_rate // 20
@@ -1350,72 +1364,113 @@ class QuickVoiceEnhancement:
             spectral_centroids.append(vc.spectral_centroid_hz)
             spectral_rolloffs.append(vc.spectral_rolloff_hz)
             spectral_fluxes.append(vc.spectral_flux)
-            spectral_entropies.append(getattr(vc, 'spectral_entropy', 0.5))  # Default if missing
+            spectral_entropies.append(getattr(vc, 'spectral_entropy', UNMEASURED))
 
             # Temporal
             speaking_rates.append(vc.speech_rate_wpm)
             pause_ratios.append(vc.pause_ratio)
 
-            # Voice quality (use sample quality metrics if not in VoiceCharacteristics)
-            jitters.append(getattr(vc, 'jitter', 0.01))  # Default 1%
-            shimmers.append(getattr(vc, 'shimmer', 0.05))  # Default 5%
-            hnrs.append(getattr(vc, 'harmonic_to_noise_ratio', 15.0))  # Default 15 dB
+            # Voice quality.
+            #
+            # These defaults were 0.01 / 0.05 / 15.0 — "1%", "5%", "15 dB", a
+            # healthy adult voice, substituted whenever the attribute was
+            # ABSENT. Multiplied by 100 on the way to the database below, they
+            # are exactly the 1.0 and 5.0 sitting in this machine's profile, and
+            # the 15.0 HNR beside them. A missing attribute became a clean bill
+            # of vocal health for a sample nobody had analysed.
+            #
+            # UNMEASURED instead. `_agg.mean` drops it, and if no sample
+            # carried the attribute the column is written NULL rather than
+            # describing a voice that was never measured.
+            jitters.append(getattr(vc, 'jitter', UNMEASURED))
+            shimmers.append(getattr(vc, 'shimmer', UNMEASURED))
+            hnrs.append(getattr(vc, 'harmonic_to_noise_ratio', UNMEASURED))
 
             # Energy
             energies.append(vc.rms_energy)
 
-        # Compute aggregate statistics
+        # Compute aggregate statistics.
+        #
+        # Every reduction below goes through _agg, which averages only the
+        # samples that were actually measured. Two failure modes it removes:
+        # a single NaN sample used to make the whole column NaN via np.mean,
+        # discarding nineteen good samples; and an out-of-band value used to be
+        # averaged in at full weight, dragging the enrolled figure toward a
+        # number no vocal tract produces. A quantity with nothing measurable
+        # left comes out UNMEASURED and is written NULL.
+        flatness = [getattr(s.voice_characteristics, 'spectral_flatness',
+                            s.quality_metrics.spectral_flatness)
+                    for s in self.samples]
+        mean_rate = _agg.mean('speaking_rate_wpm', speaking_rates)
+        mean_pause = _agg.mean('pause_ratio', pause_ratios)
+
         features = {
             # Pitch features
-            'pitch_mean_hz': float(np.mean(pitch_means)),
-            'pitch_std_hz': float(np.std(pitch_means)),
-            'pitch_range_hz': float(np.mean(pitch_ranges)),
-            'pitch_min_hz': float(np.min(pitch_means)),
-            'pitch_max_hz': float(np.max(pitch_means)),
+            'pitch_mean_hz': _agg.mean('pitch_mean_hz', pitch_means),
+            'pitch_std_hz': _agg.std('pitch_mean_hz', pitch_means),
+            'pitch_range_hz': _agg.mean('pitch_range_hz', pitch_ranges),
+            'pitch_min_hz': _agg.min('pitch_mean_hz', pitch_means),
+            'pitch_max_hz': _agg.max('pitch_mean_hz', pitch_means),
 
             # Formant features (mean and variance across samples)
-            'formant_f1_hz': float(np.mean(formant_f1s)),
-            'formant_f1_std': float(np.std(formant_f1s)),
-            'formant_f2_hz': float(np.mean(formant_f2s)),
-            'formant_f2_std': float(np.std(formant_f2s)),
-            'formant_f3_hz': float(np.mean(formant_f3s)),
-            'formant_f3_std': float(np.std(formant_f3s)),
-            'formant_f4_hz': float(np.mean(formant_f4s)),
-            'formant_f4_std': float(np.std(formant_f4s)),
+            'formant_f1_hz': _agg.mean('formant_f1_hz', formant_f1s),
+            'formant_f1_std': _agg.std('formant_f1_hz', formant_f1s),
+            'formant_f2_hz': _agg.mean('formant_f2_hz', formant_f2s),
+            'formant_f2_std': _agg.std('formant_f2_hz', formant_f2s),
+            'formant_f3_hz': _agg.mean('formant_f3_hz', formant_f3s),
+            'formant_f3_std': _agg.std('formant_f3_hz', formant_f3s),
+            'formant_f4_hz': _agg.mean('formant_f4_hz', formant_f4s),
+            'formant_f4_std': _agg.std('formant_f4_hz', formant_f4s),
 
             # Spectral features
-            'spectral_centroid_hz': float(np.mean(spectral_centroids)),
-            'spectral_centroid_std': float(np.std(spectral_centroids)),
-            'spectral_rolloff_hz': float(np.mean(spectral_rolloffs)),
-            'spectral_rolloff_std': float(np.std(spectral_rolloffs)),
-            'spectral_flux': float(np.mean(spectral_fluxes)),
-            'spectral_flux_std': float(np.std(spectral_fluxes)),
-            'spectral_entropy': float(np.mean(spectral_entropies)),
-            'spectral_entropy_std': float(np.std(spectral_entropies)),
-            'spectral_flatness': float(np.mean([getattr(s.voice_characteristics, 'spectral_flatness', s.quality_metrics.spectral_flatness) for s in self.samples])),
-            'spectral_bandwidth_hz': float(np.std(spectral_centroids) * 2),  # Approximate bandwidth
+            'spectral_centroid_hz': _agg.mean('spectral_centroid_hz', spectral_centroids),
+            'spectral_centroid_std': _agg.std('spectral_centroid_hz', spectral_centroids),
+            'spectral_rolloff_hz': _agg.mean('spectral_rolloff_hz', spectral_rolloffs),
+            'spectral_rolloff_std': _agg.std('spectral_rolloff_hz', spectral_rolloffs),
+            'spectral_flux': _agg.mean('spectral_flux', spectral_fluxes),
+            'spectral_flux_std': _agg.std('spectral_flux', spectral_fluxes),
+            'spectral_entropy': _agg.mean('spectral_entropy', spectral_entropies),
+            'spectral_entropy_std': _agg.std('spectral_entropy', spectral_entropies),
+            'spectral_flatness': _agg.mean('spectral_flatness', flatness),
+            'spectral_bandwidth_hz': _agg.std('spectral_centroid_hz', spectral_centroids) * 2,
 
             # Temporal features
-            'speaking_rate_wpm': float(np.mean(speaking_rates)),
-            'speaking_rate_std': float(np.std(speaking_rates)),
-            'pause_ratio': float(np.mean(pause_ratios)),
-            'pause_ratio_std': float(np.std(pause_ratios)),
-            'syllable_rate': float(np.mean(speaking_rates) / 60.0 * 2.5),  # Approximate syllables
-            'articulation_rate': float(np.mean(speaking_rates) / (1.0 - np.mean(pause_ratios)) if np.mean(pause_ratios) < 1.0 else 0.0),
+            'speaking_rate_wpm': mean_rate,
+            'speaking_rate_std': _agg.std('speaking_rate_wpm', speaking_rates),
+            'pause_ratio': mean_pause,
+            'pause_ratio_std': _agg.std('pause_ratio', pause_ratios),
+            # Derived from the rate, so they inherit its absence rather than
+            # computing a syllable count from a speaking rate nobody measured.
+            'syllable_rate': mean_rate / 60.0 * 2.5,
+            'articulation_rate': (mean_rate / (1.0 - mean_pause)
+                                  if math.isfinite(mean_pause) and mean_pause < 1.0
+                                  else UNMEASURED),
 
             # Energy features
-            'energy_mean': float(np.mean(energies)),
-            'energy_std': float(np.std(energies)),
-            'energy_dynamic_range_db': float(20 * np.log10((np.max(energies) / (np.min(energies) + 1e-10)) + 1e-10)),
+            'energy_mean': _agg.mean('energy_mean', energies),
+            'energy_std': _agg.std('energy_mean', energies),
+            'energy_dynamic_range_db': _agg.dynamic_range_db(energies),
 
-            # Voice quality features
-            'jitter_percent': float(np.mean(jitters) * 100),
-            'jitter_std': float(np.std(jitters) * 100),
-            'shimmer_percent': float(np.mean(shimmers) * 100),
-            'shimmer_std': float(np.std(shimmers) * 100),
-            'harmonic_to_noise_ratio_db': float(np.mean(hnrs)),
-            'hnr_std': float(np.std(hnrs)),
+            # Voice quality features. The *100 makes these PERCENT, which is why
+            # `jitter_percent` carries a different band from the in-memory
+            # `jitter` fraction — see biological_bounds.BOUNDS.
+            'jitter_percent': _agg.mean('jitter', jitters) * 100,
+            'jitter_std': _agg.std('jitter', jitters) * 100,
+            'shimmer_percent': _agg.mean('shimmer', shimmers) * 100,
+            'shimmer_std': _agg.std('shimmer', shimmers) * 100,
+            'harmonic_to_noise_ratio_db': _agg.mean('harmonic_to_noise_ratio_db', hnrs),
+            'hnr_std': _agg.std('harmonic_to_noise_ratio_db', hnrs),
         }
+
+        # THE WRITE GATE. Last stop before these become a stored profile that
+        # every future verification is judged against: anything outside its
+        # biological band is written NULL rather than compared against for
+        # months. NaN is converted to None here too — SQLite would happily
+        # store a NaN, and it would read back as a float that no `IS NULL`
+        # check catches.
+        sanitized = _VALIDATOR.sanitize(features, label="enrolled profile")
+        features = {k: (None if isinstance(v, float) and not math.isfinite(v) else v)
+                    for k, v in sanitized.clean.items()}
 
         # Compute covariance matrix for Mahalanobis distance
         # Extract feature vectors for covariance computation

--- a/backend/voice/advanced_biometric_verification.py
+++ b/backend/voice/advanced_biometric_verification.py
@@ -42,6 +42,20 @@ try:
 except ImportError:
     _HAS_MANAGED_EXECUTOR = False
 
+# The measurability bands and the one ``is this a measurement`` predicate.
+#
+# This module is imported both as ``backend.voice.…`` and as ``voice.…``
+# depending on which root is on sys.path — the same reason the executor import
+# above is guarded. ``biological_bounds`` and ``embedding_ops`` pull in nothing
+# heavier than numpy, so neither costs this path the SpeechBrain import it is
+# careful to avoid.
+try:  # pragma: no cover - exercised by whichever root the process happens to use
+    from backend.voice.biological_bounds import BOUNDS, is_measured
+    from backend.voice.embedding_ops import coerce_vector
+except ImportError:  # pragma: no cover
+    from voice.biological_bounds import BOUNDS, is_measured
+    from voice.embedding_ops import coerce_vector
+
 logger = logging.getLogger(__name__)
 
 # Shared thread pool for CPU-intensive biometric computations
@@ -180,15 +194,36 @@ class PhysicsConstraints:
     # speech is 110-180) and formants of 42.9 Hz / 80.0 Hz (F1 is ~500 Hz, F2
     # ~1500 Hz — these are off by an order of magnitude and are not formants).
     # Compared against, they made the operator's own voice look synthetic.
-    min_formant_f1_hz: float = 150.0
-    max_formant_f1_hz: float = 1200.0
-    min_formant_f2_hz: float = 500.0
-    max_formant_f2_hz: float = 3500.0
-    min_speaking_rate_wpm: float = 40.0
-    max_speaking_rate_wpm: float = 300.0
-    min_pitch_std_hz: float = 0.5
-    max_pitch_std_hz: float = 200.0
-    max_hnr_db: float = 45.0
+    #
+    # The numbers live in ``biological_bounds.BOUNDS``, which is also what the
+    # *extractors* gate on before writing. Sourcing the defaults from there
+    # rather than restating them is what keeps the write side and the read side
+    # from drifting into two different opinions of "possible" — the enrolled
+    # 420 wpm passed the writer precisely because the writer had no opinion.
+    # The env override namespace is unchanged and unified: each band has exactly
+    # one knob, ``JARVIS_VOICE_PHYSICS_{MIN,MAX}_<NAME>``, honoured identically
+    # by ``from_env`` below and by ``BiologicalBoundsValidator.from_env``.
+    min_formant_f1_hz: float = BOUNDS["formant_f1_hz"].low
+    max_formant_f1_hz: float = BOUNDS["formant_f1_hz"].high
+    min_formant_f2_hz: float = BOUNDS["formant_f2_hz"].low
+    max_formant_f2_hz: float = BOUNDS["formant_f2_hz"].high
+    min_speaking_rate_wpm: float = BOUNDS["speaking_rate_wpm"].low
+    max_speaking_rate_wpm: float = BOUNDS["speaking_rate_wpm"].high
+    min_pitch_std_hz: float = BOUNDS["pitch_std_hz"].low
+    max_pitch_std_hz: float = BOUNDS["pitch_std_hz"].high
+    max_hnr_db: float = BOUNDS["harmonic_to_noise_ratio_db"].high
+
+    # Measurability floor for HNR, distinct from ``min_hnr_db`` above.
+    #
+    # ``min_hnr_db`` (5.0) is a *plausibility* threshold — below it a voice
+    # scores poorly on the harmonic check. Using it as the measurability gate
+    # too, as the first version of this did, means a genuinely noisy but
+    # perfectly real 3 dB capture reads as "never measured" and the check
+    # abstains instead of scoring the evidence it has. The two bands answer
+    # different questions and must be two fields.
+    min_hnr_db_measurable: float = BOUNDS["harmonic_to_noise_ratio_db"].low
+    min_pitch_hz_measurable: float = BOUNDS["pitch_mean_hz"].low
+    max_pitch_hz_measurable: float = BOUNDS["pitch_mean_hz"].high
 
     @classmethod
     def from_env(cls, env: Optional[Mapping[str, str]] = None) -> "PhysicsConstraints":
@@ -223,23 +258,18 @@ class PhysicsConstraints:
         """
         True when ``value`` is a real measurement inside its plausible band.
 
-        ``None``, non-numeric, non-finite, and out-of-band all read as NOT
-        measured. Zero is excluded by every band below, which is deliberate:
-        an unset float field defaults to 0.0, and 0 Hz is not a formant.
+        ``None``, NaN, infinity, non-numeric and out-of-band all read as NOT
+        measured. Zero is excluded by every band below, which is deliberate: an
+        unset float field defaults to 0.0, and 0 Hz is not a formant.
 
-        The type check is strict on purpose. ``float("500")`` succeeds, so a
-        permissive version accepts a feature field holding a *string* — but a
-        numeric field that arrived as text was not produced by the measurement
-        path, and quietly parsing it is the same leniency that let unset zeros
-        become spoofing findings. ``bool`` is excluded explicitly because it is
-        a subclass of ``int``, and ``float(True)`` is 1.0 — a silent 1 Hz.
+        This is a thin delegate to ``biological_bounds.is_measured``, which is
+        the one predicate the extractors, the anti-spoofing stage and the
+        plausibility scorer all share. It stays here because callers hold a
+        ``PhysicsConstraints`` and their bands live on it; it must not grow a
+        second implementation, or the write side and the read side can once
+        again disagree about what "measured" means.
         """
-        if isinstance(value, bool) or not isinstance(value, (int, float)):
-            return False
-        numeric = float(value)
-        if not math.isfinite(numeric):
-            return False
-        return low <= numeric <= high
+        return is_measured(value, low, high)
 
 
 @dataclass
@@ -265,6 +295,55 @@ class SpoofingAssessment:
         fired = ", ".join(f"{n}:{p}" for n, p in self.indicators) or "none"
         skipped = ", ".join(self.abstained) or "none"
         return f"score={self.score:.2f} fired=[{fired}] abstained=[{skipped}]"
+
+
+@dataclass
+class PlausibilityAssessment:
+    """
+    What the physics stage scored, and what it could not look at.
+
+    The twin of :class:`SpoofingAssessment`, deliberately the same shape: both
+    stages read raw features, both can be handed quantities nothing measured,
+    and both previously turned that into a confident number. Keeping the two
+    result types symmetric is what stops one of them being fixed and the other
+    quietly regressing — which is exactly what happened between #70426 and this
+    change.
+
+    ``score`` alone cannot distinguish "I checked and every component passed"
+    from "I could not check anything", so the components that ran are kept by
+    name alongside the ones that abstained.
+    """
+
+    score: float = 1.0
+    components: Dict[str, float] = field(default_factory=dict)
+    abstained: List[str] = field(default_factory=list)
+
+    @property
+    def evidence_complete(self) -> bool:
+        return not self.abstained
+
+    def finalize(self) -> "PlausibilityAssessment":
+        """
+        Set ``score`` to the mean of the components that actually ran.
+
+        With no component measurable the score is 1.0 — NEUTRAL, not zero. This
+        stage is a veto on impossible voices; with no evidence it must veto
+        nothing and say so via ``abstained``. Scoring 0.0 here would convert a
+        broken feature extractor into a rejection of the speaker, which is the
+        precise defect this change exists to remove. The fused verdict is not
+        thereby weakened: the embedding comparison is the primary gate and a
+        failed one already scores 0.0 on its own.
+        """
+        if self.components:
+            self.score = float(np.clip(np.mean(list(self.components.values())), 0.0, 1.0))
+        else:
+            self.score = 1.0
+        return self
+
+    def describe(self) -> str:
+        ran = ", ".join(f"{n}:{v:.2f}" for n, v in self.components.items()) or "none"
+        skipped = ", ".join(self.abstained) or "none"
+        return f"score={self.score:.2f} scored=[{ran}] abstained=[{skipped}]"
 
 
 @dataclass
@@ -435,10 +514,21 @@ class AdvancedBiometricVerifier:
         # neutral 0.5 would carry a FAILED comparison into the fused score as
         # though it were a middling match. A fault must not become a verdict —
         # the same defect this chain has produced at every other layer.
-        embedding_sim = results[0] if not isinstance(results[0], Exception) else 0.0
-        mahal_distance = results[1] if not isinstance(results[1], Exception) else 0.5
-        acoustic_score = results[2] if not isinstance(results[2], Exception) else 0.5
-        physics_score = results[3] if not isinstance(results[3], Exception) else 0.8
+        embedding_sim = float(results[0]) if not isinstance(results[0], BaseException) else 0.0
+        mahal_distance = float(results[1]) if not isinstance(results[1], BaseException) else 0.5
+        acoustic_score = float(results[2]) if not isinstance(results[2], BaseException) else 0.5
+
+        # Physics returns an assessment, not a bare number: the score alone
+        # cannot say which components were unmeasurable, and that distinction is
+        # the whole point of the stage. A raised exception yields an assessment
+        # that abstained on everything — neutral score, evidence incomplete —
+        # rather than the old bare 0.8, which was a fabricated near-pass.
+        if isinstance(results[3], BaseException):
+            physics = PlausibilityAssessment(
+                abstained=[f"stage_failed({type(results[3]).__name__})"]).finalize()
+        else:
+            physics = results[3]
+        physics_score = physics.score
 
         # Log any exceptions
         for i, r in enumerate(results):
@@ -513,6 +603,14 @@ class AdvancedBiometricVerifier:
             warnings.append(f"High uncertainty ({uncertainty:.1%})")
         if physics_score < 0.7:
             warnings.append("Voice physics constraints violated")
+        if not physics.evidence_complete:
+            # Symmetric with the anti-spoofing warning below, and for the same
+            # reason: a plausibility score reached by skipping components is not
+            # the same claim as one reached by passing them.
+            warnings.append(
+                f"Physics evidence incomplete: {len(physics.abstained)} "
+                f"component(s) abstained ({'; '.join(physics.abstained)})"
+            )
         if spoofing_score < 0.8:
             warnings.append("Spoofing indicators detected")
         if not spoof.evidence_complete:
@@ -586,33 +684,20 @@ class AdvancedBiometricVerifier:
     def _as_similarity_vector(embedding) -> "Optional[np.ndarray]":
         """Coerce an embedding to a flat float32 vector, or None.
 
-        Mirrors `SpeechBrainEngine._as_host_vector`. The duplication is REAL and
-        deliberate rather than hidden: that method lives on the engine class,
-        and importing it here would pull the whole SpeechBrain module — torch,
-        speechbrain, model registry — into a verification path that otherwise
-        needs none of it, on a process already starved for event-loop time.
+        This used to re-implement `SpeechBrainEngine._as_host_vector` here, on
+        the argument that importing the engine would pull torch, speechbrain and
+        the model registry into a verification path that needs none of them. The
+        argument was sound; the conclusion — copy the coercion — was not, and it
+        is why a `list` (the one form `get_all_speaker_profiles` actually
+        returns) fell through every branch of the third copy on 2026-08-06.
 
-        The honest resolution is a shared `voice/embedding_ops` module that both
-        import, which is a refactor of two call sites in two layers and is named
-        here as follow-up rather than done unverified at the end of a long
-        session.
-
-        dtype and device are representation differences and are cast. Shape is
-        not, and is the caller's to reject.
+        The follow-up this docstring named is now done: `voice/embedding_ops`
+        exists, costs nothing but numpy, and is the single answer all three
+        layers call. dtype and device are representation differences and are
+        cast; shape is not, and remains the caller's to reject — which is why
+        this asks for no `expected_dim`.
         """
-        try:
-            if embedding is None:
-                return None
-            if hasattr(embedding, "detach") and hasattr(embedding, "cpu"):
-                embedding = embedding.detach().cpu().numpy()
-            vec = np.asarray(embedding)
-            if vec.size == 0:
-                return None
-            return vec.flatten().astype(np.float32, copy=False)
-        except Exception as exc:  # noqa: BLE001 — never raise into a verdict
-            logger.error("Embedding coercion failed (%s: %s)",
-                         type(exc).__name__, exc)
-            return None
+        return coerce_vector(embedding)
 
     def _compute_embedding_similarity_sync(
         self,
@@ -630,9 +715,13 @@ class AdvancedBiometricVerifier:
         #
         # measured 2026-08-06 23:22:17. The function assumed 1-D vectors and
         # never enforced it; ECAPA emits (1, 192) and SQLite returns (192,).
-        test_emb = self._as_similarity_vector(test_emb)
-        enrolled_emb = self._as_similarity_vector(enrolled_emb)
-        if test_emb is None or enrolled_emb is None:
+        # Bound to new names rather than reassigned: the parameters are declared
+        # non-optional, and rebinding them to an Optional makes a type checker
+        # treat the None guard below as dead code — a warning that would sit in
+        # the file forever right next to the guard it wrongly indicts.
+        test_vec = self._as_similarity_vector(test_emb)
+        enrolled_vec = self._as_similarity_vector(enrolled_emb)
+        if test_vec is None or enrolled_vec is None:
             logger.error(
                 "Embedding similarity: an embedding could not be coerced to a "
                 "vector — refusing to score"
@@ -642,26 +731,26 @@ class AdvancedBiometricVerifier:
         # A 192D voiceprint against a differently-shaped vector is NOT a weak
         # match, it is not a comparison. Computing anyway would produce a
         # plausible number for arithmetic that never validly happened.
-        if test_emb.shape[0] != enrolled_emb.shape[0]:
+        if test_vec.shape[0] != enrolled_vec.shape[0]:
             logger.error(
                 "Embedding similarity: ShapeMismatch %dD vs %dD — the live "
                 "embedding came from a different encoder than the enrolled "
                 "voiceprint. Refusing to score.",
-                test_emb.shape[0], enrolled_emb.shape[0],
+                test_vec.shape[0], enrolled_vec.shape[0],
             )
             return 0.0
 
         # Cosine similarity (fast, baseline)
-        test_norm = np.linalg.norm(test_emb)
-        enrolled_norm = np.linalg.norm(enrolled_emb)
+        test_norm = np.linalg.norm(test_vec)
+        enrolled_norm = np.linalg.norm(enrolled_vec)
 
         if test_norm == 0 or enrolled_norm == 0:
             return 0.0
 
-        cosine_sim = np.dot(test_emb, enrolled_emb) / (test_norm * enrolled_norm)
+        cosine_sim = np.dot(test_vec, enrolled_vec) / (test_norm * enrolled_norm)
 
         # Euclidean distance (normalized)
-        euclidean_dist = np.linalg.norm(test_emb - enrolled_emb)
+        euclidean_dist = np.linalg.norm(test_vec - enrolled_vec)
         euclidean_sim = 1.0 / (1.0 + euclidean_dist)
 
         # Weighted combination (learned)
@@ -776,7 +865,7 @@ class AdvancedBiometricVerifier:
     async def _check_physics_plausibility(
         self,
         features: VoiceBiometricFeatures
-    ) -> float:
+    ) -> "PlausibilityAssessment":
         """Check if voice features are physically plausible (thread pool)."""
         return await self._run_in_executor(
             self._check_physics_plausibility_sync,
@@ -786,59 +875,134 @@ class AdvancedBiometricVerifier:
     def _check_physics_plausibility_sync(
         self,
         features: VoiceBiometricFeatures
-    ) -> float:
-        """Sync physics plausibility check."""
-        plausibility_scores = []
+    ) -> "PlausibilityAssessment":
+        """
+        Sync physics plausibility check — a component scores only on a measurement.
 
-        # 1. Pitch range check
-        if self.physics.min_pitch_male <= features.pitch_mean <= self.physics.max_pitch_female:
-            pitch_plausibility = 1.0
-        else:
-            if features.pitch_mean < self.physics.min_pitch_male:
-                deviation = (self.physics.min_pitch_male - features.pitch_mean) / self.physics.min_pitch_male
+        This is the anti-spoofing stage's twin, and carried the identical defect
+        after that one was fixed. Every component below reads a feature and
+        compares it to a threshold; the comparison is arithmetically valid even
+        when nothing measured the feature, which is exactly the trap:
+
+          * an unset 0.0 formant gives ``0.0 / max(0.0, 1.0) = 0.0``, falls
+            outside the F1/F2 ratio band, and scores that component **0.5**;
+          * an unset 0.0 HNR gives ``0.0 / 5.0`` and scores it **0.0**.
+
+        Two of five components pinned low by quantities nobody looked at, then
+        averaged. On 2026-08-06 that produced ``physics_score < 0.7`` and the
+        warning "Voice physics constraints violated" alongside the spoofing
+        finding, against the enrolled operator's own voice.
+
+        So each component is gated on its input being *measurable*, and a
+        component whose input was not measured ABSTAINS: it is excluded from the
+        mean entirely rather than contributing a low score, and it is recorded
+        by name. Excluding rather than substituting a neutral 1.0 matters — a
+        neutral value still dilutes a genuine finding from a component that did
+        run, which would weaken the check exactly when evidence is thinnest.
+
+        Measurability is not typicality, and the two bands are deliberately
+        different. ``pitch_mean`` is *measurable* over 50-500 Hz while the
+        typical band scored here is 85-255 Hz: a genuine 260 Hz speaker is a
+        real measurement that scores below 1.0, not missing evidence. Narrowing
+        the first band to the second would silently discard real speakers, and
+        widening the second to the first would stop the check discriminating.
+
+        Abstaining costs nothing in security terms. Physics plausibility is a
+        veto on *impossible* voices, not a proxy for extractor health, and the
+        primary gate is untouched: a failed embedding comparison already scores
+        0.0 and cannot be rescued here.
+        """
+        physics = self.physics
+        assessment = PlausibilityAssessment()
+
+        def scores(name: str, value: float) -> None:
+            assessment.components[name] = float(np.clip(value, 0.0, 1.0))
+
+        def abstain(name: str, why: str) -> None:
+            assessment.abstained.append(f"{name}({why})")
+
+        # 1. Pitch — typical-range scoring, gated on a measurable f0.
+        if physics.measured(features.pitch_mean,
+                            physics.min_pitch_hz_measurable,
+                            physics.max_pitch_hz_measurable):
+            if physics.min_pitch_male <= features.pitch_mean <= physics.max_pitch_female:
+                scores("pitch", 1.0)
+            elif features.pitch_mean < physics.min_pitch_male:
+                deviation = (physics.min_pitch_male - features.pitch_mean) / physics.min_pitch_male
+                scores("pitch", float(np.exp(-deviation * 5.0)))
             else:
-                deviation = (features.pitch_mean - self.physics.max_pitch_female) / self.physics.max_pitch_female
-            pitch_plausibility = np.exp(-deviation * 5.0)
-
-        plausibility_scores.append(pitch_plausibility)
-
-        # 2. Formant relationship check
-        f1_f2_ratio = features.formant_f1 / max(features.formant_f2, 1.0)
-
-        if self.physics.f1_f2_min_ratio <= f1_f2_ratio <= self.physics.f1_f2_max_ratio:
-            formant_plausibility = 1.0
+                deviation = (features.pitch_mean - physics.max_pitch_female) / physics.max_pitch_female
+                scores("pitch", float(np.exp(-deviation * 5.0)))
         else:
-            formant_plausibility = 0.5
+            abstain("pitch", "pitch_mean unmeasured")
 
-        plausibility_scores.append(formant_plausibility)
-
-        # 3. Harmonic-to-Noise Ratio check
-        if features.harmonic_to_noise_ratio >= self.physics.min_hnr_db:
-            hnr_plausibility = 1.0
+        # 2. Formant relationship — needs BOTH formants, and the ratio is only
+        #    meaningful when each is a formant. The old ``max(f2, 1.0)`` guard
+        #    protected the division and nothing else: it turned an unmeasured
+        #    pair into the well-defined, entirely fictional ratio 0.0.
+        f1_ok = physics.measured(features.formant_f1,
+                                 physics.min_formant_f1_hz, physics.max_formant_f1_hz)
+        f2_ok = physics.measured(features.formant_f2,
+                                 physics.min_formant_f2_hz, physics.max_formant_f2_hz)
+        if f1_ok and f2_ok:
+            ratio = features.formant_f1 / features.formant_f2
+            in_band = physics.f1_f2_min_ratio <= ratio <= physics.f1_f2_max_ratio
+            scores("formants", 1.0 if in_band else 0.5)
         else:
-            hnr_plausibility = features.harmonic_to_noise_ratio / self.physics.min_hnr_db
+            missing = "F1" if not f1_ok else ""
+            missing += ("+" if missing and not f2_ok else "") + ("F2" if not f2_ok else "")
+            abstain("formants", f"{missing} outside human range")
 
-        plausibility_scores.append(hnr_plausibility)
-
-        # 4. Jitter check
-        if features.jitter <= self.physics.max_jitter:
-            jitter_plausibility = 1.0
+        # 3. Harmonic-to-Noise Ratio — measurability floor, not the plausibility
+        #    floor. A real 3 dB capture is noisy evidence, not absent evidence.
+        if physics.measured(features.harmonic_to_noise_ratio,
+                            physics.min_hnr_db_measurable, physics.max_hnr_db):
+            hnr = features.harmonic_to_noise_ratio
+            if hnr >= physics.min_hnr_db:
+                scores("hnr", 1.0)
+            else:
+                # Below the plausibility floor the score falls off toward zero.
+                # ``max(min_hnr_db, ε)`` guards a zeroed override, not a missing
+                # measurement — that case abstained above.
+                scores("hnr", hnr / max(physics.min_hnr_db, 1e-6))
         else:
-            jitter_plausibility = self.physics.max_jitter / features.jitter
+            abstain("hnr", "harmonic_to_noise_ratio unmeasured")
 
-        plausibility_scores.append(jitter_plausibility)
-
-        # 5. Shimmer check
-        if features.shimmer <= self.physics.max_shimmer:
-            shimmer_plausibility = 1.0
+        # 4/5. Jitter and shimmer — perturbation fractions. Zero IS a legitimate
+        #      reading here (a perfectly steady synthetic tone is 0.0 jitter and
+        #      that is a finding), so these bands admit it and only a non-finite
+        #      or out-of-range value abstains.
+        jitter_bound = BOUNDS["jitter"]
+        if physics.measured(features.jitter, jitter_bound.low, jitter_bound.high):
+            if features.jitter <= physics.max_jitter:
+                scores("jitter", 1.0)
+            else:
+                scores("jitter", physics.max_jitter / features.jitter)
         else:
-            shimmer_plausibility = self.physics.max_shimmer / features.shimmer
+            abstain("jitter", "jitter unmeasured")
 
-        plausibility_scores.append(shimmer_plausibility)
+        shimmer_bound = BOUNDS["shimmer"]
+        if physics.measured(features.shimmer, shimmer_bound.low, shimmer_bound.high):
+            if features.shimmer <= physics.max_shimmer:
+                scores("shimmer", 1.0)
+            else:
+                scores("shimmer", physics.max_shimmer / features.shimmer)
+        else:
+            abstain("shimmer", "shimmer unmeasured")
 
-        plausibility = np.mean(plausibility_scores)
+        assessment.finalize()
 
-        return float(np.clip(plausibility, 0.0, 1.0))
+        if assessment.abstained:
+            # Never silent. A plausibility score obtained by not looking is not
+            # a plausibility score, and the operator is entitled to know which
+            # components did not run.
+            logger.warning(
+                "[Physics] %d component(s) ABSTAINED — inputs were not "
+                "measurable, so they were excluded from the mean rather than "
+                "scored: %s", len(assessment.abstained), assessment.describe(),
+            )
+
+        return assessment
 
     async def _detect_spoofing(
         self,

--- a/backend/voice/advanced_feature_extraction.py
+++ b/backend/voice/advanced_feature_extraction.py
@@ -34,7 +34,19 @@ try:
 except ImportError:
     _HAS_MANAGED_EXECUTOR = False
 
+# The bounds gate and the one formant estimator. Guarded the same way as the
+# executor import above because this module is reached under both roots.
+try:  # pragma: no cover - depends on which root is on sys.path
+    from backend.voice.biological_bounds import BOUNDS, UNMEASURED, default_validator
+    from backend.voice.formant_estimation import estimate_formants
+except ImportError:  # pragma: no cover
+    from voice.biological_bounds import BOUNDS, UNMEASURED, default_validator
+    from voice.formant_estimation import estimate_formants
+
 logger = logging.getLogger(__name__)
+
+_VALIDATOR = default_validator()
+_HNR_BAND = BOUNDS["harmonic_to_noise_ratio_db"]
 
 # Shared thread pool for CPU-intensive feature extraction
 # Using a dedicated pool prevents blocking the main event loop
@@ -118,48 +130,82 @@ class AdvancedFeatureExtractor:
 
         pitch_features, formants, spectral_features, temporal_features, quality_features = results
 
-        # Handle any exceptions with safe defaults
-        if isinstance(pitch_features, Exception):
-            logger.warning(f"Pitch extraction failed: {pitch_features}")
-            pitch_features = {'mean': 150.0, 'std': 20.0, 'range': 50.0}
+        # A stage that raised produced NO measurement. It used to produce a
+        # textbook one — pitch 150/20/50, formants [500, 1500, 2500, 3500],
+        # jitter 0.01, shimmer 0.05, HNR 15.0 — which is an average adult male
+        # voice, emitted from a failure path, carrying the units and the type of
+        # real data and nothing to mark it apart from real data. Compared
+        # against an enrolled profile it is a confident statement about a voice
+        # that was never analysed.
+        #
+        # Every substitute below is UNMEASURED instead, and the failure is
+        # logged at WARNING with the exception type so a persistently broken
+        # stage is visible rather than inferred from a suspiciously average
+        # profile months later.
+        if isinstance(pitch_features, BaseException):
+            logger.warning("[Features] pitch stage failed (%s: %s) — pitch unmeasured",
+                           type(pitch_features).__name__, pitch_features)
+            pitch_features = {'mean': UNMEASURED, 'std': UNMEASURED, 'range': UNMEASURED}
 
-        if isinstance(formants, Exception):
-            logger.warning(f"Formant extraction failed: {formants}")
-            formants = [500.0, 1500.0, 2500.0, 3500.0]
+        if isinstance(formants, BaseException):
+            logger.warning("[Features] formant stage failed (%s: %s) — formants unmeasured",
+                           type(formants).__name__, formants)
+            formants = [UNMEASURED] * 4
 
-        if isinstance(spectral_features, Exception):
-            logger.warning(f"Spectral extraction failed: {spectral_features}")
-            spectral_features = {'centroid': 1000.0, 'rolloff': 2000.0, 'flux': 0.1, 'entropy': 0.5}
+        if isinstance(spectral_features, BaseException):
+            logger.warning("[Features] spectral stage failed (%s: %s) — spectra unmeasured",
+                           type(spectral_features).__name__, spectral_features)
+            spectral_features = {'centroid': UNMEASURED, 'rolloff': UNMEASURED,
+                                 'flux': UNMEASURED, 'entropy': UNMEASURED}
 
-        if isinstance(temporal_features, Exception):
-            logger.warning(f"Temporal extraction failed: {temporal_features}")
-            temporal_features = {'rate': 0.0, 'pause_ratio': 0.3, 'energy': np.zeros(100)}
+        if isinstance(temporal_features, BaseException):
+            logger.warning("[Features] temporal stage failed (%s: %s) — rate unmeasured",
+                           type(temporal_features).__name__, temporal_features)
+            temporal_features = {'rate': UNMEASURED, 'pause_ratio': UNMEASURED,
+                                 'energy': np.zeros(0)}
 
-        if isinstance(quality_features, Exception):
-            logger.warning(f"Quality extraction failed: {quality_features}")
-            quality_features = {'jitter': 0.01, 'shimmer': 0.05, 'hnr': 15.0}
+        if isinstance(quality_features, BaseException):
+            logger.warning("[Features] quality stage failed (%s: %s) — jitter/shimmer/HNR unmeasured",
+                           type(quality_features).__name__, quality_features)
+            quality_features = {'jitter': UNMEASURED, 'shimmer': UNMEASURED, 'hnr': UNMEASURED}
 
-        # Create feature object
+        # Formant lists shorter than 4 are padded with absence, never with the
+        # next textbook value, so positional indexing below stays safe.
+        formants = list(formants) + [UNMEASURED] * max(0, 4 - len(formants))
+
+        # THE GATE. Every DSP scalar crosses the biological bounds on its way
+        # into the feature object, so a value that no human vocal tract can
+        # produce becomes UNMEASURED here rather than being stored, compared
+        # against, and eventually reported as a spoofing indicator.
+        #
+        # It is deliberately applied at the assembly point rather than inside
+        # each extractor: this is the single seam every feature passes through,
+        # so a stage added later is gated by construction instead of by its
+        # author remembering to. The extractors above ALSO refuse to fabricate,
+        # which is not redundancy — they catch what a band cannot, namely a
+        # value that is unmeasured yet physically legal (an unset 0.0 jitter
+        # sits squarely inside its band and would sail through this gate).
+        measure = _VALIDATOR.coerce
         features = VoiceBiometricFeatures(
             embedding=embedding,
             embedding_confidence=0.9,
-            pitch_mean=pitch_features['mean'],
-            pitch_std=pitch_features['std'],
-            pitch_range=pitch_features['range'],
-            formant_f1=formants[0],
-            formant_f2=formants[1],
-            formant_f3=formants[2],
-            formant_f4=formants[3],
-            spectral_centroid=spectral_features['centroid'],
-            spectral_rolloff=spectral_features['rolloff'],
+            pitch_mean=measure('pitch_mean_hz', pitch_features['mean']),
+            pitch_std=measure('pitch_std_hz', pitch_features['std']),
+            pitch_range=measure('pitch_range_hz', pitch_features['range']),
+            formant_f1=measure('formant_f1_hz', formants[0]),
+            formant_f2=measure('formant_f2_hz', formants[1]),
+            formant_f3=measure('formant_f3_hz', formants[2]),
+            formant_f4=measure('formant_f4_hz', formants[3]),
+            spectral_centroid=measure('spectral_centroid_hz', spectral_features['centroid']),
+            spectral_rolloff=measure('spectral_rolloff_hz', spectral_features['rolloff']),
             spectral_flux=spectral_features['flux'],
             spectral_entropy=spectral_features['entropy'],
-            speaking_rate=temporal_features['rate'],
-            pause_ratio=temporal_features['pause_ratio'],
+            speaking_rate=measure('speaking_rate_wpm', temporal_features['rate']),
+            pause_ratio=measure('pause_ratio', temporal_features['pause_ratio']),
             energy_contour=temporal_features['energy'],
-            jitter=quality_features['jitter'],
-            shimmer=quality_features['shimmer'],
-            harmonic_to_noise_ratio=quality_features['hnr'],
+            jitter=measure('jitter', quality_features['jitter']),
+            shimmer=measure('shimmer', quality_features['shimmer']),
+            harmonic_to_noise_ratio=measure('harmonic_to_noise_ratio_db', quality_features['hnr']),
             duration_seconds=len(audio_np) / self.sample_rate,
             sample_rate=self.sample_rate
         )
@@ -226,34 +272,36 @@ class AdvancedFeatureExtractor:
                 'std': float(np.std(pitches)),
                 'range': float(np.max(pitches) - np.min(pitches))
             }
-        else:
-            return {'mean': 150.0, 'std': 20.0, 'range': 50.0}
+
+        # No frame produced a periodic peak: this recording has no trackable f0.
+        # It used to return {'mean': 150.0, 'std': 20.0, 'range': 50.0} — an
+        # invented average male voice, indistinguishable downstream from a
+        # measured one, and scored against the enrolled speaker as if real.
+        logger.warning(
+            "[Features] no voiced frame yielded a pitch period across %d "
+            "samples — reporting pitch unmeasured", len(audio),
+        )
+        return {'mean': UNMEASURED, 'std': UNMEASURED, 'range': UNMEASURED}
 
     def _extract_formants_sync(self, audio: np.ndarray) -> list:
-        """Extract formant frequencies using LPC (CPU-intensive)."""
-        try:
-            # Pre-emphasis
-            emphasized = np.append(audio[0], audio[1:] - 0.97 * audio[:-1])
+        """
+        Extract formant frequencies using LPC (CPU-intensive).
 
-            # FFT
-            fft = np.fft.rfft(emphasized)
-            magnitude = np.abs(fft)
-            freqs = np.fft.rfftfreq(len(audio), 1 / self.sample_rate)
+        This function used to claim LPC and perform spectral peak-picking: it
+        took ``find_peaks`` over the whole-utterance magnitude spectrum and
+        returned ``freqs[peaks[:4]]`` — the four LOWEST peaks by frequency,
+        which in any real recording are DC offset, mains hum and f0 harmonics.
+        Its sibling in ``enroll_voice`` did the same and wrote the result to
+        this machine's profile: F1 = 42.9 Hz, F2 = 80.0 Hz.
 
-            # Find peaks
-            from scipy.signal import find_peaks
-            peaks, _ = find_peaks(magnitude, height=np.max(magnitude) * 0.1, distance=20)
-
-            if len(peaks) >= 4:
-                formants = [float(freqs[p]) for p in peaks[:4]]
-            else:
-                formants = [500.0, 1500.0, 2500.0, 3500.0]
-
-            return formants
-
-        except Exception as e:
-            logger.debug(f"Formant extraction failed: {e}")
-            return [500.0, 1500.0, 2500.0, 3500.0]
+        Both are now the one estimator in ``voice/formant_estimation``, which
+        fits an all-pole model per voiced frame and reads the pole angles. The
+        constants that used to be returned on failure are gone: an unresolvable
+        formant is NaN, because ``[500, 1500, 2500, 3500]`` is the textbook male
+        average and writing it into a specific speaker's profile as though it
+        had been measured is the defect, not the mitigation.
+        """
+        return estimate_formants(audio, self.sample_rate, n_formants=4)
 
     def _extract_spectral_features_sync(self, audio: np.ndarray) -> dict:
         """Extract spectral features (CPU-intensive FFT operations)."""
@@ -289,9 +337,37 @@ class AdvancedFeatureExtractor:
         """Extract temporal features (CPU-intensive)."""
         duration = len(audio) / self.sample_rate
 
-        # Speaking rate (words per minute)
+        # Speaking rate (words per minute).
+        #
+        # This is where 420 wpm came from. Two ways, both of which used to be
+        # reported as a rate:
+        #
+        #   * No transcription. ``word_count`` is 0, the rate is 0.0 wpm, and a
+        #     speaker who said nothing is stored as one who speaks at zero words
+        #     per minute — then differenced against the live speaker and found
+        #     to be inconsistent. Callers that pass ``transcription=""`` (the
+        #     acoustic-only path in ``speaker_verification_service``) hit this
+        #     on every single sample.
+        #   * A short clip. Words counted over a window trimmed to the speech
+        #     segment divides by a duration far smaller than the utterance took,
+        #     and 7 words over 1.0 s is exactly 420 wpm.
+        #
+        # Neither is a measurement of how fast this person speaks, so neither is
+        # reported as one. The band check catches the second case; only the
+        # explicit absence check can catch the first, because 0.0 is a perfectly
+        # well-formed float that no downstream consumer can distinguish from a
+        # measurement.
         word_count = len(transcription.split()) if transcription else 0
-        speaking_rate = (word_count / duration) * 60 if duration > 0 else 0.0
+        if word_count == 0 or duration <= 0:
+            logger.debug(
+                "[Features] speaking rate needs words and a duration "
+                "(words=%d, duration=%.2fs) — reporting unmeasured",
+                word_count, duration,
+            )
+            speaking_rate = UNMEASURED
+        else:
+            speaking_rate = _VALIDATOR.coerce(
+                "speaking_rate_wpm", (word_count / duration) * 60)
 
         # Energy contour (frame-based)
         frame_size = self.sample_rate // 20
@@ -369,12 +445,23 @@ class AdvancedFeatureExtractor:
             if len(periods) > 1:
                 diffs = np.abs(np.diff(periods))
                 jitter = np.mean(diffs) / np.mean(periods)
-                return min(jitter, 0.1)
+                return float(min(jitter, 0.1))
 
-            return 0.01
+            # Jitter is a cycle-TO-CYCLE ratio; with fewer than two periods
+            # there is no pair to compare. The 0.01 this used to return is a
+            # healthy-voice value, so an unanalysable recording scored as a
+            # clean one — and unlike the formants, 0.01 is inside the plausible
+            # band, so no downstream gate can catch it. Only the extractor can.
+            logger.warning(
+                "[Features] jitter needs 2+ pitch periods, found %d — "
+                "reporting unmeasured", len(periods),
+            )
+            return UNMEASURED
 
-        except Exception:
-            return 0.01
+        except Exception as exc:  # noqa: BLE001 — a failed measurement is not a value
+            logger.warning("[Features] jitter computation failed (%s: %s) — "
+                           "reporting unmeasured", type(exc).__name__, exc)
+            return UNMEASURED
 
     def _compute_shimmer_sync(self, audio: np.ndarray) -> float:
         """Compute shimmer (amplitude variation)."""
@@ -389,14 +476,28 @@ class AdvancedFeatureExtractor:
                 peaks.append(peak)
 
             if len(peaks) > 1:
+                mean_peak = float(np.mean(peaks))
+                if mean_peak <= 0:
+                    # Every frame peaked at zero: silence, not a steady voice.
+                    # The +1e-10 guard below used to turn this into shimmer 0.0,
+                    # a perfect score for a recording with no signal in it.
+                    logger.warning("[Features] shimmer: all frames are silent — "
+                                   "reporting unmeasured")
+                    return UNMEASURED
                 diffs = np.abs(np.diff(peaks))
-                shimmer = np.mean(diffs) / (np.mean(peaks) + 1e-10)
-                return min(shimmer, 0.5)
+                shimmer = np.mean(diffs) / mean_peak
+                return float(min(shimmer, 0.5))
 
-            return 0.05
+            logger.warning(
+                "[Features] shimmer needs 2+ frames, found %d — reporting "
+                "unmeasured", len(peaks),
+            )
+            return UNMEASURED
 
-        except Exception:
-            return 0.05
+        except Exception as exc:  # noqa: BLE001 — a failed measurement is not a value
+            logger.warning("[Features] shimmer computation failed (%s: %s) — "
+                           "reporting unmeasured", type(exc).__name__, exc)
+            return UNMEASURED
 
     def _compute_hnr_sync(self, audio: np.ndarray) -> float:
         """Compute Harmonic-to-Noise Ratio.
@@ -424,19 +525,39 @@ class AdvancedFeatureExtractor:
                     peak_value = correlation[peak_idx]
 
                     noise_floor = np.median(correlation[min_lag:max_lag])
-                    hnr_linear = peak_value / (noise_floor + 1e-10)
-                    hnr_db = 10 * np.log10(hnr_linear + 1e-10)
+                    if noise_floor <= 0:
+                        logger.warning("[Features] HNR: no positive noise floor "
+                                       "— reporting unmeasured")
+                        return UNMEASURED
+                    hnr_linear = peak_value / noise_floor
+                    if hnr_linear <= 0:
+                        return UNMEASURED
+                    hnr_db = 10 * np.log10(hnr_linear)
 
-                    # Handle NaN (can occur with noise-only audio)
-                    if np.isnan(hnr_db):
-                        return 15.0
+                    # NaN here means the arithmetic could not be completed — it
+                    # used to become 15.0, a healthy-voice HNR, on exactly the
+                    # noise-only audio the comment names. Keep it as NaN.
+                    if not np.isfinite(hnr_db):
+                        logger.warning("[Features] HNR is not finite — "
+                                       "reporting unmeasured")
+                        return UNMEASURED
 
-                    return float(np.clip(hnr_db, 0.0, 40.0))
+                    # Clipped to the measurable band rather than to [0, 40]: the
+                    # old lower clip at 0.0 silently converted every negative
+                    # HNR (noise louder than harmonics — a real, informative
+                    # reading) into the boundary value.
+                    return float(np.clip(hnr_db, _HNR_BAND.low, _HNR_BAND.high))
 
-            return 15.0
+            logger.warning(
+                "[Features] HNR: no usable autocorrelation lag in %d samples — "
+                "reporting unmeasured", len(audio),
+            )
+            return UNMEASURED
 
-        except Exception:
-            return 15.0
+        except Exception as exc:  # noqa: BLE001 — a failed measurement is not a value
+            logger.warning("[Features] HNR computation failed (%s: %s) — "
+                           "reporting unmeasured", type(exc).__name__, exc)
+            return UNMEASURED
 
 
 def shutdown_feature_executor():

--- a/backend/voice/biological_bounds.py
+++ b/backend/voice/biological_bounds.py
@@ -1,0 +1,645 @@
+"""
+One place that decides whether a number is a measurement of a human voice.
+
+WHY THIS EXISTS
+---------------
+On 2026-08-06 the operator's own voice was rejected by his own profile::
+
+    ⚠️  Spoofing indicators detected:
+        [('unnatural_formants', 0.5), ('inconsistent_rate', 0.2)]
+    ⚠️  Warnings: High uncertainty (53.9%), Voice physics constraints violated
+    [CapabilityRouter] 'unlock_screen' NOT authorised (That didn't sound like you)
+
+Neither indicator was a measurement. ``speaker_profiles`` on that machine held::
+
+    speaking_rate_wpm = 420.0     # no human sustains 420 wpm; speech is 110-180
+    formant_f1_hz     = 42.9      # F1 is ~500 Hz
+    formant_f2_hz     = 80.03     # F2 is ~1500 Hz
+
+PR #70426 taught the *anti-spoofing* stage to abstain on inputs like these. That
+is a downstream mitigation: it stops the system reasoning from the garbage, it
+does not stop the garbage being written. Two extractors were producing it:
+
+  * ``enroll_voice._analyze_formants`` took peaks of the whole-utterance FFT **in
+    frequency order** and called the first two F1/F2. At 16 kHz over a
+    multi-second sample the bin spacing is sub-Hz and ``distance=20`` bins is
+    ~4 Hz, so "the first two peaks" are DC-adjacent rumble — 42.9 Hz and
+    80.0 Hz, precisely the values found on disk. On failure it returned a
+    hardcoded ``(500.0, 1500.0)``.
+  * ``advanced_feature_extraction.extract_features`` substituted textbook
+    constants for every stage that raised — ``formants = [500, 1500, 2500,
+    3500]``, ``pitch = 150/20/50``, ``hnr = 15.0``. A failure, wearing the
+    units of a measurement.
+
+Both are the arc's recurring defect: **a fault presented as a verdict.** The
+answer is the same at every layer — say "I could not measure this", in a form
+no downstream consumer can mistake for a value.
+
+MEASURABILITY IS NOT PLAUSIBILITY
+---------------------------------
+These two bands are different and conflating them would disable the biometric:
+
+  * A **measurability** band (this module) is the range a quantity occupies
+    across *all* humans, generously drawn. Outside it, no human produced the
+    number: the extractor failed, the unit is not the one declared, or the field
+    was never filled in. Such a value carries no information and must be dropped.
+  * A **plausibility** band (``PhysicsConstraints``' scoring thresholds) is the
+    range a *typical* voice occupies. Inside the measurability band but outside
+    this one is a real measurement of an unusual voice — evidence, to be scored,
+    possibly penalised. Never dropped.
+
+So ``pitch_mean_hz`` is measurable over 50-500 Hz while the scorer's typical band
+is 85-255 Hz. Narrowing the first to the second would silently discard genuine
+high-pitched speakers instead of scoring them.
+
+THE TWO ABSENCE VALUES, AND WHY THERE ARE TWO
+---------------------------------------------
+  * ``None`` at the dict/database layer. SQL NULL is the store's own word for
+    "no value", and every reader here already treats NULL as absent.
+  * ``UNMEASURED`` (NaN) in ``float``-typed dataclass fields, where ``None``
+    would be a type violation rippling through a dozen call sites. NaN is the
+    IEEE encoding of exactly this fact, it is rejected by ``is_measured``, and
+    it is loud: it propagates through arithmetic instead of averaging in as a
+    plausible zero the way ``0.0`` does.
+
+``0.0`` is never used for absence. That substitution is the original bug: an
+unset 0.0 formant gives a ratio of 0.0, trips ``< 0.1``, and lands a confident
+0.5 spoofing penalty on a voice nobody looked at.
+
+Never raises. A validator that throws on a security path converts missing
+evidence into an outage, and the caller learns nothing either way.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import os
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "UNMEASURED",
+    "Bound",
+    "BOUNDS",
+    "bound_for",
+    "canonical_name",
+    "is_measured",
+    "is_absent",
+    "BiologicalBoundsValidator",
+    "MeasuredAggregator",
+    "SanitizeResult",
+    "Violation",
+    "default_validator",
+]
+
+
+#: The in-memory "this was not measured" float. NaN, not 0.0 — see module docs.
+UNMEASURED = float("nan")
+
+
+@dataclass(frozen=True)
+class Bound:
+    """
+    The range a quantity occupies in real human speech, and why.
+
+    ``low``/``high`` are inclusive. ``why`` is carried so a drop can explain
+    itself in a log line without the reader going to find this table.
+    """
+
+    name: str
+    low: float
+    high: float
+    unit: str
+    why: str
+
+    @property
+    def min_env(self) -> str:
+        return f"JARVIS_VOICE_PHYSICS_MIN_{self.name.upper()}"
+
+    @property
+    def max_env(self) -> str:
+        return f"JARVIS_VOICE_PHYSICS_MAX_{self.name.upper()}"
+
+    def contains(self, value: float) -> bool:
+        return self.low <= value <= self.high
+
+    def describe(self) -> str:
+        return f"{self.low:g}-{self.high:g} {self.unit}"
+
+
+def _b(name: str, low: float, high: float, unit: str, why: str) -> Tuple[str, Bound]:
+    return name, Bound(name=name, low=low, high=high, unit=unit, why=why)
+
+
+#: Canonical quantity -> measurability band.
+#:
+#: Only quantities with a *physiological* range appear here. A quantity with no
+#: principled bound (energy, spectral flux, an embedding norm) is deliberately
+#: absent: the validator then checks only that the value is a finite number and
+#: passes it through, rather than inventing a limit to enforce. Adding a bound is
+#: how a new quantity opts in; nothing needs to be edited elsewhere.
+BOUNDS: Dict[str, Bound] = dict([
+    _b("pitch_mean_hz", 50.0, 500.0, "Hz",
+       "human f0 spans ~50 Hz (deep male creak) to ~500 Hz (child); "
+       "outside this is not a pitch track"),
+    # The 0.5 Hz floor is measurability, not typicality: a tracker that reports
+    # zero spread across a whole utterance did not track anything. Genuinely
+    # monotone delivery still lands above it and is scored, not dropped — that
+    # is what the ``low_pitch_variation`` synthesis indicator is for.
+    #
+    # KNOWN TRADE-OFF, chosen deliberately. The pitch extractor now emits NaN
+    # when no frame yielded a period, so it CAN distinguish "unset" from "a
+    # measured spread of exactly 0.0" — which means this floor could drop to 0.0
+    # and let a perfectly flat synthetic voice fire ``low_pitch_variation``
+    # instead of abstaining. It stays at 0.5 because profiles written by the old
+    # extractors are still on disk holding 0.0 as an unset default, and lowering
+    # the floor would turn each of those into a 0.4 spoofing penalty against the
+    # enrolled speaker — the precise defect this arc exists to remove. A false
+    # negative on a degenerate input (a literally 0.000 Hz spread, which real
+    # replay and conversion attacks do not produce, and which the embedding
+    # comparison scores near zero anyway) is the cheaper error. Revisit once no
+    # pre-#70427 profile remains.
+    _b("pitch_std_hz", 0.5, 200.0, "Hz",
+       "within-utterance f0 spread; >200 Hz is a tracker jumping octaves"),
+    _b("pitch_range_hz", 0.0, 1000.0, "Hz",
+       "max-min f0 over an utterance"),
+    _b("formant_f1_hz", 150.0, 1200.0, "Hz",
+       "F1 is set by vocal tract opening: ~250 Hz (/i/) to ~1000 Hz (/a/). "
+       "42.9 Hz is DC rumble, not a formant"),
+    _b("formant_f2_hz", 500.0, 3500.0, "Hz",
+       "F2 tracks tongue advancement: ~600 Hz (/u/) to ~2800 Hz (/i/)"),
+    _b("formant_f3_hz", 1200.0, 4500.0, "Hz",
+       "F3 is largely speaker-anatomy; below F2 is a mis-ordered root set"),
+    _b("formant_f4_hz", 2000.0, 5500.0, "Hz",
+       "F4 approaches the Nyquist limit of a 16 kHz capture"),
+    _b("speaking_rate_wpm", 40.0, 300.0, "wpm",
+       "conversational speech is 110-180 wpm; trained auctioneers reach ~250. "
+       "420 wpm is a word count divided by the wrong duration"),
+    _b("pause_ratio", 0.0, 1.0, "ratio",
+       "a fraction of frames; outside [0,1] is not a ratio"),
+    _b("spectral_centroid_hz", 20.0, 8000.0, "Hz",
+       "bounded above by Nyquist at the 16 kHz capture rate"),
+    _b("spectral_rolloff_hz", 20.0, 8000.0, "Hz",
+       "bounded above by Nyquist at the 16 kHz capture rate"),
+    _b("jitter", 0.0, 0.5, "fraction",
+       "cycle-to-cycle f0 perturbation; >50% is not a periodic signal"),
+    _b("shimmer", 0.0, 0.5, "fraction",
+       "cycle-to-cycle amplitude perturbation"),
+
+    # ── The ``_percent`` columns are a SEPARATE quantity, not an alias ────
+    #
+    # The in-memory fields are fractions (``PhysicsConstraints.max_jitter =
+    # 0.02`` means 2%) but the database columns are named ``jitter_percent`` /
+    # ``shimmer_percent``, and TWO live writers disagree about which unit they
+    # hold:
+    #
+    #   quick_voice_enhancement.py:1412   'jitter_percent': mean(jitters) * 100
+    #   speaker_verification_service:2927 "jitter_percent": features.jitter
+    #
+    # The first scales to percent, the second stores the raw fraction. This
+    # machine's row holds 1.0 and 5.0 — exactly 100x the old fabricated
+    # defaults of 0.01 and 0.05, so this profile came from the percent writer.
+    #
+    # Treating the column as an alias of the fraction quantity, as a first
+    # version of this file did, gave it the 0-0.5 band and flagged those stored
+    # values as biologically impossible. They are not: 1% jitter and 5% shimmer
+    # are textbook healthy-voice numbers. The boot sanitiser would have deleted
+    # correctly-scaled real data on the strength of a unit guess — the exact
+    # class of error this module exists to prevent, pointed the other way.
+    #
+    # So the columns get their own band, drawn to be impossible under EITHER
+    # reading: 50 is beyond any real voice as a percentage AND far beyond one as
+    # a fraction. Nothing legitimate is rejected under either unit, and nothing
+    # impossible is admitted under either. The bound refuses to guess.
+    #
+    # FOLLOW-UP, deliberately not done here: unify the writers on one unit and
+    # migrate the column. That is a data migration touching four call sites and
+    # a stored schema, and doing it unverified at the end of this change would
+    # risk rescaling real profiles by 100x — precisely the kind of silent
+    # numeric damage that produced the 42.9 Hz formants.
+    _b("jitter_percent", 0.0, 50.0, "fraction-or-percent",
+       "unit-ambiguous column: bounded to what is impossible under either "
+       "reading, pending writer unification"),
+    _b("shimmer_percent", 0.0, 50.0, "fraction-or-percent",
+       "unit-ambiguous column: bounded to what is impossible under either "
+       "reading, pending writer unification"),
+    _b("harmonic_to_noise_ratio_db", -10.0, 45.0, "dB",
+       "voiced speech is ~7-25 dB; >45 dB has no vocal-fold noise floor "
+       "and is synthesis"),
+])
+
+
+#: Names the rest of the system uses for the same quantity.
+#:
+#: The DB columns, the ``VoiceBiometricFeatures`` attributes and the enrollment
+#: dataclass drifted apart long before this module existed. Mapping them is
+#: strictly cheaper — and far more auditable — than renaming three schemas.
+ALIASES: Dict[str, str] = {
+    # VoiceBiometricFeatures attribute names
+    "pitch_mean": "pitch_mean_hz",
+    "pitch_std": "pitch_std_hz",
+    "pitch_range": "pitch_range_hz",
+    "formant_f1": "formant_f1_hz",
+    "formant_f2": "formant_f2_hz",
+    "formant_f3": "formant_f3_hz",
+    "formant_f4": "formant_f4_hz",
+    "spectral_centroid": "spectral_centroid_hz",
+    "spectral_rolloff": "spectral_rolloff_hz",
+    "speaking_rate": "speaking_rate_wpm",
+    "harmonic_to_noise_ratio": "harmonic_to_noise_ratio_db",
+    "hnr": "harmonic_to_noise_ratio_db",
+    # Database column names that differ from the canonical key.
+    #
+    # ``jitter_percent`` and ``shimmer_percent`` are deliberately ABSENT: they
+    # are registered as quantities in their own right above, because their unit
+    # is not the same as the in-memory field's and aliasing them applied the
+    # fraction band to percent data. See the note in BOUNDS.
+    "speech_rate_wpm": "speaking_rate_wpm",
+    "average_pitch_hz": "pitch_mean_hz",
+    # Enrollment dataclass
+    "rate": "speaking_rate_wpm",
+}
+
+
+def canonical_name(name: str) -> str:
+    """The registry key for whatever this layer happens to call the quantity."""
+    key = str(name).strip().lower()
+    if key in BOUNDS:
+        return key
+    return ALIASES.get(key, key)
+
+
+def bound_for(name: str) -> Optional[Bound]:
+    """The band for ``name``, or ``None`` when the quantity has no physiological range."""
+    return BOUNDS.get(canonical_name(name))
+
+
+def is_absent(value: Any) -> bool:
+    """
+    True when ``value`` is one of the two absence forms, or unreadable as a number.
+
+    This is the single ``None``/NaN predicate shared by the extractor, the
+    anti-spoofing stage and the plausibility scorer, so the three cannot drift
+    into disagreeing about what "missing" means.
+    """
+    if value is None:
+        return True
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return True
+    return not math.isfinite(float(value))
+
+
+def is_measured(value: Any, low: Optional[float] = None, high: Optional[float] = None) -> bool:
+    """
+    True when ``value`` is a real measurement, inside its band when one is given.
+
+    ``None``, NaN, infinity, non-numeric and out-of-band all read as NOT
+    measured. Zero is excluded by every band whose quantity cannot be zero,
+    which is deliberate: an unset float field defaults to 0.0, and 0 Hz is not
+    a formant.
+
+    The type check is strict on purpose. ``float("500")`` succeeds, so a
+    permissive version accepts a feature field holding a *string* — but a
+    numeric field that arrived as text was not produced by the measurement path,
+    and quietly parsing it is the same leniency that let unset zeros become
+    spoofing findings. ``bool`` is excluded explicitly because it is a subclass
+    of ``int`` and ``float(True)`` is 1.0 — a silent 1 Hz.
+    """
+    if is_absent(value):
+        return False
+    numeric = float(value)
+    if low is not None and numeric < low:
+        return False
+    if high is not None and numeric > high:
+        return False
+    return True
+
+
+def _env_float(key: str, default: float, source: Mapping[str, str]) -> float:
+    """
+    A bound read from the environment, defaulting on anything unreadable.
+
+    A malformed override must not reach a security decision: keeping the default
+    is correct, and the warning names the knob so a typo does not persist as
+    "the bound is not working".
+    """
+    raw = str(source.get(key, "")).strip()
+    if not raw:
+        return default
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        logger.warning("[Bounds] %s=%r is not a number — keeping %g", key, raw, default)
+        return default
+    if not math.isfinite(value):
+        logger.warning("[Bounds] %s=%r is not finite — keeping %g", key, raw, default)
+        return default
+    return value
+
+
+@dataclass(frozen=True)
+class Violation:
+    """A quantity that failed its band, and by how much."""
+
+    name: str
+    value: Any
+    bound: Optional[Bound]
+    reason: str
+
+    def describe(self) -> str:
+        where = f" (band {self.bound.describe()})" if self.bound else ""
+        return f"{self.name}={self.value!r}{where}: {self.reason}"
+
+
+@dataclass
+class SanitizeResult:
+    """What survived a sanitisation pass, and what did not."""
+
+    clean: Dict[str, Any] = field(default_factory=dict)
+    dropped: List[Violation] = field(default_factory=list)
+
+    @property
+    def is_clean(self) -> bool:
+        return not self.dropped
+
+    def describe(self) -> str:
+        if not self.dropped:
+            return "all measured"
+        return "; ".join(v.describe() for v in self.dropped)
+
+    def names(self) -> List[str]:
+        return [v.name for v in self.dropped]
+
+
+class BiologicalBoundsValidator:
+    """
+    The gate every DSP feature crosses before it is stored or scored.
+
+    Built from the environment so a different microphone, codec or extractor
+    version can be accommodated without a code change: every band is overridable
+    as ``JARVIS_VOICE_PHYSICS_MIN_<NAME>`` / ``..._MAX_<NAME>``, the same
+    namespace ``PhysicsConstraints`` already uses, so each bound has exactly one
+    knob rather than two that can disagree.
+
+    Instances are cheap and immutable in practice; ``default_validator()``
+    returns a process-wide one for callers with no reason to hold their own.
+    """
+
+    def __init__(self, bounds: Optional[Mapping[str, Bound]] = None) -> None:
+        self._bounds: Dict[str, Bound] = dict(bounds if bounds is not None else BOUNDS)
+
+    # ── construction ────────────────────────────────────────────────────
+    @classmethod
+    def from_env(cls, env: Optional[Mapping[str, str]] = None) -> "BiologicalBoundsValidator":
+        source = os.environ if env is None else env
+        resolved: Dict[str, Bound] = {}
+        for name, bound in BOUNDS.items():
+            low = _env_float(bound.min_env, bound.low, source)
+            high = _env_float(bound.max_env, bound.high, source)
+            if low > high:
+                # An inverted band rejects everything, which would present as
+                # "the extractor is broken" for every field at once. Refuse the
+                # override rather than enforce a bound that cannot be satisfied.
+                logger.warning(
+                    "[Bounds] %s: overridden band %g-%g is inverted — keeping %s",
+                    name, low, high, bound.describe(),
+                )
+                resolved[name] = bound
+                continue
+            resolved[name] = Bound(name=name, low=low, high=high,
+                                   unit=bound.unit, why=bound.why)
+        return cls(resolved)
+
+    # ── introspection ───────────────────────────────────────────────────
+    def bound(self, name: str) -> Optional[Bound]:
+        return self._bounds.get(canonical_name(name))
+
+    def bounds(self) -> Mapping[str, Bound]:
+        return dict(self._bounds)
+
+    # ── the three answers ───────────────────────────────────────────────
+    def check(self, name: str, value: Any) -> Optional[Violation]:
+        """
+        ``None`` when ``value`` is a usable measurement of ``name``; the
+        violation otherwise. This is the one place the decision is made — every
+        other method here is a shape adapter over it.
+        """
+        if value is None:
+            return Violation(name, value, self.bound(name), "absent")
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            return Violation(name, value, self.bound(name),
+                             f"{type(value).__name__} is not a measurement")
+        numeric = float(value)
+        if not math.isfinite(numeric):
+            return Violation(name, value, self.bound(name), "not finite")
+
+        bound = self.bound(name)
+        if bound is None:
+            return None  # finite number, no physiological range to enforce
+        if not bound.contains(numeric):
+            return Violation(name, numeric, bound,
+                             f"outside {bound.describe()} — {bound.why}")
+        return None
+
+    def validate(self, name: str, value: Any) -> Optional[float]:
+        """The value as a float when measured, else ``None`` — for dicts and SQL."""
+        return None if self.check(name, value) else float(value)
+
+    def coerce(self, name: str, value: Any) -> float:
+        """
+        The value as a float when measured, else ``UNMEASURED`` — for ``float``
+        dataclass fields, where ``None`` would be a type violation.
+        """
+        return UNMEASURED if self.check(name, value) else float(value)
+
+    def measured(self, name: str, value: Any) -> bool:
+        """True when ``value`` is a usable measurement of ``name``."""
+        return self.check(name, value) is None
+
+    # ── bulk shapes ─────────────────────────────────────────────────────
+    def _is_measurement_field(self, name: str, value: Any) -> bool:
+        """
+        True when ``name``/``value`` is something this validator has any
+        business judging.
+
+        A profile row carries a speaker name, a BLOB, timestamps and counters
+        alongside the acoustics. Without this, ``sanitize`` on a whole row nulls
+        the speaker's NAME — "str is not a measurement" is true and completely
+        beside the point, and it was caught by a test rather than by reading.
+
+        A registered quantity is always judged. Anything else is judged only if
+        it is already numeric, where the finiteness check is meaningful and the
+        type check cannot fire.
+        """
+        if self.bound(name) is not None:
+            return True
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def sanitize(
+        self,
+        mapping: Mapping[str, Any],
+        *,
+        label: str = "features",
+        only: Optional[Iterable[str]] = None,
+    ) -> SanitizeResult:
+        """
+        A copy of ``mapping`` with every unmeasurable entry set to ``None``.
+
+        The key is kept rather than removed: a caller building a SQL row needs
+        the column to exist so it can be written NULL, and a caller comparing
+        dicts needs the absence to be visible rather than inferred.
+
+        Dropping is logged at WARNING, never silently — a value that failed its
+        band means an extractor is broken, and that is operational news.
+        """
+        selected = set(only) if only is not None else None
+        result = SanitizeResult()
+        for key, value in mapping.items():
+            if selected is not None and key not in selected:
+                result.clean[key] = value
+                continue
+            if not self._is_measurement_field(key, value):
+                result.clean[key] = value
+                continue
+            violation = self.check(key, value)
+            if violation is None:
+                result.clean[key] = value
+            else:
+                result.clean[key] = None
+                result.dropped.append(violation)
+        if result.dropped:
+            logger.warning(
+                "[Bounds] %s: %d field(s) dropped as unmeasurable — %s",
+                label, len(result.dropped), result.describe(),
+            )
+        return result
+
+    def audit(self, mapping: Mapping[str, Any]) -> List[Violation]:
+        """
+        Every entry of ``mapping`` that is present but biologically impossible.
+
+        Absent entries are NOT violations: a profile that never recorded a
+        formant is incomplete, not corrupt, and the two warrant different
+        handling on disk. Only a value that is *there* and *impossible* means
+        something wrote a fabrication.
+        """
+        violations: List[Violation] = []
+        for key, value in mapping.items():
+            if value is None:
+                continue
+            if self.bound(key) is None and not isinstance(value, (int, float)):
+                continue  # unbounded non-numeric column (name, blob, timestamp)
+            violation = self.check(key, value)
+            if violation is not None:
+                violations.append(violation)
+        return violations
+
+
+class MeasuredAggregator:
+    """
+    Reductions over per-sample features that ignore what was never measured.
+
+    Enrolment averages N samples into the one profile every later verification
+    is judged against, so the reduction is as load-bearing as the extraction.
+    Two failure modes a bare ``np.mean`` has here:
+
+      * one NaN makes the whole column NaN, discarding the other nineteen
+        samples — which would turn the extractors' new honesty about failure
+        into a total enrolment failure;
+      * an out-of-band value is averaged in at full weight, dragging the
+        enrolled figure toward a number no vocal tract produces.
+
+    Every method returns ``UNMEASURED`` when nothing measurable survives, which
+    the write gate turns into SQL NULL. It lives here rather than in either
+    caller because ``quick_voice_enhancement`` and ``enroll_voice`` both need
+    it, and because this module imports nothing heavier than the standard
+    library — the enrolment scripts pull in the whole SpeechBrain stack, so a
+    helper defined there cannot be exercised without it.
+    """
+
+    def __init__(self, validator: Optional[BiologicalBoundsValidator] = None) -> None:
+        self._validator = validator or default_validator()
+
+    def measured_values(self, quantity: str, values: Iterable[Any]) -> List[float]:
+        return [float(v) for v in values if self._validator.measured(quantity, v)]
+
+    def mean(self, quantity: str, values: Iterable[Any]) -> float:
+        materialized = list(values)
+        kept = self.measured_values(quantity, materialized)
+        if not kept:
+            logger.warning(
+                "[Bounds] %s: no sample of %d was measurable — reporting "
+                "unmeasured rather than a value nothing measured",
+                quantity, len(materialized),
+            )
+            return UNMEASURED
+        if len(kept) < len(materialized):
+            logger.info(
+                "[Bounds] %s: averaged %d of %d sample(s); %d unmeasurable",
+                quantity, len(kept), len(materialized), len(materialized) - len(kept),
+            )
+        return sum(kept) / len(kept)
+
+    def std(self, quantity: str, values: Iterable[Any]) -> float:
+        """
+        Population standard deviation, or ``UNMEASURED``.
+
+        Fewer than two measured samples gives ``UNMEASURED`` rather than 0.0: a
+        single sample produces a zero spread, which reads as "this speaker is
+        perfectly consistent" when it means "there was nothing to compare".
+        """
+        kept = self.measured_values(quantity, values)
+        if len(kept) < 2:
+            return UNMEASURED
+        mean = sum(kept) / len(kept)
+        return (sum((v - mean) ** 2 for v in kept) / len(kept)) ** 0.5
+
+    def min(self, quantity: str, values: Iterable[Any]) -> float:
+        kept = self.measured_values(quantity, values)
+        return min(kept) if kept else UNMEASURED
+
+    def max(self, quantity: str, values: Iterable[Any]) -> float:
+        kept = self.measured_values(quantity, values)
+        return max(kept) if kept else UNMEASURED
+
+    def dynamic_range_db(self, energies: Iterable[Any]) -> float:
+        """
+        Peak-to-floor energy in dB, or ``UNMEASURED``.
+
+        The form this replaces was ``20*log10(max/(min + 1e-10) + 1e-10)``,
+        where the epsilon turned a zero floor — silence in at least one sample —
+        into a ~200 dB range presented as a measurement of the speaker's
+        dynamics. A non-positive floor means there is no floor to measure.
+        """
+        kept = [float(e) for e in energies
+                if isinstance(e, (int, float)) and not isinstance(e, bool)
+                and math.isfinite(e) and e > 0]
+        if len(kept) < 2:
+            return UNMEASURED
+        return 20.0 * math.log10(max(kept) / min(kept))
+
+
+_DEFAULT: Optional[BiologicalBoundsValidator] = None
+
+
+def default_validator() -> BiologicalBoundsValidator:
+    """
+    The process-wide validator, built from the environment on first use.
+
+    Lazy rather than module-level so a test can set ``JARVIS_VOICE_PHYSICS_*``
+    before the first call, and so importing this module never reads the
+    environment as a side effect.
+    """
+    global _DEFAULT
+    if _DEFAULT is None:
+        _DEFAULT = BiologicalBoundsValidator.from_env()
+    return _DEFAULT
+
+
+def reset_default_validator() -> None:
+    """Drop the cached process-wide validator (tests that change the env)."""
+    global _DEFAULT
+    _DEFAULT = None

--- a/backend/voice/enroll_voice.py
+++ b/backend/voice/enroll_voice.py
@@ -35,7 +35,9 @@ import soundfile as sf
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from intelligence.learning_database import JARVISLearningDatabase
+from voice.biological_bounds import UNMEASURED, MeasuredAggregator, default_validator
 from voice.engines.speechbrain_engine import SpeechBrainEngine
+from voice.formant_estimation import estimate_formants
 from voice.stt_config import ModelConfig, STTEngine
 
 logging.basicConfig(
@@ -50,6 +52,21 @@ logging.basicConfig(
     ],
 )
 logger = logging.getLogger(__name__)
+
+# Enrolment writes the profile every later verification is judged against, so
+# this is the highest-stakes place in the system for an unmeasured value to be
+# stored as a measurement. It is also where 42.9 Hz / 80.0 Hz / 420 wpm came in.
+_VALIDATOR = default_validator()
+
+# Shared with quick_voice_enhancement, the other path that writes these same
+# columns. Two enrolment paths averaging the same quantities by different rules
+# is how the stored profile came to disagree with itself.
+_AGG = MeasuredAggregator(_VALIDATOR)
+
+
+def _fmt_hz(value: float) -> str:
+    """Render a possibly-absent measurement for the operator, never as a number."""
+    return f"{value:.1f} Hz" if np.isfinite(value) else "unmeasured"
 
 
 @dataclass
@@ -416,40 +433,48 @@ class VoiceCharacteristicsAnalyzer:
                             pitches.append(pitch)
 
         if pitches:
-            pitch_mean = float(np.mean(pitches))
-            pitch_std = float(np.std(pitches))
-            pitch_range = float(np.max(pitches) - np.min(pitches))
+            pitch_mean = _VALIDATOR.coerce("pitch_mean_hz", float(np.mean(pitches)))
+            pitch_std = _VALIDATOR.coerce("pitch_std_hz", float(np.std(pitches)))
+            pitch_range = _VALIDATOR.coerce(
+                "pitch_range_hz", float(np.max(pitches) - np.min(pitches)))
         else:
-            pitch_mean = 150.0  # Default
-            pitch_std = 20.0
-            pitch_range = 50.0
+            # No frame yielded a period. This used to enrol 150/20/50 Hz — an
+            # invented average male voice — as THIS speaker's pitch, against
+            # which he would then be compared for the life of the profile.
+            logger.warning(
+                "[Enroll] no voiced frame yielded a pitch period — enrolling "
+                "pitch as unmeasured rather than as a default voice"
+            )
+            pitch_mean = pitch_std = pitch_range = UNMEASURED
 
         return pitch_mean, pitch_std, pitch_range
 
     def _analyze_formants(self, audio_data: np.ndarray) -> Tuple[float, float]:
-        """Estimate formant frequencies F1 and F2"""
-        # Apply LPC (Linear Predictive Coding) for formant estimation
-        # Simplified approach: use spectral peaks
+        """
+        Estimate F1 and F2 by linear prediction.
 
-        # Compute power spectrum
-        fft = np.fft.rfft(audio_data)
-        magnitude = np.abs(fft)
-        freqs = np.fft.rfftfreq(len(audio_data), 1 / self.sample_rate)
+        THIS IS THE FUNCTION THAT WROTE 42.9 Hz AND 80.0 Hz. It claimed LPC in a
+        comment and performed spectral peak-picking::
 
-        # Find peaks in magnitude spectrum
-        from scipy.signal import find_peaks
-
-        peaks, _ = find_peaks(magnitude, height=np.max(magnitude) * 0.1, distance=20)
-
-        if len(peaks) >= 2:
-            # First two peaks are approximations of F1 and F2
-            f1 = float(freqs[peaks[0]])
+            peaks, _ = find_peaks(magnitude, height=np.max(magnitude)*0.1, distance=20)
+            f1 = float(freqs[peaks[0]])   # "first two peaks approximate F1 and F2"
             f2 = float(freqs[peaks[1]])
-        else:
-            # Default formants (male voice approximation)
-            f1 = 500.0
-            f2 = 1500.0
 
+        ``peaks`` is ordered by frequency, so ``peaks[0]`` and ``peaks[1]`` are
+        the two LOWEST spectral peaks in the recording — DC offset, mains hum and
+        desk rumble, never vowel resonances. With ``rfftfreq`` over a multi-second
+        sample the bins are sub-Hz apart and ``distance=20`` excludes only ~4 Hz,
+        so both "peaks" came out of the same low-frequency lobe. The values it
+        stored for the operator, 42.9 Hz and 80.03 Hz, are an order of magnitude
+        below the F1 of any human being.
+
+        A formant is a pole of the vocal tract filter, not a peak of the signal
+        spectrum — which is dominated by the glottal source. The shared estimator
+        fits an all-pole model to voiced frames and reads the pole angles, and
+        reports UNMEASURED rather than the old ``(500.0, 1500.0)`` textbook male
+        average when it cannot resolve one.
+        """
+        f1, f2, _, _ = estimate_formants(audio_data, self.sample_rate, n_formants=4)
         return f1, f2
 
     def _calculate_spectral_centroid(self, audio_data: np.ndarray) -> float:
@@ -883,9 +908,17 @@ class VoiceEnrollment:
         formant_f1s = [s.voice_characteristics.formant_f1_hz for s in real_samples]
         formant_f2s = [s.voice_characteristics.formant_f2_hz for s in real_samples]
 
-        avg_pitch = np.mean(pitches)
-        avg_f1 = np.mean(formant_f1s)
-        avg_f2 = np.mean(formant_f2s)
+        # NaN-aware, and per-quantity. A single sample whose formants could not
+        # be resolved must cost that one sample's contribution, not the whole
+        # enrolment: plain ``np.mean`` over a list holding one NaN returns NaN
+        # for every speaker, which would convert the honest per-sample absence
+        # introduced above into a total enrolment failure. ``MeasuredAggregator``
+        # drops the absent entries, and reports UNMEASURED only when nothing
+        # measurable is left — the one case where there is genuinely nothing to
+        # average.
+        avg_pitch = _AGG.mean("pitch_mean_hz", pitches)
+        avg_f1 = _AGG.mean("formant_f1_hz", formant_f1s)
+        avg_f2 = _AGG.mean("formant_f2_hz", formant_f2s)
 
         # Display comprehensive statistics
         print(f"\n📊 Enrollment Statistics:")
@@ -897,11 +930,20 @@ class VoiceEnrollment:
         print(f"   Average quality: {avg_quality:.2%}")
         print(f"   Final confidence: {confidence:.2%}")
 
+        # Printed via _fmt_hz so an unmeasured characteristic reads as
+        # "unmeasured" rather than as "nan Hz" — the operator is the last line
+        # of defence against a bad enrolment, and can only act on what the
+        # summary actually tells them.
+        measured_pitches = [p for p in pitches if np.isfinite(p)]
         print(f"\n🎵 Voice Characteristics:")
-        print(f"   Average pitch: {avg_pitch:.1f} Hz")
-        print(f"   Pitch range: {np.min(pitches):.1f} - {np.max(pitches):.1f} Hz")
-        print(f"   Formant F1: {avg_f1:.0f} Hz")
-        print(f"   Formant F2: {avg_f2:.0f} Hz")
+        print(f"   Average pitch: {_fmt_hz(avg_pitch)}")
+        if measured_pitches:
+            print(f"   Pitch range: {np.min(measured_pitches):.1f} - "
+                  f"{np.max(measured_pitches):.1f} Hz")
+        else:
+            print(f"   Pitch range: unmeasured")
+        print(f"   Formant F1: {_fmt_hz(avg_f1)}")
+        print(f"   Formant F2: {_fmt_hz(avg_f2)}")
 
         print(f"\n📈 Quality Breakdown:")
         snr_values = [s.quality_metrics.snr_db for s in real_samples]

--- a/backend/voice/formant_estimation.py
+++ b/backend/voice/formant_estimation.py
@@ -1,0 +1,380 @@
+"""
+One correct formant estimator, replacing two copies of the same wrong one.
+
+WHAT WAS WRONG
+--------------
+Two independent implementations claimed LPC in their docstrings and did
+something else entirely::
+
+    # enroll_voice.VoiceCharacteristicsAnalyzer._analyze_formants
+    peaks, _ = find_peaks(magnitude, height=np.max(magnitude) * 0.1, distance=20)
+    f1 = float(freqs[peaks[0]])      # "first two peaks approximate F1 and F2"
+    f2 = float(freqs[peaks[1]])
+
+    # advanced_feature_extraction._extract_formants_sync
+    formants = [float(freqs[p]) for p in peaks[:4]]
+
+Both take peaks of the whole-utterance magnitude spectrum **in frequency
+order** and call the lowest ones formants. Two things break at once:
+
+1. ``freqs`` comes from ``rfftfreq(len(audio), 1/16000)``, so bin spacing is
+   ``16000/N``. Over a 4-second sample that is 0.25 Hz, and ``distance=20``
+   bins is a 5 Hz exclusion window — no protection at all against picking
+   several "peaks" out of the same low-frequency lobe.
+2. The lowest spectral peaks of a speech recording are not formants. They are
+   DC offset, mains hum, HVAC, desk rumble and the f0 harmonics themselves.
+
+The result on this machine, written to ``speaker_profiles`` and compared
+against for months::
+
+    formant_f1_hz = 42.9      # F1 is ~500 Hz
+    formant_f2_hz = 80.03     # F2 is ~1500 Hz
+
+Both under 100 Hz — inaudible as vowel resonances, and an exact match for the
+rumble floor of a desk microphone. On failure each copy returned a hardcoded
+``(500, 1500)`` / ``[500, 1500, 2500, 3500]``: the textbook male average,
+written into a *specific* speaker's profile as if it had been measured.
+
+WHAT A FORMANT ACTUALLY IS
+--------------------------
+A resonance of the vocal tract — a pole of the transfer function, not a peak of
+the signal spectrum. The signal spectrum is the *source* (glottal harmonics,
+spaced at f0) multiplied by that filter, which is why picking spectral peaks
+finds harmonics rather than resonances.
+
+Linear prediction estimates the filter directly: fit an all-pole model to each
+frame, then read the pole angles as frequencies. This module does that, and
+only that:
+
+  * pre-emphasis, then 25 ms Hamming frames at 10 ms hop;
+  * silent and unvoiced frames dropped — a frame with no vocal tract excitation
+    has no vocal tract resonance to find, and averaging it in is how noise
+    becomes a formant;
+  * autocorrelation, Levinson-Durbin to LPC coefficients of order 2 + fs/1000;
+  * polynomial roots, upper half plane, angle to frequency, radius to bandwidth;
+  * candidates outside the plausible formant range or with implausibly wide
+    bandwidths are discarded — a wide "pole" is the model fitting noise;
+  * per-formant MEDIAN across surviving frames, not the mean: a median is
+    unmoved by a handful of frames where the root ordering slipped, which is
+    the dominant error mode of root-based formant tracking.
+
+WHEN IT CANNOT MEASURE, IT SAYS SO
+----------------------------------
+Every unresolvable formant is ``UNMEASURED`` (NaN). There is no fallback
+constant anywhere in this file, by design: a default that looks like a
+measurement is what put 500/1500 into a profile that had never been measured,
+and NaN is the one value no downstream consumer can mistake for evidence.
+
+Estimating from silence yields all-NaN rather than an exception — an extractor
+that raises turns missing evidence into an outage on a verification path.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import os
+from typing import List, Optional, Sequence
+
+import numpy as np
+
+try:  # pragma: no cover - depends on which root is on sys.path
+    from backend.voice.biological_bounds import UNMEASURED, BOUNDS
+except ImportError:  # pragma: no cover
+    from voice.biological_bounds import UNMEASURED, BOUNDS
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["estimate_formants", "FormantConfig", "lpc_coefficients"]
+
+
+def _env_float(key: str, default: float) -> float:
+    raw = str(os.environ.get(key, "")).strip()
+    if not raw:
+        return default
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        logger.warning("[Formants] %s=%r is not a number — keeping %g", key, raw, default)
+        return default
+    return value if math.isfinite(value) else default
+
+
+def _env_int(key: str, default: int) -> int:
+    raw = str(os.environ.get(key, "")).strip()
+    if not raw:
+        return default
+    try:
+        return int(float(raw))
+    except (TypeError, ValueError):
+        logger.warning("[Formants] %s=%r is not an integer — keeping %d", key, raw, default)
+        return default
+
+
+class FormantConfig:
+    """
+    Analysis parameters, every one env-overridable.
+
+    Defaults are the standard values for 16 kHz speech analysis; they are
+    parameters of the *method*, not thresholds on the *speaker*, which is why
+    they live here rather than in ``biological_bounds`` — that module owns what
+    a human voice can be, this one owns how hard we look for it.
+    """
+
+    def __init__(self, sample_rate: int = 16000) -> None:
+        self.sample_rate = int(sample_rate)
+        self.window_s = _env_float("JARVIS_FORMANT_WINDOW_S", 0.025)
+        self.hop_s = _env_float("JARVIS_FORMANT_HOP_S", 0.010)
+        self.preemphasis = _env_float("JARVIS_FORMANT_PREEMPHASIS", 0.97)
+        # Silence gate: a frame must carry this fraction of the utterance's
+        # RMS to be analysed. Speech is bursty, so an absolute threshold would
+        # need per-microphone tuning; a relative one does not.
+        self.energy_floor_ratio = _env_float("JARVIS_FORMANT_ENERGY_FLOOR_RATIO", 0.25)
+        # A pole wider than this is the model fitting broadband noise, not a
+        # resonance. 400 Hz is the usual cutoff in formant tracking.
+        self.max_bandwidth_hz = _env_float("JARVIS_FORMANT_MAX_BANDWIDTH_HZ", 400.0)
+        # Below this a "root" is DC drift or mains hum — the exact class of
+        # thing the old peak-picking code was reporting as F1.
+        self.min_formant_hz = _env_float("JARVIS_FORMANT_MIN_HZ", 90.0)
+        # A formant supported by fewer frames than this was not tracked, it was
+        # glimpsed. Reporting it would be the same overreach as the constants.
+        self.min_supporting_frames = _env_int("JARVIS_FORMANT_MIN_FRAMES", 3)
+
+    @property
+    def frame_length(self) -> int:
+        return max(64, int(round(self.window_s * self.sample_rate)))
+
+    @property
+    def hop_length(self) -> int:
+        return max(1, int(round(self.hop_s * self.sample_rate)))
+
+    @property
+    def lpc_order(self) -> int:
+        # 2 poles per expected formant plus 2 for spectral tilt — the standard
+        # 2 + fs/1000 rule (18 at 16 kHz, resolving ~4 formants below Nyquist).
+        return int(2 + self.sample_rate // 1000)
+
+    @property
+    def max_formant_hz(self) -> float:
+        # Poles within 100 Hz of Nyquist are edge artefacts of the fit.
+        return self.sample_rate / 2.0 - 100.0
+
+
+def lpc_coefficients(frame: np.ndarray, order: int) -> Optional[np.ndarray]:
+    """
+    LPC coefficients ``[1, a1, ..., ap]`` by Levinson-Durbin, or ``None``.
+
+    ``None`` when the frame carries no energy or the recursion becomes
+    numerically degenerate — both mean "this frame has no all-pole structure to
+    read", which is missing evidence and not a reason to raise.
+    """
+    frame = np.asarray(frame, dtype=np.float64)
+    if frame.size <= order or not np.all(np.isfinite(frame)):
+        return None
+
+    # Autocorrelation up to `order` lags.
+    autocorr = np.correlate(frame, frame, mode="full")[frame.size - 1:]
+    if autocorr.size < order + 1:
+        return None
+    r = autocorr[: order + 1]
+    if r[0] <= 0 or not np.all(np.isfinite(r)):
+        return None
+
+    a = np.zeros(order + 1, dtype=np.float64)
+    a[0] = 1.0
+    error = float(r[0])
+
+    for i in range(1, order + 1):
+        acc = r[i] + float(np.dot(a[1:i], r[i - 1:0:-1])) if i > 1 else float(r[i])
+        if error <= 0:
+            return None
+        k = -acc / error
+        if not math.isfinite(k) or abs(k) >= 1.0:
+            # |k| >= 1 makes the resulting filter unstable; its "poles" would
+            # be outside the unit circle and their angles are not frequencies.
+            return None
+        a[1:i] = a[1:i] + k * a[i - 1:0:-1]
+        a[i] = k
+        error *= (1.0 - k * k)
+
+    return a if np.all(np.isfinite(a)) else None
+
+
+def _frame_formants(frame: np.ndarray, cfg: FormantConfig) -> List[float]:
+    """Ascending formant candidates for one frame; empty when it has none."""
+    coeffs = lpc_coefficients(frame, cfg.lpc_order)
+    if coeffs is None:
+        return []
+
+    try:
+        roots = np.roots(coeffs)
+    except (np.linalg.LinAlgError, ValueError):
+        return []
+
+    candidates: List[float] = []
+    nyquist_factor = cfg.sample_rate / (2.0 * math.pi)
+    for root in roots:
+        if root.imag <= 0:
+            continue  # conjugate pairs — one of each pair carries the frequency
+        magnitude = abs(root)
+        if not (0.0 < magnitude < 1.0):
+            continue
+        freq = math.atan2(root.imag, root.real) * nyquist_factor
+        bandwidth = -2.0 * nyquist_factor * math.log(magnitude)
+        if freq < cfg.min_formant_hz or freq > cfg.max_formant_hz:
+            continue
+        if bandwidth > cfg.max_bandwidth_hz:
+            continue
+        candidates.append(freq)
+
+    candidates.sort()
+    return candidates
+
+
+def estimate_formants(
+    audio: Sequence[float] | np.ndarray,
+    sample_rate: int = 16000,
+    n_formants: int = 4,
+    config: Optional[FormantConfig] = None,
+) -> List[float]:
+    """
+    Estimate ``n_formants`` formants in Hz, ``UNMEASURED`` where unresolvable.
+
+    Always returns exactly ``n_formants`` entries so callers can index F1..F4
+    positionally, and never raises: a formant that could not be measured is NaN,
+    which every consumer of this repo's voice features treats as absent.
+    """
+    cfg = config or FormantConfig(sample_rate)
+    result = [UNMEASURED] * n_formants
+
+    samples = np.asarray(audio, dtype=np.float64).flatten()
+    if samples.size < cfg.frame_length or not np.any(np.isfinite(samples)):
+        logger.debug("[Formants] %d samples is too short to analyse", samples.size)
+        return result
+
+    samples = np.nan_to_num(samples, nan=0.0, posinf=0.0, neginf=0.0)
+
+    # Pre-emphasis flattens the -6 dB/octave glottal tilt so the higher formants
+    # are not swamped by F1 in the all-pole fit.
+    emphasized = np.append(samples[0], samples[1:] - cfg.preemphasis * samples[:-1])
+
+    frame_length, hop = cfg.frame_length, cfg.hop_length
+    n_frames = 1 + (emphasized.size - frame_length) // hop
+    if n_frames < 1:
+        return result
+
+    strides = np.lib.stride_tricks.sliding_window_view(emphasized, frame_length)[::hop]
+    rms = np.sqrt(np.mean(strides ** 2, axis=1))
+    overall_rms = float(np.sqrt(np.mean(emphasized ** 2)))
+    if overall_rms <= 0:
+        logger.debug("[Formants] signal is silent — no resonances to measure")
+        return result
+
+    # Only frames with real excitation. Analysing silence is precisely how a
+    # rumble floor becomes an F1.
+    voiced = strides[rms >= cfg.energy_floor_ratio * overall_rms]
+    if voiced.shape[0] == 0:
+        logger.debug("[Formants] no frame cleared the energy floor")
+        return result
+
+    window = np.hamming(frame_length)
+    per_formant: List[List[float]] = [[] for _ in range(n_formants)]
+    for frame in voiced:
+        candidates = _frame_formants(frame * window, cfg)
+        for index in range(min(n_formants, len(candidates))):
+            per_formant[index].append(candidates[index])
+
+    for index, values in enumerate(per_formant):
+        if len(values) < cfg.min_supporting_frames:
+            continue
+        # Median, not mean: root ordering slips on a minority of frames and a
+        # mean would carry those excursions into the reported value.
+        result[index] = float(np.median(values))
+
+    result = _enforce_ordering(result)
+    result = _enforce_bounds(result)
+    _log_outcome(result, len(voiced))
+    return result
+
+
+def _enforce_ordering(formants: List[float]) -> List[float]:
+    """
+    Drop any formant that is not above the last one resolved below it.
+
+    ``per_formant[k]`` collects the k-th candidate *of each frame*, and that
+    index only means "the k-th formant" while every frame resolves the same
+    number of candidates. When some frames find three poles and others five,
+    index 2 refers to different resonances in different frames and the median
+    across them is a number with no referent.
+
+    A non-ascending result is the observable symptom of exactly that, and it is
+    detectable without knowing the true answer: formants are ordered by
+    definition. Measured on white noise, this estimator returned
+    ``[2508, 5069, 4212, 6929]`` — F3 below F2, so the set is incoherent.
+    Reporting the offending entries as unmeasured is the honest response;
+    keeping them would be publishing a number the method cannot support.
+    """
+    result = list(formants)
+    highest = 0.0
+    for index, value in enumerate(result):
+        if not math.isfinite(value):
+            continue
+        if value <= highest:
+            logger.info(
+                "[Formants] F%d=%.0f Hz is not above F%d — frame candidate "
+                "ordering was inconsistent; reporting it unmeasured",
+                index + 1, value, index,
+            )
+            result[index] = UNMEASURED
+            continue
+        highest = value
+    return result
+
+
+def _enforce_bounds(formants: List[float]) -> List[float]:
+    """
+    Drop any formant outside the band that formant occupies in human speech.
+
+    This is the mandate the two previous implementations lacked entirely: a
+    value is validated against physiology *before* it is yielded, so an
+    impossible number never reaches a database, a comparison or a verdict. It
+    is the same registry the verifier reads, so the writer and the reader cannot
+    hold different opinions about what is possible — the enrolled 42.9 Hz passed
+    the writer precisely because the writer had no opinion at all.
+    """
+    result = list(formants)
+    for index, value in enumerate(result):
+        if not math.isfinite(value):
+            continue
+        bound = BOUNDS.get(f"formant_f{index + 1}_hz")
+        if bound is None or bound.contains(value):
+            continue
+        logger.warning(
+            "[Formants] F%d=%.0f Hz is outside %s — not a formant, reporting "
+            "unmeasured", index + 1, value, bound.describe(),
+        )
+        result[index] = UNMEASURED
+    return result
+
+
+def _log_outcome(formants: Sequence[float], n_frames: int) -> None:
+    """One line naming what was resolved, so a silent all-NaN is never silent."""
+    unresolved = [f"F{i + 1}" for i, value in enumerate(formants) if not math.isfinite(value)]
+    if not unresolved:
+        return
+    if len(unresolved) == len(formants):
+        logger.warning(
+            "[Formants] no formant resolved from %d voiced frame(s) — reporting "
+            "unmeasured rather than a default", n_frames,
+        )
+    else:
+        logger.info(
+            "[Formants] %s unresolved from %d voiced frame(s) — reported unmeasured",
+            "+".join(unresolved), n_frames,
+        )
+
+
+def plausible_band(index: int) -> Optional[str]:
+    """The measurability band for formant ``index`` (0-based), for log lines."""
+    bound = BOUNDS.get(f"formant_f{index + 1}_hz")
+    return bound.describe() if bound else None

--- a/backend/voice/voice_profile_sanitizer.py
+++ b/backend/voice/voice_profile_sanitizer.py
@@ -1,0 +1,488 @@
+"""
+Boot-time removal of biologically impossible values from stored voice profiles.
+
+The extractors no longer write fabrications and the read path no longer reasons
+from them, but neither of those removes what is already on disk. This does,
+once per boot, off the event loop, and without ever destroying evidence it
+cannot regenerate.
+
+WHAT IS ON DISK
+---------------
+``~/.jarvis/learning/jarvis_learning.db``, ``speaker_profiles``, row 1::
+
+    speaker_name      = Derek J. Russell
+    speaking_rate_wpm = 420.0        # 40-300 wpm
+    formant_f1_hz     = 42.91        # 150-1200 Hz
+    formant_f2_hz     = 80.03        # 500-3500 Hz
+    pitch_mean_hz     = 246.85       # plausible, kept
+    voiceprint_embedding = <BLOB>    # the only thing that authorises anything
+
+QUARANTINE, NOT DELETION — AND WHY
+----------------------------------
+The obvious reading of "purge the corrupted row" is ``DELETE FROM
+speaker_profiles``. This does not do that by default, and the reason is worth
+stating plainly because it is a deliberate departure:
+
+**The embedding is not corrupt, and it is the only thing that can authorise an
+unlock.** The verdict is ``posterior_prob >= threshold``, dominated by the
+embedding comparison; the acoustic scalars are a minority contribution that now
+abstains when absent. Deleting the row to remove three bad scalars would also
+destroy a 192-dimensional voiceprint that passed every finiteness and dimension
+check — leaving the operator unable to unlock by voice AT ALL until a full
+re-enrolment completes, in exchange for removing values that the read gate
+already neutralises.
+
+So the default is to null the impossible columns and archive the original row
+first. That satisfies the actual requirement — no impossible value survives on
+disk, and the profile is flagged for re-enrolment — without a destructive step
+that cannot be undone and that trades a working authenticator for a clean one.
+
+Full-row purge remains available, and happens automatically in the one case
+where the row genuinely has no salvageable content: an embedding that is
+missing, non-finite, or of a dimension nothing can compare against. There, the
+row cannot authorise anything, and keeping it only produces confusing partial
+matches. ``JARVIS_VOICE_PROFILE_PURGE_MODE=row`` forces the destructive
+behaviour for every violating profile if that is what the operator wants.
+
+WHY IT NEVER BLOCKS THE LOOP
+----------------------------
+Every sqlite3 call runs in a worker thread via the repo's serialised offload
+helper, not on the event loop, and the whole sweep is fire-and-forget. PR #70425
+established the rule this follows: the starver was ``import`` blocking on a
+module lock, and the fix was to funnel deferred work through ONE serialised
+worker rather than scattering it across ``asyncio.to_thread`` calls that contend
+for a shared executor. A boot hook that stalls the loop to clean a database is a
+worse defect than the data it cleans.
+
+Failure is never fatal. A locked, missing, read-only or schema-drifted database
+leaves the profile untouched and logs why: the read gate in
+``learning_database`` already prevents the stored values being reasoned from, so
+this pass is hygiene, not a load-bearing control.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import sqlite3
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+
+try:  # pragma: no cover - depends on which root is on sys.path
+    from backend.voice.biological_bounds import BiologicalBoundsValidator, Violation
+except ImportError:  # pragma: no cover
+    from voice.biological_bounds import BiologicalBoundsValidator, Violation
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "SanitizationReport",
+    "VoiceProfileSanitizer",
+    "sanitize_voice_profiles",
+    "schedule_voice_profile_sanitization",
+    "default_profile_db_path",
+]
+
+#: Columns that describe the voice. Kept in step with ``learning_database``'s
+#: ``_ACOUSTIC_COLUMNS``; the sanitiser intersects this with the table's actual
+#: PRAGMA output, so a schema that predates any of them costs that column and
+#: not the sweep.
+ACOUSTIC_COLUMNS: Tuple[str, ...] = (
+    "pitch_mean_hz", "pitch_std_hz", "pitch_range_hz", "pitch_min_hz", "pitch_max_hz",
+    "formant_f1_hz", "formant_f2_hz", "formant_f3_hz", "formant_f4_hz",
+    "spectral_centroid_hz", "spectral_rolloff_hz",
+    "speaking_rate_wpm", "speech_rate_wpm", "average_pitch_hz", "pause_ratio",
+    "jitter_percent", "shimmer_percent", "harmonic_to_noise_ratio_db",
+)
+
+_QUARANTINE_TABLE = "speaker_profiles_quarantine"
+_FLAG_TABLE = "speaker_profile_flags"
+
+
+def _env_flag(name: str, default: bool) -> bool:
+    raw = str(os.environ.get(name, "")).strip().lower()
+    if not raw:
+        return default
+    return raw in ("1", "true", "yes", "on")
+
+
+def default_profile_db_path() -> Path:
+    """
+    Where the speaker profiles live.
+
+    Resolved exactly as ``VoiceProfileConfig`` resolves it — ``JARVIS_DATA_DIR``
+    then the ``learning/jarvis_learning.db`` suffix — because a sanitiser that
+    computes its own path will one day clean a different file than the one the
+    system reads. Callers that already hold a configured path should pass it
+    rather than rely on this, and the boot hook does.
+    """
+    override = str(os.environ.get("JARVIS_SPEAKER_PROFILE_DB", "")).strip()
+    if override:
+        return Path(override).expanduser()
+    data_dir = str(os.environ.get("JARVIS_DATA_DIR", "~/.jarvis")).strip() or "~/.jarvis"
+    return Path(data_dir).expanduser() / "learning" / "jarvis_learning.db"
+
+
+@dataclass
+class SanitizationReport:
+    """What the sweep found and did. Returned rather than logged-and-discarded."""
+
+    scanned: int = 0
+    profiles_cleaned: int = 0
+    values_nulled: int = 0
+    rows_purged: int = 0
+    flagged_for_reenrollment: List[str] = field(default_factory=list)
+    violations: List[str] = field(default_factory=list)
+    skipped_reason: Optional[str] = None
+    duration_ms: float = 0.0
+
+    @property
+    def changed(self) -> bool:
+        return bool(self.values_nulled or self.rows_purged)
+
+    def describe(self) -> str:
+        if self.skipped_reason:
+            return f"skipped ({self.skipped_reason})"
+        return (
+            f"scanned={self.scanned} cleaned={self.profiles_cleaned} "
+            f"nulled={self.values_nulled} purged={self.rows_purged} "
+            f"flagged={len(self.flagged_for_reenrollment)} "
+            f"in {self.duration_ms:.0f}ms"
+        )
+
+
+class VoiceProfileSanitizer:
+    """
+    Scans ``speaker_profiles`` and removes values no vocal tract can produce.
+
+    All database work is synchronous and expected to run in a worker thread —
+    :func:`sanitize_voice_profiles` is the async entry point that arranges that.
+    Constructed with an explicit validator in tests; defaults to the
+    environment-configured one in production.
+    """
+
+    def __init__(
+        self,
+        db_path: Optional[Union[str, Path]] = None,
+        validator: Optional[BiologicalBoundsValidator] = None,
+        *,
+        purge_rows: Optional[bool] = None,
+        timeout_s: float = 5.0,
+    ) -> None:
+        self.db_path = Path(db_path) if db_path else default_profile_db_path()
+        self.validator = validator or BiologicalBoundsValidator.from_env()
+        mode = str(os.environ.get("JARVIS_VOICE_PROFILE_PURGE_MODE", "columns")).strip().lower()
+        self.purge_rows = (mode == "row") if purge_rows is None else purge_rows
+        self.timeout_s = timeout_s
+
+    # ── sync core (runs in a worker thread) ─────────────────────────────
+    def run(self) -> SanitizationReport:
+        report = SanitizationReport()
+        started = time.monotonic()
+
+        if not self.db_path.exists():
+            report.skipped_reason = f"no database at {self.db_path}"
+            return report
+
+        connection: Optional[sqlite3.Connection] = None
+        try:
+            connection = sqlite3.connect(str(self.db_path), timeout=self.timeout_s)
+            connection.row_factory = sqlite3.Row
+            self._sweep(connection, report)
+            connection.commit()
+        except sqlite3.OperationalError as exc:
+            # Locked or read-only. The read gate already neutralises the stored
+            # values, so a failed sweep is hygiene deferred, not a control lost.
+            report.skipped_reason = f"database unavailable ({exc})"
+            logger.warning("[ProfileSanitizer] %s", report.skipped_reason)
+        except Exception as exc:  # noqa: BLE001 — a hygiene pass may not take the boot down
+            report.skipped_reason = f"{type(exc).__name__}: {exc}"
+            logger.warning("[ProfileSanitizer] sweep failed — %s", report.skipped_reason)
+        finally:
+            if connection is not None:
+                connection.close()
+            report.duration_ms = (time.monotonic() - started) * 1000.0
+
+        return report
+
+    # ── internals ───────────────────────────────────────────────────────
+    def _sweep(self, connection: sqlite3.Connection, report: SanitizationReport) -> None:
+        columns = self._table_columns(connection, "speaker_profiles")
+        if not columns:
+            report.skipped_reason = "speaker_profiles table not present"
+            return
+
+        # Only columns this schema actually has. An older table costs that
+        # column's check, never the sweep — the same PRAGMA-driven discipline
+        # the metrics database adopted in d02ccb1014.
+        checkable = [c for c in ACOUSTIC_COLUMNS if c in columns]
+        if not checkable:
+            report.skipped_reason = "no acoustic columns in this schema"
+            return
+
+        key = "speaker_id" if "speaker_id" in columns else None
+        if key is None:
+            report.skipped_reason = "speaker_profiles has no speaker_id key"
+            return
+
+        rows = connection.execute(
+            f"SELECT * FROM speaker_profiles"  # noqa: S608 - fixed table name
+        ).fetchall()
+        report.scanned = len(rows)
+
+        for row in rows:
+            profile = dict(row)
+            violations = self._violations(profile, checkable)
+            if not violations:
+                continue
+
+            speaker = str(profile.get("speaker_name") or profile.get(key))
+            report.violations.extend(f"{speaker}: {v.describe()}" for v in violations)
+
+            self._archive(connection, profile)
+
+            if self.purge_rows or self._embedding_is_unusable(profile, columns):
+                self._purge_row(connection, key, profile[key], speaker, report)
+            else:
+                self._null_columns(connection, key, profile[key], violations, report)
+
+            self._flag_for_reenrollment(connection, speaker, violations)
+            report.flagged_for_reenrollment.append(speaker)
+            report.profiles_cleaned += 1
+
+    def _violations(self, profile: Dict[str, Any], columns: Sequence[str]) -> List[Violation]:
+        found: List[Violation] = []
+        for column in columns:
+            value = profile.get(column)
+            if value is None:
+                continue
+            violation = self.validator.check(column, value)
+            if violation is not None:
+                found.append(violation)
+        return found
+
+    def _embedding_is_unusable(self, profile: Dict[str, Any], columns: Sequence[str]) -> bool:
+        """
+        True when the row cannot authorise anything even after cleaning.
+
+        Only then is a full purge the right call: with no usable voiceprint the
+        profile produces no comparison, and keeping it yields confusing partial
+        matches rather than a clean "not enrolled".
+
+        Deliberately conservative — a BLOB that is merely *unexpected* is left
+        alone. ``embedding_ops`` is the authority on decoding these, and this
+        pass must not become a second, dumber opinion that deletes a profile
+        the real decoder could have read.
+        """
+        if "voiceprint_embedding" not in columns:
+            return False
+        blob = profile.get("voiceprint_embedding")
+        if blob is None:
+            return True
+        if isinstance(blob, (bytes, bytearray, memoryview)):
+            raw = bytes(blob)
+            # float32 vectors only; a length that is not a whole number of
+            # float32s is a different encoding, not a broken embedding.
+            return len(raw) == 0
+        return False
+
+    def _table_columns(self, connection: sqlite3.Connection, table: str) -> List[str]:
+        try:
+            return [r[1] for r in connection.execute(f"PRAGMA table_info({table})")]
+        except sqlite3.Error:
+            return []
+
+    def _archive(self, connection: sqlite3.Connection, profile: Dict[str, Any]) -> None:
+        """
+        Keep the original row as JSON before touching it.
+
+        Nothing here is recoverable from anywhere else, and a sanitiser that
+        cannot be second-guessed is a sanitiser nobody can audit. The archive is
+        text so it survives every future schema change to ``speaker_profiles``.
+        """
+        try:
+            connection.execute(
+                f"""CREATE TABLE IF NOT EXISTS {_QUARANTINE_TABLE} (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        speaker_name TEXT,
+                        quarantined_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                        reason TEXT,
+                        original_row TEXT
+                    )"""
+            )
+            serialisable = {
+                k: (v if isinstance(v, (int, float, str, type(None))) else repr(v))
+                for k, v in profile.items()
+            }
+            connection.execute(
+                f"INSERT INTO {_QUARANTINE_TABLE} (speaker_name, reason, original_row) "
+                f"VALUES (?, ?, ?)",
+                (
+                    str(profile.get("speaker_name") or ""),
+                    "biologically impossible acoustic values",
+                    json.dumps(serialisable, default=str),
+                ),
+            )
+        except sqlite3.Error as exc:
+            # An un-archivable row is still worth cleaning; say so rather than
+            # silently proceeding as though a backup exists.
+            logger.warning(
+                "[ProfileSanitizer] could not archive '%s' (%s) — cleaning "
+                "anyway, without a recoverable copy",
+                profile.get("speaker_name"), exc,
+            )
+
+    def _null_columns(
+        self,
+        connection: sqlite3.Connection,
+        key: str,
+        key_value: Any,
+        violations: Sequence[Violation],
+        report: SanitizationReport,
+    ) -> None:
+        names = sorted({v.name for v in violations})
+        assignments = ", ".join(f"{name} = NULL" for name in names)
+        connection.execute(
+            f"UPDATE speaker_profiles SET {assignments} WHERE {key} = ?",  # noqa: S608
+            (key_value,),
+        )
+        report.values_nulled += len(names)
+        logger.warning(
+            "[ProfileSanitizer] nulled %d impossible value(s) on profile %s=%r: %s",
+            len(names), key, key_value, ", ".join(names),
+        )
+
+    def _purge_row(
+        self,
+        connection: sqlite3.Connection,
+        key: str,
+        key_value: Any,
+        speaker: str,
+        report: SanitizationReport,
+    ) -> None:
+        connection.execute(
+            f"DELETE FROM speaker_profiles WHERE {key} = ?", (key_value,)  # noqa: S608
+        )
+        report.rows_purged += 1
+        logger.warning(
+            "[ProfileSanitizer] PURGED profile '%s' (%s=%r) — archived to %s. "
+            "Re-enrolment is required before voice authentication can succeed.",
+            speaker, key, key_value, _QUARANTINE_TABLE,
+        )
+
+    def _flag_for_reenrollment(
+        self,
+        connection: sqlite3.Connection,
+        speaker: str,
+        violations: Sequence[Violation],
+    ) -> None:
+        """
+        Record that this speaker needs enrolling again, durably.
+
+        A log line is not a flag: it scrolls away, and the next boot has no way
+        to know the profile it just loaded is a cleaned remnant rather than a
+        complete one. This table is the durable answer, and the natural key on
+        ``speaker_name`` makes repeated sweeps idempotent.
+        """
+        try:
+            connection.execute(
+                f"""CREATE TABLE IF NOT EXISTS {_FLAG_TABLE} (
+                        speaker_name TEXT PRIMARY KEY,
+                        needs_reenrollment INTEGER NOT NULL DEFAULT 1,
+                        flagged_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                        detail TEXT
+                    )"""
+            )
+            connection.execute(
+                f"""INSERT INTO {_FLAG_TABLE} (speaker_name, needs_reenrollment, detail)
+                    VALUES (?, 1, ?)
+                    ON CONFLICT(speaker_name) DO UPDATE SET
+                        needs_reenrollment = 1,
+                        flagged_at = CURRENT_TIMESTAMP,
+                        detail = excluded.detail""",
+                (speaker, "; ".join(v.describe() for v in violations)),
+            )
+        except sqlite3.Error as exc:
+            logger.warning("[ProfileSanitizer] could not flag '%s' (%s)", speaker, exc)
+
+
+async def sanitize_voice_profiles(
+    db_path: Optional[Union[str, Path]] = None,
+    validator: Optional[BiologicalBoundsValidator] = None,
+) -> SanitizationReport:
+    """
+    Run the sweep off the event loop and return what it did.
+
+    The sqlite3 work goes through ``async_offload.call_off_loop`` when it is
+    importable, and falls back to ``asyncio.to_thread`` when it is not.
+
+    That preference is the whole point, not a stylistic one. ``call_off_loop``
+    uses a pool *separate from asyncio's default executor*, which the 200+
+    ``to_thread`` call sites in this repo share and which is sized for short
+    work. PR #70425 measured what happens when blocking work is scattered across
+    that shared pool instead: four threads contending at once and a 12.38 s loop
+    stall. A boot-time database sweep is exactly the shape of work that belongs
+    on the dedicated pool.
+    """
+    sanitizer = VoiceProfileSanitizer(db_path=db_path, validator=validator)
+
+    try:  # pragma: no cover - availability differs per root
+        try:
+            from backend.core.async_offload import call_off_loop
+        except ImportError:
+            from core.async_offload import call_off_loop  # type: ignore
+        return await call_off_loop(sanitizer.run)
+    except ImportError:
+        pass
+    except Exception as exc:  # noqa: BLE001 — never let hygiene break the boot
+        logger.debug("[ProfileSanitizer] dedicated offload unavailable (%s)", exc)
+
+    return await asyncio.to_thread(sanitizer.run)
+
+
+def schedule_voice_profile_sanitization(
+    db_path: Optional[Path] = None,
+) -> "Optional[asyncio.Task[SanitizationReport]]":
+    """
+    Fire-and-forget the sweep on the running loop; ``None`` when there is none.
+
+    Boot calls this. It returns immediately — nothing waits on the result, and
+    nothing downstream depends on it having finished, because the read gate in
+    ``learning_database`` is what actually prevents impossible stored values
+    reaching a verdict. This pass only stops them being loaded again tomorrow.
+    """
+    if not _env_flag("JARVIS_VOICE_PROFILE_SANITIZE_ENABLED", True):
+        logger.info("[ProfileSanitizer] disabled by "
+                    "JARVIS_VOICE_PROFILE_SANITIZE_ENABLED")
+        return None
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        logger.debug("[ProfileSanitizer] no running loop — not scheduling")
+        return None
+
+    async def _run() -> SanitizationReport:
+        report = await sanitize_voice_profiles(db_path)
+        if report.skipped_reason:
+            logger.info("[ProfileSanitizer] %s", report.describe())
+        elif report.changed:
+            logger.warning(
+                "[ProfileSanitizer] %s — re-enrol %s to restore full acoustic "
+                "verification: python3 backend/voice/enroll_voice.py",
+                report.describe(), ", ".join(report.flagged_for_reenrollment),
+            )
+        else:
+            logger.info("[ProfileSanitizer] %s — all stored profiles are "
+                        "biologically plausible", report.describe())
+        return report
+
+    task = loop.create_task(_run(), name="voice-profile-sanitizer")
+    # Never let a failure here surface as an unretrieved-exception warning at
+    # interpreter shutdown; this is hygiene and its failure is already logged.
+    task.add_done_callback(lambda t: t.exception() if not t.cancelled() else None)
+    return task

--- a/backend/voice_unlock/voice_profile_startup_service.py
+++ b/backend/voice_unlock/voice_profile_startup_service.py
@@ -493,7 +493,24 @@ class VoiceProfileStartupService:
                     asyncio.gather(*tasks, return_exceptions=True),
                     timeout=timeout / 3  # 1/3 of timeout for setup
                 )
-                
+
+                # Remove biologically impossible values from the store BEFORE
+                # loading from it.
+                #
+                # Ordering is load-bearing here. `_load_from_sqlite` reads the
+                # profile table directly and so does NOT pass through the
+                # bounds gate in `learning_database.get_all_speaker_profiles`;
+                # sanitising afterwards would leave this service's in-memory
+                # copy holding the very values just cleaned off disk, and that
+                # copy is what the verifier compares against.
+                #
+                # It does not block the event loop — the sqlite3 work runs on
+                # async_offload's dedicated pool — and it cannot delay boot: the
+                # measured sweep is ~12ms, the timeout is a small fraction of
+                # the setup budget, and every failure path leaves the profiles
+                # untouched rather than unloadable.
+                await self._sanitize_profiles_before_load()
+
                 # Load profiles with priority cascade
                 loaded = await self._load_profiles_with_priority(
                     timeout=timeout * 2 / 3  # 2/3 of timeout for loading
@@ -539,6 +556,64 @@ class VoiceProfileStartupService:
                 # ALWAYS reset loading flag so retries can work
                 self._loading_in_progress = False
     
+    async def _sanitize_profiles_before_load(self) -> None:
+        """
+        Strip impossible acoustic values from the local store, fail-soft.
+
+        Never raises and never propagates a timeout. A sanitiser that can fail
+        the boot is worse than the data it cleans: the read gate in
+        `learning_database` already prevents impossible stored values reaching a
+        verdict, so this pass is hygiene, and hygiene may not cost the operator
+        their voice authentication.
+
+        The budget is env-tunable (`JARVIS_VOICE_PROFILE_SANITIZE_TIMEOUT_S`)
+        because a database on a slow or contended volume should defer the sweep,
+        not stall behind it.
+        """
+        if not _get_env_bool("JARVIS_VOICE_PROFILE_SANITIZE_ENABLED", True):
+            return
+
+        budget = _get_env_float("JARVIS_VOICE_PROFILE_SANITIZE_TIMEOUT_S", 5.0)
+        try:
+            from voice.voice_profile_sanitizer import sanitize_voice_profiles
+        except ImportError:
+            try:
+                from backend.voice.voice_profile_sanitizer import sanitize_voice_profiles
+            except ImportError:
+                logger.debug("Voice profile sanitizer unavailable — skipping")
+                return
+
+        try:
+            # This service's OWN configured path, not the sanitiser's default.
+            # Both resolve JARVIS_DATA_DIR the same way today; passing it makes
+            # it impossible for them to drift apart and clean a file nobody
+            # reads.
+            report = await asyncio.wait_for(
+                sanitize_voice_profiles(self._config.learning_db_path),
+                timeout=budget,
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "⏱️ Voice profile sanitiser exceeded %.1fs — proceeding with "
+                "profiles as stored (the bounds gate still refuses to reason "
+                "from impossible values)", budget,
+            )
+            return
+        except Exception as exc:  # noqa: BLE001 — hygiene may not break the boot
+            logger.warning("Voice profile sanitiser failed (%s: %s) — proceeding",
+                           type(exc).__name__, exc)
+            return
+
+        if report.changed:
+            logger.warning(
+                "🧪 Voice profile sanitiser: %s. Re-enrol %s to restore full "
+                "acoustic verification — the voiceprint itself is intact and "
+                "unlock still works on it.",
+                report.describe(), ", ".join(report.flagged_for_reenrollment),
+            )
+        elif report.skipped_reason:
+            logger.debug("Voice profile sanitiser skipped: %s", report.skipped_reason)
+
     async def _check_cloudsql_availability(self) -> bool:
         """Check if CloudSQL is available and configured."""
         try:

--- a/tests/security/test_biological_bounds_gate.py
+++ b/tests/security/test_biological_bounds_gate.py
@@ -1,0 +1,553 @@
+"""
+The extractor may not write what no vocal tract can produce.
+
+PR #70426 taught the anti-spoofing stage to abstain on unmeasurable inputs. That
+stopped the system reasoning from garbage; it did not stop the garbage being
+written, and it left the physics plausibility scorer — the twin stage, in the
+same file — carrying the identical defect.
+
+The values below are the ones read out of ``speaker_profiles`` on this machine
+on 2026-08-06, kept verbatim so a regression is recognisable as the original
+bug rather than as an abstract bounds failure::
+
+    speaking_rate_wpm = 420.0     # 40-300 wpm
+    formant_f1_hz     = 42.9      # 150-1200 Hz
+    formant_f2_hz     = 80.03     # 500-3500 Hz
+    formant_f3_hz     = 102.76    # 1200-4500 Hz
+    formant_f4_hz     = 107.35    # 2000-5500 Hz
+
+They came from two extractors that claimed LPC and performed spectral
+peak-picking, returning the LOWEST peaks in the spectrum — DC offset, mains hum
+and desk rumble — and a hardcoded ``(500, 1500)`` textbook male average when
+even that failed.
+
+These tests pin four rules:
+
+  1. an extractor reports UNMEASURED, never a default, when it cannot measure;
+  2. a value outside the human band never reaches storage or a verdict;
+  3. a scorer excludes an unmeasurable component rather than scoring it low;
+  4. none of the above weakens a check against a REAL but implausible voice.
+
+Rule 4 is the one that makes the rest safe. Without it this change would be
+indistinguishable from disabling the biometric.
+"""
+
+from __future__ import annotations
+
+import math
+import sqlite3
+
+import numpy as np
+import pytest
+
+from backend.voice.advanced_biometric_verification import (
+    AdvancedBiometricVerifier,
+    PhysicsConstraints,
+    PlausibilityAssessment,
+)
+from backend.voice.biological_bounds import (
+    BOUNDS,
+    UNMEASURED,
+    BiologicalBoundsValidator,
+    MeasuredAggregator,
+    canonical_name,
+    is_absent,
+    is_measured,
+)
+from backend.voice.formant_estimation import estimate_formants
+
+# Read from the live profile 2026-08-06, kept verbatim.
+ENROLLED_RATE_WPM = 420.0
+ENROLLED_F1_HZ = 42.9099998474121
+ENROLLED_F2_HZ = 80.0299987792969
+ENROLLED_F3_HZ = 102.76000213623047
+ENROLLED_F4_HZ = 107.3499984741211
+ENROLLED_PITCH_HZ = 246.85124206543  # plausible — must SURVIVE
+ENROLLED_CENTROID_HZ = 1676.98645019531  # plausible — must SURVIVE
+
+
+class _Features:
+    """Only the attributes the scored stages read."""
+
+    def __init__(self, **kw):
+        self.pitch_mean = kw.get("pitch_mean", 120.0)
+        self.pitch_std = kw.get("pitch_std", 30.0)
+        self.formant_f1 = kw.get("formant_f1", 520.0)
+        self.formant_f2 = kw.get("formant_f2", 1480.0)
+        self.harmonic_to_noise_ratio = kw.get("hnr", 18.0)
+        self.jitter = kw.get("jitter", 0.01)
+        self.shimmer = kw.get("shimmer", 0.04)
+
+
+def _verifier() -> AdvancedBiometricVerifier:
+    v = AdvancedBiometricVerifier.__new__(AdvancedBiometricVerifier)
+    v.physics = PhysicsConstraints()
+    return v
+
+
+def _synthesize_vowel(f0: float, formants, duration=1.0, sr=16000, bandwidth=80.0):
+    """A source-filter vowel with KNOWN formants, to test against truth."""
+    from scipy.signal import lfilter
+
+    n = int(duration * sr)
+    excitation = np.zeros(n)
+    excitation[:: max(1, int(sr / f0))] = 1.0
+    signal = excitation
+    for freq in formants:
+        r = math.exp(-math.pi * bandwidth / sr)
+        theta = 2 * math.pi * freq / sr
+        signal = lfilter([1.0], [1.0, -2 * r * math.cos(theta), r * r], signal)
+    return signal / (np.max(np.abs(signal)) + 1e-9)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 1. The shared predicate
+# ─────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("value,label", [
+    (None, "None"),
+    (float("nan"), "NaN"),
+    (float("inf"), "infinity"),
+    (float("-inf"), "negative infinity"),
+    ("500", "a numeric string"),
+    (True, "bool True"),
+    (False, "bool False"),
+    (object(), "an arbitrary object"),
+])
+def test_absence_forms_are_never_measurements(value, label):
+    assert is_absent(value) is True, label
+    assert is_measured(value, 0.0, 10_000.0) is False, label
+
+
+def test_bool_is_excluded_because_float_true_is_one():
+    """``float(True)`` is 1.0 — a silent 1 Hz if bool were accepted as numeric."""
+    assert is_measured(True, 0.5, 200.0) is False
+    assert is_measured(1.0, 0.5, 200.0) is True
+
+
+def test_physics_constraints_measured_delegates_to_the_shared_predicate():
+    """
+    One predicate, not two.
+
+    The write side and the read side disagreeing about what counts as a
+    measurement is the condition that let 420 wpm be stored and then be
+    reasoned from. They must call the same function.
+    """
+    physics = PhysicsConstraints()
+    for value in (None, float("nan"), "500", True, 42.9, 500.0):
+        assert physics.measured(value, 150.0, 1200.0) == is_measured(value, 150.0, 1200.0)
+
+
+def test_bands_have_exactly_one_env_knob_shared_with_physics_constraints():
+    """
+    ``PhysicsConstraints`` sources its band defaults from the registry, so a
+    bound cannot be changed in one place and stay stale in the other.
+    """
+    physics = PhysicsConstraints()
+    assert physics.min_formant_f1_hz == BOUNDS["formant_f1_hz"].low
+    assert physics.max_formant_f1_hz == BOUNDS["formant_f1_hz"].high
+    assert physics.min_speaking_rate_wpm == BOUNDS["speaking_rate_wpm"].low
+    assert physics.max_speaking_rate_wpm == BOUNDS["speaking_rate_wpm"].high
+    assert BOUNDS["formant_f1_hz"].min_env == "JARVIS_VOICE_PHYSICS_MIN_FORMANT_F1_HZ"
+
+
+def test_hnr_measurability_floor_is_not_the_plausibility_floor():
+    """
+    A 3 dB capture is noisy evidence, not absent evidence.
+
+    Using ``min_hnr_db`` (the plausibility threshold) as the measurability gate
+    would make every genuinely noisy recording abstain instead of scoring.
+    """
+    physics = PhysicsConstraints()
+    assert physics.min_hnr_db_measurable < physics.min_hnr_db
+    assert physics.measured(3.0, physics.min_hnr_db_measurable, physics.max_hnr_db)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 2. The validator
+# ─────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("quantity,value", [
+    ("formant_f1_hz", ENROLLED_F1_HZ),
+    ("formant_f2_hz", ENROLLED_F2_HZ),
+    ("formant_f3_hz", ENROLLED_F3_HZ),
+    ("formant_f4_hz", ENROLLED_F4_HZ),
+    ("speaking_rate_wpm", ENROLLED_RATE_WPM),
+])
+def test_the_live_poisoned_values_are_all_rejected(quantity, value):
+    validator = BiologicalBoundsValidator.from_env()
+    assert validator.validate(quantity, value) is None
+    assert math.isnan(validator.coerce(quantity, value))
+    violation = validator.check(quantity, value)
+    assert violation is not None
+    assert quantity in violation.describe()
+
+
+@pytest.mark.parametrize("quantity,value", [
+    ("pitch_mean_hz", ENROLLED_PITCH_HZ),
+    ("spectral_centroid_hz", ENROLLED_CENTROID_HZ),
+    ("formant_f1_hz", 520.0),
+    ("speaking_rate_wpm", 150.0),
+])
+def test_plausible_values_survive_untouched(quantity, value):
+    """The gate must not be a filter that empties the profile."""
+    validator = BiologicalBoundsValidator.from_env()
+    assert validator.validate(quantity, value) == value
+    assert validator.check(quantity, value) is None
+
+
+def test_absence_is_never_zero():
+    """
+    ``coerce`` yields NaN, not 0.0.
+
+    An unset 0.0 formant gives ratio 0.0, trips ``< 0.1`` and lands a confident
+    0.5 spoofing penalty. That substitution IS the original defect.
+    """
+    validator = BiologicalBoundsValidator.from_env()
+    coerced = validator.coerce("formant_f1_hz", ENROLLED_F1_HZ)
+    assert math.isnan(coerced)
+    assert coerced != 0.0
+
+
+def test_unbounded_quantities_pass_through_rather_than_inventing_a_limit():
+    """A quantity with no physiological range gets a finiteness check only."""
+    validator = BiologicalBoundsValidator.from_env()
+    assert validator.bound("energy_mean") is None
+    assert validator.validate("energy_mean", 12345.0) == 12345.0
+    assert validator.validate("energy_mean", float("nan")) is None
+
+
+def test_percent_columns_are_not_aliased_to_the_fraction_band():
+    """
+    ``jitter_percent`` holds percent from one writer and a fraction from
+    another. Aliasing it to the fraction band flagged 1.0 (a textbook healthy 1%
+    jitter) as biologically impossible, which would have deleted correct data.
+    """
+    validator = BiologicalBoundsValidator.from_env()
+    assert canonical_name("jitter_percent") == "jitter_percent"
+    assert validator.validate("jitter_percent", 1.0) == 1.0      # 1% — real
+    assert validator.validate("jitter_percent", 0.01) == 0.01    # fraction — real
+    assert validator.validate("jitter_percent", 500.0) is None   # impossible either way
+
+
+def test_sanitize_nulls_the_impossible_and_keeps_the_key():
+    validator = BiologicalBoundsValidator.from_env()
+    result = validator.sanitize({
+        "formant_f1_hz": ENROLLED_F1_HZ,
+        "pitch_mean_hz": ENROLLED_PITCH_HZ,
+        "speaker_name": "Derek J. Russell",
+    })
+    assert result.clean["formant_f1_hz"] is None      # NULL, not deleted
+    assert "formant_f1_hz" in result.clean            # key survives for SQL
+    assert result.clean["pitch_mean_hz"] == ENROLLED_PITCH_HZ
+    assert result.names() == ["formant_f1_hz"]
+
+
+def test_inverted_env_override_is_refused_rather_than_enforced():
+    """A band that rejects everything would read as "every extractor is broken"."""
+    validator = BiologicalBoundsValidator.from_env({
+        "JARVIS_VOICE_PHYSICS_MIN_FORMANT_F1_HZ": "2000",
+        "JARVIS_VOICE_PHYSICS_MAX_FORMANT_F1_HZ": "100",
+    })
+    assert validator.validate("formant_f1_hz", 520.0) == 520.0
+
+
+def test_malformed_env_override_keeps_the_default():
+    validator = BiologicalBoundsValidator.from_env(
+        {"JARVIS_VOICE_PHYSICS_MIN_FORMANT_F1_HZ": "not-a-number"})
+    assert validator.bound("formant_f1_hz").low == BOUNDS["formant_f1_hz"].low
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 2b. The aggregator — enrolment reduces N samples into the stored profile
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_one_unmeasurable_sample_does_not_discard_the_others():
+    """
+    A bare ``np.mean`` over a list holding one NaN returns NaN for the whole
+    column, so honest per-sample absence would become total enrolment failure.
+    """
+    aggregator = MeasuredAggregator(BiologicalBoundsValidator.from_env())
+    assert aggregator.mean("formant_f1_hz", [500.0, UNMEASURED, 540.0]) == pytest.approx(520.0)
+
+
+def test_out_of_band_samples_are_dropped_not_averaged_in():
+    """
+    Averaging 42.9 Hz in at full weight drags the enrolled value toward a
+    number no vocal tract produces.
+    """
+    aggregator = MeasuredAggregator(BiologicalBoundsValidator.from_env())
+    assert aggregator.mean("formant_f1_hz", [ENROLLED_F1_HZ, 500.0, 540.0]) == pytest.approx(520.0)
+
+
+def test_nothing_measurable_yields_unmeasured_not_zero():
+    aggregator = MeasuredAggregator(BiologicalBoundsValidator.from_env())
+    assert math.isnan(aggregator.mean("formant_f1_hz", [ENROLLED_F1_HZ, UNMEASURED]))
+    assert math.isnan(aggregator.mean("formant_f1_hz", []))
+
+
+def test_a_single_sample_has_no_standard_deviation():
+    """
+    One sample gives a spread of 0.0, which reads as "perfectly consistent"
+    when it means "there was nothing to compare".
+    """
+    aggregator = MeasuredAggregator(BiologicalBoundsValidator.from_env())
+    assert math.isnan(aggregator.std("formant_f1_hz", [520.0]))
+    assert aggregator.std("formant_f1_hz", [500.0, 540.0]) == pytest.approx(20.0)
+
+
+def test_dynamic_range_refuses_a_zero_floor_instead_of_epsilon_padding():
+    """
+    ``20*log10(max/(min + 1e-10))`` turned silence in one sample into a ~200 dB
+    range reported as this speaker's dynamics.
+    """
+    aggregator = MeasuredAggregator(BiologicalBoundsValidator.from_env())
+    assert math.isnan(aggregator.dynamic_range_db([0.0, 0.5]))
+    assert aggregator.dynamic_range_db([0.05, 0.5]) == pytest.approx(20.0, abs=0.1)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 3. The formant estimator
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_estimator_recovers_known_formants_from_a_synthetic_vowel():
+    """
+    The check neither previous implementation had.
+
+    Both claimed LPC, and neither was ever run against a signal with a known
+    answer — which is how peak-picking survived long enough to write 42.9 Hz.
+    """
+    truth = [730.0, 1090.0, 2440.0, 3350.0]
+    estimated = estimate_formants(_synthesize_vowel(120.0, truth), 16000)
+    assert abs(estimated[0] - truth[0]) < 60.0, f"F1 {estimated[0]}"
+    assert abs(estimated[1] - truth[1]) < 60.0, f"F2 {estimated[1]}"
+
+
+@pytest.mark.parametrize("signal,label", [
+    (np.zeros(16000), "silence"),
+    (np.random.RandomState(1).normal(0, 1, 16000), "white noise"),
+    (0.5 + 0.2 * np.sin(2 * np.pi * 60 * np.arange(16000) / 16000), "DC + 60 Hz hum"),
+    (np.zeros(10), "too short to frame"),
+    (np.full(16000, np.nan), "all NaN"),
+])
+def test_estimator_reports_unmeasured_rather_than_a_default(signal, label):
+    """
+    The DC + hum case is the exact signal class that produced 42.9 / 80.0 Hz.
+    The old code returned those as formants; this must return nothing at all.
+    """
+    for value in estimate_formants(signal, 16000):
+        assert math.isnan(value), f"{label} produced {value}"
+
+
+def test_estimator_never_returns_the_textbook_male_average():
+    """``(500, 1500)`` was the old failure value. It must not appear from silence."""
+    estimated = estimate_formants(np.zeros(16000), 16000)
+    assert not any(v in (500.0, 1500.0, 2500.0, 3500.0) for v in estimated)
+
+
+def test_estimator_always_returns_the_requested_arity():
+    """Callers index F1..F4 positionally; a short list would IndexError."""
+    assert len(estimate_formants(np.zeros(100), 16000, n_formants=4)) == 4
+    assert len(estimate_formants(np.zeros(100), 16000, n_formants=2)) == 2
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 4. The plausibility scorer — the twin of the anti-spoofing stage
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_unmeasured_components_abstain_instead_of_scoring_zero():
+    """
+    The live 2026-08-06 shape: formants unset.
+
+    Before, ``0.0 / max(0.0, 1.0)`` fell outside the ratio band and scored that
+    component 0.5, and an unset HNR scored 0.0 — two of five components pinned
+    low by quantities nobody measured, then averaged.
+    """
+    assessment = _verifier()._check_physics_plausibility_sync(
+        _Features(formant_f1=0.0, formant_f2=0.0))
+    assert "formants" not in assessment.components
+    assert any("formants" in a for a in assessment.abstained)
+    assert assessment.evidence_complete is False
+
+
+def test_no_measurable_component_scores_neutral_not_zero():
+    """
+    With no evidence the stage must veto nothing.
+
+    Scoring 0.0 would convert a broken feature extractor into a rejection of the
+    speaker — the precise defect this change removes.
+    """
+    assessment = _verifier()._check_physics_plausibility_sync(_Features(
+        pitch_mean=float("nan"), formant_f1=float("nan"), formant_f2=float("nan"),
+        hnr=float("nan"), jitter=float("nan"), shimmer=float("nan")))
+    assert assessment.components == {}
+    assert assessment.score == 1.0
+    assert assessment.evidence_complete is False
+
+
+def test_a_fully_measured_real_voice_scores_one():
+    assessment = _verifier()._check_physics_plausibility_sync(_Features())
+    assert assessment.score == pytest.approx(1.0)
+    assert assessment.evidence_complete is True
+
+
+def test_a_measurable_but_implausible_voice_still_scores_low():
+    """
+    THE GUARD ON THE WHOLE CHANGE.
+
+    Without this, abstention is indistinguishable from switching the check off.
+    Every value here is inside its measurability band and outside its
+    plausibility band — real measurements of an impossible voice.
+    """
+    assessment = _verifier()._check_physics_plausibility_sync(_Features(
+        formant_f1=1100.0, formant_f2=1200.0,  # ratio 0.92, outside [0.2, 0.8]
+        hnr=2.0,                                # below the plausibility floor
+        jitter=0.30, shimmer=0.40))             # far above the perturbation caps
+    assert assessment.evidence_complete is True, "these are measurements, not absences"
+    assert assessment.score < 0.7, assessment.describe()
+
+
+def test_abstention_is_recorded_by_name_never_silently():
+    """A clean score obtained by not looking is not a clean score."""
+    assessment = _verifier()._check_physics_plausibility_sync(
+        _Features(hnr=float("nan")))
+    assert any("hnr" in a for a in assessment.abstained)
+    assert "abstained=[hnr" in assessment.describe()
+
+
+def test_a_failed_stage_yields_an_abstaining_assessment_not_a_near_pass():
+    """The old code substituted a bare 0.8 for a raised exception."""
+    assessment = PlausibilityAssessment(abstained=["stage_failed(RuntimeError)"]).finalize()
+    assert assessment.score == 1.0
+    assert assessment.evidence_complete is False
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 5. The boot sanitiser
+# ─────────────────────────────────────────────────────────────────────────
+
+def _poisoned_db(path):
+    connection = sqlite3.connect(str(path))
+    connection.execute("""
+        CREATE TABLE speaker_profiles (
+            speaker_id INTEGER PRIMARY KEY,
+            speaker_name TEXT,
+            voiceprint_embedding BLOB,
+            pitch_mean_hz REAL,
+            formant_f1_hz REAL,
+            formant_f2_hz REAL,
+            speaking_rate_wpm REAL,
+            spectral_centroid_hz REAL,
+            jitter_percent REAL
+        )""")
+    connection.execute(
+        "INSERT INTO speaker_profiles VALUES (1, 'Derek J. Russell', ?, ?, ?, ?, ?, ?, ?)",
+        (np.zeros(192, dtype=np.float32).tobytes(), ENROLLED_PITCH_HZ,
+         ENROLLED_F1_HZ, ENROLLED_F2_HZ, ENROLLED_RATE_WPM, ENROLLED_CENTROID_HZ, 1.0),
+    )
+    connection.commit()
+    connection.close()
+    return path
+
+
+@pytest.mark.asyncio
+async def test_sanitizer_nulls_impossible_values_and_keeps_the_voiceprint(tmp_path):
+    """
+    Quarantine, not annihilation.
+
+    The embedding is the only thing that can authorise an unlock and it is not
+    corrupt. Deleting the row to remove three bad scalars would leave the
+    operator unable to unlock by voice at all.
+    """
+    from backend.voice.voice_profile_sanitizer import sanitize_voice_profiles
+
+    db = _poisoned_db(tmp_path / "profiles.db")
+    report = await sanitize_voice_profiles(db)
+
+    assert report.changed is True
+    assert report.rows_purged == 0
+    assert "Derek J. Russell" in report.flagged_for_reenrollment
+
+    connection = sqlite3.connect(str(db))
+    connection.row_factory = sqlite3.Row
+    row = dict(connection.execute("SELECT * FROM speaker_profiles").fetchone())
+    assert row["formant_f1_hz"] is None
+    assert row["formant_f2_hz"] is None
+    assert row["speaking_rate_wpm"] is None
+    assert row["pitch_mean_hz"] == pytest.approx(ENROLLED_PITCH_HZ)
+    assert row["spectral_centroid_hz"] == pytest.approx(ENROLLED_CENTROID_HZ)
+    assert row["jitter_percent"] == 1.0, "a real 1% jitter must survive"
+    assert row["voiceprint_embedding"] is not None, "the authenticator must survive"
+    connection.close()
+
+
+@pytest.mark.asyncio
+async def test_sanitizer_archives_before_it_changes_anything(tmp_path):
+    """A sanitiser nobody can second-guess is a sanitiser nobody can audit."""
+    from backend.voice.voice_profile_sanitizer import sanitize_voice_profiles
+
+    db = _poisoned_db(tmp_path / "profiles.db")
+    await sanitize_voice_profiles(db)
+
+    connection = sqlite3.connect(str(db))
+    archived = connection.execute(
+        "SELECT original_row FROM speaker_profiles_quarantine").fetchone()[0]
+    assert "42.9" in archived and "420.0" in archived
+    connection.close()
+
+
+@pytest.mark.asyncio
+async def test_sanitizer_is_idempotent(tmp_path):
+    from backend.voice.voice_profile_sanitizer import sanitize_voice_profiles
+
+    db = _poisoned_db(tmp_path / "profiles.db")
+    await sanitize_voice_profiles(db)
+    second = await sanitize_voice_profiles(db)
+    assert second.changed is False
+    assert second.values_nulled == 0
+
+
+@pytest.mark.asyncio
+async def test_sanitizer_leaves_a_clean_profile_completely_alone(tmp_path):
+    from backend.voice.voice_profile_sanitizer import sanitize_voice_profiles
+
+    db = tmp_path / "clean.db"
+    connection = sqlite3.connect(str(db))
+    connection.execute("""
+        CREATE TABLE speaker_profiles (
+            speaker_id INTEGER PRIMARY KEY, speaker_name TEXT,
+            voiceprint_embedding BLOB, formant_f1_hz REAL, speaking_rate_wpm REAL)""")
+    connection.execute("INSERT INTO speaker_profiles VALUES (1, 'Real', ?, 520.0, 150.0)",
+                       (np.zeros(192, dtype=np.float32).tobytes(),))
+    connection.commit()
+    connection.close()
+
+    report = await sanitize_voice_profiles(db)
+    assert report.changed is False
+    assert report.flagged_for_reenrollment == []
+
+
+@pytest.mark.asyncio
+async def test_a_missing_database_is_skipped_not_fatal(tmp_path):
+    """Hygiene may never take the boot down."""
+    from backend.voice.voice_profile_sanitizer import sanitize_voice_profiles
+
+    report = await sanitize_voice_profiles(tmp_path / "does-not-exist.db")
+    assert report.skipped_reason is not None
+    assert report.changed is False
+
+
+@pytest.mark.asyncio
+async def test_a_schema_without_acoustic_columns_is_skipped(tmp_path):
+    """An older table costs that column's check, never the sweep."""
+    from backend.voice.voice_profile_sanitizer import sanitize_voice_profiles
+
+    db = tmp_path / "old.db"
+    connection = sqlite3.connect(str(db))
+    connection.execute(
+        "CREATE TABLE speaker_profiles (speaker_id INTEGER PRIMARY KEY, speaker_name TEXT)")
+    connection.commit()
+    connection.close()
+
+    report = await sanitize_voice_profiles(db)
+    assert report.skipped_reason == "no acoustic columns in this schema"


### PR DESCRIPTION
## The writer, not the reader

PR #70426 taught the anti-spoofing stage to abstain on inputs nothing had measured. That was a downstream mitigation — it stopped the system reasoning from the garbage, it did not stop the garbage being written, and it left the physics plausibility scorer (the twin stage, forty lines away in the same file) carrying the identical defect.

Three functions claimed Linear Predictive Coding in their names or docstrings. None contained any:

```python
# quick_voice_enhancement._analyze_formants_lpc  <- wrote the live profile
peaks, _ = find_peaks(magnitude_emph, height=max*0.15, distance=30)
formants = [float(f) for f in freqs[peaks[:4]]]
```

`peaks` is ordered by **frequency**, so `peaks[:4]` are the four lowest peaks in the recording: DC offset, mains hum, desk rumble. What it stored for the operator:

```
formant_f1_hz = 42.91      formant_f3_hz = 102.76
formant_f2_hz = 80.03      formant_f4_hz = 107.35
```

An ascending run of rumble — every value below the F1 of any human being. A formant is a **pole of the vocal tract filter**, not a peak of the signal spectrum; the spectrum is dominated by the glottal source, which is why peak-picking finds harmonics and hum instead of resonances.

On failure each copy returned `[500, 1500, 2500, 3500]` — the textbook male average, written into a *specific* speaker's profile as though measured. One padded with `formants[-1] + 1000.0`: a resonance invented from an invented resonance.

The same file defaulted absent attributes to `jitter=0.01` / `shimmer=0.05` (×100 into the DB — the exact 1.0 and 5.0 on disk) and `hnr=15.0`. A missing attribute became a clean bill of vocal health for a sample nobody analysed. `speaking_rate` divided a word count by a trimmed duration → 420 wpm; with no transcription → 0.0 wpm, a speaker who said nothing recorded as one who speaks at zero.

## The fix — one gate, one estimator, one predicate

`biological_bounds.py` is the single authority on whether a number is a measurement of a human voice. `PhysicsConstraints` now *sources* its band defaults from that registry and delegates `measured()` to its predicate, so the write side and read side cannot hold different opinions about what is possible — the enrolled 420 wpm passed the writer precisely because the writer had none. One env knob per band.

**Measurability is not plausibility**, and conflating them would disable the biometric. Measurability = what *all* humans span, drawn generously; outside it nobody produced the number. Plausibility = what a *typical* voice spans. Between them is a real measurement of an unusual speaker — scored, possibly penalised, never dropped.

`formant_estimation.py` replaces all three peak-pickers with actual linear prediction, validated against synthesized vowels with **known** formants — the check none of the three originals ever had:

| Input | Before | After |
|---|---|---|
| `/a/` male, truth [730, 1090] | 42.9 / 80.0 class | **735 / 1089** |
| silence | `[500, 1500, 2500, 3500]` | **all NaN** |
| white noise | numbers | **all NaN** |
| DC + 60 Hz hum ← *the defect signal* | numbers | **all NaN** |

Two absence values, both deliberate: `None` at the SQL layer, NaN in float-typed dataclass fields. Never `0.0` — that substitution *is* the original bug.

## Downstream, symmetrically

`_check_physics_plausibility_sync` abstains exactly as its anti-spoofing twin does and returns a matching assessment type, so one cannot be fixed while the other silently regresses again. An abstaining component is **excluded** from the mean — not scored 0.0, not neutralised to 1.0 (a neutral value still dilutes a finding from a component that did run).

The gate is narrow, and one test exists to prove it: a voice that is *measurable but implausible* (F1/F2 ratio 0.92, HNR 2 dB, 30% jitter) still scores **0.44** with `evidence_complete=True`. Without that, this change would be indistinguishable from switching the biometric off.

## On disk

`voice_profile_sanitizer.py` runs **before** the profile load — that path reads SQLite directly and bypasses the read gate, so sanitising afterwards would leave the in-memory copy the verifier compares against holding the values just cleaned off disk. It runs on `async_offload`'s dedicated pool, never the loop (the #70425 lesson), and every failure path is fail-soft.

It **quarantines rather than deletes**, a deliberate departure from "purge the row": the embedding is not corrupt and is the only thing that can authorise an unlock. Archive → NULL the impossible columns → flag durably for re-enrolment. Full-row purge still fires when the embedding itself is unusable, and `JARVIS_VOICE_PROFILE_PURGE_MODE=row` forces it.

Verified on a copy of the live DB: 5 values nulled, archived, flagged, idempotent, embedding and plausible pitch/centroid intact.

## What the tests caught that reading did not

- `sanitize()` blanked `speaker_name` — "a str is not a measurement" is true and entirely beside the point.
- The sanitiser flagged `jitter_percent=1.0` / `shimmer_percent=5.0` as impossible. **They are not** — 1% jitter and 5% shimmer are textbook healthy. Two live writers disagree about that column's unit (`quick_voice_enhancement` scales ×100, `speaker_verification_service` stores the raw fraction), and the first band would have **deleted correctly-scaled real data**. Now bounded to what is impossible under either reading. Unifying the writers is named as follow-up, not done unverified — rescaling stored profiles by 100× is the same class of silent numeric damage as the 42.9 Hz formants.

## Not claimed

Unverified live. This does **not** prove the unlock will succeed: the verdict is `posterior_prob >= threshold` and the embedding similarity has still never been measured.

The stored `harmonic_to_noise_ratio_db = 15.0` survives the sweep — it is the old fabricated default and it is physically plausible, so no bound can catch it. Re-enrolment is the only real repair, and it will now write measurements or nothing.

Bands cannot catch an unmeasured value that is physically legal (an unset `0.0` jitter sits inside its band). Only the extractor's refusal to fabricate covers that — which is why both layers exist.

**677 green** (tests/security + tests/hud 358, tests/voice + tests/voice_unlock 319), 52 new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the fake “LPC” peak-pickers with a real LPC formant estimator and introduced a single biological-bounds gate so we only write/read real measurements. A boot-time sanitizer now clears impossible profile values, and physics plausibility now abstains symmetrically to avoid garbage influencing unlock.

- **New Features**
  - Single measurability registry in `voice/biological_bounds.py` with env overrides; shared by write and read paths.
  - Real LPC formant estimation in `voice/formant_estimation.py`; drops silence/noise, validates on known vowels, returns `None`/NaN for unmeasurable; used by `enroll_voice` and `quick_voice_enhancement`.
  - Measured-only aggregation via `MeasuredAggregator` and a consistent `UNMEASURED` sentinel; no 0.0 fallbacks.
  - Boot-time `voice_profile_sanitizer.py` quarantines impossible scalars, nulls columns, and flags for re‑enrolment; runs before load on the offload pool. `JARVIS_VOICE_PROFILE_PURGE_MODE=row` forces full-row purge.

- **Bug Fixes**
  - Removed spectral peak-picking mislabelled as LPC and the `[500,1500,2500,3500]`/`hnr=15` fallbacks; prevented fabricated values from being stored or read as measurements.
  - `PhysicsConstraints` now sources bands from the registry and uses a shared `is_measured` predicate; measurability is distinct from plausibility, and abstaining components are excluded from scoring means.
  - Fixed handling of missing data (use `None` at SQL, NaN in floats); no silent 0.0 substitutions. Bounds account for jitter/shimmer unit inconsistency to avoid deleting real data; sanitizer no longer blanks `speaker_name`.
  - Added a narrow abstention gate and tests to ensure “measurable but implausible” voices are scored (not dropped).

<sup>Written for commit 3461c04e5be5a940caf16417a147d5d3154ed7c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

