### PR TITLE
fix(security): the installer authored the authorization rule instead of amending it

### DIFF
--- a/backend/voice_unlock/README.md
+++ b/backend/voice_unlock/README.md
@@ -2,7 +2,35 @@
 
 A sophisticated voice-based authentication system for macOS that provides hands-free screen unlocking through voice commands. Perfect for users who don't have an Apple Watch but want the same convenient unlock experience. Built with a hybrid Objective-C and Python architecture for optimal performance and security.
 
-> **Status**: ✅ Fully integrated with JARVIS startup. Voice Unlock starts automatically when you launch JARVIS and processes commands like "unlock my mac" directly without giving instructions.
+> ## ⏸️ STATUS — read this before the rest of the document
+>
+> **Updated 2026-08-07. Screen UNLOCK is on hold and is not wired in.** Much of
+> what follows describes intent rather than current behaviour; it has not been
+> rewritten, so treat any unlock claim below as unverified unless this block
+> says otherwise.
+>
+> | capability | state |
+> |---|---|
+> | **Locking** the screen by voice | ✅ live-proven end to end (#70386–#70389) |
+> | **Unlocking** the screen by voice | ⏸️ **ON HOLD — deliberately not wired in** |
+> | Grant broker + signed XPC channel | ✅ proven working (25/25 lifecycles, 0 crashes) |
+>
+> The unlock path requires placing a mechanism into
+> `system.login.screensaver.unlock` — the only right on macOS 26 that can host
+> one. Apple labels it **"Do not modify"**, it has `tries: 1`, and it has no
+> password mechanism behind us. Whether a yield still reaches a password prompt
+> there could only be answered by putting a real lock screen into a state nobody
+> has observed on this OS. **That trade was declined.**
+>
+> An earlier attempt at this converted `system.login.screensaver` — a
+> *delegating* rule that hands the entire lock screen to loginwindow — into a
+> mechanism chain, and the machine authenticated into a black screen with a live
+> cursor. That is fixed, structurally and with 106 regression tests, and the
+> authorization database is now untouched.
+>
+> **📖 Full record: [`authplugin/README.md`](authplugin/README.md)** — root
+> cause, the five layers built, exactly what was proven and what was not, how to
+> remove it, and how to resume if that day comes.
 
 ## Features
 

--- a/backend/voice_unlock/authplugin/Makefile
+++ b/backend/voice_unlock/authplugin/Makefile
@@ -23,9 +23,10 @@ ifneq ($(SDK),)
 CFLAGS   += -isysroot $(SDK)
 endif
 
-SRC      := src
-BUILD    := build
-DIST     := dist
+SRC         := src
+BUILD       := build
+DIST        := dist
+INSTALL_DIR := install
 
 # --- Components -------------------------------------------------------------
 # JARVISGrantProtocol.m is linked by all three: it defines the symbols the
@@ -94,6 +95,12 @@ verify: all ## Assert structural invariants on the built artifacts
 	@env -i $(abspath $(HELPER_BIN)) probe >/dev/null 2>&1; \
 		test $$? -eq 78 && echo "  ✓ helper refuses without config (EX_CONFIG)" \
 		|| { echo "  FATAL: helper ran without configuration"; exit 1; }
+	@# The authorization rule layer. Not an artifact check, but it belongs to the
+	@# same guarantee: install.sh runs `make verify` as its first step, so the code
+	@# that decides whether a right may be converted into a mechanism chain is
+	@# exercised before any install can reach it. That decision was previously a
+	@# template literal with no test of any kind, and it black-screened the machine.
+	@$(INSTALL_DIR)/test_rule_shape.sh
 	@echo "all structural invariants hold"
 
 clean: ## Remove build artifacts

--- a/backend/voice_unlock/authplugin/README.md
+++ b/backend/voice_unlock/authplugin/README.md
@@ -1,0 +1,472 @@
+# JARVIS Authorization Plugin — screen unlock via SecurityAgent
+
+> ## ⏸️ STATUS: ON HOLD — deliberately not wired in
+>
+> **Decision, 2026-08-07: JARVIS will not lock or unlock the screen.** The
+> infrastructure is built, installed and proven; the final step — placing our
+> mechanism into the live unlock chain — is **not being taken**, and this is an
+> accepted decision rather than an unfinished task.
+>
+> The reason is stated in full under [Why it stopped](#why-it-stopped). In short:
+> the only right on macOS 26 that can host an unlock mechanism is
+> `system.login.screensaver.unlock`, Apple labels it **"Do not modify"**, it has
+> `tries: 1` and no password mechanism behind us, and the one remaining unknown
+> could only be resolved by putting a real lock screen into a state nobody has
+> observed on this OS. The value did not justify that.
+>
+> **Nothing here affects your ability to unlock your Mac.** The authorization
+> database is untouched. See [Current machine state](#current-machine-state).
+
+---
+
+## Table of contents
+
+- [What this is](#what-this-is)
+- [The defect that started it](#the-defect-that-started-it)
+- [The second defect: a guard inside what it guarded](#the-second-defect-a-guard-inside-what-it-guarded)
+- [What was built](#what-was-built)
+- [What was proven, and what was not](#what-was-proven-and-what-was-not)
+- [Why it stopped](#why-it-stopped)
+- [Current machine state](#current-machine-state)
+- [How to remove it](#how-to-remove-it)
+- [How to resume, if that day comes](#how-to-resume-if-that-day-comes)
+- [File map](#file-map)
+- [Durable lessons](#durable-lessons)
+
+---
+
+## What this is
+
+A macOS Authorization Plugin — a bundle loaded by SecurityAgent into
+`authorizationhosthelper` — that can grant a screen unlock when JARVIS has
+independently verified the operator's voice.
+
+Four components, each authorising its peers by **code-signing requirement
+computed from the actual signed binary on this machine**. No requirement string
+is written down anywhere; a literal would be a claim about a signing identity
+nobody has seen.
+
+```
+jarvis-unlock-grant      helper. Deposits a short-lived grant.
+        │ XPC (deposit service, peer verified by requirement)
+        ▼
+jarvis-unlock-broker     LaunchDaemon. Holds grants, TTL-bounded.
+        │ XPC (consume service, peer verified by requirement)
+        ▼
+JARVISUnlock.bundle      mechanism. Runs inside SecurityAgent's host process.
+        │
+        ▼
+system.login.screensaver.unlock          ← the step NOT taken
+```
+
+The mechanism **never denies**. It either grants or yields, and a yield is
+`kAuthorizationResultAllow` — "I am satisfied, continue" — never `Deny`, which
+would fail the whole right and lock the operator out of their own machine. There
+is deliberately no code path that can emit `Deny`.
+
+---
+
+## The defect that started it
+
+On 2026-08-06/07 this machine authenticated into a **black screen with a live
+cursor**, repeatedly, after Touch ID accepted.
+
+`install.sh` **authored** the authorization rule it wrote, from a template
+literal in its own body:
+
+```xml
+class      = evaluate-mechanisms
+mechanisms = ( JARVISUnlock:grant,privileged, builtin:authenticate,privileged )
+```
+
+and wrote that over `system.login.screensaver`, whose stock definition is:
+
+```xml
+class = rule
+rule  = use-login-window-ui
+```
+
+**`use-login-window-ui` is a delegation, not an authenticator.** It hands the
+right to **loginwindow**, which owns the lock screen: the wallpaper, the clock,
+your avatar, the password field, and the session resume that re-attaches
+WindowServer after a successful authentication. An `evaluate-mechanisms` chain
+only **authenticates**. Nothing in it paints a panel and nothing in it resumes a
+session — so the machine authenticated into nothing, and WindowServer kept
+drawing the cursor on its own plane.
+
+### The evidence had been spent on a different configuration
+
+The risk was known. `probe_screensaver_rule.sh` existed specifically to measure
+it — and it measured the wrong thing. It swapped the right to
+`authenticate-session-owner-or-admin`, which is **`class: user`**: a
+SecurityAgent-evaluated rule with **no `mechanisms` array at all**. It confirmed
+Touch ID and the password survived, and closed by advising that the plugin was
+therefore viable *"against evaluate-mechanisms"*.
+
+Two different configurations. The one that was measured worked. The one that was
+installed black-screened the machine.
+
+> **A measurement of one shape cannot be spent on another** — not by a comment,
+> not by an argument about equivalence, and not by a flag.
+
+### Nothing noticed
+
+Every check in `verify.sh` was **static** — hashes and plist keys. All of them
+stayed green throughout, because the chain they found *was* coherent. It simply
+had nothing to draw with.
+
+---
+
+## The second defect: a guard inside what it guarded
+
+Independently, `authorizationhosthelper` **segfaulted 27 times across two days**
+while every static check reported the installation healthy. Twelve reports were
+parseable; **all twelve** landed in our delivery path (8 × `JARVISDeliver`,
+4 × `os_log_type_enabled` called from inside it).
+
+The mechanism armed an uncancellable `dispatch_after` and kept its
+"already delivered" `atomic_flag` **inside the `calloc`'d `JARVISMechanism`**.
+SecurityAgent calls `MechanismDestroy` — freeing that allocation — the instant
+the chain advances past us, and every escaping callback can still fire
+afterwards. So reading the flag to ask *"did I lose the race?"* **was** the
+use-after-free.
+
+> **A guard placed inside the thing it guards is not a guard.**
+
+Fixed by **ownership, not defensiveness**: `JARVISDelivery` is an ARC object every
+racer co-owns strongly, so its memory cannot go away while any callback can still
+run — by construction. Blocks capture `self` **strongly on purpose**: a weak
+capture would trade the crash for a hang, with `SetResult` never called and the
+chain stalled forever — the same black screen reached through `nil` instead of
+through a segfault.
+
+A dead host is strictly worse than a mismatch. A mismatch fails **closed** to a
+password prompt. A host that dies before `SetResult` means *nothing in the chain
+ever answers* — including the `builtin:authenticate` that the install had
+carefully kept behind us, which is never reached.
+
+---
+
+## What was built
+
+Five layers. The first four stop the installer; the fifth stops the *machine*
+from staying broken.
+
+### 1 · Gate 7a — ask Apple's schema, about the stock definition
+
+Reads `/System/Library/Security/authorization.plist` and refuses any right whose
+**stock** class is not `evaluate-mechanisms`.
+
+Consulted against the **stock** definition, never the live one: after a
+conversion the live rule *is* a mechanism chain, so a live-rule check would
+cheerfully ratify its own damage on every reinstall.
+
+### 2 · Gate 7b — derive, never author
+
+The rule written is a **byte copy of the incumbent** with `mechanisms.0`
+inserted. `tries`, `shared`, `allow-root`, `version` and anything a future macOS
+adds now survive; the template literal silently dropped all of them and invented
+values of its own. Idempotent, and it verifies the result differs from the
+incumbent by exactly one entry in exactly one position.
+
+### 3 · Gate 7c — a shape may only be written if that shape was measured here
+
+`probe_*` records a **shape identity** (`class=…;mechanisms=a|b|c`) computed from
+the rule the authorization engine was *actually left holding*, not from what was
+requested. `install.sh` matches on it as a whole whitespace-delimited field, so a
+shape that merely *starts with* another cannot borrow its evidence.
+
+**There is no override flag**, on purpose. A flag is the shortest path back to
+spending one configuration's evidence on another.
+
+Shapes naming our mechanism must additionally clear **`failopen=proven`** —
+see [Why it stopped](#why-it-stopped).
+
+### 4 · The login-rights guard
+
+Lives at `jarvis_authdb_write`, the single seam every mutation passes through —
+not at four call sites with four chances to be missed by the fifth.
+
+> Refuse to write a rule **naming our mechanism** into a right whose stock chain
+> runs a **`loginwindow:`** mechanism.
+
+Both halves are load-bearing:
+
+- **"naming our mechanism"** — restore and strip still pass. A safety check that
+  blocks the recovery path strands someone at a lock screen.
+- **`loginwindow:` prefix, not the substring `login`** — our own target's sole
+  mechanism is `CryptoTokenKit:login`. A guard that bans its own target gets
+  removed by the first person it inconveniences.
+
+Derived, not listed, so a login right shipped by a future macOS is protected on
+day one:
+
+| right | stock chain runs `loginwindow:` | |
+|---|---|---|
+| `system.login.console` | yes | **protected** |
+| `system.login.filevault` | yes | **protected** |
+| `system.login.fus` | yes | **protected** |
+| `system.login.screensaver.unlock` | no — `CryptoTokenKit:login` | allowed |
+| `system.restart`, `system.disk.unlock` | no | allowed |
+
+A right absent from the schema is refused outright: unknown provenance is not a
+yes.
+
+### 5 · The sentinel — the machine cannot stay in an unsanctioned state
+
+The four gates stop the *installer*. Four roads to a black screen stay open after
+a **correct** install:
+
+1. the mechanism starts crashing its host
+2. an OS update rewrites the right *(what "Do not modify" is about)*
+3. the bundle goes away while the chain still names it
+4. someone edits the rule by hand *(how this machine got here)*
+
+All four end the same way: the machine sits broken until a human notices.
+
+The sentinel inverts that. **The default state is safe and JARVIS has to keep
+earning its place.** A LaunchDaemon watching `SecurityAgentPlugins`,
+`DiagnosticReports` and `/var/db/auth.db` checks five things — bundle present, no
+crash reports *naming us*, live shape equals the sanctioned one, chain still
+contains everything the backup had, right still a mechanism host — and pulls our
+mechanism out if any fail. No prompt, no human.
+
+**No resident daemon, and therefore no `KeepAlive`.** launchd's `WatchPaths` is
+kqueue-backed, so the script is *invoked* on a change rather than polling for
+one. Idle cost is not near-zero — it is **zero**, because between events there is
+no process. That answers *"what if the sentinel itself crashes"* at the root
+rather than with restarts: a thing that is not running cannot crash.
+
+Its only write is a **revert**, through the same function `uninstall.sh` uses. A
+sentinel that could put the mechanism back would be a second installer with no
+gates in front of it, and a test asserts it cannot.
+
+Urgency is graded: a vanished bundle or a crashing host repairs **immediately,
+even mid-authentication**, because an active lock screen is exactly when a stuck
+user needs it. Shape drift defers while SecurityAgent is running — but only for a
+bounded number of passes, because a guard that waits for the guarded system to go
+idle is a deadlock.
+
+---
+
+## What was proven, and what was not
+
+All measurements on **macOS 26.6.1 (25G76)**, 2026-08-07.
+
+| # | Claim | Result |
+|---|---|---|
+| 1 | The build is coherent; every requirement derives from a real signature | ✅ `make verify` green |
+| 2 | The XPC channel works and signatures are accepted by a **live peer** | ✅ `self-test PASSED` — grant `EFFBFA33-ABDA-465C-8D27-2C7B39A0B01F` |
+| 3 | The sentinel arms, runs, and leaves no resident process | ✅ `runs=1 · exit=0 · state=not running`, 2 × watch active |
+| 4 | Every component agrees about every peer | ✅ `verify.sh` → *coherent, and deliberately not wired in* |
+| 5 | **The use-after-free class is closed** | ✅ **25 lifecycles, 25 yields, 0 host crashes** |
+| 6 | A yield still reaches a password prompt on `tries: 1` | ❌ **NEVER MEASURED** |
+
+### On claim 5
+
+`probe_mechanism_lifecycle.sh` created a right of our own invention
+(`com.jarvis.probe.lifecycle`, in our own reverse-DNS namespace, consulted by
+nothing), put our mechanism in it **alone**, and invoked it 25 times with
+`security authorize` — then removed it and proved it was gone.
+
+The ratio is the result, not the absence of crashes:
+
+```
+authorize returned ok : 25     yields observed : 25     host crashes : 0
+```
+
+**25 invocations, exactly 25 yields.** The use-after-free was a *race* — one
+racer freeing what the other still read. Twenty-five consecutive full
+`Create → Invoke → SetResult → Destroy` cycles delivering exactly one result
+each, with the host alive at the end of every one, is the ownership rewrite doing
+precisely what it was designed to do, inside the process that died 27 times.
+
+`system.restart` was considered as a venue and **rejected**: invoking it runs
+`RestartAuthorization:restart`, and whether that mechanism merely *checks* or
+actually initiates a restart is not something to learn by being wrong about it.
+
+### On claim 6 — the one that stopped everything
+
+Never measured, and **not measurable without risking the lock screen.**
+
+---
+
+## Why it stopped
+
+`system.login.screensaver` (`class: rule` → `use-login-window-ui`) delegates to
+loginwindow, which internally evaluates **`system.login.screensaver.unlock`** —
+and *that* is a real mechanism chain, already shipping `CryptoTokenKit:login`,
+which is how smartcard unlock works. It is the supported host, one level below
+the delegator the original design was destroying.
+
+The architecture was right. The insertion point was one level off.
+
+But that right has three properties that together ended it:
+
+| | |
+|---|---|
+| **`tries: 1`** | One attempt. Nothing retries on our behalf. |
+| **no `builtin:authenticate` in the chain** | The old design put the stock authenticator directly behind us, so *"we yield and it prompts"* was a property of the chain. **Here it is not.** Whatever password path exists belongs to loginwindow, **outside** the chain. |
+| **Apple's comment: `"Do not modify."`** | Unsupported, and an OS update may rewrite it without notice. |
+
+Whether a yield reaches a prompt is therefore **not derivable from the
+configuration**. It is a runtime property of loginwindow, and the only instrument
+that can answer it is `probe_screensaver_rule.sh` — which must write our
+mechanism into the live unlock chain and hold it there while the operator locks
+their real screen.
+
+That probe is well-defended: dead man's switch armed *before* the write,
+Option-key panic bypass, the sentinel watching `/var/db/auth.db`, and a verdict
+read from crash reports and the unified log rather than from the operator. The
+worst realistic case is a hard power cycle — `system.login.console` is untouched,
+so a reboot always reaches a normal login window.
+
+**It was still a lock screen in a state nobody has observed on macOS 26, for a
+convenience feature.** That trade was declined.
+
+### What survives the decision
+
+The grant-broker architecture is proven and does **not** require the lock screen.
+The lifecycle probe demonstrated the whole chain working through a right *we
+invented*. Authorising JARVIS's own privileged actions through a
+`com.jarvis.*` right that nothing in macOS consults carries none of the risk
+above, cannot black-screen anything, and no OS update can break it.
+
+---
+
+## Current machine state
+
+As of 2026-08-07, after `install.sh --skip-authdb`:
+
+```
+✓ /Library/Security/SecurityAgentPlugins/JARVISUnlock.bundle
+✓ /usr/local/libexec/jarvis-unlock-broker        (running)
+✓ /usr/local/libexec/jarvis-unlock-grant
+✓ /Library/LaunchDaemons/com.jarvis.unlockbroker.plist
+✓ /Library/LaunchDaemons/com.jarvis.unlocksentinel.plist
+✓ /usr/local/libexec/jarvis-authplugin/          (recovery scripts)
+
+system.login.screensaver.unlock:  UNTOUCHED
+    class=evaluate-mechanisms  mechanisms=[CryptoTokenKit:login]
+    modified == created   ← never written
+```
+
+**SecurityAgent is not consulting anything of ours.** Files on disk and a daemon
+running; the unlock path is exactly as macOS shipped it.
+
+Recovery scripts install to `/usr/local/libexec/jarvis-authplugin/` rather than
+running from the repository: a machine that will not unlock is a bad time to
+discover the checkout lives in a cloud-synced directory that has not mounted.
+
+---
+
+## How to remove it
+
+```bash
+sudo /usr/local/libexec/jarvis-authplugin/uninstall.sh
+```
+
+Order matters and is enforced: the authorization rule is restored **first** —
+that is what unwedges a machine — then the sentinel is disarmed, then the broker,
+then the bundle. Removing the bundle first would leave a rule pointing at a
+mechanism that no longer exists, which is strictly worse than either the
+installed or the stock configuration.
+
+Safe to run twice, half-way through a failed install, or when nothing is
+installed at all. Runs from a Recovery Terminal or a bare SSH session, and
+depends on no Python, no virtualenv, and no repository.
+
+---
+
+## How to resume, if that day comes
+
+The ladder, in order. Each rung is cheap; only the last has teeth.
+
+```bash
+cd backend/voice_unlock/authplugin
+
+sudo ./install/install.sh --dry-run          # mutates nothing
+sudo ./install/install.sh --skip-authdb      # everything except the rule
+sudo ./install/verify.sh                     # coherence + crash history
+sudo ./install/probe_mechanism_lifecycle.sh  # the UAF class, zero stakes
+sudo ./install/probe_screensaver_rule.sh     # ← the only rung with risk
+sudo ./install/install.sh                    # refuses without failopen=proven
+```
+
+**Before the last two:**
+
+1. `sudo systemsetup -setremotelogin on` — and **verify SSH from another device
+   first**. An untested escape hatch is not an escape hatch. *(It was OFF when
+   this was written.)*
+2. Save all work. The realistic cost of a bad run is unsaved documents, not a
+   lost machine.
+3. Daylight, no time pressure, second machine already connected.
+
+Consider re-pointing `JARVIS_AUTH_RIGHT` at a `com.jarvis.*` right instead and
+taking none of this risk.
+
+---
+
+## File map
+
+```
+Makefile                      build + `verify` (runs the self-tests; install.sh
+                              calls this as step 1, so the gates cannot rot)
+src/
+  JARVISUnlockMechanism.m     the mechanism. Ownership-based race arbiter.
+  JARVISUnlockBroker.m        LaunchDaemon holding TTL-bounded grants
+  jarvis_unlock_grant.m       depositing helper
+  JARVISGrantProtocol.[hm]    shared XPC protocol + verdict vocabulary
+  JARVISUnlockConfig.[hm]     Info.plist config incl. the panic key
+install/
+  common.sh                   ALL shared logic: rule shape, composition,
+                              classification, the login guard, revert,
+                              dead man's switch, crash + log evidence
+  install.sh                  ordered install; gates 7a/7b/7c live here
+  uninstall.sh                recovery. Written before the plugin, on purpose.
+  verify.sh                   static coherence + rule shape + crash history
+  sentinel.sh                 launchd-invoked health check (layer 5)
+  probe_mechanism_lifecycle.sh   synthetic right; proves the UAF fix
+  probe_screensaver_rule.sh      the real right; the rung not taken
+  test_rule_shape.sh          106 self-tests, run by `make verify`
+```
+
+---
+
+## Durable lessons
+
+Each of these cost a session.
+
+**A guard placed inside the thing it guards is not a guard.** The `atomic_flag`
+lived in the allocation whose lifetime it was policing, so reading it *was* the
+use-after-free.
+
+**A measurement of one shape cannot be spent on another.** `class: user` was
+probed; `evaluate-mechanisms` was installed.
+
+**Never author a rule — amend one.** A template literal cannot know what it is
+destroying, because it never read it.
+
+**Ask the stock schema, not the live state.** After a conversion the live state
+*is* the damage, so a live check ratifies it.
+
+**Match the prefix, not the substring.** `CryptoTokenKit:login` contains
+`login`. (`"lock" in "unlock my screen"` is also `True`.)
+
+**A safety check must never block the recovery path.** Scope guards to what adds
+risk, never to what removes it.
+
+**A check that reports the safe state as a fault, and names the dangerous action
+as its remedy, is worse than no check.** `verify.sh` said *"partially installed,
+1 component absent"* with everything green — the "absent" thing was the rule
+being deliberately unwired — and prescribed `install.sh`, the one irreversible
+step. All 99 tests passed while that was live. **It took running it.**
+
+**Static checks cannot see a runtime death.** 27 crashes, every check green.
+
+**A watchdog that shares a resource with the system it guards is not a
+watchdog** — including a state-ledger. The correct answer to "it got severed
+mid-operation" is a larger *static* margin, never an activity-gated waiver.
+
+**The strongest guarantee is not a better gate; it is a system that cannot stay
+in a bad state.** Gates stop the installer. Only the sentinel stops the machine.

--- a/backend/voice_unlock/authplugin/install/common.sh
+++ b/backend/voice_unlock/authplugin/install/common.sh
@@ -86,7 +86,31 @@ jarvis_restore_auth_rule_from_pointer() {
     # than it found them.
     plutil -lint "${backup}" >/dev/null 2>&1 || return 1
 
+    # A backup that already names the plugin is not a restore point.
+    #
+    # Reinstalling over an existing install used to overwrite the pointer with a
+    # capture of the ALREADY-MODIFIED rule. Uninstall then faithfully restored
+    # that, logged "authorization rule restored from backup", and returned --
+    # putting the mechanism straight back while the bundle it names had just been
+    # deleted. That state is strictly worse than doing nothing: SecurityAgent
+    # cannot load a missing mechanism, so the chain fails before reaching
+    # builtin:authenticate and the screen has no authenticator at all.
+    if grep -q "${JARVIS_PLUGIN_NAME}" "${backup}" 2>/dev/null; then
+        _jarvis_warn "backup names ${JARVIS_PLUGIN_NAME}; not a restore point: ${backup}"
+        return 1
+    fi
+
     jarvis_authdb_write "${JARVIS_AUTH_RIGHT}" "${backup}" >/dev/null 2>&1 || return 1
+
+    # Prove the write achieved the GOAL, not merely that it succeeded. A restore
+    # that returns 0 with our mechanism still live is precisely the failure this
+    # function exists to prevent, and the caller has a working fallback -- but
+    # only if we admit we did not do the job.
+    if jarvis_rule_references_plugin; then
+        _jarvis_warn "restored ${backup} but the live rule still names ${JARVIS_PLUGIN_NAME}"
+        return 1
+    fi
+
     rm -f "${JARVIS_AUTHDB_BACKUP_POINTER}"
     return 0
 }
@@ -94,6 +118,313 @@ jarvis_restore_auth_rule_from_pointer() {
 # Does the live rule currently name our mechanism?
 jarvis_rule_references_plugin() {
     jarvis_authdb_read "${JARVIS_AUTH_RIGHT}" 2>/dev/null | grep -q "${JARVIS_PLUGIN_NAME}"
+}
+
+# =============================================================================
+# AUTHORIZATION RULE SHAPE
+# =============================================================================
+# This section exists because of one specific incident, and every function in it
+# is shaped by that incident.
+#
+# install.sh used to AUTHOR the rule it wrote, from a template literal in its own
+# body: class = evaluate-mechanisms, mechanisms = ( ours, builtin:authenticate ).
+# It wrote that over system.login.screensaver, whose stock definition is
+#
+#     class = rule
+#     rule  = use-login-window-ui
+#
+# use-login-window-ui delegates the right to loginwindow, which owns the lock
+# screen: the wallpaper, the clock, the user's name, the password field, and the
+# session resume that re-attaches WindowServer after a successful authentication.
+# An evaluate-mechanisms chain only AUTHENTICATES. Nothing in it paints a panel
+# and nothing in it resumes a session -- so the machine authenticated into a
+# black screen with a live cursor and no way back.
+#
+# The measurement that authorised that change had been taken against a DIFFERENT
+# shape. probe_screensaver_rule.sh swapped the right to
+# authenticate-session-owner-or-admin -- which is class = user, a SecurityAgent-
+# evaluated rule with no mechanisms array at all -- confirmed Touch ID and the
+# password still worked, and that result was spent to justify writing a mechanism
+# chain nobody had ever run. Two different configurations; only one was measured.
+#
+# Hence three rules, each enforced by a function below:
+#
+#   1. NEVER AUTHOR A RULE. Derive what is written from the bytes of the rule
+#      that is already live, changing only what must change. A template literal
+#      cannot know what it is destroying.
+#
+#   2. ASK APPLE'S SCHEMA whether a right can host a mechanism, and ask it about
+#      the STOCK definition rather than the live one. On a reinstall the live
+#      rule is our own previous mutation, so a check that consulted it would
+#      cheerfully ratify the damage it exists to detect.
+#
+#   3. A SHAPE MAY ONLY BE WRITTEN IF THAT EXACT SHAPE HAS BEEN MEASURED on this
+#      machine. Not a similar one, and not one a comment claims is equivalent.
+#
+# Everything here uses plutil, which install.sh already depends on and which
+# Recovery ships. No python: uninstall.sh must run from a Recovery shell.
+
+# The class an authorization right must have in order to evaluate a mechanism
+# chain. Deliberately NOT environment-overridable -- it is a constant of the
+# macOS authorization schema, not a tunable, and an env-overridable version would
+# be a one-variable bypass of the only check standing between a template literal
+# and the lock screen.
+JARVIS_MECHANISM_HOST_CLASS="evaluate-mechanisms"
+
+# The authoritative schema for what every right's stock definition is. Overridable
+# ONLY so the self-tests can point the classifier at a fixture; install.sh pins it
+# back to the system path and refuses to run against anything else, so this is
+# testability without a production bypass.
+JARVIS_SYSTEM_AUTH_TEMPLATE_DEFAULT="/System/Library/Security/authorization.plist"
+JARVIS_SYSTEM_AUTH_TEMPLATE="${JARVIS_SYSTEM_AUTH_TEMPLATE:-${JARVIS_SYSTEM_AUTH_TEMPLATE_DEFAULT}}"
+
+# Where probe_screensaver_rule.sh records what it measured, and where install.sh
+# looks for permission to write a shape. One definition, because a producer and a
+# consumer that disagree about a path is a gate that silently never fires.
+JARVIS_PROBE_RESULTS_LOG="${JARVIS_STATE_DIR}/probe-results.log"
+
+# plutil key paths are dot-separated, so a right named "system.login.screensaver"
+# has to have its own dots escaped or it reads as a four-level nesting.
+_jarvis_plist_escape_key() { printf '%s' "$1" | sed 's/\./\\./g'; }
+
+# Read one value out of a plist. The single place that shells out to plutil for
+# reads, so there is one definition of "how do we ask a plist a question".
+jarvis_plist_value() {
+    local file="$1" keypath="$2"
+    [ -f "${file}" ] || return 1
+    plutil -extract "${keypath}" raw -o - "${file}" 2>/dev/null
+}
+
+jarvis_rule_class() { jarvis_plist_value "$1" class; }
+
+# Emit a rule's mechanisms, one per line, in order.
+#
+# Bounded by the array's OWN element count rather than by walking until an
+# extraction fails: a count is an exact answer the file already contains, and a
+# sentinel loop over an unfamiliar plist shape is a guess with no upper bound.
+# Returns 1 if an element the count promised cannot be read -- a malformed rule
+# must not read as a short one.
+jarvis_rule_mechanisms() {
+    local file="$1" count idx value
+    count="$(jarvis_plist_value "${file}" mechanisms 2>/dev/null || true)"
+    # Absent key, or a non-array whose raw form is not a count: no mechanisms.
+    case "${count}" in ''|*[!0-9]*) return 0 ;; esac
+
+    idx=0
+    while [ "${idx}" -lt "${count}" ]; do
+        value="$(jarvis_plist_value "${file}" "mechanisms.${idx}")" || return 1
+        printf '%s\n' "${value}"
+        idx=$(( idx + 1 ))
+    done
+}
+
+# Exact-line membership test over a newline-delimited list.
+#
+# Exists because `producer | grep -qxF needle` is wrong here and looks right.
+# These scripts run under `set -o pipefail`, and grep -q exits the instant it
+# matches -- which SIGPIPEs the producer, fails the pipeline, and inverts the
+# test: the chain that DID contain the mechanism reported that it did not. The
+# same trap applies to `| head -1`. Consumers of jarvis_rule_mechanisms must
+# either read all of their input or, as here, not be a pipeline at all.
+_jarvis_lines_contain() {
+    local list="$1" needle="$2" line
+    [ -n "${list}" ] || return 1
+    while IFS= read -r line; do
+        [ "${line}" = "${needle}" ] && return 0
+    done <<EOF
+${list}
+EOF
+    return 1
+}
+
+# The canonical identity of a rule's SHAPE: its class and its ordered mechanism
+# list, and nothing else.
+#
+# This is the key the evidence gate is stated in, so what it deliberately omits
+# matters as much as what it includes. comment and version are documentation and
+# bookkeeping; two rules differing only there behave identically, and letting
+# them read as different shapes would invalidate a real measurement over a
+# cosmetic edit. Contains no spaces by construction, so it survives being one
+# field in a whitespace-delimited log line.
+jarvis_rule_shape() {
+    local file="$1" class mechs
+    class="$(jarvis_rule_class "${file}" 2>/dev/null || true)"
+    [ -n "${class}" ] || return 1
+    mechs="$(jarvis_rule_mechanisms "${file}" | tr '\n' '|' | sed 's/|$//')" || return 1
+    printf 'class=%s;mechanisms=%s' "${class}" "${mechs}"
+}
+
+# The class a right has in Apple's schema, before anyone on this machine touched
+# it. Rights and rules live in separate buckets of the same file; a right can be
+# in either, so both are consulted.
+jarvis_stock_rule_class() {
+    local right="$1" key bucket value
+    [ -r "${JARVIS_SYSTEM_AUTH_TEMPLATE}" ] || return 1
+    key="$(_jarvis_plist_escape_key "${right}")"
+    for bucket in rights rules; do
+        value="$(jarvis_plist_value "${JARVIS_SYSTEM_AUTH_TEMPLATE}" "${bucket}.${key}.class" || true)"
+        if [ -n "${value}" ]; then
+            printf '%s' "${value}"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Human-readable stock definition, for the refusal message. An operator being
+# told "no" is owed the evidence, and Apple's own comment on the right is usually
+# the most useful sentence available -- on system.login.screensaver it names the
+# supported alternative outright.
+jarvis_stock_rule_summary() {
+    local right="$1" key bucket found=0 value
+    [ -r "${JARVIS_SYSTEM_AUTH_TEMPLATE}" ] || return 1
+    key="$(_jarvis_plist_escape_key "${right}")"
+    for bucket in rights rules; do
+        jarvis_plist_value "${JARVIS_SYSTEM_AUTH_TEMPLATE}" "${bucket}.${key}.class" >/dev/null 2>&1 \
+            || continue
+        found=1
+        for field in class rule comment; do
+            value="$(jarvis_plist_value "${JARVIS_SYSTEM_AUTH_TEMPLATE}" "${bucket}.${key}.${field}" || true)"
+            [ -n "${value}" ] && printf '%s: %s\n' "${field}" "${value}"
+        done
+        value="$(jarvis_plist_value "${JARVIS_SYSTEM_AUTH_TEMPLATE}" "${bucket}.${key}.mechanisms" || true)"
+        [ -n "${value}" ] && printf 'mechanisms: %s entr(y/ies)\n' "${value}"
+        break
+    done
+    [ "${found}" -eq 1 ]
+}
+
+# THE GATE. Can this right host a mechanism chain at all?
+#
+#   0  yes -- stock class is the mechanism-host class
+#   2  no  -- stock class is something else; converting it destroys a delegation
+#   1  unknown -- schema unreadable or the right is not in it
+#
+# 1 and 2 are distinguished because they need different messages, not because
+# they need different outcomes. Both fail closed.
+jarvis_right_hosts_mechanisms() {
+    local stock
+    stock="$(jarvis_stock_rule_class "$1")" || return 1
+    [ "${stock}" = "${JARVIS_MECHANISM_HOST_CLASS}" ] || return 2
+    return 0
+}
+
+# Derive the rule to write from the rule that is live.
+#
+#   0  composed -- out is the incumbent plus our mechanism at the head
+#   2  no-op    -- the incumbent already names it; out is a copy, unchanged
+#   3  refused  -- the incumbent is not a mechanism chain
+#   1  error
+#
+# The output starts as a byte copy of the incumbent, so every key we have no
+# opinion about -- tries, shared, allow-root, version, anything a future macOS
+# adds -- survives untouched. The previous template literal silently dropped all
+# of them and invented values of its own.
+jarvis_compose_mechanism_rule() {
+    local incumbent="$1" out="$2" mechanism="$3"
+    local class composed head rest original comment
+
+    [ -f "${incumbent}" ] || return 1
+    [ -n "${mechanism}" ] || return 1
+    class="$(jarvis_rule_class "${incumbent}" 2>/dev/null || true)"
+    [ -n "${class}" ] || return 1
+    [ "${class}" = "${JARVIS_MECHANISM_HOST_CLASS}" ] || return 3
+
+    original="$(jarvis_rule_mechanisms "${incumbent}")" || return 1
+
+    cp "${incumbent}" "${out}" 2>/dev/null || return 1
+
+    # Idempotent. A reinstall must not stack a second copy of our mechanism onto
+    # a chain that already runs it.
+    if _jarvis_lines_contain "${original}" "${mechanism}"; then
+        return 2
+    fi
+
+    # Head position, not appended. Ours either grants or yields, and a yield has
+    # to still reach whatever the right already had. Appended, it would run after
+    # the stock authenticator -- where a grant is worthless because the user has
+    # already typed their password.
+    plutil -insert "mechanisms.0" -string "${mechanism}" "${out}" >/dev/null 2>&1 || return 1
+
+    # Prove the file on disk is what was intended, rather than trusting that
+    # plutil returned 0. The composed chain must differ from the incumbent by
+    # exactly one entry, in exactly one position.
+    composed="$(jarvis_rule_mechanisms "${out}")" || return 1
+    # Split by parameter expansion rather than head/tail: no subprocess, and
+    # nothing that can early-exit into the SIGPIPE trap described above.
+    head="${composed%%$'\n'*}"
+    if [ "${composed}" = "${head}" ]; then rest=""; else rest="${composed#*$'\n'}"; fi
+    [ "${head}" = "${mechanism}" ] || return 1
+    [ "${rest}" = "${original}" ] || return 1
+    [ "$(jarvis_rule_class "${out}")" = "${class}" ] || return 1
+
+    # Provenance, best-effort and deliberately last: the rule is what a stranded
+    # operator reads with `security authorizationdb read`, and it should name its
+    # own undo. A failure here is not a failure of the composition -- comment is
+    # documentation, the authorization engine never evaluates it, and it is
+    # excluded from the shape identity above -- so it must not fail the write.
+    comment="$(jarvis_plist_value "${out}" comment || true)"
+    if [ -n "${comment}" ]; then
+        plutil -replace comment -string \
+            "${comment} [${JARVIS_PLUGIN_NAME}: added ${mechanism}; remove with install/uninstall.sh]" \
+            "${out}" >/dev/null 2>&1 || true
+    else
+        plutil -insert comment -string \
+            "[${JARVIS_PLUGIN_NAME}: added ${mechanism}; remove with install/uninstall.sh]" \
+            "${out}" >/dev/null 2>&1 || true
+    fi
+    return 0
+}
+
+# Remove every mechanism entry mentioning a needle. Echoes how many were removed.
+#
+# Walks BACKWARDS. A forward walk has to deliberately not advance its index after
+# a delete, because the entries shift down -- correct, but the kind of correct
+# that breaks the first time someone tidies the loop. Iterating from the end
+# means no delete can ever move an entry that has not been visited yet.
+jarvis_rule_strip_mechanism() {
+    local file="$1" needle="$2" count idx value removed=0
+    count="$(jarvis_plist_value "${file}" mechanisms 2>/dev/null || true)"
+    case "${count}" in ''|*[!0-9]*) printf '0'; return 0 ;; esac
+
+    idx=$(( count - 1 ))
+    while [ "${idx}" -ge 0 ]; do
+        value="$(jarvis_plist_value "${file}" "mechanisms.${idx}" || true)"
+        case "${value}" in
+            *"${needle}"*)
+                if plutil -remove "mechanisms.${idx}" "${file}" >/dev/null 2>&1; then
+                    removed=$(( removed + 1 ))
+                fi
+                ;;
+        esac
+        idx=$(( idx - 1 ))
+    done
+    printf '%s' "${removed}"
+}
+
+# Has THIS shape been measured on THIS machine, with the password still working?
+#
+# Matches shape as a whole whitespace-delimited field rather than by substring,
+# so a shape that merely starts with another shape's text cannot borrow its
+# evidence -- which is the entire class of mistake this gate exists to stop.
+# locked=yes is required because a probe run in which the operator never locked
+# the screen measured nothing, and the probe records that fact honestly.
+jarvis_probe_evidence_for_shape() {
+    local shape="$1"
+    [ -n "${shape}" ] || return 1
+    [ -r "${JARVIS_PROBE_RESULTS_LOG}" ] || return 1
+    awk -v want="shape=${shape}" '
+        {
+            s = 0; p = 0; l = 0
+            for (i = 1; i <= NF; i++) {
+                if ($i == want)           s = 1
+                if ($i == "password=yes") p = 1
+                if ($i == "locked=yes")   l = 1
+            }
+            if (s && p && l) last = $0
+        }
+        END { if (last != "") { print last; exit 0 } exit 1 }
+    ' "${JARVIS_PROBE_RESULTS_LOG}"
 }
 
 # Wait for a system service to be fully gone.

--- a/backend/voice_unlock/authplugin/install/common.sh
+++ b/backend/voice_unlock/authplugin/install/common.sh
@@ -18,10 +18,38 @@ JARVIS_MECHANISM="${JARVIS_PLUGIN_NAME}:grant,privileged"
 JARVIS_BROKER_LABEL="com.jarvis.unlockbroker"
 
 # --- Authorization right we participate in ----------------------------------
-# Only the screensaver right. system.login.console is deliberately NEVER
-# touched: a defect there costs you login, not just unlock, and the difference
-# is the difference between "annoying" and "boot from Recovery".
-JARVIS_AUTH_RIGHT="system.login.screensaver"
+# system.login.console is deliberately NEVER touched: a defect there costs you
+# login, not just unlock, and the difference is the difference between
+# "annoying" and "boot from Recovery".
+#
+# NOT system.login.screensaver either, which is what this used to be. That right
+# is class=rule delegating to use-login-window-ui -- it hands the whole lock
+# screen to loginwindow, panel and password field and the session resume that
+# re-attaches WindowServer. Converting it to a mechanism chain replaced a user
+# interface with an authenticator and black-screened the machine.
+#
+# loginwindow, in turn, evaluates system.login.screensaver.unlock -- and THAT is
+# a real evaluate-mechanisms chain, shipping CryptoTokenKit:login, which is how
+# smartcard unlock already works. It is the supported host, one level below the
+# delegator the previous design was destroying.
+#
+# TWO PROPERTIES OF THIS RIGHT MAKE IT UNFORGIVING, AND BOTH ARE LOAD-BEARING:
+#
+#   tries = 1        One attempt. Nothing retries on our behalf.
+#
+#   no builtin:authenticate in the chain
+#                    The old design put the stock authenticator directly behind
+#                    us, so "we yield and it prompts" was a property of the
+#                    chain itself. Here it is not. Whatever password path exists
+#                    belongs to loginwindow, OUTSIDE this chain, and whether it
+#                    is reached is a MEASUREMENT -- see probe_screensaver_rule.sh
+#                    and its fail-open battery. Do not assume it. It has to be
+#                    proven on the machine, under the dead man's switch, before
+#                    an install is allowed anywhere near it.
+#
+# Apple's own comment on this right is "Do not modify." That is not decoration:
+# it means unsupported, and it means an OS update may rewrite it without notice.
+JARVIS_AUTH_RIGHT="system.login.screensaver.unlock"
 
 # --- Filesystem layout ------------------------------------------------------
 JARVIS_PLUGIN_DIR="/Library/Security/SecurityAgentPlugins"
@@ -85,6 +113,30 @@ jarvis_restore_auth_rule_from_pointer() {
     # authorization database is the one way recovery could make things worse
     # than it found them.
     plutil -lint "${backup}" >/dev/null 2>&1 || return 1
+
+    # The backup has to be a backup OF THIS RIGHT.
+    #
+    # The pointer file records a path and nothing else, and the target right has
+    # already changed once -- from system.login.screensaver to
+    # system.login.screensaver.unlock. A pointer left behind by an install of the
+    # old target would be restored, faithfully and with a success message, into
+    # the NEW right: writing a class=rule delegating definition over a mechanism
+    # chain. That is not a restore, it is a second conversion, performed by the
+    # recovery path, on a machine already in trouble.
+    #
+    # Every backup this system writes embeds the right in its filename, so the
+    # provenance is already recorded; it was simply never checked.
+    # The timestamp is part of the pattern, not decoration. Matching on
+    # "<right>.*" alone would let a backup of system.login.screensaver.unlock
+    # satisfy a check for system.login.screensaver, because the longer name has
+    # the shorter one as a prefix -- the wrong direction of the same mistake.
+    case "$(basename "${backup}")" in
+        "${JARVIS_AUTH_RIGHT}."[0-9]*) : ;;
+        *)
+            _jarvis_warn "restore point is not for ${JARVIS_AUTH_RIGHT}: ${backup}"
+            return 1
+            ;;
+    esac
 
     # A backup that already names the plugin is not a restore point.
     #
@@ -409,22 +461,126 @@ jarvis_rule_strip_mechanism() {
 # evidence -- which is the entire class of mistake this gate exists to stop.
 # locked=yes is required because a probe run in which the operator never locked
 # the screen measured nothing, and the probe records that fact honestly.
+# A shape that actually contains OUR mechanism has to clear a higher bar:
+# failopen=proven. Derived from the shape itself rather than passed in, so a
+# caller cannot ask the easier question by accident.
+#
+# The reason is specific to system.login.screensaver.unlock. The old right had
+# builtin:authenticate directly behind us, so "we yield and the stock
+# authenticator prompts" was a property of the chain. This one has no password
+# mechanism in it and tries=1 -- whatever prompt exists belongs to loginwindow,
+# outside the chain, and whether a yield reaches it is not derivable from the
+# configuration. Only a run that yielded, survived, and still got a password
+# prompt establishes it. A shape that merely swaps in a named rule keeps the old
+# bar, because it has no mechanism of ours to fail open FROM.
 jarvis_probe_evidence_for_shape() {
-    local shape="$1"
+    local shape="$1" need_failopen=0
     [ -n "${shape}" ] || return 1
     [ -r "${JARVIS_PROBE_RESULTS_LOG}" ] || return 1
-    awk -v want="shape=${shape}" '
+    case "${shape}" in *"${JARVIS_MECHANISM}"*) need_failopen=1 ;; esac
+    awk -v want="shape=${shape}" -v needfo="${need_failopen}" '
         {
-            s = 0; p = 0; l = 0
+            s = 0; p = 0; l = 0; f = 0
             for (i = 1; i <= NF; i++) {
-                if ($i == want)           s = 1
-                if ($i == "password=yes") p = 1
-                if ($i == "locked=yes")   l = 1
+                if ($i == want)             s = 1
+                if ($i == "password=yes")   p = 1
+                if ($i == "locked=yes")     l = 1
+                if ($i == "failopen=proven") f = 1
             }
-            if (s && p && l) last = $0
+            if (s && p && l && (needfo != "1" || f)) last = $0
         }
         END { if (last != "") { print last; exit 0 } exit 1 }
     ' "${JARVIS_PROBE_RESULTS_LOG}"
+}
+
+# =============================================================================
+# RUNTIME EVIDENCE
+# =============================================================================
+# Everything above this line inspects CONFIGURATION. None of it can see a
+# mechanism that loads correctly and then dies, which is precisely what happened:
+# 27 segfaults across two days while every static check reported the install
+# coherent, because the mechanism runs inside a process we do not own and its
+# corpses land in DiagnosticReports rather than anywhere anyone was looking.
+#
+# These are the primitives for asking what actually HAPPENED. Defined here, not
+# in verify.sh, because the probe needs the identical questions -- and a probe
+# that measured "did it crash" differently from the verifier would be two
+# opinions about one machine.
+
+JARVIS_LOG_SUBSYSTEM_PLUGIN="com.jarvis.unlockplugin"
+JARVIS_CRASH_REPORTS_DIR="${JARVIS_CRASH_REPORTS_DIR:-/Library/Logs/DiagnosticReports}"
+# The process that hosts a SecurityAgent mechanism. Ours dying means THIS dying.
+JARVIS_AUTH_HOST_PROCESS="${JARVIS_AUTH_HOST_PROCESS:-authorizationhosthelper}"
+
+jarvis_plugin_bundle_present() { [ -d "${JARVIS_PLUGIN_PATH}" ]; }
+
+# Paths of host crash reports modified at or after <epoch>, one per line.
+# Emits nothing (rc 0) when there are none; rc 1 only if the directory is
+# unreadable, which needs membership in _analyticsusers and is a different fact
+# from "there were no crashes".
+jarvis_crash_reports_since() {
+    local since="$1" rep mtime
+    [ -r "${JARVIS_CRASH_REPORTS_DIR}" ] || return 1
+    for rep in "${JARVIS_CRASH_REPORTS_DIR}/${JARVIS_AUTH_HOST_PROCESS}"*.ips; do
+        [ -e "${rep}" ] || continue
+        mtime="$(stat -f %m "${rep}" 2>/dev/null || echo 0)"
+        [ "${mtime}" -ge "${since}" ] || continue
+        printf '%s\n' "${rep}"
+    done
+    return 0
+}
+
+# The faulting symbol of a crash report: the top frame of the TRIGGERED thread.
+#
+# Both narrowing steps are load-bearing. Without "triggered":true you get thread
+# 0's idle runloop frame, which every report has and which means nothing.
+# Without "frames":[ you get a symbol out of the preceding threadState, where the
+# crash reporter annotates register VALUES that happen to land on known
+# addresses -- the first draft of this reported OBJC_CLASS_$___NSTaggedDate,
+# which was the contents of x14 and not a stack frame at all.
+jarvis_crash_faulting_symbol() {
+    local report="$1"
+    [ -r "${report}" ] || return 1
+    tr -d '\n' < "${report}" 2>/dev/null \
+        | sed -e 's/.*"triggered":true//' -e 's/.*"frames":\[//' \
+        | grep -o '"symbol":"[^"]*"' \
+        | head -1 | cut -d'"' -f4
+}
+
+# Unified-log lines from our subsystems and from the mechanism host, since a
+# `log show`-formatted start time ("YYYY-MM-DD HH:MM:SS").
+#
+# Needs root. A non-root caller gets zero lines with no error, which reads
+# exactly like "nothing happened" -- so callers must decide whether they are
+# entitled to the answer before they interpret an empty one.
+jarvis_unlock_log_since() {
+    local since="$1"
+    log show --style compact --start "${since}" --predicate \
+        "subsystem == \"${JARVIS_LOG_SUBSYSTEM_PLUGIN}\" OR process == \"${JARVIS_AUTH_HOST_PROCESS}\"" \
+        2>/dev/null
+}
+
+# Does the live chain still contain every mechanism the backup had?
+#
+# The question verify.sh used to ask as `grep -q builtin:authenticate`, which was
+# a literal describing one particular chain. On system.login.screensaver.unlock
+# there is no builtin:authenticate -- there is CryptoTokenKit:login -- so the
+# named check would fail a CORRECT install and pass a chain that had silently
+# lost smartcard unlock. What matters is not which mechanisms are there but that
+# we took nothing away, and the only thing that knows what was there is the
+# backup.
+jarvis_chain_preserves_backup() {
+    local live="$1" backup="$2" want livelist backlist
+    livelist="$(jarvis_rule_mechanisms "${live}")" || return 1
+    backlist="$(jarvis_rule_mechanisms "${backup}")" || return 1
+    [ -n "${backlist}" ] || return 0
+    while IFS= read -r want; do
+        [ -n "${want}" ] || continue
+        _jarvis_lines_contain "${livelist}" "${want}" || return 1
+    done <<EOF
+${backlist}
+EOF
+    return 0
 }
 
 # Wait for a system service to be fully gone.

--- a/backend/voice_unlock/authplugin/install/common.sh
+++ b/backend/voice_unlock/authplugin/install/common.sh
@@ -49,7 +49,35 @@ JARVIS_BROKER_LABEL="com.jarvis.unlockbroker"
 #
 # Apple's own comment on this right is "Do not modify." That is not decoration:
 # it means unsupported, and it means an OS update may rewrite it without notice.
-JARVIS_AUTH_RIGHT="system.login.screensaver.unlock"
+#
+# Selectable so the lifecycle probe can exercise a synthetic right of our own.
+# That does NOT reopen the original defect: the installer's gate asks the schema
+# what CLASS a right is, never what it is CALLED, so pointing this back at
+# system.login.screensaver is still refused. A name-based check is the kind that
+# rots; this one cannot.
+JARVIS_AUTH_RIGHT="${JARVIS_AUTH_RIGHT:-system.login.screensaver.unlock}"
+
+# Rights in our own reverse-DNS namespace are ones we created. Nothing in macOS
+# consults them, so they are exempt from the login-rights guard below -- which
+# otherwise fails closed on any right absent from Apple's schema.
+JARVIS_RIGHT_NAMESPACE="com.jarvis."
+
+# --- Sentinel ----------------------------------------------------------------
+# The recovery scripts are installed to a fixed system path, not run from the
+# repository. A machine that will not unlock is a bad time to discover that the
+# checkout lives in a cloud-synced directory that has not mounted yet, and the
+# sentinel launchd invokes must not hold a path into someone's home directory.
+JARVIS_SYSTEM_TOOLS_DIR="/usr/local/libexec/jarvis-authplugin"
+JARVIS_SENTINEL_LABEL="com.jarvis.unlocksentinel"
+JARVIS_SENTINEL_BIN="${JARVIS_SYSTEM_TOOLS_DIR}/sentinel.sh"
+JARVIS_SENTINEL_PLIST="/Library/LaunchDaemons/${JARVIS_SENTINEL_LABEL}.plist"
+# Scripts copied to JARVIS_SYSTEM_TOOLS_DIR. sentinel needs common; uninstall and
+# verify are there so recovery and diagnosis work from a bare SSH session.
+JARVIS_SYSTEM_TOOLS="common.sh sentinel.sh uninstall.sh verify.sh"
+# The authorization database itself. Watched so a rule edited BY HAND -- the way
+# this machine got into trouble in the first place -- is noticed like any other
+# drift. No installer gate can cover that path; only something watching can.
+JARVIS_AUTHDB_FILE="${JARVIS_AUTHDB_FILE:-/var/db/auth.db}"
 
 # --- Filesystem layout ------------------------------------------------------
 JARVIS_PLUGIN_DIR="/Library/Security/SecurityAgentPlugins"
@@ -88,9 +116,29 @@ jarvis_authdb_read() {
 }
 
 # Write a rule plist (path) into the authorization database for a right.
+#
+# THE MUTATION CHOKEPOINT. install, probe, uninstall-restore and uninstall-strip
+# all pass through here, which is why the login-rights guard lives here and not
+# in any of them. A guard replicated at four call sites is a guard with four
+# chances to be forgotten by the fifth.
 jarvis_authdb_write() {
     local right="$1" plist="$2"
     [ -f "$plist" ] || _jarvis_die "rule plist not found: $plist"
+
+    # Refuse to place OUR MECHANISM into a right that performs login.
+    #
+    # Scoped to rules that name us, deliberately. Restoring a backup and writing
+    # a stripped rule both pass, because both REMOVE us -- and a safety check
+    # that blocks the recovery path is how someone ends up stranded at a lock
+    # screen holding a script that will not help them.
+    if grep -q "${JARVIS_PLUGIN_NAME}" "${plist}" 2>/dev/null \
+       && jarvis_right_performs_login "${right}"; then
+        _jarvis_warn "refusing to place ${JARVIS_PLUGIN_NAME} into ${right}"
+        _jarvis_warn "  its stock chain runs a ${JARVIS_LOGIN_PLUGIN_PREFIX} mechanism, so this right"
+        _jarvis_warn "  performs LOGIN. A defect there costs you the machine, not the lock screen."
+        return 1
+    fi
+
     security authorizationdb write "$right" < "$plist"
 }
 
@@ -222,6 +270,16 @@ jarvis_rule_references_plugin() {
 # be a one-variable bypass of the only check standing between a template literal
 # and the lock screen.
 JARVIS_MECHANISM_HOST_CLASS="evaluate-mechanisms"
+
+# The plugin that performs login. A right whose STOCK chain runs one of its
+# mechanisms is a login right, whatever it happens to be named.
+#
+# The colon is part of the prefix and is load-bearing. Matching the substring
+# "login" would classify CryptoTokenKit:login as a login mechanism -- and that is
+# the sole entry in system.login.screensaver.unlock, the right we actually want.
+# A guard that bans its own target is worse than no guard: it gets removed.
+# (Same shape as `"lock" in "unlock my screen"` being true.)
+JARVIS_LOGIN_PLUGIN_PREFIX="loginwindow:"
 
 # The authoritative schema for what every right's stock definition is. Overridable
 # ONLY so the self-tests can point the classifier at a fixture; install.sh pins it
@@ -358,6 +416,45 @@ jarvis_right_hosts_mechanisms() {
     local stock
     stock="$(jarvis_stock_rule_class "$1")" || return 1
     [ "${stock}" = "${JARVIS_MECHANISM_HOST_CLASS}" ] || return 2
+    return 0
+}
+
+# Does this right perform LOGIN, as opposed to unlock or anything else?
+#
+# Derived from the stock chain rather than from a list of names, so a login right
+# introduced by a future macOS is protected the day it ships and nobody has to
+# remember to add it. Verified against the live schema in both directions:
+#
+#   protected  system.login.console / .filevault / .fus   -- all run loginwindow:
+#   allowed    system.login.screensaver.unlock            -- CryptoTokenKit:login
+#   allowed    system.restart / system.disk.unlock        -- no loginwindow:
+#
+# Returns 0 (protected) for a right that is not in the schema at all. An unknown
+# right could be anything, and this is the one question where a guess costs you
+# the machine. Rights in our own namespace are exempt -- we created them, so
+# their provenance is not in doubt.
+jarvis_right_performs_login() {
+    local right="$1" key bucket count idx mech
+
+    case "${right}" in "${JARVIS_RIGHT_NAMESPACE}"*) return 1 ;; esac
+    [ -r "${JARVIS_SYSTEM_AUTH_TEMPLATE}" ] || return 0
+
+    key="$(_jarvis_plist_escape_key "${right}")"
+    for bucket in rights rules; do
+        jarvis_plist_value "${JARVIS_SYSTEM_AUTH_TEMPLATE}" "${bucket}.${key}.class" >/dev/null 2>&1 \
+            || continue
+
+        count="$(jarvis_plist_value "${JARVIS_SYSTEM_AUTH_TEMPLATE}" "${bucket}.${key}.mechanisms" || true)"
+        case "${count}" in ''|*[!0-9]*) return 1 ;; esac
+
+        idx=0
+        while [ "${idx}" -lt "${count}" ]; do
+            mech="$(jarvis_plist_value "${JARVIS_SYSTEM_AUTH_TEMPLATE}" "${bucket}.${key}.mechanisms.${idx}" || true)"
+            case "${mech}" in "${JARVIS_LOGIN_PLUGIN_PREFIX}"*) return 0 ;; esac
+            idx=$(( idx + 1 ))
+        done
+        return 1
+    done
     return 0
 }
 
@@ -581,6 +678,141 @@ jarvis_chain_preserves_backup() {
 ${backlist}
 EOF
     return 0
+}
+
+# =============================================================================
+# REVERT -- the one way out, used by uninstall AND the sentinel
+# =============================================================================
+# uninstall.sh owned this. The sentinel needs the identical operation, and a
+# second implementation of "how do we get our mechanism out of the lock screen"
+# would be discovered by whoever the drifted copy failed, at a machine that will
+# not unlock. So it moved here, unchanged in behaviour.
+#
+# Every path is a REPAIR, so it degrades rather than aborting: a failed restore
+# falls through to stripping our mechanism out of whatever is live.
+
+# Strip our mechanism from the live rule, leaving every other entry untouched.
+# Never invents a rule. Echoes nothing; returns 0 if the rule no longer names us.
+jarvis_strip_mechanism_in_place() {
+    local current scratch removed
+
+    if ! current="$(jarvis_authdb_read "${JARVIS_AUTH_RIGHT}")"; then
+        _jarvis_warn "cannot read ${JARVIS_AUTH_RIGHT}; leaving it alone"
+        return 1
+    fi
+
+    if ! printf '%s' "${current}" | grep -q "${JARVIS_PLUGIN_NAME}"; then
+        _jarvis_log "${JARVIS_AUTH_RIGHT} does not reference ${JARVIS_PLUGIN_NAME}; nothing to strip"
+        return 0
+    fi
+
+    scratch="$(mktemp -t jarvis-authdb)" || { _jarvis_warn "mktemp failed"; return 1; }
+    printf '%s' "${current}" > "${scratch}"
+
+    removed="$(jarvis_rule_strip_mechanism "${scratch}" "${JARVIS_PLUGIN_NAME}")"
+    if [ "${removed}" -eq 0 ]; then
+        # The rule mentions us somewhere plutil found nothing to delete: a
+        # different key, or a shape this function does not understand. Writing it
+        # back unchanged would be a no-op reported as a repair.
+        _jarvis_warn "${JARVIS_AUTH_RIGHT} names ${JARVIS_PLUGIN_NAME} but no mechanism entry matched"
+        _jarvis_warn "  inspect: security authorizationdb read ${JARVIS_AUTH_RIGHT}"
+        rm -f "${scratch}"
+        return 1
+    fi
+
+    if jarvis_authdb_write "${JARVIS_AUTH_RIGHT}" "${scratch}"; then
+        _jarvis_log "stripped ${removed} ${JARVIS_PLUGIN_NAME} mechanism(s) from ${JARVIS_AUTH_RIGHT}"
+        rm -f "${scratch}"
+        return 0
+    fi
+    _jarvis_warn "could not write stripped rule for ${JARVIS_AUTH_RIGHT}"
+    rm -f "${scratch}"
+    return 1
+}
+
+# Get our mechanism out, by whichever route works. 0 if the rule no longer names
+# us when this returns.
+jarvis_revert_auth_rule() {
+    if jarvis_restore_auth_rule_from_pointer; then
+        _jarvis_log "authorization rule restored from backup"
+        return 0
+    fi
+    _jarvis_warn "no usable backup (absent pointer, wrong right, missing file, or unparseable plist)"
+    jarvis_strip_mechanism_in_place
+}
+
+# =============================================================================
+# DEAD MAN'S SWITCH
+# =============================================================================
+# A detached timer holding nothing but a duration and a command. It observes
+# NOTHING about whether its caller is alive, healthy, or finished, which is the
+# entire point: a watchdog that shares state with the thing it guards is not a
+# watchdog. It survives the caller crashing, the terminal closing, the SSH
+# session dropping, and the parent being SIGKILLed -- none of those are
+# conditions it can see.
+#
+# Extracted here when a second probe needed one. Two implementations of "put the
+# machine back if I die" would differ in the details that matter at 3am.
+#
+# Echoes the detached pid.
+jarvis_arm_deadman() {   # <window_s> <logfile> <recovery-command> <manual-hint>
+    local window="$1" logfile="$2" cmd="$3" hint="$4" pid
+    mkdir -p "$(dirname "${logfile}")" 2>/dev/null || true
+    nohup bash -c "
+        sleep ${window}
+        for attempt in 1 2 3; do
+            if ${cmd} 2>/dev/null; then
+                printf '%s dead-man recovery OK (attempt %s)\n' \"\$(date -u +%FT%TZ)\" \"\$attempt\" >> '${logfile}'
+                exit 0
+            fi
+            sleep 2
+        done
+        printf '%s DEAD-MAN RECOVERY FAILED -- by hand: %s\n' \"\$(date -u +%FT%TZ)\" '${hint}' >> '${logfile}'
+    " >/dev/null 2>&1 &
+    pid=$!
+    disown "${pid}" 2>/dev/null || true
+    printf '%s' "${pid}"
+}
+
+# =============================================================================
+# SANCTIONED STATE -- what the installer proved, for the sentinel to check
+# =============================================================================
+# The installer measured a shape, gated it on evidence, and wrote it. The
+# sentinel's job is to notice when the live rule stops being that. Without a
+# record of what was sanctioned, "has it drifted" is not answerable, and a
+# sentinel that cannot answer it would have to guess.
+JARVIS_SANCTIONED_SHAPE_FILE="${JARVIS_STATE_DIR}/sanctioned-shape"
+
+jarvis_record_sanctioned_shape() {
+    printf '%s' "$1" > "${JARVIS_SANCTIONED_SHAPE_FILE}" || return 1
+    chmod 600 "${JARVIS_SANCTIONED_SHAPE_FILE}" 2>/dev/null || true
+}
+
+jarvis_sanctioned_shape() {
+    [ -r "${JARVIS_SANCTIONED_SHAPE_FILE}" ] || return 1
+    cat "${JARVIS_SANCTIONED_SHAPE_FILE}" 2>/dev/null
+}
+
+# Is an authorization currently being evaluated, or the console locked?
+#
+# Two independent signals because they answer slightly different questions and
+# either alone has a blind spot: SecurityAgent is the process that evaluates the
+# chain, and IOConsoleLocked is the console's own state. Used to DEFER a
+# non-urgent repair, never to defer an urgent one -- a lock screen is exactly
+# when a stuck user needs the repair to happen, and a guard that waits for the
+# guarded system to become idle is the deadlock Slice 47 retired.
+jarvis_authentication_in_flight() {
+    pgrep -qx SecurityAgent 2>/dev/null && return 0
+
+    local tmp rc=1
+    tmp="$(mktemp -t jarvis-console)" || return 1
+    if ioreg -n Root -d1 -a > "${tmp}" 2>/dev/null; then
+        case "$(jarvis_plist_value "${tmp}" IOConsoleLocked || true)" in
+            true|1|YES) rc=0 ;;
+        esac
+    fi
+    rm -f "${tmp}"
+    return "${rc}"
 }
 
 # Wait for a system service to be fully gone.

--- a/backend/voice_unlock/authplugin/install/install.sh
+++ b/backend/voice_unlock/authplugin/install/install.sh
@@ -345,6 +345,7 @@ else
     rm -f "${DAEMON_TMP}"
     chown -R root:wheel "${JARVIS_PLUGIN_PATH}"
 
+
     # A failure from here on can leave the rule pointing at a mechanism whose
     # broker is down. That is fail-open safe -- the mechanism yields and
     # builtin:authenticate prompts -- but it is a half-installed system, which is
@@ -363,6 +364,82 @@ else
         fi
         _jarvis_die "$1"
     }
+
+    # ------------------------------------------------------------------
+    # 6a. THE SENTINEL  -- installed BEFORE the rule, on purpose
+    # ------------------------------------------------------------------
+    # It watches for the states no installer gate can prevent: the mechanism
+    # crashing its host, an OS update rewriting the right, the bundle going away
+    # underneath a chain that still names it, and a rule edited by hand. Any of
+    # those and it takes our mechanism back out, with no human in the loop.
+    #
+    # Before the rule because a sentinel that starts watching afterwards has a
+    # window in which the very thing it guards against is unobserved. It costs
+    # nothing to run early: with no mechanism in the chain it exits immediately.
+    _jarvis_log "installing the sentinel"
+    mkdir -p "${JARVIS_SYSTEM_TOOLS_DIR}"
+    chown root:wheel "${JARVIS_SYSTEM_TOOLS_DIR}"
+    chmod 755 "${JARVIS_SYSTEM_TOOLS_DIR}"
+    for _tool in ${JARVIS_SYSTEM_TOOLS}; do
+        [ -f "${_here}/${_tool}" ] || _abort_incoherent "missing ${_tool}; cannot install the sentinel"
+        install -m 755 -o root -g wheel "${_here}/${_tool}" "${JARVIS_SYSTEM_TOOLS_DIR}/${_tool}"
+    done
+
+    SENTINEL_TMP="$(mktemp -t jarvis-sentinel-plist)"
+    cat > "${SENTINEL_TMP}" <<SENTINEL
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>${JARVIS_SENTINEL_LABEL}</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>${JARVIS_SENTINEL_BIN}</string>
+    </array>
+    <!-- Boot. The first thing that runs after a crash, an update, or a power cut. -->
+    <key>RunAtLoad</key>
+    <true/>
+    <!-- kqueue-backed. launchd wakes the script on a change; between changes
+         there is no process at all, so idle cost is zero and there is nothing
+         resident that could crash. -->
+    <key>WatchPaths</key>
+    <array>
+        <string>${JARVIS_CRASH_REPORTS_DIR}</string>
+        <string>${JARVIS_PLUGIN_DIR}</string>
+        <string>${JARVIS_AUTHDB_FILE}</string>
+    </array>
+    <!-- Backstop ONLY. Insurance against a coalesced kqueue event or a machine
+         that was asleep; deliberately long enough that it is never what notices
+         first. If this is what catches something, the watches need looking at. -->
+    <key>StartInterval</key>
+    <integer>${JARVIS_SENTINEL_BACKSTOP_S:-3600}</integer>
+    <key>ProcessType</key>
+    <string>Background</string>
+    <key>LowPriorityIO</key>
+    <true/>
+    <!-- No KeepAlive. This is a short-lived script, not a daemon: relaunching it
+         on exit would mean running it in a tight loop forever. -->
+    <key>StandardErrorPath</key>
+    <string>${JARVIS_STATE_DIR}/sentinel.err.log</string>
+</dict>
+</plist>
+SENTINEL
+    plutil -lint "${SENTINEL_TMP}" >/dev/null 2>&1 \
+        || { rm -f "${SENTINEL_TMP}"; _abort_incoherent "generated sentinel plist is malformed"; }
+    install -m 644 -o root -g wheel "${SENTINEL_TMP}" "${JARVIS_SENTINEL_PLIST}"
+    rm -f "${SENTINEL_TMP}"
+
+    launchctl bootout "system/${JARVIS_SENTINEL_LABEL}" >/dev/null 2>&1 || true
+    jarvis_wait_for_service_gone "${JARVIS_SENTINEL_LABEL}" || true
+    if launchctl bootstrap system "${JARVIS_SENTINEL_PLIST}" 2>/dev/null; then
+        _jarvis_log "sentinel armed (watching ${JARVIS_PLUGIN_DIR}, ${JARVIS_CRASH_REPORTS_DIR}, ${JARVIS_AUTHDB_FILE})"
+    else
+        # Fail closed. Installing the mechanism with nothing watching it is the
+        # state this whole layer exists to make impossible, and it is strictly
+        # worse than not installing at all.
+        _abort_incoherent "sentinel did not load; refusing to continue without it"
+    fi
 
     _jarvis_log "loading ${JARVIS_BROKER_LABEL}"
     launchctl bootout "system/${JARVIS_BROKER_LABEL}" >/dev/null 2>&1 || true
@@ -678,6 +755,14 @@ if [ "${_compose_rc}" -eq 0 ]; then
        && [ "$(jarvis_rule_shape "${_live_tmp}" 2>/dev/null || true)" = "${_shape}" ]; then
         _jarvis_log "verified: the live rule is the shape that was measured"
         rm -f "${_live_tmp}"
+
+        # Hand the sentinel its baseline. Written only here -- after the gates
+        # passed, the write landed, and the live rule read back as the shape that
+        # was measured. Anything the sentinel later sees that is not this is
+        # drift, and the record has to mean "someone proved this", not "someone
+        # wrote this".
+        jarvis_record_sanctioned_shape "${_shape}" \
+            || _jarvis_warn "could not record the sanctioned shape; the sentinel will treat the rule as unsanctioned"
     else
         rm -f "${_live_tmp}"
         _jarvis_warn "the live rule does not read back as the shape that was written"

--- a/backend/voice_unlock/authplugin/install/install.sh
+++ b/backend/voice_unlock/authplugin/install/install.sh
@@ -465,6 +465,24 @@ stopped before the authorization rule.
     helper   ${HELPER_REQ}
 
 STOPPED
+    # Report the rule pre-flight even though this mode will not act on it.
+    # "Next: sudo $0" is a promise, and on a machine whose right cannot host a
+    # mechanism it is a promise the next run will refuse to keep. Finding that
+    # out here costs nothing; finding it out after a full install is how a
+    # half-configured system gets blamed on the wrong step. Needs no privileges
+    # -- it reads Apple's schema, not the live database.
+    _preflight_rc=0
+    jarvis_right_hosts_mechanisms "${JARVIS_AUTH_RIGHT}" || _preflight_rc=$?
+    if [ "${_preflight_rc}" -eq 0 ]; then
+        echo "  authorization pre-flight: ${JARVIS_AUTH_RIGHT} can host a mechanism."
+    else
+        echo "  authorization pre-flight: ${JARVIS_AUTH_RIGHT} CANNOT host a mechanism."
+        jarvis_stock_rule_summary "${JARVIS_AUTH_RIGHT}" 2>/dev/null | sed 's/^/      /' || true
+        echo "      A full install will refuse this right. See common.sh,"
+        echo "      AUTHORIZATION RULE SHAPE."
+    fi
+    echo
+
     if [ "${DRY_RUN}" -eq 1 ]; then
         # ${DIST} has been reassigned to the staging directory by now, and
         # naming it here would under-report: the build also wrote ${_root}/dist.
@@ -476,11 +494,62 @@ STOPPED
         echo "  Next: sudo $0 --skip-authdb   (installs, and proves the XPC channel works)"
     else
         echo "  The deposit path is installed and self-tested."
-        echo "  Next: sudo $0                 (rewrites the rule; reversible via uninstall.sh)"
+        if [ "${_preflight_rc}" -eq 0 ]; then
+            echo "  Next: sudo $0                 (amends the rule; reversible via uninstall.sh)"
+        else
+            echo "  There is no next step on this right. A full install would refuse."
+        fi
     fi
     echo
     exit 0
 fi
+
+# -----------------------------------------------------------------------------
+# 7a. CAN THIS RIGHT HOST A MECHANISM AT ALL?
+# -----------------------------------------------------------------------------
+# Asked first, before a single byte is written anywhere -- a refusal here leaves
+# no backup file, no pointer, and no trace.
+#
+# The classifier is pinned to the system schema rather than allowed to read
+# JARVIS_SYSTEM_AUTH_TEMPLATE, which exists for the self-tests. A check whose
+# oracle can be swapped by an environment variable is a check with an off switch,
+# and this is the one that stands between a template literal and the lock screen.
+if [ "${JARVIS_SYSTEM_AUTH_TEMPLATE}" != "${JARVIS_SYSTEM_AUTH_TEMPLATE_DEFAULT}" ]; then
+    _jarvis_die "JARVIS_SYSTEM_AUTH_TEMPLATE is set to ${JARVIS_SYSTEM_AUTH_TEMPLATE}; the installer classifies rights against the system schema only"
+fi
+
+_host_rc=0
+jarvis_right_hosts_mechanisms "${JARVIS_AUTH_RIGHT}" || _host_rc=$?
+
+if [ "${_host_rc}" -ne 0 ]; then
+    _jarvis_warn "${JARVIS_AUTH_RIGHT} cannot host an authorization mechanism."
+    _jarvis_warn ""
+    if [ "${_host_rc}" -eq 2 ]; then
+        _jarvis_warn "  stock definition, per ${JARVIS_SYSTEM_AUTH_TEMPLATE_DEFAULT}:"
+        jarvis_stock_rule_summary "${JARVIS_AUTH_RIGHT}" 2>/dev/null | sed 's/^/      /' >&2 || true
+        _jarvis_warn ""
+        _jarvis_warn "  A right of that class DELEGATES. A mechanism chain only AUTHENTICATES."
+        _jarvis_warn "  Converting one into the other removes the delegation, and with it the"
+        _jarvis_warn "  lock screen's own UI and the session resume that follows a successful"
+        _jarvis_warn "  authentication -- so the machine authenticates into a black screen with"
+        _jarvis_warn "  a live cursor and no way back."
+        _jarvis_warn ""
+        _jarvis_warn "  This is not a hypothetical. It is what the previous version of this"
+        _jarvis_warn "  script did, and it is why this check exists. See the AUTHORIZATION RULE"
+        _jarvis_warn "  SHAPE section of common.sh."
+    else
+        _jarvis_warn "  ${JARVIS_AUTH_RIGHT} is not present in ${JARVIS_SYSTEM_AUTH_TEMPLATE_DEFAULT},"
+        _jarvis_warn "  or that file could not be read. The stock shape of this right is therefore"
+        _jarvis_warn "  unknown, and an unknown is not a yes."
+    fi
+    _jarvis_warn ""
+    _jarvis_warn "  Nothing about unlocking has changed. Everything else IS installed and"
+    _jarvis_warn "  self-tested -- \`sudo $0 --skip-authdb\` reaches the same state without"
+    _jarvis_warn "  this refusal."
+    _jarvis_die "refusing to convert ${JARVIS_AUTH_RIGHT}"
+fi
+
+_jarvis_log "${JARVIS_AUTH_RIGHT} is class ${JARVIS_MECHANISM_HOST_CLASS} in the system schema; it can host a mechanism"
 
 _stamp="$(date +%Y%m%d-%H%M%S)"
 BACKUP="${JARVIS_AUTHDB_BACKUP_DIR}/${JARVIS_AUTH_RIGHT}.${_stamp}.install.plist"
@@ -489,47 +558,150 @@ jarvis_authdb_read "${JARVIS_AUTH_RIGHT}" > "${BACKUP}" \
     || _jarvis_die "could not read ${JARVIS_AUTH_RIGHT}; nothing changed"
 plutil -lint "${BACKUP}" >/dev/null 2>&1 \
     || _jarvis_die "backup of ${JARVIS_AUTH_RIGHT} is not a valid plist; refusing to proceed"
-printf '%s' "${BACKUP}" > "${JARVIS_AUTHDB_BACKUP_POINTER}"
-_jarvis_log "backed up ${JARVIS_AUTH_RIGHT} -> ${BACKUP}"
 
+# Advance the pointer ONLY if this capture is a genuine restore point.
+#
+# On a reinstall the live rule already names us, so this capture reproduces the
+# installed state. Overwriting the pointer with it destroys the only artifact
+# that can undo the install -- which is how uninstall.sh came to "restore" the
+# plugin onto a machine whose bundle it had just deleted.
+#
+# The capture is still written and retained for audit; it is only disqualified
+# from being the thing uninstall trusts.
+if grep -q "${JARVIS_PLUGIN_NAME}" "${BACKUP}" 2>/dev/null; then
+    _jarvis_warn "live rule already names ${JARVIS_PLUGIN_NAME} -- reinstall detected"
+    if [ -f "${JARVIS_AUTHDB_BACKUP_POINTER}" ]; then
+        _jarvis_log "keeping existing restore point: $(cat "${JARVIS_AUTHDB_BACKUP_POINTER}")"
+    else
+        # No pristine artifact exists and the live rule is already modified. We
+        # cannot manufacture one, and proceeding would install over a state we
+        # could never reverse. uninstall.sh strips in place without a backup, so
+        # the recovery path is real -- take it before installing again.
+        _jarvis_die "no pristine restore point and the live rule is already modified; run uninstall.sh first"
+    fi
+else
+    printf '%s' "${BACKUP}" > "${JARVIS_AUTHDB_BACKUP_POINTER}"
+    _jarvis_log "backed up ${JARVIS_AUTH_RIGHT} -> ${BACKUP}"
+fi
+
+# -----------------------------------------------------------------------------
+# 7b. DERIVE THE RULE FROM THE ONE THAT IS LIVE
+# -----------------------------------------------------------------------------
+# This used to be a heredoc: a complete rule, written from a literal in this
+# file, that replaced whatever it found. It dropped every key it had no opinion
+# about, invented values for the ones it did, and could not have known what it
+# was destroying because it never read it.
+#
+# It is now an amendment to the incumbent bytes. See common.sh, AUTHORIZATION
+# RULE SHAPE.
 RULE_TMP="$(mktemp -t jarvis-authrule)"
-cat > "${RULE_TMP}" <<RULE
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>class</key>
-    <string>evaluate-mechanisms</string>
-    <key>comment</key>
-    <string>JARVIS voice unlock. Restore with backend/voice_unlock/authplugin/install/uninstall.sh</string>
-    <key>mechanisms</key>
-    <array>
-        <!-- Ours runs first and either grants or yields; it never denies. -->
-        <string>${JARVIS_MECHANISM}</string>
-        <!-- The stock authenticator still runs and still prompts. Touch ID was
-             measured working under a SecurityAgent-evaluated rule before this
-             design was committed to. -->
-        <string>builtin:authenticate,privileged</string>
-    </array>
-    <key>tries</key>
-    <integer>10000</integer>
-    <key>version</key>
-    <integer>1</integer>
-</dict>
-RULE
-echo "</plist>" >> "${RULE_TMP}"
+_cleanup_rule_tmp() { rm -f "${RULE_TMP}"; }
 
-plutil -lint "${RULE_TMP}" >/dev/null 2>&1 || _jarvis_die "generated authorization rule is malformed; nothing changed"
+_compose_rc=0
+jarvis_compose_mechanism_rule "${BACKUP}" "${RULE_TMP}" "${JARVIS_MECHANISM}" || _compose_rc=$?
 
-_jarvis_log "writing ${JARVIS_AUTH_RIGHT}"
-jarvis_authdb_write "${JARVIS_AUTH_RIGHT}" "${RULE_TMP}" \
-    || _jarvis_die "failed to write ${JARVIS_AUTH_RIGHT}; restore: security authorizationdb write ${JARVIS_AUTH_RIGHT} < ${BACKUP}"
-rm -f "${RULE_TMP}"
+case "${_compose_rc}" in
+    0)
+        _jarvis_log "composed: ${JARVIS_MECHANISM} ahead of $(jarvis_rule_mechanisms "${BACKUP}" | grep -c . || true) existing mechanism(s), every other key preserved"
+        ;;
+    2)
+        # The live rule already runs us. There is no shape change to make, so
+        # there is nothing to write and nothing for the evidence gate to guard.
+        _cleanup_rule_tmp
+        _jarvis_log "${JARVIS_AUTH_RIGHT} already names ${JARVIS_MECHANISM}; rule left exactly as it is"
+        _jarvis_log "  (the bundle and broker were reinstalled and self-tested above)"
+        _rule_written=0
+        ;;
+    3)
+        _cleanup_rule_tmp
+        _jarvis_warn "${JARVIS_AUTH_RIGHT} is class '$(jarvis_rule_class "${BACKUP}" 2>/dev/null || echo unreadable)' live, but the system schema calls it ${JARVIS_MECHANISM_HOST_CLASS}."
+        _jarvis_warn "  Something has already changed this right. Amending a rule we do not"
+        _jarvis_warn "  recognise would be authoring one, which is the defect this path exists"
+        _jarvis_warn "  to prevent. The live rule is backed up at:"
+        _jarvis_warn "    ${BACKUP}"
+        _jarvis_die "refusing to compose over an unrecognised rule; nothing changed"
+        ;;
+    *)
+        _cleanup_rule_tmp
+        _jarvis_die "could not derive a rule from ${BACKUP}; nothing changed"
+        ;;
+esac
+
+if [ "${_compose_rc}" -eq 0 ]; then
+    plutil -lint "${RULE_TMP}" >/dev/null 2>&1 \
+        || { _cleanup_rule_tmp; _jarvis_die "derived authorization rule is malformed; nothing changed"; }
+
+    # -------------------------------------------------------------------------
+    # 7c. HAS THIS EXACT SHAPE EVER BEEN MEASURED HERE?
+    # -------------------------------------------------------------------------
+    # The last gate, and the one that would have stopped the original defect on
+    # its own. Every other check in this script asks whether the configuration is
+    # COHERENT. This one asks whether it has ever been RUN.
+    #
+    # There is no override flag, on purpose. A flag would be the shortest path
+    # back to spending one configuration's measurement on another.
+    _shape="$(jarvis_rule_shape "${RULE_TMP}")" \
+        || { _cleanup_rule_tmp; _jarvis_die "could not compute the shape of the derived rule; nothing changed"; }
+
+    _evidence=""
+    if _evidence="$(jarvis_probe_evidence_for_shape "${_shape}")"; then
+        _jarvis_log "shape measured on this machine:"
+        _jarvis_log "  ${_evidence}"
+    else
+        _jarvis_warn "this rule shape has never been measured on this machine:"
+        _jarvis_warn "    ${_shape}"
+        _jarvis_warn ""
+        _jarvis_warn "  ${JARVIS_PROBE_RESULTS_LOG} holds no run that applied this exact shape,"
+        _jarvis_warn "  locked the screen, and confirmed the password still worked."
+        _jarvis_warn ""
+        _jarvis_warn "  A measurement of a DIFFERENT shape does not transfer. That substitution"
+        _jarvis_warn "  is what put this machine behind a black lock screen: a rule of class"
+        _jarvis_warn "  'user' was probed, and the result was spent authorising a mechanism"
+        _jarvis_warn "  chain nobody had ever run."
+        _jarvis_warn ""
+        _jarvis_warn "  Measure it, inside a window that reverts itself:"
+        _jarvis_warn "    sudo ${_here}/probe_screensaver_rule.sh"
+        _cleanup_rule_tmp
+        _jarvis_die "refusing to write an unmeasured rule shape; nothing changed"
+    fi
+
+    _jarvis_log "writing ${JARVIS_AUTH_RIGHT}"
+    jarvis_authdb_write "${JARVIS_AUTH_RIGHT}" "${RULE_TMP}" \
+        || { _cleanup_rule_tmp; _jarvis_die "failed to write ${JARVIS_AUTH_RIGHT}; restore: security authorizationdb write ${JARVIS_AUTH_RIGHT} < ${BACKUP}"; }
+    _cleanup_rule_tmp
+    _rule_written=1
+
+    # Read back what actually landed. A write that returns 0 is a claim about
+    # `security`; the shape of the live rule is a claim about the lock screen.
+    _live_tmp="$(mktemp -t jarvis-authlive)"
+    if jarvis_authdb_read "${JARVIS_AUTH_RIGHT}" > "${_live_tmp}" 2>/dev/null \
+       && [ "$(jarvis_rule_shape "${_live_tmp}" 2>/dev/null || true)" = "${_shape}" ]; then
+        _jarvis_log "verified: the live rule is the shape that was measured"
+        rm -f "${_live_tmp}"
+    else
+        rm -f "${_live_tmp}"
+        _jarvis_warn "the live rule does not read back as the shape that was written"
+        _jarvis_warn "  restoring the rule you started with:"
+        if jarvis_restore_auth_rule_from_pointer; then
+            _jarvis_warn "  restored -- your lock screen is back to how it was"
+        else
+            _jarvis_warn "  COULD NOT restore automatically. Run: sudo ${_here}/uninstall.sh"
+        fi
+        _jarvis_die "post-write verification failed"
+    fi
+fi
+
+if [ "${_rule_written:-0}" -eq 1 ]; then
+    _rule_state="amended -- ${JARVIS_MECHANISM} now runs first in the existing chain"
+else
+    _rule_state="unchanged -- it already named ${JARVIS_MECHANISM}"
+fi
 
 cat <<DONE
 
 installed.
 
+  rule     ${JARVIS_AUTH_RIGHT}: ${_rule_state}
   plugin   ${JARVIS_PLUGIN_PATH}
   broker   ${JARVIS_BROKER_BIN}  (${JARVIS_BROKER_LABEL})
   helper   ${HELPER_INSTALL_PATH}

--- a/backend/voice_unlock/authplugin/install/probe_mechanism_lifecycle.sh
+++ b/backend/voice_unlock/authplugin/install/probe_mechanism_lifecycle.sh
@@ -1,0 +1,243 @@
+#!/bin/bash
+# JARVIS -- Mechanism lifecycle probe.
+#
+# WHAT THIS ANSWERS
+# -----------------
+# "Does our mechanism survive being loaded, invoked, answered and destroyed
+# inside authorizationhosthelper -- repeatedly?"
+#
+# That is the question 27 segfaults across two days says nobody may assume. The
+# use-after-free lived precisely in that lifecycle: SecurityAgent frees the
+# mechanism the instant the chain advances past it, and every escaping callback
+# can still fire afterwards. A single successful invocation proves almost
+# nothing about a race; a few dozen back-to-back invocations are what shake one
+# out.
+#
+# WHY IT COSTS NOTHING TO RUN
+# ---------------------------
+# It does not touch the lock screen, the login window, or any right macOS
+# consults. It creates a right of our OWN -- in our own reverse-DNS namespace,
+# referenced by nothing, evaluated by nobody -- puts our mechanism in it alone,
+# and invokes it directly with `security authorize`. Cleanup is
+# `authorizationdb remove`: the right never existed, so there is nothing to
+# restore and no backup to get wrong.
+#
+# Compare with the alternatives that were considered and rejected:
+#
+#   system.login.screensaver.unlock  tries=1, no password mechanism behind us,
+#                                    and failure locks you out of your session.
+#   system.restart                   forgiving, but invoking it runs
+#                                    RestartAuthorization:restart, and whether
+#                                    that mechanism merely CHECKS or actually
+#                                    initiates a restart is not something to
+#                                    find out by being wrong about it.
+#
+# WHAT IT DOES NOT ANSWER
+# -----------------------
+# Whether a yield reaches a password prompt. No synthetic right can tell you
+# that -- it is a property of loginwindow, on the real right, and it needs
+# probe_screensaver_rule.sh. Run this one first anyway: if the mechanism cannot
+# survive its own lifecycle here, there is no point risking a lock screen to
+# learn the same thing.
+#
+# USAGE
+#   sudo ./probe_mechanism_lifecycle.sh
+#   sudo JARVIS_LIFECYCLE_ITERATIONS=100 ./probe_mechanism_lifecycle.sh
+
+set -euo pipefail
+
+_here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common.sh
+. "${_here}/common.sh"
+
+jarvis_require_macos
+jarvis_require_root
+
+# --- Tunables ----------------------------------------------------------------
+PROBE_RIGHT="${JARVIS_LIFECYCLE_RIGHT:-${JARVIS_RIGHT_NAMESPACE}probe.lifecycle}"
+ITERATIONS="${JARVIS_LIFECYCLE_ITERATIONS:-25}"
+# The dead man's window has to outlast the whole run by a comfortable margin, so
+# it is derived from the iteration count rather than fixed. A constant here would
+# either fire mid-run on a slow machine or leave a synthetic right lying around
+# for minutes on a fast one.
+DEADMAN_S="${JARVIS_LIFECYCLE_DEADMAN_S:-$(( ITERATIONS * 4 + 60 ))}"
+PROBE_LOG="${JARVIS_STATE_DIR}/probe.log"
+
+case "${ITERATIONS}" in
+    ''|*[!0-9]*) _jarvis_die "JARVIS_LIFECYCLE_ITERATIONS must be a positive integer" ;;
+esac
+[ "${ITERATIONS}" -ge 1 ] || _jarvis_die "iterations must be >= 1"
+[ "${ITERATIONS}" -le 1000 ] || _jarvis_die "iterations must be <= 1000; this is a probe, not a soak host"
+
+# The right must be ours. A synthetic right is only safe because nothing consults
+# it, and that is guaranteed by the namespace and by nothing else.
+case "${PROBE_RIGHT}" in
+    "${JARVIS_RIGHT_NAMESPACE}"*) : ;;
+    *) _jarvis_die "the lifecycle right must be under ${JARVIS_RIGHT_NAMESPACE}; ${PROBE_RIGHT} is not ours to invent" ;;
+esac
+
+# It must not already exist. If it does, something else is using this name and
+# removing it afterwards would be destroying someone else's configuration.
+if jarvis_authdb_read "${PROBE_RIGHT}" >/dev/null 2>&1; then
+    _jarvis_die "${PROBE_RIGHT} already exists; refusing to reuse a name that is already in the database"
+fi
+
+# The bundle has to be there. Composing a chain around a mechanism that cannot be
+# loaded would measure SecurityAgent's failure to find a file, not our code.
+jarvis_plugin_bundle_present || _jarvis_die "${JARVIS_PLUGIN_PATH} is not installed; run: sudo ${_here}/install.sh --skip-authdb"
+
+mkdir -p "${JARVIS_STATE_DIR}"
+chmod 700 "${JARVIS_STATE_DIR}" 2>/dev/null || true
+
+# =============================================================================
+# 1. ARM THE DEAD MAN'S SWITCH  (before the right exists, on purpose)
+# =============================================================================
+# Same discipline as the screensaver probe and the same function: there must be
+# no window in which something has been created and nothing is scheduled to
+# remove it. Removal, not restoration -- the right had no previous state.
+REAPER_PID="$(jarvis_arm_deadman "${DEADMAN_S}" "${PROBE_LOG}" \
+    "/usr/bin/security authorizationdb remove '${PROBE_RIGHT}'" \
+    "sudo security authorizationdb remove ${PROBE_RIGHT}")"
+_jarvis_log "dead man's switch armed (pid ${REAPER_PID}, removes the right in ${DEADMAN_S}s)"
+
+_removed=0
+_remove_now() {
+    [ "${_removed}" -eq 1 ] && return 0
+    _removed=1
+    if security authorizationdb remove "${PROBE_RIGHT}" >/dev/null 2>&1; then
+        _jarvis_log "removed ${PROBE_RIGHT}"
+    else
+        _jarvis_warn "could not remove ${PROBE_RIGHT}; the dead man's switch will retry"
+    fi
+}
+trap _remove_now EXIT INT TERM
+
+# =============================================================================
+# 2. CREATE THE RIGHT
+# =============================================================================
+# Our mechanism ALONE. Nothing else in the chain, deliberately: a second
+# mechanism could answer for us and mask a failure to answer at all, which is
+# exactly the symptom a dead host produces.
+RULE_TMP="$(mktemp -t jarvis-lifecycle-rule)"
+cat > "${RULE_TMP}" <<RULE
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>class</key>
+    <string>${JARVIS_MECHANISM_HOST_CLASS}</string>
+    <key>comment</key>
+    <string>JARVIS lifecycle probe. Ephemeral; nothing in macOS consults this right. Remove with: security authorizationdb remove ${PROBE_RIGHT}</string>
+    <key>mechanisms</key>
+    <array>
+        <string>${JARVIS_MECHANISM}</string>
+    </array>
+    <key>shared</key>
+    <false/>
+    <key>tries</key>
+    <integer>1</integer>
+</dict>
+</plist>
+RULE
+plutil -lint "${RULE_TMP}" >/dev/null 2>&1 || _jarvis_die "generated lifecycle rule is malformed; nothing created"
+
+# Authored rather than derived, and that is correct HERE and nowhere else: there
+# is no incumbent to derive from. The right does not exist until this line. The
+# "never author a rule" discipline exists to stop us destroying a configuration
+# we did not read -- there is nothing here to destroy.
+if ! jarvis_authdb_write "${PROBE_RIGHT}" "${RULE_TMP}"; then
+    rm -f "${RULE_TMP}"
+    _jarvis_die "could not create ${PROBE_RIGHT}"
+fi
+rm -f "${RULE_TMP}"
+_jarvis_log "created ${PROBE_RIGHT} -> ${JARVIS_MECHANISM}"
+
+# =============================================================================
+# 3. BASELINE, THEN HAMMER IT
+# =============================================================================
+T0_EPOCH="$(date +%s)"
+T0_LOG="$(date '+%Y-%m-%d %H:%M:%S')"
+
+_jarvis_log "invoking ${ITERATIONS}x -- each one is a full Create/Invoke/SetResult/Destroy"
+_ok_count=0
+_fail_count=0
+_i=1
+while [ "${_i}" -le "${ITERATIONS}" ]; do
+    printf '\r[jarvis-authplugin] invocation %d/%d (ok=%d fail=%d) ' \
+        "${_i}" "${ITERATIONS}" "${_ok_count}" "${_fail_count}" >&2
+    # No -u: user interaction is exactly what we do not want. The mechanism
+    # yields with no grant present and the chain completes without any UI.
+    if security authorize "${PROBE_RIGHT}" >/dev/null 2>&1; then
+        _ok_count=$(( _ok_count + 1 ))
+    else
+        _fail_count=$(( _fail_count + 1 ))
+    fi
+    _i=$(( _i + 1 ))
+done
+printf '\r%*s\r' 70 '' >&2
+
+_remove_now
+
+# =============================================================================
+# 4. THE VERDICT  -- from crash reports and the log, not from the exit codes
+# =============================================================================
+# `security authorize` returning non-zero is not the failure that matters. A
+# mechanism that yields cleanly and a mechanism that never answers can both end
+# with a non-zero authorization; only the host's corpses distinguish them.
+_crashes="$(jarvis_crash_reports_since "${T0_EPOCH}" 2>/dev/null || true)"
+_crash_count="$(printf '%s' "${_crashes}" | grep -c . || true)"
+
+EVIDENCE_LOG="${JARVIS_STATE_DIR}/lifecycle-$(date +%Y%m%d-%H%M%S).log"
+jarvis_unlock_log_since "${T0_LOG}" > "${EVIDENCE_LOG}" 2>/dev/null || true
+chmod 600 "${EVIDENCE_LOG}" 2>/dev/null || true
+
+_mech_lines="$(grep -c "${JARVIS_LOG_SUBSYSTEM_PLUGIN}" "${EVIDENCE_LOG}" 2>/dev/null || true)"
+_yields="$(grep -ci 'yield' "${EVIDENCE_LOG}" 2>/dev/null || true)"
+
+echo
+echo "================================================================================"
+echo "  MECHANISM LIFECYCLE -- ${ITERATIONS} invocation(s) of ${PROBE_RIGHT}"
+echo "================================================================================"
+printf '  authorize returned ok : %s\n' "${_ok_count}"
+printf '  authorize returned no : %s\n' "${_fail_count}"
+printf '  mechanism log lines   : %s\n' "${_mech_lines}"
+printf '  yields observed       : %s\n' "${_yields}"
+printf '  host crashes          : %s\n' "${_crash_count}"
+printf '  window log            : %s\n' "${EVIDENCE_LOG}"
+echo
+
+_verdict_rc=0
+if [ "${_crash_count}" -gt 0 ]; then
+    _newest="$(printf '%s\n' "${_crashes}" | sed -n '$p')"
+    _jarvis_warn "FAILED -- the mechanism host died ${_crash_count} time(s)"
+    if grep -q "${JARVIS_PLUGIN_NAME}" "${_newest}" 2>/dev/null; then
+        _jarvis_warn "  the newest report NAMES ${JARVIS_PLUGIN_NAME} -- our defect"
+    fi
+    _sym="$(jarvis_crash_faulting_symbol "${_newest}" 2>/dev/null || true)"
+    [ -n "${_sym}" ] && _jarvis_warn "  faulting frame: ${_sym}"
+    _jarvis_warn "  DO NOT go near the lock screen. Fix this first."
+    _verdict_rc=1
+elif [ "${_mech_lines}" -eq 0 ]; then
+    # Honest ambiguity. Either the chain never reached us, or the unified log was
+    # not readable. Neither is a pass, and calling it one is how an unproven fix
+    # ends up on a tries=1 right.
+    _jarvis_warn "INCONCLUSIVE -- our mechanism produced no log output"
+    _jarvis_warn "  the chain may never have reached it, or the log was unreadable"
+    _verdict_rc=2
+else
+    _jarvis_log "PASSED -- ${ITERATIONS} full lifecycles, ${_yields} yield(s), zero host crashes"
+    _jarvis_log "  the use-after-free class is not reproducible at this iteration count"
+    _jarvis_log "  next: sudo ${_here}/probe_screensaver_rule.sh  (the fail-open question)"
+fi
+
+# Prove we left nothing behind. A probe that creates a right and cannot
+# demonstrate its removal has not finished.
+if jarvis_authdb_read "${PROBE_RIGHT}" >/dev/null 2>&1; then
+    _jarvis_warn "${PROBE_RIGHT} still exists -- remove by hand:"
+    _jarvis_warn "  sudo security authorizationdb remove ${PROBE_RIGHT}"
+    _verdict_rc=1
+else
+    _jarvis_log "verified: ${PROBE_RIGHT} is gone; the database is as it was"
+fi
+
+exit "${_verdict_rc}"

--- a/backend/voice_unlock/authplugin/install/probe_screensaver_rule.sh
+++ b/backend/voice_unlock/authplugin/install/probe_screensaver_rule.sh
@@ -60,11 +60,36 @@ jarvis_require_root
 # unlock, return to the terminal. A 60s window fit about three of those five
 # steps, so the first run measured nothing.
 PROBE_WINDOW_S="${JARVIS_PROBE_WINDOW_S:-180}"
-# The SecurityAgent-evaluated rule we swap in. Named by the stock rule's own
+
+# HOW THIS PROBE MUTATES IS DERIVED, NOT CONFIGURED.
+#
+#   mechanism host -> COMPOSE. Insert our mechanism at the head of the live
+#                     chain, by the same function install.sh uses. This is the
+#                     only mode that produces evidence install.sh can accept,
+#                     because the shape applied IS the shape install.sh writes.
+#                     Anything less is the substitution that caused the incident.
+#
+#   anything else  -> RULE SWAP. Point the right at a named SecurityAgent rule.
+#                     Measures whether SecurityAgent evaluation works at all, and
+#                     produces a shape that can never authorise a mechanism
+#                     install -- which is correct, not a shortcoming.
+#
+# Deliberately not overridable. A flag that forced COMPOSE onto a delegating
+# right would be a supported way to perform the exact conversion that
+# black-screened this machine, and the evidence it produced could never be spent
+# anyway: install.sh refuses that right at gate 7a regardless.
+_probe_host_rc=0
+jarvis_right_hosts_mechanisms "${JARVIS_AUTH_RIGHT}" || _probe_host_rc=$?
+case "${_probe_host_rc}" in
+    0) PROBE_MODE="compose" ;;
+    2) PROBE_MODE="rule-swap" ;;
+    *) _jarvis_die "cannot classify ${JARVIS_AUTH_RIGHT} against the system schema; refusing to probe blind" ;;
+esac
+
+# Only consulted in rule-swap mode. Named by the stock screensaver rule's own
 # comment as the supported alternative to use-login-window-ui.
 PROBE_RULE_NAME="${JARVIS_PROBE_RULE:-authenticate-session-owner-or-admin}"
