### PR TITLE
feat(liquidity): the provider dashboard had no word for "out of money"

### DIFF
--- a/backend/core/ouroboros/aegis/forwarding.py
+++ b/backend/core/ouroboros/aegis/forwarding.py
@@ -708,11 +708,35 @@ async def forward_request(
                 provider_for_upstream,
                 record_headers,
             )
+            _liq_provider = provider_for_upstream(str(request.path))
             record_headers(
-                provider_for_upstream(str(request.path)),
+                _liq_provider,
                 dict(upstream_resp.headers),
                 status=upstream_resp.status,
             )
+            # ECONOMIC fold. `record_headers` above returns early when the
+            # response declares no rate-limit telemetry — and an economic
+            # refusal never does, because the problem is not quota. So the one
+            # response that proves a lane is dead is exactly the one the
+            # ledger discarded: on 2026-08-08 DoubleWord returned 402
+            # "Account balance too low" and never appeared in the ledger at
+            # all, while the dashboard showed the other lane at "runway: ok".
+            #
+            # Classified here because this is the ONE chokepoint every
+            # upstream response crosses. Synchronous by design (pure CPU over
+            # values already in hand) so the proxy hot path grows no await.
+            # Fail-soft: telemetry must never break forwarding.
+            try:
+                from backend.core.ouroboros.governance.economic_state import (  # noqa: E501,PLC0415
+                    fold_economic_state,
+                )
+                fold_economic_state(
+                    _liq_provider,
+                    status=upstream_resp.status,
+                    headers=dict(upstream_resp.headers),
+                )
+            except Exception:  # noqa: BLE001
+                pass
             for _hk, _hv in upstream_resp.headers.items():
                 _lk = _hk.lower()
                 if (_lk.startswith("anthropic-ratelimit-")

--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -4657,6 +4657,55 @@ class BattleTestHarness:
                     f"  {name}: {tok_txt} · {reset_txt} · "
                     f"status: {status} · runway: {verdict}"
                 )
+                # THE missing column. Every field above measures QUOTA; none
+                # of them can express "the account has no money", so on
+                # 2026-08-08 this rendered "5,000,000 tokens · status: 200 ·
+                # runway: ok" while a live probe returned 402 and every op
+                # died at GENERATE. Composed, not stored — `economic_view`
+                # reads the row `record_quota_exhaustion` already owns.
+                try:
+                    from backend.core.ouroboros.governance.economic_state import (  # noqa: E501
+                        ECONOMIC,
+                        RATE_LIMITED,
+                        UNKNOWN,
+                        economic_view,
+                    )
+                    ev = economic_view(name)
+                    st = ev.get("state")
+                    if st == ECONOMIC and ev.get("hard_open"):
+                        secs = int(ev.get("expires_in_s") or 0)
+                        lines.append(
+                            f"      ⛔ funding: OUT OF CREDIT (hard-open, "
+                            f"re-probes in {secs}s)"
+                        )
+                    elif st == RATE_LIMITED and ev.get("hard_open"):
+                        secs = int(ev.get("expires_in_s") or 0)
+                        lines.append(
+                            f"      ⏳ quota outage (self-healing in {secs}s)"
+                        )
+                    elif ev.get("unverified_since"):
+                        # The TTL lapsed. That is proof time passed, NOT proof
+                        # the wallet was topped up — money does not return on
+                        # a timer. Routing keeps its fail-open optimism; the
+                        # display stops calling that optimism knowledge.
+                        when = time.strftime(
+                            "%H:%M", time.localtime(ev["unverified_since"]),
+                        )
+                        lines.append(
+                            f"      ⚠️ funding: UNVERIFIED since {when} "
+                            f"(economic flag lapsed on a timer, not a probe)"
+                        )
+                    elif st == UNKNOWN and ev.get("reason"):
+                        lines.append("      ⚠️ funding: unknown")
+                    if ev.get("reason"):
+                        lines.append(f"      ↳ {str(ev['reason'])[:118]}")
+                    if ev.get("stale_clock"):
+                        lines.append(
+                            "      ⚠️ reset horizon unreliable — recorded_unix "
+                            "failed the plausibility guard (stale/fixture row)"
+                        )
+                except Exception:  # noqa: BLE001 — a column must not eat the view
+                    pass
             lines.append(
                 f"  floor: {min_tokens_floor():,} tokens · "
                 f"exhausted: {'yes' if any_runway_exhausted() else 'no'}"
@@ -4665,6 +4714,48 @@ class BattleTestHarness:
                     if any_runway_exhausted() else ""
                 )
             )
