### PR TITLE
fix(voice): the Bayesian fusion was computed and thrown away on the next line

### DIFF
--- a/backend/voice/advanced_biometric_verification.py
+++ b/backend/voice/advanced_biometric_verification.py
@@ -50,11 +50,24 @@ except ImportError:
 # heavier than numpy, so neither costs this path the SpeechBrain import it is
 # careful to avoid.
 try:  # pragma: no cover - exercised by whichever root the process happens to use
-    from backend.voice.biological_bounds import BOUNDS, is_measured
+    from backend.voice.biological_bounds import (
+        BOUNDS, UNMEASURED, PerturbationCaps, PerturbationTolerance,
+        default_validator, fold_measurement, is_measured,
+        renormalized_weighted_mean,
+    )
     from backend.voice.embedding_ops import coerce_vector
 except ImportError:  # pragma: no cover
-    from voice.biological_bounds import BOUNDS, is_measured
+    from voice.biological_bounds import (
+        BOUNDS, UNMEASURED, PerturbationCaps, PerturbationTolerance,
+        default_validator, fold_measurement, is_measured,
+        renormalized_weighted_mean,
+    )
     from voice.embedding_ops import coerce_vector
+
+#: Shared with the extractors and the sanitiser — the adaptive model must judge
+#: an observation by the same bands the writer used, or it will learn from a
+#: value the writer would have refused.
+_BOUNDS_VALIDATOR = default_validator()
 
 logger = logging.getLogger(__name__)
 
@@ -298,6 +311,63 @@ class SpoofingAssessment:
 
 
 @dataclass
+class AcousticAssessment:
+    """
+    What the acoustic stage compared, and what it could not.
+
+    The third sibling of :class:`SpoofingAssessment` and
+    :class:`PlausibilityAssessment`. All three read raw features, all three can
+    be handed quantities nothing measured, and all three turned that into a
+    confident number until they were fixed one at a time — which is the
+    argument for their result types being the same shape. A future reader
+    adding a fourth stage should find three identical patterns, not three
+    different ones.
+
+    ``weights`` carries the model's learned weight for each component that ran,
+    so the mean can renormalise over survivors instead of assuming all four
+    contributed.
+    """
+
+    score: float = UNMEASURED
+    components: Dict[str, float] = field(default_factory=dict)
+    weights: Dict[str, float] = field(default_factory=dict)
+    abstained: List[str] = field(default_factory=list)
+    partial: List[str] = field(default_factory=list)
+
+    @property
+    def evidence_complete(self) -> bool:
+        return not self.abstained and not self.partial
+
+    @property
+    def has_evidence(self) -> bool:
+        """True when at least one component actually compared something."""
+        return bool(self.components) and is_measured(self.score, 0.0, 1.0)
+
+    def finalize(self) -> "AcousticAssessment":
+        """
+        Weighted mean over the components that ran, weights renormalised.
+
+        With nothing measurable the score stays ``UNMEASURED`` — deliberately
+        NOT a neutral 0.5. This stage must then be DROPPED from the fusion
+        rather than contribute a fabricated middle value, and ``has_evidence``
+        is how the fusion knows. Naming the absence is what lets the caller do
+        the neutral thing; naming a number would force it to do the wrong one.
+        """
+        contributions = [(score, self.weights.get(name, 1.0))
+                         for name, score in self.components.items()]
+        self.score = renormalized_weighted_mean(contributions)
+        if is_measured(self.score, None, None):
+            self.score = float(np.clip(self.score, 0.0, 1.0))
+        return self
+
+    def describe(self) -> str:
+        ran = ", ".join(f"{n}:{v:.2f}" for n, v in self.components.items()) or "none"
+        skipped = ", ".join(self.abstained + self.partial) or "none"
+        shown = f"{self.score:.2f}" if is_measured(self.score, None, None) else "unmeasured"
+        return f"score={shown} scored=[{ran}] abstained=[{skipped}]"
+
+
+@dataclass
 class PlausibilityAssessment:
     """
     What the physics stage scored, and what it could not look at.
@@ -317,6 +387,10 @@ class PlausibilityAssessment:
     score: float = 1.0
     components: Dict[str, float] = field(default_factory=dict)
     abstained: List[str] = field(default_factory=list)
+    #: The jitter/shimmer limits this recording was actually held to, so a log
+    #: line can say WHICH caps produced a low score rather than leaving the
+    #: reader to assume the clinical ones.
+    perturbation_caps: Optional[PerturbationCaps] = None
 
     @property
     def evidence_complete(self) -> bool:
@@ -436,6 +510,11 @@ class AdvancedBiometricVerifier:
         # Physics constraints — every band overridable per deployment.
         self.physics = PhysicsConstraints.from_env()
 
+        # Perturbation limits scaled to the recording, not to a clinic. The
+        # 0.02/0.10 constants this replaces are head-mounted-microphone figures
+        # and they penalised the operator's own verified sample by 0.27/0.33.
+        self._perturbation = PerturbationTolerance.from_env()
+
         # Anti-spoofing trip points. Read from the environment rather than
         # written into the checks, so a mic or codec that shifts the noise
         # floor can be accommodated without editing a security decision.
@@ -503,7 +582,8 @@ class AdvancedBiometricVerifier:
                 speaker_model
             ),
             self._check_physics_plausibility(
-                test_features
+                test_features,
+                context
             ),
             return_exceptions=True
         )
@@ -516,7 +596,18 @@ class AdvancedBiometricVerifier:
         # the same defect this chain has produced at every other layer.
         embedding_sim = float(results[0]) if not isinstance(results[0], BaseException) else 0.0
         mahal_distance = float(results[1]) if not isinstance(results[1], BaseException) else 0.5
-        acoustic_score = float(results[2]) if not isinstance(results[2], BaseException) else 0.5
+
+        # Acoustic returns an assessment for the same reason physics does: the
+        # score alone cannot say whether any component actually compared
+        # anything. A raised stage yields an assessment that abstained on
+        # everything rather than the old bare 0.5, which was a fabricated
+        # middling match manufactured by a crash.
+        if isinstance(results[2], BaseException):
+            acoustic = AcousticAssessment(
+                abstained=[f"stage_failed({type(results[2]).__name__})"]).finalize()
+        else:
+            acoustic = results[2]
+        acoustic_score = acoustic.score
 
         # Physics returns an assessment, not a bare number: the score alone
         # cannot say which components were unmeasurable, and that distinction is
@@ -603,6 +694,17 @@ class AdvancedBiometricVerifier:
             warnings.append(f"High uncertainty ({uncertainty:.1%})")
         if physics_score < 0.7:
             warnings.append("Voice physics constraints violated")
+        if not acoustic.has_evidence:
+            warnings.append(
+                "Acoustic comparison had no evidence: every component abstained "
+                f"({'; '.join(acoustic.abstained) or 'no components'}) — the "
+                "term was dropped from the fusion rather than scored"
+            )
+        elif not acoustic.evidence_complete:
+            warnings.append(
+                f"Acoustic evidence incomplete: {len(acoustic.abstained + acoustic.partial)} "
+                f"component(s) reduced ({'; '.join(acoustic.abstained + acoustic.partial)})"
+            )
         if not physics.evidence_complete:
             # Symmetric with the anti-spoofing warning below, and for the same
             # reason: a plausibility score reached by skipping components is not
@@ -653,6 +755,11 @@ class AdvancedBiometricVerifier:
         # Track verification
         self.verification_history.append(result)
         await self._update_performance_metrics(result)
+
+        # Escalate anything the fusion guard intercepted. This is the async
+        # side of that guard: the fusion runs in a worker thread and cannot
+        # await, so it records the anomaly and this drains it.
+        await self._escalate_authorization_anomaly(speaker_model, speaker_name)
 
         logger.info(
             f"🎯 Verification: {speaker_name} | "
@@ -810,12 +917,77 @@ class AdvancedBiometricVerifier:
             distance = np.linalg.norm(test_vector - enrolled_vector)
             return float(np.exp(-distance))
 
+    async def _escalate_authorization_anomaly(
+        self,
+        speaker_model: "SpeakerModel",
+        speaker_name: str,
+    ) -> None:
+        """
+        Hand a non-finite authorization value to the runtime health sensor.
+
+        A NaN reaching the authorization tensor is not a voice problem, it is a
+        RUNTIME problem: something upstream produced a value that is not a
+        number and every guard between there and here failed to notice. It must
+        be visible to the organism that fixes such things, not buried in a log
+        line inside a thread pool.
+
+        Uses the sensor's existing push entry point — the same one
+        ``TaskHarvester`` and ``LoopSentinel`` use — so this adds a reporter,
+        not a second sensor. Registration rather than import, so a verifier
+        running before the intake layer is up simply finds nothing and moves on.
+
+        NEVER raises. A failure to report a fault must not become a second
+        fault on the authorization path, and the verdict has already been
+        decided (deny) by the time this runs.
+        """
+        debug = getattr(speaker_model, "last_fusion_debug", None)
+        if not isinstance(debug, dict):
+            return
+        anomaly = debug.pop("authorization_anomaly", None)
+        if not anomaly:
+            return
+
+        try:
+            try:
+                from backend.core.ouroboros.governance.intake.sensors.runtime_health_sensor import (
+                    HealthFinding, get_runtime_health_sensor,
+                )
+            except ImportError:
+                from core.ouroboros.governance.intake.sensors.runtime_health_sensor import (  # type: ignore
+                    HealthFinding, get_runtime_health_sensor,
+                )
+
+            sensor = get_runtime_health_sensor()
+            if sensor is None:
+                logger.critical(
+                    "🚨 [Verify] authorization anomaly with no runtime health "
+                    "sensor registered to receive it: %s", anomaly,
+                )
+                return
+
+            await sensor.report(HealthFinding(
+                category="authorization_integrity",
+                severity="critical",
+                summary=(
+                    f"Non-finite value reached the voice authorization tensor "
+                    f"({anomaly.get('kind', 'unknown')}) — verification failed "
+                    f"closed for '{speaker_name}'"
+                ),
+                details=dict(anomaly, speaker=speaker_name),
+                target_files=("backend/voice/advanced_biometric_verification.py",),
+            ))
+        except Exception:  # noqa: BLE001 — reporting a fault may not create one
+            logger.critical(
+                "🚨 [Verify] authorization anomaly could not be reported: %s",
+                anomaly, exc_info=True,
+            )
+
     async def _compute_acoustic_match(
         self,
         test_features: VoiceBiometricFeatures,
         enrolled_features: VoiceBiometricFeatures,
         speaker_model: "SpeakerModel"
-    ) -> float:
+    ) -> "AcousticAssessment":
         """Compute acoustic feature matching score (thread pool)."""
         return await self._run_in_executor(
             self._compute_acoustic_match_sync,
@@ -827,54 +999,179 @@ class AdvancedBiometricVerifier:
         test_features: VoiceBiometricFeatures,
         enrolled_features: VoiceBiometricFeatures,
         speaker_model: "SpeakerModel"
-    ) -> float:
-        """Sync acoustic matching computation."""
-        scores = []
+    ) -> "AcousticAssessment":
+        """
+        Sync acoustic matching — a component contributes only when BOTH sides
+        were measured.
 