-# The marker that proves the live rule is the stock, loginwindow-owned one.
-STOCK_MARKER="${JARVIS_PROBE_STOCK_MARKER:-use-login-window-ui}"
+[ "${PROBE_MODE}" = "compose" ] && PROBE_RULE_NAME="compose:${JARVIS_MECHANISM}"
 
 PROBE_LOG="${JARVIS_STATE_DIR}/probe.log"
 
@@ -101,24 +126,57 @@ if ! plutil -lint "${BACKUP}" >/dev/null 2>&1; then
     _jarvis_die "aborting without touching the system"
 fi
 
-if ! grep -q "${STOCK_MARKER}" "${BACKUP}"; then
-    _jarvis_warn "live rule does not contain '${STOCK_MARKER}'."
-    _jarvis_warn "current rule:"
-    sed 's/^/    /' "${BACKUP}" >&2
-    _jarvis_warn "the machine is not in the stock configuration this probe knows how to restore."
+# The baseline must be a rule we do not already appear in. If it names us, this
+# is not a probe of a clean machine -- it is a measurement of an install, and
+# reverting "to the backup" afterwards would restore our own mechanism while
+# calling it stock.
+if grep -q "${JARVIS_PLUGIN_NAME}" "${BACKUP}" 2>/dev/null; then
+    _jarvis_warn "the live rule already names ${JARVIS_PLUGIN_NAME}; this is not a clean baseline"
+    _jarvis_warn "  remove the install first:  sudo ${_here}/uninstall.sh"
+    rm -f "${BACKUP}"
     _jarvis_die "aborting without touching the system"
 fi
 
