### PR TITLE
fix(ov): close the unmounted-feature defect class (§28 C2 + /reach)

### DIFF
--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -3032,6 +3032,46 @@ def _client_extra_bindings(ui: Any, client: Any) -> Any:
             install_completion_arbiter(kb)
         except Exception:  # noqa: BLE001
             pass
+
+        # PRD §28 C2 — single-key gate answering, on the surface `ov attach`
+        # actually mounts.
+        #
+        # `install_confirm_actions` has existed and worked since it shipped,
+        # imported at exactly ONE site: bipartite_layout. The capability was
+        # never missing; it was unreachable from this cockpit. Mounted at
+        # THIS builder for the reason the arbiter above states in its own
+        # comment — "this builder is the one action set both attach surfaces
+        # share; binding it at either call site would fix the surface that
+        # was looked at and leave the other one dead."
+        #
+        # `submit` routes through `_route_operator_line`, the same path a
+        # typed `/accept` takes, so the risk tier, the audit trail and the
+        # countdown clear identically. A key that bypassed the verb would be
+        # a second approval path, and approval is the one surface where two
+        # paths that disagree is a governance problem rather than a UI one.
+        #
+        # CONCURRENCY: no lock is added here, deliberately. The pending gate
+        # is a fact about the ORGANISM, not about a screen — both cockpits
+        # should see the same one — and `pending_apply` already guards its
+        # state with a `threading.Lock` while `snapshot()` returns a copy, so
+        # a reader never sees a torn row. Two cockpits answering at once are
+        # separated where it matters: `send_input` tags every verdict with
+        # its `prompt_id` and the daemon refuses a mismatch rather than
+        # landing "y" on whichever op happens to be armed. A lock here would
+        # serialise two reads that were never in conflict.
+        try:
+            from backend.core.ouroboros.battle_test.menu_bindings import (
+                install_confirm_actions,
+            )
+            _n_confirm = install_confirm_actions(
+                kb, submit=lambda _text: _route_operator_line(
+                    client, ui, _text),
+            )
+            logger.debug(
+                "[ov] mounted %d confirm action(s) on the attach surface",
+                _n_confirm)
+        except Exception:  # noqa: BLE001
+            logger.debug("[ov] confirm actions unavailable", exc_info=True)
         return kb
     except Exception:  # noqa: BLE001
         return None

