### PR TITLE
fix(verification): the alarm counted ops that could not have claimed

### DIFF
--- a/backend/core/ouroboros/governance/intake/sensors/meta_sensor.py
+++ b/backend/core/ouroboros/governance/intake/sensors/meta_sensor.py
@@ -354,28 +354,53 @@ def _evaluate_empty_postmortem_rate() -> Optional[DormancyFinding]:
         pms = list_recent_postmortems(limit=window)
     except Exception:  # noqa: BLE001
         return None
-    if len(pms) < min_records:
+    # Only ops that got PAST the claim-capture phase belong in this rate.
+    #
+    # The first version of this detector divided by every postmortem in the
+    # window. Measured on the live ledger the day the alarm was first heard:
+    # 3,333 of 5,644 empty records were ops that terminated at CLASSIFY,
+    # before PLAN exists to capture anything, and 100% of routed ops with a
+    # postmortem HAD captured claims. So the alarm sat at a permanent 71%,
+    # named the wrong subsystem, and pointed the operator at wiring that was
+    # working — while the real signal (claims captured and then unjudgeable)
+    # went unreported for months.
+    #
+    # `claims_were_applicable` is derived from the enclosing ledger record's
+    # phase against the FSM's own canonical ordering. `unknown` provenance is
+    # excluded from BOTH numerator and denominator rather than assumed
+    # either way.
+    applicable = [pm for pm in pms if getattr(pm, "claims_were_applicable", True)]
+    if len(applicable) < min_records:
+        # Not enough ops reached the capture phase to say anything. Silence
+        # here is a measurement, not an all-clear — a window in which almost
+        # nothing routes is its own signal, and belongs to a detector that
+        # names THAT rather than being smuggled in under this one.
         return None
     empty_count = sum(
-        1 for pm in pms if getattr(pm, "total_claims", 0) == 0
+        1 for pm in applicable if getattr(pm, "total_claims", 0) == 0
     )
-    rate = empty_count / max(1, len(pms))
+    rate = empty_count / max(1, len(applicable))
     if rate < threshold:
         return None
