### PR TITLE
fix(chat): a dropped duplicate said "queued" and named nothing

### DIFF
--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -5339,12 +5339,11 @@ class BattleTestHarness:
 
             result = submit(envelope)
             if asyncio.iscoroutine(result):
-                loop = getattr(self, "_operator_goal_loop", None)
-                if loop is None:
-                    try:
-                        loop = asyncio.get_running_loop()
-                    except RuntimeError:
-                        loop = None
+                try:
+                    running = asyncio.get_running_loop()
+                except RuntimeError:
+                    running = None          # the normal case: a to_thread worker
+                loop = getattr(self, "_operator_goal_loop", None) or running
                 if loop is None:
                     # Close the coroutine explicitly — an un-awaited coroutine
                     # leaks and warns, and the goal must fall back cleanly.
@@ -5354,13 +5353,35 @@ class BattleTestHarness:
                         "FILED, not run",
                     )
                     return None
+                if running is not None and running is loop:
+                    # ON the loop the coroutine must run on. Blocking here
+                    # would wedge the whole event loop for the timeout and
+                    # then fail anyway — the caller is the only thing that
+                    # could drive the coroutine it is waiting for.
+                    #
+                    # Production never lands here (`chat_text_bridge._run`
+                    # dispatches this executor through `asyncio.to_thread`),
+                    # but "never" was also true of the envelope contract this
+                    # function got wrong, so it is enforced rather than
+                    # assumed. File the goal instead of deadlocking, and say
+                    # so loudly — a caller on the wrong thread is a wiring
+                    # bug, not a runtime condition to absorb silently.
+                    result.close()
+                    logger.warning(
+                        "[OperatorGoal] submitter called ON the event loop "
+                        "(expected a to_thread worker) — cannot await intake "
+                        "without deadlocking it; goal will be FILED, not run",
+                    )
+                    return None
                 verdict = asyncio.run_coroutine_threadsafe(result, loop).result(
                     timeout=_OPERATOR_GOAL_INGEST_TIMEOUT_S,
                 )
             else:
                 verdict = result
 
-            return self._operator_goal_receipt(verdict, origin_id)
+            return self._operator_goal_receipt(
+                verdict, origin_id, router=router, envelope=envelope,
+            )
         except Exception:  # noqa: BLE001
             # WARNING, not DEBUG. This is the operator's primary input path;
             # when it dies the goal silently degrades to a backlog file, and
@@ -5372,7 +5393,13 @@ class BattleTestHarness:
             return None
 
     @staticmethod
-    def _operator_goal_receipt(verdict: Any, origin_id: str) -> Optional[str]:
+    def _operator_goal_receipt(
+        verdict: Any,
+        origin_id: str,
+        *,
+        router: Any = None,
+        envelope: Any = None,
+    ) -> Optional[str]:
         """Intake's verdict → the receipt the cockpit renders. NEVER raises.
 
         ``op-`` means "intake accepted it and a worker has it". Only the two
@@ -5382,9 +5409,19 @@ class BattleTestHarness:
           * ``pending_ack``   — parked, but intake HOLDS it; it is not lost
                                 and the backlog is not where it lives
 
-        ``deduplicated`` and ``backpressure`` return None, so the executor
-        files the goal and the reply says queued — which is then true.
-        Returning an id for those would report acceptance intake refused.
+        ``deduplicated`` is DISTINCT from a refusal and must not be reported
+        as one. Collapsing it into ``None`` — the same value returned when
+        intake is unreachable — is what made the cockpit say "queued … the
+        Backlog sensor will pick it up" about a goal that was dropped because
+        the operator had already asked for it. True, and unactionable.
+
+        So the collision travels as a receipt of its own, built from the facts
+        the router ALREADY holds (`describe_dedup_collision` — no second
+        tracker). This layer only carries them; `chat_response_style` decides
+        how they read.
+
+        ``backpressure`` and anything else still return None: intake refused
+        the goal outright, the executor files it, and "queued" is then true.
         """
         try:
             v = str(verdict or "").strip().lower()
@@ -5394,11 +5431,62 @@ class BattleTestHarness:
                     origin_id, v,
                 )
                 return origin_id or None
+            if v == "deduplicated":
+                receipt = BattleTestHarness._dedup_receipt(router, envelope)
+                if receipt:
+                    logger.info(
+                        "[OperatorGoal] op=%s deduplicated (%s) — the earlier "
+                        "goal stands; filing as a safety net",
+                        origin_id, receipt,
+                    )
+                    return receipt
+                # The collision is real but its detail is unavailable (an
+                # older router with no accessor). Fall through to the filing
+                # path rather than invent an age we did not measure.
+                logger.info(
+                    "[OperatorGoal] op=%s deduplicated (no collision detail) "
+                    "— goal will be FILED", origin_id,
+                )
+                return None
             logger.warning(
                 "[OperatorGoal] op=%s intake declined (verdict=%s) — goal "
                 "will be FILED, not run", origin_id, v or "<empty>",
             )
             return None
+        except Exception:  # noqa: BLE001
+            return None
+
+    @staticmethod
+    def _dedup_receipt(router: Any, envelope: Any) -> Optional[str]:
+        """Encode the router's own account of the collision. NEVER raises.
+
+        Returns None — not a fabricated one — when the router cannot explain
+        itself (no accessor, or the entry expired between the verdict and this
+        read). An unexplained collision falls back to the filing path, which
+        is honest; a receipt carrying an age nobody measured would be the
+        fabrication class this arc exists to kill.
+        """
+        try:
+            if router is None or envelope is None:
+                return None
+            describe = getattr(router, "describe_dedup_collision", None)
+            if not callable(describe):
+                return None
+            collision = describe(envelope)
+            if collision is None:
+                return None
+            from backend.core.ouroboros.governance.chat_response_style import (
+                make_dedup_receipt,
+            )
+            return make_dedup_receipt(
+                collision.short_hash,
+                collision.age_s,
+                collision.window_s,
+                # The submitter cannot know whether the backlog write later
+                # succeeds. The executor re-stamps this via `with_filed`; it
+                # starts false so an unfiled goal is never claimed as filed.
+                filed=False,
+            )
         except Exception:  # noqa: BLE001
             return None
 

--- a/backend/core/ouroboros/governance/chat_repl_backlog_executor.py
+++ b/backend/core/ouroboros/governance/chat_repl_backlog_executor.py
@@ -180,6 +180,46 @@ def get_operator_dispatcher() -> Optional[Callable[[str, Any], Optional[str]]]:
     return _OPERATOR_DISPATCH
 
 