+            # BLAST RADIUS — who absorbs the traffic, and whether they CAN.
+            #
+            # Naming a fallback without checking it is worse than silence: it
+            # reports a successful handoff into a lane that may be just as
+            # dead. On 2026-08-08 the generator logged "IMMEDIATE reroute → DW"
+            # and "DW AUTARKY ENGAGED" seconds before failing, because DW was
+            # also out of credit. A handoff into a dead lane is a CASCADING
+            # ROUTE FAILURE, and the dashboard now says so.
+            try:
+                from backend.core.ouroboros.governance.economic_state import (
+                    blast_radius,
+                )
+                br = blast_radius()
+                if br.get("lanes"):
+                    lines.append("  blast radius:")
+                    for lane, info in sorted(br["lanes"].items()):
+                        if info.get("viable"):
+                            lines.append(
+                                f"    {lane}: viable ({info.get('reason') or 'ok'})"
+                            )
+                            continue
+                        absorbed = info.get("absorbed_by") or []
+                        why = info.get("reason") or info.get("economic") or "down"
+                        if absorbed:
+                            lines.append(
+                                f"    {lane}: DOWN ({why}) → absorbed by "
+                                f"{', '.join(absorbed)}"
+                            )
+                        else:
+                            lines.append(
+                                f"    {lane}: DOWN ({why}) → ⛔ CASCADING ROUTE "
+                                f"FAILURE — no viable lane is absorbing this"
+                            )
+                    if br.get("cascading"):
+                        lines.append(
+                            "    ⛔ every fallback for "
+                            f"{', '.join(sorted(br['cascading']))} is itself "
+                            "economically or quota-exhausted — generation "
+                            "cannot succeed on any lane"
+                        )
+            except Exception:  # noqa: BLE001 — optional surface
+                pass
             # Lease economy — best-effort (pool may not be constructed).
             try:
                 from backend.core.ouroboros.governance.liquidity_pool import (

--- a/backend/core/ouroboros/governance/economic_state.py
+++ b/backend/core/ouroboros/governance/economic_state.py
@@ -1,0 +1,485 @@
+"""Economic death, said in one vocabulary — and what it costs downstream.
+
+`/liquidity` was a RATE-LIMIT dashboard wearing the name of a funding one. On
+2026-08-08, with both paid lanes returning "account balance too low", it
+rendered::
+
+    anthropic: 5,000,000 tokens · no reset horizon · status: 200 · runway: ok
+    floor: 2,000 tokens · exhausted: no
+
+Five million tokens, HTTP 200, runway ok — while every op died at GENERATE and
+a live probe returned `402 Account balance too low`. Not one field was lying
+about the thing it measured; the dashboard simply had no field for the thing
+that was wrong.
+
+Why the ledger went blind
+-------------------------
+`record_headers` bails early::
+
+    if tokens is None and reset_delta is None:
+        return False          # nothing declared
+
+An economic refusal carries no rate-limit headers — there is no quota to
+report, because the problem is not quota. So the response that proves the lane
+is dead is exactly the response the ledger discards. The state was recorded
+later, by `record_quota_exhaustion` from the generator's error path, and then
+never displayed.
+
+This module supplies the missing vocabulary. It stores nothing: it classifies
+an upstream refusal, folds the verdict into the row `record_quota_exhaustion`
+already owns, and reads back a rendering-ready view. No second tracker, no new
+table, no database.
+
+Why the classifier is a TABLE and not an `if status == 402`
+-----------------------------------------------------------
+Providers disagree about how to say "you are out of money". Observed on ONE
+afternoon, from two vendors:
+
+  * DoubleWord  → ``402`` + ``"Account balance too low. Please add credits"``
+  * Anthropic   → ``400`` + ``invalid_request_error`` + ``"Your credit balance
+    is too low to access the Anthropic API"``
+
+A `== 402` check catches the first and misses the second — and the second is
+the one that had already tripped the Claude lane. Status alone is not the
+signal; status *plus phrase* is. Both live in tables below, so teaching this a
+third vendor's shape is a data edit, not a code path.
+
+Why it is SYNCHRONOUS
+---------------------
+Classification is pure CPU over values the caller already holds — no I/O, no
+network, microseconds. Making it a coroutine would force `record_headers` and
+`record_quota_exhaustion` to become awaitable, which would ripple into Aegis's
+*synchronous* response hook (`forwarding.py:711`) and put an `await` on the
+proxy's hot path in exchange for nothing. The same reasoning that rejected
+`to_thread` as a fix for import contention: async is for waiting, and nothing
+here waits.
+
+If confirmation ever matters — probing a billing endpoint to verify a balance
+rather than inferring it from a refusal — that is genuinely I/O and belongs in
+a separate, cancellable enrichment that must never block the dashboard.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import time
+from typing import Any, Dict, Mapping, Optional, Tuple
+
+logger = logging.getLogger("Ouroboros.EconomicState")
+
+__all__ = [
+    "ECONOMIC",
+    "RATE_LIMITED",
+    "HEALTHY",
+    "UNKNOWN",
+    "classify_refusal",
+    "fold_economic_state",
+    "economic_view",
+    "blast_radius",
+]
+
+# --- the four things an upstream refusal can mean, for our purposes ---------
+#
+# Deliberately NOT an enum: these travel into `quota_reason` (a string field
+# that already exists) and out to a renderer. A str subclass would be
+# ceremony; the values are the contract.
+ECONOMIC = "economic"          # out of money — a human must act
+RATE_LIMITED = "rate_limited"  # out of quota FOR NOW — a clock will fix it
+HEALTHY = "healthy"            # nothing wrong
+UNKNOWN = "unknown"            # could not tell — say so, never guess
+
+#: Marker prefixed onto `quota_reason` so a reader can tell an economic outage
+#: from a quota one without re-parsing prose. Kept short: the field is capped
+#: at 160 chars by `record_quota_exhaustion` and the vendor message is the
+#: valuable part.
+_CLASS_PREFIX = "class="
+
+
+# --- the tables -------------------------------------------------------------
+#
+# Phrases are matched case-insensitively as substrings against the response
+# body. They are deliberately vendor-agnostic fragments rather than whole
+# messages, because vendors reword ("Please add credits" → "Add credits to
+# continue") far more often than they change the noun.
+
+_ECONOMIC_PHRASES: Tuple[str, ...] = (
+    "balance too low",
+    "credit balance",
+    "add credits",
+    "insufficient credit",
+    "insufficient funds",
+    "insufficient balance",
+    "payment required",
+    "billing",
+    "past due",
+    "spending limit",
+    "no active subscription",
+    "purchase additional",
+)
+
+#: Rate-limit phrasing that must NOT be read as economic even when it shares a
+#: status code with one. "quota" is the trap: providers use it for both a
+#: monthly spend cap and a per-minute token ceiling.
+_RATE_LIMIT_PHRASES: Tuple[str, ...] = (
+    "rate limit",
+    "rate_limit",
+    "too many requests",
+    "requests per",
+    "tokens per",
+    "try again in",
+    "retry after",
+    "slow down",
+)
+
+#: status -> what that status means ON ITS OWN, before phrases are consulted.
+#: `None` means "the status is not decisive; the body decides."
+#:
+#: 402 is here as DATA, not as an `if`. Adding a vendor that signals funding
+#: with 423 is a one-line edit here.
+_STATUS_CLASS: Dict[int, Optional[str]] = {
+    402: ECONOMIC,        # Payment Required — unambiguous by definition
+    403: None,            # auth OR billing — body decides
+    429: None,            # rate limit OR spend cap — body decides
+    400: None,            # Anthropic signals credit exhaustion here
+    401: None,            # usually auth, but some vendors 401 a dead account
+}
+
+#: Headers that, when present, mean a real rate-limit window exists. Their
+#: presence is strong evidence AGAINST an economic reading: a provider that is
+#: refusing you for money has no window to advertise.
+_RATE_LIMIT_HEADER_HINTS: Tuple[str, ...] = (
+    "retry-after",
+    "x-ratelimit-reset",
+    "anthropic-ratelimit-tokens-reset",
+    "x-ratelimit-remaining",
+)
+
+
+def _text_of(body: Any) -> str:
+    """Flatten any body shape to lowercase searchable text. NEVER raises.
+
+    Bodies arrive as dicts, bytes, `str`, exception reprs, or half-truncated
+    JSON from a connection that died mid-payload. Mandate: a malformed body
+    must degrade to UNKNOWN, never to an exception on a telemetry path.
+    """
+    try:
+        if body is None:
+            return ""
+        if isinstance(body, (dict, list)):
+            return json.dumps(body, default=str).lower()
+        if isinstance(body, (bytes, bytearray)):
+            return bytes(body).decode("utf-8", errors="replace").lower()
+        return str(body).lower()
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def _headers_of(headers: Any) -> Dict[str, str]:
+    """Lowercase header map from anything map-like. NEVER raises."""
+    out: Dict[str, str] = {}
+    try:
+        if not headers:
+            return out
+        items = (
+            headers.items() if isinstance(headers, Mapping)
+            else getattr(headers, "items", lambda: [])()
+        )
+        for k, v in items:
+            try:
+                out[str(k).lower()] = str(v)
+            except Exception:  # noqa: BLE001
+                continue
+    except Exception:  # noqa: BLE001
+        return {}
+    return out
+
+
+def classify_refusal(
+    status: Any = None,
+    body: Any = None,
+    headers: Any = None,
+) -> Tuple[str, str]:
+    """Translate one upstream refusal into a unified economic verdict.
+
+    Returns ``(verdict, evidence)`` where verdict is one of ECONOMIC /
+    RATE_LIMITED / HEALTHY / UNKNOWN and evidence is a short human-readable
+    fragment naming WHY — so a dashboard can show the reasoning rather than a
+    bare label.
+
+    Precedence, and the reason for it:
+
+    1. **A rate-limit window in the headers wins over a money phrase.** A
+       provider refusing you for funds has no reset horizon to advertise; if
+       one is present, a clock will fix this.
+    2. **Explicit economic phrasing wins over an ambiguous status.** This is
+       what catches Anthropic's ``400 + "credit balance too low"``, which no
+       status-based rule would.
+    3. **A decisive status wins when the body says nothing.** 402 means
+       Payment Required whether or not anyone wrote a message.
+    4. **Otherwise UNKNOWN.** Never guess: a wrong ECONOMIC verdict tells the
+       operator to go top up an account that is fine, and a wrong HEALTHY
+       hides the reason nothing works.
+
+    NEVER raises. Malformed or absent inputs → ``(UNKNOWN, ...)``.
+    """
+    try:
+        text = _text_of(body)
+        head = _headers_of(headers)
+
+        try:
+            code: Optional[int] = int(status) if status is not None else None
+        except (TypeError, ValueError):
+            code = None
+
+        # 2xx is not a refusal at all.
+        if code is not None and 200 <= code < 300:
+            return HEALTHY, f"status {code}"
+
+        has_window = any(h in head for h in _RATE_LIMIT_HEADER_HINTS)
+        econ_hit = next((p for p in _ECONOMIC_PHRASES if p in text), None)
+        rate_hit = next((p for p in _RATE_LIMIT_PHRASES if p in text), None)
+
+        # (1) an advertised window means a clock fixes this
+        if has_window and not econ_hit:
+            return RATE_LIMITED, "reset window advertised"
+        if rate_hit and not econ_hit:
+            return RATE_LIMITED, f"body: {rate_hit!r}"
+
+        # (2) explicit money phrasing beats an ambiguous status
+        if econ_hit:
+            return ECONOMIC, f"body: {econ_hit!r}"
+
+        # (3) the status alone, only where it is decisive
+        if code is not None:
+            decided = _STATUS_CLASS.get(code, UNKNOWN)
+            if decided:
+                return decided, f"status {code}"
+            if code in _STATUS_CLASS:
+                return UNKNOWN, f"status {code}, body inconclusive"
+            return UNKNOWN, f"status {code} unmapped"
+
+        return UNKNOWN, "no status, no phrase"
+    except Exception:  # noqa: BLE001 — a classifier must never break telemetry
+        logger.debug("[EconomicState] classify degraded", exc_info=True)
+        return UNKNOWN, "classifier degraded"
+
+
+def fold_economic_state(
+    provider: str,
+    *,
+    status: Any = None,
+    body: Any = None,
+    headers: Any = None,
+    now: Optional[float] = None,
+) -> str:
+    """Classify a refusal and, when economic, record it via the EXISTING hook.
+
+    Composition only: the durable write is `record_quota_exhaustion`, which
+    already owns the row, the TTL and the merge-without-clobber semantics. This
+    adds the classification the hook was always missing — its `reason` field
+    was free-text, so nothing downstream could distinguish "out of money" from
+    "out of quota" without re-reading prose.
+
+    Returns the verdict. Non-economic verdicts write NOTHING: a rate limit is
+    already the header path's job, and duplicating it here would give one
+    condition two writers.
+
+    NEVER raises.
+    """
+    verdict, evidence = classify_refusal(status, body, headers)
+    try:
+        if verdict != ECONOMIC:
+            return verdict
+        from backend.core.ouroboros.governance.provider_liquidity_ledger import (
+            record_quota_exhaustion,
+        )
+        # The vendor's own words are the valuable part — an operator should be
+        # able to read the refusal, not a paraphrase of it. The class marker
+        # rides in front so `economic_view` can classify without re-parsing.
+        detail = _text_of(body).strip()[:110] or evidence
+        record_quota_exhaustion(
+            provider,
+            reason=f"{_CLASS_PREFIX}{ECONOMIC} {evidence} :: {detail}",
+            now=now,
+        )
+        logger.warning(
+            "[EconomicState] %s ECONOMIC outage recorded (%s)",
+            provider, evidence,
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug("[EconomicState] fold degraded", exc_info=True)
+    return verdict
+
+
+#: A `recorded_unix` older than this is not believable as a real observation
+#: from this deployment — it is fixture residue or a clock fault. The live
+#: ledger on 2026-08-08 carried `recorded_unix: 1010.0` (→ 1969-12-31), the
+#: exact fixture value from `test_header_refresh_never_clears_quota_state`,
+#: left in a gitignored file by a historical un-isolated run. It silently
+#: poisoned every reset-horizon subtraction that read it.
+#:
+#: Guarding the READER is the honest fix: production writes `time.time()`, so
+#: there is no production time bug to patch. What there is, is a reader that
+#: trusts any float.
+_PLAUSIBLE_EPOCH_FLOOR = 1_600_000_000.0     # 2020-09-13
+
+
+def _plausible_recorded(ts: Any) -> Optional[float]:
+    """Return *ts* as epoch seconds iff it could be a real observation."""
+    try:
+        v = float(ts)
+    except (TypeError, ValueError):
+        return None
+    if v < _PLAUSIBLE_EPOCH_FLOOR:
+        return None                       # pre-2020 → not from this system
+    if v > time.time() + 86_400.0:
+        return None                       # a day in the future → clock fault
+    return v
+
+
+def economic_view(provider: str, *, now: Optional[float] = None) -> Dict[str, Any]:
+    """Rendering-ready economic state for one provider. NEVER raises.
+
+    Keys:
+      ``state``        ECONOMIC / RATE_LIMITED / HEALTHY / UNKNOWN
+      ``reason``       the vendor's own refusal text (already truncated)
+      ``hard_open``    True while the recorded outage window is still live
+      ``expires_in_s`` seconds until the TTL lapses (None when not open)
+      ``unverified_since`` epoch at which an economic flag lapsed WITHOUT any
+                       evidence the wallet was topped up — the honest reading
+                       of an assumption-based TTL
+      ``stale_clock``  True when `recorded_unix` failed the plausibility guard
+
+    The `unverified_since` distinction is the point. `record_quota_exhaustion`
+    self-heals after `JARVIS_QUOTA_EXHAUSTION_TTL_S` (1800s) so a topped-up
+    wallet recovers without manual clearing. That is right for routing — but
+    the TTL is an ASSUMPTION, not a measurement. Money does not return on a
+    timer. On 2026-08-08 the flag lapsed at 14:42 and the dashboard reverted to
+    `ok` while the account stayed empty for hours. Routing keeps its fail-open
+    optimism; the display stops calling it knowledge.
+    """
+    out: Dict[str, Any] = {
+        "state": UNKNOWN, "reason": "", "hard_open": False,
+        "expires_in_s": None, "unverified_since": None, "stale_clock": False,
+    }
+    try:
+        from backend.core.ouroboros.governance.provider_liquidity_ledger import (
+            _load,
+        )
+        row = (_load().get("providers") or {}).get(
+            str(provider or "unknown").lower()) or {}
+        t = float(now if now is not None else time.time())
+
+        if row.get("recorded_unix") is not None:
+            out["stale_clock"] = _plausible_recorded(row.get("recorded_unix")) is None
+
+        reason = str(row.get("quota_reason") or "")
+        until = row.get("quota_exhausted_until")
+        is_economic = f"{_CLASS_PREFIX}{ECONOMIC}" in reason
+        # Pre-existing rows predate the class marker. Fall back to the phrase
+        # table so history recorded before this module still reads correctly.
+        if not is_economic and reason:
+            is_economic = classify_refusal(None, reason, None)[0] == ECONOMIC
+
+        # Strip the machine marker; an operator wants the vendor's sentence.
+        out["reason"] = reason.split("::", 1)[-1].strip() if "::" in reason else reason
+
+        if until is None:
+            out["state"] = HEALTHY if not reason else UNKNOWN
+            return out
+        try:
+            until_f = float(until)
+        except (TypeError, ValueError):
+            return out                     # malformed row → UNKNOWN, no crash
+
+        if t < until_f:
+            out["state"] = ECONOMIC if is_economic else RATE_LIMITED
+            out["hard_open"] = True
+            out["expires_in_s"] = max(0.0, until_f - t)
+        else:
+            # Lapsed. NOT proof of recovery — only proof that time passed.
+            out["state"] = UNKNOWN if is_economic else HEALTHY
+            if is_economic:
+                out["unverified_since"] = until_f
+        return out
+    except Exception:  # noqa: BLE001
+        logger.debug("[EconomicState] view degraded", exc_info=True)
+        return out
+
+
+def blast_radius(*, now: Optional[float] = None) -> Dict[str, Any]:
+    """Who absorbs the traffic when a lane is down — and whether they CAN.
+
+    A naive blast radius names the fallback and stops, which is worse than
+    silence: it reports a successful handoff to a lane that may itself be
+    dead. On 2026-08-08 that was exactly the situation — Claude economically
+    tripped, traffic nominally rerouted to DW, and DW was *also* out of
+    credit. The generator logged `IMMEDIATE reroute → DW` and `DW AUTARKY
+    ENGAGED` seconds before failing.
+
+    So every absorbing lane is evaluated for its OWN economic and quota
+    viability, and a handoff into a dead lane is reported as a cascading route
+    failure rather than a handoff.
+
+    Composition only — `collect_provider_availability` already computes each
+    lane's verdict and forensic reason; this reads it, and reads the ledger for
+    the funding half. No new health model.
+
+    NEVER raises; on any sensing failure returns an empty, honest shape.
+    """
+    out: Dict[str, Any] = {"lanes": {}, "cascading": [], "degraded": False}
+    try:
+        from backend.core.ouroboros.governance.provider_availability import (
+            collect_provider_availability,
+        )
+        from backend.core.ouroboros.governance.provider_liquidity_ledger import (
+            runway_exhausted,
+        )
+
+        snap = collect_provider_availability()
+        # (lane, ledger key, available, forensic reason). The ledger and the
+        # availability model name providers differently; this is the only
+        # place that has to know both.
+        lanes = (
+            ("claude", "anthropic",
+             bool(getattr(snap, "claude_available", True)),
+             str(getattr(snap, "claude_reason", "") or "")),
+            ("doubleword", "doubleword",
+             bool(getattr(snap, "dw_healthy", True)),
+             str(getattr(snap, "dw_reason", "") or "")),
+        )
+
+        for lane, key, ok, reason in lanes:
+            view = economic_view(key, now=now)
+            dry = False
+            try:
+                dry = bool(runway_exhausted(key))
+            except Exception:  # noqa: BLE001
+                dry = False
+            viable = bool(ok) and view.get("state") != ECONOMIC and not dry
+            out["lanes"][lane] = {
+                "available": ok, "reason": reason,
+                "economic": view.get("state"), "runway_dry": dry,
+                "viable": viable, "unverified_since": view.get("unverified_since"),
+            }
+
+        # A lane that is down hands off to every OTHER lane. If none of them is
+        # viable, the handoff is fiction.
+        for lane, info in out["lanes"].items():
+            if info["viable"]:
+                continue
+            others = [n for n, i in out["lanes"].items() if n != lane]
+            absorbing = [n for n in others if out["lanes"][n]["viable"]]
+            if absorbing:
+                info["absorbed_by"] = absorbing
+            else:
+                info["absorbed_by"] = []
+                out["cascading"].append(lane)
+
+        if out["lanes"]:
+            any_viable = any(x["viable"] for x in out["lanes"].values())
+            out["degraded"] = bool(out["cascading"]) or not any_viable
+        return out
+    except Exception:  # noqa: BLE001
+        logger.debug("[EconomicState] blast radius degraded", exc_info=True)
+        return out

--- a/tests/governance/test_economic_state_dashboard.py
+++ b/tests/governance/test_economic_state_dashboard.py
@@ -1,0 +1,397 @@
+"""`/liquidity` was a rate-limit dashboard wearing a funding dashboard's name.
+
+On 2026-08-08, with both paid lanes returning "account balance too low", it
+rendered ``anthropic: 5,000,000 tokens · status: 200 · runway: ok`` while a
+live `dw realtime` probe returned ``402 Account balance too low`` and every op
+died at GENERATE. No field was lying about the thing it measured. There was no
+field for the thing that was wrong.
+
+The ledger went blind because `record_headers` returns early when a response
+declares no rate-limit telemetry — and an economic refusal never does, since
+the problem is not quota. The response that PROVES a lane is dead was the one
+response the ledger discarded.
+
+These pin the repair: a table-driven classifier that speaks every vendor's
+economic dialect, a fold through the EXISTING `record_quota_exhaustion` hook,
+a display that distinguishes hard-open from lapsed-on-a-timer, and a blast
+radius that refuses to report a handoff into a lane that is equally dead.
+
+Ledger writes are isolated to `tmp_path` — the bug that opened this arc was
+fixture residue (`recorded_unix: 1010.0`, `tokens_remaining: 5000000`) left in
+the real gitignored ledger by a historical un-isolated run.
+"""
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from backend.core.ouroboros.governance.economic_state import (
+    ECONOMIC,
+    HEALTHY,
+    RATE_LIMITED,
+    UNKNOWN,
+    blast_radius,
+    classify_refusal,
+    economic_view,
+    fold_economic_state,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_ledger(tmp_path: Path, monkeypatch: Any):
+    monkeypatch.setenv(
+        "JARVIS_PROVIDER_LIQUIDITY_PATH", str(tmp_path / "liq.json"),
+    )
+    yield
+
+
+# ---------------------------------------------------------------------------
+# 1. the classifier speaks every dialect it has actually met
+# ---------------------------------------------------------------------------
+
+def test_the_two_shapes_that_broke_us_both_read_ECONOMIC() -> None:
+    """Observed within one hour, from two vendors, with DIFFERENT statuses.
+
+    A `status == 402` check catches DoubleWord and misses Anthropic — and
+    Anthropic's was the one that had already tripped the Claude lane.
+    """
+    dw, _ = classify_refusal(
+        402, "Account balance too low. Please add credits to continue.", {},
+    )
+    anthropic, _ = classify_refusal(
+        400,
+        {"type": "error", "error": {
+            "type": "invalid_request_error",
+            "message": "Your credit balance is too low to access the "
+                       "Anthropic API"}},
+        {},
+    )
+    assert dw == ECONOMIC
+    assert anthropic == ECONOMIC, "a status-only rule would miss this one"
+
+
+def test_a_real_rate_limit_is_not_read_as_poverty() -> None:
+    """An advertised reset window means a CLOCK fixes this. Calling it
+    economic would send the operator to a billing page over a 20s wait."""
+    v, why = classify_refusal(
+        429, "Rate limit exceeded, try again in 20s", {"retry-after": "20"},
+    )
+    assert v == RATE_LIMITED
+    assert "window" in why or "body" in why
+
+
+def test_a_spend_cap_on_the_SAME_status_is_economic() -> None:
+    """429 is the trap: providers use it for a per-minute ceiling AND a
+    monthly spend cap. Status cannot decide; the phrase can."""
+    v, _ = classify_refusal(429, "Monthly spending limit reached", {})
+    assert v == ECONOMIC
+
+
+def test_a_window_beats_a_money_word_only_when_no_money_word_is_present() -> None:
+    """Precedence, pinned. A provider refusing you for funds has no window to
+    advertise — but if it somehow sends both, the money word wins, because
+    waiting will not fix an empty account."""
+    assert classify_refusal(429, "slow down", {"retry-after": "5"})[0] == RATE_LIMITED
+    assert classify_refusal(
+        429, "credit balance too low", {"retry-after": "5"},
+    )[0] == ECONOMIC
+
+
+def test_403_auth_is_not_mistaken_for_403_billing() -> None:
+    assert classify_refusal(403, "Billing account is past due", {})[0] == ECONOMIC
+    assert classify_refusal(403, "Forbidden", {})[0] == UNKNOWN, (
+        "a bare 403 is an auth problem; guessing economic sends the operator "
+        "to top up an account that is fine"
+    )
+
+
+def test_success_is_not_a_refusal() -> None:
+    assert classify_refusal(200, "{}", {})[0] == HEALTHY
+
+
+def test_no_literal_status_comparison_survives_in_the_branching() -> None:
+    """Mandate: table-driven, not `if status == 402`. The status numbers live
+    in `_STATUS_CLASS` as DATA so a third vendor's shape is a data edit."""
+    import inspect
+
+    from backend.core.ouroboros.governance import economic_state as es
+
+    src = inspect.getsource(es.classify_refusal)
+    for literal in ("== 402", "==402", "!= 402", "== 403", "== 429"):
+        assert literal not in src, f"{literal!r} hardcoded in the classifier"
+    assert 402 in es._STATUS_CLASS, "402 must be table DATA, not absent"
+
+
+# ---------------------------------------------------------------------------
+# 2. resilience — a telemetry path may never raise
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("status,body,headers", [
+    (402, b"\xff\xfe malformed bytes", {}),
+    (500, '{"truncated', {}),
+    (None, None, None),
+    (402, {"nested": {"deep": [1, 2, {"x": object()}]}}, {}),
+    ("not-an-int", "whatever", {"retry-after": None}),
+    (429, "", {"x": object()}),
+    (402, "balance too low", object()),          # headers not map-like
+])
+def test_malformed_input_degrades_and_never_raises(status, body, headers) -> None:
+    v, why = classify_refusal(status, body, headers)
+    assert v in (ECONOMIC, RATE_LIMITED, HEALTHY, UNKNOWN)
+    assert isinstance(why, str)
+
+
+def test_a_decisive_status_still_classifies_through_an_unreadable_body() -> None:
+    """402 means Payment Required whether or not the payload survived."""
+    assert classify_refusal(402, b"\xff\xfe", {})[0] == ECONOMIC
+
+
+# ---------------------------------------------------------------------------
+# 3. the fold reuses the existing hook (DRY) and writes nothing else
+# ---------------------------------------------------------------------------
+
+def test_an_economic_refusal_lands_via_record_quota_exhaustion() -> None:
+    from backend.core.ouroboros.governance import provider_liquidity_ledger as pll
+
+    assert fold_economic_state(
+        "doubleword", status=402,
+        body="Account balance too low. Please add credits to continue.",
+    ) == ECONOMIC
+    assert pll.quota_exhausted("doubleword") is True
+    row = (pll._load().get("providers") or {}).get("doubleword") or {}
+    assert "quota_exhausted_until" in row, "used a store other than the hook"
+    assert "balance too low" in row.get("quota_reason", "").lower(), (
+        "the vendor's own words must survive to the operator"
+    )
+
+
+def test_a_rate_limit_does_NOT_write_an_economic_flag() -> None:
+    """One condition, one writer. The header path already owns rate limits."""
+    from backend.core.ouroboros.governance import provider_liquidity_ledger as pll
+
+    assert fold_economic_state(
+        "doubleword", status=429, body="try again in 20s",
+        headers={"retry-after": "20"},
+    ) == RATE_LIMITED
+    assert pll.quota_exhausted("doubleword") is False
+
+
+def test_the_fold_builds_no_new_storage() -> None:
+    import inspect
+
+    from backend.core.ouroboros.governance import economic_state as es
+
+    src = inspect.getsource(es)
+    assert "record_quota_exhaustion" in src
+    for forbidden in ("sqlite", "open(", "shelve", "pickle"):
+        assert forbidden not in src, f"{forbidden!r} — a second store appeared"
+
+
+# ---------------------------------------------------------------------------
+# 4. hard-open vs lapsed-on-a-timer (mandate 4)
+# ---------------------------------------------------------------------------
+
+def test_a_live_outage_reads_hard_open() -> None:
+    fold_economic_state("doubleword", status=402, body="balance too low")
+    v = economic_view("doubleword")
+    assert v["state"] == ECONOMIC
+    assert v["hard_open"] is True
+    assert (v["expires_in_s"] or 0) > 0
+    assert v["unverified_since"] is None
+
+
+def test_a_lapsed_flag_is_UNVERIFIED_not_healthy(monkeypatch: Any) -> None:
+    """THE display defect. The 1800s TTL self-heals so a topped-up wallet
+    recovers without manual clearing — right for routing. But it is an
+    ASSUMPTION: money does not return on a timer. On 2026-08-08 the flag
+    lapsed at 14:42 and the dashboard said `ok` for hours while the account
+    stayed empty."""
+    monkeypatch.setenv("JARVIS_QUOTA_EXHAUSTION_TTL_S", "10")
+    t0 = time.time()
+    fold_economic_state(
+        "doubleword", status=402, body="balance too low", now=t0,
+    )
+    later = economic_view("doubleword", now=t0 + 999)
+    assert later["hard_open"] is False
+    assert later["state"] == UNKNOWN, "a lapsed economic flag is not 'healthy'"
+    assert later["unverified_since"] is not None
+
+
+def test_a_lapsed_RATE_LIMIT_may_honestly_read_healthy(monkeypatch: Any) -> None:
+    """The asymmetry is the point: a quota window really does reset on a
+    clock, so its expiry IS evidence. An empty wallet's is not."""
+    from backend.core.ouroboros.governance import provider_liquidity_ledger as pll
+
+    monkeypatch.setenv("JARVIS_QUOTA_EXHAUSTION_TTL_S", "10")
+    t0 = time.time()
+    pll.record_quota_exhaustion("doubleword", reason="rate limit", now=t0)
+    v = economic_view("doubleword", now=t0 + 999)
+    assert v["unverified_since"] is None
+    assert v["state"] == HEALTHY
+
+
+def test_the_stale_clock_guard_catches_the_fixture_residue() -> None:
+    """The row that started this: `recorded_unix: 1010.0` → 1969-12-31, left
+    in the real gitignored ledger by a historical un-isolated test run. It
+    silently poisoned every reset-horizon subtraction that read it.
+
+    Production writes `time.time()`, so there is no production time bug to
+    patch — the honest fix guards the READER, which trusted any float.
+    """
+    from backend.core.ouroboros.governance import provider_liquidity_ledger as pll
+
+    pll.record_headers(
+        "doubleword", {"x-ratelimit-remaining": "5000000"}, now=1010.0,
+    )
+    assert economic_view("doubleword")["stale_clock"] is True
+
+    pll.record_headers(
+        "anthropic", {"x-ratelimit-remaining": "5000000"}, now=time.time(),
+    )
+    assert economic_view("anthropic")["stale_clock"] is False
+
+
+def test_a_malformed_row_degrades_without_crashing_the_renderer() -> None:
+    import json
+
+    from backend.core.ouroboros.governance import provider_liquidity_ledger as pll
+
+    p = pll._ledger_path()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps({"providers": {
+        "doubleword": {"quota_exhausted_until": "not-a-number",
+                       "quota_reason": "class=economic :: x"}}}))
+    v = economic_view("doubleword")
+    assert v["state"] in (UNKNOWN, ECONOMIC, HEALTHY, RATE_LIMITED)
+
+
+# ---------------------------------------------------------------------------
+# 5. blast radius — cascading saturation (mandate 2)
+# ---------------------------------------------------------------------------
+
+class _Snap:
+    def __init__(self, c_ok: bool, d_ok: bool) -> None:
+        self.claude_available, self.claude_reason = c_ok, "" if c_ok else "breaker_open_economic"
+        self.dw_healthy, self.dw_reason = d_ok, "" if d_ok else "transport_degraded"
+        self.kimi_available, self.kimi_reason = False, ""
+
+
+def _patch_availability(monkeypatch: Any, c_ok: bool, d_ok: bool) -> None:
+    import backend.core.ouroboros.governance.provider_availability as pa
+
+    monkeypatch.setattr(
+        pa, "collect_provider_availability", lambda **_k: _Snap(c_ok, d_ok),
+    )
+
+
+def test_a_handoff_into_a_LIVE_lane_is_reported_as_a_handoff(
+    monkeypatch: Any,
+) -> None:
+    _patch_availability(monkeypatch, c_ok=False, d_ok=True)
+    br = blast_radius()
+    assert br["lanes"]["claude"]["viable"] is False
+    assert br["lanes"]["claude"]["absorbed_by"] == ["doubleword"]
+    assert br["cascading"] == []
+
+
+def test_a_handoff_into_a_DEAD_lane_is_a_cascading_route_failure(
+    monkeypatch: Any,
+) -> None:
+    """The 2026-08-08 shape exactly: the generator logged `IMMEDIATE reroute →
+    DW` and `DW AUTARKY ENGAGED` seconds before failing, because DW was also
+    out of credit. Naming a fallback without checking it reports a successful
+    handoff into a corpse."""
+    _patch_availability(monkeypatch, c_ok=False, d_ok=False)
+    br = blast_radius()
+    assert set(br["cascading"]) == {"claude", "doubleword"}
+    assert br["degraded"] is True
+    for lane in ("claude", "doubleword"):
+        assert br["lanes"][lane]["absorbed_by"] == []
+
+
+def test_an_economically_dead_lane_is_not_viable_even_when_available(
+    monkeypatch: Any,
+) -> None:
+    """Availability and solvency are different questions. A lane whose
+    transport is fine but whose wallet is empty absorbs nothing."""
+    _patch_availability(monkeypatch, c_ok=True, d_ok=True)
+    fold_economic_state("doubleword", status=402, body="balance too low")
+    br = blast_radius()
+    assert br["lanes"]["doubleword"]["viable"] is False
+    assert br["lanes"]["doubleword"]["economic"] == ECONOMIC
+    assert br["lanes"]["claude"]["viable"] is True
+
+
+def test_blast_radius_never_raises_when_sensing_fails(monkeypatch: Any) -> None:
+    import backend.core.ouroboros.governance.provider_availability as pa
+
+    def _boom(**_k):
+        raise RuntimeError("sensing down")
+
+    monkeypatch.setattr(pa, "collect_provider_availability", _boom)
+    br = blast_radius()
+    assert br == {"lanes": {}, "cascading": [], "degraded": False}
+
+
+# ---------------------------------------------------------------------------
+# 6. the dashboard actually consumes it (the wired-but-inert guard)
+# ---------------------------------------------------------------------------
+
+def test_the_liquidity_verb_actually_RENDERS_the_economic_column(
+    monkeypatch: Any,
+) -> None:
+    """This codebase's recurring defect is a correct feature with no live
+    caller — and the recurring reason it survives is a test that asserts on
+    SOURCE TEXT, which cannot fail for a runtime reason.
+
+    So this CALLS the verb and reads what it printed. (The first draft of this
+    test did assert on source text, and failed only because a string was split
+    across two lines for width — proving the point at my own expense.)
+    """
+    from backend.core.ouroboros.battle_test.harness import BattleTestHarness
+
+    _patch_availability(monkeypatch, c_ok=False, d_ok=False)
+    fold_economic_state("doubleword", status=402, body="balance too low")
+
+    printed: list = []
+    h = BattleTestHarness.__new__(BattleTestHarness)
+    monkeypatch.setattr(
+        BattleTestHarness, "_repl_print",
+        lambda _self, msg: printed.append(str(msg)),
+    )
+    h._repl_cmd_liquidity()
+
+    out = "\n".join(printed)
+    assert out, "the verb printed nothing"
+    assert "blast radius" in out
+    assert "CASCADING ROUTE" in out, (
+        "a handoff into a dead lane was reported as a handoff"
+    )
+    assert "OUT OF CREDIT" in out, "the funding column never rendered"
+
+
+def test_the_verb_survives_a_ledger_that_cannot_be_read(monkeypatch: Any) -> None:
+    """Mandate 4: the renderer must not wedge the terminal."""
+    from backend.core.ouroboros.battle_test.harness import BattleTestHarness
+    from backend.core.ouroboros.governance import provider_liquidity_ledger as pll
+
+    monkeypatch.setattr(pll, "_load", lambda: (_ for _ in ()).throw(OSError("x")))
+    printed: list = []
+    h = BattleTestHarness.__new__(BattleTestHarness)
+    monkeypatch.setattr(
+        BattleTestHarness, "_repl_print",
+        lambda _self, msg: printed.append(str(msg)),
+    )
+    h._repl_cmd_liquidity()          # must not raise
+    assert printed, "degraded silently instead of saying so"
+
+
+def test_the_aegis_chokepoint_folds_every_upstream_response() -> None:
+    """`record_headers` discards economic refusals (they carry no rate-limit
+    headers), so the fold must sit at the ONE place every response crosses."""
+    src = (Path(__file__).resolve().parents[2]
+           / "backend/core/ouroboros/aegis/forwarding.py").read_text()
+    assert "fold_economic_state" in src


