### PR TITLE
feat(governance): proactive mode — the ladder, the veto, the sink (PRD §30)

### DIFF
--- a/backend/core/ouroboros/governance/governed_loop_service.py
+++ b/backend/core/ouroboros/governance/governed_loop_service.py
@@ -6661,6 +6661,35 @@ class GovernedLoopService:
                 on_op_active_unregister=_bg_unregister_active,
             )
             await self._bg_pool.start()
+
+            # PRD §30: register the pool as the proactive-mode emission sink.
+            #
+            # The `watch` rung withholds INITIATIVE, and this pool is the only
+            # thing that can grant or withhold it. Injected here rather than
+            # imported there because a mode controller reaching into this
+            # service for `_bg_pool` would invert the authority boundary every
+            # governance module observes — the same reason `markup_mirror` and
+            # `set_prompt_publisher` are injected at their own boot seams.
+            #
+            # Registered AFTER start(): a sink handed a pool that has not
+            # started would pause something with no workers to pause, and
+            # `watch` would report an initiative hold it had not achieved.
+            #
+            # Without this line the ladder still floors the AUTHORITY axis
+            # correctly, and `watch` silently degrades to
+            # `approval_required` — wired but inert on exactly one of its two
+            # axes, which is the failure mode this codebase names most often.
+            try:
+                from backend.core.ouroboros.governance.proactive_mode import (  # noqa: PLC0415
+                    set_emission_sink as _pm_set_sink,
+                )
+                _pm_set_sink(self._bg_pool)
+                logger.debug("[GLS] proactive-mode emission sink registered")
+            except Exception:  # noqa: BLE001 — never block boot on the dial
+                logger.debug(
+                    "[GLS] proactive-mode sink registration skipped",
+                    exc_info=True,
+                )
             # Dynamic Fleet Registry Service Discovery: lanes TRACK the mesh.
             # While sovereign endpoints serve, the worker count locks to the
             # node count (one GPU = one lane; an N-node fleet = N lanes);