+    skipped = len(pms) - len(applicable)
     return DormancyFinding(
         detector_kind="empty_postmortem_rate",
         severity="p1",
         summary=(
             f"VERIFICATION LOOP IS NOT EXERCISING — "
-            f"{empty_count}/{len(pms)} ({rate:.0%}) of recent "
-            f"postmortems have total_claims=0. Phase 2 is recording "
-            f"terminations but not predictions. Check Priority A "
+            f"{empty_count}/{len(applicable)} ({rate:.0%}) of ops that "
+            f"reached the claim-capture phase have total_claims=0. "
+            f"({skipped} of {len(pms)} records excluded: the op stopped "
+            f"before PLAN, where zero claims is correct.) Phase 2 is "
+            f"recording terminations but not predictions. Check Priority A "
             f"claim-capture wiring at every PLAN exit."
         ),
         evidence=(
             ("detector_kind", "empty_postmortem_rate"),
             ("empty_count", empty_count),
-            ("total_count", len(pms)),
+            ("total_count", len(applicable)),
+            ("records_read", len(pms)),
+            ("excluded_not_applicable", skipped),
             ("rate", rate),
             ("threshold", threshold),
             ("window", window),
@@ -398,6 +423,138 @@ def _evaluate_empty_postmortem_rate() -> Optional[DormancyFinding]:
     )
 
 
+def unjudgeable_claim_threshold() -> float:
+    """Fraction of evaluated claims returning INSUFFICIENT_EVIDENCE above
+    which the loop is judged non-exercising. Default 0.5.
+
+    Lower than the empty-postmortem threshold on purpose. A claim that cannot
+    be judged is strictly worse than one that was never made: it costs a
+    ledger write, it appears in the count, and it reads as coverage.
+    """
+    raw = os.environ.get("JARVIS_META_UNJUDGEABLE_CLAIM_THRESHOLD", "0.5")
+    try:
+        val = float(raw)
+    except (TypeError, ValueError):
+        return 0.5
+    return max(0.0, min(1.0, val))
+
+
+def unjudgeable_min_claims() -> int:
+    """Minimum evaluated claims before the unjudgeable detector speaks."""
+    raw = os.environ.get("JARVIS_META_UNJUDGEABLE_MIN_CLAIMS", "50")
+    try:
+        val = int(raw)
+    except (TypeError, ValueError):
+        return 50
+    return max(1, val)
+
+
+def _evaluate_unjudgeable_claim_rate() -> Optional[DormancyFinding]:
+    """Claims are being MADE and cannot be JUDGED.
+
+    The signal that was hiding behind the empty-postmortem alarm. On the
+    ledger the day the alarm was first heard: of 18,414 claims recorded at
+    COMPLETE, 13,911 (76%) returned INSUFFICIENT_EVIDENCE and **zero ever
+    returned FAILED** — across 151,612 claims all-time. Three default claims
+    accounted for the insufficiency in exactly equal counts (4,637 each),
+    which is the signature of properties attached to every op whose required
+    evidence is never supplied:
+
+        provider_route, is_read_only, providers_used
+        diff_text
+        test_files_pre, test_files_post
+
+    A ``must_hold`` claim that always evaluates INSUFFICIENT is not a safety
+    property. It is a comment with a ledger write attached, and because
+    INSUFFICIENT is not FAILED it never blocks and never surfaces. The
+    postmortem reports ``total_claims`` going up and the verification loop
+    reads as healthy while deciding nothing.
+
+    This detector measures whether verdicts are being REACHED, which is the
+    question ``empty_postmortem_rate`` was always meant to be asking.
+
+    NEVER raises.
+    """
+    try:
+        from backend.core.ouroboros.governance.verification import (
+            list_recent_postmortems,
+        )
+    except Exception:  # noqa: BLE001
+        return None
+    window = empty_postmortem_window()
+    threshold = unjudgeable_claim_threshold()
+    min_claims = unjudgeable_min_claims()
+    try:
+        pms = list_recent_postmortems(limit=window)
+    except Exception:  # noqa: BLE001
+        return None
+
+    total = sum(int(getattr(pm, "total_claims", 0) or 0) for pm in pms)
+    if total < min_claims:
+        return None
+    insufficient = sum(
+        int(getattr(pm, "insufficient_count", 0) or 0) for pm in pms
+    )
+    errored = sum(int(getattr(pm, "error_count", 0) or 0) for pm in pms)
+    undecided = insufficient + errored
+    rate = undecided / max(1, total)
+    if rate < threshold:
+        return None
+
+    # Name the evidence keys actually responsible rather than making the
+    # operator re-derive them: the reason strings are already on the
+    # outcomes, and a finding that says "76% unjudgeable" without saying
+    # WHICH property sends them back to a ledger walk.
+    reasons: Dict[str, int] = {}
+    for pm in pms:
+        for outcome in getattr(pm, "outcomes", ()) or ():
+            try:
+                verdict = outcome.verdict
+                if verdict.verdict.value == "passed":
+                    continue
+                key = str(verdict.property_name or verdict.kind or "?")
+                reasons[key] = reasons.get(key, 0) + 1
+            except Exception:  # noqa: BLE001 — malformed outcome, skip
+                continue
+    top = sorted(reasons.items(), key=lambda kv: (-kv[1], kv[0]))[:5]
+    top_repr = "; ".join(f"{name}={count}" for name, count in top) or "n/a"
+
+    return DormancyFinding(
+        detector_kind="unjudgeable_claim_rate",
+        severity="p1",
+        summary=(
+            f"CLAIMS ARE MADE BUT NOT JUDGED — {undecided}/{total} "
+            f"({rate:.0%}) of recorded claims returned "
+            f"INSUFFICIENT_EVIDENCE or evaluator error. A must_hold claim "
+            f"that cannot be evaluated never blocks, so the loop reports "
+            f"coverage while deciding nothing. Worst properties: {top_repr}"
+        ),
+        evidence=(
+            ("detector_kind", "unjudgeable_claim_rate"),
+            ("total_claims", total),
+            ("insufficient_count", insufficient),
+            ("error_count", errored),
+            ("rate", rate),
+            ("threshold", threshold),
+            ("window", window),
+            ("top_properties", top_repr),
+            ("remediation", (
+                "For each property above, compare its evidence_required "
+                "tuple against what the evidence collector actually "
+                "supplies at evaluation time. Either the collector must "
+                "produce those keys or the property must declare "
+                "requirements it can be judged on — a claim nobody can "
+                "settle should not carry must_hold severity."
+            )),
+        ),
+        target_files=(
+            "backend/core/ouroboros/governance/verification/evidence_collectors.py",
+            "backend/core/ouroboros/governance/verification/default_claims.py",
+            "backend/core/ouroboros/governance/verification/property_oracle.py",
+        ),
+    )
+
+
 def _register_seed_detectors() -> None:
     register_dormancy_detector(
         DormancyDetector(
@@ -409,6 +566,19 @@ def _register_seed_detectors() -> None:
                 "PLAN-time claim capture has silently disabled itself."
             ),
             evaluate=_evaluate_empty_postmortem_rate,
+        ),
+    )
+    register_dormancy_detector(
+        DormancyDetector(
+            detector_kind="unjudgeable_claim_rate",
+            severity="p1",
+            description=(
+                "Fires when >threshold of recorded claims return "
+                "INSUFFICIENT_EVIDENCE or evaluator error — the loop is "
+                "making predictions it has no evidence to settle, so it "
+                "reports coverage while deciding nothing."
+            ),
+            evaluate=_evaluate_unjudgeable_claim_rate,
         ),
     )
 

--- a/backend/core/ouroboros/governance/verification/postmortem.py
+++ b/backend/core/ouroboros/governance/verification/postmortem.py
@@ -104,7 +104,7 @@ import json
 import logging
 import os
 import time as _time
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace as _replace
 from pathlib import Path
 from typing import (
     Any, Awaitable, Callable, List, Mapping, Optional, Tuple,
@@ -195,6 +195,12 @@ class ClaimOutcome:
         )
 
 