### PR DESCRIPTION
## The defect

`/liquidity` was a **rate-limit** dashboard wearing a **funding** dashboard's name. On 2026-08-08, with both paid lanes refusing every request for lack of credit, it rendered:

```
anthropic: 5,000,000 tokens · no reset horizon · status: 200 · runway: ok
floor: 2,000 tokens · exhausted: no
```

Five million tokens, HTTP 200, runway ok — while a live `dw realtime` probe returned `402 Account balance too low` and every op died at GENERATE. **Not one field was lying about the thing it measured. There was no field for the thing that was wrong.**

### Why the ledger went blind

```python
if tokens is None and reset_delta is None:
    return False          # nothing declared
```

An economic refusal carries no rate-limit headers — there is no quota to report, because the problem is not quota. So the one response that *proves* a lane is dead is exactly the response `record_headers` discards. DoubleWord's 402 never reached the ledger at all; `doubleword` was simply absent from the file.

## What shipped

**`economic_state.py`** — a table-driven classifier over `(status, body, headers)`. Both live vendor dialects resolve to `ECONOMIC`:

| Vendor | Shape |
|---|---|
| DoubleWord | `402` + `"Account balance too low"` |
| Anthropic | `400` + `"Your credit balance is too low"` |

The second is invisible to any status-based rule — and it's the one that had already tripped the Claude lane. `429` disambiguates **both** ways (a `retry-after` window means a clock fixes it; `"monthly spending limit"` does not). A bare `403` stays `UNKNOWN` rather than sending an operator to a billing page over an auth error. A test pins that no `== 402` survives in the branching: the status numbers are **data** in `_STATUS_CLASS`, so a third vendor's shape is a data edit.

