### PR TITLE
feat(governance): the operator sees which request is in force (§30 slice 4)

### DIFF
--- a/backend/core/ouroboros/governance/proactive_mode.py
+++ b/backend/core/ouroboros/governance/proactive_mode.py
@@ -507,6 +507,82 @@ class ProactiveModeController:
 
 
 @dataclass(frozen=True)
+class Composition:
+    """How the effective rung was arrived at, for the operator to read.
+
+    The AMBIENT surfaces render the effective rung, because that is the
+    truth about the organism. Whether a given operator is being overridden
+    is a fact about THEIR screen, not about the organism, so it is answered
+    per-cockpit by :func:`override_notice` rather than baked into the shared
+    line — the same split §25.1 draws when it renders ambient content to the
+    minimum width while each cockpit keeps its own.
+    """
+
+    effective: str
+    glyph: str
+    #: Distinct rungs requested across live cockpits. >1 means composed.
+    distinct: int
+    #: Live requests, attached or within grace.
+    voters: int
+    composed: bool
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"effective": self.effective, "glyph": self.glyph,
+                "distinct": self.distinct, "voters": self.voters,
+                "composed": self.composed}
+
+
+def composition() -> Composition:
+    """Summarise how the current rung was decided. NEVER raises."""
+    try:
+        ctl = get_controller()
+        eff = ctl.effective()
+        names = {r["name"] for r in ctl.requests()}
+        return Composition(
+            effective=eff.name, glyph=eff.glyph,
+            distinct=len(names), voters=len(ctl.requests()),
+            composed=len(names) > 1,
+        )
+    except Exception:  # noqa: BLE001
+        return Composition("safe_auto", "", 0, 0, False)
+
+
+def override_notice(cockpit_id: str) -> str:
+    """What THIS cockpit should be told about its own request, or "".
+
+    Empty when the cockpit is not being overridden — the common case, and a
+    surface that shouted on every frame would be ignored by the third frame.
+
+    Non-empty when this operator asked for something LOOSER than the
+    organism is running. That is the case §30.6 exists for: today the last
+    writer wins silently, so an operator can tighten the organism and have a
+    colleague loosen it with neither seeing. Being told "your request is not
+    what is in force, and here is what is" is the whole difference between a
+    dial an operator trusts and one they stop touching.
+
+    The inverse — this cockpit is the STRICTEST and is therefore what
+    everyone else is getting — is deliberately silent. It is not news to the
+    operator who asked for it, and saying so on every frame would spend the
+    line's attention budget on a non-event.
+    """
+    try:
+        ctl = get_controller()
+        cid = str(cockpit_id or "?")
+        mine = next((r for r in ctl.requests()
+                     if r["cockpit_id"] == cid), None)
+        if mine is None:
+            return ""
+        eff = ctl.effective()
+        asked = position(mine["name"])
+        if asked.rank >= eff.rank:
+            return ""
+        return (f"{eff.glyph} {eff.name} in force "
+                f"(you asked {asked.glyph} {asked.name})")
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+@dataclass(frozen=True)
 class MutationVerdict:
     """Whether the current rung permits a candidate to reach VALIDATE."""
 

