### PR TITLE
fix(chat): the cockpit said "queued" about work it had thrown away

### DIFF
--- a/backend/core/ouroboros/governance/chat_repl_backlog_executor.py
+++ b/backend/core/ouroboros/governance/chat_repl_backlog_executor.py
@@ -97,20 +97,44 @@ _DEFAULT_CHAT_BACKLOG_PRIORITY: int = 3
 
 
 def is_enabled() -> bool:
-    """Master flag — ``JARVIS_CHAT_EXECUTOR_BACKLOG_ENABLED`` (default
-    false until graduation).
+    """Master flag — ``JARVIS_CHAT_EXECUTOR_BACKLOG_ENABLED``.
 
-    When off, the factory falls back to the safe-default
-    `LoggingChatActionExecutor` for ALL four methods (zero behavior
-    change vs the post-graduation Slice 4 wiring).
+    **Graduated default-TRUE 2026-08-08.** Off, the factory falls back to the
+    safe-default `LoggingChatActionExecutor` for ALL four methods; on, this
+    module's `dispatch_backlog` writes to `.jarvis/backlog.json` while the
+    other three still delegate until their own executors land.
 
-    When on, the factory wires `BacklogChatActionExecutor` so the
-    `dispatch_backlog` method writes to `.jarvis/backlog.json`; the
-    other three methods still delegate to LoggingChatActionExecutor
-    until their own concrete executors land in subsequent PRs."""
-    return os.environ.get(
+    WHY IT GRADUATED
+
+    Default-false meant an operator typing a real request into the cockpit
+    had it routed to `backlog_dispatch`, handed to the logging executor,
+    logged, and dropped — while the surface replied "adding that to the
+    backlog … queued … the Backlog sensor will pick it up on its next
+    sweep". Verified on the live tree the day this flipped:
+    `.jarvis/backlog.json` was last modified in April and held no chat
+    entries at all. Three false claims in one line, about the operator's own
+    work.
+
+    The renderer's half of that is fixed separately and is what makes this
+    flip safe to reason about: a `logged-` receipt is now reported as NOT
+    queued, so "off" is visibly off rather than indistinguishable from
+    success. But an executor that is correct, tested, and disabled is the
+    reachability defect this codebase keeps shipping — merged and inert —
+    and the cost of leaving it off is that the system silently discards the
+    highest-signal input it can receive.
+
+    The authority surface is why the flip is small: exactly one file written,
+    the same `.jarvis/backlog.json` that `/backlog auto-proposed approve`
+    already appends to, bounded at MAX_BACKLOG_DESCRIPTION_CHARS, and
+    deduped by `chat:{turn_id}` so a retried turn is structurally idempotent
+    at the sensor. No subprocess, no network, no env mutation.
+    """
+    raw = os.environ.get(
         "JARVIS_CHAT_EXECUTOR_BACKLOG_ENABLED", "",
-    ).strip().lower() in _TRUTHY
+    ).strip().lower()
+    if raw == "":
+        return True  # graduated default
+    return raw in _TRUTHY
 
 
 def _backlog_path(project_root: Path) -> Path:

--- a/backend/core/ouroboros/governance/chat_response_style.py
+++ b/backend/core/ouroboros/governance/chat_response_style.py
@@ -122,16 +122,63 @@ def _dispatched_now(receipt: str) -> bool:
     return bool(ref) and (ref.startswith("op-") or ref.startswith("op_"))
 
 
