### PR TITLE
fix(ov): The cockpit said IDLE while four real test failures sat queued

### DIFF
--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -3344,6 +3344,12 @@ class BattleTestHarness:
                     cost_tracker=self._cost_tracker,
                     idle_watchdog=self._idle_watchdog,
                     governed_loop_service=self._governed_loop_service,
+                    # A CALLABLE, not the service: intake is assigned several
+                    # hundred lines below this point, so passing the attribute
+                    # here would capture None for the life of the process and
+                    # the status line would report ARMING forever.
+                    intake_service=lambda: getattr(
+                        self, "_intake_service", None),
                 )
                 register_status_line_builder(_status_builder)
                 logger.info("[Harness] StatusLineBuilder registered")

--- a/backend/core/ouroboros/battle_test/status_line.py
+++ b/backend/core/ouroboros/battle_test/status_line.py
@@ -272,10 +272,25 @@ class StatusLineBuilder:
         idle_watchdog: Any = None,
         governed_loop_service: Any = None,
         repair_engine: Any = None,
+        intake_service: Any = None,
     ) -> None:
         self._cost = cost_tracker
         self._idle = idle_watchdog
         self._gls = governed_loop_service
+        # The intake layer, so "IDLE" can stop meaning two opposite things.
+        #
+        # This builder used to sample ONLY the orchestrator's live FSM
+        # contexts, and returned IDLE whenever there were none. But work
+        # exists before an op does: sensors arm, sweep, and enqueue signals
+        # for a minute or more before the first FSM context is created. An
+        # operator watching a real boot saw `IDLE · $0.00` for two minutes
+        # while four genuine test failures sat queued behind it, and
+        # reasonably concluded the organism was broken.
+        #
+        # Read-only and zero-authority — the same pull model the attach
+        # bridge's providers use. Consulted fresh at every sample so the
+        # counts are current rather than cached at construction.
+        self._intake = intake_service
         # Repair engine may be passed explicitly (tests, direct wiring)
         # OR resolved lazily from ``gls._orchestrator._config.repair_engine``
         # during each snapshot — preferred because the harness doesn't
@@ -489,12 +504,79 @@ class StatusLineBuilder:
         extras = max(0, total - 1)
         return (primary or "", extras)
 
+    def _sample_intake_state(self) -> tuple:
+        """Return (phase, detail) describing the intake layer.
+
+        The state BELOW the orchestrator, and the reason this exists: an op
+        is the last thing to happen, not the first. Sensors register, sweep,
+        and enqueue signals well before any FSM context is created, and until
+        now every moment of that was rendered ``IDLE`` — the same word used
+        for an organism with genuinely nothing to do.
+
+        Precedence is most-actionable first, and every branch is decided by a
+        live count rather than a clock. Nothing here waits, sleeps, or guesses
+        at how long a boot "should" take:
+
+          queued > 0        WORK EXISTS and no op has claimed it yet. This is
+                            the state that was invisible: four real test
+                            failures sat here for two minutes reading IDLE.
+          sensors armed     Genuinely nothing to do — but SAY so, with the
+                            count, so an operator can tell "quiet" from
+                            "nothing is watching".
+          nothing yet       Still arming. Distinguished from idle because a
+                            sensor that has not registered cannot find
+                            anything, and reporting that as idle is the
+                            failure this whole change is about.
+
+        Degrades to the historical ``("IDLE", "")`` whenever intake is absent
+        or unreadable — a status line must never be the reason a cockpit
+        raises.
+        """
+        # Resolved at SAMPLE time, never at construction — the same lazy
+        # discipline this file already applies to the repair engine, and for
+        # the same reason: the builder is constructed early in the boot and
+        # the intake layer is assigned later. Capturing it in __init__ would
+        # freeze a permanent None and this whole state machine would report
+        # ARMING forever, which is a more confident lie than the IDLE it
+        # replaces. A callable is therefore accepted as well as an object.
+        intake = self._intake
+        if callable(intake):
+            try:
+                intake = intake()
+            except Exception:  # noqa: BLE001
+                intake = None
+        if intake is None:
+            return ("IDLE", "")
+
+        try:
+            sensors = len(getattr(intake, "_sensors", ()) or ())
+        except Exception:  # noqa: BLE001
+            sensors = 0
+
+        queued = None
+        try:
+            router = getattr(intake, "_router", None)
+            depth = getattr(router, "intake_queue_depth", None)
+            if callable(depth):
+                queued = int(depth())
+        except Exception:  # noqa: BLE001
+            queued = None
+
+        if queued:
+            return ("QUEUED", f"{queued} signal{'' if queued == 1 else 's'}")
+        if sensors:
+            # Deliberately still "IDLE" — the word is correct here. What was
+            # missing was the evidence beside it.
+            return ("IDLE", f"{sensors} sensors")
+        return ("ARMING", "")
+
     def _sample_phase_and_detail(self) -> tuple:
         """Return (phase, phase_detail).
 
         Sub-detail resolution order (first match wins):
           1. L2 Repair iteration (``repair_engine.is_running``)
           2. FSM phase name of the primary op + elapsed-in-phase
+          3. Intake state — sensors arming / signals queued / idle-with-count
         """
         # L2 Repair has highest-priority detail — it's the only phase
         # where operators explicitly asked for an iter/max breakdown.