+# COMPOSE MODE HARD GUARD: the bundle has to be on disk.
+#
+# Writing a chain that names a mechanism whose bundle is absent is the one state
+# uninstall.sh calls strictly worse than either the installed or the stock
+# configuration: SecurityAgent cannot load what is not there, so the chain fails
+# before anything in it can answer. On a tries=1 right with no in-chain password
+# fallback, that is a lockout with a 3-minute dead man's switch as the only way
+# back. The probe must not create it.
+if [ "${PROBE_MODE}" = "compose" ] && ! jarvis_plugin_bundle_present; then
+    _jarvis_warn "${JARVIS_PLUGIN_PATH} is not installed."
+    _jarvis_warn "  A composed chain would name a mechanism that cannot be loaded, and this"
+    _jarvis_warn "  right has tries=1 with no password mechanism behind us."
+    _jarvis_warn ""
+    _jarvis_warn "  Install everything EXCEPT the rule first -- it leaves the lock screen"
+    _jarvis_warn "  completely untouched and proves the XPC channel works:"
+    _jarvis_warn "    sudo ${_here}/install.sh --skip-authdb"
+    rm -f "${BACKUP}"
+    _jarvis_die "aborting without touching the system"
+fi
+
+# The shape we must be able to get back to. Everything downstream compares
+# against this rather than against a marker string, so the probe stays correct on
+# any right, on any macOS, whatever the stock rule happens to be called.
+STOCK_SHAPE="$(jarvis_rule_shape "${BACKUP}" 2>/dev/null || true)"
+[ -n "${STOCK_SHAPE}" ] || { rm -f "${BACKUP}"; _jarvis_die "cannot compute the shape of the live rule; aborting without mutating"; }
+
 # Prove the restore path works on this exact file BEFORE relying on it: write the
 # backup back over the identical live value. A no-op if it succeeds, and if it