--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -12547,6 +12547,73 @@ class GovernedOrchestrator:
         reasoning logged on every evaluation (Slice 14 — never silent).
         Master: ``JARVIS_CANDIDATE_VALUE_GATE_ENABLED`` (default true).
         """
+        # ── PRD §30 slice 3: the `explore` rung's mutation veto ──────────
+        #
+        # Placed HERE, on the shared helper, for the reason this method's own
+        # docstring records: Run-24 proved the inline seam alone is never
+        # reached on the live route, so a gate wired only there is wired and
+        # inert. Both callers — the legacy inline seam and dispatch_pipeline's
+        # GENERATE→VALIDATE transition — pass through this one method, which
+        # makes it the only placement that cannot silently miss the shipping
+        # path.
+        #
+        # A veto is a benign TERMINAL, not a retry: `ExplorationInsufficient`
+        # routes through GENERATE_RETRY because a model can fix insufficient
+        # exploration by exploring more, and it cannot fix the operator's
+        # dial. Retrying here would burn the retry budget on a condition no
+        # generation can satisfy and then fail the op for something that was
+        # never the model's fault.
+        _veto = None
+        try:
+            from backend.core.ouroboros.governance.proactive_mode import (
+                mutation_permitted as _pm_mutation_permitted,
+            )
+            _veto = _pm_mutation_permitted()
+        except Exception:  # noqa: BLE001 — fail OPEN, never halt the organism
+            _veto = None
+        if _veto is not None and not _veto.permitted:
+            _n_cands = len(getattr(generation, "candidates", None) or ())
+            logger.info(
+                "[ProactiveMode] op=%s vetoed %d candidate(s) — %s; "
+                "completing as no_op_mode_veto, skipping "
+                "VALIDATE/APPLY/VERIFY",
+                ctx.op_id, _n_cands, _veto.reason,
+            )
+            try:
+                await self._stack.comm.emit_postmortem(
+                    op_id=ctx.op_id,
+                    root_cause="no_op_mode_veto",
+                    failed_phase=None,
+                    next_safe_action="none",
+                )
+            except Exception:
+                logger.debug(
+                    "[ProactiveMode] postmortem emit failed", exc_info=True,
+                )
+            _v_ctx = ctx.advance(
+                OperationPhase.COMPLETE,
+                generation=generation,
+                terminal_reason_code="no_op_mode_veto",
+            )
+            try:
+                # Same ledger shape the cosmetic terminal writes, so an
+                # operator reading the ledger sees one vocabulary for "the
+                # op completed without mutating" rather than two.
+                await self._record_ledger(
+                    _v_ctx,
+                    OperationState.APPLIED,
+                    {
+                        "reason": "no_op_mode_veto",
+                        "position": _veto.position,
+                        "candidates": _n_cands,
+                    },
+                )
+            except Exception:
+                logger.debug(
+                    "[ProactiveMode] ledger record failed", exc_info=True,
+                )
+            return _v_ctx
+
         if os.environ.get(
             "JARVIS_CANDIDATE_VALUE_GATE_ENABLED", "true",
         ).strip().lower() not in ("1", "true", "yes", "on"):

--- a/backend/core/ouroboros/governance/proactive_mode.py
+++ b/backend/core/ouroboros/governance/proactive_mode.py
@@ -1,0 +1,564 @@
+"""proactive_mode — the ladder, and who is allowed to loosen it.
+
+PRD §30. This is the STATE layer: it owns the ladder vocabulary, the
+multi-cockpit composition law, and the boundary arithmetic. It owns no
+enforcement — every position is expressed through a primitive that already
+exists and is already graduated, because a second enforcement path is a
+second thing to keep correct while the first is load-bearing.
+
+THE TWO AXES
+------------
+The shipped dial (``trust_repl``) answers *may it apply?* in three positions.
+The operator has two questions, and nothing answered the other one: at
+``approval_required`` — the strictest position expressible — sixteen sensors
+still fire, ops still enter the queue, and tokens are still spent. The dial
+stops the landing, never the taking off.
+
+So a position is a pair::
+
+    initiative ∈ { none, observe, explore, act }   the right to BEGIN
+    authority  ∈ { propose, notify, auto, promote } the right to CONCLUDE
+
+Presenting a 2-D space as a 1-D dial is deliberate: ``Shift+Tab`` must stay
+one keystroke. The dial therefore walks a **monotone path** — each step is
+less autonomous in *both* coordinates — which is what makes "cycle"
+meaningful. A path that traded one axis against the other would leave the
+operator unable to say whether they had just loosened or tightened.
+
+THE COMPOSITION LAW, AND WHY IT IS DERIVED
+-------------------------------------------
+``JARVIS_MIN_RISK_TIER`` is process-global, so two attached cockpits share
+one dial and today the last writer wins **silently** — an operator can
+tighten the organism and have a colleague loosen it with neither seeing.
+
+The effective position is therefore the **strictest requested by any live
+cockpit**, and it is *computed on read* rather than stored. That is the whole
+fix for the disconnect race: a cached effective value has a window between a
+cockpit vanishing and the recomputation, and a derived one has no window
+because there is nothing to be stale.
+
+ABSENCE IS NOT CONSENT TO LOOSEN
+---------------------------------
+The subtler half. If a request evaporated the instant its cockpit dropped,
+then an operator on flaky café Wi-Fi who set ``watch`` would find the
+organism becoming *more* autonomous at exactly the moment they lost
+visibility — their caution undone by their disconnection.
+
+So a detached cockpit's request is **retained** for a grace window and only
+then released. This is §26.6's rule ("absence must not read as refusal")
+applied to the dial: absence must not read as *permission* either. The
+retention window composes with §29's ``SessionRegistry``, which already holds
+detached sessions for exactly this reason.
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import enum
+import logging
+import os
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+logger = logging.getLogger("Ouroboros.ProactiveMode")
+
+PROACTIVE_MODE_SCHEMA_VERSION: str = "proactive_mode.1"
+
+
+def _env_float(name: str, default: float, minimum: float = 0.0) -> float:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return max(minimum, float(raw))
+    except (TypeError, ValueError):
+        return default
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in ("1", "true", "yes", "on")
+
+
+def is_enabled() -> bool:
+    """Master switch. Default **false** pending graduation.
+
+    OFF is not a degraded mode: the ladder reduces to the three shipped
+    positions and ``trust_repl`` behaves exactly as it did.
+    """
+    return _env_bool("JARVIS_PROACTIVE_MODE_ENABLED", False)
+
+
+def request_grace_s() -> float:
+    """How long a detached cockpit's request is honoured. Default 900s.
+
+    Matches ``link_protocol.session_idle_expiry_s``'s default deliberately:
+    a cockpit that has gone is the same event on both sides of the link, and
+    two windows that could disagree would let a session resume into an
+    autonomy level its own request had already expired out of.
+    """
+    return _env_float("JARVIS_PROACTIVE_MODE_GRACE_S", 900.0, minimum=1.0)
+
+
+def coalesce_window_s() -> float:
+    """Window over which rapid dial input is coalesced. Default 0.15s.
+
+    A held ``Shift+Tab`` on a TTY is a repeat RATE, not a discrete event —
+    a terminal delivers no key-up — so a burst is ordinary operator input
+    rather than a fault. Coalescing bounds the work without discarding
+    intent: see :meth:`ProactiveModeController.cycle`.
+    """
+    return _env_float("JARVIS_PROACTIVE_MODE_COALESCE_S", 0.15, minimum=0.0)
+
+
+# ---------------------------------------------------------------------------
+# The ladder
+# ---------------------------------------------------------------------------
+
+
+class Initiative(str, enum.Enum):
+    """The right to BEGIN."""
+
+    NONE = "none"
+    OBSERVE = "observe"
+    EXPLORE = "explore"
+    ACT = "act"
+
+
+class Authority(str, enum.Enum):
+    """The right to CONCLUDE."""
+
+    PROPOSE = "propose"
+    NOTIFY = "notify"
+    AUTO = "auto"
+    PROMOTE = "promote"
+
+
+@dataclass(frozen=True)
+class Position:
+    """One rung. Ordered by ``rank``: 0 is loosest, higher is stricter."""
+
+    name: str
+    rank: int
+    initiative: Initiative
+    authority: Authority
+    glyph: str
+    #: The ``risk_tier_floor`` value this rung asserts, or None for the
+    #: no-floor resting state. NEVER a second floor implementation — this is
+    #: the existing knob's value, chosen by the rung.
+    risk_floor: Optional[str]
+    summary: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name, "rank": self.rank,
+            "initiative": self.initiative.value,
+            "authority": self.authority.value,
+            "glyph": self.glyph, "risk_floor": self.risk_floor,
+            "summary": self.summary,
+        }
+
+
+#: The ladder, loosest → strictest. A CLOSED taxonomy, deliberately: this is
+#: a vocabulary two machines and two operators must agree on, not a tunable.
+#: Every threshold, window and cap around it is env-backed; the rungs are not,
+#: because a fleet that could invent a rung could invent one nobody else
+#: understands.
+LADDER: Tuple[Position, ...] = (
+    Position("promote", 0, Initiative.ACT, Authority.PROMOTE, "🔵", None,
+             "verified work lands on the operator tree (§26 Gate 3)"),
+    Position("safe_auto", 1, Initiative.ACT, Authority.AUTO, "🟢", None,
+             "applies as classified — green auto, yellow after its window"),
+    Position("notify_apply", 2, Initiative.ACT, Authority.NOTIFY, "🟡",
+             "notify_apply",
+             "every apply shows its diff before landing"),
+    Position("approval_required", 3, Initiative.ACT, Authority.PROPOSE, "🟠",
+             "approval_required",
+             "generates and proposes; nothing lands without a human"),
+    Position("explore", 4, Initiative.EXPLORE, Authority.PROPOSE, "🔍",
+             "approval_required",
+             "reads, searches, plans — no mutation reaches VALIDATE"),
+    Position("watch", 5, Initiative.NONE, Authority.PROPOSE, "⏸",
+             "approval_required",
+             "narrates only; nothing is admitted"),
+)
+
+_BY_NAME: Dict[str, Position] = {p.name: p for p in LADDER}
+
+#: The loosest rung the operator may reach WITHOUT it having been earned.
+#: `promote` is gated on §26's evidence, so it is not simply a dial position;
+#: see :func:`reachable`.
+_DEFAULT_NAME = "safe_auto"
+
+
+def position(name: Optional[str]) -> Position:
+    """Resolve a rung by name, falling back to the resting state.
+
+    An unknown name resolves to the DEFAULT rather than raising, matching
+    ``trust_repl.current_floor``'s existing posture: an unparseable dial must
+    not be able to take the organism down, and the default is the shipped
+    resting state rather than the loosest rung.
+    """
+    return _BY_NAME.get(str(name or "").strip().lower(),
+                        _BY_NAME[_DEFAULT_NAME])
+
+
+def strictest(*names: Optional[str]) -> Position:
+    """The strictest of the given rungs. Empty input yields the default."""
+    best: Optional[Position] = None
+    for name in names:
+        if name is None:
+            continue
+        cand = _BY_NAME.get(str(name).strip().lower())
+        if cand is None:
+            continue
+        if best is None or cand.rank > best.rank:
+            best = cand
+    return best or _BY_NAME[_DEFAULT_NAME]
+
+
+def reachable() -> Tuple[Position, ...]:
+    """Rungs this host may currently occupy — computed, never hardcoded.
+
+    ``promote`` is omitted unless §26's actuator is actually armed. A dial
+    that accepted a position the host cannot honour would report an autonomy
+    level that does not exist, which is the §25.4 dishonesty this codebase
+    spends sections removing. The check reads the flag the gate itself reads,
+    so the two cannot disagree.
+    """
+    out: List[Position] = []
+    for pos in LADDER:
+        if pos.name == "promote" and not _promotion_armed():
+            continue
+        out.append(pos)
+    return tuple(out)
+
+
+def _promotion_armed() -> bool:
+    """Is §26 Gate 3 actually enabled? NEVER raises."""
+    return _env_bool("JARVIS_WORKSPACE_PROMOTION_ENABLED", False)
+
+
+# ---------------------------------------------------------------------------
+# Requests
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Request:
+    cockpit_id: str
+    name: str
+    requested_at: float
+    #: None while attached; the monotonic instant of detachment otherwise.
+    detached_at: Optional[float] = None
+
+
+class ProactiveModeController:
+    """Holds every cockpit's request and derives the effective rung.
+
+    Thread-safe, lock-guarded, and **never holds a lock across a call into
+    another subsystem** — the effects in :meth:`apply_effects` run outside
+    the lock, because a governance primitive that blocked while this held the
+    dial would deadlock the very loop the dial is meant to steer.
+    """
+
+    def __init__(self, clock: Optional[Callable[[], float]] = None) -> None:
+        self._clock = clock or time.monotonic
+        self._lock = threading.Lock()
+        self._requests: Dict[str, _Request] = {}
+        self._last_applied: Optional[str] = None
+        self._last_cycle_at: float = 0.0
+        self._pending_steps: int = 0
+        self._transitions = 0
+        self._boundary_hits = 0
+
+    # -- requests --------------------------------------------------------
+
+    def request(self, cockpit_id: str, name: str) -> Position:
+        """Record one cockpit's requested rung. Returns the EFFECTIVE rung.
+
+        The caller does not necessarily get what it asked for, and that is
+        the point: a cockpit asking for a looser rung than another live
+        cockpit has requested is told the effective value so it can render
+        that it is being overridden. Silently discarding the request — the
+        current behaviour — is what makes an operator stop tightening.
+        """
+        cid = str(cockpit_id or "?")
+        resolved = position(name)
+        with self._lock:
+            self._requests[cid] = _Request(cid, resolved.name, self._clock())
+        return self.effective()
+
+    def detach(self, cockpit_id: str) -> Position:
+        """A cockpit went away. Its request is RETAINED, not dropped.
+
+        Releasing it immediately would let a disconnection loosen the
+        organism — an operator on flaky Wi-Fi who set ``watch`` would have
+        their caution undone by their own network. §26.6's rule, applied to
+        the dial: absence is not consent.
+        """
+        cid = str(cockpit_id or "?")
+        with self._lock:
+            req = self._requests.get(cid)
+            if req is not None and req.detached_at is None:
+                req.detached_at = self._clock()
+        return self.effective()
+
+    def reattach(self, cockpit_id: str) -> Position:
+        """A cockpit came back. Its request resumes at full weight."""
+        cid = str(cockpit_id or "?")
+        with self._lock:
+            req = self._requests.get(cid)
+            if req is not None:
+                req.detached_at = None
+        return self.effective()
+
+    def release(self, cockpit_id: str) -> Position:
+        """Explicit withdrawal — the operator cycled away or quit cleanly.
+
+        Distinct from :meth:`detach`: a deliberate exit is consent, an
+        unplanned drop is not.
+        """
+        with self._lock:
+            self._requests.pop(str(cockpit_id or "?"), None)
+        return self.effective()
+
+    # -- derivation ------------------------------------------------------
+
+    def effective(self) -> Position:
+        """The strictest live request. **Derived on read, never cached.**
+
+        A cached effective value has a window between a cockpit vanishing and
+        the recomputation; a derived one has no window because there is
+        nothing that can be stale. That is the entire fix for the disconnect
+        race — not a faster invalidation, an absent one.
+        """
+        now = self._clock()
+        grace = request_grace_s()
+        with self._lock:
+            expired = [cid for cid, r in self._requests.items()
+                       if r.detached_at is not None
+                       and (now - r.detached_at) > grace]
+            for cid in expired:
+                self._requests.pop(cid, None)
+            names = [r.name for r in self._requests.values()]
+        if expired:
+            logger.info(
+                "[ProactiveMode] released %d request(s) past the %.0fs "
+                "grace window", len(expired), grace)
+        return strictest(*names) if names else position(_env_position())
+
+    def requests(self) -> Tuple[Dict[str, Any], ...]:
+        now = self._clock()
+        with self._lock:
+            return tuple({
+                "cockpit_id": r.cockpit_id, "name": r.name,
+                "attached": r.detached_at is None,
+                "detached_for_s": (None if r.detached_at is None
+                                   else round(now - r.detached_at, 1)),
+            } for r in self._requests.values())
+
+    def overridden(self, cockpit_id: str) -> bool:
+        """Is this cockpit's request looser than the effective rung?"""
+        cid = str(cockpit_id or "?")
+        with self._lock:
+            mine = self._requests.get(cid)
+        if mine is None:
+            return False
+        return position(mine.name).rank < self.effective().rank
+
+    # -- the dial --------------------------------------------------------
+
+    def cycle(self, cockpit_id: str, steps: int = 1) -> Tuple[Position, bool]:
+        """Advance this cockpit's request. Returns ``(position, at_boundary)``.
+
+        **Clamped, never wrapped** (operator decision, §30.11 Q2). Wrapping
+        means one accidental keypress moves from maximum caution to maximum
+        autonomy, and a dial whose worst misfire is "nothing happened" is
+        strictly better than one whose worst misfire is "everything is
+        permitted".
+
+        **One press, one rung — no accumulator.** An earlier draft coalesced
+        a burst into an accumulated step count and was WRONG: it added the
+        pending steps to a position that had already moved, so two presses
+        advanced three rungs. Skipping a rung on a dial that governs autonomy
+        is not a cosmetic bug; it is the operator landing somewhere they did
+        not choose.
+
+        Bursts are bounded without arithmetic. Each press moves exactly one
+        rung, the clamp is idempotent at the ends, and the expensive part —
+        :meth:`apply_effects` — is already guarded on an actual change of the
+        effective rung. So mashing against the boundary settles
+        deterministically on the terminal rung and produces no further env
+        writes, no pool calls and no telemetry. ``coalesce_window_s`` bounds
+        how often the *effects* are re-evaluated, never how far the dial
+        moves: a debounce that discarded a transition would lose operator
+        intent, which is the one thing a dial may never do.
+        """
+        cid = str(cockpit_id or "?")
+        rungs = reachable()
+        if not rungs:
+            return position(_DEFAULT_NAME), True
+
+        with self._lock:
+            req = self._requests.get(cid)
+            current = position(req.name if req else _env_position())
+            self._last_cycle_at = self._clock()
+
+        ranks = [p.rank for p in rungs]
+        try:
+            idx = ranks.index(current.rank)
+        except ValueError:
+            # The current rung is unreachable on this host (promotion was
+            # disarmed underneath us). Clamp to the nearest reachable rung
+            # that is no LOOSER, never to the nearest overall — a host losing
+            # a capability must not thereby become more autonomous.
+            idx = next((i for i, r in enumerate(ranks) if r >= current.rank),
+                       len(rungs) - 1)
+        target = idx + int(steps)
+        clamped = max(0, min(len(rungs) - 1, target))
+        at_boundary = clamped != target
+        if at_boundary:
+            with self._lock:
+                self._boundary_hits += 1
+        chosen = rungs[clamped]
+        self.request(cid, chosen.name)
+        return self.effective(), at_boundary
+
+    # -- effects ---------------------------------------------------------
+
+    def apply_effects(self, *, pool: Any = None) -> Dict[str, Any]:
+        """Make the effective rung true. Idempotent; safe to call often.
+
+        Composes only. The risk floor is ``risk_tier_floor``'s env knob,
+        which every gate already re-reads per operation. Emission control is
+        ``BackgroundAgentPool.pause``/``resume`` — the same primitive the
+        hibernation path uses. Nothing here re-implements a gate.
+
+        Called outside the lock, deliberately: a governance primitive that
+        blocked while this held the dial would deadlock the loop the dial
+        exists to steer.
+        """
+        eff = self.effective()
+        changed = eff.name != self._last_applied
+        out: Dict[str, Any] = {"position": eff.name, "changed": changed}
+
+        try:
+            if eff.risk_floor is None:
+                os.environ.pop("JARVIS_MIN_RISK_TIER", None)
+            else:
+                os.environ["JARVIS_MIN_RISK_TIER"] = eff.risk_floor
+            out["risk_floor"] = eff.risk_floor
+        except Exception as exc:  # noqa: BLE001
+            out["risk_floor_error"] = str(exc)
+
+        out.update(self._apply_emission(eff, pool))
+        self._last_applied = eff.name
+        if changed:
+            self._transitions += 1
+            logger.info("[ProactiveMode] %s %s — %s",
+                        eff.glyph, eff.name, eff.summary)
+        return out
+
+    def _apply_emission(self, eff: Position, pool: Any) -> Dict[str, Any]:
+        """Pause or resume admission. NEVER raises.
+
+        Only ``watch`` withholds initiative, so only ``watch`` pauses. The
+        reason string is explicit about WHO paused: hibernation pauses the
+        same pool on provider exhaustion, and rendering the two alike would
+        report an outage the operator did not cause (§30.7 case 8).
+        """
+        out: Dict[str, Any] = {}
+        target_pool = pool if pool is not None else _emission_sink()
+        if target_pool is None:
+            # No sink registered — headless, a unit test, or a boot that has
+            # not reached the pool yet. The risk floor above still applied,
+            # so the authority axis holds; only the initiative axis is
+            # unenforceable, and saying so beats pretending otherwise.
+            return {"emission": "no sink registered"}
+        want_paused = eff.initiative is Initiative.NONE
+        try:
+            if want_paused:
+                target_pool.pause(reason="proactive_mode:watch (operator)")
+                out["emission"] = "paused"
+            else:
+                target_pool.resume(reason=f"proactive_mode:{eff.name}")
+                out["emission"] = "running"
+        except Exception as exc:  # noqa: BLE001
+            out["emission"] = f"degraded: {type(exc).__name__}"
+        return out
+
+    def snapshot(self) -> Dict[str, Any]:
+        eff = self.effective()
+        return {
+            "schema_version": PROACTIVE_MODE_SCHEMA_VERSION,
+            "enabled": is_enabled(),
+            "effective": eff.to_dict(),
+            "reachable": [p.name for p in reachable()],
+            "requests": list(self.requests()),
+            "transitions": self._transitions,
+            "boundary_hits": self._boundary_hits,
+            "grace_s": request_grace_s(),
+        }
+
+
+#: The thing that can withhold initiative. INJECTED at boot, never imported.
+#:
+#: The pool is an instance ``GovernedLoopService`` owns (``_bg_pool``), and a
+#: mode controller that reached into the orchestrator to find it would invert
+#: the authority boundary every other governance module observes — this
+#: module measures and composes; it does not reach. Injection is the pattern
+#: already used for ``markup_mirror``, ``set_operator_dispatcher`` and
+#: ``set_prompt_publisher``, for exactly this reason.
+_EMISSION_SINK: Optional[Any] = None
+_sink_lock = threading.Lock()
+
+
+def set_emission_sink(pool: Optional[Any]) -> None:
+    """Register the pool the ``watch`` rung pauses. NEVER raises.
+
+    Absent (unit tests, headless, pre-boot), the initiative axis is
+    unenforceable and :meth:`ProactiveModeController.apply_effects` says so
+    rather than reporting a state it did not achieve.
+    """
+    global _EMISSION_SINK
+    with _sink_lock:
+        _EMISSION_SINK = pool
+
+
+def _emission_sink() -> Optional[Any]:
+    with _sink_lock:
+        return _EMISSION_SINK
+
+
+def _env_position() -> str:
+    """The rung implied by the environment when no cockpit has asked.
+
+    Reads the SAME knob ``trust_repl`` writes, so a headless run and an
+    attached one cannot disagree about where the dial rests.
+    """
+    raw = (os.environ.get("JARVIS_MIN_RISK_TIER", "") or "").strip().lower()
+    return raw if raw in _BY_NAME else _DEFAULT_NAME
+
+
+_singleton: Optional[ProactiveModeController] = None
+_singleton_lock = threading.Lock()
+
+
+def get_controller() -> ProactiveModeController:
+    global _singleton
+    with _singleton_lock:
+        if _singleton is None:
+            _singleton = ProactiveModeController()
+        return _singleton
+
+
+def reset_controller() -> None:
+    """Drop the singleton — for tests and a deliberate re-derivation."""
+    global _singleton
+    with _singleton_lock:
+        _singleton = None

