### PR TITLE
fix(tests): tests were writing the operator's live .jarvis/ state

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ This file contains:
 
 import asyncio
 import pytest
+import re
 import sys
 import os
 from pathlib import Path
@@ -63,6 +64,9 @@ def temp_test_dir(tmp_path):
 
 def pytest_configure(config):
     """Configure pytest with custom settings."""
+    # Arm the live-state tripwire ONCE, at the top of the session. An audit
+    # hook cannot be removed, so it must not be installed per-test.
+    _install_live_state_audit_hook(Path(__file__).resolve().parents[1])
     # Register custom markers
     config.addinivalue_line(
         "markers", "unit: mark test as a unit test"
@@ -139,6 +143,31 @@ def pytest_report_header(config):
     ]
 
 
+def _report_live_state_writes(terminalreporter) -> None:
+    """Name every real-`.jarvis/` write the session made. NEVER raises.
+
+    Reported rather than merely counted, for the same reason the skip summary
+    below exists: a leak nobody can see is how `chat_spend.json` reached
+    `spent_usd: 1.0` across six runs, and how fixture values sat in the live
+    liquidity ledger long enough to produce a wrong root-cause diagnosis.
+    """
+    try:
+        if not _LIVE_STATE_WRITES:
+            return
+        terminalreporter.write_sep("=", "LIVE STATE WRITTEN BY TESTS")
+        for p in sorted(_LIVE_STATE_WRITES):
+            terminalreporter.write_line(f"  {p}")
+        terminalreporter.write_line(
+            f"  {len(_LIVE_STATE_WRITES)} path(s) under the operator's real "
+            ".jarvis/ were written during this run."
+        )
+        terminalreporter.write_line(
+            "  Set JARVIS_TEST_STATE_TRIPWIRE=strict to make this a failure."
+        )
+    except Exception:  # noqa: BLE001 — a report must never break the summary
+        pass
+
+
 def pytest_terminal_summary(terminalreporter, exitstatus, config):
     """Say out loud when the terminal-dependent suite did not run.
 
@@ -154,6 +183,11 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
     failures. So the summary states the count, the consequence, and the way to
     make it fatal.
     """
+    # FIRST — the PTY summary below returns early in the common case, and a
+    # leak report that only prints when a terminal was missing is a leak
+    # report nobody reads.
+    _report_live_state_writes(terminalreporter)
+
     try:
         from tests.pty_gate import REQUIRED_ENV_VAR, SKIPPED
     except Exception:  # noqa: BLE001 — a reporting aid must never break a run
@@ -260,3 +294,168 @@ def _isolate_durable_sensor_state(tmp_path, monkeypatch):
         str(tmp_path / "intents" / "journal.jsonl"),
     )
     yield
