### PR TITLE
fix(ov): the typed-goal path raised TypeError on every call for 12 days

### DIFF
--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -83,6 +83,14 @@ _TRUTHY = frozenset({"1", "true", "yes", "on"})
 #: unconditionally regardless of what happens here.
 _AWAKENING_FATAL_ABORT_BOUND_S = 3.0
 
+#: How long a typed goal waits for intake's verdict before the cockpit falls
+#: back to filing it. Bounded because the operator is watching a prompt, and
+#: generous because the alternative to waiting is CLAIMING an acceptance we
+#: have not got. Spent on a `to_thread` worker, never on the event loop.
+_OPERATOR_GOAL_INGEST_TIMEOUT_S = float(
+    os.environ.get("JARVIS_OPERATOR_GOAL_INGEST_TIMEOUT_S", "10") or 10,
+)
+
 
 def _boot_mark(name: str) -> None:
     """Defensive boot-timing mark. NEVER raises into boot path.
@@ -5069,6 +5077,18 @@ class BattleTestHarness:
                             from backend.core.ouroboros.governance.chat_repl_backlog_executor import (  # noqa: E501
                                 set_operator_dispatcher,
                             )
+                            # The chat executor is invoked through
+                            # `asyncio.to_thread` (chat_text_bridge._run), so
+                            # the submitter runs on a WORKER thread with no
+                            # running loop of its own. Capture the loop here,
+                            # where we are on it, or the submitter has no way
+                            # to reach intake at all.
+                            try:
+                                self._operator_goal_loop = (
+                                    asyncio.get_running_loop()
+                                )
+                            except RuntimeError:
+                                self._operator_goal_loop = None
                             set_operator_dispatcher(self._submit_operator_goal)
                         except Exception:  # noqa: BLE001
                             pass
@@ -5195,8 +5215,52 @@ class BattleTestHarness:
         Returns None rather than raising when intake is unreachable: the
         caller then FILES the goal and says so. A queued goal is a
         degradation; a dropped one is a betrayal.
+
+        WHY THIS IS BUILT FROM ``make_envelope`` AND NOT ``IntentEnvelope``
+
+        It used to call the raw dataclass constructor with four of its
+        fifteen required fields, so EVERY invocation raised ``TypeError``
+        before reaching intake — caught one frame down, logged at DEBUG,
+        returned None. The executor read None as "intake declined", filed the
+        goal in backlog.json, and the cockpit honestly reported it queued.
+        The feature was merged, flagged on, armed at boot, covered by fifteen
+        tests, and dead at the first statement of its own body: every test
+        either injected a fake submitter returning a literal ``"op-…"`` or
+        asserted on the SOURCE TEXT of this function
+        (``assert 'source="operator_chat"' in src``). String assertions pass
+        against code that cannot run.
+
+        ``make_envelope`` is the factory every sensor already uses. It mints
+        the ids, stamps the schema version and computes the dedup key, so
+        this path cannot drift from the sensor path by forgetting a field.
+
+        WHY THE VERDICT IS AWAITED
+
+        ``ingest`` returns ``enqueued`` / ``pending_ack`` / ``deduplicated``
+        / ``backpressure`` — a verdict, never an id. Reporting an ``op-``
+        receipt on ``backpressure`` would claim acceptance intake refused,
+        which is the exact dishonesty the receipt vocabulary exists to
+        prevent. We can afford to wait for the real answer because the chat
+        executor is invoked through ``asyncio.to_thread`` — this runs on a
+        WORKER thread, so a bounded ``run_coroutine_threadsafe`` blocks
+        nothing but the turn the operator is already waiting on. (The old
+        ``asyncio.ensure_future`` here would itself have raised
+        ``RuntimeError: no running event loop`` for the same reason — a
+        second fatal bug on the same line, reached only if the first were
+        fixed.)
         """
+        origin_id = ""
         try:
