### PR TITLE
fix(determinism): tests were writing to the production decision ledger

### DIFF
--- a/backend/core/ouroboros/governance/determinism/clock.py
+++ b/backend/core/ouroboros/governance/determinism/clock.py
@@ -48,6 +48,10 @@ Key invariants (pinned by tests):
 """
 from __future__ import annotations
 
+from backend.core.ouroboros.governance.determinism.session_identity import (
+    resolve_session_id,
+)
+
 import asyncio
 import logging
 import os
@@ -449,9 +453,7 @@ def clock_for_session(
     """
     safe_op = (str(op_id).strip() if op_id else "") or "unknown"
     if session_id is None or not session_id.strip():
-        session_id = os.environ.get(
-            "OUROBOROS_BATTLE_SESSION_ID", "",
-        ).strip() or "default"
+        session_id = resolve_session_id()
 
     resolved_mode = _resolve_mode(mode)
 
@@ -501,9 +503,7 @@ def reset_for_op(
     fresh. NEVER raises."""
     safe_op = (str(op_id).strip() if op_id else "") or "unknown"
     if session_id is None or not session_id.strip():
-        session_id = os.environ.get(
-            "OUROBOROS_BATTLE_SESSION_ID", "",
-        ).strip() or "default"
+        session_id = resolve_session_id()
     with _clock_cache_lock:
         _clock_cache.pop((session_id, safe_op), None)
 

--- a/backend/core/ouroboros/governance/determinism/decision_runtime.py
+++ b/backend/core/ouroboros/governance/determinism/decision_runtime.py
@@ -60,6 +60,10 @@ Authority invariants pinned by tests:
 """
 from __future__ import annotations
 
+from backend.core.ouroboros.governance.determinism.session_identity import (
+    resolve_session_id,
+)
+
 import asyncio
 import json
 import logging
@@ -1112,9 +1116,7 @@ def runtime_for_session(
 
     NEVER raises."""
     if session_id is None or not str(session_id).strip():
-        session_id = os.environ.get(
-            "OUROBOROS_BATTLE_SESSION_ID", "",
-        ).strip() or "default"
+        session_id = resolve_session_id()
     sid = str(session_id)
     with _runtime_cache_lock:
         cached = _runtime_cache.get(sid)

--- a/backend/core/ouroboros/governance/determinism/entropy.py
+++ b/backend/core/ouroboros/governance/determinism/entropy.py
@@ -52,6 +52,10 @@ Authority invariants (pinned by tests):
 """
 from __future__ import annotations
 
+from backend.core.ouroboros.governance.determinism.session_identity import (
+    resolve_session_id,
+)
+
 import hashlib
 import json
 import logging
@@ -460,9 +464,7 @@ def entropy_for(
 
     # Determine session_id
     if session_id is None or not session_id.strip():
-        session_id = os.environ.get(
-            "OUROBOROS_BATTLE_SESSION_ID", "",
-        ).strip() or "default"
+        session_id = resolve_session_id()
 
     cache_key = (session_id, safe_op)
     with _op_entropy_lock:
@@ -490,9 +492,7 @@ def reset_for_op(
     stream prefix. NEVER raises."""
     safe_op = (str(op_id).strip() if op_id else "") or "unknown"
     if session_id is None or not session_id.strip():
-        session_id = os.environ.get(
-            "OUROBOROS_BATTLE_SESSION_ID", "",
-        ).strip() or "default"
+        session_id = resolve_session_id()
     with _op_entropy_lock:
         _op_entropy_cache.pop((session_id, safe_op), None)
 

--- a/backend/core/ouroboros/governance/determinism/session_identity.py
+++ b/backend/core/ouroboros/governance/determinism/session_identity.py
@@ -1,0 +1,173 @@
+"""Which session a decision record belongs to — resolved once, for everyone.
+
+WHY THIS EXISTS
+---------------
+Nine modules resolved the session id with the same three lines::
+
+    os.environ.get("OUROBOROS_BATTLE_SESSION_ID", "").strip() or "default"
+
+Nine copies of one decision is the defect this repository keeps shipping, and
+here it had a consequence beyond tidiness. ``OUROBOROS_BATTLE_SESSION_ID`` is
+set by the battle-test harness and by nothing else, so under pytest it is
+unset — and every test that exercises a real write path landed in the
+PRODUCTION ledger, ``.jarvis/determinism/default/decisions.jsonl``.
+
+Measured on this repository:
+
+    39,934 records in the production ledger
+     5,619 (14%) written by 19 synthetic fixture op_ids
+           op-test-001 (2004), op-off (1931), op-on (1079), op-det-1 (109)…
+           2,184 property_claim · 1,486 terminal_postmortem
+           546 route_assignment · 523 advisor_verdict · 440 generate
+
+That was harmless while nothing read the ledger. It stopped being harmless
+when the MetaSensor was mounted: its dormancy detectors compute rates over
+exactly this file, so every verdict about whether the organism is learning
+was being taken over a population that is 14% test fixtures. The fixtures
+also reuse their op_ids across months of runs, which manufactures
+relationships that never existed — a postmortem from one run matching claims
+written 89 days later by a different process, purely because both said
+``op-off``.
+
+THE FIX IS TO ASK, NOT TO GUESS
+-------------------------------
+``PYTEST_CURRENT_TEST`` is set by pytest itself, for the duration of every
+test, and unset everywhere else. It is the same discipline
+``progress_board._is_test_path`` uses when it reads ``testpaths`` out of
+``pytest.ini``: the question "is this a test?" already has an authoritative
+answer, and restating a convention is how the wrong answer gets shipped.
+
+So an unqualified resolution under pytest yields a test-scoped session
+instead of ``default``. Nothing is blocked, nothing raises, and a test that
+WANTS the production session still gets it by naming it — being explicit is
+the whole difference between a deliberate write and an accidental one.
+
+Isolation is per-test-module rather than per-test: a test that writes in one
+function and reads in another is an ordinary shape, and per-function scoping
+would break it while fixing nothing. Two modules cannot collide, and that is
+the boundary that matters.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import re
+from typing import Optional
+
+logger = logging.getLogger("Ouroboros.SessionIdentity")
+
+SESSION_IDENTITY_SCHEMA_VERSION = "session_identity.v1"
+
+#: Set by the battle-test harness. The only signal that a real session is
+#: running, and the reason an unset value cannot simply mean "production".
+SESSION_ENV = "OUROBOROS_BATTLE_SESSION_ID"
+
+#: Set by pytest for the duration of every test, in the form
+#: ``path/to/test_file.py::TestClass::test_name (call)``. Unset outside a
+#: test run — which is exactly the discrimination this module needs and the
+#: reason it does not have to guess.
+PYTEST_ENV = "PYTEST_CURRENT_TEST"
+
+#: What an unqualified production resolution has always returned. Preserved
+#: exactly so that nothing outside a test observes any change.
+DEFAULT_SESSION = "default"
+
+#: Prefix marking a session that exists only because a test asked for one.
+#: Greppable, and obvious in a directory listing next to real session ids.
+TEST_SESSION_PREFIX = "pytest"
+
+__all__ = [
+    "SESSION_IDENTITY_SCHEMA_VERSION",
+    "SESSION_ENV",
+    "PYTEST_ENV",
+    "DEFAULT_SESSION",
+    "TEST_SESSION_PREFIX",
+    "resolve_session_id",
+    "test_isolation_enabled",
+    "under_pytest",
+]
+
+#: Anything outside this set is replaced. A session id becomes a DIRECTORY
+#: NAME, so a test id containing '/' would silently write outside the ledger
+#: root — the one way this module could make things worse than it found them.
+_UNSAFE = re.compile(r"[^A-Za-z0-9_.-]+")
+
+
+def test_isolation_enabled() -> bool:
+    """``JARVIS_LEDGER_TEST_ISOLATION`` (default ``true``).
+
+    Off restores the previous behaviour exactly — tests write to
+    ``default`` — which is the escape hatch for a test that is deliberately
+    asserting on cross-session behaviour and would rather opt out wholesale
+    than name a session.
+    """
+    raw = os.environ.get("JARVIS_LEDGER_TEST_ISOLATION", "").strip().lower()
+    return raw not in ("0", "false", "no", "off")
+
+
+def under_pytest() -> bool:
+    """True iff pytest is currently executing a test in this process."""
+    return bool(os.environ.get(PYTEST_ENV, "").strip())
+
+
+def _test_session_id() -> str:
+    """A session id scoped to the currently-running test MODULE.
+
+    ``PYTEST_CURRENT_TEST`` looks like::
+
+        tests/governance/test_meta_sensor.py::test_scan_once (call)
+
+    Only the module part is used. Per-function scoping would isolate more and
+    break the ordinary shape of a test that writes in one function and reads
+    in another; per-module is the boundary where collisions actually happen.
+
+    Falls back to a constant rather than to ``default`` if the variable is
+    malformed — an unparseable test id is still a test, and the one outcome
+    to avoid is quietly resuming writes to production.
+    """
+    raw = os.environ.get(PYTEST_ENV, "").strip()
+    module = raw.split("::", 1)[0].strip() if raw else ""
+    if not module:
+        return f"{TEST_SESSION_PREFIX}-unknown"
+    stem = module.rsplit("/", 1)[-1]
+    if stem.endswith(".py"):
+        stem = stem[:-3]
+    cleaned = _UNSAFE.sub("-", stem).strip("-")
+    return f"{TEST_SESSION_PREFIX}-{cleaned or 'unknown'}"
+
+
+def resolve_session_id(session_id: Optional[str] = None) -> str:
+    """The session a decision record belongs to. NEVER raises.
+
+    Precedence, strictest first:
+
+    1. An explicitly supplied ``session_id`` — always wins, including inside
+       a test. Naming a session is a deliberate act and this must not
+       second-guess it, or a test written to exercise cross-session behaviour
+       becomes untestable.
+    2. ``OUROBOROS_BATTLE_SESSION_ID`` — a real session is running.
+    3. Under pytest with neither of the above: a test-scoped session, so an
+       accidental write cannot reach the production ledger.
+    4. ``default``.
+
+    Sanitised in every branch, because the return value becomes a directory
+    name and a caller-supplied id containing a path separator would write
+    outside the ledger root.
+    """
+    try:
+        if session_id is not None and str(session_id).strip():
+            return _sanitise(str(session_id).strip())
+        from_env = os.environ.get(SESSION_ENV, "").strip()
+        if from_env:
+            return _sanitise(from_env)
+        if test_isolation_enabled() and under_pytest():
+            return _test_session_id()
+        return DEFAULT_SESSION
+    except Exception:  # noqa: BLE001 — a path resolver must not be the thing
+        logger.debug("[SessionIdentity] resolution degraded", exc_info=True)
+        return DEFAULT_SESSION
+
+
+def _sanitise(raw: str) -> str:
+    cleaned = _UNSAFE.sub("-", raw).strip("-.")
+    return cleaned or DEFAULT_SESSION

--- a/backend/core/ouroboros/governance/postmortem_observability.py
+++ b/backend/core/ouroboros/governance/postmortem_observability.py
@@ -43,6 +43,10 @@ surfaces in O+V have the same ergonomics.
 """
 from __future__ import annotations
 
+from backend.core.ouroboros.governance.determinism.session_identity import (
+    resolve_session_id,
+)
+
 import enum
 import json
 import logging
@@ -151,9 +155,7 @@ def _ledger_path_for_session(
     Slice 1.3 / 2.3 / 2.4 reader convention. NEVER raises."""
     sid = (str(session_id).strip() if session_id else "")
     if not sid:
-        sid = os.environ.get(
-            "OUROBOROS_BATTLE_SESSION_ID", "",
-        ).strip() or "default"
+        sid = resolve_session_id()
     base = os.environ.get(
         "JARVIS_DETERMINISM_LEDGER_DIR",
         ".jarvis/determinism",

--- a/backend/core/ouroboros/governance/verification/causality_dag.py
+++ b/backend/core/ouroboros/governance/verification/causality_dag.py
@@ -60,6 +60,10 @@ COST CONTRACT PRESERVATION (§26.6):
 """
 from __future__ import annotations
 
+from backend.core.ouroboros.governance.determinism.session_identity import (
+    resolve_session_id,
+)
+
 import json
 import logging
 import os
@@ -675,9 +679,7 @@ def build_dag(
         # Resolve session_id
         sid = session_id
         if sid is None or not str(sid).strip():
-            sid = os.environ.get(
-                "OUROBOROS_BATTLE_SESSION_ID", "",
-            ).strip() or "default"
+            sid = resolve_session_id()
         sid = str(sid).strip()
 
         # Resolve path

--- a/backend/core/ouroboros/governance/verification/postmortem.py
+++ b/backend/core/ouroboros/governance/verification/postmortem.py
@@ -100,6 +100,10 @@ AUTHORITY INVARIANTS (pinned by tests):
 """
 from __future__ import annotations
 
+from backend.core.ouroboros.governance.determinism.session_identity import (
+    resolve_session_id,
+)
+
 import json
 import logging
 import os
@@ -600,9 +604,7 @@ async def produce_verification_postmortem(
     # Resolve session_id (mirrors Slice 2.3 reader's resolution)
     sid = session_id
     if sid is None or not str(sid).strip():
-        sid = os.environ.get(
-            "OUROBOROS_BATTLE_SESSION_ID", "",
-        ).strip() or "default"
+        sid = resolve_session_id()
 
     if not postmortem_enabled():
         return VerificationPostmortem(
@@ -781,9 +783,7 @@ def _ledger_path_for_session(session_id: Optional[str] = None) -> Path:
     1.2 + 2.3 conventions. NEVER raises."""
     sid = (str(session_id).strip() if session_id else "")
     if not sid:
-        sid = os.environ.get(
-            "OUROBOROS_BATTLE_SESSION_ID", "",
-        ).strip() or "default"
+        sid = resolve_session_id()
     base = os.environ.get(
         "JARVIS_DETERMINISM_LEDGER_DIR",
         ".jarvis/determinism",

--- a/backend/core/ouroboros/governance/verification/property_capture.py
+++ b/backend/core/ouroboros/governance/verification/property_capture.py
@@ -82,6 +82,10 @@ AUTHORITY INVARIANTS (pinned by tests):
 """
 from __future__ import annotations
 
+from backend.core.ouroboros.governance.determinism.session_identity import (
+    resolve_session_id,
+)
+
 import json
 import logging
 import os
@@ -274,9 +278,7 @@ def _derive_claim_id(
         )
         sid = session_id
         if sid is None or not str(sid).strip():
-            sid = os.environ.get(
-                "OUROBOROS_BATTLE_SESSION_ID", "",
-            ).strip() or "default"
+            sid = resolve_session_id()
         se = get_session_entropy()
         session_seed = se.seed_for_session(sid)
         op_seed = _derive_op_seed(
@@ -560,9 +562,7 @@ def _ledger_path_for_session(session_id: Optional[str] = None) -> Path:
     1.2's storage layout. NEVER raises."""
     sid = (str(session_id).strip() if session_id else "")
     if not sid:
-        sid = os.environ.get(
-            "OUROBOROS_BATTLE_SESSION_ID", "",
-        ).strip() or "default"
+        sid = resolve_session_id()
     base = os.environ.get(
         "JARVIS_DETERMINISM_LEDGER_DIR",
         ".jarvis/determinism",

--- a/tests/governance/test_ledger_session_identity.py
+++ b/tests/governance/test_ledger_session_identity.py
@@ -1,0 +1,326 @@
+"""14% of the production decision ledger was written by tests.
+
+Chasing the "862 empty postmortems whose ops have claims" finding from #70445
+turned it into a measurement artifact and a real defect underneath.
+
+THE ARTIFACT
+------------
+Those 864 records span SEVEN op_ids — `op-off` (760), `op-test-001` (40),
+`op-det-1` (38), `op-on` (23) and three singletons. Zero are real UUIDv7 ops.
+The join was on `op_id` alone across a ledger holding months of history, so a
+postmortem matched claims written 89 days later by a different process,
+purely because both said `op-off`:
+
+    pm_ts - first_claim_ts : -7,722,402 s
+    pm worker / claim worker : 27261-base / 81325-base
+    real ops affected        : 0
+
+Recorded here rather than quietly dropped, because the same join is the
+natural way to ask that question and the next person will write it too.
+
+THE DEFECT IT EXPOSED
+---------------------
+Fixture op_ids are in the production ledger at all. Measured:
+
+    39,934 records in .jarvis/determinism/default/decisions.jsonl
+     5,619 (14%) from 19 synthetic op_ids
+           2,184 property_claim · 1,486 terminal_postmortem
+           546 route_assignment · 523 advisor_verdict · 440 generate
+
+`OUROBOROS_BATTLE_SESSION_ID` is set by the battle-test harness and nothing
+else, so under pytest it is unset and the session falls back to `default` —
+the production session. Every test exercising a real write path landed there.
+
+Harmless while nothing read the ledger. It stopped being harmless when the
+MetaSensor was mounted in #70444: its dormancy detectors compute rates over
+exactly this file, so every verdict about whether the organism is still
+learning was taken over a population that is 14% test fixtures, some of them
+reused across months and manufacturing relationships that never existed.
+
+THE FIX
+-------
+Nine modules resolved the session with the same three lines. One authority
+now, and it asks pytest — `PYTEST_CURRENT_TEST` is set by pytest itself for
+the duration of every test and unset everywhere else. Same discipline
+`progress_board._is_test_path` uses when it reads `testpaths` out of
+`pytest.ini`: the question already has an authoritative answer, and restating
+a convention is how the wrong answer ships.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from backend.core.ouroboros.governance.determinism.session_identity import (  # noqa: E402
+    DEFAULT_SESSION,
+    PYTEST_ENV,
+    SESSION_ENV,
+    TEST_SESSION_PREFIX,
+    resolve_session_id,
+    test_isolation_enabled,
+    under_pytest,
+)
+
+
+# ---------------------------------------------------------------------------
+# the resolution itself
+# ---------------------------------------------------------------------------
+
+def test_a_test_never_resolves_to_the_production_session(monkeypatch) -> None:
+    """THE regression. This test is itself running under pytest, so an
+    unqualified resolution here must not be `default`."""
+    monkeypatch.delenv(SESSION_ENV, raising=False)
+    got = resolve_session_id()
+    assert got != DEFAULT_SESSION
+    assert got.startswith(TEST_SESSION_PREFIX)
+
+
+def test_the_session_is_scoped_to_this_test_module(monkeypatch) -> None:
+    """Per-module, not per-function: a test that writes in one function and
+    reads in another is an ordinary shape, and per-function scoping would
+    break it while fixing nothing."""
+    monkeypatch.delenv(SESSION_ENV, raising=False)
+    assert resolve_session_id() == f"{TEST_SESSION_PREFIX}-test_ledger_session_identity"
+
+
+def test_an_explicit_session_always_wins(monkeypatch) -> None:
+    """Naming a session is a deliberate act, including inside a test. A test
+    written to exercise cross-session behaviour must stay writable."""
+    monkeypatch.delenv(SESSION_ENV, raising=False)
+    assert resolve_session_id("bt-2026-08-08-live") == "bt-2026-08-08-live"
+    assert resolve_session_id(DEFAULT_SESSION) == DEFAULT_SESSION
+
+
+def test_a_real_session_wins_over_the_pytest_fallback(monkeypatch) -> None:
+    """The harness sets this while running its own tests. Isolation must not
+    hijack a session that genuinely exists."""
+    monkeypatch.setenv(SESSION_ENV, "bt-2026-08-08-999999")
+    assert resolve_session_id() == "bt-2026-08-08-999999"
+
+
+def test_outside_pytest_nothing_changes(monkeypatch) -> None:
+    """Production behaviour is byte-identical to before. The whole change is
+    invisible to anything that is not a test."""
+    monkeypatch.delenv(SESSION_ENV, raising=False)
+    monkeypatch.delenv(PYTEST_ENV, raising=False)
+    assert under_pytest() is False
+    assert resolve_session_id() == DEFAULT_SESSION
+
+
+def test_isolation_can_be_switched_off(monkeypatch) -> None:
+    monkeypatch.delenv(SESSION_ENV, raising=False)
+    monkeypatch.setenv("JARVIS_LEDGER_TEST_ISOLATION", "0")
+    assert test_isolation_enabled() is False
+    assert resolve_session_id() == DEFAULT_SESSION
+
+
+# ---------------------------------------------------------------------------
+# the session id becomes a DIRECTORY NAME
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("hostile", [
+    "../../etc/passwd", "a/b/c", "..", ".", "  ", "sess\x00id", "s p a c e",
+])
+def test_a_hostile_session_id_cannot_escape_the_ledger_root(hostile) -> None:
+    """The one way this module could make things worse than it found them.
+    A session id is joined into a path, so a separator would write outside
+    `.jarvis/determinism/`."""
+    got = resolve_session_id(hostile)
+    assert "/" not in got and "\\" not in got
+    assert got not in ("", ".", "..")
+    assert not got.startswith(".")
+
+
+def test_a_malformed_pytest_id_still_isolates(monkeypatch) -> None:
+    """An unparseable test id is still a test. The one outcome to avoid is
+    quietly resuming writes to production."""
+    monkeypatch.delenv(SESSION_ENV, raising=False)
+    monkeypatch.setenv(PYTEST_ENV, "::::")
+    got = resolve_session_id()
+    assert got != DEFAULT_SESSION
+    assert got.startswith(TEST_SESSION_PREFIX)
+
+
+@pytest.mark.parametrize("junk", [
+    "\x01\x02", "::", "\t\n", "x" * 5000, "тест::t (call)",
+])
+def test_resolution_never_raises(monkeypatch, junk) -> None:
+    """Called on the write path of every decision record.
+
+    A null byte is deliberately not among these: `os.environ` refuses one at
+    assignment, so it is not a state this function can ever observe. The
+    first draft asserted against it and failed in the monkeypatch call rather
+    than in the code under test — a test for an unreachable input proves
+    nothing and costs a red build.
+    """
+    monkeypatch.setenv(PYTEST_ENV, junk)
+    assert isinstance(resolve_session_id(), str)
+    assert isinstance(resolve_session_id(None), str)
+    # Whatever it produced still has to be a safe directory name.
+    assert "/" not in resolve_session_id()
+
+
+# ---------------------------------------------------------------------------
+# one authority — nine copies is why the contamination was uniform
+# ---------------------------------------------------------------------------
+
+_REPO = Path(__file__).resolve().parents[2]
+_ROOT = _REPO / "backend" / "core" / "ouroboros"
+
+#: The literal that was duplicated. A docstring may still name the variable —
+#: it is the RESOLUTION that must live in one place.
+_DUPLICATE = re.compile(
+    r'os\.environ\.get\(\s*\n?\s*"OUROBOROS_BATTLE_SESSION_ID"', re.S,
+)
+
+
+def test_no_module_resolves_the_session_itself() -> None:
+    """Structural. Nine copies of one decision is why every writer landed in
+    `default` together, and why fixing one would not have held."""
+    offenders = []
+    for path in sorted(_ROOT.rglob("*.py")):
+        if path.name in ("session_identity.py", "session_replay.py"):
+            continue  # the authority, and the replay CLI that SETS the var
+        try:
+            source = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        if _DUPLICATE.search(source):
+            offenders.append(str(path.relative_to(_REPO)))
+    assert not offenders, (
+        "these resolve the session id themselves instead of calling "
+        "resolve_session_id():\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_the_writers_all_import_the_authority() -> None:
+    """The other direction: proving the sites were rewired, not just that the
+    old spelling is gone."""
+    expected = [
+        "governance/verification/postmortem.py",
+        "governance/verification/property_capture.py",
+        "governance/verification/causality_dag.py",
+        "governance/postmortem_observability.py",
+        "governance/determinism/decision_runtime.py",
+        "governance/determinism/clock.py",
+        "governance/determinism/entropy.py",
+    ]
+    for rel in expected:
+        source = (_ROOT / rel).read_text(encoding="utf-8")
+        assert "resolve_session_id" in source, rel
+
+
+# ---------------------------------------------------------------------------
+# end to end — a write under pytest must not reach the production ledger
+# ---------------------------------------------------------------------------
+
+def test_a_recorded_claim_does_not_land_in_the_production_ledger(
+        monkeypatch, tmp_path) -> None:
+    """THE property, exercised through the real writer.
+
+    2,184 property_claim records reached `default` this way.
+    """
+    monkeypatch.delenv(SESSION_ENV, raising=False)
+    monkeypatch.setenv("JARVIS_DETERMINISM_LEDGER_DIR", str(tmp_path))
+    from backend.core.ouroboros.governance.verification.postmortem import (
+        _ledger_path_for_session,
+    )
+    resolved = _ledger_path_for_session()
+    assert DEFAULT_SESSION not in resolved.parts, resolved
+    assert any(p.startswith(TEST_SESSION_PREFIX) for p in resolved.parts)
+
+
+def test_the_reader_and_the_writer_agree_on_the_path(monkeypatch, tmp_path) -> None:
+    """Isolation that split the two would be worse than none: evidence
+    written to one file and read from another looks exactly like evidence
+    that was never captured — the defect #70446 just fixed."""
+    monkeypatch.delenv(SESSION_ENV, raising=False)
+    monkeypatch.setenv("JARVIS_DETERMINISM_LEDGER_DIR", str(tmp_path))
+    from backend.core.ouroboros.governance.verification.postmortem import (
+        _ledger_path_for_session,
+    )
+    from backend.core.ouroboros.governance.verification import evidence_ledger
+
+    writer = _ledger_path_for_session()
+    reader = evidence_ledger._ledger_path()
+    assert writer == reader
+
+
+def test_two_test_modules_cannot_collide(monkeypatch) -> None:
+    monkeypatch.delenv(SESSION_ENV, raising=False)
+    monkeypatch.setenv(PYTEST_ENV, "tests/governance/test_alpha.py::t (call)")
+    a = resolve_session_id()
+    monkeypatch.setenv(PYTEST_ENV, "tests/governance/test_beta.py::t (call)")
+    b = resolve_session_id()
+    assert a != b
+
+
+# ---------------------------------------------------------------------------
+# the artifact, so nobody re-derives it as a finding
+# ---------------------------------------------------------------------------
+
+def test_op_id_alone_is_not_an_identity_across_sessions() -> None:
+    """Why "862 empty postmortems whose ops have claims" was not a bug.
+
+    The ledger is append-only across every run that ever used a session, and
+    fixture op_ids repeat. Joining on op_id alone relates records that never
+    met. A join must include the session AND be ordered, or it manufactures
+    causality — which is exactly what a determinism ledger exists to prevent.
+    """
+    rows = [
+        {"op_id": "op-off", "wall_ts": 1000.0, "kind": "terminal_postmortem"},
+        {"op_id": "op-off", "wall_ts": 8723402.0, "kind": "property_claim"},
+    ]
+    naive = [r for r in rows if r["kind"] == "terminal_postmortem"
+             and any(o["op_id"] == r["op_id"] and o["kind"] == "property_claim"
+                     for o in rows)]
+    assert len(naive) == 1, "the naive join relates them"
+
+    ordered = [r for r in rows if r["kind"] == "terminal_postmortem"
+               and any(o["op_id"] == r["op_id"]
+                       and o["kind"] == "property_claim"
+                       and o["wall_ts"] < r["wall_ts"] for o in rows)]
+    assert not ordered, "ordering dissolves the relationship"
+
+
+def test_the_production_ledger_is_not_a_test_fixture_store() -> None:
+    """Advisory guard on the real file. Skips when absent (CI, fresh clone).
+
+    Does not fail on the historical contamination — 5,619 records predate the
+    fix and deleting them would destroy real history alongside. It fails if
+    the share GROWS, which is the only thing still under anyone's control.
+    """
+    ledger = _REPO / ".jarvis" / "determinism" / DEFAULT_SESSION / "decisions.jsonl"
+    if not ledger.exists():
+        pytest.skip("no production ledger in this checkout")
+    uuidv7 = re.compile(r"^op-[0-9a-f]{8}-[0-9a-f]{4}-7")
+    total = synthetic = 0
+    with ledger.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            op_id = record.get("op_id") or ""
+            total += 1
+            if not uuidv7.match(op_id):
+                synthetic += 1
+    if total < 1000:
+        pytest.skip(f"ledger too small to judge ({total} records)")
+    share = synthetic / total
+    # 14% at the time of the fix; anything above that means a writer is still
+    # landing here from a test.
+    assert share <= 0.20, (
+        f"{synthetic}/{total} ({share:.0%}) of the production ledger has a "
+        "non-UUIDv7 op_id. A test is still writing to the production "
+        "session — find it before trusting any rate computed from this file."
+    )


### PR DESCRIPTION
Chasing the "862 empty postmortems whose ops have claims" item from #70445 turned it into **a measurement artifact — mine — and a real defect underneath.**

## I was wrong about the 862

Those 864 records span **seven op_ids**: `op-off` (760), `op-test-001` (40), `op-det-1` (38), `op-on` (23) and three singletons. **Not one is a real UUIDv7 op.**

The join was on `op_id` alone across a ledger holding months of history, so a postmortem matched claims written 89 days later by a different process, purely because both said `op-off`:

```
pm_ts - first_claim_ts   : -7,722,402 s   (~89 days)
pm worker / claim worker : 27261-base / 81325-base
real ops affected        : 0
```

**There is no read-path bug.** That's the second measurement artifact in this arc — the first was reading `total_passed` from raw JSON when it's a computed property — and both were caught by measuring rather than assuming. A regression test now records the artifact so the next person who writes that join sees why it's wrong.

## The defect it exposed

Fixture op_ids are in the production ledger *at all*:

| | |
|---|---|
| Records in `.jarvis/determinism/default/decisions.jsonl` | 39,934 |
| Written by 19 synthetic op_ids | **5,619 (14%)** |
| — `property_claim` | 2,184 |
| — `terminal_postmortem` | 1,486 |
| — `route_assignment` / `advisor_verdict` / `generate` | 546 / 523 / 440 |

`OUROBOROS_BATTLE_SESSION_ID` is set by the battle-test harness and nothing else, so **under pytest it is unset and the session falls back to `default`** — the production session. Every test exercising a real write path landed there.

Harmless while nothing read the ledger. **It stopped being harmless when the MetaSensor was mounted in #70444**: its dormancy detectors compute rates over exactly this file. Every verdict about whether the organism is still learning was taken over a population that is 14% test fixtures, some reused across months, manufacturing relationships that never existed. The instrument this arc spent three PRs sharpening was reading contaminated input.

## The fix

**Nine modules resolved the session with the same three lines.** Nine copies of one decision is why every writer landed in `default` together, and why fixing one would not have held.

One authority now, and it **asks**: `PYTEST_CURRENT_TEST` is set by pytest itself for the duration of every test and unset everywhere else — the same discipline `progress_board._is_test_path` uses when it reads `testpaths` out of `pytest.ini`.

Precedence, strictest first:

1. **Explicit `session_id`** — always wins, including inside a test. Naming a session is a deliberate act; second-guessing it would make cross-session behaviour untestable.
2. `OUROBOROS_BATTLE_SESSION_ID` — a real session is running.
3. **Under pytest** with neither — a test-scoped session.
4. `default`.

Isolation is per test **module**, not per function: writing in one function and reading in another is an ordinary shape, and per-function scoping would break it while fixing nothing. Two modules cannot collide, and that's the boundary that matters.

Every branch sanitises, because the return value becomes a **directory name** and a caller-supplied id containing a separator would write outside the ledger root — the one way this could have made things worse than it found them.

**Outside pytest the resolution is byte-identical to before.**

## Verification

27 new tests, and the change was **baseline-diffed against clean main** over 41 governance suites:

| | failed | passed |
|---|---|---|
| clean `main` | 17 | 1760 |
| with this change | 17 | 1787 (+27 new) |

`comm` on the sorted failure names: **zero introduced, zero fixed** — the same 17 by name. Those are pre-existing reds unrelated to this change (adapter round-trips and GENERATE-wiring source assertions).

One of my new tests failed first and was right to: it set an env var containing a null byte, which `os.environ` refuses at assignment. A test for an unreachable input proves nothing and costs a red build.

## What this does not do

It does not delete the 5,619 contaminated records. The guard on the production ledger is **advisory and fails on growth**, not on the historical share — those records are interleaved with real history and removing them would destroy both. Rates computed from that file remain skewed until it ages out; the honest reading is that any dormancy verdict taken before this lands was measured on a 14%-contaminated population.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops tests from writing to the production decision ledger by centralizing session resolution and routing pytest runs to module-scoped test sessions. Production behavior is unchanged (`default` remains the fallback outside pytest).

- **Bug Fixes**
  - Added `resolve_session_id()` in `governance/determinism/session_identity.py` and rewired all call sites to use it.
  - Precedence: explicit `session_id` > `OUROBOROS_BATTLE_SESSION_ID` > pytest module-scoped session > `default`.
  - Session IDs are sanitized to safe directory names to prevent path escapes.
  - Readers/writers updated: `determinism/{clock,decision_runtime,entropy}`, `verification/{postmortem,property_capture,causality_dag}`, and `postmortem_observability`.

- **Migration**
  - No changes required for production; resolution outside pytest remains `default`.
  - To disable test isolation, set `JARVIS_LEDGER_TEST_ISOLATION=0`.
  - New tests ensure no writes reach the production ledger during pytest and that reader/writer paths match.

<sup>Written for commit 5d7dac7bb27ca90cabbb9fcb20531404ac3d3383. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

