### PR TITLE
feat(cockpit): the flush valve, measured against the socket

### DIFF
--- a/backend/core/ouroboros/battle_test/adaptive_window.py
+++ b/backend/core/ouroboros/battle_test/adaptive_window.py
@@ -312,26 +312,34 @@ class FlushPolicy:
         # -> accumulate. Slow stream -> eta large -> emit promptly. No rate
         # threshold anywhere: the crossover is wherever the two measured
         # quantities happen to meet.
-        # A PARTIAL line past the drain floor. Sending it is right only if
-        # the rest is not about to arrive — otherwise a fast stream becomes
-        # one frame per token, which is the flood this module prevents.
+        # A PARTIAL line past the drain floor. Whether to send it is the
+        # question that governs everything, and the answer is a comparison
+        # BETWEEN THE TWO MEASURED DOMAINS rather than within either one.
         #
-        # "About to arrive" is measurable without a latency constant: the
-        # stream has STALLED when the wait since the last token exceeds the
-        # gap this stream normally shows, plus its jitter.
+        #     idle_s  = the gap the generator just left between tokens
+        #     t       = drain + jitter, what the sink needs per frame
         #
-        #     stalled  <=>  idle_s > gap.mean + gap.deviation
+        # Both are times, so the comparison is dimensionally honest, and it
+        # asks the only question that matters: can the sink keep up?
         #
-        # Mid-burst the gap is tiny, so a partial line is never stalled and
-        # the buffer fills to C. When the model pauses — end of a sentence,
-        # a tool round, the end of the reply — the gap blows past its own
-        # envelope immediately and the text goes out. Both sides measured;
-        # the crossover is wherever this stream's own rhythm puts it.
-        if idle_s > self.gap.upper and self.gap.samples > 0:
-            return FlushDecision(True, "stalled", c, t, cap)
+        #   idle_s > t   the generator is slower than the sink. The socket is
+        #                STARVING — there is no congestion to cause, so a
+        #                partial line costs nothing and waiting only makes
+        #                the operator watch a still screen. Send it.
+        #
+        #   idle_s <= t  the generator is outrunning the sink. Flushing now
+        #                queues frames faster than they drain, which is the
+        #                flood. Accumulate to C instead.
+        #
+        # Earlier attempts compared idle against the TOKEN envelope, which a
+        # uniform stream can never exceed — a regular 200ms trickle is never
+        # surprising to itself, so it never emitted. The gap has to be judged
+        # against the sink, not against its own history.
+        if idle_s > t:
+            return FlushDecision(True, "sink_starving", c, t, cap)
         if c <= 0:
-            # No declared width: no line to fill, so there is nothing to wait
-            # for and the drain floor alone governs.
+            # No declared width: no line to accumulate toward, so the drain
+            # floor alone governs and there is nothing to wait for.
             return FlushDecision(True, "no_line_target", c, t, cap)
         return FlushDecision(False, "filling", c, t, cap)
 

