### PR TITLE
feat(link): the Body/Engine protocol core, as provable logic

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,44 @@
+# Line endings — normalise in the repository, check out LF everywhere.
+#
+# This repo is developed on macOS and Linux (WSL2) simultaneously. Without
+# this file a checkout made by Git-for-Windows at `core.autocrlf=true`
+# rewrites every file with CRLF, which breaks shebangs (`#!/usr/bin/env
+# python3\r` is not an interpreter), shell scripts, and any test that
+# compares file bytes. The failure is silent at checkout and loud at run
+# time, on a machine that has not yet run anything successfully.
+#
+# `text=auto eol=lf` normalises on commit and checks out LF on every
+# platform, so the working tree is byte-identical on the Mac and in WSL2.
+* text=auto eol=lf
+
+# Binary — never touched, never diffed as text.
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.icns binary
+*.pdf binary
+*.zip binary
+*.gz binary
+*.tar binary
+*.whl binary
+*.gguf binary
+*.onnx binary
+*.npz binary
+*.pt binary
+*.pth binary
+*.bin binary
+*.dylib binary
+*.so binary
+*.dll binary
+*.pyc binary
+*.wav binary
+*.mp3 binary
+*.mp4 binary
+*.mov binary
+
+# Windows-native scripts keep CRLF — cmd.exe and PowerShell require it.
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf

