### PR TITLE
feat(governance): the Body never renders a rung it cannot vouch for (§30 slice 5)

### DIFF
--- a/backend/core/ouroboros/governance/link_session.py
+++ b/backend/core/ouroboros/governance/link_session.py
@@ -76,6 +76,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from backend.core.ouroboros.governance import link_protocol as proto
+from backend.core.ouroboros.governance import proactive_mode as proto_mode
 from backend.core.ouroboros.governance import link_transport as tx
 from backend.core.ouroboros.governance.link_outbox import LinkOutbox
 
@@ -334,6 +335,11 @@ class LinkSessionLoop:
         self._handshake_in_flight: Optional[Tuple[int, str]] = None
         self._resyncs = 0
         self._parks = 0
+        #: §30 slice 5 — what the PEER's dial says. Confirmation-gated, so a
+        #: reconnect invalidates it until the Engine speaks again. Owned here
+        #: rather than globally because it is a property of THIS session.
+        self.remote_mode = proto_mode.RemoteModeView()
+        self._last_mode_sent: Optional[str] = None
 
     # -- state -----------------------------------------------------------
 
@@ -483,6 +489,13 @@ class LinkSessionLoop:
         seq = record.get("seq")
         if not isinstance(seq, int):
             return []
+        if kind == tx.KIND_MODE:
+            # Confirmed BEFORE the control return below, so a mode frame can
+            # never be counted as seen without also being applied — the two
+            # would drift and the Body would show a rung it had received and
+            # discarded.
+            self.remote_mode.confirm(record)
+            return [record]
         if kind not in ORDERED_KINDS:
             # Control: acknowledged by having been seen, never ordered and
             # never applied. Returning it lets a caller react (a heartbeat
@@ -526,6 +539,34 @@ class LinkSessionLoop:
         record["node_id"] = self.config.node_id
         self.outbox.put(record)
         self.queue.put_high(record)
+
+    def publish_mode(self, *, force: bool = False) -> bool:
+        """Announce the effective rung to the peer. True when a frame was sent.
+
+        EDGE-TRIGGERED, not periodic. A rung is a state, not a measurement,
+        so re-sending an unchanged one would spend the link's budget
+        restating a fact the peer already holds. ``force`` exists for the
+        one case where the peer's knowledge is genuinely void: a fresh
+        connection, where the Body has invalidated everything and is
+        rendering *unknown* until told.
+
+        Sent on the HIGH lane: a mode frame is governance, not telemetry.
+        The lossy lane would drop it under exactly the pressure that makes
+        an accurate autonomy display matter most.
+        """
+        try:
+            frame = proto_mode.build_mode_frame(
+                seq=self.next_seq(), node_id=self.config.node_id,
+                lamport=(self._session.clock.tick() if self._session else 0),
+            )
+            if not force and frame["position"] == self._last_mode_sent:
+                return False
+            self.queue.put_high(frame)
+            self._last_mode_sent = str(frame["position"])
+            return True
+        except Exception:  # noqa: BLE001 — the dial never breaks the link
+            logger.debug("[LinkSession] mode publish degraded", exc_info=True)
+            return False
 
     def send_telemetry(self, payload: Dict[str, Any]) -> bool:
         """Queue a telemetry frame. Lossy by contract, never durable."""
