### PR TITLE
fix(scripts): Anchor the env-default check and report divergent flags

### DIFF
--- a/scripts/verify_readme_claims.py
+++ b/scripts/verify_readme_claims.py
@@ -92,10 +92,21 @@ print("=" * 78)
 print("D. ENV-VAR DEFAULTS — README table rows vs the literal in code")
 print("=" * 78)
 rows = re.findall(r"^\| `(JARVIS_[A-Z0-9_]+)` \| `([^`]*)` \|", README, re.M)
-pat = re.compile(r'"(JARVIS_[A-Z0-9_]+)"\s*,\s*"([^"]*)"')
+
+# ANCHORED to the actual read. An unanchored `"FLAG", "value"` pattern
+# also matches adjacent entries in a LIST of flag names —
+#     _FLAGS = ["JARVIS_VOICE_ENABLED", "JARVIS_AUDIO_BUS_ENABLED"]
+# reads as "JARVIS_VOICE_ENABLED defaults to 'jarvis_audio_bus_enabled'".
+# That produced 11 phantom "divergent" flags on first run: a verifier
+# manufacturing the defect it was written to detect.
+pat = re.compile(
+    r'(?:environ\.get|getenv)\(\s*"(JARVIS_[A-Z0-9_]+)"\s*,\s*"([^"]*)"'
+)
 code_defaults: dict[str, set[str]] = defaultdict(set)
 for rel in files:
-    if rel.startswith(".worktrees/"):
+    # Tests set values to exercise branches; a monkeypatched literal is
+    # not a production default and must not be read as one.
+    if rel.startswith((".worktrees/", "tests/")):
         continue
     try:
         txt = (ROOT / rel).read_text(encoding="utf-8", errors="ignore")
@@ -104,15 +115,32 @@ for rel in files:
     for m in pat.finditer(txt):
         code_defaults[m.group(1)].add(m.group(2).lower())
 
-ok = mism = unk = 0
+ok = mism = unk = split = 0
 for flag, claimed in rows:
     have = code_defaults.get(flag)
     if not have:
         unk += 1
         print(f"  ?        {flag:44s} claims {claimed!r} (no literal default)")
-    elif claimed.lower() in have:
+        continue
+    # A flag whose call sites DISAGREE is a finding on its own, whatever
+    # the README says. Testing `claimed in have` alone would pass as soon
+    # as ONE site matched — accepting a flag that means different things
+    # in different modules, which is the exact defect this file exists to
+    # surface. Report the divergence first, then the README's accuracy.
+    if len(have) > 1:
+        split += 1
+        agrees = "README agrees with one" if claimed.lower() in have \
+            else f"README {claimed!r} matches NONE"
+        print(f"  DIVERGENT {flag:43s} code has {sorted(have)} — {agrees}")
+        if claimed.lower() not in have:
+            mism += 1
+        continue
+    if claimed.lower() in have:
         ok += 1
     else:
         mism += 1
         print(f"  MISMATCH {flag:44s} README {claimed!r} vs code {sorted(have)}")
-print(f"\n  OK={ok}  MISMATCH={mism}  UNVERIFIABLE={unk}")
+print(f"\n  OK={ok}  MISMATCH={mism}  DIVERGENT={split}  UNVERIFIABLE={unk}")
+if split:
+    print("  (DIVERGENT = one flag, several literal defaults across call "
+          "sites. Unset, it means different things in different modules.)")


### PR DESCRIPTION
Follow-up to #70479. A slower duplicate of the env-default check finished after that PR merged and **disagreed with the version I shipped** — which turned out to be two real defects in the verifier.

## 1. The check passed on disagreement

It tested `claimed in have`, where `have` is the *set* of literal defaults across call sites. That passes as soon as **one** site agrees — so a flag meaning different things in different modules was accepted silently, provided the README matched any one of them.

A flag with defaults `{'true','false'}` would have passed a README claiming either. That's the precise defect class the file exists to surface, sitting inside it. Divergence is now a finding in its own right.

## 2. The pattern was unanchored, and manufactured the defect it detects

```
"(JARVIS_[A-Z0-9_]+)"\s*,\s*"([^"]*)"
```

also matches adjacent entries in a **list** of flag names:

```python
_FLAGS = ["JARVIS_VOICE_ENABLED", "JARVIS_AUDIO_BUS_ENABLED"]
```

→ *"JARVIS_VOICE_ENABLED defaults to `'jarvis_audio_bus_enabled'`"*.

First run reported **11 divergent flags**, with values like `'not-a-number'` and `'/tmp/my-repo'` — test fixtures and neighbouring flag names. Anchoring to `environ.get(` / `getenv(` and excluding `tests/` takes it to 5, all plausible.

I nearly reported those 11 as real findings.

## Result on current main

```
OK=28  MISMATCH=0  DIVERGENT=5  UNVERIFIABLE=1
```

**The README is accurate for all 34 documented rows.** The 5 divergences are real but mostly benign:

| Flag | Defaults | Assessment |
|---|---|---|
| `JARVIS_VOICE_ENABLED` | `'1'`, `'true'` | same value, written twice |
| `JARVIS_L2_TIMEBOX_S` | `'120'`, `'120.0'` | same value |
| `JARVIS_DEBUG` | `''`, `'false'` | falsy either way |
| `JARVIS_REPO_PATH` | `''`, `'.'` | worth a look |
| `JARVIS_MIN_EXPLORATION_CALLS` | `''`, `'2'` | **worth a look** — not the same number of required exploration calls |

`JARVIS_L2_ENABLED` is now UNVERIFIABLE: its reader doesn't use a literal default, so this method can't confirm the documented `true`. Reported as unverifiable rather than assumed correct.

Docs/tooling only — no runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Anchors the env-default verifier to real getenv reads and flags any env var with multiple literal defaults as DIVERGENT. Previously, the check passed if any call site matched the README and an unanchored pattern produced false positives by matching list literals.

- Anchors the regex to `environ.get(`/`getenv(`) and skips `tests/` and `.worktrees/` to avoid test fixtures and list literals.
- Treats multiple defaults across call sites as DIVERGENT and adds this to the summary output with a short explanation; mismatches and unverifiable rows are still reported.
- Current main result: OK=28, MISMATCH=0, DIVERGENT=5, UNVERIFIABLE=1; README rows are accurate. Please review the DIVERGENT flags, especially `JARVIS_REPO_PATH` and `JARVIS_MIN_EXPLORATION_CALLS`.
- No runtime code changed; tooling-only.

<sup>Written for commit b0dd24906875c9e313e23633818a7d64739c4035. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70480?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