-        # Pitch matching (with tolerance for natural variation)
-        pitch_diff = abs(test_features.pitch_mean - enrolled_features.pitch_mean)
-        pitch_tolerance = speaker_model.pitch_std * 2.0
-        pitch_score = np.exp(-pitch_diff / max(pitch_tolerance, 10.0))
-        scores.append(pitch_score)
+        The third of the three fused stages, and the last to get this. Every
+        comparison below is a difference between a test feature and an enrolled
+        one; ``abs(NaN - x)`` is NaN, ``exp(-NaN)`` is NaN, and ``np.average``
+        of anything containing NaN is NaN. Once the enrolled formants were
+        NULLed as biologically impossible, this stage emitted NaN into the
+        fusion on every single verification.
 
-        # Formant matching (speaker-specific resonances)
-        formant_diffs = [
-            abs(test_features.formant_f1 - enrolled_features.formant_f1),
-            abs(test_features.formant_f2 - enrolled_features.formant_f2),
-            abs(test_features.formant_f3 - enrolled_features.formant_f3)
-        ]
-        formant_score = np.mean([np.exp(-diff / 200.0) for diff in formant_diffs])
-        scores.append(formant_score)
+        It did not corrupt the verdict, and the reason is worse than if it had:
+        the Bayesian block that consumes it discards its own result (see
+        ``_bayesian_verification_sync``). The channel is SEVERED, not safe. A
+        NaN guard placed only there would guard nothing, and the moment anyone
+        reconnects the fusion the bomb arms itself.
 
-        # Spectral matching
-        spectral_diff = abs(test_features.spectral_centroid - enrolled_features.spectral_centroid)
-        spectral_score = np.exp(-spectral_diff / 1000.0)
-        scores.append(spectral_score)
+        BOTH sides must be measured, not just one. Comparing a live formant
+        against an absent enrolled one is not a weak match — it is not a
+        comparison, and scoring it produces a number for arithmetic that never
+        validly happened. That is the same rule ``_compute_embedding_similarity``
+        applies to a dimension mismatch.
 
-        # Speaking rate (temporal characteristic)
-        rate_diff = abs(test_features.speaking_rate - enrolled_features.speaking_rate)
-        rate_score = np.exp(-rate_diff / 50.0)
-        scores.append(rate_score)
+        Surviving components are combined with the model's learned weights
+        RENORMALISED over them, which is the only mathematically neutral way to
+        drop a term: substituting 0.5 would penalise a good match and inflate a
+        bad one, and substituting the model's own mean would maximise the
+        Gaussian likelihood downstream — a stage that measured nothing vouching
+        for the speaker.
+        """
+        assessment = AcousticAssessment()
+        physics = self.physics
+        # Learned weights, positionally aligned with the four components below.
+        weights = list(getattr(speaker_model, "acoustic_weights", []) or [])
+        while len(weights) < 4:
+            weights.append(1.0)
 
-        # Weighted average (learned weights)
-        weights = speaker_model.acoustic_weights
-        acoustic_score = np.average(scores, weights=weights)
+        def both_measured(name: str, low: float, high: float) -> bool:
+            t = getattr(test_features, name)
+            e = getattr(enrolled_features, name)
+            return physics.measured(t, low, high) and physics.measured(e, low, high)
 
-        return float(np.clip(acoustic_score, 0.0, 1.0))
+        # 1. Pitch — tolerance from the speaker's own learned spread.
+        if both_measured("pitch_mean", physics.min_pitch_hz_measurable,
+                         physics.max_pitch_hz_measurable):
+            pitch_diff = abs(test_features.pitch_mean - enrolled_features.pitch_mean)
+            tolerance = speaker_model.pitch_std * 2.0
+            if not is_measured(tolerance, 1e-6, None):
+                # A model whose learned spread is unusable falls back to the
+                # floor the original code used, rather than dividing by NaN.
+                tolerance = 10.0
+            assessment.components["pitch"] = float(np.exp(-pitch_diff / max(tolerance, 10.0)))
+            assessment.weights["pitch"] = weights[0]
+        else:
+            assessment.abstained.append("pitch(unmeasured on one or both sides)")
+
+        # 2. Formants — per-formant, so one absent formant costs that formant
+        #    rather than the whole component. F1+F2 carry most of the speaker
+        #    information; requiring all three would abstain far too often.
+        formant_scores = []
+        missing = []
+        for index, (name, low, high) in enumerate((
+            ("formant_f1", physics.min_formant_f1_hz, physics.max_formant_f1_hz),
+            ("formant_f2", physics.min_formant_f2_hz, physics.max_formant_f2_hz),
+            ("formant_f3", BOUNDS["formant_f3_hz"].low, BOUNDS["formant_f3_hz"].high),
+        )):
+            if both_measured(name, low, high):
+                diff = abs(getattr(test_features, name) - getattr(enrolled_features, name))
+                formant_scores.append(float(np.exp(-diff / 200.0)))
+            else:
+                missing.append(f"F{index + 1}")
+        if formant_scores:
+            assessment.components["formants"] = float(np.mean(formant_scores))
+            assessment.weights["formants"] = weights[1]
+            if missing:
+                assessment.partial.append(f"formants({'+'.join(missing)} unmeasured)")
+        else:
+            assessment.abstained.append("formants(none measurable on both sides)")
+
+        # 3. Spectral centroid
+        if both_measured("spectral_centroid", BOUNDS["spectral_centroid_hz"].low,
+                         BOUNDS["spectral_centroid_hz"].high):
+            diff = abs(test_features.spectral_centroid - enrolled_features.spectral_centroid)
+            assessment.components["spectral"] = float(np.exp(-diff / 1000.0))
+            assessment.weights["spectral"] = weights[2]
+        else:
+            assessment.abstained.append("spectral(unmeasured on one or both sides)")
+
+        # 4. Speaking rate — the enrolled side of this was 420 wpm.
+        if both_measured("speaking_rate", physics.min_speaking_rate_wpm,
+                         physics.max_speaking_rate_wpm):
+            diff = abs(test_features.speaking_rate - enrolled_features.speaking_rate)
+            assessment.components["rate"] = float(np.exp(-diff / 50.0))
+            assessment.weights["rate"] = weights[3]
+        else:
+            assessment.abstained.append("rate(unmeasured on one or both sides)")
+
+        assessment.finalize()
+
+        if assessment.abstained:
+            logger.warning(
+                "[Acoustic] %d component(s) ABSTAINED — one or both sides were "
+                "not measured, so they were dropped and the remaining weights "
+                "renormalised: %s", len(assessment.abstained), assessment.describe(),
+            )
+
+        return assessment
 
     async def _check_physics_plausibility(
         self,
-        features: VoiceBiometricFeatures
+        features: VoiceBiometricFeatures,
+        context: Optional[Dict] = None,
     ) -> "PlausibilityAssessment":
         """Check if voice features are physically plausible (thread pool)."""
         return await self._run_in_executor(
             self._check_physics_plausibility_sync,
-            features
+            features, context
         )
+
+    @property
+    def _tolerance(self) -> PerturbationTolerance:
+        """
+        The perturbation tolerance, built on first use.
+
+        Resolved lazily rather than read straight off ``__init__`` so that a
+        verifier reached through any construction path — a partially built
+        instance in a test, a subclass that overrides ``__init__``, an object
+        restored from a pickle — still scores instead of raising
+        ``AttributeError`` from inside a thread pool, where the traceback would
+        surface as "verification stage 3 failed" and be substituted with a
+        fabricated score. The scorer must not depend on construction order.
+        """
+        tolerance = getattr(self, "_perturbation", None)
+        if tolerance is None:
+            tolerance = PerturbationTolerance.from_env()
+            self._perturbation = tolerance
+        return tolerance
+
+    def _perturbation_caps(
+        self,
+        features: VoiceBiometricFeatures,
+        context: Optional[Dict] = None,
+    ) -> "PerturbationCaps":
+        """
+        Jitter/shimmer limits for this recording, from its measured SNR.
+
+        SNR is taken from the caller's ``context['audio_quality']`` when the
+        capture path measured it — the same block the anti-spoofing stage
+        already reads, so there is one source of truth for recording quality
+        rather than two that can disagree. Absent that, the tolerance falls back
+        to its unknown-SNR default rather than assuming studio conditions.
+
+        Deliberately NOT derived from ``energy_contour`` as a substitute: signal
+        energy is not signal-to-noise, and a loud recording in a loud room would
+        read as clean. Guessing an SNR to satisfy a parameter is the same error
+        as guessing a formant.
+        """
+        snr = None
+        if isinstance(context, dict):
+            quality = context.get("audio_quality")
+            if isinstance(quality, dict):
+                snr = quality.get("snr_db")
+            elif is_measured(quality, None, None):
+                # Some callers pass a bare quality scalar; it is not an SNR and
+                # must not be read as one.
+                snr = None
+        return self._tolerance.caps_for(snr)
 
     def _check_physics_plausibility_sync(
         self,
-        features: VoiceBiometricFeatures
+        features: VoiceBiometricFeatures,
+        context: Optional[Dict] = None,
     ) -> "PlausibilityAssessment":
         """
         Sync physics plausibility check — a component scores only on a measurement.