--- a/backend/core/ouroboros/battle_test/adaptive_window.py
+++ b/backend/core/ouroboros/battle_test/adaptive_window.py
@@ -1,0 +1,356 @@
+"""How often to send, derived from what is actually happening.
+
+`StreamMirror` batches model tokens into committed frames for the cockpit.
+Its flush policy was three module literals::
+
+    _FLUSH_CHARS      = 160
+    _FLUSH_INTERVAL_S = 0.35
+    _MAX_BUFFER_CHARS = 8192
+
+Every one of them is a guess about a situation nobody measured: how fast this
+model emits, how quickly this socket drains, how wide this terminal is. A
+200-column cockpit and an 80-column one get identically-sized frames; a
+congested socket is pushed at the same rate as an idle one; a burst and a
+trickle are batched the same way.
+
+This derives all three from signals the stream already carries.
+
+The three measurements
+----------------------
+``lam``   chars/sec arriving      — sampled from the gap between tokens
+``drain`` seconds per frame       — sampled around the sink call
+``jitter`` mean abs deviation of drain
+
+Nothing is probed. Each is recorded where the data already passes.
+
+The three derivations
+---------------------
+**Char threshold ``C = W``** — the subscriber's declared columns. One display
+line is the natural frame unit: a frame that fills exactly one line on THAT
+terminal. Wide cockpits get larger frames because they can absorb them.
+
+**Time threshold ``T = drain + jitter``** — never emit faster than the sink
+absorbs, plus its observed variance. This IS the backpressure mechanism and
+it is self-regulating: congestion raises ``drain``, which widens ``T``, which
+backs the producer off. No polling, no sleeps, no frame budget.
+
+**Ring cap = ``W x H``** — the subscriber's screenful. Past one screen the
+operator cannot read it anyway, so the oldest text is provably the right
+thing to drop.
+
+The behaviour is not coded, it falls out::
+
+    burst        lam UP   -> C reached fast, T throttles  -> frames widen
+    trickle      lam DOWN -> C rarely reached, drain small -> T fires promptly
+    congestion   drain UP -> T UP                          -> back off
+    resize       W change -> C and cap move with it
+
+Eliminating the smoothing constant
+----------------------------------
+An EWMA needs a weight. The usual answer is a time constant ``tau`` and a
+literal for it — which would put back exactly the kind of unmeasured guess
+this module exists to remove.
+
+So the weight is derived from the signal's own surprise::
+
+    residual = |sample - mean|
+    alpha    = residual / (residual + deviation)
+
+``deviation`` is the running mean-absolute-deviation — the scale of "normal"
+for this signal. The ratio is dimensionless and self-normalising:
+
+  * a sample far outside normal variation (``residual >> deviation``) drives
+    ``alpha -> 1``: adopt it, the world changed;
+  * a sample inside the noise band (``residual << deviation``) drives
+    ``alpha -> 0``: ignore it, that is just jitter;
+  * ``residual ~ deviation`` gives ``alpha ~ 0.5``.
+
+This is a normalised innovation — the same shape as a Kalman gain, where the
+weight is the ratio of innovation to total expected variance. It answers the
+"second derivative" question directly: ``residual`` measured against a
+*moving* mean IS the acceleration term, and ``deviation`` is the scale that
+makes it unitless.
+
+Cold start needs no seed either. With no history ``deviation == 0``, so
+``alpha = residual / residual = 1`` and the first sample is adopted whole —
+which is the correct thing to do with the only observation you have.
+
+The single degenerate case is ``residual == 0 and deviation == 0``: a signal
+that has never varied. ``alpha = 0`` there is not a chosen default, it is the
+limit — a sample identical to the mean carries no information, so the mean
+does not move.
+
+**There are no thresholds in this module.** Every number is measured or
+derived from a measurement. The only literals are the mathematical identities
+above (0 and 1 as the bounds of a ratio) and the structural guards that keep
+division defined.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Callable, Optional, Tuple
+
+logger = logging.getLogger("Ouroboros.AdaptiveWindow")
+
+__all__ = ["AdaptiveSignal", "FlushPolicy", "FlushDecision"]
+
+
+@dataclass
+class AdaptiveSignal:
+    """One scalar tracked with a self-deriving smoothing weight.
+
+    Not a generic EWMA: the weight comes from the sample's own surprise
+    relative to the running deviation, so there is no time constant to pick
+    and no cold-start seed to invent. See the module docstring.
+
+    NEVER raises. A non-finite or negative sample is refused rather than
+    absorbed — a NaN reaching the mean would poison every future decision,
+    and this sits on the token hot path.
+    """
+
+    mean: float = 0.0
+    deviation: float = 0.0
+    samples: int = 0
+
+    def observe(self, sample: float) -> None:
+        try:
+            x = float(sample)
+        except (TypeError, ValueError):
+            return
+        # Reject non-finite without importing math for one predicate: NaN is
+        # the only value unequal to itself, and infinities blow up the ratio.
+        if x != x or x in (float("inf"), float("-inf")):
+            return
+        if x < 0.0:
+            return                      # durations and rates are non-negative
+
+        if self.samples == 0:
+            # No history: adopt. `deviation` stays 0 so the NEXT sample's
+            # alpha is 1 as well, which is right — two points do not yet
+            # describe a noise band.
+            self.mean = x
+            self.samples = 1
+            return
+
+        residual = abs(x - self.mean)
+        denom = residual + self.deviation
+        # residual == 0 and deviation == 0 -> a signal that has never varied.
+        # alpha = 0 is the limit, not a fallback: a sample identical to the
+        # mean carries no information.
+        alpha = (residual / denom) if denom > 0.0 else 0.0
+
+        self.mean += alpha * (x - self.mean)
+        # The deviation tracks the same way, one order down: it is the scale
+        # that makes the next residual dimensionless.
+        self.deviation += alpha * (residual - self.deviation)
+        self.samples += 1
+
+    @property
+    def upper(self) -> float:
+        """mean + deviation — the value plus its observed variance.
+
+        The quantity a scheduler actually wants: not "how long does this
+        usually take" but "how long before I should be surprised".
+        """
+        return self.mean + self.deviation
+
+
+@dataclass(frozen=True)
+class FlushDecision:
+    """Why a flush should or should not happen. Rendered into telemetry, so
+    an operator can ask the window what it thinks it is doing."""
+
+    should_flush: bool
+    reason: str
+    char_threshold: int
+    time_threshold_s: float
+    ring_cap: int
+
+
+@dataclass
+class FlushPolicy:
+    """Derives the flush thresholds from live measurements. NEVER raises.
+
+    `display` is injected rather than imported so this stays testable with no
+    capability layer, no cockpit and no daemon — the same discipline
+    `StreamMirror` already applies to its sink and clock. It returns
+    ``(cols, rows)``; ``None`` means nothing has declared, and the policy
+    falls back to *measurement-only* behaviour rather than to a literal.
+    """
+
+    display: Optional[Callable[[], Tuple[int, int]]] = None
+    arrival: AdaptiveSignal = field(default_factory=AdaptiveSignal)
+    drain: AdaptiveSignal = field(default_factory=AdaptiveSignal)
+    #: Inter-token GAP, tracked alongside the rate. The rate answers "how
+    #: much text is coming"; the gap answers "is it still coming". Only the
+    #: second can distinguish a stream that is mid-burst from one that has
+    #: stopped — and that is the question a partial line depends on.
+    gap: AdaptiveSignal = field(default_factory=AdaptiveSignal)
+
+    #: Set once a frame has actually been emitted. Before that the policy
+    #: says "emit now" at the first safe boundary, so the first frame's own
+    #: drain time becomes the first measurement. The system bootstraps from
+    #: its own behaviour instead of from a guess.
+    _primed: bool = False
+
+    # -- measurement ingress ------------------------------------------------
+
+    def observe_arrival(self, chars: int, gap_s: float) -> None:
+        """One token arrived: `chars` characters, `gap_s` since the last.
+
+        Records a RATE, not a duration, so a burst and a trickle are
+        comparable. A zero gap (two tokens in the same clock tick) carries no
+        rate information and is skipped rather than dividing by zero.
+        """
+        try:
+            if gap_s > 0.0 and chars > 0:
+                self.arrival.observe(float(chars) / float(gap_s))
+                self.gap.observe(float(gap_s))
+        except Exception:  # noqa: BLE001 — telemetry cannot break a stream
+            pass
+
+    def observe_drain(self, seconds: float) -> None:
+        """One frame took `seconds` to hand to the sink."""
+        try:
+            self.drain.observe(seconds)
+            self._primed = True
+        except Exception:  # noqa: BLE001
+            pass
+
+    # -- derivations --------------------------------------------------------
+
+    def _display(self) -> Optional[Tuple[int, int]]:
+        """Read the display EVERY time, never cache.
+
+        SIGWINCH is asynchronous: the operator can resize mid-stream, and a
+        cached width would keep framing for a window that no longer exists.
+        Reading per decision makes a resize take effect on the very next
+        token, with no invalidation protocol and nothing to tear.
+        """
+        try:
+            fn = self.display
+            if fn is None:
+                return None
+            cols, rows = fn()
+            cols, rows = int(cols), int(rows)
+            return (cols, rows) if cols > 0 and rows > 0 else None
+        except Exception:  # noqa: BLE001
+            return None
+
+    def char_threshold(self) -> int:
+        """C — one display line at the subscriber's current width.
+
+        Without a declared display there is no line to fill, so the char
+        trigger is disabled (returned as 0 = "never trips") and the time
+        threshold alone governs. That is the honest degradation: emit on a
+        measured cadence rather than at an invented size.
+        """
+        d = self._display()
+        return d[0] if d is not None else 0
+
+    def time_threshold_s(self) -> float:
+        """T — drain plus its jitter. Zero until the first frame has drained.
+
+        Zero means "no minimum spacing yet", which is what lets the first
+        frame go out immediately and produce the first measurement.
+        """
+        return self.drain.upper if self._primed else 0.0
+
+    def ring_cap(self) -> int:
+        """One screenful at the current geometry, or 0 for "no cap known".
+
+        A caller seeing 0 must NOT invent one — it should hold the buffer
+        uncapped rather than drop text on a guess. Unbounded growth is
+        prevented by the cap existing the moment any cockpit declares.
+        """
+        d = self._display()
+        return d[0] * d[1] if d is not None else 0
+
+    # -- the decision -------------------------------------------------------
+
+    def evaluate(self, buffered_chars: int, since_last_flush_s: float,
+                 idle_s: float = 0.0) -> FlushDecision:
+        """Should the mirror flush now? Pure; NEVER raises."""
+        c = self.char_threshold()
+        t = self.time_threshold_s()
+        cap = self.ring_cap()
+
+        if not self._primed:
+            return FlushDecision(
+                True, "cold_start", c, t, cap,
+            )
+        # The socket floor comes first: nothing may be emitted faster than the
+        # sink has shown it can absorb, whatever the char count says. This is
+        # the whole backpressure mechanism and it must not be overridable by
+        # a burst — a burst is exactly when it matters.
+        if since_last_flush_s < t:
+            return FlushDecision(False, "drain_floor", c, t, cap)
+        if c > 0 and buffered_chars >= c:
+            return FlushDecision(True, "line_full", c, t, cap)
+        if buffered_chars <= 0:
+            return FlushDecision(False, "empty", c, t, cap)
+
+        # Past the drain floor with a PARTIAL line. Whether to send it is the
+        # question that decides burst behaviour, and answering it "yes" is
+        # what turns a fast stream into one frame per token — the socket is
+        # always ready a moment after a drain, so an eagerness test on
+        # readiness alone degenerates to no batching at all.
+        #
+        # The real question is what waiting COSTS, and that is measurable:
+        # how long until the rest of the line arrives.
+        #
+        #     eta = (C - buffered) / arrival_rate
+        #
+        # If the line will complete sooner than one drain period, waiting is
+        # free — the frame we would send now and the fuller frame we send
+        # after eta reach the operator at indistinguishable times, and the
+        # fuller one costs the socket less. If it will take longer, waiting
+        # is a stall the operator can see, so send.
+        #
+        # Both sides of the comparison are measured. Fast stream -> eta small
+        # -> accumulate. Slow stream -> eta large -> emit promptly. No rate
+        # threshold anywhere: the crossover is wherever the two measured
+        # quantities happen to meet.
+        # A PARTIAL line past the drain floor. Sending it is right only if
+        # the rest is not about to arrive — otherwise a fast stream becomes
+        # one frame per token, which is the flood this module prevents.
+        #
+        # "About to arrive" is measurable without a latency constant: the
+        # stream has STALLED when the wait since the last token exceeds the
+        # gap this stream normally shows, plus its jitter.
+        #
+        #     stalled  <=>  idle_s > gap.mean + gap.deviation
+        #
+        # Mid-burst the gap is tiny, so a partial line is never stalled and
+        # the buffer fills to C. When the model pauses — end of a sentence,
+        # a tool round, the end of the reply — the gap blows past its own
+        # envelope immediately and the text goes out. Both sides measured;
+        # the crossover is wherever this stream's own rhythm puts it.
+        if idle_s > self.gap.upper and self.gap.samples > 0:
+            return FlushDecision(True, "stalled", c, t, cap)
+        if c <= 0:
+            # No declared width: no line to fill, so there is nothing to wait
+            # for and the drain floor alone governs.
+            return FlushDecision(True, "no_line_target", c, t, cap)
+        return FlushDecision(False, "filling", c, t, cap)
+
+    def snapshot(self) -> dict:
+        """Observable state — §7. NEVER raises."""
+        try:
+            return {
+                "arrival_chars_per_s": round(self.arrival.mean, 2),
+                "arrival_deviation": round(self.arrival.deviation, 2),
+                "drain_s": round(self.drain.mean, 4),
+                "drain_jitter_s": round(self.drain.deviation, 4),
+                "char_threshold": self.char_threshold(),
+                "time_threshold_s": round(self.time_threshold_s(), 4),
+                "ring_cap": self.ring_cap(),
+                "primed": self._primed,
+                "samples": {
+                    "arrival": self.arrival.samples,
+                    "drain": self.drain.samples,
+                },
+            }
+        except Exception:  # noqa: BLE001
+            return {}

--- a/backend/core/ouroboros/battle_test/backpressure_notice.py
+++ b/backend/core/ouroboros/battle_test/backpressure_notice.py
@@ -1,0 +1,80 @@
+"""Saying what a surface did NOT receive.
+
+Two bounded buffers feed an attached cockpit and both drop under load:
+
+  * :class:`~battle_test.spooled_console.ConsoleSpooler` drops whole LINES
+    when a cockpit stops reading;
+  * :class:`~battle_test.stream_mirror.StreamMirror` drops CHARACTERS from
+    the front of the token buffer when frames outrun the socket.
+
+Both were counting. Neither was telling. A bounded queue that silently
+discards is correct engineering and dishonest reporting: the operator reads a
+continuous transcript with holes in it and has no way to know a hole is
+there.
+
+The rule is the same for both, so it lives once here rather than twice in
+them. It is also the same rule the SSE broker already applies — one
+``stream_lag`` per window, not one per dropped frame — so all three
+backpressure surfaces say the same thing the same way.
+
+Coalesced, not per-drop
+-----------------------
+Under sustained load a per-drop notice becomes the thing crowding the queue:
+the surface spends its remaining capacity announcing that it has no capacity.
+So a caller reports the DELTA since it last spoke, and only when that delta
+is positive.
+
+Pure and total. No I/O, no clock, no state of its own — the caller owns the
+watermark, because the caller owns the buffer. NEVER raises: a notice that
+can fail is a notice that turns a dropped line into a dropped stream.
+"""
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+__all__ = ["coalesced_drop_notice", "DROP_GLYPH"]
+
+#: The op-chrome continuation glyph. A gap is something that happened to the
+#: work, so it renders as work chrome rather than as prose — the same
+#: ``⎿`` an operator already reads as "and then this".
+DROP_GLYPH = "⎿"
+
+
+def coalesced_drop_notice(
+    dropped_total: int,
+    reported_total: int,
+    *,
+    unit: str = "line",
+    detail: str = "",
+) -> Tuple[Optional[str], int]:
+    """One notice for everything lost since the caller last spoke.
+
+    Returns ``(notice_or_None, new_reported_total)``. The caller stores the
+    second value and passes it back next time; the watermark lives with the
+    buffer that owns the drops.
+
+    ``unit`` names what was lost in the surface's own terms — a console loses
+    lines, a token mirror loses characters. Reporting "12 lines" for
+    characters would be precise about a quantity and wrong about the thing,
+    which is the failure mode this whole surface exists to prevent.
+
+    ``detail`` appends a surface-specific clause (where the full record
+    lives, what to do). Empty is fine; the notice stands without it.
+    """
+    try:
+        total = int(dropped_total)
+        seen = int(reported_total)
+    except (TypeError, ValueError):
+        return None, reported_total
+
+    if total <= seen:
+        return None, seen              # nothing new to confess
+
+    missed = total - seen
+    noun = str(unit or "item")
+    plural = noun if missed == 1 else f"{noun}s"
+    tail = f" — {detail}" if detail else ""
+    return (
+        f"[dim]{DROP_GLYPH} {missed} {plural} dropped{tail}[/dim]",
+        total,
+    )

--- a/backend/core/ouroboros/battle_test/spooled_console.py
+++ b/backend/core/ouroboros/battle_test/spooled_console.py
@@ -107,15 +107,16 @@ class ConsoleSpooler:
         two backpressure surfaces say the same thing the same way.
         """
         try:
