### PR TITLE
feat(link): the distributed Body/Engine link — transport, session, identity, CLI

### DIFF
--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -29,6 +29,7 @@ from typing import Any, Callable, List, Optional, Sequence
 from backend.core.ouroboros.ui.theme import build_console
 
 _VERBS = {"cockpit", "run", "daemon", "status", "attach", "system", "hive",
+          "link",
           "doctor", "demo", "restart", "version"}
 _HELP_TOKENS = {"help", "--help", "-h"}
 _VERSION_TOKENS = {"version", "--version", "-V"}
@@ -380,6 +381,8 @@ _HELP_TEXT = """ov -- Ouroboros + Venom, autonomous engineering organism
   ov doctor [--live]  8-edge connectivity matrix; --live fires the
                       trace-isolated synthetic tool probe end-to-end
   ov demo [scene]     watch the cockpit with synthetic events
+  ov link ...         the Body/Engine bridge -- issue certs, serve, connect
+                      (`ov link --help` for the full set)
   ov attach           attach this terminal to the running organism
   ov version          version + milestone
   ov help             this message
@@ -440,6 +443,8 @@ def resolve(argv: Optional[Sequence[str]] = None) -> Invocation:
         return Invocation("hive")
     if verb == "doctor":
         return Invocation("doctor", list(rest))
+    if verb == "link":
+        return Invocation("link", list(rest))
     if verb == "demo":
         return Invocation("demo", list(rest))
     if verb == "restart":
@@ -4664,6 +4669,15 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             console.print(f"ov demo unavailable: {exc}", markup=False)
             return 1
         return run_demo(console, inv.delegate_argv)
+    if inv.action == "link":
+        # Lazy, like `doctor`: `link` pulls in TLS and the transport stack,
+        # and a fault there must not be able to break `ov` itself.
+        try:
+            from backend.core.ouroboros.cli.ov_link import run_link
+        except Exception as exc:  # noqa: BLE001
+            console.print(f"ov link unavailable: {exc}", markup=False)
+            return 1
+        return run_link(console, inv.delegate_argv)
     if inv.action == "doctor":
         try:
             from backend.core.ouroboros.cli.ov_doctor import run_doctor

--- a/backend/core/ouroboros/cli/ov_link.py
+++ b/backend/core/ouroboros/cli/ov_link.py
@@ -1,0 +1,388 @@
+"""``ov link`` — issue the link's identity, serve it, or dial it.
+
+Three verbs over the modules that already do the work. This file contains no
+protocol logic, no certificate construction and no socket handling: it parses
+arguments, validates them where a wrong value would produce an obscure
+failure later, and reports what happened. Everything else is delegated.
+
+WHY VALIDATION HAPPENS HERE
+---------------------------
+Two mistakes on this path fail far from their cause:
+
+* **A wrong SAN.** A certificate issued for the wrong name fails at the
+  handshake as a *trust* error, which reads as "certificates are broken"
+  rather than "you typed the wrong hostname". So names are required and their
+  shape is checked at the point of entry.
+* **A missing peer.** ``--connect`` without a reachable host produces a
+  connection error every backoff interval, forever, which looks like a
+  network problem rather than a missing argument.
+
+Both are refused with an exit code and a sentence, never a stack trace and
+never a silent default. ``EX_USAGE`` (64) for an argument the operator can
+fix; ``EX_CONFIG`` (78) for state on disk that needs a decision.
+
+Follows ``ov doctor``'s established shape: a ``run_*`` entry point taking a
+console and an argv slice, returning a process exit code, refusing unknown
+flags rather than ignoring them.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from pathlib import Path
+from typing import Any, Optional, Sequence, Tuple
+
+logger = logging.getLogger("Ouroboros.OvLink")
+
+EX_USAGE = 64
+EX_CONFIG = 78
+EX_UNAVAILABLE = 69
+
+LINK_HELP = """ov link -- the Body/Engine bridge
+
+  ov link --issue-certs --server-name NAME [--server-name NAME ...]
+                        [--client-name NAME] [--dir PATH] [--force]
+      Issue this link's private CA and its two leaves. Run this ONCE, on the
+      Engine. Every name the Body will dial the Engine by must be listed --
+      its tailnet DNS name and its 100.x address are both normal.
+
+  ov link --serve [--host ADDR] [--port N]
+      Run the Engine side. Binds loopback unless --host says otherwise;
+      point it at the tailnet address to accept the Body.
+
+  ov link --connect HOST [--port N]
+      Run the Body side. HOST must match a name in the Engine's certificate.
+
+  ov link --status [--dir PATH]
+      What material is installed, and how many days before it expires.
+
+Flags:
+  --dir PATH          certificate directory (default: JARVIS_LINK_TLS_DIR)
+  --session ID        session identity to resume (default: JARVIS_LINK_SESSION)
+  --node ID           this node's name (default: hostname)
+  --force             re-issue over existing material (revokes the peer)
+"""
+
+
+def _hostname() -> str:
+    try:
+        import socket
+        return socket.gethostname() or "node"
+    except Exception:  # noqa: BLE001
+        return "node"
+
+
+def _looks_like_a_name(value: str) -> bool:
+    """A hostname or IP literal, not a URL, a path, or a host:port pair.
+
+    Catches the shapes an operator actually types by mistake — a ``https://``
+    prefix, an appended ``:9000``, a filesystem path — each of which produces
+    a certificate that verifies against nothing and fails at the handshake as
+    a *trust* error.
+
+    A colon is the awkward case: it is wrong in ``engine:9000`` and correct
+    in an IPv6 literal. Rather than pattern-match the difference, the value
+    is handed to ``ipaddress`` — if it parses as an address it is one, and if
+    it does not, a colon means a port was appended.
+    """
+    if not value or value != value.strip():
+        return False
+    if any(token in value for token in ("/", "\\", " ", "\t")):
+        return False
+    if ":" in value:
+        import ipaddress
+        try:
+            ipaddress.ip_address(value)
+        except ValueError:
+            return False
+    return True
+
+
+class _Args:
+    """Parsed ``ov link`` argv. Refuses what it does not recognise."""
+
+    def __init__(self) -> None:
+        self.mode: Optional[str] = None
+        self.server_names: list = []
+        self.client_names: list = []
+        self.directory: Optional[Path] = None
+        self.host: Optional[str] = None
+        self.port: Optional[int] = None
+        self.session: Optional[str] = None
+        self.node: Optional[str] = None
+        self.force = False
+        self.error: str = ""
+
+
+_MODES = {"--issue-certs": "issue", "--serve": "serve",
+          "--connect": "connect", "--status": "status"}
+_VALUED = {"--server-name", "--client-name", "--dir", "--host", "--port",
+           "--session", "--node", "--connect"}
+_KNOWN = set(_MODES) | _VALUED | {"--force", "--help", "-h"}
+
+
+def parse(argv: Sequence[str]) -> _Args:
+    """Pure argv → :class:`_Args`. Never raises, never reads the environment.
+
+    Separated from execution so the routing is unit-testable without a socket
+    or a filesystem — the same discipline ``ov.resolve`` follows.
+    """
+    args = _Args()
+    tokens = list(argv)
+    i = 0
+    while i < len(tokens):
+        tok = tokens[i]
+        if tok in ("--help", "-h"):
+            args.mode = "help"
+            return args
+        if tok not in _KNOWN:
+            hint = next((k for k in sorted(_KNOWN)
+                         if k.startswith(tok[:6]) and k != tok), None)
+            args.error = (f"unknown flag {tok!r}"
+                          + (f" — did you mean {hint!r}?" if hint else ""))
+            return args
+        if tok in _MODES:
+            if args.mode and args.mode != _MODES[tok]:
+                args.error = (f"{tok} conflicts with the mode already given "
+                              f"({args.mode}); pick one")
+                return args
+            args.mode = _MODES[tok]
+            if tok == "--connect":
+                if i + 1 >= len(tokens) or tokens[i + 1].startswith("-"):
+                    args.error = "--connect requires a HOST"
+                    return args
+                args.host = tokens[i + 1]
+                i += 2
+                continue
+            i += 1
+            continue
+        if tok == "--force":
+            args.force = True
+            i += 1
+            continue
+        if i + 1 >= len(tokens):
+            args.error = f"{tok} requires a value"
+            return args
+        value = tokens[i + 1]
+        if tok == "--server-name":
+            args.server_names.append(value)
+        elif tok == "--client-name":
+            args.client_names.append(value)
+        elif tok == "--dir":
+            args.directory = Path(value).expanduser()
+        elif tok == "--host":
+            args.host = value
+        elif tok == "--session":
+            args.session = value
+        elif tok == "--node":
+            args.node = value
+        elif tok == "--port":
+            try:
+                args.port = int(value)
+            except (TypeError, ValueError):
+                args.error = f"--port must be an integer, got {value!r}"
+                return args
+            if not (0 <= args.port <= 65535):
+                args.error = f"--port out of range: {args.port}"
+                return args
+        i += 2
+    return args
+
+
+def _say(console: Any, text: str) -> None:
+    try:
+        console.print(text, markup=False, highlight=False)
+    except Exception:  # noqa: BLE001
+        print(text, flush=True)
+
+
+def _build_loop(args: _Args) -> Any:
+    """Construct the session loop from arguments and canonical defaults."""
+    from backend.core.ouroboros.governance import link_session as ls
+    session_id = (args.session or os.environ.get("JARVIS_LINK_SESSION")
+                  or "ov-link")
+    node = args.node or os.environ.get("JARVIS_LINK_NODE") or _hostname()
+    spill_root = Path(os.environ.get("JARVIS_PROJECT_ROOT", ".")) / ".jarvis"
+    return ls.LinkSessionLoop(
+        ls.SessionConfig(
+            node_id=node, session_id=session_id,
+            spill_path=spill_root / "link_outbox.log",
+        ),
+        on_frame=lambda frame: logger.info(
+            "[ov link] %s seq=%s", frame.get("kind"), frame.get("seq")),
+    )
+
+
+def _run_issue(console: Any, args: _Args) -> int:
+    from backend.core.ouroboros.governance import link_certs as lc
+
+    names = list(args.server_names)
+    if not names:
+        _say(console,
+             "--issue-certs requires at least one --server-name.\n"
+             "It must be a name the Body will dial the Engine by — its "
+             "tailnet DNS name and/or its 100.x address. This cannot be "
+             "guessed: a certificate issued for the wrong name fails the "
+             "handshake as a trust error, which is far harder to diagnose "
+             "than a missing argument.")
+        return EX_USAGE
+    bad = [n for n in names + args.client_names if not _looks_like_a_name(n)]
+    if bad:
+        _say(console,
+             f"not usable as certificate names: {', '.join(repr(b) for b in bad)}\n"
+             "Give a bare hostname or IP — no scheme, no port, no path.")
+        return EX_USAGE
+
+    try:
+        issued = lc.issue_link_material(
+            directory=args.directory, server_names=names,
+            client_names=args.client_names or None, force=args.force)
+    except lc.CertToolUnavailable as exc:
+        _say(console, f"{exc}\n  pip install cryptography")
+        return EX_UNAVAILABLE
+    except FileExistsError as exc:
+        _say(console, f"{exc}\n\nPass --force only if you can re-copy the CA "
+                      f"to the other machine afterwards.")
+        return EX_CONFIG
+    except (ValueError, OSError) as exc:
+        _say(console, f"could not issue material: {exc}")
+        return EX_CONFIG
+
+    _say(console, f"issued link material in {issued.directory}")
+    _say(console, f"  server names : {', '.join(issued.server_names)}")
+    _say(console, f"  client names : {', '.join(issued.client_names)}")
+    _say(console, f"  valid until  : {issued.not_after}")
+    _say(console, "")
+    _say(console, "Copy EXACTLY these to the Body (the CA private key stays "
+                  "here):")
+    for name in lc.files_to_copy_to_peer():
+        _say(console, f"  {issued.directory / name}")
+    return 0
+
+
+def _run_status(console: Any, args: _Args) -> int:
+    from backend.core.ouroboros.governance import link_certs as lc
+    report = lc.inspect_material(args.directory)
+    _say(console, f"link material in {report['directory']}")
+    certs = report.get("certificates") or {}
+    if not certs:
+        _say(console, "  none installed — run `ov link --issue-certs`")
+        return EX_CONFIG
+    worst = 10 ** 6
+    for name, entry in sorted(certs.items()):
+        if "error" in entry:
+            _say(console, f"  {name}: unreadable — {entry['error']}")
+            worst = -1
+            continue
+        days = entry["days_remaining"]
+        worst = min(worst, days)
+        flag = "EXPIRED" if entry["expired"] else f"{days}d remaining"
+        _say(console, f"  {name}: {flag}")
+        if entry.get("sans"):
+            _say(console, f"      names: {', '.join(entry['sans'])}")
+    if worst < 0:
+        return EX_CONFIG
+    if worst <= 0:
+        _say(console, "\nMaterial has EXPIRED — re-issue and re-copy to the "
+                      "peer.")
+        return EX_CONFIG
+    if worst < 30:
+        _say(console, f"\nExpires in {worst} days — re-issue while you still "
+                      f"have access to both machines.")
+    return 0
+
+
+def _run_serve(console: Any, args: _Args) -> int:
+    from backend.core.ouroboros.governance import link_runner as lr
+
+    loop = _build_loop(args)
+
+    async def _main() -> int:
+        try:
+            server = await lr.serve_link(loop, host=args.host,
+                                         port=args.port)
+        except ConnectionError as exc:
+            _say(console, str(exc))
+            return EX_CONFIG
+        bound = server.sockets[0].getsockname() if server.sockets else ("?", 0)
+        _say(console, f"engine listening on {bound[0]}:{bound[1]}  "
+                      f"session={loop.config.session_id} "
+                      f"node={loop.config.node_id}")
+        _say(console, "Ctrl+C to stop; the session parks and resumes on "
+                      "reconnect.")
+        try:
+            async with server:
+                await server.serve_forever()
+        except asyncio.CancelledError:
+            pass
+        return 0
+
+    return _drive(console, _main())
+
+
+def _run_connect(console: Any, args: _Args) -> int:
+    from backend.core.ouroboros.governance import link_runner as lr
+
+    if not args.host or not _looks_like_a_name(args.host):
+        _say(console, f"--connect needs a bare host, got {args.host!r}. "
+                      "It must match a name in the Engine's certificate.")
+        return EX_USAGE
+    port = args.port if args.port is not None else int(
+        os.environ.get("JARVIS_LINK_PORT", "0") or 0)
+    if not port:
+        _say(console, "--connect requires --port (or JARVIS_LINK_PORT). The "
+                      "Engine prints the port it bound.")
+        return EX_USAGE
+
+    loop = _build_loop(args)
+    runner = lr.LinkRunner(loop, connector=lr.tls_connector(args.host, port))
+
+    async def _main() -> int:
+        _say(console, f"body dialing {args.host}:{port}  "
+                      f"session={loop.config.session_id} "
+                      f"node={loop.config.node_id}")
+        _say(console, "Ctrl+C to stop; a drop parks rather than fails.")
+        await runner.run()
+        return 0
+
+    return _drive(console, _main())
+
+
+def _drive(console: Any, coro: Any) -> int:
+    """Run a coroutine to completion, translating interruption cleanly.
+
+    Ctrl+C is an ordinary way to stop a daemon, not a crash: it exits 130
+    (128+SIGINT) with a line, never a KeyboardInterrupt traceback.
+    """
+    try:
+        return asyncio.run(coro)
+    except KeyboardInterrupt:
+        _say(console, "\nstopped")
+        return 130
+    except ConnectionError as exc:
+        _say(console, str(exc))
+        return EX_CONFIG
+
+
+def run_link(console: Any, argv: Optional[Sequence[str]] = None) -> int:
+    """``ov link`` entry point. Returns a process exit code."""
+    args = parse(list(argv or ()))
+    if args.error:
+        _say(console, args.error)
+        _say(console, "")
+        _say(console, LINK_HELP)
+        return EX_USAGE
+    if args.mode in (None, "help"):
+        _say(console, LINK_HELP)
+        return 0 if args.mode == "help" else EX_USAGE
+    if args.mode == "issue":
+        return _run_issue(console, args)
+    if args.mode == "status":
+        return _run_status(console, args)
+    if args.mode == "serve":
+        return _run_serve(console, args)
+    if args.mode == "connect":
+        return _run_connect(console, args)
+    _say(console, LINK_HELP)
+    return EX_USAGE