@@ -968,27 +1265,38 @@ class AdvancedBiometricVerifier:
         else:
             abstain("hnr", "harmonic_to_noise_ratio unmeasured")
 
-        # 4/5. Jitter and shimmer — perturbation fractions. Zero IS a legitimate
-        #      reading here (a perfectly steady synthetic tone is 0.0 jitter and
-        #      that is a finding), so these bands admit it and only a non-finite
-        #      or out-of-range value abstains.
-        jitter_bound = BOUNDS["jitter"]
-        if physics.measured(features.jitter, jitter_bound.low, jitter_bound.high):
-            if features.jitter <= physics.max_jitter:
-                scores("jitter", 1.0)
-            else:
-                scores("jitter", physics.max_jitter / features.jitter)
-        else:
-            abstain("jitter", "jitter unmeasured")
+        # 4/5. Jitter and shimmer — perturbation fractions, held to what THIS
+        #      recording can support.
+        #
+        #      The fixed 0.02 / 0.10 caps are clinical figures from voice
+        #      pathology work: head-mounted microphone, treated room, where
+        #      cycle-to-cycle perturbation is dominated by the larynx. Applied
+        #      to a laptop array in a room with a fan they measure the room. The
+        #      operator's own VERIFIED sample scored jitter:0.27 shimmer:0.33
+        #      against them and dragged an otherwise clean stage to 0.65.
+        #
+        #      So the caps scale with the measured noise floor. Below the
+        #      informative floor the estimates carry no speaker information at
+        #      all and the components abstain — a limit wide enough to pass
+        #      anything is not a check, it is a check-shaped hole.
+        caps = self._perturbation_caps(features, context)
+        assessment.perturbation_caps = caps
 
-        shimmer_bound = BOUNDS["shimmer"]
-        if physics.measured(features.shimmer, shimmer_bound.low, shimmer_bound.high):
-            if features.shimmer <= physics.max_shimmer:
-                scores("shimmer", 1.0)
+        for name, value, cap in (
+            ("jitter", features.jitter, caps.jitter),
+            ("shimmer", features.shimmer, caps.shimmer),
+        ):
+            bound = BOUNDS[name]
+            if not physics.measured(value, bound.low, bound.high):
+                abstain(name, f"{name} unmeasured")
+            elif not self._tolerance.informative(caps.snr_db):
+                # Only reachable with a MEASURED sub-floor SNR, so snr_db is a
+                # number here; unknown SNR scores against the widened caps.
+                abstain(name, f"SNR {caps.snr_db:.1f} dB below informative floor")
+            elif value <= cap:
+                scores(name, 1.0)
             else:
-                scores("shimmer", physics.max_shimmer / features.shimmer)
-        else:
-            abstain("shimmer", "shimmer unmeasured")
+                scores(name, cap / value)
 
         assessment.finalize()
 
@@ -1170,10 +1478,57 @@ class AdvancedBiometricVerifier:
         acoustic_score: float,
         physics_score: float
     ) -> Tuple[float, str, Dict[str, any]]:
-        """Sync owner-aware anti-spoof fusion."""
+        """
+        Sync owner-aware anti-spoof fusion — THE authorization tensor.
+
+        This, not ``_bayesian_verification_sync``, is what decides an unlock:
+        that function computes a full Bayesian posterior and then overwrites it
+        with this function's ``final_auth_score`` on the next line. Every guard
+        that matters therefore belongs here.
+
+        Only two inputs reach the score: ``owner_match_score`` (the embedding
+        similarity) and ``spoof_prob``. ``acoustic_score`` and ``physics_score``
+        are recorded in the debug block and do not influence the decision.
+
+        NaN is intercepted on the way in and on the way out, and it fails
+        CLOSED. A NaN comparison is False, so an unguarded NaN would fall
+        through every ``>=`` branch to whichever else-clause it happened to
+        reach — a verdict decided by control flow rather than by evidence. The
+        anomaly is recorded in the debug block for the async caller to escalate
+        to the runtime health sensor; this runs in a worker thread and cannot
+        await, and a watchdog that shares a lock with what it guards is not a
+        watchdog.
+        """
         OWNER_STRONG_MATCH_THRESHOLD = speaker_model.owner_strong_threshold
         OWNER_OVERRIDABLE_SPOOF_LIMIT = speaker_model.spoof_override_limit
         BASE_UNLOCK_THRESHOLD = speaker_model.decision_threshold
+
+        # ── NaN interceptor: inputs ──────────────────────────────────────
+        corrupt = [name for name, value in (
+            ("owner_match_score", owner_match_score),
+            ("spoof_prob", spoof_prob),
+            ("decision_threshold", BASE_UNLOCK_THRESHOLD),
+            ("owner_strong_threshold", OWNER_STRONG_MATCH_THRESHOLD),
+            ("spoof_override_limit", OWNER_OVERRIDABLE_SPOOF_LIMIT),
+        ) if not is_measured(value, None, None)]
+        if corrupt:
+            logger.critical(
+                "🚨 [Fusion] NON-FINITE INPUT to the authorization tensor: %s — "
+                "DENYING. A NaN compares False against every threshold, so an "
+                "unguarded one decides the verdict by control flow.",
+                ", ".join(corrupt),
+            )
+            return 0.0, "deny", {
+                "decision": "deny",
+                "rule_applied": "nan_input_fail_closed",
+                "final_auth_score": 0.0,
+                "authorization_anomaly": {
+                    "kind": "non_finite_fusion_input",
+                    "fields": corrupt,
+                    "owner_match_score": repr(owner_match_score),
+                    "spoof_prob": repr(spoof_prob),
+                },
+            }
 
         if is_owner:
             OWNER_WEIGHT = 0.75
@@ -1229,6 +1584,26 @@ class AdvancedBiometricVerifier:
             else:
                 decision = "deny"
 