--- a/backend/core/ouroboros/governance/reach_repl.py
+++ b/backend/core/ouroboros/governance/reach_repl.py
@@ -1,0 +1,355 @@
+"""``/reach`` — the unmounted-feature detector, given an operator and a ratchet.
+
+``surface_reachability`` already answers the question that matters: which of
+`ov`'s rendering surfaces can actually reach a module. Its docstring names
+five modules that shipped complete, tested and invisible, and PRD §28's C2
+was the sixth. The detector was right about all of them.
+
+It had no operator verb and no tests, so the instrument for finding unmounted
+features was itself unmounted. This module is the fix, and it deliberately
+adds no analysis: every number here comes from ``surface_reachability.audit``.
+
+WHY A BASELINE AND NOT A REPORT
+-------------------------------
+The naive watchdog prints every asymmetric module at boot. That watchdog is
+muted by the second week, and the detector's own history says why: of 39
+modules once reported orphaned, **32 were reachable from an entry point the
+audit had not been taught about**. A signal with a 4:1 false-positive rate is
+noise, and an operator who learns to skip a line stops reading the line that
+finally matters.
+
+So the audit is a **ratchet**. The accepted state is recorded, and the
+watchdog reports only what has changed since — a module that became
+asymmetric, or newly orphaned. Steady state is silence. That inverts the
+economics: silence means "nothing regressed", and any output is by
+construction new.
+
+The baseline lives in ``.jarvis/`` — per-repository, alongside the other
+local metadata, because "these surfaces are mounted the way I want" is a
+judgement about THIS checkout and does not travel with the branch.
+
+Auto-discovered by ``repl_dispatch_registry`` through the naming cage, the
+same way ``trust_repl`` is: a module named ``*_repl`` exposing
+``dispatch_*_command`` and ``__verb_help__`` becomes a verb without a
+registration table anyone can forget to update.
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger("Ouroboros.ReachRepl")
+
+REACH_REPL_SCHEMA_VERSION: str = "reach_repl.1"
+
+__verb_help__ = {
+    "reach": "which surfaces can reach a module — the unmounted-feature audit",
+}
+
+_HELP = (
+    "/reach — surface reachability (PRD §28)\n"
+    "\n"
+    "  /reach                 what changed since the accepted baseline\n"
+    "  /reach all             every asymmetric module, baseline or not\n"
+    "  /reach orphans         unreached by any surface OR entry point\n"
+    "  /reach <module>        which surfaces reach one module\n"
+    "  /reach accept          record the current state as the baseline\n"
+    "  /reach help            this text\n"
+    "\n"
+    "Asymmetry is EVIDENCE, not a verdict: a module reachable from one\n"
+    "surface may be correct. It is the shape every unmounted feature had.\n"
+)
+
+
+def baseline_path() -> Path:
+    """Where the accepted state lives. Per-repository, never global."""
+    root = Path(os.environ.get("JARVIS_PROJECT_ROOT", "."))
+    return Path(os.environ.get(
+        "JARVIS_REACH_BASELINE_PATH",
+        str(root / ".jarvis" / "surface_reachability_baseline.json"),
+    ))
+
+
+def watchdog_enabled() -> bool:
+    """Boot-time drift check. Default TRUE — it is silent at steady state."""
+    return (os.environ.get("JARVIS_REACH_WATCHDOG_ENABLED", "true")
+            or "").strip().lower() not in ("0", "false", "no", "off")
+
+
+@dataclass(frozen=True)
+class ReachDrift:
+    """What changed since the baseline was accepted."""
+
+    new_asymmetric: Tuple[str, ...] = ()
+    new_orphans: Tuple[str, ...] = ()
+    resolved: Tuple[str, ...] = ()
+    baseline_exists: bool = True
+    scanned: int = 0
+    error: str = ""
+
+    @property
+    def regressed(self) -> bool:
+        return bool(self.new_asymmetric or self.new_orphans)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "schema_version": REACH_REPL_SCHEMA_VERSION,
+            "new_asymmetric": list(self.new_asymmetric),
+            "new_orphans": list(self.new_orphans),
+            "resolved": list(self.resolved),
+            "baseline_exists": self.baseline_exists,
+            "scanned": self.scanned, "regressed": self.regressed,
+            "error": self.error,
+        }
+
+
+def _audit() -> Any:
+    """Run the canonical audit. Raises only what the caller will catch."""
+    from backend.core.ouroboros.battle_test.surface_reachability import audit
+    return audit()
+
+
+def _load_baseline() -> Optional[Dict[str, Any]]:
+    """The accepted state, or None. NEVER raises.
+
+    A corrupt baseline is treated as ABSENT rather than as an empty one:
+    an empty baseline would report every asymmetric module as newly
+    regressed, burying a real regression under a hundred false ones on the
+    first boot after a disk fault.
+    """
+    try:
+        raw = baseline_path().read_text(encoding="utf-8")
+        data = json.loads(raw)
+        if not isinstance(data, dict):
+            return None
+        return data
+    except (OSError, ValueError):
+        return None
+
+
+def accept_baseline() -> Dict[str, Any]:
+    """Record the current state as accepted. NEVER raises.
+
+    Written through ``durable_io.atomic_replace``: a baseline half-written
+    by a crash would be read as corrupt on the next boot, which degrades to
+    "no baseline" and floods the operator exactly when they are already
+    recovering from something.
+    """
+    try:
+        reading = _audit()
+        payload = {
+            "schema_version": REACH_REPL_SCHEMA_VERSION,
+            "asymmetric": sorted(m.module for m in reading.asymmetric()),
+            "orphans": sorted(m.module for m in reading.orphans()),
+            "surfaces": list(reading.surface_labels),
+            "scanned": reading.scanned,
+        }
+        path = baseline_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+        tmp.write_text(json.dumps(payload, indent=2, sort_keys=True),
+                       encoding="utf-8")
+        from backend.core.ouroboros.governance.durable_io import atomic_replace
+        atomic_replace(tmp, path)
+        logger.info("[Reach] baseline accepted — %d asymmetric, %d orphan(s)",
+                    len(payload["asymmetric"]), len(payload["orphans"]))
+        return payload
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[Reach] baseline write failed: %s", exc, exc_info=True)
+        return {"error": str(exc)}
+
+
+def drift() -> ReachDrift:
+    """What regressed since the baseline. NEVER raises.
+
+    With NO baseline this reports nothing rather than everything. A first
+    run on a fresh checkout has not regressed — it has not yet been
+    measured — and reporting the whole standing list as new would be the
+    4:1 false-positive flood this design exists to avoid.
+    """
+    try:
+        reading = _audit()
+    except Exception as exc:  # noqa: BLE001
+        return ReachDrift(error=f"{type(exc).__name__}: {exc}")
+    now_asym = {m.module for m in reading.asymmetric()}
+    now_orph = {m.module for m in reading.orphans()}
+    base = _load_baseline()
+    if base is None:
+        return ReachDrift(baseline_exists=False, scanned=reading.scanned)
+    was_asym = set(base.get("asymmetric") or ())
+    was_orph = set(base.get("orphans") or ())
+    return ReachDrift(
+        new_asymmetric=tuple(sorted(now_asym - was_asym)),
+        new_orphans=tuple(sorted(now_orph - was_orph)),
+        resolved=tuple(sorted((was_asym | was_orph) - (now_asym | now_orph))),
+        scanned=reading.scanned,
+    )
+
+
+async def run_watchdog() -> ReachDrift:
+    """Boot-time drift check, off the event loop. NEVER raises.
+
+    The audit walks the module tree and parses every file, which is far too
+    much work for the loop that also runs the organism — so it goes to a
+    thread. Bounded by the caller's own supervision rather than a timer
+    here: a scan that overran would be a scan worth noticing, and killing
+    it silently would hide that.
+
+    Silent at steady state, by construction: with nothing new since the
+    baseline there is no line to print.
+    """
+    if not watchdog_enabled():
+        return ReachDrift(baseline_exists=False)
+    try:
+        import asyncio
+        result = await asyncio.to_thread(drift)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[Reach] watchdog degraded: %s", exc)
+        return ReachDrift(error=str(exc))
+    if result.error:
+        logger.debug("[Reach] watchdog could not audit: %s", result.error)
+    elif not result.baseline_exists:
+        logger.info(
+            "[Reach] no reachability baseline — run `/reach accept` to "
+            "record the current surface topology as expected")
+    elif result.regressed:
+        # WARNING, not INFO: a capability that shipped unreachable is the
+        # defect class this detector exists for, and it has landed six times.
+        logger.warning(
+            "[Reach] surface reachability REGRESSED — new asymmetric: %s; "
+            "new orphans: %s. A module reachable from fewer surfaces than "
+            "before is the shape every unmounted feature had.",
+            ", ".join(result.new_asymmetric) or "-",
+            ", ".join(result.new_orphans) or "-",
+        )
+    return result
+
+
+@dataclass(frozen=True)
+class ReachReplDispatchResult:
+    ok: bool
+    text: str
+    matched: bool = True
+    schema_version: str = REACH_REPL_SCHEMA_VERSION
+
+
+def _fmt(names: List[str], cap: int = 12) -> str:
+    if not names:
+        return "  (none)"
+    shown = names[:cap]
+    tail = f"\n  … and {len(names) - cap} more" if len(names) > cap else ""
+    return "\n".join(f"  {n}" for n in shown) + tail
+
+
+def dispatch_reach_command(line: str) -> ReachReplDispatchResult:
+    """Surface-reachability audit.
+
+    Operator: find capabilities that shipped complete and unreachable.
+    """
+    try:
+        tokens = (line or "").strip().lstrip("/").split()
+        sub = tokens[1] if len(tokens) > 1 else ""
+
+        if sub in ("help", "-h", "--help"):
+            return ReachReplDispatchResult(ok=True, text=_HELP)
+
+        if sub == "accept":
+            payload = accept_baseline()
+            if "error" in payload:
+                return ReachReplDispatchResult(
+                    ok=False, text=f"could not write baseline: {payload['error']}")
+            return ReachReplDispatchResult(
+                ok=True,
+                text=(f"baseline accepted — {len(payload['asymmetric'])} "
+                      f"asymmetric, {len(payload['orphans'])} orphan(s) across "
+                      f"{payload['scanned']} module(s).\n"
+                      f"Future drift reports only what changes from here."),
+            )
+
+        if sub in ("", "drift"):
+            d = drift()
+            if d.error:
+                return ReachReplDispatchResult(
+                    ok=False, text=f"audit unavailable: {d.error}")
+            if not d.baseline_exists:
+                return ReachReplDispatchResult(
+                    ok=True,
+                    text=("no baseline recorded — run `/reach accept` to "
+                          "pin the current topology, then this reports only "
+                          "what changes."))
+            if not d.regressed and not d.resolved:
+                return ReachReplDispatchResult(
+                    ok=True,
+                    text=f"reachability unchanged ({d.scanned} modules).")
+            parts = [f"reachability drift ({d.scanned} modules):"]
+            if d.new_asymmetric:
+                parts.append("newly asymmetric:")
+                parts.append(_fmt(list(d.new_asymmetric)))
+            if d.new_orphans:
+                parts.append("newly orphaned:")
+                parts.append(_fmt(list(d.new_orphans)))
+            if d.resolved:
+                parts.append(f"resolved: {len(d.resolved)}")
+            return ReachReplDispatchResult(ok=True, text="\n".join(parts))
+
+        if sub in ("all", "asymmetric"):
+            reading = _audit()
+            rows = [f"{m.module}  ({len(m.reached_by)}/"
+                    f"{len(reading.surface_labels)})"
+                    for m in reading.asymmetric()]
+            return ReachReplDispatchResult(
+                ok=True,
+                text=(f"asymmetric modules ({len(rows)} of "
+                      f"{reading.scanned}):\n{_fmt(rows, cap=30)}"))
+
+        if sub == "orphans":
+            reading = _audit()
+            rows = [m.module for m in reading.orphans()]
+            return ReachReplDispatchResult(
+                ok=True,
+                text=(f"orphans — unreached by any surface OR entry point "
+                      f"({len(rows)}):\n{_fmt(rows, cap=30)}"))
+
+        # Anything else is treated as a module name. Matched loosely on the
+        # tail so an operator can type `menu_bindings` rather than the full
+        # dotted path — the path is an implementation detail of the tree.
+        reading = _audit()
+        needle = sub.strip().lower()
+        hits = [m for m in reading.modules
+                if needle in m.module.lower()]
+        if not hits:
+            return ReachReplDispatchResult(
+                ok=False,
+                text=(f"no module matching {sub!r} in {reading.scanned} "
+                      f"scanned — try `/reach all` or `/reach help`"))
+        lines = []
+        for m in hits[:8]:
+            reached = ", ".join(sorted(m.reached_by)) or "NOTHING"
+            lines.append(f"  {m.module}\n      reached by: {reached}")
+        return ReachReplDispatchResult(
+            ok=True,
+            text=(f"surfaces: {', '.join(reading.surface_labels)}\n"
+                  + "\n".join(lines)))
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[ReachRepl] dispatch degraded", exc_info=True)
+        return ReachReplDispatchResult(
+            ok=False, text=f"reach audit unavailable ({type(exc).__name__})")
+
+
+__all__ = [
+    "REACH_REPL_SCHEMA_VERSION",
+    "ReachDrift",
+    "ReachReplDispatchResult",
+    "accept_baseline",
+    "baseline_path",
+    "dispatch_reach_command",
+    "drift",
+    "run_watchdog",
+    "watchdog_enabled",
+]

--- a/tests/governance/test_reach_repl.py
+++ b/tests/governance/test_reach_repl.py
@@ -1,0 +1,235 @@
+"""Regression spine for `/reach` — the unmounted-feature detector's verb.
+
+The detector itself is `surface_reachability` and is not re-tested here.
+What is tested is the ratchet: that steady state is silent, that a
+regression is loud, and that the failure modes of the baseline file cannot
+turn a signal into a flood.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from backend.core.ouroboros.governance import reach_repl as rr
+
+
+@pytest.fixture(autouse=True)
+def _isolated(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_REACH_BASELINE_PATH",
+                       str(tmp_path / "baseline.json"))
+    yield
+
+
+def _reading(asym=(), orph=(), scanned=100):
+    class _M:
+        def __init__(self, name): self.module = name; self.reached_by = ("attach",)
+    class _R:
+        surface_labels = ("daemon", "attach", "cockpit")
+        modules = []
+        def __init__(self): self.scanned = scanned
+        def asymmetric(self): return [_M(n) for n in asym]
+        def orphans(self): return [_M(n) for n in orph]
+    return _R()
+
+
+# -- the ratchet -----------------------------------------------------------
+
+
+def test_no_baseline_reports_nothing_rather_than_everything(monkeypatch):
+    """A first run has not regressed — it has not yet been measured.
+    Reporting the standing list as new is the 4:1 false-positive flood this
+    design exists to avoid."""
+    monkeypatch.setattr(rr, "_audit", lambda: _reading(asym=("a", "b", "c")))
+    d = rr.drift()
+    assert d.baseline_exists is False
+    assert d.new_asymmetric == () and d.new_orphans == ()
+
+
+def test_steady_state_is_silent(monkeypatch):
+    monkeypatch.setattr(rr, "_audit", lambda: _reading(asym=("a",)))
+    rr.accept_baseline()
+    d = rr.drift()
+    assert d.regressed is False
+    assert "unchanged" in rr.dispatch_reach_command("/reach").text
+
+
+def test_a_newly_asymmetric_module_is_loud(monkeypatch):
+    """The shape every unmounted feature had."""
+    monkeypatch.setattr(rr, "_audit", lambda: _reading(asym=("a",)))
+    rr.accept_baseline()
+    monkeypatch.setattr(rr, "_audit", lambda: _reading(asym=("a", "newcomer")))
+    d = rr.drift()
+    assert d.regressed is True
+    assert d.new_asymmetric == ("newcomer",)
+
+
+def test_a_newly_orphaned_module_is_loud(monkeypatch):
+    monkeypatch.setattr(rr, "_audit", lambda: _reading())
+    rr.accept_baseline()
+    monkeypatch.setattr(rr, "_audit", lambda: _reading(orph=("dead",)))
+    assert rr.drift().new_orphans == ("dead",)
+
+
+def test_a_fixed_module_is_reported_as_resolved(monkeypatch):
+    monkeypatch.setattr(rr, "_audit", lambda: _reading(asym=("a", "b")))
+    rr.accept_baseline()
+    monkeypatch.setattr(rr, "_audit", lambda: _reading(asym=("a",)))
+    d = rr.drift()
+    assert d.resolved == ("b",) and d.regressed is False
+
+
+def test_accepting_moves_the_ratchet(monkeypatch):
+    monkeypatch.setattr(rr, "_audit", lambda: _reading(asym=("a",)))
+    rr.accept_baseline()
+    monkeypatch.setattr(rr, "_audit", lambda: _reading(asym=("a", "b")))
+    assert rr.drift().regressed is True
+    rr.accept_baseline()
+    assert rr.drift().regressed is False
+
+
+# -- baseline failure modes ------------------------------------------------
+
+
+def test_a_corrupt_baseline_is_treated_as_absent_not_empty(monkeypatch):
+    """An empty baseline would report every asymmetric module as newly
+    regressed, burying a real regression under a hundred false ones on the
+    first boot after a disk fault."""
+    rr.baseline_path().parent.mkdir(parents=True, exist_ok=True)
+    rr.baseline_path().write_text("{not json", encoding="utf-8")
+    monkeypatch.setattr(rr, "_audit", lambda: _reading(asym=("a", "b", "c")))
+    d = rr.drift()
+    assert d.baseline_exists is False
+    assert d.new_asymmetric == ()
+
+
+def test_a_baseline_that_is_not_an_object_is_treated_as_absent(monkeypatch):
+    rr.baseline_path().parent.mkdir(parents=True, exist_ok=True)
+    rr.baseline_path().write_text("[1,2,3]", encoding="utf-8")
+    monkeypatch.setattr(rr, "_audit", lambda: _reading(asym=("a",)))
+    assert rr.drift().baseline_exists is False
+
+
+def test_the_baseline_is_published_atomically():
+    """A baseline half-written by a crash reads as corrupt on the next
+    boot, which degrades to 'no baseline' and floods the operator exactly
+    when they are already recovering."""
+    import inspect
+    assert "atomic_replace" in inspect.getsource(rr.accept_baseline)
+
+
+def test_a_failing_audit_degrades_rather_than_raising(monkeypatch):
+    def _boom():
+        raise RuntimeError("tree walk exploded")
+    monkeypatch.setattr(rr, "_audit", _boom)
+    d = rr.drift()
+    assert d.error and d.regressed is False
+    assert rr.dispatch_reach_command("/reach").ok is False
+
+
+# -- the watchdog ----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_watchdog_is_silent_at_steady_state(monkeypatch, caplog):
+    monkeypatch.setattr(rr, "_audit", lambda: _reading(asym=("a",)))
+    rr.accept_baseline()
+    caplog.clear()
+    await rr.run_watchdog()
+    assert not [r for r in caplog.records if r.levelname == "WARNING"]
+
+
+@pytest.mark.asyncio
+async def test_the_watchdog_warns_on_regression(monkeypatch, caplog):
+    monkeypatch.setattr(rr, "_audit", lambda: _reading(asym=("a",)))
+    rr.accept_baseline()
+    monkeypatch.setattr(rr, "_audit", lambda: _reading(asym=("a", "newcomer")))
+    caplog.clear()
+    await rr.run_watchdog()
+    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert warnings and "newcomer" in warnings[0].getMessage()
+
+
+@pytest.mark.asyncio
+async def test_the_watchdog_runs_off_the_event_loop():
+    """The audit walks the module tree and parses every file — far too much
+    work for the loop that also runs the organism."""
+    import inspect
+    assert "to_thread" in inspect.getsource(rr.run_watchdog)
+
+
+@pytest.mark.asyncio
+async def test_the_watchdog_never_raises(monkeypatch):
+    def _boom():
+        raise RuntimeError("nope")
+    monkeypatch.setattr(rr, "_audit", _boom)
+    assert (await rr.run_watchdog()).error
+
+
+@pytest.mark.asyncio
+async def test_the_watchdog_can_be_switched_off(monkeypatch):
+    monkeypatch.setenv("JARVIS_REACH_WATCHDOG_ENABLED", "0")
+    assert rr.watchdog_enabled() is False
+
+
+# -- the verb --------------------------------------------------------------
+
+
+def test_the_verb_is_auto_discoverable():
+    """Named for the cage `repl_dispatch_registry` reads, so it becomes a
+    verb without a registration table anyone can forget to update."""
+    assert callable(rr.dispatch_reach_command)
+    assert "reach" in rr.__verb_help__
+
+
+def test_help_is_reachable():
+    assert "reachability" in rr.dispatch_reach_command("/reach help").text
+
+
+def test_a_module_query_names_its_surfaces(monkeypatch):
+    class _M:
+        module = "backend.x.menu_bindings"
+        reached_by = ("attach", "cockpit")
+        def asymmetric(self, n): return True
+        orphan = False
+    class _R:
+        surface_labels = ("daemon", "attach", "cockpit")
+        modules = [_M()]
+        scanned = 1
+        def asymmetric(self): return [_M()]
+        def orphans(self): return []
+    monkeypatch.setattr(rr, "_audit", lambda: _R())
+    out = rr.dispatch_reach_command("/reach menu_bindings")
+    assert out.ok and "attach" in out.text and "cockpit" in out.text
+
+
+def test_an_unknown_module_refuses_rather_than_returning_nothing(monkeypatch):
+    monkeypatch.setattr(rr, "_audit", lambda: _reading())
+    out = rr.dispatch_reach_command("/reach no_such_module_xyz")
+    assert out.ok is False and "no module matching" in out.text
+
+
+def test_the_verb_adds_no_analysis_of_its_own():
+    """Every number comes from surface_reachability.audit — a second
+    implementation would be a second opinion about the same tree."""
+    import pathlib
+    src = pathlib.Path(rr.__file__).read_text(encoding="utf-8")
+    assert "surface_reachability import audit" in src
+    for banned in ("ast.parse", "importlib", "os.walk"):
+        assert banned not in src
+
+
+# -- the fix this detector was built to catch ------------------------------
+
+
+def test_menu_bindings_is_now_reachable_from_the_attach_surface():
+    """§28 C2, closed: the capability existed and was mounted only on the
+    bipartite surface. This is the detector confirming its own finding is
+    fixed."""
+    from backend.core.ouroboros.battle_test.surface_reachability import audit
+    reading = audit()
+    hit = next((m for m in reading.modules
+                if m.module.endswith("menu_bindings")), None)
+    assert hit is not None, "menu_bindings vanished from the module tree"
+    assert "attach" in hit.reached_by, (
+        "menu_bindings is unreachable from the surface `ov attach` mounts")


