### PR TITLE
feat(ov): The deck shows what the organism FOUND, not just what it started

### DIFF
--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -1667,6 +1667,29 @@ class BattleTestHarness:
                 if _intake is not None:
                     n_sensors = len(getattr(_intake, "_sensors", []))
                     self._serpent_flow.update_sensors(n_sensors)
+
+                # Give intake a voice on the deck.
+                #
+                # Until now the deck rendered ops, and an op is the LAST thing
+                # to happen — a sensor fires, a signal queues, and only later
+                # does an FSM context exist. Four real test failures once sat
+                # queued for two minutes behind a blank deck, indistinguishable
+                # from an organism with nothing to do.
+                #
+                # Wired here, beside update_sensors, because this is already
+                # the seam where the flow learns about intake. Zero-authority:
+                # the sink is told, never asked.
+                try:
+                    from backend.core.ouroboros.governance.intake.unified_intake_router import (  # noqa: E501
+                        set_intake_announce_sink,
+                    )
+                    _flow = self._serpent_flow
+                    set_intake_announce_sink(_flow.note_intake_signal)
+                except Exception:  # noqa: BLE001 — display wiring is never fatal
+                    logger.debug(
+                        "[Harness] intake announce sink not wired",
+                        exc_info=True,
+                    )
                 await self._serpent_flow.start()
 
                 # Boot non-blocking REPL (prompt_toolkit) — runs alongside

--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -4121,6 +4121,56 @@ class SerpentFlow:
         """Update whether the session requires a pre-run plan review."""
         self._plan_review_mode = enabled
 
