### PR TITLE
fix(ov): The session ceiling is derived from receipts, not declared twice

### DIFF
--- a/backend/core/ouroboros/battle_test/session_economics.py
+++ b/backend/core/ouroboros/battle_test/session_economics.py
@@ -1,0 +1,271 @@
+"""What a session costs, learned from the sessions that already ran.
+
+WHY THIS EXISTS
+---------------
+The cockpit's cost ceiling was the literal ``"2.50"``, written twice — once for
+the detached cold boot and once for the launchd agent. Two copies of a magic
+number, and no record anywhere of what it was based on.
+
+It was not a bad guess. This repository holds 772 sessions with a recorded
+``cost_total``, and their 95th percentile is $0.77 against a maximum of $5.95,
+so a ceiling near $2.50 sits about where a considered one would. That is
+precisely the problem: a number that happens to be right, asserted with no
+basis, is indistinguishable from one that happens to be wrong. When the
+economics change — a cheaper model, a new provider, a quiet week — nothing
+tells anyone the constant has drifted away from reality.
+
+So the ceiling is now DERIVED from the sessions that actually spent money, and
+it carries the basis it was derived from. A proactive organism should not need
+to be told what it can afford; it has been keeping the receipts.
+
+WHAT THE CEILING IS FOR
+-----------------------
+A safety ceiling, not a forecast. It must be generous enough that an ordinary
+productive session is never truncated, and tight enough that a runaway is
+caught before it empties an account. That is a high quantile of observed spend
+multiplied by headroom — not a mean, which a single expensive session drags,
+and not a maximum, which IS the runaway case.
+
+Sessions that cost nothing are excluded from the quantile. Two thirds of the
+history spent something; the rest booted, found no work, and exited. Including
+them would drag the quantile toward zero and produce a ceiling that stops the
+first session that tries to do anything.
+
+READING IS CHEAP, ON PURPOSE
+----------------------------
+Session directories are named ``bt-YYYY-MM-DD-HHMMSS``, so lexical order IS
+chronological order. The newest N are selected by sorting names — no ``stat``
+call per directory, and no walking 950 of them at every boot. This runs once,
+during a cold boot, and must not become a reason the cockpit feels slow.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+logger = logging.getLogger("Ouroboros.SessionEconomics")
+
+#: Where sessions record what they spent.
+_SESSIONS_ENV = "JARVIS_SESSIONS_DIR"
+_SESSIONS_DEFAULT = ".ouroboros/sessions"
+
+#: The quantile of observed spend the ceiling is built on. High rather than
+#: central: the ceiling exists to not truncate a normal session, and the
+#: median session is far cheaper than the expensive-but-legitimate one.
+_QUANTILE_ENV = "JARVIS_COCKPIT_CAP_QUANTILE"
+#: Multiplier over that quantile. This is the whole safety margin, and the one
+#: number an operator might reasonably want to move.
+_HEADROOM_ENV = "JARVIS_COCKPIT_CAP_HEADROOM"
+#: How many recent sessions inform the estimate. Bounded so a long-lived
+#: repository does not make a cold boot read thousands of files.
+_SAMPLE_ENV = "JARVIS_COCKPIT_CAP_SAMPLE"
+#: Used ONLY when the history has nothing to say. Reported as unmeasured so it
+#: is never mistaken for an observation.
+_FALLBACK_ENV = "JARVIS_COCKPIT_CAP_FALLBACK"
+
+#: The smallest ceiling worth booting with. A derived value below this means
+#: the history is unrepresentative (a quiet week, a fresh clone), not that the
+#: organism should be unable to complete a single operation.
+_FLOOR_ENV = "JARVIS_COCKPIT_CAP_FLOOR"
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = str(os.environ.get(name, "")).strip()
+    if not raw:
+        return default
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        logger.debug("[Economics] ignoring malformed %s=%r", name, raw)
+        return default
+    return value if value > 0 else default
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = str(os.environ.get(name, "")).strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        logger.debug("[Economics] ignoring malformed %s=%r", name, raw)
+        return default
+    return value if value > 0 else default
+
+
+def sessions_dir() -> Path:
+    return Path(os.environ.get(_SESSIONS_ENV, "") or _SESSIONS_DEFAULT)
+
+
+def observed_session_costs(limit: Optional[int] = None) -> List[float]:
+    """Costs of the most recent sessions that spent anything, newest first.
+
+    Selection is by directory NAME, not mtime: ``bt-YYYY-MM-DD-HHMMSS`` sorts
+    lexically in chronological order, so the newest N are found without a stat
+    per directory. A malformed or truncated summary is skipped rather than
+    treated as a zero — an unreadable session is not a free one.
+    """
+    limit = limit if limit is not None else _env_int(_SAMPLE_ENV, 200)
+    root = sessions_dir()
+    try:
+        names = sorted(
+            (e.name for e in os.scandir(root) if e.is_dir()), reverse=True,
+        )[:limit]
+    except OSError:
+        return []
+
+    costs: List[float] = []
+    for name in names:
+        try:
+            with open(root / name / "summary.json", "r", encoding="utf-8") as fh:
+                total = json.load(fh).get("cost_total")
+        except (OSError, ValueError, TypeError):
+            continue
+        if isinstance(total, (int, float)) and not isinstance(total, bool):
+            value = float(total)
+            # Zero-cost sessions booted, found nothing, and exited. They are
+            # real sessions but they carry no information about what work
+            # costs, and including them drags the quantile toward a ceiling
+            # that would stop the first session that tries to do anything.
+            if value > 0.0:
+                costs.append(value)
+    return costs
+
+
+def _quantile(sorted_values: List[float], q: float) -> float:
+    if not sorted_values:
+        return 0.0
+    idx = int(q * len(sorted_values))
+    return sorted_values[min(max(idx, 0), len(sorted_values) - 1)]
+
+
+def _censored(ordered: List[float]) -> bool:
+    """Is this distribution truncated by the ceiling it is meant to inform?
+
+    A cap does not merely limit spend — it limits the RECORD of spend. Every
+    session it stopped is written down at almost exactly the cap, so the
+    largest observations cluster on one value. Estimating a new ceiling from
+    that tail is circular: it extrapolates from numbers the old ceiling chose.
+
+    The signature is a pile-up, not a maximum. One session near the top is an
+    ordinary tail; several within a hair of each other is a wall. Detected
+    rather than assumed, because today's history happens to be clean (a single
+    session at $2.4956 under a $2.50 cap) and that is exactly the condition
+    that will change quietly.
+    """
+    if len(ordered) < 4:
+        return False
+    top = ordered[-1]
+    if top <= 0:
+        return False
+    return sum(1 for v in ordered if v >= top * 0.99) > 1
+
+
+def _aegis_ceiling() -> Optional[float]:
+    """The session budget Aegis already enforces, if an operator declared one.
+
+    Read rather than duplicated. Aegis is the existing budget authority in this
+    system; a cockpit ceiling that ignored it would be a second budget, and two
+    budgets means the effective limit is whichever one nobody remembered.
+    """
+    try:
+        from backend.core.ouroboros.aegis.flags import (
+            ENV_AEGIS_SESSION_CAP_USD,
+        )
+    except Exception:  # noqa: BLE001
+        return None
+    raw = str(os.environ.get(ENV_AEGIS_SESSION_CAP_USD, "")).strip()
+    if not raw:
+        return None
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return None
+    return value if value > 0 else None
+
+
+def derived_cost_cap() -> Tuple[float, str]:
+    """The session ceiling and the basis it rests on.
+
+    Returns ``(usd, basis)``. The basis is not decoration — it is the
+    difference between "this ceiling reflects 143 sessions of real spend" and
+    "nobody has ever measured this", and a surface that shows the number
+    without it repeats the exact defect this replaces.
+    """
+    quantile = min(max(_env_float(_QUANTILE_ENV, 0.95), 0.5), 0.999)
+    headroom = _env_float(_HEADROOM_ENV, 3.0)
+    floor = _env_float(_FLOOR_ENV, 0.50)
+    fallback = _env_float(_FALLBACK_ENV, 2.50)
+
+    costs = observed_session_costs()
+    if not costs:
+        return (fallback, "unmeasured — no prior session recorded a cost")
+
+    ordered = sorted(costs)
+    note = ""
+    if _censored(ordered):
+        # The tail is the old ceiling's shadow, not evidence. Step the
+        # quantile down into the body of the distribution, where the numbers
+        # are sessions that ended because they finished rather than because
+        # they were stopped — and say so, so the estimate is never mistaken
+        # for a reading of the full range.
+        quantile = min(quantile, 0.75)
+        note = " (tail censored by a prior cap; estimated from the body)"
+
+    base = _quantile(ordered, quantile)
+    derived = base * headroom
+
+    # Never propose more than the budget authority that already exists. Aegis
+    # enforces a session cap when one is declared; a cockpit ceiling above it
+    # would be a number that can never be reached, displayed as though it
+    # were the limit.
+    aegis = _aegis_ceiling()
+    if aegis is not None and derived > aegis:
+        return (
+            aegis,
+            f"clamped to the Aegis session cap ${aegis:.2f}"
+            f" (observed would allow ${derived:.2f})",
+        )
+
+    if derived < floor:
+        # The history is real but unrepresentative — a quiet week, or a repo
+        # whose recent work was all free. Reported honestly rather than
+        # silently rounded up, so the number and its reason still agree.
+        return (
+            floor,
+            f"floor — {len(costs)} sessions, p{int(quantile * 100)}"
+            f"=${base:.2f}, below the floor{note}",
+        )
+
+    return (
+        derived,
+        f"observed — {len(costs)} sessions, p{int(quantile * 100)}"
+        f"=${base:.2f} x{headroom:g}{note}",
+    )
+
+
+def cockpit_cost_cap() -> Tuple[str, str]:
+    """The ceiling a cold boot should use, as a string, with its basis.
+
+    ONE definition, replacing the literal ``"2.50"`` that appeared in both the
+    detached-spawn path and the launchd agent. Two copies of a budget is two
+    budgets, and the one that drifts is discovered by an operator wondering
+    why the number on screen is not the number they configured.
+
+    An explicit ``JARVIS_COCKPIT_COST_CAP`` always wins and says so: an
+    operator who set a ceiling deserves to see their own number, not a
+    negotiated one.
+    """
+    explicit = str(os.environ.get("JARVIS_COCKPIT_COST_CAP", "")).strip()
+    if explicit:
+        return (explicit, "operator")
+    try:
+        usd, basis = derived_cost_cap()
+        return (f"{usd:.2f}", basis)
+    except Exception:  # noqa: BLE001 — a boot must never fail over a budget
+        logger.debug("[Economics] derivation failed", exc_info=True)
+        return (f"{_env_float(_FALLBACK_ENV, 2.50):.2f}", "unmeasured — error")

--- a/backend/core/ouroboros/cli/thin_client.py
+++ b/backend/core/ouroboros/cli/thin_client.py
@@ -278,6 +278,21 @@ def clean_stale_socket(path: Path) -> bool:
         return False
 
 
+
+def _cockpit_cost_cap() -> "tuple[str, str]":
+    """The session ceiling and its basis. Degrades to the historical literal
+    only if the estimator itself is unavailable — a boot must never fail over
+    a budget."""
+    try:
+        from backend.core.ouroboros.battle_test.session_economics import (
+            cockpit_cost_cap,
+        )
+        return cockpit_cost_cap()
+    except Exception:  # noqa: BLE001
+        import os as _os
+        return (_os.environ.get("JARVIS_COCKPIT_COST_CAP", "2.50"),
+                "unmeasured — estimator unavailable")
+
 # ---------------------------------------------------------------------------
 # Detached cold boot
 # ---------------------------------------------------------------------------
@@ -367,10 +382,15 @@ def spawn_daemon(
         env = dict(os.environ)
         # The resident organism serves cockpits — give it the cockpit
         # session economics unless the operator overrode them.
-        env.setdefault(
-            "OUROBOROS_BATTLE_COST_CAP",
-            os.environ.get("JARVIS_COCKPIT_COST_CAP", "2.50"),
-        )
+        # DERIVED, not declared. This used to be a hardcoded dollar figure,
+        # written here and again in the launchd agent — two copies of a
+        # budget, which
+        # means the effective one is whichever nobody remembered to change.
+        # The ceiling now comes from the sessions that actually spent money,
+        # and it carries the basis it rests on.
+        _cap, _cap_basis = _cockpit_cost_cap()
+        env.setdefault("OUROBOROS_BATTLE_COST_CAP", _cap)
+        logger.debug("[ov] session ceiling $%s — %s", _cap, _cap_basis)
         env.setdefault("OUROBOROS_BATTLE_IDLE_TIMEOUT", os.environ.get(
             "JARVIS_OV_DAEMON_IDLE_TIMEOUT_S", "86400",
         ))
@@ -717,9 +737,8 @@ def build_agent_plist() -> dict:
         "StandardOutPath": str(log_dir / "ov-daemon.out.log"),
         "StandardErrorPath": str(log_dir / "ov-daemon.err.log"),
         "EnvironmentVariables": {
-            "OUROBOROS_BATTLE_COST_CAP": os.environ.get(
-                "JARVIS_COCKPIT_COST_CAP", "2.50",
-            ),
+            # Same single definition the detached spawn uses.
+            "OUROBOROS_BATTLE_COST_CAP": _cockpit_cost_cap()[0],
             "OUROBOROS_BATTLE_IDLE_TIMEOUT": os.environ.get(
                 "JARVIS_OV_DAEMON_IDLE_TIMEOUT_S", "86400",
             ),

--- a/tests/battle_test/test_session_economics.py
+++ b/tests/battle_test/test_session_economics.py
@@ -1,0 +1,193 @@
+"""The session ceiling is derived from receipts, not declared as a literal.
+
+`"2.50"` appeared twice in thin_client.py — once for the detached cold boot,
+once for the launchd agent — with no record of what it was based on. It was not
+even a bad guess: 772 recorded sessions put the 95th percentile at $0.77. That
+is the problem. A number that happens to be right, asserted with no basis, is
+indistinguishable from one that happens to be wrong, and nothing announces the
+day it drifts.
+
+The statistical care here is not decoration. A cap censors the record of its
+own effect: sessions it stops are written down at almost exactly the cap, so
+estimating a new ceiling from that tail extrapolates from numbers the old
+ceiling chose.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from backend.core.ouroboros.battle_test import session_economics as se  # noqa: E402
+
+
+@pytest.fixture()
+def history(tmp_path, monkeypatch):
+    """A synthetic session history, addressed the way the real one is."""
+    def _write(costs):
+        for i, c in enumerate(costs):
+            d = tmp_path / f"bt-2026-08-{i // 24 + 1:02d}-{i % 24:02d}0000"
+            d.mkdir(parents=True, exist_ok=True)
+            if c is not None:
+                (d / "summary.json").write_text(json.dumps({"cost_total": c}))
+        monkeypatch.setenv("JARVIS_SESSIONS_DIR", str(tmp_path))
+        for var in ("JARVIS_COCKPIT_COST_CAP", "JARVIS_AEGIS_SESSION_CAP_USD"):
+            monkeypatch.delenv(var, raising=False)
+    return _write
+
+
+# ---------------------------------------------------------------------------
+# reading the receipts
+# ---------------------------------------------------------------------------
+
+def test_free_sessions_are_excluded(history) -> None:
+    """Two thirds of the real history spent nothing — they booted, found no
+    work, and exited. Counting them drags the quantile toward a ceiling that
+    stops the first session that tries to do anything."""
+    history([0.0, 0.0, 0.0, 1.0, 2.0])
+    assert sorted(se.observed_session_costs()) == [1.0, 2.0]
+
+
+def test_an_unreadable_summary_is_skipped_not_counted_as_free(history) -> None:
+    history([1.0, 2.0])
+    bad = se.sessions_dir() / "bt-2026-09-01-000000"
+    bad.mkdir(parents=True, exist_ok=True)
+    (bad / "summary.json").write_text("{ truncated")
+    assert sorted(se.observed_session_costs()) == [1.0, 2.0]
+
+
+def test_a_missing_history_is_not_an_error(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("JARVIS_SESSIONS_DIR", str(tmp_path / "nope"))
+    assert se.observed_session_costs() == []
+
+
+def test_booleans_are_not_costs(history) -> None:
+    """`True` is an int in Python and would arrive as $1.00."""
+    history([1.0])
+    d = se.sessions_dir() / "bt-2026-09-02-000000"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "summary.json").write_text(json.dumps({"cost_total": True}))
+    assert se.observed_session_costs() == [1.0]
+
+
+# ---------------------------------------------------------------------------
+# the derivation
+# ---------------------------------------------------------------------------
+
+def test_the_ceiling_is_derived_and_says_so(history, monkeypatch) -> None:
+    history([0.10] * 19 + [1.00])
+    monkeypatch.setenv("JARVIS_COCKPIT_CAP_HEADROOM", "3")
+    usd, basis = se.derived_cost_cap()
+    assert usd > 0
+    assert "observed" in basis and "sessions" in basis
+
+
+def test_no_history_is_reported_as_unmeasured(monkeypatch, tmp_path) -> None:
+    """The fallback is a real number, and must never be mistaken for one that
+    was measured."""
+    monkeypatch.setenv("JARVIS_SESSIONS_DIR", str(tmp_path))
+    monkeypatch.delenv("JARVIS_COCKPIT_COST_CAP", raising=False)
+    usd, basis = se.derived_cost_cap()
+    assert usd > 0
+    assert "unmeasured" in basis
+
+
+def test_a_quiet_history_lands_on_the_floor_and_admits_it(history, monkeypatch) -> None:
+    """Pennies-per-session weeks are real. A ceiling derived from them would
+    stop the first session that tried to do anything — so the floor holds, and
+    the basis says the floor is why."""
+    history([0.001] * 30)
+    monkeypatch.setenv("JARVIS_COCKPIT_CAP_FLOOR", "0.50")
+    usd, basis = se.derived_cost_cap()
+    assert usd == pytest.approx(0.50)
+    assert "floor" in basis
+
+
+# ---------------------------------------------------------------------------
+# the statistical trap
+# ---------------------------------------------------------------------------
+
+def test_a_natural_tail_is_not_treated_as_censored() -> None:
+    """Today's real history: one session at the top, the rest spread. That is
+    an ordinary tail and the estimate should use it."""
+    assert se._censored([0.1, 0.5, 1.4, 1.7, 2.3, 2.5]) is False
+
+
+def test_a_pile_up_at_the_maximum_is_detected_as_censoring() -> None:
+    """Several sessions within a hair of one value is a wall, not a
+    coincidence — the old cap stopping them and recording the stop."""
+    assert se._censored([0.1, 0.5, 2.50, 2.4999, 2.4998]) is True
+
+
+def test_a_censored_history_estimates_from_the_body_and_says_so(
+        history, monkeypatch) -> None:
+    history([0.05] * 12 + [2.50, 2.4999, 2.4998])
+    monkeypatch.setenv("JARVIS_COCKPIT_CAP_FLOOR", "0.01")
+    _usd, basis = se.derived_cost_cap()
+    assert "censored" in basis, basis
+
+
+# ---------------------------------------------------------------------------
+# not competing with the budget that already exists
+# ---------------------------------------------------------------------------
+
+def test_it_never_proposes_more_than_aegis_allows(history, monkeypatch) -> None:
+    """Two budgets means the effective limit is whichever one nobody
+    remembered. A ceiling above the enforced cap is a number that can never be
+    reached, displayed as though it were the limit."""
+    history([5.0] * 20)
+    monkeypatch.setenv("JARVIS_AEGIS_SESSION_CAP_USD", "2.00")
+    usd, basis = se.derived_cost_cap()
+    assert usd == pytest.approx(2.00)
+    assert "Aegis" in basis
+    assert "would allow" in basis
+
+
+def test_a_generous_aegis_cap_does_not_inflate_the_ceiling(
+        history, monkeypatch) -> None:
+    """The clamp is a ceiling, not a target."""
+    history([0.10] * 20)
+    monkeypatch.setenv("JARVIS_AEGIS_SESSION_CAP_USD", "999")
+    usd, _ = se.derived_cost_cap()
+    assert usd < 10.0
+
+
+# ---------------------------------------------------------------------------
+# the operator, and never failing a boot
+# ---------------------------------------------------------------------------
+
+def test_an_explicit_operator_cap_wins_and_is_labelled(history, monkeypatch) -> None:
+    history([0.10] * 20)
+    monkeypatch.setenv("JARVIS_COCKPIT_COST_CAP", "0.50")
+    assert se.cockpit_cost_cap() == ("0.50", "operator")
+
+
+@pytest.mark.parametrize("bad", ["abc", "-1", "", "  "])
+def test_malformed_knobs_fall_back_rather_than_crash(
+        history, monkeypatch, bad) -> None:
+    history([0.10] * 20)
+    monkeypatch.setenv("JARVIS_COCKPIT_CAP_HEADROOM", bad)
+    usd, _ = se.derived_cost_cap()
+    assert usd > 0
+
+
+def test_the_literal_is_gone_from_both_call_sites() -> None:
+    """Structural. The defect was DUPLICATION as much as the magic number: two
+    copies drift, and the survivor is discovered by an operator wondering why
+    the screen disagrees with their config."""
+    import inspect
+    from backend.core.ouroboros.cli import thin_client
+
+    src = inspect.getsource(thin_client)
+    # One tolerated occurrence: the last-resort fallback if the estimator
+    # itself cannot be imported.
+    assert src.count('"2.50"') <= 1, "the literal is still duplicated"
+    assert src.count("_cockpit_cost_cap()") >= 2, (
+        "both the detached spawn and the launchd agent must share it"
+    )