+            from backend.core.ouroboros.governance.operation_id import (
+                generate_operation_id,
+            )
+            from backend.core.ouroboros.governance.intake.intent_envelope import (  # noqa: E501
+                make_envelope,
+            )
+            from backend.core.ouroboros.governance.intake.unified_intake_router import (  # noqa: E501
+                get_default_intake_router,
+            )
+
             gls = getattr(self, "_governed_loop_service", None)
             router = None
             for _attr in ("_intake_router", "intake_router", "_router"):
@@ -5204,6 +5268,17 @@ class BattleTestHarness:
                 if router is not None:
                     break
             if router is None:
+                # The process-wide singleton the router registers on its own
+                # construction — the same handle the voice side uses. Without
+                # this, a deployment that never attached the router to the GLS
+                # files every typed goal while a live router sits one import
+                # away.
+                router = get_default_intake_router()
+            if router is None:
+                logger.warning(
+                    "[OperatorGoal] no intake router reachable — goal will "
+                    "be FILED, not run",
+                )
                 return None
             submit = (
                 getattr(router, "submit_envelope", None)
@@ -5211,14 +5286,29 @@ class BattleTestHarness:
                 or getattr(router, "emit", None)
             )
             if submit is None:
+                logger.warning(
+                    "[OperatorGoal] router %s exposes no submit seam — goal "
+                    "will be FILED, not run", type(router).__name__,
+                )
                 return None
 
-            from backend.core.ouroboros.governance.intake.intent_envelope import (  # noqa: E501
-                IntentEnvelope,
-            )
-            envelope = IntentEnvelope(
+            # causal_id == signal_id: the keystroke IS the origin event,
+            # exactly as VoiceCommandSensor treats the utterance ("vox").
+            origin_id = generate_operation_id("chat")
+            envelope = make_envelope(
                 source="operator_chat",
                 description=str(message),
+                # A sentence names an intent, not a path. `operator_chat` is
+                # exempt from the non-empty demand so the Iron Gate's
+                # exploration-first rule does the localization.
+                target_files=(),
+                # The literal every emitter in `intake_layer_service` uses.
+                # `repo` is a short origin LABEL ("jarvis"/"prime"/"reactor"),
+                # not a path — the harness holds no such attribute to read.
+                repo="jarvis",
+                # The operator typed it. There is no STT channel to be
+                # uncertain about.
+                confidence=1.0,
                 # HIGH, not critical: the operator is waiting, but a typed
                 # goal is not an emergency and must not outrank a genuine
                 # runtime alarm. IMMEDIATE eligibility comes from the SOURCE
@@ -5230,30 +5320,86 @@ class BattleTestHarness:
                     "turn_id": str(getattr(turn, "turn_id", "") or ""),
                     "session_id": str(getattr(turn, "session_id", "") or ""),
                     "origin": "cockpit_chat",
+                    "signature": str(message)[:64],
                 },
+                # The human IS the origin — there is nobody left to ack to.
+                requires_human_ack=False,
+                causal_id=origin_id,
+                signal_id=origin_id,
             )
+
             # Record it BEFORE dispatch resolves: Esc must be able to target
             # an op the moment the operator sees "dispatched", not after
             # intake finishes accepting it.
             try:
-                _oid = str(getattr(envelope, "op_id", "") or
-                           getattr(envelope, "envelope_id", "") or "")
-                if _oid and hasattr(gls, "note_operator_op"):
-                    gls.note_operator_op(_oid)
+                if hasattr(gls, "note_operator_op"):
+                    gls.note_operator_op(origin_id)
             except Exception:  # noqa: BLE001
                 pass
+
             result = submit(envelope)
             if asyncio.iscoroutine(result):