-# fails we learn that now rather than 60 seconds from now.
+# fails we learn that now rather than 180 seconds from now.
 _jarvis_log "pre-flight: verifying the restore path with a no-op write"
 if ! jarvis_authdb_write "${JARVIS_AUTH_RIGHT}" "${BACKUP}" >/dev/null 2>&1; then
     rm -f "${BACKUP}"
     _jarvis_die "restore path does not work on this machine; aborting without mutating"
 fi
 
-if ! jarvis_authdb_read "${JARVIS_AUTH_RIGHT}" | grep -q "${STOCK_MARKER}"; then
+_noop_check="$(mktemp -t jarvis-probe-noop)"
+jarvis_authdb_read "${JARVIS_AUTH_RIGHT}" > "${_noop_check}" 2>/dev/null || true
+_noop_shape="$(jarvis_rule_shape "${_noop_check}" 2>/dev/null || true)"
+rm -f "${_noop_check}"
+if [ "${_noop_shape}" != "${STOCK_SHAPE}" ]; then
     _jarvis_die "no-op restore changed the rule unexpectedly; STOP. Restore by hand from ${BACKUP}"
 fi
 
@@ -179,23 +237,57 @@ trap _revert_now EXIT
 # =============================================================================
 # 4. MUTATE
 # =============================================================================
-_jarvis_log "switching ${JARVIS_AUTH_RIGHT} -> ${PROBE_RULE_NAME}"
-if ! security authorizationdb write "${JARVIS_AUTH_RIGHT}" "${PROBE_RULE_NAME}"; then
-    _jarvis_die "mutation failed; trap and dead-man switch will restore the stock rule"
-fi
+# Everything below this point runs with the dead man's switch already armed.
+#
+# The measurement baseline is taken FIRST, before the mutation, so the crash and
+# log windows cannot miss an event that happens the instant the rule lands.
+PROBE_T0_EPOCH="$(date +%s)"
+PROBE_T0_LOG="$(date '+%Y-%m-%d %H:%M:%S')"
+PROBE_CRASHES_BEFORE="$(jarvis_crash_reports_since 0 2>/dev/null | grep -c . || true)"
+
+case "${PROBE_MODE}" in
+    compose)
+        # The SAME function install.sh calls. Not a reimplementation of it, and
+        # not an approximation of it -- if these two ever composed differently,
+        # the probe would be measuring a configuration the installer never
+        # writes, which is the failure this whole design exists to prevent.
+        _jarvis_log "composing ${JARVIS_MECHANISM} into ${JARVIS_AUTH_RIGHT}"
+        PROBE_RULE_TMP="$(mktemp -t jarvis-probe-rule)"
+        _probe_compose_rc=0
+        jarvis_compose_mechanism_rule "${BACKUP}" "${PROBE_RULE_TMP}" "${JARVIS_MECHANISM}" \
+            || _probe_compose_rc=$?
+        case "${_probe_compose_rc}" in
+            0) : ;;
+            2) rm -f "${PROBE_RULE_TMP}"; _jarvis_die "the live chain already names ${JARVIS_MECHANISM}; nothing to measure" ;;
+            3) rm -f "${PROBE_RULE_TMP}"; _jarvis_die "${JARVIS_AUTH_RIGHT} is not a mechanism chain live; refusing to author one" ;;
+            *) rm -f "${PROBE_RULE_TMP}"; _jarvis_die "could not compose a probe rule; nothing mutated" ;;
+        esac
+        plutil -lint "${PROBE_RULE_TMP}" >/dev/null 2>&1 \
+            || { rm -f "${PROBE_RULE_TMP}"; _jarvis_die "composed probe rule is malformed; nothing mutated"; }
+
+        _jarvis_log "chain to be measured: $(jarvis_rule_mechanisms "${PROBE_RULE_TMP}" | tr '\n' ' ')"
+        if ! jarvis_authdb_write "${JARVIS_AUTH_RIGHT}" "${PROBE_RULE_TMP}"; then
+            rm -f "${PROBE_RULE_TMP}"
+            _jarvis_die "mutation failed; trap and dead-man switch will restore the stock rule"
+        fi
+        rm -f "${PROBE_RULE_TMP}"
+        ;;
+    rule-swap)
+        _jarvis_log "switching ${JARVIS_AUTH_RIGHT} -> ${PROBE_RULE_NAME}"
+        if ! security authorizationdb write "${JARVIS_AUTH_RIGHT}" "${PROBE_RULE_NAME}"; then
+            _jarvis_die "mutation failed; trap and dead-man switch will restore the stock rule"
+        fi
+        ;;
+esac
 
 # Capture the shape that is actually live, from the database rather than from
-# what we asked for. `security authorizationdb write <right> <rulename>` is a
-# request; the rule the engine will evaluate is the answer, and the answer is
-# what the measurement has to be labelled with.
+# what we asked for. A write is a request; the rule the engine will evaluate is
+# the answer, and the answer is what the measurement has to be labelled with.
 LIVE_RULE="$(mktemp -t jarvis-probe-live)"
 jarvis_authdb_read "${JARVIS_AUTH_RIGHT}" > "${LIVE_RULE}" 2>/dev/null \
     || _jarvis_die "could not read back ${JARVIS_AUTH_RIGHT} after the write; trap and dead-man switch will restore the stock rule"
 
 PROBE_SHAPE="$(jarvis_rule_shape "${LIVE_RULE}" 2>/dev/null || true)"
-STOCK_SHAPE="$(jarvis_rule_shape "${BACKUP}" 2>/dev/null || true)"
-rm -f "${LIVE_RULE}"
-
 [ -n "${PROBE_SHAPE}" ] || _jarvis_die "could not compute the shape of the live rule; nothing is being measured"
 
 # Structural rather than a marker match. "Did the rule change" is answered by
@@ -204,6 +296,14 @@ rm -f "${LIVE_RULE}"
 if [ "${PROBE_SHAPE}" = "${STOCK_SHAPE}" ]; then
     _jarvis_die "the live rule is unchanged after the write; probe is not measuring anything"
 fi
+
+# In compose mode we ADDED to a chain. If anything the chain already had is now
+# missing, we have not probed our mechanism -- we have probed a machine with
+# smartcard unlock removed, and any result would be about the wrong system.
+if [ "${PROBE_MODE}" = "compose" ] && ! jarvis_chain_preserves_backup "${LIVE_RULE}" "${BACKUP}"; then
+    _jarvis_die "the composed chain dropped a mechanism the rule already had; reverting"
+fi
+rm -f "${LIVE_RULE}"
 
 _jarvis_log "measuring shape: ${PROBE_SHAPE}"
 
@@ -215,16 +315,30 @@ cat <<BANNER
 ================================================================================
   PROBE ACTIVE -- ${PROBE_WINDOW_S} SECONDS
 ================================================================================
-  system.login.screensaver is now: ${PROBE_RULE_NAME}
-  (SecurityAgent-evaluated -- the configuration a plugin would need)
+  ${JARVIS_AUTH_RIGHT}
+  mode:  ${PROBE_MODE}
+  shape: ${PROBE_SHAPE}
+
+  THE FAIL-OPEN TEST IS THE POINT OF THIS RUN.
+
+  No grant has been deposited, so JARVIS will find nothing and YIELD -- which is
+  kAuthorizationResultAllow, "I am satisfied, continue", NOT Deny. Deny would
+  fail the whole right and lock you out, and there is deliberately no code path
+  in the mechanism that can produce it. So the yield you are about to trigger is
+  the mechanism's ordinary behaviour, not a special test mode, and what it
+  proves is whether a yield on THIS right still reaches a password prompt.
+
+  That matters here and did not before: this chain has no builtin:authenticate
+  behind us, and tries=1. Nothing retries.
 
   GO TEST NOW, in this order:
 
     1. Lock the screen            (Ctrl-Cmd-Q)
-    2. Does TOUCH ID prompt/work?          -> yes / no
-    3. Does APPLE WATCH auto-unlock work?  -> yes / no
-    4. Does your PASSWORD still unlock?    -> yes / no   <- must be yes
-    5. Unlock and come back here
+    2. Wait for the prompt to appear at all -> yes / no   <- the fail-open test
+    3. Does TOUCH ID prompt/work?          -> yes / no
+    4. Does APPLE WATCH auto-unlock work?  -> yes / no
+    5. Does your PASSWORD still unlock?    -> yes / no   <- must be yes
+    6. Unlock and come back here
 
   The rule reverts automatically when the timer fires, even if this window
   closes, this script dies, or your SSH session drops.
@@ -273,6 +387,73 @@ else
 fi
 
 # =============================================================================
+# 6b. THE FAIL-OPEN BATTERY  -- decided from evidence, not from the operator
+# =============================================================================
+# Run AFTER the revert, on purpose. Reading the unified log takes seconds and
+# parsing crash reports takes longer; doing either while the machine is still
+# mutated would extend the exposure window for no reason. The evidence is
+# already on disk by then -- it does not expire.
+#
+# Three questions, none of which a human at a lock screen can answer reliably:
+#
+#   Did the mechanism host DIE?   The 27-crash failure mode. A dead host never
+#                                 calls SetResult, so nothing in the chain ever
+#                                 answers -- which on tries=1 is the black screen
+#                                 and is invisible to every static check.
+#   Did our mechanism RUN?        Distinguishes "fail-open works" from "the
+#                                 screen was never locked", which otherwise look
+#                                 identical from the operator's side.
+#   Did it YIELD rather than grant?  A yield is the fail-open path. A grant would
+#                                 mean a stale grant was sitting in the broker,
+#                                 and the run measured the wrong thing.
+PROBE_FAILOPEN="inconclusive"
+PROBE_EVIDENCE_LOG="${JARVIS_STATE_DIR}/probe-window-${_stamp}.log"
+
+_crashes_now="$(jarvis_crash_reports_since "${PROBE_T0_EPOCH}" 2>/dev/null || true)"
+_crash_count="$(printf '%s' "${_crashes_now}" | grep -c . || true)"
+
+_window_log=""
+if _window_log="$(jarvis_unlock_log_since "${PROBE_T0_LOG}" 2>/dev/null)"; then :; fi
+printf '%s\n' "${_window_log}" > "${PROBE_EVIDENCE_LOG}" 2>/dev/null || true
+chmod 600 "${PROBE_EVIDENCE_LOG}" 2>/dev/null || true
+
+_mech_lines="$(printf '%s\n' "${_window_log}" | grep -c "${JARVIS_LOG_SUBSYSTEM_PLUGIN}" || true)"
+_yielded="$(printf '%s\n' "${_window_log}" | grep -ci 'yield' || true)"
+_granted="$(printf '%s\n' "${_window_log}" | grep -ci 'grant ' || true)"
+
+echo
+echo "fail-open battery"
+if [ "${_crash_count}" -gt 0 ]; then
+    PROBE_FAILOPEN="crashed"
+    _jarvis_warn "  the mechanism host CRASHED ${_crash_count} time(s) during the window"
+    _newest_crash="$(printf '%s\n' "${_crashes_now}" | sed -n '$p')"
+    if grep -q "${JARVIS_PLUGIN_NAME}" "${_newest_crash}" 2>/dev/null; then
+        _jarvis_warn "  the newest report NAMES ${JARVIS_PLUGIN_NAME} -- this is our defect"
+    fi
+    _sym="$(jarvis_crash_faulting_symbol "${_newest_crash}" 2>/dev/null || true)"
+    [ -n "${_sym}" ] && _jarvis_warn "  faulting frame: ${_sym}"
+    _jarvis_warn "  DO NOT INSTALL. A host that dies on a tries=1 right is a lockout."
+elif [ "${_mech_lines}" -eq 0 ]; then
+    # Zero lines is genuinely ambiguous and must not be read as either answer:
+    # the screen may never have been locked, or the log may not have been
+    # readable. The probe says so rather than picking the convenient reading.
+    PROBE_FAILOPEN="not-reached"
+    _jarvis_warn "  our mechanism produced no log output during the window"
+    _jarvis_warn "  either the screen was never locked, or the chain never reached us"
+elif [ "${_granted}" -gt 0 ]; then
+    PROBE_FAILOPEN="granted-not-yield"
+    _jarvis_warn "  the mechanism GRANTED -- a stale grant was in the broker"
+    _jarvis_warn "  this run measured the unlock path, not the fail-open path; re-run"
+elif [ "${_yielded}" -gt 0 ]; then
+    PROBE_FAILOPEN="yielded"
+    _jarvis_log "  our mechanism ran and YIELDED, and the host survived"
+    _jarvis_log "  whether a prompt followed is yours to confirm below"
+else
+    _jarvis_warn "  our mechanism ran but neither granted nor yielded in the log"
+fi
+_jarvis_log "  window log: ${PROBE_EVIDENCE_LOG}"
+
+# =============================================================================
 # 7. CAPTURE THE MEASUREMENT  (a result that lives only in a terminal is not a
 #    result -- the first run reverted cleanly and recorded nothing)
 # =============================================================================
@@ -283,6 +464,7 @@ PROBE_RESULTS="${JARVIS_PROBE_RESULTS_LOG}"
 
 # Every answer defaults to the honest one for a run that did not ask.
 _locked="not-tested"; _touchid="not-tested"; _watch="not-tested"; _password="not-tested"
+_prompted="not-tested"
 
 if [ -t 0 ]; then
     printf '\n[jarvis-authplugin] recording the measurement (Enter to skip any answer)\n' >&2
@@ -304,11 +486,27 @@ if [ -t 0 ]; then
         _jarvis_warn "  sudo JARVIS_PROBE_WINDOW_S=${PROBE_WINDOW_S} $0"
     fi
 
+    _prompted="$(_ask 'Did an authentication PROMPT appear at all (not a black screen)?')"
     _touchid="$(_ask 'Did TOUCH ID work?')"
     _watch="$(_ask 'Did APPLE WATCH auto-unlock work?')"
     _password="$(_ask 'Did your PASSWORD unlock?')"
 else
     _jarvis_log "non-interactive; no answers collected"
+fi
+
+# PROVEN requires both halves and neither is sufficient alone.
+#
+# The log proves our mechanism ran, yielded, and did not take the host down with
+# it. Only the operator can say a prompt actually appeared and accepted a
+# password -- the 27 crashes produced a black screen that no amount of log
+# reading would have called a success, and a clean yield into a chain that then
+# draws nothing is exactly the failure this right's tries=1 makes unrecoverable.
+if [ "${PROBE_FAILOPEN}" = "yielded" ] \
+   && [ "${_locked}" = "yes" ] && [ "${_prompted}" = "yes" ] && [ "${_password}" = "yes" ]; then
+    PROBE_FAILOPEN="proven"
+    _jarvis_log "fail-open PROVEN: mechanism yielded, host survived, prompt appeared, password worked"
+elif [ "${PROBE_FAILOPEN}" = "yielded" ]; then
+    PROBE_FAILOPEN="yielded-unconfirmed"
 fi
 
 # Written on BOTH paths. A run that asked nothing still proves the shape was
@@ -319,9 +517,9 @@ fi
 # label, and is deliberately NOT what the gate reads: it is a request, whereas
 # shape is what the authorization engine was actually left holding.
 {
-    printf '%s rule=%s shape=%s window=%ss locked=%s touchid=%s watch=%s password=%s\n' \
+    printf '%s rule=%s shape=%s window=%ss locked=%s prompted=%s touchid=%s watch=%s password=%s failopen=%s\n' \
         "$(date -u +%FT%TZ)" "${PROBE_RULE_NAME}" "${PROBE_SHAPE}" "${PROBE_WINDOW_S}" \
-        "${_locked}" "${_touchid}" "${_watch}" "${_password}"
+        "${_locked}" "${_prompted}" "${_touchid}" "${_watch}" "${_password}" "${PROBE_FAILOPEN}"
 } >> "${PROBE_RESULTS}"
 
 _jarvis_log "recorded to ${PROBE_RESULTS}"

--- a/backend/voice_unlock/authplugin/install/probe_screensaver_rule.sh
+++ b/backend/voice_unlock/authplugin/install/probe_screensaver_rule.sh
@@ -189,20 +189,9 @@ printf '%s' "${BACKUP}" > "${JARVIS_AUTHDB_BACKUP_POINTER}"
 # Holds only a duration and a path. Reads nothing about whether the probe is
 # alive, healthy, or finished -- so nothing the probe does can wedge it.
 mkdir -p "$(dirname "${PROBE_LOG}")"
-nohup bash -c "
-    sleep ${PROBE_WINDOW_S}
-    for attempt in 1 2 3; do
-        if /usr/bin/security authorizationdb write '${JARVIS_AUTH_RIGHT}' < '${BACKUP}' 2>/dev/null; then
-            printf '%s dead-man revert OK (attempt %s)\n' \"\$(date -u +%FT%TZ)\" \"\$attempt\" >> '${PROBE_LOG}'
-            exit 0
-        fi
-        sleep 2
-    done
-    printf '%s DEAD-MAN REVERT FAILED -- restore by hand: security authorizationdb write %s < %s\n' \
-        \"\$(date -u +%FT%TZ)\" '${JARVIS_AUTH_RIGHT}' '${BACKUP}' >> '${PROBE_LOG}'
-" >/dev/null 2>&1 &
-REVERTER_PID=$!
-disown "${REVERTER_PID}" 2>/dev/null || true
+REVERTER_PID="$(jarvis_arm_deadman "${PROBE_WINDOW_S}" "${PROBE_LOG}" \
+    "/usr/bin/security authorizationdb write '${JARVIS_AUTH_RIGHT}' < '${BACKUP}'" \
+    "sudo security authorizationdb write ${JARVIS_AUTH_RIGHT} < ${BACKUP}")"
 _jarvis_log "dead man's switch armed (pid ${REVERTER_PID}, fires in ${PROBE_WINDOW_S}s)"
 
 # Layer 2: instant revert on Ctrl-C or normal exit. The timer remains the backstop.

--- a/backend/voice_unlock/authplugin/install/probe_screensaver_rule.sh
+++ b/backend/voice_unlock/authplugin/install/probe_screensaver_rule.sh
@@ -1,20 +1,30 @@
 #!/bin/bash
 # JARVIS -- Ephemeral Probe for the system.login.screensaver authorization rule.
 #
-# WHAT THIS MEASURES
-# ------------------
+# WHAT THIS MEASURES -- AND, JUST AS IMPORTANTLY, WHAT IT DOES NOT
+# ----------------------------------------------------------------
 # Your lock screen currently uses:
 #
 #     class = rule
 #     rule  = ( use-login-window-ui )
 #