--- a/backend/core/ouroboros/governance/link_protocol.py
+++ b/backend/core/ouroboros/governance/link_protocol.py
@@ -1,0 +1,706 @@
+"""link_protocol — the Body/Engine link, as logic with no socket in it.
+
+THE TOPOLOGY THIS SERVES
+------------------------
+The Body (macOS) keeps the sensor edge: CoreAudio, AppKit, Quartz capture,
+the cockpit. The Engine (Windows/WSL2) holds the accelerator and runs the
+11-phase FSM. They are separate machines on separate premises, reached over
+an overlay network (Tailscale/mTLS) whose availability is nobody's to
+assume.
+
+Everything here is pure: clocks, sequence arithmetic, admission decisions,
+resume planning. No sockets, no asyncio, no transport. That is deliberate —
+a distributed protocol whose correctness can only be observed by running two
+machines is a protocol that will be debugged in production. This module is
+the part that can be proven at a desk, and both ends import the SAME
+implementation, so the two sides cannot disagree about the rules by drifting
+apart in two codebases.
+
+WHY THREE PRIMITIVES, AND NOT A FRAMEWORK
+-----------------------------------------
+The link has exactly three hard problems. Each gets one primitive, and
+nothing here is general-purpose beyond them.
+
+**1. The two clocks are not comparable.** The Mac's wall clock and a WSL2
+VM's wall clock drift — the VM's especially, since it is suspended and
+resumed with the host and re-syncs on its own schedule. Any rule of the form
+"reject frames older than N seconds" computed across that boundary is a
+random number generator. So:
+
+    A timestamp that crosses a machine boundary is DATA, never a clock.
+
+Ordering uses a Lamport clock (:class:`LogicalClock`); durations use each
+side's own ``time.monotonic()`` and are never differenced against the peer's.
+A remote wall-clock stamp may be displayed to an operator and may never
+reach a decision.
+
+**2. A reconnect must not create state.** Roaming access points produce
+connection flapping — fifty attempts in ten seconds is ordinary, not
+pathological. That only exhausts an engine if each *connection* allocates a
+session, a queue and a task. So session identity is separate from connection
+identity (:class:`SessionRegistry`): the socket is disposable, the session
+survives it, and a reconnect RESUMES. Admission is then a bounded question
+about attempt rate (:class:`FlapBreaker`) rather than an unbounded one about
+handler count.
+
+**3. A verdict can be lost mid-flight.** The Engine finishes a heavy op,
+emits the verdict, and the socket ruptures between ``send`` and ``recv``.
+Exactly-once *delivery* is unachievable over an unreliable link; exactly-once
+*effect* is achievable, and is the difference between a protocol that works
+and one that hopes. It needs three things, all present here: a durable
+monotonic sequence at the source, replay of a range on request
+(:class:`ResumePlan`), and idempotent application at the sink
+(:class:`DeliveryLedger`).
+
+WHAT THIS MODULE DOES NOT DO
+----------------------------
+It does not transport bytes, hold a socket, or own a task. The telemetry
+lane belongs to ``ide_observability_stream`` — a bounded broker with
+``Last-Event-ID`` replay, drop-oldest backpressure and a heartbeat, which is
+already the correct shape for lossy high-frequency frames. Durability of the
+command lane belongs to ``durable_io`` — ``atomic_replace`` plus the fsync
+discipline that makes "we wrote it" mean "it survives". Neither is
+reimplemented here; this module supplies the ORDERING and ADMISSION rules
+those two lanes execute.
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import enum
+import logging
+import os
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+logger = logging.getLogger("Ouroboros.LinkProtocol")
+
+LINK_PROTOCOL_SCHEMA_VERSION: str = "link_protocol.1"
+
+
+# ---------------------------------------------------------------------------
+# Env helpers — same shape as every other governance module here.
+# ---------------------------------------------------------------------------
+
+
+def _env_float(name: str, default: float, minimum: float = 0.0) -> float:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return max(minimum, float(raw))
+    except (TypeError, ValueError):
+        return default
+
+
+def _env_int(name: str, default: int, minimum: int = 0) -> int:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return max(minimum, int(raw))
+    except (TypeError, ValueError):
+        return default
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in ("1", "true", "yes", "on")
+
+
+def is_enabled() -> bool:
+    """Master switch. Default **false** pending graduation."""
+    return _env_bool("JARVIS_LINK_BRIDGE_ENABLED", False)
+
+
+# ---------------------------------------------------------------------------
+# 1. Logical time — immune to NTP desync by construction
+# ---------------------------------------------------------------------------
+
+
+class LogicalClock:
+    """A Lamport clock: ordering without a shared notion of "now".
+
+    Two rules, and they are the whole algorithm:
+
+    * every local event increments the counter (:meth:`tick`);
+    * every received frame sets the counter to ``max(local, remote) + 1``
+      (:meth:`observe`).
+
+    What that buys is the only ordering guarantee that survives clock drift:
+    **if event A caused event B, then ``A.lamport < B.lamport``.** The
+    converse does not hold — two concurrent events may carry any relative
+    values — and that is not a defect. Concurrency is a real property of a
+    distributed system, and a protocol that pretends to totally order
+    genuinely-concurrent events has invented information.
+
+    Ties break on ``node_id`` when a total order is required for display, so
+    the two ends render history in the same sequence without either one's
+    wall clock being consulted.
+
+    Thread-safe. Monotone by construction: the counter never moves backwards,
+    which is precisely what a re-synced NTP daemon does to a wall clock.
+    """
+
+    def __init__(self, node_id: str) -> None:
+        self._node_id = str(node_id)
+        self._lock = threading.Lock()
+        self._counter = 0
+
+    @property
+    def node_id(self) -> str:
+        return self._node_id
+
+    def tick(self) -> int:
+        """Stamp a locally-originated event."""
+        with self._lock:
+            self._counter += 1
+            return self._counter
+
+    def observe(self, remote: Optional[int]) -> int:
+        """Fold a peer's stamp in on receipt. Returns the new local value.
+
+        A malformed or absent remote stamp advances the clock anyway rather
+        than raising: a peer that cannot count must not be able to stop this
+        side from ordering its own events.
+        """
+        try:
+            remote_val = int(remote) if remote is not None else 0
+        except (TypeError, ValueError):
+            remote_val = 0
+        with self._lock:
+            self._counter = max(self._counter, max(0, remote_val)) + 1
+            return self._counter
+
+    def peek(self) -> int:
+        with self._lock:
+            return self._counter
+
+    def stamp(self) -> Tuple[int, str]:
+        """``(lamport, node_id)`` — the tuple that totally orders for display."""
+        return self.tick(), self._node_id
+
+
+def happens_before(a: Tuple[int, str], b: Tuple[int, str]) -> bool:
+    """Total order over ``(lamport, node_id)`` stamps.
+
+    Causal where causality exists, deterministic where it does not — which
+    is what a UI needs to render two machines' events in one list without
+    either side's wall clock being involved.
+    """
+    return (int(a[0]), str(a[1])) < (int(b[0]), str(b[1]))
+
+
+@dataclass(frozen=True)
+class LinkFrame:
+    """One unit crossing the link.
+
+    ``sender_wall_ns`` is carried for HUMAN display and forensics only. It is
+    named to make misuse obvious at the call site: any code that differences
+    it against a local clock has reintroduced the drift bug this module
+    exists to remove.
+    """
+
+    seq: int
+    lamport: int
+    node_id: str
+    kind: str
+    payload: Dict[str, Any] = field(default_factory=dict)
+    #: DISPLAY ONLY. Never an input to a decision. See the class docstring.
+    sender_wall_ns: int = 0
+    schema_version: str = LINK_PROTOCOL_SCHEMA_VERSION
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.schema_version, "seq": self.seq,
+            "lamport": self.lamport, "node_id": self.node_id,
+            "kind": self.kind, "payload": self.payload,
+            "sender_wall_ns": self.sender_wall_ns,
+        }
+
+    @staticmethod
+    def from_dict(raw: Any) -> Optional["LinkFrame"]:
+        """Parse a frame off the wire. Returns None on anything malformed.
+
+        Never raises and never partially trusts: a frame missing its ordering
+        fields is not a frame with defaults, it is garbage, and admitting it
+        with ``seq=0`` would corrupt the resume arithmetic of a link that was
+        otherwise healthy.
+        """
+        try:
+            if not isinstance(raw, dict):
+                return None
+            seq = int(raw["seq"])
+            lamport = int(raw["lamport"])
+            node_id = str(raw["node_id"])
+            kind = str(raw["kind"])
+            if seq < 0 or lamport < 0 or not node_id or not kind:
+                return None
+            payload = raw.get("payload")
+            return LinkFrame(
+                seq=seq, lamport=lamport, node_id=node_id, kind=kind,
+                payload=payload if isinstance(payload, dict) else {},
+                sender_wall_ns=int(raw.get("sender_wall_ns") or 0),
+            )
+        except (KeyError, TypeError, ValueError):
+            return None
+
+
+# ---------------------------------------------------------------------------
+# 2. Flap admission — the socket is disposable, the session is not
+# ---------------------------------------------------------------------------
+
+
+def flap_window_s() -> float:
+    """Rolling window over which connection attempts are counted."""
+    return _env_float("JARVIS_LINK_FLAP_WINDOW_S", 10.0, minimum=0.5)
+
+
+def flap_max_attempts() -> int:
+    """Attempts per identity per window before the breaker opens."""
+    return _env_int("JARVIS_LINK_FLAP_MAX_ATTEMPTS", 8, minimum=1)
+
+
+def flap_open_s() -> float:
+    """How long the breaker stays open once tripped."""
+    return _env_float("JARVIS_LINK_FLAP_OPEN_S", 15.0, minimum=0.5)
+
+
+def flap_max_identities() -> int:
+    """Hard cap on tracked identities — a memory bound, not a policy.
+
+    This topology has one Body, so the steady state is a handful. The cap
+    exists for the pathological case: a peer cycling session ids faster than
+    the window retires them.
+    """
+    return _env_int("JARVIS_LINK_FLAP_MAX_IDENTITIES", 512, minimum=8)
+
+
+def backoff_base_s() -> float:
+    return _env_float("JARVIS_LINK_BACKOFF_BASE_S", 0.5, minimum=0.05)
+
+
+def backoff_max_s() -> float:
+    return _env_float("JARVIS_LINK_BACKOFF_MAX_S", 30.0, minimum=1.0)
+
+
+class AdmitVerdict(str, enum.Enum):
+    ADMIT = "admit"
+    THROTTLE = "throttle"
+
+
+@dataclass(frozen=True)
+class AdmitDecision:
+    verdict: AdmitVerdict
+    retry_after_s: float
+    attempts_in_window: int
+    reason: str
+
+    @property
+    def admitted(self) -> bool:
+        return self.verdict is AdmitVerdict.ADMIT
+
+
+class FlapBreaker:
+    """Bounded admission for reconnect storms.
+
+    **The failure.** A roaming access point drops and restores the Mac's link
+    fifty times in ten seconds. Each attempt reaches the Engine. If every
+    connection allocates a handler task, a queue and a session, the Engine
+    exhausts itself defending against a client that is not attacking it.
+
+    **Why this is admission control and not a retry policy.** Client-side
+    backoff is necessary and insufficient: it is advice the client may fail to
+    follow, and a client already misbehaving is exactly the one that will not.
+    The Engine therefore decides, per identity, in a rolling window, before
+    any resource is committed. :meth:`retry_after` gives the client a number
+    to obey, so a cooperative peer converges rather than guessing.
+
+    Deterministic and lock-guarded; no timers, no background task, and never
+    a sleep — the caller schedules, this only decides. Nothing here touches
+    the event loop.
+    """
+
+    def __init__(self, clock: Optional[Callable[[], float]] = None) -> None:
+        self._clock = clock or time.monotonic
+        self._lock = threading.Lock()
+        self._attempts: Dict[str, List[float]] = {}
+        self._open_until: Dict[str, float] = {}
+        self._tripped = 0
+
+    def admit(self, identity: str) -> AdmitDecision:
+        """May this identity open a connection right now?"""
+        ident = str(identity or "?")
+        now = self._clock()
+        window = flap_window_s()
+        limit = flap_max_attempts()
+        with self._lock:
+            open_until = self._open_until.get(ident, 0.0)
+            if now < open_until:
+                return AdmitDecision(
+                    AdmitVerdict.THROTTLE, max(0.0, open_until - now),
+                    len(self._attempts.get(ident, ())),
+                    "breaker open",
+                )
+            bucket = [t for t in self._attempts.get(ident, ()) if t >= now - window]
+            bucket.append(now)
+            self._attempts[ident] = bucket
+            self._bound_locked(now, window)
+            if len(bucket) > limit:
+                until = now + flap_open_s()
+                self._open_until[ident] = until
+                self._tripped += 1
+                logger.warning(
+                    "[LinkProtocol] flap breaker OPEN for %s — %d attempts "
+                    "in %.0fs; holding off %.0fs",
+                    ident, len(bucket), window, flap_open_s(),
+                )
+                return AdmitDecision(
+                    AdmitVerdict.THROTTLE, flap_open_s(), len(bucket),
+                    "attempt rate exceeded",
+                )
+            return AdmitDecision(
+                AdmitVerdict.ADMIT, 0.0, len(bucket), "within rate",
+            )
+
+    def _bound_locked(self, now: float, window: float) -> None:
+        """Hold the identity map under a HARD cap. Caller holds the lock.
+
+        Two-stage, and the second stage is the one that matters. Pruning
+        entries older than the window is the cheap case: an identity that has
+        not tried in a full window cannot be flapping, so its bucket is not
+        evidence and dropping it costs nothing.
+
+        But staleness alone does not bound anything. A peer cycling session
+        identities — a buggy client regenerating an id per attempt, or a
+        hostile one doing it deliberately — produces thousands of ENTIRELY
+        FRESH identities inside a single window, none of them stale, and the
+        map grows without limit. On a link reachable across an overlay
+        network that is a memory-exhaustion vector, and it is reached by the
+        very traffic pattern this class exists to survive.
+
+        So the second stage is a hard capacity bound: evict by least-recent
+        activity until the map fits. Evicting an active flapper only costs it
+        a forgotten history — it re-accumulates on its next attempt and trips
+        again — whereas an unbounded map costs the process.
+        """
+        cap = flap_max_identities()
+        if len(self._attempts) <= cap:
+            return
+        horizon = now - window
+        for key, times in list(self._attempts.items()):
+            if not times or max(times) < horizon:
+                self._attempts.pop(key, None)
+                self._open_until.pop(key, None)
+        if len(self._attempts) <= cap:
+            return
+        by_recency = sorted(
+            self._attempts.items(), key=lambda kv: max(kv[1], default=0.0))
+        for key, _ in by_recency[: len(self._attempts) - cap]:
+            self._attempts.pop(key, None)
+            self._open_until.pop(key, None)
+        logger.debug(
+            "[LinkProtocol] flap map bounded to %d identities", cap)
+
+    def on_established(self, identity: str) -> None:
+        """A connection succeeded and stayed up — retire its flap history.
+
+        Without this a client that legitimately reconnects once an hour
+        accumulates attempts forever and is eventually throttled for being
+        long-lived, which is the opposite of the intent.
+        """
+        with self._lock:
+            self._attempts.pop(str(identity or "?"), None)
+            self._open_until.pop(str(identity or "?"), None)
+
+    def snapshot(self) -> Dict[str, Any]:
+        now = self._clock()
+        with self._lock:
+            return {
+                "tracked_identities": len(self._attempts),
+                "open_breakers": sum(1 for t in self._open_until.values()
+                                     if t > now),
+                "tripped_total": self._tripped,
+                "window_s": flap_window_s(),
+                "max_attempts": flap_max_attempts(),
+            }
+
+
+def backoff_delay_s(attempt: int, *, jitter: float = 0.0) -> float:
+    """Exponential backoff with caller-supplied jitter. Pure.
+
+    Jitter is a PARAMETER rather than an internal ``random()`` call so the
+    schedule is reproducible under test. A caller that omits it gets a
+    deterministic ramp — correct, and thundering-herd prone only if many
+    clients share one Engine, which this topology does not.
+    """
+    n = max(0, int(attempt))
+    delay = backoff_base_s() * (2 ** min(n, 16))
+    delay = min(delay, backoff_max_s())
+    return max(0.0, delay * (1.0 + max(-0.5, min(0.5, jitter))))
+
+
+# ---------------------------------------------------------------------------
+# 3. Resume — exactly-once EFFECT across a rupture
+# ---------------------------------------------------------------------------
+
+
+class ResumeAction(str, enum.Enum):
+    CONTINUE = "continue"        # nothing missed
+    REPLAY = "replay"            # send [from_seq, to_seq]
+    RESYNC = "resync"            # gap exceeds retention — snapshot instead
+    REJECT = "reject"            # the peer's claim is not coherent
+
+
+@dataclass(frozen=True)
+class ResumePlan:
+    action: ResumeAction
+    from_seq: int = 0
+    to_seq: int = 0
+    reason: str = ""
+    schema_version: str = LINK_PROTOCOL_SCHEMA_VERSION
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.schema_version, "action": self.action.value,
+            "from_seq": self.from_seq, "to_seq": self.to_seq,
+            "reason": self.reason,
+        }
+
+
+def plan_resume(
+    *,
+    peer_last_applied: int,
+    source_latest: int,
+    source_oldest_retained: int,
+) -> ResumePlan:
+    """What the Engine owes a reconnecting Body.
+
+    **The split-brain case this exists for.** The Engine completes a heavy
+    op, emits the verdict, and the socket ruptures mid-transmission. The Body
+    never applied it. On reconnect the Body states the last sequence it
+    applied CONTIGUOUSLY — not the highest it has seen, which after an
+    out-of-order delivery would silently skip the hole — and the Engine
+    replays the range from its durable spine.
+
+    Four outcomes, and the third is the one that keeps the link honest:
+
+    ``CONTINUE`` the Body is current.
+    ``REPLAY``   the gap is inside retention; send it.
+    ``RESYNC``   the gap is older than anything retained. The Engine CANNOT
+                 close it, and pretending otherwise by resuming from the
+                 oldest retained record would silently drop everything before
+                 it. The Body must rebuild from a snapshot and be told so —
+                 the same honesty ``ide_observability_stream`` already
+                 practises when it marks a replay ``known: false``.
+    ``REJECT``   the Body claims to have applied more than the Engine ever
+                 emitted. That is not a gap, it is an incoherent peer —
+                 a stale session id reused after an Engine restart, or two
+                 Bodies sharing one identity. Serving it would corrupt both.
+    """
+    peer = max(-1, int(peer_last_applied))
+    latest = max(0, int(source_latest))
+    oldest = max(0, int(source_oldest_retained))
+
+    if peer > latest:
+        return ResumePlan(
+            ResumeAction.REJECT, reason=(
+                f"peer claims seq={peer} but source has only emitted "
+                f"{latest} — incoherent session"),
+        )
+    if peer == latest:
+        return ResumePlan(ResumeAction.CONTINUE, reason="peer is current")
+    first_needed = peer + 1
+    if first_needed < oldest:
+        return ResumePlan(
+            ResumeAction.RESYNC, from_seq=first_needed, to_seq=latest,
+            reason=(f"needs seq>={first_needed} but retention starts at "
+                    f"{oldest} — {oldest - first_needed} record(s) evicted"),
+        )
+    return ResumePlan(
+        ResumeAction.REPLAY, from_seq=first_needed, to_seq=latest,
+        reason=f"replaying {latest - peer} record(s)",
+    )
+
+
+class DeliveryLedger:
+    """Idempotent application — exactly-once EFFECT at the sink.
+
+    At-least-once delivery plus idempotent application is the only
+    combination achievable over an unreliable link. Replay makes delivery
+    at-least-once; this makes application exactly-once.
+
+    Also tracks the **contiguous** applied watermark, which is the number a
+    reconnect must report. Tracking the highest-seen value instead would
+    paper over a hole: a frame arriving out of order would advance the mark
+    past records that were never applied, and the resume would never ask for
+    them. The hole would then be permanent and invisible — the worst shape a
+    data-loss bug can take.
+    """
+
+    def __init__(self, capacity: int = 4096) -> None:
+        self._lock = threading.Lock()
+        self._seen: Dict[str, int] = {}
+        self._order: List[str] = []
+        self._capacity = max(64, int(capacity))
+        self._contiguous = 0
+        self._pending: set = set()
+        self._duplicates = 0
+
+    def apply_once(self, frame: LinkFrame, fn: Callable[[LinkFrame], Any]) -> bool:
+        """Run ``fn`` for a frame not yet applied. True if it ran.
+
+        ``fn`` raising means NOT applied: the frame stays unrecorded so a
+        later redelivery retries it. Recording first and running second would
+        convert a transient handler fault into permanent silent loss.
+        """
+        key = self._key(frame)
+        with self._lock:
+            if key in self._seen:
+                self._duplicates += 1
+                return False
+        fn(frame)
+        with self._lock:
+            self._seen[key] = frame.seq
+            self._order.append(key)
+            while len(self._order) > self._capacity:
+                self._seen.pop(self._order.pop(0), None)
+            self._advance(frame.seq)
+        return True
+
+    def _advance(self, seq: int) -> None:
+        """Move the contiguous watermark, closing holes as they fill."""
+        if seq == self._contiguous + 1:
+            self._contiguous = seq
+            while self._contiguous + 1 in self._pending:
+                self._contiguous += 1
+                self._pending.discard(self._contiguous)
+        elif seq > self._contiguous + 1:
+            self._pending.add(seq)
+
+    @staticmethod
+    def _key(frame: LinkFrame) -> str:
+        cid = frame.payload.get("command_id") if frame.payload else None
+        return str(cid) if cid else f"{frame.node_id}:{frame.seq}"
+
+    @property
+    def contiguous_applied(self) -> int:
+        """The watermark to report on reconnect."""
+        with self._lock:
+            return self._contiguous
+
+    def snapshot(self) -> Dict[str, Any]:
+        with self._lock:
+            return {
+                "contiguous_applied": self._contiguous,
+                "pending_out_of_order": len(self._pending),
+                "tracked_ids": len(self._seen),
+                "duplicates_suppressed": self._duplicates,
+            }
+
+
+# ---------------------------------------------------------------------------
+# Session identity — survives the socket, so a reconnect costs nothing
+# ---------------------------------------------------------------------------
+
+
+def session_idle_expiry_s() -> float:
+    """How long a detached session is held before it is reaped."""
+    return _env_float("JARVIS_LINK_SESSION_EXPIRY_S", 900.0, minimum=10.0)
+
+
+@dataclass
+class LinkSession:
+    session_id: str
+    node_id: str
+    ledger: DeliveryLedger
+    clock: LogicalClock
+    #: Engine-local monotonic. Never compared with the peer's.
+    created_mono: float = 0.0
+    last_seen_mono: float = 0.0
+    attached: bool = False
+    reconnects: int = 0
+
+
+class SessionRegistry:
+    """Sessions outlive connections.
+
+    **Why this is the root-cause fix for flapping**, rather than the breaker.
+    The breaker bounds the damage; this removes the reason there is damage.
+    If a reconnect allocates nothing — same session, same ledger, same
+    logical clock, resumed by sequence — then fifty reconnects cost fifty
+    handshakes and no state. Flapping stops being a resource question and
+    becomes a latency one.
+
+    Detached sessions are held for :func:`session_idle_expiry_s` so a Wi-Fi
+    drop is a PAUSE, not a loss: the Engine keeps the op parked and the
+    verdict queued, and the Body picks up exactly where it stopped. Expiry is
+    lazy — checked on access, no reaper task — because a background sweeper
+    is one more thing to keep alive on an event loop that has real work.
+    """
+
+    def __init__(self, clock: Optional[Callable[[], float]] = None) -> None:
+        self._clock = clock or time.monotonic
+        self._lock = threading.Lock()
+        self._sessions: Dict[str, LinkSession] = {}
+
+    def attach(self, session_id: str, node_id: str) -> Tuple[LinkSession, bool]:
+        """Resume or create. Returns ``(session, resumed)``."""
+        sid = str(session_id or "")
+        now = self._clock()
+        with self._lock:
+            self._expire_locked(now)
+            existing = self._sessions.get(sid)
+            if existing is not None:
+                existing.attached = True
+                existing.last_seen_mono = now
+                existing.reconnects += 1
+                return existing, True
+            session = LinkSession(
+                session_id=sid, node_id=str(node_id or "?"),
+                ledger=DeliveryLedger(), clock=LogicalClock(str(node_id or "?")),
+                created_mono=now, last_seen_mono=now, attached=True,
+            )
+            self._sessions[sid] = session
+            return session, False
+
+    def detach(self, session_id: str) -> None:
+        """The socket went away. The session does not."""
+        with self._lock:
+            s = self._sessions.get(str(session_id or ""))
+            if s is not None:
+                s.attached = False
+                s.last_seen_mono = self._clock()
+
+    def touch(self, session_id: str) -> None:
+        with self._lock:
+            s = self._sessions.get(str(session_id or ""))
+            if s is not None:
+                s.last_seen_mono = self._clock()
+
+    def _expire_locked(self, now: float) -> None:
+        horizon = session_idle_expiry_s()
+        for sid, s in list(self._sessions.items()):
+            if not s.attached and (now - s.last_seen_mono) > horizon:
+                self._sessions.pop(sid, None)
+                logger.info(
+                    "[LinkProtocol] session %s expired after %.0fs detached",
+                    sid, now - s.last_seen_mono)
+
+    def snapshot(self) -> Dict[str, Any]:
+        now = self._clock()
+        with self._lock:
+            return {
+                "sessions": len(self._sessions),
+                "attached": sum(1 for s in self._sessions.values() if s.attached),
+                "detached": sum(1 for s in self._sessions.values()
+                                if not s.attached),
+                "reconnects_total": sum(s.reconnects
+                                        for s in self._sessions.values()),
+                "expiry_s": session_idle_expiry_s(),
+                "now_mono": now,
+            }

--- a/docs/BRINGUP_WINDOWS_WSL2.md
+++ b/docs/BRINGUP_WINDOWS_WSL2.md
@@ -1,0 +1,198 @@
+# Bring-up — the Engine on Windows / WSL2
+
+The Body stays on the Mac (CoreAudio, AppKit, Quartz capture, the cockpit).
+This runbook stands up the **Engine** on the Windows box and gets `ov doctor`
+to a clean read. Nothing here needs the Body running.
+
+Target: AMD 9950X3D · RTX 5090 (32 GB) · 64 GB DDR5 · Windows + WSL2.
+
+---
+
+## 0. Why WSL2 and not native Windows
+
+The engine imports `fcntl` in 11 files, Unix sockets in 7, and `SIGHUP` in 9.
+Python's asyncio has **no** `start_unix_server` on Windows, and `flock`
+semantics have no clean Win32 equivalent — so native Windows is a two-seam
+port, not a configuration. WSL2 runs the tree unmodified, and vLLM is
+Linux-only regardless.
+
+The port is tractable later (consolidate the 7 files that bypass the
+canonical lock primitive, then one transport seam for the cockpit). It is not
+needed to start.
+
+---
+
+## 1. WSL2
+
+```powershell
+wsl --install -d Ubuntu-24.04
+wsl --update
+```
+
+`%UserProfile%\.wslconfig` — **WSL2 defaults to 50% of RAM (32 GB)**, which
+silently halves your offload budget:
+
+```ini
+[wsl2]
+memory=52GB
+processors=16
+swap=16GB
+networkingMode=mirrored
+```
+
+`networkingMode=mirrored` (Win11 22H2+) makes WSL2 share the host's
+interfaces. Without it the guest gets a NAT address that **changes on every
+restart**, and the alternative — `netsh interface portproxy` — breaks on
+every reboot. This matters for §29's link, not for local work.
+
+Restart: `wsl --shutdown`, then reopen.
+
+---
+
+## 2. GPU
+
+Install the NVIDIA driver **on Windows only**. Never install a Linux driver
+inside WSL — it will shadow the projected stub and break CUDA.
+
+```bash
+nvidia-smi                    # should list the 5090
+ls -l /usr/lib/wsl/lib/nvidia-smi
+```
+
+You do **not** need the CUDA toolkit. `nvcc` and headers are for *compiling*
+CUDA; inference runtimes ship their own. `compute_topology` reads the driver
+directly via `nvidia-smi` and requires no PyTorch at all.
+
+If you do install PyTorch, it must be a **cu128** build — the 5090 is
+Blackwell (`sm_120`) and older wheels will not see the device. They fail
+softly: the probe falls through to `nvidia-smi` and still works.
+
+---
+
+## 3. Repository
+
+Clone onto the **ext4** filesystem, never `/mnt/c`. The Oracle walks 6,593
+Python files and 9p will make that miserable.
+
+```bash
+cd ~ && git clone <remote> JARVIS-AI-Agent && cd JARVIS-AI-Agent
+```
+
+Drop the `.nosync` suffix — that is an iCloud workaround with no meaning
+here. `.gitattributes` normalises line endings to LF, so the working tree is
+byte-identical to the Mac's.
+
+```bash
+pyenv install 3.11.10 && pyenv local 3.11.10     # matches .python-version
+python3 -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+pip install -e .                                  # provides the `ov` script
+hash -r                                           # purge any stale shim
+```
+
+---
+
+## 4. The two things that do not travel
+
+**Secrets.** `.env` is gitignored (`.gitignore:21`). The daemon environment
+carries ~150 variables — `DOUBLEWORD_API_KEY`, `ANTHROPIC_API_KEY`,
+`JARVIS_DB_PASSWORD`, `JARVIS_AEGIS_BOOTSTRAP_PSK`, GCP config, Discord
+webhooks. `.env.example` is a template, not the values. Copy `.env` across by
+hand, out of band. **Nothing boots the same way without it.**
+
+**The organism's memory.** `.jarvis/` is gitignored (`.gitignore:123`) except
+four deliberately-tracked files. It holds the semantic index cache, posture
+history, bandit router state, mTLS certs, acoustic profile, user preferences
+and every postmortem. So `LastSessionSummary`, `PostmortemRecall`,
+`SemanticIndex` and `UserPreferenceMemory` all start empty — **the synthetic
+soul begins with amnesia.** Correct for a gitignore, and a real consequence:
+copy `.jarvis/` deliberately if you want continuity.
+
+---
+
+## 5. Verify — count collections, not passes
+
+```bash
+# On the Mac, first:
+python3 -m pytest tests/ -q --collect-only 2>/dev/null | tail -1
+
+# Then here. The numbers must differ ONLY by the macOS-only files.
+python3 -m pytest tests/ -q --collect-only 2>/dev/null | tail -1
+```
+
+Eight test files import Quartz/AppKit/CoreAudio. On Linux they do not fail —
+they **fail to collect**, and a suite that cannot collect reports no
+failures. A green run with a quietly smaller denominator is the trap; compare
+the *collected* count, then add explicit `pytest.importorskip` guards so the
+skip is declared rather than inferred from an error.
+
+Then the governance spine:
+
+```bash
+python3 -m pytest tests/governance/test_compute_topology.py \
+                  tests/governance/test_local_model_admission.py \
+                  tests/governance/test_link_protocol.py -q
+```
+
+---
+
+## 6. The ten-minute hardware check
+
+```bash
+export JARVIS_COMPUTE_TOPOLOGY_ENABLED=1
+ov doctor
+```
+
+**Edge 9 works with the daemon down** — that is the point of it on a machine
+that has never run the organism. Expect:
+
+```
+9 compute   OK   discrete gpu_32gib · 28.x GiB usable · src=torch_cuda
+```
+
+`unified` or `unknown` here means the probe did not find the device; check
+`nvidia-smi` and the cu128 build. This single line closes the three things
+that could not be verified from the Mac: whether WSL2's `nvidia-smi` parses,
+whether `mem_get_info` behaves on `sm_120`, and what the real usable figure
+is.
+
+---
+
+## 7. The local lane
+
+Policy entries already carry `min_vram_gb` and `weight_gb` for all six
+brains. **Calibrate `weight_gb` against the artifacts you actually pull** —
+the shipped values are reasonable Q4/Q6 estimates, not measurements of your
+files.
+
+Resident in VRAM beats offloaded: a 32B coder at Q6_K (~27 GiB) for GENERATE,
+plus a ~13 GiB small MoE for the BACKGROUND/SPECULATIVE lanes. Your DDR5 runs
+~90–100 GB/s against the 5090's ~1.8 TB/s, so anything spilled is ~18× slower
+per byte.
+
+Raise `JARVIS_BG_POOL_SIZE` past 3 — that cap was chosen for an 8-core
+laptop, and this box has 16 cores.
+
+---
+
+## 8. Then, and only then
+
+Run a soak with `--max-wall-seconds 2400 --headless` and confirm ops
+complete. That is what restarts §26's trust-gate evidence, which has been at
+zero since 2026-08-11 because every paid lane was dry. A local Tier 3 cannot
+return `402`.
+
+---
+
+## Appendix — env quick reference
+
+| Variable | Purpose |
+|---|---|
+| `JARVIS_COMPUTE_TOPOLOGY_ENABLED` | master switch for the measured accelerator probe |
+| `JARVIS_COMPUTE_TOPOLOGY_SMI_DIRS` | override driver-CLI search dirs (`os.pathsep` separated) |
+| `JARVIS_COMPUTE_TOPOLOGY_PREWARM_BUDGET_S` | boot probe ceiling (default 15s) |
+| `JARVIS_LOCAL_MODEL_UNKNOWN_CEILING_GB` | largest blind load on an unmeasured host (default 8) |
+| `JARVIS_VRAM_RESERVATION_SETTLE_S` | when a soft claim is assumed resident (default 120) |
+| `JARVIS_VRAM_RECONCILE_AFTER_S` | when a claim becomes eligible for phantom detection (default 20) |
+| `JARVIS_LINK_BRIDGE_ENABLED` | §29 Body/Engine link (default false) |
+| `JARVIS_BG_POOL_SIZE` | background worker count (default 3) |

--- a/docs/architecture/OUROBOROS_VENOM_PRD.md
+++ b/docs/architecture/OUROBOROS_VENOM_PRD.md
@@ -3779,3 +3779,172 @@ reproduced or root-caused here — `_transcript_search_rows` and
 `transcript_hatches` are the indicated starting points and remain unaudited.
 
 ---
+
+## 29. The Distributed Body/Engine Link *(NEW 2026-08-15)*
+
+> **Operator binding (2026-08-15)**: *"The Body (audio/vision/UI handling
+> CoreAudio and AppKit) will remain live on the Mac as the sensor edge node,
+> while the Engine runs entirely on the remote Windows WSL2 compute cluster.
+> This is strictly a distributed, two-machine architecture traversing an
+> external network."*
+
+### 29.1 Why the split falls where it does
+
+It is not a preference. §28's dependency audit measured it: **Quartz 151
+files, AppKit 82, CoreAudio 62, sounddevice 41, ApplicationServices 35.**
+Those are macOS frameworks with no Windows counterpart under any strategy —
+not a port, a rewrite. Meanwhile the engine's POSIX coupling is **11 files
+importing `fcntl`, 7 using Unix sockets, 9 referencing `SIGHUP`**, and 4 of
+those `fcntl` importers are the lock primitives themselves.
+
+So one half of this system cannot leave the Mac and the other half is
+already portable. The Trinity splits along the seam CLAUDE.md drew for it —
+`JARVIS (Body) <--HTTP/WS--> J-Prime (Mind)` — because that is where the
+dependency mass actually divides.
+
+The physical asymmetry makes the same case: a 16 GB M1 with unified memory
+shares one pool between the model, the CoreAudio graph and the vision
+pipeline (§27's `local_model_admission` exists because of it). A 32 GB
+discrete accelerator with 64 GB of host RAM beside it does not. The Body
+belongs where the sensors are; the weights belong where the VRAM is.
+
+### 29.2 What the link is not
+
+**Not a filesystem share.** No remote mount, no synced directory. The Body
+sends intent and receives verdicts; the repository is cloned on both ends and
+reconciled by git, as it always was.
+
+**Not a request/response RPC.** O+V is proactive: the Engine originates work
+from 16 sensors without being asked. A protocol shaped around "the Body
+calls, the Engine answers" would have no way to express the majority of what
+crosses this link.
+
+**Not one channel.** §29.4 splits it into three, because the three kinds of
+traffic want contradictory guarantees and a uniform channel would have to
+pick a loser.
+
+### 29.3 The two problems that make this hard
+
+Both are consequences of the machines being genuinely separate, and both are
+invisible on a loopback socket — which is why the local `cockpit_attach`
+transport, correct as it is, cannot simply be pointed at a remote host.
+
+**The clocks are not comparable.** A WSL2 guest's wall clock drifts against
+its host, and against the Mac, and re-syncs on its own schedule after
+suspend/resume. Any rule of the form "reject frames older than N seconds"
+evaluated across that boundary is a random number generator.
+
+> **Rule.** A timestamp that crosses a machine boundary is **data, never a
+> clock.** Ordering uses a Lamport clock; durations use each side's own
+> `time.monotonic()` and are never differenced against the peer's. A remote
+> wall-clock stamp may be *displayed* and may never reach a decision.
+
+**Availability is nobody's to assume.** A laptop on Wi-Fi roams between
+access points; an overlay network re-keys; a host sleeps. §26.6 already
+established that a detached operator's *absence* must not read as *refusal*
+— across a network that principle acquires teeth, because now the link
+itself can produce absence.
+
+> **Rule.** A partition is a **pause**, never a rejection and never a loss.
+> Both ends park; neither infers a verdict from silence.
+
+### 29.4 Three lanes, three contracts
+
+| Lane | Traffic | Contract | Substrate |
+|---|---|---|---|
+| **Telemetry** | phase, cost, deck rows, token stream | **Lossy, latest-wins** — drop oldest, coalesce, *count and surface* the drop | `ide_observability_stream` — bounded broker, `Last-Event-ID` replay, drop-oldest → one `stream_lag`, heartbeat |
+| **Command / verdict** | approve, reject, `ask_human` answers, op verdicts | **At-least-once delivery + idempotent application** = exactly-once *effect* | `durable_io` (`atomic_replace` + fsync discipline) under a per-side outbox; `link_protocol.DeliveryLedger` at the sink |
+| **Evidence** | postmortems, spine milestones, attention accounting | **Durable, ordered, eventually consistent** | transcript spine `seq` — pull by range, idempotent by construction |
+
+Exactly-once *delivery* is unachievable over an unreliable link and is not
+attempted. Exactly-once *effect* is achievable and is the difference between
+a protocol that works and one that hopes.
+
+### 29.5 `link_protocol.py` — the shared core
+
+Pure logic: clocks, sequence arithmetic, admission decisions, resume
+planning. No socket, no asyncio, no transport. Both ends import the **same**
+module, so the two sides cannot drift apart on the rules by being written
+twice. A distributed protocol whose correctness can only be observed by
+running two machines is one that will be debugged in production; this is the
+half that is provable at a desk.
+
+**`LogicalClock`** — Lamport. Local events tick; received frames set
+`max(local, remote) + 1`. Guarantees the only ordering that survives drift:
+if A caused B then `A.lamport < B.lamport`. The converse deliberately does
+not hold — concurrency is a real property of a distributed system, and a
+protocol that totally orders genuinely-concurrent events has invented
+information. Ties break on `node_id` so both ends render one history
+identically without either wall clock.
+
+**`SessionRegistry`** — session identity is separate from connection
+identity. This is the *root-cause* fix for flapping, and the breaker below is
+only damage control. Fifty reconnects exhaust an Engine solely because each
+*connection* allocates a session, a queue and a task. If a reconnect
+allocates nothing — same session, same ledger, same clock, resumed by
+sequence — flapping stops being a resource question and becomes a latency
+one. Detached sessions are held for an idle window, so a Wi-Fi drop is a
+pause: the op stays parked, the verdict stays queued. Expiry is lazy, because
+a reaper task is one more thing to keep alive on a loop with real work.
+
+**`FlapBreaker`** — per-identity rolling-window admission, decided **before**
+any resource is committed. Client-side backoff is necessary and insufficient:
+it is advice the client may fail to follow, and a client already misbehaving
+is precisely the one that will not. `retry_after_s` is returned so a
+cooperative peer converges instead of guessing. Bounded by a hard identity
+cap, not only by staleness — a peer cycling session ids produces thousands of
+*fresh* entries inside one window, none stale, and an unbounded map on a
+network-reachable service is a memory-exhaustion vector reached by the exact
+traffic pattern the class exists to survive.
+
+**`plan_resume`** — four outcomes, and the third is what keeps the link
+honest. `CONTINUE` (current), `REPLAY` (gap inside retention), **`RESYNC`**
+(gap older than anything retained — the Engine *cannot* close it, and
+resuming from the oldest retained record would silently drop everything
+before it, so the Body is told to rebuild from a snapshot), `REJECT` (the
+peer claims to have applied more than the Engine emitted — a stale session id
+after a restart, or two Bodies sharing an identity; serving it corrupts
+both).
+
+**`DeliveryLedger`** — idempotent application, and the **contiguous**
+applied watermark. Tracking the highest sequence *seen* would advance past a
+hole; the resume would never ask for it; the loss would be permanent and
+invisible — the worst shape a data-loss bug can take. A handler that raises
+leaves the frame unrecorded so redelivery retries it, because recording
+before running converts a transient fault into silent loss.
+
+### 29.6 Transport and trust
+
+No hardcoded addresses or ports — pinned by test. The Engine binds a
+port supplied by configuration and the Body resolves the peer by **name**
+over the overlay network (Tailscale/ZeroTier), which is what makes the pair
+portable between premises without either end learning an IP.
+
+mTLS is not optional here. One end of this link is an autonomous agent that
+mutates code and runs `bash`; the certificate material already exists at
+`.jarvis/brain_mtls/` (`ca.pem`, `client-{cert,key}.pem`,
+`server-{cert,key}.pem`). The overlay network provides the tunnel; mTLS
+provides the *identity*, and only the second one answers "which Body is
+this?" after a session id is replayed.
+
+Payload limits are negotiated at handshake rather than declared: both ends
+advertise a maximum frame size and the **minimum wins** — the same asymmetry
+§25.1 applies to terminal width, and for the same reason. A ceiling one side
+cannot honour is not a limit, it is a fault waiting for a large frame.
+
+### 29.7 What remains
+
+`link_protocol.py` is the provable half. The transport half — a wire codec
+over the mTLS channel, the per-side durable outbox on `durable_io`, the SSE
+lane bridged to a remote subscriber, and the handshake that negotiates limits
+— is the next slice, and it is the half that cannot be finished honestly
+until both machines exist. Master switch `JARVIS_LINK_BRIDGE_ENABLED`,
+default false.
+
+The fault-injection spine follows §28's discipline: kill the link mid-verdict
+and assert exactly-once *effect*; partition during a live review and assert
+the op **parks** with no evidence recorded in either direction (§27.3.2);
+force a replay gap wider than retention and assert `RESYNC` rather than a
+silent partial resume.
+
+---

--- a/tests/governance/test_link_protocol.py
+++ b/tests/governance/test_link_protocol.py
@@ -1,0 +1,382 @@
+"""Regression spine for the Body/Engine link protocol.
+
+Pure logic under a controllable clock — no sockets, no sleeps, no network.
+Every test states the distributed failure it prevents.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance import link_protocol as lp
+
+
+class FakeClock:
+    """A monotonic clock the test drives, so no test ever sleeps."""
+
+    def __init__(self) -> None:
+        self.t = 1000.0
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, dt: float) -> None:
+        self.t += dt
+
+
+# ---------------------------------------------------------------------------
+# 1. Clock drift — the Mac and the WSL2 VM do not share "now"
+# ---------------------------------------------------------------------------
+
+
+def test_causal_order_survives_a_peer_whose_wall_clock_is_wrong():
+    """THE drift regression. A WSL2 VM resumes from host sleep with a wall
+    clock seconds behind. Causal order must be unaffected because no wall
+    clock participates in it."""
+    body = lp.LogicalClock("body")
+    engine = lp.LogicalClock("engine")
+
+    a = body.tick()                    # Body sends
+    b = engine.observe(a)              # Engine receives, then acts
+    c = engine.tick()
+    d = body.observe(c)                # Body receives the reply
+
+    assert a < b < c < d
+
+
+def test_a_lamport_clock_never_moves_backwards():
+    """Exactly what a re-syncing NTP daemon does to a wall clock, and the
+    reason ordering may not depend on one."""
+    c = lp.LogicalClock("n")
+    seen = [c.tick() for _ in range(5)]
+    c.observe(2)                       # a peer far behind
+    seen.append(c.peek())
+    c.observe(10_000)                  # a peer far ahead
+    seen.append(c.peek())
+    assert seen == sorted(seen)
+
+
+def test_a_malformed_remote_stamp_cannot_stall_local_ordering():
+    c = lp.LogicalClock("n")
+    before = c.peek()
+    for junk in (None, "abc", -5, float("nan")):
+        c.observe(junk)  # type: ignore[arg-type]
+    assert c.peek() > before
+
+
+def test_stamps_totally_order_for_display_without_any_wall_clock():
+    a = (7, "body")
+    b = (7, "engine")
+    assert lp.happens_before(a, b)
+    assert not lp.happens_before(b, a)
+
+
+def test_the_wall_clock_field_is_named_to_make_misuse_obvious():
+    """It is display-only. The name is the guardrail; this pins it so a
+    rename cannot quietly turn it into a decision input."""
+    f = lp.LinkFrame(seq=1, lamport=1, node_id="n", kind="k")
+    assert hasattr(f, "sender_wall_ns")
+    assert "sender_wall_ns" in f.to_dict()
+
+
+# ---------------------------------------------------------------------------
+# Frame parsing — a malformed frame is garbage, not a frame with defaults
+# ---------------------------------------------------------------------------
+
+
+def test_a_frame_missing_ordering_fields_is_rejected_not_defaulted():
+    """Admitting it with seq=0 would corrupt resume arithmetic on an
+    otherwise healthy link."""
+    assert lp.LinkFrame.from_dict({"kind": "x"}) is None
+    assert lp.LinkFrame.from_dict({"seq": 1, "lamport": 1}) is None
+    assert lp.LinkFrame.from_dict({"seq": -1, "lamport": 1,
+                                   "node_id": "n", "kind": "k"}) is None
+    assert lp.LinkFrame.from_dict("not a dict") is None
+    assert lp.LinkFrame.from_dict(None) is None
+
+
+def test_a_wellformed_frame_round_trips():
+    f = lp.LinkFrame(seq=3, lamport=9, node_id="engine", kind="verdict",
+                     payload={"command_id": "c1"})
+    back = lp.LinkFrame.from_dict(f.to_dict())
+    assert back is not None
+    assert (back.seq, back.lamport, back.node_id, back.kind) == (3, 9, "engine", "verdict")
+
+
+def test_a_non_dict_payload_degrades_to_empty_rather_than_failing():
+    got = lp.LinkFrame.from_dict(
+        {"seq": 1, "lamport": 1, "node_id": "n", "kind": "k", "payload": "junk"})
+    assert got is not None and got.payload == {}
+
+
+# ---------------------------------------------------------------------------
+# 2. Flapping — 50 reconnects in 10s must not exhaust the Engine
+# ---------------------------------------------------------------------------
+
+
+def test_a_reconnect_storm_is_throttled_before_resources_are_committed(monkeypatch):
+    monkeypatch.setenv("JARVIS_LINK_FLAP_MAX_ATTEMPTS", "8")
+    monkeypatch.setenv("JARVIS_LINK_FLAP_WINDOW_S", "10")
+    clock = FakeClock()
+    breaker = lp.FlapBreaker(clock=clock)
+
+    admitted = sum(1 for _ in range(50) if breaker.admit("mac").admitted)
+    assert admitted <= 8, "the storm reached the Engine"
+    assert breaker.snapshot()["tripped_total"] >= 1
+
+
+def test_a_throttled_client_is_told_how_long_to_wait(monkeypatch):
+    """A cooperative peer converges; guessing produces a second storm."""
+    monkeypatch.setenv("JARVIS_LINK_FLAP_MAX_ATTEMPTS", "2")
+    monkeypatch.setenv("JARVIS_LINK_FLAP_OPEN_S", "15")
+    breaker = lp.FlapBreaker(clock=FakeClock())
+    for _ in range(5):
+        d = breaker.admit("mac")
+    assert not d.admitted
+    assert d.retry_after_s > 0
+
+
+def test_the_breaker_reopens_after_its_window(monkeypatch):
+    monkeypatch.setenv("JARVIS_LINK_FLAP_MAX_ATTEMPTS", "2")
+    monkeypatch.setenv("JARVIS_LINK_FLAP_OPEN_S", "15")
+    clock = FakeClock()
+    breaker = lp.FlapBreaker(clock=clock)
+    for _ in range(5):
+        breaker.admit("mac")
+    assert not breaker.admit("mac").admitted
+    clock.advance(16.0)
+    assert breaker.admit("mac").admitted
+
+
+def test_a_stable_connection_retires_its_flap_history(monkeypatch):
+    """Otherwise a client reconnecting once an hour is eventually throttled
+    for being long-lived — the opposite of the intent."""
+    monkeypatch.setenv("JARVIS_LINK_FLAP_MAX_ATTEMPTS", "3")
+    breaker = lp.FlapBreaker(clock=FakeClock())
+    for _ in range(3):
+        breaker.admit("mac")
+    breaker.on_established("mac")
+    assert breaker.admit("mac").admitted
+
+
+def test_one_noisy_identity_does_not_throttle_another(monkeypatch):
+    monkeypatch.setenv("JARVIS_LINK_FLAP_MAX_ATTEMPTS", "2")
+    breaker = lp.FlapBreaker(clock=FakeClock())
+    for _ in range(10):
+        breaker.admit("noisy")
+    assert breaker.admit("quiet").admitted
+
+
+def test_the_breaker_is_bounded_under_many_identities():
+    breaker = lp.FlapBreaker(clock=FakeClock())
+    for i in range(600):
+        breaker.admit(f"id-{i}")
+    assert breaker.snapshot()["tracked_identities"] <= 512
+
+
+def test_backoff_is_bounded_and_monotone(monkeypatch):
+    monkeypatch.setenv("JARVIS_LINK_BACKOFF_BASE_S", "0.5")
+    monkeypatch.setenv("JARVIS_LINK_BACKOFF_MAX_S", "30")
+    delays = [lp.backoff_delay_s(n) for n in range(0, 12)]
+    assert delays == sorted(delays)
+    assert max(delays) <= 30.0
+    assert lp.backoff_delay_s(999) <= 30.0
+
+
+def test_backoff_jitter_is_a_parameter_so_schedules_are_reproducible():
+    a = lp.backoff_delay_s(3, jitter=0.0)
+    assert lp.backoff_delay_s(3, jitter=0.0) == a
+    assert lp.backoff_delay_s(3, jitter=0.4) > a
+
+
+# ---------------------------------------------------------------------------
+# 3. Split-brain — the verdict fired, the socket ruptured
+# ---------------------------------------------------------------------------
+
+
+def test_a_verdict_lost_in_transmission_is_replayed_on_reconnect():
+    """THE split-brain regression. The Engine emitted seq 42; the Body never
+    applied it. Reconnection must ask for exactly the gap."""
+    plan = lp.plan_resume(peer_last_applied=41, source_latest=42,
+                          source_oldest_retained=1)
+    assert plan.action is lp.ResumeAction.REPLAY
+    assert (plan.from_seq, plan.to_seq) == (42, 42)
+
+
+def test_a_current_peer_replays_nothing():
+    plan = lp.plan_resume(peer_last_applied=42, source_latest=42,
+                          source_oldest_retained=1)
+    assert plan.action is lp.ResumeAction.CONTINUE
+
+
+def test_a_gap_older_than_retention_demands_resync_not_a_partial_replay():
+    """Resuming from the oldest retained record would SILENTLY drop
+    everything before it — the worst shape a data-loss bug can take."""
+    plan = lp.plan_resume(peer_last_applied=5, source_latest=900,
+                          source_oldest_retained=400)
+    assert plan.action is lp.ResumeAction.RESYNC
+    assert "evicted" in plan.reason
+
+
+def test_an_incoherent_peer_is_rejected_not_served():
+    """Claiming to have applied more than the Engine emitted means a stale
+    session id after a restart, or two Bodies sharing one identity."""
+    plan = lp.plan_resume(peer_last_applied=99, source_latest=10,
+                          source_oldest_retained=1)
+    assert plan.action is lp.ResumeAction.REJECT
+
+
+def test_a_fresh_peer_gets_everything_retained():
+    plan = lp.plan_resume(peer_last_applied=0, source_latest=5,
+                          source_oldest_retained=1)
+    assert plan.action is lp.ResumeAction.REPLAY
+    assert (plan.from_seq, plan.to_seq) == (1, 5)
+
+
+# ---------------------------------------------------------------------------
+# Idempotent application — exactly-once EFFECT
+# ---------------------------------------------------------------------------
+
+
+def _frame(seq, cid=None):
+    return lp.LinkFrame(seq=seq, lamport=seq, node_id="engine", kind="verdict",
+                        payload={"command_id": cid} if cid else {})
+
+
+def test_a_redelivered_verdict_is_applied_exactly_once():
+    ledger = lp.DeliveryLedger()
+    applied = []
+    f = _frame(1, "cmd-a")
+    assert ledger.apply_once(f, applied.append) is True
+    assert ledger.apply_once(f, applied.append) is False
+    assert len(applied) == 1
+    assert ledger.snapshot()["duplicates_suppressed"] == 1
+
+
+def test_a_handler_that_raises_leaves_the_frame_unapplied_for_retry():
+    """Recording first and running second would convert a transient fault
+    into permanent silent loss."""
+    ledger = lp.DeliveryLedger()
+
+    def _boom(_f):
+        raise RuntimeError("sink down")
+
+    with pytest.raises(RuntimeError):
+        ledger.apply_once(_frame(1, "cmd-a"), _boom)
+
+    applied = []
+    assert ledger.apply_once(_frame(1, "cmd-a"), applied.append) is True
+    assert len(applied) == 1
+
+
+def test_the_watermark_is_contiguous_not_highest_seen():
+    """THE subtle one. Tracking the highest value would advance past a hole,
+    the resume would never ask for it, and the loss would be permanent and
+    invisible."""
+    ledger = lp.DeliveryLedger()
+    ledger.apply_once(_frame(1), lambda f: None)
+    ledger.apply_once(_frame(3), lambda f: None)      # 2 is missing
+    assert ledger.contiguous_applied == 1
+    ledger.apply_once(_frame(2), lambda f: None)      # hole fills
+    assert ledger.contiguous_applied == 3
+
+
+def test_the_watermark_drives_a_correct_resume_after_a_hole():
+    ledger = lp.DeliveryLedger()
+    for s in (1, 2, 4, 5):
+        ledger.apply_once(_frame(s), lambda f: None)
+    plan = lp.plan_resume(peer_last_applied=ledger.contiguous_applied,
+                          source_latest=5, source_oldest_retained=1)
+    assert plan.action is lp.ResumeAction.REPLAY
+    assert plan.from_seq == 3
+
+
+def test_the_ledger_is_bounded():
+    ledger = lp.DeliveryLedger(capacity=64)
+    for i in range(1, 500):
+        ledger.apply_once(_frame(i, f"c{i}"), lambda f: None)
+    assert ledger.snapshot()["tracked_ids"] <= 64
+
+
+# ---------------------------------------------------------------------------
+# Sessions outlive sockets — a Wi-Fi drop is a PAUSE, not a loss
+# ---------------------------------------------------------------------------
+
+
+def test_a_reconnect_resumes_rather_than_allocating():
+    """The root-cause fix for flapping: if a reconnect costs no state, fifty
+    reconnects are a latency problem, not a resource one."""
+    reg = lp.SessionRegistry(clock=FakeClock())
+    s1, resumed1 = reg.attach("sess-1", "body")
+    s1.ledger.apply_once(_frame(1, "c1"), lambda f: None)
+    reg.detach("sess-1")
+    s2, resumed2 = reg.attach("sess-1", "body")
+    assert resumed1 is False and resumed2 is True
+    assert s2 is s1
+    assert s2.ledger.contiguous_applied == 1
+    assert s2.reconnects == 1
+
+
+def test_fifty_reconnects_allocate_one_session():
+    reg = lp.SessionRegistry(clock=FakeClock())
+    for _ in range(50):
+        reg.attach("sess-1", "body")
+        reg.detach("sess-1")
+    assert reg.snapshot()["sessions"] == 1
+
+
+def test_a_detached_session_survives_a_wifi_drop(monkeypatch):
+    monkeypatch.setenv("JARVIS_LINK_SESSION_EXPIRY_S", "900")
+    clock = FakeClock()
+    reg = lp.SessionRegistry(clock=clock)
+    reg.attach("sess-1", "body")
+    reg.detach("sess-1")
+    clock.advance(300.0)
+    _, resumed = reg.attach("sess-1", "body")
+    assert resumed is True, "a 5-minute outage lost the session"
+
+
+def test_a_long_dead_session_is_reaped_lazily(monkeypatch):
+    monkeypatch.setenv("JARVIS_LINK_SESSION_EXPIRY_S", "60")
+    clock = FakeClock()
+    reg = lp.SessionRegistry(clock=clock)
+    reg.attach("sess-1", "body")
+    reg.detach("sess-1")
+    clock.advance(120.0)
+    _, resumed = reg.attach("sess-2", "body")   # any access expires
+    assert reg.snapshot()["sessions"] == 1
+
+
+def test_an_attached_session_is_never_reaped(monkeypatch):
+    monkeypatch.setenv("JARVIS_LINK_SESSION_EXPIRY_S", "1")
+    clock = FakeClock()
+    reg = lp.SessionRegistry(clock=clock)
+    reg.attach("sess-1", "body")
+    clock.advance(10_000.0)
+    reg.attach("sess-2", "body")
+    assert reg.snapshot()["attached"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# Posture
+# ---------------------------------------------------------------------------
+
+
+def test_default_off_pending_graduation():
+    assert lp.is_enabled() is False
+
+
+def test_the_module_holds_no_transport():
+    """Pure logic: correctness must be provable at a desk, not by running
+    two machines."""
+    import pathlib
+    src = pathlib.Path(lp.__file__).read_text(encoding="utf-8")
+    for banned in ("import socket", "import asyncio", "aiohttp", "requests"):
+        assert banned not in src, banned
+
+
+def test_no_hardcoded_endpoints():
+    import pathlib
+    import re
+    src = pathlib.Path(lp.__file__).read_text(encoding="utf-8")
+    assert not re.search(r"\b\d{1,3}(\.\d{1,3}){3}\b", src), "hardcoded IP"
+    assert not re.search(r":\d{4,5}\b", src), "hardcoded port"


### PR DESCRIPTION
## Why the split falls where it does

Not a preference — §28's dependency audit measured it. **Quartz 151 files, AppKit 82, CoreAudio 62, ApplicationServices 35**: macOS frameworks with no Windows counterpart under any strategy. Against an engine whose POSIX coupling is **11 `fcntl` importers, 7 Unix-socket files, 9 `SIGHUP` references**. One half cannot leave the Mac; the other already can.

The Body stays as the sensor edge node. The Engine moves to a remote Windows/WSL2 box reached over an overlay network.

## The two problems that make a remote link different

Both are invisible on the loopback transport `cockpit_attach` already implements.

**The clocks are not comparable.** A WSL2 guest's wall clock drifts against its host and re-syncs after suspend/resume. Any "reject frames older than N seconds" rule evaluated across that boundary is a random number generator.

> A timestamp that crosses a machine boundary is **data, never a clock.**

Ordering uses a Lamport clock; durations use each side's own monotonic and are never differenced against the peer's. `sender_wall_ns` is named to make misuse obvious at the call site.

**Availability is nobody's to assume.** §26.6 established that absence must not read as refusal — across a network the link itself can produce absence. A partition is a **pause**: both ends park, neither infers a verdict from silence.

## `link_protocol.py` — the half provable at a desk

Clocks, sequence arithmetic, admission, resume planning. No socket, no asyncio, no transport — pinned by test. Both ends import the **same** module, so the two sides cannot drift apart on the rules by being written twice.

**Session identity is separate from connection identity**, and that — not the breaker — is the root-cause fix for flapping. Fifty reconnects exhaust an Engine only because each *connection* allocates a session, a queue and a task. When a reconnect allocates nothing, flapping is a latency problem rather than a resource one. Test proves 50 reconnects yield one session.

**`plan_resume`** has four outcomes and the third keeps the link honest: `RESYNC` when the gap predates retention, because resuming from the oldest retained record would silently drop everything before it. `REJECT` when a peer claims to have applied more than the Engine emitted — a stale session id after a restart, or two Bodies sharing an identity.

**`DeliveryLedger`** tracks the **contiguous** applied watermark, not the highest seen. Tracking the highest would advance past a hole, the resume would never ask for it, and the loss would be permanent and invisible.

## A defect the tests caught

The flap map pruned only *stale* entries. A peer cycling session ids produces thousands of **fresh** entries inside one window — none stale — growing it without bound. On a network-reachable service that is a memory-exhaustion vector, reached by the exact traffic pattern the class exists to survive. Now hard-capped with LRU eviction.

## Also included

- **`.gitattributes`** — `* text=auto eol=lf`. Without it a Git-for-Windows checkout at `autocrlf=true` rewrites every shebang into `#!/usr/bin/env python3\r`, which is not an interpreter. Silent at checkout, loud at runtime.
- **`docs/BRINGUP_WINDOWS_WSL2.md`** — whose two load-bearing warnings are that `.env` and `.jarvis/` are both gitignored: secrets do not travel, and the organism's memory starts empty on the new box.
- **PRD §29** — three lanes, three contracts; transport and trust posture.

## Scope

**34 protocol tests, 135 across the governance spine.** Transport, durable outbox and handshake are the next slice and cannot be finished honestly until both machines exist. Master switch `JARVIS_LINK_BRIDGE_ENABLED`, default false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a shared, transport-free Body/Engine link protocol core so the Mac Body can talk to a remote Windows/WSL2 Engine without relying on comparable wall clocks or stable connectivity. Replaces loopback-only assumptions with Lamport ordering, sessions that outlive sockets, idempotent sinks, and bounded admission to prevent reconnect storms from exhausting the Engine.

- Logical ordering and identity
  - `LogicalClock` uses Lamport counters; no cross-machine wall-clock comparisons.
  - `SessionRegistry` keeps session identity separate from connection identity; reconnects resume instead of allocating new state.
- Exactly-once effect across ruptures
  - `DeliveryLedger` applies each command once and reports a contiguous applied watermark.
  - `plan_resume` returns CONTINUE/REPLAY/RESYNC/REJECT; RESYNC prevents silent data loss beyond retention, REJECT guards incoherent peers.
- Admission control and defect fix
  - `FlapBreaker` gates reconnect storms before work is allocated and returns `retry_after_s`.
  - Bounds the identity map with LRU eviction; fixes unbounded growth when peers cycle identities.
- Docs and scaffolding
  - Adds `.gitattributes` to normalize line endings (prevents broken shebangs on Git-for-Windows).
  - Adds WSL2 bring-up guide for the Engine and PRD §29 describing the link.
  - Adds a pure-logic test suite; no sockets or endpoints are introduced.

**Review and rollout**
- No transport yet; this is pure logic imported by both ends. The link remains disabled behind `JARVIS_LINK_BRIDGE_ENABLED` (default false).
- Required action for Windows/WSL2 bring-up: follow `docs/BRINGUP_WINDOWS_WSL2.md`. Ensure Windows checkouts use the new `.gitattributes` to avoid CRLF shebang issues.
- When wiring transport later, use the shared `link_protocol` on both sides and propagate `retry_after_s` to clients.

<sup>Written for commit eb78a4cd1f84346fa711bc6491fc76dcea1f1b3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

