### PR TITLE
fix(cockpit): the stream published to everyone except the operator

### DIFF
--- a/backend/core/ouroboros/battle_test/stream_renderer.py
+++ b/backend/core/ouroboros/battle_test/stream_renderer.py
@@ -158,6 +158,20 @@ def mirror_stream_enabled() -> bool:
     ).strip().lower() not in ("0", "false", "no", "off")
 
 
+def local_echo_enabled() -> bool:
+    """Default ON. Whether a foreground run echoes the stream to its OWN
+    terminal when no cockpit is attached over the bridge.
+
+    Off restores the previous behaviour exactly: the generation is visible
+    only to a remote `ov attach` client, and invisible in the in-process
+    foreground run that is how `ov` actually boots the harness. That was the
+    state this exists to end. NEVER raises.
+    """
+    return os.environ.get(
+        "JARVIS_STREAM_LOCAL_ECHO_ENABLED", "1",
+    ).strip().lower() not in ("0", "false", "no", "off")
+
+
 def find_commit_boundary(text: str, start: int = 0) -> int:
     """Return the index up to which ``text`` can be safely committed to
     scrollback: just past the LAST complete blank line that sits OUTSIDE
@@ -761,9 +775,6 @@ class StreamRenderer:
                 self._mirrored_offset = end
                 return
 
-            from backend.core.ouroboros.battle_test.cockpit_attach import (
-                publish_markup_global,
-            )
             from rich.markup import escape
 
             lines = chunk.splitlines()
@@ -784,7 +795,7 @@ class StreamRenderer:
                     self._mirror_opened = True
                 else:
                     lead = f"  {body}"
-                if publish_markup_global(lead):
+                if self._emit_deck_line(lead):
                     sent_any = True
             self._mirrored_offset = end
         except Exception:  # noqa: BLE001 — a mirror must not break a stream
@@ -792,6 +803,82 @@ class StreamRenderer:
                 "[StreamRender] op=%s mirror degraded", self._op_id,
                 exc_info=True,
             )
+
+    def _emit_deck_line(self, lead: str) -> bool:
+        """One composed deck line to whoever can actually see it.
+
+        WHY THE STREAM WAS STILL INVISIBLE
+        ----------------------------------
+        `_mirror_completed_lines` correctly concluded that the Rich `Live`
+        widget "is the thing that does not fit" and routed the generation
+        into the cockpit's line-oriented deck instead. It then sent it with
+        `publish_markup_global`, which returns False unless
+        `attached_cockpits() > 0` — a client connected over the BRIDGE.
+
+        `ov` boots the harness IN-PROCESS (`ov.py` → `battle_main`), with a
+        SerpentREPL holding the operator's terminal. There is no bridge
+        client in that shape, so every line was composed, escaped, offered,
+        and dropped. The mirror published to everyone except the operator who
+        was sitting in front of it.
+
+        `cockpit_attach.operator_present()` already draws exactly this
+        distinction, and already documents it: "a cockpit is ATTACHED over
+        the bridge, or this process owns a real terminal (a foreground run
+        with its own REPL, where the operator is looking straight at it)."
+        It was written because Karen kept narrating to an empty room. This is
+        the same defect in mirror image — text falling silent for the LOCAL
+        operator for the same reason speech did for the remote one — and the
+        concept did not need inventing, only consulting.
+
+        WHY THIS IS SAFE WHERE `Live` WAS NOT
+        --------------------------------------
+        `print_fit` writes through the Rich console, which under
+        prompt_toolkit's `patch_stdout` is coordinated with the prompt: the
+        line lands in scrollback ABOVE the input and the prompt redraws
+        below it. That is what `serpent_flow._emit_fit` has always done while
+        the REPL is active. `Live` bypasses that with direct cursor
+        manipulation, which is why it had to be skipped and why re-enabling
+        it would still be wrong.
+
+        Bridge first, local second, and never both for one line: a foreground
+        run that ALSO has an attached client would otherwise print each line
+        twice on the same terminal.
+        """
+        try:
+            from backend.core.ouroboros.battle_test.cockpit_attach import (
+                publish_markup_global,
+            )
+            if publish_markup_global(lead):
+                return True
+        except Exception:  # noqa: BLE001 — bridge unavailable; try local
+            logger.debug("[StreamRender] bridge publish degraded",
+                         exc_info=True)
+
+        if not local_echo_enabled():
+            return False
+        try:
+            from backend.core.ouroboros.battle_test.presentation_restraint import (
+                print_fit,
+                real_stdout_isatty,
+            )
+            # `real_stdout_isatty` reads `sys.__stdout__`, not `sys.stdout`.
+            # Under `patch_stdout(raw=True)` the proxy reports False, and
+            # testing the proxy is the load-bearing bug that made
+            # `should_render()` blind in the presentation-restraint arc. The
+            # same trap sits here: the ONE mode this fix exists for is the
+            # one where the naive check is wrong.
+            if not real_stdout_isatty():
+                return False
+            console = self._console
+            if console is None:
+                from rich.console import Console
+                console = Console()
+                self._console = console
+            print_fit(console, lead)
+            return True
+        except Exception:  # noqa: BLE001 — a mirror must not break a stream
+            logger.debug("[StreamRender] local echo degraded", exc_info=True)
+            return False
 
     def _render_buffer_safe(self) -> None:
         """Swap the Markdown renderable on Live. Rich handles the