-# which means loginwindow owns authentication and there is no mechanism chain an
-# Authorization Plugin could join. Switching the right to a SecurityAgent-
-# evaluated rule is the only way to host a plugin -- but it may sever the
-# loginwindow-native paths for Touch ID and Apple Watch unlock.
+# which means loginwindow owns authentication. This script swaps in a different
+# rule for a bounded window so you can test Touch ID, Watch unlock and your
+# password under it yourself, then puts it back.
 #
-# Nobody should guess at that. This script switches the rule for a bounded
-# window so you can test Touch ID and Watch unlock yourself, then puts it back.
+# IT MEASURES THE SHAPE IT APPLIES, AND NOTHING ELSE. That sentence is here
+# because an earlier version of this file did not respect it. It probed
+# authenticate-session-owner-or-admin -- class = user, a SecurityAgent-evaluated
+# rule with no mechanisms array at all -- reported that Touch ID and the password
+# survived, and closed by advising that the plugin was therefore viable "against
+# evaluate-mechanisms". Those are two different configurations. The one that was
+# measured worked; the one that was installed black-screened the machine, because
+# converting a delegating rule into a mechanism chain removes the delegation, and
+# loginwindow is what draws the lock screen and resumes the session.
+#
+# So this script now records the EXACT shape it applied, as a shape identity that
+# install.sh matches on. A measurement of one shape cannot be spent on another --
+# not by a comment, not by an argument about equivalence, and not by a flag.
 #
 # WHY IT CANNOT LEAVE YOUR MACHINE MUTATED
 # ----------------------------------------
@@ -174,10 +184,28 @@ if ! security authorizationdb write "${JARVIS_AUTH_RIGHT}" "${PROBE_RULE_NAME}";
     _jarvis_die "mutation failed; trap and dead-man switch will restore the stock rule"
 fi
 
-_live_now="$(jarvis_authdb_read "${JARVIS_AUTH_RIGHT}" | tr -d '\n')"
-if printf '%s' "${_live_now}" | grep -q "${STOCK_MARKER}"; then
-    _jarvis_die "rule still reads as stock after the write; probe is not measuring anything"
+# Capture the shape that is actually live, from the database rather than from
+# what we asked for. `security authorizationdb write <right> <rulename>` is a
+# request; the rule the engine will evaluate is the answer, and the answer is
+# what the measurement has to be labelled with.
+LIVE_RULE="$(mktemp -t jarvis-probe-live)"
+jarvis_authdb_read "${JARVIS_AUTH_RIGHT}" > "${LIVE_RULE}" 2>/dev/null \
+    || _jarvis_die "could not read back ${JARVIS_AUTH_RIGHT} after the write; trap and dead-man switch will restore the stock rule"
+
+PROBE_SHAPE="$(jarvis_rule_shape "${LIVE_RULE}" 2>/dev/null || true)"
+STOCK_SHAPE="$(jarvis_rule_shape "${BACKUP}" 2>/dev/null || true)"
+rm -f "${LIVE_RULE}"
+
+[ -n "${PROBE_SHAPE}" ] || _jarvis_die "could not compute the shape of the live rule; nothing is being measured"
+
+# Structural rather than a marker match. "Did the rule change" is answered by
+# comparing the live shape to the shape we backed up -- which stays true on any
+# macOS, for any right, whatever the stock rule happens to be called.
+if [ "${PROBE_SHAPE}" = "${STOCK_SHAPE}" ]; then
+    _jarvis_die "the live rule is unchanged after the write; probe is not measuring anything"
 fi
+
+_jarvis_log "measuring shape: ${PROBE_SHAPE}"
 
 # =============================================================================
 # 5. THE MEASUREMENT WINDOW
@@ -227,8 +255,16 @@ fi
 _revert_now
 
 _jarvis_log "final state of ${JARVIS_AUTH_RIGHT}:"
-if jarvis_authdb_read "${JARVIS_AUTH_RIGHT}" | grep -q "${STOCK_MARKER}"; then
-    _jarvis_log "  STOCK (${STOCK_MARKER}) -- machine is back to how it started"
+# Compared by shape against the file we backed up, not by a marker string. The
+# question is "is the machine back to how it started", and the only thing that
+# answers it exactly is the state it started in.
+_after_revert="$(mktemp -t jarvis-probe-after)"
+jarvis_authdb_read "${JARVIS_AUTH_RIGHT}" > "${_after_revert}" 2>/dev/null || true
+_after_shape="$(jarvis_rule_shape "${_after_revert}" 2>/dev/null || true)"
+rm -f "${_after_revert}"
+
+if [ -n "${_after_shape}" ] && [ "${_after_shape}" = "${STOCK_SHAPE}" ]; then
+    _jarvis_log "  back to the shape it started with: ${STOCK_SHAPE}"
     rm -f "${JARVIS_AUTHDB_BACKUP_POINTER}"
 else
     _jarvis_warn "  NOT STOCK. Restore by hand:"
@@ -240,7 +276,13 @@ fi
 # 7. CAPTURE THE MEASUREMENT  (a result that lives only in a terminal is not a
 #    result -- the first run reverted cleanly and recorded nothing)
 # =============================================================================
-PROBE_RESULTS="${JARVIS_STATE_DIR}/probe-results.log"
+# The path is defined in common.sh, because install.sh reads this file to decide
+# whether a shape may be written. A producer and a consumer holding two literals
+# for one path is a gate that silently never fires.
+PROBE_RESULTS="${JARVIS_PROBE_RESULTS_LOG}"
+
+# Every answer defaults to the honest one for a run that did not ask.
+_locked="not-tested"; _touchid="not-tested"; _watch="not-tested"; _password="not-tested"
 
 if [ -t 0 ]; then
     printf '\n[jarvis-authplugin] recording the measurement (Enter to skip any answer)\n' >&2
@@ -265,32 +307,52 @@ if [ -t 0 ]; then
     _touchid="$(_ask 'Did TOUCH ID work?')"
     _watch="$(_ask 'Did APPLE WATCH auto-unlock work?')"
     _password="$(_ask 'Did your PASSWORD unlock?')"
-
-    {
-        printf '%s rule=%s window=%ss locked=%s touchid=%s watch=%s password=%s\n' \
-            "$(date -u +%FT%TZ)" "${PROBE_RULE_NAME}" "${PROBE_WINDOW_S}" \
-            "${_locked}" "${_touchid}" "${_watch}" "${_password}"
-    } >> "${PROBE_RESULTS}"
-
-    _jarvis_log "recorded to ${PROBE_RESULTS}"
-
-    if [ "${_password}" = "no" ]; then
-        _jarvis_warn "PASSWORD FAILED under SecurityAgent. Do not build the plugin."
-    fi
 else
-    _jarvis_log "non-interactive; skipping capture. Record answers in ${PROBE_RESULTS}"
+    _jarvis_log "non-interactive; no answers collected"
 fi
 
-cat <<'NEXT'
+# Written on BOTH paths. A run that asked nothing still proves the shape was
+# applied on this machine and at what time, and a log that only contains
+# successful interactive runs is a log that cannot show you a gap.
+#
+# shape= is the field install.sh matches on. rule= is retained as the human
+# label, and is deliberately NOT what the gate reads: it is a request, whereas
+# shape is what the authorization engine was actually left holding.
+{
+    printf '%s rule=%s shape=%s window=%ss locked=%s touchid=%s watch=%s password=%s\n' \
+        "$(date -u +%FT%TZ)" "${PROBE_RULE_NAME}" "${PROBE_SHAPE}" "${PROBE_WINDOW_S}" \
+        "${_locked}" "${_touchid}" "${_watch}" "${_password}"
+} >> "${PROBE_RESULTS}"
 
-Report back with the four yes/no answers. They decide the architecture:
+_jarvis_log "recorded to ${PROBE_RESULTS}"
 
-  Touch ID + Watch SURVIVE  -> the plugin is viable; build it against
-                               evaluate-mechanisms with no biometric cost.
-  Touch ID or Watch BREAK   -> hosting a plugin costs you native biometrics.
-                               That is a real price, and it is your call
-                               whether voice unlock is worth paying it.
-  PASSWORD fails            -> stop entirely; the SecurityAgent handoff is not
-                               safe on this machine and no plugin gets built.
+if [ "${_password}" = "no" ]; then
+    _jarvis_warn "PASSWORD FAILED under this shape. It must never be installed."
+fi
+
+cat <<NEXT
+
+WHAT THIS RUN DOES AND DOES NOT LICENSE
+
+  measured shape:  ${PROBE_SHAPE}
+
+  Those answers describe THAT shape. They describe no other. install.sh matches
+  on the shape string above, so this measurement can only ever authorise the
+  configuration it was taken under -- which is the point, and is the guarantee
+  that was missing when a class=user probe was used to justify installing a
+  mechanism chain.
+
+  Touch ID + Watch SURVIVE  -> this shape is usable, at no biometric cost.
+  Touch ID or Watch BREAK   -> this shape costs you native biometrics. A real
+                               price, and your call whether it is worth paying.
+  PASSWORD fails            -> this shape must never be installed. install.sh
+                               will not accept this record as permission.
+
+  Note that a usable shape is still not an installable one: install.sh also
+  requires that the right can host a mechanism in Apple's schema at all. A right
+  whose stock class delegates -- system.login.screensaver is class=rule pointing
+  at use-login-window-ui -- is refused no matter how well it probes, because
+  probing measures authentication and what conversion destroys is the lock
+  screen's UI and its session resume.
 
 NEXT

--- a/backend/voice_unlock/authplugin/install/sentinel.sh
+++ b/backend/voice_unlock/authplugin/install/sentinel.sh
@@ -1,0 +1,255 @@
+#!/bin/bash
+# JARVIS Authorization Plugin -- the sentinel.
+#
+# WHAT THIS INVERTS
+# -----------------
+# Every other guard in this directory stops the INSTALLER from doing the wrong
+# thing. None of them can help once the rule is written, and four ways to a black
+# lock screen remain open after a correct install:
+#
+#   1. the mechanism starts crashing its host   (27 times, over two days, unseen)
+#   2. an OS update rewrites the right          ("Do not modify" is about this)
+#   3. the bundle goes away, rule still naming it  (rebuild, make clean, rm)
+#   4. someone edits the rule by hand           (how this machine got here)
+#
+# All four end the same way: the machine sits broken until a human notices. This
+# exists so it does not.
+#
+# The default state is now safe and JARVIS has to keep earning its place: the
+# moment the configuration stops being the one the installer proved, our
+# mechanism comes out. Nothing prompts, nothing waits for a person.
+#
+# WHY THERE IS NO RESIDENT DAEMON
+# -------------------------------
+# launchd's WatchPaths is kqueue-backed, so this script is invoked on a change
+# rather than polling for one. Idle cost is not "near zero", it is zero: between
+# events there is no process. That also answers "what if the sentinel crashes"
+# at the root rather than with KeepAlive restarts -- a thing that is not running
+# cannot crash, and launchd is the one process on the system whose liveness is
+# not our problem.
+#
+# A long StartInterval remains as a backstop. It is not the mechanism; it is
+# insurance against a coalesced or missed kqueue event, and against the machine
+# having been asleep. Deliberately long enough that it is never the thing that
+# notices first.
+#
+# WHAT IT WILL NOT DO
+# -------------------
+# It never installs, never composes, never grants. Its only write is a REVERT,
+# through the same audited function uninstall.sh uses. A sentinel that could put
+# the mechanism back would be a second installer with no gates in front of it.
+
+set -uo pipefail
+
+_here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common.sh
+. "${_here}/common.sh"
+set +e
+
+SENTINEL_LOG="${JARVIS_SENTINEL_LOG:-${JARVIS_STATE_DIR}/sentinel.log}"
+SENTINEL_LOG_MAX="${JARVIS_SENTINEL_LOG_MAX_BYTES:-262144}"
+LOCK_DIR="${JARVIS_STATE_DIR}/sentinel.lock"
+DEFER_FILE="${JARVIS_STATE_DIR}/sentinel.deferrals"
+DEFER_MAX="${JARVIS_SENTINEL_MAX_DEFERRALS:-3}"
+
+# Root, or nothing. launchd invokes this as root; a human running it by hand
+# without sudo is not an error, it simply cannot read the crash reports or write
+# the database. Exit 0 rather than failing: a non-zero exit here would be a
+# launchd-visible failure that says something is wrong with the machine when the
+# only thing wrong is the invocation.
+if [ "$(id -u)" -ne 0 ]; then
+    printf '[sentinel] needs root; nothing checked (try: sudo %s)\n' "$0" >&2
+    exit 0
+fi
+
+mkdir -p "${JARVIS_STATE_DIR}" 2>/dev/null || true
+
+# Decide once whether the log is writable. A redirection to an unwritable path is
+# reported by the shell BEFORE the command runs, so `2>/dev/null` on the printf
+# does not suppress it -- every _say would emit a permission error alongside the
+# message it was trying to record.
+_LOG_OK=0
+if : >> "${SENTINEL_LOG}" 2>/dev/null; then _LOG_OK=1; fi
+
+_say() {
+    [ "${_LOG_OK}" -eq 1 ] \
+        && printf '%s [sentinel] %s\n' "$(date -u +%FT%TZ)" "$*" >> "${SENTINEL_LOG}" 2>/dev/null
+    printf '[sentinel] %s\n' "$*" >&2
+}
+
+# Bounded log. A watchdog that fills the disk it is watching has become the
+# problem it exists to prevent.
+if [ -f "${SENTINEL_LOG}" ]; then
+    _size="$(stat -f %z "${SENTINEL_LOG}" 2>/dev/null || echo 0)"
+    if [ "${_size}" -gt "${SENTINEL_LOG_MAX}" ]; then
+        tail -c $(( SENTINEL_LOG_MAX / 2 )) "${SENTINEL_LOG}" > "${SENTINEL_LOG}.tmp" 2>/dev/null \
+            && mv -f "${SENTINEL_LOG}.tmp" "${SENTINEL_LOG}" 2>/dev/null
+    fi
+fi
+
+# =============================================================================
+# SERIALISE
+# =============================================================================
+# Three WatchPaths and a RunAtLoad can fire together -- a bundle removal touches
+# the plugin directory AND, moments later, the authorization database when we
+# repair it, which re-triggers the watch. Two concurrent reverts racing on one
+# rule is how a half-written chain happens.
+#
+# mkdir because macOS ships no flock(1) and this has to work from a Recovery
+# shell. It is atomic on every filesystem that matters. The PID inside is what
+# makes a lock left behind by a SIGKILL recoverable rather than permanent.
+if ! mkdir "${LOCK_DIR}" 2>/dev/null; then
+    # mkdir fails for more than one reason, and they are not interchangeable.
+    # Only "it already exists" is contention. A missing parent or a permission
+    # error is an environment problem, and treating it as a stale lock would
+    # rm -rf a path we could not create -- and, if the directory did exist but
+    # its pid file was unreadable, would break a LIVE lock and let two reverts
+    # race on one rule.
+    if [ ! -d "${LOCK_DIR}" ]; then
+        _say "cannot create ${LOCK_DIR} (missing state directory or no permission); nothing checked"
+        exit 0
+    fi
+
+    _owner="$(cat "${LOCK_DIR}/pid" 2>/dev/null || true)"
+    if [ -n "${_owner}" ] && kill -0 "${_owner}" 2>/dev/null; then
+        _say "another sentinel is running (pid ${_owner}); this invocation defers to it"
+        exit 0
+    fi
+
+    # An existing lock with no readable pid is ambiguous, but it is also exactly
+    # what a SIGKILLed predecessor leaves behind -- and a lock that can never be
+    # broken would disable the sentinel permanently. Break it, and say so.
+    _say "breaking a stale lock (owner ${_owner:-unknown} is gone)"
+    rm -rf "${LOCK_DIR}" 2>/dev/null
+    mkdir "${LOCK_DIR}" 2>/dev/null || { _say "could not take the lock; giving up this pass"; exit 0; }
+fi
+printf '%s' "$$" > "${LOCK_DIR}/pid" 2>/dev/null
+trap 'rm -rf "${LOCK_DIR}" 2>/dev/null' EXIT
+
+# =============================================================================
+# IS THERE ANYTHING TO GUARD?
+# =============================================================================
+# If the rule does not name us there is nothing to revert, and this is the
+# overwhelmingly common case -- every boot on a machine that never installed,
+# every event after a successful uninstall. It has to be the cheapest path.
+if ! jarvis_rule_references_plugin; then
+    rm -f "${DEFER_FILE}" 2>/dev/null
+    exit 0
+fi
+
+# =============================================================================
+# THE HEALTH PREDICATE
+# =============================================================================
+# Findings are collected, not acted on one at a time, so the log records
+# everything that was wrong rather than only the first thing noticed.
+_findings=""
+_urgent=0
+_note()  { _findings="${_findings}${_findings:+; }$1"; }
+_note_urgent() { _note "$1"; _urgent=1; }
+
+# 1. The bundle. URGENT: a chain naming a mechanism that cannot be loaded fails
+#    before anything in it answers, and on tries=1 that is a lockout happening
+#    right now.
+jarvis_plugin_bundle_present \
+    || _note_urgent "bundle absent at ${JARVIS_PLUGIN_PATH}"
+
+# 2. Crashes since the bundle was installed. URGENT for the same reason: a host
+#    that dies never calls SetResult. Scoped to reports that NAME us, so an
+#    unrelated authorizationhosthelper fault does not uninstall a healthy plugin.
+_since=0
+[ -e "${JARVIS_PLUGIN_PATH}" ] && _since="$(stat -f %m "${JARVIS_PLUGIN_PATH}" 2>/dev/null || echo 0)"
+if _reports="$(jarvis_crash_reports_since "${_since}")" && [ -n "${_reports}" ]; then
+    _ours=0
+    while IFS= read -r _rep; do
+        [ -n "${_rep}" ] || continue
+        grep -q "${JARVIS_PLUGIN_NAME}" "${_rep}" 2>/dev/null && _ours=$(( _ours + 1 ))
+    done <<EOF
+${_reports}
+EOF
+    if [ "${_ours}" -gt 0 ]; then
+        _newest="$(printf '%s\n' "${_reports}" | sed -n '$p')"
+        _note_urgent "${_ours} crash(es) naming ${JARVIS_PLUGIN_NAME} (frame: $(jarvis_crash_faulting_symbol "${_newest}" 2>/dev/null || echo unknown))"
+    fi
+fi
+
+# 3-5 need the live rule on disk.
+_live="$(mktemp -t jarvis-sentinel-live)"
+if jarvis_authdb_read "${JARVIS_AUTH_RIGHT}" > "${_live}" 2>/dev/null; then
+
+    # 3. Drift from the shape the installer proved. NOT urgent: the chain is
+    #    still coherent and still has whatever it had, it is simply no longer the
+    #    configuration that was measured -- which is exactly what an OS update
+    #    rewriting the right looks like.
+    if _sanctioned="$(jarvis_sanctioned_shape)" && [ -n "${_sanctioned}" ]; then
+        _now="$(jarvis_rule_shape "${_live}" 2>/dev/null || true)"
+        [ "${_now}" = "${_sanctioned}" ] \
+            || _note "shape drifted from the sanctioned one (now: ${_now:-unreadable})"
+    else
+        # We are in the chain with no record of anyone having sanctioned it.
+        # That is finding 4 -- a hand-written rule -- and it is the case no
+        # installer gate can ever cover.
+        _note_urgent "no sanctioned shape on record, but the rule names us"
+    fi
+
+    # 4. Did we take something away? The backup is the only thing that knows what
+    #    the chain had before us.
+    _ptr=""
+    [ -f "${JARVIS_AUTHDB_BACKUP_POINTER}" ] && _ptr="$(cat "${JARVIS_AUTHDB_BACKUP_POINTER}" 2>/dev/null || true)"
+    if [ -n "${_ptr}" ] && [ -f "${_ptr}" ]; then
+        jarvis_chain_preserves_backup "${_live}" "${_ptr}" \
+            || _note "the chain has lost a mechanism it had before the install"
+    fi
+
+    # 5. Is the right still a mechanism host at all? An OS update can change what
+    #    a right IS, and being in the chain of a right that no longer hosts
+    #    mechanisms is the original defect, arrived at by a different road.
+    jarvis_right_hosts_mechanisms "${JARVIS_AUTH_RIGHT}" >/dev/null 2>&1 \
+        || _note "${JARVIS_AUTH_RIGHT} is no longer a mechanism host in the system schema"
+fi
+rm -f "${_live}"
+
+if [ -z "${_findings}" ]; then
+    rm -f "${DEFER_FILE}" 2>/dev/null
+    exit 0
+fi
+
+# =============================================================================
+# ACT
+# =============================================================================
+_say "UNHEALTHY: ${_findings}"
+
+# Defer only what is safe to defer, and only for a bounded number of passes.
+#
+# A non-urgent finding during an active authentication can wait for the user to
+# finish; rewriting the rule underneath them achieves nothing they need. An
+# URGENT finding cannot wait, because an active authentication is precisely when
+# a stuck user is staring at the failure. And the deferral is counted, so a
+# console that stays locked forever cannot postpone the repair forever -- a guard
+# that waits on the guarded system is the deadlock this project already retired
+# once.
+if [ "${_urgent}" -eq 0 ] && jarvis_authentication_in_flight; then
+    _count="$(cat "${DEFER_FILE}" 2>/dev/null || echo 0)"
+    case "${_count}" in ''|*[!0-9]*) _count=0 ;; esac
+    if [ "${_count}" -lt "${DEFER_MAX}" ]; then
+        printf '%s' "$(( _count + 1 ))" > "${DEFER_FILE}" 2>/dev/null
+        _say "authentication in flight; deferring non-urgent repair ($(( _count + 1 ))/${DEFER_MAX})"
+        exit 0
+    fi
+    _say "deferral budget spent; repairing despite the active session"
+fi
+
+[ "${_urgent}" -eq 1 ] && _say "finding is URGENT; repairing without waiting for the session"
+
+if jarvis_revert_auth_rule; then
+    _say "REPAIRED: ${JARVIS_PLUGIN_NAME} is out of ${JARVIS_AUTH_RIGHT}"
+    _say "  your lock screen is back to the configuration it had before the install"
+    _say "  diagnose with: sudo ${_here}/verify.sh"
+    rm -f "${DEFER_FILE}" 2>/dev/null
+    exit 0
+fi
+
+# Could not repair. Say so loudly and keep saying it: the next event fires this
+# again, and an unrepaired machine that stopped complaining is the worst of both.
+_say "REPAIR FAILED -- ${JARVIS_AUTH_RIGHT} still names ${JARVIS_PLUGIN_NAME}"
+_say "  recover by hand: sudo ${_here}/uninstall.sh"
+exit 1

--- a/backend/voice_unlock/authplugin/install/test_rule_shape.sh
+++ b/backend/voice_unlock/authplugin/install/test_rule_shape.sh
@@ -444,6 +444,150 @@ _rc "an unreadable report directory is distinguished from no crashes" 1 "${_e}"
 
 # =============================================================================
 echo
+echo "login-rights guard"
+# =============================================================================
+JARVIS_SYSTEM_AUTH_TEMPLATE="${JARVIS_SYSTEM_AUTH_TEMPLATE_DEFAULT}"
+if [ -r "${JARVIS_SYSTEM_AUTH_TEMPLATE}" ]; then
+    for _r in system.login.console system.login.filevault system.login.fus; do
+        jarvis_right_performs_login "${_r}" \
+            && _ok "${_r} is protected" \
+            || _no "${_r} is protected"
+    done
+
+    # THE discrimination that matters. system.login.screensaver.unlock's sole
+    # mechanism is CryptoTokenKit:login -- it contains the substring "login" and
+    # is NOT a login mechanism. A guard that banned its own target would be
+    # removed by the first person it inconvenienced.
+    for _r in system.login.screensaver.unlock system.restart system.disk.unlock; do
+        jarvis_right_performs_login "${_r}" \
+            && _no "${_r} is allowed" \
+            || _ok "${_r} is allowed"
+    done
+
+    jarvis_right_performs_login "no.such.right.at.all" \
+        && _ok "an unknown right fails closed (protected)" \
+        || _no "an unknown right fails closed (protected)"
+
+    jarvis_right_performs_login "${JARVIS_RIGHT_NAMESPACE}probe.lifecycle" \
+        && _no "a right in our own namespace is exempt" \
+        || _ok "a right in our own namespace is exempt"
+
+    JARVIS_SYSTEM_AUTH_TEMPLATE="${WORK}/absent.plist" \
+        jarvis_right_performs_login system.restart \
+        && _ok "an unreadable schema fails closed (protected)" \
+        || _no "an unreadable schema fails closed (protected)"
+    JARVIS_SYSTEM_AUTH_TEMPLATE="${JARVIS_SYSTEM_AUTH_TEMPLATE_DEFAULT}"
+fi
+
+# The chokepoint. Only the refusal branch is exercised directly -- the accepting
+# branch ends in a real `security authorizationdb write`, which a test suite must
+# never perform.
+_ours="$(_fixture ours '
+    <key>class</key><string>evaluate-mechanisms</string>
+    <key>mechanisms</key><array><string>JARVISUnlock:grant,privileged</string></array>')"
+_e=0; jarvis_authdb_write system.login.console "${_ours}" >/dev/null 2>&1 || _e=$?
+_rc "writing OUR mechanism into a login right is refused" 1 "${_e}"
+
+# Recovery must not be collateral damage. A rule that does NOT name us is allowed
+# through even for a protected right, because restoring a backup and writing a
+# stripped chain both look exactly like this -- and a guard that blocks the
+# recovery path strands someone at a lock screen.
+#
+# The stub stands in ONLY for the final exec. No logic is faked: everything the
+# guard decides has already run by the time it is reached.
+mkdir -p "${WORK}/stub"
+cat > "${WORK}/stub/security" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$*" >> "${JARVIS_TEST_SECURITY_CALLS}"
+exit 0
+STUB
+chmod +x "${WORK}/stub/security"
+export JARVIS_TEST_SECURITY_CALLS="${WORK}/security-calls"
+: > "${JARVIS_TEST_SECURITY_CALLS}"
+
+_e=0; PATH="${WORK}/stub:${PATH}" jarvis_authdb_write system.login.console "${DELEGATING}" >/dev/null 2>&1 || _e=$?
+_rc "writing a rule WITHOUT our mechanism into a login right is allowed" 0 "${_e}"
+grep -q 'authorizationdb write system.login.console' "${JARVIS_TEST_SECURITY_CALLS}" \
+    && _ok "and it actually reached the database call" \
+    || _no "and it actually reached the database call"
+
+# =============================================================================
+echo
+echo "dead man's switch"
+# =============================================================================
+# Behavioural, not structural: the switch is the last thing standing between a
+# probe that dies mid-run and a machine left mutated, so "it detaches and the
+# command runs" has to be observed rather than assumed.
+_marker="${WORK}/deadman-fired"
+_dm_log="${WORK}/deadman.log"
+_dm_pid="$(jarvis_arm_deadman 1 "${_dm_log}" "/usr/bin/touch '${_marker}'" "touch ${_marker}")"
+case "${_dm_pid}" in
+    ''|*[!0-9]*) _no "arming returns a pid" "got [${_dm_pid}]" ;;
+    *)           _ok "arming returns a pid" ;;
+esac
+[ ! -e "${_marker}" ] && _ok "it has not fired yet" || _no "it has not fired yet"
+
+_waited=0
+while [ ! -e "${_marker}" ] && [ "${_waited}" -lt 60 ]; do sleep 0.2; _waited=$(( _waited + 1 )); done
+[ -e "${_marker}" ] && _ok "it fires after its window" || _no "it fires after its window"
+grep -q 'dead-man recovery OK' "${_dm_log}" 2>/dev/null \
+    && _ok "and it records that it fired" || _no "and it records that it fired"
+
+# =============================================================================
+echo
+echo "sentinel installability"
+# =============================================================================
+# install.sh copies these to a system path and refuses to continue if one is
+# missing. Catching that here costs nothing; catching it at install time means a
+# half-installed machine.
+for _tool in ${JARVIS_SYSTEM_TOOLS}; do
+    [ -f "${_here}/${_tool}" ] \
+        && _ok "${_tool} is present to install" \
+        || _no "${_tool} is present to install"
+done
+for _script in sentinel.sh probe_mechanism_lifecycle.sh; do
+    bash -n "${_here}/${_script}" 2>/dev/null \
+        && _ok "${_script} parses" || _no "${_script} parses"
+done
+
+# The sentinel must never be able to put the mechanism BACK. Its only write is a
+# revert; a sentinel that could install would be a second installer with no gates
+# in front of it.
+grep -qE 'jarvis_compose_mechanism_rule|jarvis_record_sanctioned_shape' "${_here}/sentinel.sh" \
+    && _no "the sentinel cannot compose or sanction" \
+    || _ok "the sentinel cannot compose or sanction"
+
+# Run without privileges. This pins two bugs found by doing exactly that:
+#
+#   - every _say emitted a shell-level permission error alongside its message,
+#     because a redirection to an unwritable path is reported before the command
+#     runs and 2>/dev/null on the printf cannot suppress it.
+#
+#   - mkdir failing for a MISSING PARENT was read as "a lock is held", so the
+#     script announced a stale lock and rm -rf'd a path it had never created.
+#     The same path, with an existing-but-unreadable lock, would have broken a
+#     LIVE lock and let two reverts race on one rule.
+if [ "$(id -u)" -ne 0 ]; then
+    _sent_out="$("${_here}/sentinel.sh" 2>&1)"; _sent_rc=$?
+    _rc "the sentinel exits 0 without privileges" 0 "${_sent_rc}"
+    case "${_sent_out}" in
+        *"needs root"*) _ok "and says why" ;;
+        *)              _no "and says why" "got [${_sent_out}]" ;;
+    esac
+    case "${_sent_out}" in
+        *"breaking a stale lock"*) _no "and does not invent a stale lock" ;;
+        *)                         _ok "and does not invent a stale lock" ;;
+    esac
+    case "${_sent_out}" in
+        *"Permission denied"*) _no "and emits no shell-level permission noise" ;;
+        *)                     _ok "and emits no shell-level permission noise" ;;
+    esac
+else
+    printf '  skip sentinel no-privilege path (running as root)\n'
+fi
+
+# =============================================================================
+echo
 echo "restore-point provenance"
 # =============================================================================
 # The pointer file records a path and nothing else, and the target right has

--- a/backend/voice_unlock/authplugin/install/test_rule_shape.sh
+++ b/backend/voice_unlock/authplugin/install/test_rule_shape.sh
@@ -588,6 +588,50 @@ fi
 
 # =============================================================================
 echo
