### PR TITLE
feat(intake): mount the dormancy alarm; the instrument was wrong about two more

### DIFF
--- a/backend/core/ouroboros/battle_test/progress_board.py
+++ b/backend/core/ouroboros/battle_test/progress_board.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 
 import ast
 import asyncio
+import fnmatch
 import hashlib
 import json
 import logging
@@ -244,6 +245,18 @@ def _tree_digest(repo_root: Path, roots: Sequence[str]) -> str:
     files only one of them could see.
     """
     digest = hashlib.sha256()
+    # The pytest configuration is an input to the reading and is not a `.py`
+    # file, so the walk below cannot see it. Editing `testpaths` changes which
+    # files count as production importers and therefore which flags are dark;
+    # a key blind to that would serve the old verdict under the new rule.
+    for name in ("pytest.ini", "setup.cfg", "pyproject.toml"):
+        try:
+            stat = (repo_root / name).stat()
+            digest.update(
+                f"cfg:{name}\0{stat.st_mtime_ns}\0{stat.st_size}\n".encode(
+                    "utf-8", "replace"))
+        except OSError:
+            digest.update(f"cfg:{name}\0absent\n".encode("utf-8"))
     for rel, path in _iter_source_files(repo_root, roots):
         try:
             stat = path.stat()
@@ -409,36 +422,161 @@ def _iter_source_files(repo_root: Path,
                 yield rel, path
 
 
-def _is_test_path(rel: str) -> bool:
+#: Where tests live, and what a test file is called, when the repository does
+#: not say. Only a fallback — :func:`test_collection_config` prefers the
+#: project's own pytest configuration, which is the sole authority on the
+#: question "would this file be collected as a test".
+_FALLBACK_TESTPATHS = ("tests",)
+_FALLBACK_PYTHON_FILES = ("test_*.py", "*_test.py")
+
+
+def _parse_pytest_config(repo_root: Path) -> Tuple[Tuple[str, ...], Tuple[str, ...]]:
+    """``(testpaths, python_files)`` as the project declares them.
+
+    Reads ``pytest.ini``, then ``setup.cfg`` (``[tool:pytest]``), then
+    ``pyproject.toml`` (``[tool.pytest.ini_options]``) — pytest's own
+    precedence. Returns the fallbacks when nothing declares them.
+
+    NEVER raises: an unparseable config yields the fallback, because a status
+    view must not be the thing that breaks on a malformed ini.
+    """
+    import configparser
+
+    def _split(raw: str) -> Tuple[str, ...]:
+        return tuple(p for p in raw.replace("\n", " ").split(" ") if p.strip())
+
+    for name, section in (("pytest.ini", "pytest"),
+                          ("setup.cfg", "tool:pytest")):
+        path = repo_root / name
+        try:
+            if not path.is_file():
+                continue
+            parser = configparser.ConfigParser()
+            parser.read(path, encoding="utf-8")
+            if not parser.has_section(section):
+                continue
+            paths = _split(parser.get(section, "testpaths", fallback=""))
+            files = _split(parser.get(section, "python_files", fallback=""))
+            if paths or files:
+                return (paths or _FALLBACK_TESTPATHS,
+                        files or _FALLBACK_PYTHON_FILES)
+        except Exception:  # noqa: BLE001
+            logger.debug("[ProgressBoard] %s unreadable", name, exc_info=True)
+
+    try:
+        import tomllib  # py3.11+
+        path = repo_root / "pyproject.toml"
+        if path.is_file():
+            table = tomllib.loads(path.read_text(encoding="utf-8"))
+            opts = table.get("tool", {}).get("pytest", {}).get(
+                "ini_options", {})
+            paths = tuple(opts.get("testpaths") or ())
+            files = tuple(opts.get("python_files") or ())
+            if paths or files:
+                return (paths or _FALLBACK_TESTPATHS,
+                        files or _FALLBACK_PYTHON_FILES)
+    except Exception:  # noqa: BLE001
+        logger.debug("[ProgressBoard] pyproject unreadable", exc_info=True)
+
+    return _FALLBACK_TESTPATHS, _FALLBACK_PYTHON_FILES
+
+
+def test_collection_config(
+        repo_root: Optional[Path] = None,
+) -> Tuple[Tuple[str, ...], Tuple[str, ...]]:
+    """The project's own answer to "what is a test", cached per root."""
+    root = Path(repo_root) if repo_root else _default_root()
+    key = str(root)
+    got = _TEST_CONFIG_CACHE.get(key)
+    if got is None:
+        got = _parse_pytest_config(root)
+        _TEST_CONFIG_CACHE[key] = got
+    return got
+
+
+_TEST_CONFIG_CACHE: Dict[str, Tuple[Tuple[str, ...], Tuple[str, ...]]] = {}
+
+
+def _is_test_path(rel: str, repo_root: Optional[Path] = None) -> bool:
     """Tests import things without making them live.
 
     A module whose ONLY importers are tests is inert in production — that is
     precisely the state this board exists to surface, so test importers must
     not be allowed to launder a dark module into a live one.
 
-    Matched on SEGMENTS, not substrings. The first version tested
-    ``"/test" in lowered``, which is true of ``voice_unlock/testing/`` and of
-    ``scripts/testrunner_streaming_livefire.py`` — production modules whose
-    flags then never entered the board's universe and whose imports never
-    vouched for anything. It also tested ``"/conftest.py" in lowered``, which
-    the repository-root ``conftest.py`` does not contain, so the one conftest
-    every session loads counted as a PRODUCTION importer.
+    THE HARD PART IS THAT A NAME IS NOT A ROLE
+    ------------------------------------------
+    Two rules were tried before this one and both decided a file's role from
+    the spelling of its path.
 
-    Both directions of that error are the same mistake: deciding a path's role
-    from a substring of its spelling. A segment is what a directory actually
-    is, so that is what is compared. Measured on this tree, the two rules
-    disagree about exactly four files and each of the four is now on the
-    correct side.
+    The first matched substrings. ``"/test" in path`` is true of
+    ``voice_unlock/testing/`` and ``scripts/testrunner_streaming_livefire.py``,
+    so those production modules' flags never entered the board's universe;
+    and ``"/conftest.py"`` is false of the repository-ROOT ``conftest.py``, so
+    the one conftest every session loads counted as a production importer.
+
+    The second matched segments, which fixed those four and left the deeper
+    error in place: a bare ``name.endswith("_test.py")`` classifies
+    ``scripts/ouroboros_battle_test.py`` — THE entry point that boots the
+    six-layer stack, the thing :func:`scan_roots` was widened to include
+    precisely because it "is how this system actually runs" — as a test. So
+    did ``governance/test_runner.py``, ``intent/test_watcher.py``,
+    ``intake/sensors/test_failure_sensor.py`` and
+    ``intent/test_source_attribution.py``: production modules named for the
+    thing they OPERATE ON rather than for what they are. Everything reachable
+    only through them read DARK.
+
+    SO ASK THE PROJECT
+    ------------------
+    pytest already answers this question, in configuration, for this exact
+    repository::
+
+        testpaths    = tests test_*.py
+        python_files = test_*.py *_test.py
+
+    A file is a test iff pytest would collect it: it matches ``python_files``
+    AND lies under a declared ``testpaths`` entry. ``governance/test_runner.py``
+    matches the name pattern and is under neither, so pytest never collects
+    it and neither does this. The rule now tracks the project's own
+    definition and moves when it moves, rather than restating a convention
+    that a hundred and sixty-seven files in this tree do not follow.
+
+    Two belts stay on top of that, both conservative in the safe direction —
+    over-classifying as test costs a visible false DARK, under-classifying
+    launders a dark module into live:
+
+    * any ``test``/``tests`` DIRECTORY segment, wherever it sits;
+    * ``conftest.py`` anywhere, since it is loaded by collection and never by
+      production.
     """
     lowered = rel.replace("\\", "/").lower()
     parts = lowered.split("/")
     name = parts[-1] if parts else lowered
