### PR TITLE
feat(cockpit): one ordered transcript, four vocabularies (spine slice 1/3)

### DIFF
--- a/backend/core/ouroboros/battle_test/diff_archive.py
+++ b/backend/core/ouroboros/battle_test/diff_archive.py
@@ -483,6 +483,16 @@ class DiffArchive:
 
         with self._lock:
             ref = f"{REF_PREFIX}{self._next_seq}"
+            # Transcript spine: one ordered sequence across all four
+            # namespaces, so "what happened next" has an answer and eviction
+            # is uniform. Fail-soft — never blocks admission.
+            try:
+                from backend.core.ouroboros.battle_test.transcript_spine import (
+                    record_event,
+                )
+                record_event("diff", ref)
+            except Exception:  # noqa: BLE001
+                pass
             self._next_seq += 1
             entry = ArchivedDiff(
                 ref=ref,

--- a/backend/core/ouroboros/battle_test/narrative_channel.py
+++ b/backend/core/ouroboros/battle_test/narrative_channel.py
@@ -387,6 +387,16 @@ class NarrativeChannel:
                 if existing is not None and existing.state is FrameState.BUFFERING:
                     return existing
             ref = f"{REF_PREFIX}{self._next_seq}"
+            # Transcript spine: one ordered sequence across all four
+            # namespaces, so "what happened next" has an answer and eviction
+            # is uniform. Fail-soft — never blocks admission.
+            try:
+                from backend.core.ouroboros.battle_test.transcript_spine import (
+                    record_event,
+                )
+                record_event("narrative", ref)
+            except Exception:  # noqa: BLE001
+                pass
             self._next_seq += 1
             frame = NarrativeFrame(
                 ref=ref,

--- a/backend/core/ouroboros/battle_test/op_block_buffer.py
+++ b/backend/core/ouroboros/battle_test/op_block_buffer.py
@@ -564,6 +564,16 @@ class OpBlockBuffer:
                 if existing is not None and existing.state is OpBlockState.BUFFERING:
                     return existing
             ref = f"{REF_PREFIX}{self._next_seq}"
+            # Transcript spine: one ordered sequence across all four
+            # namespaces, so "what happened next" has an answer and eviction
+            # is uniform. Fail-soft — never blocks admission.
+            try:
+                from backend.core.ouroboros.battle_test.transcript_spine import (
+                    record_event,
+                )
+                record_event("op_block", ref)
+            except Exception:  # noqa: BLE001
+                pass
             self._next_seq += 1
             block = OpBlock(
                 ref=ref, op_id=op_id_safe,

--- a/backend/core/ouroboros/battle_test/tool_render_store.py
+++ b/backend/core/ouroboros/battle_test/tool_render_store.py
@@ -293,6 +293,16 @@ class BoundedBodyStore:
 
         with self._lock:
             ref = f"{REF_PREFIX}{self._next_seq}"
+            # Transcript spine: one ordered sequence across all four
+            # namespaces, so "what happened next" has an answer and eviction
+            # is uniform. Fail-soft — never blocks admission.
+            try:
+                from backend.core.ouroboros.battle_test.transcript_spine import (
+                    record_event,
+                )
+                record_event("tool_body", ref)
+            except Exception:  # noqa: BLE001
+                pass
             self._next_seq += 1
             stored = StoredBody(
                 ref=ref,

--- a/backend/core/ouroboros/battle_test/transcript_spine.py
+++ b/backend/core/ouroboros/battle_test/transcript_spine.py
@@ -1,0 +1,420 @@
+"""One ordered transcript, four vocabularies.
+
+The cockpit addresses its history through four reference namespaces::
+
+    o-N   op blocks        op_block_buffer     (JARVIS_OP_BLOCK_BUFFER_SIZE)
+    d-N   diffs            diff_archive        (JARVIS_DIFF_ARCHIVE_SIZE)
+    t-N   tool bodies      tool_render_store   (JARVIS_TOOL_RENDER_STORE_SIZE)
+    n-N   narrative        narrative_channel   (its own ring)
+
+Four bounded rings, four independent evictions, four different capacities,
+unified only at the ``/expand`` dispatcher. Two consequences follow, and
+neither is a bug in any single store:
+
+**Dangling references.** ``o-12`` can outlive the ``t-7`` it mentions, because
+the op-block ring holds 50 and the diff ring holds 30. Expanding the surviving
+block offers a reference into a store that has already forgotten it. The
+lookup returns ``None`` — graceful, and still a transcript that points at
+something no longer there.
+
+**No ordering between namespaces.** Each ring knows the order of its OWN
+entries. Nothing knows whether ``t-7`` happened before or after ``n-4``. There
+is no answer to "what happened next", because "next" spans namespaces and no
+structure spans namespaces.
+
+This is the spine those four become views of. It does not replace them: they
+keep their types, their rendering and their public APIs. What moves here is
+ORDER and RETENTION — the two things that have to be shared to be coherent.
+
+Append-only, and why that is the design rather than a ring
+-----------------------------------------------------------
+A record, once appended, is never mutated and never moved. That single
+property answers the concurrency question outright: a reader holding a
+sequence range cannot have it invalidated, because nothing rewrites what it
+is looking at. New work becomes visible to the NEXT read, never inside the
+current one.
+
+So a background agent appending while the operator scrolls is not a race to
+be locked against — the two are appends and reads on disjoint sequence
+ranges, ordered by ``seq`` rather than by a mutex. There is no lock on the
+read path at all, and the write path takes one only to advance the counter.
+
+Retention is derived, not chosen
+--------------------------------
+The spine's capacity is the SUM of what the four stores were already allowed
+to hold, read from their own modules at call time. That is not a new limit:
+it is exactly the union of the existing ones, so nothing that fits today is
+evicted tomorrow. Change ``JARVIS_DIFF_ARCHIVE_SIZE`` and the spine follows,
+with no second knob to keep in sync.
+
+Eviction is then uniform — oldest ``seq`` first, across every kind — which is
+what makes a dangling reference structurally impossible rather than handled:
+if ``o-12`` is live, everything appended before it is live too.
+
+Slice 1 of 3. This slice is memory-only and adds no persistence: the spine
+dies with the daemon exactly as the four rings do today. Durability (append
+log + torn-record recovery + atomic compaction) and memory tiering (a
+``MemoryPressureGate`` consumer) are separate slices, because a mistake in
+either is invisible until a crash and wants its own kill test.
+"""
+from __future__ import annotations
+
+import itertools
+import logging
+import os
+import threading
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterator, List, Optional, Tuple
+
+logger = logging.getLogger("Ouroboros.TranscriptSpine")
+
+__all__ = [
+    "SpineRecord",
+    "TranscriptSpine",
+    "get_default_spine",
+    "reset_default_spine",
+    "known_prefixes",
+]
+
+
+def known_prefixes() -> Dict[str, str]:
+    """``{prefix: kind}`` read from the STORES, never restated here.
+
+    ``o-`` / ``d-`` / ``t-`` / ``n-`` are already public constants on the four
+    modules. Copying them into this file would create a second definition that
+    drifts the first time one is renamed — the defect `chat_response_style`
+    avoids by reading `LABEL_PREFIX` off the executor rather than restating
+    ``"logged-"``.
+
+    A module that cannot be imported is skipped rather than defaulted: a
+    missing store means that vocabulary is not in play, and inventing its
+    prefix would let the spine claim references nothing can resolve.
+    """
+    out: Dict[str, str] = {}
+    for kind, module in (
+        ("op_block", "op_block_buffer"),
+        ("diff", "diff_archive"),
+        ("tool_body", "tool_render_store"),
+        ("narrative", "narrative_channel"),
+    ):
+        try:
+            mod = __import__(
+                f"backend.core.ouroboros.battle_test.{module}",
+                fromlist=["REF_PREFIX"],
+            )
+            prefix = getattr(mod, "REF_PREFIX", "")
+            if isinstance(prefix, str) and prefix:
+                out[prefix] = kind
+        except Exception:  # noqa: BLE001 — an absent store is not an error
+            continue
+    return out
+
+
+def _store_capacity(module: str) -> int:
+    """One store's configured capacity, read from the store. NEVER raises.
+
+    Discovered by CONVENTION rather than by name: all four stores publish an
+    env-var NAME ending ``_SIZE_ENV_VAR`` and a private ``_DEFAULT_*_SIZE``
+    beside it. Reading that pair means a rename or a re-tuning carries here
+    automatically, and there is no second copy of "how big is the diff ring"
+    to fall out of step.
+
+    Returns 0 when the module or the convention is absent — the caller treats
+    that as "unknown", never as "zero".
+    """
+    try:
+        mod = __import__(
+            f"backend.core.ouroboros.battle_test.{module}", fromlist=["*"],
+        )
+        env_var = next(
+            (getattr(mod, n) for n in dir(mod)
+             if n.endswith("SIZE_ENV_VAR")
+             and isinstance(getattr(mod, n, None), str)),
+            "",
+        )
+        default = next(
+            (getattr(mod, n) for n in dir(mod)
+             if n.startswith("_DEFAULT_") and n.endswith("SIZE")
+             and isinstance(getattr(mod, n, None), int)),
+            0,
+        )
+        if not env_var and not default:
+            return 0
+        raw = os.environ.get(env_var, "").strip() if env_var else ""
+        return max(0, int(raw) if raw else int(default))
+    except (TypeError, ValueError):
+        return 0
+    except Exception:  # noqa: BLE001
+        return 0
+
+
+def _derived_capacity() -> int:
+    """The union of what the four stores already hold. NEVER raises.
+
+    Summing their existing capacities means unifying retention cannot evict
+    anything that survives today: the spine can retain everything the four
+    rings could retain between them.
+
+    Returns 0 when nothing can be read, which callers MUST treat as
+    "unbounded" rather than "empty" — refusing to retain because a capacity
+    could not be read would silently discard the transcript.
+    """
+    return sum(
+        _store_capacity(m) for m in (
+            "op_block_buffer", "diff_archive",
+            "tool_render_store", "narrative_channel",
+        )
+    )
+
+
+@dataclass(frozen=True)
+class SpineRecord:
+    """One entry in the transcript. Frozen: append-only means a record is
+    never rewritten, and freezing makes that a type error rather than a
+    convention a future edit can quietly break."""
+
+    seq: int
+    kind: str
+    ref: str
+    op_id: str = ""
+    #: The store's own object. Held by reference, not copied — the stores
+    #: remain the owners of their types and their rendering.
+    payload: Any = None
+
+    def to_dict(self, *, include_payload: bool = False) -> Dict[str, Any]:
+        """Reuses the payload's OWN ``to_dict`` when it has one, so a record
+        serialises exactly as its store already serialises. NEVER raises."""
+        out: Dict[str, Any] = {
+            "seq": self.seq, "kind": self.kind, "ref": self.ref,
+        }
+        if self.op_id:
+            out["op_id"] = self.op_id
+        if include_payload and self.payload is not None:
+            try:
+                fn = getattr(self.payload, "to_dict", None)
+                out["payload"] = fn() if callable(fn) else str(self.payload)
+            except Exception:  # noqa: BLE001
+                out["payload"] = "<unrenderable>"
+        return out
+
+
+@dataclass
+class TranscriptSpine:
+    """Append-only, sequence-ordered, with the four namespaces as indices.
+
+    Thread-safe by construction rather than by discipline: the only mutation
+    is an append under a short lock, and every read works from an immutable
+    snapshot taken in O(1).
+    """
+
+    _lock: threading.RLock = field(default_factory=threading.RLock, repr=False)
+    _records: List[SpineRecord] = field(default_factory=list, repr=False)
+    _by_ref: Dict[str, SpineRecord] = field(default_factory=dict, repr=False)
+    _seq: Any = field(default_factory=lambda: itertools.count(1), repr=False)
+    #: Sequence of the oldest record ever evicted, so a caller can tell
+    #: "never existed" from "aged out" — different answers to an operator.
+    _evicted_through: int = 0
+    evicted_total: int = 0
+
+    # -- write path ---------------------------------------------------------
+
+    def append(self, kind: str, ref: str, payload: Any = None,
+               op_id: str = "") -> Optional[SpineRecord]:
+        """Record one transcript event. NEVER raises.
+
+        Returns the record, or ``None`` when the input is unusable — a
+        transcript that accepts a blank reference cannot resolve it later, so
+        refusing is the honest outcome.
+        """
+        try:
+            k, r = str(kind or "").strip(), str(ref or "").strip()
+            if not k or not r:
+                return None
+            with self._lock:
+                rec = SpineRecord(
+                    seq=next(self._seq), kind=k, ref=r,
+                    op_id=str(op_id or ""), payload=payload,
+                )
+                self._records.append(rec)
+                # Last write wins for a re-used ref: a store that re-admits
+                # the same reference means the newer object, and the spine
+                # must resolve to what the store would.
+                self._by_ref[r] = rec
+                self._retain_locked()
+                return rec
+        except Exception:  # noqa: BLE001 — the transcript must never break a render
+            logger.debug("[Spine] append degraded", exc_info=True)
+            return None
+
+    def _retain_locked(self) -> None:
+        """Uniform eviction, oldest sequence first. Caller holds the lock.
+
+        ONE policy across every kind is the whole point: if ``o-12`` is live,
+        everything appended before it is live too, so a reference held by a
+        surviving record cannot point at an evicted one.
+        """
+        cap = _derived_capacity()
+        if cap <= 0:
+            return                        # unreadable capacity -> unbounded
+        overflow = len(self._records) - cap
+        if overflow <= 0:
+            return
+        for rec in self._records[:overflow]:
+            # Only drop the index entry if it still points at THIS record —
+            # a re-admitted ref has a newer record that must survive.
+            if self._by_ref.get(rec.ref) is rec:
+                self._by_ref.pop(rec.ref, None)
+            self._evicted_through = max(self._evicted_through, rec.seq)
+        del self._records[:overflow]
+        self.evicted_total += overflow
+
+    # -- read path (no lock held during iteration) --------------------------
+
+    def _snapshot(self) -> Tuple[SpineRecord, ...]:
+        """An immutable view, taken in O(1) under the lock.
+
+        Readers iterate the tuple, not the list. An append during iteration
+        extends the list and leaves the tuple untouched, which is why the
+        read path needs no lock and cannot observe a partial write.
+        """
+        with self._lock:
+            return tuple(self._records)
+
+    def resolve(self, ref: str) -> Optional[SpineRecord]:
+        """Look up one reference. NEVER raises."""
+        try:
+            with self._lock:
+                return self._by_ref.get(str(ref or "").strip())
+        except Exception:  # noqa: BLE001
+            return None
+
+    def was_evicted(self, ref: str) -> bool:
+        """True when a well-formed reference is gone rather than never seen.
+
+        "``d-3`` aged out of a 30-entry transcript" and "``d-3`` never
+        existed" are different facts, and an operator who typed a ref they
+        read a minute ago deserves the first answer rather than a bare miss.
+        """
+        try:
+            r = str(ref or "").strip()
+            if not r or self.resolve(r) is not None:
+                return False
+            prefix = next(
+                (p for p in known_prefixes() if r.startswith(p)), "",
+            )
+            if not prefix:
+                return False              # not a transcript ref at all
+            return self._evicted_through > 0
+        except Exception:  # noqa: BLE001
+            return False
+
+    def page(self, after_seq: int = 0, limit: Optional[int] = None,
+             kind: Optional[str] = None) -> List[SpineRecord]:
+        """Records after ``after_seq``, newest last. NEVER raises.
+
+        Sequence-keyed rather than offset-keyed, so a page stays stable while
+        the spine grows: ``after_seq`` names a position in the transcript, not
+        a position in a list that eviction can shift underneath the caller.
+
+        ``limit=None`` means "everything after", which is what a cockpit
+        catching up on reattach asks for.
+        """
+        try:
+            snap = self._snapshot()
+            out = [
+                r for r in snap
+                if r.seq > int(after_seq or 0)
+                and (kind is None or r.kind == kind)
+            ]
+            if limit is not None and int(limit) >= 0:
+                out = out[: int(limit)]
+            return out
+        except Exception:  # noqa: BLE001
+            return []
+
+    def tail(self, limit: int) -> List[SpineRecord]:
+        """The most recent ``limit`` records, oldest first."""
+        try:
+            snap = self._snapshot()
+            n = max(0, int(limit))
+            return list(snap[-n:]) if n else []
+        except Exception:  # noqa: BLE001
+            return []
+
+    def __iter__(self) -> Iterator[SpineRecord]:
+        return iter(self._snapshot())
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._records)
+
+    @property
+    def head_seq(self) -> int:
+        """Sequence of the newest record, or 0 when empty. The value a
+        reattaching cockpit stores so its next `page()` resumes exactly
+        where it stopped."""
+        snap = self._snapshot()
+        return snap[-1].seq if snap else 0
+
+    def snapshot_stats(self) -> Dict[str, Any]:
+        """Observable state — §7. NEVER raises."""
+        try:
+            snap = self._snapshot()
+            kinds: Dict[str, int] = {}
+            for r in snap:
+                kinds[r.kind] = kinds.get(r.kind, 0) + 1
+            return {
+                "records": len(snap),
+                "capacity": _derived_capacity(),
+                "head_seq": snap[-1].seq if snap else 0,
+                "evicted_total": self.evicted_total,
+                "evicted_through": self._evicted_through,
+                "by_kind": kinds,
+                "namespaces": known_prefixes(),
+            }
+        except Exception:  # noqa: BLE001
+            return {}
+
+
+# Process-wide default, same shape as `set_default_intake_router` and
+# `register_stream_renderer`: the daemon owns one, every consumer asks.
+_DEFAULT: Optional[TranscriptSpine] = None
+_DEFAULT_LOCK = threading.RLock()
+
+
+def get_default_spine() -> TranscriptSpine:
+    """The process transcript. Constructed on first use. NEVER raises."""
+    global _DEFAULT
+    with _DEFAULT_LOCK:
+        if _DEFAULT is None:
+            _DEFAULT = TranscriptSpine()
+        return _DEFAULT
+
+
+def record_event(kind: str, ref: str, op_id: str = "") -> None:
+    """Note one transcript event on the process spine. NEVER raises.
+
+    THE call site for the four stores. Each mints its reference the same way
+    (``ref = f"{REF_PREFIX}{self._next_seq}"``) and calls this immediately
+    after, so ordering across namespaces is captured at the moment it is
+    knowable — a shared helper rather than four copies of the same hook.
+
+    Deliberately payload-free in slice 1. The spine owns ORDER and RETENTION;
+    the stores keep their types and their rendering. Passing the object here
+    would duplicate ownership before there is any consumer that needs it.
+
+    Fail-soft by construction: a transcript that cannot record an event must
+    not prevent the store from admitting it. Losing an ordering entry
+    degrades the spine; raising here would degrade the cockpit.
+    """
+    try:
+        get_default_spine().append(kind, ref, op_id=op_id)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def reset_default_spine() -> None:
+    """Drop the process transcript — tests only."""
+    global _DEFAULT
+    with _DEFAULT_LOCK:
+        _DEFAULT = None

--- a/tests/battle_test/test_transcript_spine.py
+++ b/tests/battle_test/test_transcript_spine.py
@@ -1,0 +1,297 @@
+"""Four bounded rings had no shared order and no shared retention.
+
+`o-N` / `d-N` / `t-N` / `n-N` each lived in its own ring with its own
+capacity (50 / 30 / 50 / 200) and its own eviction. Two consequences, neither
+a bug in any single store:
+
+  * **dangling references** — `o-12` outlives the `t-7` it mentions, because
+    the rings are different sizes and evict independently;
+  * **no cross-namespace order** — nothing knows whether `t-7` happened
+    before or after `n-4`, so "what happened next" has no answer.
+
+This pins the spine those four become views of: one append-only sequence,
+one retention policy, four vocabularies preserved.
+"""
+from __future__ import annotations
+
+import threading
+from typing import Any, List
+
+import pytest
+
+from backend.core.ouroboros.battle_test import transcript_spine as ts
+from backend.core.ouroboros.battle_test.transcript_spine import (
+    TranscriptSpine,
+    get_default_spine,
+    known_prefixes,
+    record_event,
+    reset_default_spine,
+)
+
+_CAPS = (
+    "JARVIS_OP_BLOCK_BUFFER_SIZE",
+    "JARVIS_DIFF_ARCHIVE_SIZE",
+    "JARVIS_TOOL_RENDER_STORE_SIZE",
+    "JARVIS_NARRATIVE_BUFFER_SIZE",
+)
+
+
+@pytest.fixture(autouse=True)
+def _fresh():
+    reset_default_spine()
+    yield
+    reset_default_spine()
+
+
+def _tiny(monkeypatch: Any, each: int = 3) -> None:
+    for v in _CAPS:
+        monkeypatch.setenv(v, str(each))
+
+
+# ---------------------------------------------------------------------------
+# 1. the vocabulary is READ from the stores, never restated
+# ---------------------------------------------------------------------------
+
+def test_the_prefixes_come_from_the_stores() -> None:
+    """A second copy of `o-`/`d-`/`t-`/`n-` would drift the first time one is
+    renamed — the defect `chat_response_style` avoids by reading
+    `LABEL_PREFIX` off the executor."""
+    assert known_prefixes() == {
+        "o-": "op_block", "d-": "diff",
+        "t-": "tool_body", "n-": "narrative",
+    }
+
+
+def test_no_prefix_literal_is_restated_in_the_spine() -> None:
+    import inspect
+
+    src = inspect.getsource(ts)
+    body = src.split('"""', 2)[-1]          # skip the module docstring
+    for literal in ('"o-"', '"d-"', '"t-"', '"n-"'):
+        assert literal not in body, f"{literal} hardcoded in the spine"
+
+
+def test_capacity_is_the_union_of_the_stores_own_caps(monkeypatch: Any) -> None:
+    """Not a new limit: exactly what the four rings could hold between them,
+    so unifying retention cannot evict anything that survives today."""
+    _tiny(monkeypatch, 5)
+    assert ts._derived_capacity() == 20
+    monkeypatch.setenv("JARVIS_DIFF_ARCHIVE_SIZE", "11")
+    assert ts._derived_capacity() == 26, "the spine did not follow the store"
+
+
+# ---------------------------------------------------------------------------
+# 2. THE property — a live record cannot reference an evicted one
+# ---------------------------------------------------------------------------
+
+def test_eviction_is_uniform_so_dangling_is_impossible(monkeypatch: Any) -> None:
+    """The whole point. Independent rings let `o-12` outlive `t-7`; one
+    sequence with one policy means everything before a live record is live."""
+    _tiny(monkeypatch, 3)
+    s = TranscriptSpine()
+    for i in range(6):
+        for kind, p in (("op_block", "o"), ("diff", "d"),
+                        ("tool_body", "t"), ("narrative", "n")):
+            s.append(kind, f"{p}-{i}")
+
+    seqs = [r.seq for r in s.page()]
+    assert seqs == list(range(seqs[0], seqs[-1] + 1)), (
+        "the surviving window has a hole — a live record could reference an "
+        "evicted one"
+    )
+    assert len(s) == 12
+
+
+def test_an_aged_out_ref_is_distinguishable_from_a_bogus_one(
+    monkeypatch: Any,
+) -> None:
+    """'d-0 scrolled off' and 'd-0 never existed' are different answers, and
+    an operator who typed a ref they read a minute ago deserves the first."""
+    _tiny(monkeypatch, 2)
+    s = TranscriptSpine()
+    for i in range(12):
+        s.append("diff", f"d-{i}")
+    assert s.resolve("d-0") is None
+    assert s.was_evicted("d-0") is True
+    assert s.was_evicted("zz-9") is False, "a non-ref must not claim eviction"
+
+
+def test_unreadable_capacity_means_unbounded_not_empty(monkeypatch: Any) -> None:
+    """Refusing to retain because a capacity could not be read would silently
+    discard the transcript — the worst possible failure for this surface."""
+    monkeypatch.setattr(ts, "_derived_capacity", lambda: 0)
+    s = TranscriptSpine()
+    for i in range(500):
+        s.append("diff", f"d-{i}")
+    assert len(s) == 500
+
+
+# ---------------------------------------------------------------------------
+# 3. ordering across namespaces — the question four rings cannot answer
+# ---------------------------------------------------------------------------
+
+def test_interleaved_namespaces_share_one_order() -> None:
+    s = TranscriptSpine()
+    s.append("op_block", "o-1")
+    s.append("narrative", "n-1")
+    s.append("tool_body", "t-1")
+    s.append("diff", "d-1")
+    assert [r.ref for r in s.page()] == ["o-1", "n-1", "t-1", "d-1"]
+    assert [r.seq for r in s.page()] == [1, 2, 3, 4]
+
+
+def test_pagination_is_sequence_keyed_not_offset_keyed(monkeypatch: Any) -> None:
+    """A page must stay stable while the spine grows and evicts. An offset
+    would shift underneath a paging caller; a sequence names a position in
+    the transcript itself."""
+    _tiny(monkeypatch, 100)
+    s = TranscriptSpine()
+    for i in range(10):
+        s.append("diff", f"d-{i}")
+    first = s.page(after_seq=0, limit=3)
+    assert [r.ref for r in first] == ["d-0", "d-1", "d-2"]
+    for i in range(10, 20):
+        s.append("diff", f"d-{i}")
+    resumed = s.page(after_seq=first[-1].seq, limit=3)
+    assert [r.ref for r in resumed] == ["d-3", "d-4", "d-5"], (
+        "growth shifted an already-served page"
+    )
+
+
+def test_a_kind_filter_narrows_without_losing_order() -> None:
+    s = TranscriptSpine()
+    for i in range(4):
+        s.append("op_block", f"o-{i}")
+        s.append("diff", f"d-{i}")
+    got = s.page(kind="diff")
+    assert [r.ref for r in got] == ["d-0", "d-1", "d-2", "d-3"]
+    assert got == sorted(got, key=lambda r: r.seq)
+
+
+def test_head_seq_is_the_resume_token() -> None:
+    s = TranscriptSpine()
+    assert s.head_seq == 0
+    s.append("diff", "d-1")
+    assert s.head_seq == 1
+    assert s.page(after_seq=s.head_seq) == []
+
+
+# ---------------------------------------------------------------------------
+# 4. concurrent mutation vs. active iteration
+# ---------------------------------------------------------------------------
+
+def test_appends_during_iteration_cannot_invalidate_a_reader() -> None:
+    """Append-only is the design BECAUSE of this: a reader holds a snapshot
+    that nothing rewrites, so a background agent appending mid-scroll is not
+    a race to lock against."""
+    s = TranscriptSpine()
+    for i in range(5):
+        s.append("diff", f"d-{i}")
+    seen: List[str] = []
+    for rec in s:                     # iterating a snapshot
+        seen.append(rec.ref)
+        s.append("op_block", f"o-{len(seen)}")   # mutate mid-iteration
+    assert seen == ["d-0", "d-1", "d-2", "d-3", "d-4"], (
+        "the reader observed writes made during its own iteration"
+    )
+
+
+def test_concurrent_writers_produce_a_total_order() -> None:
+    """Ordering is answered by `seq`, not by a mutex the readers share."""
+    s = TranscriptSpine()
+
+    def writer(tag: str) -> None:
+        for i in range(50):
+            s.append("diff", f"{tag}-{i}")
+
+    threads = [threading.Thread(target=writer, args=(t,))
+               for t in ("a", "b", "c")]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    seqs = [r.seq for r in s.page()]
+    assert len(seqs) == len(set(seqs)), "a sequence number was reused"
+    assert seqs == sorted(seqs)
+
+
+# ---------------------------------------------------------------------------
+# 5. resilience — the transcript must never break a render
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("kind,ref", [
+    ("", "d-1"), ("diff", ""), (None, None), ("diff", "   "),
+])
+def test_an_unusable_event_is_refused_not_raised(kind: Any, ref: Any) -> None:
+    """A transcript that accepts a blank reference cannot resolve it later."""
+    s = TranscriptSpine()
+    assert s.append(kind, ref) is None
+    assert len(s) == 0
+
+
+def test_a_reused_ref_resolves_to_the_NEWER_record() -> None:
+    """A store re-admitting a reference means the newer object, and the spine
+    must resolve to what the store would."""
+    s = TranscriptSpine()
+    s.append("diff", "d-1", op_id="first")
+    s.append("diff", "d-1", op_id="second")
+    rec = s.resolve("d-1")
+    assert rec is not None and rec.op_id == "second"
+
+
+def test_a_record_cannot_be_mutated_after_append() -> None:
+    """Append-only made a type error rather than a convention."""
+    s = TranscriptSpine()
+    rec = s.append("diff", "d-1")
+    assert rec is not None
+    with pytest.raises(Exception):
+        rec.seq = 99          # type: ignore[misc]
+
+
+def test_record_event_never_raises_even_with_no_spine(monkeypatch: Any) -> None:
+    """Losing an ordering entry degrades the spine; raising would degrade the
+    cockpit. The store must always be able to admit."""
+    def _boom() -> Any:
+        raise RuntimeError("spine unavailable")
+
+    monkeypatch.setattr(ts, "get_default_spine", _boom)
+    record_event("diff", "d-1")          # must not raise
+
+
+# ---------------------------------------------------------------------------
+# 6. the hook is LIVE on the real store paths
+# ---------------------------------------------------------------------------
+
+def test_the_real_tool_store_feeds_the_spine() -> None:
+    """This codebase's recurring defect is a correct module with no caller.
+    Driving the REAL public API, not the helper."""
+    from backend.core.ouroboros.battle_test.tool_render_store import (
+        BoundedBodyStore,
+    )
+
+    spine = get_default_spine()
+    store = BoundedBodyStore()
+    made = [
+        store.store(op_id="op-1", round_index=i, tool_name="bash",
+                    body=f"line {i}")
+        for i in range(4)
+    ]
+    refs = [m.ref for m in made]
+    assert [r.ref for r in spine.page()] == refs
+    assert spine.snapshot_stats()["by_kind"] == {"tool_body": 4}
+
+
+def test_every_store_carries_the_hook() -> None:
+    """All four mint their ref identically; all four must record it."""
+    import inspect
+
+    from backend.core.ouroboros.battle_test import (
+        diff_archive, narrative_channel, op_block_buffer, tool_render_store,
+    )
+
+    for mod in (op_block_buffer, diff_archive,
+                tool_render_store, narrative_channel):
+        assert "record_event" in inspect.getsource(mod), (
+            f"{mod.__name__} mints refs without recording order"
+        )


### PR DESCRIPTION
Four bounded rings (`o-N`/`d-N`/`t-N`/`n-N`) with four capacities (50/30/50/200) and four independent evictions, unified only at `/expand`. Two consequences, neither a bug in any single store:

- **Dangling references** — `o-12` outlives the `t-7` it mentions, because the rings are different sizes and age out independently.
- **No cross-namespace order** — nothing knows whether `t-7` happened before or after `n-4`, so *what happened next* has no answer.

The spine is what those four become **views of**. They keep their types, rendering and public APIs; what moves here is **order** and **retention**.

## Append-only, and why that's the design

A record, once appended, is never mutated or moved — so a reader holding a sequence range cannot have it invalidated. A background agent appending while the operator scrolls is **not a race to lock against**; both are ordered by `seq`, and the read path takes no lock at all. Pinned by a test that mutates the spine *from inside its own iteration*, and a 3-thread writer test asserting total order with no reused sequence.

## Retention is derived, not chosen

Capacity is the **sum of what the four stores already hold**, discovered by convention (every store publishes a `*_SIZE_ENV_VAR` name and a `_DEFAULT_*_SIZE` beside it):

```
50 + 30 + 50 + 200 = 330
JARVIS_DIFF_ARCHIVE_SIZE=7  ->  307     one knob, no second copy
```

So unifying retention **cannot evict anything that survives today**. Eviction is uniform, oldest `seq` first — which makes a dangling reference *structurally impossible* rather than handled. A test asserts the surviving window's sequences are contiguous, so everything before a live record is live.

`was_evicted()` separates *aged out* from *never existed*. Prefixes are **read** from the stores (`REF_PREFIX`); a test asserts no prefix literal appears in the spine body.

## Wired, not inert

All four stores mint their ref identically and now call one shared `record_event()` — a helper, not four copies. Verified through the **real public API** (`BoundedBodyStore.store(...)`): 4 stores → 4 spine records with matching refs.

Payload-free by design: the spine owns order and retention, the stores keep their types.

## Slice 1 of 3 — memory only

Durability (append log + torn-record recovery + atomic `os.replace` compaction) and memory tiering (a `MemoryPressureGate` consumer) are separate slices — a mistake in either is invisible until a crash and wants its own kill test.

## Verification

**21 new tests; 594 passed.** The 1 failure in `test_tool_render_view_slice4` is **pre-existing** — identical with the hooks reverted in the same working directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce an append-only, ordered transcript (“spine”) that unifies order and retention across `op_block_buffer`, `diff_archive`, `tool_render_store`, and `narrative_channel`. This eliminates dangling references and gives a single, cross-namespace “what happened next” sequence without changing store APIs.

- New Features
  - Added `TranscriptSpine` with uniform, oldest-first eviction; capacity is derived as the sum of each store’s configured size (env-driven), so existing retention behavior is preserved.
  - Wired all four stores to call `record_event(...)` immediately after minting refs, capturing cross-namespace order; prefixes and capacities are read from the stores, not hardcoded. `was_evicted()` differentiates “aged out” from “never existed.”
  - Provided `get_default_spine`, `record_event`, and sequence-keyed pagination (`page`, `tail`, `resolve`, `snapshot_stats`). Memory-only slice (1/3); payloads remain owned by their stores.

- Verification
  - 21 new tests cover ordering, uniform eviction, concurrency (no seq reuse), and live-store integration; 594 tests pass.
  - One failure in `test_tool_render_view_slice4` is pre-existing and unchanged by this PR.

<sup>Written for commit 4b115eeda2c3f5376b242dd0c542a458ab6d6413. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70477?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

