### PR TITLE
feat(cockpit): spend the capability channel — one seam, every consumer

### DIFF
--- a/backend/core/ouroboros/battle_test/presentation_restraint.py
+++ b/backend/core/ouroboros/battle_test/presentation_restraint.py
@@ -1059,7 +1059,34 @@ def chrome_color(default: str = "bright_green") -> str:
     """
     if is_restraint_enabled():
         return "dim"
-    return default
+    return _theme_adapted(default)
+
+
+def _theme_adapted(color: str) -> str:
+    """Adjust a colour for the terminal that will actually display it.
+
+    The daemon picked this palette against an assumed dark background, and
+    until `terminal_capabilities` existed there was no way to know better.
+    ``bright_*`` on a light terminal is the specific failure: bright green on
+    white is close to unreadable, and it is the colour reserved for OUTCOMES —
+    the one an operator most needs to see.
+
+    Only ``bright_`` is demoted, and only on a terminal that DECLARED itself
+    light. ``unknown`` changes nothing: a guess here would repaint every
+    foreground daemon on no evidence, and "I was not told" is not "it is
+    light". NEVER raises — a colour lookup on a render path must not be able
+    to fail.
+    """
+    try:
+        from backend.core.ouroboros.battle_test.terminal_capabilities import (
+            effective_theme,
+        )
+        if effective_theme() != "light":
+            return color
+        c = str(color)
+        return c.replace("bright_", "", 1) if c.startswith("bright_") else c
+    except Exception:  # noqa: BLE001
+        return color
 
 
 def real_stdout_isatty() -> bool:

--- a/backend/core/ouroboros/battle_test/spooled_console.py
+++ b/backend/core/ouroboros/battle_test/spooled_console.py
@@ -203,7 +203,48 @@ def make_spooled_console(
     spooler = ConsoleSpooler(sink)
 
     class SpooledConsole(Console):  # type: ignore[misc]
-        """A Console that also mirrors to whoever ran the command."""
+        """A Console that also mirrors to whoever ran the command — at the
+        width of the terminal that will actually display it.
+
+        `size` is overridden rather than each consumer being converted, for
+        the same reason this class exists at all: `print_fit` reads
+        ``console.width``, Rich derives wrapping and table layout from
+        ``console.size``, and the diff formatters ask the console how much
+        room they have. Every one of them becomes capability-aware by
+        changing the object they already hold — no call site moves.
+
+        Before this, the daemon rendered every mirrored line at a literal 120
+        columns no matter who was watching: an 80-column cockpit got wrapped
+        diffs and a broken gutter, a 200-column one got two-thirds of a
+        screen. `terminal_capabilities` knows the real answer per subscriber;
+        this is where that answer is spent.
+        """
+
+        @property
+        def size(self):  # type: ignore[override]
+            """Live dimensions for THIS render. NEVER raises.
+
+            Read per access, not cached: a SIGWINCH between two prints must
+            take effect on the second one. Falls through to Rich's own
+            detection when nothing has declared, so a foreground daemon on a
+            real terminal keeps behaving exactly as it did.
+            """
+            try:
+                from rich.console import ConsoleDimensions
+
+                from backend.core.ouroboros.battle_test.terminal_capabilities import (  # noqa: E501
+                    current_capabilities,
+                )
+                caps = current_capabilities()
+                if caps is not None and caps.cols > 0:
+                    return ConsoleDimensions(caps.cols, max(1, caps.rows))
+            except Exception:  # noqa: BLE001 — never break a render path
+                pass
+            try:
+                return super().size
+            except Exception:  # noqa: BLE001
+                from rich.console import ConsoleDimensions
+                return ConsoleDimensions(width, 24)
 
         def print(self, *args: Any, **kwargs: Any) -> None:  # noqa: A003
             # LOCAL RENDER FIRST, and unconditionally. A daemon running in the
@@ -213,7 +254,11 @@ def make_spooled_console(
             except Exception:  # noqa: BLE001
                 pass
             try:
-                text = _render_to_text(args, kwargs, width=width)
+                # Rendered for the cockpit this line is ADDRESSED to —
+                # `current_session()` is read below for routing, and the
+                # width must come from the same subscriber or the text is
+                # wrapped for a terminal that will never see it.
+                text = _render_to_text(args, kwargs, width=_mirror_width(width))
                 if text.strip():
                     from backend.core.ouroboros.battle_test.attach_session import (
                         current_session,
@@ -231,6 +276,23 @@ def make_spooled_console(
         force_terminal=getattr(base, "is_terminal", False) or None,
     )
     return console, spooler
+
+
+def _mirror_width(fallback: int) -> int:
+    """Columns to render a MIRRORED line at. NEVER raises.
+
+    Resolves through `terminal_capabilities`, which answers per-subscriber
+    for addressed output and with the minimum across live cockpits for
+    ambient. `fallback` is the caller's literal and is reached only when no
+    display has ever declared — a foreground daemon with no cockpit attached.
+    """
+    try:
+        from backend.core.ouroboros.battle_test.terminal_capabilities import (
+            effective_width,
+        )
+        return int(effective_width(fallback))
+    except Exception:  # noqa: BLE001
+        return int(fallback)
 
 
 def _render_to_text(args: Any, kwargs: Any, *, width: int) -> str:

--- a/tests/battle_test/test_terminal_capabilities.py
+++ b/tests/battle_test/test_terminal_capabilities.py
@@ -287,3 +287,97 @@ def test_the_lag_notice_is_coalesced_not_per_drop() -> None:
     first = sp._lag_notice()
     assert first is not None and "dropped" in first
     assert sp._lag_notice() is None, "announced the same drops twice"
+
+
+# --------------------------------------------------------------------------
+# 7. the channel is CONSUMED — the half that was missing
+# --------------------------------------------------------------------------
+#
+# The first cut of this work shipped the measurement and no consumer:
+# `effective_width()` had zero production callers and `chrome_color()` never
+# consulted the theme. A capability channel talking to nobody is precisely the
+# wired-but-inert defect this codebase keeps paying for, so these pin the
+# CONSUMPTION rather than the plumbing.
+
+
+def _console():
+    from backend.core.ouroboros.battle_test.spooled_console import (
+        make_spooled_console,
+    )
+    con, _sp = make_spooled_console(lambda _s, _t: None)
+    return con
+
+
+def test_the_console_adapts_to_the_attached_cockpit() -> None:
+    """ONE seam converts every consumer. `print_fit` reads `console.width`,
+    Rich derives table layout and wrapping from `console.size`, and the diff
+    formatters ask the console how much room they have — so overriding the
+    object they already hold beats converting N call sites."""
+    con = _console()
+    declare("narrow", TerminalCapabilities(cols=80, rows=24))
+    declare("wide", TerminalCapabilities(cols=200, rows=50))
+    assert con.width == 80, "ambient must render at the MINIMUM"
+
+
+def test_addressed_output_renders_at_that_cockpits_width() -> None:
+    from backend.core.ouroboros.battle_test.attach_session import session_scope
+
+    con = _console()
+    declare("narrow", TerminalCapabilities(cols=80, rows=24))
+    declare("wide", TerminalCapabilities(cols=200, rows=50))
+    with session_scope("wide"):
+        assert con.width == 200
+    with session_scope("narrow"):
+        assert con.width == 80
+
+
+def test_the_console_falls_back_when_nothing_is_attached() -> None:
+    """A foreground daemon with no cockpit must behave exactly as before —
+    this is additive, never a redirect."""
+    con = _console()
+    assert con.width > 0
+
+
+def test_the_width_is_read_per_access_not_cached() -> None:
+    """A SIGWINCH between two prints must take effect on the second one."""
+    con = _console()
+    declare("s", TerminalCapabilities(cols=100, rows=24))
+    assert con.width == 100
+    declare("s", TerminalCapabilities(cols=160, rows=24))   # resize
+    assert con.width == 160, "the console cached a stale width"
+
+
+def test_a_poisoned_registry_cannot_break_a_render() -> None:
+    con = _console()
+    tc._CAPS["bad"] = "not-capabilities"  # type: ignore[assignment]
+    try:
+        assert con.width > 0
+    finally:
+        tc._CAPS.pop("bad", None)
+
+
+def test_chrome_demotes_bright_only_on_a_DECLARED_light_terminal() -> None:
+    """bright green on white is near-unreadable, and it is the colour
+    reserved for OUTCOMES. `unknown` must change nothing — a guess would
+    repaint every foreground daemon on no evidence."""
+    import os
+
+    from backend.core.ouroboros.battle_test.presentation_restraint import (
+        chrome_color,
+    )
+
+    prev = os.environ.get("JARVIS_PRESENTATION_RESTRAINT_ENABLED")
+    os.environ["JARVIS_PRESENTATION_RESTRAINT_ENABLED"] = "false"
+    try:
+        assert chrome_color("bright_green") == "bright_green"   # unknown
+        declare("light", TerminalCapabilities(cols=100, rows=24, theme="light"))
+        assert chrome_color("bright_green") == "green"
+        forget("light")
+        declare("dark", TerminalCapabilities(cols=100, rows=24, theme="dark"))
+        assert chrome_color("bright_green") == "bright_green"
+        assert chrome_color("cyan") == "cyan", "non-bright colours untouched"
+    finally:
+        if prev is None:
+            os.environ.pop("JARVIS_PRESENTATION_RESTRAINT_ENABLED", None)
+        else:
+            os.environ["JARVIS_PRESENTATION_RESTRAINT_ENABLED"] = prev


### PR DESCRIPTION
## The half that was missing

#70470 shipped the measurement and **no consumer**. `effective_width()` had zero production callers; `chrome_color()` never consulted the theme. The operator's terminal looked identical — a capability channel talking to nobody, which is the wired-but-inert defect this codebase keeps paying for.

## The literal that was doing the damage

```python
def make_spooled_console(..., width: int = 120)
SpooledConsole(file=..., width=width, ...)
_render_to_text(args, kwargs, width=width)
```

Every mirrored line rendered at **120 columns** regardless of who was watching: an 80-column cockpit got wrapped diffs and a broken gutter, a 200-column one got two-thirds of a screen, and with two attached neither was right.

## One seam, not N call sites

`print_fit` reads `console.width`. Rich derives wrapping and table layout from `console.size`. The diff formatters ask the console how much room they have.

So `SpooledConsole.size` becomes a **live property** resolving through `terminal_capabilities` — and every consumer becomes capability-aware by changing the object it already holds. No call site moves. Same lever that made the console mirror ~76 handlers without touching one of them.

Read **per access, never cached**: a SIGWINCH between two prints must take effect on the second. Falls through to Rich's own detection when nothing has declared, so a foreground daemon on a real terminal behaves exactly as before — additive, never a redirect.

Measured live:

```
no cockpit attached    -> 120   (the caller's fallback, preserved)
two attached, ambient  ->  80   (MINIMUM — wrapping is worse than margin)
addressed to wide      -> 200
addressed to narrow    ->  80
narrow detaches        -> 200   (a dead cockpit stops constraining)
```

## Theme, narrowly

`chrome_color()` demotes `bright_*` on a terminal that **declared** itself light. Bright green on white is near-unreadable, and it's the colour reserved for *outcomes* — the one an operator most needs to see.

`unknown` changes nothing. A guess there would repaint every foreground daemon on no evidence, and *"I was not told"* is not *"it is light"*. Non-bright colours untouched.

## Not claiming what isn't done

`supports_wide_glyphs()` is **still unconsumed**. The gutter emitter is a different surface and converting it is its own change. The capability flows and is tested; the glyph half is not done.

## Verification

- 34 tests in the capability spine — 6 new, all pinning **consumption** rather than plumbing (including one that a stale-cached width would fail).
- **170 passed** across presentation-restraint, cockpit attach, console hygiene, mirror completeness, status-line mount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make mirrored output adapt to the real cockpit width and improve color readability on light terminals. This spends the `terminal_capabilities` channel so existing consumers become capability-aware without touching call sites.

- **New Features**
  - `SpooledConsole.size` now resolves through `terminal_capabilities` per access (not cached). Ambient mirrors at the minimum width across attached cockpits; addressed output renders at that cockpit’s width; falls back to the caller’s width when none are attached.
  - `_render_to_text` uses `_mirror_width()` to match the addressed subscriber’s width, preventing wrapped diffs and broken gutters.
  - `chrome_color()` demotes `bright_*` only when `effective_theme()` is `light`; `unknown` and non-bright values stay unchanged.

<sup>Written for commit 56a4f37feb1fa29ddf5b164e12910c237cc70f8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

