### PR TITLE
fix(test): the dispatcher suite proposed a candidate identical to its baseline

### DIFF
--- a/tests/governance/phase_runner/test_phase_dispatcher_terminals.py
+++ b/tests/governance/phase_runner/test_phase_dispatcher_terminals.py
@@ -18,6 +18,10 @@ Authority invariant: no candidate_generator / iron_gate / change_engine.
 """
 from __future__ import annotations
 
+import time
+
+import os
+
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -63,6 +67,24 @@ _FIXED_TS = datetime(2026, 3, 7, 12, 0, tzinfo=timezone.utc)
 #: reading either one alone.
 _TARGET_REL = "backend/core/utils.py"
 
+#: What the target file holds on disk BEFORE the op runs.
+_BASELINE_SRC = "def hello():\n    pass\n"
+
+#: What the mocked generator proposes. It MUST be a real executable change
+#: from the baseline, not a reformat.
+#:
+#: Slice 13's `CandidateValueGate` completes an op as benign `no_op_cosmetic`
+#: at the post-GENERATE seam when every file is mathematically cosmetic (AST
+#: equality after docstring stripping). The baseline and the candidate used to
+#: be the SAME string, so every op in this suite was correctly short-circuited
+#: before it could reach GATE / APPROVE / APPLY — and eight tests asserting on
+#: those terminals failed against a production path that was behaving exactly
+#: as designed.
+#:
+#: The assertions were never wrong. The INPUT was: a candidate that changes
+#: nothing is a no-op, and the gate said so.
+_CANDIDATE_SRC = "def hello():\n    return 42\n"
+
 #: Set per-test by `_materialise_project_root`. Module-level because
 #: `_build_cfg` is a plain function called from ~20 tests; threading a fixture
 #: through every signature would be a larger edit than the bug warrants.
@@ -91,7 +113,47 @@ def _materialise_project_root(tmp_path):
     target.parent.mkdir(parents=True, exist_ok=True)
     # Real, parseable content — VALIDATE runs an AST pass, so an empty
     # placeholder would trade target_file_missing for a SyntaxError.
-    target.write_text("def hello():\n    pass\n", encoding="utf-8")
+    target.write_text(_BASELINE_SRC, encoding="utf-8")
+
+    # BACKDATE the target so it represents a file AT REST in the repo.
+    #
+    # `LiveWorkSensor` computes `age = time.time() - st_mtime` and treats
+    # anything inside its active window as human-occupied — correctly, since a
+    # file a person just saved must not be mutated under them. A fixture that
+    # writes its target microseconds before the op runs looks exactly like
+    # that, and APPLY terminates `human_active_on_target` before ChangeEngine
+    # is ever called.
+    #
+    # The guard is right; the fixture was unfaithful. Backdating past the
+    # sensor's OWN window makes it represent what the suite means: a file that
+    # has been sitting in the tree. The offset is READ from the sensor rather
+    # than written here, so a change to the window carries automatically
+    # instead of silently re-breaking APPLY.
+    try:
+        from backend.core.ouroboros.governance.live_work_sensor import (
+            _DEFAULT_ACTIVE_WINDOW_S,
+        )
+        _quiet_s = float(_DEFAULT_ACTIVE_WINDOW_S) * 2.0 + 60.0
+    except Exception:  # noqa: BLE001 — sensor absent → any large offset is fine
+        _quiet_s = 3600.0
+    _at_rest = time.time() - _quiet_s
+    os.utime(target, (_at_rest, _at_rest))
+    # SELF-VERIFYING PREMISE. Asserted through the PRODUCTION predicate, not
+    # a local reimplementation of "is this cosmetic" — if Slice 13 ever widens
+    # what counts as cosmetic, this fails loudly here instead of silently
+    # neutering the eight tests that assert on GATE / APPROVE / APPLY
+    # terminals. That silent-neutering is exactly what happened when the
+    # baseline and the candidate were the same string.
+    from backend.core.ouroboros.governance.candidate_value_gate import (
+        classify_file_change,
+    )
+    verdict = classify_file_change(tmp_path, _TARGET_REL, _CANDIDATE_SRC)
+    assert verdict != "cosmetic", (
+        f"the fixture candidate is {verdict!r} against its own baseline — the "
+        "CandidateValueGate will complete every op as no_op_cosmetic before it "
+        "reaches the terminals this suite exists to test"
+    )
+
     _FIXTURE_ROOT = tmp_path
     try:
         yield tmp_path
@@ -168,7 +230,7 @@ def _build_generator(
             {
                 "candidate_id": "c1",
                 "file_path": _TARGET_REL,
-                "full_content": "def hello():\n    pass\n",
+                "full_content": _CANDIDATE_SRC,
                 "rationale": "stub",
             },
         )
@@ -550,6 +612,26 @@ async def test_artifact_t_apply_threads_apply_to_complete(monkeypatch):
 
 
 @pytest.mark.asyncio
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "LAYER MISMATCH, not a cancel regression. `OperationPhase.CANCELLED` "
+        "is set in exactly one place — governed_loop_service.py (7 sites) — "
+        "and never by the orchestrator or the phase dispatcher this suite "
+        "exercises. A cancelled op therefore leaves the dispatcher at the "
+        "phase it stopped in (CLASSIFY) and the GLS above translates that "
+        "into the CANCELLED terminal. This test asserts a GLS-layer outcome "
+        "against a dispatcher-layer result.\n\n"
+        "NOT rewritten to assert CLASSIFY: that would encode the current "
+        "shape as intent, and if cancellation ever genuinely stops producing "
+        "a terminal the rewritten test would still pass. strict=True means "
+        "this fails loudly the moment the dispatcher does start emitting "
+        "CANCELLED, which is the signal worth keeping.\n\n"
+        "The parity half of this test is doing real work and still runs: "
+        "`_assert_terminal_parity(out_off, out_on)` passes, so the extracted "
+        "and inline dispatch paths agree on the cancelled outcome."
+    ),
+)
 async def test_pre_apply_user_cancel_terminal(monkeypatch):
     """is_cancel_requested=True pre-APPLY → user_cancelled terminal.
     6a covered this via dedicated parity test — here we re-pin it as