-            total = int(self.dropped)
-            if total <= self._lag_reported:
-                return None
-            missed = total - self._lag_reported
-            self._lag_reported = total
-            return (
-                f"[dim]⎿ {missed} line(s) dropped — this cockpit fell behind; "
-                f"the daemon's log has the full record[/dim]"
+            from backend.core.ouroboros.battle_test.backpressure_notice import (
+                coalesced_drop_notice,
             )
+            notice, self._lag_reported = coalesced_drop_notice(
+                self.dropped, self._lag_reported,
+                unit="line",
+                detail=("this cockpit fell behind; the daemon's log has the "
+                        "full record"),
+            )
+            return notice
         except Exception:  # noqa: BLE001
             return None
 

--- a/backend/core/ouroboros/battle_test/stream_mirror.py
+++ b/backend/core/ouroboros/battle_test/stream_mirror.py
@@ -96,6 +96,11 @@ class StreamMirror:
         self._size = 0
         self._last_flush = self._clock()
         self._last_token_at: Optional[float] = None
+        #: Seconds spent INSIDE our own sink since the last token arrived.
+        #: Subtracted from the next measured gap so the generator's idle time
+        #: is not inflated by our own draining — the observer must not appear
+        #: in its own observation.
+        self._self_time_s = 0.0
         self.frames_emitted = 0
         self.chars_dropped = 0
         #: Watermark for the coalesced drop notice — see backpressure_notice.
@@ -145,7 +150,16 @@ class StreamMirror:
                 # should go out now. A trickle therefore emits per token
                 # while a burst accumulates — from one measurement, with no
                 # timer task and no idle-poll loop to schedule.
-                idle = 0.0 if prev_token_at is None else (now - prev_token_at)
+                # The wall gap minus the time WE spent draining. Without
+                # this subtraction a flush inflates the next measured gap by
+                # exactly one drain period, which forces `idle > T_drain`
+                # forever and collapses the policy to one frame per token.
+                # The observer's own cost cannot be part of the measurement.
+                idle = (
+                    0.0 if prev_token_at is None
+                    else max(0.0, (now - prev_token_at) - self._self_time_s)
+                )
+                self._self_time_s = 0.0
                 decision = self._policy.evaluate(
                     self._size, now - self._last_flush, idle_s=idle,
                 )
@@ -206,8 +220,10 @@ class StreamMirror:
                 # backpressure the socket is applying right now.
                 started = self._clock()
                 sink(head)
+                elapsed = self._clock() - started
+                self._self_time_s += elapsed
                 if self._policy is not None:
-                    self._policy.observe_drain(self._clock() - started)
+                    self._policy.observe_drain(elapsed)
                 self.frames_emitted += 1
         except Exception:  # noqa: BLE001
             logger.debug("[StreamMirror] flush degraded", exc_info=True)

--- a/backend/core/ouroboros/battle_test/stream_mirror.py
+++ b/backend/core/ouroboros/battle_test/stream_mirror.py
@@ -40,7 +40,10 @@ from __future__ import annotations
 import logging
 import os
 import time
-from typing import Any, Callable, List, Optional
+from typing import TYPE_CHECKING, Any, Callable, List, Optional
+
+if TYPE_CHECKING:  # pragma: no cover
+    from backend.core.ouroboros.battle_test.adaptive_window import FlushPolicy
 
 logger = logging.getLogger("Ouroboros.StreamMirror")
 
@@ -76,6 +79,7 @@ class StreamMirror:
         flush_chars: int = _FLUSH_CHARS,
         flush_interval_s: float = _FLUSH_INTERVAL_S,
         clock: Optional[Callable[[], float]] = None,
+        policy: Optional["FlushPolicy"] = None,
     ) -> None:
         # INJECTED sink and clock: this must be testable with no bridge, no
         # daemon and no wall-clock dependence.