+#: The phase at whose exit default claims are captured
+#: (``plan_runner._capture_default_claims_at_plan_exit``). Named once here
+#: rather than spelled at each comparison site.
+_CLAIM_CAPTURE_PHASE = "PLAN"
+
+
 @dataclass(frozen=True)
 class VerificationPostmortem:
     """Structured postmortem record of all claim verifications for
@@ -235,6 +241,15 @@ class VerificationPostmortem:
     started_unix: float = 0.0
     completed_unix: float = 0.0
     schema_version: str = VERIFICATION_POSTMORTEM_SCHEMA_VERSION
+    #: Which ledger record this reading came from and where the op stopped.
+    #:
+    #: Both are properties of the ENCLOSING record, not of the payload, so
+    #: they are stamped by the reader rather than serialised by the writer —
+    #: which also means every historical record acquires them for free.
+    #: Empty means the reading did not come through a reader that knows
+    #: (a freshly built postmortem, a hand-constructed one in a test).
+    record_kind: str = ""
+    terminated_at_phase: str = ""
 
     @property
     def total_failed(self) -> int:
@@ -249,6 +264,60 @@ class VerificationPostmortem:
     def total_passed(self) -> int:
         """All PASSED verdicts (any severity)."""
         return sum(1 for o in self.outcomes if o.passed)
+
+    @property
+    def claims_provenance(self) -> str:
+        """WHY ``total_claims`` is what it is. Never a guess.
+
+        ``total_claims == 0`` had four different meanings and one spelling,
+        and the MetaSensor's empty-postmortem alarm was reading all four as
+        the same defect. Measured on this repository's ledger the day the
+        alarm was first heard: of 8,288 postmortem records, 5,644 were empty
+        — and 3,333 of those were ops that terminated at CLASSIFY, before the
+        phase where claims are captured. Those records are CORRECT. Pooling
+        them into a rate produced a permanent 71% alarm pointing at
+        claim-capture wiring that was working at 100%.
+
+        An alarm that cannot be cleared is an alarm that gets ignored, so the
+        rate has to be taken over the population that could have claimed.
+        This is the same discipline `advisor_locality` established for blast
+        radius: a state that cannot be measured is reported as unknown, and a
+        measurement carries where it came from.
+
+        * ``evaluated``      — claims were found and judged.
+        * ``not_applicable`` — the op stopped before the claim-capture phase,
+          so zero is the right answer and not a finding.
+        * ``none_recorded``  — the op got past that point and this record
+          still has no claims. States the fact, asserts no cause: PLAN may
+          have been skipped by policy for a trivial op, or capture may have
+          failed. Both deserve a look; neither is assumed.
+        * ``unknown``        — the record did not come through a reader that
+          knows where the op stopped. Never counted either way.
+        """
+        if self.total_claims > 0:
+            return "evaluated"
+        phase = (self.terminated_at_phase or "").strip().upper()
+        if not phase:
+            return "unknown"
+        try:
+            from backend.core.ouroboros.governance.phase_cost import (
+                CANONICAL_PHASE_ORDER,
+            )
+            order = list(CANONICAL_PHASE_ORDER)
+            # Claims are captured at PLAN exit; anything strictly earlier in
+            # the canonical sequence never reached the capture site. Asking
+            # the FSM's own ordering rather than restating it keeps this
+            # correct when a phase is inserted.
+            here, plan = order.index(phase), order.index(_CLAIM_CAPTURE_PHASE)
+        except Exception:  # noqa: BLE001 — unknown phase, or no ordering
+            return "unknown"
+        return "not_applicable" if here < plan else "none_recorded"
+
+    @property
+    def claims_were_applicable(self) -> bool:
+        """True iff this record belongs in the denominator of a
+        claim-capture-health rate."""
+        return self.claims_provenance in ("evaluated", "none_recorded")
 
     @property
     def is_clean(self) -> bool:
@@ -770,6 +839,18 @@ def list_recent_postmortems(
                     continue
                 pm = VerificationPostmortem.from_dict(pm_dict)
                 if pm is not None:
+                    # Stamp the ENCLOSING record's identity onto the reading.
+                    # Both values were already parsed two lines above and
+                    # then dropped, and dropping them is what made
+                    # `total_claims == 0` unreadable: a CLASSIFY termination
+                    # and a COMPLETE with no claims arrived here identical.
+                    # Carrying them costs nothing and needs no migration —
+                    # every historical record acquires provenance on read.
+                    pm = _replace(
+                        pm,
+                        record_kind=str(record.get("kind") or ""),
+                        terminated_at_phase=str(record.get("phase") or ""),
+                    )
                     pms.append(pm)
     except OSError as exc:
         logger.debug(

--- a/tests/governance/test_postmortem_claims_provenance.py
+++ b/tests/governance/test_postmortem_claims_provenance.py
@@ -1,0 +1,446 @@
+"""`total_claims == 0` had four meanings and one spelling.
+
+The MetaSensor's dormancy alarm was mounted on 2026-08-08 and fired
+immediately:
+
+    p1  VERIFICATION LOOP IS NOT EXERCISING — 71/100 (71%) of recent
+    postmortems have total_claims=0 ... Check Priority A claim-capture
+    wiring at every PLAN exit.
+
+The claim-capture wiring was working at 100%. Measured on the live ledger:
+every one of 2,014 routed ops with a postmortem had captured claims. What the
+alarm was actually counting was ops that never got that far — 3,333 of its
+5,644 empty records terminated at CLASSIFY, before PLAN exists to capture
+anything. For those, zero is the correct answer.
+
+`list_recent_postmortems` deliberately pools two record kinds:
+
+    verification_postmortem   written at COMPLETE, claims evaluated
+    terminal_postmortem       written at EVERY non-COMPLETE termination
+
+A `terminal_postmortem` is by definition an op that did not complete. Pooling
+them into one rate produced an alarm stuck at ~71% forever, naming the wrong
+subsystem. An alarm that cannot be cleared is an alarm that gets ignored, and
+this one had been ignorable since the day it was written — it had no caller.
+
+THE ROOT CAUSE IS THAT THE RECORD COULD NOT SAY WHY IT WAS EMPTY
+----------------------------------------------------------------
+The enclosing ledger record carries `kind` and `phase`. `list_recent_
+postmortems` parsed both and dropped them one line later, so a CLASSIFY
+termination and a COMPLETE-with-no-claims arrived at the detector identical.
+Neither an operator nor a detector could tell "nothing was claimable" from
+"capture is broken".
+
+Provenance is now stamped by the reader from the record it already parses —
+no writer change, no schema migration, and every historical record acquires
+it on read. Same discipline `advisor_locality` established for blast radius:
+a measurement carries where it came from, and what cannot be measured is
+`unknown` rather than assumed.
+
+WHAT THE FIX EXPOSED
+--------------------
+With the denominator corrected the empty rate on the live window falls to 22%
+and the alarm goes quiet. The signal that had been hiding behind it does not:
+of 18,414 claims recorded at COMPLETE, 13,911 (76%) returned
+INSUFFICIENT_EVIDENCE, and across 151,612 claims all-time **not one has ever
+returned FAILED**. Three universal default claims account for it in exactly
+equal counts. A must_hold claim that can never be evaluated does not block,
+so the loop reports rising coverage while deciding nothing — which is what
+"the verification loop is not exercising" always meant.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from backend.core.ouroboros.governance.phase_cost import (  # noqa: E402
+    CANONICAL_PHASE_ORDER,
+)
+from backend.core.ouroboros.governance.verification.postmortem import (  # noqa: E402
+    _CLAIM_CAPTURE_PHASE,
+    VERIFICATION_POSTMORTEM_SCHEMA_VERSION,
+    VerificationPostmortem,
+    list_recent_postmortems,
+)
+
+
+def _pm(**kw) -> VerificationPostmortem:
+    base = dict(op_id="op-1", session_id="s")
+    base.update(kw)
+    return VerificationPostmortem(**base)
+
+
+# ---------------------------------------------------------------------------
+# the provenance itself
+# ---------------------------------------------------------------------------
+
+def test_claims_present_is_always_evaluated() -> None:
+    """A record with claims needs no phase reasoning."""
+    got = _pm(total_claims=3, terminated_at_phase="CLASSIFY")
+    assert got.claims_provenance == "evaluated"
+    assert got.claims_were_applicable is True
+
+
+@pytest.mark.parametrize("phase", ["CLASSIFY", "ROUTE", "CONTEXT_EXPANSION"])
+def test_stopping_before_plan_is_not_applicable(phase) -> None:
+    """THE 3,333 records. An op that never reached PLAN could not have
+    claimed, so its zero is correct and must not enter the rate."""
+    got = _pm(total_claims=0, terminated_at_phase=phase)
+    assert got.claims_provenance == "not_applicable"
+    assert got.claims_were_applicable is False
+
+
+@pytest.mark.parametrize("phase", ["GENERATE", "GATE", "APPLY", "COMPLETE",
+                                   "POSTMORTEM"])
+def test_stopping_after_plan_with_no_claims_is_a_finding(phase) -> None:
+    """States the fact and asserts no cause. PLAN may have been skipped by
+    policy for a trivial op, or capture may have failed. Both deserve a look;
+    neither is assumed here."""
+    got = _pm(total_claims=0, terminated_at_phase=phase)
+    assert got.claims_provenance == "none_recorded"
+    assert got.claims_were_applicable is True
+
+
+def test_an_unstamped_record_is_unknown_and_counted_neither_way() -> None:
+    """A postmortem built in memory, or read by something that does not know
+    where the op stopped, must not be guessed at in either direction."""
+    got = _pm(total_claims=0)
+    assert got.claims_provenance == "unknown"
+    assert got.claims_were_applicable is False
+
+
+def test_an_unrecognised_phase_is_unknown_not_optimistic() -> None:
+    got = _pm(total_claims=0, terminated_at_phase="TELEPORT")
+    assert got.claims_provenance == "unknown"
+
+
+def test_phase_matching_is_case_and_space_insensitive() -> None:
+    assert _pm(total_claims=0,
+               terminated_at_phase=" classify ").claims_provenance == \
+        "not_applicable"
+
+
+def test_the_capture_phase_is_in_the_canonical_order() -> None:
+    """The whole derivation hangs on this name existing in the FSM's own
+    ordering. If PLAN is ever renamed, every record silently becomes
+    `unknown` — visible as a dead alarm, but only if someone is looking."""
+    assert _CLAIM_CAPTURE_PHASE in CANONICAL_PHASE_ORDER
+
+
+def test_plan_itself_counts_as_having_reached_capture() -> None:
+    """Claims are captured at PLAN *exit*, so an op that terminated AT plan
+    got there. The live ledger has 9 such records and none is empty."""
+    assert _pm(total_claims=0,
+               terminated_at_phase="PLAN").claims_provenance == "none_recorded"
+
+
+# ---------------------------------------------------------------------------
+# the reader, which is where the information was being dropped
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def ledger(tmp_path, monkeypatch):
+    """A real per-session ledger, written in the on-disk shape."""
+    session = "provenance-test"
+    root = tmp_path / "determinism" / session
+    root.mkdir(parents=True)
+    monkeypatch.setenv("JARVIS_PROJECT_ROOT", str(tmp_path.parent))
+    return root / "decisions.jsonl", session
+
+
+def _write(path: Path, rows) -> None:
+    """Write the on-disk shape exactly, schema stamp included.
+
+    `from_dict` refuses a payload whose `schema_version` does not match, and
+    it is right to: a reader that accepts an unversioned blob will one day
+    accept a differently-shaped one and report whatever the defaults are. The
+    first draft of this helper omitted the stamp and three tests failed —
+    correctly.
+    """
+    with path.open("w", encoding="utf-8") as fh:
+        for kind, phase, payload in rows:
+            body = {"schema_version": VERIFICATION_POSTMORTEM_SCHEMA_VERSION}
+            body.update(payload)
+            fh.write(json.dumps({
+                "kind": kind, "phase": phase, "op_id": payload["op_id"],
+                "output_repr": json.dumps(body),
+            }) + "\n")
+
+
+def test_the_reader_stamps_kind_and_phase(monkeypatch, tmp_path) -> None:
+    """The regression. Both values were parsed and discarded one line later,
+    which is the entire reason the alarm could not tell its populations
+    apart."""
+    from backend.core.ouroboros.governance.verification import postmortem as pmod
+
+    path = tmp_path / "decisions.jsonl"
+    _write(path, [
+        ("terminal_postmortem", "CLASSIFY",
+         {"op_id": "op-a", "session_id": "s", "total_claims": 0}),
+        ("verification_postmortem", "COMPLETE",
+         {"op_id": "op-b", "session_id": "s", "total_claims": 2}),
+    ])
+    monkeypatch.setattr(pmod, "_ledger_path_for_session", lambda *_a, **_k: path)
+
+    rows = list_recent_postmortems(limit=10)
+    assert len(rows) == 2
+    by = {r.op_id: r for r in rows}
+    assert by["op-a"].record_kind == "terminal_postmortem"
+    assert by["op-a"].terminated_at_phase == "CLASSIFY"
+    assert by["op-a"].claims_provenance == "not_applicable"
+    assert by["op-b"].record_kind == "verification_postmortem"
+    assert by["op-b"].claims_provenance == "evaluated"
+
+
+def test_historical_records_acquire_provenance_without_migration(
+        monkeypatch, tmp_path) -> None:
+    """The payloads on disk predate these fields and are never rewritten.
+    Stamping from the ENCLOSING record is what makes 8,288 existing records
+    readable rather than requiring a migration nobody would run."""
+    from backend.core.ouroboros.governance.verification import postmortem as pmod
+
+    path = tmp_path / "decisions.jsonl"
+    # Exactly the historical shape: no provenance keys in the payload.
+    _write(path, [("terminal_postmortem", "CLASSIFY",
+                   {"op_id": "old", "session_id": "s", "total_claims": 0})])
+    monkeypatch.setattr(pmod, "_ledger_path_for_session", lambda *_a, **_k: path)
+    got = list_recent_postmortems(limit=1)[0]
+    assert got.claims_provenance == "not_applicable"
+
+
+def test_from_dict_without_the_new_keys_still_parses() -> None:
+    """Back-compat in the other direction: an old payload must not raise."""
+    got = VerificationPostmortem.from_dict({
+        "schema_version": VERIFICATION_POSTMORTEM_SCHEMA_VERSION,
+        "op_id": "x", "session_id": "s", "total_claims": 0,
+    })
+    assert got is not None
+    assert got.record_kind == ""
+    assert got.claims_provenance == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# the detector — the reason any of this matters
+# ---------------------------------------------------------------------------
+
+def test_a_window_of_pre_plan_terminations_does_not_fire(monkeypatch) -> None:
+    """THE false alarm, reproduced and killed.
+
+    100 ops that all died at CLASSIFY. Claim capture is perfect; there was
+    simply nothing to capture. The old detector reported 100% and blamed
+    PLAN.
+    """
+    from backend.core.ouroboros.governance.intake.sensors import meta_sensor
+
+    rows = tuple(
+        _pm(op_id=f"op-{i}", total_claims=0, terminated_at_phase="CLASSIFY")
+        for i in range(100)
+    )
+    monkeypatch.setattr(meta_sensor, "empty_postmortem_window", lambda: 100)
+    monkeypatch.setattr(
+        "backend.core.ouroboros.governance.verification.list_recent_postmortems",
+        lambda **_k: rows,
+    )
+    assert meta_sensor._evaluate_empty_postmortem_rate() is None
+
+
+def test_a_genuine_capture_failure_still_fires(monkeypatch) -> None:
+    """The other half. Silencing the false alarm must not silence the true
+    one — 100 ops that reached COMPLETE and captured nothing is exactly the
+    defect the detector was written for."""
+    from backend.core.ouroboros.governance.intake.sensors import meta_sensor
+
+    rows = tuple(
+        _pm(op_id=f"op-{i}", total_claims=0, terminated_at_phase="COMPLETE")
+        for i in range(100)
+    )
+    monkeypatch.setattr(meta_sensor, "empty_postmortem_window", lambda: 100)
+    monkeypatch.setattr(
+        "backend.core.ouroboros.governance.verification.list_recent_postmortems",
+        lambda **_k: rows,
+    )
+    got = meta_sensor._evaluate_empty_postmortem_rate()
+    assert got is not None
+    assert got.severity == "p1"
+    ev = dict(got.evidence)
+    assert ev["total_count"] == 100
+    assert ev["excluded_not_applicable"] == 0
+
+
+def test_the_excluded_population_is_reported_not_hidden(monkeypatch) -> None:
+    """A rate that silently drops two thirds of its input is a rate nobody
+    should trust. The finding says how many were excluded and why."""
+    from backend.core.ouroboros.governance.intake.sensors import meta_sensor
+
+    rows = tuple(
+        [_pm(op_id=f"n-{i}", total_claims=0, terminated_at_phase="CLASSIFY")
+         for i in range(60)]
+        + [_pm(op_id=f"c-{i}", total_claims=0, terminated_at_phase="COMPLETE")
+           for i in range(40)]
+    )
+    monkeypatch.setattr(meta_sensor, "empty_postmortem_window", lambda: 100)
+    monkeypatch.setattr(meta_sensor, "empty_postmortem_min_records", lambda: 20)
+    monkeypatch.setattr(
+        "backend.core.ouroboros.governance.verification.list_recent_postmortems",
+        lambda **_k: rows,
+    )
+    got = meta_sensor._evaluate_empty_postmortem_rate()
+    assert got is not None
+    ev = dict(got.evidence)
+    assert ev["total_count"] == 40 and ev["excluded_not_applicable"] == 60
+    assert ev["records_read"] == 100
+    assert "excluded" in got.summary
+
+
+def test_too_few_applicable_ops_is_silence_not_an_all_clear(
+        monkeypatch) -> None:
+    """min_records now applies to the APPLICABLE population. A window in
+    which almost nothing routed cannot support a claim-capture verdict."""
+    from backend.core.ouroboros.governance.intake.sensors import meta_sensor
+
+    rows = tuple(
+        [_pm(op_id=f"n-{i}", total_claims=0, terminated_at_phase="CLASSIFY")
+         for i in range(99)]
+        + [_pm(op_id="c", total_claims=0, terminated_at_phase="COMPLETE")]
+    )
+    monkeypatch.setattr(meta_sensor, "empty_postmortem_window", lambda: 100)
+    monkeypatch.setattr(meta_sensor, "empty_postmortem_min_records", lambda: 20)
+    monkeypatch.setattr(
+        "backend.core.ouroboros.governance.verification.list_recent_postmortems",
+        lambda **_k: rows,
+    )
+    assert meta_sensor._evaluate_empty_postmortem_rate() is None
+
+
+def test_unknown_provenance_is_excluded_from_both_sides(monkeypatch) -> None:
+    """Never counted as healthy, never counted as broken."""
+    from backend.core.ouroboros.governance.intake.sensors import meta_sensor
+
+    rows = tuple(_pm(op_id=f"u-{i}", total_claims=0) for i in range(100))
+    monkeypatch.setattr(meta_sensor, "empty_postmortem_window", lambda: 100)
+    monkeypatch.setattr(
+        "backend.core.ouroboros.governance.verification.list_recent_postmortems",
+        lambda **_k: rows,
+    )
+    assert meta_sensor._evaluate_empty_postmortem_rate() is None
+
+
+# ---------------------------------------------------------------------------
+# the detector for what was hiding behind the false alarm
+# ---------------------------------------------------------------------------
+
+def test_claims_that_cannot_be_judged_fire(monkeypatch) -> None:
+    """The real signal: 76% of claims at COMPLETE return INSUFFICIENT and not
+    one has ever returned FAILED."""
+    from backend.core.ouroboros.governance.intake.sensors import meta_sensor
+
+    rows = tuple(
+        _pm(op_id=f"op-{i}", total_claims=4, insufficient_count=3,
+            terminated_at_phase="COMPLETE")
+        for i in range(30)
+    )
+    monkeypatch.setattr(meta_sensor, "empty_postmortem_window", lambda: 100)
+    monkeypatch.setattr(
+        "backend.core.ouroboros.governance.verification.list_recent_postmortems",
+        lambda **_k: rows,
+    )
+    got = meta_sensor._evaluate_unjudgeable_claim_rate()
+    assert got is not None and got.severity == "p1"
+    ev = dict(got.evidence)
+    assert ev["total_claims"] == 120 and ev["insufficient_count"] == 90
+    assert 0.74 < ev["rate"] < 0.76
+
+
+def test_evaluator_errors_count_as_undecided(monkeypatch) -> None:
+    """A claim whose evaluator raised is no more settled than one with
+    missing evidence. Counting only INSUFFICIENT would let a broken
+    evaluator read as a healthy loop."""
+    from backend.core.ouroboros.governance.intake.sensors import meta_sensor
+
+    rows = tuple(
+        _pm(op_id=f"op-{i}", total_claims=4, error_count=3,
+            terminated_at_phase="COMPLETE")
+        for i in range(30)
+    )
+    monkeypatch.setattr(meta_sensor, "empty_postmortem_window", lambda: 100)
+    monkeypatch.setattr(
+        "backend.core.ouroboros.governance.verification.list_recent_postmortems",
+        lambda **_k: rows,
+    )
+    got = meta_sensor._evaluate_unjudgeable_claim_rate()
+    assert got is not None
+    assert dict(got.evidence)["error_count"] == 90
+
+
+def test_a_healthy_loop_is_quiet(monkeypatch) -> None:
+    from backend.core.ouroboros.governance.intake.sensors import meta_sensor
+
+    rows = tuple(
+        _pm(op_id=f"op-{i}", total_claims=4, insufficient_count=0,
+            terminated_at_phase="COMPLETE")
+        for i in range(30)
+    )
+    monkeypatch.setattr(meta_sensor, "empty_postmortem_window", lambda: 100)
+    monkeypatch.setattr(
+        "backend.core.ouroboros.governance.verification.list_recent_postmortems",
+        lambda **_k: rows,
+    )
+    assert meta_sensor._evaluate_unjudgeable_claim_rate() is None
+
+
+def test_too_few_claims_is_silence(monkeypatch) -> None:
+    from backend.core.ouroboros.governance.intake.sensors import meta_sensor
+
+    rows = (_pm(op_id="op-1", total_claims=2, insufficient_count=2,
+                terminated_at_phase="COMPLETE"),)
+    monkeypatch.setattr(meta_sensor, "empty_postmortem_window", lambda: 100)
+    monkeypatch.setattr(
+        "backend.core.ouroboros.governance.verification.list_recent_postmortems",
+        lambda **_k: rows,
+    )
+    assert meta_sensor._evaluate_unjudgeable_claim_rate() is None
+
+
+def test_both_detectors_are_registered() -> None:
+    """Registration is what makes an evaluate() function a sensor. A detector
+    written and not registered is the same defect as a module merged and not
+    imported — which is how this whole arc started."""
+    from backend.core.ouroboros.governance.intake.sensors.meta_sensor import (
+        list_dormancy_detectors,
+    )
+    kinds = {d.detector_kind for d in list_dormancy_detectors()}
+    assert {"empty_postmortem_rate", "unjudgeable_claim_rate"} <= kinds
+
+
+def test_neither_detector_raises_when_the_ledger_is_unreadable(
+        monkeypatch) -> None:
+    """Both are called from a sensor whose contract is NEVER raises."""
+    from backend.core.ouroboros.governance.intake.sensors import meta_sensor
+
+    def _boom(**_k):
+        raise OSError("ledger on fire")
+
+    monkeypatch.setattr(
+        "backend.core.ouroboros.governance.verification.list_recent_postmortems",
+        _boom,
+    )
+    assert meta_sensor._evaluate_empty_postmortem_rate() is None
+    assert meta_sensor._evaluate_unjudgeable_claim_rate() is None
+
+
+def test_the_thresholds_are_configurable_and_bounded(monkeypatch) -> None:
+    from backend.core.ouroboros.governance.intake.sensors import meta_sensor
+
+    monkeypatch.setenv("JARVIS_META_UNJUDGEABLE_CLAIM_THRESHOLD", "0.9")
+    assert meta_sensor.unjudgeable_claim_threshold() == 0.9
+    monkeypatch.setenv("JARVIS_META_UNJUDGEABLE_CLAIM_THRESHOLD", "12")
+    assert meta_sensor.unjudgeable_claim_threshold() == 1.0
+    monkeypatch.setenv("JARVIS_META_UNJUDGEABLE_CLAIM_THRESHOLD", "nonsense")
+    assert meta_sensor.unjudgeable_claim_threshold() == 0.5
+    monkeypatch.setenv("JARVIS_META_UNJUDGEABLE_MIN_CLAIMS", "0")
+    assert meta_sensor.unjudgeable_min_claims() == 1