--- a/tests/battle_test/test_stream_local_echo.py
+++ b/tests/battle_test/test_stream_local_echo.py
@@ -1,0 +1,263 @@
+"""The generation stream published to everyone except the operator.
+
+You run `ov`, the organism generates, and nothing appears. That has been true
+since the streaming renderer shipped, and every layer along the way was
+individually correct.
+
+`stream_renderer` skips the Rich `Live` widget whenever a SerpentREPL is
+active, because `Live` writes by direct cursor manipulation and would shred
+the prompt. Right call. `_mirror_completed_lines` was then written to route
+the generation into the cockpit's line-oriented deck instead — its docstring
+reaches the same conclusion this arc did independently: "The widget cannot be
+the answer; it is the thing that does not fit."
+
+It sends with `publish_markup_global`, which returns False unless
+`attached_cockpits() > 0` — a client connected over the BRIDGE.
+
+`ov` boots the harness IN-PROCESS (`ov.py` → `battle_main`), with a
+SerpentREPL holding the operator's terminal. There is no bridge client in
+that shape. So every line was composed, escaped, offered, and dropped, and
+the one surface guaranteed to be watching was the one surface never written
+to.
+
+THE CONCEPT ALREADY EXISTED
+---------------------------
+`cockpit_attach.operator_present()` draws exactly this distinction and
+documents it: "a cockpit is ATTACHED over the bridge, or this process owns a
+real terminal (a foreground run with its own REPL, where the operator is
+looking straight at it)." It was written because Karen kept narrating to an
+empty room after the operator went home. This is that defect in mirror image
+— text falling silent for the LOCAL operator for the same reason speech did
+for the remote one — and the fix is to consult it, not to invent it.
+
+WHY LOCAL ECHO IS SAFE WHERE `Live` WAS NOT
+--------------------------------------------
+`print_fit` writes through the Rich console, which under prompt_toolkit's
+`patch_stdout` is coordinated with the prompt: the line lands in scrollback
+ABOVE the input and the prompt redraws below. That is what
+`serpent_flow._emit_fit` has always done while the REPL is active. Nothing
+here re-enables `Live`, and nothing should.
+"""
+from __future__ import annotations
+
+import io
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from rich.console import Console
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+import backend.core.ouroboros.battle_test.stream_renderer as sr  # noqa: E402
+
+
+def _renderer(width: int = 100):
+    buf = io.StringIO()
+    r = sr.StreamRenderer(
+        console=Console(file=buf, width=width, force_terminal=True))
+    return r, buf
+
+
+def _mirror(renderer, text: str) -> None:
+    renderer._buffer = text
+    renderer._mirrored_offset = 0
+    renderer._mirror_completed_lines()
+
+
+@pytest.fixture()
+def local_tty():
+    """No bridge client; this process owns a real terminal — the exact shape
+    `ov` produces when it boots the harness in-process."""
+    with patch("backend.core.ouroboros.battle_test.presentation_restraint"
+               ".real_stdout_isatty", lambda: True), \
+         patch("backend.core.ouroboros.battle_test.cockpit_attach"
+               ".publish_markup_global", lambda *a, **k: False):
+        yield
+
+
+# ---------------------------------------------------------------------------
+# the regression
+# ---------------------------------------------------------------------------
+
+def test_the_stream_reaches_a_foreground_terminal(local_tty) -> None:
+    """THE regression. No bridge client, real terminal — and until now,
+    silence."""
+    r, buf = _renderer()
+    _mirror(r, "Reading orchestrator.py.\nThe gate fires early.\n")
+    out = buf.getvalue()
+    assert "Reading orchestrator.py" in out
+    assert "The gate fires early" in out
+
+
+def test_it_uses_the_decks_own_grammar(local_tty) -> None:
+    """One glyph opens the block, continuations indent under it — the same
+    shape assistant prose already has in the deck. A second grammar for the
+    same content would read as a different kind of event."""
+    r, buf = _renderer()
+    _mirror(r, "first line\nsecond line\nthird line\n")
+    lines = [ln for ln in buf.getvalue().splitlines() if ln.strip()]
+    assert lines[0].lstrip().startswith("⏺")
+    assert all(not ln.lstrip().startswith("⏺") for ln in lines[1:])
+
+
+def test_only_complete_lines_are_emitted(local_tty) -> None:
+    """A partial trailing line must be held. Emitting it would print a
+    fragment that the next flush prints again."""
+    r, buf = _renderer()
+    r._buffer = "complete line\npartial without newline"
+    r._mirrored_offset = 0
+    r._mirror_completed_lines()
+    out = buf.getvalue()
+    assert "complete line" in out
+    assert "partial without newline" not in out
+
+
+def test_the_held_remainder_is_flushed_at_the_end(local_tty) -> None:
+    """`final=True` is what closes the stream, and a dropped last line is the
+    one the operator most wants."""
+    r, buf = _renderer()
+    r._buffer = "complete\ntrailing fragment"
+    r._mirrored_offset = 0
+    r._mirror_completed_lines()
+    r._mirror_completed_lines(final=True)
+    assert "trailing fragment" in buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# not both — a line must never print twice
+# ---------------------------------------------------------------------------
+
+def test_an_attached_bridge_wins_and_suppresses_the_local_echo() -> None:
+    """A foreground run that ALSO has an attached client would otherwise
+    print every line twice on the same terminal."""
+    sent = []
+    r, buf = _renderer()
+    with patch("backend.core.ouroboros.battle_test.cockpit_attach"
+               ".publish_markup_global", lambda t, **k: sent.append(t) or True), \
+         patch("backend.core.ouroboros.battle_test.presentation_restraint"
+               ".real_stdout_isatty", lambda: True):
+        _mirror(r, "one line\n")
+    assert sent and "one line" in sent[0]
+    assert buf.getvalue() == "", "line printed to the bridge AND locally"
+
+
+def test_a_detached_daemon_stays_silent() -> None:
+    """No bridge client and no terminal: nobody can perceive this. Writing
+    anyway is how a background daemon fills a log with prose."""
+    r, buf = _renderer()
+    with patch("backend.core.ouroboros.battle_test.cockpit_attach"
+               ".publish_markup_global", lambda *a, **k: False), \
+         patch("backend.core.ouroboros.battle_test.presentation_restraint"
+               ".real_stdout_isatty", lambda: False):
+        _mirror(r, "unheard\n")
+    assert buf.getvalue() == ""
+
+
+# ---------------------------------------------------------------------------
+# the trap this arc has already been bitten by
+# ---------------------------------------------------------------------------
+
+def test_the_tty_check_reads_the_real_stdout_not_the_proxy() -> None:
+    """Load-bearing, and the one mode this fix exists for.
+
+    Under `patch_stdout(raw=True)` — which is exactly when a SerpentREPL is
+    active — `sys.stdout` is a prompt_toolkit proxy whose `isatty()` returns
+    False. `real_stdout_isatty` reads `sys.__stdout__` instead. Testing the
+    proxy is the bug that made `should_render()` blind in the
+    presentation-restraint arc, and it would make this echo dead in precisely
+    the mode it was written for.
+    """
+    import inspect
+    src = inspect.getsource(sr.StreamRenderer._emit_deck_line)
+    assert "real_stdout_isatty" in src
+    assert "sys.stdout.isatty" not in src
+
+
+def test_live_is_not_re_enabled_under_a_repl() -> None:
+    """The widget is still the thing that does not fit. This change adds a
+    sink; it must not resurrect the renderer that clobbers the prompt."""
+    import inspect
+    src = inspect.getsource(sr.StreamRenderer.start)
+    assert "_repl_active" in src
+    assert "self._live = None" in src
+
+
+# ---------------------------------------------------------------------------
+# resilience — this runs on the token hot path
+# ---------------------------------------------------------------------------
+
+def test_untrusted_model_output_is_escaped(local_tty) -> None:
+    """The deck channel is styled chrome around inert data. Model output that
+    contains markup must not be interpreted as it."""
+    r, buf = _renderer()
+    _mirror(r, "[bold red]not a style[/bold red]\n")
+    assert "not a style" in buf.getvalue()
+
+
+def test_a_very_long_line_is_bounded(local_tty) -> None:
+    """One pathological line must not scroll the operator's screen away."""
+    r, buf = _renderer(width=80)
+    _mirror(r, "x" * 20000 + "\n")
+    assert max(len(ln) for ln in buf.getvalue().splitlines()) <= 200
+
+
+def test_blank_lines_do_not_open_an_empty_block(local_tty) -> None:
+    r, buf = _renderer()
+    _mirror(r, "\n\n\n")
+    assert buf.getvalue().strip() == ""
+
+
+def test_a_broken_console_never_breaks_the_stream(local_tty) -> None:
+    """`_mirror_completed_lines` is called from the consumer task on the
+    token hot path. A render fault must cost a line, never the generation."""
+    class Exploding:
+        def print(self, *a, **k):
+            raise RuntimeError("terminal on fire")
+        @property
+        def width(self):
+            raise RuntimeError("terminal on fire")
+
+    r = sr.StreamRenderer(console=Exploding())
+    _mirror(r, "still fine\n")  # must not raise
+
+
+def test_local_echo_can_be_switched_off(monkeypatch) -> None:
+    """Reverts to the previous behaviour exactly: bridge-only."""
+    monkeypatch.setenv("JARVIS_STREAM_LOCAL_ECHO_ENABLED", "0")
+    assert sr.local_echo_enabled() is False
+    r, buf = _renderer()
+    with patch("backend.core.ouroboros.battle_test.cockpit_attach"
+               ".publish_markup_global", lambda *a, **k: False), \
+         patch("backend.core.ouroboros.battle_test.presentation_restraint"
+               ".real_stdout_isatty", lambda: True):
+        _mirror(r, "suppressed\n")
+    assert buf.getvalue() == ""
+
+
+def test_local_echo_defaults_on(monkeypatch) -> None:
+    monkeypatch.delenv("JARVIS_STREAM_LOCAL_ECHO_ENABLED", raising=False)
+    assert sr.local_echo_enabled() is True
+
+
+def test_the_mirror_master_flag_still_governs_everything(monkeypatch) -> None:
+    monkeypatch.setenv("JARVIS_STREAM_MIRROR_ENABLED", "0")
+    r, buf = _renderer()
+    with patch("backend.core.ouroboros.battle_test.presentation_restraint"
+               ".real_stdout_isatty", lambda: True):
+        _mirror(r, "suppressed\n")
+    assert buf.getvalue() == ""
+
+
+def test_offset_advances_so_a_line_is_never_repeated(local_tty) -> None:
+    """Two flushes over a growing buffer, as the consumer does every 16 ms."""
+    r, buf = _renderer()
+    r._buffer = "alpha\n"
+    r._mirrored_offset = 0
+    r._mirror_completed_lines()
+    r._buffer += "beta\n"
+    r._mirror_completed_lines()
+    out = buf.getvalue()
+    assert out.count("alpha") == 1
+    assert out.count("beta") == 1