-    return (
-        any(segment in ("test", "tests") for segment in parts[:-1])
-        or name.startswith("test_")
-        or name.endswith("_test.py")
-        or name == "conftest.py"
-    )
+
+    if name == "conftest.py":
+        return True
+    if any(segment in ("test", "tests") for segment in parts[:-1]):
+        return True
+
+    testpaths, python_files = test_collection_config(repo_root)
+    if not any(fnmatch.fnmatch(name, pat) for pat in python_files):
+        return False
+
+    for entry in testpaths:
+        cleaned = entry.strip("/").lower()
+        if not cleaned:
+            continue
+        if "*" in cleaned or "?" in cleaned:
+            # A bare glob in `testpaths` addresses files at the root — pytest
+            # resolves testpaths relative to the rootdir, and fnmatch's `*`
+            # would otherwise cross directory boundaries and re-swallow
+            # `scripts/ouroboros_battle_test.py` through the back door.
+            if len(parts) == 1 and fnmatch.fnmatch(name, cleaned):
+                return True
+            continue
+        if lowered == cleaned or lowered.startswith(f"{cleaned}/"):
+            return True
+    return False
 
 
 @dataclass(frozen=True)
@@ -667,7 +805,7 @@ class ProgressBoard:
                 root_prefix = f"{root}."
                 if self_mod.startswith(root_prefix):
                     aliases.setdefault(self_mod[len(root_prefix):], self_mod)
