### PR TITLE
fix(governance): One governance mode, one authority — never the optimistic one

### DIFF
--- a/backend/core/ouroboros/consciousness/health_cortex.py
+++ b/backend/core/ouroboros/consciousness/health_cortex.py
@@ -452,7 +452,19 @@ class HealthCortex:
     @staticmethod
     def _poll_trust() -> TrustHealth:
         """Read trust tier from env; return governed/0.0 when not configured."""
-        tier = os.getenv("JARVIS_GOVERNANCE_MODE", "governed")
+        # The authority's answer, not a second one. This defaulted to
+        # "governed" while the governance stack itself defaults to "sandbox",
+        # so with nothing configured the health report claimed the organism
+        # was under governance it was not under. `"safe"` is an alias for
+        # SANDBOX in the mode map, which settles which direction is
+        # conservative — and a health surface must never be the optimistic one.
+        try:
+            from backend.core.ouroboros.governance.integration import (
+                configured_governance_mode,
+            )
+            tier = configured_governance_mode()
+        except Exception:  # noqa: BLE001 — health polling is never fatal
+            tier = "sandbox"
         try:
             progress = float(os.getenv("JARVIS_TRUST_GRADUATION_PROGRESS", "0.0"))
         except (ValueError, TypeError):

--- a/backend/core/ouroboros/governance/integration.py
+++ b/backend/core/ouroboros/governance/integration.py
@@ -105,6 +105,55 @@ _MODE_MAP = {
     "safe": GovernanceMode.SANDBOX,  # alias
 }
 
+GOVERNANCE_MODE_ENV = "JARVIS_GOVERNANCE_MODE"
+
+#: The mode assumed when nobody has said otherwise.
+#:
+#: SANDBOX, and the direction matters more than the value: `"safe"` is an alias
+#: for SANDBOX in the map above, so this is the CONSERVATIVE mode. Falling back
+#: to "governed" would have a surface claim the organism is under governance it
+#: may not be under, and over-claiming governance is the one direction that
+#: cannot be walked back by a reader.
+_DEFAULT_GOVERNANCE_MODE = "sandbox"
+
+#: The mode actually in effect, published when a config is built.
+#:
+#: Registered rather than re-derived because `from_env_and_args` resolves a CLI
+#: argument BEFORE the environment — so a run started with
+#: `--governance-mode governed` is invisible to anything reading the env, and
+#: every reporting surface was reading the env. The status endpoint could
+#: therefore announce "sandbox" for a process running GOVERNED, with nothing
+#: anywhere disagreeing.
+#:
+#: Same shape as `set_default_intake_router` / `set_active_bridge`: last write
+#: wins, never raises, and holds a plain string rather than the config so a
+#: reader cannot reach through it into governance state.
+_ACTIVE_GOVERNANCE_MODE: "Optional[str]" = None
+
+
+def set_active_governance_mode(mode: "Optional[str]") -> None:
+    """Publish the mode a built config resolved to. NEVER raises."""
+    global _ACTIVE_GOVERNANCE_MODE
+    _ACTIVE_GOVERNANCE_MODE = str(mode) if mode else None
+
+
+def configured_governance_mode() -> str:
+    """The governance mode in effect, for anything that REPORTS it.
+
+    Precedence mirrors `from_env_and_args` exactly, most authoritative first:
+    the mode a config actually resolved to, then the environment, then the
+    conservative default. A value outside `_MODE_MAP` is not repeated back —
+    the constructor rejects it, so a reporter must not present it as live.
+    """
+    active = _ACTIVE_GOVERNANCE_MODE
+    if active and active in _MODE_MAP:
+        return active
+    raw = str(os.environ.get(GOVERNANCE_MODE_ENV, "")).strip().lower()
+    if raw in _MODE_MAP:
+        return raw
+    return _DEFAULT_GOVERNANCE_MODE
+
+
 
 @dataclass(frozen=True)
 class GovernanceConfig:
@@ -147,7 +196,12 @@ class GovernanceConfig:
         skip = getattr(args, "skip_governance", False)
         mode_str = (
             getattr(args, "governance_mode", None)
-            or os.environ.get("JARVIS_GOVERNANCE_MODE", "sandbox")
+            # The resolver, not a second reading of the environment. Writing
+            # the env lookup here again gave this variable two defaults inside
+            # ONE file — the precise defect the resolver was added to end,
+            # reintroduced three lines from it, and caught only because the
+            # architecture pin was watching.
+            or configured_governance_mode()
         )
 
         if skip:
