### PR TITLE
fix(governance): Failover moved J-Prime; this module never heard it

### DIFF
--- a/backend/core/ouroboros/governance/distributed_resilience.py
+++ b/backend/core/ouroboros/governance/distributed_resilience.py
@@ -24,7 +24,26 @@ logger = logging.getLogger(__name__)
 _HEARTBEAT_S = float(os.environ.get("JARVIS_RESILIENCE_HEARTBEAT_S", "60"))
 _FAILOVER_S = float(os.environ.get("JARVIS_RESILIENCE_FAILOVER_TIMEOUT_S", "300"))
 _SYNC_S = float(os.environ.get("JARVIS_RESILIENCE_SYNC_INTERVAL_S", "300"))
-_GCP_HOST = os.environ.get("JARVIS_PRIME_HOST", "136.113.252.164")
+#: J-Prime's address, read AT CALL TIME rather than captured at import.
+#:
+#: This was a module-level constant, and that made failover a no-op for this
+#: module. `failover_lifecycle` writes ``os.environ["JARVIS_PRIME_HOST"] = ip``
+#: when it wires a new node and logs "endpoint WIRED ... PrimeProvider now
+#: targets the live node" — but a constant bound at import cannot see a write
+#: that happens later, so every rsync and every heartbeat here kept addressing
+#: whatever the value was when the module first loaded. With the variable
+#: unset that is the fallback below: a hardcoded public IP, which by then may
+#: belong to an instance that no longer exists.
+#:
+#: A value that must track a runtime change cannot be a constant. The fallback
+#: is retained unchanged so behaviour with no failover is identical.
+_GCP_HOST_DEFAULT = "136.113.252.164"
+
+
+def _gcp_host() -> str:
+    """The address to reach J-Prime on, now. NEVER raises."""
+    return os.environ.get("JARVIS_PRIME_HOST", "").strip() or _GCP_HOST_DEFAULT
+
 _GCP_USER = os.environ.get("JARVIS_GCP_USER", "djrussell23")
 _ENABLED = os.environ.get("JARVIS_RESILIENCE_ENABLED", "false").lower() in ("true", "1", "yes")
 
@@ -55,7 +74,7 @@ class DistributedResilienceManager:
         self._running = True
         self._hb_task = asyncio.create_task(self._hb_loop(), name="resilience_hb")
         self._sync_task = asyncio.create_task(self._sync_loop(), name="resilience_sync")
-        logger.info("[Resilience] Started — hb=%ds, sync=%ds, host=%s", _HEARTBEAT_S, _SYNC_S, _GCP_HOST)
+        logger.info("[Resilience] Started — hb=%ds, sync=%ds, host=%s", _HEARTBEAT_S, _SYNC_S, _gcp_host())
 
     def stop(self) -> None:
         self._running = False