-            is_test = _is_test_path(rel)
+            is_test = _is_test_path(rel, self._repo_root)
             if not is_test:
                 for name in _imported_modules(
                         tree, self_mod, rel.endswith("__init__.py")):

--- a/backend/core/ouroboros/governance/capability_liveness.py
+++ b/backend/core/ouroboros/governance/capability_liveness.py
@@ -116,13 +116,40 @@ def _snapshot_ttl_s() -> float:
 
 
 def _is_test_path(rel: str) -> bool:
-    """Test-path exclusion, consistent with reverse_dep_resolver semantics."""
-    r = rel.replace("\\", "/")
-    parts = r.split("/")
-    if any(p in ("tests", "test") for p in parts):
-        return True
-    base = parts[-1] if parts else r
-    return base.startswith("test_") or base == "conftest.py" or base.endswith("_test.py")
+    """Test-path exclusion. Delegates to the board's rule.
+
+    This module and ``progress_board`` are asking the SAME question — "does
+    this file count as production for reachability purposes" — and until now
+    each answered it with its own copy of a naming convention. Both copies
+    were wrong the same way: a bare ``endswith("_test.py")`` classifies
+    ``scripts/ouroboros_battle_test.py`` (THE entry point that boots the
+    six-layer stack) as a test, along with ``governance/test_runner.py``,
+    ``intent/test_watcher.py`` and ``intake/sensors/test_failure_sensor.py``.
+    Anything reachable only through those read as unreferenced.
+
+    Two authorities for one question is the defect this repository keeps
+    shipping, so there is now one. The board derives the answer from the
+    project's own pytest ``testpaths``/``python_files``, which is the only
+    thing that actually decides whether a file is collected as a test.
+
+    Falls back to the previous local rule if the board is unimportable — this
+    module must keep working in a stripped install, and a conservative
+    over-classification (a production file treated as a test) costs a visible
+    false severance rather than a silently laundered one.
+    """
+    try:
+        from backend.core.ouroboros.battle_test.progress_board import (
+            _is_test_path as _board_is_test_path,
+        )
+        return _board_is_test_path(rel)
+    except Exception:  # noqa: BLE001
+        r = rel.replace("\\", "/")
+        parts = r.split("/")
+        if any(p in ("tests", "test") for p in parts):
+            return True
+        base = parts[-1] if parts else r
+        return (base.startswith("test_") or base == "conftest.py"
+                or base.endswith("_test.py"))
 
 
 def _public_symbols(source: str) -> Tuple[str, ...]:

--- a/backend/core/ouroboros/governance/intake/intake_layer_service.py
+++ b/backend/core/ouroboros/governance/intake/intake_layer_service.py
@@ -257,6 +257,11 @@ class IntakeLayerService:
         self._cross_repo_drift_sensor: Optional[Any] = None
         # Slice 6 — PerformanceRegressionSensor handle for CI webhook route.
         self._performance_regression_sensor: Optional[Any] = None
+        # MetaSensor handle. Declared here rather than only assigned inside
+        # ``_build_components`` so a construction failure leaves a readable
+        # ``None`` instead of a missing attribute — an alarm that raises
+        # AttributeError when consulted is worse than one that says "absent".
+        self._meta_sensor: Optional[Any] = None
         self._event_channel_server: Optional[Any] = None
         # Stage-2 Task 2 -- organism-owned mTLS WS bus host. Populated in
         # ``_maybe_start_organism_bus_host`` only when the
@@ -1112,6 +1117,39 @@ class IntakeLayerService:
             logger.info("[IntakeLayer] ProactiveExplorationSensor added (curiosity-driven)")
         except Exception as exc:
             logger.debug("[IntakeLayer] ProactiveExplorationSensor skipped: %s", exc)