@@ -515,14 +597,14 @@ class StatusLineBuilder:
                 pass
 
         if self._gls is None:
-            return ("IDLE", "")
+            return self._sample_intake_state()
 
         try:
             fsm_contexts = getattr(self._gls, "_fsm_contexts", None) or {}
         except Exception:  # noqa: BLE001
             fsm_contexts = {}
         if not fsm_contexts:
-            return ("IDLE", "")
+            return self._sample_intake_state()
 
         # Pick the most-recently-entered phase across all ops (same
         # selector as _sample_ops for consistency).
@@ -544,7 +626,7 @@ class StatusLineBuilder:
                 continue
 
         if not primary_phase:
-            return ("IDLE", "")
+            return self._sample_intake_state()
 
         # Elapsed-in-phase sub-detail (compact, e.g. "47s"). Only show
         # for phases where "how long has this been running?" is useful —

--- a/tests/battle_test/test_status_line_intake_state.py
+++ b/tests/battle_test/test_status_line_intake_state.py
@@ -1,0 +1,178 @@
+"""The status line must distinguish "nothing to do" from "not started yet".
+
+A real boot, watched by the operator:
+
+    22:18:20  session boots
+    22:19:05  cockpit reads  IDLE · $0.00/$0.50      <- screenshot taken here
+    22:20:32  TestFailureSensor enqueues 4 REAL failures
+    22:20:44  Advisor runs, Orchestrator reaches caution
+
+For two minutes the cockpit said IDLE while sensors were arming and then
+while four genuine test failures sat queued. The operator reasonably
+concluded the organism was broken. It was not — the status line simply had
+no handle on the intake layer, so every moment before the first FSM context
+existed rendered as the same word used for an organism with nothing to do.
+
+These tests pin the distinction, and the lazy resolution that makes it work.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from backend.core.ouroboros.battle_test.status_line import (  # noqa: E402
+    StatusLineBuilder,
+)
+
+
+class _Router:
+    def __init__(self, depth: int) -> None:
+        self._depth = depth
+
+    def intake_queue_depth(self) -> int:
+        return self._depth
+
+
+class _Intake:
+    """Shaped like the real IntakeLayerService for the two attributes read."""
+
+    def __init__(self, sensors: int, queued: int) -> None:
+        self._sensors = list(range(sensors))
+        self._router = _Router(queued)
+
+
+def _builder(intake) -> StatusLineBuilder:
+    # No governed loop service: the orchestrator has no live FSM context,
+    # which is exactly the window this change is about.
+    return StatusLineBuilder(governed_loop_service=None, intake_service=intake)
+
+
+# ---------------------------------------------------------------------------
+# the state that was invisible
+# ---------------------------------------------------------------------------
+
+def test_queued_signals_are_not_reported_as_idle() -> None:
+    """THE regression. Four enqueued failures read as IDLE for two minutes."""
+    phase, detail = _builder(_Intake(sensors=17, queued=4))._sample_phase_and_detail()
+    assert phase == "QUEUED", f"work was waiting and the line said {phase!r}"
+    assert "4" in detail
+
+
+def test_a_single_queued_signal_is_not_pluralised() -> None:
+    phase, detail = _builder(_Intake(sensors=17, queued=1))._sample_phase_and_detail()
+    assert (phase, detail) == ("QUEUED", "1 signal")
+
+
+def test_idle_still_says_idle_but_shows_its_evidence() -> None:
+    """The word was never wrong. What was missing was the count beside it —
+    the difference between "quiet" and "nothing is watching"."""
+    phase, detail = _builder(_Intake(sensors=17, queued=0))._sample_phase_and_detail()
+    assert phase == "IDLE"
+    assert "17 sensors" == detail
+
+
+def test_no_sensors_yet_is_arming_not_idle() -> None:
+    """A sensor that has not registered cannot find anything. Reporting that
+    as idle is the same failure, one step earlier in the boot."""
+    phase, _ = _builder(_Intake(sensors=0, queued=0))._sample_phase_and_detail()
+    assert phase == "ARMING"
+
+
+# ---------------------------------------------------------------------------
+# the wiring that makes it work at all
+# ---------------------------------------------------------------------------
+
+def test_intake_is_resolved_lazily_through_a_callable() -> None:
+    """The builder is constructed hundreds of lines before intake exists.
+
+    Passing the attribute eagerly captures None forever, and the status line
+    then reports ARMING for the life of the process — a more confident lie
+    than the IDLE it replaces.
+    """
+    box = {"intake": None}
+    builder = _builder(lambda: box["intake"])
+
+    assert builder._sample_phase_and_detail()[0] == "IDLE", (
+        "with nothing resolvable yet it must fall back, not invent a state"
+    )
+
+    box["intake"] = _Intake(sensors=17, queued=3)
+    phase, detail = builder._sample_phase_and_detail()
+    assert (phase, detail) == ("QUEUED", "3 signals"), (
+        "the callable was resolved once and cached — it must be sampled fresh"
+    )
+
+
+def test_the_harness_passes_a_callable_not_the_attribute() -> None:
+    """Structural, because the eager version fails silently and forever.
+
+    `_intake_service` is assigned well after `StatusLineBuilder(...)` is
+    constructed. A test that only exercised the builder would pass while the
+    shipped wiring captured None.
+    """
+    import inspect
+    from backend.core.ouroboros.battle_test import harness
+
+    src = inspect.getsource(harness)
+    idx = src.index("_status_builder = StatusLineBuilder(")
+    window = src[idx:idx + 700]
+    assert "intake_service=" in window, "the builder is not given intake at all"
+    assert "lambda" in window, (
+        "intake_service was passed eagerly; it must be a callable resolved "
+        "at sample time"
+    )
+
+
+# ---------------------------------------------------------------------------
+# it must never be the reason a cockpit breaks
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "intake",
+    [
+        None,
+        object(),                       # no _sensors, no _router
+        _Intake(sensors=3, queued=0),
+    ],
+    ids=["absent", "wrong-shape", "healthy"],
+)
+def test_it_never_raises(intake) -> None:
+    phase, detail = _builder(intake)._sample_phase_and_detail()
+    assert isinstance(phase, str) and isinstance(detail, str)
+
+
+def test_a_router_that_raises_degrades_to_sensor_count() -> None:
+    """A queue that cannot be read is not a queue that is empty — but it is
+    also not a reason to stop rendering. Report what IS known."""
+    class _Angry:
+        def intake_queue_depth(self):
+            raise RuntimeError("queue is mid-swap")
+
+    intake = _Intake(sensors=17, queued=0)
+    intake._router = _Angry()
+    phase, detail = _builder(intake)._sample_phase_and_detail()
+    assert (phase, detail) == ("IDLE", "17 sensors")
+
+
+def test_a_live_fsm_phase_still_wins() -> None:
+    """Intake is the state BELOW the orchestrator. Once an op exists, the op
+    is the answer — this must not shadow GENERATE/VALIDATE/APPLY."""
+    from datetime import datetime, timezone
+
+    class _Ctx:
+        phase = "GENERATE"
+        phase_entered_at = datetime.now(tz=timezone.utc)
+
+    class _GLS:
+        _fsm_contexts = {"op-1": _Ctx()}
+
+    b = StatusLineBuilder(
+        governed_loop_service=_GLS(),
+        intake_service=_Intake(sensors=17, queued=9),
+    )
+    assert b._sample_phase_and_detail()[0] == "GENERATE"


### PR DESCRIPTION
Watched on a real boot:

```
22:18:20  session boots
22:19:05  cockpit reads  IDLE · $0.00/$0.50     ← operator looks here
22:20:32  TestFailureSensor enqueues 4 REAL failures
22:20:44  Advisor scans, Orchestrator reaches caution (risk=0.47)
```

The organism was working perfectly. For two minutes the cockpit told the operator it was doing nothing, and the operator reasonably concluded it was broken.

## Root cause

`StatusLineBuilder` is constructed with `governed_loop_service` and nothing else. It samples the orchestrator's `_fsm_contexts` and returns `("IDLE", "")` whenever there are none. **It has no handle on the intake layer at all** — so sensors registering, sensors sweeping, and signals sitting in the dispatch queue are all structurally invisible to it.

An op is the *last* thing to happen, not the first. Everything before the first FSM context existed rendered as the same word used for an organism with genuinely nothing to do, which makes `IDLE` mean two opposite things with no way to tell which.

## The fix

Every branch decided by a live count. Nothing sleeps, polls a clock, or guesses how long a boot "should" take:

| condition | renders |
|---|---|
| `queued > 0` | `QUEUED · 4 signals` ← the state that was invisible |
| sensors armed | `IDLE · 17 sensors` ← still IDLE, now with its evidence |
| nothing yet | `ARMING` ← cannot find anything, so not idle |

**DRY:** `intake_queue_depth()` is already public on `UnifiedIntakeRouter`, and reading `_sensors` follows the precedent at `harness.py:1668`. Nothing was added to intake — it was simply never asked.

## The trap this would otherwise have fallen into

The builder is constructed at `harness.py:3343`; `_intake_service` is assigned at **3970**. Passing the attribute eagerly captures `None` for the life of the process and reports `ARMING` forever — *a more confident lie than the `IDLE` it replaces*.

So intake resolves **lazily through a callable**, the same discipline this file already applies to `repair_engine`. A structural test pins the callable, because the eager version fails silently and permanently.

## Resilience

Intake absent, wrong shape, or a router that raises mid-swap all fall back to what *is* known rather than to an exception. A live FSM phase still wins — this is the state *below* the orchestrator and must never shadow GENERATE/VALIDATE/APPLY.

**11 new tests · 199 status-line tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the cockpit status misreporting “IDLE” during boot while real failures were queued. The status line now shows intake activity before the first op: `QUEUED · n signal(s)`, `IDLE · n sensors`, or `ARMING`.

- **Bug Fixes**
  - `StatusLineBuilder` now samples intake via an `intake_service` callable and reports queue depth and sensor count using `intake_queue_depth()`.
  - Intake states apply only when no live FSM contexts exist; active phases still take precedence.
  - Resilient fallbacks: missing/wrong-shaped intake or router errors degrade to `IDLE` (with no exceptions).
  - 11 new tests (`test_status_line_intake_state.py`) cover pluralization, lazy wiring, and failure modes; existing 199 status-line tests pass.

<sup>Written for commit 49a3a4dc3dd0791cda85de9c32c844a3dd464783. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