+        # ── NaN interceptor: output ──────────────────────────────────────
+        # The inputs were finite, so an infinite output means the arithmetic
+        # between them produced one — a corrupted threshold, a poisoned
+        # confidence boost. Fail closed and say so rather than clip a NaN into
+        # a plausible-looking number.
+        anomaly = None
+        if not is_measured(final_auth_score, None, None):
+            logger.critical(
+                "🚨 [Fusion] authorization tensor evaluated to %r from finite "
+                "inputs (owner=%r spoof=%r rule=%s) — DENYING",
+                final_auth_score, owner_match_score, spoof_prob, rule_applied,
+            )
+            anomaly = {
+                "kind": "non_finite_fusion_output",
+                "rule_applied": rule_applied,
+                "owner_match_score": float(owner_match_score),
+                "spoof_prob": float(spoof_prob),
+            }
+            final_auth_score, decision, rule_applied = 0.0, "deny", "nan_output_fail_closed"
+
         debug_info = {
             "owner_match_score": float(owner_match_score),
             "spoof_prob": float(spoof_prob),
@@ -1240,12 +1615,20 @@ class AdvancedBiometricVerifier:
             "decision": decision,
             "rule_applied": rule_applied,
             "embedding_sim": float(embedding_sim),
+            # Recorded, NOT decisive — neither of these reaches final_auth_score.
+            # They are reported as-is, including NaN, because an absent stage is
+            # a fact worth seeing in the debug block rather than a 0.0 that
+            # reads like a measured failure.
             "acoustic_score": float(acoustic_score),
             "physics_score": float(physics_score),
+            "acoustic_is_evidence": bool(is_measured(acoustic_score, 0.0, 1.0)),
+            "physics_is_evidence": bool(is_measured(physics_score, 0.0, 1.0)),
             "threshold": float(BASE_UNLOCK_THRESHOLD),
             "owner_strong_threshold": float(OWNER_STRONG_MATCH_THRESHOLD),
             "spoof_override_limit": float(OWNER_OVERRIDABLE_SPOOF_LIMIT),
         }
+        if anomaly is not None:
+            debug_info["authorization_anomaly"] = anomaly
 
         return final_auth_score, decision, debug_info
 
@@ -1276,7 +1659,37 @@ class AdvancedBiometricVerifier:
         fusion_weights: Dict[str, float],
         speaker_model: "SpeakerModel"
     ) -> Tuple[float, float]:
-        """Sync Bayesian verification."""
+        """
+        Sync verification — returns the owner-aware fusion score and uncertainty.
+
+        NAMED "BAYESIAN", AND IT WAS NOT. This function used to compute a full
+        Bayesian posterior — prior, per-stage Gaussian likelihoods, weighted
+        likelihood, normaliser — and then discard every bit of it::
+
+            posterior = unnormalized_posterior / max(normalizer, 1e-10)
+            posterior = float(np.clip(final_auth_score, 0.0, 1.0))   # <- overwrite
+
+        The second line overwrote the first. The verdict has always come from
+        ``_owner_aware_antispoof_fusion_sync``; the Bayesian block burned CPU on
+        every verification and, far worse, made the file read as though physics
+        and acoustic scores influenced authorization when they never did.
+
+        That misreading had a cost. It is why a NaN from the acoustic stage
+        looked harmless: it flowed only into arithmetic whose result was thrown
+        away. The channel was severed, not safe — and a NaN guard installed on
+        that block would have guarded nothing while looking like diligence.
+
+        The dead computation is removed rather than repaired, because repairing
+        it means WIRING IT IN, and wiring it in changes what authorises an
+        unlock (physics and acoustic would begin to move the verdict). That is
+        a security-semantics decision for the operator, not a tidy-up. What
+        remains is honest about being a thin wrapper.
+
+        ``fusion_weights`` is retained in the signature: it still shapes
+        ``_compute_fusion_weights``' contract and the caller's reporting, and
+        removing a parameter to reflect dead code would hide the fact that the
+        weights are currently advisory.
+        """
         spoof_prob = 1.0 - spoofing_score
         is_owner = speaker_model.is_primary_owner
         owner_match_score = embedding_sim
@@ -1297,37 +1710,26 @@ class AdvancedBiometricVerifier:
         uncertainty = max(0.1, 1.0 - (distance_from_threshold * 2.0))
         uncertainty = np.clip(uncertainty, 0.0, 1.0)
 
-        prior = speaker_model.prior_probability
-        likelihoods = []
-
-        if fusion_weights.get('embedding', 0) > 0:
-            emb_likelihood = self._score_to_likelihood(embedding_sim, speaker_model.embedding_mean, speaker_model.embedding_std)
-            likelihoods.append((emb_likelihood, fusion_weights['embedding']))
-
-        if fusion_weights.get('mahalanobis', 0) > 0:
-            mahal_likelihood = self._score_to_likelihood(mahal_distance, 0.8, 0.15)
-            likelihoods.append((mahal_likelihood, fusion_weights['mahalanobis']))
-
-        if fusion_weights.get('acoustic', 0) > 0:
-            acoustic_likelihood = self._score_to_likelihood(acoustic_score, speaker_model.acoustic_mean, speaker_model.acoustic_std)
-            likelihoods.append((acoustic_likelihood, fusion_weights['acoustic']))
-
-        if fusion_weights.get('physics', 0) > 0:
-            likelihoods.append((physics_score, fusion_weights['physics']))
-
-        if fusion_weights.get('spoofing', 0) > 0:
-            live_speech_score = 1.0 - spoof_prob
-            likelihoods.append((live_speech_score, fusion_weights['spoofing']))
-
-        weighted_likelihood = sum(l * w for l, w in likelihoods) / max(sum(w for _, w in likelihoods), 1.0)
-
-        unnormalized_posterior = weighted_likelihood * prior
-        impostor_prior = 1.0 - prior
-        impostor_likelihood = 1.0 - weighted_likelihood
-        normalizer = unnormalized_posterior + (impostor_likelihood * impostor_prior)
-
-        posterior = unnormalized_posterior / max(normalizer, 1e-10)
         posterior = float(np.clip(final_auth_score, 0.0, 1.0))
+
+        # Last line of defence. The fusion already fails closed on a non-finite
+        # score, so reaching this means a NaN was introduced between there and
+        # here — a case no test covers precisely because nothing should be able
+        # to do it. Deny, and surface it: the anomaly rides back in the debug
+        # block, which the async caller drains to the runtime health sensor.
+        if not is_measured(posterior, 0.0, 1.0):
+            logger.critical(
+                "🚨 [Verify] posterior is %r after the fusion guard — DENYING",
+                posterior,
+            )
+            debug = getattr(speaker_model, "last_fusion_debug", None)
+            if isinstance(debug, dict):
+                debug["authorization_anomaly"] = {
+                    "kind": "non_finite_posterior",
+                    "posterior": repr(posterior),
+                    "final_auth_score": repr(final_auth_score),
+                }
+            posterior = 0.0
 
         return posterior, float(uncertainty)
 
@@ -1469,18 +1871,64 @@ class AdvancedBiometricVerifier:
                     speaker_model.embedding_mean = np.mean(sims)
                     speaker_model.embedding_std = np.std(sims)
 