### PR DESCRIPTION
The dormancy alarm mounted in #70444 fired on its first scan. It was wrong about the cause, and right that something was broken.

## The alarm

```
p1  VERIFICATION LOOP IS NOT EXERCISING — 71/100 (71%) of recent
postmortems have total_claims=0 ... Check Priority A claim-capture
wiring at every PLAN exit.
```

**Claim capture was working at 100%.** Every one of 2,014 routed ops with a postmortem had captured claims.

`list_recent_postmortems` deliberately pools two record kinds:

| kind | written | claims |
|---|---|---|
| `verification_postmortem` | at COMPLETE | evaluated |
| `terminal_postmortem` | at **every** non-COMPLETE termination | none — the op never got there |

A `terminal_postmortem` is by definition an op that did not complete. Measured on the live ledger:

| kind | phase | records | empty |
|---|---|---|---|
| terminal | CLASSIFY | 3375 | **99%** |
| terminal | GENERATE | 2127 | 2% |
| terminal | POSTMORTEM | 1861 | 99% |
| verification | COMPLETE | 612 | 67% |

The last 100 records the alarm reads were **100% `terminal_postmortem`**. Its 71% was measuring how many recent ops died before PLAN, labelled as a claim-capture failure. An alarm that cannot be cleared is an alarm that gets ignored — and this one had been ignorable since the day it was written, because it had no caller.