-                # The caller is synchronous (the chat executor). Schedule and
-                # report the id we already hold, rather than blocking the loop
-                # waiting for intake to accept.
-                asyncio.ensure_future(result)
-                return str(getattr(envelope, "op_id", "") or
-                           getattr(envelope, "envelope_id", "") or "") or None
-            return str(result) if result else None
+                loop = getattr(self, "_operator_goal_loop", None)
+                if loop is None:
+                    try:
+                        loop = asyncio.get_running_loop()
+                    except RuntimeError:
+                        loop = None
+                if loop is None:
+                    # Close the coroutine explicitly — an un-awaited coroutine
+                    # leaks and warns, and the goal must fall back cleanly.
+                    result.close()
+                    logger.warning(
+                        "[OperatorGoal] no loop to dispatch on — goal will be "
+                        "FILED, not run",
+                    )
+                    return None
+                verdict = asyncio.run_coroutine_threadsafe(result, loop).result(
+                    timeout=_OPERATOR_GOAL_INGEST_TIMEOUT_S,
+                )
+            else:
+                verdict = result
+
+            return self._operator_goal_receipt(verdict, origin_id)
         except Exception:  # noqa: BLE001
-            logger.debug("[OperatorGoal] immediate dispatch degraded",
-                         exc_info=True)
+            # WARNING, not DEBUG. This is the operator's primary input path;
+            # when it dies the goal silently degrades to a backlog file, and
+            # a failure nobody can see is how this one survived twelve days.
+            logger.warning(
+                "[OperatorGoal] immediate dispatch failed (op=%s) — goal "
+                "will be FILED, not run", origin_id or "?", exc_info=True,
+            )
+            return None
+
+    @staticmethod
+    def _operator_goal_receipt(verdict: Any, origin_id: str) -> Optional[str]:
+        """Intake's verdict → the receipt the cockpit renders. NEVER raises.
+
+        ``op-`` means "intake accepted it and a worker has it". Only the two
+        verdicts that are actually that may mint one:
+
+          * ``enqueued``      — on the priority queue
+          * ``pending_ack``   — parked, but intake HOLDS it; it is not lost
+                                and the backlog is not where it lives
+
+        ``deduplicated`` and ``backpressure`` return None, so the executor
+        files the goal and the reply says queued — which is then true.
+        Returning an id for those would report acceptance intake refused.
+        """
+        try:
+            v = str(verdict or "").strip().lower()
+            if v in ("enqueued", "pending_ack"):
+                logger.info(
+                    "[OperatorGoal] op=%s verdict=%s (source=operator_chat)",
+                    origin_id, v,
+                )
+                return origin_id or None
+            logger.warning(
+                "[OperatorGoal] op=%s intake declined (verdict=%s) — goal "
+                "will be FILED, not run", origin_id, v or "<empty>",
+            )
+            return None
+        except Exception:  # noqa: BLE001
             return None
 
     def _qos_note_override(self, kind: str = "sigint") -> None:

--- a/backend/core/ouroboros/governance/intake/intent_envelope.py
+++ b/backend/core/ouroboros/governance/intake/intent_envelope.py
@@ -171,6 +171,14 @@ _EMPTY_TARGET_FILES_EXEMPT_SOURCES = frozenset({
     # A resumed op may re-localize from its preserved exploration context rather
     # than a pinned target list (the checkpoint carries tool/exploration history).
     "fsm_resume",
+    # A goal TYPED at the cockpit is a sentence, not a work item: "make the
+    # attach handshake honest" names an intent, not a path. Demanding
+    # target_files of it is demanding the operator do the localization the
+    # exploration-first Iron Gate exists to force the model to do — the same
+    # reasoning that exempts ``swe_bench_pro`` above and operator ``/attach``
+    # uploads below. Its spoken twin (``voice_human``) is NOT exempt only
+    # because the voice pipeline resolves paths upstream before emitting.
+    "operator_chat",
 })
 
 

--- a/tests/governance/test_operator_chat_immediate.py
+++ b/tests/governance/test_operator_chat_immediate.py
@@ -212,3 +212,239 @@ def test_an_unreachable_intake_returns_none_rather_than_raising() -> None:
 
     bare = BattleTestHarness.__new__(BattleTestHarness)
     assert bare._submit_operator_goal("fix the tests", _Turn()) is None