### PR DESCRIPTION
Two items that together close a defect class this codebase has hit **six times**.

## Item 1 — mount the confirm actions where `ov attach` can reach them

`install_confirm_actions` has worked since it shipped, imported at exactly **one** site: `bipartite_layout`. The capability was never missing — it was unreachable from the cockpit an operator actually mounts. Answering a pending apply from `ov attach` meant noticing the badge, pressing `Ctrl+P`, typing `n`, pressing Enter. It is now one key.

Mounted at `_client_extra_bindings` for the reason the completion arbiter states two lines above it:

> *"this builder is the one action set both attach surfaces share; binding it at either call site would fix the surface that was looked at and leave the other one dead."*

That is the sentence §28 needed and did not find — it was already written.

`submit` routes through `_route_operator_line`, the path a typed `/accept` takes, so the risk tier, audit trail and countdown clear identically. A key that bypassed the verb would be a second approval path, and approval is the one surface where two paths that disagree is a governance problem rather than a UI one.

**No lock is added, deliberately.** The pending gate is a fact about the *organism*, not a screen; `pending_apply` already guards its state with a `threading.Lock` and `snapshot()` returns a copy; and two cockpits answering at once are separated by `prompt_id`, which the daemon refuses on mismatch. A lock here would serialise two reads that were never in conflict.

