### PR TITLE
fix(ci): Three workflows installed a package that does not exist on PyPI

### DIFF
--- a/.github/workflows/biometric-voice-unlock-e2e.yml
+++ b/.github/workflows/biometric-voice-unlock-e2e.yml
@@ -238,7 +238,7 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install pytest pytest-asyncio pytest-timeout pytest-mock aiohttp asyncio-pool numpy scipy
-          pip install google-cloud-sql-python-connector google-cloud-speech
+          pip install google-cloud-speech
           echo "✅ Dependencies installed"
 
       - name: Verify Test Script Exists

--- a/.github/workflows/database-validation.yml
+++ b/.github/workflows/database-validation.yml
@@ -238,19 +238,56 @@ jobs:
         with:
           python-version: '3.10'
 
+      # ONE declaration of what this job depends on, as `pip-name=import-name`
+      # pairs. The install step and the verification step both read it, so the
+      # thing installed and the thing proven importable cannot drift apart —
+      # which is precisely how this job came to assert three successful imports
+      # it never performed.
       - name: Install Dependencies
+        env:
+          DB_DEPS: "sqlalchemy=sqlalchemy psycopg2-binary=psycopg2"
         run: |
-          pip install sqlalchemy psycopg2-binary google-cloud-sql-python-connector
+          echo "DB_DEPS=$DB_DEPS" >> "$GITHUB_ENV"
+          pip install $(echo "$DB_DEPS" | tr ' ' '\n' | cut -d= -f1 | tr '\n' ' ')
+
+      # `google-cloud-sql-python-connector` used to be installed here. It does
+      # not exist on PyPI (404 — the published package is named differently),
+      # so this job failed at dependency resolution on every run and never
+      # reached a single assertion. Nothing in this repository imports a Cloud
+      # SQL connector: the e2e suite imports the repo's own
+      # `intelligence.cloud_database_adapter`, and this job imports nothing at
+      # all. Renaming it would have installed a package no code uses — fixing
+      # the exit code while preserving the reason it was wrong.
 
       - name: Dry Run Connection Test
         run: |
-          python3 << 'EOF'
-          print("\n🧪 Running database connection dry run...")
-          print("✅ SQLAlchemy imported successfully")
-          print("✅ psycopg2 imported successfully")
-          print("✅ Google Cloud SQL connector imported successfully")
-          print("\n💡 Actual connection test requires valid credentials")
-          print("   This dry run validates that all required libraries are available")
+          python3 - <<'EOF'
+          import importlib, os, sys
+
+          # Derived from the same declaration the install step used, never a
+          # hand-written list of things to congratulate ourselves about. The
+          # previous version of this step printed three "imported successfully"
+          # lines and contained no import statement, so it reported success
+          # whatever was actually installed.
+          pairs = [p for p in os.environ.get("DB_DEPS", "").split() if "=" in p]
+          if not pairs:
+              sys.exit("DB_DEPS was not propagated; nothing was verified")
+
+          print("\n🧪 Verifying the libraries this job claims to need...")
+          failed = []
+          for pair in pairs:
+              package, module = pair.split("=", 1)
+              try:
+                  importlib.import_module(module)
+                  print(f"✅ {module} imported successfully (from {package})")
+              except Exception as exc:
+                  failed.append(f"{module} (from {package}): {exc}")
+                  print(f"❌ {module} FAILED to import (from {package}): {exc}")
+
+          if failed:
+              sys.exit("libraries missing: " + "; ".join(failed))
+          print("\n💡 An actual connection still requires valid credentials.")
+          print("   This step proves the libraries are importable — nothing more.")
           EOF
 
       - name: Connection Test Summary

--- a/.github/workflows/voice-biometric-edge-cases.yml
+++ b/.github/workflows/voice-biometric-edge-cases.yml
@@ -234,7 +234,6 @@ jobs:
           pip install --upgrade pip
           pip install pytest pytest-asyncio pytest-timeout pytest-mock
           pip install numpy scipy librosa soundfile
-          pip install google-cloud-sql-python-connector
           echo "✅ Dependencies installed"
 
       - name: 🧪 Run Edge Case Test - ${{ matrix.edge_case.name }}


### PR DESCRIPTION
`pip install google-cloud-sql-python-connector` — **a 404.** Every run of all three jobs died at dependency resolution and never reached a single assertion.

The biometric matrix has been reporting failure for a reason that has nothing to do with any code it was meant to test — which is exactly as uninformative as reporting success for one.

## The fix is removal, not renaming

Nothing in this repository imports a Cloud SQL connector:

| workflow | what it actually imports |
|---|---|
| `voice-biometric-edge-cases` | generates its own script: `asyncio, json, logging, time, sys, pathlib, typing, numpy`. Nothing else. |
| `biometric-voice-unlock-e2e` | the repo's own `intelligence.cloud_database_adapter` — never the PyPI package, and in MOCK mode not even that |
| `database-validation` | nothing at all. See below. |

Installing a correctly-named package that no code imports would have fixed the exit code while preserving the reason it was wrong.

## `database-validation` was worse than broken

```python
python3 << 'EOF'
print("✅ SQLAlchemy imported successfully")
print("✅ psycopg2 imported successfully")
print("✅ Google Cloud SQL connector imported successfully")
EOF
```

**Three claims of successful imports. Zero import statements.**

Had the pin been correct, this step would have passed on a runner with none of those libraries installed. A check that reports success without measuring is the same defect as one that reports failure without measuring — this job had both at once.

It now derives what to verify from the **same declaration the install step reads** (`pip-name=import-name` pairs in one env var), actually imports each module, and exits non-zero naming what is missing. The installed set and the verified set cannot drift, because there is only one list.

## Verified

- All three workflows parse
- The new dry-run logic exercised locally: correctly **fails** on an absent module, passes on a present one
- No behavioural change to any test — only to whether the jobs can reach them

## Note

`.github/workflows/biometric-voice-unlock-e2e.yml.bak` still carries the old line. GitHub ignores `.bak`, so it is inert — but it is a stale copy of a workflow and probably wants deleting separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI by removing installs of a nonexistent package and adding a real import check for database dependencies. Workflows now install only needed packages and can reach their tests.

- **Bug Fixes**
  - Removed `google-cloud-sql-python-connector` from `voice-biometric-edge-cases` and `biometric-voice-unlock-e2e` (package does not exist on PyPI).
  - Reworked `database-validation`: declare deps once in `DB_DEPS` (`pip-name=import-name`), install from it, then actually import each module (`sqlalchemy`, `psycopg2`) and fail if missing.
  - No test logic changed; only CI setup.

<sup>Written for commit 302c0413f2a6e81dec56ce365724562d3725b6da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