+
+
+# --------------------------------------------------------------------------
+# 4. the submitter is CALLED, against the real envelope contract
+# --------------------------------------------------------------------------
+#
+# Everything above this line either injects a fake submitter that returns a
+# literal "op-…" or greps the SOURCE TEXT of `_submit_operator_goal`. Both
+# pass against a function that cannot run — and for twelve days both did.
+#
+# `_submit_operator_goal` built its envelope with the raw `IntentEnvelope`
+# dataclass constructor, passing 4 of its 15 required fields. Every call
+# raised TypeError, was caught one frame down, logged at DEBUG, and returned
+# None. The executor read None as "intake declined" and filed the goal. The
+# cockpit then honestly reported it queued — the renderer was right; the path
+# behind it was dead.
+#
+# So these tests CALL it, and let the REAL `make_envelope` validate what it
+# built. A fake that accepts an envelope the real constructor would reject is
+# the mirror of the bug it is supposed to catch.
+
+
+class _RecordingRouter:
+    """Shaped like UnifiedIntakeRouter: `ingest` is async and returns a
+    VERDICT string, never an id. Getting that wrong is the second half of
+    the original defect."""
+
+    def __init__(self, verdict: str = "enqueued") -> None:
+        self.verdict = verdict
+        self.envelopes: List[Any] = []
+
+    async def ingest(self, envelope: Any) -> str:
+        self.envelopes.append(envelope)
+        return self.verdict
+
+
+class _GLS:
+    def __init__(self, router: Any) -> None:
+        self._intake_router = router
+        self.operator_ops: List[str] = []
+
+    def note_operator_op(self, op_id: str) -> None:
+        self.operator_ops.append(op_id)
+
+
+def _harness_with(router: Any, loop: Any) -> Any:
+    from backend.core.ouroboros.battle_test.harness import BattleTestHarness
+
+    h = BattleTestHarness.__new__(BattleTestHarness)
+    h._governed_loop_service = _GLS(router)
+    h._operator_goal_loop = loop
+    h.repo = "jarvis"
+    return h
+
+
+@pytest.fixture()
+def bg_loop():
+    """A loop running on ANOTHER thread — because that is the real topology.
+
+    `chat_text_bridge._run` dispatches through `asyncio.to_thread`, so the
+    executor calls the submitter from a worker thread with no running loop of
+    its own. A same-thread `asyncio.run(...)` test would hide that.
+    """
+    import asyncio
+    import threading
+
+    loop = asyncio.new_event_loop()
+    t = threading.Thread(target=loop.run_forever, daemon=True)
+    t.start()
+    try:
+        yield loop
+    finally:
+        loop.call_soon_threadsafe(loop.stop)
+        t.join(timeout=5)
+        loop.close()
+
+
+def test_it_returns_a_real_op_id_when_intake_accepts(bg_loop) -> None:
+    """THE regression. This is what every string assertion above believed."""
+    router = _RecordingRouter("enqueued")
+    out = _harness_with(router, bg_loop)._submit_operator_goal(
+        "make the attach handshake honest", _Turn(),
+    )
+    assert out is not None, "the submitter returned None — the goal was FILED"
+    assert out.startswith("op-"), (
+        f"receipt {out!r} does not read as dispatched; chat_response_style."
+        "_dispatched_now only recognises an `op-` prefix, so anything else "
+        "renders as queued"
+    )
+    assert router.envelopes, "nothing ever reached intake"
+
+
+def test_the_envelope_it_builds_passes_real_validation(bg_loop) -> None:
+    """Not a shape-alike. The frozen dataclass validates in __post_init__, and
+    it is that validation the original constructor call never survived."""
+    from backend.core.ouroboros.governance.intake.intent_envelope import (
+        SCHEMA_VERSION,
+        IntentEnvelope,
+    )
+
+    router = _RecordingRouter("enqueued")
+    _harness_with(router, bg_loop)._submit_operator_goal("fix the tests", _Turn())
+
+    env = router.envelopes[0]
+    assert isinstance(env, IntentEnvelope)
+    assert env.source == "operator_chat"
+    assert env.description == "fix the tests"
+    assert env.urgency == "high"
+    assert env.schema_version == SCHEMA_VERSION
+    # causal == signal: the keystroke IS the origin event, as the utterance is
+    # for VoiceCommandSensor.
+    assert env.causal_id == env.signal_id
+    assert not env.requires_human_ack, "the human IS the origin"
+    assert env.evidence.get("origin") == "cockpit_chat"
+    assert env.evidence.get("turn_id") == _Turn.turn_id
+
+
+def test_a_typed_goal_needs_no_target_files() -> None:
+    """A sentence names an intent, not a path. Localization is the Iron
+    Gate's job — demanding target_files here would make the operator do it."""
+    from backend.core.ouroboros.governance.intake.intent_envelope import (
+        _EMPTY_TARGET_FILES_EXEMPT_SOURCES,
+        make_envelope,
+    )
+
+    assert "operator_chat" in _EMPTY_TARGET_FILES_EXEMPT_SOURCES
+    env = make_envelope(
+        source="operator_chat", description="do the thing", target_files=(),
+        repo="jarvis", confidence=1.0, urgency="high", evidence={},
+        requires_human_ack=False,
+    )
+    assert env.target_files == ()
+
+
+def test_the_receipt_is_recognised_as_dispatched_by_the_renderer(bg_loop) -> None:
+    """End of the chain: the id this mints must make the cockpit say `on it`.
+    Minting a correct id the renderer reads as queued would fix nothing the
+    operator can see."""
+    from backend.core.ouroboros.governance.chat_response_style import compose_reply
+
+    out = _harness_with(_RecordingRouter("enqueued"), bg_loop)._submit_operator_goal(
+        "fix the tests", _Turn(),
+    )
+    reply = compose_reply("backlog_dispatch", receipt=out or "")
+    assert "on it" in reply
+    assert "queued" not in reply
+    assert "backlog" not in reply.lower()
+
+
+@pytest.mark.parametrize("verdict", ["deduplicated", "backpressure", ""])
+def test_a_refused_goal_is_filed_not_claimed(bg_loop, verdict: str) -> None:
+    """`ingest` returns a verdict, never an id. `backpressure` means intake
+    REFUSED it — reporting `op-` for that claims an acceptance we were denied,
+    which is the exact dishonesty the receipt vocabulary exists to prevent."""
+    out = _harness_with(_RecordingRouter(verdict), bg_loop)._submit_operator_goal(
+        "fix the tests", _Turn(),
+    )
+    assert out is None, (
+        f"verdict={verdict!r} was reported as dispatched; the goal must fall "
+        "back to the backlog so the reply's 'queued' is true"
+    )
+
+
+@pytest.mark.parametrize("verdict", ["enqueued", "pending_ack"])
+def test_both_accepting_verdicts_mint_a_receipt(bg_loop, verdict: str) -> None:
+    """`pending_ack` is parked, but intake HOLDS it — it is not lost, and the
+    backlog is not where it lives."""
+    out = _harness_with(_RecordingRouter(verdict), bg_loop)._submit_operator_goal(
+        "fix the tests", _Turn(),
+    )
+    assert out is not None and out.startswith("op-")
+
+
+def test_esc_can_target_the_op_before_intake_answers(bg_loop) -> None:
+    """Esc must be able to cancel what the operator just watched dispatch."""
+    h = _harness_with(_RecordingRouter("enqueued"), bg_loop)
+    out = h._submit_operator_goal("fix the tests", _Turn())
+    assert h._governed_loop_service.operator_ops == [out]
+
+
+def test_it_falls_back_to_the_process_wide_router(bg_loop) -> None:
+    """The singleton the router registers on its own construction — the same
+    handle the voice side uses. A deployment that never attached it to the GLS
+    would otherwise file every goal with a live router one import away."""
+    from backend.core.ouroboros.governance.intake import unified_intake_router as uir
+
+    router = _RecordingRouter("enqueued")
+    h = _harness_with(router, bg_loop)
+    h._governed_loop_service = None          # nothing attached
+    prev = uir.get_default_intake_router()
+    try:
+        uir.set_default_intake_router(router)  # type: ignore[arg-type]
+        out = h._submit_operator_goal("fix the tests", _Turn())
+    finally:
+        uir.set_default_intake_router(prev)  # type: ignore[arg-type]
+    assert out is not None and out.startswith("op-")
+
+
+def test_an_intake_that_raises_files_rather_than_drops(bg_loop) -> None:
+    """A queued goal is a degradation. A dropped one is a betrayal."""
+    class _Boom:
+        async def ingest(self, _envelope: Any) -> str:
+            raise RuntimeError("intake unreachable")
+
+    out = _harness_with(_Boom(), bg_loop)._submit_operator_goal("x", _Turn())
+    assert out is None
+
+
+def test_a_typed_goal_never_skips_PLAN() -> None:
+    """The consequence of the exemption above, pinned deliberately.
+
+    `PlanGenerator._should_skip` returns "" (do not skip) for every source in
+    the exempt set, because an op with no target_files must reason about its
+    OWN localization rather than be skipped for looking trivial. A typed goal
+    is exactly that op — `n_files == 0` would otherwise read as "nothing to
+    plan" and skip straight to GENERATE.
+    """
+    import inspect
+
+    from backend.core.ouroboros.governance.plan_generator import PlanGenerator
+
+    src = inspect.getsource(PlanGenerator._should_skip)
+    assert "_EMPTY_TARGET_FILES_EXEMPT_SOURCES" in src
+
+
+def test_a_typed_goal_is_not_floored_to_COMPLEX() -> None:
+    """The exemption must NOT leak into the complexity floor. `operator_chat`
+    covers everything from "fix a typo" to "rebuild the IPC layer"; forcing
+    every typed sentence onto the COMPLEX route would buy Claude planning
+    budget for "what time is it"."""
+    from backend.core.ouroboros.governance.complexity_classifier import (
+        _COMPLEX_FLOOR_SOURCES,
+    )
+
+    assert "operator_chat" not in _COMPLEX_FLOOR_SOURCES
+    assert "swe_bench_pro" in _COMPLEX_FLOOR_SOURCES