## Item 2 — `/reach`, the detector's operator

`surface_reachability` already answers the question that matters, and its docstring names five modules that shipped complete, tested and invisible. §28's C2 was the sixth. The detector was right about all of them — it had no verb and no tests, so **the instrument for finding unmounted features was itself unmounted**.

This adds **no analysis**. Every number comes from `surface_reachability.audit`, pinned by a test asserting the module contains no `ast.parse`, no `importlib`, no `os.walk`.

### A ratchet, not a report

The naive watchdog prints every asymmetric module at boot, and is muted by the second week. The detector's own history says why: of 39 modules once reported orphaned, **32 were reachable from an entry point the audit had not been taught about**. A signal with a 4:1 false-positive rate is noise, and an operator who learns to skip a line stops reading the line that finally matters.

So only **drift** is reported. Steady state is silence, which inverts the economics: silence means nothing regressed, and any output is by construction new. `/reach accept` moves the ratchet.

### Baseline failure modes collapse to one deliberate answer

Missing, corrupt, or non-object baselines all read as **absent, not empty**. An empty baseline would report every asymmetric module as newly regressed, burying a real regression under a hundred false ones on the first boot after a disk fault. Published through `durable_io.atomic_replace` for the same reason.

The watchdog runs off the loop — the audit walks the module tree and parses every file — and **warns** rather than informs on regression.

