### PR TITLE
fix(ov): The breadcrumb re-asserted IDLE over an answer already computed

### DIFF
--- a/backend/core/ouroboros/battle_test/presentation_restraint.py
+++ b/backend/core/ouroboros/battle_test/presentation_restraint.py
@@ -1184,6 +1184,7 @@ def format_idle_breadcrumb(
     cost_budget: float = 0.0,
     posture: str = "",
     op_id: str = "",
+    detail: str = "",
 ) -> str:
     """One-line breadcrumb for the IDLE phase — replaces the silent
     empty status line that today leaves operators wondering whether
@@ -1197,7 +1198,21 @@ def format_idle_breadcrumb(
     Format: ``IDLE · main · $0.04/$0.50 · EXPLORE`` — only includes
     fields the caller supplies. NEVER raises.
     """
+    # "IDLE" plus the evidence for it, when the caller has any.
+    #
+    # This used to be the bare literal, and the literal was the bug: the
+    # sampler upstream had already worked out that the organism was idle with
+    # 17 sensors armed, or that 4 signals were queued and no op had claimed
+    # them — and every word of that was discarded here, because this function
+    # re-asserted the state instead of rendering the one it was handed.
+    #
+    # An operator watching a real boot therefore read `IDLE` for two minutes
+    # while four genuine test failures sat in the queue, and could not tell it
+    # apart from an organism with nothing to do. The detail IS the difference
+    # between those two, which makes dropping it the whole defect.
     parts: List[str] = ["IDLE"]
+    if isinstance(detail, str) and detail:
+        parts[0] = f"IDLE · {detail}"
     if isinstance(branch, str) and branch:
         parts.append(branch)
     if cost_budget > 0.0:

--- a/backend/core/ouroboros/battle_test/status_line.py
+++ b/backend/core/ouroboros/battle_test/status_line.py
@@ -216,6 +216,13 @@ def _statusline_payload(snapshot: Any = None) -> str:
             # things an O+V operator most wants on a status line, so they
             # ride alongside rather than being contorted into CC's shape.
             payload["phase"] = getattr(snap, "phase", "") or "IDLE"
+            # The qualifier travels WITH the phase or it does not travel at
+            # all. "IDLE" and "IDLE, 17 sensors armed" are different claims,
+            # and a payload carrying only the first forces every downstream
+            # surface to render the ambiguous one.
+            _detail = getattr(snap, "phase_detail", "") or ""
+            if _detail:
+                payload["phase_detail"] = _detail
             if getattr(snap, "route", ""):
                 payload["route"] = snap.route
             # `.model.id` must be the MODEL. This reported `snap.provider`,
@@ -841,6 +848,11 @@ def _format_plain(snap: StatusSnapshot, *, compact: bool) -> str:
                 cost_spent=snap.cost_spent_usd,
                 cost_budget=snap.cost_budget_usd,
                 op_id=snap.primary_op_id or "",
+                # The sampler already worked out WHY it is idle — how many
+                # sensors are armed, or that nothing has registered yet.
+                # Not forwarding it meant the breadcrumb re-asserted a bare
+                # "IDLE" over an answer that had already been computed.
+                detail=getattr(snap, "phase_detail", "") or "",
             )
             # A dry provider runway is MOST relevant while idle — the
             # organism may be idle BECAUSE it is dry. The one exception