-def _queue_note(action: str, receipt: str = "") -> Optional[str]:
-    """Say plainly when work is queued rather than started.
+def _logging_prefix() -> str:
+    """The marker the safe-default executor stamps on a receipt for work it
+    did NOT do. Read from the executor rather than restated here, so the two
+    cannot drift into disagreeing about what "logged" looks like."""
+    try:
+        from backend.core.ouroboros.governance.chat_repl_dispatcher import (
+            LoggingChatActionExecutor,
+        )
+        return str(getattr(LoggingChatActionExecutor, "LABEL_PREFIX", "logged-"))
+    except Exception:  # noqa: BLE001 — dispatcher unavailable
+        return "logged-"
 
-    ``backlog_dispatch`` hands the goal to a sensor that polls. "logged" hides
-    that; silence hides it worse. An operator staring at an unchanged screen
-    needs to know whether to wait or to worry.
+
+def _was_discarded(receipt: str) -> bool:
+    """Did the executor decline to do anything at all?
+
+    ``LoggingChatActionExecutor`` — the safe default wired whenever
+    ``JARVIS_CHAT_EXECUTOR_BACKLOG_ENABLED`` is off — logs the message and
+    returns a synthetic token it deliberately prefixes ``logged-``. That
+    prefix is the executor saying, in the only channel it has, "I did not do
+    this."
+    """
+    return str(receipt or "").strip().startswith(_logging_prefix())
+
+
+def _queue_note(action: str, receipt: str = "") -> Optional[str]:
+    """Say plainly what happened to the work. NEVER guess.
+
+    ``backlog_dispatch`` has THREE outcomes and this used to render two:
+
+      * an ``op-`` receipt — intake accepted it, a worker has it
+      * a ``chat:`` receipt — filed in backlog.json for the sensor to collect
+      * a ``logged-`` receipt — the executor is the safe-default logger and
+        NOTHING happened
+
+    The third fell through to the second, so an operator who typed a real
+    request was told "queued — the Backlog sensor will pick it up on its next
+    sweep" about an entry that was never written. Verified against the live
+    tree: ``.jarvis/backlog.json`` was last modified in April and contained
+    no chat entries at all.
+
+    Three claims in one line, all false, about the operator's own work. The
+    receipt already carried the truth; the renderer had two branches for
+    three realities, which is the same defect as every other one in this
+    arc — a surface reporting a state it did not measure — with the sharpest
+    possible consequence, because this one eats the request and says thank
+    you.
     """
     _phrase, deferred = _voice(action)
     if not deferred or _dispatched_now(receipt):
         return None
+    if _was_discarded(receipt):
+        # Name the flag. An operator who has just watched their request
+        # vanish should not have to grep for why.
+        return ("⎿ NOT queued — the chat executor is the safe-default "
+                "logger, so nothing was written. Set "
+                "JARVIS_CHAT_EXECUTOR_BACKLOG_ENABLED=1 to make this real.")
     ref = f" ({receipt})" if receipt else ""
     return (f"⎿ queued{ref} — the Backlog sensor will pick it up on its "
             f"next sweep")

--- a/tests/governance/test_chat_receipt_honesty.py
+++ b/tests/governance/test_chat_receipt_honesty.py
@@ -1,0 +1,223 @@
+"""The cockpit told the operator three things and all three were false.
+
+The operator typed a real request into `ov`:
+
+    ❯ add a module docstring to .../session_identity.py explaining the
+      pytest isolation rule
+    ● adding that to the backlog
+      ⎿ queued (logged-backlog-chat-cbda1fd0f016) — the Backlog sensor
+        will pick it up on its next sweep
+
+Nothing was added. Nothing was queued. There was nothing for the sensor to
+pick up. Verified on the live tree at the time: `.jarvis/backlog.json` was
+last modified in April and contained zero chat entries.
+
+WHY
+---
+`backlog_dispatch` has THREE outcomes and the renderer had TWO branches:
+
+    op-…      intake accepted it, a worker has it        → say nothing
+    chat:…    filed in backlog.json for the sensor       → "queued"
+    logged-…  the safe-default executor DECLINED         → fell through
+
+`LoggingChatActionExecutor` is wired whenever
+`JARVIS_CHAT_EXECUTOR_BACKLOG_ENABLED` is off. It logs the message and
+returns a synthetic token it deliberately prefixes `logged-` — it even
+declares `LABEL_PREFIX = "logged-"` as a class attribute. That prefix is the
+executor saying, in the only channel it has, "I did not do this."
+
+Nothing read it. The third reality fell into the second branch, so the most
+comfortable of the three answers was the one printed.
+
+Same defect as the rest of this arc — a surface reporting a state it did not
+measure — with the sharpest consequence available, because this one eats the
+operator's work and thanks them for it.
+
+THE FIX IS BOTH HALVES
+----------------------
+Reading the prefix makes "off" visibly off. Flipping the flag makes it not
+off. Either alone is wrong: honesty without capability just documents a dead
+end, and capability without honesty leaves the next inert executor free to
+lie the same way.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from backend.core.ouroboros.governance.chat_repl_dispatcher import (  # noqa: E402
+    LoggingChatActionExecutor,
+)
+from backend.core.ouroboros.governance.chat_response_style import (  # noqa: E402
+    _dispatched_now,
+    _logging_prefix,
+    _queue_note,
+    _was_discarded,
+)
+
+
+# ---------------------------------------------------------------------------
+# the three realities
+# ---------------------------------------------------------------------------
+
+def test_a_discarded_request_is_reported_as_discarded() -> None:
+    """THE regression. This exact receipt printed "queued" for months."""
+    note = _queue_note("backlog_dispatch", "logged-backlog-chat-cbda1fd0f016")
+    assert note is not None
+    assert "NOT queued" in note
+    assert "queued (" not in note, "still claiming the entry was filed"
+
+
+def test_the_operator_is_told_which_flag_to_set() -> None:
+    """Someone who has just watched their request vanish should not have to
+    grep for why."""
+    note = _queue_note("backlog_dispatch", "logged-x")
+    assert "JARVIS_CHAT_EXECUTOR_BACKLOG_ENABLED" in note
+
+
+def test_a_filed_request_still_says_queued() -> None:
+    note = _queue_note("backlog_dispatch", "chat:turn-123")
+    assert note is not None and "queued (chat:turn-123)" in note
+    assert "NOT queued" not in note
+
+
+def test_a_running_request_says_nothing() -> None:
+    """An op-id means a worker already has it; a queue note would be wrong."""
+    assert _queue_note("backlog_dispatch", "op-019fd3a6-23d8-7bb2") is None
+    assert _dispatched_now("op-019fd3a6-23d8-7bb2") is True
+
+
+@pytest.mark.parametrize("action", ["subagent_explore", "claude_query",
+                                    "context_attach", "social_ack", "noop"])
+def test_non_deferred_actions_are_unaffected(action) -> None:
+    assert _queue_note(action, "logged-x") is None
+
+
+# ---------------------------------------------------------------------------
+# one authority for what "logged" looks like
+# ---------------------------------------------------------------------------
+
+def test_the_prefix_comes_from_the_executor_not_a_copy() -> None:
+    """Two spellings of the same marker is how this breaks again: the
+    executor renames its prefix, the renderer keeps matching the old one, and
+    the lie returns silently."""
+    assert _logging_prefix() == LoggingChatActionExecutor.LABEL_PREFIX
+
+
+def test_the_executor_still_stamps_that_prefix() -> None:
+    """The other direction. If the safe default stops marking its receipts,
+    a discarded request becomes indistinguishable from a filed one again."""
+    assert LoggingChatActionExecutor.LABEL_PREFIX
+    assert str(LoggingChatActionExecutor.LABEL_PREFIX).strip()
+
+
+@pytest.mark.parametrize("receipt,discarded", [
+    ("logged-backlog-chat-abc", True),
+    ("chat:turn-1", False),
+    ("op-019f-7abc", False),
+    ("", False),
+    ("   ", False),
+    (None, False),
+])
+def test_discard_detection_is_exact(receipt, discarded) -> None:
+    assert _was_discarded(receipt) is discarded
+
+
+def test_an_empty_receipt_is_not_called_discarded() -> None:
+    """An executor that returned nothing is a different failure from one that
+    declined. Claiming the flag is off would send the operator to fix
+    something that is already on."""
+    note = _queue_note("backlog_dispatch", "")
+    assert note is not None and "NOT queued" not in note
+
+
+def test_the_renderer_survives_a_missing_dispatcher(monkeypatch) -> None:
+    """`_logging_prefix` lazily imports the dispatcher. A render path must not
+    raise because an import failed."""
+    import builtins
+    real = builtins.__import__
+
+    def _boom(name, *a, **k):
+        if "chat_repl_dispatcher" in name:
+            raise ImportError("gone")
+        return real(name, *a, **k)
+
+    monkeypatch.setattr(builtins, "__import__", _boom)
+    assert _logging_prefix() == "logged-"
+    assert "NOT queued" in _queue_note("backlog_dispatch", "logged-x")
+
+
+# ---------------------------------------------------------------------------
+# the capability half — the executor was correct, tested, and switched off
+# ---------------------------------------------------------------------------
+
+def test_the_backlog_executor_is_on_by_default(monkeypatch) -> None:
+    """Merged and inert is the defect this codebase keeps shipping. An
+    executor that writes one bounded, deduped file has no business being the
+    reason the operator's input disappears."""
+    from backend.core.ouroboros.governance import chat_repl_backlog_executor as ex
+    monkeypatch.delenv("JARVIS_CHAT_EXECUTOR_BACKLOG_ENABLED", raising=False)
+    assert ex.is_enabled() is True
+
+
+@pytest.mark.parametrize("raw,expected", [
+    ("0", False), ("false", False), ("no", False), ("off", False),
+    ("1", True), ("true", True), ("yes", True), ("on", True),
+])
+def test_the_flag_still_switches_it_off(monkeypatch, raw, expected) -> None:
+    from backend.core.ouroboros.governance import chat_repl_backlog_executor as ex
+    monkeypatch.setenv("JARVIS_CHAT_EXECUTOR_BACKLOG_ENABLED", raw)
+    assert ex.is_enabled() is expected
+
+
+def test_a_dispatched_request_actually_lands_on_disk(tmp_path) -> None:
+    """End to end through the real executor. The receipt shape and the file
+    must agree — a `chat:` receipt over an unwritten file would be the same
+    lie one layer down."""
+    import inspect
+    from backend.core.ouroboros.governance.chat_repl_backlog_executor import (
+        BacklogChatActionExecutor,
+    )
+    from backend.core.ouroboros.governance.conversation_orchestrator import (
+        ChatTurn,
+    )
+    (tmp_path / ".jarvis").mkdir()
+    kw = {n: ("t-1" if "id" in n else "x")
+          for n, p in inspect.signature(ChatTurn).parameters.items()
+          if p.default is inspect.Parameter.empty}
+    receipt = BacklogChatActionExecutor(project_root=tmp_path).dispatch_backlog(
+        "add a docstring explaining the pytest isolation rule", ChatTurn(**kw))
+
+    assert not _was_discarded(receipt), receipt
+    assert receipt.startswith("chat:")
+
+    raw = json.loads((tmp_path / ".jarvis" / "backlog.json").read_text())
+    items = raw if isinstance(raw, list) else raw.get("tasks") or raw.get("items")
+    assert any("pytest isolation rule" in json.dumps(t) for t in items)
+    # And the line the operator sees is now true of the file that exists.
+    assert "queued" in _queue_note("backlog_dispatch", receipt)
+
+
+def test_the_same_turn_twice_is_idempotent(tmp_path) -> None:
+    """`chat:{turn_id}` dedup at the sensor. An operator retrying a request
+    must not fan out into two ops."""
+    import inspect
+    from backend.core.ouroboros.governance.chat_repl_backlog_executor import (
+        BacklogChatActionExecutor,
+    )
+    from backend.core.ouroboros.governance.conversation_orchestrator import (
+        ChatTurn,
+    )
+    (tmp_path / ".jarvis").mkdir()
+    kw = {n: ("t-dup" if "id" in n else "x")
+          for n, p in inspect.signature(ChatTurn).parameters.items()
+          if p.default is inspect.Parameter.empty}
+    ex = BacklogChatActionExecutor(project_root=tmp_path)
+    a = ex.dispatch_backlog("same request", ChatTurn(**kw))
+    b = ex.dispatch_backlog("same request", ChatTurn(**kw))
+    assert a == b, "the receipt must be stable for a retried turn"