+
+        # ---- MetaSensor (Priority B: the degenerate-loop dormancy alarm) ----
+        # Every other sensor watches the world; this one watches O+V watching
+        # the world, and fires when a subsystem has gone silently inert —
+        # postmortems arriving with total_claims=0 being the seed detector.
+        #
+        # It was merged with JARVIS_META_SENSOR_ENABLED defaulting TRUE and
+        # zero import statements anywhere in the tree, tests included: the
+        # alarm for silent inertness was itself silently inert, which is the
+        # single most quotable row in the 2026-08-08 reachability audit.
+        #
+        # Registered unconditionally for lifecycle, following WorkOrderSensor:
+        # `start()` and `scan_once()` both consult the master flag themselves,
+        # so the flag governs BEHAVIOUR and the mount governs REACHABILITY.
+        # Gating the construction on the flag would recreate the defect in its
+        # subtler form — dark whenever the flag happens to be off, and no
+        # longer distinguishable from dead-by-omission.
+        try:
+            from backend.core.ouroboros.governance.intake.sensors.meta_sensor import (
+                MetaSensor,
+            )
+            _meta_sensor = MetaSensor(
+                repo="jarvis",
+                router=self._router,
+                # No interval argument on purpose. `meta_sensor_interval_s()`
+                # is the single authority for that number; resolving the env
+                # here would put a second default beside the constructor's.
+            )
+            self._sensors.append(_meta_sensor)
+            self._meta_sensor = _meta_sensor
+            logger.info("[IntakeLayer] MetaSensor added (degenerate-loop dormancy alarm)")
+        except Exception as exc:
+            logger.debug("[IntakeLayer] MetaSensor skipped: %s", exc)
 
         # ---- IntentDiscoverySensor (Manifesto §1: intent-driven exploration) ----
         # Connects StrategicDirection + DreamEngine + Oracle + DW to explore

--- a/backend/core/ouroboros/governance/intake/sensors/meta_sensor.py
+++ b/backend/core/ouroboros/governance/intake/sensors/meta_sensor.py
@@ -83,6 +83,31 @@ def meta_sensor_enabled() -> bool:
     return raw in ("1", "true", "yes", "on")
 
 
+def meta_sensor_interval_s() -> float:
+    """Seconds between dormancy sweeps. Default 1800 (30 min).
+
+    Lives here beside the other knobs rather than at the construction site,
+    which is where every other sensor resolves its interval. The difference
+    matters: ``MetaSensor.__init__`` already carried ``1800.0`` as a keyword
+    default, so an ``os.environ.get(..., "1800")`` written next to the
+    constructor call would have made two authorities for one number — the
+    defect ``tests/architecture/test_env_default_single_authority.py`` exists
+    to catch, reintroduced in the act of wiring the sensor that watches for
+    exactly this class of silent inertness.
+
+    Dormancy is a slow signal: it is computed over a rolling window of
+    ``empty_postmortem_window()`` postmortems, so sweeping faster than the
+    ledger changes costs disk reads and tells nobody anything new. Floored at
+    one minute so a mistyped value cannot turn an alarm into a busy-loop.
+    """
+    raw = os.environ.get("JARVIS_META_SENSOR_INTERVAL_S", "1800")
+    try:
+        val = float(raw)
+    except (TypeError, ValueError):
+        return 1800.0
+    return max(60.0, val)
+
+
 def empty_postmortem_threshold() -> float:
     """Fraction of recent postmortems with ``total_claims=0`` above
     which the detector fires. Default 0.7 (70%) per PRD §25.5.2."""
@@ -410,11 +435,17 @@ class MetaSensor:
         self,
         repo: str,
         router: Any,
-        poll_interval_s: float = 1800.0,  # 30 min default
+        poll_interval_s: Optional[float] = None,
     ) -> None:
         self._repo = repo
         self._router = router
-        self._poll_interval_s = poll_interval_s
+        # `None` means "ask the resolver", which is the only place the 1800
+        # lives. An explicit value still wins, so every existing caller and
+        # test behaves exactly as before.
+        self._poll_interval_s = (
+            meta_sensor_interval_s() if poll_interval_s is None
+            else float(poll_interval_s)
+        )
         self._running = False
         self._task: Optional[asyncio.Task] = None
         # Dedup by (detector_kind, summary) — when severity / sample