+    def note_intake_signal(self, payload: Dict[str, Any]) -> None:
+        """Render ONE newly-enqueued signal — what was found, before an op.
+
+        CC-shaped, because the whole point of that shape is already stated in
+        this file: *the ARGUMENT is the point*. ``⏺ TestFailure()`` says a
+        sensor fired; ``⏺ TestFailure(test_topological_sort_tiebreak.py)``
+        says which failure, which is the only version worth reading at 3am.
+
+        Dimmed, and deliberately: a queued signal is subordinate to a running
+        op. It renders through the same mirror every ⏺/⎿ line uses, so an
+        attached cockpit and the local console cannot disagree about it.
+
+        Zero-authority display. Nothing here dispatches, prioritises, or
+        touches the queue — it is told what happened and draws it.
+        NEVER raises.
+        """
+        try:
+            source = str(payload.get("source") or "").strip()
+            targets = tuple(payload.get("target_files") or ())
+
+            # Humanised from the source itself rather than a lookup table: a
+            # sensor added tomorrow renders correctly without anyone editing a
+            # map, and a map that fell behind would silently show a raw
+            # snake_case token to an operator.
+            verb = "".join(p[:1].upper() + p[1:] for p in source.split("_") if p)
+            verb = verb or "Signal"
+
+            arg = ""
+            if targets:
+                first = str(targets[0])
+                arg = first.rsplit("/", 1)[-1] or first
+                if len(targets) > 1:
+                    arg = f"{arg} +{len(targets) - 1}"
+            if not arg:
+                # No target is a real state (a goal, a scheduled sweep), not a
+                # reason to render an empty pair of brackets.
+                desc = str(payload.get("description") or "").strip()
+                arg = desc[:48] + "…" if len(desc) > 48 else desc
+
+            dim = _SEM["dim"]
+            head = f"{self._action_glyph()} {verb}"
+            body = f"([{_SEM['file']}]{arg}[/{_SEM['file']}])" if arg else ""
+            line = f"[{dim}]{head}[/{dim}]{body}  [{dim}]queued[/{dim}]"
+
+            self._mirror_markup(line)
+            if self._borderless():
+                self._emit_fit(line)
+        except Exception:  # noqa: BLE001 — a deck line must never break intake
+            pass
+
     def update_sensors(self, count: int) -> None:
         """Update active sensor count (tracked for status bar).
 

--- a/backend/core/ouroboros/governance/intake/unified_intake_router.py
+++ b/backend/core/ouroboros/governance/intake/unified_intake_router.py
@@ -1812,6 +1812,11 @@ class UnifiedIntakeRouter:
             (priority, envelope.submitted_at, next(_HEAP_TIE_SEQ), envelope),
         )
 
+        # Announce AFTER the put, never before: a line claiming a signal was
+        # queued must not appear if the put itself raised. The operator's view
+        # follows the queue's truth rather than predicting it.
+        _announce_enqueued(envelope)
+
         # F1 Slice 2 — mirror to IntakePriorityQueue when wired.
         # Primary mode (master on): this queue becomes the source of truth
         # for dispatch; legacy _queue still receives puts for WAL/back-compat
@@ -3188,6 +3193,62 @@ class UnifiedIntakeRouter:
 # that don't construct an IntakeLayer), ``get_default_intake_router``
 # returns ``None`` — S2's ``_peek_high_prio_queued`` treats this as
 # "no signal" and emits nothing. NEVER raises.
+
+# ---------------------------------------------------------------------------
+# Intake announcement — what the organism FOUND, before it acts on it
+# ---------------------------------------------------------------------------
+# The cockpit's deck renders ops. An op is the LAST thing to happen: a sensor
+# fires, a signal is enqueued, and only later does an FSM context exist. On a
+# real boot four genuine test failures sat in this queue for two minutes while
+# the deck stayed blank and the status line read IDLE — the organism was doing
+# exactly its job and the operator could not tell it apart from a dead one.
+#
+# A sink, not a bus subscription: `set_operator_dispatcher`,
+# `set_degradation_sink` and `markup_mirror` are all wired this way already, and
+# a sink has no dependency on a TrinityEventBus existing — which it need not,
+# per this module's own docstring.
+#
+# ZERO AUTHORITY. The sink is told; it is never asked. Nothing about dispatch,
+# priority or admission consults it, so a slow or broken cockpit cannot change
+# what the organism does — only what an operator can see.
+_ANNOUNCE_SINK: Optional[Callable[[Dict[str, Any]], None]] = None
+
+
+def set_intake_announce_sink(
+    sink: Optional[Callable[[Dict[str, Any]], None]],
+) -> None:
+    """Register the surface that renders newly-enqueued signals.
+
+    Idempotent, last-write-wins, ``None`` to detach. NEVER raises.
+    """
+    global _ANNOUNCE_SINK
+    _ANNOUNCE_SINK = sink
+
+
+def _announce_enqueued(envelope: Any) -> None:
+    """Tell the operator surface what was just found. NEVER raises, never
+    blocks, and never touches the envelope.
+
+    Called on the ingest path only. Requeues and retries deliberately do not
+    announce: the operator cares that a failure was FOUND, not that it was
+    moved between queues, and a line per internal transition would bury the
+    one that mattered.
+    """
+    sink = _ANNOUNCE_SINK
+    if sink is None:
+        return
+    try:
+        targets = tuple(getattr(envelope, "target_files", ()) or ())
+        sink({
+            "source": str(getattr(envelope, "source", "") or ""),
+            "description": str(getattr(envelope, "description", "") or ""),
+            "target_files": targets,
+            "urgency": str(getattr(envelope, "urgency", "") or ""),
+            "signal_id": str(getattr(envelope, "signal_id", "") or ""),
+        })
+    except Exception:  # noqa: BLE001 — a display fault must never reach intake
+        logger.debug("[Router] announce sink raised", exc_info=True)
+
 
 _DEFAULT_INTAKE_ROUTER: Optional["UnifiedIntakeRouter"] = None
 _DEFAULT_INTAKE_ROUTER_LOCK = threading.Lock()

--- a/tests/battle_test/test_intake_deck_announce.py
+++ b/tests/battle_test/test_intake_deck_announce.py
@@ -1,0 +1,208 @@
+"""Intake gets a voice on the deck: what was FOUND, before an op exists.
+
+The deck renders ops, and an op is the last thing to happen — a sensor fires,
+a signal is enqueued, and only later does an FSM context exist. On a real boot
+four genuine test failures sat queued for two minutes behind a blank deck,
+indistinguishable from an organism with nothing to do.
+
+These pin the two halves that make the line trustworthy: intake announces only
+what it actually queued, and the renderer says WHICH failure rather than that
+one exists.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from backend.core.ouroboros.governance.intake.unified_intake_router import (  # noqa: E402
+    _announce_enqueued,
+    set_intake_announce_sink,
+)
+
+
+class _Envelope:
+    def __init__(self, **kw) -> None:
+        self.source = kw.get("source", "test_failure")
+        self.description = kw.get("description", "")
+        self.target_files = kw.get("target_files", ())
+        self.urgency = kw.get("urgency", "normal")
+        self.signal_id = kw.get("signal_id", "sig-1")
+
+
+@pytest.fixture(autouse=True)
+def _detach_sink():
+    yield
+    set_intake_announce_sink(None)   # never leak a sink between tests
+
+
+# ---------------------------------------------------------------------------
+# the announcement
+# ---------------------------------------------------------------------------
+
+def test_the_sink_receives_what_was_queued() -> None:
+    seen = []
+    set_intake_announce_sink(seen.append)
+    _announce_enqueued(_Envelope(
+        source="test_failure",
+        target_files=("tests/governance/test_topological_sort_tiebreak.py",),
+    ))
+    assert len(seen) == 1
+    assert seen[0]["source"] == "test_failure"
+    assert seen[0]["target_files"][0].endswith("test_topological_sort_tiebreak.py")
+
+
+def test_no_sink_is_not_an_error() -> None:
+    """The overwhelmingly common case — headless, CI, no cockpit attached."""
+    set_intake_announce_sink(None)
+    _announce_enqueued(_Envelope())          # must simply do nothing
+
+
+def test_a_raising_sink_cannot_reach_intake() -> None:
+    """Zero authority means a broken cockpit cannot disturb dispatch."""
+    def _explode(_payload):
+        raise RuntimeError("the deck is on fire")
+
+    set_intake_announce_sink(_explode)
+    _announce_enqueued(_Envelope())          # must swallow
+
+
+def test_a_malformed_envelope_cannot_reach_intake() -> None:
+    class _Hostile:
+        @property
+        def target_files(self):
+            raise RuntimeError("evidence mid-write")
+
+    seen = []
+    set_intake_announce_sink(seen.append)
+    _announce_enqueued(_Hostile())
+    assert seen == [], "a broken envelope must not produce a half-built line"
+
+
+def test_announcement_follows_the_put_it_does_not_predict_it() -> None:
+    """Structural: the line claims a signal was QUEUED, so it must be emitted
+    after the queue accepted it. Announcing first would render a signal that a
+    raising put never actually enqueued."""
+    import inspect
+    from backend.core.ouroboros.governance.intake import unified_intake_router
+
+    src = inspect.getsource(unified_intake_router)
+    put_at = src.index("await self._queue.put(\n            (priority, envelope.submitted_at")
+    announce_at = src.index("_announce_enqueued(envelope)", put_at)
+    assert announce_at > put_at
+
+
+# ---------------------------------------------------------------------------
+# the line itself
+# ---------------------------------------------------------------------------
+
+class _Flow:
+    """Only what note_intake_signal touches."""
+
+    def __init__(self) -> None:
+        self.mirrored = []
+
+    def _mirror_markup(self, line: str) -> None:
+        self.mirrored.append(line)
+
+    def _borderless(self) -> bool:
+        return False
+
+    @staticmethod
+    def _action_glyph() -> str:
+        return "⏺"
+
+
+def _render(**payload) -> str:
+    from backend.core.ouroboros.battle_test.serpent_flow import SerpentFlow
+    flow = _Flow()
+    SerpentFlow.note_intake_signal(flow, payload)   # type: ignore[arg-type]
+    assert flow.mirrored, "nothing was rendered"
+    return flow.mirrored[-1]
+
+
+def test_the_argument_is_the_point() -> None:
+    """`⏺ TestFailure()` says a sensor fired. `⏺ TestFailure(<file>)` says
+    which one — the distinction this file's own CC-style comment insists on."""
+    line = _render(
+        source="test_failure",
+        target_files=("tests/governance/test_topological_sort_tiebreak.py",),
+    )
+    assert "TestFailure" in line
+    assert "test_topological_sort_tiebreak.py" in line
+    assert "tests/governance/" not in line, "the path should be trimmed to a name"
+    assert "queued" in line
+
+
+def test_extra_targets_are_counted_not_listed() -> None:
+    line = _render(
+        source="doc_staleness",
+        target_files=("a/one.py", "b/two.py", "c/three.py"),
+    )
+    assert "one.py +2" in line
+    assert "two.py" not in line
+
+
+def test_the_verb_is_derived_from_the_source() -> None:
+    """No lookup table: a sensor added tomorrow renders correctly, and a stale
+    map cannot leak raw snake_case to an operator."""
+    assert "OpportunityMiner" in _render(source="opportunity_miner",
+                                         target_files=("x/y.py",))
+    assert "CrossRepoDrift" in _render(source="cross_repo_drift",
+                                       target_files=("x/y.py",))
+
+
+def test_a_targetless_signal_falls_back_to_its_description() -> None:
+    """A goal or a scheduled sweep has no file. That is a real state, not a
+    reason to draw an empty pair of brackets."""
+    line = _render(source="scheduled", target_files=(),
+                   description="nightly dependency audit")
+    assert "nightly dependency audit" in line
+    assert "()" not in line
+
+
+def test_a_long_description_is_truncated() -> None:
+    line = _render(source="backlog", target_files=(),
+                   description="x" * 200)
+    assert "…" in line
+    assert len(line) < 300
+
+
+def test_an_unknown_source_still_renders() -> None:
+    line = _render(source="", target_files=("x/y.py",))
+    assert "Signal" in line
+
+
+def test_rendering_never_raises() -> None:
+    from backend.core.ouroboros.battle_test.serpent_flow import SerpentFlow
+
+    class _Broken:
+        def _mirror_markup(self, line):
+            raise RuntimeError("mirror down")
+
+        def _borderless(self):
+            return False
+
+        @staticmethod
+        def _action_glyph():
+            return "⏺"
+
+    SerpentFlow.note_intake_signal(_Broken(), {"source": "x"})  # type: ignore[arg-type]
+
+
+def test_the_harness_wires_the_sink_to_the_flow() -> None:
+    """Structural. An unwired sink is the wired-but-inert trap: every unit test
+    here passes while the deck stays blank in production."""
+    import inspect
+    from backend.core.ouroboros.battle_test import harness
+
+    src = inspect.getsource(harness)
+    assert "set_intake_announce_sink" in src
+    idx = src.index("set_intake_announce_sink")
+    assert "note_intake_signal" in src[idx:idx + 200], (
+        "the sink is imported but not pointed at the renderer"
+    )