@@ -159,6 +213,10 @@ class GovernanceConfig:
                     f"Valid: {list(_MODE_MAP.keys())}"
                 )
             initial_mode = _MODE_MAP[mode_str]
+            # Publish what was actually resolved, so every reporting surface
+            # reads the live mode instead of re-deriving one that cannot see
+            # the CLI argument above.
+            set_active_governance_mode(mode_str)
 
         ledger_dir = Path(
             os.environ.get(

--- a/backend/core/ouroboros/governance/remote_status.py
+++ b/backend/core/ouroboros/governance/remote_status.py
@@ -30,6 +30,19 @@ _ENABLED = os.environ.get(
 ).lower() in ("true", "1", "yes")
 
 
+def _governance_mode() -> str:
+    """The live governance mode. Falls back to the conservative one rather
+    than to an optimistic guess: over-claiming governance is the direction a
+    reader cannot walk back. NEVER raises."""
+    try:
+        from backend.core.ouroboros.governance.integration import (
+            configured_governance_mode,
+        )
+        return configured_governance_mode()
+    except Exception:  # noqa: BLE001 — a status endpoint never fails on this
+        return "sandbox"
+
+
 class RemoteStatusAPI:
     """HTTP API for remote monitoring of the Ouroboros pipeline.
 
@@ -96,11 +109,18 @@ class RemoteStatusAPI:
             "uptime_s": round(time.time() - self._boot_time),
         })
 
+
     async def _handle_status(self, request: Any) -> Any:
         from aiohttp import web
         status: Dict[str, Any] = {
             "uptime_s": round(time.time() - self._boot_time),
-            "governance_mode": os.environ.get("JARVIS_GOVERNANCE_MODE", "sandbox"),
+            # READ the mode, never re-derive it. This resolved the env
+            # directly, and `GovernanceConfig.from_env_and_args` honours a CLI
+            # argument BEFORE the env — so a process started with
+            # `--governance-mode governed` was reported here as "sandbox",
+            # with nothing anywhere disagreeing. An externally-visible status
+            # endpoint is the last place that should be guessing.
+            "governance_mode": _governance_mode(),
             "python_version": "",
         }
 

--- a/tests/architecture/test_env_default_single_authority.py
+++ b/tests/architecture/test_env_default_single_authority.py
@@ -120,14 +120,6 @@ _WAIVED: Dict[str, str] = {
     # Waived so this pin stays green for NEW regressions. Every entry here is
     # a to-do, and the self-cleaning check above deletes it the day it is
     # fixed. None of these were introduced by the work that added this file.
-    "JARVIS_GOVERNANCE_MODE": (
-        "KNOWN DEFECT. health_cortex defaults to 'governed' while "
-        "remote_status and integration default to 'sandbox'. Unset, the "
-        "health cortex believes one tier while the surface that REPORTS "
-        "governance mode externally announces the other. The most "
-        "safety-relevant instance found; needs an owner to decide which is "
-        "correct before a resolver can be written."
-    ),
     "JARVIS_PRIME_API_KEY": (
         "KNOWN DEFECT. engine.py defaults to 'sk-local-jarvis-key'; "
         "integration.py defaults to 'sk-local-jarvis' in two places. If "

--- a/tests/architecture/test_governance_mode_single_authority.py
+++ b/tests/architecture/test_governance_mode_single_authority.py
@@ -1,0 +1,175 @@
+"""One governance mode, one authority — and never the optimistic one.
+
+Found by the conflicting-defaults pin, and the worst instance it reported:
+
+    integration.py:150     "sandbox"   ← the constructor, which validates
+    remote_status.py:103   "sandbox"   ← what external observers are TOLD
+    health_cortex.py:455   "governed"  ← the health report
+
+With nothing configured, the health cortex claimed the organism was under
+governance while the governance stack itself was in sandbox. `"safe"` is an
+alias for SANDBOX in `_MODE_MAP`, which settles which direction is
+conservative: the health surface was the optimistic one.
+
+Underneath the mismatched defaults was a defect the defaults hid.
+``GovernanceConfig.from_env_and_args`` resolves a CLI argument BEFORE the
+environment, and both reporters read the environment — so a process started
+with ``--governance-mode governed`` was reported as "sandbox" by the status
+endpoint, with nothing anywhere disagreeing. Matching the defaults would not
+have fixed that; only a queryable authority does.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from backend.core.ouroboros.governance.integration import (  # noqa: E402
+    _DEFAULT_GOVERNANCE_MODE,
+    _MODE_MAP,
+    GOVERNANCE_MODE_ENV,
+    configured_governance_mode,
+    set_active_governance_mode,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean(monkeypatch):
+    set_active_governance_mode(None)
+    monkeypatch.delenv(GOVERNANCE_MODE_ENV, raising=False)
+    yield
+    set_active_governance_mode(None)
+
+
+# ---------------------------------------------------------------------------
+# the safety property
+# ---------------------------------------------------------------------------
+
+def test_the_fallback_is_the_conservative_mode() -> None:
+    """The direction matters more than the value. Over-claiming governance is
+    the one error a reader cannot walk back."""
+    assert configured_governance_mode() == "sandbox"
+    assert _MODE_MAP["safe"] is _MODE_MAP["sandbox"], (
+        "'safe' aliasing SANDBOX is what makes sandbox the conservative "
+        "fallback — if that changes, this default must be revisited"
+    )
+
+
+def test_an_unknown_value_is_not_repeated_back(monkeypatch) -> None:
+    """The constructor REJECTS a value outside the map, so a reporter must not
+    present one as live — it would describe a process that cannot exist."""
+    monkeypatch.setenv(GOVERNANCE_MODE_ENV, "yolo")
+    assert configured_governance_mode() == _DEFAULT_GOVERNANCE_MODE
+
+
+@pytest.mark.parametrize("value", sorted(_MODE_MAP))
+def test_every_valid_mode_round_trips(monkeypatch, value) -> None:
+    monkeypatch.setenv(GOVERNANCE_MODE_ENV, value)
+    assert configured_governance_mode() == value
+
+
+def test_case_and_whitespace_do_not_defeat_it(monkeypatch) -> None:
+    monkeypatch.setenv(GOVERNANCE_MODE_ENV, "  GOVERNED  ")
+    assert configured_governance_mode() == "governed"
+
+
+# ---------------------------------------------------------------------------
+# the defect the defaults were hiding
+# ---------------------------------------------------------------------------
+
+def test_a_resolved_config_outranks_the_environment(monkeypatch) -> None:
+    """THE reason matching the defaults would not have been enough.
+
+    `from_env_and_args` honours a CLI argument first, so a run started with
+    `--governance-mode governed` leaves the env unset. Every reporter read the
+    env, so the status endpoint announced "sandbox" for a GOVERNED process.
+    """
+    monkeypatch.delenv(GOVERNANCE_MODE_ENV, raising=False)
+    set_active_governance_mode("governed")
+    assert configured_governance_mode() == "governed"
+
+
+def test_a_published_mode_beats_a_contradicting_environment(monkeypatch) -> None:
+    monkeypatch.setenv(GOVERNANCE_MODE_ENV, "sandbox")
+    set_active_governance_mode("governed")
+    assert configured_governance_mode() == "governed", (
+        "the mode a config RESOLVED to outranks the raw environment"
+    )
+
+
+def test_a_published_junk_mode_is_ignored() -> None:
+    """Publishing is not a bypass of the vocabulary."""
+    set_active_governance_mode("not-a-mode")
+    assert configured_governance_mode() == _DEFAULT_GOVERNANCE_MODE
+
+
+def test_the_constructor_publishes_what_it_resolved() -> None:
+    import inspect
+    from backend.core.ouroboros.governance import integration
+
+    src = inspect.getsource(integration.GovernanceConfig.from_env_and_args)
+    assert "set_active_governance_mode(mode_str)" in src, (
+        "the constructor resolves a mode and never publishes it, so every "
+        "reporter is back to guessing"
+    )
+
+
+# ---------------------------------------------------------------------------
+# the reporters
+# ---------------------------------------------------------------------------
+
+def test_the_status_endpoint_reads_the_authority() -> None:
+    import inspect
+    from backend.core.ouroboros.governance import remote_status
+
+    src = inspect.getsource(remote_status)
+    assert "configured_governance_mode" in src
+    assert f'"{GOVERNANCE_MODE_ENV}"' not in src, (
+        "the status endpoint still resolves the variable itself"
+    )
+
+
+def test_the_health_cortex_reads_the_authority() -> None:
+    import inspect
+    from backend.core.ouroboros.consciousness import health_cortex
+
+    src = inspect.getsource(health_cortex)
+    assert "configured_governance_mode" in src
+    assert f'"{GOVERNANCE_MODE_ENV}"' not in src, (
+        "the health cortex still resolves the variable itself"
+    )
+
+
+def test_no_reporter_falls_back_to_governed() -> None:
+    """Both degrade to sandbox when the authority is unreachable. A surface
+    that guesses "governed" while unable to reach governance is asserting the
+    single most misleading thing it could."""
+    import inspect
+    from backend.core.ouroboros.consciousness import health_cortex
+    from backend.core.ouroboros.governance import remote_status
+
+    for module in (remote_status, health_cortex):
+        src = inspect.getsource(module)
+        idx = src.index("configured_governance_mode")
+        window = src[idx:idx + 500]
+        assert '"governed"' not in window, (
+            f"{module.__name__} falls back to the optimistic mode"
+        )
+        assert '"sandbox"' in window, (
+            f"{module.__name__} has no conservative fallback"
+        )
+
+
+def test_the_status_endpoint_reports_a_published_mode(monkeypatch) -> None:
+    """End to end on the value an external observer actually receives."""
+    from backend.core.ouroboros.governance.remote_status import _governance_mode
+
+    monkeypatch.delenv(GOVERNANCE_MODE_ENV, raising=False)
+    set_active_governance_mode("governed")
+    assert _governance_mode() == "governed"
+    set_active_governance_mode(None)
+    assert _governance_mode() == "sandbox"


### PR DESCRIPTION
The worst instance the conflicting-defaults pin (#70440) reported:

```
integration.py    "sandbox"    the constructor, which validates
remote_status.py  "sandbox"    what external observers are TOLD
health_cortex.py  "governed"   the health report
```

With nothing configured, the health cortex claimed the organism was under governance while the governance stack was in sandbox. `_MODE_MAP` has `"safe": GovernanceMode.SANDBOX`, which settles which direction is conservative: **the health surface was the optimistic one**, and over-claiming governance is the single error a reader cannot walk back.

## Matching the defaults would not have fixed it

Underneath sat a defect the mismatch hid. `GovernanceConfig.from_env_and_args` resolves a **CLI argument before the environment**, and both reporters read the environment. A process started with `--governance-mode governed` was reported as `sandbox` by the status endpoint, **with nothing anywhere disagreeing.**

The mode had no queryable authority, so every surface re-derived it — and one structurally could not see the value that wins.

```
--governance-mode governed, env unset
  before → sandbox
  after  → governed
```

## The fix

The resolved mode is **published** when a config is built — same shape as `set_default_intake_router` / `set_active_bridge`: last write wins, never raises, holds a plain string so a reader cannot reach through it into governance state.

`configured_governance_mode()` mirrors the constructor's precedence exactly (resolved config → environment → conservative default) and **refuses to repeat back a value outside `_MODE_MAP`** — the constructor rejects one, so a reporter must not present a process that cannot exist. Both reporters read it, and both degrade to sandbox rather than to an optimistic guess.

## The pin caught me twice more

**The first draft of this fix** left the constructor re-reading the environment three lines below the resolver — two defaults **inside one file**, the precise defect the resolver was added to end. The self-cleaning waiver check then refused to let the waiver be deleted until the conflict was genuinely gone. The mechanism working against its author is the point of it.

**And a plainer mistake:** the helper was first inserted at module indentation *inside the class body*, which ends a class early and orphans every method after it. Four tests failed on `RemoteStatusAPI has no attribute _handle_team`. Fixed before commit, but written. A mechanical edit is not a safe edit.

**14 new tests · 583 pass across `tests/architecture` · 49 across every suite touching the three modules.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make governance mode a single, conservative source of truth. We now publish the resolved mode from config and have status/health read it, so we never over-claim governance and `--governance-mode` properly outranks env.

- **Bug Fixes**
  - Publish the resolved mode in `GovernanceConfig.from_env_and_args` via `set_active_governance_mode`.
  - Add `configured_governance_mode()` with precedence: active → env → `sandbox`; ignores invalid values.
  - Update `health_cortex` and `remote_status` to read `configured_governance_mode()` and fall back to `sandbox` on errors.
  - Remove conflicting defaults for `JARVIS_GOVERNANCE_MODE`; drop the architecture pin waiver.
  - Tests: new suite covering precedence, fallbacks, and reporter behavior.

<sup>Written for commit 06814e80816feeece442965557869868f74af0f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

