### PR TITLE
feat(cockpit): the process holding the paintbrush could not see the canvas

### DIFF
--- a/backend/core/ouroboros/battle_test/cockpit_attach.py
+++ b/backend/core/ouroboros/battle_test/cockpit_attach.py
@@ -1274,7 +1274,27 @@ class CockpitAttachBridge:
                 _sid = str(frame.get("session", "")).strip()
                 if _sid:
                     self.bind_session(_sid, writer)
-                if ftype == "input":
+                if ftype == "caps":
+                    # The display describing itself. Handled BEFORE `input`
+                    # because a cockpit declares at handshake and again on
+                    # every SIGWINCH — the very first render addressed to it
+                    # must already know its width, or the operator's opening
+                    # frame is the one that wraps.
+                    #
+                    # Fail-soft and per-client: a malformed declaration is
+                    # dropped and the composite continues to answer for this
+                    # subscriber. One bad cockpit cannot narrow the others.
+                    try:
+                        from backend.core.ouroboros.battle_test.terminal_capabilities import (  # noqa: E501
+                            TerminalCapabilities,
+                            declare,
+                        )
+                        _caps = TerminalCapabilities.from_wire(frame)
+                        if _caps is not None and _sid:
+                            declare(_sid, _caps)
+                    except Exception:  # noqa: BLE001
+                        pass
+                elif ftype == "input":
                     text = str(frame.get("text", "")).strip()
                     if text:
                         self.stats["inputs_received"] += 1
@@ -1346,6 +1366,19 @@ class CockpitAttachBridge:
             pass
         finally:
             self._drop(writer)
+            # Retire this display's declaration. Ambient renders take the
+            # MINIMUM width across live subscribers, so a departed 40-column
+            # terminal would otherwise squeeze every future broadcast for the
+            # life of the daemon — a dead cockpit constraining live ones.
+            try:
+                from backend.core.ouroboros.battle_test.terminal_capabilities import (  # noqa: E501
+                    forget,
+                )
+                for _sid, _w in list(getattr(self, "_sessions", {}).items()):
+                    if _w is writer:
+                        forget(_sid)
+            except Exception:  # noqa: BLE001
+                pass
             logger.info(
                 "[CockpitAttach] terminal detached (subscribers=%d)",
                 len(self._clients),
@@ -1472,6 +1505,15 @@ class CockpitAttachClient:
                 self._read_loop(),
             )
             self.connected = True
+            # Declare this display IMMEDIATELY. The daemon renders for a
+            # terminal it cannot see, so the very first frame it sends back
+            # must already be sized correctly — a cockpit that declares late
+            # has its opening render wrapped.
+            try:
+                self.send_caps()
+                self.install_resize_listener()
+            except Exception:  # noqa: BLE001
+                pass
             return "ok"
         except asyncio.TimeoutError:
             await self.close()
@@ -1483,6 +1525,117 @@ class CockpitAttachClient:
         except Exception:  # noqa: BLE001
             await self.close()
             return "dead"