### PR DESCRIPTION
You run `ov`, the organism generates, and nothing appears. **Every layer along the way was individually correct.**

## The chain

`stream_renderer` skips the Rich `Live` widget whenever a SerpentREPL is active, because `Live` writes by direct cursor manipulation and would shred the prompt. Right call.

`_mirror_completed_lines` was then written to route the generation into the cockpit's line-oriented deck instead. Its docstring reaches the same conclusion this arc reached independently this morning:

> *"The widget cannot be the answer; it is the thing that does not fit."*

It sends with `publish_markup_global`, which returns `False` unless **`attached_cockpits() > 0`** — a client connected over the *bridge*.

**`ov` boots the harness in-process** (`ov.py:4734` → `battle_main`), with a SerpentREPL holding the operator's terminal. There is no bridge client in that shape. So every line was composed, escaped, offered, and dropped. The one surface guaranteed to be watching was the one never written to.

## The concept already existed

`cockpit_attach.operator_present()` draws exactly this distinction and documents it:

> *"Two ways a human can be present, and both count: a cockpit is ATTACHED over the bridge, or **this process owns a real terminal** (a foreground run with its own REPL, where the operator is looking straight at it)."*

It was written because **Karen kept narrating to an empty room** after the operator went home. This is that defect in mirror image — text falling silent for the *local* operator for the same reason speech did for the *remote* one. The fix consults the concept rather than inventing one.