-        speaker_model.pitch_mean = (1 - alpha) * speaker_model.pitch_mean + alpha * new_features.pitch_mean
-        speaker_model.pitch_std = np.sqrt(
-            (1 - alpha) * speaker_model.pitch_std**2 +
-            alpha * (new_features.pitch_mean - speaker_model.pitch_mean)**2
+        # THE ADAPTIVE MODEL MAY ONLY LEARN FROM MEASUREMENTS.
+        #
+        # These are exponential moving averages over PERSISTENT state, and an
+        # EMA cannot recover from NaN: `(1-a)*NaN + a*x` is NaN, and so is every
+        # update after it. One unmeasurable pitch permanently corrupts the model
+        # that every later verification is judged against.
+        #
+        # And this runs only when `verified` is True — so the poisoning would be
+        # seeded by the SUCCESS path, the one nobody inspects for corruption. It
+        # became reachable the moment the extractors started honestly reporting
+        # NaN instead of substituting 150.0 Hz, which is exactly the kind of
+        # second-order consequence that makes a partial fix worse than none.
+        #
+        # `fold_measurement` refuses a non-measurement and leaves the running
+        # value alone. Skipping an update costs one sample of adaptation;
+        # accepting one costs the model.
+        previous_pitch_mean = speaker_model.pitch_mean
+        speaker_model.pitch_mean = fold_measurement(
+            speaker_model.pitch_mean, new_features.pitch_mean, alpha,
+            quantity="pitch_mean_hz", validator=_BOUNDS_VALIDATOR,
+            label="speaker_model.pitch_mean",
         )
 
-        feature_vector = self._features_to_vector(new_features)
-        speaker_model.feature_samples.append(feature_vector)
+        # Only update the spread if the mean actually moved — otherwise the
+        # deviation term is measured against a mean that ignored this sample.
+        if speaker_model.pitch_mean != previous_pitch_mean and is_measured(
+            new_features.pitch_mean, None, None
+        ):
+            variance = ((1 - alpha) * speaker_model.pitch_std ** 2 +
+                        alpha * (new_features.pitch_mean - speaker_model.pitch_mean) ** 2)
+            if is_measured(variance, 0.0, None):
+                speaker_model.pitch_std = float(np.sqrt(variance))
 
-        if len(speaker_model.feature_samples) > 10:
-            feature_samples = speaker_model.feature_samples[-50:]
-            speaker_model.covariance_matrix = np.cov(np.array(feature_samples).T)
+        # The covariance matrix feeds Mahalanobis distance. One NaN row makes
+        # every entry NaN, so a sample carrying any unmeasured feature is not
+        # admitted to the sample set at all rather than being admitted and
+        # poisoning the matrix on the next recompute.
+        feature_vector = self._features_to_vector(new_features)
+        if np.all(np.isfinite(feature_vector)):
+            speaker_model.feature_samples.append(feature_vector)
+
+            if len(speaker_model.feature_samples) > 10:
+                feature_samples = speaker_model.feature_samples[-50:]
+                covariance = np.cov(np.array(feature_samples).T)
+                if np.all(np.isfinite(covariance)):
+                    speaker_model.covariance_matrix = covariance
+                else:
+                    logger.warning(
+                        "[SpeakerModel] recomputed covariance is not finite — "
+                        "keeping the previous matrix rather than poisoning "
+                        "Mahalanobis distance for every future verification"
+                    )
+        else:
+            unmeasured = int(np.sum(~np.isfinite(feature_vector)))
+            logger.info(
+                "[SpeakerModel] sample has %d unmeasured feature(s) — not "
+                "admitted to the covariance sample set", unmeasured,
+            )
 
     async def _update_performance_metrics(self, result: VerificationResult):
         """Track performance metrics."""

--- a/backend/voice/biological_bounds.py
+++ b/backend/voice/biological_bounds.py
@@ -76,7 +76,7 @@ import logging
 import math
 import os
 from dataclasses import dataclass, field
-from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -90,9 +90,13 @@ __all__ = [
     "is_absent",
     "BiologicalBoundsValidator",
     "MeasuredAggregator",
+    "PerturbationCaps",
+    "PerturbationTolerance",
     "SanitizeResult",
     "Violation",
     "default_validator",
+    "fold_measurement",
+    "renormalized_weighted_mean",
 ]
 
 
@@ -536,6 +540,219 @@ class BiologicalBoundsValidator:
             if violation is not None:
                 violations.append(violation)
         return violations
+
+
+def renormalized_weighted_mean(contributions: Sequence[Tuple[float, float]]) -> float:
+    """
+    Weighted mean over the terms that ran, with the weights renormalised.
+
+    THIS IS WHAT "A NEUTRAL PRIOR" MEANS IN A WEIGHTED FUSION, and the
+    distinction is the whole point:
+
+      * substituting 0.5 for an absent term drags the result toward 0.5 —
+        it penalises a high score and inflates a low one;
+      * substituting 1.0 (or the model's own mean, which maximises a Gaussian
+        likelihood) inflates unconditionally, and would let a stage that
+        measured NOTHING vouch for the speaker;
+      * DROPPING the term and renormalising the remaining weights leaves the
+        posterior exactly where the surviving evidence puts it. That is the
+        only operation that neither penalises nor inflates, and it is the same
+        discipline the physics scorer applies by excluding a component from its
+        mean rather than scoring it.
+
+    Returns ``UNMEASURED`` when nothing survives — there is no answer to give,
+    and the caller must drop its own term in turn rather than invent one.
+    """
+    usable = [(float(v), float(w)) for v, w in contributions
+              if not is_absent(v) and not is_absent(w) and float(w) > 0.0]
+    if not usable:
+        return UNMEASURED
+    total_weight = sum(w for _, w in usable)
+    if total_weight <= 0.0:
+        return UNMEASURED
+    return sum(v * w for v, w in usable) / total_weight
+
+
+def fold_measurement(
+    current: Any,
+    observed: Any,
+    alpha: float,
+    *,
+    quantity: str = "",
+    validator: Optional["BiologicalBoundsValidator"] = None,
+    label: str = "",
+) -> float:
+    """
+    Exponential-moving-average update that REFUSES an unmeasured observation.
+
+    An EMA is ``(1-a)*current + a*observed``. Feed it one NaN and the running
+    value is NaN forever — there is no subsequent observation that can pull it
+    back, because every future update multiplies the NaN through. When the
+    running value is a speaker's adaptive pitch model, one unmeasurable sample
+    permanently corrupts the model every later verification is judged against.
+
+    Worse, the update in ``advanced_biometric_verification`` runs only on a
+    SUCCESSFUL verification, so the poisoning is seeded by the success path —
+    the one nobody watches for corruption.
+
+    So an observation that is absent, non-finite, or outside its band leaves
+    ``current`` untouched and is logged. Refusing to learn from a
+    non-measurement is not a lost update; it is the only correct one.
+    """
+    if is_absent(current):
+        # The running value is already unusable — adopt a good observation to
+        # recover rather than propagating the corruption forever.
+        if not is_absent(observed) and (
+            validator is None or not quantity or validator.measured(quantity, observed)
+        ):
+            logger.warning(
+                "[Bounds] %s: running value was not finite — reseeding from a "
+                "measured observation", label or quantity or "EMA",
+            )
+            return float(observed)
+        return UNMEASURED
+
+    if is_absent(observed):
+        logger.info(
+            "[Bounds] %s: observation was not measured — leaving the running "
+            "value unchanged rather than folding NaN into it",
+            label or quantity or "EMA",
+        )
+        return float(current)
+
+    if validator is not None and quantity and not validator.measured(quantity, observed):
+        logger.warning(
+            "[Bounds] %s: observation %r is outside its biological band — not "
+            "folding it into the running value",
+            label or quantity, observed,
+        )
+        return float(current)
+
+    rate = float(alpha)
+    if not math.isfinite(rate) or not (0.0 <= rate <= 1.0):
+        logger.warning("[Bounds] %s: alpha %r is not a rate in [0,1] — not updating",
+                       label or quantity or "EMA", alpha)
+        return float(current)
+
+    return (1.0 - rate) * float(current) + rate * float(observed)
+
+
+@dataclass(frozen=True)
+class PerturbationCaps:
+    """The jitter and shimmer a recording of this quality can be held to."""
+
+    jitter: float
+    shimmer: float
+    snr_db: Optional[float]
+    scale: float
+    basis: str
+
+    def describe(self) -> str:
+        measured = f"{self.snr_db:.1f} dB" if self.snr_db is not None else "unknown SNR"
+        return (f"jitter<={self.jitter:.3f} shimmer<={self.shimmer:.3f} "
+                f"(x{self.scale:.2f} from {measured} via {self.basis})")
+
+
+class PerturbationTolerance:
+    """
+    Jitter and shimmer limits scaled to the quality of the actual recording.
+
+    The fixed 0.02 / 0.10 caps are CLINICAL figures. They come from voice
+    pathology work using a head-mounted microphone in a treated room, where
+    cycle-to-cycle perturbation is dominated by the larynx. Applied to a laptop
+    array in a room with a fan, they are measuring the room: the operator's own
+    verified sample scored ``jitter:0.27 shimmer:0.33`` against them, dragging
+    a stage that was otherwise clean down to 0.65.
+
+    Perturbation estimates degrade predictably as the noise floor rises — noise
+    perturbs the period and amplitude estimates directly — so the tolerance is
+    derived from measured SNR rather than assumed. A clean capture is still
+    held to the clinical figure; a noisy one is held to what a noisy capture
+    can actually support; below a floor the measurement carries no information
+    and the caller is told to abstain instead of being handed a limit so wide
+    it would pass anything.
+
+    Every constant is env-overridable (``JARVIS_VOICE_PERTURBATION_*``): these
+    are properties of the microphone and room, and the right values for a
+    headset are not the right values for a MacBook across a desk.
+    """
+
+    def __init__(
+        self,
+        base_jitter: float = 0.02,
+        base_shimmer: float = 0.10,
+        clean_snr_db: float = 30.0,
+        floor_snr_db: float = 5.0,
+        max_scale: float = 6.0,
+        unknown_scale: float = 3.0,
+    ) -> None:
+        self.base_jitter = base_jitter
+        self.base_shimmer = base_shimmer
+        self.clean_snr_db = clean_snr_db
+        self.floor_snr_db = floor_snr_db
+        self.max_scale = max_scale
+        self.unknown_scale = unknown_scale
+
+    @classmethod
+    def from_env(cls, env: Optional[Mapping[str, str]] = None) -> "PerturbationTolerance":
+        source = os.environ if env is None else env
+        defaults = cls()
+        return cls(
+            base_jitter=_env_float("JARVIS_VOICE_PERTURBATION_BASE_JITTER",
+                                   defaults.base_jitter, source),
+            base_shimmer=_env_float("JARVIS_VOICE_PERTURBATION_BASE_SHIMMER",
+                                    defaults.base_shimmer, source),
+            clean_snr_db=_env_float("JARVIS_VOICE_PERTURBATION_CLEAN_SNR_DB",
+                                    defaults.clean_snr_db, source),
+            floor_snr_db=_env_float("JARVIS_VOICE_PERTURBATION_FLOOR_SNR_DB",
+                                    defaults.floor_snr_db, source),
+            max_scale=_env_float("JARVIS_VOICE_PERTURBATION_MAX_SCALE",
+                                 defaults.max_scale, source),
+            unknown_scale=_env_float("JARVIS_VOICE_PERTURBATION_UNKNOWN_SCALE",
+                                     defaults.unknown_scale, source),
+        )
+
+    def informative(self, snr_db: Any) -> bool:
+        """
+        False only when the capture is MEASURED and too noisy to inform.
+
+        "We measured 2 dB" and "we do not know the SNR" are different facts and
+        must not collapse into one answer. Below the floor, perturbation
+        estimates are dominated by noise and carry no speaker information, so
+        the component abstains. With SNR simply unknown, ``caps_for`` has
+        already widened the limits by ``unknown_scale`` to cover the
+        uncertainty — abstaining as well would discard a component twice for
+        the same reason, and would silently disable jitter and shimmer on every
+        caller that does not happen to pass an ``audio_quality`` block.
+        """
+        if not is_measured(snr_db, None, None):
+            return True  # unknown: scored against the widened caps
+        return float(snr_db) >= self.floor_snr_db
+
+    def caps_for(self, snr_db: Any = None) -> PerturbationCaps:
+        """
+        Caps for a recording at ``snr_db``.
+
+        Unknown SNR gets a fixed middling widening rather than either extreme:
+        assuming studio conditions would penalise every real capture (the bug
+        being fixed), and assuming the worst would disable the check.
+        """
+        if not is_measured(snr_db, None, None):
+            scale = max(1.0, self.unknown_scale)
+            return PerturbationCaps(self.base_jitter * scale, self.base_shimmer * scale,
+                                    None, scale, "unmeasured-SNR default")
+
+        snr = float(snr_db)
+        span = self.clean_snr_db - self.floor_snr_db
+        if span <= 0:
+            scale = 1.0
+        else:
+            # 1.0 at clean_snr_db, rising linearly to max_scale at the floor.
+            deficit = (self.clean_snr_db - snr) / span
+            scale = 1.0 + max(0.0, deficit) * (self.max_scale - 1.0)
+        scale = float(min(max(scale, 1.0), self.max_scale))
+        return PerturbationCaps(self.base_jitter * scale, self.base_shimmer * scale,
+                                snr, scale, "measured SNR")
 
 
 class MeasuredAggregator:

--- a/tests/security/test_authorization_nan_integrity.py
+++ b/tests/security/test_authorization_nan_integrity.py
@@ -1,0 +1,394 @@
+"""
+A NaN may never reach, or survive in, anything that authorises.
+
+Four defects, found while closing the acoustic stage:
+
+1. ``_compute_acoustic_match_sync`` emitted NaN into the fusion on every
+   verification once the enrolled formants were NULLed as impossible.
+   ``abs(NaN - x)`` is NaN, ``exp(-NaN)`` is NaN, ``np.average`` of a list
+   containing NaN is NaN.
+
+2. It did not corrupt the verdict, and the reason is worse than if it had:
+   ``_bayesian_verification_sync`` computed a full posterior and then
+   overwrote it with ``final_auth_score`` on the next line. The channel was
+   SEVERED, not safe. A guard installed there would have guarded nothing.
+
+3. The real authorization tensor is ``_owner_aware_antispoof_fusion_sync``,
+   where a NaN would compare False against every ``>=`` and fall through to
+   whichever else-branch it reached — a verdict decided by control flow.
+
+4. ``_update_speaker_model_sync`` folds features into EMAs over PERSISTENT
+   state, on the SUCCESS path. One NaN makes ``speaker_model.pitch_mean`` NaN
+   forever; an EMA cannot recover. The honest extractors introduced in #70427
+   made that reachable for the first time.
+
+And one calibration defect: the jitter/shimmer caps were clinical constants
+(head-mounted mic, treated room) applied to a laptop array. The operator's own
+VERIFIED sample scored jitter:0.27 shimmer:0.33 against them.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from backend.voice.advanced_biometric_verification import (
+    AcousticAssessment,
+    AdvancedBiometricVerifier,
+    PhysicsConstraints,
+)
+from backend.voice.biological_bounds import (
+    UNMEASURED,
+    BiologicalBoundsValidator,
+    PerturbationTolerance,
+    fold_measurement,
+    renormalized_weighted_mean,
+)
+
+
+class _Features:
+    def __init__(self, **kw):
+        self.embedding = kw.get("embedding", np.zeros(192, dtype=np.float32))
+        self.pitch_mean = kw.get("pitch_mean", 120.0)
+        self.pitch_std = kw.get("pitch_std", 30.0)
+        self.formant_f1 = kw.get("formant_f1", 520.0)
+        self.formant_f2 = kw.get("formant_f2", 1480.0)
+        self.formant_f3 = kw.get("formant_f3", 2500.0)
+        self.spectral_centroid = kw.get("spectral_centroid", 1600.0)
+        self.speaking_rate = kw.get("speaking_rate", 150.0)
+        self.harmonic_to_noise_ratio = kw.get("hnr", 18.0)
+        self.jitter = kw.get("jitter", 0.01)
+        self.shimmer = kw.get("shimmer", 0.04)
+
+
+class _Model:
+    def __init__(self, **kw):
+        self.pitch_std = kw.get("pitch_std", 20.0)
+        self.pitch_mean = kw.get("pitch_mean", 120.0)
+        self.acoustic_weights = kw.get("acoustic_weights", [0.4, 0.3, 0.2, 0.1])
+        self.is_primary_owner = kw.get("is_primary_owner", True)
+        self.owner_strong_threshold = kw.get("owner_strong_threshold", 0.65)
+        self.spoof_override_limit = kw.get("spoof_override_limit", 0.90)
+        self.decision_threshold = kw.get("decision_threshold", 0.4885)
+        self.last_fusion_debug = None
+        self.embedding_samples = []
+        self.feature_samples = []
+        self.covariance_matrix = np.eye(3)
+
+
+def _verifier() -> AdvancedBiometricVerifier:
+    v = AdvancedBiometricVerifier.__new__(AdvancedBiometricVerifier)
+    v.physics = PhysicsConstraints()
+    return v
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 1. The neutral prior — what "drop the term" means
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_renormalising_is_neither_penalty_nor_inflation():
+    """
+    Dropping a term and renormalising leaves the result exactly where the
+    surviving evidence puts it. Substituting a constant does not.
+    """
+    survivors = [(0.9, 0.4), (0.9, 0.3)]
+    assert renormalized_weighted_mean(survivors) == pytest.approx(0.9)
+
+    # A 0.5 stand-in for the absent term would drag a strong result down...
+    with_neutral_half = renormalized_weighted_mean(survivors + [(0.5, 0.3)])
+    assert with_neutral_half < 0.9
+    # ...and a 1.0 stand-in would inflate a weak one.
+    weak = [(0.2, 0.4), (0.2, 0.3)]
+    assert renormalized_weighted_mean(weak + [(1.0, 0.3)]) > 0.2
+
+
+def test_nothing_measurable_yields_unmeasured_not_a_middle_value():
+    """The caller must drop its own term in turn, not inherit a fabricated 0.5."""
+    assert math.isnan(renormalized_weighted_mean([]))
+    assert math.isnan(renormalized_weighted_mean([(UNMEASURED, 0.4)]))
+    assert math.isnan(renormalized_weighted_mean([(0.9, 0.0)]))
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 2. The acoustic stage
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_acoustic_emits_no_nan_when_the_enrolled_side_was_nulled():
+    """
+    The live 2026-08-07 shape: the sanitiser NULLed the enrolled formants and
+    rate, so those comparisons cannot be made.
+    """
+    assessment = _verifier()._compute_acoustic_match_sync(
+        _Features(),
+        _Features(formant_f1=UNMEASURED, formant_f2=UNMEASURED,
+                  formant_f3=UNMEASURED, speaking_rate=UNMEASURED),
+        _Model())
+    assert not math.isnan(assessment.score), assessment.describe()
+    assert "formants" not in assessment.components
+    assert "rate" not in assessment.components
+    assert assessment.has_evidence, "pitch and spectral were measurable on both sides"
+
+
+def test_acoustic_requires_both_sides_measured():
+    """
+    Comparing a live formant against an absent enrolled one is not a weak
+    match — it is not a comparison.
+    """
+    assessment = _verifier()._compute_acoustic_match_sync(
+        _Features(formant_f1=520.0),
+        _Features(formant_f1=UNMEASURED, formant_f2=UNMEASURED, formant_f3=UNMEASURED),
+        _Model())
+    assert "formants" not in assessment.components
+    assert any("formants" in a for a in assessment.abstained)
+
+
+def test_acoustic_with_no_evidence_at_all_reports_absence_not_a_score():
+    assessment = _verifier()._compute_acoustic_match_sync(
+        _Features(), _Features(pitch_mean=UNMEASURED, formant_f1=UNMEASURED,
+                               formant_f2=UNMEASURED, formant_f3=UNMEASURED,
+                               spectral_centroid=UNMEASURED, speaking_rate=UNMEASURED),
+        _Model())
+    assert assessment.components == {}
+    assert math.isnan(assessment.score)
+    assert assessment.has_evidence is False
+
+
+def test_acoustic_weights_renormalise_over_survivors():
+    """
+    With only pitch surviving, the score IS the pitch score — not the pitch
+    score diluted by three absent components.
+    """
+    assessment = _verifier()._compute_acoustic_match_sync(
+        _Features(pitch_mean=120.0),
+        _Features(pitch_mean=120.0, formant_f1=UNMEASURED, formant_f2=UNMEASURED,
+                  formant_f3=UNMEASURED, spectral_centroid=UNMEASURED,
+                  speaking_rate=UNMEASURED),
+        _Model())
+    assert assessment.components == {"pitch": pytest.approx(1.0)}
+    assert assessment.score == pytest.approx(1.0)
+
+
+def test_a_real_mismatch_still_scores_low():
+    """Abstention must not be indistinguishable from switching the stage off."""
+    assessment = _verifier()._compute_acoustic_match_sync(
+        _Features(pitch_mean=110.0, formant_f1=500.0, formant_f2=1400.0,
+                  formant_f3=2400.0, spectral_centroid=1500.0, speaking_rate=140.0),
+        _Features(pitch_mean=260.0, formant_f1=900.0, formant_f2=2600.0,
+                  formant_f3=3400.0, spectral_centroid=4000.0, speaking_rate=260.0),
+        _Model())
+    assert assessment.has_evidence is True
+    assert assessment.score < 0.3, assessment.describe()
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 3. The authorization tensor — the guard on the LIVE path
+# ─────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("field,value", [
+    ("owner_match_score", float("nan")),
+    ("owner_match_score", float("inf")),
+    ("spoof_prob", float("nan")),
+])
+def test_non_finite_fusion_input_fails_closed(field, value):
+    """
+    A NaN compares False against every threshold, so an unguarded one picks a
+    verdict by control flow. It must deny, loudly.
+    """
+    kwargs = dict(owner_match_score=0.9, spoof_prob=0.1)
+    kwargs[field] = value
+    score, decision, debug = _verifier()._owner_aware_antispoof_fusion_sync(
+        is_owner=True, speaker_model=_Model(), embedding_sim=0.9,
+        acoustic_score=0.8, physics_score=0.9, **kwargs)
+    assert decision == "deny"
+    assert score == 0.0
+    assert debug["rule_applied"] == "nan_input_fail_closed"
+    assert debug["authorization_anomaly"]["kind"] == "non_finite_fusion_input"
+    assert field in debug["authorization_anomaly"]["fields"]
+
+
+def test_a_corrupt_threshold_on_the_model_also_fails_closed():
+    """The thresholds are inputs too — a NaN one makes every comparison False."""
+    _, decision, debug = _verifier()._owner_aware_antispoof_fusion_sync(
+        owner_match_score=0.9, spoof_prob=0.1, is_owner=True,
+        speaker_model=_Model(decision_threshold=float("nan")),
+        embedding_sim=0.9, acoustic_score=0.8, physics_score=0.9)
+    assert decision == "deny"
+    assert "decision_threshold" in debug["authorization_anomaly"]["fields"]
+
+
+def test_a_nan_acoustic_score_does_not_block_a_valid_authorization():
+    """
+    acoustic_score is RECORDED, not decisive. A NaN there must be visible in
+    the debug block and must not deny a speaker the embedding matched.
+    """
+    score, decision, debug = _verifier()._owner_aware_antispoof_fusion_sync(
+        owner_match_score=0.92, spoof_prob=0.05, is_owner=True,
+        speaker_model=_Model(), embedding_sim=0.92,
+        acoustic_score=UNMEASURED, physics_score=UNMEASURED)
+    assert decision == "allow"
+    assert math.isfinite(score)
+    assert debug["acoustic_is_evidence"] is False
+    assert debug["physics_is_evidence"] is False
+    assert "authorization_anomaly" not in debug
+
+
+def test_a_genuine_owner_still_authorises():
+    """The guards must not have broken the happy path."""
+    score, decision, _ = _verifier()._owner_aware_antispoof_fusion_sync(
+        owner_match_score=0.90, spoof_prob=0.02, is_owner=True,
+        speaker_model=_Model(), embedding_sim=0.90,
+        acoustic_score=0.85, physics_score=0.95)
+    assert decision == "allow"
+    assert score >= 0.4885
+
+
+def test_an_extreme_spoof_still_denies():
+    _, decision, debug = _verifier()._owner_aware_antispoof_fusion_sync(
+        owner_match_score=0.95, spoof_prob=0.95, is_owner=True,
+        speaker_model=_Model(), embedding_sim=0.95,
+        acoustic_score=0.9, physics_score=0.9)
+    assert decision == "deny"
+    assert debug["rule_applied"] == "extreme_spoof_attack"
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 4. Persistent state — the EMA that cannot recover
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_an_ema_refuses_an_unmeasured_observation():
+    """
+    ``(1-a)*current + a*NaN`` is NaN, and so is every update after it. One
+    unmeasurable sample would corrupt the model permanently.
+    """
+    assert fold_measurement(120.0, UNMEASURED, 0.1) == 120.0
+    assert fold_measurement(120.0, None, 0.1) == 120.0
+    assert fold_measurement(120.0, float("inf"), 0.1) == 120.0
+
+
+def test_an_ema_refuses_an_out_of_band_observation():
+    validator = BiologicalBoundsValidator.from_env()
+    assert fold_measurement(120.0, 5000.0, 0.1, quantity="pitch_mean_hz",
+                            validator=validator) == 120.0
+
+
+def test_an_ema_folds_a_real_observation_normally():
+    assert fold_measurement(100.0, 200.0, 0.1) == pytest.approx(110.0)
+
+
+def test_an_already_corrupt_running_value_reseeds_from_a_measurement():
+    """
+    Recovery matters: a model poisoned before this fix existed must be able to
+    heal rather than stay NaN forever.
+    """
+    assert fold_measurement(UNMEASURED, 130.0, 0.1) == 130.0
+    assert math.isnan(fold_measurement(UNMEASURED, UNMEASURED, 0.1))
+
+
+def test_speaker_model_update_never_admits_a_nan_feature_vector():
+    """
+    A single NaN row makes every entry of the covariance matrix NaN, and that
+    matrix feeds Mahalanobis distance for every future verification.
+    """
+    verifier = _verifier()
+    verifier._features_to_vector = lambda f: np.array([1.0, np.nan, 3.0])
+    model = _Model()
+    original = model.covariance_matrix.copy()
+
+    verifier._update_speaker_model_sync(model, _Features(), confidence=0.9)
+
+    assert model.feature_samples == [], "a NaN sample must not enter the set"
+    assert np.array_equal(model.covariance_matrix, original)
+    assert math.isfinite(model.pitch_mean)
+
+
+def test_speaker_model_pitch_survives_an_unmeasured_sample():
+    verifier = _verifier()
+    verifier._features_to_vector = lambda f: np.array([1.0, 2.0, 3.0])
+    model = _Model(pitch_mean=120.0)
+
+    verifier._update_speaker_model_sync(
+        model, _Features(pitch_mean=UNMEASURED), confidence=0.9)
+
+    assert model.pitch_mean == 120.0, "the running value must be untouched"
+    assert math.isfinite(model.pitch_std)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 5. Perturbation tolerance — calibration, not constants
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_a_clean_capture_is_still_held_to_the_clinical_figure():
+    caps = PerturbationTolerance().caps_for(35.0)
+    assert caps.jitter == pytest.approx(0.02)
+    assert caps.shimmer == pytest.approx(0.10)
+
+
+def test_a_noisy_capture_gets_a_proportionally_wider_limit():
+    tolerance = PerturbationTolerance()
+    clean = tolerance.caps_for(30.0)
+    noisy = tolerance.caps_for(12.0)
+    assert noisy.jitter > clean.jitter
+    assert noisy.scale > 1.0
+
+
+def test_the_widening_is_bounded():
+    """A limit wide enough to pass anything is a check-shaped hole."""
+    tolerance = PerturbationTolerance()
+    caps = tolerance.caps_for(-50.0)
+    assert caps.scale <= tolerance.max_scale
+
+
+def test_unknown_snr_is_not_treated_as_too_noisy_to_inform():
+    """
+    "We measured 2 dB" and "we do not know" are different facts. Unknown SNR is
+    already compensated by the widened caps; abstaining as well would silently
+    disable jitter and shimmer for every caller that passes no audio_quality.
+    """
+    tolerance = PerturbationTolerance()
+    assert tolerance.informative(None) is True
+    assert tolerance.informative(2.0) is False
+    assert tolerance.informative(20.0) is True
+
+
+def test_the_operators_own_measured_perturbation_no_longer_tanks_the_score():
+    """
+    The verified 2026-08-07 sample measured jitter 0.07 / shimmer 0.30 on a
+    laptop array and scored 0.27 / 0.33 against clinical caps.
+    """
+    verifier = _verifier()
+    assessment = verifier._check_physics_plausibility_sync(
+        _Features(jitter=0.07, shimmer=0.30),
+        context={"audio_quality": {"snr_db": 12.0}})
+    assert assessment.components["jitter"] > 0.5, assessment.describe()
+    assert assessment.components["shimmer"] > 0.5, assessment.describe()
+
+
+def test_a_genuinely_impossible_perturbation_still_fails_at_any_snr():
+    """Scaling the caps must not become "no caps"."""
+    verifier = _verifier()
+    assessment = verifier._check_physics_plausibility_sync(
+        _Features(jitter=0.45, shimmer=0.48),
+        context={"audio_quality": {"snr_db": 8.0}})
+    assert assessment.components["jitter"] < 0.5, assessment.describe()
+
+
+def test_sub_floor_snr_abstains_rather_than_scoring_noise():
+    verifier = _verifier()
+    assessment = verifier._check_physics_plausibility_sync(
+        _Features(), context={"audio_quality": {"snr_db": 1.0}})
+    assert "jitter" not in assessment.components
+    assert any("jitter" in a for a in assessment.abstained)
+
+
+def test_perturbation_bands_are_env_overridable():
+    tolerance = PerturbationTolerance.from_env(
+        {"JARVIS_VOICE_PERTURBATION_BASE_JITTER": "0.05"})
+    assert tolerance.caps_for(35.0).jitter == pytest.approx(0.05)
+
+
+def test_a_malformed_perturbation_override_keeps_the_default():
+    tolerance = PerturbationTolerance.from_env(
+        {"JARVIS_VOICE_PERTURBATION_BASE_JITTER": "wide-open"})
+    assert tolerance.caps_for(35.0).jitter == pytest.approx(0.02)


### PR DESCRIPTION
## The guard had to go somewhere other than where its name pointed

`_bayesian_verification_sync` computed a prior, per-stage Gaussian likelihoods, a weighted likelihood, a normaliser and a posterior — then:

```python
posterior = unnormalized_posterior / max(normalizer, 1e-10)
posterior = float(np.clip(final_auth_score, 0.0, 1.0))   # <- overwrite
```

**Every Bayesian value was discarded on every verification.** That is *why* the acoustic NaN looked harmless — it flowed only into arithmetic whose result was thrown away. The channel was **severed, not safe**. A NaN filter installed on that matrix would have guarded nothing while looking like diligence, and would have armed itself the moment anyone reconnected the fusion.

The real authorization tensor is `_owner_aware_antispoof_fusion_sync`:

```python
final_auth_score = owner_match_score * 0.75 + live_speech_score * 0.25
```

Only embedding similarity and spoof probability reach it. **`acoustic_score` and `physics_score` do not influence the verdict** — worth stating plainly, because #70427 reads as though they did.

The dead computation is removed rather than repaired: repairing it means wiring it in, and wiring it in changes what authorises an unlock. That is an operator decision, not a tidy-up.

## Four guards, on the path that actually authorises

1. **Acoustic abstention.** A component contributes only when *both* sides were measured — comparing a live formant against an absent enrolled one is not a weak match, it is not a comparison.
2. **The neutral prior is dropping the term, not substituting a value.** In a weighted fusion 0.5 drags a strong result down and a weak one up; the model's own mean maximises the downstream Gaussian likelihood — a stage that measured nothing vouching for the speaker. `renormalized_weighted_mean` removes the term and renormalises the survivors.
3. **NaN interceptor on the fusion, in and out, failing closed.** A NaN compares False against every `>=`, so an unguarded one picks a verdict by control flow. Escalates to `runtime_health_sensor` through the existing push entry point (`TaskHarvester`, `LoopSentinel`).
4. **The worse bomb**, found while fixing the first: `_update_speaker_model_sync` folds features into EMAs over *persistent* state. One NaN makes `speaker_model.pitch_mean` NaN forever — an EMA has no recovery path — and a NaN feature vector poisons the covariance matrix Mahalanobis depends on. It runs only when `verified` is True, so corruption would be seeded by the **success** path. It became reachable when #70427 taught the extractors to report NaN honestly.

## Clinical thresholds on a laptop microphone

0.02 jitter / 0.10 shimmer are voice-pathology figures — head-mounted mic, treated room. On a laptop array they measure the room: the operator's own **verified** sample scored 0.27 / 0.33 and dragged an otherwise clean stage to 0.65. `PerturbationTolerance` scales both from measured SNR, abstaining below an informative floor because a limit wide enough to pass anything is a check-shaped hole. Deliberately *not* derived from `energy_contour` — energy is not signal-to-noise, and a loud recording in a loud room would read as clean.

## What the tests caught

`informative()` conflated "we measured 2 dB" with "we do not know the SNR". The unknown case is already compensated by the widened caps, so abstaining as well would have **silently disabled jitter and shimmer** for every caller passing no `audio_quality` block — a check disabled by a helper that looked careful.

## Measured, on the real rejected audio (2026-08-06, 6.10 s)

| | before | after |
|---|---|---|
| `acoustic_match_score` | **NaN** | **0.9104** |
| `physics_plausibility` | 0.6491 | **0.9473** |
| `anti_spoofing_score` | 1.0000 | 1.0000 |
| verdict | VERIFIED | VERIFIED, margin **+0.2690** |

The `Voice physics constraints violated` warning is gone — it was the clinical caps measuring the room.

## Not claimed

Still not live; this is an offline reconstruction against one stored sample. The verdict did not move (0.7575 both ways) **because acoustic and physics do not reach it**. What moved is that all three stages now report what they actually measured, and no NaN can enter the tensor or the adaptive model.

**706 green**, 29 new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a severed “Bayesian” path and adds fail-closed NaN guards to the real authorization tensor, while making acoustic/physics stages honest (abstain when unmeasured) and calibrating jitter/shimmer by SNR. This prevents NaNs from influencing decisions or corrupting the adaptive model; decision semantics are unchanged.

- **Bug Fixes**
  - Removed the dead Bayesian posterior; `_owner_aware_antispoof_fusion_sync` is the authority. Intercepts non-finite inputs/outputs, denies, and records an anomaly for `runtime_health_sensor`.
  - Acoustic stage now compares only when both sides are measured, returns an `AcousticAssessment`, and renormalizes weights via `renormalized_weighted_mean` (no fabricated 0.5, no NaN propagation).
  - Physics plausibility uses SNR-based perturbation caps; abstains below a floor; unknown SNR widens caps without disabling checks.
  - Adaptive model updates guarded by `fold_measurement`; refuse unmeasured/out-of-band samples; ignore non-finite feature vectors to protect covariance/Mahalanobis.
  - `_bayesian_verification_sync` now transparently wraps the fusion and denies if a non-finite posterior ever appears.

- **New Features**
  - `PerturbationTolerance`/`PerturbationCaps` with env overrides (`JARVIS_VOICE_PERTURBATION_*`) to scale jitter/shimmer by measured SNR.
  - Fusion anomaly escalation to `runtime_health_sensor`; helpers `renormalized_weighted_mean` and `fold_measurement`.
  - Added `tests/security/test_authorization_nan_integrity.py` covering NaN integrity, abstention, SNR tolerance, and adaptive model safety.

<sup>Written for commit 626df1e377fb219b0a2cc673ab81cae44d197494. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