--- a/backend/core/ouroboros/governance/trust_repl.py
+++ b/backend/core/ouroboros/governance/trust_repl.py
@@ -101,11 +101,44 @@ def current_floor() -> str:
 
 def floor_chip() -> str:
     """The status-line chip: empty at rest so the line stays calm, loud
-    when the operator has raised the floor. NEVER raises."""
+    when the operator has raised the floor. NEVER raises.
+
+    §30.6 — when more than one cockpit has asked for a different rung, the
+    chip says the position is COMPOSED. It does not say whose request won,
+    because that is a fact about a particular screen rather than about the
+    organism, and this line is mirrored to every surface: naming one
+    operator here would tell the others something false about themselves.
+    ``proactive_mode.override_notice`` answers the per-cockpit question
+    where the cockpit's own identity is known.
+
+    A composed chip renders even at the resting rung. Silence is the right
+    default for a dial nobody has touched; it is the wrong default for a
+    dial two people are pulling in different directions, because the
+    operator whose request lost needs to know a negotiation happened at all.
+    """
     tier = current_floor()
-    if tier == "safe_auto":
+    comp = None
+    try:
+        from backend.core.ouroboros.governance import proactive_mode as _pm
+        if _pm.is_enabled():
+            comp = _pm.composition()
+            # The controller is authoritative when it holds requests: the
+            # env knob records the LAST write, and the effective rung is the
+            # strictest across live cockpits. Reading the knob here would
+            # reintroduce the last-writer-wins race the controller exists to
+            # remove.
+            if comp.voters:
+                tier = comp.effective
+    except Exception:  # noqa: BLE001
+        comp = None
+
+    composed = bool(comp and comp.composed)
+    if tier == "safe_auto" and not composed:
         return ""
-    return f"{_glyph_for(tier)}⛨ {tier}"
+    chip = f"{_glyph_for(tier)}⛨ {tier}"
+    if composed:
+        chip = f"{chip} (composed ×{comp.distinct})"
+    return chip
 
 
 def _describe(tier: str) -> str:

--- a/tests/governance/test_proactive_mode.py
+++ b/tests/governance/test_proactive_mode.py
@@ -568,3 +568,150 @@ def test_a_registered_sink_is_used_without_an_explicit_pool():
     out = c.apply_effects()
     assert out["emission"] == "paused"
     assert pool.paused is True
+
+
+# ---------------------------------------------------------------------------
+# Slice 4 — the operator sees which request is in force
+# ---------------------------------------------------------------------------
+
+
+def test_a_single_cockpit_chip_is_unchanged(monkeypatch):
+    from backend.core.ouroboros.governance import trust_repl as t
+    monkeypatch.setenv("JARVIS_PROACTIVE_MODE_ENABLED", "1")
+    pm.get_controller().request("mac", "approval_required")
+    assert t.floor_chip() == "🟠⛨ approval_required"
+
+
+def test_the_chip_says_composed_when_cockpits_disagree(monkeypatch):
+    """Silence is right for a dial nobody touched and wrong for one two
+    people are pulling in different directions."""
+    from backend.core.ouroboros.governance import trust_repl as t
+    monkeypatch.setenv("JARVIS_PROACTIVE_MODE_ENABLED", "1")
+    c = pm.get_controller()
+    c.request("mac", "approval_required")
+    c.request("desktop", "safe_auto")
+    chip = t.floor_chip()
+    assert "approval_required" in chip and "composed" in chip
+
+
+def test_a_composed_chip_renders_even_at_the_resting_rung(monkeypatch):
+    """The operator whose request lost needs to know a negotiation happened
+    at all — the resting rung is not evidence that nothing did."""
+    from backend.core.ouroboros.governance import trust_repl as t
+    monkeypatch.setenv("JARVIS_PROACTIVE_MODE_ENABLED", "1")
+    c = pm.get_controller()
+    c.request("mac", "safe_auto")
+    assert t.floor_chip() == ""
+    c.request("desktop", "notify_apply")
+    assert t.floor_chip() != ""
+
+
+def test_agreement_is_not_reported_as_composition(monkeypatch):
+    from backend.core.ouroboros.governance import trust_repl as t
+    monkeypatch.setenv("JARVIS_PROACTIVE_MODE_ENABLED", "1")
+    c = pm.get_controller()
+    c.request("mac", "watch")
+    c.request("desktop", "watch")
+    assert "composed" not in t.floor_chip()
+
+
+def test_the_shared_chip_never_names_a_cockpit(monkeypatch):
+    """This line is mirrored to every surface. Naming one operator here
+    tells the others something false about themselves."""
+    from backend.core.ouroboros.governance import trust_repl as t
+    monkeypatch.setenv("JARVIS_PROACTIVE_MODE_ENABLED", "1")
+    c = pm.get_controller()
+    c.request("mac", "watch")
+    c.request("desktop", "safe_auto")
+    chip = t.floor_chip()
+    assert "mac" not in chip and "desktop" not in chip
+
+
+def test_the_chip_reads_the_controller_not_the_env_knob(monkeypatch):
+    """The knob records the LAST write; the effective rung is the strictest
+    across live cockpits. Reading the knob reintroduces the race."""
+    from backend.core.ouroboros.governance import trust_repl as t
+    monkeypatch.setenv("JARVIS_PROACTIVE_MODE_ENABLED", "1")
+    c = pm.get_controller()
+    c.request("mac", "watch")
+    c.request("desktop", "safe_auto")
+    monkeypatch.setenv("JARVIS_MIN_RISK_TIER", "safe_auto")
+    assert "watch" in t.floor_chip(), "the chip believed the last writer"
+
+
+def test_an_overridden_cockpit_is_told_what_is_in_force(monkeypatch):
+    """§30.6 — an operator whose tightening is invisibly discarded stops
+    tightening."""
+    monkeypatch.setenv("JARVIS_PROACTIVE_MODE_ENABLED", "1")
+    c = pm.get_controller()
+    c.request("mac", "approval_required")
+    c.request("desktop", "safe_auto")
+    notice = pm.override_notice("desktop")
+    assert "approval_required" in notice and "safe_auto" in notice
+
+
+def test_the_strictest_cockpit_is_told_nothing(monkeypatch):
+    """Not news to the operator who asked for it; saying so every frame
+    spends the line's attention budget on a non-event."""
+    monkeypatch.setenv("JARVIS_PROACTIVE_MODE_ENABLED", "1")
+    c = pm.get_controller()
+    c.request("mac", "approval_required")
+    c.request("desktop", "safe_auto")
+    assert pm.override_notice("mac") == ""
+
+
+def test_agreeing_cockpits_get_no_notice(monkeypatch):
+    monkeypatch.setenv("JARVIS_PROACTIVE_MODE_ENABLED", "1")
+    c = pm.get_controller()
+    c.request("mac", "watch")
+    c.request("desktop", "watch")
+    assert pm.override_notice("desktop") == ""
+
+
+def test_an_unknown_cockpit_gets_no_notice(monkeypatch):
+    monkeypatch.setenv("JARVIS_PROACTIVE_MODE_ENABLED", "1")
+    pm.get_controller().request("mac", "watch")
+    assert pm.override_notice("never-attached") == ""
+    assert pm.override_notice("") == ""
+
+
+def test_a_notice_clears_when_the_stricter_cockpit_leaves(monkeypatch):
+    """Deliberate exit is consent, so the override genuinely ends."""
+    monkeypatch.setenv("JARVIS_PROACTIVE_MODE_ENABLED", "1")
+    c = pm.get_controller()
+    c.request("mac", "watch")
+    c.request("desktop", "safe_auto")
+    assert pm.override_notice("desktop") != ""
+    c.release("mac")
+    assert pm.override_notice("desktop") == ""
+
+
+def test_a_notice_persists_while_the_stricter_cockpit_is_merely_detached(
+        monkeypatch):
+    """Absence is not consent — the notice must not clear on a Wi-Fi drop,
+    because the override has not actually ended."""
+    monkeypatch.setenv("JARVIS_PROACTIVE_MODE_ENABLED", "1")
+    c = pm.get_controller()
+    c.request("mac", "watch")
+    c.request("desktop", "safe_auto")
+    c.detach("mac")
+    assert pm.override_notice("desktop") != ""
+
+
+def test_composition_and_notice_never_raise(monkeypatch):
+    monkeypatch.setenv("JARVIS_PROACTIVE_MODE_ENABLED", "1")
+
+    def _boom():
+        raise RuntimeError("controller exploded")
+
+    monkeypatch.setattr(pm, "get_controller", _boom)
+    assert pm.composition().composed is False
+    assert pm.override_notice("mac") == ""
+
+
+def test_the_chip_survives_proactive_mode_being_absent(monkeypatch):
+    """Master-off must be the pre-§30 chip, byte-identically."""
+    from backend.core.ouroboros.governance import trust_repl as t
+    monkeypatch.delenv("JARVIS_PROACTIVE_MODE_ENABLED", raising=False)
+    monkeypatch.setenv("JARVIS_MIN_RISK_TIER", "notify_apply")
+    assert t.floor_chip() == "🟡⛨ notify_apply"