### PR DESCRIPTION
## The defect

`harness.py::_submit_operator_goal` is the entirety of "a typed goal runs now" (#70159, landed 2026-07-27). It built its envelope with the raw `IntentEnvelope` dataclass constructor, passing **4 of its 15 required fields**:

```python
IntentEnvelope(source=..., description=..., urgency=..., evidence=...)
# TypeError: missing 11 required positional arguments
```

Caught one frame down, logged at **DEBUG**, returned `None`. The executor reads `None` as "intake declined", files the goal in `backlog.json`, and the cockpit reports it queued — truthfully, about a fallback that fired because the primary path was dead.

Same human, same intent, two paths:

| Input | Path | Result |
|---|---|---|
| Operator **speaks** | `make_envelope(source="voice_human", urgency="critical")` → `router.ingest()` | straight to intake |
| Operator **types** | `TypeError` → DEBUG → `None` → append to `.jarvis/backlog.json` | waits for a 60s sensor sweep |

Three further defects sat behind the first, each reachable only by fixing it:

- `op_id` / `envelope_id` are not fields of `IntentEnvelope` — the success branch returned `""` → `None` regardless.
- `operator_chat` was not in `_EMPTY_TARGET_FILES_EXEMPT_SOURCES`, so an empty `target_files` raised `EnvelopeValidationError`. A typed sentence names an intent, not a path.
- `asyncio.ensure_future` would raise `RuntimeError: no running event loop` — the chat executor is invoked through `asyncio.to_thread`, so this runs on a **worker thread**.

## The fix

- Build through **`make_envelope`**, the factory every sensor already uses — it mints the ids, stamps the schema version and computes the dedup key, so this path cannot drift by forgetting a field. Origin id is `generate_operation_id("chat")` as `causal_id == signal_id`, mirroring `VoiceCommandSensor`'s `"vox"`: the keystroke IS the origin event.
- **Await the verdict.** `ingest` returns `enqueued` / `pending_ack` / `deduplicated` / `backpressure` — a verdict, never an id. Only the two accepting verdicts mint an `op-` receipt; a refused goal falls back to the backlog so the reply's "queued" is true. Reporting `op-` for `backpressure` would claim an acceptance intake denied — the exact dishonesty the receipt vocabulary exists to prevent. Running off-loop is what makes a bounded `run_coroutine_threadsafe` correct here, so no fourth receipt shape is needed.
- `get_default_intake_router()` fallback — a deployment that never attached the router to the GLS otherwise files every goal with a live router one import away.
- Failure logs at **WARNING**, not DEBUG. This is the operator's primary input path; a failure nobody can see is how this one survived 12 days.
- `operator_chat` joins the target-files exemption. Consequence pinned deliberately: a typed goal now always runs **PLAN** (it must reason about its own localization), and is **not** added to `_COMPLEX_FLOOR_SOURCES`, so "what time is it" does not buy Claude planning budget.

## Why the suite was green throughout

Fifteen tests covered this path. Every one either injected a fake submitter returning a literal `"op-…"`, or asserted on the function's **own source text**:

```python
assert 'source="operator_chat"' in inspect.getsource(BattleTestHarness._submit_operator_goal)
```

A string assertion is not a weak test of behaviour, it is a test of *spelling*. It cannot fail for any runtime reason, so it reports green against code that cannot execute — while looking like the AST wiring pins this codebase legitimately uses elsewhere.

The 16 tests added here **call** the function, on a loop running in another thread (the real topology), and let the real `make_envelope` validate what it built.

## Verification

- **Against clean HEAD, 8 of the new tests fail** — including `test_the_receipt_is_recognised_as_dispatched_by_the_renderer`, which reproduces the operator's exact symptom: `'⏺ adding th...s next sweep'`.
- Green: operator-chat 31 · chat surfaces 265 · envelope/intake 129 · esc-interrupt 20.
- The 5 reds in `test_deck_grammar_unification` are **pre-existing**: reverting only these source files *in the same working directory* reproduces all 5. (A HEAD worktree lacks the `.jarvis/` posture state, so worktree-vs-tree is not a single-variable comparison — that mistake initially showed 4 phantom regressions.)

## Status

**Code-proven, not `ov`-proven.** It still needs a live session that types a goal and watches it dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the typed operator goal path so it no longer raises TypeError and correctly dispatches to intake. Restores the “typed goal runs now” flow (#70159) by returning a real `op-…` receipt only when intake accepts.

- **Bug Fixes**
  - Build envelopes via `make_envelope` with `generate_operation_id("chat")` (causal_id == signal_id). Set `repo="jarvis"`, `confidence=1.0`, `urgency="high"`, and no human ack.
  - Await router `ingest` using `run_coroutine_threadsafe` with `_OPERATOR_GOAL_INGEST_TIMEOUT_S`. Return `op-…` only for `enqueued`/`pending_ack`; return `None` for `deduplicated`/`backpressure` so the backlog path is truthful.
  - Capture the main loop at boot and use it from the worker thread; if no loop is available, close the coroutine and fall back cleanly.
  - Fall back to `get_default_intake_router()` and warn if no router or submit seam is found; upgrade failure logs to WARNING.
  - Add `operator_chat` to `_EMPTY_TARGET_FILES_EXEMPT_SOURCES` so empty `target_files` are valid and PLAN runs; do not add it to `_COMPLEX_FLOOR_SOURCES`.
  - Record the op id early via `note_operator_op` so Esc can target it immediately; tests now exercise the real async path and envelope validation.

<sup>Written for commit 11b4f85cc6813c1e3b8575ac6c201fe650c073cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