+# ---------------------------------------------------------------------------
+# Receipt grammar — read from its owner, never restated
+# ---------------------------------------------------------------------------
+#
+# `chat_response_style` owns what a receipt MEANS (it already reads the
+# `op-` and `logged-` prefixes off the receipt to decide how a turn renders).
+# This executor needs one bit of that vocabulary — "is this a dedup
+# collision?" — to know whether it must still write the backlog safety net.
+#
+# Imported lazily through a helper rather than restated as a literal here,
+# exactly as `chat_response_style._logging_prefix()` reads its marker off
+# THIS module's executor: two copies of a grammar are two grammars, and the
+# second one drifts silently.
+
+
+def _is_dedup_receipt(receipt: Any) -> bool:
+    """True iff the submitter reported a dedup collision (not a dispatch).
+    Fail-soft: an unavailable renderer means we treat the token as a normal
+    dispatch receipt, which is the pre-existing behaviour."""
+    try:
+        from backend.core.ouroboros.governance.chat_response_style import (
+            is_dedup_receipt,
+        )
+        return bool(is_dedup_receipt(str(receipt)))
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _stamp_filed(receipt: str, filed: bool) -> str:
+    """Record on the receipt whether the backlog safety net was written.
+    Degrades to the unstamped receipt rather than losing it."""
+    try:
+        from backend.core.ouroboros.governance.chat_response_style import (
+            with_filed,
+        )
+        return str(with_filed(receipt, filed))
+    except Exception:  # noqa: BLE001
+        return receipt
+
+
 class BacklogChatActionExecutor:
     """Concrete ChatActionExecutor that wires `dispatch_backlog`
     against the real `.jarvis/backlog.json` writer.
@@ -242,11 +282,28 @@ class BacklogChatActionExecutor:
         # every autonomous op uses.
         # Explicit injection wins (tests, callers that know better); the
         # registry is the daemon's standing answer.
+        # A dedup collision is carried, not returned: the goal must ALSO be
+        # filed (below) so a failed earlier run is still recoverable by the
+        # Backlog sensor. Held here across the write so the receipt can be
+        # stamped with whether that write actually succeeded.
+        dedup_receipt: Optional[str] = None
+
         submitter = self._submit_now or get_operator_dispatcher()
         if submitter is not None and msg_clipped.strip():
             try:
                 op_id = submitter(msg_clipped, turn)
-                if op_id:
+                if op_id and _is_dedup_receipt(op_id):
+                    # NOT a dispatch. Intake dropped this as a duplicate, so
+                    # returning now would skip the safety net and leave the
+                    # operator's goal existing only as an earlier run that may
+                    # already have failed.
+                    dedup_receipt = str(op_id)
+                    logger.info(
+                        "[BacklogChatExecutor] turn=%s DEDUPLICATED (%s) — "
+                        "filing anyway as a safety net",
+                        turn.turn_id, dedup_receipt,
+                    )
+                elif op_id:
                     self.calls.append(str(op_id))
                     logger.info(
                         "[BacklogChatExecutor] turn=%s dispatched IMMEDIATE "
@@ -290,11 +347,31 @@ class BacklogChatActionExecutor:
         backlog_path = _backlog_path(self._project_root)
         ok = _append_to_backlog_json(backlog_path, entry)
         if not ok:
-            token = f"error-append-failed-{turn.turn_id}"
-            self.calls.append(token)
             logger.warning(
                 "[BacklogChatExecutor] turn=%s append to %s failed",
                 turn.turn_id, backlog_path,
+            )
+            if dedup_receipt is not None:
+                # The collision is still the headline fact — but the safety
+                # net does NOT exist, and the receipt must say so rather than
+                # letting `f=0` be mistaken for "not attempted".
+                token = _stamp_filed(dedup_receipt, False)
+                self.calls.append(token)
+                return token
+            token = f"error-append-failed-{turn.turn_id}"
+            self.calls.append(token)
+            return token
+
+        if dedup_receipt is not None:
+            # Filed AND deduplicated. The receipt reports both, because
+            # either alone misleads: "queued" hides that an identical goal is
+            # already accepted, and "deduplicated" alone hides the safety net.
+            token = _stamp_filed(dedup_receipt, True)
+            self.calls.append(token)
+            logger.info(
+                "[BacklogChatExecutor] turn=%s deduplicated + filed "
+                "task_id=%s (safety net for a failed earlier run)",
+                turn.turn_id, entry["task_id"],
             )
             return token
 

--- a/backend/core/ouroboros/governance/chat_response_style.py
+++ b/backend/core/ouroboros/governance/chat_response_style.py
@@ -61,6 +61,13 @@ __all__ = [
     "compose_reply",
     "acknowledge",
     "trace_lines",
+    # The dedup receipt grammar. Public because this module OWNS what a
+    # receipt means, and the submitter (harness) and the executor both have
+    # to speak it — importing from here is what stops a second, drifting copy.
+    "make_dedup_receipt",
+    "is_dedup_receipt",
+    "with_filed",
+    "dedup_lines",
 ]
 
 #: What each routing action MEANS, said the way a colleague would say it.
@@ -147,6 +154,152 @@ def _was_discarded(receipt: str) -> bool:
     return str(receipt or "").strip().startswith(_logging_prefix())
 
 
+# ---------------------------------------------------------------------------
+# The deduplication receipt
+# ---------------------------------------------------------------------------
+#
+# `router.ingest` answers `deduplicated` when a goal's dedup_key was accepted
+# inside the window. Before this, that verdict was collapsed into None by the
+# submitter, which is the same value it returns when intake is UNREACHABLE —
+# so the renderer could not tell "you already asked for this" from "nothing is
+# listening", and said "queued … the Backlog sensor will pick it up" about
+# both. True, and useless: it explains nothing an operator can act on.
+#
+# The fix is a state chain, not a string. The router exposes the facts it
+# already holds (`describe_dedup_collision` → key, age, window — no second
+# tracker), the submitter encodes them, the executor stamps whether the goal
+# was ALSO filed, and this module — which already owns receipt interpretation
+# — is the only layer that decides how any of it reads.
+#
+# Grammar is key=value rather than positional so a missing, extra or reordered
+# field degrades one fact instead of misaligning all of them:
+#
+#     dedup:h=<sha256[:12]>;a=<age_s>;w=<window_s>;f=<0|1>
+#
+# Both producers import these helpers rather than restating the format, for
+# the same reason `_logging_prefix()` reads its marker off the executor: two
+# copies of a grammar are two grammars.
+
+_DEDUP_PREFIX = "dedup:"
+
+
+def make_dedup_receipt(
+    short_hash: str, age_s: float, window_s: float, filed: bool = False,
+) -> str:
+    """Encode a deduplication collision as a receipt token. NEVER raises."""
+    try:
+        return (
+            f"{_DEDUP_PREFIX}h={str(short_hash)[:12]};"
+            f"a={float(age_s):.1f};w={float(window_s):.1f};"
+            f"f={1 if filed else 0}"
+        )
+    except Exception:  # noqa: BLE001
+        return f"{_DEDUP_PREFIX}h=;a=;w=;f={1 if filed else 0}"
+
+
+def is_dedup_receipt(receipt: str) -> bool:
+    """True iff this receipt reports a dedup collision rather than a dispatch
+    or a filing. The executor asks this to decide whether it must STILL write
+    the backlog safety net."""
+    return str(receipt or "").strip().startswith(_DEDUP_PREFIX)
+
+
+def with_filed(receipt: str, filed: bool) -> str:
+    """Re-stamp the ``f`` flag. The submitter mints the collision but cannot
+    know whether the backlog write later succeeded; the executor can, and
+    only it may answer that. Non-dedup receipts pass through untouched."""
+    if not is_dedup_receipt(receipt):
+        return receipt
+    fields = _parse_dedup(receipt)
+    return make_dedup_receipt(
+        fields.get("h", ""),
+        _as_float(fields.get("a")), _as_float(fields.get("w")),
+        filed=filed,
+    )
+
+
+def _as_float(raw: Any) -> float:
+    try:
+        return float(str(raw))
+    except (TypeError, ValueError):
+        return -1.0
+
+
+def _parse_dedup(receipt: str) -> dict:
+    """Tolerant parse. An unreadable field is absent, never fatal."""
+    out: dict = {}
+    try:
+        body = str(receipt or "").strip()[len(_DEDUP_PREFIX):]
+        for part in body.split(";"):
+            if "=" in part:
+                k, _, v = part.partition("=")
+                out[k.strip()] = v.strip()
+    except Exception:  # noqa: BLE001
+        pass
+    return out
+
+
+def _humanize(seconds: float) -> str:
+    """A duration said the way a person says it. Negative/unknown → ''."""
+    try:
+        s = float(seconds)
+    except (TypeError, ValueError):
+        return ""
+    if s < 0:
+        return ""
+    if s < 2:
+        return "moments"
+    if s < 60:
+        return f"{int(s)}s"
+    if s < 3600:
+        m, rem = divmod(int(s), 60)
+        return f"{m}m{rem:02d}s" if rem else f"{m}m"
+    h, rem = divmod(int(s), 3600)
+    m = rem // 60
+    return f"{h}h{m:02d}m" if m else f"{h}h"
+
+
+def dedup_lines(receipt: str) -> List[str]:
+    """Render a dedup collision as op chrome. Adaptive: every clause appears
+    only when the fact behind it is actually known.
+
+    Says "accepted", never "in flight". The registry stores ONE thing — when
+    a key was last accepted — so a goal that has since completed or failed
+    still collides. Claiming the earlier op is still running would be a state
+    nothing measures, which is the defect class this whole arc exists to kill.
+    """
+    f = _parse_dedup(receipt)
+    age, window = _as_float(f.get("a")), _as_float(f.get("w"))
+    h = str(f.get("h", "") or "")
+
+    bits: List[str] = ["Status: Deduplicated"]
+    ago = _humanize(age)
+    bits.append(
+        f"an identical goal was accepted {ago} ago" if ago
+        else "an identical goal was already accepted"
+    )
+    retry = _humanize(window - age) if (window >= 0 and age >= 0) else ""
+    if retry:
+        bits.append(f"re-runnable in {retry}")
+    line = " · ".join(bits)
+    if h:
+        line += f" [hash: {h}]"
+
+    out = [f"⎿ {line}"]
+    # The safety net, stated only when it actually exists.
+    if str(f.get("f", "")) == "1":
+        out.append(
+            "⎿ filed to the backlog as well — if that first run failed, the "
+            "Backlog sensor still collects this one"
+        )
+    else:
+        out.append(
+            "⎿ NOT filed — this goal exists only as the earlier run; if that "
+            "one failed, ask again after the window"
+        )
+    return out
+
+
 def _queue_note(action: str, receipt: str = "") -> Optional[str]:
     """Say plainly what happened to the work. NEVER guess.
 