--- a/tests/battle_test/test_idle_breadcrumb_carries_detail.py
+++ b/tests/battle_test/test_idle_breadcrumb_carries_detail.py
@@ -1,0 +1,116 @@
+"""The idle breadcrumb must render the state it was handed, not re-assert one.
+
+An operator watched a real boot and read `IDLE · $0.00/$2.50` for two minutes
+while four genuine test failures sat queued. The sampler had already worked out
+the truth — 17 sensors armed, then 4 signals queued — and every word of it was
+discarded at two seams:
+
+  * `format_idle_breadcrumb` opened with the literal ``["IDLE"]`` and took no
+    detail argument at all;
+  * `_statusline_payload` carried ``phase`` and not ``phase_detail``.
+
+So `IDLE · 17 sensors` could never have reached a screen regardless of whether
+intake was wired, and the two possible causes were indistinguishable.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from backend.core.ouroboros.battle_test.presentation_restraint import (  # noqa: E402
+    format_idle_breadcrumb,
+)
+from backend.core.ouroboros.battle_test.status_line import (  # noqa: E402
+    StatusSnapshot,
+    _format_plain,
+    _statusline_payload,
+)
+
+
+# ---------------------------------------------------------------------------
+# the breadcrumb
+# ---------------------------------------------------------------------------
+
+def test_the_breadcrumb_renders_the_detail_it_is_given() -> None:
+    crumb = format_idle_breadcrumb(detail="17 sensors")
+    assert crumb.startswith("IDLE · 17 sensors"), crumb
+
+
+def test_idle_without_detail_is_unchanged() -> None:
+    """The historical shape, for every caller that has nothing to add."""
+    assert format_idle_breadcrumb(cost_spent=0.04, cost_budget=0.5) == (
+        "IDLE · $0.04/$0.50"
+    )
+
+
+def test_detail_precedes_the_other_fields() -> None:
+    """Why the organism is idle outranks how much it has spent being idle."""
+    crumb = format_idle_breadcrumb(
+        detail="17 sensors", cost_spent=0.0, cost_budget=2.5, op_id="abc-sig",
+    )
+    assert crumb.index("17 sensors") < crumb.index("$0.00")
+
+
+@pytest.mark.parametrize("bad", [None, 0, [], {}])
+def test_a_non_string_detail_is_ignored_not_rendered(bad) -> None:
+    assert format_idle_breadcrumb(detail=bad) == "IDLE"   # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# the seam that dropped it
+# ---------------------------------------------------------------------------
+
+def test_the_plain_renderer_forwards_phase_detail() -> None:
+    """THE regression. `_format_plain` took the breadcrumb path for IDLE and
+    called it without the detail, so the sampler's answer was thrown away one
+    line after it was computed."""
+    out = _format_plain(
+        StatusSnapshot(phase="IDLE", phase_detail="17 sensors",
+                       cost_spent_usd=0.0, cost_budget_usd=2.5),
+        compact=False,
+    )
+    assert "17 sensors" in out, out
+
+
+def test_a_queued_phase_is_not_swallowed_by_the_idle_path() -> None:
+    """QUEUED is not IDLE and must not be routed through the idle breadcrumb —
+    that branch exists to compress the *quiet* state."""
+    out = _format_plain(
+        StatusSnapshot(phase="QUEUED", phase_detail="4 signals"),
+        compact=False,
+    )
+    assert "QUEUED" in out
+    assert "4 signals" in out
+
+
+# ---------------------------------------------------------------------------
+# the payload that dropped it
+# ---------------------------------------------------------------------------
+
+def test_the_payload_carries_the_qualifier_with_the_phase() -> None:
+    """"IDLE" and "IDLE, 17 sensors armed" are different claims. A payload
+    carrying only the first forces every downstream surface to render the
+    ambiguous one."""
+    payload = json.loads(_statusline_payload(
+        StatusSnapshot(phase="IDLE", phase_detail="17 sensors"),
+    ))
+    assert payload.get("phase") == "IDLE"
+    assert payload.get("phase_detail") == "17 sensors"
+
+
+def test_the_payload_omits_an_empty_qualifier() -> None:
+    """Absent, not empty-string: a consumer testing truthiness and one testing
+    presence must reach the same conclusion."""
+    payload = json.loads(_statusline_payload(StatusSnapshot(phase="IDLE")))
+    assert "phase_detail" not in payload
+
+
+def test_the_payload_still_defaults_phase() -> None:
+    payload = json.loads(_statusline_payload(StatusSnapshot(phase="")))
+    assert payload.get("phase") == "IDLE"


### PR DESCRIPTION
Live boot, watched by the operator: `IDLE · $0.00/$2.50` for two minutes while four genuine test failures sat queued.

#70434 taught the sampler to work out exactly that — 17 sensors armed, then 4 signals queued. The answer was then thrown away **twice** on its way to the screen:

| seam | what it did |
|---|---|
| `format_idle_breadcrumb` | opened with the literal `["IDLE"]` and took **no detail argument at all** — it re-asserted the state instead of rendering the one it was handed |
| `_statusline_payload` | carried `phase` and not `phase_detail` |

So `IDLE · 17 sensors` could never have reached a screen no matter what the sampler concluded.

**That is the part that matters most.** With the detail dropped, *"intake was unreachable"* and *"intake answered and nobody printed it"* were indistinguishable. Fixing the drops does not merely add a word — it makes the remaining unknown observable instead of guessable.

## Third divergent-surface instance today

After the slash palette (bipartite vs PromptSession) and the status line (`StatusLineBuilder` vs this breadcrumb). The lesson keeps arriving from new directions: **a value computed correctly and then re-derived downstream has two authorities, and the second one always wins on screen.**

## Compatibility

`IDLE` with no detail renders exactly as before, so every existing caller is untouched. `QUEUED` and `ARMING` never take the breadcrumb path — that branch exists to compress the *quiet* state, and a non-empty queue is not quiet. The qualifier is omitted from the payload rather than sent empty, so a consumer testing truthiness and one testing presence reach the same conclusion.

**12 new tests · 83 status-line/breadcrumb/deck tests pass · 89 across the restraint suite.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the idle breadcrumb dropping the computed detail and reasserting bare IDLE, so operators now see the actual qualifier (e.g., "IDLE · 17 sensors") instead of an ambiguous state.

- **Bug Fixes**
  - `format_idle_breadcrumb` now accepts a `detail` string and renders "IDLE · {detail}" when provided; non-strings are ignored; no-detail output is unchanged.
  - `_statusline_payload` includes `phase_detail` when present, and `_format_plain` forwards it to the breadcrumb; `QUEUED`/`ARMING` paths remain unchanged.

<sup>Written for commit 00ff479a71c07a3f18b149759706d4961a0d5d2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