`_emit_deck_line` tries the bridge first and the local terminal second, and **never both for one line**: a foreground run that also has an attached client would otherwise print every line twice on the same terminal.

## Why local echo is safe where `Live` was not

`print_fit` writes through the Rich console, which under prompt_toolkit's `patch_stdout` is coordinated with the prompt — the line lands in scrollback **above** the input and the prompt redraws below. That is what `serpent_flow._emit_fit` has always done while the REPL is active.

**Nothing here re-enables `Live`**, and a test pins that it stays disabled.

The TTY check reads `real_stdout_isatty` (`sys.__stdout__`), **not** `sys.stdout.isatty()`. Under `patch_stdout(raw=True)` — exactly when a REPL is active — the proxy reports `False`. That is the bug that made `should_render()` blind in the presentation-restraint arc, and it would have made this echo dead in precisely the mode it exists for. Also pinned.

## What it looks like

```
⏺ Reading orchestrator.py to find the seam.
  The gate fires before the claim is captured.
```

The deck's own grammar — one glyph opens the block, continuations indent under it, same shape assistant prose already has. A second grammar for the same content would read as a different kind of event.

## Verification

**16 new tests**: line grammar, partial-line holding, final flush, no double-print when a bridge is attached, silence when nobody can perceive it, markup escaping of untrusted model output, long-line bounding, a console that raises on every call, and offset advance across repeated flushes.