## Root cause: the record could not say why it was empty

The enclosing ledger record carries `kind` and `phase`. The reader parsed both and **dropped them one line later**, so a CLASSIFY termination and a COMPLETE-with-no-claims arrived at the detector identical. `total_claims == 0` had four meanings and one spelling.

`VerificationPostmortem` now carries `record_kind` + `terminated_at_phase`, **stamped by the reader from the record it already parses** — no writer change, no migration, and all 8,288 existing records acquire provenance on read.

`claims_provenance` derives four values against the FSM's own `CANONICAL_PHASE_ORDER` rather than a restated phase list:

- `evaluated` — claims found and judged
- `not_applicable` — stopped before the capture phase; zero is correct, not a finding
- `none_recorded` — got past it and still has none. States the fact, **asserts no cause** — PLAN may have been skipped by policy for a trivial op, or capture may have failed
- `unknown` — the reading did not come through a reader that knows. Excluded from **both** numerator and denominator rather than assumed either way

Same discipline `advisor_locality` established for blast radius.

The detector now divides by the applicable population, reports how many records it excluded and why, and applies `min_records` to the applicable set so a window in which nothing routed yields silence rather than a verdict. **Live: 71% → 22%, and the alarm goes quiet. Correctly.**

## What that exposed

The signal hiding behind the false one does **not** go quiet.