@@ -83,11 +87,19 @@ class StreamMirror:
         self._flush_chars = max(1, int(flush_chars))
         self._interval = max(0.0, float(flush_interval_s))
         self._clock = clock or time.monotonic
+        # ADAPTIVE POLICY (optional). When present it supersedes the scalar
+        # thresholds above, which stay as the injected-static path so this
+        # class remains testable with no capability layer and no daemon.
+        # Absent a policy the behaviour is byte-identical to before.
+        self._policy = policy
         self._buf: List[str] = []
         self._size = 0
         self._last_flush = self._clock()
+        self._last_token_at: Optional[float] = None
         self.frames_emitted = 0
         self.chars_dropped = 0
+        #: Watermark for the coalesced drop notice — see backpressure_notice.
+        self._drops_reported = 0
 
     # -- token side --------------------------------------------------------
 
@@ -97,16 +109,52 @@ class StreamMirror:
             chunk = str(text or "")
             if not chunk:
                 return
+            # Arrival telemetry BEFORE buffering, so the rate reflects the
+            # producer rather than our own bookkeeping.
+            now = self._clock()
+            prev_token_at = self._last_token_at
+            if self._policy is not None and self._last_token_at is not None:
+                self._policy.observe_arrival(len(chunk), now - self._last_token_at)
+            self._last_token_at = now
+
             self._buf.append(chunk)
             self._size += len(chunk)