### PR DESCRIPTION
**Supersedes #70216**, whose project-root fix is included here.

That fix was correct and insufficient: it took the suite from timing out (213s) to running (13s), and left **9 of 20 failing**. The nine were one root cause, not nine.

```python
target.write_text("def hello():\n    pass\n")   # the file on disk
"full_content": "def hello():\n    pass\n",      # the candidate
```

Byte-identical. Slice 13's `CandidateValueGate` completes an op as benign `no_op_cosmetic` at the post-GENERATE seam when every file is mathematically cosmetic — so every op was correctly short-circuited before reaching the GATE / APPROVE / APPLY terminals this suite exists to assert on.

**The assertions were never wrong. The input was.** A candidate that changes nothing *is* a no-op, and the gate said so. Rewriting them to expect `no_op_cosmetic` would have made 8 tests pass while testing nothing.

## Three fixes, none of them an assertion

- **`_BASELINE_SRC` / `_CANDIDATE_SRC` split** — the proposal is now a real executable change rather than a reformat.
- **The fixture asserts its own premise through the production predicate** (`classify_file_change`), not a local reimplementation of "is this cosmetic". If Slice 13 ever widens that definition, this fails loudly here instead of silently neutering 8 terminal tests again.
- **The target is backdated past `LiveWorkSensor`'s active window.** That sensor computes `age = time.time() - st_mtime` and treats a fresh file as human-occupied — correctly, since a file someone just saved must not be mutated under them. A fixture writing its target microseconds before the op looks exactly like that, and APPLY terminated `human_active_on_target` before ChangeEngine was ever called. The offset is **read from the sensor's own window**, so a change there carries automatically.

**9 failed → 1, without touching a single assertion.**

## The survivor is `xfail(strict=True)`, not rewritten

`test_pre_apply_user_cancel_terminal` expects `OperationPhase.CANCELLED` and gets `CLASSIFY`. That's a **layer mismatch**: `CANCELLED` is set in exactly one place — `governed_loop_service.py` — and never by the orchestrator or the phase dispatcher this suite drives. A cancelled op leaves the dispatcher at the phase it stopped in; the GLS above translates that into the terminal.

Deliberately **not** rewritten to assert `CLASSIFY`. That would encode the current shape as intent, and if cancellation ever genuinely stopped producing a terminal, the rewritten test would still pass. `strict=True` fails loudly the moment the dispatcher does emit `CANCELLED` — which is the signal worth keeping.

The parity half still runs and passes, so both dispatch paths agree on the cancelled outcome.

## Verification

**19 passed, 1 xfailed** (was 11 passed, 9 failed), run in the sovereignty-owned tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the dispatcher terminal tests by proposing a real code change, backdating the target file to avoid false human-activity signals, and validating non-cosmetic changes via the production gate. Test suite now runs cleanly: 19 pass, 1 strict xfail.

- **Bug Fixes**
  - Split `_BASELINE_SRC` and `_CANDIDATE_SRC`; candidate now changes behavior (`return 42`).
  - Fixture self-check uses `classify_file_change(...)` to ensure the candidate is not cosmetic.
  - Backdate target mtime beyond `LiveWorkSensor`’s active window (using its own setting) to avoid `human_active_on_target`.
  - Generator now emits `_CANDIDATE_SRC` for `_TARGET_REL`.
  - Marked `test_pre_apply_user_cancel_terminal` as `xfail(strict=True)` due to dispatcher vs. GLS layer mismatch; assertions unchanged.

<sup>Written for commit 9295c52392792fa83683f088e16d74a9145d0cfa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70472?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