+
+
+# ---------------------------------------------------------------------------
+# Global state VFS — tests must never touch the operator's live `.jarvis/`
+# ---------------------------------------------------------------------------
+#
+# The fixture above is the right idea enumerated twice by hand, and the hazard
+# it names kept recurring in state it did not cover. Two instances found on
+# 2026-08-08 alone:
+#
+#   * `.jarvis/chat_spend.json` — the chat cost breaker's REAL ledger. Six
+#     suite runs drove it to `spent_usd: 1.0, trips: 6`; the breaker then
+#     correctly fail-closed and two tests started failing in a way that read
+#     exactly like a Claude wiring bug. Pointing `JARVIS_CHAT_SPEND_LEDGER` at
+#     a temp file → 51/51 green.
+#   * `.jarvis/provider_liquidity.json` — carried `recorded_unix: 1010.0`
+#     (→ 1969-12-31) and `tokens_remaining: 5000000`, the exact fixture pair
+#     from `test_header_refresh_never_clears_quota_state`, left by a run
+#     predating that test's isolation. It silently poisoned every reset-horizon
+#     subtraction that read it, and cost a wrong root-cause diagnosis
+#     ("monotonic/epoch mismatch") before the residue was identified.
+#
+# So this is DISCOVERED, not listed — the same discipline the module docstring
+# already states for root-test collection: "The rule is computed, not a
+# hand-maintained denylist, so it stays correct as files are added or gutted."
+
+_STATE_VAR_RE = re.compile(
+    r"""environ\.get\(\s*["'](JARVIS_[A-Z0-9_]+)["']\s*,\s*"""
+    r"""["']([^"']*\.jarvis[^"']*)["']""",
+    re.VERBOSE,
+)
+
+#: Bounded scan roots. A full sweep of backend/ is ~23k files; state lives in
+#: these. Bounded for speed, not correctness — the audit tripwire below is what
+#: makes coverage gaps loud rather than silent.
+_STATE_SCAN_ROOTS = ("backend/core/ouroboros", "backend/core/secret_manager.py")
+
+#: Seed set — vars the regex CANNOT find, because their `.jarvis` default is a
+#: module constant rather than a literal inside `environ.get(...)`:
+#:
+#:     _DEFAULT_LEDGER = ".jarvis/chat_spend.json"
+#:     ...
+#:     explicit = os.environ.get(LEDGER_PATH_ENV_VAR, "")     # <- regex misses
+#:
+#: Verified empirically, not guessed: with discovery alone,
+#: `test_chat_repl_claude_executor` still read the operator's real
+#: `chat_spend.json` (`spent_usd: 1.0, trips: 6`) and two tests failed in a way
+#: that reads exactly like a Claude wiring bug.
+#:
+#: A seed alongside discovery is the same shape FlagRegistry uses (52 curated
+#: entries against a discovered universe). The seed is for what discovery
+#: provably cannot reach — NOT a substitute for it.
+_STATE_VAR_SEED = {
+    "JARVIS_CHAT_SPEND_LEDGER": ".jarvis/chat_spend.json",
+    "JARVIS_PROVIDER_LIQUIDITY_PATH": ".jarvis/provider_liquidity.json",
+}
+
+
+@pytest.fixture(scope="session")
+def _discovered_state_vars():
+    """Every ``JARVIS_*`` env var whose DEFAULT names a `.jarvis` path.
+
+    Computed once per session by reading source — never executed, so a scan
+    cannot itself trigger a write.
+    """
+    found: dict = dict(_STATE_VAR_SEED)
+    root = Path(__file__).resolve().parents[1]
+    try:
+        for rel in _STATE_SCAN_ROOTS:
+            base = root / rel
+            files = [base] if base.is_file() else base.rglob("*.py")
+            for f in files:
+                try:
+                    for var, default in _STATE_VAR_RE.findall(
+                        f.read_text(encoding="utf-8", errors="ignore")
+                    ):
+                        found.setdefault(var, default)
+                except (OSError, ValueError):
+                    continue
+    except Exception:  # noqa: BLE001 — discovery must never break collection
+        pass
+    return found
+
+
+@pytest.fixture(autouse=True)
+def _isolate_jarvis_state_vfs(tmp_path, monkeypatch, _discovered_state_vars):
+    """Redirect every discovered state path into an ephemeral per-test VFS.
+
+    PER TEST, matching the cadence of the singletons this state belongs to —
+    a session-scoped dir was already tried for the CU journal above and was not
+    enough, because durable state has to reset when its owner does.
+
+    A test that sets one of these itself still wins: `monkeypatch` applies in
+    fixture order and module-level fixtures run after this one, so suites that
+    deliberately exercise real restarts keep working.
+    """
+    vfs = tmp_path / "_jarvis_vfs"
+    for var, default in (_discovered_state_vars or {}).items():
+        if os.environ.get(var):
+            continue                     # an explicit outer setting wins
+        monkeypatch.setenv(var, str(vfs / Path(default).name))
+    yield
+
+
+#: ``strict`` turns a live-state write into a test failure. Default is REPORT:
+#: this tripwire is new, the suite is 3,308 files, and detonating every
+#: pre-existing offender in one commit would bury the signal it exists to
+#: raise. Flip to strict once the reported set is empty.
+_TRIPWIRE_MODE = os.environ.get("JARVIS_TEST_STATE_TRIPWIRE", "report").lower()
+
+_LIVE_STATE_WRITES: set = set()
+
+
+def _install_live_state_audit_hook(repo_root: Path) -> None:
+    """Record any write-open of the REAL `.jarvis/` from THIS process.
+
+    An mtime diff cannot be used: the operator's daemon writes `.jarvis/`
+    continuously, so a snapshot comparison would attribute daemon activity to
+    whichever test happened to straddle it. An audit hook sees only this
+    interpreter, so attribution is exact.
+    """
+    live = str((repo_root / ".jarvis").resolve())
+
+    def _hook(event: str, args) -> None:
+        if event != "open" or not args:
+            return
+        try:
+            path, mode = args[0], (args[1] or "")
+        except (IndexError, TypeError):
+            return
+        if not isinstance(path, (str, bytes)) or not mode:
+            return
+        if not any(m in str(mode) for m in ("w", "a", "x", "+")):
+            return
+        try:
+            p = str(path)
+        except Exception:  # noqa: BLE001
+            return
+        if p.startswith(live):
+            _LIVE_STATE_WRITES.add(p)
+
+    try:
+        sys.addaudithook(_hook)
+    except Exception:  # noqa: BLE001 — hook is diagnostic, never load-bearing
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _live_state_tripwire(request):
+    """Fail (strict) or report (default) when a test writes real `.jarvis/`.
+
+    The redirect above covers every path it could DISCOVER. This covers the
+    rest — CWD-relative writers like
+    ``Path(".jarvis/provider_liquidity.json")``, which no env var governs and
+    which is exactly the shape that produced the 1969 residue.
+    """
+    before = len(_LIVE_STATE_WRITES)
+    yield
+    new = len(_LIVE_STATE_WRITES) - before
+    if new and _TRIPWIRE_MODE == "strict":
+        offenders = sorted(list(_LIVE_STATE_WRITES))[-new:]
+        pytest.fail(
+            "test wrote the operator's live .jarvis/ state: "
+            + ", ".join(offenders)
+        )