### PR DESCRIPTION
Slice 1 made the effective rung the strictest across live cockpits — but nothing rendered it, so the composition was **correct and invisible**. An operator could tighten the organism, have a colleague loosen it, and neither would see that a negotiation had happened.

## Two surfaces, two questions

Separating them is the design.

**The ambient chip** answers *"what is the organism doing"* — a fact about the organism, so it belongs on the line every surface mirrors. `floor_chip()` was already appended at that seam, whose own comment records why:

> *"every surface (daemon toolbar, attach heartbeat, both cockpits) mirrors this one line, so a Shift+Tab in any pane shows in all of them within a heartbeat."*

Extending it there means slice 4 reaches every surface at once and **cannot become the sixth instance of the surface-parity defect §28 found**.

The chip now says `(composed ×2)` when cockpits disagree, and deliberately **does not name whose request won** — this line is mirrored to everyone, and naming one operator would tell the others something false about themselves. It also renders at the resting rung when composed: silence is the right default for a dial nobody has touched and the wrong one for a dial two people are pulling in different directions, because the operator whose request lost needs to know a negotiation occurred at all.

**The per-cockpit notice** answers *"is what I asked for what is running"* — a fact about one screen, so `override_notice(cockpit_id)` answers it where the cockpit's identity is known:

```
🟠 approval_required in force (you asked 🟢 safe_auto)
```