@@ -624,6 +665,10 @@ class LinkSessionLoop:
         """
         self.registry.detach(self.config.session_id)
         self._handshake_in_flight = None
+        # The peer's rung is no longer confirmable. NOT void — a park is a
+        # pause, and advancing the epoch here would let an in-flight frame
+        # from this connection confirm the next one.
+        self.remote_mode.on_disconnected()
         self._transition(SessionState.PARKED, reason)
 
     def reconnect_delay_s(self) -> float:
@@ -636,6 +681,11 @@ class LinkSessionLoop:
         return proto.backoff_delay_s(self._attempt)
 
     def on_established(self) -> None:
+        # A new connection voids every prior confirmation: the Body renders
+        # *unknown* until the Engine speaks, rather than carrying a rung
+        # across a gap it cannot vouch for.
+        self.remote_mode.on_connected()
+        self._last_mode_sent = None
         self._attempt = 0
         self.breaker.on_established(self.config.node_id)
 
@@ -655,6 +705,7 @@ class LinkSessionLoop:
             "outbox": self.outbox.stats().to_dict(),
             "liveness": self.liveness.snapshot(),
             "reassembly": self.reassembly.snapshot(),
+            "remote_mode": self.remote_mode.snapshot(),
             "registry": self.registry.snapshot(),
             "breaker": self.breaker.snapshot(),
         }

--- a/backend/core/ouroboros/governance/link_transport.py
+++ b/backend/core/ouroboros/governance/link_transport.py
@@ -86,11 +86,20 @@ KIND_COMMAND = "command"
 KIND_VERDICT = "verdict"
 KIND_RESUME = "resume"
 KIND_RESUME_PLAN = "resume_plan"
+#: PRD §30 slice 5 — the Engine's effective proactive-mode rung.
+#:
+#: Its own kind rather than a telemetry payload, for two reasons. Telemetry
+#: is LOSSY by contract (§29.4): the lane drops its oldest under pressure,
+#: and a dropped mode frame would leave the Body rendering an autonomy level
+#: the Engine has left. And a mode frame must be legible to the reader
+#: BEFORE any dispatch — it changes what the operator is being told the
+#: organism may do, which is not a thing to discover after a queue.
+KIND_MODE = "mode"
 
 _KNOWN_KINDS = frozenset({
     KIND_HELLO, KIND_WELCOME, KIND_HEARTBEAT, KIND_HEARTBEAT_ACK,
     KIND_TELEMETRY, KIND_COMMAND, KIND_VERDICT, KIND_RESUME,
-    KIND_RESUME_PLAN,
+    KIND_RESUME_PLAN, KIND_MODE,
 })
 
 

--- a/backend/core/ouroboros/governance/proactive_mode.py
+++ b/backend/core/ouroboros/governance/proactive_mode.py
@@ -582,6 +582,139 @@ def override_notice(cockpit_id: str) -> str:
         return ""
 
 
+class RemoteModeView:
+    """What the BODY may say about a rung it does not own. §30 slice 5.
+
+    The Engine holds the dial; the Body renders it. Across §29's link that
+    creates a failure the local cockpit cannot have: **a stale rung on a
+    screen.** A Body showing 🟠 while the Engine runs 🟢 is worse than a Body
+    showing nothing, because the operator reads a guarantee that is not in
+    force and stops watching accordingly.
+
+    So the view is CONFIRMATION-GATED, not merely cached. A rung is
+    renderable only while it has been confirmed since the current connection
+    began; a reconnect invalidates it until the Engine says so again. The
+    gap between reconnecting and confirming renders as *unknown*, which is
+    the honest state and the one every other surface in this codebase
+    already prefers — the same choice ``_ignition_line`` makes when it
+    refuses to let a blank deck mean three different things.
+
+    Not a second dial. The Body cannot decide a rung from this class; it can
+    only report one, or report that it does not know. Authority stays where
+    the enforcement is.
+    """
+
+    def __init__(self, clock: Optional[Callable[[], float]] = None) -> None:
+        self._clock = clock or time.monotonic
+        self._lock = threading.Lock()
+        self._name: Optional[str] = None
+        self._confirmed_at: Optional[float] = None
+        #: Bumped on every reconnect. A confirmation carrying an older epoch
+        #: belongs to a previous connection and is refused — the same
+        #: seq-gating §26.5 uses so an op is judged under the regime it
+        #: entered.
+        self._epoch: int = 0
+        self._confirmed_epoch: int = -1
+        self._stale_renders_refused = 0
+
+    def on_connected(self) -> None:
+        """A new connection. Every prior confirmation is void."""
+        with self._lock:
+            self._epoch += 1
+            self._confirmed_epoch = -1
+            self._name = None
+            self._confirmed_at = None
+
+    def on_disconnected(self) -> None:
+        """The link dropped. The rung is no longer confirmable.
+
+        Distinct from :meth:`on_connected`: a drop does not advance the
+        epoch, so a frame still in flight from the old connection cannot be
+        mistaken for a confirmation of the next one.
+        """
+        with self._lock:
+            self._confirmed_epoch = -1
+            self._confirmed_at = None
+
+    def confirm(self, frame: Any) -> bool:
+        """Accept a MODE frame from the Engine. True when it was taken.
+
+        Refuses anything that is not a well-formed mode frame naming a rung
+        this side knows. An unknown rung is NOT rendered as itself: a Body
+        that echoed a name it could not interpret would be showing the
+        operator a word rather than a state, and the closed ladder exists
+        precisely so both ends mean the same thing by it.
+        """
+        try:
+            if not isinstance(frame, dict):
+                return False
+            if str(frame.get("kind") or "") != "mode":
+                return False
+            name = str(frame.get("position") or "").strip().lower()
+            if name not in _BY_NAME:
+                logger.warning(
+                    "[ProactiveMode] peer reported unknown rung %r — not "
+                    "rendering it", name)
+                return False
+            with self._lock:
+                self._name = name
+                self._confirmed_at = self._clock()
+                self._confirmed_epoch = self._epoch
+            return True
+        except Exception:  # noqa: BLE001
+            return False
+
+    def renderable(self) -> Optional[Position]:
+        """The rung the Body may display, or None for *unknown*."""
+        with self._lock:
+            fresh = (self._confirmed_epoch == self._epoch
+                     and self._name is not None)
+            name = self._name
+            if not fresh:
+                self._stale_renders_refused += 1
+        return position(name) if fresh else None
+
+    def chip(self) -> str:
+        """The Body's chip. Explicitly *unknown* rather than silent.
+
+        Silence would be read as "nothing to report", and the whole point is
+        that there IS something to report and this side cannot currently
+        vouch for it.
+        """
+        rung = self.renderable()
+        if rung is None:
+            return "⛨ mode unknown (awaiting engine)"
+        return f"{rung.glyph}⛨ {rung.name}"
+
+    def snapshot(self) -> Dict[str, Any]:
+        with self._lock:
+            age = (None if self._confirmed_at is None
+                   else round(self._clock() - self._confirmed_at, 2))
+            return {
+                "position": self._name,
+                "confirmed": self._confirmed_epoch == self._epoch,
+                "confirmed_age_s": age,
+                "epoch": self._epoch,
+                "stale_renders_refused": self._stale_renders_refused,
+            }
+
+
+def build_mode_frame(seq: int, node_id: str, lamport: int = 0) -> Dict[str, Any]:
+    """The Engine's MODE frame for the current effective rung.
+
+    Carries the composition too, so the Body can render "composed" without
+    holding a second opinion about who is attached to the Engine — that is
+    the Engine's fact, and shipping it is cheaper and more honest than
+    inferring it.
+    """
+    comp = composition()
+    return {
+        "kind": "mode", "seq": int(seq), "lamport": int(lamport),
+        "node_id": str(node_id), "position": comp.effective,
+        "composed": comp.composed, "distinct": comp.distinct,
+    }
+
+
 @dataclass(frozen=True)
 class MutationVerdict:
     """Whether the current rung permits a candidate to reach VALIDATE."""

--- a/tests/governance/test_proactive_mode.py
+++ b/tests/governance/test_proactive_mode.py
@@ -715,3 +715,176 @@ def test_the_chip_survives_proactive_mode_being_absent(monkeypatch):
     monkeypatch.delenv("JARVIS_PROACTIVE_MODE_ENABLED", raising=False)
     monkeypatch.setenv("JARVIS_MIN_RISK_TIER", "notify_apply")
     assert t.floor_chip() == "🟡⛨ notify_apply"
+
+
+# ---------------------------------------------------------------------------
+# Slice 5 — the Body never renders a rung it cannot vouch for
+# ---------------------------------------------------------------------------
+
+
+def _mode_frame(position="watch", **kw):
+    f = {"kind": "mode", "seq": 1, "lamport": 1, "node_id": "engine",
+         "position": position}
+    f.update(kw)
+    return f
+
+
+def test_a_fresh_view_renders_unknown_not_a_guess():
+    """A stale rung on a screen is worse than no rung: the operator reads a
+    guarantee that is not in force and stops watching accordingly."""
+    v = pm.RemoteModeView(clock=FakeClock())
+    assert v.renderable() is None
+    assert "unknown" in v.chip()
+
+
+def test_a_confirmed_rung_renders():
+    v = pm.RemoteModeView(clock=FakeClock())
+    v.on_connected()
+    assert v.confirm(_mode_frame("explore")) is True
+    assert v.renderable().name == "explore"
+    assert "explore" in v.chip()
+
+
+def test_a_reconnect_voids_every_prior_confirmation():
+    """THE slice-5 regression: carrying a rung across a gap the Body cannot
+    vouch for."""
+    v = pm.RemoteModeView(clock=FakeClock())
+    v.on_connected()
+    v.confirm(_mode_frame("watch"))
+    v.on_connected()
+    assert v.renderable() is None, "a rung survived a reconnect"
+
+
+def test_a_drop_unconfirms_without_advancing_the_epoch():
+    """A park is a pause. Advancing the epoch would let an in-flight frame
+    from this connection confirm the next one."""
+    v = pm.RemoteModeView(clock=FakeClock())
+    v.on_connected()
+    v.confirm(_mode_frame("watch"))
+    before = v.snapshot()["epoch"]
+    v.on_disconnected()
+    assert v.renderable() is None
+    assert v.snapshot()["epoch"] == before
+
+
+def test_an_unknown_rung_is_refused_not_echoed():
+    """A Body echoing a name it cannot interpret shows the operator a word
+    rather than a state."""
+    v = pm.RemoteModeView(clock=FakeClock())
+    v.on_connected()
+    assert v.confirm(_mode_frame("turbo_mode")) is False
+    assert v.renderable() is None
+
+
+def test_a_malformed_frame_is_refused():
+    v = pm.RemoteModeView(clock=FakeClock())
+    v.on_connected()
+    for junk in (None, "mode", {}, {"kind": "telemetry", "position": "watch"},
+                 {"kind": "mode"}):
+        assert v.confirm(junk) is False
+
+
+def test_the_view_cannot_decide_a_rung_only_report_one():
+    """Not a second dial — authority stays where the enforcement is."""
+    assert not hasattr(pm.RemoteModeView, "request")
+    assert not hasattr(pm.RemoteModeView, "cycle")
+
+
+def test_refused_renders_are_counted_for_the_operator():
+    v = pm.RemoteModeView(clock=FakeClock())
+    v.renderable(); v.renderable()
+    assert v.snapshot()["stale_renders_refused"] >= 2
+
+
+# -- the frame ------------------------------------------------------------
+
+
+def test_the_mode_frame_carries_the_composition(monkeypatch):
+    """The Body renders 'composed' from the Engine's fact rather than
+    inferring who is attached to a machine it cannot see."""
+    monkeypatch.setenv("JARVIS_PROACTIVE_MODE_ENABLED", "1")
+    c = pm.get_controller()
+    c.request("mac", "watch")
+    c.request("desktop", "safe_auto")
+    f = pm.build_mode_frame(seq=7, node_id="engine")
+    assert f["kind"] == "mode" and f["position"] == "watch"
+    assert f["composed"] is True and f["distinct"] == 2
+
+
+def test_mode_is_a_known_frame_kind():
+    from backend.core.ouroboros.governance import link_transport as tx
+    assert tx.is_known_kind(tx.KIND_MODE)
+
+
+def test_mode_is_not_carried_on_the_lossy_lane():
+    """Telemetry drops its oldest under pressure, and a dropped mode frame
+    leaves the Body rendering an autonomy level the Engine has left."""
+    from backend.core.ouroboros.governance import link_session as ls
+    assert "mode" not in {k for k in ls.ORDERED_KINDS}
+    import inspect
+    assert "put_high" in inspect.getsource(ls.LinkSessionLoop.publish_mode)
+
+
+# -- session integration --------------------------------------------------
+
+
+def _loop(node="engine"):
+    from backend.core.ouroboros.governance import link_session as ls
+    return ls.LinkSessionLoop(
+        ls.SessionConfig(node_id=node, session_id="s-1"))
+
+
+def test_publishing_is_edge_triggered(monkeypatch):
+    """A rung is a state, not a measurement — restating it spends the
+    link's budget on a fact the peer already holds."""
+    monkeypatch.setenv("JARVIS_PROACTIVE_MODE_ENABLED", "1")
+    pm.get_controller().request("mac", "explore")
+    loop = _loop()
+    assert loop.publish_mode() is True
+    assert loop.publish_mode() is False
+    pm.get_controller().request("mac", "watch")
+    assert loop.publish_mode() is True
+
+
+def test_a_fresh_connection_forces_a_republish(monkeypatch):
+    """The peer has invalidated everything and is rendering unknown."""
+    monkeypatch.setenv("JARVIS_PROACTIVE_MODE_ENABLED", "1")
+    pm.get_controller().request("mac", "explore")
+    loop = _loop()
+    loop.publish_mode()
+    loop.on_established()
+    assert loop.publish_mode(force=True) is True
+
+
+def test_an_inbound_mode_frame_confirms_the_view():
+    loop = _loop("body")
+    loop.on_established()
+    loop.dispatch(_mode_frame("approval_required"))
+    assert loop.remote_mode.renderable().name == "approval_required"
+
+
+def test_a_park_unconfirms_the_peers_rung():
+    loop = _loop("body")
+    loop.on_established()
+    loop.dispatch(_mode_frame("watch"))
+    loop.park("wifi dropped")
+    assert loop.remote_mode.renderable() is None
+
+
+def test_reconnecting_voids_then_reconfirms():
+    loop = _loop("body")
+    loop.on_established()
+    loop.dispatch(_mode_frame("watch"))
+    loop.park("drop")
+    loop.on_established()
+    assert loop.remote_mode.renderable() is None
+    loop.dispatch(_mode_frame("safe_auto"))
+    assert loop.remote_mode.renderable().name == "safe_auto"
+
+
+def test_the_session_snapshot_reports_the_remote_view():
+    import json
+    loop = _loop("body")
+    snap = loop.snapshot()
+    json.dumps(snap)
+    assert "remote_mode" in snap