**Baseline-diffed against clean main** across the stream / cockpit-attach / presentation-restraint suites: **30 failures before, 30 after, zero introduced.** Those 30 are pre-existing reds unrelated to this change.

`JARVIS_STREAM_LOCAL_ECHO_ENABLED` (default true) reverts to bridge-only.

## What this does not claim

It is proven at the unit level and against a real Rich console, but it has **not been watched in a live `ov` boot** — which is the next thing to do, and the whole reason it was built. Live shell `stdout` (the `tool_executor.py:1047` streaming tool) still has nowhere to draw; it needs the same sink and is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the invisible stream when running `ov` in a foreground REPL by echoing generated lines to the operator’s terminal when no cockpit is attached. Keeps the deck as the sink and avoids clobbering the prompt.

- **Bug Fixes**
  - Added `_emit_deck_line`: tries `publish_markup_global` first; if no attached cockpit, echoes locally via `print_fit` when `real_stdout_isatty()` is true.
  - Keeps `Live` disabled under a REPL and never prints the same line to both bridge and local.
  - Uses the deck’s line grammar; escapes markup, bounds long lines, and holds partial trailing lines until final flush.
  - New env flag `JARVIS_STREAM_LOCAL_ECHO_ENABLED` (default on) to disable local echo; added 16 tests; no new failures introduced.

<sup>Written for commit ac062ce8c5167dc23eedcaa7aa3cbbce6c053b27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