--- a/tests/governance/test_chat_repl_backlog_executor.py
+++ b/tests/governance/test_chat_repl_backlog_executor.py
@@ -103,12 +103,23 @@ def test_max_backlog_description_chars_pinned():
     assert MAX_BACKLOG_DESCRIPTION_CHARS == 1024
 
 
-def test_master_flag_default_false_pre_graduation(monkeypatch):
-    """Pin: this concrete executor ships default-OFF until its own
-    graduation. Operator opts in via env knob; legacy fallback to
-    LoggingChatActionExecutor remains the safe-default."""
+def test_master_flag_graduated_default_true(monkeypatch):
+    """Was `test_master_flag_default_false_pre_graduation`. This IS that
+    graduation, 2026-08-08.
+
+    Default-OFF meant an operator typing a real request into the cockpit had
+    it routed to `backlog_dispatch`, handed to `LoggingChatActionExecutor`,
+    logged, and dropped — while the surface replied "adding that to the
+    backlog … queued … the Backlog sensor will pick it up". Verified on the
+    live tree: `.jarvis/backlog.json` was last touched in April and held no
+    chat entries at all.
+
+    The renderer's half is fixed in `chat_response_style` and is what makes
+    this safe: a `logged-` receipt now reports NOT queued, so "off" is
+    visibly off rather than indistinguishable from success.
+    """
     monkeypatch.delenv("JARVIS_CHAT_EXECUTOR_BACKLOG_ENABLED", raising=False)