@@ -79,7 +98,7 @@ class DistributedResilienceManager:
         # Write payload to remote via SSH (argv, no shell interpolation)
         proc = await asyncio.create_subprocess_exec(
             "ssh", "-o", "ConnectTimeout=5", "-o", "StrictHostKeyChecking=no",
-            f"{_GCP_USER}@{_GCP_HOST}",
+            f"{_GCP_USER}@{_gcp_host()}",
             "tee", "/tmp/jarvis_heartbeat.json",
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
@@ -110,7 +129,7 @@ class DistributedResilienceManager:
         for sf in _STATE_FILES:
             lp = _LOCAL_DIR / sf
             if not lp.exists(): continue
-            rp = f"{_GCP_USER}@{_GCP_HOST}:{_REMOTE_DIR}/{sf}"
+            rp = f"{_GCP_USER}@{_gcp_host()}:{_REMOTE_DIR}/{sf}"
             try:
                 proc = await asyncio.create_subprocess_exec(
                     "rsync", "-az", "--timeout=10", str(lp), rp,
@@ -129,5 +148,5 @@ class DistributedResilienceManager:
             "last_heartbeat": self._last_hb,
             "seconds_since_hb": round(now - self._last_hb) if self._last_hb else -1,
             "last_sync": self._last_sync, "files_synced": self._synced,
-            "gcp_host": _GCP_HOST, "failover_timeout_s": _FAILOVER_S,
+            "gcp_host": _gcp_host(), "failover_timeout_s": _FAILOVER_S,
         }

--- a/tests/architecture/test_prime_host_tracks_failover.py
+++ b/tests/architecture/test_prime_host_tracks_failover.py
@@ -1,0 +1,107 @@
+"""Failover writes J-Prime's address; a module-level constant cannot hear it.
+
+`failover_lifecycle` wires a new node and writes the address into the
+environment:
+
+    os.environ["JARVIS_PRIME_URL"]  = url
+    os.environ["JARVIS_PRIME_HOST"] = ip
+
+then logs "endpoint WIRED ... PrimeProvider now targets the live node".
+
+`distributed_resilience` bound that variable to a module constant at import:
+
+    _GCP_HOST = os.environ.get("JARVIS_PRIME_HOST", "136.113.252.164")
+
+A constant bound at import cannot see a write that happens later, so every
+rsync and heartbeat in that module kept addressing whatever the value was when
+the module first loaded — with the variable unset, a hardcoded public IP that
+by then may belong to an instance which no longer exists. The failover log said
+the endpoint was wired. For this module it was not.
+
+A claim outrunning the measurement, which is the same defect as every other one
+found in this sweep — here in its module-level-constant form, and the only one
+where the stale value is a network address.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from backend.core.ouroboros.governance import distributed_resilience as dr  # noqa: E402
+
+_ENV = "JARVIS_PRIME_HOST"
+
+
+@pytest.fixture(autouse=True)
+def _clean(monkeypatch):
+    monkeypatch.delenv(_ENV, raising=False)
+
+
+def test_a_failover_write_is_seen_without_reimport(monkeypatch) -> None:
+    """THE regression. The module is already imported — as it is in a live
+    process — and the address must still change."""
+    before = dr._gcp_host()
+    monkeypatch.setenv(_ENV, "10.1.2.3")
+    assert dr._gcp_host() == "10.1.2.3"
+    assert dr._gcp_host() != before
+
+
+def test_the_fallback_is_unchanged_when_no_failover_has_run(monkeypatch) -> None:
+    """Behaviour with nothing configured is identical to before, so this
+    changes when the value is read and never what it is."""
+    assert dr._gcp_host() == dr._GCP_HOST_DEFAULT
+
+
+@pytest.mark.parametrize("blank", ["", "   ", "\t"])
+def test_a_blank_address_falls_back_rather_than_addressing_nothing(
+        monkeypatch, blank) -> None:
+    """An empty JARVIS_PRIME_HOST would otherwise build `user@` and rsync to a
+    hostname that is not there."""
+    monkeypatch.setenv(_ENV, blank)
+    assert dr._gcp_host() == dr._GCP_HOST_DEFAULT
+
+
+def test_every_consumer_asks_rather_than_reading_a_frozen_copy() -> None:
+    """Structural: one surviving `_GCP_HOST` reference would be a site that
+    silently keeps the import-time address while its neighbours track failover
+    — harder to diagnose than uniform staleness."""
+    import inspect
+
+    src = inspect.getsource(dr)
+    # The default constant is expected; a bare frozen host is not.
+    assert "_GCP_HOST =" not in src, "the import-time capture is back"
+    for line in src.splitlines():
+        stripped = line.strip()
+        if "_GCP_HOST" in stripped and "_GCP_HOST_DEFAULT" not in stripped:
+            raise AssertionError(f"frozen host still read at: {stripped}")
+
+
+def test_the_writer_and_the_reader_agree_on_the_variable() -> None:
+    """The two halves are in different modules and only this name joins them.
+    If either renames it, the failover goes quiet rather than failing."""
+    import inspect
+    from backend.core.ouroboros.governance import failover_lifecycle
+
+    writer = inspect.getsource(failover_lifecycle)
+    assert f'os.environ["{_ENV}"]' in writer, (
+        "failover no longer publishes the host under this name"
+    )
+    assert _ENV in inspect.getsource(dr)
+
+
+def test_reading_is_cheap_enough_to_do_every_time() -> None:
+    """The reason a constant was tempting. An env read is nanoseconds; an rsync
+    is milliseconds at best, so there is no cost argument for caching an
+    address that must be allowed to change."""
+    import time
+
+    start = time.perf_counter()
+    for _ in range(10_000):
+        dr._gcp_host()
+    elapsed = time.perf_counter() - start
+    assert elapsed < 1.0, f"10k resolutions took {elapsed:.3f}s"


### PR DESCRIPTION
Investigating the Prime trio from the conflicting-defaults pin (#70440) turned up something more serious than the mismatched defaults.

```python
# failover_lifecycle.py — writes at runtime
os.environ["JARVIS_PRIME_HOST"] = ip
logger.info("endpoint WIRED ... PrimeProvider now targets the live node")

# distributed_resilience.py — bound at IMPORT
_GCP_HOST = os.environ.get("JARVIS_PRIME_HOST", "136.113.252.164")
```

A constant bound at import cannot see a write that happens later. Every rsync and heartbeat in that module kept addressing whatever the value was when the module first loaded — with the variable unset, **a hardcoded public IP that by then may belong to an instance which no longer exists.** The failover log said the endpoint was wired. For this module it was not.

Same defect as everything else this sweep has found — a claim outrunning the measurement — here in its module-level-constant form, and the only instance where the stale value is a network address.

## The fix

Resolved at call time. **Behaviour with nothing configured is byte-identical:** this changes *when* the value is read, never what it is. A blank address falls back rather than building `user@` and rsyncing to a hostname that is not there.

Every consumer asks — asserted structurally, because one surviving frozen read would be a site that silently keeps the import-time address while its neighbours track failover, which is harder to diagnose than uniform staleness.

10,000 resolutions in well under a second: there was never a cost argument for caching an address that must be allowed to change.

## Deliberately NOT done here

Four variables describe this one endpoint, with **three different default ports**:

```
JARVIS_PRIME_HOST      localhost · "" · 136.113.252.164
JARVIS_PRIME_PORT      8000
JARVIS_PRIME_API_BASE  http://localhost:8000/v1 (x5) · http://localhost:8080
JARVIS_PRIME_URL       http://localhost:8001 (x3)
```

Failover writes `HOST` and `URL` but **not** `API_BASE`, so after a failover every `api_base` consumer still points at localhost.

Consolidating that means one endpoint authority consumed by ~12 sites across `governance/`, `clients/`, `native_integration`, `engine` and `brain_orchestrator` — a live networking layer with a failover path. **A partial consolidation would be worse than none:** some sites tracking failover and others not is harder to diagnose than all of them being uniformly wrong. It needs its own change, with those modules read first.

**8 tests · 18 pass with the conflicting-defaults pin.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes resilience failover by reading `JARVIS_PRIME_HOST` at call time instead of at import, so heartbeats and rsync always target the current live J‑Prime node. Behavior is unchanged when unset; blank values now safely fall back to the default.

- **Bug Fixes**
  - Replaced module constant with `_gcp_host()` that resolves `JARVIS_PRIME_HOST` on each call (keeps `_GCP_HOST_DEFAULT`).
  - Switched heartbeat, rsync, status, and startup logging to use `_gcp_host()`.
  - Added tests to verify runtime updates without re-import, blank-host fallback, and guard against any surviving frozen reads; includes a perf check (10k resolutions < 1s).

<sup>Written for commit 52d1a94cbb97a05efced3a1b02b0fc71a00e045c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