+echo "verify.sh does not prescribe the dangerous action"
+# =============================================================================
+# A live run after --skip-authdb reported "partially installed. 1 component(s)
+# absent." with every component present -- the "absent" thing was the rule being
+# deliberately unwired -- and offered `install.sh` as the repair. That is the
+# rule rewrite: the one irreversible step, prescribed as the fix for a machine
+# that was exactly where it should be.
+bash -n "${_here}/verify.sh" 2>/dev/null && _ok "verify.sh parses" || _no "verify.sh parses"
+
+grep -q '^_state()' "${_here}/verify.sh" \
+    && _ok "a valid state is reportable without being counted as absent" \
+    || _no "a valid state is reportable without being counted as absent"
+
+grep -q '_state "stock rule; the plugin is installed but not wired in"' "${_here}/verify.sh" \
+    && _ok "the unwired rule is a state, not a missing component" \
+    || _no "the unwired rule is a state, not a missing component"
+
+# The load-bearing one: the unwired verdict must not send the operator to
+# install.sh. It would refuse anyway -- no shape has been measured -- so the
+# advice was both dangerous and wrong.
+_verdict="$(sed -n '/_wired:-1/,/^fi/p' "${_here}/verify.sh")"
+[ -n "${_verdict}" ] \
+    && _ok "there is a distinct verdict for coherent-but-unwired" \
+    || _no "there is a distinct verdict for coherent-but-unwired"
+# "Prescribe" means offering it as a runnable command, not naming it. The
+# verdict SHOULD say why install.sh is not the next step -- that sentence is the
+# correction. What it must never contain is a `sudo .../install.sh` line an
+# operator can paste.
+case "${_verdict}" in
+    *'sudo ${_here}/install.sh'*|*"sudo ${_here}/install.sh"*)
+        _no "and it does not offer install.sh as a command" ;;
+    *)  _ok "and it does not offer install.sh as a command" ;;
+esac
+case "${_verdict}" in
+    *"NOT install.sh"*) _ok "and says explicitly why it is not the next step" ;;
+    *)                  _no "and says explicitly why it is not the next step" ;;
+esac
+case "${_verdict}" in
+    *probe_mechanism_lifecycle.sh*) _ok "and it points at the measurement instead" ;;
+    *)                              _no "and it points at the measurement instead" ;;
+esac
+
+# =============================================================================
+echo
 echo "restore-point provenance"
 # =============================================================================
 # The pointer file records a path and nothing else, and the target right has

--- a/backend/voice_unlock/authplugin/install/test_rule_shape.sh
+++ b/backend/voice_unlock/authplugin/install/test_rule_shape.sh
@@ -327,14 +327,156 @@ echo "this machine (against the real schema)"
 # always refuse would pass every test above.
 JARVIS_SYSTEM_AUTH_TEMPLATE="${JARVIS_SYSTEM_AUTH_TEMPLATE_DEFAULT}"
 if [ -r "${JARVIS_SYSTEM_AUTH_TEMPLATE}" ]; then
+    # The right the previous design targeted. Pinned as still refused, so a
+    # future edit cannot quietly point the installer back at the delegator.
+    _h=0; jarvis_right_hosts_mechanisms system.login.screensaver >/dev/null 2>&1 || _h=$?
+    _rc "system.login.screensaver stays refused (class $(jarvis_stock_rule_class system.login.screensaver 2>/dev/null || echo '?'))" 2 "${_h}"
+
+    # The right we now target: the chain loginwindow evaluates one level below it.
     _h=0; jarvis_right_hosts_mechanisms "${JARVIS_AUTH_RIGHT}" >/dev/null 2>&1 || _h=$?
-    _rc "${JARVIS_AUTH_RIGHT} is refused on this OS (class $(jarvis_stock_rule_class "${JARVIS_AUTH_RIGHT}" 2>/dev/null || echo '?'))" 2 "${_h}"
+    _rc "${JARVIS_AUTH_RIGHT} is a mechanism host (class $(jarvis_stock_rule_class "${JARVIS_AUTH_RIGHT}" 2>/dev/null || echo '?'))" 0 "${_h}"
 
     _h=0; jarvis_right_hosts_mechanisms system.login.console >/dev/null 2>&1 || _h=$?
     _rc "system.login.console is accepted (the classifier is not just refusing)" 0 "${_h}"
+
+    # The installer must never be pointed at the login right, whatever else
+    # changes. A defect there costs login, not unlock.
+    if [ "${JARVIS_AUTH_RIGHT}" = "system.login.console" ]; then
+        _no "the target right is system.login.console -- a defect there costs LOGIN"
+    else
+        _ok "the target right is not system.login.console"
+    fi
 else
     printf '  skip system schema unreadable at %s\n' "${JARVIS_SYSTEM_AUTH_TEMPLATE}"
 fi
+
+# =============================================================================
+echo
+echo "incumbent chain preservation"
+# =============================================================================
+# What verify.sh asks instead of grepping for a mechanism name it expects. On
+# system.login.screensaver.unlock the expected name would have been wrong: there
+# is no builtin:authenticate, there is CryptoTokenKit:login.
+_c=0; jarvis_compose_mechanism_rule "${HOSTED}" "${WORK}/pres.plist" "${MECH}" >/dev/null 2>&1 || _c=$?
+jarvis_chain_preserves_backup "${WORK}/pres.plist" "${HOSTED}" \
+    && _ok "a composed chain preserves the incumbent" \
+    || _no "a composed chain preserves the incumbent"
+
+# Drop one of the incumbent's mechanisms and it must be caught. This is the
+# regression that would mean smartcard unlock had been silently removed.
+cp "${WORK}/pres.plist" "${WORK}/lossy.plist"
+_dropped="$(jarvis_rule_strip_mechanism "${WORK}/lossy.plist" "loginwindow:login")"
+_is "the fixture actually lost a mechanism" "1" "${_dropped}"
+jarvis_chain_preserves_backup "${WORK}/lossy.plist" "${HOSTED}" \
+    && _no "a chain that dropped an incumbent mechanism is caught" \
+    || _ok "a chain that dropped an incumbent mechanism is caught"
+
+jarvis_chain_preserves_backup "${HOSTED}" "${DELEGATING}" \
+    && _ok "a backup with no mechanisms demands nothing" \
+    || _no "a backup with no mechanisms demands nothing"
+
+# =============================================================================
+echo
+echo "fail-open evidence (the tries=1 bar)"
+# =============================================================================
+# A shape naming OUR mechanism must clear failopen=proven. A shape that does not
+# keeps the old bar, because it has no mechanism of ours to fail open from.
+JARVIS_PROBE_RESULTS_LOG="${WORK}/failopen.log"
+MECH_SHAPE="class=evaluate-mechanisms;mechanisms=${MECH}|CryptoTokenKit:login"
+
+{
+    printf 'T1 shape=%s locked=yes prompted=yes touchid=yes watch=no password=yes failopen=yielded-unconfirmed\n' "${MECH_SHAPE}"
+    printf 'T2 shape=%s locked=yes prompted=no  touchid=no  watch=no password=yes failopen=crashed\n'             "${MECH_SHAPE}"
+    printf 'T3 shape=%s locked=yes prompted=no  touchid=no  watch=no password=yes failopen=not-reached\n'         "${MECH_SHAPE}"
+} > "${JARVIS_PROBE_RESULTS_LOG}"
+_e=0; jarvis_probe_evidence_for_shape "${MECH_SHAPE}" >/dev/null 2>&1 || _e=$?
+_rc "password=yes alone does NOT authorise a mechanism shape" 1 "${_e}"
+
+printf 'T4 shape=%s locked=yes prompted=yes touchid=yes watch=no password=yes failopen=proven\n' \
+    "${MECH_SHAPE}" >> "${JARVIS_PROBE_RESULTS_LOG}"
+_e=0; _rec="$(jarvis_probe_evidence_for_shape "${MECH_SHAPE}")" || _e=$?
+_rc "failopen=proven authorises a mechanism shape" 0 "${_e}"
+case "${_rec}" in T4*) _ok "the proven record is the one returned" ;;
+                  *)   _no "the proven record is the one returned" "got [${_rec}]" ;; esac
+
+# A crashed run must never become permission, however many times it is repeated.
+{
+    printf 'C1 shape=%s locked=yes prompted=yes touchid=yes watch=no password=yes failopen=crashed\n' "${MECH_SHAPE}"
+    printf 'C2 shape=%s locked=yes prompted=yes touchid=yes watch=no password=yes failopen=crashed\n' "${MECH_SHAPE}"
+} > "${JARVIS_PROBE_RESULTS_LOG}"
+_e=0; jarvis_probe_evidence_for_shape "${MECH_SHAPE}" >/dev/null 2>&1 || _e=$?
+_rc "a crashed run is never permission" 1 "${_e}"
+
+# Non-mechanism shapes keep the old bar: there is nothing of ours to fail open.
+NONMECH_SHAPE="class=user;mechanisms="
+printf 'R1 shape=%s locked=yes prompted=yes touchid=yes watch=no password=yes\n' \
+    "${NONMECH_SHAPE}" > "${JARVIS_PROBE_RESULTS_LOG}"
+_e=0; jarvis_probe_evidence_for_shape "${NONMECH_SHAPE}" >/dev/null 2>&1 || _e=$?
+_rc "a shape without our mechanism does not need failopen" 0 "${_e}"
+
+# =============================================================================
+echo
+echo "crash-report walk"
+# =============================================================================
+JARVIS_CRASH_REPORTS_DIR="${WORK}/reports"
+JARVIS_AUTH_HOST_PROCESS="fakehost"
+mkdir -p "${JARVIS_CRASH_REPORTS_DIR}"
+_is "an empty report directory yields nothing" "" "$(jarvis_crash_reports_since 0)"
+
+printf '{"triggered":true,"frames":[{"symbol":"JARVISDeliver"}]}\n' \
+    > "${JARVIS_CRASH_REPORTS_DIR}/fakehost.arm64-old.ips"
+touch -t 200001010000 "${JARVIS_CRASH_REPORTS_DIR}/fakehost.arm64-old.ips"
+_is "a report older than the cutoff is excluded" "" "$(jarvis_crash_reports_since "$(date +%s)")"
+_is "and included when the cutoff precedes it" \
+    "${JARVIS_CRASH_REPORTS_DIR}/fakehost.arm64-old.ips" "$(jarvis_crash_reports_since 0)"
+
+# The parse that must not read a register annotation as a stack frame.
+_is "the faulting symbol comes from the triggered thread" \
+    "JARVISDeliver" "$(jarvis_crash_faulting_symbol "${JARVIS_CRASH_REPORTS_DIR}/fakehost.arm64-old.ips")"
+
+printf '{"threadState":{"x14":{"symbol":"OBJC_CLASS_$___NSTaggedDate"}},"triggered":true,"frames":[{"symbol":"realFrame"}]}\n' \
+    > "${JARVIS_CRASH_REPORTS_DIR}/fakehost.arm64-reg.ips"
+_is "a register annotation is not mistaken for a frame" \
+    "realFrame" "$(jarvis_crash_faulting_symbol "${JARVIS_CRASH_REPORTS_DIR}/fakehost.arm64-reg.ips")"
+
+_e=0; JARVIS_CRASH_REPORTS_DIR="${WORK}/nonexistent" jarvis_crash_reports_since 0 >/dev/null 2>&1 || _e=$?
+_rc "an unreadable report directory is distinguished from no crashes" 1 "${_e}"
+
+# =============================================================================
+echo
+echo "restore-point provenance"
+# =============================================================================
+# The pointer file records a path and nothing else, and the target right has
+# already changed once. A pointer left by an install of the OLD right would
+# otherwise be restored into the NEW one -- a class=rule delegating definition
+# written over a mechanism chain, by the recovery path, on a machine already in
+# trouble. Only the refusal is exercised here: the accepting path writes to the
+# authorization database and needs root, which a test suite must not require.
+JARVIS_AUTHDB_BACKUP_POINTER="${WORK}/pointer"
+
+_wrong="${WORK}/system.login.screensaver.20260807-000000.install.plist"
+cp "${DELEGATING}" "${_wrong}"
+printf '%s' "${_wrong}" > "${JARVIS_AUTHDB_BACKUP_POINTER}"
+_e=0; jarvis_restore_auth_rule_from_pointer >/dev/null 2>&1 || _e=$?
+_rc "a backup taken for a DIFFERENT right is refused" 1 "${_e}"
+
+# The prefix trap in the other direction: system.login.screensaver.unlock has
+# system.login.screensaver as a prefix, so a bare "<right>.*" match would accept
+# the longer name for the shorter right.
+_longer="${WORK}/system.login.screensaver.unlock.20260807-000000.install.plist"
+cp "${DELEGATING}" "${_longer}"
+printf '%s' "${_longer}" > "${JARVIS_AUTHDB_BACKUP_POINTER}"
+_e=0; JARVIS_AUTH_RIGHT="system.login.screensaver" \
+    jarvis_restore_auth_rule_from_pointer >/dev/null 2>&1 || _e=$?
+_rc "a longer right name cannot satisfy a shorter one" 1 "${_e}"
+
+printf '%s' "${WORK}/absent-backup.plist" > "${JARVIS_AUTHDB_BACKUP_POINTER}"
+_e=0; jarvis_restore_auth_rule_from_pointer >/dev/null 2>&1 || _e=$?
+_rc "a pointer naming a missing file is refused" 1 "${_e}"
+
+rm -f "${JARVIS_AUTHDB_BACKUP_POINTER}"
+_e=0; jarvis_restore_auth_rule_from_pointer >/dev/null 2>&1 || _e=$?
+_rc "no pointer at all is refused" 1 "${_e}"
 
 # =============================================================================
 echo

--- a/backend/voice_unlock/authplugin/install/test_rule_shape.sh
+++ b/backend/voice_unlock/authplugin/install/test_rule_shape.sh
@@ -1,0 +1,345 @@
+#!/bin/bash
+# JARVIS Authorization Plugin -- self-tests for the rule-shape layer.
+#
+# WHY THIS FILE EXISTS
+# --------------------
+# install.sh used to author the authorization rule it wrote from a template
+# literal, and wrote it over system.login.screensaver -- a right whose stock
+# class is `rule`, delegating the entire lock screen to loginwindow. The machine
+# then authenticated into a black screen with a live cursor. Every other check in
+# this directory stayed green throughout, because every other check asks whether
+# the configuration is COHERENT and none of them asked whether it was ALLOWED.
+#
+# So the code that decides that is exercised here, against fixtures, on every
+# build -- `make verify` runs this, and install.sh runs `make verify` as step 1.
+# The gate cannot rot silently while the thing it guards is a lock screen.
+#
+# Runs as any user. Touches no system state: the authorization database is never
+# read or written, and the schema oracle is pointed at a fixture. The two tests
+# that DO consult the real /System/Library/Security/authorization.plist read it
+# and nothing else -- they are the pins that keep the classifier honest about
+# this machine.
+
+set -uo pipefail
+
+_here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common.sh
+. "${_here}/common.sh"
+# common.sh sets -e for the installers. The tests deliberately drive failure
+# paths, so exit-on-error is turned back off here and every expected non-zero is
+# captured explicitly.
+set +e
+
+# An explicit template rather than `mktemp -t`: on macOS the -t form resolves
+# through confstr(_CS_DARWIN_USER_TEMP_DIR) and ignores TMPDIR, which makes the
+# scratch location unoverridable in sandboxed and CI environments. The installers
+# keep -t because they run as root on a real machine; a test suite has to be
+# runnable anywhere.
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/jarvis-ruleshape-test.XXXXXX")" \
+    || { echo "FATAL: could not create a scratch directory under ${TMPDIR:-/tmp}"; exit 1; }
+trap 'rm -rf "${WORK}"' EXIT
+
+_pass=0
+_fail=0
+_ok()   { _pass=$(( _pass + 1 )); printf '  ok   %s\n' "$1"; }
+_no()   { _fail=$(( _fail + 1 )); printf '  FAIL %s\n' "$1"; [ $# -gt 1 ] && printf '         %s\n' "$2"; }
+_is()   { # _is <label> <expected> <actual>
+    if [ "$2" = "$3" ]; then _ok "$1"; else _no "$1" "expected [$2] got [$3]"; fi
+}
+_rc()   { # _rc <label> <expected-rc> <actual-rc>
+    if [ "$2" = "$3" ]; then _ok "$1"; else _no "$1" "expected rc $2 got rc $3"; fi
+}
+
+# --- Fixtures ----------------------------------------------------------------
+# Written as XML and normalised through plutil, so a malformed fixture fails here
+# rather than being mistaken for a malformed implementation.
+_fixture() { # _fixture <name> <inner-xml>
+    local path="${WORK}/$1.plist"
+    {
+        printf '<?xml version="1.0" encoding="UTF-8"?>\n'
+        printf '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n'
+        printf '<plist version="1.0"><dict>%s</dict></plist>\n' "$2"
+    } > "${path}"
+    plutil -lint "${path}" >/dev/null 2>&1 || { echo "FATAL: fixture $1 is malformed"; exit 1; }
+    printf '%s' "${path}"
+}
+
+DELEGATING="$(_fixture delegating '
+    <key>class</key><string>rule</string>
+    <key>comment</key><string>The owner or any administrator can unlock.</string>
+    <key>rule</key><string>use-login-window-ui</string>
+    <key>version</key><integer>1</integer>')"
+
+USERCLASS="$(_fixture userclass '
+    <key>class</key><string>user</string>
+    <key>group</key><string>admin</string>
+    <key>session-owner</key><true/>
+    <key>shared</key><false/>')"
+
+# Carries keys the old template literal silently discarded. If composition ever
+# regresses to authoring, tries/shared/allow-root vanish and these tests say so.
+HOSTED="$(_fixture hosted '
+    <key>class</key><string>evaluate-mechanisms</string>
+    <key>comment</key><string>Login mechanism based rule.</string>
+    <key>mechanisms</key><array>
+        <string>builtin:prelogin</string>
+        <string>loginwindow:login</string>
+        <string>builtin:authenticate,privileged</string>
+    </array>
+    <key>tries</key><integer>10000</integer>
+    <key>shared</key><false/>
+    <key>allow-root</key><false/>
+    <key>version</key><integer>11</integer>')"
+
+EMPTYCHAIN="$(_fixture emptychain '
+    <key>class</key><string>evaluate-mechanisms</string>
+    <key>mechanisms</key><array/>')"
+
+NOTAPLIST="${WORK}/garbage.plist"
+printf 'this is not a plist\n' > "${NOTAPLIST}"
+
+MECH="JARVISUnlock:grant,privileged"
+
+# A fixture standing in for Apple's schema, so the classifier's behaviour is
+# pinned independently of whatever macOS this happens to run on.
+TEMPLATE="$(_fixture template '
+    <key>rights</key><dict>
+        <key>system.login.screensaver</key><dict>
+            <key>class</key><string>rule</string>
+            <key>rule</key><string>use-login-window-ui</string>
+            <key>comment</key><string>set rule to authenticate-session-owner-or-admin to enable SecurityAgent.</string>
+        </dict>
+        <key>system.login.console</key><dict>
+            <key>class</key><string>evaluate-mechanisms</string>
+            <key>mechanisms</key><array><string>builtin:authenticate,privileged</string></array>
+        </dict>
+    </dict>
+    <key>rules</key><dict>
+        <key>authenticate-session-owner-or-admin</key><dict>
+            <key>class</key><string>user</string>
+            <key>group</key><string>admin</string>
+        </dict>
+    </dict>')"
+
+echo
+echo "rule shape self-tests"
+echo "====================="
+
+# =============================================================================
+echo
+echo "reading"
+# =============================================================================
+_is "class of a delegating rule"      "rule"                "$(jarvis_rule_class "${DELEGATING}")"
+_is "class of a mechanism chain"      "evaluate-mechanisms" "$(jarvis_rule_class "${HOSTED}")"
+
+_is "mechanisms are returned in order" \
+    "builtin:prelogin|loginwindow:login|builtin:authenticate,privileged" \
+    "$(jarvis_rule_mechanisms "${HOSTED}" | tr '\n' '|' | sed 's/|$//')"
+
+_is "a rule with no mechanisms key yields nothing" "" "$(jarvis_rule_mechanisms "${DELEGATING}")"
+_is "an empty chain yields nothing"                "" "$(jarvis_rule_mechanisms "${EMPTYCHAIN}")"
+
+_is "shape of a delegating rule" \
+    "class=rule;mechanisms=" \
+    "$(jarvis_rule_shape "${DELEGATING}")"
+
+_is "shape of a mechanism chain" \
+    "class=evaluate-mechanisms;mechanisms=builtin:prelogin|loginwindow:login|builtin:authenticate,privileged" \
+    "$(jarvis_rule_shape "${HOSTED}")"
+
+# The shape is the evidence key, so it has to be stable against edits that do not
+# change behaviour -- otherwise a comment tweak silently invalidates a real
+# measurement and the gate starts refusing for no reason.
+_cosmetic="${WORK}/cosmetic.plist"
+cp "${HOSTED}" "${_cosmetic}"
+plutil -replace comment -string 'a completely different comment' "${_cosmetic}" >/dev/null 2>&1
+plutil -replace version -integer 99 "${_cosmetic}" >/dev/null 2>&1
+_is "shape ignores comment and version" \
+    "$(jarvis_rule_shape "${HOSTED}")" "$(jarvis_rule_shape "${_cosmetic}")"
+
+_is "shape contains no whitespace (survives one log field)" \
+    "" "$(jarvis_rule_shape "${HOSTED}" | tr -dc '[:space:]')"
+
+_shape_rc=0; jarvis_rule_shape "${NOTAPLIST}" >/dev/null 2>&1 || _shape_rc=$?
+_rc "shape of an unparseable file fails" 1 "${_shape_rc}"
+
+# =============================================================================
+echo
+echo "classifying against the schema"
+# =============================================================================
+JARVIS_SYSTEM_AUTH_TEMPLATE="${TEMPLATE}"
+
+_is "stock class from the rights bucket" "rule" "$(jarvis_stock_rule_class system.login.screensaver)"
+_is "stock class from the rules bucket"  "user" "$(jarvis_stock_rule_class authenticate-session-owner-or-admin)"
+
+_stock_rc=0; jarvis_stock_rule_class no.such.right >/dev/null 2>&1 || _stock_rc=$?
+_rc "unknown right is not classified" 1 "${_stock_rc}"
+
+# The dotted name must be escaped or plutil reads it as four levels of nesting
+# and every right in the system reads as absent -- which fails closed, but for
+# the wrong reason, and would make the gate refuse everything forever.
+_is "dotted right names are escaped for plutil" \
+    'system\.login\.screensaver' "$(_jarvis_plist_escape_key system.login.screensaver)"
+
+_h=0; jarvis_right_hosts_mechanisms system.login.console >/dev/null 2>&1 || _h=$?
+_rc "a mechanism-host right is accepted" 0 "${_h}"
+
+_h=0; jarvis_right_hosts_mechanisms system.login.screensaver >/dev/null 2>&1 || _h=$?
+_rc "a delegating right is refused" 2 "${_h}"
+
+_h=0; jarvis_right_hosts_mechanisms authenticate-session-owner-or-admin >/dev/null 2>&1 || _h=$?
+_rc "a class=user rule is refused" 2 "${_h}"
+
+_h=0; jarvis_right_hosts_mechanisms no.such.right >/dev/null 2>&1 || _h=$?
+_rc "an unknown right is refused as unknown" 1 "${_h}"
+
+_h=0; JARVIS_SYSTEM_AUTH_TEMPLATE="${WORK}/absent.plist" \
+    jarvis_right_hosts_mechanisms system.login.console >/dev/null 2>&1 || _h=$?
+_rc "an unreadable schema refuses rather than assumes" 1 "${_h}"
+
+# =============================================================================
+echo
+echo "composing"
+# =============================================================================
+OUT="${WORK}/composed.plist"
+
+_c=0; jarvis_compose_mechanism_rule "${HOSTED}" "${OUT}" "${MECH}" >/dev/null 2>&1 || _c=$?
+_rc "composes onto a mechanism chain" 0 "${_c}"
+# sed rather than head/tail on purpose: under pipefail an early-exiting consumer
+# SIGPIPEs the producer, which is the exact bug these tests caught in the
+# composer. A test that reproduces the trap it is testing for proves nothing.
+_is "our mechanism is at the head"  "${MECH}" "$(jarvis_rule_mechanisms "${OUT}" | sed -n '1p')"
+_is "the incumbent chain is preserved beneath it" \
+    "$(jarvis_rule_mechanisms "${HOSTED}")" "$(jarvis_rule_mechanisms "${OUT}" | sed '1d')"
+_is "class is untouched" "evaluate-mechanisms" "$(jarvis_rule_class "${OUT}")"
+plutil -lint "${OUT}" >/dev/null 2>&1 && _ok "the composed rule is a valid plist" \
+    || _no "the composed rule is a valid plist"
+
+# The specific regression: the template literal wrote four keys and destroyed
+# every other one the incumbent had.
+for _key in tries shared allow-root version; do
+    _is "key '${_key}' survives composition" \
+        "$(jarvis_plist_value "${HOSTED}" "${_key}")" "$(jarvis_plist_value "${OUT}" "${_key}")"
+done
+
+_c=0; jarvis_compose_mechanism_rule "${OUT}" "${WORK}/again.plist" "${MECH}" >/dev/null 2>&1 || _c=$?
+_rc "composing twice is a no-op, not a duplicate" 2 "${_c}"
+
+_c=0; jarvis_compose_mechanism_rule "${EMPTYCHAIN}" "${WORK}/onempty.plist" "${MECH}" >/dev/null 2>&1 || _c=$?
+_rc "composes onto an empty chain" 0 "${_c}"
+_is "empty chain gains exactly our mechanism" "${MECH}" "$(jarvis_rule_mechanisms "${WORK}/onempty.plist")"
+
+# THE regression. This is the write that black-screened the machine.
+_c=0; jarvis_compose_mechanism_rule "${DELEGATING}" "${WORK}/nope.plist" "${MECH}" >/dev/null 2>&1 || _c=$?
+_rc "REFUSES to compose over a delegating rule" 3 "${_c}"
+
+_c=0; jarvis_compose_mechanism_rule "${USERCLASS}" "${WORK}/nope2.plist" "${MECH}" >/dev/null 2>&1 || _c=$?
+_rc "REFUSES to compose over a class=user rule" 3 "${_c}"
+
+_c=0; jarvis_compose_mechanism_rule "${NOTAPLIST}" "${WORK}/nope3.plist" "${MECH}" >/dev/null 2>&1 || _c=$?
+_rc "refuses to compose from an unparseable rule" 1 "${_c}"
+
+_c=0; jarvis_compose_mechanism_rule "${WORK}/absent.plist" "${WORK}/nope4.plist" "${MECH}" >/dev/null 2>&1 || _c=$?
+_rc "refuses to compose from a missing file" 1 "${_c}"
+
+_c=0; jarvis_compose_mechanism_rule "${HOSTED}" "${WORK}/nope5.plist" "" >/dev/null 2>&1 || _c=$?
+_rc "refuses to compose an empty mechanism" 1 "${_c}"
+
+# =============================================================================
+echo
+echo "stripping (the inverse -- uninstall depends on this)"
+# =============================================================================
+ROUND="${WORK}/roundtrip.plist"
+cp "${OUT}" "${ROUND}"
+_removed="$(jarvis_rule_strip_mechanism "${ROUND}" "${JARVIS_PLUGIN_NAME}")"
+_is "strip removes exactly one entry" "1" "${_removed}"
+_is "compose then strip returns the original chain" \
+    "$(jarvis_rule_mechanisms "${HOSTED}")" "$(jarvis_rule_mechanisms "${ROUND}")"
+_is "strip leaves other keys alone" \
+    "$(jarvis_plist_value "${HOSTED}" tries)" "$(jarvis_plist_value "${ROUND}" tries)"
+
+# A half-finished install can leave two. Removing one of them would report
+# success while the lock screen still runs a mechanism whose bundle is gone.
+DUPES="$(_fixture dupes '
+    <key>class</key><string>evaluate-mechanisms</string>
+    <key>mechanisms</key><array>
+        <string>JARVISUnlock:grant,privileged</string>
+        <string>builtin:authenticate,privileged</string>
+        <string>JARVISUnlock:grant,privileged</string>
+    </array>')"
+_removed="$(jarvis_rule_strip_mechanism "${DUPES}" "${JARVIS_PLUGIN_NAME}")"
+_is "strip removes every matching entry"  "2" "${_removed}"
+_is "strip keeps the stock authenticator" "builtin:authenticate,privileged" \
+    "$(jarvis_rule_mechanisms "${DUPES}")"
+
+_removed="$(jarvis_rule_strip_mechanism "${DELEGATING}" "${JARVIS_PLUGIN_NAME}")"
+_is "strip reports 0 on a rule with no mechanisms" "0" "${_removed}"
+
+_untouched="$(_fixture untouched '
+    <key>class</key><string>evaluate-mechanisms</string>
+    <key>mechanisms</key><array><string>builtin:authenticate,privileged</string></array>')"
+_removed="$(jarvis_rule_strip_mechanism "${_untouched}" "${JARVIS_PLUGIN_NAME}")"
+_is "strip reports 0 when we are not in the chain" "0" "${_removed}"
+_is "and changes nothing" "builtin:authenticate,privileged" \
+    "$(jarvis_rule_mechanisms "${_untouched}")"
+
+# =============================================================================
+echo
+echo "evidence gate"
+# =============================================================================
+JARVIS_PROBE_RESULTS_LOG="${WORK}/probe-results.log"
+SHAPE_A="class=evaluate-mechanisms;mechanisms=A:x|B:y"
+SHAPE_PREFIX="class=evaluate-mechanisms;mechanisms=A:x"
+
+_e=0; jarvis_probe_evidence_for_shape "${SHAPE_A}" >/dev/null 2>&1 || _e=$?
+_rc "no log at all is not permission" 1 "${_e}"
+
+{
+    printf 'T1 rule=r shape=%s window=180s locked=yes touchid=yes watch=no password=no\n'        "${SHAPE_A}"
+    printf 'T2 rule=r shape=%s window=180s locked=no  touchid=yes watch=no password=yes\n'      "${SHAPE_A}"
+    printf 'T3 rule=r shape=%s window=180s locked=yes touchid=yes watch=no password=yes\n'      "${SHAPE_PREFIX}"
+    printf 'T4 rule=r shape=%s window=180s locked=yes touchid=not-tested watch=no password=yes\n' "${SHAPE_A}"
+} > "${JARVIS_PROBE_RESULTS_LOG}"
+
+_e=0; _rec="$(jarvis_probe_evidence_for_shape "${SHAPE_A}")" || _e=$?
+_rc "an exact match with locked=yes and password=yes is permission" 0 "${_e}"
+case "${_rec}" in T4*) _ok "the qualifying record is the one returned" ;;
+                  *)   _no "the qualifying record is the one returned" "got [${_rec}]" ;; esac
+
+# T3 is a strict prefix of SHAPE_A. Substring matching would hand SHAPE_A's
+# permission to a chain that is missing a mechanism -- exactly the class of
+# "close enough" substitution that caused the incident.
+_e=0; jarvis_probe_evidence_for_shape "${SHAPE_PREFIX}${SHAPE_PREFIX}" >/dev/null 2>&1 || _e=$?
+_rc "an unmeasured shape gets nothing" 1 "${_e}"
+
+{
+    printf 'T5 rule=r shape=%s window=180s locked=yes touchid=yes watch=no password=no\n'  "${SHAPE_A}"
+    printf 'T6 rule=r shape=%s window=180s locked=no  touchid=yes watch=no password=yes\n' "${SHAPE_A}"
+} > "${JARVIS_PROBE_RESULTS_LOG}"
+_e=0; jarvis_probe_evidence_for_shape "${SHAPE_A}" >/dev/null 2>&1 || _e=$?
+_rc "password=no and locked=no are both disqualifying" 1 "${_e}"
+
+# =============================================================================
+echo
+echo "this machine (against the real schema)"
+# =============================================================================
+# Two pins, in opposite directions. Without the second, a classifier broken to
+# always refuse would pass every test above.
+JARVIS_SYSTEM_AUTH_TEMPLATE="${JARVIS_SYSTEM_AUTH_TEMPLATE_DEFAULT}"
+if [ -r "${JARVIS_SYSTEM_AUTH_TEMPLATE}" ]; then
+    _h=0; jarvis_right_hosts_mechanisms "${JARVIS_AUTH_RIGHT}" >/dev/null 2>&1 || _h=$?
+    _rc "${JARVIS_AUTH_RIGHT} is refused on this OS (class $(jarvis_stock_rule_class "${JARVIS_AUTH_RIGHT}" 2>/dev/null || echo '?'))" 2 "${_h}"
+
+    _h=0; jarvis_right_hosts_mechanisms system.login.console >/dev/null 2>&1 || _h=$?
+    _rc "system.login.console is accepted (the classifier is not just refusing)" 0 "${_h}"
+else
+    printf '  skip system schema unreadable at %s\n' "${JARVIS_SYSTEM_AUTH_TEMPLATE}"
+fi
+
+# =============================================================================
+echo
+if [ "${_fail}" -ne 0 ]; then
+    printf 'rule shape: %d passed, %d FAILED\n\n' "${_pass}" "${_fail}"
+    exit 1
+fi
+printf 'rule shape: %d passed\n\n' "${_pass}"