@@ -571,6 +602,7 @@ __all__ = [
     "empty_postmortem_window",
     "list_dormancy_detectors",
     "meta_sensor_enabled",
+    "meta_sensor_interval_s",
     "register_dormancy_detector",
     "reset_registry_for_tests",
     "unregister_dormancy_detector",

--- a/tests/architecture/test_reachability_single_authority.py
+++ b/tests/architecture/test_reachability_single_authority.py
@@ -1,16 +1,26 @@
 """Architecture pin: a switch that is ON must be reachable.
 
-``JARVIS_META_SENSOR_ENABLED`` defaults to true. The PRD records it as
-"graduated default-true (§25 Priority B)". ``meta_sensor.py`` is on disk, has
-tests, and has **zero import statements anywhere in the tree**. The sensor
-whose job is to notice that O+V has stopped learning is itself the thing
-nobody noticed.
+``JARVIS_META_SENSOR_ENABLED`` defaults to true. The PRD recorded it as
+"graduated default-true (§25 Priority B)". ``meta_sensor.py`` was on disk,
+had tests, and had **zero import statements anywhere in the tree**. The
+sensor whose job is to notice that O+V has stopped learning was itself the
+thing nobody noticed. It is now mounted, and
+``test_the_dormancy_alarm_stays_reachable`` below defends that.
 
-It is not alone. A full board scan on 2026-08-08 found 37 switches in that
+It was not alone. A full board scan on 2026-08-08 found 37 switches in that
 state, and they are not scattered — 12 are the adaptive immune system
 (``governance/adaptation/``), 6 are closed-loop verification and replay
 (``governance/verification/``), 3 are temporal observability. Those are
 precisely the tiers the PRD grades A, A− and A+.
+
+Two of the 37 were never dark at all: ``replay_from_record`` and
+``multi_op_renderer`` are imported by ``scripts/ouroboros_battle_test.py``,
+and ``_is_test_path`` was classifying THE entry point that boots the
+six-layer stack as a test file because its name ends ``_test.py``. So did
+``governance/test_runner.py``, ``intent/test_watcher.py`` and
+``intake/sensors/test_failure_sensor.py``. That is fixed at the root — the
+board now asks pytest's own ``testpaths``/``python_files`` configuration
+whether a file would be collected — and the count is 34 with the alarm wired.
 
 So the defect is not any one dark module. It is that **this repository
 measures merges and reports them as capability.** A merge is evidence that
@@ -108,12 +118,6 @@ _WAIVED: Dict[str, str] = {
     # The feedback edge. These six are why O+V cannot learn across ops, and
     # they must be wired BEFORE the adaptive tier below — Pass C's tighteners
     # consume this signal, so adapting first would adapt on noise.
-    "JARVIS_META_SENSOR_ENABLED": (
-        "TIER 1. The degenerate-loop alarm: fires when postmortems go empty, "
-        "i.e. when the organism has stopped learning. Zero import statements "
-        "in the entire tree, tests included. Wiring this one first is what "
-        "would let O+V find the rest of this list without a human."
-    ),
     "JARVIS_POSTMORTEM_INJECTION_ENABLED": (
         "TIER 1. Injects prior postmortems into the generation prompt. "
         "Without it every operation reasons from a blank slate about failures "
@@ -133,15 +137,12 @@ _WAIVED: Dict[str, str] = {
         "urgency alone. The PRD grades 'Confidence-Aware Execution CLOSED "
         "2026-04-29'; the import graph disagrees."
     ),
-    "JARVIS_CAUSALITY_REPLAY_FROM_RECORD_ENABLED": (
-        "TIER 1. Deterministic replay of a recorded decision — the "
-        "time-travel debugging the roadmap asks for, already written. "
-        "Imported by scripts/ouroboros_battle_test.py alone, so it is "
-        "reachable in a soak and dark in `ov`."
-    ),
     "JARVIS_REPLAY_HOOK_ENABLED": (
-        "TIER 1. The orchestrator-side hook replay_from_record needs to "
-        "capture from. Dark for the same reason and fixed by the same change."
+        "TIER 1. replay_orchestrator_hook — `record_session_replay()`, the "
+        "surface that feeds the replay pipeline after a session completes. "
+        "Genuinely unimported: unlike replay_from_record beside it, not even "
+        "the soak harness calls this one, so nothing ever records a session "
+        "for the replay machinery to fork from."
     ),
     "JARVIS_CIGW_COLLECTOR_ENABLED": (
         "TIER 1. gradient_collector — gathers the per-op signal the "
@@ -210,11 +211,6 @@ _WAIVED: Dict[str, str] = {
     ),
 
     # ---- Tier 3: temporal observability + Order-2 -------------------------
-    "JARVIS_PHASE8_MULTI_OP_RENDERER_ENABLED": (
-        "TIER 3. multi_op_renderer — the synchronized multi-op timeline. "
-        "Imported by the soak harness only. It also has nowhere to draw: the "
-        "cockpit has no live region, which is the separate renderer defect."
-    ),
     "JARVIS_PHASE8_IDE_OBSERVABILITY_ENABLED": (
         "TIER 3. observability/ide_routes — the Phase 8 GET surface. Distinct "
         "from ide_observability.py, which IS live; this is the temporal one."
@@ -501,7 +497,11 @@ def test_the_self_cleaning_check_fails_on_a_waiver_that_outlived_its_defect(
     then stale, and it must say so."""
     with pytest.raises(AssertionError) as caught:
         test_every_waiver_still_excuses_a_dark_switch(_reading_with())
-    assert "JARVIS_META_SENSOR_ENABLED" in str(caught.value)
+    # Every waiver is stale against an empty reading, so the message must
+    # enumerate them rather than say "34 stale waivers" — a count sends the
+    # reader back to a cold scan to find out which.
+    for flag in _WAIVED:
+        assert flag in str(caught.value), flag
 
 
 def test_the_ceiling_fails_when_the_backlog_grows() -> None:
@@ -799,19 +799,92 @@ def test_the_cache_cannot_perturb_its_own_key(isolated) -> None:
 # the findings this pin was built from, as regressions
 # ---------------------------------------------------------------------------
 
-def test_meta_sensor_is_still_the_headline(reading: BoardReading) -> None:
-    """The single most quotable row. When this fails, it is either because
-    meta_sensor was wired — delete this test and its waiver — or because the
-    board stopped seeing it, which is far more serious."""
+def test_the_dormancy_alarm_stays_reachable(reading: BoardReading) -> None:
+    """meta_sensor was the headline finding and is now wired. This defends it.
+
+    It is the one module on the list whose absence hides the others: a sensor
+    that fires when postmortems arrive empty is how O+V would notice a
+    subsystem had gone inert WITHOUT a human running an audit. Losing it again
+    would cost more than the row itself.
+
+    A regression here means the mount in `intake_layer_service._build_
+    components` was removed or the import moved somewhere the graph cannot
+    see. Both are silent in every other test.
+    """
     rows = {r.flag: r for r in reading.rows}
     got = rows.get("JARVIS_META_SENSOR_ENABLED")
     assert got is not None, "the flag vanished from the board entirely"
-    assert got.state in (DARK, "live"), got.state
-    if got.state != DARK:
-        pytest.fail(
-            "meta_sensor is reachable now — delete this test and its waiver, "
-            "and lower the ceiling in test_the_backlog_is_shrinking_not_growing"
-        )
+    assert got.state != DARK, (
+        "the dormancy alarm is unreachable again — check that "
+        "intake_layer_service still constructs MetaSensor and appends it to "
+        "self._sensors"
+    )
+    assert got.importers >= 1, got.reason
+
+
+def test_the_alarm_is_mounted_for_lifecycle_not_gated_on_its_own_flag(
+) -> None:
+    """Reachability and behaviour are different questions.
+
+    The flag governs whether the sensor DOES anything — `start()` and
+    `scan_once()` both consult `meta_sensor_enabled()` themselves. The mount
+    governs whether it EXISTS. Wrapping the construction in a flag check would
+    reintroduce the defect in its subtler form: dark whenever the flag is off,
+    and no longer distinguishable from dead-by-omission.
+    """
+    import inspect
+    from backend.core.ouroboros.governance.intake import intake_layer_service
+
+    src = inspect.getsource(intake_layer_service)
+    idx = src.index("MetaSensor(")
+    # The construction and the append must sit together with no flag between.
+    window = src[idx:idx + 400]
+    assert "self._sensors.append(_meta_sensor)" in window
+    assert "meta_sensor_enabled" not in src, (
+        "the mount consults the master flag — that gates REACHABILITY on a "
+        "behaviour switch and puts the sensor back in the dark when it is off"
+    )
+
+
+def test_the_alarm_has_one_authority_for_its_interval() -> None:
+    """The wiring must not reintroduce the defect the sibling pin catches.
+
+    `MetaSensor.__init__` already carried 1800.0. Resolving
+    `JARVIS_META_SENSOR_INTERVAL_S` at the construction site — which is what
+    every other sensor in that file does — would have made two defaults for
+    one number, in the act of wiring the sensor that watches for exactly this
+    class of silent wrongness.
+    """
+    import inspect
+    from backend.core.ouroboros.governance.intake import intake_layer_service
+    from backend.core.ouroboros.governance.intake.sensors import meta_sensor
+
+    import ast as _ast
+    import textwrap
+
+    mount = inspect.getsource(intake_layer_service)
+    idx = mount.index("MetaSensor(")
+    assert "JARVIS_META_SENSOR_INTERVAL_S" not in mount[idx - 600:idx + 400], (
+        "the mount resolves the interval itself"
+    )
+
+    ctor = inspect.getsource(meta_sensor.MetaSensor.__init__)
+    assert "meta_sensor_interval_s()" in ctor, (
+        "the constructor no longer defers to the resolver"
+    )
+    # A substring search for "1800" would match this test's own explanation of
+    # why 1800 must not appear — and it did, on the first version of this
+    # assertion. Comments are not code; only a literal in the AST is a second
+    # default.
+    tree = _ast.parse(textwrap.dedent(ctor))
+    literals = {
+        node.value for node in _ast.walk(tree)
+        if isinstance(node, _ast.Constant) and isinstance(node.value, (int, float))
+        and not isinstance(node.value, bool)
+    }
+    assert 1800 not in literals and 1800.0 not in literals, (
+        f"the constructor carries a second default: {sorted(literals)}"
+    )
 
 
 def test_the_dark_tiers_are_still_where_the_audit_found_them(

--- a/tests/battle_test/test_progress_board.py
+++ b/tests/battle_test/test_progress_board.py
@@ -180,14 +180,43 @@ class TestHelpers:
         assert _module_name("backend/core/__init__.py") == "backend.core"
 
     @pytest.mark.parametrize("rel", [
-        "tests/x.py", "backend/tests/y.py", "backend/test_z.py",
-        "backend/conftest.py",
+        "tests/x.py", "backend/tests/y.py", "backend/conftest.py",
+        "conftest.py",          # the ROOT conftest, which "/conftest.py" missed
+        "test_actual_voice.py",  # root-level: pytest.ini names `test_*.py`
     ])
     def test_test_paths_are_recognised(self, rel):
         assert _is_test_path(rel)
 
-    def test_production_paths_are_not(self):
-        assert not _is_test_path("backend/core/ouroboros/orchestrator.py")
+    @pytest.mark.parametrize("rel", [
+        "backend/core/ouroboros/orchestrator.py",
+        # These four match a test NAME and are production. `_is_test_path`
+        # used to call all of them tests, which made every module reachable
+        # only through them read DARK — including the two flags the
+        # 2026-08-08 reachability audit wrongly listed as unwired.
+        "scripts/ouroboros_battle_test.py",
+        "backend/core/ouroboros/governance/test_runner.py",
+        "backend/core/ouroboros/governance/intent/test_watcher.py",
+        "backend/core/ouroboros/governance/intake/sensors/test_failure_sensor.py",
+    ])
+    def test_production_paths_are_not(self, rel):
+        assert not _is_test_path(rel)
+
+    def test_the_rule_comes_from_the_project_not_from_a_convention(self):
+        """`backend/test_z.py` USED to assert True here.
+
+        It is not collected by this repository's pytest — `testpaths` is
+        `tests test_*.py`, so a `test_*.py` nested under `backend/` is never
+        run — and the convention it encoded is the one that misclassified the
+        four production modules above. The rule now reads the project's own
+        configuration, so it moves when `pytest.ini` moves.
+        """
+        from backend.core.ouroboros.battle_test.progress_board import (
+            test_collection_config,
+        )
+        testpaths, python_files = test_collection_config()
+        assert "tests" in testpaths
+        assert "test_*.py" in python_files
+        assert not _is_test_path("backend/test_z.py")
 
 
 class TestEntryPoints:


### PR DESCRIPTION
Move #2 of the reachability critical path. Two findings, one of which **corrects #70443's numbers**.

## The instrument was classifying the entry point as a test

`_is_test_path` ended with a bare `name.endswith("_test.py")`. That is true of **`scripts/ouroboros_battle_test.py`** — THE entry point that boots the six-layer stack, the file `scan_roots()` was widened to include precisely because it *"is how this system actually runs."*

It was also true of five more production modules named for what they *operate on* rather than what they *are*:

| Module | What it is |
|---|---|
| `governance/test_runner.py` | TestRunner — a key subsystem in CLAUDE.md |
| `intent/test_watcher.py` | TestWatcher — the pytest poller |
| `intake/sensors/test_failure_sensor.py` | one of the 17 sensors |
| `intent/test_source_attribution.py` | the Slice 6 attribution bridge |
| `governance/test_subprocess_helper.py` | subprocess helper |

Everything reachable *only* through those read DARK.

**So #70443 was wrong about two of its 37.** `JARVIS_CAUSALITY_REPLAY_FROM_RECORD_ENABLED` and `JARVIS_PHASE8_MULTI_OP_RENDERER_ENABLED` are imported by the soak harness and always were. Their waivers said exactly that — *"imported by scripts/ouroboros_battle_test.py alone"* — which is how this was found: **the waiver text and the verdict disagreed.**

## Root cause, and the fix

This is the same defect as the substring bug fixed in #70443, one level up. Both decided a file's **role** from the spelling of its **name**. Neither asked anything.

pytest already answers this question, in configuration, for this repository:

```ini
testpaths    = tests test_*.py
python_files = test_*.py *_test.py
```

A file is a test **iff pytest would collect it** — matches `python_files` AND lies under a `testpaths` entry. `governance/test_runner.py` matches the name and is under neither, so pytest never collects it and neither does the board. The rule now tracks the project's own definition and moves when it moves, instead of restating a convention that 167 files in this tree do not follow.

Two conservative belts stay on top, both erring toward over-classifying as test (a false DARK is visible; a laundered module is not): any `test`/`tests` **directory segment**, and `conftest.py` anywhere.

**Measured:** the rule change moves exactly two flags and introduces zero false LIVEs. **37 → 35** dark switches, **131 → 127** dark total.

`pytest.ini` / `setup.cfg` / `pyproject.toml` are folded into the cache fingerprint — editing `testpaths` changes which flags are dark, and the `.py` walk cannot see a non-Python file.

**`capability_liveness.py` carried a second copy of the rule with the same bug.** It now delegates, with the old local rule retained as a fallback for a stripped install. One question, one authority.

## Wiring the dormancy alarm

`meta_sensor.py` is mounted in `intake_layer_service._build_components`, following the `WorkOrderSensor` precedent: **registered unconditionally for lifecycle**, with `start()` and `scan_once()` consulting the master flag themselves.

The flag governs **behaviour**; the mount governs **reachability**. Gating construction on the flag would recreate the defect in its subtler form — dark whenever the flag is off, and no longer distinguishable from dead-by-omission. Pinned by a test.

`meta_sensor_interval_s()` is added beside the module's existing knob resolvers, and `__init__` defers to it. Resolving `JARVIS_META_SENSOR_INTERVAL_S` at the construction site — which is what every other sensor in that file does — would have put a second default beside the constructor's existing `1800.0`, **in the act of wiring the sensor that watches for exactly this class of silent wrongness.**

Pinned by an AST test, because the first version of that check was a substring search that matched the digits in its own comment. That is the third instance of the same mistake in this arc, which is why the check is now structural.

## What the alarm said the moment it could be heard

```
p1  empty_postmortem_rate
VERIFICATION LOOP IS NOT EXERCISING — 71/100 (71%) of recent
postmortems have total_claims=0
```

First scan, real ledger, one envelope emitted. **The alarm was correct the whole time and nothing was listening.** That is a standing P1 for a separate investigation — it is the same gap the PRD grades A− for "closed-loop memory."

## Verification

| Suite | Result |
|---|---|
| `test_reachability_single_authority` | 29 passed |
| `test_progress_board` + `_relative` | 120 passed |
| `test_surface_reachability` + `test_source_assertion_audit` | 41 passed |
| `test_meta_sensor` | 40 passed |
| `test_capability_liveness` | 18 passed |
| `test_env_default_single_authority` | 10 passed |
| **total** | **258 passed** |

Live-fire: `MetaSensor` constructed with the mount's exact arguments resolves its interval from the single authority, runs `scan_once()`, produces one finding and emits one envelope.

Backlog ceiling lowered **37 → 34**: two waivers deleted because the instrument was wrong, one because the module is now wired. The self-cleaning check forced all three — it failed until each was removed, which is the mechanism working as designed on its first real use.

## Still dark, next

`postmortem_recall_injector` + `_consumer`, `confidence_route_advisor`, `replay_orchestrator_hook`, `gradient_collector`. Those need seams in CONTEXT_EXPANSION and the route dispatcher — real integration surface, not a mount — so they get their own PR with their own proof rather than riding along unproven here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mounts the dormancy alarm (`MetaSensor`) and aligns test-file detection with pytest so the reachability board stops misclassifying production files. This corrects two false-dark switches and keeps the alarm reachable while its behavior remains behind the flag.

- **Bug Fixes**
  - `_is_test_path` now reads pytest config (`testpaths`, `python_files`) and still treats `conftest.py` and `tests/` segments as tests; `pytest.ini`/`setup.cfg`/`pyproject.toml` are folded into the cache key.
  - Stops classifying `scripts/ouroboros_battle_test.py` and similar production modules as tests, moving two switches from dark to live.
  - `capability_liveness` delegates test-path logic to the board’s rule with a safe fallback.

- **New Features**
  - Wired `MetaSensor` in `intake_layer_service._build_components` unconditionally; `start()` and `scan_once()` check `JARVIS_META_SENSOR_ENABLED` so the flag governs behavior, not reachability.
  - Added `meta_sensor_interval_s()` and made `MetaSensor.__init__` use it when `poll_interval_s=None`; no env read at the call site and a 60s minimum interval.

<sup>Written for commit 6fbba90e67df3c5d763fec55d3d31e54c3b83132. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