### PR DESCRIPTION
The cockpit's cost ceiling was a hardcoded dollar figure written **twice** — once for the detached cold boot, once for the launchd agent — with no record of what it was based on. Two copies of a budget means the effective limit is whichever one nobody remembered to change.

It was not even a bad guess: 772 recorded sessions put the 95th percentile at $0.77. **That is the problem.** A number that happens to be right, asserted with no basis, is indistinguishable from one that happens to be wrong, and nothing announces the day the economics move.

```
$4.22   observed — 111 sessions, p95=$1.41 x3
```

A safety ceiling, not a forecast. High quantile × headroom — not a mean (one expensive session drags it) and not a maximum (that IS the runaway case). Zero-cost sessions excluded: two thirds of the history booted, found no work and exited, and counting them produces a ceiling that stops the first session that tries anything.

## The statistical trap, handled

**A cap censors the record of its own effect.** Every session it stops is written down at almost exactly the cap, so estimating a new ceiling from that tail extrapolates from numbers the *old* ceiling chose.

Today's history is clean — one session at `$2.4956` under a `$2.50` cap, the rest spread naturally — which is exactly the condition that changes quietly. So censoring is **detected** (a pile-up at the maximum, not merely a maximum), and the estimate steps down into the uncensored body and says so.

## Not a second budget