### PR DESCRIPTION
## Three leaks, each of which cost a wrong conclusion

| File | What it cost |
|---|---|
| `.jarvis/chat_spend.json` | Six suite runs drove the **real** breaker ledger to `spent_usd: 1.0, trips: 6`. The breaker then correctly fail-closed and two tests began failing in a way that reads exactly like a Claude wiring bug — diagnosed as "pre-existing" twice before the cause was found. |
| `.jarvis/provider_liquidity.json` | Carried `recorded_unix: 1010.0` (→ 1969-12-31) and `tokens_remaining: 5000000` — the exact fixture pair from `test_header_refresh_never_clears_quota_state`, left by a run predating that test's isolation. Poisoned every reset-horizon subtraction and produced a wrong root-cause diagnosis ("monotonic/epoch mismatch") that had to be retracted. |
| `.jarvis/semantic_index.npz` | The operator's real embedding cache. Found by the tripwire below on its **first broad run** — nobody knew about this one. |

`_isolate_durable_sensor_state` already had the right idea, enumerated twice by hand, and the hazard kept recurring in state it did not cover.

## Three pieces, extending the existing `_isolate_*` pattern

**Discovery** — a session-scoped regex over `backend/core/ouroboros` for `environ.get("JARVIS_*", "…​.jarvis/…")`, redirecting each into a per-test tmp VFS. Computed, not hand-maintained, per this module's own stated philosophy for root-test collection. **Per test**, not per session: durable state must reset on the same cadence as the singleton it belongs to — the CU journal above already learned that the hard way.

**A documented seed** for what discovery *provably* cannot reach. `JARVIS_CHAT_SPEND_LEDGER`'s `.jarvis` default lives in a module constant, not inline in `environ.get`:

```python
_DEFAULT_LEDGER = ".jarvis/chat_spend.json"
...
explicit = os.environ.get(LEDGER_PATH_ENV_VAR, "")     # <- regex misses
```

Verified empirically, not assumed: with discovery alone the claude-executor suite still read the operator's real ledger and still failed 2/51. Same shape as FlagRegistry's curated seed against a discovered universe — for what discovery **cannot** reach, never a substitute for it.

**An audit-hook tripwire** for the rest — CWD-relative writers like `Path(".jarvis/provider_liquidity.json")`, which no env var governs, and which is exactly the shape that produced the 1969 residue.

An mtime diff was unusable: the operator's daemon writes `.jarvis/` continuously, so a snapshot would attribute daemon activity to whichever test straddled it. `sys.addaudithook` sees only this interpreter, so attribution is exact.

Reports by default; `JARVIS_TEST_STATE_TRIPWIRE=strict` makes it fatal. Left non-fatal deliberately — flipping it across a 3,308-file suite in the same commit would bury the signal it exists to raise. Flip once the reported set is empty.

## Verification

- `test_chat_repl_claude_executor`: **2 failed → 51 passed**, live ledger byte-identical before and after. The failures previously written off as pre-existing are fixed at the root, not worked around with an env override.
- **466 passed** across the governance / intake / chat / liquidity spine with the global redirect active.
- Tripwire fired on its first broad run and named `semantic_index.npz`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents tests from writing to the live `.jarvis/` directory by sandboxing state and adding a write tripwire. Fixes flaky failures and bad diagnoses caused by leaked state.

- **Bug Fixes**
  - Discover `JARVIS_*` env vars with `.jarvis` defaults by scanning source and redirect each to a per-test tmp VFS.
  - Seed non-discoverable vars to ensure isolation: `JARVIS_CHAT_SPEND_LEDGER`, `JARVIS_PROVIDER_LIQUIDITY_PATH`.
  - Add an audit-hook tripwire to record and optionally fail on real `.jarvis/` writes; set `JARVIS_TEST_STATE_TRIPWIRE=strict` to enforce. A summary report lists any offenders.
  - Results: `test_chat_repl_claude_executor` 2 failed → 51 passed; 466 passed across core suites; tripwire flagged `.jarvis/semantic_index.npz`.

<sup>Written for commit c2a9f8fc4a54da0c3ebc8aaf03ef7069a2f8ad65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70453?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

