### PR TITLE
feat(governance): admission measures the pool the weights land in

### DIFF
--- a/backend/core/ouroboros/cli/ov_doctor.py
+++ b/backend/core/ouroboros/cli/ov_doctor.py
@@ -266,6 +266,58 @@ def _verdicts_from_hydration(
     return out
 
 
+async def probe_edge_compute() -> EdgeVerdict:
+    """Edge 9 — what this host can actually load, and which pool it lands in.
+
+    Deliberately INDEPENDENT of the socket. This is the edge an operator
+    needs most on a machine the organism has never run on: a fresh box where
+    the daemon is not up yet, and the first question is whether the hardware
+    is even visible. Every other hydration-derived edge goes SKIPPED there;
+    this one still answers.
+
+    Reports the accelerator reading and the admission ceiling together,
+    because a refusal is unreadable without both — an operator who sees
+    "deferred" on a 64 GB machine, with no accelerator half to explain it,
+    turns the gate off. NEVER raises.
+    """
+    try:
+        from backend.core.ouroboros.governance import compute_topology as ct
+        if not ct.is_enabled():
+            return EdgeVerdict(
+                "9 compute", EdgeState.SKIPPED,
+                "topology probe disabled (JARVIS_COMPUTE_TOPOLOGY_ENABLED)")
+        reading = await asyncio.wait_for(
+            ct.resolve(), timeout=_edge_timeout_s() * 4)
+    except asyncio.TimeoutError:
+        return EdgeVerdict("9 compute", EdgeState.DEGRADED,
+                           "topology probe timed out — driver may be wedged")
+    except Exception as exc:  # noqa: BLE001
+        return EdgeVerdict("9 compute", EdgeState.DEGRADED,
+                           f"topology unavailable ({type(exc).__name__})")
+
+    if not getattr(reading, "measured", False):
+        return EdgeVerdict(
+            "9 compute", EdgeState.DEGRADED,
+            f"host unresolved ({reading.source}) — admission falls back to "
+            f"the host bound with the unverified ceiling")
+
+    gib = 1024 ** 3
+    detail = (f"{reading.topology.value} {reading.resolved_class} · "
+              f"{reading.usable_bytes / gib:.1f} GiB usable · "
+              f"src={reading.source}")
+    if not getattr(reading, "free_is_measured", True):
+        detail += " · free derived from host RAM"
+    try:
+        from backend.core.ouroboros.governance import local_model_admission as lma
+        snap = lma.snapshot()
+        ooms = sum((snap.get("observed_ooms") or {}).values())
+        if ooms:
+            detail += f" · {ooms} recent OOM(s) raising the margin"
+    except Exception:  # noqa: BLE001 — the reading alone is still useful
+        pass
+    return EdgeVerdict("9 compute", EdgeState.OK, detail)
+
+
 async def _http_get(path: str) -> Tuple[Optional[int], Optional[Any]]:
     """Minimal bounded HTTP/1.1 GET → (status_code, parsed_json|None).
 
@@ -398,35 +450,42 @@ async def run_matrix() -> DoctorReport:
     report.verdicts.append(v2)
 
     if sock_state == "live":
-        (hyd, lh), (v5, l5), (v7, l7), (v8, l8) = await asyncio.gather(
+        (hyd, lh), (v5, l5), (v7, l7), (v8, l8), (v9, l9) = await asyncio.gather(
             _timed(_read_hydration()),
             _timed(probe_edge_sensors()),
             _timed(probe_edge_liveness()),
             _timed(probe_edge_mcp()),
+            _timed(probe_edge_compute()),
         )
         hydration_verdicts = _verdicts_from_hydration(hyd)
         for v in hydration_verdicts:
             v.latency_ms = lh / max(1, len(hydration_verdicts))
         v5.latency_ms, v7.latency_ms, v8.latency_ms = l5, l7, l8
-        # canonical edge order: 3,4,5,6,7,8
+        v9.latency_ms = l9
+        # canonical edge order: 3,4,5,6,7,8,9
         e3, e4, e6 = hydration_verdicts
-        report.verdicts.extend([e3, e4, v5, e6, v7, v8])
+        report.verdicts.extend([e3, e4, v5, e6, v7, v8, v9])
     else:
         # chain severed at the socket — probe the independent HTTP/static
         # edges anyway (they may localize the fault), skip the UDS-bound ones.
-        (v5, l5), (v7, l7), (v8, l8) = await asyncio.gather(
+        (v5, l5), (v7, l7), (v8, l8), (v9, l9) = await asyncio.gather(
             _timed(probe_edge_sensors()),
             _timed(probe_edge_liveness()),
             _timed(probe_edge_mcp()),
+            # Socket-independent BY DESIGN: on a machine the organism has
+            # never run on, "can this host load anything?" is the first
+            # question and the daemon is not up to answer it.
+            _timed(probe_edge_compute()),
         )
         v5.latency_ms, v7.latency_ms, v8.latency_ms = l5, l7, l8
+        v9.latency_ms = l9
         report.verdicts.extend([
             EdgeVerdict("3 hydration", EdgeState.SKIPPED, "socket not serving"),
             EdgeVerdict("4 hive fabrics", EdgeState.SKIPPED,
                         "socket not serving"),
             v5,
             EdgeVerdict("6 providers", EdgeState.SKIPPED, "socket not serving"),
-            v7, v8,
+            v7, v8, v9,
         ])
     return report
 

--- a/backend/core/ouroboros/governance/brain_selection_policy.yaml
+++ b/backend/core/ouroboros/governance/brain_selection_policy.yaml
@@ -48,6 +48,11 @@ brains:
       compute_class: "cpu"
       min_compute_class: "cpu"
       model_artifact: "Llama-3.2-1B-Instruct-Q4_K_M.gguf"
+      # Measured admission (compute_topology): capacity this brain
+      # NEEDS, independent of any GPU model name. min_vram_gb wins
+      # over min_compute_class; weight_gb is the resident footprint.
+      min_vram_gb: 0.0
+      weight_gb: 1.5
 
     - brain_id: "qwen_coder"
       provider: "gcp_prime"
@@ -65,6 +70,11 @@ brains:
       compute_class: "gpu_t4"
       min_compute_class: "gpu_t4"
       model_artifact: "qwen2.5-coder-7b-instruct-q4_k_m.gguf"
+      # Measured admission (compute_topology): capacity this brain
+      # NEEDS, independent of any GPU model name. min_vram_gb wins
+      # over min_compute_class; weight_gb is the resident footprint.
+      min_vram_gb: 6.0
+      weight_gb: 5.0
 
     - brain_id: "qwen_coder_14b"
       provider: "gcp_prime"
@@ -82,6 +92,11 @@ brains:
       compute_class: "gpu_l4"
       min_compute_class: "gpu_t4"
       model_artifact: "Qwen2.5-Coder-14B-Instruct-Q4_K_M.gguf"
+      # Measured admission (compute_topology): capacity this brain
+      # NEEDS, independent of any GPU model name. min_vram_gb wins
+      # over min_compute_class; weight_gb is the resident footprint.
+      min_vram_gb: 11.0
+      weight_gb: 9.5
 
     - brain_id: "qwen_coder_32b"
       provider: "gcp_prime"
@@ -99,6 +114,11 @@ brains:
       compute_class: "gpu_l4"
       min_compute_class: "gpu_l4"
       model_artifact: "Qwen2.5-Coder-32B-Instruct-Q4_K_M.gguf"
+      # Measured admission (compute_topology): capacity this brain
+      # NEEDS, independent of any GPU model name. min_vram_gb wins
+      # over min_compute_class; weight_gb is the resident footprint.
+      min_vram_gb: 22.0
+      weight_gb: 20.0
 
     - brain_id: "deepseek_r1"
       provider: "gcp_prime"
@@ -116,6 +136,11 @@ brains:
       compute_class: "gpu_t4"
       min_compute_class: "gpu_t4"
       model_artifact: "DeepSeek-R1-Distill-Qwen-7B-Q4_K_M.gguf"
+      # Measured admission (compute_topology): capacity this brain
+      # NEEDS, independent of any GPU model name. min_vram_gb wins
+      # over min_compute_class; weight_gb is the resident footprint.
+      min_vram_gb: 6.0
+      weight_gb: 5.0
 
   optional:
     - brain_id: "mistral_7b_fallback"
@@ -133,6 +158,11 @@ brains:
       compute_class: "gpu_t4"
       min_compute_class: "gpu_t4"
       model_artifact: "mistral-7b-instruct-v0.2.Q4_K_M.gguf"
+      # Measured admission (compute_topology): capacity this brain
+      # NEEDS, independent of any GPU model name. min_vram_gb wins
+      # over min_compute_class; weight_gb is the resident footprint.
+      min_vram_gb: 6.0
+      weight_gb: 4.5
 
 allowlist:
   allow_unlisted_runtime_brains: false

--- a/backend/core/ouroboros/governance/brain_selector.py
+++ b/backend/core/ouroboros/governance/brain_selector.py
@@ -31,11 +31,12 @@ import json
 import logging
 import os
 import re
+import threading
 import time
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 from backend.core.ouroboros.governance.resource_monitor import (
     ResourceSnapshot,  # retained in signatures for caller compatibility
@@ -574,3 +575,75 @@ _DEFAULT_POLICY: Dict = {
         "cost_gate": {"daily_budget_usd": 0.50, "budget_exceeded_action": "queue"},
     },
 }
+
+
+# ---------------------------------------------------------------------------
+# Declared footprint — the policy's answer to "how much will this weigh?"
+# ---------------------------------------------------------------------------
+
+_FOOTPRINT_GIB = 1024 ** 3
+_footprint_selector: "Optional[BrainSelector]" = None
+_footprint_lock = threading.Lock()
+
+
+def _footprint_policy() -> Dict[str, Any]:
+    """The live policy dict, via the module that already owns loading it.
+
+    Reuses ``BrainSelector`` — including its mtime hot-reload — rather than
+    opening the YAML a second time. A second reader would be a second
+    authority for a file an operator edits expecting one effect, and the two
+    would disagree for exactly as long as one of them held a stale mtime.
+    """
+    global _footprint_selector
+    with _footprint_lock:
+        if _footprint_selector is None:
+            _footprint_selector = BrainSelector()
+        sel = _footprint_selector
+    try:
+        sel._maybe_reload_policy()
+        return sel._policy or {}
+    except Exception:  # noqa: BLE001
+        return {}
+
+
+def footprint_bytes_for(brain_id: Optional[str]) -> int:
+    """Resident weight footprint a brain DECLARES, in bytes. 0 when unstated.
+
+    Zero is meaningful and must not be read as "small": it means the policy
+    made no claim, and ``local_model_admission`` treats an unstated footprint
+    by skipping the accelerator bound entirely rather than inferring one. A
+    guessed footprint driving a real refusal would be a fabricated
+    measurement — the failure class this whole arc exists to remove.
+
+    Searches every brain list under ``brains`` (``required``, ``optional``,
+    and any future sibling) so a brain does not become invisible here merely
+    by moving between them. NEVER raises.
+    """
+    if not brain_id:
+        return 0
+    target = str(brain_id).strip().lower()
+    try:
+        brains = (_footprint_policy().get("brains") or {})
+        for entries in brains.values():
+            if not isinstance(entries, list):
+                continue
+            for entry in entries:
+                if not isinstance(entry, dict):
+                    continue
+                bid = str(entry.get("brain_id") or entry.get("id") or "").strip().lower()
+                if bid != target:
+                    continue
+                raw = entry.get("weight_gb")
+                if raw is None:
+                    return 0
+                return max(0, int(float(raw) * _FOOTPRINT_GIB))
+    except Exception:  # noqa: BLE001
+        logger.debug("[BrainSelector] footprint lookup degraded", exc_info=True)
+    return 0
+
+
+def reset_footprint_cache() -> None:
+    """Drop the cached selector — for tests and deliberate re-reads."""
+    global _footprint_selector
+    with _footprint_lock:
+        _footprint_selector = None

--- a/backend/core/ouroboros/governance/compute_topology.py
+++ b/backend/core/ouroboros/governance/compute_topology.py
@@ -1,0 +1,1388 @@
+"""compute_topology — which memory pool a model actually lands in.
+
+THE DEFECT THIS CLOSES
+----------------------
+``local_model_admission`` guards the act of loading model weights, and it
+asks ``memory_pressure_gate`` how much room there is. That gate's probe
+cascade is ``psutil → /proc/meminfo → vm_stat → fallback`` — **every stage
+of which measures SYSTEM RAM.** Its own module docstring states the premise
+out loud:
+
+    "Tier 2 now runs LOCALLY — Ollama on the same unified memory as the HUD.
+     ... There is no separate VRAM to spill into, and no pressure valve
+     except swap."
+
+On the 16 GB M1 that is not merely true, it is the whole story: unified
+memory means one pool, so a system-RAM reading genuinely predicts whether a
+weight-load will page the machine and take the microphone down with it.
+
+Move the same code to a discrete-GPU host and the premise inverts. System
+RAM stops predicting anything about a load that lands in VRAM: the gate
+reads 64 GB of DDR5, finds abundant headroom, and admits a model whose real
+ceiling is a 32 GB card it has no probe for. The failure is not a crash the
+gate anticipated — it is a CUDA OOM the gate had no opinion about, or a
+silent demotion to a smaller brain with no reason attached.
+
+So this is not a missing threshold or a stale constant. It is a **hardware
+topology assumed by shared reasoning**, correct on the machine it was
+written for and unstated everywhere else. The fix is to make topology a
+measured, first-class property, and to route the admission question to the
+pool that actually bounds it.
+
+WHY THIS ADDS NO SECOND MEMORY PROBE
+------------------------------------
+``memory_pressure_gate`` already owns system RAM: four cascade stages, a
+process-tree dimension, a reservation dimension, strictest-wins composition
+and a graduated flag. **This module never probes system RAM.** It probes the
+ACCELERATOR, classifies the topology, and — under ``unified`` — defers to
+that gate outright, because under unified memory the gate's reading is the
+correct one and a second opinion would be a second thing to keep true. The
+day two probes disagreed, the machine would hold two beliefs about whether
+it was safe to allocate.
+
+This is the same division of labour that module already documents for
+itself: it measures, and the policy layer decides what to do about the
+measurement.
+
+MEASURED, NOT ENUMERATED
+------------------------
+``governed_loop_service._COMPUTE_RANK`` ranks GPUs by NAME —
+``{cpu, gpu_t4, gpu_l4, gpu_v100, gpu_a100}``. A name-ranked table cannot
+express a card nobody typed into it, which is why a 32 GB consumer card has
+no representable class, and why every future card is a code change.
+
+The root cause there is that admission compares ORDINALS when the question
+is about BYTES. So this module resolves a class from measurement and exposes
+``bytes_for_class()``, letting admission compare capacity to requirement.
+Legacy policy strings keep working — they become a lookup into a byte
+requirement rather than a rung on a ladder — and a brain may instead declare
+``min_vram_gb`` directly and skip the vocabulary altogether. Nothing needs a
+new rung, ever.
+
+STATIC FACTS VS DYNAMIC ONES
+----------------------------
+Total VRAM, device name and topology do not change while the process runs;
+free VRAM changes constantly. Caching them on one clock would either re-run
+device enumeration forever or serve a stale free-byte reading as fact. They
+are therefore cached separately: identity is resolved once and pinned, and
+only the free-byte dimension carries a TTL.
+
+AUTHORITY POSTURE
+-----------------
+* §1 Boundary — **advisory measurement only.** This module returns readings
+  and a resolved class. It admits nothing, loads nothing, and reaches into
+  no scheduler. Callers pull.
+* §5 Tier 0 — stdlib + optional accelerated probes; no LLM, no network.
+* §8 Observability — every reading is ``snapshot()``-able and carries the
+  cascade stage that produced it.
+* Authority invariant: zero imports from ``orchestrator``, ``policy``,
+  ``iron_gate``, ``risk_tier``, ``change_engine``, ``candidate_generator``,
+  ``gate``. The single governance import is ``memory_pressure_gate``, and
+  it is consumed read-only for the unified-memory case.
+
+FAILURE POSTURE
+---------------
+Never raises. An unresolvable host yields ``UNKNOWN`` topology, which
+callers must treat as "do not claim to know" — never as "plenty of room".
+An unknown reading may not authorize a load; that is the same epistemic
+discipline ``advisor_locality`` applies to blast radius, for the same
+reason: a fabricated measurement is worse than an absent one.
+"""
+from __future__ import annotations
+
+import asyncio
+import enum
+import json
+import logging
+import os
+import re
+import shutil
+import sys
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger("Ouroboros.ComputeTopology")
+
+
+COMPUTE_TOPOLOGY_SCHEMA_VERSION = "compute_topology.1"
+
+_BYTES_PER_GIB = 1024 ** 3
+
+
+# ---------------------------------------------------------------------------
+# Env helpers — same shape as memory_pressure_gate's, read at CALL time so a
+# knob turned mid-session takes effect without a restart.
+# ---------------------------------------------------------------------------
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in ("1", "true", "yes", "on")
+
+
+def _env_float(name: str, default: float, minimum: float = 0.0) -> float:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return max(minimum, float(raw))
+    except (TypeError, ValueError):
+        return default
+
+
+def is_enabled() -> bool:
+    """Master switch. Default **false** pending graduation.
+
+    OFF is not a degraded mode — it is the pre-module status quo:
+    :func:`resolve` returns a reading whose topology is ``UNKNOWN`` and
+    whose ``enabled`` flag is False, and every consumer's documented
+    unknown-path keeps the legacy behaviour byte for byte.
+    """
+    return _env_bool("JARVIS_COMPUTE_TOPOLOGY_ENABLED", False)
+
+
+def probe_timeout_s() -> float:
+    """Wall-clock ceiling for any single external probe. Default 4s.
+
+    Bounded because ``nvidia-smi`` on a wedged driver can hang
+    indefinitely, and a boot-time capability read must not be able to
+    hold the awakening open (§2 Progressive Awakening).
+    """
+    return _env_float("JARVIS_COMPUTE_TOPOLOGY_PROBE_TIMEOUT_S", 4.0, minimum=0.1)
+
+
+def free_ttl_s() -> float:
+    """TTL for the DYNAMIC dimension (free bytes). Default 5s.
+
+    Identity — device name, total capacity, topology — is pinned after the
+    first successful resolution and never re-probed; only free bytes expire.
+    """
+    return _env_float("JARVIS_COMPUTE_TOPOLOGY_FREE_TTL_S", 5.0, minimum=0.0)
+
+
+def identity_repin_s() -> float:
+    """Age after which pinned identity is re-resolved anyway. Default 0 = never.
+
+    Zero is correct for a physical host: a GPU does not appear mid-session.
+    A non-zero value exists for hosts where it can — hot-plugged eGPU, a
+    container that gains a device mapping, a VM migrated between nodes.
+    """
+    return _env_float("JARVIS_COMPUTE_TOPOLOGY_IDENTITY_REPIN_S", 0.0, minimum=0.0)
+
+
+def unified_budget_fraction() -> float:
+    """Share of unified memory a model may treat as accelerator budget.
+
+    Default 0.75, matching the fraction Apple's Metal runtime reports as
+    ``recommendedMaxWorkingSetSize`` on Apple Silicon. It is a FRACTION and
+    not a constant because the correct number is a property of the host,
+    and on a machine also running a real-time audio graph and a vision
+    pipeline the honest budget is well under the nameplate.
+    """
+    return _env_float(
+        "JARVIS_COMPUTE_TOPOLOGY_UNIFIED_BUDGET_FRACTION", 0.75,
+        minimum=0.05,
+    )
+
+
+def headroom_fraction() -> float:
+    """Fraction of accelerator capacity held back from any single load.
+
+    Default 0.10. Weights are not the only resident allocation: KV cache,
+    activation scratch, CUDA context and fragmentation all draw on the same
+    pool, and a load sized to the last free byte OOMs on its first long
+    prompt rather than at load time — which is far harder to attribute.
+    """
+    return _env_float(
+        "JARVIS_COMPUTE_TOPOLOGY_HEADROOM_FRACTION", 0.10, minimum=0.0,
+    )
+
+
+def reference_class_bytes() -> Dict[str, int]:
+    """Legacy ``compute_class`` name → the capacity that name IMPLIES.
+
+    This is a COMPATIBILITY MAPPING, not a ladder. It exists so a policy
+    written as ``min_compute_class: "gpu_l4"`` keeps meaning what it meant —
+    "at least an L4's worth of memory" — while admission compares bytes.
+
+    Fully overridable as JSON via
+    ``JARVIS_COMPUTE_TOPOLOGY_CLASS_BYTES`` (values in GiB), because the
+    same class name denotes different capacities across vendor SKUs (V100
+    ships 16 and 32; A100 ships 40 and 80) and a fleet is entitled to say
+    which one it means. Malformed entries are skipped individually — one
+    bad key never costs the whole table.
+    """
+    table_gib: Dict[str, float] = {
+        "cpu": 0.0,
+        "gpu_t4": 16.0,
+        "gpu_l4": 24.0,
+        "gpu_v100": 32.0,
+        "gpu_a100": 40.0,
+    }
+    raw = os.environ.get("JARVIS_COMPUTE_TOPOLOGY_CLASS_BYTES")
+    if raw:
+        try:
+            override = json.loads(raw)
+            if isinstance(override, dict):
+                for key, val in override.items():
+                    try:
+                        table_gib[str(key).strip().lower()] = max(0.0, float(val))
+                    except (TypeError, ValueError):
+                        continue
+        except (ValueError, TypeError):
+            logger.debug("[ComputeTopology] class-bytes override unparseable")
+    return {k: int(v * _BYTES_PER_GIB) for k, v in table_gib.items()}
+
+
+def _truthy_env_names() -> Tuple[str, ...]:
+    """Env vars whose presence proves a WSL2 guest. Read as data, not code."""
+    raw = os.environ.get(
+        "JARVIS_COMPUTE_TOPOLOGY_WSL_MARKERS", "WSL_DISTRO_NAME,WSL_INTEROP",
+    )
+    return tuple(p.strip() for p in raw.split(",") if p.strip())
+
+
+# ---------------------------------------------------------------------------
+# Vocabulary
+# ---------------------------------------------------------------------------
+
+
+class MemoryTopology(str, enum.Enum):
+    """Where a model's weights land, relative to system RAM.
+
+    ``UNIFIED``   one physical pool shared by CPU and GPU (Apple Silicon).
+                  System-RAM pressure IS accelerator pressure; the canonical
+                  ``memory_pressure_gate`` reading governs.
+    ``DISCRETE``  an accelerator with its own memory. Two independent
+                  ceilings; system RAM says nothing about VRAM.
+    ``NONE``      no accelerator. CPU inference out of system RAM — which is
+                  unified in effect, but named separately because the
+                  BUDGET differs: there is no reserved working set.
+    ``UNKNOWN``   the host could not be resolved. Not a synonym for NONE:
+                  NONE is a measurement, UNKNOWN is its absence.
+    """
+
+    UNIFIED = "unified"
+    DISCRETE = "discrete"
+    NONE = "none"
+    UNKNOWN = "unknown"
+
+
+#: Topologies from which a capacity claim may be trusted. UNKNOWN is
+#: excluded by construction — see the module docstring's failure posture.
+_MEASURED = (MemoryTopology.UNIFIED, MemoryTopology.DISCRETE, MemoryTopology.NONE)
+
+
+@dataclass(frozen=True)
+class AcceleratorProbe:
+    """One probe attempt's result.
+
+    ``source`` names the cascade stage so a surprising reading can be
+    attributed without re-deriving it. ``ok`` False carries ``error`` and
+    contributes nothing to resolution — a failed stage is skipped, never
+    interpreted as zero capacity.
+    """
+
+    topology: MemoryTopology
+    total_bytes: int
+    free_bytes: int
+    device_name: str
+    device_count: int
+    source: str
+    ok: bool = True
+    error: Optional[str] = None
+    #: True when ``free_bytes`` was measured; False when it was DERIVED
+    #: from a system-RAM reading (unified) and therefore moves with it.
+    free_is_measured: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "topology": self.topology.value,
+            "total_bytes": self.total_bytes,
+            "free_bytes": self.free_bytes,
+            "device_name": self.device_name,
+            "device_count": self.device_count,
+            "source": self.source,
+            "ok": self.ok,
+            "error": self.error,
+            "free_is_measured": self.free_is_measured,
+        }
+
+
+@dataclass(frozen=True)
+class ComputeReading:
+    """A resolved view of this host's accelerator situation."""
+
+    topology: MemoryTopology
+    total_bytes: int
+    free_bytes: int
+    device_name: str
+    device_count: int
+    source: str
+    resolved_class: str
+    enabled: bool
+    probed_at: float
+    free_probed_at: float
+    schema_version: str = COMPUTE_TOPOLOGY_SCHEMA_VERSION
+    free_is_measured: bool = True
+    degraded: bool = False
+    error: Optional[str] = None
+    notes: Tuple[str, ...] = field(default_factory=tuple)
+
+    @property
+    def measured(self) -> bool:
+        """True when the topology is a reading rather than an absence."""
+        return self.topology in _MEASURED
+
+    @property
+    def usable_bytes(self) -> int:
+        """Free capacity minus the reserved headroom. Never negative."""
+        return max(0, int(self.free_bytes * (1.0 - headroom_fraction())))
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "topology": self.topology.value,
+            "measured": self.measured,
+            "total_bytes": self.total_bytes,
+            "total_gib": round(self.total_bytes / _BYTES_PER_GIB, 2),
+            "free_bytes": self.free_bytes,
+            "free_gib": round(self.free_bytes / _BYTES_PER_GIB, 2),
+            "usable_bytes": self.usable_bytes,
+            "usable_gib": round(self.usable_bytes / _BYTES_PER_GIB, 2),
+            "device_name": self.device_name,
+            "device_count": self.device_count,
+            "source": self.source,
+            "resolved_class": self.resolved_class,
+            "enabled": self.enabled,
+            "degraded": self.degraded,
+            "free_is_measured": self.free_is_measured,
+            "probed_at": self.probed_at,
+            "free_age_s": round(max(0.0, time.time() - self.free_probed_at), 3),
+            "error": self.error,
+            "notes": list(self.notes),
+        }
+
+
+@dataclass(frozen=True)
+class FitDecision:
+    """Whether a stated weight footprint fits this host.
+
+    ``fits`` False with ``reason_code == "unknown_topology"`` means *we do
+    not know*, and callers must not read it as *no*. The distinction is the
+    difference between a refusal and a fabrication.
+    """
+
+    fits: bool
+    required_bytes: int
+    usable_bytes: int
+    topology: MemoryTopology
+    reason_code: str
+    resolved_class: str
+    schema_version: str = COMPUTE_TOPOLOGY_SCHEMA_VERSION
+    #: Bytes that would have to spill to host RAM under this fit. Zero when
+    #: resident. Non-zero is not fatal for a MoE with few active params, so
+    #: it is REPORTED rather than judged here.
+    spill_bytes: int = 0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "fits": self.fits,
+            "required_bytes": self.required_bytes,
+            "required_gib": round(self.required_bytes / _BYTES_PER_GIB, 2),
+            "usable_bytes": self.usable_bytes,
+            "usable_gib": round(self.usable_bytes / _BYTES_PER_GIB, 2),
+            "spill_bytes": self.spill_bytes,
+            "topology": self.topology.value,
+            "reason_code": self.reason_code,
+            "resolved_class": self.resolved_class,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Class resolution — measured, not enumerated
+# ---------------------------------------------------------------------------
+
+
+def bytes_for_class(name: Optional[str]) -> int:
+    """Capacity a legacy ``compute_class`` string implies, in bytes.
+
+    An unrecognised name resolves to 0 rather than raising: an unknown
+    requirement must not be able to deny a route by being unparseable. The
+    caller sees "no stated requirement", which is the honest reading of a
+    name this side has never heard of — the same posture
+    ``memory_pressure_gate`` takes toward an unrecognised Rust arena level.
+    """
+    if not name:
+        return 0
+    return reference_class_bytes().get(str(name).strip().lower(), 0)
+
+
+def bytes_for_requirement(
+    min_compute_class: Optional[str] = None,
+    min_vram_gb: Optional[float] = None,
+) -> int:
+    """The byte requirement a brain declares, by either vocabulary.
+
+    ``min_vram_gb`` is direct and always wins when present — a policy that
+    states a number has said precisely what it means, and no name lookup can
+    improve on that. ``min_compute_class`` remains supported so existing
+    policy keeps working unchanged.
+    """
+    if min_vram_gb is not None:
+        try:
+            return max(0, int(float(min_vram_gb) * _BYTES_PER_GIB))
+        except (TypeError, ValueError):
+            pass
+    return bytes_for_class(min_compute_class)
+
+
+def _local_host_aliases() -> Tuple[str, ...]:
+    """Names that denote THIS machine. Overridable, never assumed complete.
+
+    ``JARVIS_COMPUTE_TOPOLOGY_LOCAL_ALIASES`` (comma-separated) extends the
+    set for hosts whose advertised name matches neither their hostname nor a
+    loopback literal — a container reporting its service name, a VM behind a
+    stable DNS alias.
+    """
+    aliases = {"localhost", "127.0.0.1", "::1", "0.0.0.0", "loopback"}
+    for probe in ("gethostname", "getfqdn"):
+        try:
+            import socket
+            value = getattr(socket, probe)()
+            if value:
+                aliases.add(str(value).strip().lower())
+        except Exception:  # noqa: BLE001
+            continue
+    try:
+        import platform
+        node = platform.node()
+        if node:
+            aliases.add(str(node).strip().lower())
+    except Exception:  # noqa: BLE001
+        pass
+    raw = os.environ.get("JARVIS_COMPUTE_TOPOLOGY_LOCAL_ALIASES", "")
+    for part in raw.split(","):
+        part = part.strip().lower()
+        if part:
+            aliases.add(part)
+    return tuple(sorted(aliases))
+
+
+def describes_this_host(capability: Any) -> bool:
+    """Does a fetched capability describe the machine this process runs on?
+
+    **Why this gate exists.** A capability payload arrives over HTTP from a
+    J-Prime endpoint that may be a GCP VM on the other side of the planet.
+    A local accelerator reading says nothing whatsoever about that machine,
+    and using one to authorize a route to the other would be the very defect
+    this module was written to close — measuring something real and
+    presenting it as the answer to a different question.
+
+    **Positive proof only.** Returns True only when the payload's ``host``
+    matches a known alias for this machine. Absence, mismatch, or a
+    malformed payload all return False, and the caller falls back to the
+    class-name comparison that never claimed to be a measurement. An
+    unproven locality is not a local host.
+    """
+    try:
+        host = None
+        if isinstance(capability, dict):
+            host = capability.get("host") or capability.get("execution_host")
+        else:
+            host = getattr(capability, "host", None)
+        if not host:
+            return False
+        return str(host).strip().lower() in _local_host_aliases()
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def class_for_bytes(total_bytes: int, topology: MemoryTopology) -> str:
+    """Name this host's capacity honestly.
+
+    Returns a MEASURED descriptor — ``gpu_32gib``, ``unified_16gib``, ``cpu``
+    — rather than the nearest legacy rung. Naming a 32 GiB consumer card
+    ``gpu_v100`` because that rung happens to sit at 32 GiB would be a
+    fabrication in a field an operator reads, and the reference table exists
+    to interpret REQUIREMENTS, not to relabel hardware.
+
+    Admission never consumes this string; it compares bytes. This is for
+    humans and for telemetry.
+    """
+    if topology is MemoryTopology.UNKNOWN:
+        return "unknown"
+    if topology is MemoryTopology.NONE or total_bytes <= 0:
+        return "cpu"
+    gib = int(total_bytes // _BYTES_PER_GIB)
+    prefix = "unified" if topology is MemoryTopology.UNIFIED else "gpu"
+    return f"{prefix}_{gib}gib"
+
+
+# ---------------------------------------------------------------------------
+# Probe cascade — accelerator only. System RAM belongs to memory_pressure_gate.
+# ---------------------------------------------------------------------------
+
+
+def _is_wsl() -> bool:
+    """WSL2 guest detection.
+
+    Load-bearing for attribution rather than for the reading itself: under
+    WSL2 the CUDA probes report the HOST's physical card correctly, while
+    ``/proc/meminfo`` reports only the guest VM's slice of host RAM. A
+    surprising system-RAM number on this host has a known cause, and the
+    note says so rather than leaving it to be rediscovered.
+    """
+    try:
+        if any(os.environ.get(n) for n in _truthy_env_names()):
+            return True
+        rel = "/proc/sys/kernel/osrelease"
+        if os.path.exists(rel):
+            with open(rel, "r", encoding="utf-8", errors="replace") as fh:
+                return "microsoft" in fh.read().lower()
+    except OSError:
+        pass
+    return False
+
+
+def _probe_torch_cuda() -> Optional[AcceleratorProbe]:
+    """Most authoritative CUDA reading: driver-level free AND total.
+
+    ``mem_get_info`` reports what the driver will actually hand out, which
+    already accounts for the CUDA context and other processes' allocations —
+    a number no arithmetic over nameplate capacity can reconstruct.
+
+    Multi-GPU resolves to the LARGEST SINGLE device, not the sum. A model
+    must fit on one device unless it was sharded, and sharding is a property
+    of the serving stack rather than of the host; summing would authorize a
+    load that cannot physically land.
+    """
+    try:
+        # Optional accelerated probe: torch is not a dependency of this
+        # module and must never become one. Absent, CPU-only, or a broken
+        # CUDA build all decline identically.
+        import torch  # type: ignore[import-not-found]  # noqa: F401
+    except Exception:  # noqa: BLE001 — absent, or broken build
+        return None
+    try:
+        import torch  # type: ignore[import-not-found]
+        if not torch.cuda.is_available():
+            return None
+        count = int(torch.cuda.device_count())
+        if count <= 0:
+            return None
+        best: Optional[Tuple[int, int, str]] = None
+        for idx in range(count):
+            try:
+                free_b, total_b = torch.cuda.mem_get_info(idx)
+                name = str(torch.cuda.get_device_name(idx))
+            except Exception:  # noqa: BLE001 — one bad device never voids the rest
+                continue
+            if best is None or int(total_b) > best[1]:
+                best = (int(free_b), int(total_b), name)
+        if best is None:
+            return None
+        return AcceleratorProbe(
+            topology=MemoryTopology.DISCRETE,
+            total_bytes=best[1], free_bytes=best[0],
+            device_name=best[2], device_count=count, source="torch_cuda",
+        )
+    except Exception as exc:  # noqa: BLE001
+        return AcceleratorProbe(
+            topology=MemoryTopology.UNKNOWN, total_bytes=0, free_bytes=0,
+            device_name="", device_count=0, source="torch_cuda",
+            ok=False, error=str(exc),
+        )
+
+
+def nvidia_smi_binary_names() -> Tuple[str, ...]:
+    """Names the driver CLI may carry. Overridable, ordered by likelihood."""
+    raw = os.environ.get(
+        "JARVIS_COMPUTE_TOPOLOGY_SMI_NAMES", "nvidia-smi,nvidia-smi.exe",
+    )
+    return tuple(p.strip() for p in raw.split(",") if p.strip())
+
+
+def nvidia_smi_search_dirs() -> Tuple[str, ...]:
+    """Directories to search when ``PATH`` does not carry the driver CLI.
+
+    **The root cause this closes.** Binary discovery bound to ``PATH`` alone
+    is bound to a variable the LAUNCH CONTEXT owns, not the machine. WSL2
+    injects its GPU stub directory from the interactive login profile, so a
+    shell finds ``nvidia-smi`` and a systemd unit, cron job or launchd daemon
+    started with a sanitized environment does not. The host is identical; the
+    answer differs. A probe whose verdict depends on how its process was
+    started is not measuring hardware.
+
+    So discovery composes ``PATH`` (operator intent, always first) with the
+    locations a driver actually installs to. Data on the module, overridable
+    wholesale via ``JARVIS_COMPUTE_TOPOLOGY_SMI_DIRS`` (``os.pathsep``
+    separated) — the same posture as ``reference_class_bytes`` and
+    ``_local_host_aliases``: a fleet is entitled to say where its own
+    binaries live, and none of this belongs inline in execution logic.
+
+    Order is authority-descending and the last entry is deliberate: the
+    Windows-interop binary answers correctly from inside WSL2 but crosses the
+    9p filesystem boundary to do it, which is slow enough that it must never
+    outrank a native one.
+    """
+    override = os.environ.get("JARVIS_COMPUTE_TOPOLOGY_SMI_DIRS")
+    if override is not None:
+        return tuple(p.strip() for p in override.split(os.pathsep) if p.strip())
+    return (
+        # WSL2: the driver stub the Windows host projects into the guest.
+        "/usr/lib/wsl/lib",
+        # Ordinary Linux driver installs.
+        "/usr/bin", "/usr/local/bin", "/usr/local/nvidia/bin", "/opt/bin",
+        # Native Windows, when this ever runs there directly.
+        "C:\\Windows\\System32",
+        "C:\\Program Files\\NVIDIA Corporation\\NVSMI",
+        # Last resort: reach the Windows binary through WSL interop. Correct,
+        # and slow — 9p, so only when nothing native answered.
+        "/mnt/c/Windows/System32",
+    )
+
+
+def _executable_at(path_str: str, name: str) -> Optional[str]:
+    """A runnable file at ``path_str/name``, or None. NEVER raises.
+
+    Rejects the three shapes that look like a hit and are not: a directory
+    carrying the binary's name, a dangling symlink, and a present-but-not-
+    executable file. Each would otherwise reach ``create_subprocess_exec``
+    and surface as an opaque OSError attributed to the driver.
+    """
+    try:
+        import pathlib
+        candidate = pathlib.Path(path_str) / name
+        if not candidate.is_file():          # False for dirs AND dead links
+            return None
+        if not os.access(str(candidate), os.X_OK):
+            return None
+        return str(candidate.resolve())
+    except (OSError, ValueError):
+        return None
+
+
+def _resolve_nvidia_smi_uncached() -> Optional[str]:
+    """Locate the driver CLI across launch contexts. NEVER raises."""
+    for name in nvidia_smi_binary_names():
+        found = shutil.which(name)          # PATH first: operator intent wins
+        if found:
+            return found
+    for directory in nvidia_smi_search_dirs():
+        # An override may name the binary itself rather than its directory —
+        # an operator who wrote a full path has been unambiguous, and
+        # demanding they split it would be pedantry.
+        direct = _executable_at(os.path.dirname(directory) or "/",
+                                os.path.basename(directory))
+        if direct and os.path.basename(directory) in nvidia_smi_binary_names():
+            return direct
+        for name in nvidia_smi_binary_names():
+            found = _executable_at(directory, name)
+            if found:
+                return found
+    return None
+
+
+_smi_path_cache: Dict[str, Optional[str]] = {}
+_smi_path_lock = threading.Lock()
+
+
+def resolve_nvidia_smi() -> Optional[str]:
+    """Cached driver-CLI path, revalidated on every read. NEVER raises.
+
+    A driver binary does not move, so the search is cached — but the cache is
+    *checked*, not trusted: a package upgrade or a container layer swap can
+    delete the resolved path underneath a long-lived daemon, and a stale hit
+    would fail every probe thereafter with an error that names the wrong
+    cause. Revalidation is one ``access`` call; a miss re-runs discovery.
+    """
+    with _smi_path_lock:
+        cached = _smi_path_cache.get("path", "__unset__")
+    if cached != "__unset__" and cached is not None:
+        try:
+            if os.access(cached, os.X_OK):
+                return cached
+        except (OSError, ValueError):
+            pass
+        with _smi_path_lock:
+            _smi_path_cache.pop("path", None)
+    elif cached is None:
+        return None
+    resolved = _resolve_nvidia_smi_uncached()
+    with _smi_path_lock:
+        _smi_path_cache["path"] = resolved
+    if resolved:
+        logger.debug("[ComputeTopology] driver CLI at %s", resolved)
+    return resolved
+
+
+def reset_nvidia_smi_cache() -> None:
+    """Drop the resolved path — for tests and after a driver reinstall."""
+    with _smi_path_lock:
+        _smi_path_cache.clear()
+
+
+def _parse_nvidia_smi(text: str) -> Optional[Tuple[int, int, str, int]]:
+    """(free, total, name, count) from ``nvidia-smi`` CSV. None if unparseable.
+
+    Values arrive in MiB. Rows that do not parse are skipped rather than
+    zeroed, for the same reason a failed cascade stage is skipped: a
+    malformed row is missing data, not a device with no memory.
+    """
+    rows: List[Tuple[int, int, str]] = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        parts = [p.strip() for p in line.split(",")]
+        if len(parts) < 3:
+            continue
+        try:
+            total_mib = int(float(re.sub(r"[^\d.]", "", parts[0]) or 0))
+            free_mib = int(float(re.sub(r"[^\d.]", "", parts[1]) or 0))
+        except (TypeError, ValueError):
+            continue
+        if total_mib <= 0:
+            continue
+        rows.append((free_mib * 1024 * 1024, total_mib * 1024 * 1024, parts[2]))
+    if not rows:
+        return None
+    best = max(rows, key=lambda r: r[1])
+    return best[0], best[1], best[2], len(rows)
+
+
+async def _probe_nvidia_smi_async() -> Optional[AcceleratorProbe]:
+    """Driverless-Python CUDA reading via ``nvidia-smi``.
+
+    Reached when torch is absent or CPU-only — the common shape on a serving
+    host where inference runs in Ollama/vLLM and the Python process merely
+    governs. Uses ``create_subprocess_exec`` with an explicit wait bound so a
+    wedged driver cannot hold the event loop: on timeout the child is killed
+    and reaped rather than left to accumulate.
+
+    Discovery runs off-loop: it stats candidate directories, and one of them
+    may be a 9p or network mount where a stat can block for seconds. The
+    binary is never shell-invoked, so an operator-supplied search path cannot
+    become an injection surface.
+    """
+    binary = await asyncio.to_thread(resolve_nvidia_smi)
+    if not binary:
+        return None
+    proc = None
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            binary,
+            "--query-gpu=memory.total,memory.free,name",
+            "--format=csv,noheader,nounits",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        out, err = await asyncio.wait_for(
+            proc.communicate(), timeout=probe_timeout_s(),
+        )
+    except asyncio.TimeoutError:
+        await _terminate(proc)
+        return AcceleratorProbe(
+            topology=MemoryTopology.UNKNOWN, total_bytes=0, free_bytes=0,
+            device_name="", device_count=0, source="nvidia_smi",
+            ok=False, error="timeout",
+        )
+    except (OSError, ValueError) as exc:
+        await _terminate(proc)
+        return AcceleratorProbe(
+            topology=MemoryTopology.UNKNOWN, total_bytes=0, free_bytes=0,
+            device_name="", device_count=0, source="nvidia_smi",
+            ok=False, error=str(exc),
+        )
+    if proc.returncode != 0:
+        return AcceleratorProbe(
+            topology=MemoryTopology.UNKNOWN, total_bytes=0, free_bytes=0,
+            device_name="", device_count=0, source="nvidia_smi",
+            ok=False,
+            error=f"rc={proc.returncode} {(err or b'').decode(errors='replace')[:120]}",
+        )
+    parsed = _parse_nvidia_smi((out or b"").decode(errors="replace"))
+    if parsed is None:
+        return AcceleratorProbe(
+            topology=MemoryTopology.UNKNOWN, total_bytes=0, free_bytes=0,
+            device_name="", device_count=0, source="nvidia_smi",
+            ok=False, error="unparseable",
+        )
+    free_b, total_b, name, count = parsed
+    return AcceleratorProbe(
+        topology=MemoryTopology.DISCRETE, total_bytes=total_b,
+        free_bytes=free_b, device_name=name, device_count=count,
+        source="nvidia_smi",
+    )
+
+
+async def _terminate(proc: Any) -> None:
+    """Kill and REAP a child. Never raises.
+
+    Reaping matters: an unawaited transport leaks a zombie and a
+    ``ResourceWarning`` per probe, and this runs on a TTL.
+    """
+    if proc is None:
+        return
+    try:
+        if proc.returncode is None:
+            proc.kill()
+            await asyncio.wait_for(proc.wait(), timeout=1.0)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _probe_unified() -> Optional[AcceleratorProbe]:
+    """Apple Silicon: one pool, budgeted.
+
+    The accelerator "capacity" here is a FRACTION of system RAM, not its
+    total — the GPU's working set is bounded well below nameplate, and on
+    this host the same bytes also carry a real-time audio graph and a vision
+    pipeline. Free bytes are DERIVED from the canonical system-RAM gate
+    rather than probed, and flagged ``free_is_measured=False`` so no
+    consumer mistakes a derivation for a driver reading.
+    """
+    if not sys.platform.startswith("darwin"):
+        return None
+    try:
+        import platform
+        if platform.machine().lower() not in ("arm64", "aarch64"):
+            return None  # Intel Mac: any dGPU is discrete, and not CUDA
+    except Exception:  # noqa: BLE001
+        return None
+    total_ram, avail_ram = _system_ram_from_canonical_gate()
+    if total_ram <= 0:
+        return AcceleratorProbe(
+            topology=MemoryTopology.UNIFIED, total_bytes=0, free_bytes=0,
+            device_name="Apple Silicon", device_count=1, source="unified",
+            ok=False, error="system ram unresolved", free_is_measured=False,
+        )
+    frac = unified_budget_fraction()
+    return AcceleratorProbe(
+        topology=MemoryTopology.UNIFIED,
+        total_bytes=int(total_ram * frac),
+        free_bytes=int(min(avail_ram, total_ram * frac)),
+        device_name="Apple Silicon (unified)", device_count=1,
+        source="unified", free_is_measured=False,
+    )
+
+
+def _system_ram_from_canonical_gate() -> Tuple[int, int]:
+    """(total, available) system RAM — from ``memory_pressure_gate``, always.
+
+    DRY, and more than DRY: that module's cascade already handles psutil
+    absence, container limits, ``/proc/meminfo`` and ``vm_stat``, and it is
+    the reading every other consumer in the system acts on. Re-deriving the
+    number here would create a second authority for a value the operator
+    sees in one place, which is this codebase's most-repeated defect.
+
+    Returns ``(0, 0)`` when the gate cannot resolve — never a guess.
+    """
+    try:
+        from backend.core.ouroboros.governance.memory_pressure_gate import (
+            get_default_gate,
+        )
+        probe = get_default_gate().probe()
+        if not getattr(probe, "ok", False):
+            return 0, 0
+        return int(probe.total_bytes), int(probe.available_bytes)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[ComputeTopology] canonical RAM gate unavailable: %s", exc)
+        return 0, 0
+
+
+def _probe_cpu_only() -> AcceleratorProbe:
+    """Terminal stage: no accelerator found, but the host IS resolved.
+
+    NONE is a measurement and must be distinguishable from UNKNOWN. Reaching
+    here means every accelerator probe declined — not that they errored — so
+    a CPU-inference budget out of system RAM is a legitimate answer.
+    """
+    total_ram, avail_ram = _system_ram_from_canonical_gate()
+    if total_ram <= 0:
+        return AcceleratorProbe(
+            topology=MemoryTopology.UNKNOWN, total_bytes=0, free_bytes=0,
+            device_name="", device_count=0, source="cpu_only",
+            ok=False, error="system ram unresolved", free_is_measured=False,
+        )
+    frac = unified_budget_fraction()
+    return AcceleratorProbe(
+        topology=MemoryTopology.NONE,
+        total_bytes=int(total_ram * frac),
+        free_bytes=int(min(avail_ram, total_ram * frac)),
+        device_name="cpu", device_count=0, source="cpu_only",
+        free_is_measured=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Resolver — single-flight, split-clock cache
+# ---------------------------------------------------------------------------
+
+
+class ComputeTopologyResolver:
+    """Resolves and caches this host's accelerator situation.
+
+    Two clocks, because the facts have two lifetimes: identity (device,
+    capacity, topology) is pinned on first success; free bytes carry a TTL.
+
+    Single-flight: concurrent callers await ONE in-flight probe rather than
+    each spawning ``nvidia-smi``. Under an L3 fan-out that difference is
+    dozens of subprocesses against a driver that is already the reason the
+    probe is bounded.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._identity: Optional[AcceleratorProbe] = None
+        self._identity_at: float = 0.0
+        self._free_bytes: int = 0
+        self._free_at: float = 0.0
+        self._inflight: Optional["asyncio.Future[AcceleratorProbe]"] = None
+        #: The loop that owns ``_inflight``. A future may only be awaited
+        #: from its own loop, and this process has more than one.
+        self._inflight_loop: Optional[Any] = None
+        self._notes: Tuple[str, ...] = ()
+
+    # -- cascade ---------------------------------------------------------
+
+    async def _run_cascade(self) -> AcceleratorProbe:
+        """Ordered probe cascade. Never raises.
+
+        Order is authority-descending: a driver-level reading beats a CLI
+        one, which beats a derivation from system RAM. A stage returning
+        ``None`` DECLINED (not applicable here); a stage returning
+        ``ok=False`` FAILED and is recorded but skipped. Conflating the two
+        would let a broken driver masquerade as a machine with no GPU.
+        """
+        errors: List[str] = []
+
+        for stage in (self._stage_torch, self._stage_nvidia_smi,
+                      self._stage_unified):
+            try:
+                probe = await stage()
+            except Exception as exc:  # noqa: BLE001 — a stage never voids the cascade
+                errors.append(f"{getattr(stage, '__name__', 'stage')}:{exc}")
+                continue
+            if probe is None:
+                continue
+            if probe.ok:
+                if errors:
+                    self._notes = tuple(errors)
+                return probe
+            errors.append(f"{probe.source}:{probe.error}")
+
+        self._notes = tuple(errors)
+        return _probe_cpu_only()
+
+    async def _stage_torch(self) -> Optional[AcceleratorProbe]:
+        """torch's CUDA API — off-loop: import and driver init both block."""
+        return await asyncio.to_thread(_probe_torch_cuda)
+
+    async def _stage_nvidia_smi(self) -> Optional[AcceleratorProbe]:
+        return await _probe_nvidia_smi_async()
+
+    async def _stage_unified(self) -> Optional[AcceleratorProbe]:
+        return await asyncio.to_thread(_probe_unified)
+
+    # -- public ----------------------------------------------------------
+
+    async def resolve(
+        self, *, force: bool = False, max_free_age_s: Optional[float] = None,
+    ) -> ComputeReading:
+        """Current reading. Async-native, single-flight, never raises.
+
+        ``max_free_age_s`` overrides the free-byte TTL for THIS call only.
+        Zero forces a just-in-time re-read of the dynamic dimension while
+        leaving pinned identity untouched — the admission gate's JIT probe,
+        which must see the OS state as of microseconds ago rather than as of
+        whenever the last caller happened to ask. It is a per-call argument
+        rather than an env knob because freshness is a property of the
+        QUESTION: a dashboard refresh and a weight-load decision have
+        legitimately different tolerances for a stale byte count.
+
+        ``force`` re-runs the whole cascade including device enumeration and
+        is reserved for boot and for a deliberate re-probe.
+        """
+        if not is_enabled():
+            return self._disabled_reading()
+
+        now = time.time()
+        identity = self._pinned_identity(now, force)
+        ttl = free_ttl_s() if max_free_age_s is None else max(0.0, max_free_age_s)
+
+        if identity is not None and not force:
+            if (now - self._free_at) <= ttl:
+                return self._compose(identity, self._free_bytes, self._free_at)
+            fresh = await self._refresh_free(identity)
+            return self._compose(identity, fresh, time.time())
+
+        probe = await self._single_flight()
+        with self._lock:
+            if probe.ok and probe.topology in _MEASURED:
+                self._identity = probe
+                self._identity_at = time.time()
+            self._free_bytes = probe.free_bytes
+            self._free_at = time.time()
+        return self._compose(probe, probe.free_bytes, self._free_at)
+
+    def resolve_sync(self) -> ComputeReading:
+        """Synchronous façade for callers that are not async.
+
+        Serves the cache when one exists — which is the common case, since
+        boot resolves early. With no cache and no running loop it drives the
+        cascade to completion on a private loop. With no cache INSIDE a
+        running loop it refuses to block that loop and returns a degraded
+        reading instead; blocking an event loop to answer a capability
+        question is precisely the failure class this codebase has spent
+        slices removing (§3 Asynchronous Tendrils).
+        """
+        if not is_enabled():
+            return self._disabled_reading()
+        now = time.time()
+        identity = self._pinned_identity(now, False)
+        if identity is not None:
+            return self._compose(identity, self._free_bytes, self._free_at)
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            try:
+                return asyncio.run(self.resolve())
+            except Exception as exc:  # noqa: BLE001
+                return self._degraded_reading(str(exc))
+        return self._degraded_reading("async context; awaiting first resolve")
+
+    async def fits(
+        self,
+        required_bytes: int,
+        *,
+        allow_spill: bool = False,
+        spill_capacity_bytes: Optional[int] = None,
+    ) -> FitDecision:
+        """Does a stated weight footprint fit this host?
+
+        ``allow_spill`` models the MoE case honestly: a 120B model with ~5B
+        active params can run with experts resident in host RAM at a real
+        but tolerable cost. The spill remainder is REPORTED either way; only
+        the verdict changes, because whether that trade is acceptable is a
+        policy question and this module does not hold policy.
+
+        Spill capacity defaults to what the canonical system-RAM gate says
+        is available — never to nameplate, and never to a constant.
+        """
+        reading = await self.resolve()
+        return self._decide_fit(
+            reading, required_bytes, allow_spill, spill_capacity_bytes,
+        )
+
+    def _decide_fit(
+        self,
+        reading: ComputeReading,
+        required_bytes: int,
+        allow_spill: bool,
+        spill_capacity_bytes: Optional[int],
+    ) -> FitDecision:
+        req = max(0, int(required_bytes))
+        usable = reading.usable_bytes
+
+        if not reading.measured:
+            # Epistemic humility: an unresolved host may not authorize a
+            # load, and may not be reported as having refused one.
+            return FitDecision(
+                fits=False, required_bytes=req, usable_bytes=0,
+                topology=reading.topology, reason_code="unknown_topology",
+                resolved_class=reading.resolved_class,
+            )
+        if req == 0:
+            return FitDecision(
+                fits=True, required_bytes=0, usable_bytes=usable,
+                topology=reading.topology, reason_code="no_requirement",
+                resolved_class=reading.resolved_class,
+            )
+        if req <= usable:
+            return FitDecision(
+                fits=True, required_bytes=req, usable_bytes=usable,
+                topology=reading.topology, reason_code="resident",
+                resolved_class=reading.resolved_class,
+            )
+
+        spill = req - usable
+        if not allow_spill:
+            return FitDecision(
+                fits=False, required_bytes=req, usable_bytes=usable,
+                topology=reading.topology, reason_code="exceeds_accelerator",
+                resolved_class=reading.resolved_class, spill_bytes=spill,
+            )
+        # Under UNIFIED/NONE the "spill pool" IS the pool already counted —
+        # there is nowhere else for it to go, so spill cannot rescue a fit.
+        if reading.topology is not MemoryTopology.DISCRETE:
+            return FitDecision(
+                fits=False, required_bytes=req, usable_bytes=usable,
+                topology=reading.topology, reason_code="no_spill_pool",
+                resolved_class=reading.resolved_class, spill_bytes=spill,
+            )
+        capacity = spill_capacity_bytes
+        if capacity is None:
+            _, capacity = _system_ram_from_canonical_gate()
+        capacity = max(0, int(capacity or 0))
+        headroom_adjusted = int(capacity * (1.0 - headroom_fraction()))
+        if spill <= headroom_adjusted:
+            return FitDecision(
+                fits=True, required_bytes=req, usable_bytes=usable,
+                topology=reading.topology, reason_code="fits_with_spill",
+                resolved_class=reading.resolved_class, spill_bytes=spill,
+            )
+        return FitDecision(
+            fits=False, required_bytes=req, usable_bytes=usable,
+            topology=reading.topology, reason_code="exceeds_host_memory",
+            resolved_class=reading.resolved_class, spill_bytes=spill,
+        )
+
+    async def snapshot(self) -> Dict[str, Any]:
+        """Observability projection (§8). Read-only, never raises."""
+        reading = await self.resolve()
+        out = reading.to_dict()
+        out["wsl"] = _is_wsl()
+        out["headroom_fraction"] = headroom_fraction()
+        out["unified_budget_fraction"] = unified_budget_fraction()
+        out["free_ttl_s"] = free_ttl_s()
+        return out
+
+    # -- internals -------------------------------------------------------
+
+    def _pinned_identity(self, now: float, force: bool) -> Optional[AcceleratorProbe]:
+        if force:
+            return None
+        with self._lock:
+            identity = self._identity
+            pinned_at = self._identity_at
+        if identity is None:
+            return None
+        repin = identity_repin_s()
+        if repin > 0.0 and (now - pinned_at) > repin:
+            return None
+        return identity
+
+    async def _single_flight(self) -> AcceleratorProbe:
+        """One cascade at a time; concurrent callers share the result.
+
+        The in-flight future is bound to the loop that created it. A caller
+        arriving from a DIFFERENT loop — this codebase runs
+        ``asyncio.to_thread`` and the harness owns more than one loop over a
+        session — cannot legally await it, so it runs its own cascade rather
+        than raising a cross-loop error. Correctness first: sharing is an
+        optimisation, and an optimisation may never be the reason a
+        capability read fails.
+        """
+        loop = asyncio.get_running_loop()
+        share: Optional["asyncio.Future[AcceleratorProbe]"] = None
+        fut: Optional["asyncio.Future[AcceleratorProbe]"] = None
+
+        with self._lock:
+            existing = self._inflight
+            existing_loop = self._inflight_loop
+            if (existing is not None and not existing.done()
+                    and existing_loop is loop):
+                share = existing
+            elif existing is None or existing.done():
+                fut = loop.create_future()
+                self._inflight = fut
+                self._inflight_loop = loop
+
+        if share is not None:
+            try:
+                return await asyncio.shield(share)
+            except Exception:  # noqa: BLE001 — owner failed; answer honestly
+                return _probe_cpu_only()
+
+        try:
+            probe = await self._run_cascade()
+        except Exception as exc:  # noqa: BLE001
+            probe = AcceleratorProbe(
+                topology=MemoryTopology.UNKNOWN, total_bytes=0, free_bytes=0,
+                device_name="", device_count=0, source="cascade",
+                ok=False, error=str(exc),
+            )
+
+        if fut is not None:
+            with self._lock:
+                if self._inflight is fut:
+                    self._inflight = None
+                    self._inflight_loop = None
+            if not fut.done():
+                fut.set_result(probe)
+        return probe
+
+    async def _refresh_free(self, identity: AcceleratorProbe) -> int:
+        """Re-read ONLY the dynamic dimension. Falls back to the last value.
+
+        A failed refresh must not demote a host that was already resolved:
+        the identity stands and the previous free reading is reused, with
+        its age visible in ``snapshot()`` so staleness is legible rather
+        than silent — the ``_heartbeat_age`` discipline, applied to bytes.
+        """
+        try:
+            if identity.source == "torch_cuda":
+                probe = await asyncio.to_thread(_probe_torch_cuda)
+            elif identity.source == "nvidia_smi":
+                probe = await _probe_nvidia_smi_async()
+            elif identity.source == "unified":
+                probe = await asyncio.to_thread(_probe_unified)
+            else:
+                probe = await asyncio.to_thread(_probe_cpu_only)
+        except Exception:  # noqa: BLE001
+            probe = None
+        if probe is not None and probe.ok:
+            with self._lock:
+                self._free_bytes = probe.free_bytes
+                self._free_at = time.time()
+            return probe.free_bytes
+        with self._lock:
+            return self._free_bytes
+
+    def _compose(
+        self, probe: AcceleratorProbe, free_bytes: int, free_at: float,
+    ) -> ComputeReading:
+        notes = list(self._notes)
+        if _is_wsl():
+            notes.append(
+                "wsl2: accelerator reading is the host GPU; system-RAM "
+                "readings are the guest's allocation, not the host's",
+            )
+        return ComputeReading(
+            topology=probe.topology,
+            total_bytes=probe.total_bytes,
+            free_bytes=max(0, int(free_bytes)),
+            device_name=probe.device_name,
+            device_count=probe.device_count,
+            source=probe.source,
+            resolved_class=class_for_bytes(probe.total_bytes, probe.topology),
+            enabled=True,
+            probed_at=self._identity_at or time.time(),
+            free_probed_at=free_at,
+            free_is_measured=probe.free_is_measured,
+            degraded=not probe.ok,
+            error=probe.error,
+            notes=tuple(notes),
+        )
+
+    def _disabled_reading(self) -> ComputeReading:
+        return ComputeReading(
+            topology=MemoryTopology.UNKNOWN, total_bytes=0, free_bytes=0,
+            device_name="", device_count=0, source="disabled",
+            resolved_class="unknown", enabled=False,
+            probed_at=0.0, free_probed_at=0.0, free_is_measured=False,
+        )
+
+    def _degraded_reading(self, error: str) -> ComputeReading:
+        return ComputeReading(
+            topology=MemoryTopology.UNKNOWN, total_bytes=0, free_bytes=0,
+            device_name="", device_count=0, source="degraded",
+            resolved_class="unknown", enabled=True,
+            probed_at=0.0, free_probed_at=0.0, free_is_measured=False,
+            degraded=True, error=error,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton — mirrors memory_pressure_gate's accessor shape
+# ---------------------------------------------------------------------------
+
+_singleton: Optional[ComputeTopologyResolver] = None
+_singleton_lock = threading.Lock()
+
+
+def get_default_resolver() -> ComputeTopologyResolver:
+    global _singleton
+    with _singleton_lock:
+        if _singleton is None:
+            _singleton = ComputeTopologyResolver()
+        return _singleton
+
+
+def reset_default_resolver() -> None:
+    """Drop the singleton — for tests and for a deliberate re-probe."""
+    global _singleton
+    with _singleton_lock:
+        _singleton = None
+
+
+async def resolve(max_free_age_s: Optional[float] = None) -> ComputeReading:
+    """Module-level convenience over the default resolver."""
+    return await get_default_resolver().resolve(max_free_age_s=max_free_age_s)
+
+
+async def resolve_jit() -> ComputeReading:
+    """A reading whose free-byte dimension is re-read NOW.
+
+    The admission gate's probe. Identity stays pinned — device enumeration
+    is not repeated — so the cost is one bounded driver query, not a full
+    cascade. Use when the answer will authorize an allocation; use
+    :func:`resolve` when it will render a dashboard.
+    """
+    return await get_default_resolver().resolve(max_free_age_s=0.0)
+
+
+def resolve_sync() -> ComputeReading:
+    return get_default_resolver().resolve_sync()
+
+
+async def fits(required_bytes: int, **kwargs: Any) -> FitDecision:
+    return await get_default_resolver().fits(required_bytes, **kwargs)
+
+
+async def snapshot() -> Dict[str, Any]:
+    return await get_default_resolver().snapshot()
+
+
+def prewarm_budget_s() -> float:
+    """Total wall-clock the boot prewarm may consume. Default 15s.
+
+    Covers the WHOLE cascade, not one stage: importing ``torch`` alone can
+    take many seconds on a cold page cache, and that import happens off-loop
+    but still inside this budget.
+    """
+    return _env_float(
+        "JARVIS_COMPUTE_TOPOLOGY_PREWARM_BUDGET_S", 15.0, minimum=0.5,
+    )
+
+
+async def prewarm() -> ComputeReading:
+    """Resolve identity early so ``resolve_sync`` never has to refuse.
+
+    **Why this is load-bearing rather than an optimisation.**
+    ``_check_compute_admission`` runs inside a live event loop (its caller
+    awaits ``fetch_capability``). ``resolve_sync`` refuses to block a running
+    loop — correctly, per §3 Asynchronous Tendrils — so with no cache it
+    returns a degraded reading and the measured path never engages. Without
+    this call at boot the entire measured admission would be *wired but
+    inert*: present, tested, and never reached. Prewarm is what makes it
+    live.
+
+    Bounded and fail-soft (§2 Progressive Awakening): a wedged driver costs
+    the budget and nothing more. On timeout or fault the resolver simply
+    stays unpinned, every consumer takes its documented unknown-path, and
+    admission falls back to the legacy ordinal comparison — which is exactly
+    the pre-module behaviour.
+    """
+    resolver = get_default_resolver()
+    try:
+        return await asyncio.wait_for(
+            resolver.resolve(force=True), timeout=prewarm_budget_s(),
+        )
+    except asyncio.TimeoutError:
+        logger.info(
+            "[ComputeTopology] prewarm exceeded %.1fs budget; "
+            "admission falls back to ordinal comparison",
+            prewarm_budget_s(),
+        )
+        return resolver._degraded_reading("prewarm timeout")
+    except Exception as exc:  # noqa: BLE001 — boot is never blocked by a probe
+        logger.debug("[ComputeTopology] prewarm failed: %s", exc)
+        return resolver._degraded_reading(str(exc))

--- a/backend/core/ouroboros/governance/governed_loop_service.py
+++ b/backend/core/ouroboros/governance/governed_loop_service.py
@@ -421,12 +421,67 @@ class ComputeClassMismatch(RuntimeError):
 
 
 def _check_compute_admission(brain_cfg: dict, capability: dict) -> None:
-    """Hard-fail if VM compute_class < brain min_compute_class.
+    """Hard-fail if this host cannot carry the brain's memory requirement.
 
-    Raises ComputeClassMismatch if VM rank < brain minimum rank.
+    Two authorities, in priority order, because the question being asked is
+    about BYTES and only one of them can answer it in bytes.
+
+    **Measured (preferred).** ``compute_topology`` probes the accelerator and
+    reports capacity. The brain states a requirement as ``min_vram_gb`` or —
+    for policy written before that field existed — as a legacy
+    ``min_compute_class`` name, which ``bytes_for_requirement`` interprets as
+    the capacity that name implies. Admission then compares capacity to
+    requirement directly. A card nobody enumerated needs no new rung: a
+    32 GiB consumer GPU outranks ``gpu_l4`` because 32 > 24, which is the
+    fact the name-ranked table was standing in for all along.
+
+    **Ordinal (fallback).** When the probe is disabled, or the host cannot be
+    resolved, the legacy ``_COMPUTE_RANK`` comparison runs unchanged. This is
+    not a degraded mode — it is byte-for-byte the pre-existing behaviour, and
+    it is what an ``UNKNOWN`` topology is *for*: an unresolved host may not
+    have a capacity claim invented on its behalf in either direction.
+
+    **Locality is proven, never assumed.** ``capability`` is fetched over
+    HTTP from a J-Prime endpoint that may be a GCP VM on another continent.
+    A local accelerator reading describes only this machine, so the measured
+    path engages solely when ``describes_this_host`` positively matches the
+    payload's host against this machine. Anything else — a remote brain, an
+    absent host field, a malformed payload — takes the ordinal path.
+    Authorizing a remote route with a local GPU reading would be the same
+    wrong-resource error this work exists to remove, wearing new clothes.
     """
     vm_class = capability.get("compute_class", "cpu")
     min_class = brain_cfg.get("min_compute_class", "cpu")
+    min_vram_gb = brain_cfg.get("min_vram_gb")
+
+    try:
+        from backend.core.ouroboros.governance import compute_topology as _ct
+
+        required = _ct.bytes_for_requirement(
+            min_compute_class=min_class, min_vram_gb=min_vram_gb,
+        )
+        local = _ct.describes_this_host(capability)
+        reading = _ct.resolve_sync() if local else None
+        if reading is not None and reading.measured and required > 0:
+            if reading.usable_bytes >= required:
+                return
+            raise ComputeClassMismatch(
+                f"host {reading.resolved_class!r} "
+                f"({reading.usable_bytes / (1024 ** 3):.1f} GiB usable, "
+                f"topology={reading.topology.value}, source={reading.source}) "
+                f"cannot carry brain requirement "
+                f"{required / (1024 ** 3):.1f} GiB "
+                f"(min_vram_gb={min_vram_gb!r} min_compute_class={min_class!r}). "
+                f"Route is denied. Select a lower-tier brain or a larger host."
+            )
+    except ComputeClassMismatch:
+        raise
+    except Exception as exc:  # noqa: BLE001 — measurement never blocks admission
+        logger.debug(
+            "[ComputeAdmission] measured path unavailable (%s); "
+            "falling back to ordinal comparison", exc,
+        )
+
     vm_rank = _COMPUTE_RANK.get(vm_class, 0)
     min_rank = _COMPUTE_RANK.get(min_class, 0)
     if vm_rank < min_rank:
@@ -1671,6 +1726,35 @@ class GovernedLoopService:
                                         _boot_brain_cfg = {k: v for k, v in _e.items() if k not in ("brain_id", "id")}
                                         break
                             if _boot_brain_cfg:
+                                # Resolve this host's accelerator ONCE, here, before
+                                # the first admission question is asked. Load-bearing,
+                                # not an optimisation: _check_compute_admission runs
+                                # inside this running loop, and compute_topology's
+                                # sync facade refuses to block a loop (§3) — so with
+                                # no cache the measured path would never engage and
+                                # the whole gate would be wired-but-inert. Bounded and
+                                # fail-soft: a wedged driver costs its budget, then
+                                # admission falls back to the ordinal comparison.
+                                try:
+                                    from backend.core.ouroboros.governance import (
+                                        compute_topology as _ct_boot,
+                                    )
+                                    if _ct_boot.is_enabled():
+                                        _ct_reading = await _ct_boot.prewarm()
+                                        logger.info(
+                                            "[GLS] compute topology: %s %s "
+                                            "(%.1f GiB usable, source=%s)",
+                                            _ct_reading.topology.value,
+                                            _ct_reading.resolved_class,
+                                            _ct_reading.usable_bytes / (1024 ** 3),
+                                            _ct_reading.source,
+                                        )
+                                except Exception:  # noqa: BLE001
+                                    logger.debug(
+                                        "[GLS] compute topology prewarm skipped",
+                                        exc_info=True,
+                                    )
+
                                 # Boot-time: only gate on compute class (does VM have
                                 # the minimum GPU tier?).  Artifact integrity is checked
                                 # per-operation in _preflight_check() where we know

--- a/backend/core/ouroboros/governance/local_model_admission.py
+++ b/backend/core/ouroboros/governance/local_model_admission.py
@@ -68,12 +68,33 @@ from __future__ import annotations
 import enum
 import logging
 import os
+import threading
+import time
 from dataclasses import dataclass
 from typing import Any, Dict, Optional, Tuple
 
 logger = logging.getLogger("Ouroboros.LocalModelAdmission")
 
-LOCAL_MODEL_ADMISSION_SCHEMA_VERSION: str = "local_model_admission.v1"
+LOCAL_MODEL_ADMISSION_SCHEMA_VERSION: str = "local_model_admission.v2"
+
+_GIB = 1024 ** 3
+
+
+def unknown_topology_ceiling_bytes() -> int:
+    """Largest weight footprint admissible on an UNMEASURED accelerator.
+
+    The degradation state for a malformed, hung, or absent topology probe.
+    Zero disables the ceiling entirely (pure v1 behaviour — the host bound
+    alone). The default is deliberately modest: enough for the small brains
+    that keep an organism alive, never enough to blind-load a frontier model
+    onto a capacity nobody could read.
+    """
+    try:
+        raw = (os.environ.get(
+            "JARVIS_LOCAL_MODEL_UNKNOWN_CEILING_GB", "") or "").strip()
+        return int(max(0.0, float(raw)) * _GIB) if raw else 8 * _GIB
+    except (TypeError, ValueError):
+        return 8 * _GIB
 
 #: Fed back verbatim when a request is deferred. A stable, greppable token
 #: rather than prose — the same discipline as `capability_router
@@ -143,6 +164,30 @@ class AdmissionDecision:
     spoken_reason: str = ""
     schema_version: str = LOCAL_MODEL_ADMISSION_SCHEMA_VERSION
 
+    # -- accelerator dimension (v2) -------------------------------------
+    #: Which pool the weights land in, per ``compute_topology``.
+    topology: str = "unknown"
+    #: Free accelerator bytes at the moment of the ruling — re-read at
+    #: dispatch, never inherited from the boot prewarm.
+    accel_free_bytes: int = 0
+    #: What the caller said it intends to allocate. 0 = it did not say.
+    weight_bytes: int = 0
+    #: Bytes held back beyond the caller's request: static headroom plus
+    #: whatever this model's OOM history has taught us to add.
+    margin_bytes: int = 0
+    #: The largest weight footprint that would be admitted right now. The
+    #: caller may use it to pick a smaller artifact instead of deferring —
+    #: a downshift is a better outcome than a refusal.
+    max_weight_bytes: int = 0
+    #: Which dimension produced the ruling: ``accelerator`` | ``host`` |
+    #: ``none``. Without this a DEFER on a 64 GB machine reads as a bug.
+    bound: str = "none"
+    #: Soft claim recorded for this admission, or None. The caller releases
+    #: it via :func:`release_reservation` when the load finishes or fails.
+    #: Forgetting is survivable — the claim settles out and is reconciled —
+    #: but releasing promptly is what keeps concurrent workers unthrottled.
+    reservation_id: Optional[str] = None
+
     @property
     def proceeds(self) -> bool:
         try:
@@ -156,16 +201,364 @@ class AdmissionDecision:
             "level": self.level, "free_pct": round(self.free_pct, 2),
             "source": self.source, "num_ctx": self.num_ctx,
             "pruned": self.pruned, "reason": self.reason,
+            "topology": self.topology, "bound": self.bound,
+            "accel_free_gib": round(self.accel_free_bytes / _GIB, 2),
+            "weight_gib": round(self.weight_bytes / _GIB, 2),
+            "margin_gib": round(self.margin_bytes / _GIB, 2),
+            "max_weight_gib": round(self.max_weight_bytes / _GIB, 2),
         }
 
 
-def _read_pressure() -> Tuple[str, float, str]:
-    """(level, free_pct, source) from the EXISTING gate. NEVER raises.
+# ---------------------------------------------------------------------------
+# Adaptive margin — the only defensible proxy for what cannot be measured
+# ---------------------------------------------------------------------------
 
-    Fails toward OK. A probe that cannot read memory must not itself become a
-    reason to refuse work — that would let one broken cascade stage silently
-    disable Tier 2 for a whole session, a larger outage than the swap storm it
-    was guarding against.
+
+def margin_base_fraction() -> float:
+    """Starting margin, as a fraction of the requested weight footprint."""
+    try:
+        raw = (os.environ.get("JARVIS_LOCAL_MODEL_MARGIN_BASE", "") or "").strip()
+        return max(0.0, min(1.0, float(raw))) if raw else 0.08
+    except (TypeError, ValueError):
+        return 0.08
+
+
+def margin_step_fraction() -> float:
+    """How much one observed OOM raises this model's margin."""
+    try:
+        raw = (os.environ.get("JARVIS_LOCAL_MODEL_MARGIN_STEP", "") or "").strip()
+        return max(0.0, min(1.0, float(raw))) if raw else 0.06
+    except (TypeError, ValueError):
+        return 0.06
+
+
+def margin_max_fraction() -> float:
+    """Ceiling, so a pathological host cannot learn its way to refusing all."""
+    try:
+        raw = (os.environ.get("JARVIS_LOCAL_MODEL_MARGIN_MAX", "") or "").strip()
+        return max(0.0, min(0.9, float(raw))) if raw else 0.40
+    except (TypeError, ValueError):
+        return 0.40
+
+
+def margin_decay_s() -> float:
+    """Age after which one recorded OOM stops counting. Default 1h."""
+    try:
+        raw = (os.environ.get("JARVIS_LOCAL_MODEL_MARGIN_DECAY_S", "") or "").strip()
+        return max(1.0, float(raw)) if raw else 3600.0
+    except (TypeError, ValueError):
+        return 3600.0
+
+
+class _MarginLedger:
+    """What this host's OOM history has taught us, per model.
+
+    **Why a ledger and not a constant.** Contiguous VRAM is not observable
+    (no CUDA or NVML call returns the largest allocatable block), so no probe
+    can predict a fragmentation-induced OOM. What CAN be observed is that a
+    load of size S failed on this host while the driver reported F free. That
+    observation is the only real evidence available, and it is worth exactly
+    what it says: on THIS machine, for THIS model, F free was not enough.
+
+    So the margin is learned rather than declared: each OOM raises it a step,
+    each recorded success and the passage of time decay it back down. Bounded
+    at both ends — a host that OOMs constantly cannot learn its way to
+    refusing everything, and a lucky streak cannot erase a real constraint
+    faster than the decay window.
+
+    Bounded in size, thread-safe, and process-local by design: this is a
+    property of a machine at a moment, not a fact worth persisting across a
+    reboot that may have changed the hardware.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._events: Dict[str, list] = {}
+
+    def _key(self, model_id: Optional[str]) -> str:
+        return (model_id or "*").strip().lower() or "*"
+
+    def record_oom(self, model_id: Optional[str]) -> None:
+        now = time.time()
+        cap = 32
+        with self._lock:
+            bucket = self._events.setdefault(self._key(model_id), [])
+            bucket.append(now)
+            if len(bucket) > cap:
+                del bucket[: len(bucket) - cap]
+            if len(self._events) > 64:
+                # Bounded: drop the least recently touched model.
+                oldest = min(self._events.items(),
+                             key=lambda kv: max(kv[1], default=0.0))
+                self._events.pop(oldest[0], None)
+
+    def record_success(self, model_id: Optional[str]) -> None:
+        """A clean load retires one prior OOM — evidence cuts both ways."""
+        with self._lock:
+            bucket = self._events.get(self._key(model_id))
+            if bucket:
+                bucket.pop(0)
+
+    def fraction_for(self, model_id: Optional[str]) -> float:
+        cutoff = time.time() - margin_decay_s()
+        with self._lock:
+            bucket = [t for t in self._events.get(self._key(model_id), [])
+                      if t >= cutoff]
+            self._events[self._key(model_id)] = bucket
+        learned = margin_base_fraction() + len(bucket) * margin_step_fraction()
+        return min(margin_max_fraction(), learned)
+
+    def snapshot(self) -> Dict[str, Any]:
+        cutoff = time.time() - margin_decay_s()
+        with self._lock:
+            return {
+                k: len([t for t in v if t >= cutoff])
+                for k, v in self._events.items()
+            }
+
+
+_margin_ledger = _MarginLedger()
+
+
+def record_load_outcome(
+    model_id: Optional[str] = None, *, ok: bool, error: Any = None,
+) -> None:
+    """Feed the ledger the one thing that is ground truth: what happened.
+
+    The load itself is the authority no probe can be. Call this after every
+    local weight-load attempt. An OOM raises this model's margin; a clean
+    load retires one prior OOM.
+
+    Only memory-shaped failures count. A 404 on a missing artifact says
+    nothing about capacity, and letting it raise the margin would teach the
+    host a superstition. NEVER raises.
+    """
+    try:
+        if ok:
+            _margin_ledger.record_success(model_id)
+            return
+        text = f"{type(error).__name__}: {error}".lower() if error else ""
+        markers = ("out of memory", "oom", "cuda error", "alloc",
+                   "insufficient", "resource exhausted")
+        if not text or any(m in text for m in markers):
+            _margin_ledger.record_oom(model_id)
+            logger.info(
+                "[LocalModelAdmission] recorded OOM for model=%s; margin now %.0f%%",
+                model_id or "*", _margin_ledger.fraction_for(model_id) * 100.0,
+            )
+    except Exception:  # noqa: BLE001
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Anticipatory ledger — what has been PROMISED but is not yet resident
+# ---------------------------------------------------------------------------
+
+
+def reservation_settle_s() -> float:
+    """Age after which a grant is assumed RESIDENT and stops being counted.
+
+    Mirrors ``memory_pressure_gate.reservation_settle_s`` deliberately: past
+    the settle window the OS probe carries the allocation's weight, so
+    continuing to subtract it would double-count one set of bytes. Same
+    contract, same default, different pool.
+    """
+    try:
+        raw = (os.environ.get("JARVIS_VRAM_RESERVATION_SETTLE_S", "") or "").strip()
+        return max(1.0, float(raw)) if raw else 120.0
+    except (TypeError, ValueError):
+        return 120.0
+
+
+def reconcile_after_s() -> float:
+    """Age at which a grant becomes eligible for EVIDENCE-based reconciliation.
+
+    Shorter than the settle window on purpose: a crashed worker's phantom
+    reservation is detectable long before it would time out, and waiting the
+    full window would throttle every other worker on a promise nobody is
+    keeping.
+    """
+    try:
+        raw = (os.environ.get("JARVIS_VRAM_RECONCILE_AFTER_S", "") or "").strip()
+        return max(1.0, float(raw)) if raw else 20.0
+    except (TypeError, ValueError):
+        return 20.0
+
+
+def reconcile_epsilon_bytes() -> int:
+    """Slack when judging whether reserved bytes were ever really consumed.
+
+    Free VRAM drifts by tens of MiB from compositor and driver activity
+    alone, so an exact comparison would call every reservation phantom.
+    """
+    try:
+        raw = (os.environ.get("JARVIS_VRAM_RECONCILE_EPSILON_MB", "") or "").strip()
+        return int(max(0.0, float(raw)) * 1024 * 1024) if raw else 256 * 1024 * 1024
+    except (TypeError, ValueError):
+        return 256 * 1024 * 1024
+
+
+@dataclass
+class _Reservation:
+    """One worker's soft claim on accelerator memory it is about to allocate."""
+
+    rid: str
+    bytes_: int
+    owner: str
+    granted_at: float
+    #: Free bytes the OS reported at grant time. This is the evidence the
+    #: reconciler compares against — without it a phantom is indistinguishable
+    #: from a slow loader.
+    free_at_grant: int
+
+
+class _VramLedger:
+    """Soft reservations across concurrent workers, with self-healing.
+
+    **The race this closes.** ``BackgroundAgentPool`` runs three workers and
+    L3 fans out further. Each asks "does my model fit?", each is told yes
+    against the same free-byte reading, and all three then allocate. The
+    admission gate was correct three times and the machine still OOMs,
+    because nothing represented *intent* — only current state.
+
+    So a grant is recorded the moment admission says yes, and subsequent
+    callers see free bytes MINUS what has been promised. This is the same
+    contract ``ProactiveResourceGuard`` implements for system RAM, and
+    deliberately NOT the same storage: that guard's unsettled total is
+    subtracted from system-RAM free-%, so posting VRAM bytes into it would
+    corrupt the RAM dimension for every unrelated consumer. Same discipline,
+    separate pool.
+
+    **Three ways a reservation ends**, and the third is the interesting one:
+
+    1. ``release()`` — the worker finished or failed. The normal path.
+    2. **Settle** — past ``reservation_settle_s`` the allocation is assumed
+       resident and the OS probe now carries it. Stopping the subtraction
+       here is what prevents a permanent double-count.
+    3. **Reconciliation** — the worker died without releasing. See
+       :meth:`_reconcile`.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._live: Dict[str, _Reservation] = {}
+        self._seq = 0
+        self._phantoms_dropped = 0
+
+    def reserve(self, nbytes: int, *, owner: str, free_now: int) -> Optional[str]:
+        """Record a soft claim. Returns its id, or None when unusable."""
+        if nbytes <= 0:
+            return None
+        with self._lock:
+            self._seq += 1
+            rid = f"r{self._seq}"
+            self._live[rid] = _Reservation(
+                rid=rid, bytes_=int(nbytes), owner=str(owner or "?"),
+                granted_at=time.time(), free_at_grant=int(max(0, free_now)),
+            )
+            return rid
+
+    def release(self, rid: Optional[str]) -> None:
+        if not rid:
+            return
+        with self._lock:
+            self._live.pop(rid, None)
+
+    def unsettled_bytes(self, *, free_now: int) -> int:
+        """Bytes promised but not yet visible to the OS probe.
+
+        Runs reconciliation first, so a caller never budgets against a
+        promise that has already been proven phantom.
+        """
+        self._reconcile(free_now=free_now)
+        cutoff = time.time() - reservation_settle_s()
+        with self._lock:
+            return sum(r.bytes_ for r in self._live.values()
+                       if r.granted_at >= cutoff)
+
+    def _reconcile(self, *, free_now: int) -> None:
+        """Resolve ledger-vs-OS desyncs on EVIDENCE, not on a timer.
+
+        **The hallucination.** A worker crashes between admission and load —
+        SIGKILL, OOM-killer, a hard driver fault. Its reservation is never
+        released, so the ledger insists memory is spoken for while the OS
+        reports it free. Every other worker is then throttled by a promise
+        nobody is keeping, and the longer the process lives the more of these
+        accumulate. A pure timeout eventually clears them, but it clears a
+        *live* slow loader on exactly the same schedule as a dead one.
+
+        **The evidence.** Each grant recorded the free bytes at the moment it
+        was made. If the reservation is old enough to have been acted on and
+        free memory has NOT fallen — it is at or above where it started, less
+        an epsilon for compositor drift — then the promised allocation never
+        happened. That is a measurement, not a guess, and it distinguishes a
+        dead worker from a slow one: a slow worker that has begun allocating
+        shows a falling free count and is left alone.
+
+        **Direction of authority is fixed.** When ledger and OS disagree the
+        OS wins, always: the ledger is a claim about the future, the probe is
+        a fact about the present. So reconciliation only ever DROPS phantom
+        claims — it never invents one to explain memory the probe cannot see.
+        Failing in that direction is what keeps a desync from becoming a
+        self-inflicted outage.
+        """
+        if free_now <= 0:
+            return  # No usable evidence — leave every claim standing.
+        now = time.time()
+        eligible_before = now - reconcile_after_s()
+        epsilon = reconcile_epsilon_bytes()
+        dropped = []
+        with self._lock:
+            for rid, r in list(self._live.items()):
+                if r.granted_at > eligible_before:
+                    continue
+                if free_now + epsilon >= r.free_at_grant:
+                    self._live.pop(rid, None)
+                    self._phantoms_dropped += 1
+                    dropped.append(r)
+        for r in dropped:
+            logger.warning(
+                "[LocalModelAdmission] reconciled phantom reservation "
+                "%s owner=%s %.1f GiB — granted %.0fs ago with %.1f GiB free, "
+                "now %.1f GiB free: the allocation never happened",
+                r.rid, r.owner, r.bytes_ / _GIB, now - r.granted_at,
+                r.free_at_grant / _GIB, free_now / _GIB,
+            )
+
+    def snapshot(self) -> Dict[str, Any]:
+        with self._lock:
+            return {
+                "live": len(self._live),
+                "promised_gib": round(
+                    sum(r.bytes_ for r in self._live.values()) / _GIB, 2),
+                "phantoms_dropped": self._phantoms_dropped,
+                "owners": sorted({r.owner for r in self._live.values()}),
+            }
+
+
+_vram_ledger = _VramLedger()
+
+
+def release_reservation(rid: Optional[str]) -> None:
+    """Hand back a soft claim. Safe to call twice, or with None."""
+    try:
+        _vram_ledger.release(rid)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+# ---------------------------------------------------------------------------
+# The two bounds. Neither is derived here — both are CONSUMED.
+# ---------------------------------------------------------------------------
+
+
+def _read_host_pressure() -> Tuple[str, float, str]:
+    """(level, free_pct, source) from the canonical system-RAM gate.
+
+    Fails toward OK, deliberately and unchanged from v1: a probe that cannot
+    read memory must not itself become a reason to refuse work — that would
+    let one broken cascade stage silently disable Tier 2 for a whole session,
+    a larger outage than the swap storm it was guarding against.
     """
     try:
         from backend.core.ouroboros.governance.memory_pressure_gate import (
@@ -177,26 +570,195 @@ def _read_pressure() -> Tuple[str, float, str]:
         return (str(getattr(level, "value", level)), float(probe.free_pct),
                 str(probe.source or "unknown"))
     except Exception:  # noqa: BLE001
-        logger.debug("[LocalModelAdmission] pressure probe unavailable",
+        logger.debug("[LocalModelAdmission] host pressure probe unavailable",
                      exc_info=True)
         return ("unknown", -1.0, "unavailable")
 
 
-def assess(requested_ctx: Optional[int] = None) -> AdmissionDecision:
-    """Should this generation be admitted right now? NEVER raises.
+async def assess_async(
+    requested_ctx: Optional[int] = None,
+    *,
+    weight_bytes: int = 0,
+    model_id: Optional[str] = None,
+) -> AdmissionDecision:
+    """:func:`assess`, with a JIT probe instead of a cached reading.
 
-    Pure read plus arithmetic — no allocation and no I/O beyond the gate's own
-    probe, so it is safe immediately before dispatch on the hot path.
+    **Why a separate entry point rather than making ``assess`` async.** The
+    sync form is called from hot paths that are already inside a running
+    loop, where blocking to re-read a driver would be the very starvation
+    this codebase has spent slices removing. So the sync form serves the
+    short-TTL cache — correct, and up to ``free_ttl_s`` stale — and callers
+    that are *about to allocate*, and can await, use this one.
+
+    The freshness gap this closes is real: an external process (a compositor,
+    another model server, a zombie holding a context) can consume gigabytes
+    between one cached reading and the load it authorized. Re-reading here
+    narrows that window to the dispatch itself. It cannot close it — nothing
+    can, short of the allocator — which is why the pessimistic margin and the
+    OOM ledger sit behind it.
+
+    Identity is not re-enumerated; only the free-byte dimension is re-read.
+    NEVER raises.
+    """
+    try:
+        from backend.core.ouroboros.governance import compute_topology as ct
+        if ct.is_enabled():
+            await ct.resolve_jit()
+    except Exception as exc:  # noqa: BLE001 — a stale reading beats no ruling
+        logger.debug("[LocalModelAdmission] JIT probe degraded: %s", exc)
+    return assess(requested_ctx, weight_bytes=weight_bytes, model_id=model_id)
+
+
+def _read_accelerator() -> Any:
+    """This host's accelerator reading, from ``compute_topology``.
+
+    Consumed, never re-derived: that module owns device enumeration, the
+    unified/discrete distinction, the free-byte TTL and the malformed-host
+    degradation state. Duplicating any of it here would create a second
+    authority for a number the operator reads in one place.
+
+    **Freshness is the whole point.** ``resolve_sync`` serves a cache whose
+    DYNAMIC dimension carries a short TTL, so the free-byte figure is re-read
+    at dispatch rather than inherited from the boot prewarm — which is the
+    window an external process would otherwise race through.
+
+    Returns None when topology is unavailable or unresolved; callers must
+    treat that as "do not know", never as "plenty".
+    """
+    try:
+        from backend.core.ouroboros.governance import compute_topology as ct
+        if not ct.is_enabled():
+            return None
+        reading = ct.resolve_sync()
+        return reading if getattr(reading, "measured", False) else None
+    except Exception:  # noqa: BLE001
+        logger.debug("[LocalModelAdmission] topology unavailable", exc_info=True)
+        return None
+
+
+def assess(
+    requested_ctx: Optional[int] = None,
+    *,
+    weight_bytes: int = 0,
+    model_id: Optional[str] = None,
+) -> AdmissionDecision:
+    """Should this generation be admitted right now?
+
+    **NEVER raises — structurally, not by inspection.** The contract is
+    enforced by this wrapper rather than by auditing every path inside, so a
+    fault introduced later in the decision logic degrades to an ADMIT instead
+    of escaping into the provider as a lane failure. That direction is
+    deliberate and matches the v1 posture: a broken gate must not silently
+    disable Tier 2 for a whole session, which is a larger outage than the
+    condition it guards against.
+    """
+    try:
+        return _assess_impl(requested_ctx, weight_bytes=weight_bytes,
+                            model_id=model_id)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[LocalModelAdmission] assess degraded: %s", exc,
+                     exc_info=True)
+        return AdmissionDecision(
+            action=Admission.ADMIT.value, level="unknown", free_pct=-1.0,
+            source="degraded", bound="none",
+            reason=f"admission check degraded ({type(exc).__name__}) — admitting")
+
+
+def _assess_impl(
+    requested_ctx: Optional[int] = None,
+    *,
+    weight_bytes: int = 0,
+    model_id: Optional[str] = None,
+) -> AdmissionDecision:
+    """The decision itself. See :func:`assess` for the raise contract.
+
+    Two INDEPENDENT bounds, composed strictest-wins — the same composition
+    discipline ``memory_pressure_gate`` applies across its own dimensions:
+
+    * **accelerator** — will the weights plus their margin fit in the pool
+      they actually land in? Meaningful only on ``discrete``, where VRAM and
+      system RAM are genuinely separate ceilings.
+    * **host** — is the machine about to swap? This is the v1 question, and
+      it remains the whole story under ``unified``.
+
+    Under UNIFIED the two are the same physical pool, and
+    ``compute_topology`` already derives its free figure FROM the canonical
+    RAM gate. Applying both would double-count one constraint, so the
+    accelerator bound is skipped and the host bound rules — which is not a
+    weakening: under unified memory the host bound is the correct and
+    complete answer.
+
+    ``weight_bytes`` is optional. A caller that does not state a footprint
+    gets the v1 behaviour exactly: the host bound alone. Nothing is inferred
+    on its behalf, because a guessed footprint would be a fabricated
+    measurement driving a real refusal.
     """
     if not admission_enabled():
         return AdmissionDecision(action=Admission.ADMIT.value,
                                  reason="admission control disabled")
-    level, free_pct, source = _read_pressure()
 
+    level, free_pct, source = _read_host_pressure()
+    reading = _read_accelerator()
+    topology = getattr(getattr(reading, "topology", None), "value", "unknown")
+
+    # -- accelerator bound (discrete only; see docstring) ----------------
+    accel_free = 0
+    margin = 0
+    max_weight = 0
+    if reading is not None and topology == "discrete" and weight_bytes > 0:
+        measured_free = int(getattr(reading, "usable_bytes", 0) or 0)
+        # Subtract what OTHER workers have already been promised but have not
+        # yet allocated. Without this, N concurrent workers each pass against
+        # the same reading and collectively overcommit — the gate is correct
+        # N times and the machine still OOMs. Reconciliation runs inside, so
+        # a crashed worker's phantom claim is dropped before it throttles
+        # anyone.
+        promised = _vram_ledger.unsettled_bytes(free_now=measured_free)
+        accel_free = max(0, measured_free - promised)
+        margin = int(weight_bytes * _margin_ledger.fraction_for(model_id))
+        max_weight = max(0, accel_free - margin)
+        if weight_bytes + margin > accel_free:
+            return AdmissionDecision(
+                action=Admission.DEFER.value, level=level, free_pct=free_pct,
+                source=source, topology=topology, bound="accelerator",
+                accel_free_bytes=accel_free, weight_bytes=weight_bytes,
+                margin_bytes=margin, max_weight_bytes=max_weight,
+                reason=(
+                    f"{weight_bytes / _GIB:.1f} GiB of weights plus a "
+                    f"{margin / _GIB:.1f} GiB learned margin exceeds the "
+                    f"{accel_free / _GIB:.1f} GiB free on this accelerator "
+                    f"— largest admissible now is {max_weight / _GIB:.1f} GiB"
+                ),
+                spoken_reason=("That model is larger than the free space on "
+                               "my graphics card right now."))
+
+    # -- unknown topology with a stated footprint ------------------------
+    # Fail-open on WHETHER to run, fail-closed on HOW BIG. An unresolved host
+    # may still serve a small model — refusing everything would be the
+    # session-wide outage v1's fail-toward-OK posture exists to prevent — but
+    # it may not authorize a large one on a capacity nobody measured.
+    if reading is None and weight_bytes > 0:
+        ceiling = unknown_topology_ceiling_bytes()
+        if ceiling > 0 and weight_bytes > ceiling:
+            return AdmissionDecision(
+                action=Admission.DEFER.value, level=level, free_pct=free_pct,
+                source=source, topology="unknown", bound="accelerator",
+                weight_bytes=weight_bytes, max_weight_bytes=ceiling,
+                reason=(
+                    f"accelerator capacity is unmeasured and "
+                    f"{weight_bytes / _GIB:.1f} GiB exceeds the "
+                    f"{ceiling / _GIB:.1f} GiB unverified-host ceiling"
+                ),
+                spoken_reason=("I can't see my graphics card's memory, so I "
+                               "won't load something that large blind."))
+
+    # -- host bound (v1, unchanged) --------------------------------------
     if level == "critical":
         return AdmissionDecision(
             action=Admission.DEFER.value, level=level, free_pct=free_pct,
-            source=source,
+            source=source, topology=topology, bound="host",
+            accel_free_bytes=accel_free, weight_bytes=weight_bytes,
+            margin_bytes=margin, max_weight_bytes=max_weight,
             reason=(f"{free_pct:.1f}% memory free — loading a local model now "
                     f"would swap, and the audio graph shares this memory"),
             spoken_reason=("My machine is low on memory, so I've held that "
@@ -207,13 +769,33 @@ def assess(requested_ctx: Optional[int] = None) -> AdmissionDecision:
                       if requested_ctx else None)
         return AdmissionDecision(
             action=Admission.PRUNE.value, level=level, free_pct=free_pct,
-            source=source, num_ctx=pruned_ctx,
+            source=source, topology=topology, bound="host",
+            accel_free_bytes=accel_free, weight_bytes=weight_bytes,
+            margin_bytes=margin, max_weight_bytes=max_weight,
+            num_ctx=pruned_ctx,
             reason=(f"{free_pct:.1f}% memory free — shrinking the KV cache "
                     f"rather than refusing the work"))
 
-    return AdmissionDecision(action=Admission.ADMIT.value, level=level,
-                             free_pct=free_pct, source=source,
-                             reason=f"{free_pct:.1f}% memory free")
+    # An ADMIT is a promise, so record it. Only on the discrete path with a
+    # stated footprint: elsewhere there is no distinct pool to overcommit,
+    # and a reservation nobody can act on is bookkeeping that only ever
+    # throttles. The caller MUST release it — `release_reservation` on
+    # completion — but a caller that forgets, or dies, is handled: the claim
+    # settles out on its own window and is reconciled away earlier than that
+    # if the allocation provably never happened.
+    rid = None
+    if accel_free and weight_bytes > 0:
+        rid = _vram_ledger.reserve(
+            weight_bytes + margin, owner=str(model_id or "?"),
+            free_now=accel_free)
+    return AdmissionDecision(
+        action=Admission.ADMIT.value, level=level, free_pct=free_pct,
+        source=source, topology=topology,
+        bound="accelerator" if accel_free else "none",
+        accel_free_bytes=accel_free, weight_bytes=weight_bytes,
+        margin_bytes=margin, max_weight_bytes=max_weight,
+        reservation_id=rid,
+        reason=f"{free_pct:.1f}% memory free")
 
 
 def prune_messages(messages: Any, decision: AdmissionDecision) -> Tuple[Any, int]:
@@ -304,9 +886,16 @@ def report(decision: AdmissionDecision, *, what: str = "local Tier 2") -> None:
 
 
 def snapshot() -> Dict[str, Any]:
-    """Current admission posture, for `/observability`. NEVER raises."""
-    level, free_pct, source = _read_pressure()
-    return {
+    """Current admission posture, for `/observability` and `ov doctor`.
+
+    Carries BOTH bounds and their provenance. A DEFER on a machine with 60 GB
+    of free RAM is incomprehensible without the accelerator half, and an
+    operator staring at a refusal they cannot explain will disable the gate.
+    NEVER raises.
+    """
+    level, free_pct, source = _read_host_pressure()
+    reading = _read_accelerator()
+    out: Dict[str, Any] = {
         "schema_version": LOCAL_MODEL_ADMISSION_SCHEMA_VERSION,
         "enabled": admission_enabled(),
         "level": level,
@@ -314,4 +903,29 @@ def snapshot() -> Dict[str, Any]:
         "source": source,
         "prune_floor_messages": prune_floor_messages(),
         "pruned_ctx_fraction": pruned_ctx_fraction(),
+        "unknown_ceiling_gib": round(
+            unknown_topology_ceiling_bytes() / _GIB, 2),
+        "margin_base_fraction": margin_base_fraction(),
+        "margin_max_fraction": margin_max_fraction(),
+        "observed_ooms": _margin_ledger.snapshot(),
+        "reservations": _vram_ledger.snapshot(),
+        "reservation_settle_s": reservation_settle_s(),
+        "reconcile_after_s": reconcile_after_s(),
     }
+    if reading is not None:
+        out["accelerator"] = {
+            "topology": getattr(getattr(reading, "topology", None), "value",
+                                "unknown"),
+            "resolved_class": getattr(reading, "resolved_class", "unknown"),
+            "usable_gib": round(
+                int(getattr(reading, "usable_bytes", 0) or 0) / _GIB, 2),
+            "source": getattr(reading, "source", ""),
+            "free_is_measured": getattr(reading, "free_is_measured", False),
+        }
+    else:
+        out["accelerator"] = {
+            "topology": "unknown",
+            "note": ("unmeasured — admission falls back to the host bound "
+                     "with the unverified-host ceiling"),
+        }
+    return out

--- a/backend/core/ouroboros/governance/providers.py
+++ b/backend/core/ouroboros/governance/providers.py
@@ -5539,11 +5539,51 @@ class PrimeProvider:
         18 GB model load and the 37 ms voice path.
         """
         _adm = None
+        # Bound HERE, not inside the try below: `_generate_raw` closes over
+        # this name, and a lazily-bound name read from a closure becomes a
+        # bare NameError the moment the binding block raises early — a fault
+        # on the dispatch path that reads as a generation failure rather than
+        # as the telemetry wiring it actually is (PR #70386's class).
+        _brain_for_adm: Optional[str] = None
+        # A one-slot cell rather than a bare name: `_generate_raw` closes over
+        # it and must see the id assigned AFTER the closure was defined.
+        _adm_reservation: list = [None]
         try:
             from backend.core.ouroboros.governance import (
                 local_model_admission as _lma,
             )
-            _adm = _lma.assess()
+            # Resolve what this dispatch will actually WEIGH, so the
+            # accelerator bound has something to bind against. Without a
+            # stated footprint `assess` uses the host bound alone — correct,
+            # but on a discrete-GPU host that is the pre-v2 blindness: 64 GB
+            # of free system RAM says nothing about a 32 GB card.
+            #
+            # The brain comes from the routing intent already on `context`
+            # (the same `ri.brain_id` this method reads further down for
+            # TaskProfile), and its declared footprint from the module that
+            # owns the policy. Nothing is inferred: an unstated weight
+            # resolves to 0 and skips the bound rather than guessing.
+            _weight_bytes = 0
+            try:
+                _tel = getattr(context, "telemetry", None)
+                _ri = getattr(_tel, "routing_intent", None) if _tel else None
+                _brain_for_adm = getattr(_ri, "brain_id", None) if _ri else None
+                if _brain_for_adm:
+                    from backend.core.ouroboros.governance.brain_selector import (
+                        footprint_bytes_for as _footprint,
+                    )
+                    _weight_bytes = _footprint(_brain_for_adm)
+            except Exception:  # noqa: BLE001 — an unresolved brain is not a fault
+                _brain_for_adm, _weight_bytes = None, 0
+
+            # JIT: re-read the accelerator's free bytes now rather than
+            # trusting a cached reading. We are inside a running loop and
+            # about to allocate, which is exactly the case `assess_async`
+            # exists for.
+            _adm = await _lma.assess_async(
+                weight_bytes=_weight_bytes, model_id=_brain_for_adm,
+            )
+            _adm_reservation[0] = getattr(_adm, "reservation_id", None)
             if not _adm.proceeds:
                 _lma.report(_adm, what="J-Prime generation")
                 logger.warning("[PrimeProvider] %s %s",
@@ -5773,14 +5813,48 @@ class PrimeProvider:
         _eff_temperature = 0.2 if temperature is None else float(temperature)
 
         async def _generate_raw(p: str) -> str:
-            resp = await self._client.generate(
-                prompt=p,
-                system_prompt=_CODEGEN_SYSTEM_PROMPT + _a1_exploration_addendum(),
-                max_tokens=_retry_max_tokens,
-                temperature=_eff_temperature,
-                model_name=_brain_model,
-                task_profile=_task_profile,
-            )
+            # The load is the authority no probe can be. Contiguous VRAM is
+            # not observable from outside the allocator, so a fit cannot be
+            # proven in advance — it can only be attempted and OBSERVED. This
+            # is the one seam where the attempt actually happens, so it is
+            # where the admission ledger learns: an OOM here raises this
+            # brain's margin, a clean load retires a prior one. Purely
+            # additive — the recording never alters control flow.
+            try:
+                resp = await self._client.generate(
+                    prompt=p,
+                    system_prompt=_CODEGEN_SYSTEM_PROMPT + _a1_exploration_addendum(),
+                    max_tokens=_retry_max_tokens,
+                    temperature=_eff_temperature,
+                    model_name=_brain_model,
+                    task_profile=_task_profile,
+                )
+            except BaseException as _load_err:
+                try:
+                    from backend.core.ouroboros.governance import (
+                        local_model_admission as _lma_out,
+                    )
+                    _lma_out.record_load_outcome(
+                        _brain_for_adm, ok=False, error=_load_err)
+                    # Hand back the soft claim on the failure path too. The
+                    # ledger self-heals if we don't, but only after a settle
+                    # window during which every other worker is throttled by
+                    # memory this one has definitively stopped wanting.
+                    _lma_out.release_reservation(_adm_reservation[0])
+                except Exception:  # noqa: BLE001 — telemetry never masks a fault
+                    pass
+                raise
+            try:
+                from backend.core.ouroboros.governance import (
+                    local_model_admission as _lma_out,
+                )
+                _lma_out.record_load_outcome(_brain_for_adm, ok=True)
+                # The allocation is now resident and visible to the OS probe;
+                # continuing to subtract it would double-count one set of
+                # bytes against every subsequent worker.
+                _lma_out.release_reservation(_adm_reservation[0])
+            except Exception:  # noqa: BLE001
+                pass
             _last_response[0] = resp
             raw_content = resp.content or ""
             logger.warning(

--- a/docs/architecture/OUROBOROS_VENOM_PRD.md
+++ b/docs/architecture/OUROBOROS_VENOM_PRD.md
@@ -196,6 +196,22 @@
 24. [Voice I/O — the `ov` Conversational Loop](#24-voice-io--the-ov-conversational-loop-new-2026-07-26)
     - [24.4 Root problems, ranked](#244-root-problems-ranked)
     - [24.6 Roadmap](#246-roadmap)
+25. [Cockpit Fidelity — the Audit Surface](#25-cockpit-fidelity--the-audit-surface-new-2026-08-11)
+26. [The Trust Boundary](#26-the-trust-boundary-new-2026-08-11)
+27. [Initiative and Steering — the Operator's Half of Autonomy](#27-initiative-and-steering--the-operators-half-of-autonomy-new-2026-08-13)
+    - [27.2 The operator is an editor, not an initiator](#272-the-operator-is-an-editor-not-an-initiator)
+    - [27.3 Attention is the metered resource](#273-attention-is-the-metered-resource)
+    - [27.4 The five frames](#274-the-five-frames)
+    - [27.5 The steering grammar](#275-the-steering-grammar)
+    - [27.6 The trust ladder as the progression surface](#276-the-trust-ladder-as-the-progression-surface)
+    - [27.8 Edge cases and nuances](#278-edge-cases-and-nuances)
+    - [27.10 Build plan](#2710-build-plan)
+28. [The Cockpit as Control Surface — Implementation Audit](#28-the-cockpit-as-control-surface--implementation-audit-new-2026-08-13)
+    - [28.2 What the audit found excellent — and promotes to standards](#282-what-the-audit-found-excellent--and-promotes-to-standards)
+    - [28.3 Findings that survived verification](#283-findings-that-survived-verification)
+    - [28.4 Findings withdrawn under verification](#284-findings-withdrawn-under-verification)
+    - [28.5 Measured affordance costs](#285-measured-affordance-costs)
+    - [28.6 Remediation, ranked by leverage per line changed](#286-remediation-ranked-by-leverage-per-line-changed)
 
 ## 1. Executive Summary
 
@@ -2919,5 +2935,847 @@ a reattaching operator sees what is waiting before anything expires.
 
 An op discarded because nobody was watching is the same defect class as a
 receipt that says "queued" about work that was thrown away.
+
+---
+
+## 27. Initiative and Steering — the Operator's Half of Autonomy *(NEW 2026-08-13)*
+
+> **Operator binding (verbatim, 2026-08-13)**: *"CC's first run teaches you to ask,
+> but we want O+V to be able to demonstrate initiative and teach you to steer."*
+
+### 27.0 What this section owns — and what it deliberately does not restate
+
+Four prior sections touch this ground. §27 is written **after** a reconciliation
+pass against all four, in the discipline §38.11.5a established: one canonical
+owner per surface, no duplicated substrate, no second data contract.
+
+| Prior § | What it owns | §27's relationship |
+|---|---|---|
+| **§38.11** | 12 proactive-only *visibility* features (curiosity surfacing, dream log, graduation ticker, memory diff, risk-tier light, time-of-presence) + sequencing A–F | **Consumes.** §27 introduces no new read surface. Where §27 names a frame, it names which §38.11 producer fills it. |
+| **§39 #12** | "Proactive context preview" — the session-start anchor | **§27.4.2 (Handover) is declared the canonical render of this row.** §39 #12 gains a spec; it does not gain a second implementation. |
+| **§41.3** | 27 UX gaps graded against Claude Code parity | **Critiques the ruler** (§27.1). Does not re-list the gaps; all 27 remain valid floor work. |
+| **§25** | Cockpit fidelity — the daemon can now see the canvas; the spine gives order a home | **Depends on.** §27 is unbuildable without §25's capability channel and transcript spine. |
+| **§26** | The trust boundary — *when* the organism may act, and the evidence required | **Renders it** (§27.6). §26 stays the authority; §27 makes its state legible and its evidence honest. |
+| **§24** | Voice I/O | Orthogonal. Every §27 frame has a spoken form, deferred until §24's RP-1 clears. |
+
+**The gap §27 closes.** §38.11 makes the organism's inner life *visible*.
+§41.3 makes the CLI *comfortable*. §26 defines when the organism *may act*.
+Nowhere in this PRD is there a specification for **how a human redirects work
+they did not initiate**, or for **what the first ten seconds of contact teach a
+new operator**. Visibility is not control, and comfort is not competence.
+§27 is the control model and the first-contact contract.
+
+---
+
+### 27.1 The ruler problem — parity with a reactive tool cannot express initiative
+
+§41.3 enumerates 27 UX gaps and grades each against Claude Code. Every one of
+them is a reactive-tool affordance: tab completion, welcome banner, typo
+suggestion, per-command `--help`, conversation export, bookmark/star turns.
+Shipping all 27 yields an excellent reactive CLI.
+
+**A parity metric cannot contain an initiative metric**, because there is no CC
+behaviour to be at parity *with*. §41.3 is not wrong — it measures the floor,
+and the floor matters. §27 measures the ceiling.
+
+The same defect sits in §6's target-state table, in the one row that touches
+operator experience:
+
+> `Operator UX — < 30s from "I want X" → "X is being worked on"`
+
+That sentence begins with *the human wanting*. It is Claude Code's stopwatch
+transcribed into an autonomy PRD. For an organism whose entire thesis is that
+it works when nobody is wanting anything, it measures the wrong interval.
+§27.7 proposes the four signals that measure the right ones.
+
+---
+
+### 27.2 The operator is an editor, not an initiator
+
+Claude Code runs **one** loop: ask → answer. Every UI decision descends from it
+— the transcript is a conversation, the caret is an invitation, and the scarce
+resource being managed on screen is the *model's context*.
+
+O+V runs **three** loops concurrently, and the operator is inside only one:
+
+```
+  sense → hypothesize → generate → validate → gate → apply → verify   (16 sensors, continuous)
+  judge → tier → escalate → breaker                                   (Iron Gate, SemanticGuardian, risk ladder)
+  observe → steer                                                     ← the operator's loop, and only this one
+```
+
+The product that follows is therefore **not a chat window with autonomy bolted
+on**. It is a feed with brakes. And the governing economics invert:
+
+> **Initiative economics.** In a reactive tool the cheapest act must be
+> *asking*. In a proactive organism the cheapest act must be **declining**.
+
+The corollary is load-bearing, and it is the single sentence in §27 most likely
+to be violated under implementation pressure:
+
+> Any design in which refusing costs the operator more keystrokes than the
+> organism spent proposing will train the operator to stop watching.
+
+Assent-by-silence is the operator's structural default — they are frequently
+detached, and §26.6 has already established that absence must not be read as
+refusal. If silence grants, then reversing silence must be the cheapest
+interaction in the product. The affordance budget:
+
+| Operator act | Target cost | Today |
+|---|---|---|
+| Decline the thing on screen | **1 key** | **2+ keys through a line router.** The decision *channel* exists and is well built — `FocusShield` renders an addressed `[y/n]` gate and `CockpitAttachBridge.send_input(text, prompt_id)` tags the verdict with the gate it was written for, so a deferred answer cannot land on whichever op is armed now. But it is a **line** channel: `y` + Enter through `_route_operator_line`, with an operator echo. `/reject` during a `NOTIFY_APPLY` window is eight. The gap is the input model, not a missing feature. |
+| Ask why it did that | **1 verb** | **unbuilt** (§25.5 lists `/why <ref>` as remaining) |
+| Redirect to something adjacent | 1 short line of plain text | partial — `/chat` classifies, but nothing binds a turn to a live op |
+| Grant standing preference | 1 line | built (`UserPreferenceMemory`, 6 kinds, post-rejection auto-extraction) |
+| Initiate work explicitly | 1 line | built (intent classifier → backlog) |
+
+Note the shape: O+V has already built the *expensive* end of that table and
+left the cheap end empty. That is the exact inverse of what initiative
+economics requires.
+
+---
+
+### 27.3 Attention is the metered resource
+
+`attention_ledger.py` (landed `a5dd8b777f`, 2026-08-11) is the first primitive
+in this repository that treats **the operator's presence as a measurable,
+monotone quantity**. It was built to fix one bug — a review budget burning
+against an empty socket — but its significance is larger: it is the meter for
+the resource this entire section spends.
+
+CC manages context. Context is compactable, purchasable, and provider-bounded.
+**Operator attention is none of those things.** It is bursty, non-transferable,
+and strictly finite per day. Any proactive system that spends it carelessly
+degrades to noise within a week.
+
+Three consequences, all normative:
+
+**27.3.1 — Every operator-facing deadline is denominated in attended seconds.**
+Not wall time. `ReviewCoordinator` already does this; the rule generalizes to
+`ask_human`, proposal countdowns, and any future affordance with an expiry.
+The rendered form must say so: *"240s of your attention left"*, never *"240s"*.
+
+**27.3.2 — Absence produces no evidence.** This is the deepest rule in §27 and
+it composes directly with §26. An expiry that occurred while no cockpit was
+attached must:
+
+* **not** feed `UserPreferenceMemory` post-rejection extraction — the organism
+  would be learning the operator's preferences from the operator's *sleep*;
+* **not** count toward any §26 trust window, in either direction — neither as
+  alignment nor as divergence;
+* **not** be recorded in POSTMORTEM as a rejection — it is a *lapse*, a
+  distinct terminal that the ledger must be able to name.
+
+An organism that learns from absence will converge on a model of an operator
+who is never there. That is a self-fulfilling failure mode, and it is cheap to
+prevent exactly once, at the ledger.
+
+**27.3.3 — Attended expiry is a real signal.** The operator who saw the
+proposal, said nothing, and let it lapse *has* decided. That is a **weak
+reject**: it feeds preference extraction at reduced weight and it counts toward
+§26 windows. Distinguishing the two expiries is now possible for the first
+time, and doing so is the whole point of having built the ledger.
+
+**27.3.4 — Nuance: never let the decision clock hold the resources.** An
+attention-gated budget that can never be spent pins the process forever — a
+detached operator would accumulate parked ops indefinitely. The resolution is
+**two clocks, never one**: the *decision* clock is attended and may pause
+indefinitely; the *resource* clock is wall-time and is short. On resource
+expiry the op **parks** — releases its `BackgroundAgentPool` worker, drops to a
+durable record in the spine, surrenders its file locks — while its decision
+remains pending and answerable on reattach. Parking is cheap; waiting is not.
+
+---
+
+### 27.4 The five frames
+
+`ov` today has one frame — a state readout — doing the work of five. The
+composition is specified below; each frame names the canonical producer that
+fills it, and no frame introduces a new one.
+
+#### 27.4.1 First contact — the initiative demonstration
+
+The operator has typed one word and knows nothing. Within ten seconds they must
+see the organism **choose something specific about *this* repository and begin**,
+with refusal costing one key.
+
+```
+O+V v0.1.0 · first run in JARVIS-AI-Agent
+
+  ⎿ oracle indexing ······················· 6,593 files · 4.1s
+  ⎿ 16 sensors armed · 4 event-primary · 12 polling
+
+  Three things stood out:
+  ⎿ 41 TODOs · 6 older than 90 days
+  ⎿ tests/governance/ · 3 files with no assertions
+  ⎿ attention_ledger.py · 107 tests, never exercised live
+
+  Taking the stale TODOs.
+  ⎿ in 8s     [enter] now     [tab] something else     [esc] just watch
+
+  ⏺ read  backend/core/ouroboros/governance/orchestrator.py:2140     (1/2 explore)
+  ⏺ grep  "TODO(2026-0[1-5]" → 6 hits in 4 files                     (2/2 explore ✓)
+  🗣 the oldest guards a retry path that no longer exists — checking callers
+  ⏺ get_callers  _legacy_retry_guard                                 → 0
+```
+
+Three elements are doing product work, and one of them is a safety property:
+
+* **The countdown** makes initiative the default and refusal a reflex. It
+  requires no vocabulary — the new operator's first successful interaction can
+  be *not pressing a key*.
+* **The `(1/2 explore)` counter** is not decoration. The Iron Gate's
+  exploration-first rule already *requires* ≥2 `read_file`/`search_code`/
+  `get_callers` before a patch may exist, and `ExplorationLedger` enforces
+  diversity across 5 categories. Rendering that ledger live means the "watching
+  it search your codebase" experience is a **governance invariant reporting
+  itself**, not an animation. It cannot desynchronize from reality because it
+  *is* the gate.
+* **`[esc] just watch`** is the permanent escape hatch. There must always be a
+  mode in which the organism narrates and touches nothing.
+
+> **27.4.1.1 — The countdown buys an EXPLORE, never an APPLY.**
+> Initiative granted by *silence* is bounded to read-only work. A countdown may
+> auto-start exploration, planning, or analysis. It may **never** auto-start a
+> mutation, regardless of risk tier, regardless of `JARVIS_MIN_RISK_TIER`.
+> Mutations follow the §26 ladder and the risk-tier floor exactly as they do
+> today. This single rule is what makes auto-start defensible rather than
+> reckless, and it must be an AST-pinned invariant, not a convention.
+
+Producer map: proposal ranking is §38.11-E's `proactive_proposal_emitted`
+contract (`proactive_curiosity_reader` + `OpportunityMinerSensor` +
+`CapabilityGapSensor` + `TodoScanner`) — **§27 adds no new proposal source.**
+The exploration line is `ExplorationLedger`. The 🗣 line is
+`NarrativeChannel`'s existing `TOOL_PREAMBLE`.
+
+#### 27.4.2 Handover — the returning operator
+
+Canonical render of §39 #12, composed with §38.11-B (cross-session memory diff).
+Three blocks, three tenses, under one second, **zero tokens**:
+
+```
+● dormant · 4h 12m since last op · main @ f70a397
+
+  While you were gone
+  ⎿ 3 ops · 1 applied · 1 rejected (Yellow — expired, nobody attached) · 1 dry
+  ⎿ hibernated 16:11 — every provider lane out of credit
+
+  Needs you
+  ⎿ d-7  attention_ledger.py  +18/−4   240s of your attention left  →  /review d-7
+
+  Watching   16 sensors · nothing queued · $0.00 this hour
+```
+
+"While you were gone" is the block Claude Code structurally cannot have; it is
+the most concentrated expression of proactivity in the product. Every input
+exists today: `LastSessionSummary`, the spine's `m-` milestones,
+`ReviewCoordinator`'s pending set, the liquidity table, `AttentionLedger`.
+**Nothing composes them.**
+
+Note *"expired, nobody attached"* rather than *"rejected"*. That is §26.6 and
+§27.3.2 surfacing in the operator's first frame instead of dying in a ledger.
+
+#### 27.4.3 Ambient — the idle contract
+
+`_ignition_line`'s implementation comment already states the principle
+precisely: *a blank deck during a cold boot is indistinguishable from a healthy
+idle organism with nothing to say — and from a dead socket.* §27 promotes it:
+
+> **Idle must be narrated, and narration must be free.** A proactive agent that
+> goes quiet reads as broken. Narration that costs tokens turns idling into
+> burning. Therefore the always-on idle surface is **deterministic** — no LLM
+> call, ever — and carries a heartbeat age so a frozen line is visibly frozen.
+
+```
+  ⎿ watching · TestWatcher 30s · last sensor fire 2m ago · $0.00/hr · ♥ 3s
+```
+
+`NarrativeChannel`'s `💭` INTENT surface stays reserved for moments where
+reasoning genuinely occurs. This is a boundary, not a preference: the ambient
+line is the *liveness* channel and must never fail for provider reasons.
+
+#### 27.4.4 Interrupt — how the organism asks
+
+> **An interruption may take the bottom of the screen. It may never take the
+> cursor.**
+
+`ask_human`, Yellow `NOTIFY_APPLY` diffs, Orange approvals: all render as a
+bottom affordance carrying a ref, never a modal, never a reflow of the input
+line the operator is mid-way through typing. Concurrent interrupts **coalesce
+into a count**, they do not stack. Priority ordering follows the existing risk
+ladder (Orange > Yellow > `ask_human`).
+
+#### 27.4.5 Detach — the farewell
+
+`Ctrl+C detaches, the organism keeps running` is currently a fragment of a hint
+line. It is the deepest single divergence from CC — **quitting Claude ends the
+work; quitting `ov` does not** — and it earns a frame:
+
+```
+  detached · 2 ops in flight · organism continues · 'ov' to rejoin
+```
+
+Composes §38.11 #12 (time-of-presence), corrected per §27.3.1 to report
+*attended* duration.
+
+---
+
+### 27.5 The steering grammar
+
+Four acts, specified in strict cost order. The ordering *is* the specification.
+
+| # | Act | Cost | Semantics | Substrate |
+|---|---|---|---|---|
+| 1 | **decline** — `esc` / `n` | 1 key | strong reject on the focused proposal; extraction at full weight | `UserPreferenceMemory` post-rejection hook (built) |
+| 2 | **`/why <ref>`** | 1 verb | the causal account of a decision | `transcript_timeline` causal join (`63cb4344b3`) over the spine — **unbuilt** |
+| 3 | **redirect** — plain text while a ref is focused | 1 line | "not that, this" — reject + seed a successor signal | intent classifier + `ConversationBridge` (built, unbound to ops) |
+| 4 | **standing preference** — plain text | 1 line | carried across sessions | `UserPreferenceMemory` STYLE / PROJECT / FORBIDDEN_PATH (built) |
+
+**27.5.1 — `/why` is the load-bearing missing verb.** For a proactive agent,
+*"why did you do that"* is the primary human question. In CC the question never
+arises, because the human asked. Without `/why`, every proactive act is
+trusted blindly or refused blindly, and **neither outcome teaches anybody
+anything** — not the operator, and not the preference memory.
+
+**27.5.2 — `/why` must be answerable deterministically.** The causal chain is
+already recorded: sensor → signal → attribution → plan → tool rounds → gate
+verdict → risk tier → terminal. `transcript_timeline`'s causal join over the
+spine can render it with **zero model calls**. Model-authored prose is optional
+garnish, never the mechanism. Two properties follow, both required:
+
+* `/why` works when every provider lane is dry — which is precisely the state
+  in which an operator most wants to ask it;
+* `/why` cannot hallucinate a rationale, because it is a projection of the
+  ledger rather than a generation from it.
+
+**27.5.3 — Refusals are explainable too.** `/why` over a *rejection* must
+report which stored preference, gate, or tier caused it. A preference memory
+that cannot be interrogated becomes an invisible cage the operator built by
+accident three weeks earlier.
+
+---
+
+### 27.6 The trust ladder as the progression surface
+
+§26 specifies four gates with hard evidence criteria. Today they exist only as
+prose plus four `false` flags. §27 renders them as **the operator's progression
+system** — the same data, made motivating:
+
+```
+  Trust                                                promotion: off
+
+  REVIEW    ████████████░░░░░░░░  31/50 aligned · 0 false-blocks
+  PLAN      ███░░░░░░░░░░░░░░░░░   8/50 · DAG coverage 100%
+  PROMOTE   ░░░░░░░░░░░░░░░░░░░░  locked — needs REVIEW + PLAN
+  BUS       ░░░░░░░░░░░░░░░░░░░░  locked — graduates with PROMOTE
+
+  ⎿ REVIEW graduates in ~3 days at current cadence          /trust why
+```
+
+This does four jobs simultaneously: it makes the honest present state (**O+V
+cannot currently touch your tree**) legible instead of concealed; it converts a
+wait into visible progress; it gives the operator a reason to run sessions; and
+it makes `/trust why` the natural home for "what evidence is being collected."
+
+Two hardening rules, both novel to §27 and both load-bearing:
+
+> **27.6.1 — Only attended decisions count toward a trust window.** A window
+> filled while nobody was watching measures the auto-reject timeout, not
+> operator alignment. Per §27.3.2, unattended lapses are excluded from the
+> numerator *and* the denominator. This composes `AttentionLedger` with §26's
+> counters and is the difference between evidence and noise.
+
+> **27.6.2 — The counter must be diversity-weighted.** A bare "N consecutive
+> agreements" window is gameable by an optimizing agent: propose only trivially
+> agreeable ops and the bar fills without any evidence about the hard cases.
+> Reuse the `ExplorationLedger` category concept — a window requires alignment
+> across *distinct op classes* (risk tier × file count × sensor source), not 50
+> instances of the cheapest one.
+
+**27.6.3 — Demotion must be as visible as promotion.** §26's breakers revert to
+shadow on 3 consecutive divergences. That reversion renders — the bar visibly
+drops with a reason. A silently-emptied bar reads as a bug and destroys trust
+in the surface that exists to build trust.
+
+**27.6.4 — The ladder is skippable, explicitly.** It is the operator's tree.
+`/trust grant REVIEW --unproven` must exist, must record who granted what and
+when, and must be revocable in one verb. A safety ladder with no override is a
+ladder operators route around silently, which is strictly worse.
+
+---
+
+### 27.7 Four A-level signals to add to §6
+
+§6's target-state table has no row that measures steering. Proposed additions,
+all computable from substrate that exists today:
+
+| Signal | Definition | A-level target | Instrument |
+|---|---|---|---|
+| **Time-to-first-initiative (TTFI)** | cold `ov` in an unseen repo → first specific, repo-grounded proposal rendered | **< 10s** | Oracle index + §38.11-E proposal contract |
+| **Steer cost** | median keystrokes to redirect or kill an in-flight op | **≤ 3** | verb dispatcher instrumentation |
+| **Attended-decision ratio** | Yellow/Orange ops decided while attended ÷ all such ops reaching terminal | **≥ 90%** | `AttentionLedger` + `ReviewCoordinator` |
+| **Unattended yield** | verified commits per unattended hour | **> 0, trending** | `AutoCommitter` + `AttentionLedger` |
+
+Unattended yield is the product promise stated as a number. It is currently
+**zero**, honestly so: §26's four actuators are `false` and every provider lane
+is dry. Publishing it as a metric is how the zero stops being invisible.
+
+---
+
+### 27.8 Edge cases and nuances
+
+The frames above are the happy path. What follows is the specification that
+actually governs implementation.
+
+#### 27.8.1 First contact
+
+| # | Case | Required behaviour |
+|---|---|---|
+| 1 | **Index not finished** — 6,593 files, TTFI budget expires mid-walk | Propose from the partial index and **say so**: "from 1,200 of 6,593 files so far." A bounded honest proposal beats a complete late one. Never present partial coverage as complete. |
+| 2 | **Nothing to propose** — clean repo, no TODOs, no red tests | "Nothing stands out yet" is a **sentence**, not an empty block. Follow with what will be watched. Never fabricate a proposal to fill the frame. |
+| 3 | **Every lane dry** (today's literal state) | **The countdown must not start.** Degrade to: "I can see, but I can't act — every provider lane is out of credit." Offer `/liquidity`. A countdown that expires into an exhaustion error teaches the operator that the surface lies. |
+| 4 | **Not a git repo / empty dir** | Refuse to propose mutations. Offer to watch. `ov doctor` is the suggested next step. |
+| 5 | **Foreign repository** — a clone the operator does not own | First contact proposes **read-only** analysis only, and asks for scope before any mutation class is offered. Composes `UserPreferenceMemory` FORBIDDEN_PATH. |
+| 6 | **Not a TTY** (piped, CI, `ov run`) | No countdown, no keys, no frame. Falls through to existing `--headless` semantics. The countdown is a TTY affordance and must be gated on `real_stdout_isatty` — the load-bearing lesson from the Presentation Restraint arc, where `sys.stdout.isatty()` fails under `patch_stdout(raw=True)`. |
+| 7 | **Accidental `[enter]`** | The started work is cancellable at the next phase boundary via existing cooperative cancellation. The affordance line must survive one beat after start so the operator can reverse a mis-key. |
+| 8 | **Single-flight collision** — a second `ov` in another repo | Existing `EX_TEMPFAIL` (75) path renders as a frame, not a stack trace: "another organism holds the lock — attaching instead." |
+| 9 | **Operator idles through the countdown mid-read** | Acceptable **only** because of §27.4.1.1: what auto-started is read-only. This is why that rule is the safety property and not a preference. |
+
+#### 27.8.2 Handover
+
+| # | Case | Required behaviour |
+|---|---|---|
+| 10 | **Nothing happened** | Distinguish the three causes — idle (no signals), hibernated (exhaustion), or dead daemon. "Nothing happened" without a cause is indistinguishable from a broken sensor layer. |
+| 11 | **Too much happened** — 200 ops | The handover is a **digest that never scrolls**. Hard cap of 3 lines per block; depth lives behind `/why` and `/expand`. A handover that requires scrolling is a log, and the operator will stop reading it. |
+| 12 | **Daemon is dead** | Facts must be marked historical, not live. The existing unreachable path (`JARVIS_IGNITION_TIMEOUT_S`, default 10s) governs the transition. |
+| 13 | **Long absence** — 12 days | Relative time degrades gracefully; any pending decision older than its resource clock is shown as **lapsed**, never as actionable. Offering `/accept` on a dead decision is a lie the operator can act on. |
+| 14 | **Pending diff whose base drifted** | `state_drift.file_sha256` already answers this. Render "stale — the file changed underneath" and refuse the accept path. Never offer an apply that will fail. |
+| 15 | **Two cockpits attached** | The handover is **per-client**; the attention ledger is **process-wide**. A decision taken in cockpit A must retract the affordance in cockpit B within one frame. Per §25.1, ambient content renders to the minimum width across live cockpits. |
+| 16 | **Different branch/worktree than the run** | Say which. `main @ f70a397` in the header is not decoration — a handover about work done on another branch is actively misleading without it. |
+
+#### 27.8.3 Attention and interrupts
+
+| # | Case | Required behaviour |
+|---|---|---|
+| 17 | **Attended expiry vs unattended lapse** | Two distinct terminals with two distinct evidence weights (§27.3.2 / §27.3.3). This must be a ledger-level distinction, not a rendering one. |
+| 18 | **Attention flaps** — operator attaches/detaches repeatedly | Hysteresis debounces the **state machine**, never the **ledger**. A debounce applied to accounting turns grace periods into billable time. (Recorded verbatim from the arc that built the ledger.) |
+| 19 | **Two interrupts at once** | Coalesce to a count with the highest-tier one focused. Never stack. Never modal. |
+| 20 | **Detach mid-interrupt** | Decision clock pauses; resource clock continues; on resource expiry the op **parks** (§27.3.4) and appears in the next handover's "Needs you". |
+| 21 | **Decision clock can never be spent** | Guaranteed non-pinning by §27.3.4's two-clock split. This is the failure mode that would otherwise accumulate parked workers until the pool starves. |
+| 22 | **Interrupt during typing** | Bottom-anchored render only; the input line neither reflows nor loses its buffer. |
+
+#### 27.8.4 Steering and learning
+
+| # | Case | Required behaviour |
+|---|---|---|
+| 23 | **`/why` on an evicted ref** | Post-spine, uniform eviction makes dangling refs structurally impossible (§25.3). Pre-spine refs answer honestly: "before the transcript spine — not recorded." |
+| 24 | **`/why` with lanes dry** | Must still work — deterministic projection, zero model calls (§27.5.2). |
+| 25 | **Ambiguous `decline`** — no focused ref | **Refuse, never guess.** Ask which, or require an explicit ref. The `ov doctor` unknown-flag path (`EX_USAGE` 64) is the established precedent. |
+| 26 | **Preference poisoning** — 3 rejections of a kind silence it forever | Extracted preferences need decay, must be inspectable (`/why` on a refusal), and must be revocable in one verb. An invisible permanent cage assembled from three bad afternoons is a real risk. |
+| 27 | **Rejection during APPLY** | Cooperative cancellation at phase boundaries; mid-write is protected by the existing op-scoped freeze / 2PC. A steering act must never be able to corrupt a partially-applied multi-file batch. |
+| 28 | **Redirect with no successor** | "Not that" alone is a valid, complete act. It must not demand a replacement suggestion — demanding one raises the cost of declining, which violates §27.2. |
+
+#### 27.8.5 Trust ladder
+
+| # | Case | Required behaviour |
+|---|---|---|
+| 29 | **Window filled unattended** | Excluded from numerator and denominator (§27.6.1). |
+| 30 | **Trivial-op gaming** | Diversity-weighted windows (§27.6.2). |
+| 31 | **Post-graduation regression** | Breaker reverts; bar visibly drops with reason (§27.6.3). |
+| 32 | **Operator overrides the ladder** | Explicit, recorded, revocable (§27.6.4). |
+| 33 | **Thundering herd on flip** | Already specified in §26.5 — seq-gated, caps stand, ramped `1/N` admission. §27 renders the ramp: "first authoritative op: 1 of 12 eligible." |
+
+---
+
+### 27.9 Scenarios
+
+**Scenario A — Day 0, new operator, funded lane.** `ov` in an unseen repo.
+Crest at ~0.4s. Index streams. At 6s three findings render; at 8s the organism
+begins exploring the stale TODOs; the exploration counter reaches 2/2 and a
+plan appears. The operator does nothing — which was a decision, and a
+read-only one. At the first mutation the risk ladder stops the op cold and
+raises a Yellow diff. **The operator's first mutation-facing interaction is a
+review, not a prompt.** They have learned the product's actual grammar without
+reading a word of documentation.
+
+**Scenario B — Day 0, today's real conditions.** Same command; DW returns 402,
+Claude's preflight refuses at `est $0.50 > session_remaining $0.175`. **No
+countdown starts.** The frame reads: "I can see, but I can't act — every
+provider lane is out of credit," with `/liquidity` and the funding column.
+Indexing and sensors continue; `/why` and `/expand` work. The operator learns
+the surface tells the truth in the worst case, which is the only case where
+that lesson is worth anything.
+
+**Scenario C — Day 12, returning.** Handover: 14 ops while away, 2 applied, 1
+Yellow **lapsed unattended** (excluded from all evidence), 1 pending whose base
+has since drifted (rendered stale, accept refused). Trust panel: REVIEW 31/50,
+0 false-blocks, ~3 days at current cadence. The operator answers the one live
+decision, and that decision — attended — is the 32nd sample.
+
+**Scenario D — Day 40, first authoritative op.** REVIEW graduates. Ramped
+admission: 1 of 12 eligible ops carries authority. The panel renders exactly
+that. The first authoritative op is one op, and the operator can see that it is
+one op — which is the difference between a graduation and a leap of faith.
+
+---
+
+### 27.10 Build plan
+
+Seven slices, each composing existing canonical substrate, each default-`false`
+until its §33.1 graduation contract is satisfied, each with AST pins enforcing
+composition rather than duplication.
+
+| Slice | Ships | Composes | Flag | Blocked by |
+|---|---|---|---|---|
+| **1 — Prototype frames** | `ov demo handover` + `ov demo firstcontact` scenes | `ov_demo.py` real-renderer harness (5 existing scenes) | — (demo) | **nothing** |
+| **2 — `/why <ref>`** | deterministic causal account | `transcript_timeline` join + spine | `JARVIS_WHY_VERB_ENABLED` | slice 1 informs shape |
+| **3 — Attention-gated evidence** | attended/unattended terminal split; extraction + §26 counters suppressed on lapse | `AttentionLedger`, `UserPreferenceMemory`, `ReviewCoordinator` | `JARVIS_ATTENDED_EVIDENCE_ONLY` | nothing |
+| **4 — Handover composer** | the three-block frame on real data | `LastSessionSummary` + `m-` milestones + pending set + liquidity | `JARVIS_HANDOVER_FRAME_ENABLED` | slice 3 (lapse rendering) |
+| **5 — First-contact runtime** | TTFI instrumentation, explore-only countdown, live exploration counter | §38.11-E proposal contract + `ExplorationLedger` | `JARVIS_FIRST_CONTACT_ENABLED` | a funded lane |
+| **6 — Trust panel + `/trust`** | §26 counters accumulated, diversity-weighted, rendered | §26 gates + §38.11 #4 graduation ticker | `JARVIS_TRUST_PANEL_ENABLED` | slice 3 |
+| **7 — Steering metrics** | the four §27.7 signals into `/metrics` | Phase 4 metrics suite | — | slices 3–6 |
+
+**Sequencing rationale.** Slice 1 is the only work in the entire section that
+is **not blocked on provider credit** — `ov_demo` drives the real renderers
+with synthetic events, so both frames can be built, watched, and iterated
+without a daemon or a dollar. Start there; it de-risks slices 4 and 5 before
+either becomes expensive. Slices 2 and 3 are pure-composition and unblocked.
+Slices 5–7 need ops, which need a funded lane.
+
+**Invariant pins required** (AST, per §33.1):
+
+1. no countdown path can reach a mutation phase (§27.4.1.1);
+2. no unattended terminal can reach `UserPreferenceMemory` or a §26 counter
+   (§27.3.2);
+3. `/why` imports no provider client (§27.5.2);
+4. the ambient idle line imports no provider client (§27.4.3);
+5. the trust panel is read-only with respect to every §26 flag — rendering
+   authority is never write authority (the `ide_observability.py` precedent).
+
+---
+
+### 27.11 Anti-goals
+
+Extends §38.11.4; these are specific to initiative and steering.
+
+| Pattern | Why §27 rejects it |
+|---|---|
+| A "start working" button | Reintroduces the reactive loop as the primary affordance. The organism starts; the operator stops. |
+| Notifications outside the terminal for routine proposals | Attention is metered (§27.3). Push escalation is reserved for Orange and breaker events. |
+| An LLM-authored handover | The frame must be free and must work when lanes are dry. Prose is garnish. |
+| A confidence percentage on every proposal | Uncalibrated numbers read as measurement. §27 surfaces *evidence* (2/2 explored, 0 callers), never a fabricated score. This is the §25.4 honesty discipline. |
+| Auto-accepting Yellow after a timeout | Absence is not consent, exactly as absence is not refusal (§26.6). Both directions of that error are the same error. |
+| A dedicated onboarding wizard | §41.3 already shipped `/tutorial` + setup walkthrough. First contact teaches by *doing*; a wizard teaches by reading, which is CC's model. |
+
+---
+
+### 27.12 Open questions for operator decision
+
+1. **Countdown default** — is first contact `[esc] to stop` (initiative by
+   default) or `[enter] to start` (consent by default) on the very first run in
+   an unseen repo? *(Recommend: initiative by default, given §27.4.1.1 bounds
+   it to read-only work; consent-by-default on the first **mutation** class.)*
+2. **TTFI budget** — 10s target, or slower with richer findings? *(Recommend:
+   10s with partial-index honesty per edge case #1; a fast honest proposal
+   beats a slow complete one.)*
+3. **Weak-reject weight** — what fraction of a strong reject does an attended
+   expiry carry into preference extraction? *(Recommend: 0.5, env-tunable,
+   with decay — and revisit once slice 3 produces data.)*
+4. **Trust window diversity dimensions** — risk tier × file count × sensor
+   source, or a narrower set? *(Recommend: start with risk tier × sensor
+   source; add file count if gaming is observed.)*
+5. **`/why` depth default** — one hop (what caused this op) or the full chain
+   to the sensor? *(Recommend: one hop, with `/why <ref> --full` for the
+   chain — steering acts must stay cheap to read.)*
+
+---
+
+## 28. The Cockpit as Control Surface — Implementation Audit *(NEW 2026-08-13)*
+
+§27 specifies the control model O+V needs in order to be steered rather than
+merely watched. §28 audits what `ov` **actually implements today** against it,
+so the build plan in §27.10 starts from measured ground rather than assumption.
+
+### 28.0 Method, and the scope limits that bound every claim below
+
+Read in full or in the regions that carry the behaviour: `cli/ov.py` (4,765
+lines), `battle_test/cockpit_attach.py` (1,940), `cockpit_fsm.py` (213),
+`focus_shield.py` (347), `pending_apply.py` (191), `keymap.py` (953),
+`operator_prompt_bridge.py`, `cli/thin_client.py` (840), `cli/ov_demo.py`
+(2,325). Counts are measured with `grep -c`, not estimated.
+
+**Three limits the reader must carry into every finding:**
+
+1. **This is a static read. Nothing here was observed on a screen.** No claim
+   in §28 has been live-proven, and per this repository's own repeated lesson
+   (`feedback_per_slice_e2e_livefire`; the typed-goal path that raised
+   `TypeError` on every call for twelve days beneath fifteen green tests) a
+   rendering path is *easier* to be wrong about than a logic path. Findings
+   are code-evidenced, not eye-confirmed.
+2. **Coverage is partial.** 123 modules live in `battle_test/`; roughly a
+   dozen were read. A surface not named here was not audited and must not be
+   read as absent.
+3. **Two findings from the first pass were withdrawn under verification**
+   (§28.4). They are documented rather than deleted, because the *rate* at
+   which confident structural claims about this cockpit fail verification is
+   itself an audit result — and the correction mechanism is the only reason
+   the surviving findings are trustworthy.
+
+---
+
+### 28.1 Verdict
+
+> **The `ov` cockpit is an outstanding observability instrument for an
+> autonomous system, and is not yet a control surface for one.**
+
+Ten surfaces render above the caret — pulse, flash, agent roster, deck rows,
+status line, stream tail, forensic rows, panic rows, queue rows, search rows.
+**All ten report state.** Two afford decisions (the Iron Gate queue and the
+`NOTIFY_APPLY` window), and both are reactive to an op that already exists and
+is already mid-pipeline.
+
+The gap is not craft. The craft is, in places, better than the product it
+serves. The gap is that **the surface was designed around the question "what is
+happening?" and full autonomy is governed through the question "what should I
+allow?"**
+
+---
+
+### 28.2 What the audit found excellent — and promotes to standards
+
+These are not compliments. Each is a pattern the rest of the product should be
+held to, and each has a named failure it prevents.
+
+**28.2.1 — One definition of "lost contact"** (`ov.py:1387`,
+`_heartbeat_age`). The pulse, roster, status line, apply countdown and
+forensic strip all retire on a single clock. Its docstring names the failure
+exactly: *"if the daemon dies mid-dispatch, the last frame this process holds
+says three agents are running, phase is GENERATE and the border should be
+moving — and it will say that forever."*
+
+> **Standard**: a confident, coherent, wrong picture of a dead organism is the
+> most dangerous thing a proactive cockpit can render. Every surface fed by a
+> remote snapshot retires on ONE clock, never its own.
+
+**28.2.2 — Verdicts are addressed, not broadcast** (`cockpit_attach.py:1759`,
+`send_input(text, prompt_id)`): *"a deferred verdict can outlive the slot it
+was meant for, and the daemon refuses a mismatch rather than landing 'y' on
+whichever op happens to be armed now."* This closes the single most dangerous
+bug class in any autonomous approval path.
+
+**28.2.3 — The deferral FSM refuses to stack** (`focus_shield.py`). Gates
+queue rather than pile up — *"or one unanswered gate becomes a queue of
+itself"* — carry a live `pending_count` that **excludes expired gates**
+(*"a badge that advertises a dead approval is worse than no badge"*), render a
+persistent toolbar badge (`⚠ N pending approvals · ctrl-p`, consumed at
+`ov.py:1833`), and are re-surfaceable on demand via the `gate:review` action.
+This is a complete, correct implementation of §27.4.4's interrupt discipline,
+built before §27 specified it.
+
+**28.2.4 — A sentence is a goal; a word is a verdict**
+(`operator_prompt_bridge.py:93`). Under `strict_verdicts_enabled()` a
+multi-word answer is refused as a verdict — *"Punctuation is tolerated ('y.' /
+'no!') — an extra WORD is what disqualifies."* An elegant, zero-cost
+disambiguation between steering and answering on one shared input line.
+
+**28.2.5 — The keymap is finished infrastructure** (`keymap.py`, 953 lines):
+remappable via `keybindings.json`, action namespaces with aliases to CC's
+vocabulary, per-context filters, `/keys` introspection, and the binding
+contract *"every action ALSO reachable as a typed verb so keystroke and verb
+are one code path."* Eleven actions are bound in the cockpit today.
+
+---
+
+### 28.3 Findings that survived verification
+
+#### C1 — The organism's proposals have no cockpit consumer *(load-bearing)*
+
+**Evidence, exact:**
+
+| Layer | State |
+|---|---|
+| Producer | `governance/proactive_proposal_surface.py` — exists |
+| Signal source | `governance/proactive_curiosity_reader.py` — exists |
+| Event type | `proactive_proposal_emitted`, registered at `ide_observability_stream.py:840` |
+| Operator verb | `governance/proposals_repl.py` — exists, **daemon-side** |
+| **Cockpit client** | **`grep -c proposal ov.py` → `0`** |
+
+The single most proactive artifact O+V produces — *"I noticed X across five
+files, want me to explore?"* — has a producer, an event type, a graduation
+contract and a REPL verb, and **no home in the operator's window.** It is
+reachable only by typing a daemon-side verb, whose output travels the exact
+path C3 documents as broken.
+
+This is §27's entire thesis confirmed from the code side rather than the
+document side: §38.11-E built the proposal *substrate*; nothing ever built the
+proposal *surface*.
+
+**Required**: a cockpit consumer for `proactive_proposal_emitted` with a
+per-proposal affordance. This is §27.10 slice 5 and it is the difference
+between an organism that proposes and an operator who can hear it.
+
+#### C2 — The decision channel is complete except for the answer key
+
+The channel is queued, badged, addressed, re-surfaceable, and parsed with
+strict single-token discipline (§28.2.2–28.2.4). One vocabulary item is
+missing: **there is no action that answers a gate.**
+
+Bound cockpit actions: `app:cycleTrust`, `app:dismissPanic`, `app:help`,
+`chat:externalEditor`, `chat:interrupt`, `deck:{open,next,previous,focus,escape}`,
+`gate:review`. `gate:review` (Ctrl+P) **surfaces** a deferred gate; nothing
+**answers** one. Answering is a typed line through `_route_operator_line`,
+which also echoes the operator's text into the transcript.
+
+Measured cost to decline a pending gate: notice badge → `Ctrl+P` → type `n` →
+`Enter`. Against §27.2's target of one key, and against a proposal the
+organism made for zero.
+
+> **This is a two-`bind_action`-call gap in finished infrastructure**, not a
+> missing feature: `gate:approve` / `gate:decline`, routed through the same
+> `send_input(text, prompt_id)` that already addresses verdicts correctly, and
+> filtered on "a gate is on screen" exactly as the deck actions filter on
+> `in_select`. The initiative economics of §27.2 are one afternoon away.
+
+#### C3 — Process ownership is a manual chain, and its failure is pre-diagnosed
+
+`_daemon_owns()` (`ov.py:223`) plus an `if/elif` ladder in
+`_route_operator_line` (`ov.py:2152`) decides per verb which side of the socket
+executes. The comment on the `/tasks` branch already names the open defect
+verbatim:
+
+> *"The two-process trap: a verb that runs on the wrong side of the socket
+> reports success and changes nothing the operator can see."*
+
+The repository diagnosed its own live bug in prose and left the structure that
+generates it. Every new verb is a fresh opportunity to choose wrong, and the
+failure mode is **silent success** — which, for a proactive tool, is
+indistinguishable from the organism ignoring the operator. That is the worst
+available failure on a steering path, and per C1 it is also the path the
+proposal verb currently depends on.
+
+**Required**: one console seam. Client/daemon placement becomes an
+implementation detail of a single dispatcher rather than a per-verb decision.
+
+#### C4 — The cockpit is honest about the daemon and blind to itself
+
+Measured in `cli/ov.py`:
+
+| Quantity | Count |
+|---|---|
+| `except Exception:  # noqa: BLE001` | **169** |
+| `NEVER raises` contracts | **61** |
+| Render-failure counters, of any kind | **0** |
+
+Every individual swallow is correct — chrome must not kill the cockpit.
+Collectively they mean that if `_status_rows` begins throwing, the status line
+silently vanishes and **nothing anywhere records that it did.** A dead surface
+is indistinguishable from an empty one.
+
+That is precisely the failure class `_ignition_line` was written to kill —
+*"a blank deck is indistinguishable from a healthy idle organism with nothing
+to say, and from a dead socket"* — reappearing one level up and aimed at the
+instrument itself. §25.4's honesty doctrine is applied rigorously to the
+organism and not at all to the window through which the organism is seen.
+
+**Required**: one process-wide render-degradation counter, surfaced in the idle
+breadcrumb (`⚠ 3 surfaces degraded`) with the list behind a verb. Roughly
+thirty lines. For a product whose only operator channel is this window, silent
+degradation of the window is a first-tier risk, and it is currently unobservable
+by construction.
+
+---
+
+### 28.4 Findings withdrawn under verification
+
+Documented because the method is part of the result.
+
+| Withdrawn claim | Why it was wrong |
+|---|---|
+| *"Keybindings total two (`s-tab`, `c-t`) — decisions are lines because there is no keymap."* | A `grep` for literal `kb.add` missed `keymap.bind_action`, the actual binding seam. There is a 953-line remappable keymap with eleven bound cockpit actions. **The infrastructure claim was inverted**; the surviving narrow finding is C2. |
+| *"The higher-severity Iron Gate prompt renders transiently to scrollback and scrolls away while its clock runs, while the lower-severity `NOTIFY_APPLY` row persists — the severity tiers have inverted persistence."* | `FocusShield.badge()` renders `⚠ N pending approvals · ctrl-p` persistently and is consumed at `ov.py:1833`; expired gates are excluded; `gate:review` re-surfaces on demand. **Persistence is handled.** A related claim — that no rule governs the proactive interrupt direction — falls with it: `FocusShield` *is* that rule. |
+
+**The lesson the audit takes from its own errors.** Both failures share one
+shape: a structural conclusion drawn from a grep that did not cover the seam
+where the behaviour actually lives. In a codebase that composes through named
+registries and injected publishers rather than direct calls, **absence of a
+literal is not absence of a capability** — the same trap as
+`memory/project_ov_dark_code_audit_2026_08_01.md`'s retraction (*"being NAMED
+by a registry ≠ being MOUNTED by one"*), inverted. Before any future claim that
+this cockpit lacks a capability: find the registry, then the consumer, then the
+flag default — three checks, in that order.
+
+---
+
+### 28.5 Measured affordance costs
+
+The §27.2 initiative-economics table, filled in with what the code actually
+costs today.
+
+| Operator act | §27 target | Measured today | Gap |
+|---|---|---|---|
+| Decline the gate on screen | 1 key | badge → `Ctrl+P` → `n` → `Enter` | **C2** — no `gate:decline` action |
+| Approve the gate on screen | 1 key | badge → `Ctrl+P` → `y` → `Enter` | **C2** |
+| Reject a `NOTIFY_APPLY` in its window | 1 key | `/reject` + `Enter` (8 keys) | **C2** |
+| Hear a proactive proposal at all | ambient | **not possible in the cockpit** | **C1** |
+| Ask why the organism did something | 1 verb | **unbuilt** (§25.5) | §27.10 slice 2 |
+| Raise the session risk floor | 1 key | `Shift+Tab` → `/trust cycle` | ✅ shipped |
+| Surface a deferred gate | 1 key | `Ctrl+P` | ✅ shipped |
+| Interrupt a live turn | 1 key | `chat:interrupt` | ✅ shipped |
+
+Note what the shape of that table says: **every act the operator performs
+*about the interface* is one key, and every act the operator performs *about
+the work* is a typed line.** The cockpit is optimized for navigating itself.
+
+> **Nuance — two different dials both called "trust."** `Shift+Tab` →
+> `app:cycleTrust` → `/trust cycle` raises the **session risk floor**
+> (`risk_tier_floor`), and it ships today. §27.6's trust ladder renders §26's
+> **graduation evidence**, and does not exist. Same word, different objects:
+> one bounds what this session may do, the other records what the organism has
+> earned. §27.10 slice 6 must not collide with the shipped verb — recommend
+> `/trust` for the ladder with the existing dial demoted to `/trust floor`.
+
+---
+
+### 28.6 Remediation, ranked by leverage per line changed
+
+| # | Change | Closes | Size | Blocked by |
+|---|---|---|---|---|
+| 1 | `gate:approve` / `gate:decline` actions via `bind_action`, filtered on gate-visible, routed through existing `send_input(text, prompt_id)` | **C2** | ~2 call sites | nothing |
+| 2 | Render-degradation counter + breadcrumb surface | **C4** | ~30 lines | nothing |
+| 3 | Cockpit consumer for `proactive_proposal_emitted` + per-proposal affordance reusing the `FocusShield` queue/badge/pop machinery | **C1** | one consumer | nothing (render); a funded lane to *populate* it |
+| 4 | Collapse `_daemon_owns` + the routing ladder to one console seam | **C3** | structural | nothing |
+| 5 | Extract the `AttachUI` class out of `ov.py` | maintainability | structural | do after 1–4 |
+
+Items 1–3 are small, independent, and **unblocked by provider credit**. Item 3
+reuses the deferral FSM wholesale rather than building a second one — a
+proposal and a gate are the same shape of object (addressed, expiring,
+queued, badged), and §28.2.3 already built the correct machinery for it.
+
+---
+
+### 28.7 Invariants worth pinning
+
+1. Every surface fed by the daemon snapshot retires on `_heartbeat_age()` — no
+   surface may introduce a second staleness clock (§28.2.1).
+2. Every verdict crossing the bridge carries a `prompt_id` (§28.2.2).
+3. No render path may swallow an exception without incrementing the
+   degradation counter (C4's fix, pinned so it cannot rot back).
+4. Every new operator action is registered through `bind_action` and is
+   reachable as a typed verb — the existing contract, made a pin.
+5. No verb decides its own execution side; placement is the dispatcher's
+   (C3's fix).
+
+---
+
+### 28.8 What this audit did not examine
+
+Named so the gaps are not mistaken for clean bills of health: the bipartite
+cockpit surface and its Float/overlay arbiter; `serpent_flow.py`'s 30
+daemon-side handlers; the audio plane (oscilloscope, PTT protocol probe,
+`ov.py` §24 surfaces); `ov_doctor`'s 8-edge matrix; the Sublime / JetBrains /
+VS Code extensions; and the five `ov demo` scenes as *rendered output* rather
+than as source. The `/`-key freeze recorded in operator memory was not
+reproduced or root-caused here — `_transcript_search_rows` and
+`transcript_hatches` are the indicated starting points and remain unaudited.
 
 ---

--- a/tests/governance/test_compute_topology.py
+++ b/tests/governance/test_compute_topology.py
@@ -1,0 +1,724 @@
+"""Regression spine for compute_topology + measured compute-class admission.
+
+These tests assert BEHAVIOUR under substituted probes, not the spelling of
+the module. Every probe stage is monkeypatched at its seam so the suite runs
+identically on a 16 GB M1, a 32 GB discrete-GPU host, and a CI container with
+no accelerator at all — which is the whole point of the module under test.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+
+import pytest
+
+from backend.core.ouroboros.governance import compute_topology as ct
+
+GIB = 1024 ** 3
+
+
+@pytest.fixture(autouse=True)
+def _enabled(monkeypatch):
+    """Master switch on, singleton clean, every knob at its default."""
+    monkeypatch.setenv("JARVIS_COMPUTE_TOPOLOGY_ENABLED", "1")
+    for knob in (
+        "JARVIS_COMPUTE_TOPOLOGY_CLASS_BYTES",
+        "JARVIS_COMPUTE_TOPOLOGY_HEADROOM_FRACTION",
+        "JARVIS_COMPUTE_TOPOLOGY_UNIFIED_BUDGET_FRACTION",
+        "JARVIS_COMPUTE_TOPOLOGY_FREE_TTL_S",
+        "JARVIS_COMPUTE_TOPOLOGY_IDENTITY_REPIN_S",
+        "JARVIS_COMPUTE_TOPOLOGY_LOCAL_ALIASES",
+    ):
+        monkeypatch.delenv(knob, raising=False)
+    ct.reset_default_resolver()
+    yield
+    ct.reset_default_resolver()
+
+
+def _discrete(total_gib=32, free_gib=30, name="NVIDIA GeForce RTX 5090"):
+    return ct.AcceleratorProbe(
+        topology=ct.MemoryTopology.DISCRETE,
+        total_bytes=total_gib * GIB, free_bytes=free_gib * GIB,
+        device_name=name, device_count=1, source="torch_cuda",
+    )
+
+
+def _silence_cascade(monkeypatch, *, torch=None, smi=None, unified=None,
+                     ram=(0, 0)):
+    """Pin every cascade stage. None means the stage DECLINES."""
+    monkeypatch.setattr(ct, "_probe_torch_cuda", lambda: torch)
+    async def _smi():
+        return smi
+    monkeypatch.setattr(ct, "_probe_nvidia_smi_async", _smi)
+    monkeypatch.setattr(ct, "_probe_unified", lambda: unified)
+    monkeypatch.setattr(ct, "_system_ram_from_canonical_gate", lambda: ram)
+
+
+# ---------------------------------------------------------------------------
+# The defect this module exists to close
+# ---------------------------------------------------------------------------
+
+
+def test_discrete_host_is_not_judged_by_system_ram(monkeypatch):
+    """THE regression: 64 GB of host RAM must not authorize a 40 GiB load
+    onto a 32 GiB card. This is the exact misjudgement the old path made."""
+    _silence_cascade(monkeypatch, torch=_discrete(32, 30), ram=(64 * GIB, 60 * GIB))
+    decision = asyncio.run(ct.fits(40 * GIB))
+    assert decision.fits is False
+    assert decision.reason_code == "exceeds_accelerator"
+    assert decision.spill_bytes > 0
+
+
+def test_unified_host_defers_to_the_canonical_ram_gate(monkeypatch):
+    """Under unified memory the system-RAM reading IS the accelerator
+    reading — and it must arrive via memory_pressure_gate, not a second probe."""
+    calls = []
+
+    def _ram():
+        calls.append(1)
+        return 16 * GIB, 8 * GIB
+
+    monkeypatch.setattr(ct, "_probe_torch_cuda", lambda: None)
+    async def _smi():
+        return None
+    monkeypatch.setattr(ct, "_probe_nvidia_smi_async", _smi)
+    monkeypatch.setattr(ct, "_system_ram_from_canonical_gate", _ram)
+    monkeypatch.setattr(ct.sys, "platform", "darwin")
+    monkeypatch.setattr("platform.machine", lambda: "arm64")
+
+    reading = asyncio.run(ct.resolve())
+    assert reading.topology is ct.MemoryTopology.UNIFIED
+    assert calls, "unified probe must consume the canonical RAM gate"
+    # 75% budget fraction of 16 GiB, not the nameplate.
+    assert reading.total_bytes == int(16 * GIB * 0.75)
+    assert reading.free_is_measured is False
+
+
+# ---------------------------------------------------------------------------
+# Epistemic posture: unknown is not zero, and not "plenty"
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_topology_refuses_rather_than_inventing(monkeypatch):
+    _silence_cascade(monkeypatch, ram=(0, 0))
+    reading = asyncio.run(ct.resolve())
+    assert reading.topology is ct.MemoryTopology.UNKNOWN
+    assert reading.measured is False
+    decision = asyncio.run(ct.fits(1 * GIB))
+    assert decision.fits is False
+    assert decision.reason_code == "unknown_topology"
+
+
+def test_no_accelerator_is_a_measurement_not_an_absence(monkeypatch):
+    """NONE and UNKNOWN must stay distinguishable: one is a reading."""
+    _silence_cascade(monkeypatch, ram=(32 * GIB, 24 * GIB))
+    reading = asyncio.run(ct.resolve())
+    assert reading.topology is ct.MemoryTopology.NONE
+    assert reading.measured is True
+
+
+def test_disabled_is_status_quo_not_degraded(monkeypatch):
+    monkeypatch.setenv("JARVIS_COMPUTE_TOPOLOGY_ENABLED", "0")
+    ct.reset_default_resolver()
+    reading = asyncio.run(ct.resolve())
+    assert reading.enabled is False
+    assert reading.topology is ct.MemoryTopology.UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# Cascade discipline
+# ---------------------------------------------------------------------------
+
+
+def test_failed_stage_is_skipped_not_read_as_zero_capacity(monkeypatch):
+    """A broken driver must not masquerade as a machine with no GPU."""
+    broken = ct.AcceleratorProbe(
+        topology=ct.MemoryTopology.UNKNOWN, total_bytes=0, free_bytes=0,
+        device_name="", device_count=0, source="torch_cuda",
+        ok=False, error="driver init failed",
+    )
+    _silence_cascade(monkeypatch, torch=broken, smi=_discrete(32, 31),
+                     ram=(64 * GIB, 50 * GIB))
+    reading = asyncio.run(ct.resolve())
+    assert reading.topology is ct.MemoryTopology.DISCRETE
+    assert reading.total_bytes == 32 * GIB
+    assert any("driver init failed" in n for n in reading.notes)
+
+
+def test_multi_gpu_resolves_largest_single_device_never_the_sum(monkeypatch):
+    """A model must fit on ONE device; summing would authorize an
+    impossible load."""
+    text = "24576, 24000, NVIDIA L4\n32768, 32000, NVIDIA RTX 5090\n"
+    parsed = ct._parse_nvidia_smi(text)
+    assert parsed is not None
+    free_b, total_b, name, count = parsed
+    assert total_b == 32768 * 1024 * 1024
+    assert count == 2
+    assert "5090" in name
+
+
+def test_unparseable_smi_rows_are_skipped_individually():
+    text = "garbage\n32768, 32000, RTX 5090\n, , \n"
+    parsed = ct._parse_nvidia_smi(text)
+    assert parsed is not None
+    assert parsed[1] == 32768 * 1024 * 1024
+
+
+def test_smi_with_no_usable_rows_returns_none():
+    assert ct._parse_nvidia_smi("garbage\n\n") is None
+
+
+# ---------------------------------------------------------------------------
+# Requirement interpretation — bytes, not ordinals
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_class_names_resolve_to_byte_requirements():
+    assert ct.bytes_for_requirement(min_compute_class="gpu_l4") == 24 * GIB
+    assert ct.bytes_for_requirement(min_compute_class="gpu_t4") == 16 * GIB
+    assert ct.bytes_for_requirement(min_compute_class="cpu") == 0
+
+
+def test_explicit_vram_requirement_outranks_the_legacy_name():
+    got = ct.bytes_for_requirement(min_compute_class="gpu_t4", min_vram_gb=27)
+    assert got == 27 * GIB
+
+
+def test_unknown_class_name_states_no_requirement_rather_than_denying():
+    assert ct.bytes_for_requirement(min_compute_class="gpu_from_2031") == 0
+
+
+def test_class_table_is_overridable(monkeypatch):
+    monkeypatch.setenv(
+        "JARVIS_COMPUTE_TOPOLOGY_CLASS_BYTES", '{"gpu_l4": 48}',
+    )
+    assert ct.bytes_for_requirement(min_compute_class="gpu_l4") == 48 * GIB
+
+
+def test_malformed_override_entry_does_not_void_the_table(monkeypatch):
+    monkeypatch.setenv(
+        "JARVIS_COMPUTE_TOPOLOGY_CLASS_BYTES", '{"gpu_l4": "nonsense"}',
+    )
+    assert ct.bytes_for_requirement(min_compute_class="gpu_t4") == 16 * GIB
+
+
+def test_resolved_class_names_the_measurement_not_the_nearest_rung(monkeypatch):
+    """A 32 GiB consumer card must not be relabelled 'gpu_v100' merely
+    because that legacy rung sits at 32 GiB."""
+    _silence_cascade(monkeypatch, torch=_discrete(32, 30))
+    reading = asyncio.run(ct.resolve())
+    assert reading.resolved_class == "gpu_32gib"
+
+
+# ---------------------------------------------------------------------------
+# Headroom + spill
+# ---------------------------------------------------------------------------
+
+
+def test_headroom_is_withheld_from_every_fit(monkeypatch):
+    _silence_cascade(monkeypatch, torch=_discrete(32, 30))
+    reading = asyncio.run(ct.resolve())
+    assert reading.usable_bytes == int(30 * GIB * 0.9)
+
+
+def test_spill_can_rescue_a_fit_only_on_discrete(monkeypatch):
+    _silence_cascade(monkeypatch, torch=_discrete(32, 30),
+                     ram=(64 * GIB, 48 * GIB))
+    decision = asyncio.run(ct.fits(40 * GIB, allow_spill=True))
+    assert decision.fits is True
+    assert decision.reason_code == "fits_with_spill"
+    assert decision.spill_bytes > 0
+
+
+def test_spill_cannot_rescue_a_fit_under_unified(monkeypatch):
+    """There is nowhere for it to spill TO — the pool is already counted."""
+    monkeypatch.setattr(ct, "_probe_torch_cuda", lambda: None)
+    async def _smi():
+        return None
+    monkeypatch.setattr(ct, "_probe_nvidia_smi_async", _smi)
+    monkeypatch.setattr(ct, "_system_ram_from_canonical_gate",
+                        lambda: (16 * GIB, 12 * GIB))
+    monkeypatch.setattr(ct.sys, "platform", "darwin")
+    monkeypatch.setattr("platform.machine", lambda: "arm64")
+    decision = asyncio.run(ct.fits(40 * GIB, allow_spill=True))
+    assert decision.fits is False
+    assert decision.reason_code == "no_spill_pool"
+
+
+def test_spill_beyond_host_memory_is_refused(monkeypatch):
+    _silence_cascade(monkeypatch, torch=_discrete(32, 30),
+                     ram=(64 * GIB, 4 * GIB))
+    decision = asyncio.run(ct.fits(120 * GIB, allow_spill=True))
+    assert decision.fits is False
+    assert decision.reason_code == "exceeds_host_memory"
+
+
+# ---------------------------------------------------------------------------
+# Caching: two clocks
+# ---------------------------------------------------------------------------
+
+
+def test_identity_is_pinned_and_only_free_bytes_re_probe(monkeypatch):
+    """Device enumeration must not re-run on every question."""
+    identity_calls = {"n": 0}
+
+    def _torch():
+        identity_calls["n"] += 1
+        return _discrete(32, 30 - identity_calls["n"])
+
+    _silence_cascade(monkeypatch, torch=None, ram=(64 * GIB, 60 * GIB))
+    monkeypatch.setattr(ct, "_probe_torch_cuda", _torch)
+    monkeypatch.setenv("JARVIS_COMPUTE_TOPOLOGY_FREE_TTL_S", "0")
+    ct.reset_default_resolver()
+
+    async def _drive():
+        r1 = await ct.resolve()
+        r2 = await ct.resolve()
+        return r1, r2
+
+    r1, r2 = asyncio.run(_drive())
+    assert r1.total_bytes == r2.total_bytes == 32 * GIB
+    # Second call refreshed the dynamic dimension only.
+    assert identity_calls["n"] >= 2
+    assert r2.free_bytes <= r1.free_bytes
+
+
+def test_failed_free_refresh_keeps_the_host_resolved(monkeypatch):
+    """A transient probe failure must not demote an already-known host."""
+    state = {"n": 0}
+
+    def _torch():
+        state["n"] += 1
+        if state["n"] == 1:
+            return _discrete(32, 30)
+        return ct.AcceleratorProbe(
+            topology=ct.MemoryTopology.UNKNOWN, total_bytes=0, free_bytes=0,
+            device_name="", device_count=0, source="torch_cuda",
+            ok=False, error="transient",
+        )
+
+    _silence_cascade(monkeypatch, ram=(64 * GIB, 60 * GIB))
+    monkeypatch.setattr(ct, "_probe_torch_cuda", _torch)
+    monkeypatch.setenv("JARVIS_COMPUTE_TOPOLOGY_FREE_TTL_S", "0")
+    ct.reset_default_resolver()
+
+    async def _drive():
+        await ct.resolve()
+        return await ct.resolve()
+
+    reading = asyncio.run(_drive())
+    assert reading.topology is ct.MemoryTopology.DISCRETE
+    assert reading.free_bytes == 30 * GIB
+
+
+def test_concurrent_resolves_share_one_cascade(monkeypatch):
+    calls = {"n": 0}
+
+    async def _slow_smi():
+        calls["n"] += 1
+        await asyncio.sleep(0.01)
+        return _discrete(32, 30, name="shared")
+
+    monkeypatch.setattr(ct, "_probe_torch_cuda", lambda: None)
+    monkeypatch.setattr(ct, "_probe_nvidia_smi_async", _slow_smi)
+    monkeypatch.setattr(ct, "_system_ram_from_canonical_gate",
+                        lambda: (64 * GIB, 60 * GIB))
+    ct.reset_default_resolver()
+
+    async def _drive():
+        return await asyncio.gather(*(ct.resolve() for _ in range(8)))
+
+    readings = asyncio.run(_drive())
+    assert all(r.total_bytes == 32 * GIB for r in readings)
+    assert calls["n"] == 1, "single-flight must collapse concurrent probes"
+
+
+def test_sync_facade_refuses_to_block_a_running_loop(monkeypatch):
+    """Blocking an event loop to answer a capability question is the
+    failure class this codebase has spent slices removing."""
+    _silence_cascade(monkeypatch, torch=_discrete(32, 30))
+
+    async def _drive():
+        return ct.resolve_sync()
+
+    reading = asyncio.run(_drive())
+    assert reading.degraded is True
+    assert reading.topology is ct.MemoryTopology.UNKNOWN
+
+
+def test_sync_facade_serves_the_cache_after_prewarm(monkeypatch):
+    _silence_cascade(monkeypatch, torch=_discrete(32, 30))
+
+    async def _warm():
+        await ct.prewarm()
+
+    asyncio.run(_warm())
+    reading = ct.resolve_sync()
+    assert reading.topology is ct.MemoryTopology.DISCRETE
+    assert reading.total_bytes == 32 * GIB
+
+
+# ---------------------------------------------------------------------------
+# Locality — the remote-VM trap
+# ---------------------------------------------------------------------------
+
+
+def test_remote_capability_is_not_this_host():
+    assert ct.describes_this_host({"host": "jarvis-brain-gcp-us-central1"}) is False
+
+
+def test_absent_host_field_is_not_proof_of_locality():
+    assert ct.describes_this_host({}) is False
+    assert ct.describes_this_host(None) is False
+
+
+def test_loopback_capability_is_this_host():
+    assert ct.describes_this_host({"host": "127.0.0.1"}) is True
+    assert ct.describes_this_host({"host": "localhost"}) is True
+
+
+def test_local_aliases_are_extensible(monkeypatch):
+    monkeypatch.setenv("JARVIS_COMPUTE_TOPOLOGY_LOCAL_ALIASES", "my-rig")
+    assert ct.describes_this_host({"host": "my-rig"}) is True
+
+
+# ---------------------------------------------------------------------------
+# Admission integration
+# ---------------------------------------------------------------------------
+
+
+def test_admission_admits_a_32gib_host_for_an_l4_class_brain(monkeypatch):
+    """The headline: a card no legacy rung can name passes an L4
+    requirement, because 32 GiB > 24 GiB."""
+    from backend.core.ouroboros.governance.governed_loop_service import (
+        _check_compute_admission,
+    )
+    _silence_cascade(monkeypatch, torch=_discrete(32, 31))
+    asyncio.run(ct.prewarm())
+    _check_compute_admission(
+        {"min_compute_class": "gpu_l4"},
+        {"compute_class": "cpu", "host": "localhost"},
+    )
+
+
+def test_admission_denies_when_the_measured_host_is_too_small(monkeypatch):
+    from backend.core.ouroboros.governance.governed_loop_service import (
+        ComputeClassMismatch,
+        _check_compute_admission,
+    )
+    _silence_cascade(monkeypatch, torch=_discrete(8, 7))
+    asyncio.run(ct.prewarm())
+    with pytest.raises(ComputeClassMismatch):
+        _check_compute_admission(
+            {"min_vram_gb": 27},
+            {"compute_class": "gpu_a100", "host": "localhost"},
+        )
+
+
+def test_admission_uses_ordinal_path_for_a_remote_brain(monkeypatch):
+    """A local 32 GiB card must NOT authorize a route to an undersized
+    remote VM — the wrong-resource error in new clothes."""
+    from backend.core.ouroboros.governance.governed_loop_service import (
+        ComputeClassMismatch,
+        _check_compute_admission,
+    )
+    _silence_cascade(monkeypatch, torch=_discrete(32, 31))
+    asyncio.run(ct.prewarm())
+    with pytest.raises(ComputeClassMismatch):
+        _check_compute_admission(
+            {"min_compute_class": "gpu_a100"},
+            {"compute_class": "gpu_t4", "host": "jarvis-brain-gcp"},
+        )
+
+
+def test_admission_legacy_behaviour_is_unchanged_when_disabled(monkeypatch):
+    from backend.core.ouroboros.governance.governed_loop_service import (
+        ComputeClassMismatch,
+        _check_compute_admission,
+    )
+    monkeypatch.setenv("JARVIS_COMPUTE_TOPOLOGY_ENABLED", "0")
+    ct.reset_default_resolver()
+    _check_compute_admission(
+        {"min_compute_class": "gpu_t4"}, {"compute_class": "gpu_l4"},
+    )
+    with pytest.raises(ComputeClassMismatch):
+        _check_compute_admission(
+            {"min_compute_class": "gpu_a100"}, {"compute_class": "gpu_t4"},
+        )
+
+
+def test_admission_survives_a_module_level_fault(monkeypatch):
+    """A measurement fault must fall back, never deny."""
+    from backend.core.ouroboros.governance import governed_loop_service as gls
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("probe exploded")
+
+    monkeypatch.setattr(ct, "describes_this_host", _boom)
+    gls._check_compute_admission(
+        {"min_compute_class": "gpu_t4"}, {"compute_class": "gpu_l4"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Observability + authority invariant
+# ---------------------------------------------------------------------------
+
+
+def test_prewarm_is_bounded_and_never_raises(monkeypatch):
+    """A wedged driver costs the budget and nothing more — boot is never
+    held open by a capability probe (§2 Progressive Awakening)."""
+    async def _hang():
+        await asyncio.sleep(30)
+        return _discrete(32, 30)
+
+    monkeypatch.setattr(ct, "_probe_torch_cuda", lambda: None)
+    monkeypatch.setattr(ct, "_probe_nvidia_smi_async", _hang)
+    monkeypatch.setattr(ct, "_system_ram_from_canonical_gate",
+                        lambda: (64 * GIB, 60 * GIB))
+    monkeypatch.setenv("JARVIS_COMPUTE_TOPOLOGY_PREWARM_BUDGET_S", "0.5")
+    ct.reset_default_resolver()
+
+    reading = asyncio.run(ct.prewarm())
+    assert reading.degraded is True
+    assert reading.measured is False
+
+
+def test_boot_prewarms_topology_so_admission_is_not_inert():
+    """THE inertness pin. ``_check_compute_admission`` runs inside a running
+    loop, and ``resolve_sync`` refuses to block one. Without a boot prewarm
+    the measured path can never engage — present, tested, never reached.
+    This asserts the boot path still contains that call."""
+    import inspect
+    from backend.core.ouroboros.governance import governed_loop_service as gls
+
+    src = inspect.getsource(gls)
+    assert "compute_topology as _ct_boot" in src
+    assert "_ct_boot.prewarm()" in src
+    # And it must be awaited BEFORE the admission question is asked.
+    assert src.index("_ct_boot.prewarm()") < src.index(
+        "_check_compute_admission(_boot_brain_cfg, cap)",
+    )
+
+
+def test_measured_path_is_reachable_from_an_async_caller(monkeypatch):
+    """Behavioural counterpart to the source pin above: after a prewarm,
+    a caller inside a running loop gets the MEASURED verdict, not a
+    degraded fallback."""
+    from backend.core.ouroboros.governance.governed_loop_service import (
+        ComputeClassMismatch,
+        _check_compute_admission,
+    )
+    _silence_cascade(monkeypatch, torch=_discrete(8, 7))
+
+    async def _boot_then_admit():
+        await ct.prewarm()
+        _check_compute_admission(
+            {"min_vram_gb": 27}, {"compute_class": "gpu_a100", "host": "localhost"},
+        )
+
+    with pytest.raises(ComputeClassMismatch):
+        asyncio.run(_boot_then_admit())
+
+
+def test_snapshot_is_serialisable_and_carries_provenance(monkeypatch):
+    import json
+    _silence_cascade(monkeypatch, torch=_discrete(32, 30))
+    snap = asyncio.run(ct.snapshot())
+    json.dumps(snap)
+    assert snap["source"] == "torch_cuda"
+    assert snap["topology"] == "discrete"
+    assert snap["schema_version"] == ct.COMPUTE_TOPOLOGY_SCHEMA_VERSION
+    assert "free_age_s" in snap
+
+
+def test_authority_invariant_no_forbidden_imports():
+    """§1 — this module measures; it must never reach into governance."""
+    import pathlib
+    src = pathlib.Path(ct.__file__).read_text(encoding="utf-8")
+    for banned in ("orchestrator", "iron_gate", "risk_tier", "change_engine",
+                   "candidate_generator", "policy"):
+        assert f"import {banned}" not in src
+        assert f"from backend.core.ouroboros.governance.{banned}" not in src
+
+
+def test_only_governance_import_is_the_canonical_ram_gate():
+    """DRY, structurally pinned: system RAM has exactly one authority."""
+    import pathlib
+    import re
+    src = pathlib.Path(ct.__file__).read_text(encoding="utf-8")
+    imports = set(re.findall(
+        r"from backend\.core\.ouroboros\.governance import (\w+)", src,
+    )) | set(re.findall(
+        r"from backend\.core\.ouroboros\.governance\.(\w+) import", src,
+    ))
+    assert imports == {"memory_pressure_gate"}, imports
+
+
+# ---------------------------------------------------------------------------
+# Driver-CLI discovery across launch contexts (the WSL2 / stripped-PATH class)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_smi_cache():
+    ct.reset_nvidia_smi_cache()
+    yield
+    ct.reset_nvidia_smi_cache()
+
+
+def _fake_bin(tmp_path, name="nvidia-smi", mode=0o755, kind="file"):
+    p = tmp_path / name
+    if kind == "dir":
+        p.mkdir()
+    elif kind == "deadlink":
+        p.symlink_to(tmp_path / "does-not-exist")
+    else:
+        p.write_text("#!/bin/sh\necho stub\n")
+        p.chmod(mode)
+    return p
+
+
+def test_path_is_searched_first_because_it_is_operator_intent(monkeypatch, tmp_path):
+    """An operator who put a binary on PATH has been explicit; a fallback
+    directory must never outrank that."""
+    path_dir = tmp_path / "on_path"
+    path_dir.mkdir()
+    on_path = _fake_bin(path_dir)
+    monkeypatch.setattr(ct.shutil, "which", lambda n: str(on_path))
+    monkeypatch.setenv("JARVIS_COMPUTE_TOPOLOGY_SMI_DIRS", str(tmp_path))
+    assert ct.resolve_nvidia_smi() == str(on_path)
+
+
+def test_stripped_path_still_finds_the_driver_in_a_search_dir(monkeypatch, tmp_path):
+    """THE regression: a systemd unit / cron job / launchd daemon starts with
+    a sanitized PATH. The host is identical; the answer must not differ."""
+    binary = _fake_bin(tmp_path)
+    monkeypatch.setattr(ct.shutil, "which", lambda n: None)
+    monkeypatch.setenv("JARVIS_COMPUTE_TOPOLOGY_SMI_DIRS", str(tmp_path))
+    assert ct.resolve_nvidia_smi() == str(binary.resolve())
+
+
+def test_wsl_stub_directory_is_searched_by_default():
+    """WSL2 projects the driver into /usr/lib/wsl/lib from the login profile,
+    not from the kernel — it must be a default candidate, not an env opt-in."""
+    assert "/usr/lib/wsl/lib" in ct.nvidia_smi_search_dirs()
+
+
+def test_windows_interop_path_is_ranked_last():
+    """It answers correctly from inside WSL2 and crosses 9p to do it — it
+    must never outrank a native binary."""
+    dirs = ct.nvidia_smi_search_dirs()
+    assert dirs[-1].startswith("/mnt/c"), dirs
+
+
+def test_a_directory_named_like_the_binary_is_not_a_hit(monkeypatch, tmp_path):
+    _fake_bin(tmp_path, kind="dir")
+    monkeypatch.setattr(ct.shutil, "which", lambda n: None)
+    monkeypatch.setenv("JARVIS_COMPUTE_TOPOLOGY_SMI_DIRS", str(tmp_path))
+    assert ct.resolve_nvidia_smi() is None
+
+
+def test_a_dangling_symlink_is_not_a_hit(monkeypatch, tmp_path):
+    _fake_bin(tmp_path, kind="deadlink")
+    monkeypatch.setattr(ct.shutil, "which", lambda n: None)
+    monkeypatch.setenv("JARVIS_COMPUTE_TOPOLOGY_SMI_DIRS", str(tmp_path))
+    assert ct.resolve_nvidia_smi() is None
+
+
+def test_a_present_but_non_executable_file_is_not_a_hit(monkeypatch, tmp_path):
+    _fake_bin(tmp_path, mode=0o644)
+    monkeypatch.setattr(ct.shutil, "which", lambda n: None)
+    monkeypatch.setenv("JARVIS_COMPUTE_TOPOLOGY_SMI_DIRS", str(tmp_path))
+    assert ct.resolve_nvidia_smi() is None
+
+
+def test_windows_exe_suffix_is_a_candidate_name():
+    assert "nvidia-smi.exe" in ct.nvidia_smi_binary_names()
+
+
+def test_search_dirs_are_fully_overridable(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_COMPUTE_TOPOLOGY_SMI_DIRS",
+                       os.pathsep.join([str(tmp_path), "/nope"]))
+    assert ct.nvidia_smi_search_dirs() == (str(tmp_path), "/nope")
+
+
+def test_empty_override_entries_are_skipped(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_COMPUTE_TOPOLOGY_SMI_DIRS",
+                       f"{os.pathsep}  {os.pathsep}{tmp_path}")
+    assert ct.nvidia_smi_search_dirs() == (str(tmp_path),)
+
+
+def test_a_deleted_binary_invalidates_the_cache(monkeypatch, tmp_path):
+    """A package upgrade can delete the resolved path under a long-lived
+    daemon; a stale hit would fail every probe naming the wrong cause."""
+    binary = _fake_bin(tmp_path)
+    monkeypatch.setattr(ct.shutil, "which", lambda n: None)
+    monkeypatch.setenv("JARVIS_COMPUTE_TOPOLOGY_SMI_DIRS", str(tmp_path))
+    assert ct.resolve_nvidia_smi() == str(binary.resolve())
+    binary.unlink()
+    assert ct.resolve_nvidia_smi() is None
+
+
+def test_discovery_is_cached_not_re_walked(monkeypatch, tmp_path):
+    calls = {"n": 0}
+    real = ct._resolve_nvidia_smi_uncached
+
+    def _counting():
+        calls["n"] += 1
+        return real()
+
+    binary = _fake_bin(tmp_path)
+    monkeypatch.setattr(ct.shutil, "which", lambda n: None)
+    monkeypatch.setenv("JARVIS_COMPUTE_TOPOLOGY_SMI_DIRS", str(tmp_path))
+    monkeypatch.setattr(ct, "_resolve_nvidia_smi_uncached", _counting)
+    for _ in range(5):
+        assert ct.resolve_nvidia_smi() == str(binary.resolve())
+    assert calls["n"] == 1
+
+
+def test_absent_driver_is_cached_as_absent(monkeypatch):
+    calls = {"n": 0}
+
+    def _counting():
+        calls["n"] += 1
+        return None
+
+    monkeypatch.setattr(ct.shutil, "which", lambda n: None)
+    monkeypatch.setenv("JARVIS_COMPUTE_TOPOLOGY_SMI_DIRS", "/nonexistent-xyz")
+    monkeypatch.setattr(ct, "_resolve_nvidia_smi_uncached", _counting)
+    for _ in range(3):
+        assert ct.resolve_nvidia_smi() is None
+    assert calls["n"] == 1, "a negative result must not re-walk the filesystem"
+
+
+def test_resolution_never_raises_on_a_hostile_path(monkeypatch):
+    """Inputs that can ACTUALLY arrive. A null byte is not among them —
+    ``os.environ`` rejects one at assignment, so that scenario is
+    unreachable rather than merely unhandled."""
+    monkeypatch.setattr(ct.shutil, "which", lambda n: None)
+    hostile = os.pathsep.join([
+        "/proc/self/mem",          # a device-ish file, not a directory
+        "/root/forbidden",         # permission denied for a normal user
+        "relative/not/absolute",   # never resolves
+        "x" * 4096,                # over PATH_MAX
+    ])
+    monkeypatch.setenv("JARVIS_COMPUTE_TOPOLOGY_SMI_DIRS", hostile)
+    assert ct.resolve_nvidia_smi() is None
+
+
+def test_discovery_runs_off_loop(monkeypatch, tmp_path):
+    """Discovery stats candidate dirs, one of which may be a 9p or network
+    mount where a stat blocks for seconds — it must not sit on the loop."""
+    import inspect
+    src = inspect.getsource(ct._probe_nvidia_smi_async)
+    assert "to_thread(resolve_nvidia_smi)" in src
+
+
+def test_the_binary_is_never_shell_invoked():
+    """An operator-supplied search path must not become an injection
+    surface."""
+    import inspect
+    src = inspect.getsource(ct._probe_nvidia_smi_async)
+    assert "create_subprocess_shell" not in src
+    assert "shell=True" not in src

--- a/tests/governance/test_local_model_admission.py
+++ b/tests/governance/test_local_model_admission.py
@@ -169,7 +169,7 @@ def test_a_broken_probe_admits_rather_than_refusing():
     work. That would let one broken cascade stage silently disable Tier 2 for
     a whole session — a larger outage than the swap storm it guards against.
     """
-    with patch.object(LMA, "_read_pressure",
+    with patch.object(LMA, "_read_host_pressure",
                       return_value=("unknown", -1.0, "unavailable")):
         d = LMA.assess(requested_ctx=8192)
     assert d.proceeds is True
@@ -215,3 +215,463 @@ def test_snapshot_reports_the_live_reading():
     s = LMA.snapshot()
     assert s["schema_version"] == LMA.LOCAL_MODEL_ADMISSION_SCHEMA_VERSION
     assert "level" in s and "free_pct" in s and "source" in s
+
+
+# ---------------------------------------------------------------------------
+# v2 — the accelerator bound, the degradation state, and the adaptive margin
+# ---------------------------------------------------------------------------
+
+import types  # noqa: E402
+
+GIB = 1024 ** 3
+
+
+def _reading(topology="discrete", usable_gib=30.0, resolved="gpu_32gib"):
+    """A compute_topology reading stand-in, duck-typed at the seam LMA uses."""
+    return types.SimpleNamespace(
+        topology=types.SimpleNamespace(value=topology),
+        usable_bytes=int(usable_gib * GIB),
+        resolved_class=resolved, source="torch_cuda",
+        measured=True, free_is_measured=True,
+    )
+
+
+def test_weights_larger_than_free_vram_defer_on_a_healthy_host():
+    """THE v2 regression: 64 GB of free system RAM must not admit a 40 GiB
+    load onto a card with 30 GiB free. v1 had no opinion here."""
+    with patch.object(LMA, "_read_host_pressure",
+                      return_value=("ok", 90.0, "psutil")), \
+         patch.object(LMA, "_read_accelerator", return_value=_reading()):
+        d = LMA.assess(weight_bytes=40 * GIB, model_id="big")
+    assert d.proceeds is False
+    assert d.bound == "accelerator"
+    assert d.max_weight_bytes > 0, "a defer must say what WOULD fit"
+
+
+def test_a_fitting_model_is_admitted_with_the_bound_named():
+    with patch.object(LMA, "_read_host_pressure",
+                      return_value=("ok", 90.0, "psutil")), \
+         patch.object(LMA, "_read_accelerator", return_value=_reading()):
+        d = LMA.assess(weight_bytes=20 * GIB, model_id="ok-model")
+    assert d.proceeds is True
+    assert d.topology == "discrete"
+
+
+def test_unified_does_not_double_count_one_pool():
+    """Under unified memory compute_topology DERIVES its free figure from the
+    RAM gate. Applying both bounds would refuse on one constraint twice."""
+    with patch.object(LMA, "_read_host_pressure",
+                      return_value=("ok", 80.0, "vm_stat")), \
+         patch.object(LMA, "_read_accelerator",
+                      return_value=_reading("unified", 9.0, "unified_12gib")):
+        d = LMA.assess(weight_bytes=40 * GIB, model_id="m")
+    # Host bound is OK, so it admits — the accelerator bound is skipped
+    # rather than counted a second time.
+    assert d.proceeds is True
+    assert d.bound != "accelerator"
+
+
+def test_no_stated_footprint_reproduces_v1_exactly():
+    """A caller that does not declare weights gets the host bound alone —
+    nothing is inferred on its behalf."""
+    with patch.object(LMA, "_read_host_pressure",
+                      return_value=("ok", 90.0, "psutil")), \
+         patch.object(LMA, "_read_accelerator", return_value=_reading()):
+        d = LMA.assess(requested_ctx=8192)
+    assert d.proceeds is True
+    assert d.weight_bytes == 0
+
+
+def test_unmeasured_topology_admits_small_and_refuses_large(monkeypatch):
+    """Fail-open on WHETHER to run, fail-closed on HOW BIG."""
+    monkeypatch.setenv("JARVIS_LOCAL_MODEL_UNKNOWN_CEILING_GB", "8")
+    with patch.object(LMA, "_read_host_pressure",
+                      return_value=("ok", 90.0, "psutil")), \
+         patch.object(LMA, "_read_accelerator", return_value=None):
+        small = LMA.assess(weight_bytes=4 * GIB, model_id="small")
+        large = LMA.assess(weight_bytes=40 * GIB, model_id="large")
+    assert small.proceeds is True
+    assert large.proceeds is False
+    assert large.topology == "unknown"
+
+
+def test_malformed_topology_object_degrades_rather_than_raising():
+    """A host returning garbage must not take the gate down with it."""
+    junk = types.SimpleNamespace()  # no topology, no usable_bytes
+    with patch.object(LMA, "_read_host_pressure",
+                      return_value=("ok", 90.0, "psutil")), \
+         patch.object(LMA, "_read_accelerator", return_value=junk):
+        d = LMA.assess(weight_bytes=4 * GIB)
+    assert d.proceeds is True
+
+
+def test_topology_probe_that_raises_never_blocks_admission():
+    def _boom():
+        raise RuntimeError("driver hung")
+    with patch.object(LMA, "_read_host_pressure",
+                      return_value=("ok", 90.0, "psutil")), \
+         patch.object(LMA, "_read_accelerator", _boom):
+        try:
+            d = LMA.assess(weight_bytes=4 * GIB)
+        except Exception as exc:  # pragma: no cover
+            raise AssertionError(f"assess must never raise: {exc}")
+    assert d.proceeds is True
+
+
+def test_observed_ooms_raise_the_margin_and_narrow_what_fits(monkeypatch):
+    """Contiguity is unobservable, so the margin is LEARNED. An OOM at a
+    given size must make the next identical request stricter."""
+    monkeypatch.setenv("JARVIS_LOCAL_MODEL_MARGIN_BASE", "0.05")
+    monkeypatch.setenv("JARVIS_LOCAL_MODEL_MARGIN_STEP", "0.20")
+    LMA._margin_ledger.__init__()
+
+    before = LMA._margin_ledger.fraction_for("m")
+    LMA.record_load_outcome("m", ok=False, error=RuntimeError("CUDA out of memory"))
+    after = LMA._margin_ledger.fraction_for("m")
+    assert after > before
+
+    with patch.object(LMA, "_read_host_pressure",
+                      return_value=("ok", 90.0, "psutil")), \
+         patch.object(LMA, "_read_accelerator", return_value=_reading()):
+        d = LMA.assess(weight_bytes=27 * GIB, model_id="m")
+    assert d.margin_bytes > 0
+    assert d.proceeds is False, "the learned margin must actually bind"
+
+
+def test_margin_is_capped_so_a_host_cannot_learn_to_refuse_everything(monkeypatch):
+    monkeypatch.setenv("JARVIS_LOCAL_MODEL_MARGIN_MAX", "0.30")
+    LMA._margin_ledger.__init__()
+    for _ in range(50):
+        LMA.record_load_outcome("m", ok=False, error=MemoryError("oom"))
+    assert LMA._margin_ledger.fraction_for("m") <= 0.30
+
+
+def test_a_clean_load_retires_a_prior_oom():
+    LMA._margin_ledger.__init__()
+    LMA.record_load_outcome("m", ok=False, error=MemoryError("oom"))
+    raised = LMA._margin_ledger.fraction_for("m")
+    LMA.record_load_outcome("m", ok=True)
+    assert LMA._margin_ledger.fraction_for("m") < raised
+
+
+def test_a_non_memory_failure_teaches_the_host_nothing():
+    """A 404 on a missing artifact says nothing about capacity. Letting it
+    raise the margin would teach a superstition."""
+    LMA._margin_ledger.__init__()
+    base = LMA._margin_ledger.fraction_for("m")
+    LMA.record_load_outcome("m", ok=False, error=FileNotFoundError("no such model"))
+    assert LMA._margin_ledger.fraction_for("m") == base
+
+
+def test_snapshot_carries_both_bounds_for_the_operator():
+    with patch.object(LMA, "_read_host_pressure",
+                      return_value=("ok", 90.0, "psutil")), \
+         patch.object(LMA, "_read_accelerator", return_value=_reading()):
+        snap = LMA.snapshot()
+    import json
+    json.dumps(snap)
+    assert snap["schema_version"].endswith("v2")
+    assert snap["accelerator"]["topology"] == "discrete"
+    assert "observed_ooms" in snap
+
+
+def test_dry_admission_derives_neither_reading_itself():
+    """Strict single-source-of-truth: both bounds are CONSUMED, never
+    re-derived. Checked against the AST rather than the prose — the module
+    legitimately DISCUSSES psutil and vm_stat in its docstring while calling
+    neither, and a substring match cannot tell an explanation from a use."""
+    import ast, pathlib
+    tree = ast.parse(pathlib.Path(LMA.__file__).read_text(encoding="utf-8"))
+    imported = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(a.name.split(".")[0] for a in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module.split(".")[0])
+            if node.module.startswith("backend.core.ouroboros.governance"):
+                tail = node.module.split(".")[-1]
+                if tail != "governance":
+                    imported.add(tail)
+                imported.update(a.name for a in node.names)
+    # It may not reach for either probe substrate directly.
+    assert "psutil" not in imported, "system RAM belongs to memory_pressure_gate"
+    assert "subprocess" not in imported, "accelerator belongs to compute_topology"
+    # Its governance surface is exactly the two canonical readings.
+    governance = imported & {"compute_topology", "memory_pressure_gate",
+                             "runtime_health_types", "get_default_gate"}
+    assert "compute_topology" in governance
+    assert "memory_pressure_gate" in governance
+
+
+# ---------------------------------------------------------------------------
+# The last link — policy footprint reaches the gate, outcomes reach the ledger
+# ---------------------------------------------------------------------------
+
+
+def test_policy_declares_a_footprint_for_every_required_brain():
+    """A brain with no declared weight silently disables the accelerator
+    bound for that route. Absence must be a decision, not an oversight."""
+    from backend.core.ouroboros.governance import brain_selector as bs
+    policy = bs._footprint_policy()
+    required = (policy.get("brains") or {}).get("required") or []
+    assert required, "policy has no required brains"
+    for entry in required:
+        bid = entry.get("brain_id")
+        assert bs.footprint_bytes_for(bid) > 0, f"{bid} declares no weight_gb"
+
+
+def test_unknown_brain_declares_nothing_rather_than_guessing():
+    from backend.core.ouroboros.governance import brain_selector as bs
+    assert bs.footprint_bytes_for("no-such-brain") == 0
+    assert bs.footprint_bytes_for(None) == 0
+
+
+@pytest.mark.asyncio
+async def test_provider_passes_the_declared_footprint_to_the_gate():
+    """THE inertness pin for the last link. If the provider stops passing a
+    footprint, the accelerator bound silently stops binding and v2 degrades
+    to v1 with nobody noticing."""
+    from backend.core.ouroboros.governance.providers import PrimeProvider
+
+    seen = {}
+
+    def _spy(requested_ctx=None, *, weight_bytes=0, model_id=None):
+        seen["weight_bytes"] = weight_bytes
+        seen["model_id"] = model_id
+        return LMA.AdmissionDecision(action=LMA.Admission.DEFER.value,
+                                     reason="spy")
+
+    ri = SimpleNamespace(brain_id="qwen_coder_32b",
+                         brain_model="qwen-2.5-coder-32b",
+                         routing_reason="x", task_complexity="heavy")
+    ctx = SimpleNamespace(op_id="op-w", telemetry=SimpleNamespace(routing_intent=ri))
+
+    p = PrimeProvider.__new__(PrimeProvider)
+    p._generate_impl = lambda *a, **k: None
+    p._max_tokens = 8192
+
+    with patch.object(LMA, "assess", _spy):
+        await p.generate(context=ctx, deadline=None)
+
+    assert seen["model_id"] == "qwen_coder_32b"
+    assert seen["weight_bytes"] > 0, "the declared footprint never reached the gate"
+
+
+@pytest.mark.asyncio
+async def test_provider_survives_a_brain_with_no_routing_intent():
+    """No telemetry is the common case for many callers — it must degrade to
+    the host bound, not fault."""
+    from backend.core.ouroboros.governance.providers import PrimeProvider
+
+    p = PrimeProvider.__new__(PrimeProvider)
+    p._generate_impl = lambda *a, **k: None
+    p._max_tokens = 8192
+
+    with _at(96.0):
+        result = await p.generate(context=SimpleNamespace(op_id="op-n",
+                                                          telemetry=None),
+                                  deadline=None)
+    assert result.candidates == ()
+
+
+# ---------------------------------------------------------------------------
+# Anticipatory ledger — concurrent workers, and the self-healing reconciler
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_ledgers():
+    LMA._vram_ledger.__init__()
+    LMA._margin_ledger.__init__()
+    yield
+    LMA._vram_ledger.__init__()
+    LMA._margin_ledger.__init__()
+
+
+def _discrete_at(usable_gib):
+    return types.SimpleNamespace(
+        topology=types.SimpleNamespace(value="discrete"),
+        usable_bytes=int(usable_gib * GIB), resolved_class="gpu_32gib",
+        source="torch_cuda", measured=True, free_is_measured=True)
+
+
+def test_concurrent_workers_cannot_collectively_overcommit():
+    """THE race: three workers each ask against the SAME free reading. Without
+    a ledger the gate is correct three times and the machine still OOMs."""
+    with patch.object(LMA, "_read_host_pressure",
+                      return_value=("ok", 90.0, "psutil")), \
+         patch.object(LMA, "_read_accelerator", return_value=_discrete_at(27)):
+        a = LMA.assess(weight_bytes=12 * GIB, model_id="w")
+        b = LMA.assess(weight_bytes=12 * GIB, model_id="w")
+        c = LMA.assess(weight_bytes=12 * GIB, model_id="w")
+    assert a.proceeds and b.proceeds
+    assert not c.proceeds, "the third worker overcommitted a 27 GiB card"
+    assert c.bound == "accelerator"
+
+
+def test_releasing_a_claim_frees_the_next_worker():
+    with patch.object(LMA, "_read_host_pressure",
+                      return_value=("ok", 90.0, "psutil")), \
+         patch.object(LMA, "_read_accelerator", return_value=_discrete_at(27)):
+        a = LMA.assess(weight_bytes=12 * GIB, model_id="w")
+        b = LMA.assess(weight_bytes=12 * GIB, model_id="w")
+        assert not LMA.assess(weight_bytes=12 * GIB, model_id="w").proceeds
+        LMA.release_reservation(a.reservation_id)
+        assert LMA.assess(weight_bytes=12 * GIB, model_id="w").proceeds
+
+
+def test_an_admit_carries_a_reservation_id_to_release():
+    with patch.object(LMA, "_read_host_pressure",
+                      return_value=("ok", 90.0, "psutil")), \
+         patch.object(LMA, "_read_accelerator", return_value=_discrete_at(27)):
+        d = LMA.assess(weight_bytes=10 * GIB, model_id="w")
+    assert d.proceeds and d.reservation_id
+
+
+def test_release_is_idempotent_and_null_safe():
+    LMA.release_reservation(None)
+    LMA.release_reservation("nope")
+    with patch.object(LMA, "_read_host_pressure",
+                      return_value=("ok", 90.0, "psutil")), \
+         patch.object(LMA, "_read_accelerator", return_value=_discrete_at(27)):
+        d = LMA.assess(weight_bytes=10 * GIB, model_id="w")
+    LMA.release_reservation(d.reservation_id)
+    LMA.release_reservation(d.reservation_id)
+
+
+def test_a_phantom_claim_is_reconciled_on_evidence_not_a_timer(monkeypatch):
+    """A worker crashed between admission and load. Free memory NEVER fell,
+    so the promised allocation provably never happened — drop it, rather than
+    throttling everyone else until a timeout expires."""
+    monkeypatch.setenv("JARVIS_VRAM_RECONCILE_AFTER_S", "1")
+    with patch.object(LMA, "_read_host_pressure",
+                      return_value=("ok", 90.0, "psutil")), \
+         patch.object(LMA, "_read_accelerator", return_value=_discrete_at(27)):
+        dead = LMA.assess(weight_bytes=20 * GIB, model_id="crasher")
+        assert dead.proceeds
+        # The worker dies. Age its claim past the reconcile floor — the floor
+        # is deliberate: a claim must never be reconcilable the instant it is
+        # made, or the ledger could not hold anything.
+        for r in LMA._vram_ledger._live.values():
+            r.granted_at -= 5.0
+        # It never released, and never allocated — so free bytes are
+        # unchanged on the next look.
+        revived = LMA.assess(weight_bytes=20 * GIB, model_id="next")
+    assert revived.proceeds, "a phantom claim throttled a healthy worker"
+    assert LMA._vram_ledger.snapshot()["phantoms_dropped"] >= 1
+
+
+def test_a_slow_but_live_worker_is_not_reconciled_away(monkeypatch):
+    """The counterpart: free memory HAS fallen, so the allocation is really
+    happening. A timer alone could not tell these two apart."""
+    monkeypatch.setenv("JARVIS_VRAM_RECONCILE_AFTER_S", "1")
+    with patch.object(LMA, "_read_host_pressure",
+                      return_value=("ok", 90.0, "psutil")), \
+         patch.object(LMA, "_read_accelerator", return_value=_discrete_at(27)):
+        live = LMA.assess(weight_bytes=20 * GIB, model_id="slow")
+        assert live.proceeds
+        for r in LMA._vram_ledger._live.values():
+            r.granted_at -= 5.0
+    # Now the loader has actually consumed the memory.
+    with patch.object(LMA, "_read_host_pressure",
+                      return_value=("ok", 90.0, "psutil")), \
+         patch.object(LMA, "_read_accelerator", return_value=_discrete_at(6)):
+        nxt = LMA.assess(weight_bytes=20 * GIB, model_id="next")
+    assert not nxt.proceeds
+    assert LMA._vram_ledger.snapshot()["phantoms_dropped"] == 0
+
+
+def test_settled_claims_stop_being_counted(monkeypatch):
+    """Past the settle window the OS probe carries the allocation; continuing
+    to subtract it would double-count one set of bytes."""
+    monkeypatch.setenv("JARVIS_VRAM_RESERVATION_SETTLE_S", "1")
+    monkeypatch.setenv("JARVIS_VRAM_RECONCILE_AFTER_S", "99999")
+    with patch.object(LMA, "_read_host_pressure",
+                      return_value=("ok", 90.0, "psutil")), \
+         patch.object(LMA, "_read_accelerator", return_value=_discrete_at(27)):
+        LMA.assess(weight_bytes=20 * GIB, model_id="w")
+        for r in LMA._vram_ledger._live.values():
+            r.granted_at -= 5.0            # age it past the settle window
+        again = LMA.assess(weight_bytes=20 * GIB, model_id="w2")
+    assert again.proceeds
+
+
+def test_reconciliation_never_invents_a_claim():
+    """Direction of authority is fixed: the OS is fact, the ledger is a
+    prediction. Reconciliation may only DROP, never add."""
+    before = LMA._vram_ledger.snapshot()["live"]
+    LMA._vram_ledger._reconcile(free_now=99 * GIB)
+    assert LMA._vram_ledger.snapshot()["live"] == before
+
+
+def test_no_evidence_leaves_every_claim_standing():
+    """free_now == 0 is 'we could not read', not 'nothing is free'."""
+    with patch.object(LMA, "_read_host_pressure",
+                      return_value=("ok", 90.0, "psutil")), \
+         patch.object(LMA, "_read_accelerator", return_value=_discrete_at(27)):
+        LMA.assess(weight_bytes=10 * GIB, model_id="w")
+    live = LMA._vram_ledger.snapshot()["live"]
+    LMA._vram_ledger._reconcile(free_now=0)
+    assert LMA._vram_ledger.snapshot()["live"] == live
+
+
+def test_unified_hosts_take_no_reservations():
+    """One pool — there is nothing distinct to overcommit, so a claim here
+    would be bookkeeping that only ever throttles."""
+    with patch.object(LMA, "_read_host_pressure",
+                      return_value=("ok", 90.0, "vm_stat")), \
+         patch.object(LMA, "_read_accelerator",
+                      return_value=types.SimpleNamespace(
+                          topology=types.SimpleNamespace(value="unified"),
+                          usable_bytes=9 * GIB, resolved_class="unified_12gib",
+                          source="unified", measured=True,
+                          free_is_measured=False)):
+        d = LMA.assess(weight_bytes=4 * GIB, model_id="w")
+    assert d.proceeds
+    assert d.reservation_id is None
+
+
+@pytest.mark.asyncio
+async def test_assess_async_forces_a_jit_reread():
+    """The sync form serves a cache; the async form must re-read before it
+    authorizes an allocation."""
+    from backend.core.ouroboros.governance import compute_topology as ct
+    calls = {"n": 0}
+
+    async def _jit():
+        calls["n"] += 1
+        return None
+
+    with patch.object(ct, "is_enabled", lambda: True), \
+         patch.object(ct, "resolve_jit", _jit), \
+         patch.object(LMA, "_read_host_pressure",
+                      return_value=("ok", 90.0, "psutil")), \
+         patch.object(LMA, "_read_accelerator", return_value=_discrete_at(27)):
+        d = await LMA.assess_async(weight_bytes=10 * GIB, model_id="w")
+    assert calls["n"] == 1
+    assert d.proceeds
+
+
+@pytest.mark.asyncio
+async def test_assess_async_survives_a_failed_jit_probe():
+    """A stale reading beats no ruling — the gate must not fault because a
+    driver query timed out."""
+    from backend.core.ouroboros.governance import compute_topology as ct
+
+    async def _boom():
+        raise RuntimeError("driver wedged")
+
+    with patch.object(ct, "is_enabled", lambda: True), \
+         patch.object(ct, "resolve_jit", _boom), \
+         patch.object(LMA, "_read_host_pressure",
+                      return_value=("ok", 90.0, "psutil")), \
+         patch.object(LMA, "_read_accelerator", return_value=_discrete_at(27)):
+        d = await LMA.assess_async(weight_bytes=10 * GIB, model_id="w")
+    assert d.proceeds
+
+
+def test_snapshot_exposes_the_ledger_for_the_operator():
+    snap = LMA.snapshot()
+    assert "reservations" in snap
+    assert set(snap["reservations"]) >= {"live", "promised_gib",
+                                         "phantoms_dropped", "owners"}


### PR DESCRIPTION
## The defect

`local_model_admission` guarded weight-loads by asking `memory_pressure_gate` for headroom — and every stage of that cascade (`psutil` → `/proc/meminfo` → `vm_stat`) measures **system RAM**. On the 16 GB M1 that is the whole story: unified memory means one pool, so a system-RAM reading genuinely predicts whether a load will page the machine and take the audio graph down with it.

On a discrete-GPU host the premise inverts. System RAM stops predicting anything about a load that lands in VRAM: the gate reads 64 GB of DDR5, finds abundant headroom, and admits a model whose real ceiling is a card it has no probe for.

Not a stale threshold — **a hardware topology assumed by shared reasoning**, correct where it was written and unstated everywhere else.

## What changed

**`compute_topology.py`** (new) measures the accelerator and classifies the pool. It never probes system RAM: under `unified` it defers to the canonical gate outright, because a second opinion there would be a second thing to keep true. Cascade is `torch.cuda` → `nvidia-smi` → `unified` → `cpu_only`, authority-descending, with a *declining* stage distinguished from a *failing* one so a broken driver cannot masquerade as a machine with no GPU. Identity is pinned on first success; only free bytes carry a TTL.

**Admission compares bytes, not ordinals.** `_COMPUTE_RANK` ranked GPUs by name, which is why a 32 GiB consumer card had no representable class and every future card was a code change. Legacy `min_compute_class` strings now resolve to the capacity they imply, brains may state `min_vram_gb` directly, and a 32 GiB host passes a `gpu_l4` requirement because 32 > 24.

**Locality is proven, never assumed.** `capability` is fetched over HTTP from a J-Prime endpoint that may be a GCP VM, so the measured path engages only when `describes_this_host` positively matches. Authorizing a remote route with a local GPU reading would be the same wrong-resource error in new clothes.

## Contiguous VRAM is not observable

No CUDA or NVML call returns the largest allocatable block, so a fit cannot be proven in advance — only attempted and observed. Three mechanisms follow:

- **Learned margin** — base 8%, +6% per observed OOM, capped, decaying. The load is the authority no probe can be.
- **Anticipatory ledger** — N concurrent workers (3 pool workers + L3 fan-out) can each pass against the same reading and collectively overcommit. A grant is recorded at ADMIT so the next caller sees free bytes minus what is promised.
- **Evidence-based reconciliation** — a claim whose promised allocation *provably never happened* (free bytes did not fall) is dropped. This distinguishes a dead worker from a slow one, where a timeout could not. The OS is fact and the ledger is a prediction, so reconciliation may only ever drop claims, never invent one.

VRAM claims deliberately do **not** route through `ProactiveResourceGuard` — its unsettled total is subtracted from system-RAM free-%, so posting VRAM bytes there would corrupt the RAM dimension for every unrelated consumer. Same contract, separate pool.

## Failure posture

Unknown topology fails **open on whether to run** and **closed on how big**: an unresolved host still serves a small model — refusing everything would be the session-wide outage the v1 fail-toward-OK posture exists to prevent — but may not blind-load a frontier model onto capacity nobody could read.

Driver-CLI discovery no longer depends on `PATH` alone, a variable the launch context owns rather than the machine: WSL2 injects its GPU stub dir from the login profile, so a shell finds `nvidia-smi` and a systemd unit does not. Same hardware, different verdict.

Boot prewarms the reading. Without it the measured path could never engage — `_check_compute_admission` runs inside a live loop and the sync facade refuses to block one — so the whole gate would be **wired but inert**. Pinned by a test.

## Evidence

- **111 tests.** Behaviour under substituted probes, so the suite runs identically on the M1, a discrete-GPU host, and a GPU-less CI container.
- **Live-verified on the M1**: `unified`, 12 GiB budgeted from 16 GB, correctly refusing a 27 GiB load — a refusal the old path had no opinion about.
- Baseline reds unchanged (17 failed / 115 passed with *and* without the change, verified by stashing).
- `ov doctor` edge 9 answers with the daemon down, which is the fresh-box case.

## Not proven

**The discrete path has never touched real hardware** — substituted probes only. Unverified until the target machine exists: `nvidia-smi` output under WSL2, `torch.cuda.mem_get_info` on Blackwell `sm_120`, and whether the 256 MiB reconcile epsilon suits a desktop compositor's VRAM churn.

Default-off behind `JARVIS_COMPUTE_TOPOLOGY_ENABLED`; legacy behaviour is byte-identical when disabled or when topology is unresolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Admission measures the pool weights land in and enforces VRAM ceilings. Previously `local_model_admission` gated on system RAM, which mis-admitted loads on discrete-GPU hosts; now `compute_topology` detects unified vs GPU VRAM and admission compares byte capacity.

- Enable with `JARVIS_COMPUTE_TOPOLOGY_ENABLED=1`; disabled keeps legacy behavior byte-identical.
- Policy authors: add `min_vram_gb` and `weight_gb` to brains; legacy `min_compute_class` still resolves to a capacity.
- Unknown topology serves small models only; the ceiling is configurable via `JARVIS_LOCAL_MODEL_UNKNOWN_CEILING_GB`.
- Measured path: `torch.cuda` → `nvidia-smi` → unified → cpu-only; identity is pinned on first success, free-bytes readings carry a TTL; engages only when capability describes this host.
- Admission adds a learned margin, an anticipatory VRAM ledger, and evidence-based reconciliation; VRAM accounting is separate from system-RAM guards.
- `ov doctor` adds Edge 9 to report accelerator and admission ceiling without a running daemon.
- Primary review focus: `compute_topology.py`, `local_model_admission.py` (v2 schema, VRAM ledger/margin), `governed_loop_service.py` (byte-based admission), `brain_selection_policy.yaml` (new fields), and tests.

<sup>Written for commit aa21e65fa65d53db119f7d3465f3758871213021. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