## The detector confirms its own finding

`/reach menu_bindings` now reports `reached by: attach, cockpit`. Pinned as a test.

**21 tests.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mounts confirm actions on the `ov attach` surface and adds the `/reach` operator to detect drift in surface reachability. Previously the confirm actions existed but were only mounted in `bipartite_layout` (multi-step invocation from `ov attach`); now they are a single key on `ov attach`. The new `/reach` verb reports only drift from a recorded baseline and warns via a watchdog.

- Confirm actions are installed from `install_confirm_actions` at `_client_extra_bindings`, with `submit` routed through `_route_operator_line` (same path as `/accept`); no new lock is added.
- Adds `governance/reach_repl.py`: `/reach` supports `accept`, `all`, `orphans`, `<module>`, and default drift; all numbers come from `surface_reachability.audit`.
- Baseline is stored per repo at `.jarvis/surface_reachability_baseline.json` and written via `durable_io.atomic_replace`. Watchdog runs off the loop; configure via `JARVIS_REACH_WATCHDOG_ENABLED` and `JARVIS_REACH_BASELINE_PATH`.
- Tests ensure the ratchet behavior and confirm `menu_bindings` is reachable from `attach`.

**Rollout**
- Run `/reach accept` once per repository to establish the baseline; without it, drift checks will report “no baseline” and the watchdog will not warn.

<sup>Written for commit f6f0ff051e69ed70eaffb8d472d8eedb1682b118. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