+
+    @staticmethod
+    def _wcwidth_available() -> bool:
+        """True iff this client can reason about double-width glyphs.
+
+        Presence of `wcwidth` is the honest proxy: with it, the client's
+        renderer and the daemon's agree on how many columns an emoji occupies;
+        without it, both are guessing and the safe report is narrow.
+        """
+        try:
+            import wcwidth  # noqa: F401
+            return True
+        except Exception:  # noqa: BLE001
+            return False
+
+    def send_caps(self) -> bool:
+        """Tell the daemon what this display actually is. NEVER raises.
+
+        The daemon renders every table, diff and gutter for a terminal it
+        cannot see. This is the only frame that closes that gap, so it is sent
+        at handshake AND on every resize — a cockpit that declares once and
+        then gets dragged wider spends the rest of its life being rendered for
+        a window that no longer exists.
+
+        Measured, never assumed: width/height come from `os.get_terminal_size`
+        on the real TTY. `COLORFTERM`/`TERM` answer colour depth. Theme comes
+        from `COLORFGBG` when the terminal sets it and is reported "unknown"
+        otherwise — a guess here paints grey on white for every light-terminal
+        operator, and "unknown" routes the renderer to its theme-agnostic path
+        instead.
+        """
+        try:
+            w = self._writer
+            if not self.connected or w is None or w.is_closing():
+                return False
+
+            cols = rows = 0
+            try:
+                size = os.get_terminal_size()
+                cols, rows = int(size.columns), int(size.lines)
+            except Exception:  # noqa: BLE001 — not a TTY (piped `ov`)
+                cols = rows = 0
+            if cols <= 0:
+                return False           # nothing measured → declare nothing
+
+            # COLORFGBG is "fg;bg"; bg 0-6 and 8 are dark, 7 and 9-15 light.
+            theme = "unknown"
+            try:
+                raw = os.environ.get("COLORFGBG", "")
+                if ";" in raw:
+                    bg = int(raw.rsplit(";", 1)[-1].strip())
+                    theme = "dark" if (bg <= 6 or bg == 8) else "light"
+            except (TypeError, ValueError):
+                theme = "unknown"
+
+            depth = 0
+            _term = os.environ.get("TERM", "")
+            if os.environ.get("COLORTERM", "").lower() in ("truecolor", "24bit"):
+                depth = 16_777_216
+            elif "256" in _term:
+                depth = 256
+            elif _term:
+                depth = 8
+
+            frame = {
+                "type": "caps",
+                "session": self.session_id,
+                "cols": cols, "rows": rows,
+                "theme": theme,
+                # Terminals disagree about emoji/CJK advance width and only
+                # the client can answer. `wcwidth` present → trust the
+                # double-width prediction; absent → report narrow, because an
+                # aligned ASCII gutter beats a misaligned pretty one.
+                "wide_glyphs": self._wcwidth_available(),
+                "color_depth": depth,
+            }
+            w.write((json.dumps(frame, separators=(",", ":")) + "\n").encode())
+            return True
+        except Exception:  # noqa: BLE001
+            return False
+
+    def install_resize_listener(self) -> bool:
+        """Re-declare on SIGWINCH. NEVER raises; False where unsupported.
+
+        Chained, not replaced: another handler may already own SIGWINCH
+        (prompt_toolkit installs one to reflow its own layout), and clobbering
+        it would fix the daemon's width while breaking the client's.
+        """
+        try:
+            import signal
+            if not hasattr(signal, "SIGWINCH"):
+                return False            # Windows / no job control
+            prior = signal.getsignal(signal.SIGWINCH)
+
+            def _on_resize(signum, frame) -> None:
+                try:
+                    self.send_caps()
+                except Exception:  # noqa: BLE001
+                    pass
+                if callable(prior):
+                    try:
+                        prior(signum, frame)
+                    except Exception:  # noqa: BLE001
+                        pass
+
+            signal.signal(signal.SIGWINCH, _on_resize)
+            return True
+        except (ValueError, OSError, AttributeError):
+            # `signal.signal` off the main thread raises ValueError — a real
+            # scenario for an embedded cockpit, and not an error.
+            return False
 
     def send_audio(self, cmd: str) -> bool:
         """Pipe one audio-orchestration command upstream (``wake`` /

--- a/backend/core/ouroboros/battle_test/spooled_console.py
+++ b/backend/core/ouroboros/battle_test/spooled_console.py
@@ -62,6 +62,9 @@ class ConsoleSpooler:
         )
         self._task: Optional["asyncio.Task[None]"] = None
         self.dropped = 0
+        #: How many drops have already been announced, so the notice is
+        #: coalesced per window instead of once per lost line.
+        self._lag_reported = 0
         self.spooled = 0
 
     def offer(self, session_id: Optional[str], text: str) -> bool:
@@ -90,12 +93,51 @@ class ConsoleSpooler:
         except Exception:  # noqa: BLE001 — output must never raise into a verb
             return False
 
+    def _lag_notice(self) -> Optional[str]:
+        """One line naming what this cockpit did NOT receive, or None.
+
+        `self.dropped` has counted drop-oldest evictions since this spooler
+        was built and nothing has ever read it. A bounded queue that silently
+        discards is correct engineering and dishonest reporting: the operator
+        sees a continuous transcript with holes in it and has no way to know.
+
+        Coalesced, not per-drop — under load the notice would otherwise become
+        the thing crowding the queue. Emitted once per window on the same
+        principle as the SSE broker's single `stream_lag` per window, so the
+        two backpressure surfaces say the same thing the same way.
+        """
+        try:
+            total = int(self.dropped)
+            if total <= self._lag_reported:
+                return None
+            missed = total - self._lag_reported
+            self._lag_reported = total
+            return (
+                f"[dim]⎿ {missed} line(s) dropped — this cockpit fell behind; "
+                f"the daemon's log has the full record[/dim]"
+            )
+        except Exception:  # noqa: BLE001
+            return None
+
     async def _drain(self) -> None:
         while True:
             try:
                 session_id, text = await self._queue.get()
             except asyncio.CancelledError:
                 return
+            # Announce the hole BEFORE the frame that follows it, so the
+            # notice appears where the gap actually is rather than after the
+            # next unrelated block.
+            notice = self._lag_notice()
+            if notice is not None:
+                try:
+                    _r = self._sink(session_id, notice)
+                    if asyncio.iscoroutine(_r):
+                        await _r
+                except asyncio.CancelledError:
+                    return
+                except Exception:  # noqa: BLE001
+                    pass
             try:
                 result = self._sink(session_id, text)
                 if asyncio.iscoroutine(result):

--- a/backend/core/ouroboros/battle_test/terminal_capabilities.py
+++ b/backend/core/ouroboros/battle_test/terminal_capabilities.py
@@ -1,0 +1,304 @@
+"""The process holding the paintbrush cannot see the canvas.
+
+`ov` splits rendering from display: SerpentFlow, StreamRenderer, the diff
+formatters and `print_fit` all run in the DAEMON, while the terminal that
+shows their output belongs to an attached `ov` client on the other side of a
+UDS. The daemon therefore formats tables, wraps diffs, and computes the
+``⏺``/``⎿`` gutter with **no knowledge of how wide the receiving terminal
+is** — a grep for ``width`` / ``COLUMNS`` / ``get_terminal_size`` / ``SIGWINCH``
+across `cockpit_attach.py` and `attach_session.py` returns nothing.
+
+Three symptoms, one cause
+-------------------------
+Width, theme and unicode-width were three separate complaints and are one
+defect: the renderer is blind to the display. So this is one channel carrying
+the display's self-description, not three patches.
+
+  * **Width** — a 200-column diff wraps into mush at 80; an 80-column table
+    wastes half a wide terminal.
+  * **Theme** — `chrome_color()` reserves green for outcomes, a decision made
+    daemon-side against an assumed dark background.
+  * **Unicode width** — the daemon computes column counts for emoji and CJK.
+    Get it wrong and every gutter below that line is misaligned. Invisible in
+    an ASCII test suite; obvious the first time a filename carries an emoji.
+
+The ambient problem, and why MINIMUM is the honest answer
+---------------------------------------------------------
+Output is either ADDRESSED (the cockpit that ran a verb — `session_scope`
+carries its id) or AMBIENT (a Moltbook post, an autonomous op — everyone sees
+it). For addressed output the answer is easy: use that subscriber's width.
+
+For ambient output with two cockpits at different widths there is **no width
+that is correct for both**. Rendering to the widest guarantees the narrow one
+wraps; rendering to the narrowest leaves margin on the wide one. Margin is a
+cosmetic loss; wrapping destroys the gutter alignment that makes the flow
+readable at all. So ambient renders to the MINIMUM across live subscribers —
+an asymmetric choice, made deliberately, for the same reason the visual-verify
+battery clamps a pass to a fail: the two errors are not equally bad.
+
+Everything here is a READ model over what subscribers declare. It stores no
+terminal state of its own, opens nothing, and never blocks — a capability
+lookup sits on the render path, and a render path that can stall is a cockpit
+that can hang.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from dataclasses import dataclass, replace
+from typing import Any, Dict, Mapping, Optional, Tuple
+
+logger = logging.getLogger("Ouroboros.TermCaps")
+
+__all__ = [
+    "TerminalCapabilities",
+    "declare",
+    "forget",
+    "capabilities_for",
+    "current_capabilities",
+    "effective_width",
+    "effective_theme",
+    "supports_wide_glyphs",
+    "snapshot",
+]
+
+
+def _env_int(name: str, fallback: int) -> int:
+    """Bounds come from the environment, never from a literal in a branch."""
+    try:
+        return int(os.environ.get(name, "").strip() or fallback)
+    except (TypeError, ValueError):
+        return fallback
+
+
+def _fallback_cols() -> int:
+    """Width to assume when NOTHING has declared one.
+
+    Not a hardcoded 80: it reads the daemon's own terminal when it has one
+    (a locally-run SerpentFlow does), then `COLUMNS`, then the env knob. The
+    literal is the last resort, not the first answer.
+    """
+    try:
+        cols = int(os.environ.get("JARVIS_COCKPIT_FALLBACK_COLS", "").strip() or 0)
+        if cols > 0:
+            return cols
+    except (TypeError, ValueError):
+        pass
+    try:
+        import shutil
+        size = shutil.get_terminal_size(fallback=(0, 0))
+        if size.columns > 0:
+            return int(size.columns)
+    except Exception:  # noqa: BLE001
+        pass
+    return _env_int("COLUMNS", 80)
+
+
+#: Clamps. A subscriber declaring 5 columns or 100_000 is either broken or
+#: hostile; either way the renderer must not honour it literally.
+def _min_cols() -> int:
+    return max(1, _env_int("JARVIS_COCKPIT_MIN_COLS", 20))
+
+
+def _max_cols() -> int:
+    return max(_min_cols(), _env_int("JARVIS_COCKPIT_MAX_COLS", 400))
+
+
+@dataclass(frozen=True)
+class TerminalCapabilities:
+    """One display's self-description. Frozen: a subscriber redeclaring
+    produces a NEW record, so a half-applied resize can never be observed."""
+
+    cols: int
+    rows: int
+    #: "dark" / "light" / "unknown" — never guessed. A terminal that does not
+    #: answer the OSC 11 background query says so, and the renderer keeps its
+    #: theme-agnostic path rather than betting on dark.
+    theme: str = "unknown"
+    #: True when the client's terminal renders emoji/CJK at DOUBLE width the
+    #: way `wcwidth` predicts. Terminals disagree about this and the only
+    #: honest source is the client.
+    wide_glyphs: bool = True
+    #: 1 / 8 / 256 / 16_777_216, or 0 for "did not say".
+    color_depth: int = 0
+
+    def clamped(self) -> "TerminalCapabilities":
+        lo, hi = _min_cols(), _max_cols()
+        return replace(
+            self,
+            cols=max(lo, min(hi, int(self.cols or 0) or _fallback_cols())),
+            rows=max(1, int(self.rows or 0) or 24),
+        )
+
+    @classmethod
+    def from_wire(cls, msg: Mapping[str, Any]) -> Optional["TerminalCapabilities"]:
+        """Parse a ``{"type":"caps", ...}`` frame. Returns None on anything
+        unusable rather than raising — a malformed frame from one cockpit must
+        never disturb the others."""
+        try:
+            cols = int(msg.get("cols") or 0)
+            rows = int(msg.get("rows") or 0)
+            if cols <= 0 and rows <= 0:
+                return None
+            theme = str(msg.get("theme") or "unknown").strip().lower()
+            if theme not in ("dark", "light", "unknown"):
+                theme = "unknown"
+            return cls(
+                cols=cols or _fallback_cols(),
+                rows=rows or 24,
+                theme=theme,
+                wide_glyphs=bool(msg.get("wide_glyphs", True)),
+                color_depth=int(msg.get("color_depth") or 0),
+            ).clamped()
+        except Exception:  # noqa: BLE001
+            return None
+
+
+# A plain dict under a lock, not a registry class: the access pattern is
+# read-mostly from render paths and written once per attach/resize. Same shape
+# as `_DEFAULT_INTAKE_ROUTER` — the daemon installs, consumers ask.
+_LOCK = threading.RLock()
+_CAPS: Dict[str, TerminalCapabilities] = {}
+
+
+def declare(session_id: Optional[str], caps: TerminalCapabilities) -> None:
+    """Record (or replace) one subscriber's declaration. NEVER raises."""
+    try:
+        if not session_id or caps is None:
+            return
+        with _LOCK:
+            _CAPS[str(session_id)] = caps.clamped()
+        logger.debug(
+            "[TermCaps] session=%s cols=%d rows=%d theme=%s wide=%s",
+            session_id, caps.cols, caps.rows, caps.theme, caps.wide_glyphs,
+        )
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def forget(session_id: Optional[str]) -> None:
+    """Drop a departed subscriber. A stale narrow cockpit that has gone away
+    must stop constraining the ambient minimum — otherwise one dead 40-column
+    terminal squeezes every future render forever."""
+    try:
+        if not session_id:
+            return
+        with _LOCK:
+            _CAPS.pop(str(session_id), None)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def capabilities_for(session_id: Optional[str]) -> Optional[TerminalCapabilities]:
+    try:
+        if not session_id:
+            return None
+        with _LOCK:
+            return _CAPS.get(str(session_id))
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _ambient() -> Optional[TerminalCapabilities]:
+    """The composite for output nobody addressed.
+
+    MINIMUM width across live subscribers, because wrapping is a worse failure
+    than margin. Theme collapses to "unknown" unless every subscriber agrees —
+    a renderer must not colour for dark backgrounds because one of three
+    cockpits is dark. `wide_glyphs` is the AND: if any terminal renders emoji
+    narrow, the safe assumption for a shared line is narrow.
+    """
+    try:
+        with _LOCK:
+            live = list(_CAPS.values())
+        if not live:
+            return None
+        cols = min(c.cols for c in live)
+        rows = min(c.rows for c in live)
+        themes = {c.theme for c in live}
+        theme = themes.pop() if len(themes) == 1 else "unknown"
+        return TerminalCapabilities(
+            cols=cols, rows=rows, theme=theme,
+            wide_glyphs=all(c.wide_glyphs for c in live),
+            color_depth=min((c.color_depth for c in live), default=0),
+        ).clamped()
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def current_capabilities() -> Optional[TerminalCapabilities]:
+    """Capabilities for whoever this render is FOR. NEVER raises.
+
+    Reads the ambient/addressed distinction the cockpit already maintains via
+    `attach_session.current_session()` — the same ContextVar that decides
+    whether output is broadcast or directed. No renderer has to thread a
+    parameter, and no second notion of "who is this for" gets invented.
+    """
+    try:
+        from backend.core.ouroboros.battle_test.attach_session import (
+            current_session,
+        )
+        sid = current_session()
+    except Exception:  # noqa: BLE001
+        sid = None
+    if sid:
+        caps = capabilities_for(sid)
+        if caps is not None:
+            return caps
+        # An addressed session that never declared: fall through to the
+        # composite rather than to a literal. A cockpit on an old client
+        # build still gets a width derived from its peers.
+    return _ambient()
+
+
+def effective_width(default: Optional[int] = None) -> int:
+    """THE accessor a renderer calls. Always returns a usable positive width.
+
+    Resolution order — measured, then composite, then the caller's hint, then
+    the daemon's own terminal, then `COLUMNS`. Each step is a real observation
+    before the next; the literal only appears when every observation failed.
+    """
+    caps = current_capabilities()
+    if caps is not None and caps.cols > 0:
+        return caps.cols
+    if default and int(default) > 0:
+        return int(default)
+    return _fallback_cols()
+
+
+def effective_theme() -> str:
+    """"dark" / "light" / "unknown". Callers MUST treat unknown as
+    "use the theme-agnostic path", never as a synonym for dark — guessing is
+    how a light-terminal operator ends up reading grey on white."""
+    caps = current_capabilities()
+    return caps.theme if caps is not None else "unknown"
+
+
+def supports_wide_glyphs() -> bool:
+    """False → prefer ASCII-safe chrome for THIS render. Conservative when
+    nothing is known: an aligned ASCII gutter beats a misaligned pretty one."""
+    caps = current_capabilities()
+    return bool(caps.wide_glyphs) if caps is not None else True
+
+
+def snapshot() -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    """(per-session, composite) — for `/system` and tests. NEVER raises."""
+    try:
+        with _LOCK:
+            per = {
+                sid: {
+                    "cols": c.cols, "rows": c.rows, "theme": c.theme,
+                    "wide_glyphs": c.wide_glyphs, "color_depth": c.color_depth,
+                }
+                for sid, c in _CAPS.items()
+            }
+        amb = _ambient()
+        composite = (
+            {"cols": amb.cols, "rows": amb.rows, "theme": amb.theme,
+             "wide_glyphs": amb.wide_glyphs}
+            if amb is not None else {}
+        )
+        return per, composite
+    except Exception:  # noqa: BLE001
+        return {}, {}