Aegis already enforces a session cap when declared. The derived ceiling is **clamped** to it rather than competing:

```
$2.00   clamped to the Aegis session cap $2.00 (observed would allow $4.22)
```

A ceiling above the enforced cap is a number that can never be reached, displayed as though it were the limit.

An explicit `JARVIS_COCKPIT_COST_CAP` still wins and is labelled `operator`. Reading is bounded and stat-free — session directories sort lexically in chronological order, so 950 of them do not make the cockpit feel slow (99ms for 200).

**18 tests**, one of which caught me leaving the literal in two places *after* I believed I had removed it. 121 pass across everything touched tonight; 89 in the suites importing `thin_client`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Derives the cockpit session cost ceiling from recent session receipts and removes the duplicated hardcoded cap. A single source now sets `OUROBOROS_BATTLE_COST_CAP` for both detached and launchd boots, with the basis logged.

- **Bug Fixes**
  - Replaced literals with `session_economics.cockpit_cost_cap()` used in both call sites.
  - Computes ceiling from recent non-zero `cost_total` using a configurable quantile and headroom; detects censoring and includes a clear basis.
  - Clamps to the existing Aegis session cap when present; `JARVIS_COCKPIT_COST_CAP` still overrides.
  - Fast, name-sorted scan of recent sessions; robust fallback if history is missing or estimator is unavailable.
  - Added tests for derivation, censoring, clamping, overrides, and boot fallback.

<sup>Written for commit 23e466931dd39908d868aefe00dd77d974dddc13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

