### PR TITLE
feat(cockpit): glyphs followed the daemon's locale, not the watching terminal

### DIFF
--- a/backend/core/ouroboros/ui/theme.py
+++ b/backend/core/ouroboros/ui/theme.py
@@ -103,14 +103,60 @@ def _forced_tier_from_env() -> Optional[ColorTier]:
         return None
 
 
-def supports_unicode(env: Optional[Mapping[str, str]] = None) -> bool:
-    """True when the locale advertises a UTF-8 codec.
+def _declared_glyph_support() -> Optional[bool]:
+    """What the terminal THAT WILL DISPLAY THIS declared, or ``None``.
 
-    Purely locale-env based so it is deterministic and testable: pass an
-    explicit ``env`` mapping in tests. In production (``env=None``) it reads
-    ``os.environ``. An env with no UTF-8 locale hint yields ``False`` -- the
-    conservative choice that degrades glyphs to ASCII.
+    Tri-state on purpose. ``supports_wide_glyphs()`` collapses "nothing
+    attached" into ``True`` because a renderer needs an answer; here the
+    difference is load-bearing — "no cockpit declared" must fall through to
+    the locale, while "a cockpit declared narrow" must override a UTF-8
+    daemon locale.
+
+    Lazy + fail-soft: `ui/` sits below `battle_test/`, so this is a runtime
+    consultation rather than a module-level dependency. Absent the capability
+    layer — the client process, a bare import, a test — it returns ``None``
+    and `supports_unicode` behaves exactly as it did before.
     """
+    try:
+        from backend.core.ouroboros.battle_test.terminal_capabilities import (
+            current_capabilities,
+        )
+        caps = current_capabilities()
+        return None if caps is None else bool(caps.wide_glyphs)
+    except Exception:  # noqa: BLE001 — glyph choice must never raise
+        return None
+
+
+def supports_unicode(env: Optional[Mapping[str, str]] = None) -> bool:
+    """True when the terminal that will DISPLAY this can render the glyph.
+
+    The daemon renders for a terminal it does not own. Consulting its own
+    ``LC_ALL``/``LANG`` answers the wrong question: a daemon launched under
+    ``LANG=C`` degrades every glyph to ASCII while the operator watches a
+    UTF-8 cockpit, and a UTF-8 daemon emits ``⏺``/``⎿`` into an ASCII
+    terminal as mojibake — which is worse, because a misrendered gutter
+    misaligns every line beneath it.
+
+    Resolution order, measured before assumed:
+
+    1. **An explicit ``env`` always wins.** Callers passing a mapping are
+       asking a deterministic question about a locale, and this stays a pure
+       function of that mapping — the existing test contract is unchanged.
+    2. **The attached cockpit's declaration**, when one exists. Per-subscriber
+       for addressed output; for ambient output `terminal_capabilities`
+       already ANDs across live cockpits, so one ASCII terminal degrades the
+       shared line — an aligned ASCII gutter beats a misaligned pretty one.
+    3. **The local locale**, unchanged. This is the answer in the CLIENT
+       process (which owns a real terminal and has no subscribers) and in a
+       foreground daemon with nothing attached.
+
+    An env with no UTF-8 hint still yields ``False`` — the conservative
+    choice that degrades glyphs to ASCII. NEVER raises.
+    """
+    if env is None:
+        declared = _declared_glyph_support()
+        if declared is not None:
+            return declared
     e = os.environ if env is None else env
     for key in ("LC_ALL", "LC_CTYPE", "LANG"):
         val = e.get(key, "") or ""

--- a/tests/battle_test/test_terminal_capabilities.py
+++ b/tests/battle_test/test_terminal_capabilities.py
@@ -381,3 +381,127 @@ def test_chrome_demotes_bright_only_on_a_DECLARED_light_terminal() -> None:
             os.environ.pop("JARVIS_PRESENTATION_RESTRAINT_ENABLED", None)
         else:
             os.environ["JARVIS_PRESENTATION_RESTRAINT_ENABLED"] = prev
+
+
+# --------------------------------------------------------------------------
+# 8. glyphs follow the DISPLAY, not the daemon's locale (polish gap 3)
+# --------------------------------------------------------------------------
+#
+# `theme.supports_unicode()` read the daemon's own LC_ALL/LANG. The daemon
+# renders for a terminal it does not own, so that answered the wrong question:
+# a daemon launched under LANG=C degraded every glyph while the operator
+# watched a UTF-8 cockpit, and a UTF-8 daemon emitted ⏺/⎿ into an ASCII
+# terminal as mojibake — worse, because a misrendered gutter misaligns every
+# line beneath it.
+#
+# ONE seam again: `mark()` and `ouroboros_frame()` both route through
+# `supports_unicode()`, so converting it carries every glyph with no call site
+# moved.
+
+
+def _utf8_daemon(monkeypatch: Any) -> None:
+    for k in ("LC_ALL", "LC_CTYPE"):
+        monkeypatch.delenv(k, raising=False)
+    monkeypatch.setenv("LANG", "en_US.UTF-8")
+
+
+def test_an_ascii_cockpit_degrades_a_utf8_daemons_glyphs(monkeypatch: Any) -> None:
+    """THE defect. The daemon's locale said unicode; the terminal said no."""
+    from backend.core.ouroboros.ui.theme import mark, supports_unicode
+
+    _utf8_daemon(monkeypatch)
+    assert supports_unicode() is True and mark("check") == "✓"
+
+    declare("ascii", TerminalCapabilities(cols=80, rows=24, wide_glyphs=False))
+    assert supports_unicode() is False
+    assert mark("check") == "OK", "a UTF-8 daemon painted ✓ into an ASCII terminal"
+
+
+def test_a_utf8_cockpit_LIFTS_an_ascii_daemon(monkeypatch: Any) -> None:
+    """The inverse, and the reason this is a capability rather than a floor:
+    a daemon launched under LANG=C must not strip glyphs from a terminal that
+    can render them."""
+    from backend.core.ouroboros.ui.theme import mark, supports_unicode
+
+    monkeypatch.setenv("LANG", "C")
+    for k in ("LC_ALL", "LC_CTYPE"):
+        monkeypatch.delenv(k, raising=False)
+    assert supports_unicode() is False
+
+    declare("utf8", TerminalCapabilities(cols=120, rows=40, wide_glyphs=True))
+    assert supports_unicode() is True
+    assert mark("check") == "✓"
+
+
+def test_addressed_output_uses_THAT_terminals_glyph_support(monkeypatch: Any) -> None:
+    from backend.core.ouroboros.battle_test.attach_session import session_scope
+    from backend.core.ouroboros.ui.theme import mark
+
+    _utf8_daemon(monkeypatch)
+    declare("utf8", TerminalCapabilities(cols=120, rows=40, wide_glyphs=True))
+    declare("ascii", TerminalCapabilities(cols=80, rows=24, wide_glyphs=False))
+    with session_scope("utf8"):
+        assert mark("check") == "✓"
+    with session_scope("ascii"):
+        assert mark("check") == "OK"
+
+
+def test_ambient_degrades_if_ANY_cockpit_is_ascii(monkeypatch: Any) -> None:
+    """A shared line has one rendering. An aligned ASCII gutter beats a
+    misaligned pretty one, so the AND is the safe composition."""
+    from backend.core.ouroboros.ui.theme import supports_unicode
+
+    _utf8_daemon(monkeypatch)
+    declare("utf8", TerminalCapabilities(cols=120, rows=40, wide_glyphs=True))
+    assert supports_unicode() is True
+    declare("ascii", TerminalCapabilities(cols=80, rows=24, wide_glyphs=False))
+    assert supports_unicode() is False
+    forget("ascii")
+    assert supports_unicode() is True, "a departed cockpit still degraded the living"
+
+
+def test_an_explicit_env_stays_a_PURE_function(monkeypatch: Any) -> None:
+    """The existing contract: callers passing a mapping are asking a
+    deterministic question about a locale. A declared cockpit must not leak
+    into that answer or every locale test becomes order-dependent."""
+    from backend.core.ouroboros.ui.theme import supports_unicode
+
+    declare("ascii", TerminalCapabilities(cols=80, rows=24, wide_glyphs=False))
+    assert supports_unicode({"LANG": "en_US.UTF-8"}) is True
+    assert supports_unicode({"LANG": "C"}) is False
+
+
+def test_no_cockpit_falls_through_to_the_locale(monkeypatch: Any) -> None:
+    """The CLIENT process owns a real terminal and has no subscribers; a
+    foreground daemon with nothing attached is the same case. Both must
+    behave exactly as before this change."""
+    from backend.core.ouroboros.ui.theme import supports_unicode
+
+    _utf8_daemon(monkeypatch)
+    assert supports_unicode() is True
+    monkeypatch.setenv("LANG", "C")
+    assert supports_unicode() is False
+
+
+def test_the_spinner_follows_the_same_seam(monkeypatch: Any) -> None:
+    """`ouroboros_frame()` routes through `supports_unicode()` too, so the
+    organism's identity glyph degrades with everything else rather than being
+    the one thing that mojibakes."""
+    from backend.core.ouroboros.ui.theme import ouroboros_frame
+
+    _utf8_daemon(monkeypatch)
+    assert ouroboros_frame(0.0) == "🐍"
+    declare("ascii", TerminalCapabilities(cols=80, rows=24, wide_glyphs=False))
+    assert ouroboros_frame(0.0) == "~"
+
+
+def test_a_poisoned_registry_cannot_break_glyph_choice(monkeypatch: Any) -> None:
+    from backend.core.ouroboros.ui.theme import mark, supports_unicode
+
+    _utf8_daemon(monkeypatch)
+    tc._CAPS["bad"] = "not-capabilities"  # type: ignore[assignment]
+    try:
+        assert isinstance(supports_unicode(), bool)
+        assert isinstance(mark("check"), str)
+    finally:
+        tc._CAPS.pop("bad", None)


