### PR TITLE
feat(ov): Dynamic event-loop latency watchdog — hunt the stall, don't wait for one

### DIFF
--- a/backend/core/ouroboros/battle_test/loop_watchdog.py
+++ b/backend/core/ouroboros/battle_test/loop_watchdog.py
@@ -1,0 +1,433 @@
+"""An event-loop latency watchdog that hunts a stall instead of waiting for one.
+
+WHAT IT REPLACES
+----------------
+The standing instrument for the `ov` freeze is `kill -USR1` — a human,
+present at the moment of the wedge, sending a signal twice and comparing
+stacks. That catches a total freeze and nothing else. The stalls that PRECEDE
+one are invisible: nobody sends a signal for a 300 ms hitch, and a hitch is
+where the cause is still legible.
+
+This measures every tick, so a hitch is data rather than an impression.
+
+THE MEASUREMENT
+---------------
+An in-loop task sleeps a fixed interval and records how LATE its wakeup was:
+
+    lateness = elapsed_wall_time - requested_sleep
+
+That number is the loop's scheduling delay, and it is the only honest measure
+of "is the loop being starved" available from inside it. A busy coroutine, a
+blocking call on the loop thread, GIL contention with a hot background thread,
+a `run_in_terminal` suspension that outstays its welcome — all of them show up
+here as lateness, whatever their cause.
+
+WHY MEDIAN + MAD, AND NOT MEAN + STANDARD DEVIATION
+---------------------------------------------------
+A σ-threshold is the intuitive choice and it is self-defeating for this signal.
+Latency distributions are heavy-tailed, and the samples we are hunting ARE the
+tail — so every stall inflates the very standard deviation meant to catch the
+next one. Under a sustained storm the threshold climbs to meet the anomaly and
+the detector goes quiet exactly when it matters. A detector blinded by the
+thing it hunts is not a detector.
+
+The median absolute deviation has a 50% breakdown point: half the window can be
+garbage before the estimate moves. Scaled by 1.4826 it is a consistent
+estimator of σ for normally distributed data, so a threshold of "k sigmas"
+still means what it says — it is simply computed in a way the outliers cannot
+drag. Both figures are reported, so the difference is visible rather than
+asserted.
+
+WHY THE DUMP IS ARMED IN C AND NOT SCHEDULED IN PYTHON
+------------------------------------------------------
+A watchdog that shares a resource with the system it guards is not a watchdog
+(the Slice 47 rule, arrived at here from a new direction). The resource an
+event-loop watchdog would naturally share is the GIL — and the total-wedge case
+is precisely the one where the main thread will not release it. A Python
+sentinel thread cannot run a single bytecode to report that, so it would be
+mute in the only situation that matters.
+
+``faulthandler.dump_traceback_later`` runs on a C thread and writes from C. It
+does not need the interpreter to be available, so it fires while the loop is
+wedged, and it costs nothing while the loop is healthy.
+
+The trick is that the timer is RE-ARMED on every healthy tick with a deadline
+recomputed from live statistics. A loop that keeps ticking keeps pushing its
+own execution date back and the timer never fires. A loop that stops ticking
+stops postponing, and the dump lands on its own. There is no polling, no
+sentinel thread, and no fixed timeout anywhere.
+
+THE OBSERVER EFFECT
+-------------------
+Per tick: one `monotonic()`, one ring append, one median/MAD over a bounded
+window, and two C calls to cancel/re-arm the timer. At the default interval
+that is a few microseconds of work per second. The 29 kHz output ceiling
+measured on this surface is four orders of magnitude away from being disturbed
+by it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from typing import Any, Callable, Deque, Optional, Tuple
+
+from collections import deque
+
+logger = logging.getLogger("Ouroboros.LoopWatchdog")
+
+#: Makes MAD a consistent estimator of σ for normally distributed data. A
+#: mathematical constant of the estimator, not a tunable: changing it would not
+#: adjust sensitivity, it would make the reported "sigmas" mean something else.
+_MAD_TO_SIGMA = 1.4826
+
+
+def _env_float(name: str, default: float) -> float:
+    try:
+        raw = str(os.environ.get(name, "")).strip()
+        return float(raw) if raw else default
+    except (TypeError, ValueError):
+        logger.debug("[LoopWatchdog] ignoring malformed %s", name)
+        return default
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        raw = str(os.environ.get(name, "")).strip()
+        return int(raw) if raw else default
+    except (TypeError, ValueError):
+        logger.debug("[LoopWatchdog] ignoring malformed %s", name)
+        return default
+
+
+def watchdog_enabled() -> bool:
+    """Default ON. It is a few microseconds a second and it is the only thing
+    that can see a stall nobody was watching for."""
+    raw = str(os.environ.get("JARVIS_LOOP_WATCHDOG_ENABLED", "1")).strip().lower()
+    return raw not in ("0", "false", "no", "off")
+
+
+class LatencyWindow:
+    """A bounded rolling window with robust dispersion.
+
+    Deliberately not a running mean: an anomaly must not permanently move the
+    baseline, and a window that forgets is what lets the detector re-arm after
+    a storm passes.
+    """
+
+    def __init__(self, size: int) -> None:
+        self._samples: Deque[float] = deque(maxlen=max(int(size), 1))
+
+    def __len__(self) -> int:
+        return len(self._samples)
+
+    def add(self, value: float) -> None:
+        self._samples.append(float(value))
+
+    @property
+    def samples(self) -> Tuple[float, ...]:
+        return tuple(self._samples)
+
+    def median(self) -> float:
+        n = len(self._samples)
+        if n == 0:
+            return 0.0
+        ordered = sorted(self._samples)
+        mid = n // 2
+        if n % 2:
+            return ordered[mid]
+        return (ordered[mid - 1] + ordered[mid]) / 2.0
+
+    def mad_sigma(self) -> float:
+        """Dispersion as a σ-equivalent, resistant to the tail we are hunting."""
+        n = len(self._samples)
+        if n == 0:
+            return 0.0
+        med = self.median()
+        deviations = sorted(abs(s - med) for s in self._samples)
+        mid = n // 2
+        if n % 2:
+            mad = deviations[mid]
+        else:
+            mad = (deviations[mid - 1] + deviations[mid]) / 2.0
+        return mad * _MAD_TO_SIGMA
+
+    def mean(self) -> float:
+        if not self._samples:
+            return 0.0
+        return sum(self._samples) / len(self._samples)
+
+    def stdev(self) -> float:
+        """Reported alongside MAD so the contamination is visible, never used
+        as the trigger."""
+        n = len(self._samples)
+        if n < 2:
+            return 0.0
+        mu = self.mean()
+        var = sum((s - mu) ** 2 for s in self._samples) / (n - 1)
+        return var ** 0.5
+
+
+class LoopLatencyWatchdog:
+    """Measures loop scheduling delay; arms a C-level dump against a wedge."""
+
+    def __init__(
+        self,
+        *,
+        interval_s: Optional[float] = None,
+        window: Optional[int] = None,
+        sigma: Optional[float] = None,
+        min_samples: Optional[int] = None,
+        interval_floor_multiple: Optional[float] = None,
+        dump_file: Any = None,
+        on_anomaly: Optional[Callable[[dict], None]] = None,
+    ) -> None:
+        # Sampling period. Short enough that a sub-second hitch is caught,
+        # long enough that the task is invisible in a profile.
+        self.interval_s = interval_s if interval_s is not None else _env_float(
+            "JARVIS_LOOP_WATCHDOG_INTERVAL_S", 0.25)
+        # How much history defines "normal". Bounded so an anomaly ages out.
+        self.window_size = window if window is not None else _env_int(
+            "JARVIS_LOOP_WATCHDOG_WINDOW", 120)
+        # Sensitivity, in σ-equivalents above the median.
+        self.sigma = sigma if sigma is not None else _env_float(
+            "JARVIS_LOOP_WATCHDOG_SIGMA", 6.0)
+        # No verdict before there is a baseline to have a verdict about.
+        self.min_samples = min_samples if min_samples is not None else _env_int(
+            "JARVIS_LOOP_WATCHDOG_MIN_SAMPLES", 24)
+        # The degenerate case that would otherwise make this useless: on a
+        # perfectly regular loop MAD collapses to ~0, every sub-millisecond
+        # jitter becomes "infinite sigmas", and the log fills with nothing.
+        #
+        # The floor is a MULTIPLE OF THE SAMPLING INTERVAL, and the default of
+        # 1.0 is a statement about resolution rather than a tuned constant: a
+        # sampler cannot resolve a stall shorter than its own period, so a
+        # lateness below one interval is indistinguishable from ordinary
+        # scheduling jitter no matter what the statistics say about it.
+        #
+        # An earlier 0.5 default proved the point by failing — at a 20 ms
+        # interval it tolerated only 10 ms, and a perfectly healthy loop on a
+        # loaded machine tripped it with a 12.8 ms hiccup. A detector that
+        # fires on ordinary jitter gets muted, and a muted detector is the
+        # state this replaces.
+        self.interval_floor_multiple = (
+            interval_floor_multiple if interval_floor_multiple is not None
+            else _env_float("JARVIS_LOOP_WATCHDOG_FLOOR_MULTIPLE", 1.0))
+
+        self._window = LatencyWindow(self.window_size)
+        self._task: Optional[asyncio.Task] = None
+        self._dump_file = dump_file
+        self._on_anomaly = on_anomaly
+        self._armed = False
+        self._atexit_registered = False
+
+        self.anomalies = 0
+        self.ticks = 0
+        self.worst_lateness = 0.0
+        self.last_threshold = 0.0
+
+    # -- statistics ---------------------------------------------------------
+    def threshold(self) -> float:
+        """The lateness above which this tick is anomalous.
+
+        Two conditions, and a sample must clear BOTH: statistically unusual
+        against the rolling baseline, AND large enough in absolute terms to
+        matter at the configured resolution.
+        """
+        statistical = self._window.median() + self.sigma * self._window.mad_sigma()
+        floor = self.interval_s * self.interval_floor_multiple
+        return max(statistical, floor)
+
+    def snapshot(self) -> dict:
+        """Everything a reader needs to judge the verdict for themselves."""
+        return {
+            "ticks": self.ticks,
+            "samples": len(self._window),
+            "median_s": round(self._window.median(), 6),
+            "mad_sigma_s": round(self._window.mad_sigma(), 6),
+            # Reported for contrast: on a contaminated window this is visibly
+            # larger than the MAD estimate, which is the argument for using MAD
+            # made as data rather than as prose.
+            "mean_s": round(self._window.mean(), 6),
+            "stdev_s": round(self._window.stdev(), 6),
+            "threshold_s": round(self.last_threshold, 6),
+            "worst_lateness_s": round(self.worst_lateness, 6),
+            "anomalies": self.anomalies,
+        }
+
+    # -- the C-level deadline ----------------------------------------------
+    def _rearm(self, deadline_s: float) -> None:
+        """Push the dump timer out to ``deadline_s`` from now.
+
+        Cancel-then-set, every healthy tick. The loop postpones its own autopsy
+        for as long as it keeps running; the moment it stops, the postponement
+        stops with it and the dump fires from C.
+        """
+        try:
+            import faulthandler
+            faulthandler.cancel_dump_traceback_later()
+            faulthandler.dump_traceback_later(
+                max(deadline_s, self.interval_s),
+                repeat=False,
+                file=self._dump_file,
+                exit=False,          # diagnose a wedge, never kill it
+            )
+            self._armed = True
+        except Exception:  # noqa: BLE001 — diagnostics must never be fatal
+            logger.debug("[LoopWatchdog] could not arm the dump timer",
+                         exc_info=True)
+
+    def _disarm(self) -> None:
+        if not self._armed:
+            return
+        try:
+            import faulthandler
+            faulthandler.cancel_dump_traceback_later()
+        except Exception:  # noqa: BLE001
+            pass
+        self._armed = False
+
+    # -- the sampler --------------------------------------------------------
+    def observe(self, lateness: float) -> Optional[dict]:
+        """Feed one measurement. Returns the anomaly record, or None.
+
+        Separated from the sleeping loop so the decision is testable without
+        real time passing — a detector whose logic can only be exercised by
+        waiting is a detector nobody exercises.
+        """
+        self.ticks += 1
+        lateness = max(float(lateness), 0.0)
+        self.worst_lateness = max(self.worst_lateness, lateness)
+
+        # Warm-up: record, never judge. A verdict from four samples is noise
+        # with a decimal point.
+        if len(self._window) < self.min_samples:
+            self._window.add(lateness)
+            self.last_threshold = self.threshold()
+            return None
+
+        limit = self.threshold()
+        self.last_threshold = limit
+        anomalous = lateness > limit
+
+        # The anomaly is EXCLUDED from the baseline it was judged against.
+        # Admitting it would let a sustained stall teach the detector that
+        # stalling is normal -- the masking failure this design exists to
+        # avoid, arriving by the back door.
+        if not anomalous:
+            self._window.add(lateness)
+            return None
+
+        self.anomalies += 1
+        record = {
+            "lateness_s": round(lateness, 6),
+            "sigmas": round(
+                (lateness - self._window.median())
+                / self._window.mad_sigma(), 2,
+            ) if self._window.mad_sigma() > 0 else None,
+            **self.snapshot(),
+        }
+        logger.warning(
+            "[LoopWatchdog] event loop stalled %.3fs (threshold %.3fs, "
+            "median %.4fs, mad-sigma %.4fs, stdev %.4fs) — %d/%d ticks",
+            lateness, limit, self._window.median(), self._window.mad_sigma(),
+            self._window.stdev(), self.anomalies, self.ticks,
+        )
+        if self._on_anomaly is not None:
+            try:
+                self._on_anomaly(record)
+            except Exception:  # noqa: BLE001
+                logger.debug("[LoopWatchdog] anomaly sink raised",
+                             exc_info=True)
+        return record
+
+    async def _run(self) -> None:
+        # perf_counter, not time(): a wall clock that steps backwards during an
+        # NTP correction would manufacture a stall that never happened.
+        while True:
+            began = time.perf_counter()
+            try:
+                await asyncio.sleep(self.interval_s)
+            except asyncio.CancelledError:
+                raise
+            elapsed = time.perf_counter() - began
+            self.observe(elapsed - self.interval_s)
+            # Re-arm AFTER observing, with a deadline derived from the
+            # baseline this tick just updated.
+            self._rearm(self.interval_s + self.threshold())
+
+    # -- lifecycle ----------------------------------------------------------
+    def start(self, loop: Optional[asyncio.AbstractEventLoop] = None) -> bool:
+        """Begin sampling. Idempotent; NEVER raises."""
+        if self._task is not None and not self._task.done():
+            return True
+        try:
+            loop = loop or asyncio.get_running_loop()
+        except RuntimeError:
+            logger.debug("[LoopWatchdog] no running loop; not started")
+            return False
+        try:
+            self._task = loop.create_task(self._run())
+        except Exception:  # noqa: BLE001
+            logger.debug("[LoopWatchdog] could not start", exc_info=True)
+            return False
+
+        # Disarm at exit, whatever route the process takes out.
+        #
+        # The sampling task is harmless to leak — the interpreter is going away
+        # regardless. The C-level dump deadline is NOT: it is scheduled against
+        # a real timer and would fire during shutdown, writing a full
+        # multi-thread stack dump for a process that is merely finishing
+        # normally. An operator reading that log would find an autopsy of a
+        # healthy exit, which is exactly the kind of false evidence this whole
+        # instrument exists to stop producing.
+        #
+        # Registered here rather than at the call site because every caller
+        # would otherwise have to remember, and the one that forgot would be
+        # discovered by someone reading a crash log that describes nothing.
+        if not self._atexit_registered:
+            try:
+                import atexit
+                atexit.register(self._disarm)
+                self._atexit_registered = True
+            except Exception:  # noqa: BLE001
+                pass
+        logger.info(
+            "[LoopWatchdog] armed — %.0fms sampling, %d-sample window, "
+            "%.1f sigma, dump deadline recomputed per tick",
+            self.interval_s * 1000.0, self.window_size, self.sigma,
+        )
+        return True
+
+    def stop(self) -> None:
+        """Stop sampling and cancel the pending dump. NEVER raises."""
+        self._disarm()
+        task, self._task = self._task, None
+        if task is not None and not task.done():
+            task.cancel()
+
+
+def install_loop_watchdog(**kwargs: Any) -> Optional[LoopLatencyWatchdog]:
+    """Arm the watchdog on the running loop, writing to the shared crash log.
+
+    Returns the instance, or None if disabled or unstartable. The dump target
+    is the SAME descriptor the SIGUSR1 trap uses, so an operator reads one file
+    whether the stacks were requested by hand or produced automatically.
+    """
+    if not watchdog_enabled():
+        return None
+    dump_file = None
+    try:
+        from backend.core.ouroboros.battle_test.oob_diagnostics import (
+            crash_log_handle,
+        )
+        dump_file = crash_log_handle()
+    except Exception:  # noqa: BLE001
+        dump_file = None      # faulthandler falls back to stderr
+
+    watchdog = LoopLatencyWatchdog(dump_file=dump_file, **kwargs)
+    if not watchdog.start():
+        return None
+    return watchdog

--- a/backend/core/ouroboros/battle_test/oob_diagnostics.py
+++ b/backend/core/ouroboros/battle_test/oob_diagnostics.py
@@ -101,30 +101,55 @@ def dump_all_threads(file: Any = None) -> bool:
         return False
 
 
+def crash_log_handle(path: Optional[Path] = None) -> Any:
+    """The append handle every stack dump in this process writes to.
+
+    ONE descriptor, opened once and held for the process lifetime, shared by
+    every producer: the SIGUSR1 trap, and the loop watchdog's C-level timer.
+    That sharing is not tidiness — ``faulthandler`` writes from contexts that
+    cannot open a file, resolve a path, or take a lock (a C signal handler, and
+    a watchdog thread firing while the GIL is held elsewhere), so the
+    descriptor MUST already exist and stay valid. A second producer opening its
+    own would interleave two independent buffers into one file.
+
+    Returns None if the log cannot be opened; callers degrade to stderr.
+    """
+    global _LOG_HANDLE
+    if _LOG_HANDLE is not None:
+        return _LOG_HANDLE
+    try:
+        target = path if path is not None else _log_path()
+        target.parent.mkdir(parents=True, exist_ok=True)
+        # Line-buffered append. A wedged process is usually killed eventually,
+        # and a buffered dump dies with it.
+        _LOG_HANDLE = target.open("a", buffering=1, encoding="utf-8")
+        _LOG_HANDLE.write(
+            f"\n{'=' * 72}\n"
+            f"[oob] stack-dump log opened — pid {os.getpid()}\n"
+            f"{'=' * 72}\n"
+        )
+        _LOG_HANDLE.flush()
+        return _LOG_HANDLE
+    except Exception:  # noqa: BLE001
+        logger.debug("[OOB] could not open the crash log", exc_info=True)
+        return None
+
+
 def install_oob_stack_dump(path: Optional[Path] = None) -> bool:
     """Arm ``kill -USR1``. Returns True if the trap is live. NEVER raises.
 
     Idempotent, and a no-op on platforms without SIGUSR1 (Windows), where the
     absence of the signal is not an error — just an unavailable facility.
     """
-    global _LOG_HANDLE
     if OOB_SIGNAL is None:
         return False
     try:
         import faulthandler
 
         target = path if path is not None else _log_path()
-        if _LOG_HANDLE is None:
-            target.parent.mkdir(parents=True, exist_ok=True)
-            # Line-buffered append. A wedged process is usually killed
-            # eventually, and a buffered dump dies with it.
-            _LOG_HANDLE = target.open("a", buffering=1, encoding="utf-8")
-            _LOG_HANDLE.write(
-                f"\n{'=' * 72}\n"
-                f"[oob] stack-dump trap armed — kill -USR1 {os.getpid()}\n"
-                f"{'=' * 72}\n"
-            )
-            _LOG_HANDLE.flush()
+        handle = crash_log_handle(path)
+        if handle is None:
+            return False
 
         # chain=False, and this is load-bearing.
         #
@@ -138,7 +163,7 @@ def install_oob_stack_dump(path: Optional[Path] = None) -> bool:
         # handler — does not apply: nothing else handles SIGUSR1 here, and
         # what would be preserved is a fatal default.
         faulthandler.register(
-            OOB_SIGNAL, file=_LOG_HANDLE, all_threads=True, chain=False,
+            OOB_SIGNAL, file=handle, all_threads=True, chain=False,
         )
         logger.info(
             "[OOB] stack-dump trap armed on SIGUSR1 (pid=%d) -> %s",

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -2417,6 +2417,28 @@ async def _split_plane_loop(
                 console.print(_glyph("detail", "-") + f" {hint}", markup=False, highlight=False)
     except Exception:  # noqa: BLE001 — a missing debugger must not stop a boot
         pass
+    # …and the automatic half of the same instrument.
+    #
+    # `kill -USR1` needs a human present at the moment of the wedge, so it can
+    # only ever catch a TOTAL freeze — the sub-second stalls that precede one
+    # are invisible, and those are where the cause is still legible.
+    #
+    # The watchdog samples this loop's scheduling delay, builds a rolling
+    # baseline, and re-arms a C-level dump deadline on every healthy tick. A
+    # loop that keeps ticking keeps postponing its own autopsy; a loop that
+    # wedges stops postponing and the stacks land in the SAME crash log the
+    # signal writes to, without anyone being awake to ask.
+    #
+    # Deliberately after the mount hint and before the prompt loop, so it
+    # covers the surface that actually hosts the reported freeze.
+    _loop_watchdog = None
+    try:
+        from backend.core.ouroboros.battle_test.loop_watchdog import (
+            install_loop_watchdog,
+        )
+        _loop_watchdog = install_loop_watchdog()
+    except Exception:  # noqa: BLE001 — diagnostics never block an attach
+        _loop_watchdog = None
     # This surface has no container to float the palette into, so it draws it
     # in the toolbar. The cockpit floats it and must NOT opt in, or it renders
     # twice.

--- a/tests/battle_test/test_loop_watchdog.py
+++ b/tests/battle_test/test_loop_watchdog.py
@@ -1,0 +1,320 @@
+"""The loop watchdog's detector, including the case that motivates its shape.
+
+The interesting assertions here are not "does it compute a median". They are:
+
+  * a mean+stdev threshold MISSES the stall that median+MAD catches, on real
+    numbers rather than by argument;
+  * a sustained stall keeps firing instead of teaching the detector that
+    stalling is normal;
+  * a perfectly regular loop, where MAD collapses to zero, does not produce a
+    verdict on every microsecond of jitter.
+
+Every one of those is a way a latency detector silently stops detecting, which
+is worse than not having one: it converts "nobody was watching" into "we
+checked and it was fine".
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from backend.core.ouroboros.battle_test.loop_watchdog import (  # noqa: E402
+    LatencyWindow,
+    LoopLatencyWatchdog,
+)
+
+
+# ---------------------------------------------------------------------------
+# the window
+# ---------------------------------------------------------------------------
+
+def test_the_window_is_bounded() -> None:
+    """An anomaly must age out, or the baseline never recovers."""
+    w = LatencyWindow(4)
+    for v in (1.0, 2.0, 3.0, 4.0, 5.0):
+        w.add(v)
+    assert len(w) == 4
+    assert w.samples == (2.0, 3.0, 4.0, 5.0)
+
+
+@pytest.mark.parametrize(
+    "values, median",
+    [
+        ([1.0], 1.0),
+        ([1.0, 3.0], 2.0),
+        ([3.0, 1.0, 2.0], 2.0),
+        ([], 0.0),
+    ],
+)
+def test_median(values, median) -> None:
+    w = LatencyWindow(64)
+    for v in values:
+        w.add(v)
+    assert w.median() == pytest.approx(median)
+
+
+def test_mad_is_a_sigma_equivalent() -> None:
+    """Scaled by 1.4826 so "k sigmas" keeps meaning k sigmas."""
+    w = LatencyWindow(64)
+    for v in (1.0, 2.0, 3.0, 4.0, 5.0):
+        w.add(v)
+    # median 3, deviations (2,1,0,1,2) -> MAD 1 -> sigma-equivalent 1.4826
+    assert w.mad_sigma() == pytest.approx(1.4826, rel=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# THE case the design exists for
+# ---------------------------------------------------------------------------
+
+def test_stdev_masks_the_stall_that_mad_catches() -> None:
+    """The empirical argument for not using mean+stdev.
+
+    A latency window is heavy-tailed and the samples being hunted ARE the tail,
+    so each stall inflates the very deviation meant to catch the next one. On
+    these numbers a 6-sigma stdev threshold sits ABOVE the stall it is supposed
+    to flag, while the MAD estimate is unmoved.
+    """
+    quiet, stall = 0.001, 0.5
+    w = LatencyWindow(64)
+    for _ in range(9):
+        w.add(quiet)
+    w.add(stall)
+
+    stdev_threshold = w.mean() + 6.0 * w.stdev()
+    mad_threshold = w.median() + 6.0 * w.mad_sigma()
+
+    assert stall < stdev_threshold, (
+        "premise broken: stdev no longer masks the stall on these numbers"
+    )
+    assert mad_threshold < stall, (
+        "the MAD estimate was dragged by the outlier it is supposed to resist"
+    )
+    # And the contrast is reported rather than merely relied upon.
+    assert w.stdev() > w.mad_sigma() * 10
+
+
+def test_a_sustained_stall_does_not_become_the_new_normal() -> None:
+    """The masking failure by the back door.
+
+    If anomalous samples entered the baseline, a storm would raise the median
+    until stalling looked ordinary and the detector fell silent — precisely
+    when it is most needed.
+    """
+    wd = LoopLatencyWatchdog(
+        interval_s=0.01, window=32, sigma=6.0, min_samples=8,
+        interval_floor_multiple=0.5,
+    )
+    for _ in range(16):
+        assert wd.observe(0.0005) is None
+
+    fired = sum(1 for _ in range(40) if wd.observe(0.4) is not None)
+    assert fired == 40, (
+        f"only {fired}/40 sustained stalls were reported — the baseline "
+        f"absorbed them (median now {wd.snapshot()['median_s']}s)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# the degenerate and warm-up cases
+# ---------------------------------------------------------------------------
+
+def test_no_verdict_before_there_is_a_baseline() -> None:
+    """A verdict from four samples is noise with a decimal point."""
+    wd = LoopLatencyWatchdog(interval_s=0.01, min_samples=20, window=64)
+    for _ in range(19):
+        assert wd.observe(5.0) is None, "judged during warm-up"
+    assert wd.ticks == 19
+
+
+def test_a_perfectly_regular_loop_does_not_cry_wolf() -> None:
+    """MAD collapses to zero on identical samples, which would make every
+    microsecond of jitter infinitely many sigmas. The floor — expressed as a
+    fraction of the sampling interval, not as a duration — is what keeps that
+    from filling the log."""
+    wd = LoopLatencyWatchdog(
+        interval_s=0.25, window=64, sigma=6.0, min_samples=8,
+        interval_floor_multiple=0.5,
+    )
+    for _ in range(32):
+        wd.observe(0.0)
+    assert wd._window.mad_sigma() == pytest.approx(0.0)
+
+    # Well under the floor (0.25 * 0.5 = 0.125s): jitter, not a stall.
+    assert wd.observe(0.01) is None
+    assert wd.observe(0.05) is None
+    # Comfortably over it: a real stall, and it must survive MAD being zero.
+    assert wd.observe(0.4) is not None
+
+
+def test_the_floor_scales_with_the_configured_interval() -> None:
+    """Derived, not declared. A watchdog sampling ten times slower tolerates
+    proportionally more lateness without anyone editing a constant."""
+    fast = LoopLatencyWatchdog(interval_s=0.05, interval_floor_multiple=0.5,
+                               min_samples=1, window=8)
+    slow = LoopLatencyWatchdog(interval_s=0.50, interval_floor_multiple=0.5,
+                               min_samples=1, window=8)
+    for wd in (fast, slow):
+        for _ in range(8):
+            wd.observe(0.0)
+    assert slow.threshold() == pytest.approx(fast.threshold() * 10.0)
+
+
+def test_negative_lateness_is_clamped() -> None:
+    """A sleep that returns early (coarse timers, clock granularity) is not
+    evidence of anything and must not skew the baseline downward."""
+    wd = LoopLatencyWatchdog(interval_s=0.01, min_samples=2, window=8)
+    wd.observe(-0.5)
+    wd.observe(-0.5)
+    assert wd.snapshot()["median_s"] == pytest.approx(0.0)
+    assert wd.worst_lateness == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# against a real event loop
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_it_detects_a_real_blocking_call_on_the_loop_thread() -> None:
+    """The whole point, end to end.
+
+    A synchronous sleep on the loop thread is exactly the shape of the bug
+    class being hunted — `run_in_terminal` suspensions, a blocking write, a C
+    call holding the GIL — and it must show up as lateness without anyone
+    telling the watchdog it happened.
+    """
+    seen: "list[dict]" = []
+    wd = LoopLatencyWatchdog(
+        interval_s=0.02, window=64, sigma=6.0, min_samples=10,
+        interval_floor_multiple=0.5, on_anomaly=seen.append,
+    )
+    assert wd.start() is True
+    try:
+        # Let a quiet baseline establish itself.
+        await asyncio.sleep(0.02 * 15)
+        # Block the loop thread outright.
+        time.sleep(0.5)
+        await asyncio.sleep(0.05)
+    finally:
+        wd.stop()
+
+    assert seen, (
+        f"a 0.5s block of the loop thread went unreported: {wd.snapshot()}"
+    )
+    assert seen[0]["lateness_s"] >= 0.3, seen[0]
+    assert wd.worst_lateness >= 0.3
+
+
+@pytest.mark.asyncio
+async def test_a_quiet_loop_reports_nothing() -> None:
+    """The false-positive floor. A detector that fires on a healthy loop gets
+    muted, and a muted detector is the state this replaces."""
+    seen: "list[dict]" = []
+    # The DEFAULT floor, deliberately: this test's whole job is to catch the
+    # shipped configuration crying wolf. An earlier 0.5 default failed here
+    # with a 12.8 ms hiccup against a 10 ms floor, on a machine doing nothing
+    # more unusual than running the rest of the suite.
+    wd = LoopLatencyWatchdog(
+        interval_s=0.02, window=64, sigma=6.0, min_samples=10,
+        on_anomaly=seen.append,
+    )
+    assert wd.start() is True
+    try:
+        await asyncio.sleep(0.02 * 30)
+    finally:
+        wd.stop()
+    assert not seen, f"cried wolf on an idle loop: {seen[:3]}"
+
+
+def test_the_floor_is_at_least_one_sampling_period() -> None:
+    """Resolution, not taste.
+
+    A sampler cannot distinguish a stall shorter than its own period from the
+    jitter of its own wakeup, so a floor below one interval reports noise with
+    great statistical confidence.
+    """
+    wd = LoopLatencyWatchdog(interval_s=0.25, min_samples=1, window=8)
+    for _ in range(8):
+        wd.observe(0.0)
+    assert wd.threshold() >= wd.interval_s
+
+
+@pytest.mark.asyncio
+async def test_start_and_stop_are_idempotent_and_never_raise() -> None:
+    wd = LoopLatencyWatchdog(interval_s=0.01)
+    assert wd.start() is True
+    assert wd.start() is True          # second call is a no-op, not an error
+    wd.stop()
+    wd.stop()                          # stopping twice must be safe
+
+
+def test_start_without_a_running_loop_declines_rather_than_raising() -> None:
+    """Diagnostics must never be the reason a process fails to boot."""
+    wd = LoopLatencyWatchdog(interval_s=0.01)
+    assert wd.start() is False
+
+
+def test_it_is_armed_on_the_surface_that_hosts_the_freeze() -> None:
+    """Wired, and wired to the RIGHT surface.
+
+    The reported freeze belongs to the `PromptSession` + `patch_stdout` attach
+    path, not the full-screen cockpit. A watchdog installed on the other one
+    would pass every unit test in this file and watch a loop nobody complained
+    about — the same divergence that let a slash-palette test cover a surface
+    with no `run_in_terminal` in it.
+
+    Asserted on order, not merely presence: armed AFTER the mount and BEFORE
+    the prompt loop, so it covers the loop it is measuring.
+    """
+    import inspect
+    from backend.core.ouroboros.cli import ov
+
+    source = inspect.getsource(ov._split_plane_loop)
+    assert "install_loop_watchdog" in source, (
+        "the watchdog is not armed on the attach prompt surface"
+    )
+    assert source.index("install_loop_watchdog") < source.index(
+        "patch_stdout(raw=True)"
+    ), "the watchdog is armed after the prompt loop it is supposed to measure"
+
+
+def test_the_dump_target_is_the_same_log_the_signal_writes_to() -> None:
+    """One file, whether the stacks were asked for or produced automatically.
+
+    An operator debugging a wedge should not have to know which of two logs to
+    read, and two producers opening independent handles would interleave two
+    buffers into one file.
+    """
+    import inspect
+    from backend.core.ouroboros.battle_test import loop_watchdog
+
+    source = inspect.getsource(loop_watchdog.install_loop_watchdog)
+    assert "crash_log_handle" in source, (
+        "the watchdog opens its own dump target instead of sharing the "
+        "SIGUSR1 trap's descriptor"
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_dump_deadline_is_rearmed_and_cancelled() -> None:
+    """The C-level timer is the wedge detector; leaving one armed after stop
+    would dump the stacks of a perfectly healthy process later on."""
+    import faulthandler
+
+    wd = LoopLatencyWatchdog(interval_s=0.01, min_samples=2, window=8)
+    assert wd.start() is True
+    try:
+        await asyncio.sleep(0.08)
+        assert wd._armed is True, "the dump timer was never armed"
+    finally:
+        wd.stop()
+    assert wd._armed is False
+    # Cancelling twice must be safe; if stop() left it armed this would be the
+    # only sign until an unrelated process dumped its stacks.
+    faulthandler.cancel_dump_traceback_later()


### PR DESCRIPTION
`kill -USR1` needs an operator present at the moment of the wedge, so it can only catch a **total** freeze. The sub-second stalls that precede one are invisible — and those are where the cause is still legible.

## The measurement

An in-loop task sleeps a fixed interval and records how **late** its wakeup was. That lateness *is* the loop's scheduling delay: a blocking call on the loop thread, GIL contention with a hot background thread, a `run_in_terminal` suspension that outstays its welcome — all appear here, whatever their cause.

## Median + MAD, not mean + stdev

This is not stylistic. Latency distributions are heavy-tailed and **the samples being hunted *are* the tail**, so every stall inflates the very deviation meant to catch the next one. Measured on nine 1 ms samples plus one 500 ms stall:

```
median 0.0010    mad_sigma 0.000000
mean   0.0509    stdev     0.157800   ← 158×, dragged by the outlier
```

A 6σ **stdev** threshold lands at **0.998s — above the 0.5s stall it exists to flag.** The MAD estimate doesn't move. A detector blinded by the thing it hunts is not a detector, and that case is now a test rather than an argument.

Anomalous samples are also excluded from the baseline they were judged against, so a sustained storm cannot teach the detector that stalling is normal.

## The dump is armed in C, not scheduled in Python

The resource an event-loop watchdog would naturally share with its subject is **the GIL** — and the total-wedge case is exactly the one where the main thread won't release it. A Python sentinel thread cannot execute a single bytecode to report the only situation that matters.

`faulthandler.dump_traceback_later` runs on a C thread and writes from C. Every healthy tick cancels and re-arms it with a deadline **recomputed from live statistics**, so a loop that keeps ticking keeps postponing its own autopsy; a loop that wedges stops postponing and the stacks land unattended.

No polling, no sentinel thread, no fixed timeout anywhere. (Slice 47's rule, arrived at from a new direction.)

## The floor is one sampling period

A statement about resolution, not a tuned constant: a sampler cannot distinguish a stall shorter than its own wakeup jitter. An earlier `0.5×` default proved it by failing — at 20 ms sampling it tolerated 10 ms, and a healthy loop tripped it with a 12.8 ms hiccup. A detector that fires on ordinary jitter gets muted, and a muted detector is the state this replaces.

## DRY

The dump target is the **same descriptor** the SIGUSR1 trap holds, via a new shared `crash_log_handle()` — one file whether stacks were requested by hand or produced automatically, and never two buffers interleaved into one log. Disarming is registered with `atexit` inside `start()`, because the C timer is scheduled against a real clock and would otherwise fire during a normal shutdown, writing an autopsy of a healthy exit.

Armed on the **`PromptSession` attach path** — the surface that actually hosts the reported freeze — after the mount and before the prompt loop, asserted on *order* rather than presence.

## Verified

- **20 unit tests**, including detection of a real 0.5s block of a live asyncio loop
- **22 pty tests** still green with it live, including the escalation to **28,703 frames/sec**, where it reported nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a dynamic event-loop latency watchdog that detects sub-second stalls and triggers an automatic C-level stack dump to the shared crash log. This catches the stall before a full freeze and reduces reliance on `kill -USR1`.

- **New Features**
  - In-loop sampler measures scheduling delay; detects anomalies via median + MAD with a floor of at least 1× the sampling interval.
  - Uses `faulthandler.dump_traceback_later` and re-arms the deadline on every healthy tick; dumps only when the loop wedges.
  - Anomalous samples are excluded from the baseline, so sustained stalls don’t get normalized.
  - Armed on the `PromptSession` attach path (after mount, before prompt loop).
  - Default ON; configurable via `JARVIS_LOOP_WATCHDOG_*` env vars; disarmed at exit. Includes unit tests and a real asyncio block test.

- **Refactors**
  - Introduced `crash_log_handle()` in `oob_diagnostics.py` and wired both SIGUSR1 and the watchdog to the same append handle to avoid interleaved logs.
  - Updated `ov.py` to install the watchdog on attach without affecting normal startup.

<sup>Written for commit 0680e956c796f4153a8d6dcfbcabe50e2dd6ccc4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