-            if self._size > _MAX_BUFFER_CHARS:
+            # Ring cap: one screenful at the subscriber's CURRENT geometry,
+            # re-read per token so a SIGWINCH mid-stream takes effect on the
+            # next one. A shrink trims once here and we are back in bounds;
+            # a growth simply stops trimming. Nothing to invalidate, nothing
+            # to tear. `0` means no display has declared — hold uncapped
+            # rather than drop text against an invented size.
+            cap = _MAX_BUFFER_CHARS
+            if self._policy is not None:
+                derived = self._policy.ring_cap()
+                cap = derived if derived > 0 else 0
+            if cap > 0 and self._size > cap:
                 # Drop from the FRONT: when a cockpit falls behind, the recent
                 # text is what the operator is waiting for.
-                dropped = self._size - _MAX_BUFFER_CHARS
+                dropped = self._size - cap
                 joined = "".join(self._buf)[dropped:]
                 self._buf = [joined]
                 self._size = len(joined)
                 self.chars_dropped += dropped
+            if self._policy is not None:
+                # The pause is knowable HERE, without a poller: the moment
+                # token N arrives we learn how long the stream was silent
+                # before it. If that silence exceeded this stream's own
+                # rhythm, it HAD stalled, and the text waiting behind it
+                # should go out now. A trickle therefore emits per token
+                # while a burst accumulates — from one measurement, with no
+                # timer task and no idle-poll loop to schedule.
+                idle = 0.0 if prev_token_at is None else (now - prev_token_at)
+                decision = self._policy.evaluate(
+                    self._size, now - self._last_flush, idle_s=idle,
+                )
+                if decision.should_flush:
+                    # cold_start / drain_ready have no clean-cut guarantee to
+                    # wait for; line_full does. Forcing only where the policy
+                    # says the deadline governs preserves the boundary rule.
+                    self.flush(force=decision.reason != "line_full")
+                return
             if self._size >= self._flush_chars:
                 self.flush()
             elif (self._clock() - self._last_flush) >= self._interval:
@@ -145,10 +193,45 @@ class StreamMirror:
             self._last_flush = self._clock()
             sink = self._emit
             if sink is not None and head.strip():
+                # Confess the gap BEFORE the frame that follows it, so the
+                # marker sits where the hole actually is rather than after
+                # the next unrelated block. Same rule, same implementation
+                # as ConsoleSpooler — see backpressure_notice.
+                notice = self._drop_notice()
+                if notice is not None:
+                    sink(notice)
+                # DRAIN measurement wraps the sink call and nothing else:
+                # this is exactly the quantity the policy needs — how long
+                # this surface takes to absorb one frame, including whatever
+                # backpressure the socket is applying right now.
+                started = self._clock()
                 sink(head)
+                if self._policy is not None:
+                    self._policy.observe_drain(self._clock() - started)
                 self.frames_emitted += 1
         except Exception:  # noqa: BLE001
             logger.debug("[StreamMirror] flush degraded", exc_info=True)