--- a/backend/core/ouroboros/governance/link_certs.py
+++ b/backend/core/ouroboros/governance/link_certs.py
@@ -1,0 +1,415 @@
+"""link_certs — the link's own identity, issued locally and honestly.
+
+WHY THIS EXISTS AT ALL
+----------------------
+The overlay network (Tailscale) supplies a tunnel. It does not supply an
+answer to *which Body is this?* — and that question is load-bearing, because
+:func:`link_protocol.plan_resume` will happily serve a replayed session id to
+whoever presents it. Anything on the tailnet could resume another Body's
+session and receive its verdicts. mTLS is what makes the session id a claim
+that has to be proven.
+
+WHAT WENT WRONG WITH THE MATERIAL THAT ALREADY EXISTED
+------------------------------------------------------
+``.jarvis/brain_mtls/`` holds a working CA — for a different trust domain.
+Its leaves are issued to ``jarvis-brain``, it belongs to the J-Prime channel,
+and (as of this writing) it had expired weeks earlier on a **seven-day**
+validity. Three separate reasons it cannot be reused, and only the third is
+fixable by waiting:
+
+* **Wrong names.** A leaf whose SAN is ``jarvis-brain`` cannot authenticate a
+  host reached as a tailnet name, and turning off hostname verification to
+  make it fit is how an mTLS deployment silently becomes encryption without
+  identity.
+* **Wrong domain.** One directory shared by two trust domains means rotating
+  either silently re-keys the other, and a leaf issued for one peer is
+  accepted by the other's verifier.
+* **Wrong lifetime.** Seven days is a rotation cadence nobody sustained. A
+  link between two machines in two houses cannot require a physical visit
+  every week to keep working — the same reason Tailscale key expiry must be
+  disabled on the Engine.
+
+So the link gets its own CA, its own directory, and a validity chosen for how
+often someone will actually be in the same room as both machines.
+
+DESIGN
+------
+Generated locally with ``cryptography``; no network, no external PKI, no
+shelling out to ``openssl`` with a hand-built config file. A private CA whose
+only job is to sign exactly two leaves is the correct shape here — the trust
+decision is "these two machines", and that is precisely what a two-leaf CA
+encodes.
+
+Nothing is hardcoded. Names, validity, key size and output directory are all
+arguments with env-backed defaults, because the peer names are properties of
+someone's tailnet and cannot be known here.
+
+Refuses to overwrite existing material unless explicitly told to. A silent
+regeneration on a working deployment would revoke the peer's trust from
+across the country, and the operator would discover it as a handshake failure
+with no obvious cause.
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import ipaddress
+import logging
+import os
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+logger = logging.getLogger("Ouroboros.LinkCerts")
+
+LINK_CERTS_SCHEMA_VERSION: str = "link_certs.1"
+
+#: Filenames the transport expects. Kept here so the writer and the reader
+#: cannot disagree about what a directory of material looks like.
+CA_CERT = "ca.pem"
+CA_KEY = "ca-key.pem"
+SERVER_CERT = "server-cert.pem"
+SERVER_KEY = "server-key.pem"
+CLIENT_CERT = "client-cert.pem"
+CLIENT_KEY = "client-key.pem"
+
+_LEAF_FILES = (SERVER_CERT, SERVER_KEY, CLIENT_CERT, CLIENT_KEY)
+_ALL_FILES = (CA_CERT, CA_KEY) + _LEAF_FILES
+
+
+def _env_int(name: str, default: int, minimum: int = 1) -> int:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return max(minimum, int(raw))
+    except (TypeError, ValueError):
+        return default
+
+
+def validity_days() -> int:
+    """Leaf lifetime. Default 825 days.
+
+    Not a security compromise — a deployment one. The two machines are in two
+    houses, so rotation requires either a visit or a remote procedure someone
+    has to remember. 825 is the longest a public CA may issue and is the
+    conventional ceiling for a private one; anything shorter re-creates the
+    expiry that made the brain material unusable.
+    """
+    return _env_int("JARVIS_LINK_CERT_DAYS", 825)
+
+
+def ca_validity_days() -> int:
+    """CA lifetime. Must outlive every leaf it signs, or rotation cascades."""
+    return _env_int("JARVIS_LINK_CA_DAYS", validity_days() * 2)
+
+
+def key_bits() -> int:
+    """RSA modulus size. Default 3072."""
+    return _env_int("JARVIS_LINK_CERT_BITS", 3072, minimum=2048)
+
+
+def clock_skew_hours() -> int:
+    """Backdating on ``notBefore``. Default 24h.
+
+    Directly load-bearing here: §29 exists because these two clocks drift,
+    and a certificate whose validity begins "now" is rejected by a peer whose
+    clock is a few minutes behind — a handshake failure whose cause looks
+    like anything but a clock.
+    """
+    return _env_int("JARVIS_LINK_CERT_SKEW_HOURS", 24)
+
+
+@dataclass(frozen=True)
+class IssuedMaterial:
+    directory: Path
+    ca_subject: str
+    server_names: Tuple[str, ...]
+    client_names: Tuple[str, ...]
+    not_after: str
+    files: Tuple[str, ...]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "schema_version": LINK_CERTS_SCHEMA_VERSION,
+            "directory": str(self.directory),
+            "ca_subject": self.ca_subject,
+            "server_names": list(self.server_names),
+            "client_names": list(self.client_names),
+            "not_after": self.not_after,
+            "files": list(self.files),
+        }
+
+
+class CertToolUnavailable(RuntimeError):
+    """``cryptography`` is not importable. Stated, never worked around."""
+
+
+def _split_names(raw: Any) -> Tuple[str, ...]:
+    if raw is None:
+        return ()
+    if isinstance(raw, str):
+        parts = [p.strip() for p in raw.replace(",", " ").split()]
+    else:
+        parts = [str(p).strip() for p in raw]
+    return tuple(p for p in parts if p)
+
+
+def _san_entries(names: Sequence[str]) -> List[Any]:
+    """Build SANs, routing literals to IPAddress and the rest to DNSName.
+
+    A tailnet address is a ``100.x.y.z`` literal, and putting one in a DNSName
+    produces a certificate that verifies against nothing: peers match IP
+    literals against ``iPAddress`` SANs only. Getting this wrong yields a
+    handshake failure that reads as a trust problem rather than an encoding
+    one, so the split is made here rather than left to the caller.
+    """
+    from cryptography import x509
+
+    out: List[Any] = []
+    for name in names:
+        try:
+            out.append(x509.IPAddress(ipaddress.ip_address(name)))
+        except ValueError:
+            out.append(x509.DNSName(name))
+    return out
+
+
+def _write_secret(path: Path, data: bytes) -> None:
+    """Write a private key readable only by its owner.
+
+    Created with the mode already applied rather than chmod'ed afterwards:
+    between ``open`` and ``chmod`` the key is world-readable, and on a shared
+    machine that window is the whole vulnerability.
+    """
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    fd = os.open(str(path), flags, stat.S_IRUSR | stat.S_IWUSR)
+    try:
+        os.write(fd, data)
+    finally:
+        os.close(fd)
+
+
+def existing_material(directory: Optional[Path] = None) -> Dict[str, bool]:
+    """Which expected files are present. Never raises."""
+    base = Path(directory) if directory else _default_dir()
+    out: Dict[str, bool] = {}
+    for name in _ALL_FILES:
+        try:
+            out[name] = (base / name).exists()
+        except OSError:
+            out[name] = False
+    return out
+
+
+def _default_dir() -> Path:
+    from backend.core.ouroboros.governance.link_transport import tls_dir
+    return tls_dir()
+
+
+def inspect_material(directory: Optional[Path] = None) -> Dict[str, Any]:
+    """Report what is installed and whether it is currently usable.
+
+    Reports expiry as a FACT with days remaining rather than a boolean, so an
+    operator sees a rotation coming instead of discovering it as an outage —
+    which is exactly how the brain material failed.
+    """
+    base = Path(directory) if directory else _default_dir()
+    report: Dict[str, Any] = {
+        "schema_version": LINK_CERTS_SCHEMA_VERSION,
+        "directory": str(base), "present": existing_material(base),
+        "certificates": {},
+    }
+    try:
+        from cryptography import x509
+    except ImportError:
+        report["error"] = "cryptography unavailable — cannot inspect"
+        return report
+    now = _dt.datetime.now(_dt.timezone.utc)
+    for name in (CA_CERT, SERVER_CERT, CLIENT_CERT):
+        path = base / name
+        if not path.exists():
+            continue
+        try:
+            cert = x509.load_pem_x509_certificate(path.read_bytes())
+            not_after = cert.not_valid_after_utc
+            sans: List[str] = []
+            try:
+                ext = cert.extensions.get_extension_for_class(
+                    x509.SubjectAlternativeName)
+                sans = [str(v) for v in ext.value.get_values_for_type(
+                    x509.DNSName)]
+                sans += [str(v) for v in ext.value.get_values_for_type(
+                    x509.IPAddress)]
+            except x509.ExtensionNotFound:
+                pass
+            report["certificates"][name] = {
+                "subject": cert.subject.rfc4514_string(),
+                "not_after": not_after.isoformat(),
+                "days_remaining": (not_after - now).days,
+                "expired": not_after <= now,
+                "sans": sans,
+            }
+        except Exception as exc:  # noqa: BLE001
+            report["certificates"][name] = {"error": str(exc)}
+    return report
+
+
+def issue_link_material(
+    *,
+    directory: Optional[Path] = None,
+    server_names: Optional[Sequence[str]] = None,
+    client_names: Optional[Sequence[str]] = None,
+    force: bool = False,
+) -> IssuedMaterial:
+    """Create a private CA and the two leaves the link needs.
+
+    ``server_names`` are every name or address the Body will dial the Engine
+    by — its tailnet DNS name and its ``100.x`` address are both normal, and
+    both belong in the SAN because a client that connects by address verifies
+    against the address.
+
+    Refuses to overwrite unless ``force``. Regenerating silently on a live
+    deployment revokes the peer's trust from across the country, and the
+    operator meets it as an inexplicable handshake failure.
+    """
+    try:
+        from cryptography import x509
+        from cryptography.hazmat.primitives import hashes, serialization
+        from cryptography.hazmat.primitives.asymmetric import rsa
+        from cryptography.x509.oid import NameOID
+    except ImportError as exc:  # pragma: no cover - environment dependent
+        raise CertToolUnavailable(
+            "cryptography is required to issue link material; install it "
+            "rather than falling back to a hand-built openssl config"
+        ) from exc
+
+    base = Path(directory) if directory else _default_dir()
+    srv = _split_names(server_names) or _split_names(
+        os.environ.get("JARVIS_LINK_SERVER_NAMES"))
+    cli = _split_names(client_names) or _split_names(
+        os.environ.get("JARVIS_LINK_CLIENT_NAMES")) or ("jarvis-body",)
+    if not srv:
+        raise ValueError(
+            "server_names is required — the Engine's tailnet name and/or "
+            "address. It is a property of your tailnet and cannot be guessed "
+            "here; a wrong SAN fails the handshake as a trust error.")
+
+    present = [n for n, ok in existing_material(base).items() if ok]
+    if present and not force:
+        raise FileExistsError(
+            f"{base} already holds {len(present)} file(s): "
+            f"{', '.join(sorted(present))}. Re-issuing revokes the peer's "
+            f"trust — pass force=True only if you can re-copy the CA to the "
+            f"other machine.")
+
+    base.mkdir(parents=True, exist_ok=True)
+    now = _dt.datetime.now(_dt.timezone.utc)
+    not_before = now - _dt.timedelta(hours=clock_skew_hours())
+
+    def _key():
+        return rsa.generate_private_key(public_exponent=65537,
+                                        key_size=key_bits())
+
+    def _pem_key(key) -> bytes:
+        return key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+
+    ca_key = _key()
+    ca_subject = x509.Name([
+        x509.NameAttribute(NameOID.COMMON_NAME, "jarvis-link-ca"),
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, "JARVIS O+V"),
+    ])
+    ca_cert = (
+        x509.CertificateBuilder()
+        .subject_name(ca_subject).issuer_name(ca_subject)
+        .public_key(ca_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(not_before)
+        .not_valid_after(now + _dt.timedelta(days=ca_validity_days()))
+        # A CA that can sign anything is a CA that can impersonate anything.
+        # path_length=0 means it may sign leaves and never another CA.
+        .add_extension(x509.BasicConstraints(ca=True, path_length=0),
+                       critical=True)
+        .add_extension(
+            x509.KeyUsage(
+                digital_signature=True, key_cert_sign=True, crl_sign=True,
+                content_commitment=False, key_encipherment=False,
+                data_encipherment=False, key_agreement=False,
+                encipher_only=False, decipher_only=False),
+            critical=True)
+        .sign(ca_key, hashes.SHA256())
+    )
+
+    def _leaf(names: Sequence[str], cn: str, server: bool):
+        from cryptography.x509.oid import ExtendedKeyUsageOID
+        key = _key()
+        cert = (
+            x509.CertificateBuilder()
+            .subject_name(x509.Name([
+                x509.NameAttribute(NameOID.COMMON_NAME, cn)]))
+            .issuer_name(ca_subject)
+            .public_key(key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(not_before)
+            .not_valid_after(now + _dt.timedelta(days=validity_days()))
+            .add_extension(x509.BasicConstraints(ca=False, path_length=None),
+                           critical=True)
+            .add_extension(x509.SubjectAlternativeName(_san_entries(names)),
+                           critical=False)
+            # Narrow EKU on both sides. A leaf usable as both client and
+            # server lets a compromised Body impersonate the Engine to
+            # itself, which is exactly the confusion mTLS is bought to
+            # prevent.
+            .add_extension(
+                x509.ExtendedKeyUsage([
+                    ExtendedKeyUsageOID.SERVER_AUTH if server
+                    else ExtendedKeyUsageOID.CLIENT_AUTH]),
+                critical=False)
+            .add_extension(
+                x509.KeyUsage(
+                    digital_signature=True, key_encipherment=True,
+                    content_commitment=False, data_encipherment=False,
+                    key_agreement=False, key_cert_sign=False, crl_sign=False,
+                    encipher_only=False, decipher_only=False),
+                critical=True)
+            .sign(ca_key, hashes.SHA256())
+        )
+        return key, cert
+
+    server_key, server_cert = _leaf(srv, srv[0], server=True)
+    client_key, client_cert = _leaf(cli, cli[0], server=False)
+
+    pem = serialization.Encoding.PEM
+    (base / CA_CERT).write_bytes(ca_cert.public_bytes(pem))
+    (base / SERVER_CERT).write_bytes(server_cert.public_bytes(pem))
+    (base / CLIENT_CERT).write_bytes(client_cert.public_bytes(pem))
+    _write_secret(base / CA_KEY, _pem_key(ca_key))
+    _write_secret(base / SERVER_KEY, _pem_key(server_key))
+    _write_secret(base / CLIENT_KEY, _pem_key(client_key))
+
+    logger.info(
+        "[LinkCerts] issued link material in %s — server SAN %s, valid %dd",
+        base, ", ".join(srv), validity_days())
+    return IssuedMaterial(
+        directory=base, ca_subject=ca_subject.rfc4514_string(),
+        server_names=srv, client_names=cli,
+        not_after=(now + _dt.timedelta(days=validity_days())).isoformat(),
+        files=_ALL_FILES,
+    )
+
+
+def files_to_copy_to_peer() -> Tuple[str, ...]:
+    """What the Body needs from the Engine's issuing run.
+
+    The CA's PRIVATE key is deliberately absent: it stays on the machine that
+    issued, and copying it would give each end the power to mint identities
+    for the other. The Body needs the CA certificate to verify the Engine, and
+    its own leaf — nothing more.
+    """
+    return (CA_CERT, CLIENT_CERT, CLIENT_KEY)

--- a/backend/core/ouroboros/governance/link_certs.py
+++ b/backend/core/ouroboros/governance/link_certs.py
@@ -53,6 +53,7 @@ Python 3.9+, ``from __future__ import annotations``.
 """
 from __future__ import annotations
 
+import contextlib
 import datetime as _dt
 import ipaddress
 import logging
@@ -177,19 +178,79 @@ def _san_entries(names: Sequence[str]) -> List[Any]:
     return out
 
 
-def _write_secret(path: Path, data: bytes) -> None:
-    """Write a private key readable only by its owner.
+def _publish(path: Path, data: bytes, *, secret: bool) -> None:
+    """Write ``data`` to ``path`` atomically and durably.
 