@@ -172,6 +325,12 @@ def _queue_note(action: str, receipt: str = "") -> Optional[str]:
     """
     _phrase, deferred = _voice(action)
     if not deferred or _dispatched_now(receipt):
+        return None
+    if is_dedup_receipt(receipt):
+        # A FOURTH reality, and the one this note would lie about hardest:
+        # the goal was dropped as a duplicate, not filed-and-waiting. Handled
+        # by `dedup_lines` in compose_reply; saying "queued" here would be the
+        # same defect as the `logged-` case above.
         return None
     if _was_discarded(receipt):
         # Name the flag. An operator who has just watched their request
@@ -259,6 +418,12 @@ def compose_reply(
                 lines.append("⏺ on it")
                 lines.append(f"  ⎿ dispatched {_short_ref(receipt)} · "
                              f"immediate · watching")
+            elif is_dedup_receipt(receipt):
+                # Neither started nor merely filed. The head names what the
+                # operator actually did — asked twice — because "adding that
+                # to the backlog" would describe the safety net as if it were
+                # the outcome.
+                lines.append("⏺ you have already asked for this")
             else:
                 head = acknowledge(action, message)
                 if head:
@@ -272,7 +437,14 @@ def compose_reply(
             note = _queue_note(action, receipt)
             if _dispatched_now(receipt):
                 note = None                      # already said above
-            if note:
+            if is_dedup_receipt(receipt):
+                # The collision IS the op chrome for this turn — status,
+                # measured age, when it becomes re-runnable, and whether the
+                # backlog safety net exists. Rendered from the receipt's own
+                # fields, so a fact absent from the receipt is absent here
+                # rather than guessed.
+                lines.extend(f"  {ln}" for ln in dedup_lines(receipt))
+            elif note:
                 lines.append(f"  {note.lstrip()}")
             elif receipt and action != "noop" and not _dispatched_now(receipt):
                 # Not repeated when dispatched: the ref is already on the

--- a/backend/core/ouroboros/governance/intake/unified_intake_router.py
+++ b/backend/core/ouroboros/governance/intake/unified_intake_router.py
@@ -1025,6 +1025,41 @@ def _compute_priority(
     return priority, alignment
 
 
+#: Size at which `_prune_dedup` sweeps expired entries. Not a cap — the dict
+#: may legitimately exceed it between sweeps; it is the point where an O(n)
+#: pass is cheap relative to the leak it prevents.
+_DEDUP_PRUNE_THRESHOLD: int = 512
+
+
+@dataclass(frozen=True)
+class DedupCollision:
+    """Why an envelope deduplicated, in facts the registry already holds.
+
+    Deliberately does NOT claim the colliding op is still running. The
+    registry stores one thing — the monotonic time a dedup_key was last
+    accepted — so an op that has since COMPLETED or FAILED still collides
+    inside the window. "Already in flight" would be a state nothing here
+    measures; `age_s` and `retry_after_s` are measured, and a renderer can
+    say something true from them.
+    """
+
+    dedup_key: str
+    age_s: float
+    window_s: float
+
+    @property
+    def short_hash(self) -> str:
+        """The distinguishing head of the sha256. The key is already a
+        digest, so its PREFIX distinguishes (unlike a UUIDv7 op id, whose
+        tail does)."""
+        return str(self.dedup_key)[:12]
+
+    @property
+    def retry_after_s(self) -> float:
+        """Seconds until this key is accepted again. Never negative."""
+        return max(0.0, float(self.window_s) - float(self.age_s))
+
+
 @dataclass(frozen=True)
 class IntakeRouterConfig:
     project_root: Path
@@ -2989,13 +3024,19 @@ class UnifiedIntakeRouter:
     # Deduplication
     # ------------------------------------------------------------------
 
-    def _is_duplicate(self, envelope: IntentEnvelope) -> bool:
-        """Return True if the envelope's dedup_key was seen within its window."""
-        window = (
+    def _dedup_window_s(self, envelope: IntentEnvelope) -> float:
+        """The window that governs THIS envelope. One definition, two readers
+        (`_is_duplicate` decides; `describe_dedup_collision` explains) — so a
+        verdict and its explanation can never disagree about the rule."""
+        return (
             self._config.voice_dedup_window_s
             if envelope.source == "voice_human"
             else self._config.dedup_window_s
         )
+
+    def _is_duplicate(self, envelope: IntentEnvelope) -> bool:
+        """Return True if the envelope's dedup_key was seen within its window."""
+        window = self._dedup_window_s(envelope)
         # Window of 0.0 effectively disables dedup
         if window <= 0.0:
             return False
@@ -3004,9 +3045,82 @@ class UnifiedIntakeRouter:
             return False
         return (time.monotonic() - last) < window
 
+    def describe_dedup_collision(
+        self, envelope: IntentEnvelope,
+    ) -> Optional["DedupCollision"]:
+        """Read-only: WHY this envelope deduplicated. ``None`` if it did not.
+
+        The verdict `ingest` returns is the bare string ``"deduplicated"``,
+        which tells a caller that the goal was dropped but nothing a human
+        could act on — so a cockpit reporting it had to either stay silent or
+        invent a reason. This exposes the facts the registry ALREADY holds
+        (the key, and when it was last seen) without adding a second tracker,
+        a cache, or any writable surface.
+
+        NOT an authority: it reads `self._dedup` and returns; it never
+        registers, evicts, or influences a verdict. Callers must treat a
+        ``None`` return as "no collision recorded", never as an error.
+        """
+        try:
+            window = self._dedup_window_s(envelope)
+            if window <= 0.0:
+                return None
+            last = self._dedup.get(envelope.dedup_key)
+            if last is None:
+                return None
+            age = max(0.0, time.monotonic() - last)
+            if age >= window:
+                return None            # expired — not the reason it dropped
+            return DedupCollision(
+                dedup_key=str(envelope.dedup_key),
+                age_s=age,
+                window_s=float(window),
+            )
+        except Exception:  # noqa: BLE001 — explanation is never load-bearing
+            return None
+
     def _register_dedup(self, envelope: IntentEnvelope) -> None:
         """Record the current monotonic time for the envelope's dedup_key."""
         self._dedup[envelope.dedup_key] = time.monotonic()
+        self._prune_dedup()
+
+    def _prune_dedup(self) -> None:
+        """Drop entries no window can still consider a duplicate.
+
+        `self._dedup` was append-only: one entry per distinct dedup_key, kept
+        for the life of the process. Every distinct signature an operator ever
+        types, every distinct sensor signature, forever — unbounded growth on
+        the intake hot path.
+
+        Provably semantics-preserving: an entry is evicted only once it is
+        older than the LONGEST configured window, at which point
+        `_is_duplicate` would already have returned False for it under any
+        source. So pruning can never turn a duplicate into an accepted
+        envelope.
+
+        Amortized: the O(n) sweep runs only when the dict crosses a
+        threshold, so steady-state ingest stays O(1). NEVER raises — a
+        housekeeping failure must not drop a signal.
+        """
+        try:
+            if len(self._dedup) < _DEDUP_PRUNE_THRESHOLD:
+                return
+            horizon = max(
+                float(self._config.dedup_window_s),
+                float(self._config.voice_dedup_window_s),
+                0.0,
+            )
+            now = time.monotonic()
+            stale = [k for k, t in self._dedup.items() if (now - t) >= horizon]
+            for k in stale:
+                self._dedup.pop(k, None)
+            if stale:
+                logger.debug(
+                    "[IntakeRouter] dedup prune evicted=%d remaining=%d",
+                    len(stale), len(self._dedup),
+                )
+        except Exception:  # noqa: BLE001
+            pass
 
     # ------------------------------------------------------------------
     # Advisory file lock

--- a/tests/governance/test_dedup_receipt_transparency.py
+++ b/tests/governance/test_dedup_receipt_transparency.py
@@ -1,0 +1,581 @@
+"""A dropped duplicate must say so, in facts something measured.
+
+`router.ingest` answers `"deduplicated"` when a goal's dedup_key was accepted
+inside the window. That verdict used to be collapsed into `None` by
+`_submit_operator_goal` — the SAME value it returns when intake is
+unreachable. Two different realities, one token, so the renderer could not
+tell "you already asked for this" from "nothing is listening" and said
+"queued — the Backlog sensor will pick it up on its next sweep" about both.
+
+Mechanically true (the goal really was filed), and unactionable: it names
+neither the collision nor when the goal becomes runnable again.
+
+This suite pins the repaired chain end to end:
+
+    router.describe_dedup_collision   facts the registry ALREADY holds
+      -> harness._dedup_receipt       encoded, never invented
+      -> executor.dispatch_backlog    files the safety net, stamps `f`
+      -> chat_response_style          the only layer that decides how it reads
+
+and the two properties that make it safe: the backlog safety net still gets
+written (a duplicate of a FAILED run must remain recoverable), and the dedup
+registry is now bounded.
+"""
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from backend.core.ouroboros.governance.intake.intent_envelope import make_envelope
+from backend.core.ouroboros.governance.intake.unified_intake_router import (
+    DedupCollision,
+    IntakeRouterConfig,
+    UnifiedIntakeRouter,
+    _DEDUP_PRUNE_THRESHOLD,
+)
+
+
+def _router(tmp_path: Path, **cfg: Any) -> UnifiedIntakeRouter:
+    gls = MagicMock()
+    gls.submit = MagicMock(return_value=None)
+    config = IntakeRouterConfig(
+        project_root=tmp_path,
+        wal_path=tmp_path / ".jarvis" / "intake_wal.jsonl",
+        lock_path=tmp_path / ".jarvis" / "intake_router.lock",
+        max_queue_size=100,
+        **cfg,
+    )
+    return UnifiedIntakeRouter(gls=gls, config=config)
+
+
+def _envelope(message: str = "fix the tests") -> Any:
+    return make_envelope(
+        source="operator_chat", description=message, target_files=(),
+        repo="jarvis", confidence=1.0, urgency="high",
+        evidence={"signature": message[:64]}, requires_human_ack=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. the router explains itself — from the registry it already keeps
+# ---------------------------------------------------------------------------
+
+def test_no_collision_reads_as_no_collision(tmp_path: Path) -> None:
+    assert _router(tmp_path).describe_dedup_collision(_envelope()) is None
+
+
+def test_a_registered_key_reports_its_age_and_window(tmp_path: Path) -> None:
+    r = _router(tmp_path, dedup_window_s=600.0)
+    env = _envelope()
+    r._register_dedup(env)
+
+    c = r.describe_dedup_collision(env)
+    assert c is not None
+    assert c.dedup_key == env.dedup_key
+    assert 0.0 <= c.age_s < 5.0, "just registered — age must be ~0"
+    assert c.window_s == 600.0
+
+
+def test_it_never_invents_a_collision_that_expired(tmp_path: Path) -> None:
+    """`_is_duplicate` and this must agree. An entry past its window is not
+    why anything dropped, so explaining one would be a fabricated cause."""
+    r = _router(tmp_path, dedup_window_s=60.0)
+    env = _envelope()
+    r._dedup[env.dedup_key] = time.monotonic() - 3600.0   # long expired
+
+    assert r._is_duplicate(env) is False
+    assert r.describe_dedup_collision(env) is None
+
+
+def test_a_disabled_window_explains_nothing(tmp_path: Path) -> None:
+    """window <= 0 disables dedup, so nothing can have deduplicated."""
+    r = _router(tmp_path, dedup_window_s=0.0)
+    env = _envelope()
+    r._dedup[env.dedup_key] = time.monotonic()
+    assert r._is_duplicate(env) is False
+    assert r.describe_dedup_collision(env) is None
+
+
+def test_describing_is_READ_ONLY(tmp_path: Path) -> None:
+    """It must not register, evict, or otherwise become an authority — an
+    explanation that mutates the thing it explains is a second tracker."""
+    r = _router(tmp_path)
+    env = _envelope()
+
+    before = dict(r._dedup)
+    assert r.describe_dedup_collision(env) is None
+    assert r._dedup == before, "explaining a miss registered a key"
+
+    r._register_dedup(env)
+    snapshot = dict(r._dedup)
+    for _ in range(5):
+        r.describe_dedup_collision(env)
+    assert r._dedup == snapshot, "explaining mutated the registry"
+
+
+def test_the_collision_math_is_sane() -> None:
+    c = DedupCollision(dedup_key="a" * 64, age_s=45.0, window_s=600.0)
+    assert c.short_hash == "a" * 12
+    assert c.dedup_key.startswith(c.short_hash), "hash must be a PREFIX"
+    assert c.retry_after_s == 555.0
+    # Never negative, even when the age has overrun the window.
+    assert DedupCollision("x", age_s=900.0, window_s=600.0).retry_after_s == 0.0
+
+
+def test_the_hash_is_the_dedup_key_not_a_new_one(tmp_path: Path) -> None:
+    """DRY: `sha256(source | target_files | signature)` already exists. A
+    second hash would be a second identity for the same collision."""
+    r = _router(tmp_path)
+    env = _envelope()
+    r._register_dedup(env)
+    c = r.describe_dedup_collision(env)
+    assert c is not None and env.dedup_key.startswith(c.short_hash)
+
+
+# ---------------------------------------------------------------------------
+# 2. the registry is bounded (mandate 4 — no leak)
+# ---------------------------------------------------------------------------
+
+def test_the_dedup_registry_no_longer_grows_without_bound(tmp_path: Path) -> None:
+    """It was append-only: one entry per distinct key, for the life of the
+    process. Every distinct signature an operator ever types, forever."""
+    r = _router(tmp_path, dedup_window_s=1.0, voice_dedup_window_s=1.0)
+
+    for i in range(_DEDUP_PRUNE_THRESHOLD + 50):
+        e = _envelope(f"goal number {i}")
+        r._dedup[e.dedup_key] = time.monotonic() - 3600.0     # all expired
+    r._register_dedup(_envelope("the one that triggers the sweep"))
+
+    assert len(r._dedup) < _DEDUP_PRUNE_THRESHOLD, (
+        f"registry still holds {len(r._dedup)} entries — the sweep did not run"
+    )
+
+
+def test_pruning_can_never_turn_a_duplicate_into_an_accepted_goal(
+    tmp_path: Path,
+) -> None:
+    """The safety property. Only entries older than the LONGEST window are
+    evicted — at which point `_is_duplicate` was already False for them."""
+    r = _router(tmp_path, dedup_window_s=600.0, voice_dedup_window_s=300.0)
+    live = _envelope("a goal still inside its window")
+    r._register_dedup(live)
+
+    for i in range(_DEDUP_PRUNE_THRESHOLD + 10):
+        e = _envelope(f"ancient goal {i}")
+        r._dedup[e.dedup_key] = time.monotonic() - 100_000.0
+    r._register_dedup(_envelope("trigger"))
+
+    assert live.dedup_key in r._dedup, "a LIVE dedup entry was evicted"
+    assert r._is_duplicate(live) is True
+
+
+def test_pruning_never_raises_into_the_ingest_path(tmp_path: Path) -> None:
+    """Housekeeping must not be able to drop a signal."""
+    r = _router(tmp_path)
+    r._dedup = {"junk": "not-a-float"}          # type: ignore[dict-item]
+    for i in range(_DEDUP_PRUNE_THRESHOLD + 5):
+        r._dedup[f"k{i}"] = time.monotonic()
+    r._register_dedup(_envelope())              # must not raise
+
+
+# ---------------------------------------------------------------------------
+# 3. the receipt grammar — one definition, both producers read it
+# ---------------------------------------------------------------------------
+
+def test_the_grammar_round_trips() -> None:
+    from backend.core.ouroboros.governance.chat_response_style import (
+        is_dedup_receipt,
+        make_dedup_receipt,
+        with_filed,
+    )
+
+    r = make_dedup_receipt("a1b2c3d4e5f6", 45.0, 600.0, filed=False)
+    assert is_dedup_receipt(r)
+    assert r.endswith("f=0")
+    assert with_filed(r, True).endswith("f=1")
+    assert "a1b2c3d4e5f6" in with_filed(r, True), "the hash survived re-stamping"
+
+
+def test_a_dedup_receipt_is_not_mistaken_for_a_dispatch() -> None:
+    """`op-` is the ONLY shape that means "a worker has it". A collision must
+    never satisfy that test or the cockpit says `on it` about a dropped goal."""
+    from backend.core.ouroboros.governance.chat_response_style import (
+        _dispatched_now,
+        _was_discarded,
+        is_dedup_receipt,
+        make_dedup_receipt,
+    )
+
+    r = make_dedup_receipt("abc123", 1.0, 600.0, filed=True)
+    assert is_dedup_receipt(r)
+    assert not _dispatched_now(r)
+    assert not _was_discarded(r)
+    for other in ("op-019fa4-jarvis", "chat:chat-abc", "logged-backlog-x", ""):
+        assert not is_dedup_receipt(other)
+
+
+def test_with_filed_leaves_other_receipts_alone() -> None:
+    from backend.core.ouroboros.governance.chat_response_style import with_filed
+
+    for other in ("op-019fa4-jarvis", "chat:chat-abc", "logged-backlog-x"):
+        assert with_filed(other, True) == other
+
+
+@pytest.mark.parametrize("junk", [
+    "dedup:", "dedup:h=;a=zz;w=;f=", "dedup:garbage", "dedup:a=1;a=2",
+])
+def test_a_garbled_receipt_renders_rather_than_raising(junk: str) -> None:
+    """A formatting fault must never swallow a real response."""
+    from backend.core.ouroboros.governance.chat_response_style import (
+        compose_reply,
+        dedup_lines,
+    )
+
+    assert dedup_lines(junk)
+    out = compose_reply("backlog_dispatch", receipt=junk)
+    assert "Deduplicated" in out
+
+
+# ---------------------------------------------------------------------------
+# 4. what the operator reads
+# ---------------------------------------------------------------------------
+
+def _reply(age: float = 45.0, window: float = 600.0, filed: bool = True) -> str:
+    from backend.core.ouroboros.governance.chat_response_style import (
+        compose_reply,
+        make_dedup_receipt,
+    )
+
+    return compose_reply(
+        "backlog_dispatch",
+        receipt=make_dedup_receipt("a1b2c3d4e5f6", age, window, filed=filed),
+    )
+
+
+def test_it_never_says_queued_about_a_dropped_duplicate() -> None:
+    """THE defect. "queued — the Backlog sensor will pick it up on its next
+    sweep" describes the safety net as if it were the outcome."""
+    out = _reply()
+    assert "queued" not in out
+    assert "next sweep" not in out
+    assert "Deduplicated" in out
+
+
+def test_it_reports_the_measured_age_and_the_retry_horizon() -> None:
+    out = _reply(age=45.0, window=600.0)
+    assert "45s ago" in out
+    assert "9m15s" in out, "the retry horizon is window - age"
+    assert "a1b2c3d4e5f6" in out
+
+
+def test_it_does_NOT_claim_the_earlier_op_is_still_running() -> None:
+    """The registry stores ONE fact: when a key was last accepted. An op that
+    has since completed or FAILED still collides, so "already in flight" is a
+    state nothing measures — the exact fabrication class this arc kills."""
+    out = _reply().lower()
+    for lie in ("in flight", "in-flight", "still running", "executing now"):
+        assert lie not in out, f"claimed {lie!r} without measuring it"
+    assert "accepted" in out
+
+
+def test_the_safety_net_is_reported_only_when_it_exists() -> None:
+    assert "filed to the backlog as well" in _reply(filed=True)
+    filed_false = _reply(filed=False)
+    assert "NOT filed" in filed_false
+    assert "filed to the backlog as well" not in filed_false
+
+
+def test_the_head_line_does_not_describe_the_backlog_write() -> None:
+    """`acknowledge()` would say "adding that to the backlog" — true of the
+    safety net, wrong as the answer to what the operator asked."""
+    out = _reply()
+    assert "you have already asked for this" in out
+    assert "adding that to the backlog" not in out
+
+
+def test_the_raw_token_never_reaches_the_operator() -> None:
+    out = _reply()
+    assert "dedup:h=" not in out and "f=1" not in out
+
+
+# ---------------------------------------------------------------------------
+# 5. the harness mints it — and refuses to invent one
+# ---------------------------------------------------------------------------
+
+class _Turn:
+    turn_id = "chat-1dc4650228e7"
+    session_id = "repl"
+
+
+def test_the_submitter_returns_a_collision_receipt(tmp_path: Path) -> None:
+    from backend.core.ouroboros.battle_test.harness import BattleTestHarness
+    from backend.core.ouroboros.governance.chat_response_style import (
+        is_dedup_receipt,
+    )
+
+    r = _router(tmp_path)
+    env = _envelope()
+    r._register_dedup(env)
+
+    out = BattleTestHarness._operator_goal_receipt(
+        "deduplicated", "op-x-chat", router=r, envelope=env,
+    )
+    assert out is not None and is_dedup_receipt(out)
+
+
+def test_an_unexplainable_collision_falls_back_rather_than_fabricating() -> None:
+    """A router with no accessor (or an entry that expired between the verdict
+    and the read) must yield None -> the goal is FILED. A receipt carrying an
+    age nobody measured would be worse than the vague one it replaced."""
+    from backend.core.ouroboros.battle_test.harness import BattleTestHarness
+
+    class _Old:            # no describe_dedup_collision
+        pass
+
+    assert BattleTestHarness._operator_goal_receipt(
+        "deduplicated", "op-x", router=_Old(), envelope=_envelope(),
+    ) is None
+    assert BattleTestHarness._operator_goal_receipt(
+        "deduplicated", "op-x", router=None, envelope=None,
+    ) is None
+
+
+@pytest.mark.parametrize("verdict", ["backpressure", "", "nonsense"])
+def test_other_refusals_are_unchanged(verdict: str) -> None:
+    from backend.core.ouroboros.battle_test.harness import BattleTestHarness
+
+    assert BattleTestHarness._operator_goal_receipt(verdict, "op-x") is None
+
+
+@pytest.mark.parametrize("verdict", ["enqueued", "pending_ack"])
+def test_acceptance_is_unchanged(verdict: str) -> None:
+    from backend.core.ouroboros.battle_test.harness import BattleTestHarness
+
+    assert BattleTestHarness._operator_goal_receipt(verdict, "op-x") == "op-x"
+
+
+# ---------------------------------------------------------------------------
+# 6. the safety net still gets written (mandate 4)
+# ---------------------------------------------------------------------------
+
+def _executor(tmp_path: Path, submit: Any) -> Any:
+    from backend.core.ouroboros.governance.chat_repl_backlog_executor import (
+        BacklogChatActionExecutor,
+    )
+    return BacklogChatActionExecutor(tmp_path, submit_now=submit)
+
+
+def _dedup_token(filed: bool = False) -> str:
+    from backend.core.ouroboros.governance.chat_response_style import (
+        make_dedup_receipt,
+    )
+    return make_dedup_receipt("a1b2c3d4e5f6", 45.0, 600.0, filed=filed)
+
+
+def test_a_deduplicated_goal_is_STILL_filed(tmp_path: Path) -> None:
+    """The load-bearing one. The earlier run may have already FAILED; if the
+    duplicate is dropped AND unfiled, the operator's goal is simply gone."""
+    import json
+
+    out = _executor(tmp_path, lambda _m, _t: _dedup_token()).dispatch_backlog(
+        "fix the tests", _Turn(),
+    )
+    backlog = tmp_path / ".jarvis" / "backlog.json"
+    assert backlog.exists(), "the safety net was never written"
+    body = json.loads(backlog.read_text())
+    rows = body if isinstance(body, list) else body.get("tasks", body)
+    assert rows, "backlog.json is empty"
+    assert out.endswith("f=1"), "the receipt denies a filing that happened"
+
+
+def test_a_dispatched_goal_is_NOT_filed(tmp_path: Path) -> None:
+    """Unchanged: a real dispatch must not also queue duplicate work."""
+    out = _executor(tmp_path, lambda _m, _t: "op-019fa4-chat").dispatch_backlog(
+        "fix the tests", _Turn(),
+    )
+    assert out == "op-019fa4-chat"
+    assert not (tmp_path / ".jarvis" / "backlog.json").exists()
+
+
+def test_a_failed_filing_is_not_reported_as_filed(tmp_path: Path) -> None:
+    """`f=0` must mean "no safety net", never "not attempted"."""
+    import backend.core.ouroboros.governance.chat_repl_backlog_executor as mod
+
+    ex = _executor(tmp_path, lambda _m, _t: _dedup_token())
+    original = mod._append_to_backlog_json
+    mod._append_to_backlog_json = lambda *_a, **_k: False
+    try:
+        out = ex.dispatch_backlog("fix the tests", _Turn())
+    finally:
+        mod._append_to_backlog_json = original
+
+    assert out.endswith("f=0")
+    from backend.core.ouroboros.governance.chat_response_style import compose_reply
+    assert "NOT filed" in compose_reply("backlog_dispatch", receipt=out)
+
+
+def test_the_executor_reads_the_grammar_rather_than_restating_it() -> None:
+    """Two copies of a grammar are two grammars, and the second one drifts."""
+    import inspect
+
+    import backend.core.ouroboros.governance.chat_repl_backlog_executor as mod
+
+    src = inspect.getsource(mod)
+    assert "from backend.core.ouroboros.governance.chat_response_style import" in src
+    assert '"dedup:"' not in src and "'dedup:'" not in src, (
+        "the executor restated the prefix instead of importing it"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 7. the whole chain, against the real router
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_end_to_end_the_second_identical_goal_explains_itself(
+    tmp_path: Path,
+) -> None:
+    """Real router, real verdict, real receipt, real rendering. The first goal
+    dispatches; the second — identical, inside the window — comes back naming
+    the collision instead of claiming a queue position."""
+    from backend.core.ouroboros.battle_test.harness import BattleTestHarness
+    from backend.core.ouroboros.governance.chat_response_style import compose_reply
+
+    r = _router(tmp_path, dedup_window_s=600.0)
+
+    first = _envelope("rebuild the IPC layer")
+    assert await r.ingest(first) == "enqueued"
+    assert BattleTestHarness._operator_goal_receipt(
+        "enqueued", "op-first-chat", router=r, envelope=first,
+    ) == "op-first-chat"
+
+    second = _envelope("rebuild the IPC layer")
+    assert second.dedup_key == first.dedup_key, "same goal, same key"
+    verdict = await r.ingest(second)
+    assert verdict == "deduplicated"
+
+    receipt = BattleTestHarness._operator_goal_receipt(
+        verdict, "op-second-chat", router=r, envelope=second,
+    )
+    assert receipt is not None
+
+    reply = compose_reply("backlog_dispatch", receipt=receipt)
+    assert "Deduplicated" in reply
+    assert "queued" not in reply
+    assert "on it" not in reply
+    assert second.dedup_key.startswith(
+        reply.split("[hash: ")[1].split("]")[0]
+    ), "the rendered hash is not this goal's dedup_key"
+
+
+@pytest.mark.asyncio
+async def test_the_submitter_refuses_to_block_the_loop_it_needs(
+    tmp_path: Path,
+) -> None:
+    """Called ON the loop, it must file rather than deadlock.
+
+    `run_coroutine_threadsafe` schedules onto the loop the caller is sitting
+    on, so blocking for the result waits for work only the caller could drive:
+    the loop wedges for the full timeout and then fails anyway. Caught by the
+    four-layer test below before it was guarded — the loop stalled ~3.9s and
+    `LoopSink` flagged it.
+
+    Production reaches this through `asyncio.to_thread` and never lands here,
+    but "never" was equally true of the envelope contract this same function
+    got wrong, so it is enforced rather than assumed.
+    """
+    import asyncio
+
+    from backend.core.ouroboros.battle_test.harness import BattleTestHarness
+
+    router = _router(tmp_path)
+
+    class _GLS:
+        _intake_router = router
+
+    h = BattleTestHarness.__new__(BattleTestHarness)
+    h._governed_loop_service = _GLS()
+    h._operator_goal_loop = asyncio.get_running_loop()
+
+    started = time.monotonic()
+    out = h._submit_operator_goal("fix the tests", _Turn())
+    elapsed = time.monotonic() - started
+
+    assert out is None, "it claimed a dispatch it could not confirm"
+    assert elapsed < 1.0, (
+        f"blocked the event loop for {elapsed:.1f}s instead of failing fast"
+    )
+
+
+@pytest.mark.asyncio
+async def test_all_four_layers_together(tmp_path: Path) -> None:
+    """Router -> harness submitter -> executor -> renderer, no fakes between.
+
+    Each layer is pinned above in isolation; this is the one that would catch
+    a seam where two correct layers disagree — the failure mode that let
+    `_submit_operator_goal` sit dead behind a green suite for twelve days.
+    """
+    import json
+
+    from backend.core.ouroboros.battle_test.harness import BattleTestHarness
+    from backend.core.ouroboros.governance.chat_repl_backlog_executor import (
+        BacklogChatActionExecutor,
+    )
+    from backend.core.ouroboros.governance.chat_response_style import compose_reply
+
+    import asyncio
+
+    router = _router(tmp_path, dedup_window_s=600.0)
+
+    class _GLS:
+        def __init__(self) -> None:
+            self._intake_router = router
+
+        def note_operator_op(self, op_id: str) -> None:
+            pass
+
+    harness = BattleTestHarness.__new__(BattleTestHarness)
+    harness._governed_loop_service = _GLS()
+    # The loop the daemon captures when it arms the seam at boot.
+    harness._operator_goal_loop = asyncio.get_running_loop()
+
+    executor = BacklogChatActionExecutor(
+        tmp_path, submit_now=harness._submit_operator_goal,
+    )
+
+    # THE production topology: `chat_text_bridge._run` dispatches the executor
+    # through `asyncio.to_thread`, so the submitter runs on a worker thread.
+    # Calling it inline here would test a path the daemon never takes — and
+    # would deadlock, since the coroutine needs the loop the caller is sitting
+    # on (see `test_the_submitter_refuses_to_block_the_loop_it_needs`).
+    async def _turn(text: str, turn: Any) -> str:
+        return await asyncio.to_thread(executor.dispatch_backlog, text, turn)
+
+    first = await _turn("rebuild the IPC layer", _Turn())
+    assert first.startswith("op-"), f"first goal did not dispatch: {first}"
+    assert "on it" in compose_reply("backlog_dispatch", receipt=first)
+
+    class _Turn2:
+        turn_id = "chat-second-turn"
+        session_id = "repl"
+
+    second = await _turn("rebuild the IPC layer", _Turn2())
+    assert second.startswith("dedup:"), (
+        f"the identical goal did not report a collision: {second}"
+    )
+    assert second.endswith("f=1"), "the safety net was not written or not stamped"
+
+    # Mandate 4, proven on the real path: the goal survives as a backlog row.
+    backlog = tmp_path / ".jarvis" / "backlog.json"
+    assert backlog.exists()
+    body = json.loads(backlog.read_text())
+    rows = body if isinstance(body, list) else body.get("tasks", body)
+    assert any("rebuild the IPC layer" in json.dumps(r) for r in rows)
+
+    reply = compose_reply("backlog_dispatch", receipt=second)
+    assert "Deduplicated" in reply and "queued" not in reply
+    assert "filed to the backlog as well" in reply


### PR DESCRIPTION
## The defect

`router.ingest` answers `"deduplicated"` when a goal's dedup_key was accepted inside the window. That verdict was collapsed into `None` by `_submit_operator_goal` — **the same value it returns when intake is unreachable**. Two different realities, one token, so the renderer could not tell "you already asked for this" from "nothing is listening" and said *"queued — the Backlog sensor will pick it up on its next sweep"* about both.

Mechanically true (the goal really was filed). Unactionable: it names neither the collision nor when the goal becomes runnable again.

## Three severed links, repaired in order

```
router.ingest → "deduplicated"        a verdict; the REASON stayed private
_submit_operator_goal → None          indistinguishable from unreachable
executor: if op_id: return            would skip the backlog safety net
compose_reply → "queued…next sweep"   true, and useless
```

- **`UnifiedIntakeRouter.describe_dedup_collision()`** — read-only over the **existing** `self._dedup` registry. No second tracker, no cache, no writable surface (a test asserts five calls leave the registry byte-identical). `_dedup_window_s()` is now one definition with two readers — `_is_duplicate` decides, `describe` explains — so a verdict and its explanation cannot disagree about the rule.
- **The grammar has one home.** `chat_response_style` already owned what a receipt *means* (`_dispatched_now`, `_was_discarded`, `_logging_prefix`), so it owns this too; harness and executor import it. A test greps the executor to prove it never restates `"dedup:"` as a literal — two copies of a grammar are two grammars, and the second one drifts.
- **The hash is the existing one.** The rendered value *is* `envelope.dedup_key[:12]` — the same `sha256(source | target_files | signature)`. A test asserts the rendered hash is a prefix of the goal's real key.

## One amendment to the spec: "accepted", not "in flight"

The spec asked for `Execution Already In-Flight`. The registry stores exactly one fact — when a key was last accepted — so an op that has since **completed or failed** still collides inside the window. "In flight" would be a state nothing measures: the same fabrication class as the `blast=50` advisory and the "queued" line this replaces. A test pins that the phrase never appears.

```
⏺ you have already asked for this
  ⎿ Status: Deduplicated · an identical goal was accepted 45s ago · re-runnable in 9m15s [hash: a1b2c3d4e5f6]
  ⎿ filed to the backlog as well — if that first run failed, the Backlog sensor still collects this one
```

Every clause is conditional on its fact being known; a garbled receipt degrades to `Status: Deduplicated` rather than raising.

## Resilience

- **The backlog write still happens on a collision.** The earlier run may already have failed, and a duplicate that is both dropped *and* unfiled is a goal that simply vanished. The `f` flag is stamped by the executor — the only layer that knows whether the write succeeded — so `f=0` renders as `NOT filed` rather than being mistaken for "not attempted".
- **The dedup cache leak was real.** `self._dedup` was **append-only for the life of the process** — one entry per distinct signature, forever. It now prunes at 512 entries, evicting only entries older than the *longest* window, at which point `_is_duplicate` was already `False` for them. Pruning therefore can never turn a duplicate into an accepted envelope (pinned: a live entry survives a sweep of 522 ancient ones). Amortized O(1) on the ingest hot path; never raises.

## A bug the end-to-end test caught in yesterday's code

Called **on** the event loop, `run_coroutine_threadsafe` schedules onto the loop the caller is blocking — the loop wedged 3.9s (`LoopSink` flagged it) and then timed out. Production always arrives via `asyncio.to_thread` (`chat_text_bridge._run`), but "never" was equally true of the envelope contract this same function got wrong last week, so it is now enforced rather than assumed and pinned by a test asserting it fails in under a second.

## Verification

**405 passed** across chat surfaces, operator-chat, dedup, intake and esc-interrupt. 37 new tests.

Two pre-existing red sets **diagnosed, not assumed**:

- `test_chat_repl_claude_executor` (2) — these spend against the **real repo-local** `.jarvis/chat_spend.json`, which read `spent_usd: 1.0, trips: 6` (one per suite run I'd done), so the breaker correctly fail-closes. **51/51 pass** with `JARVIS_CHAT_SPEND_LEDGER` pointed at a temp file. A test-isolation defect worth its own fix; the ledger was left untouched.
- `test_no_loss_submit_boundary` + `test_out_of_order_events` (8) — byte-identical failure set with and without this change, verified by reverting only the router *in the same working directory*.

## Status

**Code-proven, not `ov`-proven.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops saying “queued” for dropped duplicates and shows a clear “Deduplicated” status instead. Adds a structured receipt with hash, age, and retry window, and always stamps whether the backlog safety net was written.

- **Bug Fixes**
  - Router: added `describe_dedup_collision()` to expose dedup facts (short hash from `dedup_key`, age, window); unified window via `_dedup_window_s()`; prunes `_dedup` at 512 entries, evicting only keys older than the longest window.
  - Executor/Harness: propagate a dedup receipt instead of collapsing to `None`, still file the backlog, and stamp `f=1/0`; refuse to block the event loop when called on it and fall back to filing.
  - Renderer: `chat_response_style` owns the dedup grammar (`make_dedup_receipt`, `is_dedup_receipt`, `with_filed`) and rendering; never shows “queued” for dedup; says “accepted” with age and re-run ETA; renders the hash as `envelope.dedup_key[:12]`.
  - Tests: added `tests/governance/test_dedup_receipt_transparency.py` with end-to-end coverage for receipts, pruning, and loop safety.

<sup>Written for commit 1ed90c5144abc632db36a1e200e99fa79fd4245c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

