### PR TITLE
fix(ov): The boot panel reported L2 absent while the engine was running it

### DIFF
--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -2754,7 +2754,18 @@ class BattleTestHarness:
             and getattr(_gls, "_config", None) is not None
             and getattr(_gls._config, "tool_use_enabled", False)
         )
-        _has_l2 = bool(os.environ.get("JARVIS_L2_ENABLED", "").lower() == "true")
+        # READ the capability, never re-derive it. This resolved the same
+        # variable with a default of "" and an `== "true"` test, so with the
+        # variable unset — the documented default — the engine ran L2 and this
+        # panel reported it absent. They also disagreed about `1`, `yes` and
+        # `on`. An unreadable authority reports absent rather than guessing.
+        try:
+            from backend.core.ouroboros.governance.repair_engine import (
+                l2_enabled as _l2_enabled,
+            )
+            _has_l2 = bool(_l2_enabled())
+        except Exception:  # noqa: BLE001 — a boot panel is never fatal
+            _has_l2 = False
         _has_bg_pool = (
             _gls is not None
             and getattr(_gls, "_bg_pool", None) is not None

--- a/backend/core/ouroboros/governance/repair_engine.py
+++ b/backend/core/ouroboros/governance/repair_engine.py
@@ -61,6 +61,26 @@ _logger = logging.getLogger(__name__)
 __firing_ledgers__ = ("repair_tree",)
 
 
+L2_ENABLED_ENV = "JARVIS_L2_ENABLED"
+
+
+def l2_enabled() -> bool:
+    """Is L2 iterative repair enabled? The ONE answer to that question.
+
+    L2 defaults to ENABLED (Manifesto §6 — the self-repair loop is load-bearing
+    for the Ouroboros cycle); explicit "false"/"0"/"no"/"off" opts out.
+
+    Public because the boot panel resolved the same variable itself, with a
+    default of "" and an `== "true"` comparison. Unset — the documented default
+    — the engine ran L2 and the panel reported it absent, and the two also
+    disagreed about `1`, `yes` and `on`. A reporter that re-derives a
+    capability is a second authority, and the operator only ever sees the
+    second one. NEVER raises.
+    """
+    raw = str(os.environ.get(L2_ENABLED_ENV, "true")).strip().lower()
+    return raw not in ("false", "0", "no", "off")
+
+
 def _l2_test_threading_enabled() -> bool:
     return os.environ.get(
         "JARVIS_L2_TEST_TARGET_THREADING_ENABLED", "true",
@@ -218,8 +238,7 @@ class RepairBudget:
         # Boolean parsing: L2 defaults to enabled (Manifesto §6 — the
         # self-repair loop is load-bearing for the Ouroboros cycle).
         # Accept explicit "false" / "0" / "no" to opt out.
-        enabled_str = os.environ.get("JARVIS_L2_ENABLED", "true").lower()
-        enabled = enabled_str not in ("false", "0", "no", "off")
+        enabled = l2_enabled()
 
         # Integer parsing
         max_iterations = int(os.environ.get("JARVIS_L2_MAX_ITERS", "5"))

--- a/tests/battle_test/test_tool_rounds_single_authority.py
+++ b/tests/battle_test/test_tool_rounds_single_authority.py
@@ -88,3 +88,60 @@ def test_the_panel_omits_the_line_rather_than_guessing() -> None:
     idx = src.index("configured_max_tool_rounds")
     window = src[idx:idx + 400]
     assert "except Exception" in window and "pass" in window
+
+
+# ---------------------------------------------------------------------------
+# JARVIS_L2_ENABLED — the same defect, found by the same sweep
+# ---------------------------------------------------------------------------
+
+from backend.core.ouroboros.governance.repair_engine import (  # noqa: E402
+    L2_ENABLED_ENV,
+    l2_enabled,
+)
+
+
+@pytest.fixture()
+def _clean_l2(monkeypatch):
+    monkeypatch.delenv(L2_ENABLED_ENV, raising=False)
+
+
+def test_l2_defaults_to_enabled(_clean_l2) -> None:
+    """The documented default, and the one the boot panel got wrong: it
+    compared against "" and reported L2 absent while the engine ran it."""
+    assert l2_enabled() is True
+
+
+@pytest.mark.parametrize("truthy", ["true", "TRUE", "1", "yes", "on", "  "])
+def test_l2_truthy_grammars_agree(monkeypatch, truthy) -> None:
+    """The panel used `== "true"`, so `1`, `yes` and `on` read as DISABLED to
+    it and ENABLED to the engine. One grammar now."""
+    monkeypatch.setenv(L2_ENABLED_ENV, truthy)
+    assert l2_enabled() is True
+
+
+@pytest.mark.parametrize("falsy", ["false", "FALSE", "0", "no", "off"])
+def test_l2_opt_out_is_honoured(monkeypatch, falsy) -> None:
+    monkeypatch.setenv(L2_ENABLED_ENV, falsy)
+    assert l2_enabled() is False
+
+
+def test_the_engine_builds_its_budget_from_the_resolver() -> None:
+    import inspect
+    from backend.core.ouroboros.governance import repair_engine
+
+    src = inspect.getsource(repair_engine)
+    assert "enabled = l2_enabled()" in src
+    assert src.count(f'"{L2_ENABLED_ENV}"') == 1, (
+        "the variable is resolved in more than one place again"
+    )
+
+
+def test_the_boot_panel_reads_the_authority() -> None:
+    import inspect
+    from backend.core.ouroboros.battle_test import harness
+
+    src = inspect.getsource(harness)
+    assert "_l2_enabled()" in src, "the panel is not reading the authority"
+    assert f'"{L2_ENABLED_ENV}"' not in src, (
+        "the panel still resolves the variable independently"
+    )


### PR DESCRIPTION
Second confirmed hit from the conflicting-defaults sweep, same shape as #70438.

```
engine   repair_engine.py:221   default "true"  → not in (false,0,no,off)
panel    harness.py:2757        default ""      → == "true"
```

With the variable **unset** — which `CLAUDE.md` documents as the default, and which `repair_engine`'s own comment calls load-bearing for the Ouroboros cycle — the engine ran L2 and the boot panel reported it absent. That flag also drives the Venom capability line, so it read `tools active` instead of `bash + web + tests + L2`.

The two also used **different truthiness grammars**: `1`, `yes` and `on` enabled L2 in the engine and disabled it in the panel. Not a default mismatch — two different definitions of the same word.

## The fix

One resolver, `repair_engine.l2_enabled()`. Public because **a capability the operator is shown must be the capability that runs.** The engine builds its budget from it and the panel reads it — both asserted structurally, because two copies drifting apart again is exactly how this started, and it drifts silently.

An unreadable authority reports the capability **absent** rather than guessing. Under-claiming a feature is recoverable; over-claiming one is how an operator concludes a working system is broken.

## Verified

- 25 tests in the file (14 new)
- **127 pass** across the suites importing `repair_engine`; 99 across everything touched this session
- `test_governed_loop_service.py`'s 12 failures are pre-existing — verified identical with the change stashed and unstashed, and reconfirmed on a full 15-minute run

## Still open, deliberately not fixed here

`JARVIS_MIN_EXPLORATION_CALLS` is read directly by `orchestrator.py`, `validate_runner.py` and `providers.py` with a flat default of `"2"`, while `exploration_floor.py` exists specifically to be the single **complexity-scaled** authority — and none of the three import it.

That module's own docstring records this exact defect happening once already: *"moderate/complex ops saw floor=1 in the loop but floor=2..."*. Fixing it means threading complexity context into three call sites — a real change rather than a rename, and not something to guess at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies L2 capability resolution behind `repair_engine.l2_enabled()` so the boot panel and engine agree on L2 status. Fixes the panel misreporting L2 as absent (and the Venom line) when `JARVIS_L2_ENABLED` was unset or set to `1/yes/on`.

- **Bug Fixes**
  - Added `l2_enabled()` in `repair_engine.py`; default enabled, with `false/0/no/off` as opt-out.
  - Engine builds its budget from this resolver; boot panel imports it and shows L2 absent if unreadable instead of guessing.
  - Removed ad-hoc env parsing and mismatched truthiness; added tests for defaults, truthy/falsy handling, and single-authority enforcement.

<sup>Written for commit 8a9363931012d251331c72b4080b967ecfd8007f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70439?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