### PR DESCRIPTION
Closes **CLI/TUI polish gap 3** — the last unconsumed half of the capability channel. `supports_wide_glyphs()` shipped in #70470 with zero consumers; this spends it.

## The defect

`theme.supports_unicode()` read the **daemon's own** `LC_ALL` / `LC_CTYPE` / `LANG`. The daemon renders for a terminal it does not own, so that answered the wrong question in both directions:

- a daemon launched under `LANG=C` degraded every glyph to ASCII while the operator watched a perfectly capable UTF-8 cockpit;
- a UTF-8 daemon emitted `⏺` / `⎿` into an ASCII terminal as mojibake — the worse direction, because a misrendered gutter misaligns **every line beneath it**.

## One seam, not N call sites

`mark()` and `ouroboros_frame()` both resolve through the same line:

```python
use_unicode = supports_unicode() if unicode is None else unicode
```

So converting that one function carries every glyph on every daemon-side surface, with no call site moved. Same lever as `SpooledConsole.size` in #70471, and the console swap that mirrored ~76 handlers without touching one.

## Resolution order — measured before assumed

1. **An explicit `env` mapping always wins.** Callers passing one are asking a deterministic question about a locale, and this stays a pure function of that mapping. A declared cockpit must never leak in, or every locale test becomes order-dependent.
2. **The attached cockpit's declaration.** Per-subscriber for addressed output; for ambient, `terminal_capabilities` already ANDs across live cockpits, so one ASCII terminal degrades the shared line.
3. **The local locale, unchanged** — the answer in the CLIENT process (which owns a real terminal and has no subscribers) and in a foreground daemon with nothing attached.