--- a/backend/voice_unlock/authplugin/install/uninstall.sh
+++ b/backend/voice_unlock/authplugin/install/uninstall.sh
@@ -71,25 +71,27 @@ _remove_mechanism_in_place() {
     scratch="$(mktemp -t jarvis-authdb)" || { _note_failure "mktemp failed"; return; }
     printf '%s' "${current}" > "${scratch}"
 
-    # Delete every mechanisms[] entry whose value mentions our plugin. Uses
-    # PlistBuddy (present in the base OS and in Recovery) rather than python,
-    # which Recovery does not ship.
-    local idx entry
-    idx=0
-    while entry="$(/usr/libexec/PlistBuddy -c "Print :mechanisms:${idx}" "${scratch}" 2>/dev/null)"; do
-        case "${entry}" in
-            *"${JARVIS_PLUGIN_NAME}"*)
-                /usr/libexec/PlistBuddy -c "Delete :mechanisms:${idx}" "${scratch}" >/dev/null 2>&1 || true
-                # Do not advance: entries shift down after a delete.
-                ;;
-            *)
-                idx=$((idx + 1))
-                ;;
-        esac
-    done
+    # Delete every mechanisms[] entry whose value mentions our plugin.
+    #
+    # The walk itself lives in common.sh alongside the composition that creates
+    # these entries. They are inverses of one another, and an inverse pair that
+    # drifts apart is how a removal leaves behind exactly the entry it was run to
+    # remove -- on a machine whose screen will not unlock.
+    local removed
+    removed="$(jarvis_rule_strip_mechanism "${scratch}" "${JARVIS_PLUGIN_NAME}")"
+
+    if [ "${removed}" -eq 0 ]; then
+        # The rule mentions us somewhere plutil found nothing to delete: a
+        # different key, or a shape this function does not understand. Writing it
+        # back unchanged would be a no-op reported as a repair.
+        _note_failure "${JARVIS_AUTH_RIGHT} names ${JARVIS_PLUGIN_NAME} but no mechanism entry matched; leaving it alone"
+        _jarvis_warn "  inspect: security authorizationdb read ${JARVIS_AUTH_RIGHT}"
+        rm -f "${scratch}"
+        return
+    fi
 
     if jarvis_authdb_write "${JARVIS_AUTH_RIGHT}" "${scratch}"; then
-        _jarvis_log "stripped ${JARVIS_PLUGIN_NAME} from ${JARVIS_AUTH_RIGHT}"
+        _jarvis_log "stripped ${removed} ${JARVIS_PLUGIN_NAME} mechanism(s) from ${JARVIS_AUTH_RIGHT}"
     else
         _note_failure "could not write stripped rule for ${JARVIS_AUTH_RIGHT}"
     fi

--- a/backend/voice_unlock/authplugin/install/uninstall.sh
+++ b/backend/voice_unlock/authplugin/install/uninstall.sh
@@ -34,71 +34,51 @@ _jarvis_log "starting removal"
 # =============================================================================
 # 1. RESTORE THE AUTHORIZATION RULE  (first -- this is what unwedges a machine)
 # =============================================================================