-    assert is_enabled() is False
+    assert is_enabled() is True
 
 
 def test_master_flag_truthy_variants(monkeypatch):
@@ -118,9 +129,19 @@ def test_master_flag_truthy_variants(monkeypatch):
 
 
 def test_master_flag_falsy_variants(monkeypatch):
-    for val in ("0", "false", "no", "off", "", "garbage"):
+    """`""` is no longer here: an unset variable now means the graduated
+    default, which is the whole point of the flip. Every EXPLICIT falsy
+    spelling must still switch the executor off."""
+    for val in ("0", "false", "no", "off", "garbage"):
         monkeypatch.setenv("JARVIS_CHAT_EXECUTOR_BACKLOG_ENABLED", val)
         assert is_enabled() is False, f"value {val!r} should be falsy"
+
+
+def test_an_unset_flag_is_the_graduated_default_not_falsy(monkeypatch):
+    """The one behaviour the old `""` case was asserting, restated so the
+    distinction between "unset" and "explicitly off" cannot be lost again."""
+    monkeypatch.setenv("JARVIS_CHAT_EXECUTOR_BACKLOG_ENABLED", "")
+    assert is_enabled() is True
 
 
 # ===========================================================================


### PR DESCRIPTION
The operator typed a real request into `ov`:

```
❯ add a module docstring to .../session_identity.py explaining the pytest isolation rule
● adding that to the backlog
  ⎿ queued (logged-backlog-chat-cbda1fd0f016) — the Backlog sensor will pick it up on its next sweep
```