`_declared_glyph_support()` is deliberately **tri-state**. `supports_wide_glyphs()` collapses "nothing attached" into `True` because a renderer needs an answer; here the difference is load-bearing — *"no cockpit declared"* must fall through to the locale, while *"a cockpit declared narrow"* must override a UTF-8 daemon.

**Layering:** `ui/` sits below `battle_test/`, so the capability read is a lazy, fail-soft runtime consultation rather than a module-level dependency. Absent the capability layer, the function behaves exactly as before.

## Measured

UTF-8 daemon, ASCII cockpit attached:

```
·  ✓   ✗  ›  ─      ->      -  OK  X  >  -
```

And the inverse — a `LANG=C` daemon is *lifted* by a UTF-8 cockpit, which is why this is a capability rather than a floor.

## Verification

- **42 tests** in the capability spine (8 new), covering both directions, addressed vs ambient, the AND across cockpits, explicit-env purity, the no-cockpit fallthrough, the spinner, and a poisoned registry.
- **197 passed** across glyph ratchet + presentation-restraint + console hygiene + esc-interrupt.
- The 5 `test_deck_grammar_unification` failures are **pre-existing** — identical 5 with `theme.py` reverted in the same working directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Glyph selection now follows the watching terminal’s capabilities instead of the daemon’s locale. This prevents mojibake and keeps gutters aligned across mixed terminals.

- **Bug Fixes**
  - Updated `supports_unicode()` resolution to: explicit `env` > attached cockpit `wide_glyphs` > local locale.
  - Added tri‑state `_declared_glyph_support()` using `terminal_capabilities`, fail‑soft and only when present.
  - Routed via the existing seam so `mark()` and `ouroboros_frame()` render consistently for addressed output and ambient lines (ambient ANDs across cockpits).
  - Added tests covering both directions, explicit‑env purity, no‑cockpit fallthrough, spinner behavior, and poisoned registry safety.

<sup>Written for commit a5401a27e4e24d451614f7fad1f747c2402db727. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70475?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