-    Created with the mode already applied rather than chmod'ed afterwards:
-    between ``open`` and ``chmod`` the key is world-readable, and on a shared
-    machine that window is the whole vulnerability.
+    **Why atomic matters here specifically.** A reader of this directory is
+    an SSL context being built at connection time, and a half-written PEM is
+    not a recoverable partial read — OpenSSL rejects it, and the operator
+    sees a trust failure with no hint that the cause was a concurrent writer.
+    So every file is written to a temp in the SAME directory (a rename is
+    only atomic within a filesystem) and published with
+    ``durable_io.atomic_replace``, which already sequences fsync-data →
+    rename → fsync-dir. Reusing it means the certificate directory gets the
+    same durability guarantee as the transcript log rather than a second,
+    weaker one written here.
+
+    Secrets are created with mode 0600 applied at ``open`` rather than
+    chmod'ed afterwards: between the two calls the key is world-readable,
+    and on a shared machine that window is the whole vulnerability. The temp
+    carries the mode too, since a temp file in a readable directory is just
+    as exposed as the final name.
     """
+    from backend.core.ouroboros.governance.durable_io import atomic_replace
+
+    tmp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    mode = (stat.S_IRUSR | stat.S_IWUSR) if secret else 0o644
     flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
-    fd = os.open(str(path), flags, stat.S_IRUSR | stat.S_IWUSR)
+    fd = os.open(str(tmp), flags, mode)
     try:
         os.write(fd, data)
     finally:
         os.close(fd)
+    try:
+        atomic_replace(tmp, path)
+    except Exception:
+        with contextlib.suppress(OSError):
+            tmp.unlink()
+        raise
+
+
+@contextlib.contextmanager
+def _issuance_lock(directory: Path):
+    """Serialise concurrent issuance. Fails fast; never waits.
+
+    Two ``--issue-certs`` runs interleaving would produce a CA from one and
+    leaves from the other — material that is individually well-formed and
+    collectively unverifiable, which is a far worse failure than a refusal.
+    An ``O_EXCL`` create is the mutex because it is atomic on every
+    filesystem this runs on, including over SMB on the Windows box.
+
+    Fails fast rather than blocking: a second issuer is a mistake, not a
+    queue, and telling the operator immediately is more useful than making
+    them wait for a lock whose holder may have died. A stale lock names its
+    owning pid so the remedy is obvious.
+    """
+    directory.mkdir(parents=True, exist_ok=True)
+    lock = directory / ".issue.lock"
+    try:
+        fd = os.open(str(lock), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+    except FileExistsError:
+        try:
+            holder = lock.read_text(encoding="utf-8").strip()
+        except OSError:
+            holder = "unknown"
+        raise FileExistsError(
+            f"another issuance is in progress (holder pid {holder}). If no "
+            f"such process exists, remove {lock} and retry."
+        ) from None
+    try:
+        os.write(fd, str(os.getpid()).encode("ascii"))
+        os.close(fd)
+        yield
+    finally:
+        with contextlib.suppress(OSError):
+            lock.unlink()
 
 
 def existing_material(directory: Optional[Path] = None) -> Dict[str, bool]:
@@ -386,12 +447,17 @@ def issue_link_material(
     client_key, client_cert = _leaf(cli, cli[0], server=False)
 
     pem = serialization.Encoding.PEM
-    (base / CA_CERT).write_bytes(ca_cert.public_bytes(pem))
-    (base / SERVER_CERT).write_bytes(server_cert.public_bytes(pem))
-    (base / CLIENT_CERT).write_bytes(client_cert.public_bytes(pem))
-    _write_secret(base / CA_KEY, _pem_key(ca_key))
-    _write_secret(base / SERVER_KEY, _pem_key(server_key))
-    _write_secret(base / CLIENT_KEY, _pem_key(client_key))
+    # Published under the issuance lock so two concurrent runs cannot
+    # interleave a CA from one with leaves from the other.
+    with _issuance_lock(base):
+        _publish(base / CA_CERT, ca_cert.public_bytes(pem), secret=False)
+        _publish(base / SERVER_CERT, server_cert.public_bytes(pem),
+                 secret=False)
+        _publish(base / CLIENT_CERT, client_cert.public_bytes(pem),
+                 secret=False)
+        _publish(base / CA_KEY, _pem_key(ca_key), secret=True)
+        _publish(base / SERVER_KEY, _pem_key(server_key), secret=True)
+        _publish(base / CLIENT_KEY, _pem_key(client_key), secret=True)
 
     logger.info(
         "[LinkCerts] issued link material in %s — server SAN %s, valid %dd",

--- a/backend/core/ouroboros/governance/link_outbox.py
+++ b/backend/core/ouroboros/governance/link_outbox.py
@@ -1,0 +1,399 @@
+"""link_outbox — verdicts survive the Body being gone.
+
+THE FAILURE THIS EXISTS FOR
+---------------------------
+The Body is on a laptop that leaves the house. The Engine keeps working —
+that is the entire point of a proactive organism — and every completed op
+produces a verdict the Body has not acknowledged. Held in a list, those
+accumulate for as long as the outage lasts, and an outage measured in hours
+ends as an OOM on the machine holding the accelerator.
+
+The naive fixes are both wrong. An unbounded queue trades a network problem
+for a memory problem. A bounded queue that drops silently trades it for a
+correctness problem, and a dropped verdict is indistinguishable from an op
+that never ran — the exact ambiguity §26.6 spent a section removing.
+
+So: bounded in memory, **spilled to disk** past the threshold, and shed only
+at a second bound with a loud, countable signal. Disk is cheap and a laptop
+can be away a long time; silence is what must never happen.
+
+WHY THIS REUSES THE TRANSCRIPT CODEC
+------------------------------------
+``transcript_log.encode_record`` produces ``<crc32-hex>\\t<json>\\n``:
+self-delimiting by newline, CRC before payload, version per record. It was
+built for an append log, and every property it was built for is the same
+property a spill file needs — a frame torn by a power cut is rejected by
+arithmetic rather than by a JSON parser's opinion, and ``recover_log``
+returns the longest valid prefix instead of failing the file.
+
+It is also the codec on the wire (see ``link_transport``). One encoding for
+both, so a verdict spilled to disk and the same verdict on the socket are
+byte-identical, and there is no serialise/deserialise seam between them
+where a schema could drift.
+
+Durability is ``durable_io``'s: ``flush_and_sync`` before the record is
+counted as spilled, because "we wrote it" must mean "it survives".
+
+ORDERING
+--------
+FIFO across both tiers, always. Drain reads the disk generation before the
+memory tail, because anything spilled is by definition older. A verdict
+delivered out of order is a verdict the Body's contiguous watermark will
+refuse to advance past, so ordering here is not tidiness — it is what makes
+the resume arithmetic in ``link_protocol`` work at all.
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from collections import deque
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger("Ouroboros.LinkOutbox")
+
+LINK_OUTBOX_SCHEMA_VERSION: str = "link_outbox.1"
+
+
+def _env_int(name: str, default: int, minimum: int = 0) -> int:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return max(minimum, int(raw))
+    except (TypeError, ValueError):
+        return default
+
+
+def memory_high_water() -> int:
+    """Records held in RAM before spilling begins."""
+    return _env_int("JARVIS_LINK_OUTBOX_MEM_RECORDS", 512, minimum=8)
+
+
+def disk_max_records() -> int:
+    """Hard ceiling across the spill file. Beyond this the link is hopeless."""
+    return _env_int("JARVIS_LINK_OUTBOX_DISK_RECORDS", 50_000, minimum=64)
+
+
+def spill_under_pressure_level() -> str:
+    """Memory-pressure level at which spilling starts early. Default ``high``.
+
+    Composes ``memory_pressure_gate`` rather than probing: the Engine's RAM
+    is that module's subject, and a second reading here would be a second
+    authority for a number the operator sees in one place.
+    """
+    return (os.environ.get("JARVIS_LINK_OUTBOX_SPILL_LEVEL", "high")
+            or "high").strip().lower()
+
+
+@dataclass(frozen=True)
+class OutboxStats:
+    queued: int
+    in_memory: int
+    on_disk: int
+    spilled_total: int
+    shed_total: int
+    delivered_total: int
+    disk_bytes: int
+    schema_version: str = LINK_OUTBOX_SCHEMA_VERSION
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.schema_version, "queued": self.queued,
+            "in_memory": self.in_memory, "on_disk": self.on_disk,
+            "spilled_total": self.spilled_total, "shed_total": self.shed_total,
+            "delivered_total": self.delivered_total,
+            "disk_bytes": self.disk_bytes,
+        }
+
+
+class LinkOutbox:
+    """A FIFO of undelivered records that survives both absence and restart.
+
+    Two tiers, one order. Records enter memory; once memory is at its high
+    water mark the OLDEST are appended to a spill file and dropped from RAM.
+    Draining reads disk first, so FIFO holds across the boundary.
+
+    Not a queue of tasks — a queue of BYTES already encoded. Encoding at
+    ``put`` time means a record that cannot be represented fails at the
+    caller, not later at the socket where the only options are to crash the
+    writer or to silently drop.
+    """
+
+    def __init__(self, spill_path: Optional[Path] = None) -> None:
+        self._lock = threading.Lock()
+        self._mem: "deque[bytes]" = deque()
+        self._spill_path = Path(spill_path) if spill_path else None
+        self._disk_count = 0
+        self._disk_consumed = 0
+        self._spilled_total = 0
+        self._shed_total = 0
+        self._delivered_total = 0
+        self._sealed = False
+
+    # -- ingress ---------------------------------------------------------
+
+    def put(self, record: Dict[str, Any]) -> bool:
+        """Queue one record. False when it was shed (and said so loudly).
+
+        The record must satisfy the transcript codec's envelope contract —
+        ``v``/``seq``/``kind``/``ref`` — because reusing a codec means
+        accepting its shape, not only its bytes. Its own comment says why:
+        *a line whose CRC is intact but whose shape is wrong is still
+        unusable, and accepting it would push the failure downstream.* A
+        record that skipped the contract would encode cleanly, spill
+        cleanly, and then be rejected by ``recover_log`` after a restart —
+        losing exactly the verdicts this module exists to preserve, at
+        exactly the moment they matter.
+
+        ``seq`` and ``kind`` are the CALLER's to supply and are never
+        invented here: ``seq`` is load-bearing for resume arithmetic, and a
+        fabricated one would put a hole in a range the peer will later ask
+        to replay. ``ref`` is derived, because for a link frame it is a
+        restatement of the two.
+        """
+        try:
+            from backend.core.ouroboros.battle_test.transcript_log import (
+                encode_record,
+            )
+            from backend.core.ouroboros.governance.link_protocol import (
+                ensure_frame_envelope,
+            )
+            payload = ensure_frame_envelope(record)
+            frame = encode_record(payload)
+        except (ValueError, TypeError) as exc:
+            # Deliberately loud: an unencodable record is a caller bug, and
+            # swallowing it here would put a hole in a sequence the peer
+            # will later ask us to replay.
+            logger.error("[LinkOutbox] unencodable record dropped: %s", exc)
+            with self._lock:
+                self._shed_total += 1
+            return False
+
+        with self._lock:
+            self._mem.append(frame)
+            over = len(self._mem) - self._effective_high_water()
+        if over > 0:
+            self._spill(over)
+        return True
+
+    def _effective_high_water(self) -> int:
+        """High water, lowered when the machine is already under pressure.
+
+        Adaptive rather than fixed: holding 512 records is harmless on an
+        idle Engine and reckless on one whose RAM is already the constraint,
+        and the module that knows which is which already exists.
+        """
+        base = memory_high_water()
+        try:
+            from backend.core.ouroboros.governance.memory_pressure_gate import (
+                get_default_gate,
+            )
+            level = str(getattr(get_default_gate().pressure(), "value", ""))
+            if level in ("high", "critical"):
+                return max(8, base // 8)
+            if level == "warn":
+                return max(8, base // 2)
+        except Exception:  # noqa: BLE001 — pressure is advice, never a blocker
+            pass
+        return base
+
+    def _spill(self, count: int) -> None:
+        """Move the OLDEST ``count`` frames to disk. Never raises."""
+        if self._spill_path is None:
+            # No spill target: bound in memory alone, shedding oldest and
+            # saying so. Better a counted loss than an OOM on the machine
+            # holding the accelerator.
+            with self._lock:
+                for _ in range(count):
+                    if not self._mem:
+                        break
+                    self._mem.popleft()
+                    self._shed_total += 1
+            logger.warning(
+                "[LinkOutbox] no spill path — shed %d record(s) at the "
+                "memory bound", count)
+            return
+        with self._lock:
+            if self._disk_count - self._disk_consumed >= disk_max_records():
+                for _ in range(count):
+                    if not self._mem:
+                        break
+                    self._mem.popleft()
+                    self._shed_total += 1
+                shed = self._shed_total
+            else:
+                batch = [self._mem.popleft() for _ in range(count)
+                         if self._mem]
+                shed = None
+        if shed is not None:
+            logger.error(
+                "[LinkOutbox] spill file at its %d-record ceiling — shedding. "
+                "Total shed=%d. The peer has been unreachable long enough "
+                "that verdicts are now being lost.",
+                disk_max_records(), shed)
+            return
+        try:
+            self._spill_path.parent.mkdir(parents=True, exist_ok=True)
+            from backend.core.ouroboros.governance.durable_io import (
+                flush_and_sync,
+            )
+            with open(self._spill_path, "ab") as fh:
+                for frame in batch:
+                    fh.write(frame)
+                # Durable BEFORE the record is counted as spilled: a frame
+                # that is only in the page cache has not survived anything.
+                flush_and_sync(fh)
+            with self._lock:
+                self._disk_count += len(batch)
+                self._spilled_total += len(batch)
+        except OSError as exc:
+            # Disk refused. The frames are already out of memory, so put
+            # them back rather than losing them silently.
+            with self._lock:
+                for frame in reversed(batch):
+                    self._mem.appendleft(frame)
+            logger.error("[LinkOutbox] spill failed (%s) — held in memory", exc)
+
+    # -- egress ----------------------------------------------------------
+
+    def drain(self, limit: int) -> List[bytes]:
+        """Up to ``limit`` frames in FIFO order. Disk generation first.
+
+        Frames are NOT removed until :meth:`ack` — a drained-but-unsent
+        batch must survive the socket dying between the two, which is the
+        window this whole module exists to cover.
+        """
+        n = max(0, int(limit))
+        if n == 0:
+            return []
+        out: List[bytes] = []
+        disk_frames = self._read_disk(n)
+        out.extend(disk_frames)
+        if len(out) < n:
+            with self._lock:
+                remaining = n - len(out)
+                out.extend(list(self._mem)[:remaining])
+        return out
+
+    def ack(self, count: int) -> None:
+        """Confirm ``count`` frames reached the peer. Removes them."""
+        n = max(0, int(count))
+        with self._lock:
+            available_disk = self._disk_count - self._disk_consumed
+            from_disk = min(n, available_disk)
+            self._disk_consumed += from_disk
+            n -= from_disk
+            for _ in range(n):
+                if not self._mem:
+                    break
+                self._mem.popleft()
+            self._delivered_total += max(0, int(count))
+            compact = (self._disk_consumed > 0
+                       and self._disk_consumed == self._disk_count)
+        if compact:
+            self._truncate_spill()
+
+    def _read_disk(self, limit: int) -> List[bytes]:
+        """Re-read the spill generation. Never raises.
+
+        Uses ``recover_log``'s discipline indirectly: a torn tail is the
+        expected state after a power cut, and the longest valid prefix is
+        the honest answer rather than a parse error on the whole file.
+        """
+        if self._spill_path is None:
+            return []
+        with self._lock:
+            unread = self._disk_count - self._disk_consumed
+            skip = self._disk_consumed
+        if unread <= 0:
+            return []
+        try:
+            frames: List[bytes] = []
+            with open(self._spill_path, "rb") as fh:
+                for idx, raw in enumerate(fh):
+                    if idx < skip:
+                        continue
+                    if not raw.endswith(b"\n"):
+                        break        # torn tail — stop at the valid prefix
+                    frames.append(raw)
+                    if len(frames) >= limit:
+                        break
+            return frames
+        except OSError as exc:
+            logger.error("[LinkOutbox] spill read failed: %s", exc)
+            return []
+
+    def _truncate_spill(self) -> None:
+        """Everything on disk was acked — reclaim it durably."""
+        if self._spill_path is None:
+            return
+        try:
+            from backend.core.ouroboros.governance.durable_io import (
+                atomic_replace,
+            )
+            tmp = self._spill_path.with_suffix(
+                self._spill_path.suffix + ".compact")
+            with open(tmp, "wb") as fh:
+                from backend.core.ouroboros.governance.durable_io import (
+                    flush_and_sync,
+                )
+                flush_and_sync(fh)
+            atomic_replace(tmp, self._spill_path)
+            with self._lock:
+                self._disk_count = 0
+                self._disk_consumed = 0
+        except OSError as exc:
+            logger.debug("[LinkOutbox] compaction deferred: %s", exc)
+
+    # -- recovery --------------------------------------------------------
+
+    def recover(self) -> int:
+        """Adopt an existing spill file after a restart. Returns its count.
+
+        The Engine restarting is not a reason to lose verdicts the Body has
+        not seen: they are on disk precisely so they outlive the process
+        that produced them.
+        """
+        if self._spill_path is None or not self._spill_path.exists():
+            return 0
+        try:
+            from backend.core.ouroboros.battle_test.transcript_log import (
+                recover_log,
+            )
+            result = recover_log(self._spill_path)
+            count = len(getattr(result, "records", ()) or ())
+            with self._lock:
+                self._disk_count = count
+                self._disk_consumed = 0
+            if count:
+                logger.info(
+                    "[LinkOutbox] recovered %d undelivered record(s) from a "
+                    "previous process", count)
+            return count
+        except Exception as exc:  # noqa: BLE001
+            logger.error("[LinkOutbox] spill recovery failed: %s", exc)
+            return 0
+
+    # -- observability ---------------------------------------------------
+
+    def stats(self) -> OutboxStats:
+        with self._lock:
+            on_disk = max(0, self._disk_count - self._disk_consumed)
+            mem = len(self._mem)
+        size = 0
+        try:
+            if self._spill_path and self._spill_path.exists():
+                size = self._spill_path.stat().st_size
+        except OSError:
+            size = 0
+        with self._lock:
+            return OutboxStats(
+                queued=mem + on_disk, in_memory=mem, on_disk=on_disk,
+                spilled_total=self._spilled_total, shed_total=self._shed_total,
+                delivered_total=self._delivered_total, disk_bytes=size,
+            )

--- a/backend/core/ouroboros/governance/link_protocol.py
+++ b/backend/core/ouroboros/governance/link_protocol.py
@@ -250,6 +250,46 @@ class LinkFrame:
             return None
 
 
+def ensure_frame_envelope(record: Dict[str, Any]) -> Dict[str, Any]:
+    """Return ``record`` conforming to the shared frame contract, or raise.
+
+    **One validator, both directions, both media.** The wire codec and the
+    spill file are the same encoder (``transcript_log``), and that encoder
+    enforces an envelope — ``v``/``seq``/``kind``/``ref``, with ``seq``
+    a positive integer. A record that skips it encodes cleanly and is
+    rejected only later: on the peer's reader, or worse, by ``recover_log``
+    after a restart, which loses exactly the verdicts durability existed to
+    protect.
+
+    So the check lives HERE, in the module both ends import, and is called
+    by the outbox before it spills and by the transport before it writes.
+    Validating in two places with two opinions is how the two sides of a
+    link start disagreeing about what a frame is.
+
+    ``seq`` is never invented. It is load-bearing for resume arithmetic, and
+    a fabricated one would put a hole in a range the peer will later ask to
+    replay. ``seq=0`` is refused because the codec reserves it, and because
+    :func:`plan_resume` reads 0 as "this peer has applied nothing" — one
+    value cannot mean both.
+
+    Raises ``ValueError``; callers catch at their boundary so the fault
+    lands on the side that can still do something about it.
+    """
+    if not isinstance(record, dict):
+        raise ValueError(f"frame must be a mapping, got {type(record).__name__}")
+    out = dict(record)
+    kind = out.get("kind")
+    if not kind or not isinstance(kind, str):
+        raise ValueError("frame requires a non-empty string 'kind'")
+    seq = out.get("seq")
+    if isinstance(seq, bool) or not isinstance(seq, int) or seq < 1:
+        raise ValueError(
+            f"frame requires an integer seq >= 1 (got {seq!r}); "
+            "seq=0 is reserved for 'nothing yet'")
+    out.setdefault("ref", f"l-{seq}")
+    return out
+
+
 # ---------------------------------------------------------------------------
 # 2. Flap admission — the socket is disposable, the session is not
 # ---------------------------------------------------------------------------

--- a/backend/core/ouroboros/governance/link_runner.py
+++ b/backend/core/ouroboros/governance/link_runner.py
@@ -1,0 +1,304 @@
+"""link_runner — opens the socket, supervises the pumps, survives the drop.
+
+This is the last piece: everything below it is tested logic with no I/O, and
+everything above it is an operator typing a command. Its whole job is to hold
+a connection open, run three coroutines against it, and do the right thing
+when one of them fails.
+
+SUPERVISION, AND WHY IT IS A GROUP
+-----------------------------------
+Three pumps share one socket: writes, heartbeat, reads. They are not
+independent — a dead peer detected by the heartbeat means the reader will
+block forever, and a reader that hits EOF means the writer is shouting into a
+closed pipe. So they are supervised as a **group**: the first to fail cancels
+the others, the connection is torn down once, and the session parks.
+
+Running them as unsupervised tasks is the failure mode this shape exists to
+prevent. A heartbeat task that raises ``ConnectionError`` into nobody's
+``await`` becomes a "Task exception was never retrieved" warning at garbage
+collection, minutes later, while the reader sits on a socket that will never
+speak again — the half-open hang wearing a different hat.
+
+RECONNECTION IS NOT A LOOP AROUND CONNECT
+------------------------------------------
+It is a loop around **park → wait → resume**. The distinction matters: a
+retry loop that re-runs ``connect`` builds new state each time, and that is
+precisely what makes fifty reconnects expensive. Here the session, its
+ledger, its clock and its outbox are untouched by a disconnection; only the
+socket is replaced. Fifty reconnects cost fifty handshakes.
+
+The wait between attempts comes from :func:`link_protocol.backoff_delay_s`
+and the decision to attempt at all from :class:`link_protocol.FlapBreaker` —
+neither is re-implemented here.
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+import random
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from backend.core.ouroboros.governance import link_protocol as proto
+from backend.core.ouroboros.governance import link_session as sess
+from backend.core.ouroboros.governance import link_transport as tx
+
+logger = logging.getLogger("Ouroboros.LinkRunner")
+
+LINK_RUNNER_SCHEMA_VERSION: str = "link_runner.1"
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in ("1", "true", "yes", "on")
+
+
+def _env_float(name: str, default: float, minimum: float = 0.0) -> float:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return max(minimum, float(raw))
+    except (TypeError, ValueError):
+        return default
+
+
+def read_idle_grace() -> float:
+    """Multiplier on the liveness deadline before a read is called stalled.
+
+    The reader's timeout must be LOOSER than the heartbeat's, or the reader
+    declares death first and the RTT estimator — the thing that actually
+    knows what this path costs — never gets consulted.
+    """
+    return _env_float("JARVIS_LINK_READ_GRACE", 3.0, minimum=1.1)
+
+
+class LinkRunner:
+    """Holds one session across however many sockets it takes."""
+
+    def __init__(
+        self,
+        loop: sess.LinkSessionLoop,
+        *,
+        connector: Optional[Callable[[], Any]] = None,
+    ) -> None:
+        self.loop = loop
+        #: Injected so tests drive a full cycle over an in-memory pair, and
+        #: so a re-key supplies a fresh SSL context without this class
+        #: knowing certificates exist.
+        self._connector = connector
+        self._stopping = asyncio.Event()
+        self._connections = 0
+        self._last_error: str = ""
+
+    # -- one connection --------------------------------------------------
+
+    async def _serve_connection(self, reader: Any, writer: Any) -> None:
+        """Run the three pumps until one fails. Always tears down once."""
+        self._connections += 1
+        self.loop.on_established()
+        pumps = [
+            asyncio.create_task(self.loop.pump_writes(writer),
+                                name="link-writes"),
+            asyncio.create_task(self.loop.pump_heartbeat(writer),
+                                name="link-heartbeat"),
+            asyncio.create_task(self._pump_reads(reader),
+                                name="link-reads"),
+        ]
+        try:
+            done, pending = await asyncio.wait(
+                pumps, return_when=asyncio.FIRST_EXCEPTION)
+            for task in done:
+                exc = task.exception()
+                if exc is not None:
+                    raise exc
+        finally:
+            for task in pumps:
+                task.cancel()
+            # Await the cancellations. A cancelled task that is never awaited
+            # surfaces minutes later as "Task exception was never retrieved",
+            # attributed to garbage collection rather than to the disconnect
+            # that caused it.
+            await asyncio.gather(*pumps, return_exceptions=True)
+            with contextlib.suppress(Exception):
+                writer.close()
+
+    async def _pump_reads(self, reader: Any) -> None:
+        """Read frames until EOF or a stall. Dispatch is the session's.
+
+        The timeout is derived from the liveness deadline rather than fixed,
+        and multiplied by a grace factor so the heartbeat — which measures
+        the path — is the component that declares death.
+        """
+        while True:
+            timeout = max(
+                tx.heartbeat_interval_s(),
+                self.loop.liveness.rtt.deadline_s()) * read_idle_grace()
+            record = await tx.read_frame(
+                reader, limits=self.loop._limits or tx.negotiate({}, {}),
+                timeout_s=timeout)
+            if record is None:
+                raise ConnectionError("peer closed the connection")
+            if record.get("kind") == "__rejected__":
+                # A corrupt frame is not a dead link. The CRC caught it, the
+                # counter records it, and the stream resynchronises on the
+                # next newline — tearing the session down would turn one bad
+                # frame into a reconnect storm.
+                continue
+            if record.get("kind") == tx.KIND_HEARTBEAT:
+                self.loop.liveness.note_inbound()
+                self.loop.queue.put_high({
+                    "kind": tx.KIND_HEARTBEAT_ACK,
+                    "seq": self.loop.next_seq(),
+                    "lamport": (self.loop._session.clock.tick()
+                                if self.loop._session else 0),
+                    "node_id": self.loop.config.node_id,
+                    "sent_mono": record.get("sent_mono"),
+                })
+                continue
+            if record.get("kind") == tx.KIND_HEARTBEAT_ACK:
+                sent = record.get("sent_mono")
+                if isinstance(sent, (int, float)):
+                    self.loop.liveness.note_ack(float(sent))
+                else:
+                    self.loop.liveness.note_inbound()
+                continue
+            self.loop.dispatch(record)
+
+    # -- the outer cycle -------------------------------------------------
+
+    async def run(self, *, max_cycles: Optional[int] = None) -> None:
+        """park → wait → resume, until stopped.
+
+        ``max_cycles`` exists for tests and for a bounded one-shot; unset, it
+        runs until :meth:`stop`.
+        """
+        cycles = 0
+        while not self._stopping.is_set():
+            if max_cycles is not None and cycles >= max_cycles:
+                return
+            cycles += 1
+
+            verdict = self.loop.breaker.admit(self.loop.config.node_id)
+            if not verdict.admitted:
+                await self._sleep_or_stop(verdict.retry_after_s)
+                continue
+
+            try:
+                if self._connector is None:
+                    raise ConnectionError("no connector configured")
+                reader, writer = await self._connector()
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:  # noqa: BLE001
+                self._last_error = f"connect: {type(exc).__name__}: {exc}"
+                self.loop.park(self._last_error)
+                await self._sleep_or_stop(self._backoff())
+                continue
+
+            try:
+                await self._serve_connection(reader, writer)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:  # noqa: BLE001
+                self._last_error = f"{type(exc).__name__}: {exc}"
+                logger.info("[LinkRunner] connection ended — %s",
+                            self._last_error)
+            self.loop.park(self._last_error or "connection ended")
+            await self._sleep_or_stop(self._backoff())
+
+    def _backoff(self) -> float:
+        """Backoff with jitter. Jitter is drawn HERE, not inside the pure
+        helper, so the schedule stays reproducible under test."""
+        return proto.backoff_delay_s(
+            self.loop._attempt + 1, jitter=random.uniform(-0.3, 0.3))
+
+    async def _sleep_or_stop(self, seconds: float) -> None:
+        """Wait, but wake immediately on stop.
+
+        A bare ``sleep`` would make shutdown take up to a full backoff
+        interval — thirty seconds of an operator watching a process that has
+        been told to exit.
+        """
+        with contextlib.suppress(asyncio.TimeoutError):
+            await asyncio.wait_for(self._stopping.wait(), timeout=seconds)
+
+    def stop(self) -> None:
+        self._stopping.set()
+
+    def snapshot(self) -> Dict[str, Any]:
+        out = self.loop.snapshot()
+        out.update({
+            "runner_schema": LINK_RUNNER_SCHEMA_VERSION,
+            "connections": self._connections,
+            "last_error": self._last_error,
+            "stopping": self._stopping.is_set(),
+        })
+        return out
+
+
+# ---------------------------------------------------------------------------
+# Connectors — the only place a socket is actually opened
+# ---------------------------------------------------------------------------
+
+
+def tls_connector(host: str, port: int) -> Callable[[], Any]:
+    """A dialer for the Body. Builds a FRESH SSL context per attempt.
+
+    Fresh per attempt is what makes re-keying free: rotated material is
+    picked up by the next reconnection with no separate code path, because
+    the context is constructed at dial time rather than held for the process
+    lifetime.
+    """
+    async def _dial() -> Tuple[Any, Any]:
+        ctx = tx.build_ssl_context(server_side=False)
+        if ctx is None:
+            raise ConnectionError(
+                "link mTLS material missing — refusing to dial "
+                "unauthenticated (see `ov link --issue-certs`)")
+        return await asyncio.open_connection(host, port, ssl=ctx,
+                                             server_hostname=host)
+    return _dial
+
+
+async def serve_link(
+    loop: sess.LinkSessionLoop, *, host: Optional[str] = None,
+    port: Optional[int] = None,
+) -> Any:
+    """Bind and accept for the Engine. Returns the asyncio Server.
+
+    Binds where configuration says, defaulting to loopback. A caller that
+    wants the tailnet address supplies it deliberately; nothing here widens
+    the surface on its own.
+    """
+    ctx = tx.build_ssl_context(server_side=True)
+    if ctx is None:
+        raise ConnectionError(
+            "link mTLS material missing — refusing to serve unauthenticated "
+            "(see `ov link --issue-certs`)")
+    runner = LinkRunner(loop)
+
+    async def _on_client(reader: Any, writer: Any) -> None:
+        peer = writer.get_extra_info("peername")
+        verdict = loop.breaker.admit(str(peer))
+        if not verdict.admitted:
+            logger.warning("[LinkRunner] refusing %s — %s (retry in %.1fs)",
+                           peer, verdict.reason, verdict.retry_after_s)
+            with contextlib.suppress(Exception):
+                writer.close()
+            return
+        logger.info("[LinkRunner] peer connected: %s", peer)
+        try:
+            await runner._serve_connection(reader, writer)
+        except Exception as exc:  # noqa: BLE001
+            logger.info("[LinkRunner] peer %s ended: %s", peer, exc)
+        finally:
+            loop.park("peer disconnected")
+
+    return await asyncio.start_server(
+        _on_client, host or tx.bind_host(), port or tx.bind_port(), ssl=ctx)

--- a/backend/core/ouroboros/governance/link_runner.py
+++ b/backend/core/ouroboros/governance/link_runner.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import errno
 import logging
 import os
 import random
@@ -300,5 +301,31 @@ async def serve_link(
         finally:
             loop.park("peer disconnected")
 
-    return await asyncio.start_server(
-        _on_client, host or tx.bind_host(), port or tx.bind_port(), ssl=ctx)
+    bind = host or tx.bind_host()
+    listen = tx.bind_port() if port is None else port
+    try:
+        return await asyncio.start_server(_on_client, bind, listen, ssl=ctx)
+    except OSError as exc:
+        if exc.errno not in (errno.EADDRINUSE, errno.EACCES):
+            raise
+        # An ungraceful termination leaves the previous socket in TIME_WAIT.
+        # asyncio sets SO_REUSEADDR on POSIX but deliberately NOT on Windows,
+        # where that option permits hijacking an active listener rather than
+        # merely reclaiming a dead one — so the Engine is exactly the host
+        # where this is reachable.
+        #
+        # Not retried in a loop: if another Engine is genuinely running,
+        # silently waiting for it to exit would be indistinguishable from a
+        # hang, and stealing the port would be worse. The operator is told
+        # what holds it and how to check.
+        remedy = (
+            f"lsof -nP -iTCP:{listen} -sTCP:LISTEN"
+            if os.name != "nt"
+            else f'netstat -ano | findstr ":{listen}"')
+        raise ConnectionError(
+            f"cannot bind {bind}:{listen} — {exc.strerror}. Either an Engine "
+            f"is already running, or a previous one left the socket in "
+            f"TIME_WAIT. Check with:  {remedy}\n"
+            f"Set JARVIS_LINK_PORT to a different port, or wait for the "
+            f"kernel to release it."
+        ) from exc

--- a/backend/core/ouroboros/governance/link_session.py
+++ b/backend/core/ouroboros/governance/link_session.py
@@ -1,0 +1,697 @@
+"""link_session — the loop that makes the Body/Engine link a running system.
+
+WHAT THIS ASSEMBLES
+-------------------
+``link_protocol`` supplies the rules (clocks, resume planning, admission,
+delivery). ``link_transport`` supplies the wire (framing, negotiation,
+liveness, reassembly). ``link_outbox`` supplies durability. None of them
+runs. This is the state machine that drives them, and it deliberately adds
+no new rule of its own — every decision it makes is delegated to one of the
+three, so a change in policy happens in one place and this loop does not
+have to be re-reasoned about.
+
+THE STATE MACHINE
+-----------------
+::
+
+    DISCONNECTED ─connect─▶ HANDSHAKING ─welcome─▶ RESUMING ─plan─▶ ACTIVE
+         ▲                       │                     │              │
+         │                       ▼                     ▼              │
+         └──────────────────── PARKED ◀────────── link fault ─────────┘
+
+``PARKED`` is the state that makes this link honest. §26.6 established that
+a detached operator's absence must not read as refusal; across a network the
+link itself produces absence, so a fault parks the session rather than
+failing the work. Ops stay queued, the outbox keeps its contents, the
+logical clock keeps counting, and reconnection RESUMES rather than restarts.
+Nothing infers a verdict from silence.
+
+THREE FAILURE MODES THIS STRUCTURALLY PREVENTS
+----------------------------------------------
+
+**Handshake collision.** On a flapping link both ends can dial at the same
+instant, each accepting the other's connection while its own is in flight.
+Two live handshakes for one session id is split-brain: two ledgers, two
+clocks, two opinions about what was applied. Resolved by a deterministic
+tie-break both sides compute independently and identically — Lamport stamp
+first, node id lexically second (see :func:`resolve_collision`). The loser
+abandons its OWN handshake and keeps serving the peer's; the socket is not
+severed, because severing it would drop the very connection that won.
+
+**Re-keying mid-stream.** Certificate rotation must not cost the queue. It
+does not, and not by special-casing: session state lives in the registry,
+never in the connection, so a re-key is *a reconnect with a different SSL
+context*. The outbox is untouched, unacknowledged frames are re-sent by the
+resume path, and the state machine cannot tell the difference between a
+re-key and a Wi-Fi drop. A dedicated "hot-swap" code path would be a second
+way to do the thing the resume path already does correctly.
+
+**Writer contention under backpressure.** Two producers — the outbox pump
+(verdicts) and the SSE bridge (telemetry) — want the same socket. Locking
+around a shared writer is how an event loop deadlocks under pressure. So
+there is no shared writer: **one task owns the socket**, and both producers
+enqueue into :class:`PriorityWriteQueue`. Contention is not managed, it is
+removed. Verdicts outrank telemetry, telemetry is dropped rather than
+blocking, and a bounded anti-starvation quantum guarantees the low lane
+still moves under a sustained flood of the high one.
+
+INVARIANT
+---------
+No lock is ever held across an ``await``. Every lock in this module guards a
+handful of field assignments and is released before any I/O — which is the
+single discipline that makes "deadlock under backpressure" unreachable
+rather than merely unlikely.
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import asyncio
+import enum
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from backend.core.ouroboros.governance import link_protocol as proto
+from backend.core.ouroboros.governance import link_transport as tx
+from backend.core.ouroboros.governance.link_outbox import LinkOutbox
+
+logger = logging.getLogger("Ouroboros.LinkSession")
+
+LINK_SESSION_SCHEMA_VERSION: str = "link_session.1"
+
+
+def _env_int(name: str, default: int, minimum: int = 0) -> int:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return max(minimum, int(raw))
+    except (TypeError, ValueError):
+        return default
+
+
+def _env_float(name: str, default: float, minimum: float = 0.0) -> float:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return max(minimum, float(raw))
+    except (TypeError, ValueError):
+        return default
+
+
+def telemetry_queue_depth() -> int:
+    """Telemetry frames buffered before the oldest are dropped."""
+    return _env_int("JARVIS_LINK_TELEMETRY_DEPTH", 256, minimum=8)
+
+
+def starvation_quantum() -> int:
+    """High-priority frames sent before the low lane is given a turn.
+
+    Strict priority starves. A sustained verdict flood would silence
+    telemetry entirely, and an operator watching a blank deck cannot tell a
+    busy Engine from a dead one — the failure ``_ignition_line`` exists to
+    prevent, reappearing across a network.
+    """
+    return _env_int("JARVIS_LINK_STARVATION_QUANTUM", 16, minimum=1)
+
+
+def handshake_timeout_s() -> float:
+    """Ceiling on one handshake. Bounded so a silent peer cannot pin a task."""
+    return _env_float("JARVIS_LINK_HANDSHAKE_TIMEOUT_S", 10.0, minimum=0.5)
+
+
+# ---------------------------------------------------------------------------
+# States
+# ---------------------------------------------------------------------------
+
+
+#: Kinds that carry the ORDERED, applied stream. Everything else is control
+#: and bypasses reassembly — a heartbeat is not part of the history a resume
+#: replays, and treating it as one puts holes in that history.
+ORDERED_KINDS = frozenset({
+    tx.KIND_VERDICT, tx.KIND_COMMAND, tx.KIND_TELEMETRY,
+})
+
+
+class SessionState(str, enum.Enum):
+    DISCONNECTED = "disconnected"
+    HANDSHAKING = "handshaking"
+    RESUMING = "resuming"
+    ACTIVE = "active"
+    PARKED = "parked"
+    CLOSED = "closed"
+
+
+class HandshakeError(RuntimeError):
+    """A handshake could not complete. Always carries why."""
+
+
+class CollisionLost(HandshakeError):
+    """This side lost a deterministic handshake tie-break. Not a fault."""
+
+
+# ---------------------------------------------------------------------------
+# Handshake collision — decided identically on both ends
+# ---------------------------------------------------------------------------
+
+
+def resolve_collision(
+    local: Tuple[int, str], remote: Tuple[int, str],
+) -> bool:
+    """True when the LOCAL handshake wins. Pure, total, and symmetric.
+
+    Both ends run this with the arguments swapped and must reach opposite
+    answers — that is the entire requirement, and it is why the comparison
+    is a total order over ``(lamport, node_id)`` rather than a heuristic.
+    A rule that could return "win" to both (a timestamp compared with
+    tolerance, say) recreates the split-brain it was meant to prevent.
+
+    Lamport first because it carries causality: a node that has observed
+    more of the shared history is further along, and its view should
+    survive. Node id second, lexically, because two concurrent stamps are
+    genuinely tied and a tie needs an arbitrary but AGREED answer.
+
+    Identical ``(lamport, node_id)`` means the peer is us — a loopback
+    misconfiguration or a duplicated identity — and is refused rather than
+    resolved, because there is no correct winner between a node and itself.
+    """
+    l_stamp, l_node = int(local[0]), str(local[1])
+    r_stamp, r_node = int(remote[0]), str(remote[1])
+    if (l_stamp, l_node) == (r_stamp, r_node):
+        raise HandshakeError(
+            f"peer advertises this node's own identity ({l_node!r}) — "
+            "duplicate node id or a loopback misconfiguration")
+    return (l_stamp, l_node) > (r_stamp, r_node)
+
+
+# ---------------------------------------------------------------------------
+# One writer, two lanes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Pending:
+    record: Dict[str, Any]
+    high: bool
+
+
+class PriorityWriteQueue:
+    """The socket's single ingress. Verdicts outrank telemetry; nothing blocks.
+
+    **Why a queue and not a lock.** Two producers sharing a writer must
+    serialise somehow. A lock around the writer serialises by BLOCKING, and
+    a producer blocked while holding anything else is how an event loop
+    deadlocks under backpressure. A queue serialises by HANDING OFF: the
+    producers never touch the socket, one consumer does, and there is no
+    lock to contend for.
+
+    The two lanes have different contracts, matching §29.4:
+
+    * **High (verdicts, commands, control).** Never dropped. If the link
+      cannot carry them they belong in the durable outbox, not in RAM — so
+      this lane is bounded only by the outbox's own policy upstream.
+    * **Low (telemetry).** Lossy by design. A full lane drops its OLDEST
+      and counts it, because stale telemetry is worthless and blocking a
+      producer to preserve it converts a display problem into a stall.
+
+    Anti-starvation is a bounded quantum rather than a fair-share weight:
+    after ``starvation_quantum()`` high frames, one low frame goes out even
+    if high work remains. Simple, provable, and enough — the goal is that
+    the deck keeps moving, not that telemetry gets a guaranteed share.
+    """
+
+    def __init__(self) -> None:
+        self._high: "asyncio.Queue[_Pending]" = asyncio.Queue()
+        self._low: List[_Pending] = []
+        self._wake = asyncio.Event()
+        self._high_streak = 0
+        self._dropped_low = 0
+        self._sent_high = 0
+        self._sent_low = 0
+
+    def put_high(self, record: Dict[str, Any]) -> None:
+        """Enqueue a verdict/command. Never blocks, never drops."""
+        self._high.put_nowait(_Pending(record, True))
+        self._wake.set()
+
+    def put_low(self, record: Dict[str, Any]) -> bool:
+        """Enqueue telemetry. False when it displaced an older frame."""
+        dropped = False
+        while len(self._low) >= telemetry_queue_depth():
+            self._low.pop(0)
+            self._dropped_low += 1
+            dropped = True
+        self._low.append(_Pending(record, False))
+        self._wake.set()
+        return not dropped
+
+    async def get(self) -> _Pending:
+        """Next frame to write, honouring priority and the quantum."""
+        while True:
+            if self._low and self._high_streak >= starvation_quantum():
+                self._high_streak = 0
+                self._sent_low += 1
+                return self._low.pop(0)
+            if not self._high.empty():
+                self._high_streak += 1
+                self._sent_high += 1
+                return self._high.get_nowait()
+            if self._low:
+                self._high_streak = 0
+                self._sent_low += 1
+                return self._low.pop(0)
+            self._wake.clear()
+            await self._wake.wait()
+
+    @property
+    def depth(self) -> int:
+        return self._high.qsize() + len(self._low)
+
+    def snapshot(self) -> Dict[str, Any]:
+        return {
+            "high_queued": self._high.qsize(), "low_queued": len(self._low),
+            "sent_high": self._sent_high, "sent_low": self._sent_low,
+            "telemetry_dropped": self._dropped_low,
+            "quantum": starvation_quantum(),
+        }
+
+
+# ---------------------------------------------------------------------------
+# The session loop
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SessionConfig:
+    node_id: str
+    session_id: str
+    peer_host: str = ""
+    peer_port: int = 0
+    server_side: bool = False
+    spill_path: Optional[Path] = None
+    #: Injected so tests drive the loop without a socket, and so a re-key
+    #: supplies a fresh context without this module knowing about certs.
+    ssl_factory: Optional[Callable[[], Any]] = None
+
+
+class LinkSessionLoop:
+    """Drives one logical session across however many sockets it takes.
+
+    The session outlives every connection it uses. Reconnection, re-keying
+    and a Wi-Fi drop are the same event to this class, which is why none of
+    them has a special path.
+    """
+
+    def __init__(
+        self,
+        config: SessionConfig,
+        *,
+        registry: Optional[proto.SessionRegistry] = None,
+        breaker: Optional[proto.FlapBreaker] = None,
+        outbox: Optional[LinkOutbox] = None,
+        on_frame: Optional[Callable[[Dict[str, Any]], Any]] = None,
+    ) -> None:
+        self.config = config
+        self.registry = registry or proto.SessionRegistry()
+        self.breaker = breaker or proto.FlapBreaker()
+        self.outbox = outbox or LinkOutbox(spill_path=config.spill_path)
+        self.queue = PriorityWriteQueue()
+        self.liveness = tx.LivenessMonitor()
+        self.batcher = tx.AdaptiveBatcher()
+        self.reassembly = tx.ReassemblyBuffer()
+        self._on_frame = on_frame
+        self._state = SessionState.DISCONNECTED
+        self._limits: Optional[tx.NegotiatedLimits] = None
+        self._session: Optional[proto.LinkSession] = None
+        self._ctrl_seq = 0
+        self._data_seq = 0
+        self._attempt = 0
+        self._handshake_in_flight: Optional[Tuple[int, str]] = None
+        self._resyncs = 0
+        self._parks = 0
+
+    # -- state -----------------------------------------------------------
+
+    @property
+    def state(self) -> SessionState:
+        return self._state
+
+    def _transition(self, to: SessionState, reason: str = "") -> None:
+        if to is self._state:
+            return
+        logger.info("[LinkSession] %s → %s%s", self._state.value, to.value,
+                    f" ({reason})" if reason else "")
+        self._state = to
+        if to is SessionState.PARKED:
+            self._parks += 1
+
+    def next_seq(self) -> int:
+        """Next CONTROL sequence. 1-indexed; 0 is reserved for 'nothing yet'."""
+        self._ctrl_seq += 1
+        return self._ctrl_seq
+
+    def next_data_seq(self) -> int:
+        """Next ORDERED-DATA sequence.
+
+        **Two spaces, deliberately.** Control frames — hello, welcome,
+        heartbeat — are not part of the ordered stream and are never
+        "applied", so they must not consume data sequence numbers. Sharing
+        one counter looks tidy and is a correctness bug in two directions:
+
+        * the handshake consumes seq 1, so the peer's reassembly waits
+          forever for a data frame that will never exist;
+        * a heartbeat that is dropped or reordered punches a permanent hole
+          in the data sequence, and ``plan_resume`` — which is defined over
+          APPLIED frames — would be asked to replay a range containing
+          numbers no data frame ever carried.
+
+        The receiver bypasses reassembly for control kinds, so the two
+        spaces never interact and a collision between them is meaningless.
+        """
+        self._data_seq += 1
+        return self._data_seq
+
+    # -- handshake -------------------------------------------------------
+
+    def build_hello(self) -> Dict[str, Any]:
+        """The advertisement, stamped so a collision can be resolved."""
+        sess = self._session
+        clock = sess.clock if sess else proto.LogicalClock(self.config.node_id)
+        lamport = clock.tick()
+        self._handshake_in_flight = (lamport, self.config.node_id)
+        frame = dict(tx.local_advertisement(self.config.node_id))
+        frame.update({
+            "kind": tx.KIND_HELLO, "seq": self.next_seq(),
+            "lamport": lamport, "session_id": self.config.session_id,
+            "last_applied": self._last_applied(),
+        })
+        return frame
+
+    def _last_applied(self) -> int:
+        sess = self._session
+        return sess.ledger.contiguous_applied if sess else 0
+
+    def on_hello(self, hello: Dict[str, Any]) -> Dict[str, Any]:
+        """Handle an inbound HELLO, resolving a collision if one exists.
+
+        Raises :class:`CollisionLost` when this side's own in-flight
+        handshake loses — which the caller treats as "abandon mine, keep
+        serving theirs", NOT as a transport fault. Severing the socket here
+        would drop the connection that just won.
+        """
+        remote_stamp = (int(hello.get("lamport") or 0),
+                        str(hello.get("node_id") or "?"))
+        if self._handshake_in_flight is not None:
+            mine = self._handshake_in_flight
+            if not resolve_collision(mine, remote_stamp):
+                logger.info(
+                    "[LinkSession] handshake collision: local %s loses to "
+                    "peer %s — abandoning our attempt, keeping theirs",
+                    mine, remote_stamp)
+                self._handshake_in_flight = None
+                raise CollisionLost(f"local {mine} < peer {remote_stamp}")
+            logger.info(
+                "[LinkSession] handshake collision: local %s wins over peer "
+                "%s", self._handshake_in_flight, remote_stamp)
+
+        session, resumed = self.registry.attach(
+            str(hello.get("session_id") or self.config.session_id),
+            str(hello.get("node_id") or "?"))
+        self._session = session
+        session.clock.observe(remote_stamp[0])
+        self._limits = tx.negotiate(
+            tx.local_advertisement(self.config.node_id), hello)
+        welcome = dict(tx.local_advertisement(self.config.node_id))
+        welcome.update({
+            "kind": tx.KIND_WELCOME, "seq": self.next_seq(),
+            "lamport": session.clock.tick(),
+            "session_id": session.session_id, "resumed": resumed,
+            "last_applied": self._last_applied(),
+        })
+        self._transition(SessionState.RESUMING,
+                         "resumed" if resumed else "new session")
+        return welcome
+
+    def on_welcome(self, welcome: Dict[str, Any]) -> proto.ResumePlan:
+        """Accept the peer's WELCOME and compute what we are owed."""
+        self._handshake_in_flight = None
+        self._limits = tx.negotiate(
+            tx.local_advertisement(self.config.node_id), welcome)
+        session, _ = self.registry.attach(
+            str(welcome.get("session_id") or self.config.session_id),
+            str(welcome.get("node_id") or "?"))
+        self._session = session
+        session.clock.observe(int(welcome.get("lamport") or 0))
+        plan = proto.plan_resume(
+            peer_last_applied=self._last_applied(),
+            source_latest=int(welcome.get("source_latest")
+                              or welcome.get("last_applied") or 0),
+            source_oldest_retained=int(welcome.get("oldest_retained") or 1),
+        )
+        if plan.action is proto.ResumeAction.RESYNC:
+            self._resyncs += 1
+            self.reassembly.reset(next_expected=plan.to_seq + 1)
+            logger.warning("[LinkSession] %s", plan.reason)
+        elif plan.action is proto.ResumeAction.REJECT:
+            self._transition(SessionState.DISCONNECTED, "incoherent peer")
+            raise HandshakeError(plan.reason)
+        self._transition(SessionState.ACTIVE, plan.action.value)
+        return plan
+
+    # -- inbound ---------------------------------------------------------
+
+    def dispatch(self, record: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """Fold one inbound frame in. Returns frames ready to APPLY.
+
+        Reassembly then idempotent application, in that order: contiguity is
+        restored before anything is applied, so a consumer never sees a
+        partial sequence it would have to reason about.
+        """
+        self.liveness.note_inbound()
+        kind = record.get("kind")
+        if not tx.is_known_kind(kind):
+            logger.debug("[LinkSession] dropped unknown kind %r", kind)
+            return []
+        sess = self._session
+        if sess is not None:
+            sess.clock.observe(record.get("lamport"))
+        seq = record.get("seq")
+        if not isinstance(seq, int):
+            return []
+        if kind not in ORDERED_KINDS:
+            # Control: acknowledged by having been seen, never ordered and
+            # never applied. Returning it lets a caller react (a heartbeat
+            # ack, a resume plan) without it entering the replayed history.
+            return [record]
+        result = self.reassembly.offer(seq, record)
+        if result.gap_unrecoverable:
+            self._resyncs += 1
+            logger.warning("[LinkSession] %s", result.reason)
+            return []
+        ready: List[Dict[str, Any]] = []
+        for frame in result.ready:
+            lf = proto.LinkFrame(
+                seq=int(frame.get("seq") or 0),
+                lamport=int(frame.get("lamport") or 0),
+                node_id=str(frame.get("node_id") or "?"),
+                kind=str(frame.get("kind") or ""), payload=frame,
+            )
+            applied = True
+            if sess is not None:
+                applied = sess.ledger.apply_once(
+                    lf, lambda _f, fr=frame: self._apply(fr))
+            elif self._on_frame is not None:
+                self._apply(frame)
+            if applied:
+                ready.append(frame)
+        return ready
+
+    def _apply(self, frame: Dict[str, Any]) -> None:
+        if self._on_frame is not None:
+            self._on_frame(frame)
+
+    # -- outbound --------------------------------------------------------
+
+    def send_verdict(self, payload: Dict[str, Any]) -> None:
+        """Queue a governance verdict. Durable, prioritised, never dropped."""
+        record = dict(payload)
+        record.setdefault("kind", tx.KIND_VERDICT)
+        record["seq"] = self.next_data_seq()
+        record["lamport"] = self._session.clock.tick() if self._session else 0
+        record["node_id"] = self.config.node_id
+        self.outbox.put(record)
+        self.queue.put_high(record)
+
+    def send_telemetry(self, payload: Dict[str, Any]) -> bool:
+        """Queue a telemetry frame. Lossy by contract, never durable."""
+        record = dict(payload)
+        record.setdefault("kind", tx.KIND_TELEMETRY)
+        record["seq"] = self.next_data_seq()
+        record["lamport"] = self._session.clock.tick() if self._session else 0
+        record["node_id"] = self.config.node_id
+        return self.queue.put_low(record)
+
+    # -- the pump --------------------------------------------------------
+
+    async def pump_writes(self, writer: Any) -> None:
+        """Sole owner of the socket's write side. Runs until cancelled.
+
+        Backpressure arrives through ``write_frame``'s ``drain()``: when the
+        kernel buffer fills this coroutine suspends, the queue grows, and
+        telemetry begins dropping at its own bound. No lock is held across
+        that await — there is no lock at all — so a slow link throttles the
+        producers without any possibility of deadlock.
+        """
+        limits = self._limits or tx.negotiate({}, {})
+        while True:
+            pending = await self.queue.get()
+            started = time.monotonic()
+            try:
+                await tx.write_frame(writer, pending.record, limits=limits)
+            except tx.FrameTooLarge as exc:
+                # Refused before the wire. A verdict too large is a caller
+                # bug and must be loud; dropping it silently would be
+                # indistinguishable from an op that never ran.
+                logger.error("[LinkSession] frame refused: %s", exc)
+                continue
+            self.batcher.observe_drain(time.monotonic() - started)
+
+    async def pump_heartbeat(self, writer: Any) -> None:
+        """Prove liveness on a cadence the RTT estimator sets.
+
+        The wait is on the estimator's deadline, not a constant, and it is
+        the ONLY timer in this module. It exists because a silent peer
+        produces no event to react to — the absence IS the signal — which is
+        the one case where a timer is the correct mechanism rather than a
+        substitute for one.
+        """
+        while True:
+            interval = max(tx.heartbeat_interval_s(),
+                           self.liveness.rtt.deadline_s() / 2.0)
+            await asyncio.sleep(interval)
+            sent = time.monotonic()
+            self.queue.put_high({
+                "kind": tx.KIND_HEARTBEAT, "seq": self.next_seq(),
+                "lamport": self._session.clock.tick() if self._session else 0,
+                "node_id": self.config.node_id, "sent_mono": sent,
+            })
+            if self.liveness.silent_for_s > self.liveness.rtt.deadline_s():
+                if self.liveness.note_miss():
+                    raise ConnectionError(
+                        f"peer silent for {self.liveness.silent_for_s:.1f}s "
+                        f"across {tx.heartbeat_miss_limit()} deadlines — "
+                        "declaring the link dead")
+
+    async def pump_outbox(self, writer: Any) -> None:
+        """Re-offer durable frames the peer has not acknowledged.
+
+        Drains a batch, hands it to the priority queue, and acks only what
+        the queue accepted. Batch size follows observed drain latency, so a
+        congested link re-offers less and notices a stall sooner.
+        """
+        while True:
+            batch = self.outbox.drain(self.batcher.size)
+            if not batch:
+                await asyncio.sleep(tx.heartbeat_interval_s() / 2.0)
+                continue
+            from backend.core.ouroboros.battle_test.transcript_log import (
+                decode_frame,
+            )
+            accepted = 0
+            for raw in batch:
+                record, _reason = decode_frame(raw.rstrip(b"\n"))
+                if record is None:
+                    accepted += 1        # unusable; acking clears it
+                    continue
+                self.queue.put_high(record)
+                accepted += 1
+            self.outbox.ack(accepted)
+
+    # -- lifecycle -------------------------------------------------------
+
+    def park(self, reason: str) -> None:
+        """The link failed. Hold everything; infer nothing.
+
+        Explicitly NOT a failure of the work: §26.6's rule crossing the
+        network. The outbox keeps its contents, the ledger keeps its
+        watermark, the session stays in the registry, and reconnection
+        resumes from exactly here.
+        """
+        self.registry.detach(self.config.session_id)
+        self._handshake_in_flight = None
+        self._transition(SessionState.PARKED, reason)
+
+    def reconnect_delay_s(self) -> float:
+        """Backoff for the next attempt. Also the re-key path.
+
+        A re-key is a reconnect with a different SSL context — same state,
+        same queue, same ledger — so it needs no separate machinery.
+        """
+        self._attempt += 1
+        return proto.backoff_delay_s(self._attempt)
+
+    def on_established(self) -> None:
+        self._attempt = 0
+        self.breaker.on_established(self.config.node_id)
+
+    def snapshot(self) -> Dict[str, Any]:
+        return {
+            "schema_version": LINK_SESSION_SCHEMA_VERSION,
+            "state": self._state.value,
+            "session_id": self.config.session_id,
+            "node_id": self.config.node_id,
+            "ctrl_seq": self._ctrl_seq,
+            "data_seq": self._data_seq,
+            "last_applied": self._last_applied(),
+            "resyncs": self._resyncs,
+            "parks": self._parks,
+            "limits": self._limits.to_dict() if self._limits else None,
+            "queue": self.queue.snapshot(),
+            "outbox": self.outbox.stats().to_dict(),
+            "liveness": self.liveness.snapshot(),
+            "reassembly": self.reassembly.snapshot(),
+            "registry": self.registry.snapshot(),
+            "breaker": self.breaker.snapshot(),
+        }
+
+
+# ---------------------------------------------------------------------------
+# SSE bridge — the telemetry lane, fed from the existing broker
+# ---------------------------------------------------------------------------
+
+
+class SseTelemetryBridge:
+    """Forwards the observability stream onto the link's low lane.
+
+    Injected rather than importing the broker directly, for two reasons: the
+    loop stays testable without one, and a re-key or reconnect swaps the
+    sink without the broker knowing a network exists. The broker's own
+    contract already matches the lane's — bounded, drop-oldest, lossy — so
+    this adapter adds a hop and no policy.
+    """
+
+    def __init__(self, session: LinkSessionLoop) -> None:
+        self._session = session
+        self._forwarded = 0
+        self._suppressed = 0
+
+    def on_event(self, event: Any) -> None:
+        """Sink for one broker event. NEVER raises into the broker."""
+        try:
+            payload = (event.to_dict() if hasattr(event, "to_dict")
+                       else dict(event))
+            payload["kind"] = tx.KIND_TELEMETRY
+            if self._session.send_telemetry(payload):
+                self._forwarded += 1
+            else:
+                self._suppressed += 1
+        except Exception:  # noqa: BLE001 — telemetry never breaks its producer
+            self._suppressed += 1
+
+    def snapshot(self) -> Dict[str, Any]:
+        return {"forwarded": self._forwarded, "suppressed": self._suppressed}

--- a/backend/core/ouroboros/governance/link_transport.py
+++ b/backend/core/ouroboros/governance/link_transport.py
@@ -1,0 +1,605 @@
+"""link_transport — the wire under the Body/Engine link.
+
+WHAT THIS ADDS TO ``link_protocol``
+-----------------------------------
+``link_protocol`` is the half provable at a desk: clocks, sequence
+arithmetic, admission, resume planning. This is the half that touches a
+socket — and it deliberately owns nothing but the socket. Every rule it
+executes comes from that module, so the transport can be replaced without
+renegotiating the protocol and the protocol can be tested without a network.
+
+ON "ADAPT THE FRAME SIZE TO MTU"
+--------------------------------
+It is worth saying plainly why this module does not do that, because the
+request is reasonable and the answer is not obvious.
+
+MTU is a property of a path, and TCP already owns it: the kernel does path
+MTU discovery, segments the stream, and retransmits per segment. An
+application writing 8 KiB or 64 KiB into a TCP socket produces the same
+packets on the wire — the framing above the stream is invisible to it. Code
+that read an MTU and sized application frames to it would be performing a
+calculation whose result changes nothing, which is a fabricated measurement
+in the same family as a blast radius nobody scanned.
+
+What DOES matter above TCP, and is implemented here:
+
+* **A negotiated maximum frame** (§29.6), so neither side can be made to
+  buffer an allocation the other chose. Minimum of the two advertisements
+  wins — a ceiling one side cannot honour is not a limit, it is a fault
+  waiting for a large frame.
+* **Backpressure that propagates**, via ``StreamWriter.drain()``. When the
+  kernel send buffer fills, ``drain()`` suspends the producer instead of
+  letting an in-process queue grow — buffer bloat moved from the socket into
+  Python is still buffer bloat, and now it is invisible to ``ss``.
+* **A batch size that adapts to observed drain latency**, which is the real
+  congestion signal available at this layer. A link that is draining slowly
+  gets smaller batches, so a stall is detected in one batch time rather than
+  after a large write has already committed.
+
+HALF-OPEN SOCKETS
+-----------------
+If the peer loses power, no FIN is sent. The local socket stays ESTABLISHED
+and a ``read`` blocks — by default until the OS TCP keepalive fires, which
+on Linux is **two hours**. That is indistinguishable from an idle link, and
+it is the single most important failure this module has to catch quickly.
+
+``SO_KEEPALIVE`` is enabled as defence in depth but is not relied upon: its
+timers are OS-global policy, not this link's to set portably. The detection
+that matters is an application heartbeat whose deadline is derived from
+*measured* round-trip time — Jacobson's smoothed RTT and variance, the same
+estimator TCP uses for its own retransmit timer — rather than from a
+constant. A constant is wrong in both directions: too tight on a congested
+café link (false deaths, reconnect storms) and too loose on a fast one
+(minutes of silence before anyone notices).
+
+Nothing here sleeps to wait. Every wait is an ``asyncio.wait_for`` on real
+I/O with a computed deadline, so a stalled peer produces a timeout at the
+read, not a task parked on a timer.
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import socket
+import ssl
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
+
+logger = logging.getLogger("Ouroboros.LinkTransport")
+
+LINK_TRANSPORT_SCHEMA_VERSION: str = "link_transport.1"
+
+#: Frame kinds. A closed vocabulary: an unrecognised kind is dropped with a
+#: counter rather than dispatched, so a newer peer cannot drive an older one
+#: down a path it does not have.
+KIND_HELLO = "hello"
+KIND_WELCOME = "welcome"
+KIND_HEARTBEAT = "heartbeat"
+KIND_HEARTBEAT_ACK = "heartbeat_ack"
+KIND_TELEMETRY = "telemetry"
+KIND_COMMAND = "command"
+KIND_VERDICT = "verdict"
+KIND_RESUME = "resume"
+KIND_RESUME_PLAN = "resume_plan"
+
+_KNOWN_KINDS = frozenset({
+    KIND_HELLO, KIND_WELCOME, KIND_HEARTBEAT, KIND_HEARTBEAT_ACK,
+    KIND_TELEMETRY, KIND_COMMAND, KIND_VERDICT, KIND_RESUME,
+    KIND_RESUME_PLAN,
+})
+
+
+def _env_int(name: str, default: int, minimum: int = 0) -> int:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return max(minimum, int(raw))
+    except (TypeError, ValueError):
+        return default
+
+
+def _env_float(name: str, default: float, minimum: float = 0.0) -> float:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return max(minimum, float(raw))
+    except (TypeError, ValueError):
+        return default
+
+
+def _env_str(name: str, default: str) -> str:
+    return (os.environ.get(name) or default).strip()
+
+
+# ---------------------------------------------------------------------------
+# Configuration — every value negotiated or tunable, none baked in
+# ---------------------------------------------------------------------------
+
+
+def max_frame_bytes() -> int:
+    """This side's advertised frame ceiling. The peer's may differ."""
+    return _env_int("JARVIS_LINK_MAX_FRAME_BYTES", 1 << 20, minimum=4096)
+
+
+def heartbeat_interval_s() -> float:
+    """Floor for the heartbeat cadence; the adaptive estimator may slow it."""
+    return _env_float("JARVIS_LINK_HEARTBEAT_S", 5.0, minimum=0.5)
+
+
+def heartbeat_miss_limit() -> int:
+    """Consecutive missed heartbeats before the peer is declared dead."""
+    return _env_int("JARVIS_LINK_HEARTBEAT_MISSES", 3, minimum=1)
+
+
+def rtt_window() -> int:
+    """Samples in the sliding RTT window."""
+    return _env_int("JARVIS_LINK_RTT_WINDOW", 16, minimum=4)
+
+
+def reassembly_capacity() -> int:
+    """Out-of-order frames held before the gap is declared unrecoverable."""
+    return _env_int("JARVIS_LINK_REASSEMBLY_CAPACITY", 256, minimum=8)
+
+
+def tls_dir() -> Path:
+    """Where the mTLS material lives. Never a hardcoded path in logic."""
+    return Path(_env_str(
+        "JARVIS_LINK_TLS_DIR",
+        str(Path(_env_str("JARVIS_PROJECT_ROOT", ".")) / ".jarvis" / "brain_mtls"),
+    ))
+
+
+# ---------------------------------------------------------------------------
+# Adaptive liveness — RTT-derived, not constant
+# ---------------------------------------------------------------------------
+
+
+class RttEstimator:
+    """Jacobson/Karels smoothed RTT and variance over a sliding window.
+
+    The same estimator TCP uses for its retransmit timer, for the same
+    reason: a deadline must track the path, because a path that changes by
+    an order of magnitude (Ethernet → café Wi-Fi → 5G tether) makes any
+    constant wrong somewhere. ``deadline`` is ``srtt + 4*rttvar`` clamped to
+    a floor — the classic RTO form, whose 4-sigma margin is what keeps a
+    normally-jittery link from being declared dead.
+
+    Pure and lock-guarded; no I/O, no clock of its own beyond the samples
+    it is handed.
+    """
+
+    def __init__(self) -> None:
+        self._srtt: Optional[float] = None
+        self._rttvar: float = 0.0
+        self._samples: List[float] = []
+
+    def observe(self, rtt_s: float) -> None:
+        r = max(0.0, float(rtt_s))
+        self._samples.append(r)
+        if len(self._samples) > rtt_window():
+            del self._samples[0]
+        if self._srtt is None:
+            self._srtt = r
+            self._rttvar = r / 2.0
+            return
+        # RFC 6298 constants: alpha=1/8, beta=1/4.
+        self._rttvar = 0.75 * self._rttvar + 0.25 * abs(self._srtt - r)
+        self._srtt = 0.875 * self._srtt + 0.125 * r
+
+    @property
+    def srtt(self) -> Optional[float]:
+        return self._srtt
+
+    def deadline_s(self) -> float:
+        """How long to wait for a heartbeat ack before counting a miss."""
+        floor = heartbeat_interval_s()
+        if self._srtt is None:
+            return floor
+        return max(floor, self._srtt + 4.0 * self._rttvar)
+
+    def snapshot(self) -> Dict[str, Any]:
+        return {
+            "srtt_ms": round((self._srtt or 0.0) * 1000.0, 2),
+            "rttvar_ms": round(self._rttvar * 1000.0, 2),
+            "deadline_ms": round(self.deadline_s() * 1000.0, 2),
+            "samples": len(self._samples),
+        }
+
+
+class LivenessMonitor:
+    """Sliding-window dead-peer detection above a half-open socket.
+
+    A miss is not a death. Wi-Fi loses single packets constantly, and a
+    detector that killed the session on one would produce exactly the
+    reconnect storm ``FlapBreaker`` exists to survive. ``miss_limit``
+    consecutive misses — each measured against an RTT-derived deadline
+    rather than a constant — is the signal.
+
+    Any inbound traffic counts as liveness, not only an ack: a peer sending
+    telemetry is demonstrably alive, and demanding a specific frame type as
+    proof would declare a busy peer dead.
+    """
+
+    def __init__(self) -> None:
+        self.rtt = RttEstimator()
+        self._consecutive_misses = 0
+        self._last_inbound_mono = time.monotonic()
+        self._deaths = 0
+
+    def note_inbound(self) -> None:
+        self._consecutive_misses = 0
+        self._last_inbound_mono = time.monotonic()
+
+    def note_ack(self, sent_mono: float) -> None:
+        self.rtt.observe(time.monotonic() - sent_mono)
+        self.note_inbound()
+
+    def note_miss(self) -> bool:
+        """Record a missed deadline. True when the peer is now dead."""
+        self._consecutive_misses += 1
+        if self._consecutive_misses >= heartbeat_miss_limit():
+            self._deaths += 1
+            return True
+        return False
+
+    @property
+    def silent_for_s(self) -> float:
+        return max(0.0, time.monotonic() - self._last_inbound_mono)
+
+    def snapshot(self) -> Dict[str, Any]:
+        out = self.rtt.snapshot()
+        out.update({
+            "consecutive_misses": self._consecutive_misses,
+            "silent_for_s": round(self.silent_for_s, 2),
+            "miss_limit": heartbeat_miss_limit(),
+            "deaths": self._deaths,
+        })
+        return out
+
+
+# ---------------------------------------------------------------------------
+# Reassembly — contiguity restored before anything is applied
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ReassemblyResult:
+    ready: List[Any] = field(default_factory=list)
+    buffered: int = 0
+    gap_unrecoverable: bool = False
+    reason: str = ""
+
+
+class ReassemblyBuffer:
+    """Holds out-of-order frames until contiguity is restored.
+
+    **When frames actually arrive out of order.** Not on one TCP connection
+    — TCP delivers a stream in order by definition, and any design premised
+    on reordering *within* a connection is solving a problem that does not
+    exist. The real case is a RECONNECT: replayed frames from the durable
+    generation interleave with live ones produced while the replay was in
+    flight, and the live ones can land first.
+
+    So this buffer is small and its job is narrow: hold the ahead-of-time
+    frames, release them the moment the hole fills, and release them
+    **atomically** as a contiguous run so a consumer never sees a partial
+    sequence it would have to reason about.
+
+    Bounded. A gap that cannot be closed within capacity is not a buffering
+    problem to be solved with more memory — it is a lost range, and the
+    honest response is to say so and let ``plan_resume`` ask for a resync.
+    """
+
+    def __init__(self, next_expected: int = 1) -> None:
+        self._next = max(1, int(next_expected))
+        self._held: Dict[int, Any] = {}
+
+    @property
+    def next_expected(self) -> int:
+        return self._next
+
+    def offer(self, seq: int, frame: Any) -> ReassemblyResult:
+        s = int(seq)
+        if s < self._next:
+            # Already applied — a duplicate from a replay. Not an error;
+            # the sink's DeliveryLedger suppresses it idempotently.
+            return ReassemblyResult(buffered=len(self._held),
+                                    reason="duplicate")
+        if s > self._next:
+            if len(self._held) >= reassembly_capacity():
+                return ReassemblyResult(
+                    buffered=len(self._held), gap_unrecoverable=True,
+                    reason=(f"gap at seq={self._next} still open with "
+                            f"{len(self._held)} frames held — resync"),
+                )
+            self._held[s] = frame
+            return ReassemblyResult(buffered=len(self._held),
+                                    reason="held out of order")
+        ready = [frame]
+        self._next = s + 1
+        while self._next in self._held:
+            ready.append(self._held.pop(self._next))
+            self._next += 1
+        return ReassemblyResult(ready=ready, buffered=len(self._held),
+                                reason="contiguous")
+
+    def reset(self, next_expected: int) -> None:
+        self._next = max(1, int(next_expected))
+        self._held.clear()
+
+    def snapshot(self) -> Dict[str, Any]:
+        return {
+            "next_expected": self._next, "held": len(self._held),
+            "capacity": reassembly_capacity(),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Handshake — limits are agreed, never assumed
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class NegotiatedLimits:
+    max_frame_bytes: int
+    heartbeat_s: float
+    protocol_version: str
+    peer_node_id: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "max_frame_bytes": self.max_frame_bytes,
+            "heartbeat_s": self.heartbeat_s,
+            "protocol_version": self.protocol_version,
+            "peer_node_id": self.peer_node_id,
+        }
+
+
+def negotiate(local: Dict[str, Any], remote: Dict[str, Any]) -> NegotiatedLimits:
+    """Reconcile two advertisements. Pure, so it is testable without a socket.
+
+    **Minimum wins on every dimension.** A ceiling one side cannot honour is
+    not a limit — it is a fault waiting for a large frame. The heartbeat
+    takes the FASTER of the two (the shorter interval), because liveness is
+    the one axis where the more demanding party should win: a peer that
+    wants proof of life every second is not harmed by getting it, and a peer
+    that needs it cannot be overruled by a lazier one.
+    """
+    def _int(d: Dict[str, Any], k: str, fallback: int) -> int:
+        try:
+            v = int(d.get(k, fallback))
+            return v if v > 0 else fallback
+        except (TypeError, ValueError):
+            return fallback
+
+    def _float(d: Dict[str, Any], k: str, fallback: float) -> float:
+        try:
+            v = float(d.get(k, fallback))
+            return v if v > 0 else fallback
+        except (TypeError, ValueError):
+            return fallback
+
+    return NegotiatedLimits(
+        max_frame_bytes=min(_int(local, "max_frame_bytes", max_frame_bytes()),
+                            _int(remote, "max_frame_bytes", max_frame_bytes())),
+        heartbeat_s=min(_float(local, "heartbeat_s", heartbeat_interval_s()),
+                        _float(remote, "heartbeat_s", heartbeat_interval_s())),
+        protocol_version=str(remote.get("protocol_version")
+                             or LINK_TRANSPORT_SCHEMA_VERSION),
+        peer_node_id=str(remote.get("node_id") or "?"),
+    )
+
+
+def local_advertisement(node_id: str) -> Dict[str, Any]:
+    return {
+        "node_id": str(node_id),
+        "protocol_version": LINK_TRANSPORT_SCHEMA_VERSION,
+        "max_frame_bytes": max_frame_bytes(),
+        "heartbeat_s": heartbeat_interval_s(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# TLS — identity, not merely encryption
+# ---------------------------------------------------------------------------
+
+
+def build_ssl_context(*, server_side: bool) -> Optional[ssl.SSLContext]:
+    """Mutual-TLS context from ``.jarvis/brain_mtls/``. None when absent.
+
+    The overlay network (Tailscale) supplies the tunnel; this supplies the
+    IDENTITY. Only the second one answers "which Body is this?" after a
+    session id is replayed — which is exactly the ``REJECT`` case
+    ``plan_resume`` exists to catch. Encryption without authentication would
+    let anything on the tailnet resume another Body's session.
+
+    ``CERT_REQUIRED`` on both sides: the client verifies the Engine and the
+    Engine verifies the client. A missing certificate returns None so the
+    caller can refuse to start rather than silently downgrading — a link
+    that quietly ran unauthenticated would be worse than one that did not
+    run.
+    """
+    base = tls_dir()
+    ca = base / "ca.pem"
+    cert = base / ("server-cert.pem" if server_side else "client-cert.pem")
+    key = base / ("server-key.pem" if server_side else "client-key.pem")
+    missing = [str(p.name) for p in (ca, cert, key) if not p.exists()]
+    if missing:
+        logger.error(
+            "[LinkTransport] mTLS material missing from %s: %s — refusing to "
+            "start unauthenticated", base, ", ".join(missing))
+        return None
+    try:
+        purpose = (ssl.Purpose.CLIENT_AUTH if server_side
+                   else ssl.Purpose.SERVER_AUTH)
+        ctx = ssl.create_default_context(purpose, cafile=str(ca))
+        ctx.load_cert_chain(certfile=str(cert), keyfile=str(key))
+        ctx.verify_mode = ssl.CERT_REQUIRED
+        ctx.minimum_version = ssl.TLSVersion.TLSv1_3
+        if not server_side:
+            # The peer is reached by tailnet NAME, and the certificate is
+            # issued to that name. Hostname checking stays ON: turning it
+            # off is how an mTLS deployment silently becomes encryption
+            # without identity.
+            ctx.check_hostname = True
+        return ctx
+    except (ssl.SSLError, OSError) as exc:
+        logger.error("[LinkTransport] mTLS context failed: %s", exc)
+        return None
+
+
+def bind_host() -> str:
+    """Address to bind. Default LOOPBACK, never ``0.0.0.0``.
+
+    A default of ``0.0.0.0`` would listen on every interface — the home LAN,
+    any café Wi-Fi the host joins, anything a router later forwards. One end
+    of this link runs ``bash`` and mutates code, so the correct default is
+    the narrowest thing that works, and the operator widens it deliberately
+    to the tailnet address.
+    """
+    return _env_str("JARVIS_LINK_BIND_HOST", "127.0.0.1")
+
+
+def bind_port() -> int:
+    """Port to bind. 0 asks the OS to choose, which is what tests use."""
+    return _env_int("JARVIS_LINK_PORT", 0, minimum=0)
+
+
+def _tune_socket(sock: Optional[socket.socket]) -> None:
+    """TCP options that make a stall visible sooner. Never raises.
+
+    ``TCP_NODELAY`` because heartbeats are tiny and Nagle would coalesce
+    them into exactly the delay the estimator is trying to measure.
+    ``SO_KEEPALIVE`` as defence in depth — its timers are OS policy and not
+    portably ours, which is why the application heartbeat is the detector
+    that matters rather than a fallback.
+    """
+    if sock is None:
+        return
+    for level, opt in ((socket.IPPROTO_TCP, "TCP_NODELAY"),
+                       (socket.SOL_SOCKET, "SO_KEEPALIVE")):
+        try:
+            flag = getattr(socket, opt, None)
+            if flag is not None:
+                sock.setsockopt(level, flag, 1)
+        except OSError:
+            continue
+
+
+# ---------------------------------------------------------------------------
+# Framed stream I/O — the codec is the transcript's, not a second one
+# ---------------------------------------------------------------------------
+
+
+class FrameTooLarge(ValueError):
+    """A frame exceeded the NEGOTIATED ceiling."""
+
+
+async def write_frame(
+    writer: Any, record: Dict[str, Any], *, limits: NegotiatedLimits,
+) -> int:
+    """Encode, bound-check, write and DRAIN. Returns bytes written.
+
+    ``drain()`` is the backpressure seam and is not optional: without it a
+    producer faster than the link fills an in-process buffer instead of the
+    socket's, which is buffer bloat relocated somewhere ``ss`` cannot see
+    it. Awaiting drain suspends the producer at the exact rate the path
+    allows.
+    """
+    from backend.core.ouroboros.battle_test.transcript_log import encode_record
+    from backend.core.ouroboros.governance.link_protocol import (
+        ensure_frame_envelope,
+    )
+    # Same validator the outbox uses. A frame that skips the envelope
+    # encodes cleanly and is rejected only at the PEER's reader, where this
+    # side can no longer do anything about it.
+    frame = encode_record(ensure_frame_envelope(record))
+    if len(frame) > limits.max_frame_bytes:
+        raise FrameTooLarge(
+            f"frame is {len(frame)}B, negotiated ceiling is "
+            f"{limits.max_frame_bytes}B")
+    writer.write(frame)
+    await writer.drain()
+    return len(frame)
+
+
+async def read_frame(
+    reader: Any, *, limits: NegotiatedLimits, timeout_s: float,
+) -> Optional[Dict[str, Any]]:
+    """One frame, or None on EOF. Raises ``asyncio.TimeoutError`` on stall.
+
+    The timeout is the half-open detector: a peer that lost power sends no
+    FIN, so the only evidence is that nothing arrived within a deadline the
+    RTT estimator says is generous. ``readuntil`` is bounded by the
+    negotiated ceiling, so a peer cannot make this side buffer without limit
+    by omitting a terminator.
+    """
+    from backend.core.ouroboros.battle_test.transcript_log import decode_frame
+    try:
+        raw = await asyncio.wait_for(
+            reader.readuntil(b"\n"), timeout=timeout_s)
+    except asyncio.IncompleteReadError:
+        return None                      # clean EOF
+    except asyncio.LimitOverrunError as exc:
+        raise FrameTooLarge(f"frame exceeds stream limit: {exc}") from exc
+    if not raw:
+        return None
+    record, reason = decode_frame(raw.rstrip(b"\n"))
+    if record is None:
+        logger.warning("[LinkTransport] rejected frame: %s",
+                       getattr(reason, "value", reason))
+        return {"kind": "__rejected__", "reason": str(
+            getattr(reason, "value", reason))}
+    return record
+
+
+def is_known_kind(kind: Any) -> bool:
+    """Closed vocabulary: a newer peer cannot drive an older one off-path."""
+    return str(kind) in _KNOWN_KINDS
+
+
+# ---------------------------------------------------------------------------
+# Adaptive batching — the congestion signal that exists at this layer
+# ---------------------------------------------------------------------------
+
+
+class AdaptiveBatcher:
+    """Batch size follows observed drain latency.
+
+    Not MTU (see the module docstring) but the one congestion signal
+    genuinely visible above TCP: how long ``drain()`` took. A link whose
+    drains are slow is congested, and shrinking the batch means a stall is
+    noticed within one batch rather than after a large write has already
+    been committed to a socket that will not accept it.
+
+    Multiplicative decrease, additive increase — the shape that converges
+    rather than oscillating, for the same reason TCP uses it.
+    """
+
+    def __init__(self) -> None:
+        self._batch = float(_env_int("JARVIS_LINK_BATCH_START", 16, minimum=1))
+        self._min = float(_env_int("JARVIS_LINK_BATCH_MIN", 1, minimum=1))
+        self._max = float(_env_int("JARVIS_LINK_BATCH_MAX", 256, minimum=1))
+        self._target_s = _env_float("JARVIS_LINK_DRAIN_TARGET_S", 0.05,
+                                    minimum=0.001)
+
+    def observe_drain(self, seconds: float) -> None:
+        if seconds > self._target_s:
+            self._batch = max(self._min, self._batch / 2.0)
+        else:
+            self._batch = min(self._max, self._batch + 1.0)
+
+    @property
+    def size(self) -> int:
+        return max(1, int(self._batch))
+
+    def snapshot(self) -> Dict[str, Any]:
+        return {"batch": self.size, "target_drain_s": self._target_s,
+                "min": int(self._min), "max": int(self._max)}

--- a/backend/core/ouroboros/governance/link_transport.py
+++ b/backend/core/ouroboros/governance/link_transport.py
@@ -149,10 +149,20 @@ def reassembly_capacity() -> int:
 
 
 def tls_dir() -> Path:
-    """Where the mTLS material lives. Never a hardcoded path in logic."""
+    """Where the LINK's mTLS material lives. Never a hardcoded path in logic.
+
+    Deliberately NOT ``.jarvis/brain_mtls`` — that directory belongs to the
+    J-Prime brain channel, carries a CA whose leaf SANs name ``jarvis-brain``,
+    and is rotated on that subsystem's schedule. Two trust domains sharing one
+    directory means rotating either one silently re-keys the other, and a leaf
+    issued for one peer would be accepted by the other's verifier.
+
+    Separate directory, separate CA, separate lifetime. The link's identity is
+    its own.
+    """
     return Path(_env_str(
         "JARVIS_LINK_TLS_DIR",
-        str(Path(_env_str("JARVIS_PROJECT_ROOT", ".")) / ".jarvis" / "brain_mtls"),
+        str(Path(_env_str("JARVIS_PROJECT_ROOT", ".")) / ".jarvis" / "link_mtls"),
     ))
 
 

--- a/tests/governance/test_link_certs_runner.py
+++ b/tests/governance/test_link_certs_runner.py
@@ -1,0 +1,342 @@
+"""Regression spine for link certificate issuance and the connection runner.
+
+The handshake tests use REAL TLS over a loopback pair with material issued by
+the module under test — the one thing that cannot be proven by substituting a
+fake, because a certificate that fails to verify fails inside OpenSSL.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import stat
+
+import pytest
+
+from backend.core.ouroboros.governance import link_certs as lc
+from backend.core.ouroboros.governance import link_runner as lr
+from backend.core.ouroboros.governance import link_session as ls
+from backend.core.ouroboros.governance import link_transport as tx
+
+crypto = pytest.importorskip("cryptography")
+
+
+@pytest.fixture
+def material(tmp_path, monkeypatch):
+    """Issued material, with the transport pointed at it."""
+    monkeypatch.setenv("JARVIS_LINK_TLS_DIR", str(tmp_path / "mtls"))
+    lc.issue_link_material(
+        directory=tmp_path / "mtls",
+        server_names=["engine.tailnet.ts.net", "100.64.1.2"],
+        client_names=["body-mac"],
+    )
+    return tmp_path / "mtls"
+
+
+# ---------------------------------------------------------------------------
+# Issuance
+# ---------------------------------------------------------------------------
+
+
+def test_private_keys_are_owner_only(material):
+    """Created with the mode applied, not chmod'ed after: between open and
+    chmod the key is world-readable, and that window is the vulnerability."""
+    for name in (lc.CA_KEY, lc.SERVER_KEY, lc.CLIENT_KEY):
+        mode = stat.S_IMODE(os.stat(material / name).st_mode)
+        assert mode == 0o600, f"{name} is {oct(mode)}"
+
+
+def test_an_ip_literal_becomes_an_ip_san_not_a_dns_name(material):
+    """Peers match IP literals against iPAddress SANs only. A tailnet address
+    in a DNSName verifies against nothing."""
+    report = lc.inspect_material(material)
+    sans = report["certificates"][lc.SERVER_CERT]["sans"]
+    assert "engine.tailnet.ts.net" in sans
+    assert "100.64.1.2" in sans
+
+
+def test_the_ca_cannot_sign_another_ca(material):
+    """A CA that can sign anything can impersonate anything."""
+    from cryptography import x509
+    cert = x509.load_pem_x509_certificate((material / lc.CA_CERT).read_bytes())
+    bc = cert.extensions.get_extension_for_class(x509.BasicConstraints).value
+    assert bc.ca is True and bc.path_length == 0
+
+
+def test_leaves_carry_narrow_extended_key_usage(material):
+    """A leaf usable as both client and server lets a compromised Body
+    impersonate the Engine to itself."""
+    from cryptography import x509
+    from cryptography.x509.oid import ExtendedKeyUsageOID
+    for name, expected in ((lc.SERVER_CERT, ExtendedKeyUsageOID.SERVER_AUTH),
+                           (lc.CLIENT_CERT, ExtendedKeyUsageOID.CLIENT_AUTH)):
+        cert = x509.load_pem_x509_certificate((material / name).read_bytes())
+        eku = cert.extensions.get_extension_for_class(
+            x509.ExtendedKeyUsage).value
+        assert list(eku) == [expected]
+
+
+def test_validity_outlives_a_weekly_visit(material):
+    """Seven-day material is what made the brain certs unusable: a link
+    between two houses cannot need a physical visit every week."""
+    report = lc.inspect_material(material)
+    assert report["certificates"][lc.SERVER_CERT]["days_remaining"] > 365
+
+
+def test_notbefore_is_backdated_against_clock_skew(material):
+    """§29 exists because these clocks drift. A certificate valid from 'now'
+    is rejected by a peer a few minutes behind, and the failure looks like
+    anything but a clock."""
+    from cryptography import x509
+    import datetime as dt
+    cert = x509.load_pem_x509_certificate(
+        (material / lc.SERVER_CERT).read_bytes())
+    assert cert.not_valid_before_utc < dt.datetime.now(dt.timezone.utc)
+
+
+def test_the_ca_private_key_is_not_in_the_peer_bundle():
+    """Copying it would let each end mint identities for the other."""
+    assert lc.CA_KEY not in lc.files_to_copy_to_peer()
+    assert set(lc.files_to_copy_to_peer()) == {
+        lc.CA_CERT, lc.CLIENT_CERT, lc.CLIENT_KEY}
+
+
+def test_reissue_refuses_to_silently_revoke_the_peer(material):
+    """A silent regeneration revokes trust from across the country, and the
+    operator meets it as an inexplicable handshake failure."""
+    with pytest.raises(FileExistsError):
+        lc.issue_link_material(directory=material,
+                               server_names=["engine.tailnet.ts.net"])
+    lc.issue_link_material(directory=material,
+                           server_names=["engine.tailnet.ts.net"], force=True)
+
+
+def test_missing_server_names_is_refused_rather_than_guessed():
+    """The peer's name is a property of someone's tailnet. A wrong SAN fails
+    the handshake as a trust error, which is far harder to diagnose."""
+    with pytest.raises(ValueError):
+        lc.issue_link_material(directory=None, server_names=[])
+
+
+def test_inspection_reports_expiry_as_a_countdown(material):
+    """Reported as days remaining, so rotation is seen coming rather than
+    discovered as an outage."""
+    report = lc.inspect_material(material)
+    entry = report["certificates"][lc.SERVER_CERT]
+    assert entry["expired"] is False
+    assert isinstance(entry["days_remaining"], int)
+
+
+def test_the_link_does_not_share_the_brain_trust_domain(monkeypatch):
+    """Two trust domains in one directory means rotating either silently
+    re-keys the other."""
+    monkeypatch.delenv("JARVIS_LINK_TLS_DIR", raising=False)
+    assert "brain_mtls" not in str(tx.tls_dir())
+    assert "link_mtls" in str(tx.tls_dir())
+
+
+# ---------------------------------------------------------------------------
+# Real TLS
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.socket
+@pytest.mark.asyncio
+async def test_a_real_mtls_handshake_completes_and_verifies_identity(material):
+    """THE test that cannot be faked: a certificate that does not verify
+    fails inside OpenSSL, not in our code."""
+    engine = ls.LinkSessionLoop(
+        ls.SessionConfig(node_id="engine", session_id="s-1"))
+    server = await lr.serve_link(engine, host="127.0.0.1", port=0)
+    port = server.sockets[0].getsockname()[1]
+    ctx = tx.build_ssl_context(server_side=False)
+    assert ctx is not None and ctx.check_hostname is True
+    reader, writer = await asyncio.wait_for(
+        asyncio.open_connection("127.0.0.1", port, ssl=ctx,
+                                server_hostname="engine.tailnet.ts.net"),
+        timeout=10)
+    peer = writer.get_extra_info("peercert")
+    assert peer, "the Engine presented no certificate"
+    names = [v for field in peer["subject"] for _, v in field]
+    assert "engine.tailnet.ts.net" in names
+    writer.close()
+    server.close()
+    await server.wait_closed()
+
+
+@pytest.mark.socket
+@pytest.mark.asyncio
+async def test_a_wrong_hostname_is_refused(material):
+    """Turning hostname checking off to make a name fit is how an mTLS
+    deployment silently becomes encryption without identity."""
+    engine = ls.LinkSessionLoop(
+        ls.SessionConfig(node_id="engine", session_id="s-1"))
+    server = await lr.serve_link(engine, host="127.0.0.1", port=0)
+    port = server.sockets[0].getsockname()[1]
+    ctx = tx.build_ssl_context(server_side=False)
+    with pytest.raises(Exception):
+        await asyncio.wait_for(
+            asyncio.open_connection("127.0.0.1", port, ssl=ctx,
+                                    server_hostname="attacker.example.com"),
+            timeout=10)
+    server.close()
+    await server.wait_closed()
+
+
+@pytest.mark.socket
+@pytest.mark.asyncio
+async def test_an_unauthenticated_client_gets_no_data(material):
+    """mTLS means the Engine verifies the Body too — anything on the tailnet
+    could otherwise resume another Body's session.
+
+    Asserted as "exchanges nothing", not "raises on connect": under TLS 1.3
+    the server evaluates the client certificate AFTER its own Finished, so a
+    certificate-less client's `open_connection` returns before the rejection
+    is known. The security property is that no application data crosses, and
+    that is what this checks — asserting an exception would be asserting a
+    protocol version's timing rather than the guarantee."""
+    import ssl
+    engine = ls.LinkSessionLoop(
+        ls.SessionConfig(node_id="engine", session_id="s-1"))
+    server = await lr.serve_link(engine, host="127.0.0.1", port=0)
+    port = server.sockets[0].getsockname()[1]
+
+    naked = ssl.create_default_context(cafile=str(material / lc.CA_CERT))
+    naked.check_hostname = True                      # no client cert loaded
+
+    exchanged = None
+    try:
+        reader, writer = await asyncio.wait_for(
+            asyncio.open_connection("127.0.0.1", port, ssl=naked,
+                                    server_hostname="engine.tailnet.ts.net"),
+            timeout=10)
+        writer.write(b"x\n")
+        await writer.drain()
+        exchanged = await asyncio.wait_for(reader.read(64), timeout=5)
+        writer.close()
+    except Exception:
+        exchanged = b""                              # rejected outright
+    assert not exchanged, "an unauthenticated client exchanged data"
+    server.close()
+    await server.wait_closed()
+
+
+def test_serving_without_material_refuses_rather_than_downgrading(monkeypatch,
+                                                                  tmp_path):
+    monkeypatch.setenv("JARVIS_LINK_TLS_DIR", str(tmp_path / "absent"))
+    engine = ls.LinkSessionLoop(
+        ls.SessionConfig(node_id="engine", session_id="s-1"))
+    with pytest.raises(ConnectionError):
+        asyncio.get_event_loop_policy().new_event_loop().run_until_complete(
+            lr.serve_link(engine, host="127.0.0.1", port=0))
+
+
+# ---------------------------------------------------------------------------
+# Supervision
+# ---------------------------------------------------------------------------
+
+
+def _loop(node="body"):
+    return ls.LinkSessionLoop(ls.SessionConfig(node_id=node, session_id="s-1"))
+
+
+@pytest.mark.asyncio
+async def test_one_failing_pump_tears_the_whole_connection_down():
+    """They share a socket: a dead peer means the reader blocks forever, and
+    a closed pipe means the writer shouts into nothing."""
+    loop = _loop()
+
+    class _Reader:
+        async def readuntil(self, sep):
+            raise ConnectionResetError("peer vanished")
+
+    class _Writer:
+        def write(self, b): pass
+        async def drain(self): pass
+        def close(self): self.closed = True
+        closed = False
+
+    runner = lr.LinkRunner(loop)
+    writer = _Writer()
+    with pytest.raises(Exception):
+        await asyncio.wait_for(
+            runner._serve_connection(_Reader(), writer), timeout=5)
+    assert writer.closed, "the connection was not torn down"
+
+
+@pytest.mark.asyncio
+async def test_a_corrupt_frame_does_not_tear_down_the_link():
+    """The CRC caught it and the stream resynchronises on the next newline —
+    tearing down would turn one bad frame into a reconnect storm."""
+    loop = _loop()
+    frames = [b"deadbeef\t{\"kind\":\"telemetry\"}\n", b""]
+
+    class _Reader:
+        async def readuntil(self, sep):
+            if frames:
+                nxt = frames.pop(0)
+                if nxt:
+                    return nxt
+            raise asyncio.IncompleteReadError(b"", None)
+
+    runner = lr.LinkRunner(loop)
+    with pytest.raises(ConnectionError):     # EOF, not the corrupt frame
+        await asyncio.wait_for(runner._pump_reads(_Reader()), timeout=5)
+
+
+@pytest.mark.asyncio
+async def test_the_runner_stops_promptly_rather_than_sleeping_out_a_backoff():
+    """A bare sleep would make shutdown take a full backoff interval — half
+    a minute of an operator watching a process told to exit."""
+    loop = _loop()
+    runner = lr.LinkRunner(loop, connector=None)
+    task = asyncio.create_task(runner.run())
+    await asyncio.sleep(0.05)
+    runner.stop()
+    await asyncio.wait_for(task, timeout=2.0)
+
+
+@pytest.mark.asyncio
+async def test_a_failed_connect_parks_rather_than_raising():
+    """A partition is a pause. The runner must keep the session and retry."""
+    loop = _loop()
+
+    async def _refuse():
+        raise ConnectionRefusedError("engine is asleep")
+
+    runner = lr.LinkRunner(loop, connector=_refuse)
+    await asyncio.wait_for(runner.run(max_cycles=2), timeout=5.0)
+    assert loop.state is ls.SessionState.PARKED
+    assert "ConnectionRefusedError" in runner.snapshot()["last_error"]
+
+
+@pytest.mark.asyncio
+async def test_the_flap_breaker_gates_reconnect_attempts(monkeypatch):
+    monkeypatch.setenv("JARVIS_LINK_FLAP_MAX_ATTEMPTS", "2")
+    monkeypatch.setenv("JARVIS_LINK_FLAP_OPEN_S", "30")
+    loop = _loop()
+    attempts = {"n": 0}
+
+    async def _refuse():
+        attempts["n"] += 1
+        raise ConnectionRefusedError("nope")
+
+    runner = lr.LinkRunner(loop, connector=_refuse)
+    task = asyncio.create_task(runner.run(max_cycles=8))
+    await asyncio.sleep(0.2)
+    runner.stop()
+    await asyncio.wait_for(task, timeout=5.0)
+    assert attempts["n"] <= 3, "the breaker did not gate reconnection"
+
+
+def test_the_connector_builds_a_fresh_context_each_dial():
+    """Fresh per attempt is what makes re-keying free: rotated material is
+    picked up by the next reconnection with no separate code path."""
+    import inspect
+    src = inspect.getsource(lr.tls_connector)
+    assert "build_ssl_context" in src
+    assert src.index("async def _dial") < src.index("build_ssl_context")
+
+
+def test_the_runner_snapshot_is_serialisable():
+    import json
+    json.dumps(lr.LinkRunner(_loop()).snapshot())

--- a/tests/governance/test_link_session.py
+++ b/tests/governance/test_link_session.py
@@ -1,0 +1,421 @@
+"""Regression spine for the Body/Engine session loop.
+
+Two loops are driven against each other in-process, so a full handshake →
+resume → partition → reconnect cycle runs deterministically with no sockets
+and no sleeps. Every test names the distributed failure it prevents.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from backend.core.ouroboros.governance import link_protocol as proto
+from backend.core.ouroboros.governance import link_session as ls
+from backend.core.ouroboros.governance import link_transport as tx
+
+
+def _loop(node, session="s-1", **kw):
+    applied = []
+    loop = ls.LinkSessionLoop(
+        ls.SessionConfig(node_id=node, session_id=session, **kw),
+        on_frame=applied.append,
+    )
+    loop.applied = applied  # type: ignore[attr-defined]
+    return loop
+
+
+# ---------------------------------------------------------------------------
+# Handshake collision — two dials, one winner, decided identically
+# ---------------------------------------------------------------------------
+
+
+def test_both_ends_compute_opposite_answers():
+    """THE split-brain requirement. A rule that could return 'win' to both
+    recreates exactly what it was meant to prevent."""
+    a, b = (7, "body"), (7, "engine")
+    assert ls.resolve_collision(a, b) != ls.resolve_collision(b, a)
+
+
+def test_lamport_precedence_beats_node_id():
+    """A node that has observed more of the shared history is further along;
+    its view should survive."""
+    assert ls.resolve_collision((9, "aaa"), (3, "zzz")) is True
+
+
+def test_node_id_breaks_a_genuine_tie():
+    assert ls.resolve_collision((5, "zzz"), (5, "aaa")) is True
+    assert ls.resolve_collision((5, "aaa"), (5, "zzz")) is False
+
+
+def test_a_peer_advertising_our_own_identity_is_refused():
+    """There is no correct winner between a node and itself — a duplicated
+    identity or a loopback misconfiguration."""
+    with pytest.raises(ls.HandshakeError):
+        ls.resolve_collision((5, "same"), (5, "same"))
+
+
+def test_the_losing_side_abandons_its_own_handshake_not_the_socket():
+    """Severing here would drop the connection that just won."""
+    body = _loop("body")
+    body.build_hello()                       # ours is in flight
+    with pytest.raises(ls.CollisionLost):
+        body.on_hello({"node_id": "engine", "lamport": 9_999,
+                       "session_id": "s-1"})
+    assert body.state is not ls.SessionState.CLOSED
+
+
+def test_the_winning_side_proceeds_to_resume():
+    engine = _loop("engine")
+    engine.build_hello()
+    welcome = engine.on_hello({"node_id": "aaa", "lamport": 1,
+                               "session_id": "s-1"})
+    assert welcome["kind"] == tx.KIND_WELCOME
+    assert engine.state is ls.SessionState.RESUMING
+
+
+def test_simultaneous_dials_converge_on_one_session():
+    """Both ends dial; exactly one handshake survives and both agree which."""
+    body, engine = _loop("body"), _loop("engine")
+    h_body, h_engine = body.build_hello(), engine.build_hello()
+
+    body_wins = ls.resolve_collision(
+        (h_body["lamport"], "body"), (h_engine["lamport"], "engine"))
+    loser, winner_hello = ((engine, h_body) if body_wins
+                           else (body, h_engine))
+    with pytest.raises(ls.CollisionLost):
+        loser.on_hello(winner_hello)
+
+
+# ---------------------------------------------------------------------------
+# Handshake + negotiation
+# ---------------------------------------------------------------------------
+
+
+def test_the_handshake_negotiates_the_smaller_ceiling(monkeypatch):
+    monkeypatch.setenv("JARVIS_LINK_MAX_FRAME_BYTES", "65536")
+    engine = _loop("engine")
+    engine.on_hello({"node_id": "body", "lamport": 1, "session_id": "s-1",
+                     "max_frame_bytes": 8192})
+    assert engine._limits is not None
+    assert engine._limits.max_frame_bytes == 8192
+
+
+def test_hello_carries_the_watermark_the_peer_needs():
+    body = _loop("body")
+    hello = body.build_hello()
+    assert "last_applied" in hello and hello["seq"] >= 1
+
+
+def test_sequences_are_one_indexed_because_zero_is_reserved():
+    body = _loop("body")
+    assert body.next_seq() == 1
+
+
+# ---------------------------------------------------------------------------
+# Resume
+# ---------------------------------------------------------------------------
+
+
+def test_a_reconnect_resumes_the_same_session_not_a_new_one():
+    body = _loop("body")
+    body.on_welcome({"node_id": "engine", "lamport": 5, "session_id": "s-1",
+                     "last_applied": 0, "oldest_retained": 1})
+    first = body._session
+    body.park("wifi drop")
+    body.on_welcome({"node_id": "engine", "lamport": 9, "session_id": "s-1",
+                     "last_applied": 0, "oldest_retained": 1})
+    assert body._session is first, "reconnection allocated new state"
+    assert body.state is ls.SessionState.ACTIVE
+
+
+def test_a_gap_past_retention_triggers_resync_not_a_partial_replay():
+    body = _loop("body")
+    body.on_welcome({"node_id": "engine", "lamport": 1, "session_id": "s-1",
+                     "source_latest": 900, "oldest_retained": 400})
+    assert body._resyncs == 1
+    assert body.reassembly.next_expected == 901
+
+
+def test_an_incoherent_peer_is_refused_at_the_handshake():
+    body = _loop("body")
+    body._session, _ = body.registry.attach("s-1", "body")
+    for s in range(1, 6):
+        body._session.ledger.apply_once(
+            proto.LinkFrame(seq=s, lamport=s, node_id="e", kind="verdict"),
+            lambda f: None)
+    with pytest.raises(ls.HandshakeError):
+        body.on_welcome({"node_id": "engine", "lamport": 1,
+                         "session_id": "s-1", "source_latest": 2,
+                         "oldest_retained": 1})
+
+
+# ---------------------------------------------------------------------------
+# Park — a partition is a pause, never a rejection
+# ---------------------------------------------------------------------------
+
+
+def test_a_partition_parks_and_keeps_everything(tmp_path):
+    """§26.6 crossing the network: nothing infers a verdict from silence."""
+    body = _loop("body", spill_path=tmp_path / "o.log")
+    body.on_welcome({"node_id": "engine", "lamport": 1, "session_id": "s-1",
+                     "last_applied": 0, "oldest_retained": 1})
+    body.send_verdict({"op": "op-1"})
+    queued = body.outbox.stats().queued
+    body.park("wifi dropped")
+    assert body.state is ls.SessionState.PARKED
+    assert body.outbox.stats().queued == queued, "parking discarded work"
+    assert body._session is not None, "parking destroyed the session"
+
+
+def test_parking_detaches_but_does_not_expire_the_session():
+    body = _loop("body")
+    body.on_welcome({"node_id": "engine", "lamport": 1, "session_id": "s-1",
+                     "last_applied": 0, "oldest_retained": 1})
+    body.park("drop")
+    assert body.registry.snapshot()["sessions"] == 1
+
+
+def test_reconnect_backoff_grows_then_resets_on_success():
+    body = _loop("body")
+    delays = [body.reconnect_delay_s() for _ in range(5)]
+    assert delays == sorted(delays)
+    body.on_established()
+    assert body.reconnect_delay_s() <= delays[0] * 2
+
+
+# ---------------------------------------------------------------------------
+# Re-keying — no special path, by construction
+# ---------------------------------------------------------------------------
+
+
+def test_a_rekey_is_a_reconnect_and_costs_the_queue_nothing(tmp_path):
+    """Certificate rotation must not flush unacknowledged work. It does not,
+    and not by special-casing: session state lives in the registry, never in
+    the connection."""
+    body = _loop("body", spill_path=tmp_path / "o.log")
+    body.on_welcome({"node_id": "engine", "lamport": 1, "session_id": "s-1",
+                     "last_applied": 0, "oldest_retained": 1})
+    for i in range(5):
+        body.send_verdict({"op": f"op-{i}"})
+    before = body.outbox.stats().queued
+    watermark = body._last_applied()
+
+    body.park("certificate rotation")          # the re-key
+    body.on_welcome({"node_id": "engine", "lamport": 7, "session_id": "s-1",
+                     "last_applied": 0, "oldest_retained": 1})
+
+    assert body.outbox.stats().queued == before
+    assert body._last_applied() == watermark
+    assert body.state is ls.SessionState.ACTIVE
+
+
+def test_the_state_machine_cannot_distinguish_a_rekey_from_a_wifi_drop():
+    """A dedicated hot-swap path would be a second way to do what resume
+    already does correctly."""
+    import inspect
+    src = inspect.getsource(ls.LinkSessionLoop)
+    assert "rekey" not in src.lower().replace("re-key", "")
+
+
+# ---------------------------------------------------------------------------
+# Priority — verdicts outrank telemetry, nothing blocks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_verdict_overtakes_queued_telemetry():
+    q = ls.PriorityWriteQueue()
+    for i in range(5):
+        q.put_low({"kind": tx.KIND_TELEMETRY, "seq": i + 1})
+    q.put_high({"kind": tx.KIND_VERDICT, "seq": 99})
+    first = await q.get()
+    assert first.record["kind"] == tx.KIND_VERDICT
+
+
+@pytest.mark.asyncio
+async def test_telemetry_drops_oldest_rather_than_blocking(monkeypatch):
+    """Blocking a producer to preserve stale telemetry converts a display
+    problem into a stall."""
+    monkeypatch.setenv("JARVIS_LINK_TELEMETRY_DEPTH", "8")
+    q = ls.PriorityWriteQueue()
+    for i in range(50):
+        q.put_low({"kind": tx.KIND_TELEMETRY, "seq": i + 1})
+    assert q.snapshot()["low_queued"] <= 8
+    assert q.snapshot()["telemetry_dropped"] > 0
+    nxt = await q.get()
+    assert nxt.record["seq"] > 1, "the oldest should have been displaced"
+
+
+@pytest.mark.asyncio
+async def test_verdicts_are_never_dropped_under_any_depth():
+    q = ls.PriorityWriteQueue()
+    for i in range(1000):
+        q.put_high({"kind": tx.KIND_VERDICT, "seq": i + 1})
+    assert q.snapshot()["high_queued"] == 1000
+
+
+@pytest.mark.asyncio
+async def test_a_verdict_flood_still_lets_telemetry_through(monkeypatch):
+    """Strict priority starves. An operator watching a blank deck cannot
+    tell a busy Engine from a dead one."""
+    monkeypatch.setenv("JARVIS_LINK_STARVATION_QUANTUM", "4")
+    q = ls.PriorityWriteQueue()
+    for i in range(100):
+        q.put_high({"kind": tx.KIND_VERDICT, "seq": i + 1})
+    q.put_low({"kind": tx.KIND_TELEMETRY, "seq": 1})
+    kinds = [(await q.get()).record["kind"] for _ in range(10)]
+    assert tx.KIND_TELEMETRY in kinds, "telemetry was starved"
+
+
+@pytest.mark.asyncio
+async def test_the_queue_blocks_only_when_genuinely_empty():
+    q = ls.PriorityWriteQueue()
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(q.get(), timeout=0.05)
+    q.put_high({"kind": tx.KIND_VERDICT, "seq": 1})
+    assert (await asyncio.wait_for(q.get(), timeout=1.0)) is not None
+
+
+def test_no_lock_is_held_across_an_await():
+    """The single discipline that makes deadlock-under-backpressure
+    unreachable rather than merely unlikely."""
+    import inspect
+    import re
+    src = inspect.getsource(ls)
+    for block in re.findall(r"with self\._lock:(.*?)(?=\n    [a-zA-Z@]|\Z)",
+                            src, re.S):
+        assert "await" not in block, "a lock is held across an await"
+
+
+# ---------------------------------------------------------------------------
+# Inbound dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_frames_apply_in_contiguous_order_only():
+    body = _loop("body")
+    body.on_welcome({"node_id": "engine", "lamport": 1, "session_id": "s-1",
+                     "last_applied": 0, "oldest_retained": 1})
+    assert body.dispatch({"kind": tx.KIND_VERDICT, "seq": 3,
+                          "node_id": "e", "lamport": 3}) == []
+    ready = body.dispatch({"kind": tx.KIND_VERDICT, "seq": 1,
+                           "node_id": "e", "lamport": 1})
+    assert [r["seq"] for r in ready] == [1]
+
+
+def test_a_redelivered_frame_applies_exactly_once():
+    body = _loop("body")
+    body.on_welcome({"node_id": "engine", "lamport": 1, "session_id": "s-1",
+                     "last_applied": 0, "oldest_retained": 1})
+    frame = {"kind": tx.KIND_VERDICT, "seq": 1, "node_id": "e", "lamport": 1,
+             "command_id": "c-1"}
+    body.dispatch(frame)
+    body.reassembly.reset(next_expected=1)
+    body.dispatch(frame)
+    assert len(body.applied) == 1
+
+
+def test_an_unknown_kind_is_dropped_not_dispatched():
+    body = _loop("body")
+    body.on_welcome({"node_id": "engine", "lamport": 1, "session_id": "s-1",
+                     "last_applied": 0, "oldest_retained": 1})
+    assert body.dispatch({"kind": "exec_arbitrary", "seq": 1,
+                          "node_id": "e"}) == []
+    assert body.applied == []
+
+
+def test_inbound_traffic_advances_the_logical_clock():
+    body = _loop("body")
+    body.on_welcome({"node_id": "engine", "lamport": 1, "session_id": "s-1",
+                     "last_applied": 0, "oldest_retained": 1})
+    before = body._session.clock.peek()
+    body.dispatch({"kind": tx.KIND_TELEMETRY, "seq": 1, "node_id": "e",
+                   "lamport": 5_000})
+    assert body._session.clock.peek() > before
+
+
+# ---------------------------------------------------------------------------
+# End to end — the chaos scenario, in process
+# ---------------------------------------------------------------------------
+
+
+def test_the_pull_the_plug_cycle_loses_nothing(tmp_path):
+    """Engine completes work while the Body is gone; the Body reconnects and
+    receives every verdict exactly once, in order."""
+    engine = _loop("engine", spill_path=tmp_path / "engine.log")
+    body = _loop("body")
+
+    engine.on_hello({"node_id": "body", "lamport": 1, "session_id": "s-1"})
+    body.on_welcome({"node_id": "engine", "lamport": 2, "session_id": "s-1",
+                     "last_applied": 0, "oldest_retained": 1})
+
+    engine.send_verdict({"op": "op-1"})          # delivered before the drop
+    delivered = engine.outbox.drain(1)
+    engine.outbox.ack(len(delivered))
+    from backend.core.ouroboros.battle_test.transcript_log import decode_frame
+    rec, _ = decode_frame(delivered[0].rstrip(b"\n"))
+    body.dispatch(rec)
+
+    body.park("the barista turned on the blender")
+    for i in range(2, 6):                         # work continues regardless
+        engine.send_verdict({"op": f"op-{i}"})
+
+    assert engine.outbox.stats().queued == 4, "work was lost while parked"
+
+    # The Engine states its TRUE position on reconnect. Understating it is
+    # what `plan_resume` calls an incoherent peer, and it refuses to serve
+    # one rather than papering over the disagreement.
+    body.on_welcome({"node_id": "engine", "lamport": 9, "session_id": "s-1",
+                     "source_latest": 5, "oldest_retained": 1})
+    for raw in engine.outbox.drain(10):
+        rec, _ = decode_frame(raw.rstrip(b"\n"))
+        body.dispatch(rec)
+
+    assert [f["seq"] for f in body.applied] == [1, 2, 3, 4, 5]
+
+
+def test_verdicts_survive_an_engine_restart_mid_outage(tmp_path):
+    from backend.core.ouroboros.governance.link_outbox import LinkOutbox
+    path = tmp_path / "engine.log"
+    engine = _loop("engine", spill_path=path)
+    import os
+    os.environ["JARVIS_LINK_OUTBOX_MEM_RECORDS"] = "8"
+    try:
+        for i in range(40):
+            engine.send_verdict({"op": f"op-{i}"})
+        spilled = engine.outbox.stats().on_disk
+        assert spilled > 0
+        assert LinkOutbox(spill_path=path).recover() == spilled
+    finally:
+        os.environ.pop("JARVIS_LINK_OUTBOX_MEM_RECORDS", None)
+
+
+# ---------------------------------------------------------------------------
+# SSE bridge + observability
+# ---------------------------------------------------------------------------
+
+
+def test_the_sse_bridge_never_raises_into_its_producer():
+    body = _loop("body")
+    bridge = ls.SseTelemetryBridge(body)
+    bridge.on_event(object())                    # not serialisable
+    assert bridge.snapshot()["suppressed"] == 1
+
+
+def test_the_sse_bridge_forwards_onto_the_lossy_lane():
+    body = _loop("body")
+    bridge = ls.SseTelemetryBridge(body)
+    bridge.on_event({"event_type": "phase", "op_id": "op-1"})
+    assert bridge.snapshot()["forwarded"] == 1
+    assert body.queue.snapshot()["low_queued"] == 1
+
+
+def test_the_snapshot_is_serialisable_and_names_every_subsystem(tmp_path):
+    import json
+    body = _loop("body", spill_path=tmp_path / "o.log")
+    snap = body.snapshot()
+    json.dumps(snap)
+    for key in ("state", "queue", "outbox", "liveness", "reassembly",
+                "registry", "breaker"):
+        assert key in snap

--- a/tests/governance/test_link_transport.py
+++ b/tests/governance/test_link_transport.py
@@ -1,0 +1,481 @@
+"""Regression spine for the Body/Engine transport and outbox.
+
+Every network failure is simulated deterministically — no sleeps, no real
+sockets except one loopback pair that proves the codec survives a stream.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+
+import pytest
+
+from backend.core.ouroboros.governance import link_outbox as lo
+from backend.core.ouroboros.governance import link_transport as lt
+
+
+# ---------------------------------------------------------------------------
+# Handshake — limits are agreed, never assumed
+# ---------------------------------------------------------------------------
+
+
+def test_the_smaller_frame_ceiling_wins():
+    """A ceiling one side cannot honour is not a limit, it is a fault
+    waiting for a large frame."""
+    n = lt.negotiate({"max_frame_bytes": 1 << 20},
+                     {"max_frame_bytes": 65536, "node_id": "engine"})
+    assert n.max_frame_bytes == 65536
+
+
+def test_the_faster_heartbeat_wins():
+    """Liveness is the one axis where the more demanding party should win:
+    a peer that wants proof of life every second is not harmed by it."""
+    n = lt.negotiate({"heartbeat_s": 5.0}, {"heartbeat_s": 2.0})
+    assert n.heartbeat_s == 2.0
+
+
+def test_a_garbage_advertisement_falls_back_to_local_defaults():
+    n = lt.negotiate({"max_frame_bytes": 65536},
+                     {"max_frame_bytes": "banana", "heartbeat_s": -3})
+    assert n.max_frame_bytes == 65536
+    assert n.heartbeat_s > 0
+
+
+def test_an_absent_advertisement_does_not_crash_the_handshake():
+    n = lt.negotiate({}, {})
+    assert n.max_frame_bytes > 0 and n.heartbeat_s > 0
+
+
+# ---------------------------------------------------------------------------
+# Dead-peer detection — the half-open socket
+# ---------------------------------------------------------------------------
+
+
+def test_the_deadline_tracks_measured_rtt_not_a_constant(monkeypatch):
+    """A constant is wrong in both directions: too tight on a café link
+    (false deaths) and too loose on a fast one (minutes of silence).
+
+    The floor is lowered here so the ADAPTATION is observable; in
+    production the floor is what keeps a LAN-fast link from heartbeating
+    itself to death."""
+    monkeypatch.setenv("JARVIS_LINK_HEARTBEAT_S", "0.5")
+    est = lt.RttEstimator()
+    for _ in range(10):
+        est.observe(0.005)
+    fast = est.deadline_s()
+
+    slow_est = lt.RttEstimator()
+    for _ in range(10):
+        slow_est.observe(0.9)
+    slow = slow_est.deadline_s()
+
+    assert slow > fast
+
+
+def test_the_deadline_never_drops_below_the_floor():
+    est = lt.RttEstimator()
+    for _ in range(20):
+        est.observe(0.0001)
+    assert est.deadline_s() >= lt.heartbeat_interval_s()
+
+
+def test_a_jittery_link_widens_the_deadline_via_variance(monkeypatch):
+    """4*rttvar is what keeps a normally-jittery path from being declared
+    dead — the classic RTO margin."""
+    monkeypatch.setenv("JARVIS_LINK_HEARTBEAT_S", "0.01")
+    steady = lt.RttEstimator()
+    jittery = lt.RttEstimator()
+    for i in range(16):
+        steady.observe(0.1)
+        jittery.observe(0.02 if i % 2 else 0.30)
+    assert jittery.deadline_s() > steady.deadline_s()
+
+
+def test_one_missed_heartbeat_is_not_a_death(monkeypatch):
+    """Wi-Fi loses single packets constantly; killing the session on one
+    would produce the reconnect storm FlapBreaker exists to survive."""
+    monkeypatch.setenv("JARVIS_LINK_HEARTBEAT_MISSES", "3")
+    mon = lt.LivenessMonitor()
+    assert mon.note_miss() is False
+    assert mon.note_miss() is False
+    assert mon.note_miss() is True
+
+
+def test_any_inbound_traffic_proves_liveness(monkeypatch):
+    """Demanding a specific frame type as proof would declare a busy peer
+    dead while it is actively sending."""
+    monkeypatch.setenv("JARVIS_LINK_HEARTBEAT_MISSES", "2")
+    mon = lt.LivenessMonitor()
+    mon.note_miss()
+    mon.note_inbound()          # telemetry arrived — it is alive
+    assert mon.note_miss() is False
+
+
+def test_an_ack_feeds_the_estimator_and_clears_the_miss_count():
+    mon = lt.LivenessMonitor()
+    mon.note_miss()
+    mon.note_ack(sent_mono=__import__("time").monotonic() - 0.05)
+    assert mon.snapshot()["consecutive_misses"] == 0
+    assert mon.rtt.srtt is not None
+
+
+# ---------------------------------------------------------------------------
+# Reassembly — contiguity restored before anything is applied
+# ---------------------------------------------------------------------------
+
+
+def test_frames_arriving_ahead_are_held_until_the_hole_fills():
+    buf = lt.ReassemblyBuffer(next_expected=1)
+    assert buf.offer(3, "c").ready == []
+    assert buf.offer(2, "b").ready == []
+    res = buf.offer(1, "a")
+    assert res.ready == ["a", "b", "c"], "the run must flush atomically"
+    assert buf.next_expected == 4
+
+
+def test_a_contiguous_frame_flushes_immediately():
+    buf = lt.ReassemblyBuffer(next_expected=1)
+    assert buf.offer(1, "a").ready == ["a"]
+
+
+def test_a_duplicate_from_a_replay_is_not_an_error():
+    buf = lt.ReassemblyBuffer(next_expected=5)
+    res = buf.offer(2, "old")
+    assert res.ready == [] and res.gap_unrecoverable is False
+    assert res.reason == "duplicate"
+
+
+def test_an_unclosable_gap_declares_resync_rather_than_buffering_forever(monkeypatch):
+    """A gap that cannot close within capacity is a lost range, not a
+    buffering problem to solve with more memory."""
+    monkeypatch.setenv("JARVIS_LINK_REASSEMBLY_CAPACITY", "8")
+    buf = lt.ReassemblyBuffer(next_expected=1)
+    last = None
+    for seq in range(2, 20):
+        last = buf.offer(seq, f"f{seq}")
+    assert last is not None and last.gap_unrecoverable is True
+    assert "resync" in last.reason
+
+
+def test_reset_after_a_resync_clears_held_frames():
+    buf = lt.ReassemblyBuffer(next_expected=1)
+    buf.offer(5, "e")
+    buf.reset(next_expected=10)
+    assert buf.snapshot()["held"] == 0
+    assert buf.offer(10, "j").ready == ["j"]
+
+
+# ---------------------------------------------------------------------------
+# Adaptive batching — the congestion signal that exists above TCP
+# ---------------------------------------------------------------------------
+
+
+def test_slow_drains_shrink_the_batch(monkeypatch):
+    monkeypatch.setenv("JARVIS_LINK_DRAIN_TARGET_S", "0.05")
+    b = lt.AdaptiveBatcher()
+    start = b.size
+    for _ in range(6):
+        b.observe_drain(0.5)
+    assert b.size < start
+
+
+def test_fast_drains_grow_the_batch_but_not_without_bound(monkeypatch):
+    monkeypatch.setenv("JARVIS_LINK_BATCH_MAX", "32")
+    b = lt.AdaptiveBatcher()
+    for _ in range(500):
+        b.observe_drain(0.0001)
+    assert b.size == 32
+
+
+# ---------------------------------------------------------------------------
+# Security posture
+# ---------------------------------------------------------------------------
+
+
+def test_the_default_bind_is_loopback_never_all_interfaces():
+    """0.0.0.0 would listen on the home LAN and any café Wi-Fi the host
+    joins. One end of this link runs bash."""
+    assert lt.bind_host() == "127.0.0.1"
+
+
+def test_missing_mtls_material_refuses_rather_than_downgrading(monkeypatch, tmp_path):
+    """A link that quietly ran unauthenticated would be worse than one that
+    did not run."""
+    monkeypatch.setenv("JARVIS_LINK_TLS_DIR", str(tmp_path / "absent"))
+    assert lt.build_ssl_context(server_side=True) is None
+    assert lt.build_ssl_context(server_side=False) is None
+
+
+def test_an_unknown_frame_kind_is_not_dispatched():
+    """A newer peer must not be able to drive an older one down a path it
+    does not have."""
+    assert lt.is_known_kind(lt.KIND_VERDICT) is True
+    assert lt.is_known_kind("exec_arbitrary") is False
+
+
+def test_no_hardcoded_endpoints_in_transport():
+    """Checked against the resolved VALUES, not the prose. The module
+    legitimately discusses 0.0.0.0 in the docstring explaining why it is
+    not the default, and a substring match cannot tell an explanation
+    from a use — the same lesson as the earlier DRY audit."""
+    assert lt.bind_host() != "0.0.0.0"
+    assert lt.bind_port() == 0, "default port must be OS-assigned"
+    import inspect
+    src = inspect.getsource(lt.bind_host)
+    assert '"0.0.0.0"' not in src.split('"""')[-1], "0.0.0.0 in executable code"
+
+
+# ---------------------------------------------------------------------------
+# Framed stream I/O over a real socket pair
+# ---------------------------------------------------------------------------
+
+
+def _limits(max_bytes=1 << 20):
+    return lt.NegotiatedLimits(max_frame_bytes=max_bytes, heartbeat_s=1.0,
+                               protocol_version="t.1", peer_node_id="peer")
+
+
+@pytest.mark.socket
+@pytest.mark.asyncio
+async def test_frames_round_trip_over_a_real_stream():
+    """Proves the transcript codec frames a STREAM, not just a file — the
+    reason it could be reused instead of writing a second codec.
+
+    Synchronised on an Event, not a sleep: a test that waits a fixed
+    duration for I/O is a flaky test on a loaded CI box."""
+    got = []
+    done = asyncio.Event()
+
+    async def _serve(reader, writer):
+        try:
+            for _ in range(3):
+                rec = await lt.read_frame(reader, limits=_limits(),
+                                          timeout_s=5.0)
+                if rec is None:
+                    break
+                got.append(rec)
+        finally:
+            done.set()
+            writer.close()
+
+    server = await asyncio.start_server(_serve, "127.0.0.1", 0)
+    port = server.sockets[0].getsockname()[1]
+    reader, writer = await asyncio.open_connection("127.0.0.1", port)
+    for i in range(3):
+        await lt.write_frame(writer, {"kind": lt.KIND_TELEMETRY, "seq": i + 1},
+                             limits=_limits())
+    await asyncio.wait_for(done.wait(), timeout=5.0)
+    writer.close()
+    server.close()
+    await server.wait_closed()
+    assert [r["seq"] for r in got] == [1, 2, 3]
+
+
+@pytest.mark.asyncio
+async def test_a_frame_over_the_negotiated_ceiling_is_refused_before_the_wire():
+    """Refusing at the writer keeps the fault on this side of the socket,
+    where it can still be handled."""
+    class _W:
+        def write(self, b): raise AssertionError("must not reach the socket")
+        async def drain(self): pass
+    with pytest.raises(lt.FrameTooLarge):
+        await lt.write_frame(_W(), {"kind": "x", "seq": 1, "blob": "y" * 5000},
+                             limits=_limits(max_bytes=1024))
+
+
+@pytest.mark.socket
+@pytest.mark.asyncio
+async def test_a_stalled_peer_times_out_rather_than_hanging_forever():
+    """THE half-open regression. No FIN arrives; the OS would wait hours."""
+    async def _serve(reader, writer):
+        await asyncio.sleep(30)          # peer is 'powered off'
+
+    server = await asyncio.start_server(_serve, "127.0.0.1", 0)
+    port = server.sockets[0].getsockname()[1]
+    reader, writer = await asyncio.open_connection("127.0.0.1", port)
+    with pytest.raises(asyncio.TimeoutError):
+        await lt.read_frame(reader, limits=_limits(), timeout_s=0.2)
+    writer.close()
+    server.close()
+    await server.wait_closed()
+
+
+@pytest.mark.socket
+@pytest.mark.asyncio
+async def test_a_corrupt_frame_is_reported_not_parsed():
+    """CRC before payload: a torn frame is rejected by arithmetic, not by a
+    JSON parser's opinion of it."""
+    async def _serve(reader, writer):
+        writer.write(b"deadbeef\t{\"kind\":\"telemetry\"}\n")  # bad CRC
+        await writer.drain()
+        writer.close()
+
+    server = await asyncio.start_server(_serve, "127.0.0.1", 0)
+    port = server.sockets[0].getsockname()[1]
+    reader, writer = await asyncio.open_connection("127.0.0.1", port)
+    rec = await lt.read_frame(reader, limits=_limits(), timeout_s=5.0)
+    assert rec is not None and rec.get("kind") == "__rejected__"
+    writer.close()
+    server.close()
+    await server.wait_closed()
+
+
+# ---------------------------------------------------------------------------
+# Outbox — an extended outage must not OOM the Engine
+# ---------------------------------------------------------------------------
+
+
+def test_records_spill_to_disk_past_the_memory_bound(monkeypatch, tmp_path):
+    """THE extended-outage regression: hours of undelivered verdicts must
+    not become an OOM on the machine holding the accelerator."""
+    monkeypatch.setenv("JARVIS_LINK_OUTBOX_MEM_RECORDS", "16")
+    box = lo.LinkOutbox(spill_path=tmp_path / "outbox.log")
+    for i in range(200):
+        box.put({"kind": "verdict", "seq": i + 1})
+    s = box.stats()
+    assert s.in_memory <= 16, "memory was not bounded"
+    assert s.on_disk > 0, "nothing spilled"
+    assert s.queued == 200, "records were lost, not spilled"
+
+
+def test_fifo_order_holds_across_the_disk_boundary(monkeypatch, tmp_path):
+    """Out-of-order delivery is a verdict the peer's contiguous watermark
+    will refuse to advance past."""
+    monkeypatch.setenv("JARVIS_LINK_OUTBOX_MEM_RECORDS", "8")
+    box = lo.LinkOutbox(spill_path=tmp_path / "outbox.log")
+    for i in range(50):
+        box.put({"kind": "verdict", "seq": i + 1})
+    frames = box.drain(50)
+    import json
+    seqs = [json.loads(f.split(b"\t", 1)[1])["seq"] for f in frames]
+    assert seqs == sorted(seqs) == list(range(1, 51))
+
+
+def test_drained_frames_survive_the_socket_dying_before_ack(monkeypatch, tmp_path):
+    """Drain must not remove: the window between drain and send is exactly
+    what this module exists to cover."""
+    monkeypatch.setenv("JARVIS_LINK_OUTBOX_MEM_RECORDS", "8")
+    box = lo.LinkOutbox(spill_path=tmp_path / "outbox.log")
+    for i in range(20):
+        box.put({"kind": "verdict", "seq": i + 1})
+    first = box.drain(10)
+    assert box.stats().queued == 20, "drain removed before acknowledgement"
+    again = box.drain(10)
+    assert [f for f in again] == [f for f in first]
+
+
+def test_ack_removes_exactly_what_was_delivered(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_LINK_OUTBOX_MEM_RECORDS", "8")
+    box = lo.LinkOutbox(spill_path=tmp_path / "outbox.log")
+    for i in range(20):
+        box.put({"kind": "verdict", "seq": i + 1})
+    box.ack(len(box.drain(10)))
+    assert box.stats().queued == 10
+
+
+def test_the_disk_ceiling_sheds_loudly_rather_than_growing(monkeypatch, tmp_path):
+    """Silence is what must never happen — a dropped verdict is
+    indistinguishable from an op that never ran."""
+    monkeypatch.setenv("JARVIS_LINK_OUTBOX_MEM_RECORDS", "8")
+    monkeypatch.setenv("JARVIS_LINK_OUTBOX_DISK_RECORDS", "64")
+    box = lo.LinkOutbox(spill_path=tmp_path / "outbox.log")
+    for i in range(500):
+        box.put({"kind": "verdict", "seq": i + 1})
+    s = box.stats()
+    assert s.shed_total > 0, "unbounded growth"
+    assert s.on_disk <= 64 + 8
+
+
+def test_undelivered_verdicts_survive_an_engine_restart(monkeypatch, tmp_path):
+    """The Engine restarting is not a reason to lose verdicts the Body has
+    not seen — that is why they are on disk."""
+    monkeypatch.setenv("JARVIS_LINK_OUTBOX_MEM_RECORDS", "8")
+    path = tmp_path / "outbox.log"
+    box = lo.LinkOutbox(spill_path=path)
+    for i in range(40):
+        box.put({"kind": "verdict", "seq": i + 1})
+    spilled = box.stats().on_disk
+    assert spilled > 0
+
+    reborn = lo.LinkOutbox(spill_path=path)      # new process
+    assert reborn.recover() == spilled
+
+
+def test_an_unencodable_record_fails_at_the_caller_not_at_the_socket(tmp_path):
+    box = lo.LinkOutbox(spill_path=tmp_path / "outbox.log")
+    assert box.put({"kind": "verdict", "seq": 1, "bad": object()}) is False
+    assert box.stats().queued == 0
+
+
+def test_without_a_spill_path_it_bounds_in_memory_and_says_so(monkeypatch):
+    monkeypatch.setenv("JARVIS_LINK_OUTBOX_MEM_RECORDS", "16")
+    box = lo.LinkOutbox(spill_path=None)
+    for i in range(100):
+        box.put({"kind": "verdict", "seq": i + 1})
+    s = box.stats()
+    assert s.in_memory <= 16
+    assert s.shed_total > 0, "an unbounded queue on the accelerator host"
+
+
+def test_memory_pressure_lowers_the_high_water_mark(monkeypatch):
+    """Holding 512 records is harmless on an idle Engine and reckless on one
+    whose RAM is already the constraint.
+
+    Both levels are FORCED. Reading the real host's pressure as a baseline
+    made this test pass or fail depending on what else was running — and on
+    this machine it was already 'high', so the comparison was 64 < 64."""
+    monkeypatch.setenv("JARVIS_LINK_OUTBOX_MEM_RECORDS", "512")
+    import backend.core.ouroboros.governance.memory_pressure_gate as mpg
+
+    def _at(level):
+        class _Gate:
+            def pressure(self):
+                class _L:
+                    value = level
+                return _L()
+        monkeypatch.setattr(mpg, "get_default_gate", lambda: _Gate())
+
+    box = lo.LinkOutbox(spill_path=None)
+    _at("ok")
+    calm = box._effective_high_water()
+    _at("warn")
+    warned = box._effective_high_water()
+    _at("high")
+    pressed = box._effective_high_water()
+
+    assert calm == 512
+    assert warned < calm
+    assert pressed < warned
+
+
+def test_stats_are_serialisable_for_the_operator(tmp_path):
+    import json
+    box = lo.LinkOutbox(spill_path=tmp_path / "o.log")
+    box.put({"kind": "verdict", "seq": 1})
+    json.dumps(box.stats().to_dict())
+
+
+# ---------------------------------------------------------------------------
+# DRY — one codec, not two
+# ---------------------------------------------------------------------------
+
+
+def test_the_wire_and_the_spill_share_one_encoding():
+    """A verdict spilled to disk and the same verdict on the socket must be
+    byte-identical — no serialise/deserialise seam where schema can drift."""
+    import pathlib
+    for mod in (lt, lo):
+        src = pathlib.Path(mod.__file__).read_text(encoding="utf-8")
+        assert "transcript_log" in src
+        assert "json.dumps" not in src, "a second encoder appeared"
+
+
+def test_seq_zero_is_refused_at_the_caller_not_after_a_restart(tmp_path):
+    """seq=0 is reserved for "nothing yet". It would encode cleanly, spill
+    cleanly, and be rejected by recover_log after a restart — losing the
+    verdicts this module exists to preserve, at the moment they matter."""
+    box = lo.LinkOutbox(spill_path=tmp_path / "o.log")
+    assert box.put({"kind": "verdict", "seq": 0}) is False
+    assert box.put({"kind": "verdict", "seq": -3}) is False
+    assert box.put({"kind": "verdict", "seq": "1"}) is False
+    assert box.put({"kind": "verdict", "seq": 1}) is True

--- a/tests/governance/test_ov_link_cli.py
+++ b/tests/governance/test_ov_link_cli.py
@@ -1,0 +1,216 @@
+"""Regression spine for `ov link`.
+
+Parsing is pure and tested without a filesystem; execution is tested against
+real issued material. Every test names the operator mistake it prevents.
+"""
+from __future__ import annotations
+
+import os
+import stat
+
+import pytest
+
+from backend.core.ouroboros.cli import ov_link
+from backend.core.ouroboros.cli.ov import resolve
+from backend.core.ouroboros.governance import link_certs as lc
+
+pytest.importorskip("cryptography")
+
+
+class _Console:
+    def __init__(self): self.lines = []
+    def print(self, text, **kw): self.lines.append(str(text))
+    @property
+    def text(self): return "\n".join(self.lines)
+
+
+# -- routing ---------------------------------------------------------------
+
+
+def test_ov_routes_link_and_forwards_its_flags():
+    inv = resolve(["link", "--connect", "engine.ts.net", "--port", "9000"])
+    assert inv.action == "link"
+    assert inv.delegate_argv == ["--connect", "engine.ts.net", "--port", "9000"]
+
+
+def test_link_is_a_registered_verb_so_bare_ov_does_not_swallow_it():
+    assert resolve(["link"]).action == "link"
+
+
+# -- parsing ---------------------------------------------------------------
+
+
+def test_an_unknown_flag_is_refused_with_a_suggestion():
+    """Refuse, never silently ignore — `ov doctor`'s established posture."""
+    args = ov_link.parse(["--serv"])
+    assert args.error and "--serve" in args.error
+
+
+def test_conflicting_modes_are_refused():
+    args = ov_link.parse(["--serve", "--connect", "host"])
+    assert args.error
+
+
+def test_a_flag_missing_its_value_is_refused():
+    assert ov_link.parse(["--port"]).error
+    assert ov_link.parse(["--connect"]).error
+
+
+def test_a_non_numeric_port_is_refused_at_parse_time():
+    assert "integer" in ov_link.parse(["--port", "abc"]).error
+
+
+def test_an_out_of_range_port_is_refused():
+    assert ov_link.parse(["--port", "99999"]).error
+
+
+def test_repeated_server_names_accumulate():
+    args = ov_link.parse(["--issue-certs", "--server-name", "a",
+                          "--server-name", "b"])
+    assert args.server_names == ["a", "b"]
+
+
+def test_parsing_reads_no_environment_and_touches_no_disk():
+    """Pure, so routing is testable without a socket — ov.resolve's rule.
+
+    Checked against the AST, not the text: the docstring legitimately
+    contains the word "environment", and a substring match cannot tell an
+    explanation from a use."""
+    import ast
+    import inspect
+    import textwrap
+    tree = ast.parse(textwrap.dedent(inspect.getsource(ov_link.parse)))
+    names = {n.attr for n in ast.walk(tree) if isinstance(n, ast.Attribute)}
+    names |= {n.id for n in ast.walk(tree) if isinstance(n, ast.Name)}
+    assert "environ" not in names and "getenv" not in names
+    assert "open" not in names
+
+
+# -- validation ------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad", [
+    "https://engine:9000", "engine:9000", "/etc/hosts", "a b", "",
+])
+def test_url_port_and_path_shapes_are_rejected_as_names(bad):
+    """A wrong SAN fails at the handshake as a TRUST error, which reads as
+    'certificates are broken' rather than 'you typed a URL'."""
+    assert ov_link._looks_like_a_name(bad) is False
+
+
+@pytest.mark.parametrize("good", ["engine.tailnet.ts.net", "100.64.1.2",
+                                  "breden-pc", "::1", "fd7a:115c::1"])
+def test_bare_hostnames_and_ip_literals_are_accepted(good):
+    assert ov_link._looks_like_a_name(good) is True
+
+
+def test_issue_without_a_server_name_exits_usage_not_a_traceback():
+    console = _Console()
+    assert ov_link.run_link(console, ["--issue-certs"]) == ov_link.EX_USAGE
+    assert "server-name" in console.text
+
+
+def test_connect_without_a_port_exits_usage():
+    console = _Console()
+    code = ov_link.run_link(console, ["--connect", "engine.ts.net"])
+    assert code == ov_link.EX_USAGE
+
+
+def test_no_mode_prints_help_and_exits_usage():
+    console = _Console()
+    assert ov_link.run_link(console, []) == ov_link.EX_USAGE
+    assert "ov link" in console.text
+
+
+def test_help_exits_zero():
+    assert ov_link.run_link(_Console(), ["--help"]) == 0
+
+
+# -- issuance --------------------------------------------------------------
+
+
+def test_issue_writes_material_and_names_the_peer_bundle(tmp_path):
+    console = _Console()
+    code = ov_link.run_link(console, [
+        "--issue-certs", "--dir", str(tmp_path / "m"),
+        "--server-name", "engine.tailnet.ts.net", "--server-name", "100.64.1.2",
+        "--client-name", "body-mac"])
+    assert code == 0
+    for name in lc.files_to_copy_to_peer():
+        assert name in console.text
+    assert lc.CA_KEY not in console.text, "the CA private key must not travel"
+
+
+def test_reissue_without_force_exits_config_not_usage(tmp_path):
+    """Distinct exit codes: a state-on-disk decision is not a typo."""
+    args = ["--issue-certs", "--dir", str(tmp_path / "m"),
+            "--server-name", "engine.ts.net"]
+    assert ov_link.run_link(_Console(), args) == 0
+    assert ov_link.run_link(_Console(), args) == ov_link.EX_CONFIG
+    assert ov_link.run_link(_Console(), args + ["--force"]) == 0
+
+
+def test_issued_keys_are_owner_only_through_the_cli(tmp_path):
+    ov_link.run_link(_Console(), [
+        "--issue-certs", "--dir", str(tmp_path / "m"),
+        "--server-name", "engine.ts.net"])
+    for name in (lc.CA_KEY, lc.SERVER_KEY, lc.CLIENT_KEY):
+        mode = stat.S_IMODE(os.stat(tmp_path / "m" / name).st_mode)
+        assert mode == 0o600
+
+
+def test_concurrent_issuance_is_refused_rather_than_interleaved(tmp_path):
+    """Two runs interleaving would produce a CA from one and leaves from the
+    other — individually well-formed, collectively unverifiable."""
+    d = tmp_path / "m"
+    d.mkdir(parents=True)
+    (d / ".issue.lock").write_text("99999")
+    with pytest.raises(FileExistsError):
+        lc.issue_link_material(directory=d, server_names=["engine.ts.net"])
+
+
+def test_a_partial_write_never_becomes_a_readable_pem(tmp_path):
+    """Published via durable_io.atomic_replace, so a reader building an SSL
+    context sees the old file or the new one, never a half-written PEM."""
+    import inspect
+    assert "atomic_replace" in inspect.getsource(lc._publish)
+
+
+# -- status ----------------------------------------------------------------
+
+
+def test_status_reports_a_countdown_not_a_boolean(tmp_path):
+    ov_link.run_link(_Console(), [
+        "--issue-certs", "--dir", str(tmp_path / "m"),
+        "--server-name", "engine.ts.net"])
+    console = _Console()
+    assert ov_link.run_link(console, ["--status", "--dir",
+                                      str(tmp_path / "m")]) == 0
+    assert "remaining" in console.text
+
+
+def test_status_on_an_empty_directory_exits_config_with_a_remedy(tmp_path):
+    console = _Console()
+    code = ov_link.run_link(console, ["--status", "--dir", str(tmp_path / "e")])
+    assert code == ov_link.EX_CONFIG
+    assert "--issue-certs" in console.text
+
+
+# -- serve/connect refuse rather than downgrade ----------------------------
+
+
+def test_serve_without_material_exits_config_not_a_traceback(tmp_path,
+                                                             monkeypatch):
+    monkeypatch.setenv("JARVIS_LINK_TLS_DIR", str(tmp_path / "absent"))
+    console = _Console()
+    code = ov_link.run_link(console, ["--serve", "--host", "127.0.0.1",
+                                      "--port", "0"])
+    assert code == ov_link.EX_CONFIG
+    assert "mTLS" in console.text or "material" in console.text
+
+
+def test_connect_with_a_url_shaped_host_exits_usage():
+    console = _Console()
+    code = ov_link.run_link(console, ["--connect", "https://engine:9000",
+                                      "--port", "9000"])
+    assert code == ov_link.EX_USAGE


### PR DESCRIPTION
Implements §29. The Body stays on the Mac as the sensor edge node; the Engine runs on a remote Windows/WSL2 box reached over an overlay network.

Four commits, layered so each is provable on its own: **wire → session → identity → CLI**.

## The two problems that make a remote link different

Both are invisible on the loopback transport `cockpit_attach` already implements.

**The clocks are not comparable.** A WSL2 guest's wall clock drifts against its host and re-syncs after suspend/resume. Any "reject frames older than N seconds" rule across that boundary is a random number generator.

> A timestamp that crosses a machine boundary is **data, never a clock.**

Ordering uses a Lamport clock; durations use each side's own monotonic. `sender_wall_ns` is named to make misuse obvious at the call site.

**Availability is nobody's to assume.** §26.6 established that absence must not read as refusal — across a network the link itself produces absence. A partition is a **pause**: both ends park, neither infers a verdict from silence.

## Design decisions worth reviewing

**One codec, not two.** `transcript_log.encode_record` already emits `<crc32-hex>\t<json>\n` — self-delimiting by newline, so it frames a stream exactly as it frames a file. A verdict spilled to disk and the same verdict on the socket are byte-identical. Pinned by a test asserting neither module contains a second encoder.

**Session identity is separate from connection identity** — the root-cause fix for flapping, of which the breaker is only damage control. Fifty reconnects exhaust an Engine because each *connection* allocates state; when a reconnect allocates nothing, flapping becomes a latency problem. Test proves 50 reconnects yield one session.

**Re-keying needed no code.** Session state lives in the registry, never in the connection, so certificate rotation is a reconnect with a different SSL context. A dedicated hot-swap path would be a second way to do what resume already does; a test asserts none exists.

**Deadlock under backpressure is removed, not managed.** Two producers wanting one writer must serialise somehow — a lock serialises by *blocking*, and a producer blocked while holding anything else is how an event loop deadlocks. One task owns the socket; both producers enqueue into a priority queue. Verdicts never drop; telemetry drops oldest. A test asserts **no lock is held across an `await`** anywhere.

**MTU is deliberately not consulted.** TCP owns path-MTU discovery; sizing application frames to it computes a number that changes nothing — a fabricated measurement. What matters above TCP is implemented instead: a negotiated ceiling, `drain()` backpressure, and batch size following observed drain latency.

## Bugs the tests caught

- **Control and data frames shared one sequence space.** The handshake consumed seq 1, so the first verdict was seq 2 and the peer's reassembly waited forever. A dropped heartbeat would have holed a range `plan_resume` is defined over. Now two counters.
- **The flap map pruned only stale entries** — a peer cycling session ids produced unbounded *fresh* entries. A memory-exhaustion vector reached by the exact traffic the class exists to survive. Now hard-capped with LRU eviction.
- **`engine:9000` was accepted as a certificate name.** A colon is wrong in host:port and correct in IPv6, so the value is handed to `ipaddress` rather than pattern-matched.

## Identity

The existing `.jarvis/brain_mtls/` could not be reused, found by inspection: **expired five weeks earlier on a seven-day validity**, leaves issued to `jarvis-brain`, and belonging to the J-Prime trust domain. `tls_dir()` now defaults to `.jarvis/link_mtls` — one directory shared by two trust domains means rotating either silently re-keys the other.

825-day validity with `notBefore` backdated 24h, because §29 exists precisely because these clocks drift. IP literals become `iPAddress` SANs; the CA carries `path_length=0`; leaves get narrow EKU; keys are created at mode 0600 at `open()`; the CA private key is excluded from the peer bundle.

## Proven, not asserted

- **Real mTLS handshake** — TLS 1.3, `TLS_AES_256_GCM_SHA384`, hostname verified against the SAN, both sides presenting certificates.
- **Two separate processes** — `ov link --serve` and `ov link --connect` established a live link: `peer connected: ('127.0.0.1', 54064)`.
- **The pull-the-plug cycle** runs in-process: handshake → deliver → park mid-work → Engine keeps working → reconnect → replay, asserting every verdict arrives exactly once in order.

**269 tests.** Master switch `JARVIS_LINK_BRIDGE_ENABLED`, default false.

## Not proven

Nothing has crossed a real network. Tailnet DNS, WSL2's NAT behaviour, and latency under a real partition all need both machines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements the distributed Body↔Engine link: framed mTLS transport, session-based resume, durable outbox, and the `ov link` CLI. Previously we only supported local loopback via `cockpit_attach`; now the Body can stay on macOS and the Engine run remotely, with partitions treated as pauses and delivery preserved.

- Adds `link_transport` (framed mTLS stream with negotiated limits and adaptive heartbeat), `link_session` (DISCONNECTED→HANDSHAKING→RESUMING→ACTIVE with PARKED on faults), `link_outbox` (bounded in-memory, spills to disk), `link_certs` (825‑day mTLS material in `.jarvis/link_mtls`), and `ov link` (issue, serve, connect).
- Keeps one codec: uses `transcript_log` for both spill and wire; `link_protocol.ensure_frame_envelope` enforces `v/seq/kind/ref` at both write sites.
- Separates session identity from connection identity; rekeys are ordinary reconnects. Resolves handshake collisions deterministically (Lamport, then node id).
- Writer owns the socket; producers enqueue via a priority queue. No lock is held across an `await`. Telemetry may drop oldest; verdicts never drop.
- Defaults bind to loopback, never `0.0.0.0`. MTU is not consulted; ceiling is negotiated and backpressure uses `drain()`.
- Guarded by `JARVIS_LINK_BRIDGE_ENABLED` (default false). 269 tests prove the loopback and in‑process paths; real tailnet still to validate.

**Rollout**

- Issue new link certificates on both hosts: `ov link --issue-certs --name <host-or-ip>`; do not reuse `.jarvis/brain_mtls`. Material lives in `.jarvis/link_mtls`.
- Use a DNS name or IP literal in SANs (e.g., `engine.ts.net`, `100.x.x.x`, or `::1`); do not pass `host:port`.
- Start the Engine side: `ov link --serve --bind <tailnet-ip> --port <port>`; start the Body side: `ov link --connect <engine-host> --port <port>`.
- Set `JARVIS_LINK_BRIDGE_ENABLED=1` to activate the bridge.
- If a port is in use, resolve the conflict; the listener will not retry in a loop.

<sup>Written for commit 7d94ea6dce447794f920cf1042922a0937e8da25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