**Nothing was added. Nothing was queued. There was nothing for the sensor to pick up.**

Verified on the live tree at that moment: `.jarvis/backlog.json` last modified in **April**, zero chat entries. Three claims in one line, all false, about the operator's own work.

## Root cause

`backlog_dispatch` has **three** outcomes and the renderer had **two** branches:

| receipt | reality | rendered |
|---|---|---|
| `op-…` | intake accepted it, a worker has it | *(silence — correct)* |
| `chat:…` | filed in backlog.json for the sensor | "queued" |
| `logged-…` | the safe-default executor **declined** | fell through → **"queued"** |

`LoggingChatActionExecutor` is wired whenever `JARVIS_CHAT_EXECUTOR_BACKLOG_ENABLED` is off. It logs the message and returns a synthetic token prefixed `logged-` — it even declares `LABEL_PREFIX = "logged-"` as a class attribute. **That prefix is the executor saying, in the only channel it has, "I did not do this."**

Nothing read it. The third reality landed in the second branch, and the most comfortable of the three answers was the one printed.

`chat_response_style` already knew `backlog_dispatch` was *"TWO outcomes wearing one action name"* and had built `_dispatched_now` to tell them apart. It was right about the shape of the problem and **one outcome short of the count.**

## Both halves, because either alone is wrong