The same split §25.1 draws when it renders ambient content to the minimum width while each cockpit keeps its own.

## Three deliberate silences

The notice is empty when this cockpit is the strictest (not news to whoever asked, and repeating it every frame spends the line's attention budget on a non-event), when everyone agrees, and for a cockpit that never asked. A surface that shouted on every frame would be ignored by the third frame.

## Absence, again

The notice **persists while the stricter cockpit is merely detached**, and clears only on a deliberate release — a Wi-Fi drop has not ended the override, and rendering it as ended would be the same "absence is consent" error the retention window exists to prevent.

## The race pin

The chip reads the **controller**, not `JARVIS_MIN_RISK_TIER`. The knob records the *last write*; the effective rung is the *strictest* across live cockpits. Reading the knob here would reintroduce the exact race the controller was built to remove — pinned by a test with two cockpits where the looser one writes last, asserting the chip still shows the stricter.

**63 tests.** Master `JARVIS_PROACTIVE_MODE_ENABLED` default false — off, the chip is the pre-§30 chip byte-identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows composition and overrides to operators during proactive mode. Previously, cockpits could disagree and the ambient chip stayed silent; now the chip marks composition and each cockpit sees if its request is overridden.

- `trust_repl.floor_chip()` reads the controller when `JARVIS_PROACTIVE_MODE_ENABLED` is on and appends "(composed ×N)" when >1 distinct requests exist. It stays empty at rest unless composed and never names a cockpit.
- Adds `proactive_mode.Composition` and `proactive_mode.composition()` to summarize effective rung and composition; safe defaults; never raises.
- Adds `proactive_mode.override_notice(cockpit_id)` that informs a cockpit when its request is looser than the effective rung; silent when strictest, on agreement, or for unknown cockpits. Persists through detach; clears on explicit release.
- Tests pin the controller-vs-env race, composed-at-rest behavior, non-raising paths, and master-off parity.

**Rollout**
- No migration required.
- Gated by `JARVIS_PROACTIVE_MODE_ENABLED` (default off). Off: chip remains byte-identical to pre-§30.
- Surfaces that mirror the status line will show the composed chip automatically; do not read `JARVIS_MIN_RISK_TIER` for display.

<sup>Written for commit 5e7e0bc50f7019d5f0186c1eec4b39f684b9baf0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