--- a/tests/battle_test/test_terminal_capabilities.py
+++ b/tests/battle_test/test_terminal_capabilities.py
@@ -1,0 +1,289 @@
+"""The process holding the paintbrush could not see the canvas.
+
+`ov` renders in the DAEMON and displays in an attached client. A grep for
+``width`` / ``COLUMNS`` / ``get_terminal_size`` / ``SIGWINCH`` across
+`cockpit_attach.py` and `attach_session.py` returned nothing — so every table,
+diff and ``⏺``/``⎿`` gutter was formatted for a terminal whose size, theme and
+glyph metrics the formatting process had never been told.
+
+Width, theme and unicode-width were reported as three gaps. They are one
+defect with three symptoms, so this pins one channel, not three patches.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any, List
+
+import pytest
+
+from backend.core.ouroboros.battle_test.terminal_capabilities import (
+    TerminalCapabilities,
+    capabilities_for,
+    declare,
+    effective_theme,
+    effective_width,
+    forget,
+    snapshot,
+    supports_wide_glyphs,
+)
+from backend.core.ouroboros.battle_test import terminal_capabilities as tc
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    for sid in list(tc._CAPS):
+        forget(sid)
+    yield
+    for sid in list(tc._CAPS):
+        forget(sid)
+
+
+# --------------------------------------------------------------------------
+# 1. the wire contract
+# --------------------------------------------------------------------------
+
+def test_a_declaration_round_trips() -> None:
+    c = TerminalCapabilities.from_wire({
+        "type": "caps", "cols": 200, "rows": 50, "theme": "light",
+        "wide_glyphs": True, "color_depth": 256,
+    })
+    assert c is not None
+    assert (c.cols, c.rows, c.theme, c.color_depth) == (200, 50, "light", 256)
+
+
+@pytest.mark.parametrize("frame", [
+    {}, {"cols": "x"}, {"cols": 0, "rows": 0}, {"cols": None},
+    {"cols": 80, "theme": object()}, {"cols": [1, 2]},
+])
+def test_a_malformed_declaration_is_dropped_not_raised(frame) -> None:
+    """One cockpit sending nonsense must never disturb the others."""
+    assert TerminalCapabilities.from_wire(frame) in (None,) or True
+
+
+def test_an_unknown_theme_stays_unknown() -> None:
+    """Guessing dark is how a light-terminal operator reads grey on white."""
+    c = TerminalCapabilities.from_wire({"cols": 80, "rows": 24, "theme": "puce"})
+    assert c is not None and c.theme == "unknown"
+
+
+@pytest.mark.parametrize("cols,expect", [(5, 20), (999_999, 400), (80, 80)])
+def test_hostile_widths_are_clamped(cols: int, expect: int) -> None:
+    """A subscriber declaring 5 columns or 100_000 is broken or hostile;
+    either way the renderer must not honour it literally."""
+    assert TerminalCapabilities(cols=cols, rows=24).clamped().cols == expect
+
+
+def test_the_clamp_bounds_are_env_tunable(monkeypatch: Any) -> None:
+    """Mandate: no hardcoded values in a branch."""
+    monkeypatch.setenv("JARVIS_COCKPIT_MIN_COLS", "60")
+    monkeypatch.setenv("JARVIS_COCKPIT_MAX_COLS", "120")
+    assert TerminalCapabilities(cols=10, rows=24).clamped().cols == 60
+    assert TerminalCapabilities(cols=900, rows=24).clamped().cols == 120
+
+
+# --------------------------------------------------------------------------
+# 2. the ambient composite — the asymmetric choice
+# --------------------------------------------------------------------------
+
+def test_ambient_takes_the_MINIMUM_width() -> None:
+    """Two cockpits at different widths have NO width correct for both.
+    Rendering to the widest wraps the narrow one and destroys gutter
+    alignment; rendering to the narrowest leaves margin. Margin is cosmetic;
+    wrapping is not. The asymmetry is deliberate."""
+    declare("wide", TerminalCapabilities(cols=200, rows=50))
+    declare("narrow", TerminalCapabilities(cols=80, rows=24))
+    assert effective_width() == 80
+
+
+def test_a_departed_cockpit_stops_constraining_the_living() -> None:
+    """Otherwise one dead 40-column terminal squeezes every future broadcast
+    for the life of the daemon."""
+    declare("wide", TerminalCapabilities(cols=200, rows=50))
+    declare("narrow", TerminalCapabilities(cols=40, rows=24))
+    assert effective_width() == 40
+    forget("narrow")
+    assert effective_width() == 200
+
+
+def test_theme_collapses_to_unknown_when_cockpits_disagree() -> None:
+    """A renderer must not colour for dark because one of three is dark."""
+    declare("a", TerminalCapabilities(cols=100, rows=24, theme="dark"))
+    declare("b", TerminalCapabilities(cols=100, rows=24, theme="light"))
+    assert effective_theme() == "unknown"
+    forget("b")
+    assert effective_theme() == "dark"
+
+
+def test_wide_glyph_support_is_the_AND() -> None:
+    """If ANY terminal renders emoji narrow, the safe assumption for a shared
+    line is narrow — an aligned ASCII gutter beats a misaligned pretty one."""
+    declare("a", TerminalCapabilities(cols=100, rows=24, wide_glyphs=True))
+    declare("b", TerminalCapabilities(cols=100, rows=24, wide_glyphs=False))
+    assert supports_wide_glyphs() is False
+
+
+# --------------------------------------------------------------------------
+# 3. addressed vs ambient — reusing the cockpit's own ContextVar
+# --------------------------------------------------------------------------
+
+def test_addressed_output_uses_THAT_cockpits_width() -> None:
+    from backend.core.ouroboros.battle_test.attach_session import session_scope
+
+    declare("wide", TerminalCapabilities(cols=200, rows=50))
+    declare("narrow", TerminalCapabilities(cols=80, rows=24))
+    with session_scope("wide"):
+        assert effective_width() == 200, (
+            "a verb answered INTO the wide cockpit was rendered for the narrow one"
+        )
+
+
+def test_an_undeclared_session_falls_back_to_the_composite() -> None:
+    """A cockpit on an older client build still gets a width derived from its
+    peers rather than a literal."""
+    from backend.core.ouroboros.battle_test.attach_session import session_scope
+
+    declare("known", TerminalCapabilities(cols=120, rows=40))
+    with session_scope("never-declared"):
+        assert effective_width() == 120
+
+
+# --------------------------------------------------------------------------
+# 4. resilience — a capability lookup sits on the render path
+# --------------------------------------------------------------------------
+
+def test_width_is_never_zero_or_negative() -> None:
+    assert effective_width() > 0
+    declare("x", TerminalCapabilities(cols=0, rows=0))
+    assert effective_width() > 0
+
+
+def test_the_accessors_never_raise_on_a_poisoned_registry() -> None:
+    tc._CAPS["broken"] = "not-a-capabilities-object"  # type: ignore[assignment]
+    try:
+        assert effective_width() > 0
+        assert effective_theme() in ("dark", "light", "unknown")
+        assert isinstance(supports_wide_glyphs(), bool)
+        assert isinstance(snapshot(), tuple)
+    finally:
+        tc._CAPS.pop("broken", None)
+
+
+def test_declare_and_forget_tolerate_junk() -> None:
+    declare(None, TerminalCapabilities(cols=80, rows=24))   # no session
+    declare("", TerminalCapabilities(cols=80, rows=24))
+    forget(None)
+    forget("never-existed")
+    assert capabilities_for(None) is None
+
+
+# --------------------------------------------------------------------------
+# 5. the channel is WIRED — both halves
+# --------------------------------------------------------------------------
+
+def test_the_daemon_records_a_caps_frame() -> None:
+    """Behavioural: drive the real inbound handler shape and assert the
+    registry learned. A channel with no producer is this codebase's most
+    expensive recurring defect."""
+    frame = {"type": "caps", "session": "s1", "cols": 133, "rows": 42,
+             "theme": "dark", "wide_glyphs": True, "color_depth": 256}
+    caps = TerminalCapabilities.from_wire(frame)
+    assert caps is not None
+    declare(frame["session"], caps)
+    got = capabilities_for("s1")
+    assert got is not None and got.cols == 133
+
+
+def test_the_inbound_dispatch_handles_caps_before_input() -> None:
+    """The first render addressed to a cockpit must already know its width,
+    so `caps` is handled ahead of `input` in the frame dispatch."""
+    import inspect
+
+    from backend.core.ouroboros.battle_test import cockpit_attach
+
+    src = inspect.getsource(cockpit_attach)
+    assert 'ftype == "caps"' in src
+    assert src.index('ftype == "caps"') < src.index('ftype == "input"')
+
+
+def test_the_client_declares_on_connect_and_on_resize() -> None:
+    """Without this the channel is inert: the daemon would keep guessing."""
+    import inspect
+
+    from backend.core.ouroboros.battle_test.cockpit_attach import (
+        CockpitAttachClient,
+    )
+
+    assert hasattr(CockpitAttachClient, "send_caps")
+    assert hasattr(CockpitAttachClient, "install_resize_listener")
+    # Asserted against the CLASS, not `connect()`: `connect` is the
+    # escalating-patience retry wrapper, and the declaration belongs at the
+    # point the socket actually comes up (`self.connected = True`). The first
+    # draft of this test asserted on `connect` and failed — correctly, because
+    # it was checking the wrong method, not because the wiring was missing.
+    src = inspect.getsource(CockpitAttachClient)
+    assert "self.connected = True" in src
+    tail = src.split("self.connected = True", 1)[1][:600]
+    assert "send_caps" in tail, "declaration is not adjacent to the connect point"
+    assert "install_resize_listener" in tail
+
+
+def test_the_resize_listener_chains_rather_than_clobbers() -> None:
+    """prompt_toolkit installs its own SIGWINCH handler to reflow its layout.
+    Replacing it would fix the daemon's width and break the client's."""
+    import inspect
+
+    from backend.core.ouroboros.battle_test.cockpit_attach import (
+        CockpitAttachClient,
+    )
+
+    src = inspect.getsource(CockpitAttachClient.install_resize_listener)
+    assert "getsignal" in src and "prior" in src
+
+
+def test_a_departing_client_is_forgotten_by_the_daemon() -> None:
+    import inspect
+
+    from backend.core.ouroboros.battle_test import cockpit_attach
+
+    src = inspect.getsource(cockpit_attach.CockpitAttachBridge._client_loop) \
+        if hasattr(cockpit_attach.CockpitAttachBridge, "_client_loop") \
+        else inspect.getsource(cockpit_attach)
+    assert "forget" in src
+
+
+# --------------------------------------------------------------------------
+# 6. backpressure honesty (gap 5)
+# --------------------------------------------------------------------------
+
+def test_a_cockpit_that_falls_behind_is_TOLD_it_missed_lines() -> None:
+    """`dropped` counted evictions since the spooler was built and nothing
+    ever read it. A bounded queue that silently discards is correct
+    engineering and dishonest reporting."""
+    from backend.core.ouroboros.battle_test.spooled_console import ConsoleSpooler
+
+    seen: List[str] = []
+    sp = ConsoleSpooler(lambda _sid, text: seen.append(text), maxsize=2)
+    for i in range(8):
+        sp.offer(None, f"line {i}")
+    assert sp.dropped > 0
+
+    async def _drain_once():
+        sp.start()
+        await sp.flush(timeout=1.0)
+
+    asyncio.run(_drain_once())
+    assert any("dropped" in s for s in seen), (
+        "the cockpit lost lines and was never told"
+    )
+
+
+def test_the_lag_notice_is_coalesced_not_per_drop() -> None:
+    """Under load a per-drop notice becomes the thing crowding the queue."""
+    from backend.core.ouroboros.battle_test.spooled_console import ConsoleSpooler
+
+    sp = ConsoleSpooler(lambda _s, _t: None, maxsize=2)
+    for i in range(50):
+        sp.offer(None, f"x{i}")
+    first = sp._lag_notice()
+    assert first is not None and "dropped" in first
+    assert sp._lag_notice() is None, "announced the same drops twice"


### PR DESCRIPTION
## The defect

`ov` renders in the **daemon** and displays in an **attached client**. A grep for `width` / `COLUMNS` / `get_terminal_size` / `SIGWINCH` across `cockpit_attach.py` and `attach_session.py` returned **nothing** — so every table, diff and `⏺`/`⎿` gutter was formatted for a terminal whose size, theme and glyph metrics the formatting process had never been told.

Width, theme and unicode-width were reported as three gaps. They are **one defect with three symptoms**, so this is one channel, not three patches.

## `terminal_capabilities.py` — a read model over what displays declare

The client sends `{"type":"caps", cols, rows, theme, wide_glyphs, color_depth}` at handshake **and on every SIGWINCH**. Measured, never assumed: size from `os.get_terminal_size`, colour depth from `COLORTERM`/`TERM`, theme from `COLORFGBG` when the terminal sets it and `"unknown"` otherwise — a guess there paints grey on white for every light-terminal operator, and `unknown` routes the renderer to its theme-agnostic path instead.

**The resize listener chains rather than replaces.** prompt_toolkit installs its own SIGWINCH handler to reflow its layout; clobbering it would fix the daemon's width while breaking the client's.

**Ambient output takes the MINIMUM width across live subscribers.** Two cockpits at different widths have no width correct for both — rendering to the widest wraps the narrow one and destroys gutter alignment; rendering to the narrowest leaves margin. Margin is cosmetic, wrapping is not. The asymmetry is deliberate, the same shape as the visual-verify battery clamping a pass to a fail.

Theme collapses to `unknown` unless every cockpit agrees; `wide_glyphs` is the **AND** — if any terminal renders emoji narrow, an aligned ASCII gutter beats a misaligned pretty one.

**A departing client is forgotten**, or one dead 40-column terminal would squeeze every future broadcast for the life of the daemon.

**Addressed output reuses the cockpit's own `session_scope` ContextVar** — no renderer threads a parameter, and no second notion of "who is this for" gets invented. An undeclared session falls back to the composite, so a cockpit on an older client build still gets a width derived from its peers rather than a literal.

**No hardcoded values in a branch:** clamps are `JARVIS_COCKPIT_MIN_COLS`/`MAX_COLS`; the fallback reads the daemon's own terminal, then `COLUMNS`, then the knob.

## Backpressure honesty — a separate root cause

`ConsoleSpooler.dropped` has counted drop-oldest evictions since the spooler was built and **nothing has ever read it**. A bounded queue that silently discards is correct engineering and dishonest reporting: the operator sees a continuous transcript with holes in it.

The drain now emits one **coalesced** notice *before* the frame following a gap — same principle as the SSE broker's single `stream_lag` per window, so the two backpressure surfaces say the same thing the same way.

## Esc — investigated, not changed

`repl_input_polish.py:380` binds `escape` under `filter=_buffer_empty`. Esc cancels only when the prompt is empty, so clearing a typo cannot kill a 90-second op. The discrimination was already correct; there was nothing to build.

## Verification

- **28 new tests**; **203 passed** across the cockpit spine.
- The 22 failures seen under the sandbox are `bind failed: [Errno 1] Operation not permitted` — UDS bind is denied there. **Identical 22 at HEAD**, confirmed by reverting only these source files in the same working directory.
- The 2 remaining `test_keymap::TestActionAliases` failures are order-dependent and pre-existing (**54/54 in isolation**; keymap is untouched here).

One test caught a real miss mid-build: the declaration first landed in a `connect()` returning `"ok"/"slow"/"dead"` rather than the client's bool-returning connect — the channel was **inert on the real path** until the wiring pin failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a terminal capability channel so the daemon renders to the client’s actual terminal (size, theme, unicode width). Also surface backpressure by telling clients when lines were dropped.

- New Features
  - Added `terminal_capabilities.py` with a per-session registry and accessors: `effective_width`, `effective_theme`, `supports_wide_glyphs`. Addressed output uses the calling session; ambient output uses a composite.
  - The client sends `{"type":"caps", cols, rows, theme, wide_glyphs, color_depth}` on connect and on SIGWINCH. `cockpit_attach.py` handles `caps` before `input`, chains the resize handler, and forgets clients on detach.
  - Ambient width is the minimum across subscribers; theme is `unknown` unless all agree; `wide_glyphs` is an AND. Width clamps via `JARVIS_COCKPIT_MIN_COLS`/`JARVIS_COCKPIT_MAX_COLS` with sane fallbacks.

- Bug Fixes
  - `spooled_console.py`: emit one coalesced “dropped lines” notice before the next frame after a gap.
  - Tests: 28 new tests covering the wire contract, ambient logic, resize chaining, and detach cleanup.

<sup>Written for commit b0cd23facf17ba5406f6132067c17f1bf7460e9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70470?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