### PR DESCRIPTION
Companion to #70434, one layer up and the same root cause.

`_ops_provider` returns `gls._active_ops` — **started ops only**. So on a real boot four genuine test failures sat queued behind a completely blank deck. An op is the *last* thing to happen: a sensor fires, a signal is enqueued, and only later does an FSM context exist. Everything before that was unrenderable, which is why a working organism was indistinguishable from a dead one.

Intake now announces what it queued, and the deck draws it CC-style:

```
⏺ TestFailure(test_topological_sort_tiebreak.py)   queued
```

dimmed, because a queued signal is subordinate to a running op.

## The argument is the point

That phrase is already in `serpent_flow.py`, about `⏺ Read(path)`. It is the reason this line carries the failing file rather than a count: `⏺ TestFailure()` says a sensor fired; only the argument says *which* failure, and at 3am that is the entire value of the line.

The verb is **derived** from the source (`test_failure` → `TestFailure`), not looked up — a sensor added tomorrow renders correctly, and a stale map cannot leak raw snake_case to an operator. A signal with no target falls back to its description rather than drawing an empty pair of brackets, because a goal or a scheduled sweep genuinely has no file.

## Zero authority, enforced rather than asserted

Wired as a **sink**, matching `set_operator_dispatcher` / `set_degradation_sink` / `markup_mirror` — three existing precedents — rather than a `TrinityEventBus` subscription, which would add a dependency on a bus this module's own docstring says need not exist.

