### PR TITLE
chore(ci): an orphan gitlink, and jq writing multi-line JSON to $GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/auto-diagram-generator.yml
+++ b/.github/workflows/auto-diagram-generator.yml
@@ -222,9 +222,13 @@ jobs:
           fi
           echo "has_changes=$has_changes" >> "$GITHUB_OUTPUT"
 
-          # Safely convert changed_files array to JSON, handling empty arrays
+          # Safely convert changed_files array to JSON, handling empty arrays.
+          # NOTE: -c (compact) is REQUIRED — $GITHUB_OUTPUT only accepts
+          # single-line `name=value` writes, and jq's default pretty-print
+          # emits multi-line JSON which the runner rejects with
+          # "Invalid format", failing the job.
           if [[ "${#changed_files[@]}" -gt 0 ]]; then
-            changed_files_json=$(printf '%s\n' "${changed_files[@]}" | jq -Rs 'split("\n") | map(select(length > 0))')
+            changed_files_json=$(printf '%s\n' "${changed_files[@]}" | jq -Rsc 'split("\n") | map(select(length > 0))')
           else
             changed_files_json='[]'
           fi

--- a/.github/workflows/screen-lock-e2e-test.yml
+++ b/.github/workflows/screen-lock-e2e-test.yml
@@ -175,7 +175,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          pip install --upgrade pip
+          pip install --upgrade pip setuptools wheel
           pip install pytest pytest-asyncio pytest-mock pytest-timeout aiohttp
 
           # Install project dependencies
@@ -931,7 +931,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          pip install --upgrade pip
+          pip install --upgrade pip setuptools wheel
           pip install pytest pytest-asyncio aiohttp
 
           if [ -f "backend/requirements.txt" ]; then

--- a/.gitignore
+++ b/.gitignore
@@ -467,3 +467,8 @@ Derek J. Russell - Resume*.pdf
 
 # Slice 25 — fastembed ONNX weight cache (durable, not committed)
 .jarvis/fastembed_cache/
+
+# Local wiki working tree — deploy-wiki.sh clones the GitHub wiki here.
+# Tracked as an orphan gitlink until now, which broke `git submodule` and
+# any CI checkout that walks submodules.
+JARVIS-AI.wiki/


### PR DESCRIPTION
**Supersedes #21835** — same four fixes, reapplied on current `main` rather than rebasing a three-month-old conflicting branch. Each was verified **still broken** before being reapplied, not assumed.

### 1. `jq -Rs` → `jq -Rsc`

`$GITHUB_OUTPUT` only accepts single-line `name=value` writes. jq's default pretty-print emits multi-line JSON, which the runner rejects with `Invalid format` and fails the job. Measured rather than argued:

```
printf 'a\nb\n' | jq -Rs  ...  ->  4 lines   (rejected)
printf 'a\nb\n' | jq -Rsc ...  ->  1 line    (accepted)
```

### 2. Orphan submodule gitlink removed

`git ls-files -s` carried a `160000` entry for `JARVIS-AI.wiki` with **no `.gitmodules` mapping**, so every submodule-walking operation failed:

```
fatal: no submodule mapping found in .gitmodules for path 'JARVIS-AI.wiki'
```

`git rm --cached` drops the gitlink and **leaves the on-disk clone alone** — `deploy-wiki.sh` keeps working. `git submodule status` is now silent.

### 3. `.gitignore` for the wiki working tree

Which is why the directory was getting staged in the first place. Removing the gitlink *without* ignoring the path would just re-add it as ~700 untracked files on the next `git add`.

### 4. `pip install --upgrade pip setuptools wheel`

Two sites in `screen-lock-e2e-test`. Modern sdists assume both are present.

Both workflow files re-validated as parseable YAML after editing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI failures by writing single-line JSON to `$GITHUB_OUTPUT` and removing an orphan `JARVIS-AI.wiki` gitlink that broke submodule walks. Also upgrades test workflow installs to include `setuptools` and `wheel`.

- **Bug Fixes**
  - Auto-diagram generator: use `jq -Rsc` to emit compact JSON so `$GITHUB_OUTPUT` accepts the value.
  - Remove orphan `JARVIS-AI.wiki` gitlink and add `.gitignore` for the wiki working tree to prevent submodule errors and accidental staging.
  - In `screen-lock-e2e-test`, run `pip install --upgrade pip setuptools wheel` to support modern sdists.

<sup>Written for commit 389645abda28f3f0739e4d301f4a2f14c85e88ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