| | |
|---|---|
| Claims recorded at COMPLETE | 18,414 |
| INSUFFICIENT_EVIDENCE | **13,911 (76%)** |
| FAILED, across 151,612 claims all-time | **0** |

Three universal default claims account for the insufficiency in *exactly* equal counts — 4,637 each:

```
provider_route, is_read_only, providers_used
diff_text
test_files_pre, test_files_post
```

Their required evidence is never supplied. **A `must_hold` claim that always evaluates INSUFFICIENT is not a safety property** — it never blocks, so the loop reports rising coverage while deciding nothing. That is what "the verification loop is not exercising" always meant.

New `unjudgeable_claim_rate` detector, registered beside the first. Counts evaluator errors as undecided too — counting only INSUFFICIENT would let a broken evaluator read as a healthy loop — and names the worst properties in the finding rather than sending the operator back to a ledger walk.

Live:

```
p1  CLAIMS ARE MADE BUT NOT JUDGED — 87/112 (78%) ... Worst properties:
default::cost_contract_bg_op_did_not_use_claude=29;
default::no_new_credential_shapes=29; default::test_set_hash_stable=29
```

29 each — one per claimed op in the window.

## Verification

**756 tests green**, 29 of them new. The regression spine covers each provenance value, the reader stamp, historical records acquiring provenance without migration, back-compat for payloads lacking the new keys, both detectors firing and staying quiet, and neither raising when the ledger is unreadable.

