### PR TITLE
fix(ov): The boot panel announced a tool-round ceiling the engine did not use

### DIFF
--- a/backend/core/ouroboros/battle_test/presentation_restraint.py
+++ b/backend/core/ouroboros/battle_test/presentation_restraint.py
@@ -470,11 +470,26 @@ def render_preflight(
             print_fn(
                 f"  [{mark}] {label:<30s} [muted]{detail}[/muted]"
             )
-        rounds = os.environ.get("JARVIS_GOVERNED_TOOL_MAX_ROUNDS", "10")
-        print_fn(
-            f"\n[muted]  Tool rounds: {rounds} "
-            "(deadline-based, safety ceiling)[/muted]"
-        )
+        # READ the ceiling, never re-derive it.
+        #
+        # This resolved the same variable with its own default of 10 while the
+        # engine used 15, so with the variable unset — the default case — this
+        # panel announced a ceiling that was not the one governing the loop.
+        # A display that re-derives a limit is a second authority, and the
+        # operator only ever sees the second one.
+        #
+        # If the authority cannot be reached, the line is omitted rather than
+        # printed with a guess: an unmeasured ceiling is not a ceiling.
+        try:
+            from backend.core.ouroboros.governance.governed_loop_service import (
+                configured_max_tool_rounds,
+            )
+            print_fn(
+                f"\n[muted]  Tool rounds: {configured_max_tool_rounds()} "
+                "(deadline-based, safety ceiling)[/muted]"
+            )
+        except Exception:  # noqa: BLE001 — a boot panel is never fatal
+            pass
         # API-key warnings (matches the legacy script's behavior).
         has_dw = bool(os.environ.get("DOUBLEWORD_API_KEY"))
         has_claude = bool(os.environ.get("ANTHROPIC_API_KEY"))

--- a/backend/core/ouroboros/governance/governed_loop_service.py
+++ b/backend/core/ouroboros/governance/governed_loop_service.py
@@ -779,6 +779,31 @@ class ServiceState(Enum):
 # ---------------------------------------------------------------------------
 
 
+MAX_TOOL_ROUNDS_ENV = "JARVIS_GOVERNED_TOOL_MAX_ROUNDS"
+
+#: The tool-loop safety ceiling, in ONE place.
+#:
+#: This was resolved independently by the engine (default 15) and by the boot
+#: panel that reports it to the operator (default 10). With the variable unset
+#: — the default case — the panel announced a ceiling of 10 while the loop
+#: allowed 15, so the number an operator read was not the number that governed
+#: them. A display that re-derives a limit instead of reading it is a second
+#: authority, and the operator only ever sees the second one.
+_MAX_TOOL_ROUNDS_DEFAULT = 15
+
+
+def configured_max_tool_rounds() -> int:
+    """The live tool-round ceiling. NEVER raises; malformed input defaults."""
+    raw = str(os.environ.get(MAX_TOOL_ROUNDS_ENV, "")).strip()
+    if not raw:
+        return _MAX_TOOL_ROUNDS_DEFAULT
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return _MAX_TOOL_ROUNDS_DEFAULT
+    return value if value > 0 else _MAX_TOOL_ROUNDS_DEFAULT
+
+
 @dataclass(frozen=True)
 class OperationResult:
     """Stable result contract returned by submit().
@@ -893,7 +918,7 @@ class GovernedLoopConfig:
     # L1 tool-use settings (Manifesto §6: tools enabled by default under
     # governance — Iron Gate + risk engine + approval gates are the safety net)
     tool_use_enabled: bool = True
-    max_tool_rounds: int = 15
+    max_tool_rounds: int = _MAX_TOOL_ROUNDS_DEFAULT
     tool_timeout_s: float = 30.0
     max_concurrent_tools: int = 2
     # Budget-derived tool-loop timing (fixes bt-2026-04-10-045911 where
@@ -999,7 +1024,7 @@ class GovernedLoopConfig:
                 _cfg("pipeline_timeout_s", "JARVIS_PIPELINE_TIMEOUT_S", "600.0")
             ),
             tool_use_enabled=os.environ.get("JARVIS_GOVERNED_TOOL_USE_ENABLED", "true").lower() == "true",
-            max_tool_rounds=int(os.environ.get("JARVIS_GOVERNED_TOOL_MAX_ROUNDS", "15")),
+            max_tool_rounds=configured_max_tool_rounds(),
             tool_timeout_s=float(os.environ.get("JARVIS_GOVERNED_TOOL_TIMEOUT_S", "30")),
             max_concurrent_tools=int(os.environ.get("JARVIS_GOVERNED_TOOL_MAX_CONCURRENT", "2")),
             tool_min_per_round_s=(

--- a/tests/battle_test/test_tool_rounds_single_authority.py
+++ b/tests/battle_test/test_tool_rounds_single_authority.py
@@ -1,0 +1,90 @@
+"""The boot panel announced a tool-round ceiling the engine did not use.
+
+Found by sweeping for environment variables read with CONFLICTING defaults —
+the same class as the cost ceiling written twice, and the same shape as every
+other defect this session: a surface asserting a value it did not get from the
+authority.
+
+    engine   governed_loop_service.py   default 15
+    display  presentation_restraint.py  default 10
+
+With the variable unset — the DEFAULT case, so the common one — the panel told
+the operator the safety ceiling was 10 while the loop allowed 15.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from backend.core.ouroboros.governance.governed_loop_service import (  # noqa: E402
+    MAX_TOOL_ROUNDS_ENV,
+    configured_max_tool_rounds,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean(monkeypatch):
+    monkeypatch.delenv(MAX_TOOL_ROUNDS_ENV, raising=False)
+
+
+def test_the_unset_default_is_the_engines(monkeypatch) -> None:
+    """15, not 10. The disagreement lived entirely in the default."""
+    assert configured_max_tool_rounds() == 15
+
+
+def test_an_operator_value_is_honoured(monkeypatch) -> None:
+    monkeypatch.setenv(MAX_TOOL_ROUNDS_ENV, "7")
+    assert configured_max_tool_rounds() == 7
+
+
+@pytest.mark.parametrize("bad", ["abc", "", "  ", "0", "-3", "1.5"])
+def test_malformed_values_fall_back_rather_than_crash(monkeypatch, bad) -> None:
+    """A tool loop must not fail to start because a knob was fat-fingered, and
+    a ceiling of zero is not a ceiling."""
+    monkeypatch.setenv(MAX_TOOL_ROUNDS_ENV, bad)
+    assert configured_max_tool_rounds() == 15
+
+
+def test_the_engine_builds_its_config_from_the_resolver() -> None:
+    """Structural. If the engine kept its own inline int(), the two could drift
+    apart again silently — which is exactly how this started."""
+    import inspect
+    from backend.core.ouroboros.governance import governed_loop_service
+
+    src = inspect.getsource(governed_loop_service)
+    assert "max_tool_rounds=configured_max_tool_rounds()" in src
+    # The literal default must exist in exactly one place: the resolver.
+    assert src.count(f'"{MAX_TOOL_ROUNDS_ENV}"') == 1, (
+        "the variable is resolved in more than one place again"
+    )
+
+
+def test_the_display_reads_the_authority_and_does_not_re_derive() -> None:
+    """The panel must not resolve the variable itself. A display that
+    re-derives a limit is a second authority, and the operator only ever sees
+    the second one."""
+    import inspect
+    from backend.core.ouroboros.battle_test import presentation_restraint
+
+    src = inspect.getsource(presentation_restraint)
+    assert "configured_max_tool_rounds" in src, "the panel is not reading it"
+    assert MAX_TOOL_ROUNDS_ENV not in src, (
+        "the panel still resolves the variable independently"
+    )
+
+
+def test_the_panel_omits_the_line_rather_than_guessing() -> None:
+    """An unmeasured ceiling is not a ceiling. If the authority cannot be
+    imported the line is dropped, never printed with a fallback number."""
+    import inspect
+    from backend.core.ouroboros.battle_test import presentation_restraint
+
+    src = inspect.getsource(presentation_restraint)
+    idx = src.index("configured_max_tool_rounds")
+    window = src[idx:idx + 400]
+    assert "except Exception" in window and "pass" in window


### PR DESCRIPTION
Found by sweeping every `JARVIS_*` variable for **conflicting defaults across files**. Sixteen turned up; most are harmless (`''` vs `'.'` for a path). This one is not:

```
engine    governed_loop_service.py:1002   default 15
display   presentation_restraint.py:473   default 10
```

With the variable unset — **the default case, so the common one** — the boot panel told the operator `Tool rounds: 10 (deadline-based, safety ceiling)` while the loop actually allowed 15. The number an operator read was not the number governing them.

Same shape as every other defect this session: a surface asserting a value it did not get from the authority. **A display that re-derives a limit is a second authority, and the operator only ever sees the second one.**

## The fix

One resolver, beside the dataclass field it feeds. The engine builds its config from it; the panel reads it rather than resolving the variable itself — asserted **structurally**, because the two drifting apart again is exactly how this started and it would drift silently.

If the authority cannot be imported the panel **omits the line** rather than printing a fallback number. An unmeasured ceiling is not a ceiling, and a plausible wrong number is worse than an absent one — that is the whole lesson of the defect being fixed.

Malformed and non-positive values fall back rather than crash: a tool loop must not fail to start because a knob was fat-fingered, and a ceiling of zero is not a ceiling.

## Verified

- **11 new tests**; 112 pass across everything touched this session, 74 across the restraint suite
- `test_governed_loop_service.py` has **12 pre-existing failures** (`TypeError: An asyncio.Future, a coroutine or an awaitable is required`) — verified **identical with this change stashed and unstashed on the same test**, so they are not from here

## Checked and deliberately NOT changed

`JARVIS_VENV_DIR` resolves to `~/...` in two files and `$HOME/...` in a third. That third is embedded into a generated **bash** launcher, where `$HOME` expands at runtime and `~` inside double quotes would not. Different consumers, correctly different defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a mismatch where the boot panel showed 10 tool rounds while the engine enforced 15. Centralizes the `JARVIS_GOVERNED_TOOL_MAX_ROUNDS` ceiling so the operator sees the real limit.

- **Bug Fixes**
  - Added `configured_max_tool_rounds()` in `governed_loop_service.py` with a default of 15 and input validation.
  - Engine config now uses the resolver; `presentation_restraint.py` reads it instead of resolving the env var.
  - Panel omits the line if the authority cannot be imported (no fallback guess).
  - Added `test_tool_rounds_single_authority.py` to lock this behavior.

<sup>Written for commit 16ce123640f6b1e5cb2f985bc10cd99c16aac797. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