**The fold sits at `aegis/forwarding.py`** — the one chokepoint every upstream response crosses, which is where DW's 402 was being lost. The durable write goes through the **existing** `record_quota_exhaustion`; a test asserts no `sqlite`/`open(`/`pickle` appears in the module. No second store.

**Cascading saturation.** A lane counts as absorbing only if it is available **and** solvent **and** not dry. Naming a fallback without checking it reports a successful handoff into a corpse — the exact 2026-08-08 shape, where the generator logged `IMMEDIATE reroute → DW` and `DW AUTARKY ENGAGED` seconds before failing because DW was equally broke.

**Hard-open vs lapsed.** The 1800s TTL self-heals so a topped-up wallet recovers without manual clearing — right for routing, and deliberately **unchanged**. But a TTL is an assumption, not a measurement: money does not return on a timer. Routing keeps its fail-open optimism; the display stops calling that optimism knowledge. A rate-limit expiry may still honestly read healthy — that asymmetry is the point.

### Before → after, on the same live state

```
BEFORE:  anthropic: 5,000,000 tokens · status: 200 · runway: ok · exhausted: no

AFTER:   ⚠️ funding: UNVERIFIED since 14:42 (lapsed on a timer, not a probe)
         ↳ "Your credit balance is too low to access the Anthropic API…"
         ⚠️ reset horizon unreliable — recorded_unix failed the plausibility guard
         blast radius:
           claude:     DOWN (breaker_open_economic_persisted) → ⛔ CASCADING ROUTE FAILURE
           doubleword: DOWN (transport_degraded)              → ⛔ CASCADING ROUTE FAILURE
           ⛔ every fallback is itself exhausted — generation cannot succeed on any lane
```