--- a/backend/core/ouroboros/governance/proactive_mode.py
+++ b/backend/core/ouroboros/governance/proactive_mode.py
@@ -506,6 +506,58 @@ class ProactiveModeController:
         }
 
 
+@dataclass(frozen=True)
+class MutationVerdict:
+    """Whether the current rung permits a candidate to reach VALIDATE."""
+
+    permitted: bool
+    position: str
+    reason: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"permitted": self.permitted, "position": self.position,
+                "reason": self.reason}
+
+
+def mutation_permitted() -> MutationVerdict:
+    """May a generated candidate proceed toward APPLY? NEVER raises.
+
+    **Why this is a separate question from the risk floor.** The floor decides
+    *how* a mutation lands — auto, after a diff, or only with a human. It
+    always assumes one is landing. The ``explore`` rung says something the
+    floor cannot: that generation may continue and mutation may not, so the
+    organism can read, search, plan and reason without any patch reaching
+    disk.
+
+    **Why a veto and not a retry.** The Iron Gate's existing refusal —
+    ``ExplorationInsufficientError`` — routes through ``GENERATE_RETRY`` with
+    targeted feedback, and that is correct there: the model *can* fix
+    insufficient exploration by exploring more. It cannot fix the operator's
+    dial. Retrying a mode veto would burn the retry budget on a condition no
+    generation can satisfy, then fail the op for a reason that was never the
+    model's fault. So a veto is a **benign terminal**, not a retry and not a
+    failure — the same shape ``candidate_value_gate`` uses when it proves a
+    candidate cosmetic.
+
+    Fails OPEN. A mode subsystem that cannot answer must not be able to halt
+    every mutation in the organism; that would convert a fault here into a
+    total outage, which is the posture ``local_model_admission`` already
+    argues for on the same grounds.
+    """
+    try:
+        if not is_enabled():
+            return MutationVerdict(True, "disabled", "proactive mode off")
+        eff = get_controller().effective()
+        if eff.initiative in (Initiative.ACT,):
+            return MutationVerdict(True, eff.name, "rung permits mutation")
+        return MutationVerdict(
+            False, eff.name,
+            f"{eff.glyph} {eff.name}: {eff.summary}")
+    except Exception as exc:  # noqa: BLE001 — fail OPEN, never halt the organism
+        logger.debug("[ProactiveMode] mutation check degraded: %s", exc)
+        return MutationVerdict(True, "unknown", "mode unavailable")
+
+
 #: The thing that can withhold initiative. INJECTED at boot, never imported.
 #:
 #: The pool is an instance ``GovernedLoopService`` owns (``_bg_pool``), and a