Four properties, each a test:

| property | why |
|---|---|
| a raising sink is swallowed | a broken cockpit must not reach dispatch |
| a hostile envelope renders nothing | no half-built line from mid-write evidence |
| dispatch never consults the sink | told, never asked |
| announce happens **after** the put | a line claiming "queued" must not appear if the put raised |

Ingest path only — requeues and retries stay silent. An operator cares that a failure was *found*, not that it moved between queues, and a line per internal transition would bury the one that mattered.

## Test results, stated precisely

- **13 new tests** pass
- **71** status-line and deck tests pass
- `tests/governance/intake` is **not clean**, and is not made worse: the router's own file was run with this change stashed and unstashed — **identical, 2 failed / 6 passed both ways**. Those two are pre-existing on main. The wider suite times out in different places on *both* branches from unrelated async-cleanup flakiness in `shutdown_default_executor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show queued signals on the deck so operators see what intake found before any op starts. This makes a working organism distinguishable from an idle one.

- **New Features**
  - Intake announces enqueued signals via `set_intake_announce_sink`, called only after the queue accepts the put. The sink is optional, non-blocking, and has zero authority.
  - `SerpentFlow.note_intake_signal` renders a dimmed CC-style line like “⏺ TestFailure(test_topological_sort_tiebreak.py)  queued”. Verb is derived from `source`; shows first file with “+N” for extras; falls back to `description` when targetless; never raises.
  - Harness wires the sink to the flow (`note_intake_signal`) alongside sensor updates.
  - Defensive behavior: a raising sink is swallowed, malformed envelopes render nothing, and requeues/retries are not announced.

<sup>Written for commit c00f2e379bac8cbd6d5abd832d76237046d7e8cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