### PR DESCRIPTION
Completes PRD §30. The Engine holds the dial and the Body renders it, which across §29's link creates a failure the local cockpit cannot have: **a stale rung on a screen.**

A Body showing 🟠 while the Engine runs 🟢 is worse than a Body showing nothing, because the operator reads a guarantee that is not in force and stops watching accordingly.

## Confirmation-gated, not cached

`RemoteModeView` renders a rung only while it has been confirmed since the **current** connection began. A reconnect voids every prior confirmation and the Body renders `⛨ mode unknown (awaiting engine)` — explicitly unknown rather than silent, because silence reads as "nothing to report" and the whole point is that there *is* something to report and this side cannot vouch for it.

The same choice `_ignition_line` makes when it refuses to let a blank deck mean three different things.

## The epoch distinguishes two ways a connection ends

- `on_connected` **advances the epoch** — every prior confirmation is void.
- `on_disconnected` **does not** — a park is a pause, and advancing the epoch there would let a frame still in flight from this connection confirm the *next* one.

That is §26.5's seq-gating applied to a display: a confirmation is judged under the connection it arrived on.

## Mode is its own frame kind

Not a telemetry payload, for two reasons:

- Telemetry is **lossy by contract** (§29.4) and drops its oldest under pressure — exactly the pressure that makes an accurate autonomy display matter most. A dropped mode frame would leave the Body rendering a level the Engine has left.
- It rides the **high lane**: a mode frame is governance, not chatter.