## A correction, since it changed what got built

The 1969 reset horizon was reported (by me) as a `time.monotonic()`/epoch mismatch. **It is not.** Production `record_headers` uses `time.time()`; the only `now=` overrides in the tree are test fixtures, and the live ledger's `recorded_unix: 1010.0` + `tokens_remaining: 5000000` are the exact fixture pair from `test_header_refresh_never_clears_quota_state` — stale residue in a gitignored file from a run predating that test's isolation.

There was no production time bug to patch, and inventing one would have been a worse violation of root-cause-only than skipping it. The honest fix guards the **reader**, which trusted any float: an implausible `recorded_unix` now renders as unreliable instead of silently poisoning every horizon subtraction.

## Verification

**85 passed** (30 new + the ledger / liquidity / quota / qos spine).

The "is it wired?" test **calls** `_repl_cmd_liquidity()` and reads what it printed. Its first draft asserted on `inspect.getsource` and failed only because a string was split across two lines for width — the 587-instance spelling-test defect proving itself at my own expense.

Diagnostic that opened this: `dw-cli` confirms **key valid, balance empty** — `dw batches list` works, `dw realtime` returns 402.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an economic funding state to `/liquidity` and routing. The dashboard now says when a provider is out of credit and shows cascading route failures, instead of falsely reporting “runway: ok”.

- **New Features**
  - `economic_state.py`: table-driven classifier over (status, body, headers) → `ECONOMIC` / `RATE_LIMITED` / `HEALTHY` / `UNKNOWN`.
  - `/liquidity` shows a funding column with vendor reason text, “hard-open” vs “unverified since …”, and a blast radius that flags cascading failures.
  - 429 is disambiguated both ways (a `retry-after` window = rate limited; phrases like “monthly spending limit” = economic). A bare 403 stays `UNKNOWN`.

- **Bug Fixes**
  - Fold economic refusals at the chokepoint in `aegis/forwarding.py`, recording via existing `record_quota_exhaustion` so 402/credit errors no longer vanish.
  - Guard against stale `recorded_unix` values; reset horizons render “unreliable” instead of poisoning calculations.
  - No new storage or blocking calls; reuse the ledger, fail-soft in forwarding and rendering.

<sup>Written for commit 42dd6137ffb8cb29e5f50dc8470fe4e15b88a688. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