**Honesty.** `_was_discarded` reads the prefix *from the executor class* rather than restating it, so the two cannot drift into disagreeing about what "logged" looks like. A discarded request now reports `NOT queued` and names the flag — someone who has just watched their request vanish should not have to grep for why.

An **empty** receipt is deliberately *not* treated as discarded: an executor that returned nothing is a different failure from one that declined, and blaming the flag would send the operator to fix something that is already on.

**Capability.** `JARVIS_CHAT_EXECUTOR_BACKLOG_ENABLED` graduates **default-TRUE**. The concrete executor was written, tested, and switched off — merged and inert, the defect this codebase keeps shipping — and the cost of leaving it off is that the system silently discards the highest-signal input it can receive.

The authority surface is why the flip is small: exactly one file written, the same `.jarvis/backlog.json` that `/backlog auto-proposed approve` already appends to, bounded at `MAX_BACKLOG_DESCRIPTION_CHARS`, deduped by `chat:{turn_id}`. No subprocess, no network, no env mutation.

> Honesty without capability documents a dead end. Capability without honesty leaves the next inert executor free to lie the same way.

## Proven end to end

```
receipt : chat:t-live-1                    (not logged-…)
file    : entry present in .jarvis/backlog.json
renders : ⎿ queued (chat:t-live-1) — the Backlog sensor will pick it up
```

— which is now a true statement about a file that exists.

## Verification

**537 tests green** across the chat/conversation suites, 30 of them new, baseline-diffed against clean main.

Two existing pins failed and were **right to**: one was literally named `test_master_flag_default_false_pre_graduation`, and the other asserted that an unset flag is falsy. Both updated, with the unset-vs-explicitly-off distinction restated as its own test so it cannot be lost again.

## What this does not fix

The request now lands in `backlog.json` and waits for the BacklogSensor's next sweep (60 s poll, fs-event-primary). That is honest deferral, not instant action — **an operator's direct request arguably deserves to skip the queue entirely**, and it still doesn't. That's a routing decision worth its own change rather than one smuggled in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the cockpit saying "queued" for chat requests it actually dropped, and enables real backlog writes by default so operator requests persist.

- **Bug Fixes**
  - Treat `logged-…` receipts as discarded and render "NOT queued" with guidance to set `JARVIS_CHAT_EXECUTOR_BACKLOG_ENABLED=1`.
  - Keep correct behaviors: silence for `op-…`; "queued (chat:…)" when an entry is written to `.jarvis/backlog.json`.
  - Read the discard prefix from `LoggingChatActionExecutor.LABEL_PREFIX` to avoid drift; handle missing dispatcher imports safely.
  - Empty receipts are not treated as discarded.

- **Migration**
  - `JARVIS_CHAT_EXECUTOR_BACKLOG_ENABLED` now defaults to true; an unset value means ON.
  - To disable, set to `0`, `false`, `no`, or `off`.
  - When enabled, backlog entries are written to `.jarvis/backlog.json`, bounded by `MAX_BACKLOG_DESCRIPTION_CHARS` and deduped by `chat:{turn_id}`.

<sup>Written for commit 92d52b4ffe44119c39e14cdcc13caaf85df302d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