+
+    def _drop_notice(self) -> Optional[str]:
+        """One coalesced line naming the characters this cockpit never got.
+
+        `chars_dropped` has been counted since this class was written and
+        never surfaced. Characters, not lines — the unit is the surface's
+        own, because reporting "12 lines" for characters would be precise
+        about a quantity and wrong about the thing. NEVER raises.
+        """
+        try:
+            from backend.core.ouroboros.battle_test.backpressure_notice import (
+                coalesced_drop_notice,
+            )
+            notice, self._drops_reported = coalesced_drop_notice(
+                self.chars_dropped, self._drops_reported,
+                unit="character",
+                detail="this cockpit fell behind mid-stream",
+            )
+            return notice
+        except Exception:  # noqa: BLE001
+            return None
 
     def _split_at_boundary(self, text: str, force: bool = False) -> tuple:
         """(committed, remainder) using the renderer's own boundary rule.

--- a/tests/battle_test/test_adaptive_window.py
+++ b/tests/battle_test/test_adaptive_window.py
@@ -1,0 +1,351 @@
+"""The flush valve, and the four wrong answers that preceded it.
+
+`StreamMirror` batched tokens into cockpit frames on three module literals —
+160 chars, 0.35s, 8192 cap — each a guess about a situation nobody measured.
+Replacing them took five attempts, and four of them were falsified only by
+running the thing. Those failures are pinned here because each one is a
+plausible design somebody will re-propose:
+
+  1. *past drain floor + text waiting*  -> one frame per token (the flood)
+  2. *eta > drain period*               -> same; compares a HUMAN latency
+                                           against a SOCKET latency
+  3. *idle > token-gap envelope*        -> a uniform stream never surprises
+                                           itself, so a 200ms trickle never
+                                           emitted
+  4. all of the above, defeated by      -> the measured gap silently included
+     OBSERVER CONTAMINATION                our own drain time
+
+The answer is a comparison across the two measured domains::
+
+    idle > drain + jitter   generator slower than sink -> sink is STARVING,
+                            no congestion possible     -> send the partial line
+    idle <= drain + jitter  generator outruns the sink -> flushing floods it
+                                                       -> accumulate to C = W
+
+Both are times. No threshold decides "burst" or "trickle": the crossover is
+wherever the two measurements happen to meet.
+"""
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any, List, Tuple
+
+import pytest
+
+from backend.core.ouroboros.battle_test.adaptive_window import (
+    AdaptiveSignal,
+    FlushPolicy,
+)
+from backend.core.ouroboros.battle_test.stream_mirror import StreamMirror
+
+WORDS = ["the ", "model ", "emits ", "prose. ", "It has ",
+         "spaces, ", "commas, ", "and stops. "]
+
+
+# ---------------------------------------------------------------------------
+# 1. the smoothing weight derives itself — no tau, no seed
+# ---------------------------------------------------------------------------
+
+def test_the_first_sample_is_adopted_whole() -> None:
+    """Cold start needs no seed constant: with no history the deviation is 0,
+    so alpha = residual/residual = 1 and the only observation wins."""
+    s = AdaptiveSignal()
+    s.observe(0.1)
+    assert s.mean == pytest.approx(0.1)
+    assert s.samples == 1
+
+
+def test_a_stable_signal_collapses_alpha() -> None:
+    """Samples inside the noise band must barely move the mean, or the
+    'envelope' becomes a copy of the last value."""
+    s = AdaptiveSignal()
+    for x in (0.100, 0.101, 0.099, 0.100, 0.102, 0.098, 0.100):
+        s.observe(x)
+    assert s.mean == pytest.approx(0.100, abs=0.003)
+    assert 0.0 < s.deviation < 0.01, "deviation should describe the noise band"
+
+
+def test_a_shock_is_adopted_in_ONE_sample() -> None:
+    """The whole point of a self-deriving weight: a regime change is
+    surprising, and surprise IS the weight."""
+    s = AdaptiveSignal()
+    for _ in range(8):
+        s.observe(0.005)
+    before = s.mean
+    s.observe(1.0)
+    assert before < 0.01 and s.mean > 0.9, (
+        f"a 200x shock moved the mean only {before:.4f} -> {s.mean:.4f}"
+    )
+
+
+@pytest.mark.parametrize("poison", [
+    float("nan"), float("inf"), float("-inf"), -1.0, "x", None, object(),
+])
+def test_a_poisoned_sample_cannot_reach_the_mean(poison: Any) -> None:
+    """This sits on the token hot path. One NaN in the mean would corrupt
+    every future flush decision, silently and permanently."""
+    s = AdaptiveSignal()
+    s.observe(0.005)
+    before = s.mean
+    s.observe(poison)
+    assert s.mean == before
+
+
+def test_a_never_varying_signal_neither_drifts_nor_divides_by_zero() -> None:
+    """residual == 0 and deviation == 0 is the one degenerate case. alpha = 0
+    is the limit there, not a chosen fallback."""
+    s = AdaptiveSignal()
+    for _ in range(5):
+        s.observe(0.5)
+    assert (s.mean, s.deviation) == (0.5, 0.0)
+
+
+def test_there_is_no_time_constant_to_tune() -> None:
+    """Structural: the module must not acquire a tau/half-life/window under
+    maintenance. The whole claim is that the weight is derived."""
+    import inspect
+
+    from backend.core.ouroboros.battle_test import adaptive_window as aw
+
+    src = inspect.getsource(aw.AdaptiveSignal)
+    for banned in ("tau", "half_life", "halflife", "window_size", "0.9", "0.1"):
+        assert banned not in src, f"{banned!r} appeared in the smoothing"
+
+
+# ---------------------------------------------------------------------------
+# 2. the valve — measured against the SOCKET, not against itself
+# ---------------------------------------------------------------------------
+
+def _policy(cols: int = 80, rows: int = 24) -> FlushPolicy:
+    p = FlushPolicy(display=lambda: (cols, rows))
+    p.observe_drain(0.005)          # prime: T = 0.005
+    return p
+
+
+def test_a_starving_sink_releases_a_partial_line() -> None:
+    """Generator slower than the sink: no congestion is possible, so holding
+    text only makes the operator watch a still screen."""
+    d = _policy().evaluate(buffered_chars=10, since_last_flush_s=0.21,
+                           idle_s=0.200)
+    assert d.should_flush and d.reason == "sink_starving"
+
+
+def test_a_burst_accumulates_instead_of_flooding() -> None:
+    """Generator outrunning the sink: flushing queues frames faster than they
+    drain, which is the flood this module exists to prevent."""
+    d = _policy().evaluate(buffered_chars=10, since_last_flush_s=0.006,
+                           idle_s=0.001)
+    assert not d.should_flush and d.reason == "filling"
+
+
+def test_the_crossover_is_the_drain_envelope_and_nothing_else() -> None:
+    """No literal defines 'burst' or 'trickle'. Straddle T and the decision
+    must flip on that boundary alone."""
+    p = _policy()
+    t = p.time_threshold_s()
+    below = p.evaluate(10, t + 0.001, idle_s=t * 0.99)
+    above = p.evaluate(10, t + 0.001, idle_s=t * 1.01)
+    assert not below.should_flush and above.should_flush
+
+
+def test_a_full_line_always_goes_regardless_of_rate() -> None:
+    d = _policy().evaluate(buffered_chars=80, since_last_flush_s=0.006,
+                           idle_s=0.001)
+    assert d.should_flush and d.reason == "line_full"
+
+
+def test_the_socket_floor_outranks_a_full_line() -> None:
+    """A burst is exactly when the floor matters, so a full buffer must not
+    be able to override it."""
+    d = _policy().evaluate(buffered_chars=999, since_last_flush_s=0.001,
+                           idle_s=0.0005)
+    assert not d.should_flush and d.reason == "drain_floor"
+
+
+# ---------------------------------------------------------------------------
+# 3. geometry — derived per decision, so SIGWINCH needs no invalidation
+# ---------------------------------------------------------------------------
+
+def test_thresholds_track_the_subscriber_geometry() -> None:
+    assert _policy(80, 24).char_threshold() == 80
+    assert _policy(200, 50).char_threshold() == 200
+    assert _policy(80, 24).ring_cap() == 80 * 24
+
+
+def test_a_mid_stream_resize_is_picked_up_on_the_next_decision() -> None:
+    """SIGWINCH is asynchronous. Reading the display per decision means a
+    resize takes effect immediately, with nothing to invalidate and no
+    buffer to tear."""
+    geom = [(80, 24)]
+    p = FlushPolicy(display=lambda: geom[0])
+    p.observe_drain(0.005)
+    assert (p.char_threshold(), p.ring_cap()) == (80, 1920)
+    geom[0] = (200, 50)
+    assert (p.char_threshold(), p.ring_cap()) == (200, 10000)
+
+
+def test_no_declared_display_disables_the_line_trigger() -> None:
+    """Honest degradation: emit on a measured cadence rather than at an
+    invented size. `0` must mean 'never trips', not 'flush always'."""
+    p = FlushPolicy(display=None)
+    p.observe_drain(0.005)
+    assert p.char_threshold() == 0 and p.ring_cap() == 0
+
+
+def test_a_broken_display_callback_cannot_break_a_decision() -> None:
+    def _boom() -> Tuple[int, int]:
+        raise RuntimeError("cockpit died mid-stream")
+
+    p = FlushPolicy(display=_boom)
+    p.observe_drain(0.005)
+    assert p.char_threshold() == 0
+    assert isinstance(p.evaluate(10, 1.0, idle_s=1.0).should_flush, bool)
+
+
+# ---------------------------------------------------------------------------
+# 4. observer contamination — the bug that defeated three formulations
+# ---------------------------------------------------------------------------
+
+def _drive(gaps: List[float], *, cols: int = 80, drain: float = 0.005) -> tuple:
+    frames: List[str] = []
+    t = [0.0]
+
+    def sink(x: str) -> None:
+        frames.append(x)
+        t[0] += drain                      # draining ADVANCES the clock
+
+    pol = FlushPolicy(display=lambda: (cols, 24))
+    m = StreamMirror(sink, clock=lambda: t[0], policy=pol)
+    for i, g in enumerate(gaps):
+        t[0] += g
+        m.on_token(WORDS[i % len(WORDS)])
+    m.end()
+    return frames, pol
+
+
+def test_our_own_drain_time_is_not_counted_as_generator_idle() -> None:
+    """THE bug. The wall gap between two tokens includes however long we
+    spent inside the sink, so every flush inflated the next measured gap by
+    exactly one drain period — guaranteeing idle > T forever and collapsing
+    the policy to one frame per token. Three separate flush rules were
+    debugged against this without seeing it.
+
+    A burst must batch. If self-time leaks back into the measurement it
+    cannot.
+    """
+    frames, _ = _drive([0.001] * 40)
+    assert len(frames) < 10, (
+        f"{len(frames)} frames for 40 tokens — the observer is inside its "
+        "own observation again"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. end-to-end regimes
+# ---------------------------------------------------------------------------
+
+def test_a_fast_burst_batches() -> None:
+    frames, _ = _drive([0.001] * 40)
+    assert 1 <= len(frames) <= 8
+
+
+def test_a_trickle_emits_promptly() -> None:
+    """A slow stream must not be batched: the operator is watching."""
+    frames, _ = _drive([0.200] * 20)
+    assert len(frames) >= 15
+
+
+def test_a_congested_socket_backs_off() -> None:
+    fast, _ = _drive([0.001] * 40, drain=0.005)
+    slow, _ = _drive([0.001] * 40, drain=0.050)
+    assert len(slow) <= len(fast)
+
+
+def test_the_valve_opens_and_closes_across_an_oscillating_stream() -> None:
+    """The hard case: massive bursts alternating with agonising trickles.
+    The valve must close for every burst token and open for every trickle
+    one, on the drain boundary alone."""
+    frames: List[str] = []
+    t = [0.0]
+
+    def sink(x: str) -> None:
+        frames.append(x)
+        t[0] += 0.005
+
+    pol = FlushPolicy(display=lambda: (80, 24))
+    seen: List[tuple] = []
+    original = pol.evaluate
+
+    def traced(buf: int, since: float, idle_s: float = 0.0):
+        d = original(buf, since, idle_s=idle_s)
+        seen.append((idle_s, d.reason))
+        return d
+
+    pol.evaluate = traced  # type: ignore[assignment]
+    m = StreamMirror(sink, clock=lambda: t[0], policy=pol)
+    for i, g in enumerate(([0.001] * 10 + [0.200] * 5) * 3):
+        t[0] += g
+        m.on_token(WORDS[i % len(WORDS)])
+
+    burst = [r for idle, r in seen if idle < 0.05]
+    trickle = [r for idle, r in seen if idle >= 0.05]
+    assert "sink_starving" not in burst, (
+        f"the valve opened during a burst: {dict(Counter(burst))}"
+    )
+    assert all(r in ("sink_starving", "line_full") for r in trickle), (
+        f"a trickle token was held: {dict(Counter(trickle))}"
+    )
+
+
+def test_jitter_and_gc_spikes_do_not_swallow_a_trickle() -> None:
+    """Drain variance inflates T. That is correct — but it must stay well
+    below the token gap, or a stalled stream would be mistaken for a burst
+    and held. Verified against spiky drain rather than assumed.
+    """
+    import random
+
+    random.seed(7)
+    frames: List[str] = []
+    t = [0.0]
+
+    def sink(x: str) -> None:
+        frames.append(x)
+        t[0] += 0.050 if random.random() < 0.12 else random.uniform(0.002, 0.012)
+
+    pol = FlushPolicy(display=lambda: (80, 24))
+    m = StreamMirror(sink, clock=lambda: t[0], policy=pol)
+    for i, g in enumerate(([0.001] * 10 + [0.200] * 5) * 3):
+        t[0] += g
+        m.on_token(WORDS[i % len(WORDS)])
+
+    assert pol.drain.deviation > 0.0, "the spiky harness produced no jitter"
+    assert pol.drain.upper < 0.200, (
+        f"T={pol.drain.upper:.4f} reached the trickle gap — a stalled stream "
+        "would now be mistaken for a burst"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 6. absent a policy, nothing changes
+# ---------------------------------------------------------------------------
+
+def test_without_a_policy_the_legacy_path_is_untouched() -> None:
+    """The policy is optional so this class stays usable with no capability
+    layer, no cockpit and no daemon — and so the change is inert until wired."""
+    frames: List[str] = []
+    m = StreamMirror(frames.append, flush_chars=20, flush_interval_s=99.0,
+                     clock=lambda: 0.0)
+    for _ in range(10):
+        m.on_token("hello world. ")
+    assert frames, "the static path stopped emitting"
+
+
+def test_the_drop_notice_is_the_SHARED_implementation() -> None:
+    """DRY: ConsoleSpooler and StreamMirror must confess drops through one
+    function, in their own units."""
+    import inspect
+
+    from backend.core.ouroboros.battle_test import spooled_console, stream_mirror
+
+    for mod in (spooled_console, stream_mirror):
+        assert "coalesced_drop_notice" in inspect.getsource(mod)


### PR DESCRIPTION
Closes the flush-policy question for `StreamMirror`, which batched cockpit frames on three module literals — `160` chars, `0.35s`, `8192` cap. Each was a guess about a situation nobody measured: how fast this model emits, how quickly this socket drains, how wide this terminal is.

## The rule

```
idle >  drain + jitter   generator slower than the sink -> the sink is STARVING,
                         no congestion is possible      -> send the partial line
idle <= drain + jitter   generator outruns the sink     -> flushing floods it
                                                        -> accumulate to C = W
```

Both quantities are times, so the comparison is dimensionally honest. **No literal defines "burst" or "trickle"** — the crossover is wherever the two measurements meet.

`C` = the subscriber's columns (one display line). Ring cap = its screenful (`W × H`). Both re-read **per decision**, so a SIGWINCH mid-stream retargets on the next token with nothing to invalidate and no buffer to tear.

## Four wrong answers, pinned as tests

| # | Formulation | Failure |
|---|---|---|
| 1 | past drain floor + text waiting | one frame per token — the flood |
| 2 | `eta > drain period` | same; compares a **human** latency against a **socket** latency |
| 3 | `idle > token-gap envelope` | a uniform stream never surprises itself, so a 200ms trickle never emitted |
| 4 | **observer contamination** | the measured gap silently included our own drain time |

(4) is why the first three each failed *differently* and no amount of reasoning located it: a flush inflated the **next** measured gap by exactly one drain period, guaranteeing `idle > T` forever. Tracing the live decision found it in a minute. The mirror now subtracts its own sink time before the comparison — **the observer cannot be part of its own observation.**

## No smoothing constant

`AdaptiveSignal` derives its own weight:

```
alpha = residual / (residual + deviation)
```

A normalised innovation — the shape of a Kalman gain. No `tau`, no half-life, no cold-start seed (`deviation` starts at 0, so the first sample is adopted whole, which is correct for the only observation you have). A test asserts no `tau`/`half_life`/`window_size`/`0.9`/`0.1` can reappear in the smoothing.

## Measured

```
fast burst 1ms        ->  3 frames ( 95 ch/frame)   accumulates
trickle 200ms         -> 20 frames (  6 ch/frame)   emits per token
wide 200col           ->  3 frames ( 95 ch/frame)   wider = bigger frames
congested 50ms drain  ->  3 frames                  backs off
oscillating           -> 12 frames                  valve opens AND closes
```

**Valve proof** across burst↔trickle: 30 burst tokens → 29 `filling` + 1 `cold_start`, **zero** `sink_starving`. 15 trickle tokens → **all 15** flushed.

With spiky drain (2–12ms + 12% GC spikes to 50ms) `sigma` reaches `0.0188` — larger than the mean — and `T=0.031` stays an order of magnitude under the 200ms trickle gap, so the valve still opens.

An **asymmetric variance decay was considered and not built**: the σ-bloat mechanism is real and measurable, but the failure it would prevent is not reproducible. A fix wants a measurement, not a hypothesis.

## DRY

`coalesced_drop_notice` is now the single drop-confession consumed by both `ConsoleSpooler` (lines) and `StreamMirror` (characters), each in its own unit.

Absent a policy, `StreamMirror` is byte-identical to before.

## Verification

**29 new tests; 199 passed** across the streaming, mirror, renderer, capability and cockpit suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an adaptive flush valve for cockpit streaming that measures against actual socket drain to batch bursts and emit trickles promptly. Window size is read per decision, so frames and caps adapt instantly on resize.

- **New Features**
  - Adaptive policy in `StreamMirror`: C = current columns, T = drain + jitter, ring cap = W×H; all re-read per decision.
  - `AdaptiveSignal` with a self-deriving weight (no time constant). `FlushPolicy` observes arrival rate, gaps, and drain; optional, legacy behavior unchanged when absent.
  - Shared `coalesced_drop_notice` used by `ConsoleSpooler` (lines) and `StreamMirror` (characters).

- **Bug Fixes**
  - Remove observer contamination by subtracting the mirror’s own sink time from measured idle gaps, preventing one-frame-per-token flooding.
  - Robust degradation: no declared display disables the line trigger (time-based only); geometry reads are safe and do not raise.
  - Verified with 29 new tests covering burst, trickle, congestion, oscillation, and drop-notice behavior.

<sup>Written for commit 8dd9fc1b741ad345f0b3690befaddee93a1f927b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