-restore_auth_rule() {
-    # The backup-pointer restore lives in common.sh because install.sh needs the
-    # identical operation when it has to abandon a half-finished install. Two
-    # copies of "how do we put the authorization rule back" is the last thing
-    # this system should have -- they would drift, and the one that drifted would
-    # be discovered by someone whose screen will not unlock.
-    #
-    # Every path this function can take is a REPAIR, so it degrades rather than
-    # aborting: a failed restore falls through to stripping our mechanism out of
-    # whatever rule is live.
-    if jarvis_restore_auth_rule_from_pointer; then
-        _jarvis_log "authorization rule restored from backup"
-        return
-    fi
+# The whole operation -- restore from the backup pointer, falling back to
+# stripping our mechanism out of whatever is live -- lives in common.sh. It moved
+# there when the sentinel needed the identical repair. Two implementations of
+# "how do we get our mechanism out of the lock screen" would drift, and the copy
+# that drifted would be discovered by whoever it failed, at a machine that will
+# not unlock.
+if ! jarvis_revert_auth_rule; then
+    _note_failure "could not remove ${JARVIS_PLUGIN_NAME} from ${JARVIS_AUTH_RIGHT}"
+fi
 
-    _jarvis_warn "no usable backup (absent pointer, missing file, or unparseable plist)"
-    _remove_mechanism_in_place
-}
-
-# Fallback: no usable backup. Strip only our own mechanism from whatever rule is
-# currently live, leaving every other entry untouched. Never invents a rule.
-_remove_mechanism_in_place() {
-    local current
-    if ! current="$(jarvis_authdb_read "${JARVIS_AUTH_RIGHT}")"; then
-        _note_failure "cannot read ${JARVIS_AUTH_RIGHT}; leaving it alone"
-        return
-    fi
-
-    if ! printf '%s' "${current}" | grep -q "${JARVIS_PLUGIN_NAME}"; then
-        _jarvis_log "${JARVIS_AUTH_RIGHT} does not reference ${JARVIS_PLUGIN_NAME}; nothing to strip"
-        return
-    fi
-
-    local scratch
-    scratch="$(mktemp -t jarvis-authdb)" || { _note_failure "mktemp failed"; return; }
-    printf '%s' "${current}" > "${scratch}"
-
-    # Delete every mechanisms[] entry whose value mentions our plugin.
-    #
-    # The walk itself lives in common.sh alongside the composition that creates
-    # these entries. They are inverses of one another, and an inverse pair that
-    # drifts apart is how a removal leaves behind exactly the entry it was run to
-    # remove -- on a machine whose screen will not unlock.
-    local removed
-    removed="$(jarvis_rule_strip_mechanism "${scratch}" "${JARVIS_PLUGIN_NAME}")"
-
-    if [ "${removed}" -eq 0 ]; then
-        # The rule mentions us somewhere plutil found nothing to delete: a
-        # different key, or a shape this function does not understand. Writing it
-        # back unchanged would be a no-op reported as a repair.
-        _note_failure "${JARVIS_AUTH_RIGHT} names ${JARVIS_PLUGIN_NAME} but no mechanism entry matched; leaving it alone"
-        _jarvis_warn "  inspect: security authorizationdb read ${JARVIS_AUTH_RIGHT}"
-        rm -f "${scratch}"
-        return
-    fi
-
-    if jarvis_authdb_write "${JARVIS_AUTH_RIGHT}" "${scratch}"; then
-        _jarvis_log "stripped ${removed} ${JARVIS_PLUGIN_NAME} mechanism(s) from ${JARVIS_AUTH_RIGHT}"
+# =============================================================================
+# 1b. DISARM THE SENTINEL
+# =============================================================================
+# After the rule is clean, never before. The sentinel's whole purpose is to pull
+# our mechanism out of a chain it should not be in; removing it first would open
+# exactly the unwatched window this uninstall is walking through.
+#
+# The sanctioned-shape record goes too. Leaving it behind would tell a future
+# sentinel that a rule naming us had been proven, when nothing had.
+remove_sentinel() {
+    if launchctl print "system/${JARVIS_SENTINEL_LABEL}" >/dev/null 2>&1; then
+        _jarvis_log "disarming ${JARVIS_SENTINEL_LABEL}"
+        launchctl bootout "system/${JARVIS_SENTINEL_LABEL}" 2>/dev/null \
+            || _note_failure "could not unload ${JARVIS_SENTINEL_LABEL}"
+        jarvis_wait_for_service_gone "${JARVIS_SENTINEL_LABEL}" || true
     else
-        _note_failure "could not write stripped rule for ${JARVIS_AUTH_RIGHT}"
+        _jarvis_log "${JARVIS_SENTINEL_LABEL} is not loaded"
     fi
-    rm -f "${scratch}"
+
+    rm -f "${JARVIS_SENTINEL_PLIST}" "${JARVIS_SANCTIONED_SHAPE_FILE}" 2>/dev/null || true
+
+    # The tools directory last, and only its own files: it holds the copy of
+    # uninstall.sh that may be the very script running right now. Deleting a
+    # running bash script is safe on macOS -- the interpreter holds the inode --
+    # but removing the directory wholesale would take verify.sh with it before
+    # anyone could use it to check this removal worked.
+    if [ -d "${JARVIS_SYSTEM_TOOLS_DIR}" ]; then
+        for _tool in ${JARVIS_SYSTEM_TOOLS}; do
+            rm -f "${JARVIS_SYSTEM_TOOLS_DIR}/${_tool}" 2>/dev/null || true
+        done
+        rmdir "${JARVIS_SYSTEM_TOOLS_DIR}" 2>/dev/null || true
+    fi
 }
 
-restore_auth_rule
+remove_sentinel
 
 # =============================================================================
 # 2. STOP AND REMOVE THE GRANT BROKER

--- a/backend/voice_unlock/authplugin/install/verify.sh
+++ b/backend/voice_unlock/authplugin/install/verify.sh
@@ -158,6 +158,123 @@ else
     _gone "stock rule; the plugin is installed but not wired in"
 fi
 
+# --- Rule shape vs Apple's schema -------------------------------------------
+# The check that would have caught the black screen, and the reason every other
+# check in this section was not enough.
+#
+# Those above ask whether the rule names the right things. This one asks whether
+# the rule is a KIND the right is allowed to be. system.login.screensaver ships
+# as class=rule pointing at use-login-window-ui, which delegates the whole lock
+# screen -- panel, password field, and the session resume that re-attaches
+# WindowServer -- to loginwindow. Converting it to a mechanism chain replaces an
+# authenticator AND a user interface with an authenticator alone. Every check
+# above stays green through that, because the chain it finds is coherent. It just
+# has nothing to draw with.
+#
+# Consulted against the stock schema, never the live rule: after the conversion
+# the live rule IS a mechanism chain, so a live-rule check would confirm its own
+# damage.
+echo
+echo "rule shape"
+_live_rule="$(mktemp -t jarvis-verify-rule)"
+if jarvis_authdb_read "${JARVIS_AUTH_RIGHT}" > "${_live_rule}" 2>/dev/null; then
+    _live_shape="$(jarvis_rule_shape "${_live_rule}" 2>/dev/null || true)"
+    _live_class="$(jarvis_rule_class "${_live_rule}" 2>/dev/null || true)"
+    printf '      live: %s\n' "${_live_shape:-<unreadable>}"
+
+    _shape_rc=0
+    jarvis_right_hosts_mechanisms "${JARVIS_AUTH_RIGHT}" || _shape_rc=$?
+
+    if [ "${_shape_rc}" -eq 0 ]; then
+        _ok "${JARVIS_AUTH_RIGHT} is a mechanism host in Apple's schema"
+    elif [ "${_live_class}" = "${JARVIS_MECHANISM_HOST_CLASS}" ]; then
+        _bad "${JARVIS_AUTH_RIGHT} has been CONVERTED into a mechanism chain"
+        jarvis_stock_rule_summary "${JARVIS_AUTH_RIGHT}" 2>/dev/null | sed 's/^/      stock /' || true
+        printf '      This is the black-screen configuration: authentication succeeds\n'
+        printf '      and nothing paints the lock screen or resumes the session.\n'
+        printf '      Recover now:  sudo %s/uninstall.sh\n' "${_here}"
+    else
+        _ok "${JARVIS_AUTH_RIGHT} is not a mechanism host, and has not been converted"
+    fi
+else
+    _bad "cannot read ${JARVIS_AUTH_RIGHT}"
+fi
+rm -f "${_live_rule}"
+
+# --- Crash history ----------------------------------------------------------
+# The check that was missing when it mattered.
+#
+# A use-after-free in the mechanism segfaulted authorizationhosthelper 27 times
+# across two days while every check above reported "coherent" -- because every
+# check above is STATIC. It compares hashes and plist keys, none of which change
+# when the mechanism dies at runtime. The mechanism runs inside a process we do
+# not own, so its deaths land in DiagnosticReports rather than anywhere this
+# script was looking, and the operator saw only a black lock screen.
+#
+# A crash here is strictly worse than a hash mismatch. A mismatch fails CLOSED
+# to a password prompt, which is the designed-for outcome. A host that dies
+# before calling SetResult means nothing in the chain ever answers -- including
+# the builtin:authenticate that the section above just confirmed was present, and
+# which never gets reached. That is the black screen, and it is invisible to
+# every other check in this file.
+echo
+echo "crash history (authorizationhosthelper)"
+_reports_dir="/Library/Logs/DiagnosticReports"
+if [ ! -r "${_reports_dir}" ]; then
+    _gone "cannot read ${_reports_dir} (needs membership in _analyticsusers)"
+else
+    # Only reports newer than the installed bundle. Older ones belong to a build
+    # that is no longer on disk, and counting them would make a fixed install
+    # look permanently broken -- a check that cannot go green is a check the
+    # operator learns to ignore.
+    _since=0
+    if [ -e "${JARVIS_PLUGIN_PATH}" ]; then
+        _since="$(stat -f %m "${JARVIS_PLUGIN_PATH}" 2>/dev/null || echo 0)"
+    fi
+
+    _crashes=0
+    _newest=""
+    for _rep in "${_reports_dir}"/authorizationhosthelper*.ips; do
+        [ -e "${_rep}" ] || continue
+        _mtime="$(stat -f %m "${_rep}" 2>/dev/null || echo 0)"
+        [ "${_mtime}" -ge "${_since}" ] || continue
+        _crashes=$(( _crashes + 1 ))
+        _newest="${_rep}"
+    done
+
+    if [ "${_crashes}" -eq 0 ]; then
+        _ok "no crashes since this bundle was installed"
+    else
+        _bad "${_crashes} crash(es) since install -- the lock screen's plugin host is DYING"
+
+        # Whether it is OUR bug is decidable from the report, so decide it here
+        # rather than leaving the operator to interpret a stack trace at a
+        # machine that will not unlock.
+        if /usr/bin/grep -q "${JARVIS_PLUGIN_NAME}" "${_newest}" 2>/dev/null; then
+            printf '      the newest report NAMES %s -- this is our defect\n' "${JARVIS_PLUGIN_NAME}"
+        else
+            printf '      the newest report does not name %s\n' "${JARVIS_PLUGIN_NAME}"
+        fi
+
+        # Faulting symbol: the top frame of the TRIGGERED thread.
+        #
+        # Both narrowing steps are load-bearing. Without "triggered":true you
+        # get thread 0's idle runloop frame, which every report has and which
+        # means nothing. Without "frames":[ you get a symbol out of the
+        # preceding threadState, where the crash reporter annotates register
+        # VALUES that happen to land on known addresses -- the first draft of
+        # this reported OBJC_CLASS_$___NSTaggedDate, which was the contents of
+        # x14, not a stack frame at all.
+        _sym="$(tr -d '\n' < "${_newest}" 2>/dev/null \
+                | /usr/bin/sed -e 's/.*"triggered":true//' -e 's/.*"frames":\[//' \
+                | /usr/bin/grep -o '"symbol":"[^"]*"' \
+                | head -1 | cut -d'"' -f4)"
+        [ -n "${_sym}" ] && printf '      faulting frame: %s\n' "${_sym}"
+        printf '      report: %s\n' "${_newest}"
+        printf '      Remove now, diagnose after:  sudo %s/uninstall.sh\n' "${_here}"
+    fi
+fi
+
 # --- Verdict ----------------------------------------------------------------
 echo
 if [ "${_problems}" -gt 0 ]; then

--- a/backend/voice_unlock/authplugin/install/verify.sh
+++ b/backend/voice_unlock/authplugin/install/verify.sh
@@ -145,14 +145,39 @@ echo
 echo "authorization rule (${JARVIS_AUTH_RIGHT})"
 if jarvis_rule_references_plugin; then
     _ok "references ${JARVIS_PLUGIN_NAME}"
-    # The stock authenticator must remain in the chain. Without it a failure in
-    # our mechanism has nothing to fall through to, and the fail-open guarantee
-    # -- the entire reason this is safe to install -- would be a comment rather
-    # than a property.
-    if jarvis_authdb_read "${JARVIS_AUTH_RIGHT}" 2>/dev/null | grep -q "builtin:authenticate"; then
-        _ok "builtin:authenticate still present (fail-open path intact)"
+
+    # Nothing the incumbent chain had may have gone missing.
+    #
+    # This used to be `grep -q builtin:authenticate` -- a literal describing one
+    # particular chain, and the wrong one. system.login.screensaver.unlock has no
+    # builtin:authenticate in it; it has CryptoTokenKit:login, which is how
+    # smartcard unlock works. The named check would have failed a CORRECT install
+    # and, worse, passed a chain that had quietly dropped smartcard support.
+    #
+    # The question is not which mechanisms are present. It is whether we took
+    # anything away -- and the only artifact that knows what was there before us
+    # is the backup this install wrote.
+    _pointer_backup=""
+    [ -f "${JARVIS_AUTHDB_BACKUP_POINTER}" ] \
+        && _pointer_backup="$(cat "${JARVIS_AUTHDB_BACKUP_POINTER}" 2>/dev/null || true)"
+
+    if [ -n "${_pointer_backup}" ] && [ -f "${_pointer_backup}" ]; then
+        _chain_live="$(mktemp -t jarvis-verify-chain)"
+        if jarvis_authdb_read "${JARVIS_AUTH_RIGHT}" > "${_chain_live}" 2>/dev/null \
+           && jarvis_chain_preserves_backup "${_chain_live}" "${_pointer_backup}"; then
+            _ok "every mechanism the rule had before the install is still in it"
+        else
+            _bad "the live chain has LOST a mechanism that was there before the install"
+            printf '      before: %s\n' "$(jarvis_rule_mechanisms "${_pointer_backup}" 2>/dev/null | tr '\n' ' ')"
+            printf '      now   : %s\n' "$(jarvis_rule_mechanisms "${_chain_live}" 2>/dev/null | tr '\n' ' ')"
+            printf '      Recover:  sudo %s/uninstall.sh\n' "${_here}"
+        fi
+        rm -f "${_chain_live}"
     else
-        _bad "builtin:authenticate is MISSING -- nothing to fall through to. Run uninstall.sh"
+        # Not a failure. Without the backup there is no baseline, and inventing
+        # one -- by naming a mechanism we expect to see -- is the mistake this
+        # check was rewritten to remove.
+        _gone "no restore point recorded; cannot prove the incumbent chain survived"
     fi
 else
     _gone "stock rule; the plugin is installed but not wired in"
@@ -219,60 +244,41 @@ rm -f "${_live_rule}"
 # every other check in this file.
 echo
 echo "crash history (authorizationhosthelper)"
-_reports_dir="/Library/Logs/DiagnosticReports"
-if [ ! -r "${_reports_dir}" ]; then
-    _gone "cannot read ${_reports_dir} (needs membership in _analyticsusers)"
+# The walk and the symbol extraction live in common.sh, because the probe asks
+# the identical question about its own measurement window. Two implementations of
+# "did the host crash" would be two opinions about one machine.
+#
+# Only reports newer than the installed bundle. Older ones belong to a build that
+# is no longer on disk, and counting them would make a fixed install look
+# permanently broken -- a check that cannot go green is a check the operator
+# learns to ignore.
+_since=0
+if [ -e "${JARVIS_PLUGIN_PATH}" ]; then
+    _since="$(stat -f %m "${JARVIS_PLUGIN_PATH}" 2>/dev/null || echo 0)"
+fi
+
+if ! _reports="$(jarvis_crash_reports_since "${_since}")"; then
+    _gone "cannot read ${JARVIS_CRASH_REPORTS_DIR} (needs membership in _analyticsusers)"
+elif [ -z "${_reports}" ]; then
+    _ok "no crashes since this bundle was installed"
 else
-    # Only reports newer than the installed bundle. Older ones belong to a build
-    # that is no longer on disk, and counting them would make a fixed install
-    # look permanently broken -- a check that cannot go green is a check the
-    # operator learns to ignore.
-    _since=0
-    if [ -e "${JARVIS_PLUGIN_PATH}" ]; then
-        _since="$(stat -f %m "${JARVIS_PLUGIN_PATH}" 2>/dev/null || echo 0)"
-    fi
+    _crashes="$(printf '%s\n' "${_reports}" | grep -c .)"
+    _newest="$(printf '%s\n' "${_reports}" | sed -n '$p')"
+    _bad "${_crashes} crash(es) since install -- the lock screen's plugin host is DYING"
 
-    _crashes=0
-    _newest=""
-    for _rep in "${_reports_dir}"/authorizationhosthelper*.ips; do
-        [ -e "${_rep}" ] || continue
-        _mtime="$(stat -f %m "${_rep}" 2>/dev/null || echo 0)"
-        [ "${_mtime}" -ge "${_since}" ] || continue
-        _crashes=$(( _crashes + 1 ))
-        _newest="${_rep}"
-    done
-
-    if [ "${_crashes}" -eq 0 ]; then
-        _ok "no crashes since this bundle was installed"
+    # Whether it is OUR bug is decidable from the report, so decide it here
+    # rather than leaving the operator to interpret a stack trace at a machine
+    # that will not unlock.
+    if /usr/bin/grep -q "${JARVIS_PLUGIN_NAME}" "${_newest}" 2>/dev/null; then
+        printf '      the newest report NAMES %s -- this is our defect\n' "${JARVIS_PLUGIN_NAME}"
     else
-        _bad "${_crashes} crash(es) since install -- the lock screen's plugin host is DYING"
-
-        # Whether it is OUR bug is decidable from the report, so decide it here
-        # rather than leaving the operator to interpret a stack trace at a
-        # machine that will not unlock.
-        if /usr/bin/grep -q "${JARVIS_PLUGIN_NAME}" "${_newest}" 2>/dev/null; then
-            printf '      the newest report NAMES %s -- this is our defect\n' "${JARVIS_PLUGIN_NAME}"
-        else
-            printf '      the newest report does not name %s\n' "${JARVIS_PLUGIN_NAME}"
-        fi
-
-        # Faulting symbol: the top frame of the TRIGGERED thread.
-        #
-        # Both narrowing steps are load-bearing. Without "triggered":true you
-        # get thread 0's idle runloop frame, which every report has and which
-        # means nothing. Without "frames":[ you get a symbol out of the
-        # preceding threadState, where the crash reporter annotates register
-        # VALUES that happen to land on known addresses -- the first draft of
-        # this reported OBJC_CLASS_$___NSTaggedDate, which was the contents of
-        # x14, not a stack frame at all.
-        _sym="$(tr -d '\n' < "${_newest}" 2>/dev/null \
-                | /usr/bin/sed -e 's/.*"triggered":true//' -e 's/.*"frames":\[//' \
-                | /usr/bin/grep -o '"symbol":"[^"]*"' \
-                | head -1 | cut -d'"' -f4)"
-        [ -n "${_sym}" ] && printf '      faulting frame: %s\n' "${_sym}"
-        printf '      report: %s\n' "${_newest}"
-        printf '      Remove now, diagnose after:  sudo %s/uninstall.sh\n' "${_here}"
+        printf '      the newest report does not name %s\n' "${JARVIS_PLUGIN_NAME}"
     fi
+
+    _sym="$(jarvis_crash_faulting_symbol "${_newest}" 2>/dev/null || true)"
+    [ -n "${_sym}" ] && printf '      faulting frame: %s\n' "${_sym}"
+    printf '      report: %s\n' "${_newest}"
+    printf '      Remove now, diagnose after:  sudo %s/uninstall.sh\n' "${_here}"
 fi
 
 # --- Verdict ----------------------------------------------------------------

--- a/backend/voice_unlock/authplugin/install/verify.sh
+++ b/backend/voice_unlock/authplugin/install/verify.sh
@@ -40,6 +40,18 @@ _ok()   { printf '  \033[32m✓\033[0m %s\n' "$*"; }
 _bad()  { printf '  \033[31m✗\033[0m %s\n' "$*"; _problems=$(( _problems + 1 )); }
 _gone() { printf '  \033[33m-\033[0m %s\n' "$*"; _missing=$(( _missing + 1 )); }
 
+# A valid state that is not a deficiency, reported without being counted.
+#
+# These were _gone, and the difference is not cosmetic. `--skip-authdb` leaves
+# the rule deliberately unwired -- the safe, documented, recommended state -- and
+# counting it as an absent component made verify report "partially installed,
+# 1 component(s) absent" with every component present, then prescribe
+# `install.sh` as the repair. That is the rule rewrite: the one irreversible
+# step, offered as the fix for a machine that was exactly where it should be.
+# A check that reports the safe state as a fault, and names the dangerous action
+# as its remedy, is worse than no check.
+_state() { printf '  \033[33m-\033[0m %s\n' "$*"; }
+
 # Reads a binary or bundle's designated requirement. Same parse as install.sh,
 # including the leading "# " that codesign puts on the line -- omitting it yields
 # an empty string that compares equal to another empty string, which would make
@@ -177,10 +189,11 @@ if jarvis_rule_references_plugin; then
         # Not a failure. Without the backup there is no baseline, and inventing
         # one -- by naming a mechanism we expect to see -- is the mistake this
         # check was rewritten to remove.
-        _gone "no restore point recorded; cannot prove the incumbent chain survived"
+        _state "no restore point recorded; cannot prove the incumbent chain survived"
     fi
 else
-    _gone "stock rule; the plugin is installed but not wired in"
+    _wired=0
+    _state "stock rule; the plugin is installed but not wired in"
 fi
 
 # --- Rule shape vs Apple's schema -------------------------------------------
@@ -299,10 +312,26 @@ if [ "${_missing}" -gt 0 ]; then
     exit 2
 fi
 
+if [ "${_wired:-1}" -eq 0 ]; then
+    printf '\033[32mcoherent, and deliberately not wired in.\033[0m\n'
+    echo
+    echo "Every component is present and agrees about every peer. ${JARVIS_AUTH_RIGHT}"
+    echo "is untouched, so nothing here can affect your ability to unlock."
+    echo
+    echo "This is the state --skip-authdb produces and it is the correct place to"
+    echo "stop. The next step is NOT install.sh: it would refuse, because no run"
+    echo "has yet measured the shape it would write. Measure it first --"
+    echo
+    echo "  sudo ${_here}/probe_mechanism_lifecycle.sh   # the mechanism survives its own lifecycle"
+    echo "  sudo ${_here}/probe_screensaver_rule.sh      # a yield still reaches a password prompt"
+    echo
+    exit 0
+fi
+
 printf '\033[32mcoherent.\033[0m Every component agrees about every peer.\n'
 echo
 echo "Not proven here: that SecurityAgent loads the mechanism. It loads only when"
-echo "the screensaver right is evaluated, so lock the screen once, then:"
-echo "  log show --predicate 'subsystem == \"com.jarvis.unlockplugin\"' --last 15m"
+echo "${JARVIS_AUTH_RIGHT} is evaluated, so lock the screen once, then:"
+echo "  log show --predicate 'subsystem == \"${JARVIS_LOG_SUBSYSTEM_PLUGIN}\"' --last 15m"
 echo
 exit 0

--- a/backend/voice_unlock/authplugin/src/JARVISUnlockMechanism.m
+++ b/backend/voice_unlock/authplugin/src/JARVISUnlockMechanism.m
@@ -19,9 +19,8 @@
  * WHY IT DOES NOT BLOCK
  * ---------------------
  * MechanismInvoke returns noErr immediately, and SetResult is called later from
- * whichever of two racers arrives first: the broker's XPC reply, or a
- * dispatch_after deadline. SecurityAgent's thread is never held for even the
- * 500ms budget.
+ * whichever of two racers arrives first: the broker's XPC reply, or a deadline
+ * timer. SecurityAgent's thread is never held for even the 500ms budget.
  *
  * A semaphore-and-wait would have been three lines shorter and is the shape
  * most examples use. It is also how you wedge a lock screen: SecurityAgent
@@ -29,6 +28,55 @@
  * reply would hold it forever. The AuthorizationPlugin API is asynchronous
  * precisely so that a mechanism cannot do this, and taking the synchronous
  * shortcut would discard the guarantee the API exists to provide.
+ *
+ * WHY THE RACE ARBITER IS A REFCOUNTED OBJECT AND NOT A FLAG IN THE MECHANISM
+ * --------------------------------------------------------------------------
+ * This is the correction of a deterministic use-after-free that black-screened
+ * the lock screen 27 times before it was found.
+ *
+ * The previous design armed an uncancellable `dispatch_after` and put the
+ * "already delivered" atomic_flag inside the calloc'd JARVISMechanism. But
+ * SecurityAgent calls MechanismDestroy -- which frees that allocation -- the
+ * instant the chain advances past us, and every escaping callback here can fire
+ * afterwards. So the deadline block dereferenced freed memory, and worse: the
+ * guard lived inside the object whose lifetime it was supposed to be guarding,
+ * which means reading the flag to ask "did I lose the race?" WAS the
+ * use-after-free. A guard placed inside the thing it guards is not a guard.
+ *
+ * The fix is ownership, not defensiveness. JARVISDelivery is an ARC object that
+ * every racer co-owns strongly. Its memory therefore cannot go away while any
+ * callback can still run -- not by discipline, but by construction.
+ *
+ * WHY THESE BLOCKS CAPTURE `self` STRONGLY, ON PURPOSE
+ * ---------------------------------------------------
+ * A weak capture here would trade a crash for a hang. If the deadline block
+ * held only a weak reference and the mechanism's reference were dropped first,
+ * strongSelf would be nil, the block would return early, SetResult would never
+ * be called, and the chain would stall forever -- the same black screen,
+ * reached through nil instead of through a segfault. Weak capture is the right
+ * default for a delegate. It is the wrong tool for a completion guarantee.
+ *
+ * That creates two intentional retain cycles: delivery -> _deadline -> timer
+ * block -> delivery, and connection -> handler block -> delivery -> connection.
+ * Both are broken deterministically in -teardownOnQueue, which every exit path
+ * runs. This is the documented pattern for a self-owned dispatch source: strong
+ * capture plus an explicit cancel, never weak references. And the cycles are
+ * bounded regardless -- authorizationhosthelper hosts exactly one authorization
+ * session and then exits.
+ *
+ * WHAT MAKES THE ENGINE HANDLE SAFE, SEPARATELY FROM THE MEMORY
+ * ------------------------------------------------------------
+ * Safe memory is not sufficient. AuthorizationEngineRef is owned by
+ * SecurityAgent and is dead after MechanismDestroy, so calling SetResult on it
+ * afterwards is a second, independent fault. All mutable state here is touched
+ * only on a serial queue; -invalidate is a dispatch_sync BARRIER, so it waits
+ * out any SetResult already in flight and then nils the engine, after which no
+ * future SetResult can run. Only then does MechanismDestroy free.
+ *
+ * -deliver is async rather than sync deliberately. Enqueueing on a serial queue
+ * costs sub-microseconds and holds no thread, whereas holding a lock across
+ * SetResult -- which is IPC to SecurityAgent -- would reintroduce exactly the
+ * kind of hang this file exists to prevent.
  *
  * The deadline is armed BEFORE the request is sent, for the same reason the
  * probe arms its dead man's switch before mutating the rule: there must be no
@@ -40,7 +88,6 @@
 #import <Security/AuthSession.h>
 #import <CoreGraphics/CoreGraphics.h>
 #import <os/log.h>
-#import <stdatomic.h>
 
 #import "JARVISGrantProtocol.h"
 #import "JARVISUnlockConfig.h"
@@ -52,62 +99,273 @@ typedef struct {
     os_log_t log;
 } JARVISPlugin;
 
+@class JARVISDelivery;
+
 typedef struct {
     JARVISPlugin *plugin;
     AuthorizationEngineRef engine;
-    /// Guarantees exactly one SetResult per invocation, whichever racer wins.
-    atomic_flag resultDelivered;
+    /**
+     * CFBridgingRetain'd JARVISDelivery for the CURRENT invocation, or NULL.
+     *
+     * A void* and manual ownership because ARC does not manage Objective-C
+     * pointers held in malloc'd structs. Every store here is paired with a
+     * CFBridgingRelease; -Invoke and -Destroy are the only writers.
+     */
+    void *delivery;
 } JARVISMechanism;
 
-#pragma mark - Result delivery
+#pragma mark - Shared validation
 
 /**
- * Deliver the verdict, exactly once.
+ * One definition of "is this handle safe to dereference", used by every entry
+ * point the OS can call.
  *
- * The timeout and the XPC reply race by design, and both call this. The atomic
- * flag is what makes that safe: a second SetResult on the same engine is
- * undefined behaviour in an API whose failure mode is a stuck lock screen.
+ * These are not paranoia. MechanismDeactivate previously walked
+ * mech->plugin->callbacks->DidDeactivate with no guard on plugin, on the same
+ * teardown path where the use-after-free lived: a null plugin there is a second
+ * crash in the same window.
  */
-static void JARVISDeliver(JARVISMechanism *mech,
-                          AuthorizationResult result,
-                          JARVISGrantVerdict verdict,
-                          NSTimeInterval elapsed) {
-    if (atomic_flag_test_and_set(&mech->resultDelivered)) {
-        // Lost the race. The winner already answered; say so at debug level
-        // rather than dropping it silently, because a persistent stream of
-        // these means the timeout is mistuned.
-        os_log_debug(mech->plugin->log,
-                     "verdict %{public}@ arrived after the result was delivered (%.0fms)",
-                     JARVISGrantVerdictName(verdict), elapsed * 1000.0);
-        return;
-    }
-
-    os_log(mech->plugin->log,
-           "verdict=%{public}@ result=%{public}s elapsed=%.0fms",
-           JARVISGrantVerdictName(verdict),
-           result == kAuthorizationResultAllow ? "allow" : "yield",
-           elapsed * 1000.0);
-
-    OSStatus status = mech->plugin->callbacks->SetResult(mech->engine, result);
-    if (status != errAuthorizationSuccess) {
-        os_log_error(mech->plugin->log, "SetResult failed: %d", (int)status);
-    }
+static BOOL JARVISPluginUsable(const JARVISPlugin *plugin) {
+    return plugin != NULL && plugin->callbacks != NULL;
 }
+
+static BOOL JARVISMechUsable(const JARVISMechanism *mech) {
+    return mech != NULL && JARVISPluginUsable(mech->plugin) && mech->engine != NULL;
+}
+
+/// Never returns NULL, so no logging call site needs its own guard.
+static os_log_t JARVISLogOf(const JARVISMechanism *mech) {
+    if (mech != NULL && mech->plugin != NULL && mech->plugin->log != NULL) {
+        return mech->plugin->log;
+    }
+    return OS_LOG_DEFAULT;
+}
+
+#pragma mark - JARVISDelivery
+
+/**
+ * The race arbiter: exactly one SetResult per invocation, whichever racer wins,
+ * and a hard guarantee that SOMETHING answers.
+ *
+ * Fail-open is a property of this class, not of its callers. Every terminal
+ * condition -- timeout, dropped connection, rejected peer, nil engine, a
+ * dispatch source that could not even be created -- routes to -yieldWithVerdict:
+ * and advances the chain to builtin:authenticate. There is no path that
+ * declines to answer.
+ */
+@interface JARVISDelivery : NSObject
+
+- (instancetype)initWithCallbacks:(const AuthorizationCallbacks *)callbacks
+                           engine:(AuthorizationEngineRef)engine
+                              log:(os_log_t)log NS_DESIGNATED_INITIALIZER;
+- (instancetype)init NS_UNAVAILABLE;
+
+/// Arm the dead man's switch. Yields immediately if the timer cannot be made.
+- (void)armDeadlineAfter:(NSTimeInterval)seconds;
+
+/// Hand the connection over so teardown can dismantle it deterministically.
+- (void)adoptConnection:(NSXPCConnection *)connection;
+
+/// Satisfied: this mechanism is done, continue the chain.
+- (void)grantWithVerdict:(JARVISGrantVerdict)verdict;
 
 /**
  * Yield to the native password UI.
  *
  * kAuthorizationResultAllow, not Deny. In an evaluate-mechanisms chain, Allow
- * means "this mechanism is satisfied, continue" -- the later builtin:authenticate
- * then does the real work and prompts as it always has. Deny would fail the
- * whole right and lock the user out of their own machine, which is the outcome
- * this plugin exists to never cause.
+ * means "this mechanism is satisfied, continue" -- the later
+ * builtin:authenticate then does the real work and prompts as it always has.
+ * Deny would fail the whole right and lock the user out of their own machine,
+ * which is the outcome this plugin exists to never cause.
  *
  * That distinction is the single most load-bearing line in this file.
  */
-static void JARVISYield(JARVISMechanism *mech, JARVISGrantVerdict why, NSTimeInterval elapsed) {
-    JARVISDeliver(mech, kAuthorizationResultAllow, why, elapsed);
+- (void)yieldWithVerdict:(JARVISGrantVerdict)verdict;
+
+/**
+ * Barrier. Waits out any in-flight SetResult, drops the engine so no later one
+ * can run, and breaks every retain cycle. Safe to call more than once.
+ *
+ * MUST be called before the owning JARVISMechanism is freed.
+ */
+- (void)invalidate;
+
+@end
+
+@implementation JARVISDelivery {
+    /// Serializes every mutation below. All ivars are queue-confined.
+    dispatch_queue_t _q;
+    const AuthorizationCallbacks *_callbacks;
+    AuthorizationEngineRef _engine;
+    os_log_t _log;
+    BOOL _delivered;
+    dispatch_source_t _deadline;
+    NSXPCConnection *_connection;
+    NSDate *_startedAt;
 }
+
+- (instancetype)initWithCallbacks:(const AuthorizationCallbacks *)callbacks
+                           engine:(AuthorizationEngineRef)engine
+                              log:(os_log_t)log {
+    self = [super init];
+    if (self == nil) { return nil; }
+
+    // User-interactive: a human is staring at a locked screen waiting for this.
+    _q = dispatch_queue_create("com.jarvis.unlockplugin.delivery",
+                               dispatch_queue_attr_make_with_qos_class(
+                                   DISPATCH_QUEUE_SERIAL, QOS_CLASS_USER_INTERACTIVE, 0));
+    _callbacks = callbacks;
+    _engine = engine;
+    _log = (log != NULL) ? log : OS_LOG_DEFAULT;
+    _delivered = NO;
+    _startedAt = [NSDate date];
+    return self;
+}
+
+#pragma mark Delivery
+
+- (void)grantWithVerdict:(JARVISGrantVerdict)verdict {
+    [self deliver:kAuthorizationResultAllow verdict:verdict granted:YES];
+}
+
+- (void)yieldWithVerdict:(JARVISGrantVerdict)verdict {
+    [self deliver:kAuthorizationResultAllow verdict:verdict granted:NO];
+}
+
+- (void)deliver:(AuthorizationResult)result
+        verdict:(JARVISGrantVerdict)verdict
+        granted:(BOOL)granted {
+    // Strong capture is the point: this block co-owns the arbiter, so the
+    // arbiter cannot be freed before it runs. See the file header.
+    dispatch_async(_q, ^{
+        NSTimeInterval elapsed = -[self->_startedAt timeIntervalSinceNow];
+
+        if (self->_delivered) {
+            // Lost the race. The winner already answered; say so at debug level
+            // rather than dropping it silently, because a persistent stream of
+            // these means the timeout is mistuned.
+            os_log_debug(self->_log,
+                         "verdict %{public}@ arrived after the result was delivered (%.0fms)",
+                         JARVISGrantVerdictName(verdict), elapsed * 1000.0);
+            return;
+        }
+
+        if (self->_engine == NULL || !self->_callbacks || !self->_callbacks->SetResult) {
+            // The engine died under us -- SecurityAgent tore the session down
+            // before anyone answered. Nothing to deliver to, and nothing we can
+            // do about it, but it must be visible: this is the shape a wedged
+            // lock screen would have if the barrier below were ever wrong.
+            os_log_error(self->_log,
+                         "engine gone before delivery; verdict %{public}@ dropped (%.0fms)",
+                         JARVISGrantVerdictName(verdict), elapsed * 1000.0);
+            self->_delivered = YES;
+            [self teardownOnQueue];
+            return;
+        }
+
+        self->_delivered = YES;
+
+        os_log(self->_log,
+               "verdict=%{public}@ result=%{public}s elapsed=%.0fms",
+               JARVISGrantVerdictName(verdict),
+               granted ? "grant" : "yield",
+               elapsed * 1000.0);
+
+        OSStatus status = self->_callbacks->SetResult(self->_engine, result);
+        if (status != errAuthorizationSuccess) {
+            os_log_error(self->_log, "SetResult failed: %d", (int)status);
+        }
+
+        // Answered. Nothing else may fire, and the cycles die here rather than
+        // waiting for -invalidate.
+        [self teardownOnQueue];
+    });
+}
+
+#pragma mark Deadline
+
+- (void)armDeadlineAfter:(NSTimeInterval)seconds {
+    dispatch_async(_q, ^{
+        if (self->_delivered || self->_engine == NULL) { return; }
+
+        dispatch_source_t timer =
+            dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, self->_q);
+        if (timer == nil) {
+            // Fail open, loudly. An unarmed deadline is the one state this
+            // class must never sit in: it is a lock screen with nothing
+            // scheduled to end the wait. Answer now instead.
+            os_log_error(self->_log,
+                         "could not create deadline timer; yielding immediately");
+            dispatch_async(self->_q, ^{
+                [self yieldWithVerdict:JARVISGrantVerdictUnavailable];
+            });
+            return;
+        }
+
+        dispatch_source_set_timer(timer,
+                                  dispatch_time(DISPATCH_TIME_NOW,
+                                                (int64_t)(seconds * NSEC_PER_SEC)),
+                                  DISPATCH_TIME_FOREVER,   // one-shot
+                                  (uint64_t)(NSEC_PER_MSEC * 10));
+        dispatch_source_set_event_handler(timer, ^{
+            // Cancel first: a one-shot must not be able to fire twice, and the
+            // cycle through _deadline is broken by teardown inside -deliver.
+            dispatch_source_cancel(timer);
+            [self yieldWithVerdict:JARVISGrantVerdictTimedOut];
+        });
+
+        self->_deadline = timer;
+        dispatch_resume(timer);
+    });
+}
+
+#pragma mark Teardown
+
+- (void)adoptConnection:(NSXPCConnection *)connection {
+    dispatch_async(_q, ^{
+        if (self->_delivered || self->_engine == NULL) {
+            // Already finished, or finishing. Do not leave a live connection
+            // behind whose handlers could re-enter after we are done.
+            [connection invalidate];
+            return;
+        }
+        self->_connection = connection;
+    });
+}
+
+/// Queue-confined. Idempotent. Breaks both intentional retain cycles.
+- (void)teardownOnQueue {
+    if (_deadline != nil) {
+        dispatch_source_cancel(_deadline);
+        _deadline = nil;                       // cycle: self -> source -> block -> self
+    }
+    if (_connection != nil) {
+        // Clearing the handlers BEFORE invalidating is load-bearing. The old
+        // code invalidated the connection on its own success path while its
+        // invalidationHandler was still installed, so a normal, deliberate
+        // teardown re-entered the yield path as though the broker had died.
+        _connection.interruptionHandler = nil;
+        _connection.invalidationHandler = nil; // cycle: connection -> block -> self
+        [_connection invalidate];
+        _connection = nil;
+    }
+}
+
+- (void)invalidate {
+    // dispatch_sync is the barrier that makes the engine handle safe: when this
+    // returns, any SetResult already in flight has completed and no future one
+    // can begin. Only then may the caller free the mechanism.
+    //
+    // Deadlock-free because -invalidate is only ever called from
+    // MechanismDestroy, on SecurityAgent's thread, never from _q itself.
+    dispatch_sync(_q, ^{
+        self->_engine = NULL;
+        self->_callbacks = NULL;
+        [self teardownOnQueue];
+    });
+}
+
+@end
 
 #pragma mark - Hardware panic choke
 
@@ -144,28 +402,23 @@ static BOOL JARVISPanicHeld(JARVISUnlockConfig *config, os_log_t log) {
 /**
  * Ask the broker whether a grant exists, without ever waiting for the answer.
  *
- * Returns immediately. Exactly one of two things will later call JARVISDeliver:
- * the reply block, or the deadline armed here before the request goes out.
+ * Returns immediately. Every terminal path -- reply, timeout, interruption,
+ * invalidation, proxy error, missing config -- lands on the delivery object,
+ * which answers exactly once.
  */
-static void JARVISAskBroker(JARVISMechanism *mech, JARVISUnlockConfig *config) {
-    os_log_t log = mech->plugin->log;
-    NSDate *started = [NSDate date];
-
+static void JARVISAskBroker(JARVISDelivery *delivery,
+                            JARVISUnlockConfig *config,
+                            os_log_t log) {
     // Arm the deadline FIRST. If anything below throws, misbehaves, or simply
     // never calls back, this still fires and the user still gets their prompt.
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW,
-                                 (int64_t)(config.grantTimeoutSeconds * NSEC_PER_SEC)),
-                   dispatch_get_global_queue(QOS_CLASS_USER_INTERACTIVE, 0), ^{
-        JARVISYield(mech, JARVISGrantVerdictTimedOut,
-                    -[started timeIntervalSinceNow]);
-    });
+    [delivery armDeadlineAfter:config.grantTimeoutSeconds];
 
     NSString *service = config.brokerMachServiceName;
     NSString *requirement = config.brokerCodeRequirement;
     if (service == nil || requirement == nil) {
         // Config already logged the specifics at load. Yield now rather than
         // making the user wait out a timeout for a decision already made.
-        JARVISYield(mech, JARVISGrantVerdictUnavailable, -[started timeIntervalSinceNow]);
+        [delivery yieldWithVerdict:JARVISGrantVerdictUnavailable];
         return;
     }
 
@@ -189,18 +442,22 @@ static void JARVISAskBroker(JARVISMechanism *mech, JARVISUnlockConfig *config) {
         os_log_error(log,
                      "code signing requirements unsupported on this OS; "
                      "refusing to trust an unverified broker");
-        JARVISYield(mech, JARVISGrantVerdictRejected, -[started timeIntervalSinceNow]);
         [connection invalidate];
+        [delivery yieldWithVerdict:JARVISGrantVerdictRejected];
         return;
     }
+
+    // Handed over before resume, so teardown owns it from here on and no
+    // handler can outlive the arbiter's answer.
+    [delivery adoptConnection:connection];
 
     // Both handlers yield. An interrupted or invalidated connection is
     // indistinguishable from a dead broker from here, and both mean "prompt".
     connection.interruptionHandler = ^{
-        JARVISYield(mech, JARVISGrantVerdictUnavailable, -[started timeIntervalSinceNow]);
+        [delivery yieldWithVerdict:JARVISGrantVerdictUnavailable];
     };
     connection.invalidationHandler = ^{
-        JARVISYield(mech, JARVISGrantVerdictUnavailable, -[started timeIntervalSinceNow]);
+        [delivery yieldWithVerdict:JARVISGrantVerdictUnavailable];
     };
 
     [connection resume];
@@ -208,22 +465,23 @@ static void JARVISAskBroker(JARVISMechanism *mech, JARVISUnlockConfig *config) {
     id<JARVISGrantConsumer> broker =
         [connection remoteObjectProxyWithErrorHandler:^(NSError *error) {
             os_log_error(log, "broker proxy error: %{public}@", error.localizedDescription);
-            JARVISYield(mech, JARVISGrantVerdictUnavailable, -[started timeIntervalSinceNow]);
+            [delivery yieldWithVerdict:JARVISGrantVerdictUnavailable];
         }];
 
     [broker consumeGrantWithSchemaVersion:config.schemaVersion
                                     reply:^(JARVISGrantVerdict verdict,
                                             NSString *correlationId) {
-        NSTimeInterval elapsed = -[started timeIntervalSinceNow];
         if (correlationId.length > 0) {
             os_log_debug(log, "broker correlation=%{public}@", correlationId);
         }
         if (verdict == JARVISGrantVerdictGranted) {
-            JARVISDeliver(mech, kAuthorizationResultAllow, verdict, elapsed);
+            [delivery grantWithVerdict:verdict];
         } else {
-            JARVISYield(mech, verdict, elapsed);
+            [delivery yieldWithVerdict:verdict];
         }
-        [connection invalidate];
+        // No explicit invalidate here: -deliver tears the connection down with
+        // its handlers already cleared, so the normal path cannot masquerade as
+        // a broker failure.
     }];
 }
 
@@ -236,12 +494,14 @@ static OSStatus JARVISMechanismCreate(AuthorizationPluginRef inPlugin,
     if (inPlugin == NULL || outMechanism == NULL) { return errAuthorizationInternal; }
 
     JARVISPlugin *plugin = (JARVISPlugin *)inPlugin;
+    if (!JARVISPluginUsable(plugin)) { return errAuthorizationInternal; }
+
     JARVISMechanism *mech = calloc(1, sizeof(JARVISMechanism));
     if (mech == NULL) { return errAuthorizationInternal; }
 
     mech->plugin = plugin;
     mech->engine = inEngine;
-    atomic_flag_clear(&mech->resultDelivered);
+    mech->delivery = NULL;
 
     os_log_debug(plugin->log, "mechanism created: %{public}s",
                  mechanismId ? mechanismId : "(unnamed)");
@@ -250,39 +510,65 @@ static OSStatus JARVISMechanismCreate(AuthorizationPluginRef inPlugin,
     return errAuthorizationSuccess;
 }
 
+/// Retire the previous invocation's arbiter, if any. Barriered, so nothing from
+/// the old attempt can answer the new one.
+static void JARVISRetireDelivery(JARVISMechanism *mech) {
+    if (mech == NULL || mech->delivery == NULL) { return; }
+    JARVISDelivery *previous = (JARVISDelivery *)CFBridgingRelease(mech->delivery);
+    mech->delivery = NULL;
+    [previous invalidate];
+}
+
 static OSStatus JARVISMechanismInvoke(AuthorizationMechanismRef inMechanism) {
     JARVISMechanism *mech = (JARVISMechanism *)inMechanism;
-    if (mech == NULL) { return errAuthorizationInternal; }
+    if (!JARVISMechUsable(mech)) { return errAuthorizationInternal; }
 
-    // Every invocation starts fresh: the same mechanism object is reused across
-    // retries, and a flag left set from a previous attempt would swallow this
-    // attempt's result and hang the chain.
-    atomic_flag_clear(&mech->resultDelivered);
+    // The same mechanism object is reused across retries. A fresh arbiter per
+    // invocation is what makes that safe -- the old design cleared a flag,
+    // which let a previous attempt's in-flight callback answer THIS attempt.
+    JARVISRetireDelivery(mech);
+
+    JARVISDelivery *delivery =
+        [[JARVISDelivery alloc] initWithCallbacks:mech->plugin->callbacks
+                                          engine:mech->engine
+                                             log:JARVISLogOf(mech)];
+    if (delivery == nil) {
+        // Cannot arbitrate, so cannot promise an answer. Yield synchronously
+        // through the raw callbacks -- mech is provably alive on this frame --
+        // rather than returning an error that stalls the chain.
+        os_log_error(JARVISLogOf(mech), "delivery alloc failed; yielding directly");
+        mech->plugin->callbacks->SetResult(mech->engine, kAuthorizationResultAllow);
+        return errAuthorizationSuccess;
+    }
+    mech->delivery = (void *)CFBridgingRetain(delivery);
 
     @autoreleasepool {
         @try {
             JARVISUnlockConfig *config = [JARVISUnlockConfig sharedConfig];
 
             if (!config.mechanismEnabled) {
-                JARVISYield(mech, JARVISGrantVerdictUnavailable, 0);
+                [delivery yieldWithVerdict:JARVISGrantVerdictUnavailable];
                 return errAuthorizationSuccess;
             }
 
             // Checked before anything else, and before any IPC: the panic key
-            // must work when the broker is the thing that is broken.
-            if (JARVISPanicHeld(config, mech->plugin->log)) {
-                JARVISYield(mech, JARVISGrantVerdictPanicBypass, 0);
+            // must work when the broker is the thing that is broken. Note that
+            // no deadline is armed on this path, so it cannot interact with the
+            // timer at all -- which is why holding the key is a clean bypass
+            // even when everything else here is misbehaving.
+            if (JARVISPanicHeld(config, JARVISLogOf(mech))) {
+                [delivery yieldWithVerdict:JARVISGrantVerdictPanicBypass];
                 return errAuthorizationSuccess;
             }
 
-            JARVISAskBroker(mech, config);
+            JARVISAskBroker(delivery, config, JARVISLogOf(mech));
         } @catch (NSException *e) {
             // An exception escaping into SecurityAgent is how a lock screen
             // dies. Nothing gets past this frame.
-            os_log_error(mech->plugin->log,
+            os_log_error(JARVISLogOf(mech),
                          "unhandled exception in Invoke (%{public}@); yielding",
                          e.name);
-            JARVISYield(mech, JARVISGrantVerdictUnavailable, 0);
+            [delivery yieldWithVerdict:JARVISGrantVerdictUnavailable];
         }
     }
 
@@ -293,12 +579,26 @@ static OSStatus JARVISMechanismInvoke(AuthorizationMechanismRef inMechanism) {
 
 static OSStatus JARVISMechanismDeactivate(AuthorizationMechanismRef inMechanism) {
     JARVISMechanism *mech = (JARVISMechanism *)inMechanism;
-    if (mech == NULL) { return errAuthorizationInternal; }
+    if (!JARVISMechUsable(mech) || mech->plugin->callbacks->DidDeactivate == NULL) {
+        return errAuthorizationInternal;
+    }
     return mech->plugin->callbacks->DidDeactivate(mech->engine);
 }
 
 static OSStatus JARVISMechanismDestroy(AuthorizationMechanismRef inMechanism) {
-    if (inMechanism != NULL) { free(inMechanism); }
+    JARVISMechanism *mech = (JARVISMechanism *)inMechanism;
+    if (mech == NULL) { return errAuthorizationSuccess; }
+
+    // Order is the entire fix. -invalidate is a barrier: it waits out any
+    // SetResult in flight, drops the engine so no later one can run, and breaks
+    // the retain cycles. Only after it returns is it safe to free -- and only
+    // then does the arbiter's own memory become unreachable, which the ARC
+    // refcount, not this free(), is what governs.
+    JARVISRetireDelivery(mech);
+
+    mech->plugin = NULL;
+    mech->engine = NULL;
+    free(mech);
     return errAuthorizationSuccess;
 }
 


### PR DESCRIPTION
Two isolated commits closing the black-lock-screen defect.

## `cd5d155c3a` — the installer authored the rule

`install.sh` wrote a complete authorization rule from a template literal in its own body — `class = evaluate-mechanisms`, `mechanisms = ( ours, builtin:authenticate )` — over `system.login.screensaver`, whose stock class is `rule` delegating to `use-login-window-ui`.

That delegation is what hands the lock screen to loginwindow: the panel, the password field, and the session resume that re-attaches WindowServer. **A mechanism chain only AUTHENTICATES.** The machine authenticated into a black screen with a live cursor.

The measurement that authorised it was taken against a different shape. `probe_screensaver_rule.sh` swapped in `authenticate-session-owner-or-admin` — `class = user`, no `mechanisms` array at all — confirmed Touch ID and the password survived, and that result was spent on a mechanism chain nobody had ever run.

Three gates, cheapest first:

| gate | question |
|---|---|
| **7a** | Does Apple's schema say this right can host a mechanism — in its **stock** definition? After a conversion the live rule *is* a mechanism chain, so a live-rule check would ratify its own damage on every reinstall. |
| **7b** | Derive, never author. Output is a byte copy of the incumbent with `mechanisms.0` inserted; `tries`, `shared`, `allow-root`, `version` survive instead of being dropped and reinvented. Idempotent. |
| **7c** | Has *this exact shape* been measured here, with `locked=yes password=yes`? No override flag — a flag is the shortest path back to spending one configuration's evidence on another. |

`install.sh` no longer contains the string `evaluate-mechanisms` anywhere.

Also: the probe now records the shape it actually applied, read back from the database rather than from what it requested. `uninstall.sh`'s mechanism walker is gone in favour of the shared primitive that composes those entries — an inverse pair that drifts is how a removal leaves behind the entry it was run to remove. `verify.sh` gained the shape check that would have caught this while every other check stayed green.

**51 self-tests** (`install/test_rule_shape.sh`) wired into `make verify`, which `install.sh` runs as step 1. They caught two bugs in the composer: under `pipefail` an early-exiting consumer SIGPIPEs the producer, which had inverted the idempotency check so every reinstall would have stacked a duplicate mechanism.

## `11221799ef` — the guard lived inside the allocation it was guarding

`authorizationhosthelper` segfaulted **27 times across two days** while every check in `verify.sh` reported the installation coherent — all of them static, none of them changing when a mechanism dies at runtime in a process we do not own.

The deadline was an uncancellable `dispatch_after` and the "already delivered" `atomic_flag` lived inside the `calloc`'d `JARVISMechanism`. `MechanismDestroy` frees that allocation the instant the chain advances past us, so reading the flag to ask "did I lose the race?" *was* the use-after-free.

Fixed by ownership rather than defensiveness: `JARVISDelivery` is an ARC object every racer co-owns strongly. Blocks capture `self` strongly on purpose — a weak capture trades the crash for a hang, which is the same black screen reached through nil. `-invalidate` is a `dispatch_sync` barrier so no `SetResult` can outlive the engine.

Isolated on purpose: this has to land before a mechanism is ever placed in `system.login.screensaver.unlock`, which is `tries: 1` with no in-chain password fallback.

## Verified

- 51/51 self-tests; `make verify` green end-to-end including the build
- `install.sh --dry-run` on macOS 26.6.1 prints the refusal, quoting Apple's own comment back
- Live authorization database untouched throughout

## Not proven

The full-install refusal branch has not been executed end-to-end — reaching it installs the bundle and loads the daemon. Its predicate is pinned by two opposite-direction tests against the real schema; the branch itself is verified by inspection.

The UAF fix has never run live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop converting `system.login.screensaver` and instead safely amend the live chain at `system.login.screensaver.unlock`, with guards and a zero‑idle‑cost sentinel that auto‑reverts unsafe states. Also fixed a mechanism UAF and updated docs to state that screen unlock is on hold and not wired in.

- **New Features**
  - Target: amend `system.login.screensaver.unlock`; derive from the incumbent; insert at `mechanisms.0`; preserve all keys; idempotent; verify live shape after write.
  - Guards: schema gate reads the stock definition; block writes that convert delegating rights or place our mechanism on rights whose stock chains include `loginwindow:`; evidence gate requires `failopen=proven`.
  - Sentinel: `launchd` `WatchPaths` over the plugin dir, `/var/db/auth.db`, and DiagnosticReports; auto‑revert on missing bundle, crashes, shape drift, or non‑host rights; no resident daemon; graded urgency; shared revert/restore; recovery scripts at `/usr/local/libexec/jarvis-authplugin`.
  - Probes/Docs: added a mechanism lifecycle probe; the screensaver probe now composes via the installer function and records the live shape; READMEs record that unlock is paused and not installed, while locking remains proven.

- **Bug Fixes**
  - Mechanism: replace flag+deadline with an ARC‑owned delivery object on a serial queue; strong‑capture callbacks; explicit teardown with a `dispatch_sync` barrier; clear XPC handlers to fix UAF and late `SetResult`.
  - Installer/Verify: stop converting `system.login.screensaver`; prevent duplicate inserts and SIGPIPE under `pipefail`; add a `_state` verdict so an intentionally unwired rule is reported as safe rather than prescribing a rewrite.

<sup>Written for commit 1c1b4c09b8e0c93dcb488594db922362495a22b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70429?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