Three of my new tests failed on first run: the helper omitted `schema_version` and `from_dict` correctly refused the payload. Fixed the test, not the reader.

## Corrections to my own analysis

I initially read `total_passed=0` across all claims from the raw JSON and nearly reported it. `total_passed` is a **computed property**, not a stored field, so the raw read returned 0 spuriously. The real figure is 4,503 passed. `failed=0` is genuine.

## Not fixed here

**862 empty `POSTMORTEM`-phase records belong to ops that DO have `property_claim` rows on the ledger** — claims captured, postmortem reports zero. Those are now visible as `none_recorded` instead of being pooled with the 3,333 correct zeros. It is a read path, a separate seam, and gets its own change rather than riding along unproven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the dormancy alarm by excluding ops that never reached claim capture, and adds a new detector for claims that cannot be judged so real verification gaps surface.

- **Bug Fixes**
  - Stamps `record_kind` and `terminated_at_phase` onto `VerificationPostmortem` during read; no writer changes or migration.
  - Adds `claims_provenance` and `claims_were_applicable` (derived from `CANONICAL_PHASE_ORDER`; capture at `PLAN` exit).
  - Empty-postmortem detector now divides by ops where claims were applicable, reports excluded counts, and applies `min_records` to that set. Live effect: 71% → 22% and the alarm stops firing for pre-PLAN terminations.
  - Ensures detectors never raise when the ledger is unreadable.

- **New Features**
  - Adds `unjudgeable_claim_rate` detector (p1) that flags high rates of `INSUFFICIENT_EVIDENCE` or evaluator errors, and lists top offending properties.
  - Configurable via `JARVIS_META_UNJUDGEABLE_CLAIM_THRESHOLD` and `JARVIS_META_UNJUDGEABLE_MIN_CLAIMS`.

<sup>Written for commit 6fbea491d1e9bb53d38b8be150e2acb0a22ad142. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