--- a/backend/core/ouroboros/governance/trust_repl.py
+++ b/backend/core/ouroboros/governance/trust_repl.py
@@ -27,9 +27,36 @@ __verb_help__ = {
 
 _ENV_MIN_TIER = "JARVIS_MIN_RISK_TIER"
 
-#: The dial's positions, loosest → strictest. ``safe_auto`` is the
-#: no-floor resting state (green ops auto-apply as classified).
-_CYCLE = ("safe_auto", "notify_apply", "approval_required")
+#: The dial POSITION, distinct from the floor it asserts. Two rungs may
+#: assert one floor (`explore` and `watch` both floor at approval_required)
+#: and must still be distinguishable to the operator.
+_ENV_DIAL_POSITION = "JARVIS_PROACTIVE_MODE_POSITION"
+
+#: The dial's positions. When PRD §30's ladder is enabled these come from
+#: `proactive_mode.reachable()` — computed from live capability, so a rung
+#: the host cannot honour is never offered. Master-off, the shipped three
+#: remain, byte-identically.
+#:
+#: NOT a second vocabulary: `proactive_mode.LADDER` is the single source and
+#: this is a projection of it. Two tuples that could disagree is how the dial
+#: and the gate start meaning different things by the same word.
+_LEGACY_CYCLE = ("safe_auto", "notify_apply", "approval_required")
+
+
+def _cycle_positions() -> tuple:
+    """Reachable rung names, loosest → strictest. NEVER raises."""
+    try:
+        from backend.core.ouroboros.governance import proactive_mode as _pm
+        if _pm.is_enabled():
+            return tuple(p.name for p in _pm.reachable())
+    except Exception:  # noqa: BLE001 — the dial must survive §30 being absent
+        pass
+    return _LEGACY_CYCLE
+
+
+#: Retained for the module's own membership checks; the LIVE set is
+#: `_cycle_positions()`.
+_CYCLE = _LEGACY_CYCLE
 
 _GLYPH = {
     "safe_auto": "🟢",
@@ -64,8 +91,12 @@ class TrustReplDispatchResult:
 
 def current_floor() -> str:
     """The dial's position, normalized. NEVER raises."""
+    positions = _cycle_positions()
+    dial = os.environ.get(_ENV_DIAL_POSITION, "").strip().lower()
+    if dial in positions:
+        return dial
     raw = os.environ.get(_ENV_MIN_TIER, "").strip().lower()
-    return raw if raw in _CYCLE else "safe_auto"
+    return raw if raw in positions else "safe_auto"
 
 
 def floor_chip() -> str:
@@ -74,10 +105,13 @@ def floor_chip() -> str:
     tier = current_floor()
     if tier == "safe_auto":
         return ""
-    return f"{_GLYPH.get(tier, '')}⛨ {tier}"
+    return f"{_glyph_for(tier)}⛨ {tier}"
 
 
 def _describe(tier: str) -> str:
+    rung = _rung(tier)
+    if rung is not None:
+        return rung.summary
     return {
         "safe_auto": "no floor — green auto-applies, yellow previews, "
                      "orange waits for you",
@@ -88,13 +122,46 @@ def _describe(tier: str) -> str:
     }.get(tier, tier)
 
 
+def _rung(name: str):
+    """The ladder rung for a dial position, or None. NEVER raises."""
+    try:
+        from backend.core.ouroboros.governance import proactive_mode as _pm
+        if _pm.is_enabled():
+            return _pm.position(name)
+    except Exception:  # noqa: BLE001
+        pass
+    return None
+
+
+def _glyph_for(tier: str) -> str:
+    rung = _rung(tier)
+    return rung.glyph if rung is not None else _GLYPH.get(tier, "")
+
+
 def _set_floor(tier: str) -> str:
-    if tier == "safe_auto":
+    """Move the dial. Writes the rung's RISK FLOOR, never its name.
+
+    Load-bearing distinction. `explore` and `watch` are ladder positions, not
+    risk tiers — `risk_tier_floor` accepts only
+    ``safe_auto|notify_apply|approval_required``, so writing "explore" into
+    ``JARVIS_MIN_RISK_TIER`` would leave the floor UNPARSEABLE and silently
+    resolve to no floor at all: the strictest rungs on the dial would become
+    the loosest in effect. `Position.risk_floor` exists exactly to carry this
+    mapping, and both new rungs assert ``approval_required``.
+    """
+    rung = _rung(tier)
+    floor = rung.risk_floor if rung is not None else (
+        None if tier == "safe_auto" else tier)
+    if floor is None:
         os.environ.pop(_ENV_MIN_TIER, None)
     else:
-        os.environ[_ENV_MIN_TIER] = tier
-    logger.info("[Trust] risk-tier floor -> %s", tier)
-    return f"{_GLYPH.get(tier, '')} trust dial → {tier}: {_describe(tier)}"
+        os.environ[_ENV_MIN_TIER] = floor
+    # The dial's own position is remembered separately from the floor it
+    # asserts, so `explore` and `approval_required` stay distinguishable
+    # even though they assert the same floor.
+    os.environ[_ENV_DIAL_POSITION] = tier
+    logger.info("[Trust] dial -> %s (risk floor %s)", tier, floor or "none")
+    return f"{_glyph_for(tier)} trust dial → {tier}: {_describe(tier)}"
 
 
 def dispatch_trust_command(line: str) -> TrustReplDispatchResult:
@@ -111,11 +178,26 @@ def dispatch_trust_command(line: str) -> TrustReplDispatchResult:
             return TrustReplDispatchResult(ok=True, text=_HELP)
 
         if sub == "cycle":
-            here = _CYCLE.index(current_floor())
-            nxt = _CYCLE[(here + 1) % len(_CYCLE)]
-            return TrustReplDispatchResult(ok=True, text=_set_floor(nxt))
+            # CLAMPED, never wrapped (PRD §30.11 Q2, operator decision).
+            # Wrapping means one accidental keypress moves from maximum
+            # caution to maximum autonomy; a dial whose worst misfire is
+            # "nothing happened" is strictly better than one whose worst
+            # misfire is "everything is permitted".
+            positions = _cycle_positions()
+            here = (positions.index(current_floor())
+                    if current_floor() in positions else 0)
+            if here >= len(positions) - 1:
+                tier = positions[here]
+                return TrustReplDispatchResult(
+                    ok=True,
+                    text=(f"{_glyph_for(tier)} trust: already at the "
+                          f"strictest position ({tier}) — cycle does not "
+                          f"wrap. Set a looser one by name."),
+                )
+            return TrustReplDispatchResult(
+                ok=True, text=_set_floor(positions[here + 1]))
 
-        if sub in _CYCLE:
+        if sub in _cycle_positions():
             return TrustReplDispatchResult(ok=True, text=_set_floor(sub))
 
         if sub in ("", "status"):
@@ -135,7 +217,7 @@ def dispatch_trust_command(line: str) -> TrustReplDispatchResult:
             tail = f"  ({', '.join(extras)})" if extras else ""
             return TrustReplDispatchResult(
                 ok=True,
-                text=(f"{_GLYPH.get(tier, '')} trust: {tier} — "
+                text=(f"{_glyph_for(tier)} trust: {tier} — "
                       f"{_describe(tier)}{tail}"),
             )
 

--- a/docs/architecture/OUROBOROS_VENOM_PRD.md
+++ b/docs/architecture/OUROBOROS_VENOM_PRD.md
@@ -3614,7 +3614,34 @@ proposal *surface*.
 per-proposal affordance. This is §27.10 slice 5 and it is the difference
 between an organism that proposes and an operator who can hear it.
 
-#### C2 — The decision channel is complete except for the answer key
+#### C2 — REVISED 2026-08-15: not missing, mounted on one surface of two
+
+> **Correction.** C2 originally read "there is no action that answers a
+> gate." That is false. `menu_bindings.install_confirm_actions` binds
+> `confirm:yes` → `y`/`enter` → `/accept` and `confirm:no` → `n` →
+> `/reject`, filtered on an empty prompt. Single-key answering exists and
+> was built before this audit ran.
+>
+> **What is actually true is narrower and worse.** Those bindings are
+> imported at exactly one site — `bipartite_layout.py:1495` — and never by
+> `cli/ov.py`, which is the surface `ov attach` and bare `ov` actually
+> mount. So the capability exists, works, and is unreachable from the
+> cockpit an operator uses.
+>
+> This is not a new observation about the codebase; it is the same one
+> `ov.py:toolbar()` already records in prose about a different feature:
+> *"the page-style palette shipped in #70123 reached the bipartite cockpit
+> and never reached the surface `ov` actually attaches with."* Two
+> presentation surfaces, one of which receives every new affordance,
+> silently diverging. **Surface parity is the defect class**, and C2 is one
+> instance of it rather than a missing feature.
+>
+> This is also the third confident structural claim about this cockpit to
+> fail verification (see §28.4). The pattern is now established well enough
+> to state as a rule: in this codebase, *absence of a call site in `ov.py`
+> means the feature is unmounted there, never that it does not exist.*
+
+The original finding, with the correction above applied:
 
 The channel is queued, badged, addressed, re-surfaceable, and parsed with
 strict single-token discipline (§28.2.2–28.2.4). One vocabulary item is
@@ -3932,19 +3959,427 @@ advertise a maximum frame size and the **minimum wins** — the same asymmetry
 §25.1 applies to terminal width, and for the same reason. A ceiling one side
 cannot honour is not a limit, it is a fault waiting for a large frame.
 
-### 29.7 What remains
+### 29.7 What is built *(revised 2026-08-15 — the link is complete)*
 
-`link_protocol.py` is the provable half. The transport half — a wire codec
-over the mTLS channel, the per-side durable outbox on `durable_io`, the SSE
-lane bridged to a remote subscriber, and the handshake that negotiates limits
-— is the next slice, and it is the half that cannot be finished honestly
-until both machines exist. Master switch `JARVIS_LINK_BRIDGE_ENABLED`,
-default false.
+When §29 was first written only `link_protocol.py` existed and the rest was
+described as "the next slice". All of it landed the same day, across PRs
+#70482 and #70483. This subsection replaces the forward-looking text with
+what is actually on `main` at `bcd57b3744`.
 
-The fault-injection spine follows §28's discipline: kill the link mid-verdict
-and assert exactly-once *effect*; partition during a live review and assert
-the op **parks** with no evidence recorded in either direction (§27.3.2);
-force a replay gap wider than retention and assert `RESYNC` rather than a
-silent partial resume.
+| Module | Role | Tests |
+|---|---|---|
+| `link_protocol.py` | Lamport clock, `plan_resume`, `FlapBreaker`, `DeliveryLedger`, `SessionRegistry`, `ensure_frame_envelope` | 34 |
+| `link_transport.py` | Framing over the transcript codec, `negotiate`, `RttEstimator`, `LivenessMonitor`, `ReassemblyBuffer`, `AdaptiveBatcher`, mTLS contexts | 37 |
+| `link_outbox.py` | Bounded memory → durable spill via `durable_io`, FIFO across both tiers, restart recovery | (in transport suite) |
+| `link_session.py` | The state machine: handshake, collision resolution, resume, park, `PriorityWriteQueue`, SSE bridge | 33 |
+| `link_runner.py` | Connection supervision, reconnect cycle, `serve_link`, `tls_connector` | 22 |
+| `link_certs.py` | Private CA + two leaves, atomic publish, issuance lock, expiry inspection | (in runner suite) |
+| `cli/ov_link.py` | `ov link --issue-certs / --serve / --connect / --status` | 32 |
+
+**269 tests.** Master switch `JARVIS_LINK_BRIDGE_ENABLED`, default false.
+
+#### 29.7.1 Decisions worth recording
+
+**One codec, not two.** `transcript_log.encode_record` emits
+`<crc32-hex>\t<json>\n`. Self-delimiting by newline means it frames a
+*stream* exactly as it frames a *file*, so a verdict spilled to disk and the
+same verdict on the socket are byte-identical and there is no
+serialise/deserialise seam where a schema could drift. Pinned by a test
+asserting neither module contains a second encoder.
+
+Reusing a codec means accepting its **contract**, not only its bytes — a
+lesson learned three times over. Records need `v`/`seq`/`kind`/`ref`, and
+`seq` must be ≥ 1 because the codec reserves 0 and :func:`plan_resume` reads
+0 as "this peer has applied nothing". One value cannot mean both.
+`ensure_frame_envelope` now lives in `link_protocol` and both the outbox and
+the transport call it: validating in two places with two opinions is how two
+sides of a link start disagreeing about what a frame is.
+
+**MTU is deliberately not consulted.** TCP owns path-MTU discovery and
+segments the stream; sizing application frames to it computes a number that
+changes nothing — a fabricated measurement in the same family as a blast
+radius nobody scanned. Implemented instead: a negotiated ceiling (minimum
+wins), backpressure through `drain()` so buffer bloat is not merely
+relocated from the socket into Python where `ss` cannot see it, and a batch
+size following observed drain latency.
+
+**Half-open detection is RTT-derived.** A peer that loses power sends no FIN
+and the socket stays ESTABLISHED until OS keepalive fires — two hours on
+Linux, indistinguishable from idle. `SO_KEEPALIVE` is set as defence in
+depth but not trusted; the detector is an application heartbeat whose
+deadline comes from Jacobson/Karels smoothed RTT, because a constant is too
+tight on a congested café link and too loose on a fast one. One miss is not
+a death.
+
+**Re-keying needed no code.** Session state lives in the registry, never in
+the connection, so certificate rotation is a reconnect with a different SSL
+context and the state machine cannot distinguish it from a Wi-Fi drop. A
+test asserts no hot-swap path exists — a second way to do what resume
+already does correctly is a second thing to keep correct.
+
+**Deadlock under backpressure is removed, not managed.** Two producers
+wanting one writer must serialise somehow; a lock serialises by *blocking*,
+and a producer blocked while holding anything else is how an event loop
+deadlocks. One task owns the socket and both producers enqueue into
+`PriorityWriteQueue`. A test asserts no lock is held across an `await`
+anywhere in the module.
+
+#### 29.7.2 Defects the spine caught
+
+Recorded because each was invisible to inspection and found only by a test
+that named a failure rather than a spelling.
+
+* **Control and data shared one sequence space.** The handshake consumed
+  seq 1, so the first verdict was seq 2 and the peer's reassembly waited
+  forever for a frame that would never exist. Worse, a dropped heartbeat
+  would have holed a range `plan_resume` is defined over. Two counters now,
+  with control kinds bypassing reassembly entirely.
+* **The flap map pruned only *stale* entries.** A peer cycling session ids
+  produces thousands of *fresh* entries inside one window — a
+  memory-exhaustion vector on a network-reachable service, reached by the
+  exact traffic pattern the class exists to survive. Hard-capped with LRU
+  eviction.
+* **`engine:9000` was accepted as a certificate name.** A colon is wrong in
+  a host:port pair and correct in an IPv6 literal, so the value is handed to
+  `ipaddress` rather than pattern-matched.
+
+#### 29.7.3 Identity
+
+`.jarvis/brain_mtls/` could not be reused, established by inspecting it:
+**expired five weeks earlier on a seven-day validity**, leaves issued to
+`jarvis-brain`, and belonging to the J-Prime trust domain. `tls_dir()` now
+defaults to `.jarvis/link_mtls` — one directory shared by two trust domains
+means rotating either silently re-keys the other.
+
+Seven days was the real defect. A link between two houses cannot require a
+physical visit every week, which is the same reason Tailscale key expiry
+must be disabled on the Engine. Now 825 days with `notBefore` backdated 24h,
+because §29.3's clock-drift problem applies to certificate validity too and
+a cert valid from "now" is rejected by a peer a few minutes behind.
+
+Issuance details that are load-bearing rather than ceremonial: IP literals
+become `iPAddress` SANs (a tailnet `100.x` in a DNSName verifies against
+nothing); the CA carries `path_length=0`; leaves carry narrow EKU so a
+compromised Body cannot impersonate the Engine to itself; keys are created
+at mode 0600 at `open()` rather than chmod'ed after; files publish through
+`durable_io.atomic_replace` so a reader building an SSL context never sees a
+half-written PEM; concurrent issuance is serialised by an `O_EXCL` lock; and
+the CA private key is excluded from the peer bundle, because copying it
+would let each end mint identities for the other.
+
+#### 29.7.4 Proven, and not
+
+**Proven.** A real mTLS handshake — TLS 1.3, `TLS_AES_256_GCM_SHA384`,
+hostname verified against the SAN, both sides presenting certificates. Two
+separate processes established a live link through the CLI
+(`peer connected: ('127.0.0.1', 54064)`). The pull-the-plug cycle runs in
+process end to end — handshake, deliver, park mid-work, keep working while
+parked, reconnect, replay — asserting every verdict arrives exactly once in
+order. An unauthenticated client exchanges no data, asserted as "exchanges
+nothing" rather than "raises on connect" because under TLS 1.3 the server
+evaluates the client certificate after its own Finished, and asserting an
+exception would be asserting a protocol version's timing rather than the
+guarantee.
+
+**Not proven.** Nothing has crossed a real network. Tailnet DNS resolution,
+WSL2's NAT behaviour under `networkingMode=mirrored`, latency under a real
+partition, and whether a DERP relay is selected instead of a direct path all
+need both machines. That is the ten minutes at the Engine's keyboard no
+amount of local testing substitutes for.
+
+### 29.8 Operator surface
+
+```
+ov link --issue-certs --server-name <tailnet-name> --server-name <100.x>
+ov link --status
+ov link --serve --host <tailnet-addr> --port <N>      # Engine
+ov link --connect <tailnet-name> --port <N>           # Body
+```
+
+Validation is at the entry point because both mistakes on this path fail far
+from their cause: a wrong SAN fails at the handshake as a *trust* error,
+reading as "certificates are broken" rather than "you typed a URL", and
+`--connect` without a reachable host produces a connection error every
+backoff interval forever. `EX_USAGE` (64) for an argument the operator can
+fix; `EX_CONFIG` (78) for state on disk that needs a decision —
+re-issuing over live material is not a typo. `EADDRINUSE` reports the port,
+the platform's own diagnostic command and both remedies, never a retry loop:
+asyncio sets `SO_REUSEADDR` on POSIX but deliberately not on Windows, where
+it permits hijacking an active listener, so the Engine is exactly the host
+where a stale bind is reachable.
+
+`--status` reports days remaining rather than a boolean, so rotation is seen
+coming instead of discovered as an outage — which is precisely how the brain
+material failed.
+
+---
+
+## 30. Proactive Mode *(NEW 2026-08-15)*
+
+> **Operator binding (2026-08-15)**: *"We know Claude Code is an interactive
+> mode, but for O+V it should be a proactive mode — the total opposite."*
+
+### 30.0 Why this is a mode and not a flag
+
+Claude Code publishes a document called *Interactive mode*. It is not a
+feature list; it is the **contract of a session** — what the caret means,
+what a keystroke does, how history is recalled, when a suggestion appears.
+Read its section list and one property holds across every entry:
+
+> **The human is the initiator, and the mode exists to make initiating cheap
+> and expressive.**
+
+Shortcuts edit *your* prompt. History recalls *your* prompts. Suggestions
+predict *your* next prompt. `/btw` asks *your* side question. Even the
+transcript viewer reviews a conversation *you* drove.
+
+O+V's session contract is the inverse and has never been written down. The
+consequence is not missing features — §28's inventory found O+V ahead of CC
+on interactive richness (37 `transcript:*` actions against CC's five viewer
+keys). The consequence is that **the organism's autonomy is configured
+rather than operated**: expressed as environment variables read at boot,
+scattered across `JARVIS_MIN_RISK_TIER`, `JARVIS_SENSOR_GOVERNOR_*`,
+`JARVIS_AUTO_APPLY_QUIET_HOURS` and four §26 actuator flags, with no single
+thing an operator can look at and say *"that is how autonomous it is right
+now."*
+
+A mode is that thing.
+
+### 30.1 The dial that already exists, and what it cannot say
+
+`trust_repl.py` is closer to this than anything else in the tree, and its
+own docstring frames it correctly: *"the operator's autonomy dial, one
+keystroke away."* `Shift+Tab` → `app:cycleTrust` → `/trust cycle` walks
+`safe_auto → notify_apply → approval_required`, writing
+`JARVIS_MIN_RISK_TIER`, which every gate re-reads per operation.
+
+That is **the same gesture Claude Code binds its permission-mode cycle to**,
+with inverted semantics: CC's cycle bounds what the agent may do *when
+asked*; O+V's bounds what it may do *on its own initiative*. The alignment
+is not coincidence — it is the correct gesture for the concept, arrived at
+twice.
+
+But the dial answers one question, and the operator has two:
+
+* **May it apply?** — the dial answers this, in three positions.
+* **May it start?** — nothing answers this.
+
+At `approval_required`, the strictest position the dial can express, sixteen
+sensors still fire, ops still enter the queue, CONTEXT_EXPANSION still runs
+and tokens are still spent. The dial stops the *landing*, never the
+*taking off*. So the request an operator most often has on first contact
+with an unfamiliar repository — *"observe, and touch nothing"* — is
+inexpressible on a dial whose every position assumes work is being
+generated.
+
+**That conflation is the root cause**, and §30 fixes it by separating the
+axes rather than by adding a fourth position to a dial that measures the
+wrong thing.
+
+### 30.2 Two axes, one dial
+
+Proactive mode is a pair:
+
+```
+    initiative ∈ { none, observe, explore, act }
+    authority  ∈ { propose, notify, auto, promote }
+```
+
+**Initiative** is the right to *begin* — to emit a signal, admit an op, spend
+a token. **Authority** is the right to *conclude* — to apply a patch, commit,
+push. They are genuinely independent: an organism may explore exhaustively
+and apply nothing (a research posture), or apply freely but only what a human
+queued (a batch posture).
+
+Presenting a 2-D space as a 1-D dial is a deliberate simplification, and the
+justification is the gesture: `Shift+Tab` must remain one keystroke. So the
+dial walks a **monotone path** through the space — every step is
+unambiguously less autonomous than the last, in both coordinates at once.
+That is what makes "cycle" meaningful; a path that traded one axis against
+the other would leave the operator unable to say whether they had just
+loosened or tightened.
+
+### 30.3 The ladder
+
+Loosest → strictest, matching `trust_repl._CYCLE`'s existing direction. The
+three shipped positions sit unchanged in the middle; `PROMOTE` is the §26
+Gate 3 endpoint; `EXPLORE` and `WATCH` are new.
+
+| # | Position | Initiative | Authority | The organism may |
+|---|---|---|---|---|
+| 0 | 🔵 `promote` | act | promote | land verified work on the operator tree (§26 Gate 3) |
+| 1 | 🟢 `safe_auto` | act | auto | apply as classified — Green auto, Yellow after its window |
+| 2 | 🟡 `notify_apply` | act | notify | apply only after showing a diff and waiting |
+| 3 | 🟠 `approval_required` | act | propose | generate and propose; every apply parks for a human |
+| 4 | 🔍 `explore` | explore | propose | read, search, plan, reason — **no mutation reaches VALIDATE** |
+| 5 | ⏸ `watch` | none | propose | narrate only; sensors observe, nothing is admitted |
+
+**`explore` is the position §27.4.1.1 requires.** That rule — *a countdown
+buys an EXPLORE, never an APPLY* — is what makes auto-starting work on a
+timer defensible rather than reckless, and it needs a mode in which
+"exploration is permitted, mutation is not" is a state of the system rather
+than a property of one op.
+
+**`watch` is the position first contact requires**, and the one `[esc] just
+watch` in §27.4.1 promises. It is also the honest state for an unfamiliar or
+borrowed repository.
+
+### 30.4 What each position binds to — composition, not new machinery
+
+Every position is expressed through primitives that already exist and are
+already graduated. §30 adds a vocabulary and a composition law; it adds no
+enforcement path, because a second enforcement path is a second thing to
+keep correct and the first one is already load-bearing.
+
+| Position | Emission lever | Authority lever |
+|---|---|---|
+| `promote` | — | `JARVIS_WORKSPACE_PROMOTION_ENABLED` (§26 Gate 3) |
+| `safe_auto` | — | `risk_tier_floor` ← `JARVIS_MIN_RISK_TIER` |
+| `notify_apply` | — | same |
+| `approval_required` | — | same |
+| `explore` | — | risk floor + **mutation veto at the Iron Gate** |
+| `watch` | `BackgroundAgentPool.pause(reason=)` + `SensorGovernor` cap → 0 | floor at `approval_required` |
+
+`BackgroundAgentPool.pause()` already exists and is already exercised — the
+hibernation path calls it, which is how the Aug 11 session logged
+`Background agent pool PAUSED`. `SensorGovernor` already caps global
+emission per hour. `watch` is those two primitives named together, not a new
+suppression mechanism.
+
+**The `explore` veto is the one genuinely new enforcement**, and it belongs
+at the Iron Gate rather than anywhere downstream: the gate already sits
+post-GENERATE and pre-VALIDATE, already routes rejections through
+`GENERATE_RETRY` with targeted feedback, and already distinguishes
+exploration tool calls from patches for the exploration-first rule. A
+mutation arriving under `explore` is refused there with the same machinery
+that refuses an under-explored one.
+
+### 30.5 The composition law
+
+> **Strictest wins, across every source, always.**
+
+This is not a new rule — `risk_tier_floor` already composes three inputs
+this way (`JARVIS_MIN_RISK_TIER`, `JARVIS_PARANOIA_MODE`,
+`JARVIS_AUTO_APPLY_QUIET_HOURS`) and `memory_pressure_gate` composes its
+dimensions the same way. §30 states it once so the sources cannot grow a
+second convention.
+
+Sources, all of which compose:
+
+1. the dial (`/trust cycle`, `Shift+Tab`)
+2. quiet hours — a *time-based* mode, already implemented
+3. `JARVIS_PARANOIA_MODE`
+4. per-sensor floors (`JARVIS_VISION_SENSOR_RISK_FLOOR`)
+5. memory pressure (`MemoryPressureGate` CRITICAL clamps fan-out)
+6. **every attached cockpit** — see §30.6
+
+The direction matters and is easy to get wrong. An operator who sets
+`watch` at 02:00 must not find that quiet hours has *loosened* the organism
+by asserting `notify_apply`; a floor only ever raises.
+
+### 30.6 Multi-cockpit: the dial is global, the operators are not
+
+`JARVIS_MIN_RISK_TIER` is process-global on the Engine. Two attached
+cockpits therefore share one dial, and today **the last writer wins,
+silently** — an operator can tighten the organism and have a colleague
+loosen it without either seeing that it happened.
+
+§25.1 already ruled on this shape for a different resource: *ambient renders
+to the MINIMUM width across live cockpits*, because two subscribers at
+different widths have no width correct for both. Autonomy is the same shape
+with higher stakes.
+
+> **Rule.** The effective position is the **strictest** requested by any live
+> cockpit. Releasing a request (detaching, or cycling back) restores the
+> strictest of what remains. Every cockpit shows the effective position AND,
+> when it differs from its own request, that it is being overridden.
+
+An operator whose tightening is invisibly discarded will stop tightening.
+
+### 30.7 Nuances and edge cases
+
+| # | Case | Required behaviour |
+|---|---|---|
+| 1 | **Mode changes mid-flight** | §26.5 already answers: seq-gated, *"an op is judged under the regime it entered."* Stated here so it is not re-derived. Tightening does **not** retroactively kill in-flight work; it stops the next admission. |
+| 2 | **Tightening during a parked review** | The parked op keeps the tier it entered under. A `watch` set while a Yellow diff waits does not silently convert it to a rejection — that would be §26.6's error in a new place. |
+| 3 | **Mode must survive detach** | Set `watch`, close the laptop, reconnect — the organism must not have silently re-armed. The dial is Engine-side env, so it persists; the requirement is that reconnection **re-asserts** the cockpit's request rather than clearing it. |
+| 4 | **Mode across the §29 link** | The Engine holds the dial; the Body displays it. A partition must not let the two disagree, and the Body must never render a position it has not confirmed since the last reconnect — a stale 🟠 on a screen while the Engine runs 🟢 is worse than showing nothing. |
+| 5 | **`watch` with work already queued** | Pausing the pool does not drain it. Queued ops stay queued and resume on the next loosening — `watch` is a pause, not a cancel, for the same reason a partition is a pause (§29.3). |
+| 6 | **`explore` and cost** | Exploration is not free: it spends tokens. `watch` is the only position with a zero-cost guarantee, and the mode line must not imply otherwise. |
+| 7 | **Silence means something different in every position** | In `watch` silence is correct; in `explore` it may mean a countdown is running; at 🟢 it may mean the link is down. §27.4.3's always-on deterministic breadcrumb is what disambiguates, and is therefore load-bearing rather than decorative. |
+| 8 | **Hibernation vs `watch`** | Both pause the pool, and they are *not* the same state. Hibernation is the organism's own decision on provider exhaustion (Aug 11: `consecutive_exhaustion=3`); `watch` is the operator's. Rendering them identically would tell an operator they had caused an outage they did not. |
+| 9 | **A position the host cannot honour** | `promote` on a host where §26's gates have not graduated must be refused at the dial with the reason, not accepted and silently ignored. |
+| 10 | **Mode in headless / soak runs** | `--headless` has no cockpit to hold a request, so the dial reduces to its env value. The composition law is unchanged; the multi-cockpit source is simply empty. |
+
+### 30.8 Scenarios
+
+**A borrowed repository.** You clone something unfamiliar and run `ov`.
+Today the strictest expressible state still fires sixteen sensors and spends
+tokens on a codebase you may not have the right to mutate. Under §30 the
+first-contact default for an unrecognised repository is `watch`: it indexes,
+narrates what it notices, and initiates nothing until you cycle up.
+
+**Overnight.** You want `explore` plus 🟡 until 08:00, then 🟠 while you are
+in meetings. Today that is two env vars set before boot and a restart to
+change. Under §30 it is the dial plus quiet hours, composing strictest-wins,
+adjustable from an attached cockpit without touching the process.
+
+**Two people watching.** You attach from a laptop at 🟠 while a colleague
+attaches from a desktop at 🟢. The effective position is 🟠, both screens say
+so, and the colleague's screen shows that their request is being overridden
+rather than silently losing.
+
+**The demo.** `ov` in an unseen repo, `watch` by default, and the operator
+presses `Shift+Tab` once — the organism visibly begins exploring. That single
+keystroke is the product's thesis: **autonomy is granted, not assumed, and
+granting it is one gesture.**
+
+### 30.9 Build plan
+
+Five slices, each default-off until its §33.1 graduation contract is met,
+each composing existing primitives.
+
+| # | Slice | Composes | Blocked by |
+|---|---|---|---|
+| 1 | Extend `trust_repl._CYCLE` to the six-position ladder; `/trust` renders the effective position and its source | `risk_tier_floor`, `trust_repl` | nothing |
+| 2 | `watch` binds `BackgroundAgentPool.pause()` + `SensorGovernor` cap 0; distinguishable from hibernation in the status line | both, already graduated | nothing |
+| 3 | `explore` mutation veto at the Iron Gate, routed through `GENERATE_RETRY` with targeted feedback | Iron Gate, exploration ledger | nothing |
+| 4 | Multi-cockpit strictest-wins with per-cockpit override display | `CockpitAttachBridge`, §25.1's width precedent | nothing |
+| 5 | Mode as a §29 frame kind; Body renders only a position confirmed since reconnect | `link_transport` closed kind vocabulary | §29 link live |
+
+Slices 1–4 need no hardware and no provider credit. Slice 3 is the one that
+makes §27.4.1's countdown shippable.
+
+**Invariant pins required.** (a) A floor may only ever raise, never lower —
+pinned across every composing source. (b) No mutation may reach VALIDATE
+under `explore`. (c) A mode change never retroactively re-tiers an in-flight
+op (§26.5). (d) `watch` and hibernation render distinguishably.
+
+### 30.10 Anti-goals
+
+| Pattern | Why §30 rejects it |
+|---|---|
+| A second enforcement path for modes | The gates already enforce. A mode that enforced independently would be a second authority for a decision the operator sees once. |
+| Per-sensor mode dials | Sixteen dials is a configuration file with a UI, not a mode. Per-sensor floors already exist for the rare case. |
+| A mode that unlocks §26's actuators | Graduation is evidence-gated (§26.1). A dial that could grant what evidence has not earned would make the ladder a bypass. |
+| Auto-loosening on idle | "It has been quiet, so relax" is exactly backwards: quiet is the state in which nobody is watching. |
+| Modes with timeouts that expire *looser* | A mode may expire toward strict. Never away from it. |
+
+### 30.11 Open questions for operator decision
+
+1. **First-contact default in an unrecognised repository** — `watch`, or
+   `explore`? *(Recommend `watch`: §27.4.1.1 bounds the countdown to
+   read-only work, but a repository the operator has not vouched for should
+   not spend tokens before they look.)*
+2. **Does `Shift+Tab` wrap** from strictest back to loosest, or stop? *(Recommend
+   stop, with a second keystroke required to cross back into `promote` —
+   wrapping means one accidental keypress moves from maximum caution to
+   maximum autonomy.)*
+3. **Should `watch` drain the queue or hold it?** *(Recommend hold, per
+   §30.7 case 5 — a pause that discards is a cancel wearing a pause's name.)*
+4. **Per-repository persistence** — should the dial remember its position per
+   repository? *(Recommend yes, in `.jarvis/`, since "this repo is one I let
+   run" is exactly the kind of standing judgement §27.5's preference memory
+   already stores.)*
 
 ---

--- a/tests/governance/test_proactive_mode.py
+++ b/tests/governance/test_proactive_mode.py
@@ -1,0 +1,428 @@
+"""Regression spine for the proactive-mode ladder (PRD §30).
+
+Every test names the operator-visible failure it prevents. The clock is
+driven, so no test sleeps.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance import proactive_mode as pm
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self.t = 1000.0
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, dt: float) -> None:
+        self.t += dt
+
+
+@pytest.fixture(autouse=True)
+def _clean(monkeypatch):
+    for knob in ("JARVIS_MIN_RISK_TIER", "JARVIS_WORKSPACE_PROMOTION_ENABLED",
+                 "JARVIS_PROACTIVE_MODE_GRACE_S",
+                 "JARVIS_PROACTIVE_MODE_COALESCE_S"):
+        monkeypatch.delenv(knob, raising=False)
+    pm.reset_controller()
+    pm.set_emission_sink(None)
+    yield
+    pm.reset_controller()
+    pm.set_emission_sink(None)
+
+
+class _Pool:
+    def __init__(self): self.paused = False; self.reasons = []
+    def pause(self, *, reason=""): self.paused = True; self.reasons.append(reason); return True
+    def resume(self, *, reason=""): self.paused = False; self.reasons.append(reason); return True
+
+
+# ---------------------------------------------------------------------------
+# The two axes
+# ---------------------------------------------------------------------------
+
+
+def test_the_ladder_is_monotone_in_both_coordinates():
+    """A path trading one axis against the other would leave the operator
+    unable to say whether they had just loosened or tightened."""
+    init_order = [pm.Initiative.ACT, pm.Initiative.EXPLORE,
+                  pm.Initiative.OBSERVE, pm.Initiative.NONE]
+    auth_order = [pm.Authority.PROMOTE, pm.Authority.AUTO,
+                  pm.Authority.NOTIFY, pm.Authority.PROPOSE]
+    prev_i = prev_a = -1
+    for pos in pm.LADDER:
+        i = init_order.index(pos.initiative)
+        a = auth_order.index(pos.authority)
+        assert i >= prev_i and a >= prev_a, f"{pos.name} loosens an axis"
+        prev_i, prev_a = i, a
+
+
+def test_watch_is_the_only_rung_that_withholds_initiative():
+    """The gap the shipped dial could not express: at approval_required,
+    sixteen sensors still fire and tokens are still spent."""
+    withholding = [p.name for p in pm.LADDER
+                   if p.initiative is pm.Initiative.NONE]
+    assert withholding == ["watch"]
+    assert pm.position("approval_required").initiative is pm.Initiative.ACT
+
+
+def test_explore_permits_initiative_but_not_authority():
+    """§27.4.1.1 — a countdown buys an EXPLORE, never an APPLY."""
+    p = pm.position("explore")
+    assert p.initiative is pm.Initiative.EXPLORE
+    assert p.authority is pm.Authority.PROPOSE
+
+
+def test_the_three_shipped_rungs_keep_their_risk_floor_values():
+    """The middle of the ladder must be the existing dial, unchanged."""
+    assert pm.position("safe_auto").risk_floor is None
+    assert pm.position("notify_apply").risk_floor == "notify_apply"
+    assert pm.position("approval_required").risk_floor == "approval_required"
+
+
+# ---------------------------------------------------------------------------
+# Boundary — clamp, never wrap (§30.11 Q2, operator decision)
+# ---------------------------------------------------------------------------
+
+
+def test_the_dial_clamps_at_strictest_and_never_wraps():
+    """Wrapping means one accidental keypress moves from maximum caution to
+    maximum autonomy."""
+    c = pm.ProactiveModeController(clock=FakeClock())
+    seen = [c.cycle("mac")[0].name for _ in range(12)]
+    assert seen[-1] == "watch"
+    assert "safe_auto" not in seen[3:], "the dial wrapped past the boundary"
+
+
+def test_each_press_moves_exactly_one_rung():
+    """An accumulator that added pending steps to an already-moved position
+    advanced three rungs on two presses — landing the operator somewhere
+    they did not choose."""
+    c = pm.ProactiveModeController(clock=FakeClock())
+    order = [c.cycle("mac")[0].name for _ in range(4)]
+    assert order == ["notify_apply", "approval_required", "explore", "watch"]
+
+
+def test_mashing_the_boundary_settles_deterministically():
+    c = pm.ProactiveModeController(clock=FakeClock())
+    for _ in range(4):
+        c.cycle("mac")
+    results = [c.cycle("mac") for _ in range(50)]
+    assert all(pos.name == "watch" for pos, _ in results)
+    assert all(boundary for _, boundary in results)
+
+
+def test_a_boundary_burst_produces_no_repeated_effects():
+    """The expensive part is guarded on an actual change, so mashing costs
+    no env writes and no pool calls."""
+    pool = _Pool()
+    c = pm.ProactiveModeController(clock=FakeClock())
+    for _ in range(4):
+        c.cycle("mac")
+    c.apply_effects(pool=pool)
+    before = len(pool.reasons)
+    for _ in range(30):
+        c.cycle("mac")
+        c.apply_effects(pool=pool)
+    assert c.snapshot()["transitions"] == 1
+    assert len(pool.reasons) - before <= 30  # idempotent pause calls only
+    assert pool.paused is True
+
+
+def test_stepping_backwards_clamps_at_the_loosest_reachable_rung():
+    c = pm.ProactiveModeController(clock=FakeClock())
+    for _ in range(10):
+        pos, _ = c.cycle("mac", steps=-1)
+    assert pos.name == "safe_auto", "stepped below the reachable floor"
+
+
+# ---------------------------------------------------------------------------
+# Reachability — computed from live capability, never hardcoded
+# ---------------------------------------------------------------------------
+
+
+def test_promote_is_unreachable_until_gate_three_is_armed():
+    """A dial accepting a position the host cannot honour would report an
+    autonomy level that does not exist."""
+    assert "promote" not in [p.name for p in pm.reachable()]
+
+
+def test_promote_appears_when_the_actuator_is_armed(monkeypatch):
+    monkeypatch.setenv("JARVIS_WORKSPACE_PROMOTION_ENABLED", "true")
+    assert "promote" in [p.name for p in pm.reachable()]
+
+
+def test_losing_a_capability_never_loosens_the_current_rung(monkeypatch):
+    """A host that loses promotion mid-session must not thereby become more
+    autonomous."""
+    monkeypatch.setenv("JARVIS_WORKSPACE_PROMOTION_ENABLED", "true")
+    c = pm.ProactiveModeController(clock=FakeClock())
+    c.request("mac", "promote")
+    monkeypatch.delenv("JARVIS_WORKSPACE_PROMOTION_ENABLED")
+    pos, _ = c.cycle("mac", steps=0)
+    assert pos.rank >= pm.position("safe_auto").rank
+
+
+# ---------------------------------------------------------------------------
+# Multi-cockpit — strictest wins, universally
+# ---------------------------------------------------------------------------
+
+
+def test_the_strictest_live_request_wins():
+    """Today the last writer wins silently: an operator can tighten the
+    organism and have a colleague loosen it with neither seeing."""
+    c = pm.ProactiveModeController(clock=FakeClock())
+    c.request("mac", "watch")
+    c.request("desktop", "safe_auto")
+    assert c.effective().name == "watch"
+
+
+def test_a_loosening_cockpit_is_told_it_is_overridden():
+    """An operator whose tightening is invisibly discarded stops
+    tightening."""
+    c = pm.ProactiveModeController(clock=FakeClock())
+    c.request("mac", "approval_required")
+    c.request("desktop", "safe_auto")
+    assert c.overridden("desktop") is True
+    assert c.overridden("mac") is False
+
+
+def test_order_of_requests_does_not_change_the_outcome():
+    a = pm.ProactiveModeController(clock=FakeClock())
+    a.request("x", "watch"); a.request("y", "safe_auto")
+    b = pm.ProactiveModeController(clock=FakeClock())
+    b.request("y", "safe_auto"); b.request("x", "watch")
+    assert a.effective().name == b.effective().name == "watch"
+
+
+def test_effective_is_derived_not_cached():
+    """A cached value has a window between a cockpit vanishing and the
+    recomputation. A derived one has no window."""
+    import inspect
+    src = inspect.getsource(pm.ProactiveModeController.effective)
+    assert "self._cached" not in src and "return self._effective" not in src
+
+
+# ---------------------------------------------------------------------------
+# Disconnect race — absence is not consent to loosen
+# ---------------------------------------------------------------------------
+
+
+def test_a_dropped_strict_cockpit_does_not_immediately_loosen():
+    """An operator on flaky Wi-Fi who set watch would otherwise have their
+    caution undone by their own network."""
+    clock = FakeClock()
+    c = pm.ProactiveModeController(clock=clock)
+    c.request("mac", "watch")
+    c.request("desktop", "safe_auto")
+    c.detach("mac")
+    assert c.effective().name == "watch", "a disconnect loosened the organism"
+
+
+def test_a_retained_request_releases_after_the_grace_window(monkeypatch):
+    monkeypatch.setenv("JARVIS_PROACTIVE_MODE_GRACE_S", "60")
+    clock = FakeClock()
+    c = pm.ProactiveModeController(clock=clock)
+    c.request("mac", "watch")
+    c.request("desktop", "safe_auto")
+    c.detach("mac")
+    clock.advance(120.0)
+    assert c.effective().name == "safe_auto"
+
+
+def test_reattaching_restores_full_weight_before_expiry(monkeypatch):
+    monkeypatch.setenv("JARVIS_PROACTIVE_MODE_GRACE_S", "60")
+    clock = FakeClock()
+    c = pm.ProactiveModeController(clock=clock)
+    c.request("mac", "watch")
+    c.detach("mac")
+    clock.advance(30.0)
+    c.reattach("mac")
+    clock.advance(120.0)
+    assert c.effective().name == "watch", "a reattached request expired anyway"
+
+
+def test_a_deliberate_exit_releases_immediately():
+    """A clean quit is consent; an unplanned drop is not."""
+    c = pm.ProactiveModeController(clock=FakeClock())
+    c.request("mac", "watch")
+    c.request("desktop", "safe_auto")
+    c.release("mac")
+    assert c.effective().name == "safe_auto"
+
+
+def test_no_requests_falls_back_to_the_environment(monkeypatch):
+    """Headless and attached must not disagree about where the dial rests."""
+    monkeypatch.setenv("JARVIS_MIN_RISK_TIER", "approval_required")
+    c = pm.ProactiveModeController(clock=FakeClock())
+    assert c.effective().name == "approval_required"
+
+
+# ---------------------------------------------------------------------------
+# Effects — composition only
+# ---------------------------------------------------------------------------
+
+
+def test_watch_pauses_admission_and_says_who_did_it():
+    """Hibernation pauses the same pool on provider exhaustion. Rendering
+    them alike would report an outage the operator did not cause."""
+    pool = _Pool()
+    c = pm.ProactiveModeController(clock=FakeClock())
+    c.request("mac", "watch")
+    out = c.apply_effects(pool=pool)
+    assert pool.paused is True
+    assert out["emission"] == "paused"
+    assert any("operator" in r for r in pool.reasons)
+
+
+def test_leaving_watch_resumes_admission():
+    pool = _Pool()
+    c = pm.ProactiveModeController(clock=FakeClock())
+    c.request("mac", "watch")
+    c.apply_effects(pool=pool)
+    c.request("mac", "notify_apply")
+    c.apply_effects(pool=pool)
+    assert pool.paused is False
+
+
+def test_no_rung_but_watch_pauses_the_pool():
+    for name in ("safe_auto", "notify_apply", "approval_required", "explore"):
+        pool = _Pool()
+        c = pm.ProactiveModeController(clock=FakeClock())
+        c.request("mac", name)
+        c.apply_effects(pool=pool)
+        assert pool.paused is False, f"{name} withheld initiative"
+
+
+def test_the_risk_floor_is_the_existing_env_knob(monkeypatch):
+    """Every gate already re-reads it per operation — no second floor."""
+    c = pm.ProactiveModeController(clock=FakeClock())
+    c.request("mac", "explore")
+    c.apply_effects(pool=_Pool())
+    import os
+    assert os.environ["JARVIS_MIN_RISK_TIER"] == "approval_required"
+    c.request("mac", "safe_auto")
+    c.apply_effects(pool=_Pool())
+    assert "JARVIS_MIN_RISK_TIER" not in os.environ
+
+
+def test_no_sink_reports_honestly_rather_than_claiming_success():
+    """The authority axis still holds; only initiative is unenforceable,
+    and saying so beats pretending otherwise."""
+    c = pm.ProactiveModeController(clock=FakeClock())
+    c.request("mac", "watch")
+    out = c.apply_effects()
+    assert out["emission"] == "no sink registered"
+
+
+def test_a_broken_pool_degrades_rather_than_raising():
+    class _Broken:
+        def pause(self, **kw): raise RuntimeError("pool is gone")
+        def resume(self, **kw): raise RuntimeError("pool is gone")
+    c = pm.ProactiveModeController(clock=FakeClock())
+    c.request("mac", "watch")
+    out = c.apply_effects(pool=_Broken())
+    assert "degraded" in out["emission"]
+
+
+def test_apply_effects_is_idempotent():
+    pool = _Pool()
+    c = pm.ProactiveModeController(clock=FakeClock())
+    c.request("mac", "explore")
+    first = c.apply_effects(pool=pool)
+    second = c.apply_effects(pool=pool)
+    assert first["changed"] is True and second["changed"] is False
+
+
+# ---------------------------------------------------------------------------
+# Posture
+# ---------------------------------------------------------------------------
+
+
+def test_default_off_pending_graduation():
+    assert pm.is_enabled() is False
+
+
+def test_an_unknown_rung_resolves_to_the_resting_state_not_the_loosest():
+    """An unparseable dial must not be able to take the organism down, and
+    must not silently become maximally autonomous either."""
+    assert pm.position("nonsense").name == "safe_auto"
+    assert pm.position(None).name == "safe_auto"
+
+
+def test_no_lock_is_held_across_a_subsystem_call():
+    """A governance primitive blocking while this held the dial would
+    deadlock the loop the dial exists to steer."""
+    import inspect
+    import re
+    src = inspect.getsource(pm.ProactiveModeController)
+    for block in re.findall(r"with self\._lock:(.*?)(?=\n    [a-zA-Z@]|\Z)",
+                            src, re.S):
+        for banned in ("pause(", "resume(", "apply_effects"):
+            assert banned not in block, f"{banned} called under the lock"
+
+
+def test_the_snapshot_is_serialisable():
+    import json
+    c = pm.ProactiveModeController(clock=FakeClock())
+    c.request("mac", "explore")
+    json.dumps(c.snapshot())
+
+
+# ---------------------------------------------------------------------------
+# trust_repl integration — one vocabulary, projected
+# ---------------------------------------------------------------------------
+
+
+def test_the_dial_offers_only_reachable_rungs(monkeypatch):
+    from backend.core.ouroboros.governance import trust_repl as t
+    monkeypatch.delenv("JARVIS_PROACTIVE_MODE_ENABLED", raising=False)
+    assert t._cycle_positions() == ("safe_auto", "notify_apply",
+                                    "approval_required")
+    monkeypatch.setenv("JARVIS_PROACTIVE_MODE_ENABLED", "1")
+    assert t._cycle_positions() == ("safe_auto", "notify_apply",
+                                    "approval_required", "explore", "watch")
+
+
+def test_the_dial_writes_a_valid_risk_floor_never_a_rung_name(monkeypatch):
+    """THE correctness bug this pins: `explore` is a ladder position, not a
+    risk tier. Writing it into JARVIS_MIN_RISK_TIER would leave the floor
+    unparseable and silently resolve to NO floor — the strictest rungs
+    becoming the loosest in effect."""
+    import os
+    from backend.core.ouroboros.governance import trust_repl as t
+    monkeypatch.setenv("JARVIS_PROACTIVE_MODE_ENABLED", "1")
+    for rung in ("explore", "watch"):
+        t.dispatch_trust_command(f"/trust {rung}")
+        assert os.environ["JARVIS_MIN_RISK_TIER"] == "approval_required"
+
+
+def test_two_rungs_asserting_one_floor_stay_distinguishable(monkeypatch):
+    from backend.core.ouroboros.governance import trust_repl as t
+    monkeypatch.setenv("JARVIS_PROACTIVE_MODE_ENABLED", "1")
+    t.dispatch_trust_command("/trust explore")
+    assert t.current_floor() == "explore"
+    t.dispatch_trust_command("/trust watch")
+    assert t.current_floor() == "watch"
+
+
+def test_the_dial_refuses_to_wrap_past_the_strictest(monkeypatch):
+    from backend.core.ouroboros.governance import trust_repl as t
+    monkeypatch.setenv("JARVIS_PROACTIVE_MODE_ENABLED", "1")
+    t.dispatch_trust_command("/trust watch")
+    for _ in range(5):
+        out = t.dispatch_trust_command("/trust cycle")
+    assert "does not wrap" in out.text
+    assert t.current_floor() == "watch"
+
+
+def test_the_glyph_table_is_not_duplicated(monkeypatch):
+    """Two tables that could disagree is how the dial and the gate start
+    meaning different things by the same word."""
+    from backend.core.ouroboros.governance import trust_repl as t
+    monkeypatch.setenv("JARVIS_PROACTIVE_MODE_ENABLED", "1")
+    for rung in pm.LADDER:
+        assert t._glyph_for(rung.name) == rung.glyph

--- a/tests/governance/test_proactive_mode.py
+++ b/tests/governance/test_proactive_mode.py
@@ -426,3 +426,145 @@ def test_the_glyph_table_is_not_duplicated(monkeypatch):
     monkeypatch.setenv("JARVIS_PROACTIVE_MODE_ENABLED", "1")
     for rung in pm.LADDER:
         assert t._glyph_for(rung.name) == rung.glyph
+
+
+# ---------------------------------------------------------------------------
+# Slice 3 — the explore rung's mutation veto
+# ---------------------------------------------------------------------------
+
+
+def test_act_rungs_permit_mutation(monkeypatch):
+    monkeypatch.setenv("JARVIS_PROACTIVE_MODE_ENABLED", "1")
+    for name in ("safe_auto", "notify_apply", "approval_required"):
+        pm.get_controller().request("mac", name)
+        assert pm.mutation_permitted().permitted is True, name
+
+
+def test_explore_vetoes_mutation_while_permitting_generation(monkeypatch):
+    """The rung the risk floor could not express: generation continues, no
+    patch reaches disk."""
+    monkeypatch.setenv("JARVIS_PROACTIVE_MODE_ENABLED", "1")
+    pm.get_controller().request("mac", "explore")
+    v = pm.mutation_permitted()
+    assert v.permitted is False
+    assert v.position == "explore"
+
+
+def test_watch_vetoes_mutation_too(monkeypatch):
+    monkeypatch.setenv("JARVIS_PROACTIVE_MODE_ENABLED", "1")
+    pm.get_controller().request("mac", "watch")
+    assert pm.mutation_permitted().permitted is False
+
+
+def test_master_off_never_vetoes(monkeypatch):
+    """Off is the pre-§30 status quo, not a degraded mode."""
+    monkeypatch.delenv("JARVIS_PROACTIVE_MODE_ENABLED", raising=False)
+    pm.get_controller().request("mac", "watch")
+    assert pm.mutation_permitted().permitted is True
+
+
+def test_the_veto_fails_open_on_any_internal_fault(monkeypatch):
+    """A mode subsystem that cannot answer must not halt every mutation in
+    the organism — that converts a fault here into a total outage."""
+    monkeypatch.setenv("JARVIS_PROACTIVE_MODE_ENABLED", "1")
+
+    def _boom():
+        raise RuntimeError("controller exploded")
+
+    monkeypatch.setattr(pm, "get_controller", _boom)
+    v = pm.mutation_permitted()
+    assert v.permitted is True
+    assert v.position == "unknown"
+
+
+def test_a_veto_is_a_terminal_not_a_retry():
+    """ExplorationInsufficientError routes through GENERATE_RETRY because a
+    model CAN fix insufficient exploration. It cannot fix the operator's
+    dial, so retrying would burn the budget then fail the op for something
+    that was never the model's fault."""
+    import inspect
+    from backend.core.ouroboros.governance import orchestrator as orch
+    src = inspect.getsource(orch.Orchestrator._maybe_complete_cosmetic_candidate)
+    assert "no_op_mode_veto" in src
+    assert "OperationPhase.COMPLETE" in src
+    assert "ExplorationInsufficientError" not in src
+
+
+def test_the_veto_rides_the_seam_both_callers_share():
+    """Run-24 proved the inline seam alone is never reached on the live
+    route. A gate wired only there is wired and inert."""
+    import inspect
+    from backend.core.ouroboros.governance import orchestrator as orch
+    from backend.core.ouroboros.governance import phase_dispatcher as pd
+    helper = "_maybe_complete_cosmetic_candidate"
+    assert helper in inspect.getsource(pd)
+    assert "mutation_permitted" in inspect.getsource(
+        orch.Orchestrator._maybe_complete_cosmetic_candidate)
+
+
+def test_the_veto_precedes_the_value_gate():
+    """A vetoed candidate must not first be walked for cosmetic-ness: the
+    mode already decided, and the walk costs an AST parse per file.
+
+    Compared over the EXECUTABLE body with the docstring stripped — the
+    docstring names the value-gate flag before any code runs, and a raw
+    text index cannot tell an explanation from a use. Same lesson as the
+    earlier DRY audits."""
+    import ast
+    import inspect
+    import textwrap
+    from backend.core.ouroboros.governance import orchestrator as orch
+    src = textwrap.dedent(
+        inspect.getsource(orch.Orchestrator._maybe_complete_cosmetic_candidate))
+    fn = ast.parse(src).body[0]
+    body = fn.body[1:] if isinstance(fn.body[0], ast.Expr) else fn.body
+    code = "\n".join(ast.unparse(stmt) for stmt in body)
+    assert "mutation_permitted" in code
+    assert code.index("mutation_permitted") < code.index(
+        "JARVIS_CANDIDATE_VALUE_GATE_ENABLED")
+
+
+# ---------------------------------------------------------------------------
+# The sink — registered, or honestly absent
+# ---------------------------------------------------------------------------
+
+
+def test_the_pool_is_registered_as_the_sink_at_boot():
+    """Without this the ladder floors the AUTHORITY axis correctly and
+    `watch` silently degrades to approval_required — wired but inert on
+    exactly one of its two axes."""
+    import inspect
+    from backend.core.ouroboros.governance import governed_loop_service as gls
+    src = inspect.getsource(gls)
+    assert "set_emission_sink as _pm_set_sink" in src
+    assert "_pm_set_sink(self._bg_pool)" in src
+
+
+def test_the_sink_is_registered_after_the_pool_starts():
+    """A sink handed a pool that has not started would pause something with
+    no workers, and `watch` would report a hold it had not achieved."""
+    import inspect
+    from backend.core.ouroboros.governance import governed_loop_service as gls
+    src = inspect.getsource(gls)
+    assert src.index("await self._bg_pool.start()") < src.index(
+        "_pm_set_sink(self._bg_pool)")
+
+
+def test_the_controller_never_imports_the_orchestrator():
+    """A mode controller reaching into GovernedLoopService for _bg_pool
+    would invert the authority boundary every governance module observes."""
+    import pathlib
+    src = pathlib.Path(pm.__file__).read_text(encoding="utf-8")
+    for banned in ("governed_loop_service", "orchestrator", "background_agent_pool"):
+        assert f"import {banned}" not in src
+        assert f"governance.{banned}" not in src
+
+
+def test_a_registered_sink_is_used_without_an_explicit_pool():
+    pool = _Pool()
+    pm.set_emission_sink(pool)
+    c = pm.ProactiveModeController(clock=FakeClock())
+    c.request("mac", "watch")
+    out = c.apply_effects()
+    assert out["emission"] == "paused"
+    assert pool.paused is True


### PR DESCRIPTION
Implements PRD §30 slices 1–3, plus the §30 spec itself, the §29 as-built rewrite, and a correction to §28.

## The root cause

`trust_repl` already calls itself *"the operator's autonomy dial"*, and `Shift+Tab` already cycles it — the same gesture Claude Code binds its permission-mode cycle to, arrived at independently.

But the dial answers **one** question, *may it apply?*, and the operator has two. At `approval_required` — the strictest position expressible today — sixteen sensors still fire, ops still enter the queue, CONTEXT_EXPANSION still runs and tokens are still spent. **The dial stops the landing, never the taking off.** So *"observe this repo and touch nothing"* — the request first contact most often needs — was inexpressible on a dial whose every position assumes work is being generated.

§30 separates the axes rather than adding a fourth position to a dial measuring the wrong thing.

## The design

A position is a pair: **initiative** (the right to BEGIN) × **authority** (the right to CONCLUDE). Presenting 2-D as a 1-D dial is deliberate — `Shift+Tab` must stay one keystroke — so the ladder walks a **monotone path**, each step less autonomous in *both* coordinates, pinned by a test. A path trading one axis against the other would leave the operator unable to say whether they had just loosened or tightened.

| # | Rung | Initiative | Authority |
|---|---|---|---|
| 0 | 🔵 `promote` | act | promote |
| 1 | 🟢 `safe_auto` | act | auto |
| 2 | 🟡 `notify_apply` | act | notify |
| 3 | 🟠 `approval_required` | act | propose |
| 4 | 🔍 `explore` | explore | propose |
| 5 | ⏸ `watch` | none | propose |

The three shipped rungs sit unchanged in the middle.

## Operator decisions, implemented

**Clamped, never wrapped.** A dial whose worst misfire is "nothing happened" is strictly better than one whose worst misfire is "everything is permitted."

**Multi-cockpit minimum flooring, universal.** The effective rung is the strictest requested by any live cockpit, **derived on read, never cached** — which is the whole fix for the disconnect race. A cached value has a window between a cockpit vanishing and recomputation; a derived one has no window because there is nothing that can be stale. Not a faster invalidation, an absent one.

## Absence is not consent to loosen

A detached cockpit's request is **retained** for a grace window. Otherwise an operator on flaky Wi-Fi who set `watch` would find the organism becoming *more* autonomous at exactly the moment they lost visibility — their caution undone by their own network. §26.6's rule applied to the dial, with the window matching `link_protocol`'s session expiry so the two cannot disagree. A deliberate quit still releases immediately: a clean exit is consent, an unplanned drop is not.

## Two bugs the tests caught, both mine

1. **The burst coalescer skipped a rung** — it accumulated pending steps *and* read an already-moved position, so two presses advanced three rungs. On a dial governing autonomy that lands the operator somewhere they did not choose. Removed entirely: one press, one rung. Bursts are bounded without arithmetic because the clamp is idempotent and `apply_effects` is guarded on actual change.
2. **`_set_floor` wrote the rung name into `JARVIS_MIN_RISK_TIER`.** `explore` is not a risk tier, so the floor would have been unparseable and silently resolved to **no floor** — the strictest rungs becoming the loosest in effect.

## DRY

A vocabulary and a composition law, **no new enforcement path**. `watch` is `BackgroundAgentPool.pause()` (whose own docstring confirms it preserves the queue — §30.7 case 5) plus the existing risk floor. `trust_repl` projects the ladder rather than holding a second tuple and a second glyph table.

The pool is **injected** via `set_emission_sink`, not imported: a mode controller reaching into `GovernedLoopService` for `_bg_pool` would invert the authority boundary every governance module observes. Same pattern as `markup_mirror` and `set_prompt_publisher`.

## The veto (slice 3)

`explore` says what the risk floor cannot: generation may continue and mutation may not. **A veto is a benign terminal, not a retry** — `ExplorationInsufficientError` routes through `GENERATE_RETRY` because a model *can* fix insufficient exploration; it cannot fix the operator's dial. It completes as `no_op_mode_veto`, the same shape `candidate_value_gate` uses.

Placement is the root-cause part: it rides `_maybe_complete_cosmetic_candidate`, for the reason that method's own docstring records — **Run-24 proved the inline seam alone is never reached on the live route**. Both callers pass through that one method, making it the only placement that cannot silently miss the shipping path.

## Also in this branch

- **§29.7/29.8 rewritten** from "what remains" to what is built — seven modules, 269 tests, decisions worth recording, three defects the spine caught, and an honest split between proven and needs-both-machines.
- **§28's C2 corrected.** It claimed no action answers a gate; false — `confirm:yes`/`confirm:no` exist. What is true is narrower and worse: they are imported at exactly one site (`bipartite_layout`) and never by `cli/ov.py`, the surface `ov attach` mounts. `surface_reachability` already names five prior instances of the same class.

**49 §30 tests; 184 across the fast governance spine.** Master `JARVIS_PROACTIVE_MODE_ENABLED` default false — off, the dial is the shipped three and `mutation_permitted()` returns True unconditionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a six-position proactive-mode ladder that separates initiative from authority and integrates it into the existing trust dial. Adds an `explore` mutation veto and a `watch` admission pause; old behavior only floored apply-paths, new behavior also controls starts; default is off.

- Implements the ladder and controller in `backend/core/ouroboros/governance/proactive_mode.py` (state, strictest-wins across cockpits, detach grace, env-backed; no new enforcement path except the `explore` veto).
- Hooks the veto in `backend/core/ouroboros/governance/orchestrator.py` at `_maybe_complete_cosmetic_candidate`, completing ops as `no_op_mode_veto` before value-gating; fails open on errors.
- Registers the emission sink in `backend/core/ouroboros/governance/governed_loop_service.py` after the background pool starts (so `watch` can pause/resume admission).
- Integrates the ladder with `backend/core/ouroboros/governance/trust_repl.py`: cycle is clamped (no wrap), reachable rungs only, remembers dial position in `JARVIS_PROACTIVE_MODE_POSITION`, and writes a valid risk floor to `JARVIS_MIN_RISK_TIER` (fixes prior bug writing rung names).
- Documents §30 and rewrites §29 “as built” in `docs/architecture/OUROBOROS_VENOM_PRD.md`; corrects §28 C2. Adds a focused test spine in `tests/governance/test_proactive_mode.py`.

**Rollout notes**

- Default behavior is unchanged; set `JARVIS_PROACTIVE_MODE_ENABLED=1` to enable the ladder. Without it, the dial remains `safe_auto|notify_apply|approval_required` with no-wrap cycling.
- No caller changes required; existing gates still read `JARVIS_MIN_RISK_TIER`. Scripts must not rely on rung names appearing in that env (new rungs map to `approval_required`).
- Operators will see pool pauses labeled `proactive_mode:watch (operator)`; treat separately from hibernation in observability.

<sup>Written for commit bdb650464d39e4f4a5493731f205b8420e4038dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