## Edge-triggered publishing

A rung is a state, not a measurement, so restating an unchanged one spends the link's budget on a fact the peer already holds. `force` exists for the one case where the peer's knowledge is genuinely void: a fresh connection.

## Two refusals

An unknown rung name is **refused, never echoed** — a Body rendering a name it cannot interpret shows the operator a word rather than a state, and the closed ladder exists precisely so both ends mean the same thing by it.

`RemoteModeView` can *report* a rung and cannot *decide* one — pinned by a test asserting it has no `request` or `cycle`. Authority stays where the enforcement is.

The frame carries the composition, so the Body renders "composed" from the Engine's own fact rather than inferring who is attached to a machine it cannot see.

**80 §30 tests; 184 across the mode and link spines.** Master `JARVIS_PROACTIVE_MODE_ENABLED` default false.

With this, PRD §30 is complete — all five slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the Body from showing a stale proactive‑mode rung. Previously it could persist a rung across reconnects; now it only renders a rung confirmed on the current connection and otherwise shows "⛨ mode unknown (awaiting engine)".

- Introduces a dedicated `mode` frame kind sent on the high lane and dispatched immediately; it is not telemetry and is never carried on the lossy lane.
- Adds RemoteModeView with epoch gating: on_connected advances the epoch and voids prior confirmations; on_disconnected clears confirmation without advancing the epoch.
- LinkSessionLoop: publish_mode(force=False) is edge‑triggered, resets on connect, confirms inbound mode frames before control returns, and includes `remote_mode` in snapshots. Frames include composition (composed/distinct).
- Refuses unknown rung names; the Body never echoes a rung it cannot interpret.
- Required: emit `mode` frames on the high lane (do not send mode via telemetry). After a reconnect, republish mode (e.g., call publish_mode(force=True) or send a fresh `mode` frame) so the Body exits "unknown".
- Guarded by `JARVIS_PROACTIVE_MODE_ENABLED` (default false).

<sup>Written for commit 99e5fea4ff99e3749e6d9fbb7f293219fb28a939. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

